### PR TITLE
Update NOTICE file for 2026.02

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -10,7 +10,6 @@ by sending an email to info@posit.co
 
 Components used by Positron
 ===========================
-* .ipynb Support (MIT license)
 * .NET csharp tmLanguage (MIT license)
 * .NET razor (MIT license)
 * abort-controller (MIT license)
@@ -27,6 +26,8 @@ Components used by Positron
 * agent-base (MIT license)
 * ahash (Apache, MIT licenses)
 * aho-corasick (MIT, Unlicense licenses)
+* @ai-sdk/provider (Apache license)
+* @ai-sdk/provider-utils (Apache license)
 * ajv (MIT license)
 * alloc-no-stdlib (BSD license)
 * alloc-stdlib (BSD license)
@@ -61,6 +62,7 @@ Components used by Positron
 * asn1.js-rfc5280 (MIT license)
 * ASP VB.NET tmBundle (TEXTMATE-BUNDLE-LICENSE license)
 * assert_matches (Apache, MIT licenses)
+* ast-types (MIT license)
 * asttokens (Apache license)
 * async (MIT license)
 * async-channel (Apache, MIT licenses)
@@ -91,10 +93,13 @@ Components used by Positron
 * @aws-sdk/client-s3 (Apache license)
 * @aws-sdk/client-sso (Apache license)
 * @aws-sdk/client-sts (Apache license)
-* @aws-sdk/core (Apache license)
+* @aws-sdk/core version 3.970.0 (Apache license)
+* @aws-sdk/core version 3.914.0 (Apache license)
+* @aws-sdk/crc64-nvme (Apache license)
 * @aws-sdk/credential-provider-env (Apache license)
 * @aws-sdk/credential-provider-http (Apache license)
 * @aws-sdk/credential-provider-ini (Apache license)
+* @aws-sdk/credential-provider-login (Apache license)
 * @aws-sdk/credential-provider-node (Apache license)
 * @aws-sdk/credential-provider-process (Apache license)
 * @aws-sdk/credential-provider-sso (Apache license)
@@ -155,6 +160,7 @@ Components used by Positron
 * balanced-match (MIT license)
 * base64 (Apache, MIT licenses)
 * base64-js (MIT license)
+* basic-ftp (MIT license)
 * bcrypt-pbkdf (BSD license)
 * before-after-hook (Apache license)
 * Better Less (MIT license)
@@ -227,6 +233,8 @@ Components used by Positron
 * cjs-module-lexer (MIT license)
 * clap (Apache, MIT licenses)
 * clap-verbosity-flag (Apache, MIT licenses)
+* Classic .ipynb Support (MIT license)
+* cliui (ISC license)
 * Clojure Language Basics (MIT license)
 * cls-hooked (BSD license)
 * Code OSS (MIT license)
@@ -334,6 +342,7 @@ Components used by Positron
 * default-browser-id (MIT license)
 * define-lazy-prop (MIT license)
 * Definitely Typed (MIT license)
+* degenerator (MIT license)
 * delaunator (ISC license)
 * delayed-stream (MIT license)
 * depd (MIT license)
@@ -342,6 +351,7 @@ Components used by Positron
 * destroy (MIT license)
 * detect-indent (MIT license)
 * detect-libc (Apache license)
+* Dev Containers (ELASTIC-2.0 license)
 * diagnostic-channel (MIT license)
 * diagnostic-channel-publishers (MIT license)
 * dialoguer (MIT license)
@@ -407,8 +417,12 @@ Components used by Positron
 * es-errors (MIT license)
 * es-object-atoms (MIT license)
 * es-set-tostringtag (MIT license)
+* escalade (MIT license)
 * escape-html (MIT license)
+* escodegen (BSD license)
 * esprima (BSD license)
+* estraverse (BSD license)
+* esutils (BSD license)
 * etag (MIT license)
 * event-listener (Apache, MIT licenses)
 * event-listener-strategy (Apache, MIT licenses)
@@ -474,9 +488,11 @@ Components used by Positron
 * gcp-metadata (Apache license)
 * generic-array (MIT license)
 * generic-pool (MIT license)
+* get-caller-file (ISC license)
 * get-intrinsic (MIT license)
 * get-proto (MIT license)
 * get-system-fonts (MIT license)
+* get-uri (MIT license)
 * getopts (Apache, MIT licenses)
 * getrandom (Apache, MIT licenses)
 * gimli (Apache, MIT licenses)
@@ -489,7 +505,6 @@ Components used by Positron
 * GitHub Authentication (MIT license)
 * github-from-package (MIT license)
 * @github/copilot (SEE-LICENSE-IN-LICENSE.MD license)
-* @github/copilot-language-server (MIT license)
 * glob versions 10.4.5, 9.3.5 (ISC license)
 * glob version 7.2.3 (ISC license)
 * globals (MIT license)
@@ -627,12 +642,13 @@ Components used by Positron
 * JSON Language Features (MIT license)
 * json-bigint (MIT license)
 * json-bignum (MIT license)
+* json-schema (AFLv2.1, BSD licenses)
 * json-schema-to-ts (MIT license)
 * json-schema-traverse (MIT license)
 * jsonc-parser (MIT license)
 * jsonfile (MIT license)
 * jsonwebtoken (MIT license)
-* jsonwebtoken version 9.0.2 (MIT license)
+* jsonwebtoken versions 9.0.3, 9.0.2 (MIT license)
 * jsonwebtoken version 9.3.1 (MIT license)
 * Julia Language Basics (MIT license)
 * jupyter-client (BSD license)
@@ -674,6 +690,7 @@ Components used by Positron
 * Log (MIT license)
 * log (Apache, MIT licenses)
 * logform (MIT license)
+* looper (MIT license)
 * loose-envify (MIT license)
 * lru-cache (ISC license)
 * lsp-types (MIT license)
@@ -726,6 +743,7 @@ Components used by Positron
 * @microsoft/fast-react-wrapper (MIT license)
 * @microsoft/fast-web-utilities (MIT license)
 * @microsoft/tiktokenizer (MIT license)
+* @midleman/playwright-reporter (MIT license)
 * mime (MIT license)
 * mime (Apache, MIT licenses)
 * mime-db (MIT license)
@@ -735,7 +753,7 @@ Components used by Positron
 * minimalistic-assert (ISC license)
 * minimatch (ISC license)
 * minimist (MIT license)
-* minipass versions 7.1.2, 5.0.0, 4.2.8 (ISC license)
+* minipass versions 7.1.2, 5.0.0, 4.2.8, 3.3.6 (ISC license)
 * minipass version 3.1.3 (ISC license)
 * minizlib (MIT license)
 * miniz_oxide (Apache, MIT, zlib licenses)
@@ -754,13 +772,16 @@ Components used by Positron
 * ms version 2.1.3 (MIT license)
 * ms version 2.0.0 (MIT license)
 * named-js-regexp (MIT license)
+* nanoid (MIT license)
 * napi-build-utils (MIT license)
 * native-is-elevated (MIT license)
 * native-keymap (MIT license)
 * native-tls (Apache, MIT licenses)
 * native-watchdog (MIT license)
+* ncp (MIT license)
 * negotiator (MIT license)
 * nest-asyncio (BSD license)
+* netmask (MIT license)
 * @nevware21/ts-async (MIT license)
 * @nevware21/ts-utils (MIT license)
 * new_debug_unreachable (MIT license)
@@ -834,6 +855,8 @@ Components used by Positron
 * p-locate (MIT license)
 * p-queue (MIT license)
 * p-timeout (MIT license)
+* pac-proxy-agent (MIT license)
+* pac-resolver (MIT license)
 * package-json-from-dist (BlueOak license)
 * package-manager-detector (MIT license)
 * packaging (Apache, BSD licenses)
@@ -889,11 +912,13 @@ Components used by Positron
 * Prompt Language Basics (MIT license)
 * prompt-toolkit (BSD license)
 * proxy-addr (MIT license)
+* proxy-agent (MIT license)
 * proxy-from-env (MIT license)
 * psutil (BSD license)
 * ptyprocess (ISC license)
 * Pug Language Basics (MIT license)
 * Pug.tmbundle (MIT license)
+* pull-stream (MIT license)
 * pump (MIT license)
 * punycode (MIT license)
 * punycode.js (MIT license)
@@ -925,6 +950,7 @@ Components used by Positron
 * react-window (MIT license)
 * readable-stream (MIT license)
 * readable-web-to-node-stream (MIT license)
+* recursive-readdir (MIT license)
 * Red Theme (MIT license)
 * redox_syscall (MIT license)
 * redox_users (MIT license)
@@ -934,6 +960,7 @@ Components used by Positron
 * regenerator-runtime (MIT license)
 * regex (Apache, MIT licenses)
 * request-light (MIT license)
+* require-directory (MIT license)
 * require-from-string (MIT license)
 * require-in-the-middle (MIT license)
 * requires-port (MIT license)
@@ -982,6 +1009,7 @@ Components used by Positron
 * scraper (ISC license)
 * SCSS Language Basics (MIT license)
 * Search Result (MIT license)
+* secure-json-parse (BSD license)
 * selectors (MPLv2 license)
 * semver (ISC license)
 * semver (Apache, MIT licenses)
@@ -1006,6 +1034,7 @@ Components used by Positron
 * shebang-command (MIT license)
 * shebang-regex (MIT license)
 * Shell Script Language Basics (MIT license)
+* shell-quote (MIT license)
 * shimmer (BSD license)
 * shlex (Apache, MIT licenses)
 * side-channel (MIT license)
@@ -1100,6 +1129,7 @@ Components used by Positron
 * statuses (MIT license)
 * stream-events (MIT license)
 * stream-shift (MIT license)
+* stream-to-pull-stream (MIT license)
 * streaming-iterator (Apache, MIT licenses)
 * string-cache (Apache, MIT licenses)
 * string-width (MIT license)
@@ -1147,6 +1177,7 @@ Components used by Positron
 * terminal_size (Apache, MIT licenses)
 * testthat Test Reporter for R Test Explorer VSCode Extension (MIT license)
 * text-hex (MIT license)
+* text-table (MIT license)
 * textwrap (MIT license)
 * thiserror (Apache, MIT licenses)
 * thread_local (Apache, MIT licenses)
@@ -1169,6 +1200,7 @@ Components used by Positron
 * toml (Apache, MIT licenses)
 * Tomorrow Night Blue Theme (MIT license)
 * @tootallnate/once (MIT license)
+* @tootallnate/quickjs-emscripten (MIT license)
 * tornado (Apache license)
 * tower (MIT license)
 * tower-lsp (Apache, MIT licenses)
@@ -1343,11 +1375,14 @@ Components used by Positron
 * @xterm/addon-webgl (MIT license)
 * @xterm/headless (MIT license)
 * @xterm/xterm (MIT license)
+* y18n (ISC license)
 * yallist (ISC license)
 * yaml version 2.8.1 (ISC license)
 * YAML Language Basics version 1.0.0 (MIT license)
 * YAML Syntax Highlighter (MIT license)
 * yaml-rust (Apache, MIT licenses)
+* yargs (MIT license)
+* yargs-parser (ISC license)
 * yauzl (MIT license)
 * yazl (MIT license)
 * yocto-queue (MIT license)
@@ -1359,6 +1394,7 @@ Components used by Positron
 * zipp (MIT license)
 * zmq (Apache, MIT licenses)
 * zmq-sys (Apache, MIT licenses)
+* zod (MIT license)
 * zstd (MIT license)
 * zstd-safe (Apache, MIT licenses)
 * zstd-sys (Apache, MIT licenses)
@@ -1861,24 +1897,23 @@ BSD 2-Clause license
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
+ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 MIT License
 -----------
@@ -1936,17 +1971,9 @@ For more information, please refer to <http://unlicense.org>
 Component-specific licenses
 ===========================
 
-.ipynb Support
---------------
-Website: https://github.com/microsoft/vscode
-
-Copyright (c) Microsoft Corporation
-Distributed under the MIT License
-
-
 .NET csharp tmLanguage
 ----------------------
-Website: https://github.com/dotnet/csharp-tmLanguage
+Source: https://github.com/dotnet/csharp-tmLanguage
 
 Copyright (c) 2016 .NET Foundation
 Distributed under the MIT License
@@ -1954,7 +1981,7 @@ Distributed under the MIT License
 
 .NET razor
 ----------
-Website: https://github.com/dotnet/razor
+Source: https://github.com/dotnet/razor
 
 Copyright (c) .NET Foundation and Contributors
 Distributed under the MIT License
@@ -1962,7 +1989,7 @@ Distributed under the MIT License
 
 abort-controller
 ----------------
-Website: https://github.com/mysticatea/abort-controller
+Source: https://github.com/mysticatea/abort-controller
 
 Copyright 2017 Toru Nagashima
 Distributed under the MIT License
@@ -1994,7 +2021,7 @@ SOFTWARE.
 
 Abyss Theme
 -----------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -2002,7 +2029,7 @@ Distributed under the MIT License
 
 accepts
 -------
-Website: https://github.com/jshttp/accepts
+Source: https://github.com/jshttp/accepts
 
 Copyright 2014 Jonathan Ong <me@jongleberry.com>
 Copyright 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
@@ -2038,7 +2065,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 acorn
 -----
-Website: https://github.com/acornjs/acorn
+Source: https://github.com/acornjs/acorn
 
 Copyright (C) 2012-2022 by various contributors (see AUTHORS)
 Distributed under the MIT License
@@ -2070,7 +2097,7 @@ THE SOFTWARE.
 
 acorn-import-assertions
 -----------------------
-Website: https://github.com/xtuc/acorn-import-assertions
+Source: https://github.com/xtuc/acorn-import-assertions
 
 Published by Sven Sauleau <sven@sauleau.com>
 Distributed under the MIT License
@@ -2078,7 +2105,7 @@ Distributed under the MIT License
 
 acorn-import-attributes
 -----------------------
-Website: https://github.com/xtuc/acorn-import-attributes
+Source: https://github.com/xtuc/acorn-import-attributes
 
 Copyright 2023 Sven Sauleau
 Distributed under the MIT License
@@ -2110,7 +2137,7 @@ SOFTWARE.
 
 actix-net
 ---------
-Website: https://github.com/actix/actix-net
+Source: https://github.com/actix/actix-net
 
 Copyright 2017-NOW Actix Team
 
@@ -2357,7 +2384,7 @@ DEALINGS IN THE SOFTWARE.
 
 actix-web
 ---------
-Website: https://github.com/actix/actix-web
+Source: https://github.com/actix/actix-web
 
 Copyright 2017-NOW Actix Team
 
@@ -2604,7 +2631,7 @@ DEALINGS IN THE SOFTWARE.
 
 addr2line
 ---------
-Website: https://github.com/gimli-rs/addr2line
+Source: https://github.com/gimli-rs/addr2line
 
 Copyright 2016-2018 The gimli Developers
 
@@ -2644,7 +2671,7 @@ DEALINGS IN THE SOFTWARE.
 
 adler
 -----
-Website: https://github.com/jonas-schievink/adler
+Source: https://github.com/jonas-schievink/adler
 
 Copyright (C) Jonas Schievink <jonasschievink@gmail.com>
 
@@ -2672,7 +2699,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 adler2
 ------
-Website: https://github.com/oyvindln/adler2
+Source: https://github.com/oyvindln/adler2
 
 Copyright (C) Jonas Schievink <jonasschievink@gmail.com>
 
@@ -2700,7 +2727,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 agent-base
 ----------
-Website: https://github.com/TooTallNate/proxy-agents
+Source: https://github.com/TooTallNate/proxy-agents
 
 Copyright 2013 Nathan Rajlich <nathan@tootallnate.net>
 Distributed under the MIT License
@@ -2733,7 +2760,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ahash
 -----
-Website: https://github.com/tkaitchuck/ahash
+Source: https://github.com/tkaitchuck/ahash
 
 Copyright 2018 Tom Kaitchuck
 
@@ -2773,7 +2800,7 @@ DEALINGS IN THE SOFTWARE.
 
 aho-corasick
 ------------
-Website: https://github.com/BurntSushi/aho-corasick
+Source: https://github.com/BurntSushi/aho-corasick
 
 Copyright 2015 Andrew Gallant
 
@@ -2783,9 +2810,57 @@ Distributed under multiple software licenses, including:
 Consult the documentation and source code of aho-corasick for more information.
 
 
+@ai-sdk/provider
+----------------
+Source: https://github.com/vercel/ai
+
+Copyright 2023 Vercel, Inc.
+Distributed under the Apache License version 2.0
+
+Apache License version 2.0 text:
+
+Copyright 2023 Vercel, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+@ai-sdk/provider-utils
+----------------------
+Source: https://github.com/vercel/ai
+
+Copyright 2023 Vercel, Inc.
+Distributed under the Apache License version 2.0
+
+Apache License version 2.0 text:
+
+Copyright 2023 Vercel, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
 ajv
 ---
-Website: https://github.com/ajv-validator/ajv
+Source: https://github.com/ajv-validator/ajv
 
 Copyright 2015-2021 Evgeny Poberezkin
 Distributed under the MIT License
@@ -2817,7 +2892,7 @@ SOFTWARE.
 
 alloc-no-stdlib
 ---------------
-Website: https://github.com/dropbox/rust-alloc-no-stdlib
+Source: https://github.com/dropbox/rust-alloc-no-stdlib
 
 Copyright 2016 Dropbox, Inc.
 Distributed under the BSD 3-Clause license
@@ -2841,7 +2916,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 alloc-stdlib
 ------------
-Website: https://github.com/dropbox/rust-alloc-no-stdlib
+Source: https://github.com/dropbox/rust-alloc-no-stdlib
 
 Copyright 2016 Dropbox, Inc.
 Distributed under the BSD 3-Clause license
@@ -2865,7 +2940,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 Amazon Q Developer CLI
 ----------------------
-Website: https://github.com/aws/amazon-q-developer-cli
+Source: https://github.com/aws/amazon-q-developer-cli
 
 Copyright (c) 2024 Amazon.com, Inc. or its affiliates.
 Distributed under the MIT License
@@ -2873,7 +2948,7 @@ Distributed under the MIT License
 
 android-tzdata
 --------------
-Website: https://github.com/RumovZ/android-tzdata
+Source: https://github.com/RumovZ/android-tzdata
 
 Copyright [year] [fullname]
 
@@ -2909,7 +2984,7 @@ SOFTWARE.
 
 android_system_properties
 -------------------------
-Website: https://github.com/nical/android_system_properties
+Source: https://github.com/nical/android_system_properties
 
 Copyright 2016 Nicolas Silva
 
@@ -2961,7 +3036,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ansi-regex
 ----------
-Website: https://github.com/chalk/ansi-regex
+Source: https://github.com/chalk/ansi-regex
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -2981,7 +3056,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ansi-styles
 -----------
-Website: https://github.com/chalk/ansi-styles
+Source: https://github.com/chalk/ansi-styles
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -3001,7 +3076,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ansi_term
 ---------
-Website: https://github.com/ogham/rust-ansi-term
+Source: https://github.com/ogham/rust-ansi-term
 
 Copyright 2014 Benjamin Sago
 Distributed under the MIT License
@@ -3033,7 +3108,7 @@ SOFTWARE.
 
 anstream
 --------
-Website: https://github.com/rust-cli/anstyle
+Source: https://github.com/rust-cli/anstyle
 
 Copyright Individual contributors
 
@@ -3067,7 +3142,7 @@ SOFTWARE.
 
 anstyle
 -------
-Website: https://github.com/rust-cli/anstyle
+Source: https://github.com/rust-cli/anstyle
 
 Copyright 2022 The rust-cli Developers
 
@@ -3101,7 +3176,7 @@ SOFTWARE.
 
 anstyle-parse
 -------------
-Website: https://github.com/rust-cli/anstyle
+Source: https://github.com/rust-cli/anstyle
 
 Copyright 2016 Joe Wilm and individual contributors
 
@@ -3141,7 +3216,7 @@ DEALINGS IN THE SOFTWARE.
 
 anstyle-query
 -------------
-Website: https://github.com/rust-cli/anstyle
+Source: https://github.com/rust-cli/anstyle
 
 Copyright Individual contributors
 
@@ -3175,7 +3250,7 @@ SOFTWARE.
 
 anstyle-wincon
 --------------
-Website: https://github.com/rust-cli/anstyle
+Source: https://github.com/rust-cli/anstyle
 
 Copyright 2015 Josh Triplett, 2022 The rust-cli Developers
 
@@ -3209,7 +3284,7 @@ SOFTWARE.
 
 @antfu/install-pkg
 ------------------
-Website: https://github.com/antfu/install-pkg
+Source: https://github.com/antfu/install-pkg
 
 Copyright 2021 Anthony Fu <https:github.com/antfu>
 Distributed under the MIT License
@@ -3241,7 +3316,7 @@ SOFTWARE.
 
 @antfu/utils
 ------------
-Website: https://github.com/antfu/utils
+Source: https://github.com/antfu/utils
 
 Copyright 2021 Anthony Fu <https:github.com/antfu>
 Distributed under the MIT License
@@ -3273,7 +3348,7 @@ SOFTWARE.
 
 @anthropic-ai/claude-code
 -------------------------
-Website: https://github.com/anthropics/claude-code
+Source: https://github.com/anthropics/claude-code
 
 Copyright © Anthropic PBC. Use is subject to Anthropic's Commercial Terms of Service.
 
@@ -3285,7 +3360,7 @@ SEE-LICENSE-IN-README.MD License text:
 
 @anthropic-ai/sdk
 -----------------
-Website: https://github.com/anthropics/anthropic-sdk-typescript
+Source: https://github.com/anthropics/anthropic-sdk-typescript
 
 Copyright 2023 Anthropic, PBC.
 Distributed under the MIT License
@@ -3303,7 +3378,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 anyhow
 ------
-Website: https://github.com/dtolnay/anyhow
+Source: https://github.com/dtolnay/anyhow
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -3315,7 +3390,7 @@ Consult the documentation and source code of anyhow for more information.
 
 apache-arrow
 ------------
-Website: https://github.com/apache/arrow
+Source: https://github.com/apache/arrow
 
 Copyright 2016-2024 The Apache Software Foundation
 Distributed under the Apache License version 2.0
@@ -5666,7 +5741,7 @@ Apache License 2.0.
 
 applicationinsights
 -------------------
-Website: https://github.com/microsoft/ApplicationInsights-node.js
+Source: https://github.com/microsoft/ApplicationInsights-node.js
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -5698,7 +5773,7 @@ SOFTWARE.
 
 appnope
 -------
-Website: http://github.com/minrk/appnope
+Source: http://github.com/minrk/appnope
 
 All rights reserved.
 Copyright (c) 2013, Min Ragan-Kelley
@@ -5707,7 +5782,7 @@ Distributed under the BSD 2-Clause license
 
 arch
 ----
-Website: https://github.com/feross/arch
+Source: https://github.com/feross/arch
 
 Copyright Feross Aboukhadijeh
 Distributed under the MIT License
@@ -5738,7 +5813,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 argparse version 2.0.1
 ----------------------
-Website: https://github.com/nodeca/argparse
+Source: https://github.com/nodeca/argparse
 
 Copyright 1991 - 1995, Stichting Mathematisch Centrum Amsterdam, The Netherlands.
 Distributed under the Python License version 2.0
@@ -6002,7 +6077,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 argparse version 1.0.9
 ----------------------
-Website: https://github.com/nodeca/argparse
+Source: https://github.com/nodeca/argparse
 
 Copyright (C) 2012 by Vitaly Puzrin
 Distributed under the MIT License
@@ -6034,7 +6109,7 @@ THE SOFTWARE.
 
 array-back
 ----------
-Website: https://github.com/75lb/array-back
+Source: https://github.com/75lb/array-back
 
 Copyright 2015-22 Lloyd Brookes <75pound@gmail.com>
 Distributed under the MIT License
@@ -6066,7 +6141,7 @@ SOFTWARE.
 
 array-flatten
 -------------
-Website: https://github.com/blakeembrey/array-flatten
+Source: https://github.com/blakeembrey/array-flatten
 
 Copyright 2014 Blake Embrey (hello@blakeembrey.com)
 Distributed under the MIT License
@@ -6098,7 +6173,7 @@ THE SOFTWARE.
 
 arrify
 ------
-Website: https://github.com/sindresorhus/arrify
+Source: https://github.com/sindresorhus/arrify
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -6118,7 +6193,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 asn1
 ----
-Website: https://github.com/joyent/node-asn1
+Source: https://github.com/joyent/node-asn1
 
 Copyright 2011 Mark Cavage,
 Distributed under the MIT License
@@ -6148,7 +6223,7 @@ THE SOFTWARE
 
 asn1.js
 -------
-Website: https://github.com/indutny/asn1.js
+Source: https://github.com/indutny/asn1.js
 
 Copyright 2017 Fedor Indutny
 Distributed under the MIT License
@@ -6180,7 +6255,7 @@ SOFTWARE.
 
 asn1.js-rfc2560
 ---------------
-Website: https://github.com/indutny/asn1.js
+Source: https://github.com/indutny/asn1.js
 
 Published by Fedor Indutny
 Distributed under the MIT License
@@ -6188,7 +6263,7 @@ Distributed under the MIT License
 
 asn1.js-rfc5280
 ---------------
-Website: https://github.com/indutny/asn1.js
+Source: https://github.com/indutny/asn1.js
 
 Published by Felix Hanley
 Distributed under the MIT License
@@ -6196,7 +6271,7 @@ Distributed under the MIT License
 
 ASP VB.NET tmBundle
 -------------------
-Website: https://github.com/textmate/asp.vb.net.tmbundle
+Source: https://github.com/textmate/asp.vb.net.tmbundle
 
 Copyright (c) textmate-asp.vb.net.tmbundle project authors
 
@@ -6220,7 +6295,7 @@ to the base-name name of the original file, and an extension of txt, html, or si
 
 assert_matches
 --------------
-Website: https://github.com/murarth/assert_matches
+Source: https://github.com/murarth/assert_matches
 
 Copyright 2016 Murarth
 
@@ -6258,9 +6333,40 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 
+ast-types
+---------
+Source: https://github.com/benjamn/ast-types
+
+Copyright 2013 Ben Newman <bn@cs.stanford.edu>
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2013 Ben Newman <bn@cs.stanford.edu>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 asttokens
 ---------
-Website: https://github.com/gristlabs/asttokens
+Source: https://github.com/gristlabs/asttokens
 
 Published by Dmitry Sagalovskiy, Grist Labs
 Distributed under the Apache License version 2.0
@@ -6268,7 +6374,7 @@ Distributed under the Apache License version 2.0
 
 async
 -----
-Website: https://github.com/caolan/async
+Source: https://github.com/caolan/async
 
 Copyright 2010-2018 Caolan McMahon
 Distributed under the MIT License
@@ -6298,7 +6404,7 @@ THE SOFTWARE.
 
 async-channel
 -------------
-Website: https://github.com/smol-rs/async-channel
+Source: https://github.com/smol-rs/async-channel
 
 Published by Stjepan Glavina <stjepang@gmail.com>
 
@@ -6310,7 +6416,7 @@ Consult the documentation and source code of async-channel for more information.
 
 async-hook-jl
 -------------
-Website: https://github.com/jeff-lewis/async-hook-jl
+Source: https://github.com/jeff-lewis/async-hook-jl
 
 Copyright 2015 Andreas Madsen
 Distributed under the MIT License
@@ -6340,7 +6446,7 @@ THE SOFTWARE.
 
 async-listener
 --------------
-Website: https://github.com/othiym23/async-listener
+Source: https://github.com/othiym23/async-listener
 
 Copyright 2013-2017, Forrest L Norvell
 Distributed under the BSD 2-Clause license
@@ -6376,7 +6482,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 async-retry
 -----------
-Website: https://github.com/vercel/async-retry
+Source: https://github.com/vercel/async-retry
 
 Copyright 2021 Vercel, Inc.
 Distributed under the MIT License
@@ -6408,7 +6514,7 @@ SOFTWARE.
 
 async-stream
 ------------
-Website: https://github.com/tokio-rs/async-stream
+Source: https://github.com/tokio-rs/async-stream
 
 Copyright 2018 David Tolnay
 Copyright 2019 Carl Lerche
@@ -6471,7 +6577,7 @@ DEALINGS IN THE SOFTWARE.
 
 async-trait
 -----------
-Website: https://github.com/dtolnay/async-trait
+Source: https://github.com/dtolnay/async-trait
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -6483,7 +6589,7 @@ Consult the documentation and source code of async-trait for more information.
 
 asynchronous-codec
 ------------------
-Website: https://github.com/mxinden/asynchronous-codec
+Source: https://github.com/mxinden/asynchronous-codec
 
 Copyright 2019 - 2020 Matt Hunzinger
 Copyright 2021 Max Inden
@@ -6518,7 +6624,7 @@ SOFTWARE.
 
 asynckit
 --------
-Website: https://github.com/alexindigo/asynckit
+Source: https://github.com/alexindigo/asynckit
 
 Copyright 2016 Alex Indigo
 Distributed under the MIT License
@@ -6550,7 +6656,7 @@ SOFTWARE.
 
 Atom Language Clojure
 ---------------------
-Website: https://github.com/atom/language-clojure
+Source: https://github.com/atom/language-clojure
 
 Copyright (c) 2014 GitHub Inc.
 Distributed under the MIT License
@@ -6609,7 +6715,7 @@ SOFTWARE.
 
 Atom Language CoffeeScript
 --------------------------
-Website: https://github.com/atom/language-coffee-script
+Source: https://github.com/atom/language-coffee-script
 
 Copyright (c) 2014 GitHub Inc.
 Distributed under the MIT License
@@ -6669,7 +6775,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 Atom Language Saas
 ------------------
-Website: https://github.com/atom/language-sass
+Source: https://github.com/atom/language-sass
 
 Copyright (c) 2014 GitHub Inc.
 Distributed under the MIT License
@@ -6677,7 +6783,7 @@ Distributed under the MIT License
 
 Atom Language XML
 -----------------
-Website: https://github.com/atom/language-xml
+Source: https://github.com/atom/language-xml
 
 Copyright (c) 2014 GitHub Inc.
 Distributed under the MIT License
@@ -6719,7 +6825,7 @@ suitability for any purpose.
 
 atom-language-julia
 -------------------
-Website: https://github.com/JuliaEditorSupport/atom-language-julia
+Source: https://github.com/JuliaEditorSupport/atom-language-julia
 
 Copyright (c) 2015 atom-language-julia authors
 Distributed under the MIT License
@@ -6727,7 +6833,7 @@ Distributed under the MIT License
 
 attrs
 -----
-Website: https://pypi.org/project/attrs/
+Source: https://pypi.org/project/attrs/
 
 Copyright 2015 Hynek Schlawack and the attrs contributors
 Distributed under the MIT License
@@ -6759,7 +6865,7 @@ SOFTWARE.
 
 atty
 ----
-Website: https://github.com/softprops/atty
+Source: https://github.com/softprops/atty
 
 Copyright 2015-2019 Doug Tangren
 Distributed under the MIT License
@@ -6790,7 +6896,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 autocfg
 -------
-Website: https://github.com/cuviper/autocfg
+Source: https://github.com/cuviper/autocfg
 
 Copyright 2018 Josh Stone
 
@@ -6830,7 +6936,7 @@ DEALINGS IN THE SOFTWARE.
 
 auto_impl
 ---------
-Website: https://github.com/auto-impl-rs/auto_impl/
+Source: https://github.com/auto-impl-rs/auto_impl/
 
 Copyright 2018 auto_impl Developers
 
@@ -6870,7 +6976,7 @@ DEALINGS IN THE SOFTWARE.
 
 @aws-crypto/crc32
 -----------------
-Website: https://github.com/aws/aws-sdk-js-crypto-helpers
+Source: https://github.com/aws/aws-sdk-js-crypto-helpers
 
 Published by AWS Crypto Tools Team
 Distributed under the Apache License version 2.0
@@ -6878,7 +6984,7 @@ Distributed under the Apache License version 2.0
 
 @aws-crypto/crc32c
 ------------------
-Website: https://github.com/aws/aws-sdk-js-crypto-helpers
+Source: https://github.com/aws/aws-sdk-js-crypto-helpers
 
 Published by AWS Crypto Tools Team
 Distributed under the Apache License version 2.0
@@ -6886,7 +6992,7 @@ Distributed under the Apache License version 2.0
 
 @aws-crypto/sha1-browser
 ------------------------
-Website: https://github.com/aws/aws-sdk-js-crypto-helpers
+Source: https://github.com/aws/aws-sdk-js-crypto-helpers
 
 Published by AWS Crypto Tools Team
 Distributed under the Apache License version 2.0
@@ -6894,7 +7000,7 @@ Distributed under the Apache License version 2.0
 
 @aws-crypto/sha256-browser
 --------------------------
-Website: https://github.com/aws/aws-sdk-js-crypto-helpers
+Source: https://github.com/aws/aws-sdk-js-crypto-helpers
 
 Published by AWS Crypto Tools Team
 Distributed under the Apache License version 2.0
@@ -6902,7 +7008,7 @@ Distributed under the Apache License version 2.0
 
 @aws-crypto/sha256-js
 ---------------------
-Website: https://github.com/aws/aws-sdk-js-crypto-helpers
+Source: https://github.com/aws/aws-sdk-js-crypto-helpers
 
 Published by AWS Crypto Tools Team
 Distributed under the Apache License version 2.0
@@ -6910,7 +7016,7 @@ Distributed under the Apache License version 2.0
 
 @aws-crypto/supports-web-crypto
 -------------------------------
-Website: https://github.com/aws/aws-sdk-js-crypto-helpers
+Source: https://github.com/aws/aws-sdk-js-crypto-helpers
 
 Published by AWS Crypto Tools Team
 Distributed under the Apache License version 2.0
@@ -6918,7 +7024,7 @@ Distributed under the Apache License version 2.0
 
 @aws-crypto/util
 ----------------
-Website: https://github.com/aws/aws-sdk-js-crypto-helpers
+Source: https://github.com/aws/aws-sdk-js-crypto-helpers
 
 Published by AWS Crypto Tools Team
 Distributed under the Apache License version 2.0
@@ -6926,7 +7032,7 @@ Distributed under the Apache License version 2.0
 
 @aws-sdk/client-bedrock
 -----------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2023 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -7140,7 +7246,7 @@ limitations under the License.
 
 @aws-sdk/client-s3
 ------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -7354,7 +7460,7 @@ limitations under the License.
 
 @aws-sdk/client-sso
 -------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -7568,7 +7674,7 @@ limitations under the License.
 
 @aws-sdk/client-sts
 -------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -7780,17 +7886,445 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-@aws-sdk/core
--------------
-Website: https://github.com/aws/aws-sdk-js-v3
+@aws-sdk/core version 3.970.0
+-----------------------------
+Source: https://github.com/aws/aws-sdk-js-v3
+
+Copyright 2018 Amazon.com, Inc. or its affiliates.
+Distributed under the Apache License version 2.0
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+@aws-sdk/core version 3.914.0
+-----------------------------
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Published by AWS SDK for JavaScript Team
 Distributed under the Apache License version 2.0
 
 
+@aws-sdk/crc64-nvme
+-------------------
+Source: https://github.com/aws/aws-sdk-js-v3
+
+Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
+Distributed under the Apache License version 2.0
+
+Apache License version 2.0 text:
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "{}"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
 @aws-sdk/credential-provider-env
 --------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -8004,7 +8538,7 @@ limitations under the License.
 
 @aws-sdk/credential-provider-http
 ---------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Published by AWS SDK for JavaScript Team
 Distributed under the Apache License version 2.0
@@ -8012,7 +8546,7 @@ Distributed under the Apache License version 2.0
 
 @aws-sdk/credential-provider-ini
 --------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -8224,9 +8758,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
+@aws-sdk/credential-provider-login
+----------------------------------
+Source: https://github.com/aws/aws-sdk-js-v3
+
+Published by AWS SDK for JavaScript Team
+Distributed under the Apache License version 2.0
+
+
 @aws-sdk/credential-provider-node
 ---------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -8440,7 +8982,7 @@ limitations under the License.
 
 @aws-sdk/credential-provider-process
 ------------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -8654,7 +9196,7 @@ limitations under the License.
 
 @aws-sdk/credential-provider-sso
 --------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -8868,7 +9410,7 @@ limitations under the License.
 
 @aws-sdk/credential-provider-web-identity
 -----------------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -9082,7 +9624,7 @@ limitations under the License.
 
 @aws-sdk/ec2-metadata-service
 -----------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -9296,7 +9838,7 @@ limitations under the License.
 
 @aws-sdk/middleware-bucket-endpoint
 -----------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -9510,7 +10052,7 @@ limitations under the License.
 
 @aws-sdk/middleware-expect-continue
 -----------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -9724,7 +10266,7 @@ limitations under the License.
 
 @aws-sdk/middleware-flexible-checksums
 --------------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2022 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -9938,7 +10480,7 @@ limitations under the License.
 
 @aws-sdk/middleware-host-header
 -------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -10152,7 +10694,7 @@ limitations under the License.
 
 @aws-sdk/middleware-location-constraint
 ---------------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -10366,7 +10908,7 @@ limitations under the License.
 
 @aws-sdk/middleware-logger
 --------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -10580,7 +11122,7 @@ limitations under the License.
 
 @aws-sdk/middleware-recursion-detection
 ---------------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -10794,7 +11336,7 @@ limitations under the License.
 
 @aws-sdk/middleware-sdk-s3
 --------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -11008,7 +11550,7 @@ limitations under the License.
 
 @aws-sdk/middleware-ssec
 ------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -11222,7 +11764,7 @@ limitations under the License.
 
 @aws-sdk/middleware-user-agent
 ------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -11436,7 +11978,7 @@ limitations under the License.
 
 @aws-sdk/nested-clients
 -----------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Published by AWS SDK for JavaScript Team
 Distributed under the Apache License version 2.0
@@ -11444,7 +11986,7 @@ Distributed under the Apache License version 2.0
 
 @aws-sdk/region-config-resolver
 -------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -11658,7 +12200,7 @@ limitations under the License.
 
 @aws-sdk/signature-v4-multi-region
 ----------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -11872,7 +12414,7 @@ limitations under the License.
 
 @aws-sdk/token-providers
 ------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -12086,7 +12628,7 @@ limitations under the License.
 
 @aws-sdk/types
 --------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -12300,7 +12842,7 @@ limitations under the License.
 
 @aws-sdk/util-arn-parser
 ------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -12514,7 +13056,7 @@ limitations under the License.
 
 @aws-sdk/util-endpoints
 -----------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -12728,7 +13270,7 @@ limitations under the License.
 
 @aws-sdk/util-locate-window
 ---------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -12942,7 +13484,7 @@ limitations under the License.
 
 @aws-sdk/util-user-agent-browser
 --------------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -13156,7 +13698,7 @@ limitations under the License.
 
 @aws-sdk/util-user-agent-node
 -----------------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -13370,7 +13912,7 @@ limitations under the License.
 
 @aws-sdk/xml-builder
 --------------------
-Website: https://github.com/aws/aws-sdk-js-v3
+Source: https://github.com/aws/aws-sdk-js-v3
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -13584,7 +14126,7 @@ limitations under the License.
 
 @aws/lambda-invoke-store
 ------------------------
-Website: https://github.com/awslabs/aws-lambda-invoke-store
+Source: https://github.com/awslabs/aws-lambda-invoke-store
 
 Published by Amazon Web Services
 Distributed under the Apache License version 2.0
@@ -13592,7 +14134,7 @@ Distributed under the Apache License version 2.0
 
 axios
 -----
-Website: https://github.com/axios/axios
+Source: https://github.com/axios/axios
 
 Copyright 2014-present Matt Zabriskie & Collaborators
 Distributed under the MIT License
@@ -13610,7 +14152,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 @azure/abort-controller
 -----------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright 2020 Microsoft
 Distributed under the MIT License
@@ -13642,7 +14184,7 @@ SOFTWARE.
 
 @azure/core-auth version 1.10.1
 -------------------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -13674,7 +14216,7 @@ SOFTWARE.
 
 @azure/core-auth versions 1.9.0, 1.7.2
 --------------------------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright 2020 Microsoft
 Distributed under the MIT License
@@ -13706,7 +14248,7 @@ SOFTWARE.
 
 @azure/core-client
 ------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -13738,7 +14280,7 @@ SOFTWARE.
 
 @azure/core-http-compat
 -----------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -13770,7 +14312,7 @@ SOFTWARE.
 
 @azure/core-lro
 ---------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright 2020 Microsoft
 Distributed under the MIT License
@@ -13802,7 +14344,7 @@ SOFTWARE.
 
 @azure/core-paging
 ------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright 2020 Microsoft
 Distributed under the MIT License
@@ -13834,7 +14376,7 @@ SOFTWARE.
 
 @azure/core-rest-pipeline version 1.22.1
 ----------------------------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -13866,7 +14408,7 @@ SOFTWARE.
 
 @azure/core-rest-pipeline version 1.16.3
 ----------------------------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright 2020 Microsoft
 Distributed under the MIT License
@@ -13898,7 +14440,7 @@ SOFTWARE.
 
 @azure/core-tracing version 1.3.1
 ---------------------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -13930,7 +14472,7 @@ SOFTWARE.
 
 @azure/core-tracing version 1.2.0
 ---------------------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright 2020 Microsoft
 Distributed under the MIT License
@@ -13962,7 +14504,7 @@ SOFTWARE.
 
 @azure/core-util version 1.13.1
 -------------------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -13994,7 +14536,7 @@ SOFTWARE.
 
 @azure/core-util version 1.11.0
 -------------------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright 2020 Microsoft
 Distributed under the MIT License
@@ -14026,7 +14568,7 @@ SOFTWARE.
 
 @azure/core-xml
 ---------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -14058,7 +14600,7 @@ SOFTWARE.
 
 @azure/identity
 ---------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -14090,7 +14632,7 @@ SOFTWARE.
 
 @azure/logger version 1.3.0
 ---------------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -14122,7 +14664,7 @@ SOFTWARE.
 
 @azure/logger version 1.1.4
 ---------------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright 2020 Microsoft
 Distributed under the MIT License
@@ -14154,7 +14696,7 @@ SOFTWARE.
 
 @azure/ms-rest-azure-env
 ------------------------
-Website: https://github.com/Azure/ms-rest-azure-env
+Source: https://github.com/Azure/ms-rest-azure-env
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -14186,7 +14728,7 @@ SOFTWARE
 
 @azure/msal-browser
 -------------------
-Website: https://github.com/AzureAD/microsoft-authentication-library-for-js
+Source: https://github.com/AzureAD/microsoft-authentication-library-for-js
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -14218,7 +14760,7 @@ SOFTWARE
 
 @azure/msal-common
 ------------------
-Website: https://github.com/AzureAD/microsoft-authentication-library-for-js
+Source: https://github.com/AzureAD/microsoft-authentication-library-for-js
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -14250,7 +14792,7 @@ SOFTWARE
 
 @azure/msal-node
 ----------------
-Website: https://github.com/AzureAD/microsoft-authentication-library-for-js
+Source: https://github.com/AzureAD/microsoft-authentication-library-for-js
 
 Copyright 2020 Microsoft
 Distributed under the MIT License
@@ -14282,7 +14824,7 @@ SOFTWARE.
 
 @azure/msal-node-extensions
 ---------------------------
-Website: https://github.com/AzureAD/microsoft-authentication-library-for-js
+Source: https://github.com/AzureAD/microsoft-authentication-library-for-js
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -14314,7 +14856,7 @@ SOFTWARE
 
 @azure/msal-node-runtime
 ------------------------
-Website: https://github.com/AzureAD/microsoft-authentication-library-for-cpp
+Source: https://github.com/AzureAD/microsoft-authentication-library-for-cpp
 
 Published by Microsoft
 Distributed under the MIT License
@@ -14322,7 +14864,7 @@ Distributed under the MIT License
 
 @azure/opentelemetry-instrumentation-azure-sdk version 1.0.0-beta.8
 -------------------------------------------------------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -14354,7 +14896,7 @@ SOFTWARE.
 
 @azure/opentelemetry-instrumentation-azure-sdk version 1.0.0-beta.5
 -------------------------------------------------------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright 2020 Microsoft
 Distributed under the MIT License
@@ -14386,7 +14928,7 @@ SOFTWARE.
 
 @azure/storage-blob
 -------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright 2020 Microsoft
 Distributed under the MIT License
@@ -14418,7 +14960,7 @@ SOFTWARE.
 
 Babel.js
 --------
-Website: https://github.com/babel/babel
+Source: https://github.com/babel/babel
 
 Copyright 2014-present Sebastian McKenzie and other contributors
 Distributed under the MIT License
@@ -14451,7 +14993,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 backports.functools-lru-cache
 -----------------------------
-Website: https://github.com/jaraco/backports.functools_lru_cache
+Source: https://github.com/jaraco/backports.functools_lru_cache
 
 Copyright (c) Jason R. Coombs
 Distributed under the MIT License
@@ -14459,7 +15001,7 @@ Distributed under the MIT License
 
 backtrace
 ---------
-Website: https://github.com/rust-lang/backtrace-rs
+Source: https://github.com/rust-lang/backtrace-rs
 
 Copyright 2014 Alex Crichton
 
@@ -14499,7 +15041,7 @@ DEALINGS IN THE SOFTWARE.
 
 balanced-match
 --------------
-Website: https://github.com/juliangruber/balanced-match
+Source: https://github.com/juliangruber/balanced-match
 
 Copyright 2013 Julian Gruber <julian@juliangruber.com>
 Distributed under the MIT License
@@ -14531,7 +15073,7 @@ SOFTWARE.
 
 base64
 ------
-Website: https://github.com/marshallpierce/rust-base64
+Source: https://github.com/marshallpierce/rust-base64
 
 Copyright 2015 Alice Maz
 
@@ -14567,7 +15109,7 @@ THE SOFTWARE.
 
 base64-js
 ---------
-Website: https://github.com/beatgammit/base64-js
+Source: https://github.com/beatgammit/base64-js
 
 Copyright 2014 Jameson Little
 Distributed under the MIT License
@@ -14597,9 +15139,39 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
+basic-ftp
+---------
+Source: https://github.com/patrickjuchli/basic-ftp
+
+Copyright 2019 Patrick Juchli
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2019 Patrick Juchli
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
 bcrypt-pbkdf
 ------------
-Website: https://github.com/joyent/node-bcrypt-pbkdf
+Source: https://github.com/joyent/node-bcrypt-pbkdf
 
 Copyright 1997 Niels Provos <provos@physnet.uni-hamburg.de>
 Copyright 2013 Ted Unangst <tedu@openbsd.org>
@@ -14677,7 +15249,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 before-after-hook
 -----------------
-Website: https://github.com/gr2m/before-after-hook
+Source: https://github.com/gr2m/before-after-hook
 
 Copyright 2018 Gregor Martynus and other contributors.
 Distributed under the Apache License version 2.0
@@ -14891,7 +15463,7 @@ limitations under the License.
 
 Better Less
 -----------
-Website: https://github.com/radium-v/Better-Less
+Source: https://github.com/radium-v/Better-Less
 
 Copyright (c) 2017 John Kreitlow
 Distributed under the MIT License
@@ -14899,7 +15471,7 @@ Distributed under the MIT License
 
 better-c-syntax
 ---------------
-Website: https://github.com/jeff-hykin/better-c-syntax
+Source: https://github.com/jeff-hykin/better-c-syntax
 
 Copyright (c) 2019 Jeff Hykin
 Distributed under the MIT License
@@ -14907,7 +15479,7 @@ Distributed under the MIT License
 
 better-cpp-syntax
 -----------------
-Website: https://github.com/jeff-hykin/better-cpp-syntax
+Source: https://github.com/jeff-hykin/better-cpp-syntax
 
 Copyright (c) 2019 Jeff Hykin
 Distributed under the MIT License
@@ -14939,7 +15511,7 @@ SOFTWARE.
 
 better-objc-syntax
 ------------------
-Website: https://github.com/jeff-hykin/better-objc-syntax
+Source: https://github.com/jeff-hykin/better-objc-syntax
 
 Copyright (c) 2019 Jeff Hykin
 Distributed under the MIT License
@@ -14947,7 +15519,7 @@ Distributed under the MIT License
 
 better-objcpp-syntax
 --------------------
-Website: https://github.com/jeff-hykin/better-objcpp-syntax
+Source: https://github.com/jeff-hykin/better-objcpp-syntax
 
 Copyright (c) 2019 Jeff Hykin
 Distributed under the MIT License
@@ -14955,7 +15527,7 @@ Distributed under the MIT License
 
 better-shell-syntax
 -------------------
-Website: https://github.com/jeff-hykin/better-shell-syntax
+Source: https://github.com/jeff-hykin/better-shell-syntax
 
 Copyright (c) 2019 Jeff Hykin
 Distributed under the MIT License
@@ -14963,7 +15535,7 @@ Distributed under the MIT License
 
 better-snippet-syntax
 ---------------------
-Website: https://github.com/jeff-hykin/better-snippet-syntax
+Source: https://github.com/jeff-hykin/better-snippet-syntax
 
 Copyright (c) 2019 Jeff Hykin
 Distributed under the MIT License
@@ -14971,7 +15543,7 @@ Distributed under the MIT License
 
 big-integer
 -----------
-Website: https://github.com/peterolson/BigInteger.js
+Source: https://github.com/peterolson/BigInteger.js
 
 Published by Peter Olson <peter.e.c.olson+npm@gmail.com>
 Distributed under the Unlicense
@@ -14979,7 +15551,7 @@ Distributed under the Unlicense
 
 bignumber.js
 ------------
-Website: https://github.com/MikeMcl/bignumber.js
+Source: https://github.com/MikeMcl/bignumber.js
 
 Copyright © `<2025>` `Michael Mclaughlin`
 Distributed under the MIT License
@@ -15016,7 +15588,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 binary
 ------
-Website: https://github.com/substack/node-binary
+Source: https://github.com/substack/node-binary
 
 Published by James Halliday
 Distributed under the MIT License
@@ -15024,7 +15596,7 @@ Distributed under the MIT License
 
 bindings
 --------
-Website: https://github.com/TooTallNate/node-bindings
+Source: https://github.com/TooTallNate/node-bindings
 
 Copyright 2012 Nathan Rajlich <nathan@tootallnate.net>
 Distributed under the MIT License
@@ -15057,7 +15629,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 biome
 -----
-Website: https://github.com/biomejs/biome
+Source: https://github.com/biomejs/biome
 
 Copyright 2023 Biome Developers and Contributors.
 
@@ -15300,7 +15872,7 @@ SOFTWARE.
 
 bitflags
 --------
-Website: https://github.com/bitflags/bitflags
+Source: https://github.com/bitflags/bitflags
 
 Copyright 2014 The Rust Project Developers
 
@@ -15340,7 +15912,7 @@ DEALINGS IN THE SOFTWARE.
 
 bl
 --
-Website: https://github.com/rvagg/bl
+Source: https://github.com/rvagg/bl
 
 Copyright 2013-2019 bl contributors
 Distributed under the MIT License
@@ -15366,7 +15938,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 block-buffer
 ------------
-Website: https://github.com/RustCrypto/utils
+Source: https://github.com/RustCrypto/utils
 
 Copyright 2018-2019 The RustCrypto Project Developers
 
@@ -15406,7 +15978,7 @@ DEALINGS IN THE SOFTWARE.
 
 bn.js
 -----
-Website: https://github.com/indutny/bn.js
+Source: https://github.com/indutny/bn.js
 
 Copyright Fedor Indutny, 2015.
 Distributed under the MIT License
@@ -15436,7 +16008,7 @@ SOFTWARE.
 
 body-parser
 -----------
-Website: https://github.com/expressjs/body-parser
+Source: https://github.com/expressjs/body-parser
 
 Copyright 2014 Jonathan Ong <me@jongleberry.com>
 Copyright 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
@@ -15472,7 +16044,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 boolbase
 --------
-Website: https://github.com/fb55/boolbase
+Source: https://github.com/fb55/boolbase
 
 Copyright 2014-2015, Felix Boehm <me@feedic.com>
 Distributed under the ISC License
@@ -15496,7 +16068,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 bowser
 ------
-Website: https://github.com/lancedikson/bowser
+Source: https://github.com/lancedikson/bowser
 
 Copyright 2015, Dustin Diaz (the "Original Author")
 Distributed under the MIT License
@@ -15545,7 +16117,7 @@ Original Author, when distributed with the Software.
 
 bpaf
 ----
-Website: https://github.com/pacak/bpaf
+Source: https://github.com/pacak/bpaf
 
 Published by Michael Baykov <manpacket@gmail.com>
 
@@ -15557,7 +16129,7 @@ Consult the documentation and source code of bpaf for more information.
 
 brace-expansion
 ---------------
-Website: https://github.com/juliangruber/brace-expansion
+Source: https://github.com/juliangruber/brace-expansion
 
 Copyright 2013 Julian Gruber <julian@juliangruber.com>
 Distributed under the MIT License
@@ -15589,7 +16161,7 @@ SOFTWARE.
 
 braces
 ------
-Website: https://github.com/micromatch/braces
+Source: https://github.com/micromatch/braces
 
 Copyright 2014-present, Jon Schlinkert.
 Distributed under the MIT License
@@ -15621,7 +16193,7 @@ THE SOFTWARE.
 
 @braintree/sanitize-url
 -----------------------
-Website: https://github.com/braintree/sanitize-url
+Source: https://github.com/braintree/sanitize-url
 
 Copyright 2017 Braintree
 Distributed under the MIT License
@@ -15653,7 +16225,7 @@ SOFTWARE.
 
 brotli
 ------
-Website: https://github.com/dropbox/rust-brotli
+Source: https://github.com/dropbox/rust-brotli
 
 Copyright 2016 Dropbox, Inc.
 
@@ -15681,7 +16253,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 brotli-decompressor
 -------------------
-Website: https://github.com/dropbox/rust-brotli-decompressor
+Source: https://github.com/dropbox/rust-brotli-decompressor
 
 Copyright 2016 Dropbox, Inc.
 
@@ -15709,7 +16281,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 browser-request
 ---------------
-Website: https://github.com/iriscouch/browser-request
+Source: https://github.com/iriscouch/browser-request
 
 Published by Jason Smith
 Distributed under the Apache License version 2.0
@@ -15717,7 +16289,7 @@ Distributed under the Apache License version 2.0
 
 bstr
 ----
-Website: https://github.com/BurntSushi/bstr
+Source: https://github.com/BurntSushi/bstr
 
 Copyright 2018-2019 Andrew Gallant
 
@@ -15753,7 +16325,7 @@ THE SOFTWARE.
 
 buffer
 ------
-Website: https://github.com/feross/buffer
+Source: https://github.com/feross/buffer
 
 Copyright Feross Aboukhadijeh, and other contributors.
 Distributed under the MIT License
@@ -15785,7 +16357,7 @@ THE SOFTWARE.
 
 buffer-crc32
 ------------
-Website: https://github.com/brianloveswords/buffer-crc32
+Source: https://github.com/brianloveswords/buffer-crc32
 
 Copyright 2013 Brian J. Brennan
 Distributed under the MIT License
@@ -15815,7 +16387,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEAL
 
 buffer-equal-constant-time
 --------------------------
-Website: https://github.com/goinstant/buffer-equal-constant-time
+Source: https://github.com/goinstant/buffer-equal-constant-time
 
 Copyright 2013, GoInstant Inc., a salesforce.com company
 Distributed under the BSD 3-Clause license
@@ -15838,7 +16410,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 buffers
 -------
-Website: https://github.com/bitpay/node-buffers/tree/master
+Source: https://github.com/bitpay/node-buffers/tree/master
 
 Published by James Halliday <mail@substack.net> (http://substack.net)
 
@@ -15850,7 +16422,7 @@ Consult the documentation and source code of buffers for more information.
 
 Builtin Notebook Output Renderers
 ---------------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -15858,7 +16430,7 @@ Distributed under the MIT License
 
 bumpalo
 -------
-Website: https://github.com/fitzgen/bumpalo
+Source: https://github.com/fitzgen/bumpalo
 
 Copyright 2019 Nick Fitzgerald
 
@@ -15898,7 +16470,7 @@ DEALINGS IN THE SOFTWARE.
 
 bundle-name
 -----------
-Website: https://github.com/sindresorhus/bundle-name
+Source: https://github.com/sindresorhus/bundle-name
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -15918,7 +16490,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 bus
 ---
-Website: https://github.com/jonhoo/bus
+Source: https://github.com/jonhoo/bus
 
 Copyright 2016 Jon Gjengset
 
@@ -15954,7 +16526,7 @@ SOFTWARE.
 
 byline
 ------
-Website: https://github.com/jahewson/node-byline
+Source: https://github.com/jahewson/node-byline
 
 Published by John Hewson
 Distributed under the MIT License
@@ -15962,7 +16534,7 @@ Distributed under the MIT License
 
 byteorder
 ---------
-Website: https://github.com/BurntSushi/byteorder
+Source: https://github.com/BurntSushi/byteorder
 
 Copyright 2015 Andrew Gallant
 
@@ -15974,7 +16546,7 @@ Consult the documentation and source code of byteorder for more information.
 
 bytes version 3.1.2
 -------------------
-Website: https://github.com/visionmedia/bytes.js
+Source: https://github.com/visionmedia/bytes.js
 
 Copyright 2012-2014 TJ Holowaychuk <tj@vision-media.ca>
 Copyright 2015 Jed Watson <jed.watson@me.com>
@@ -16010,7 +16582,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 bytes version 1.8.0
 -------------------
-Website: https://github.com/tokio-rs/bytes
+Source: https://github.com/tokio-rs/bytes
 
 Copyright 2018 Carl Lerche
 Distributed under the MIT License
@@ -16046,7 +16618,7 @@ DEALINGS IN THE SOFTWARE.
 
 C tmBundle
 ----------
-Website: https://github.com/textmate/c.tmbundle
+Source: https://github.com/textmate/c.tmbundle
 
 Copyright (c) textmate-c.tmbundle authors
 
@@ -16070,7 +16642,7 @@ to the base-name name of the original file, and an extension of txt, html, or si
 
 C# Language Basics
 ------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -16078,7 +16650,7 @@ Distributed under the MIT License
 
 C/C++ Language Basics
 ---------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -16086,7 +16658,7 @@ Distributed under the MIT License
 
 Cacheable Request
 -----------------
-Website: https://github.com/jaredwray/cacheable/tree/main/packages/cacheable-request
+Source: https://github.com/jaredwray/cacheable/tree/main/packages/cacheable-request
 
 Copyright (c) cacheable-request authors
 Distributed under the MIT License
@@ -16094,7 +16666,7 @@ Distributed under the MIT License
 
 call-bind-apply-helpers
 -----------------------
-Website: https://github.com/ljharb/call-bind-apply-helpers
+Source: https://github.com/ljharb/call-bind-apply-helpers
 
 Copyright 2024 Jordan Harband
 Distributed under the MIT License
@@ -16126,7 +16698,7 @@ SOFTWARE.
 
 call-bound
 ----------
-Website: https://github.com/ljharb/call-bound
+Source: https://github.com/ljharb/call-bound
 
 Copyright 2024 Jordan Harband
 Distributed under the MIT License
@@ -16158,7 +16730,7 @@ SOFTWARE.
 
 camino
 ------
-Website: https://github.com/camino-rs/camino
+Source: https://github.com/camino-rs/camino
 
 Published by Without Boats <saoirse@without.boats>, Ashley Williams <ashley666ashley@gmail.com>, Steve Klabnik <steve@steveklabnik.com>, Rain <rain@sunshowers.io>
 
@@ -16170,7 +16742,7 @@ Consult the documentation and source code of camino for more information.
 
 cargo
 -----
-Website: https://github.com/rust-lang/cargo
+Source: https://github.com/rust-lang/cargo
 
 Published by the Cargo team
 
@@ -16182,7 +16754,7 @@ Consult the documentation and source code of cargo for more information.
 
 cargo_metadata
 --------------
-Website: https://github.com/oli-obk/cargo_metadata
+Source: https://github.com/oli-obk/cargo_metadata
 
 Published by Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>
 Distributed under the MIT License
@@ -16190,7 +16762,7 @@ Distributed under the MIT License
 
 case
 ----
-Website: https://github.com/SkylerLipthay/case
+Source: https://github.com/SkylerLipthay/case
 
 Copyright 2015 Skyler Lipthay
 Distributed under the MIT License
@@ -16222,7 +16794,7 @@ SOFTWARE.
 
 cattrs
 ------
-Website: https://catt.rs
+Source: https://catt.rs
 
 Copyright 2016, Tin Tvrtković
 Distributed under the MIT License
@@ -16242,7 +16814,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 cc
 --
-Website: https://github.com/rust-lang/cc-rs
+Source: https://github.com/rust-lang/cc-rs
 
 Copyright 2014 Alex Crichton
 
@@ -16282,7 +16854,7 @@ DEALINGS IN THE SOFTWARE.
 
 cffi
 ----
-Website: http://cffi.readthedocs.org
+Source: http://cffi.readthedocs.org
 
 Published by Armin Rigo, Maciej Fijalkowski
 Distributed under the MIT License
@@ -16290,7 +16862,7 @@ Distributed under the MIT License
 
 cfg-expr
 --------
-Website: https://github.com/EmbarkStudios/cfg-expr
+Source: https://github.com/EmbarkStudios/cfg-expr
 
 Copyright 2019 Embark Studios
 
@@ -16330,7 +16902,7 @@ DEALINGS IN THE SOFTWARE.
 
 cfg-if
 ------
-Website: https://github.com/rust-lang/cfg-if
+Source: https://github.com/rust-lang/cfg-if
 
 Copyright 2014 Alex Crichton
 
@@ -16370,7 +16942,7 @@ DEALINGS IN THE SOFTWARE.
 
 chainsaw
 --------
-Website: https://github.com/substack/node-chainsaw
+Source: https://github.com/substack/node-chainsaw
 
 Published by James Halliday <mail@substack.net> (http://substack.net)
 
@@ -16382,7 +16954,7 @@ Consult the documentation and source code of chainsaw for more information.
 
 chalk
 -----
-Website: https://github.com/chalk/chalk
+Source: https://github.com/chalk/chalk
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -16402,7 +16974,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 chalk-template
 --------------
-Website: https://github.com/chalk/chalk-template
+Source: https://github.com/chalk/chalk-template
 
 Copyright Josh Junon
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
@@ -16425,7 +16997,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 chevrotain
 ----------
-Website: https://github.com/Chevrotain/chevrotain
+Source: https://github.com/Chevrotain/chevrotain
 
 Published by Shahar Soel
 Distributed under the Apache License version 2.0
@@ -16433,7 +17005,7 @@ Distributed under the Apache License version 2.0
 
 chevrotain-allstar
 ------------------
-Website: https://github.com/langium/chevrotain-allstar
+Source: https://github.com/langium/chevrotain-allstar
 
 Copyright 2022 TypeFox GmbH
 Distributed under the MIT License
@@ -16460,7 +17032,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 
 @chevrotain/cst-dts-gen
 -----------------------
-Website: https://github.com/Chevrotain/chevrotain
+Source: https://github.com/Chevrotain/chevrotain
 
 Copyright (c) 2015-2020 SAP SE or an SAP affiliate company.
 Copyright (c) 2021 the original author or authors from the Chevrotain project
@@ -16469,7 +17041,7 @@ Distributed under the Apache License version 2.0
 
 @chevrotain/gast
 ----------------
-Website: https://github.com/Chevrotain/chevrotain
+Source: https://github.com/Chevrotain/chevrotain
 
 Copyright (c) 2015-2020 SAP SE or an SAP affiliate company.
 Copyright (c) 2021 the original author or authors from the Chevrotain project
@@ -16478,7 +17050,7 @@ Distributed under the Apache License version 2.0
 
 @chevrotain/regexp-to-ast
 -------------------------
-Website: https://github.com/Chevrotain/chevrotain
+Source: https://github.com/Chevrotain/chevrotain
 
 Copyright (c) 2015-2020 SAP SE or an SAP affiliate company.
 Copyright (c) 2021 the original author or authors from the Chevrotain project
@@ -16487,7 +17059,7 @@ Distributed under the Apache License version 2.0
 
 @chevrotain/types
 -----------------
-Website: https://github.com/Chevrotain/chevrotain
+Source: https://github.com/Chevrotain/chevrotain
 
 Published by Shahar Soel
 Distributed under the Apache License version 2.0
@@ -16495,7 +17067,7 @@ Distributed under the Apache License version 2.0
 
 @chevrotain/utils
 -----------------
-Website: https://github.com/Chevrotain/chevrotain
+Source: https://github.com/Chevrotain/chevrotain
 
 Published by Shahar Soel
 Distributed under the Apache License version 2.0
@@ -16503,7 +17075,7 @@ Distributed under the Apache License version 2.0
 
 chownr
 ------
-Website: https://github.com/isaacs/chownr
+Source: https://github.com/isaacs/chownr
 
 Copyright Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -16529,7 +17101,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 chrome-remote-interface
 -----------------------
-Website: https://github.com/cyrus-and/chrome-remote-interface
+Source: https://github.com/cyrus-and/chrome-remote-interface
 
 Copyright 2023 Andrea Cardaci <cyrus.and@gmail.com>
 Distributed under the MIT License
@@ -16558,7 +17130,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 chrono
 ------
-Website: https://github.com/chronotope/chrono
+Source: https://github.com/chronotope/chrono
 
 Copyright 2014, Kang Seonghoon.
 
@@ -16814,7 +17386,7 @@ limitations under the License.
 
 cjs-module-lexer
 ----------------
-Website: https://github.com/nodejs/cjs-module-lexer
+Source: https://github.com/nodejs/cjs-module-lexer
 
 Copyright (C) 2018-2020 Guy Bedford
 Distributed under the MIT License
@@ -16836,7 +17408,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 clap
 ----
-Website: https://github.com/clap-rs/clap
+Source: https://github.com/clap-rs/clap
 
 Copyright 2015-2022 Kevin B. Knapp and Clap Contributors
 
@@ -16872,7 +17444,7 @@ SOFTWARE.
 
 clap-verbosity-flag
 -------------------
-Website: https://github.com/rust-clique/clap-verbosity-flag
+Source: https://github.com/rust-clique/clap-verbosity-flag
 
 Copyright 2018 The clap-verbosity-flag Developers
 
@@ -16904,9 +17476,42 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+Classic .ipynb Support
+----------------------
+Source: https://github.com/microsoft/vscode
+
+Copyright (c) Microsoft Corporation
+Distributed under the MIT License
+
+
+cliui
+-----
+Source: https://github.com/yargs/cliui
+
+Copyright 2015, Contributors
+Distributed under the ISC License
+
+ISC License text:
+
+Copyright (c) 2015, Contributors
+
+Permission to use, copy, modify, and/or distribute this software
+for any purpose with or without fee is hereby granted, provided
+that the above copyright notice and this permission notice
+appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE
+LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
 Clojure Language Basics
 -----------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -16914,7 +17519,7 @@ Distributed under the MIT License
 
 cls-hooked
 ----------
-Website: https://github.com/jeff-lewis/cls-hooked
+Source: https://github.com/jeff-lewis/cls-hooked
 
 Copyright 2013-2016, Forrest L Norvell <ogd@aoaioxxysz.net>
 Distributed under the BSD 2-Clause license
@@ -16947,7 +17552,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Code OSS
 --------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 Distributed under the MIT License
@@ -16955,7 +17560,7 @@ Distributed under the MIT License
 
 code-oss-dev-build
 ------------------
-Website: https://npmjs.com/package/code-oss-dev-build/v/1.0.0
+Source: https://npmjs.com/package/code-oss-dev-build/v/1.0.0
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -16963,7 +17568,7 @@ Distributed under the MIT License
 
 CoffeeScript Language Basics
 ----------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -16971,7 +17576,7 @@ Distributed under the MIT License
 
 color
 -----
-Website: https://github.com/Qix-/color
+Source: https://github.com/Qix-/color
 
 Copyright 2012 Heather Arthur
 Distributed under the MIT License
@@ -17002,7 +17607,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 color-convert
 -------------
-Website: https://github.com/Qix-/color-convert
+Source: https://github.com/Qix-/color-convert
 
 Copyright 2011-2016 Heather Arthur <fayearthur@gmail.com>.
 Copyright 2016-2021 Josh Junon <josh@junon.me>.
@@ -17036,7 +17641,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 color-name
 ----------
-Website: https://github.com/colorjs/color-name
+Source: https://github.com/colorjs/color-name
 
 Copyright 2015 Dmitry Ivanov
 Distributed under the MIT License
@@ -17056,7 +17661,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 color-string
 ------------
-Website: https://github.com/Qix-/color-string
+Source: https://github.com/Qix-/color-string
 
 Copyright 2011 Heather Arthur <fayearthur@gmail.com>
 Distributed under the MIT License
@@ -17087,7 +17692,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 colorama
 --------
-Website: https://github.com/tartley/colorama
+Source: https://github.com/tartley/colorama
 
 Copyright 2010 Jonathan Hartley
 Distributed under the BSD 3-Clause license
@@ -17126,7 +17731,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 colorchoice
 -----------
-Website: https://github.com/rust-cli/anstyle
+Source: https://github.com/rust-cli/anstyle
 
 Copyright Individual contributors
 
@@ -17160,7 +17765,7 @@ SOFTWARE.
 
 colored
 -------
-Website: https://github.com/mackwic/colored
+Source: https://github.com/mackwic/colored
 
 Published by Thomas Wickham <mackwic@gmail.com>
 Distributed under the Mozilla Public License version 2.0
@@ -17559,7 +18164,7 @@ defined by the Mozilla Public License, v. 2.0.
 
 colors
 ------
-Website: https://github.com/Marak/colors.js
+Source: https://github.com/Marak/colors.js
 
 Published by Marak Squires
 Distributed under the MIT License
@@ -17567,7 +18172,7 @@ Distributed under the MIT License
 
 @colors/colors
 --------------
-Website: https://github.com/DABH/colors.js
+Source: https://github.com/DABH/colors.js
 
 Published by DABH
 Distributed under the MIT License
@@ -17575,7 +18180,7 @@ Distributed under the MIT License
 
 Colorsublime Themes
 -------------------
-Website: https://github.com/Colorsublime/Colorsublime-Themes
+Source: https://github.com/Colorsublime/Colorsublime-Themes
 
 Copyright (c) 2015 Colorsublime.com
 Distributed under the MIT License
@@ -17583,7 +18188,7 @@ Distributed under the MIT License
 
 combined-stream
 ---------------
-Website: https://github.com/felixge/node-combined-stream
+Source: https://github.com/felixge/node-combined-stream
 
 Copyright 2011 Debuggable Limited <felix@debuggable.com>
 Distributed under the MIT License
@@ -17613,7 +18218,7 @@ THE SOFTWARE.
 
 comm
 ----
-Website: https://github.com/ipython/comm
+Source: https://github.com/ipython/comm
 
 Copyright 2022, Jupyter
 Distributed under the BSD 3-Clause license
@@ -17654,7 +18259,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 command-line-args
 -----------------
-Website: https://github.com/75lb/command-line-args
+Source: https://github.com/75lb/command-line-args
 
 Copyright 2014-22 Lloyd Brookes <75pound@gmail.com>
 Distributed under the MIT License
@@ -17686,7 +18291,7 @@ SOFTWARE.
 
 command-line-usage
 ------------------
-Website: https://github.com/75lb/command-line-usage
+Source: https://github.com/75lb/command-line-usage
 
 Copyright 2015-24 Lloyd Brookes <75pound@gmail.com>
 Distributed under the MIT License
@@ -17718,7 +18323,7 @@ SOFTWARE.
 
 commander
 ---------
-Website: https://github.com/tj/commander.js
+Source: https://github.com/tj/commander.js
 
 Copyright 2011 TJ Holowaychuk <tj@vision-media.ca>
 Distributed under the MIT License
@@ -17751,7 +18356,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 concat-map
 ----------
-Website: https://github.com/substack/node-concat-map
+Source: https://github.com/substack/node-concat-map
 
 Published by James Halliday
 Distributed under the MIT License
@@ -17759,7 +18364,7 @@ Distributed under the MIT License
 
 concurrent-queue
 ----------------
-Website: https://github.com/smol-rs/concurrent-queue
+Source: https://github.com/smol-rs/concurrent-queue
 
 Published by Stjepan Glavina <stjepang@gmail.com>, Taiki Endo <te316e89@gmail.com>, John Nunley <dev@notgull.net>
 
@@ -17771,7 +18376,7 @@ Consult the documentation and source code of concurrent-queue for more informati
 
 confbox version 0.2.2
 ---------------------
-Website: https://github.com/unjs/confbox
+Source: https://github.com/unjs/confbox
 
 Copyright (C) 2011-2015 by Vitaly Puzrin
 Copyright 2012-2018 Aseem Kishore, and others (https:github.com/json5/json5/graphs/contributors)
@@ -17926,7 +18531,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 confbox version 0.1.8
 ---------------------
-Website: https://github.com/unjs/confbox
+Source: https://github.com/unjs/confbox
 
 Copyright (C) 2011-2015 by Vitaly Puzrin
 Copyright 2012-2018 Aseem Kishore, and others (https:github.com/json5/json5/graphs/contributors)
@@ -18060,7 +18665,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 Configuration Editing
 ---------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -18068,7 +18673,7 @@ Distributed under the MIT License
 
 console
 -------
-Website: https://github.com/console-rs/console
+Source: https://github.com/console-rs/console
 
 Copyright 2017 Armin Ronacher <armin.ronacher@active-4.com>
 Distributed under the MIT License
@@ -18100,7 +18705,7 @@ SOFTWARE.
 
 content-disposition
 -------------------
-Website: https://github.com/jshttp/content-disposition
+Source: https://github.com/jshttp/content-disposition
 
 Copyright 2014-2017 Douglas Christopher Wilson
 Distributed under the MIT License
@@ -18133,7 +18738,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 content-type
 ------------
-Website: https://github.com/jshttp/content-type
+Source: https://github.com/jshttp/content-type
 
 Copyright 2015 Douglas Christopher Wilson
 Distributed under the MIT License
@@ -18166,7 +18771,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 continuation-local-storage
 --------------------------
-Website: https://github.com/othiym23/node-continuation-local-storage
+Source: https://github.com/othiym23/node-continuation-local-storage
 
 Copyright 2013-2016, Forrest L Norvell <ogd@aoaioxxysz.net>
 Distributed under the BSD 2-Clause license
@@ -18199,7 +18804,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 convert_case
 ------------
-Website: https://github.com/rutrum/convert-case
+Source: https://github.com/rutrum/convert-case
 
 Published by David Purdum <purdum41@gmail.com>
 Distributed under the MIT License
@@ -18207,7 +18812,7 @@ Distributed under the MIT License
 
 cookie version 0.7.1
 --------------------
-Website: https://github.com/jshttp/cookie
+Source: https://github.com/jshttp/cookie
 
 Copyright 2012-2014 Roman Shtylman <shtylman@gmail.com>
 Copyright 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
@@ -18243,7 +18848,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 cookie version 0.16.2
 ---------------------
-Website: https://github.com/SergioBenitez/cookie-rs
+Source: https://github.com/SergioBenitez/cookie-rs
 
 Copyright 2014 Alex Chricton
 Copyright 2014 Alex Crichton
@@ -18496,7 +19101,7 @@ DEALINGS IN THE SOFTWARE.
 
 cookie-signature
 ----------------
-Website: https://github.com/visionmedia/node-cookie-signature
+Source: https://github.com/visionmedia/node-cookie-signature
 
 Copyright 2012 LearnBoost <tj@learnboost.com>
 Distributed under the MIT License
@@ -18504,7 +19109,7 @@ Distributed under the MIT License
 
 core-foundation-rs
 ------------------
-Website: https://github.com/servo/core-foundation-rs
+Source: https://github.com/servo/core-foundation-rs
 
 Copyright 2012-2013 Mozilla Foundation
 
@@ -18544,7 +19149,7 @@ DEALINGS IN THE SOFTWARE.
 
 core-foundation-sys
 -------------------
-Website: https://github.com/servo/core-foundation-rs
+Source: https://github.com/servo/core-foundation-rs
 
 Copyright 2012-2013 Mozilla Foundation
 
@@ -18584,7 +19189,7 @@ DEALINGS IN THE SOFTWARE.
 
 core-js-pure
 ------------
-Website: https://github.com/zloirock/core-js
+Source: https://github.com/zloirock/core-js
 
 Copyright 2014-2024 Denis Pushkarev
 Distributed under the MIT License
@@ -18614,7 +19219,7 @@ THE SOFTWARE.
 
 cose-base
 ---------
-Website: https://github.com/iVis-at-Bilkent/cose-base
+Source: https://github.com/iVis-at-Bilkent/cose-base
 
 Copyright 2019 - present, iVis@Bilkent.
 Distributed under the MIT License
@@ -18646,7 +19251,7 @@ SOFTWARE.
 
 cpufeatures
 -----------
-Website: https://github.com/RustCrypto/utils
+Source: https://github.com/RustCrypto/utils
 
 Copyright 2020 The RustCrypto Project Developers
 
@@ -18686,7 +19291,7 @@ DEALINGS IN THE SOFTWARE.
 
 crc32fast
 ---------
-Website: https://github.com/srijs/rust-crc32fast
+Source: https://github.com/srijs/rust-crc32fast
 
 Copyright 2018 Sam Rijs, Alex Crichton and contributors
 
@@ -18722,7 +19327,7 @@ SOFTWARE.
 
 cross-spawn
 -----------
-Website: https://github.com/moxystudio/node-cross-spawn
+Source: https://github.com/moxystudio/node-cross-spawn
 
 Copyright 2018 Made With MOXY Lda <hello@moxy.studio>
 Distributed under the MIT License
@@ -18754,7 +19359,7 @@ THE SOFTWARE.
 
 crossbeam
 ---------
-Website: https://github.com/crossbeam-rs/crossbeam
+Source: https://github.com/crossbeam-rs/crossbeam
 
 Copyright 2019 The Crossbeam Project Developers
 
@@ -18796,7 +19401,7 @@ DEALINGS IN THE SOFTWARE.
 
 crossbeam-channel
 -----------------
-Website: https://github.com/crossbeam-rs/crossbeam
+Source: https://github.com/crossbeam-rs/crossbeam
 
 Copyright 2009 The Go Authors.
 Copyright 2019 The Crossbeam Project Developers
@@ -18839,7 +19444,7 @@ DEALINGS IN THE SOFTWARE.
 
 crypto-common
 -------------
-Website: https://github.com/RustCrypto/traits
+Source: https://github.com/RustCrypto/traits
 
 Copyright 2021 RustCrypto Developers
 
@@ -18879,7 +19484,7 @@ DEALINGS IN THE SOFTWARE.
 
 CSS Language Basics
 -------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -18887,7 +19492,7 @@ Distributed under the MIT License
 
 CSS Language Features
 ---------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -18895,7 +19500,7 @@ Distributed under the MIT License
 
 css-select
 ----------
-Website: https://github.com/fb55/css-select
+Source: https://github.com/fb55/css-select
 
 Copyright Felix Böhm
 Distributed under the BSD 2-Clause license
@@ -18918,7 +19523,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 css-what
 --------
-Website: https://github.com/fb55/css-what
+Source: https://github.com/fb55/css-what
 
 Copyright Felix Böhm
 Distributed under the BSD 2-Clause license
@@ -18941,7 +19546,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ctor
 ----
-Website: https://github.com/mmastrac/rust-ctor
+Source: https://github.com/mmastrac/rust-ctor
 
 Published by Matt Mastracci <matthew@mastracci.com>
 
@@ -18953,7 +19558,7 @@ Consult the documentation and source code of ctor for more information.
 
 cytoscape
 ---------
-Website: https://github.com/cytoscape/cytoscape.js
+Source: https://github.com/cytoscape/cytoscape.js
 
 Copyright 2016-2025, The Cytoscape Consortium.
 Distributed under the MIT License
@@ -18983,7 +19588,7 @@ SOFTWARE.
 
 cytoscape-cose-bilkent
 ----------------------
-Website: https://github.com/cytoscape/cytoscape.js-cose-bilkent
+Source: https://github.com/cytoscape/cytoscape.js-cose-bilkent
 
 Copyright 2016-2018, The Cytoscape Consortium.
 Distributed under the MIT License
@@ -19013,7 +19618,7 @@ SOFTWARE.
 
 cytoscape-fcose
 ---------------
-Website: https://github.com/iVis-at-Bilkent/cytoscape.js-fcose
+Source: https://github.com/iVis-at-Bilkent/cytoscape.js-fcose
 
 Copyright 2018 - present, iVis-at-Bilkent.
 Distributed under the MIT License
@@ -19043,7 +19648,7 @@ SOFTWARE.
 
 d3
 --
-Website: https://github.com/d3/d3
+Source: https://github.com/d3/d3
 
 Copyright 2010-2023 Mike Bostock
 Distributed under the ISC License
@@ -19067,7 +19672,7 @@ THIS SOFTWARE.
 
 d3-array version 3.2.4
 ----------------------
-Website: https://github.com/d3/d3-array
+Source: https://github.com/d3/d3-array
 
 Copyright 2010-2023 Mike Bostock
 Distributed under the ISC License
@@ -19091,7 +19696,7 @@ THIS SOFTWARE.
 
 d3-array version 2.12.1
 -----------------------
-Website: https://github.com/d3/d3-array
+Source: https://github.com/d3/d3-array
 
 Copyright 2010-2020 Mike Bostock
 Distributed under the BSD 3-Clause license
@@ -19130,7 +19735,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 d3-axis
 -------
-Website: https://github.com/d3/d3-axis
+Source: https://github.com/d3/d3-axis
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19154,7 +19759,7 @@ THIS SOFTWARE.
 
 d3-brush
 --------
-Website: https://github.com/d3/d3-brush
+Source: https://github.com/d3/d3-brush
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19178,7 +19783,7 @@ THIS SOFTWARE.
 
 d3-chord
 --------
-Website: https://github.com/d3/d3-chord
+Source: https://github.com/d3/d3-chord
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19202,7 +19807,7 @@ THIS SOFTWARE.
 
 d3-color
 --------
-Website: https://github.com/d3/d3-color
+Source: https://github.com/d3/d3-color
 
 Copyright 2010-2022 Mike Bostock
 Distributed under the ISC License
@@ -19226,7 +19831,7 @@ THIS SOFTWARE.
 
 d3-contour
 ----------
-Website: https://github.com/d3/d3-contour
+Source: https://github.com/d3/d3-contour
 
 Copyright 2012-2023 Mike Bostock
 Distributed under the ISC License
@@ -19250,7 +19855,7 @@ THIS SOFTWARE.
 
 d3-delaunay
 -----------
-Website: https://github.com/d3/d3-delaunay
+Source: https://github.com/d3/d3-delaunay
 
 Copyright 2018-2021 Observable, Inc.
 Copyright 2021 Mapbox
@@ -19277,7 +19882,7 @@ THIS SOFTWARE.
 
 d3-dispatch
 -----------
-Website: https://github.com/d3/d3-dispatch
+Source: https://github.com/d3/d3-dispatch
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19301,7 +19906,7 @@ THIS SOFTWARE.
 
 d3-drag
 -------
-Website: https://github.com/d3/d3-drag
+Source: https://github.com/d3/d3-drag
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19325,7 +19930,7 @@ THIS SOFTWARE.
 
 d3-dsv
 ------
-Website: https://github.com/d3/d3-dsv
+Source: https://github.com/d3/d3-dsv
 
 Copyright 2013-2021 Mike Bostock
 Distributed under the ISC License
@@ -19349,7 +19954,7 @@ THIS SOFTWARE.
 
 d3-ease
 -------
-Website: https://github.com/d3/d3-ease
+Source: https://github.com/d3/d3-ease
 
 Copyright 2001 Robert Penner
 Copyright 2010-2021 Mike Bostock
@@ -19391,7 +19996,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 d3-fetch
 --------
-Website: https://github.com/d3/d3-fetch
+Source: https://github.com/d3/d3-fetch
 
 Copyright 2016-2021 Mike Bostock
 Distributed under the ISC License
@@ -19415,7 +20020,7 @@ THIS SOFTWARE.
 
 d3-force
 --------
-Website: https://github.com/d3/d3-force
+Source: https://github.com/d3/d3-force
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19439,7 +20044,7 @@ THIS SOFTWARE.
 
 d3-format
 ---------
-Website: https://github.com/d3/d3-format
+Source: https://github.com/d3/d3-format
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19463,7 +20068,7 @@ THIS SOFTWARE.
 
 d3-geo
 ------
-Website: https://github.com/d3/d3-geo
+Source: https://github.com/d3/d3-geo
 
 Copyright 2008-2012 Charles Karney
 Copyright 2010-2024 Mike Bostock
@@ -19509,7 +20114,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 d3-hierarchy
 ------------
-Website: https://github.com/d3/d3-hierarchy
+Source: https://github.com/d3/d3-hierarchy
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19533,7 +20138,7 @@ THIS SOFTWARE.
 
 d3-interpolate
 --------------
-Website: https://github.com/d3/d3-interpolate
+Source: https://github.com/d3/d3-interpolate
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19557,7 +20162,7 @@ THIS SOFTWARE.
 
 d3-path version 3.1.0
 ---------------------
-Website: https://github.com/d3/d3-path
+Source: https://github.com/d3/d3-path
 
 Copyright 2015-2022 Mike Bostock
 Distributed under the ISC License
@@ -19581,7 +20186,7 @@ THIS SOFTWARE.
 
 d3-path version 1.0.9
 ---------------------
-Website: https://github.com/d3/d3-path
+Source: https://github.com/d3/d3-path
 
 Copyright 2015-2016 Mike Bostock
 Distributed under the BSD 3-Clause license
@@ -19620,7 +20225,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 d3-polygon
 ----------
-Website: https://github.com/d3/d3-polygon
+Source: https://github.com/d3/d3-polygon
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19644,7 +20249,7 @@ THIS SOFTWARE.
 
 d3-quadtree
 -----------
-Website: https://github.com/d3/d3-quadtree
+Source: https://github.com/d3/d3-quadtree
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19668,7 +20273,7 @@ THIS SOFTWARE.
 
 d3-random
 ---------
-Website: https://github.com/d3/d3-random
+Source: https://github.com/d3/d3-random
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19692,7 +20297,7 @@ THIS SOFTWARE.
 
 d3-sankey
 ---------
-Website: https://github.com/d3/d3-sankey
+Source: https://github.com/d3/d3-sankey
 
 Copyright 2015, Mike Bostock
 Distributed under the BSD 3-Clause license
@@ -19731,7 +20336,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 d3-scale
 --------
-Website: https://github.com/d3/d3-scale
+Source: https://github.com/d3/d3-scale
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19755,7 +20360,7 @@ THIS SOFTWARE.
 
 d3-scale-chromatic
 ------------------
-Website: https://github.com/d3/d3-scale-chromatic
+Source: https://github.com/d3/d3-scale-chromatic
 
 Copyright 2002 Cynthia Brewer, Mark Harrower, and The Pennsylvania State University
 Copyright 2010-2024 Mike Bostock
@@ -19795,7 +20400,7 @@ specific language governing permissions and limitations under the License.
 
 d3-selection
 ------------
-Website: https://github.com/d3/d3-selection
+Source: https://github.com/d3/d3-selection
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19819,7 +20424,7 @@ THIS SOFTWARE.
 
 d3-shape version 3.2.0
 ----------------------
-Website: https://github.com/d3/d3-shape
+Source: https://github.com/d3/d3-shape
 
 Copyright 2010-2022 Mike Bostock
 Distributed under the ISC License
@@ -19843,7 +20448,7 @@ THIS SOFTWARE.
 
 d3-shape version 1.3.7
 ----------------------
-Website: https://github.com/d3/d3-shape
+Source: https://github.com/d3/d3-shape
 
 Copyright 2010-2015 Mike Bostock
 Distributed under the BSD 3-Clause license
@@ -19882,7 +20487,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 d3-time
 -------
-Website: https://github.com/d3/d3-time
+Source: https://github.com/d3/d3-time
 
 Copyright 2010-2022 Mike Bostock
 Distributed under the ISC License
@@ -19906,7 +20511,7 @@ THIS SOFTWARE.
 
 d3-time-format
 --------------
-Website: https://github.com/d3/d3-time-format
+Source: https://github.com/d3/d3-time-format
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19930,7 +20535,7 @@ THIS SOFTWARE.
 
 d3-timer
 --------
-Website: https://github.com/d3/d3-timer
+Source: https://github.com/d3/d3-timer
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19954,7 +20559,7 @@ THIS SOFTWARE.
 
 d3-transition
 -------------
-Website: https://github.com/d3/d3-transition
+Source: https://github.com/d3/d3-transition
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -19978,7 +20583,7 @@ THIS SOFTWARE.
 
 d3-zoom
 -------
-Website: https://github.com/d3/d3-zoom
+Source: https://github.com/d3/d3-zoom
 
 Copyright 2010-2021 Mike Bostock
 Distributed under the ISC License
@@ -20002,7 +20607,7 @@ THIS SOFTWARE.
 
 @dabh/diagnostics
 -----------------
-Website: https://github.com/DABH/diagnostics
+Source: https://github.com/DABH/diagnostics
 
 Copyright 2015 Arnout Kazemier, Martijn Swaagman, the Contributors.
 Distributed under the MIT License
@@ -20033,7 +20638,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 dagre-d3-es
 -----------
-Website: https://github.com/tbo47/dagre-es
+Source: https://github.com/tbo47/dagre-es
 
 Copyright 2022-2024 Thibaut Lassalle, David Newell, Alois Klink, Sidharth Vinod and dagre-es contributors
 Distributed under the MIT License
@@ -20067,7 +20672,7 @@ THE SOFTWARE.
 
 dap
 ---
-Website: https://github.com/sztomi/dap-rs
+Source: https://github.com/sztomi/dap-rs
 
 Published by Tamás Szelei <szelei.t@gmail.com>
 
@@ -20079,7 +20684,7 @@ Consult the documentation and source code of dap for more information.
 
 darling
 -------
-Website: https://github.com/TedDriggs/darling
+Source: https://github.com/TedDriggs/darling
 
 Copyright 2017 Ted Driggs
 Distributed under the MIT License
@@ -20111,7 +20716,7 @@ SOFTWARE.
 
 Dart Language Basics
 --------------------
-Website: https://npmjs.com/package/Dart Language Basics/v/1.0.0
+Source: https://npmjs.com/package/Dart Language Basics/v/1.0.0
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -20119,7 +20724,7 @@ Distributed under the MIT License
 
 Dart Syntax Highlight
 ---------------------
-Website: https://github.com/dart-lang/dart-syntax-highlight
+Source: https://github.com/dart-lang/dart-syntax-highlight
 
 Copyright (c) 2020 the Dart project authors
 Distributed under the BSD 3-Clause license
@@ -20159,7 +20764,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 dashmap
 -------
-Website: https://github.com/xacrimon/dashmap
+Source: https://github.com/xacrimon/dashmap
 
 Copyright 2019 Acrimon
 Distributed under the MIT License
@@ -20191,7 +20796,7 @@ SOFTWARE.
 
 data-encoding
 -------------
-Website: https://github.com/ia0/data-encoding
+Source: https://github.com/ia0/data-encoding
 
 Copyright 2015-2020 Julien Cretin
 Copyright 2017-2020 Google Inc.
@@ -20226,15 +20831,40 @@ SOFTWARE.
 
 data-uri-to-buffer
 ------------------
-Website: https://github.com/TooTallNate/node-data-uri-to-buffer
+Source: https://github.com/TooTallNate/proxy-agents
 
 Copyright 2014 Nathan Rajlich <nathan@tootallnate.net>
 Distributed under the MIT License
 
+MIT License text:
+
+(The MIT License)
+
+Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 dayjs
 -----
-Website: https://github.com/iamkun/dayjs
+Source: https://github.com/iamkun/dayjs
 
 Copyright 2018-present, iamkun
 Distributed under the MIT License
@@ -20266,7 +20896,7 @@ SOFTWARE.
 
 debug
 -----
-Website: https://github.com/debug-js/debug
+Source: https://github.com/debug-js/debug
 
 Copyright 2014-2017 TJ Holowaychuk <tj@vision-media.ca>
 Copyright 2018-2021 Josh Junon
@@ -20298,7 +20928,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 debugpy
 -------
-Website: https://github.com/microsoft/debugpy
+Source: https://github.com/microsoft/debugpy
 
 Published by Microsoft Corporation
 Distributed under the MIT License
@@ -20306,7 +20936,7 @@ Distributed under the MIT License
 
 decompress-response
 -------------------
-Website: https://github.com/sindresorhus/decompress-response
+Source: https://github.com/sindresorhus/decompress-response
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -20326,7 +20956,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 decorator
 ---------
-Website: https://pypi.org/project/decorator/
+Source: https://pypi.org/project/decorator/
 
 Copyright 2005-2025, Michele Simionato
 Distributed under the BSD 2-Clause license
@@ -20364,7 +20994,7 @@ DAMAGE.
 
 deep-extend
 -----------
-Website: https://github.com/unclechu/node-deep-extend
+Source: https://github.com/unclechu/node-deep-extend
 
 Copyright 2013-2018, Viacheslav Lotsmanov
 Distributed under the MIT License
@@ -20395,7 +21025,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Default Themes
 --------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -20403,7 +21033,7 @@ Distributed under the MIT License
 
 default-browser
 ---------------
-Website: https://github.com/sindresorhus/default-browser
+Source: https://github.com/sindresorhus/default-browser
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -20423,7 +21053,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 default-browser-id
 ------------------
-Website: https://github.com/sindresorhus/default-browser-id
+Source: https://github.com/sindresorhus/default-browser-id
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -20443,7 +21073,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 define-lazy-prop
 ----------------
-Website: https://github.com/sindresorhus/define-lazy-prop
+Source: https://github.com/sindresorhus/define-lazy-prop
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -20463,15 +21093,23 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 Definitely Typed
 ----------------
-Website: https://github.com/DefinitelyTyped/DefinitelyTyped
+Source: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 Copyrights are respective of each contributor listed at the beginning of each definition file.
 Distributed under the MIT License
 
 
+degenerator
+-----------
+Source: https://github.com/TooTallNate/proxy-agents
+
+Copyright 2013 Nathan Rajlich <nathan@tootallnate.net>
+Distributed under the MIT License
+
+
 delaunator
 ----------
-Website: https://github.com/mapbox/delaunator
+Source: https://github.com/mapbox/delaunator
 
 Copyright 2021, Mapbox
 Distributed under the ISC License
@@ -20497,7 +21135,7 @@ THIS SOFTWARE.
 
 delayed-stream
 --------------
-Website: https://github.com/felixge/node-delayed-stream
+Source: https://github.com/felixge/node-delayed-stream
 
 Copyright 2011 Debuggable Limited <felix@debuggable.com>
 Distributed under the MIT License
@@ -20527,7 +21165,7 @@ THE SOFTWARE.
 
 depd
 ----
-Website: https://github.com/dougwilson/nodejs-depd
+Source: https://github.com/dougwilson/nodejs-depd
 
 Copyright 2014-2018 Douglas Christopher Wilson
 Distributed under the MIT License
@@ -20560,7 +21198,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 deranged
 --------
-Website: https://github.com/jhpratt/deranged
+Source: https://github.com/jhpratt/deranged
 
 Copyright 2022 Jacob Pratt et al.
 
@@ -20801,7 +21439,7 @@ SOFTWARE.
 
 derive_more
 -----------
-Website: https://github.com/JelteF/derive_more
+Source: https://github.com/JelteF/derive_more
 
 Copyright 2016 Jelte Fennema
 Distributed under the MIT License
@@ -20833,7 +21471,7 @@ SOFTWARE.
 
 destroy
 -------
-Website: https://github.com/stream-utils/destroy
+Source: https://github.com/stream-utils/destroy
 
 Copyright 2014 Jonathan Ong me@jongleberry.com
 Copyright 2015-2022 Douglas Christopher Wilson doug@somethingdoug.com
@@ -20868,7 +21506,7 @@ THE SOFTWARE.
 
 detect-indent
 -------------
-Website: https://github.com/sindresorhus/detect-indent
+Source: https://github.com/sindresorhus/detect-indent
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -20888,15 +21526,126 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 detect-libc
 -----------
-Website: https://github.com/lovell/detect-libc
+Source: https://github.com/lovell/detect-libc
 
 Copyright 2017 Lovell Fuller and others.
 Distributed under the Apache License version 2.0
 
 
+Dev Containers
+--------------
+Source: https://github.com/posit-dev/positron
+
+Copyright License
+
+
+ELASTIC-2.0 License text:
+
+POSITRON - Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
+
+BEFORE DOWNLOADING OR USING POSITRON (THE "SOFTWARE"), YOU SHOULD CAREFULLY
+READ THE FOLLOWING LICENSE AGREEMENT THAT APPLIES TO YOUR USE OF THE SOFTWARE.
+DOWNLOADING OR USING POSITRON ESTABLISHES A BINDING AGREEMENT BETWEEN POSIT
+SOFTWARE, PBC ("LICENSOR") AND YOU (INCLUDING YOUR COMPANY, IF APPLICABLE).
+YOUR ACCEPTANCE OF THIS LICENSE AGREEMENT IS REQUIRED AS A CONDITION TO
+PROCEEDING WITH YOUR DOWNLOAD OR USE OF THE SOFTWARE.
+
+Elastic License 2.0
+
+Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
+
+Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+No Liability
+
+As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.
+
+Definitions
+
+The 'licensor' is the entity offering these terms, and the 'software' is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+'you' refers to the individual or entity agreeing to these terms.
+
+'your company' is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. 'control' means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+'your licenses' are all the licenses granted to you for the software under
+these terms.
+
+'use' means anything you do with the software requiring one of your licenses.
+
+'trademark' means trademarks, service marks, and similar rights.
+
+
 diagnostic-channel
 ------------------
-Website: https://github.com/Microsoft/node-diagnostic-channel
+Source: https://github.com/Microsoft/node-diagnostic-channel
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -20928,7 +21677,7 @@ SOFTWARE.
 
 diagnostic-channel-publishers
 -----------------------------
-Website: https://github.com/Microsoft/node-diagnostic-channel
+Source: https://github.com/Microsoft/node-diagnostic-channel
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -20960,7 +21709,7 @@ SOFTWARE.
 
 dialoguer
 ---------
-Website: https://github.com/mitsuhiko/dialoguer
+Source: https://github.com/mitsuhiko/dialoguer
 
 Copyright 2017 Armin Ronacher <armin.ronacher@active-4.com>
 Distributed under the MIT License
@@ -20992,7 +21741,7 @@ SOFTWARE.
 
 diff version 8.0.2
 ------------------
-Website: https://github.com/kpdecker/jsdiff
+Source: https://github.com/kpdecker/jsdiff
 
 Copyright 2009-2015, Kevin Decker <kpdecker@gmail.com>
 Distributed under the BSD 3-Clause license
@@ -21032,7 +21781,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Diff Language Basics version 1.0.0
 ----------------------------------
-Website: https://npmjs.com/package/Diff Language Basics/v/1.0.0
+Source: https://npmjs.com/package/Diff Language Basics/v/1.0.0
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -21040,7 +21789,7 @@ Distributed under the MIT License
 
 Diff tmBundle
 -------------
-Website: https://github.com/textmate/diff.tmbundle
+Source: https://github.com/textmate/diff.tmbundle
 
 Copyright (c) textmate-diff.tmbundle project authors
 
@@ -21064,7 +21813,7 @@ to the base-name name of the original file, and an extension of txt, html, or si
 
 digest
 ------
-Website: https://github.com/RustCrypto/traits
+Source: https://github.com/RustCrypto/traits
 
 Copyright 2017 Artyom Pavlov
 
@@ -21104,7 +21853,7 @@ DEALINGS IN THE SOFTWARE.
 
 dircpy
 ------
-Website: https://github.com/woelper/dircpy/
+Source: https://github.com/woelper/dircpy/
 
 Copyright 2020 Johann Woelper
 Distributed under the MIT License
@@ -21136,7 +21885,7 @@ SOFTWARE.
 
 directories
 -----------
-Website: https://github.com/soc/directories-rs
+Source: https://github.com/soc/directories-rs
 
 Copyright 2018 directories-rs contributors
 
@@ -21170,7 +21919,7 @@ SOFTWARE.
 
 dirs
 ----
-Website: https://github.com/soc/dirs-rs
+Source: https://github.com/soc/dirs-rs
 
 Copyright 2018-2019 dirs-rs contributors
 
@@ -21204,7 +21953,7 @@ SOFTWARE.
 
 dirs-sys
 --------
-Website: https://github.com/dirs-dev/dirs-sys-rs
+Source: https://github.com/dirs-dev/dirs-sys-rs
 
 Copyright 2018-2019 dirs-rs contributors
 
@@ -21238,7 +21987,7 @@ SOFTWARE.
 
 displaydoc
 ----------
-Website: https://github.com/yaahc/displaydoc
+Source: https://github.com/yaahc/displaydoc
 
 Published by Jane Lusby <jlusby@yaah.dev>
 
@@ -21250,7 +21999,7 @@ Consult the documentation and source code of displaydoc for more information.
 
 dissimilar
 ----------
-Website: https://github.com/dtolnay/dissimilar
+Source: https://github.com/dtolnay/dissimilar
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -21262,7 +22011,7 @@ Consult the documentation and source code of dissimilar for more information.
 
 Docker Language Basics
 ----------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -21270,7 +22019,7 @@ Distributed under the MIT License
 
 docstring-to-markdown
 ---------------------
-Website: https://pypi.org/project/docstring-to-markdown/
+Source: https://pypi.org/project/docstring-to-markdown/
 
 Copyright (C) 1991, 1999 Free Software Foundation, Inc. <https:fsf.org/>
 Distributed under the GNU Lesser General Public License version 2.1
@@ -21786,7 +22535,7 @@ That's all there is to it!
 
 Document Object Model
 ---------------------
-Website: https://www.w3.org/DOM/
+Source: https://www.w3.org/DOM/
 
 Copyright (c) WHATWG (Apple, Google, Mozilla, Microsoft).
 
@@ -22145,7 +22894,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 dom-serializer
 --------------
-Website: https://github.com/cheeriojs/dom-serializer
+Source: https://github.com/cheeriojs/dom-serializer
 
 Copyright 2014 The cheeriojs contributors
 Distributed under the MIT License
@@ -22167,7 +22916,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 domelementtype
 --------------
-Website: https://github.com/fb55/domelementtype
+Source: https://github.com/fb55/domelementtype
 
 Copyright Felix Böhm
 Distributed under the BSD 2-Clause license
@@ -22190,7 +22939,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 domhandler
 ----------
-Website: https://github.com/fb55/domhandler
+Source: https://github.com/fb55/domhandler
 
 Copyright Felix Böhm
 Distributed under the BSD 2-Clause license
@@ -22213,7 +22962,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 dompurify version 3.3.0
 -----------------------
-Website: https://github.com/cure53/DOMPurify
+Source: https://github.com/cure53/DOMPurify
 
 Copyright 2025 Dr.-Ing. Mario Heiderich, Cure53
 
@@ -22803,7 +23552,7 @@ the Mozilla Public License, v. 2.0.
 
 dompurify version 3.2.7
 -----------------------
-Website: https://github.com/cure53/DOMPurify
+Source: https://github.com/cure53/DOMPurify
 
 Copyright 2025 Dr.-Ing. Mario Heiderich, Cure53
 
@@ -23393,7 +24142,7 @@ the Mozilla Public License, v. 2.0.
 
 domutils
 --------
-Website: https://github.com/fb55/domutils
+Source: https://github.com/fb55/domutils
 
 Copyright Felix Böhm
 Distributed under the BSD 2-Clause license
@@ -23416,7 +24165,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Dotenv Language Basics
 ----------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -23424,7 +24173,7 @@ Distributed under the MIT License
 
 drop_bomb
 ---------
-Website: https://github.com/matklad/drop_bomb
+Source: https://github.com/matklad/drop_bomb
 
 Published by Aleksey Kladov <aleksey.kladov@gmail.com>
 
@@ -23436,7 +24185,7 @@ Consult the documentation and source code of drop_bomb for more information.
 
 dtoa
 ----
-Website: https://github.com/dtolnay/dtoa
+Source: https://github.com/dtolnay/dtoa
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -23448,7 +24197,7 @@ Consult the documentation and source code of dtoa for more information.
 
 dtoa-short
 ----------
-Website: https://github.com/upsuper/dtoa-short
+Source: https://github.com/upsuper/dtoa-short
 
 Published by Xidorn Quan <me@upsuper.org>
 Distributed under the Mozilla Public License version 2.0
@@ -23847,7 +24596,7 @@ defined by the Mozilla Public License, v. 2.0.
 
 @duckdb/duckdb-wasm
 -------------------
-Website: https://github.com/duckdb/duckdb-wasm
+Source: https://github.com/duckdb/duckdb-wasm
 
 Copyright 2018-2025 Stichting DuckDB Foundation
 Distributed under the MIT License
@@ -23855,7 +24604,7 @@ Distributed under the MIT License
 
 dunder-proto
 ------------
-Website: https://github.com/es-shims/dunder-proto
+Source: https://github.com/es-shims/dunder-proto
 
 Copyright 2024 ECMAScript Shims
 Distributed under the MIT License
@@ -23887,7 +24636,7 @@ SOFTWARE.
 
 duplexify
 ---------
-Website: https://github.com/mafintosh/duplexify
+Source: https://github.com/mafintosh/duplexify
 
 Copyright 2014 Mathias Buus
 Distributed under the MIT License
@@ -23919,7 +24668,7 @@ THE SOFTWARE.
 
 dyn-clone
 ---------
-Website: https://github.com/dtolnay/dyn-clone
+Source: https://github.com/dtolnay/dyn-clone
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -23931,7 +24680,7 @@ Consult the documentation and source code of dyn-clone for more information.
 
 eastasianwidth
 --------------
-Website: https://github.com/komagata/eastasianwidth
+Source: https://github.com/komagata/eastasianwidth
 
 Published by Masaki Komagata
 Distributed under the MIT License
@@ -23939,7 +24688,7 @@ Distributed under the MIT License
 
 ecdsa-sig-formatter
 -------------------
-Website: https://github.com/Brightspace/node-ecdsa-sig-formatter
+Source: https://github.com/Brightspace/node-ecdsa-sig-formatter
 
 Copyright 2015 D2L Corporation
 Distributed under the Apache License version 2.0
@@ -24153,7 +24902,7 @@ limitations under the License.
 
 ee-first
 --------
-Website: https://github.com/jonathanong/ee-first
+Source: https://github.com/jonathanong/ee-first
 
 Copyright 2014 Jonathan Ong me@jongleberry.com
 Distributed under the MIT License
@@ -24185,7 +24934,7 @@ THE SOFTWARE.
 
 ego-tree
 --------
-Website: https://github.com/programble/ego-tree
+Source: https://github.com/programble/ego-tree
 
 Copyright © 2016, Curtis McEnroe <curtis@cmcenroe.me>
 Distributed under the ISC License
@@ -24209,7 +24958,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 either
 ------
-Website: https://github.com/rayon-rs/either
+Source: https://github.com/rayon-rs/either
 
 Copyright 2015 bluss
 
@@ -24249,7 +24998,7 @@ DEALINGS IN THE SOFTWARE.
 
 embed-resource
 --------------
-Website: https://github.com/nabijaczleweli/rust-embed-resource
+Source: https://github.com/nabijaczleweli/rust-embed-resource
 
 Copyright 2017 nabijaczleweli
 Distributed under the MIT License
@@ -24281,15 +25030,15 @@ SOFTWARE.
 
 emitter-listener
 ----------------
-Website: https://github.com/othiym23/emitter-listener
+Source: https://github.com/othiym23/emitter-listener
 
-Published by Forrest L Norvell <ogd@aoaioxxysz.net>
+Copyright (C) 2012-2016 Yusuke Suzuki
 Distributed under the BSD 2-Clause license
 
 
 emmet version 2.4.11
 --------------------
-Website: https://github.com/emmetio/emmet
+Source: https://github.com/emmetio/emmet
 
 Copyright 2020 Sergey Chikuyonok <serge.che@gmail.com>
 Distributed under the MIT License
@@ -24321,7 +25070,7 @@ SOFTWARE.
 
 emmet version 1.0.0
 -------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -24329,7 +25078,7 @@ Distributed under the MIT License
 
 @emmetio/abbreviation
 ---------------------
-Website: https://github.com/emmetio/emmet
+Source: https://github.com/emmetio/emmet
 
 Copyright 2020 Sergey Chikuyonok <serge.che@gmail.com>
 Distributed under the MIT License
@@ -24361,7 +25110,7 @@ SOFTWARE.
 
 @emmetio/css-abbreviation
 -------------------------
-Website: https://github.com/emmetio/emmet
+Source: https://github.com/emmetio/emmet
 
 Copyright 2020 Sergey Chikuyonok <serge.che@gmail.com>
 Distributed under the MIT License
@@ -24393,7 +25142,7 @@ SOFTWARE.
 
 @emmetio/css-parser
 -------------------
-Website: https://github.com/emmetio/css-parser
+Source: https://github.com/emmetio/css-parser
 
 Copyright 2017 Emmet.io
 Distributed under the MIT License
@@ -24425,7 +25174,7 @@ SOFTWARE.
 
 @emmetio/html-matcher
 ---------------------
-Website: https://github.com/emmetio/html-matcher
+Source: https://github.com/emmetio/html-matcher
 
 Copyright 2017 Emmet.io
 Distributed under the MIT License
@@ -24457,7 +25206,7 @@ SOFTWARE.
 
 @emmetio/math-expression
 ------------------------
-Website: https://github.com/emmetio/math-expression
+Source: https://github.com/emmetio/math-expression
 
 Copyright 2017 Emmet.io
 Distributed under the MIT License
@@ -24489,7 +25238,7 @@ SOFTWARE.
 
 @emmetio/scanner
 ----------------
-Website: https://github.com/emmetio/stream-reader
+Source: https://github.com/emmetio/stream-reader
 
 Copyright 2020 Sergey Chikuyonok <serge.che@gmail.com>
 Distributed under the MIT License
@@ -24521,7 +25270,7 @@ SOFTWARE.
 
 @emmetio/stream-reader
 ----------------------
-Website: https://github.com/emmetio/stream-reader
+Source: https://github.com/emmetio/stream-reader
 
 Copyright 2017 Emmet.io
 Distributed under the MIT License
@@ -24553,7 +25302,7 @@ SOFTWARE.
 
 @emmetio/stream-reader-utils
 ----------------------------
-Website: https://github.com/emmetio/stream-reader-utils
+Source: https://github.com/emmetio/stream-reader-utils
 
 Copyright 2017 Emmet.io
 Distributed under the MIT License
@@ -24585,7 +25334,7 @@ SOFTWARE.
 
 emoji-regex
 -----------
-Website: https://github.com/mathiasbynens/emoji-regex
+Source: https://github.com/mathiasbynens/emoji-regex
 
 Copyright Mathias Bynens <https:mathiasbynens.be/>
 Distributed under the MIT License
@@ -24616,7 +25365,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 enabled
 -------
-Website: https://github.com/3rd-Eden/enabled
+Source: https://github.com/3rd-Eden/enabled
 
 Copyright 2015 Arnout Kazemier, Martijn Swaagman, the Contributors.
 Distributed under the MIT License
@@ -24647,7 +25396,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 encodeurl
 ---------
-Website: https://github.com/pillarjs/encodeurl
+Source: https://github.com/pillarjs/encodeurl
 
 Copyright 2016 Douglas Christopher Wilson
 Distributed under the MIT License
@@ -24680,7 +25429,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 encode_unicode
 --------------
-Website: https://github.com/tormol/encode_unicode
+Source: https://github.com/tormol/encode_unicode
 
 Published by Torbjørn Birch Moltu <t.b.moltu@lyse.net>
 
@@ -24692,7 +25441,7 @@ Consult the documentation and source code of encode_unicode for more information
 
 encoding_rs
 -----------
-Website: https://github.com/hsivonen/encoding_rs
+Source: https://github.com/hsivonen/encoding_rs
 
 Copyright Mozilla Foundation
 Copyright © WHATWG (Apple, Google, Mozilla, Microsoft).
@@ -24765,7 +25514,7 @@ DEALINGS IN THE SOFTWARE.
 
 end-of-stream
 -------------
-Website: https://github.com/mafintosh/end-of-stream
+Source: https://github.com/mafintosh/end-of-stream
 
 Copyright 2014 Mathias Buus
 Distributed under the MIT License
@@ -24797,7 +25546,7 @@ THE SOFTWARE.
 
 @enonic/fnv-plus
 ----------------
-Website: https://github.com/tjwebb/fnv-plus
+Source: https://github.com/tjwebb/fnv-plus
 
 Published by Travis Webb <me@traviswebb.com>
 Distributed under the MIT License
@@ -24805,7 +25554,7 @@ Distributed under the MIT License
 
 entities
 --------
-Website: https://github.com/fb55/entities
+Source: https://github.com/fb55/entities
 
 Copyright Felix Böhm
 Distributed under the BSD 2-Clause license
@@ -24828,7 +25577,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 enumflags2
 ----------
-Website: https://github.com/meithecatte/enumflags2
+Source: https://github.com/meithecatte/enumflags2
 
 Copyright 2017-2023 Maik Klein, Maja Kądziołka
 
@@ -24939,7 +25688,7 @@ DEALINGS IN THE SOFTWARE.
 
 enumflags2_derive
 -----------------
-Website: https://github.com/meithecatte/enumflags2
+Source: https://github.com/meithecatte/enumflags2
 
 Copyright 2017 Maik Klein
 
@@ -25050,7 +25799,7 @@ DEALINGS IN THE SOFTWARE.
 
 env_logger
 ----------
-Website: https://github.com/rust-cli/env_logger
+Source: https://github.com/rust-cli/env_logger
 
 Copyright Individual contributors
 
@@ -25084,7 +25833,7 @@ SOFTWARE.
 
 equivalent
 ----------
-Website: https://github.com/cuviper/equivalent
+Source: https://github.com/cuviper/equivalent
 
 Copyright 2016--2023
 
@@ -25124,7 +25873,7 @@ DEALINGS IN THE SOFTWARE.
 
 erased-serde
 ------------
-Website: https://github.com/dtolnay/erased-serde
+Source: https://github.com/dtolnay/erased-serde
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -25136,7 +25885,7 @@ Consult the documentation and source code of erased-serde for more information.
 
 errno
 -----
-Website: https://github.com/lambda-fairy/rust-errno
+Source: https://github.com/lambda-fairy/rust-errno
 
 Copyright 2014 Chris Wong
 
@@ -25176,7 +25925,7 @@ DEALINGS IN THE SOFTWARE.
 
 es-define-property
 ------------------
-Website: https://github.com/ljharb/es-define-property
+Source: https://github.com/ljharb/es-define-property
 
 Copyright 2024 Jordan Harband
 Distributed under the MIT License
@@ -25208,7 +25957,7 @@ SOFTWARE.
 
 es-errors
 ---------
-Website: https://github.com/ljharb/es-errors
+Source: https://github.com/ljharb/es-errors
 
 Copyright 2024 Jordan Harband
 Distributed under the MIT License
@@ -25240,7 +25989,7 @@ SOFTWARE.
 
 es-object-atoms
 ---------------
-Website: https://github.com/ljharb/es-object-atoms
+Source: https://github.com/ljharb/es-object-atoms
 
 Copyright 2024 Jordan Harband
 Distributed under the MIT License
@@ -25272,7 +26021,7 @@ SOFTWARE.
 
 es-set-tostringtag
 ------------------
-Website: https://github.com/es-shims/es-set-tostringtag
+Source: https://github.com/es-shims/es-set-tostringtag
 
 Copyright 2022 ECMAScript Shims
 Distributed under the MIT License
@@ -25302,9 +26051,29 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+escalade
+--------
+Source: https://github.com/lukeed/escalade
+
+Copyright Luke Edwards <luke.edwards05@gmail.com> (lukeed.com)
+Distributed under the MIT License
+
+MIT License text:
+
+MIT License
+
+Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (lukeed.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 escape-html
 -----------
-Website: https://github.com/component/escape-html
+Source: https://github.com/component/escape-html
 
 Copyright 2012-2013 TJ Holowaychuk
 Copyright 2015 Andreas Lubbe
@@ -25341,9 +26110,42 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
+escodegen
+---------
+Source: https://github.com/estools/escodegen
+
+Copyright (C) 2012 Yusuke Suzuki (twitter: @Constellation) and other contributors.
+Distributed under the BSD 2-Clause license
+
+BSD 2-Clause license text:
+
+Copyright (C) 2012 Yusuke Suzuki (twitter: @Constellation) and other contributors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
 esprima
 -------
-Website: https://github.com/jquery/esprima
+Source: https://github.com/jquery/esprima
 
 Copyright JS Foundation and other contributors, https:js.foundation/
 Distributed under the BSD 2-Clause license
@@ -25374,9 +26176,25 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+estraverse
+----------
+Source: https://github.com/estools/estraverse
+
+Copyright (C) 2012-2016 Yusuke Suzuki
+Distributed under the BSD 2-Clause license
+
+
+esutils
+-------
+Source: https://github.com/estools/esutils
+
+Copyright (C) 2013 Yusuke Suzuki
+Distributed under the BSD 2-Clause license
+
+
 etag
 ----
-Website: https://github.com/jshttp/etag
+Source: https://github.com/jshttp/etag
 
 Copyright 2014-2016 Douglas Christopher Wilson
 Distributed under the MIT License
@@ -25409,7 +26227,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 event-listener
 --------------
-Website: https://github.com/smol-rs/event-listener
+Source: https://github.com/smol-rs/event-listener
 
 Published by Stjepan Glavina <stjepang@gmail.com>, John Nunley <dev@notgull.net>
 
@@ -25421,7 +26239,7 @@ Consult the documentation and source code of event-listener for more information
 
 event-listener-strategy
 -----------------------
-Website: https://github.com/smol-rs/event-listener-strategy
+Source: https://github.com/smol-rs/event-listener-strategy
 
 Published by John Nunley <dev@notgull.net>
 
@@ -25433,7 +26251,7 @@ Consult the documentation and source code of event-listener-strategy for more in
 
 event-target-shim
 -----------------
-Website: https://github.com/mysticatea/event-target-shim
+Source: https://github.com/mysticatea/event-target-shim
 
 Copyright 2015 Toru Nagashima
 Distributed under the MIT License
@@ -25465,7 +26283,7 @@ SOFTWARE.
 
 eventemitter3
 -------------
-Website: https://github.com/primus/eventemitter3
+Source: https://github.com/primus/eventemitter3
 
 Copyright 2014 Arnout Kazemier
 Distributed under the MIT License
@@ -25497,7 +26315,7 @@ SOFTWARE.
 
 events
 ------
-Website: https://github.com/Gozala/events
+Source: https://github.com/Gozala/events
 
 Copyright Joyent, Inc. and other Node contributors.
 Distributed under the MIT License
@@ -25530,7 +26348,7 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 exceptiongroup
 --------------
-Website: https://pypi.org/project/exceptiongroup/
+Source: https://pypi.org/project/exceptiongroup/
 
 Copyright 2022 Alex Grönholm
 Distributed under the MIT License
@@ -25613,7 +26431,7 @@ PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
 
 executing
 ---------
-Website: https://github.com/alexmojaki/executing
+Source: https://github.com/alexmojaki/executing
 
 Published by Alex Hall
 Distributed under the MIT License
@@ -25621,7 +26439,7 @@ Distributed under the MIT License
 
 exenv-es6
 ---------
-Website: https://github.com/chrisdholt/exenv-es6
+Source: https://github.com/chrisdholt/exenv-es6
 
 Copyright 2018 Chris Holt
 Distributed under the MIT License
@@ -25653,7 +26471,7 @@ SOFTWARE.
 
 expand-abbreviation
 -------------------
-Website: https://github.com/emmetio/expand-abbreviation
+Source: https://github.com/emmetio/expand-abbreviation
 
 Copyright (c) 2017 Emmet.io
 Distributed under the MIT License
@@ -25661,7 +26479,7 @@ Distributed under the MIT License
 
 expand-template
 ---------------
-Website: https://github.com/ralphtheninja/expand-template
+Source: https://github.com/ralphtheninja/expand-template
 
 Copyright 2018 Lars-Magnus Skog
 Distributed under the MIT License
@@ -25693,7 +26511,7 @@ THE SOFTWARE.
 
 expand-tilde
 ------------
-Website: https://github.com/jonschlinkert/expand-tilde
+Source: https://github.com/jonschlinkert/expand-tilde
 
 Copyright 2015-2016, Jon Schlinkert.
 Distributed under the MIT License
@@ -25725,7 +26543,7 @@ THE SOFTWARE.
 
 express
 -------
-Website: https://github.com/expressjs/express
+Source: https://github.com/expressjs/express
 
 Copyright 2009-2014 TJ Holowaychuk <tj@vision-media.ca>
 Copyright 2013-2014 Roman Shtylman <shtylman+expressjs@gmail.com>
@@ -25764,7 +26582,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 exsolve
 -------
-Website: https://github.com/unjs/exsolve
+Source: https://github.com/unjs/exsolve
 
 Copyright 2021 Titus Wormer <mailto:tituswormer@gmail.com>
 Copyright Joyent, Inc. and other Node contributors.
@@ -25889,7 +26707,7 @@ https://github.com/joyent/node repository:
 
 extend
 ------
-Website: https://github.com/justmoon/node-extend
+Source: https://github.com/justmoon/node-extend
 
 Copyright 2014 Stefan Thomas
 Distributed under the MIT License
@@ -25922,7 +26740,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Extension Authoring
 -------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -25930,7 +26748,7 @@ Distributed under the MIT License
 
 F# Language Basics
 ------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -25938,7 +26756,7 @@ Distributed under the MIT License
 
 fast-content-type-parse
 -----------------------
-Website: https://github.com/fastify/fast-content-type-parse
+Source: https://github.com/fastify/fast-content-type-parse
 
 Copyright 2023 The Fastify Team
 Distributed under the MIT License
@@ -25973,7 +26791,7 @@ SOFTWARE.
 
 fast-deep-equal
 ---------------
-Website: https://github.com/epoberezkin/fast-deep-equal
+Source: https://github.com/epoberezkin/fast-deep-equal
 
 Copyright 2017 Evgeny Poberezkin
 Distributed under the MIT License
@@ -26005,7 +26823,7 @@ SOFTWARE.
 
 fast-uri
 --------
-Website: https://github.com/fastify/fast-uri
+Source: https://github.com/fastify/fast-uri
 
 Copyright 2011-2021, Gary Court until https:github.com/garycourt/uri-js/commit/a1acf730b4bba3f1097c9f52e7d9d3aba8cdcaae
 Copyright 2021 The Fastify Team
@@ -26049,7 +26867,7 @@ The complete list of contributors can be found at:
 
 fast-xml-parser
 ---------------
-Website: https://github.com/NaturalIntelligence/fast-xml-parser
+Source: https://github.com/NaturalIntelligence/fast-xml-parser
 
 Copyright 2017 Amit Kumar Gupta
 Distributed under the MIT License
@@ -26081,7 +26899,7 @@ SOFTWARE.
 
 fastest-levenshtein
 -------------------
-Website: https://github.com/ka-weihe/fastest-levenshtein
+Source: https://github.com/ka-weihe/fastest-levenshtein
 
 Copyright 2020 Kasper Unn Weihe
 Distributed under the MIT License
@@ -26113,7 +26931,7 @@ SOFTWARE.
 
 fastrand
 --------
-Website: https://github.com/smol-rs/fastrand
+Source: https://github.com/smol-rs/fastrand
 
 Published by Stjepan Glavina <stjepang@gmail.com>
 
@@ -26125,7 +26943,7 @@ Consult the documentation and source code of fastrand for more information.
 
 fd-slicer
 ---------
-Website: https://github.com/andrewrk/node-fd-slicer
+Source: https://github.com/andrewrk/node-fd-slicer
 
 Copyright 2014 Andrew Kelley
 Distributed under the MIT License
@@ -26157,7 +26975,7 @@ SOFTWARE.
 
 fecha
 -----
-Website: https://taylorhakes@github.com/taylorhakes/fecha.git
+Source: https://taylorhakes@github.com/taylorhakes/fecha.git
 
 Copyright 2015 Taylor Hakes
 Distributed under the MIT License
@@ -26189,7 +27007,7 @@ SOFTWARE.
 
 fetch-blob
 ----------
-Website: https://github.com/node-fetch/fetch-blob
+Source: https://github.com/node-fetch/fetch-blob
 
 Copyright 2019 David Frank
 Distributed under the MIT License
@@ -26221,7 +27039,7 @@ SOFTWARE.
 
 Fig Autocomplete
 ----------------
-Website: https://github.com/withfig/autocomplete-tools
+Source: https://github.com/withfig/autocomplete-tools
 
 Copyright (c) 2021 Hercules Labs Inc. (Fig)
 Distributed under the MIT License
@@ -26253,7 +27071,7 @@ SOFTWARE.
 
 file-type
 ---------
-Website: https://github.com/sindresorhus/file-type
+Source: https://github.com/sindresorhus/file-type
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -26273,7 +27091,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 file-uri-to-path
 ----------------
-Website: https://github.com/TooTallNate/file-uri-to-path
+Source: https://github.com/TooTallNate/file-uri-to-path
 
 Copyright 2014 Nathan Rajlich <nathan@tootallnate.net>
 Distributed under the MIT License
@@ -26304,7 +27122,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 filetime
 --------
-Website: https://github.com/alexcrichton/filetime
+Source: https://github.com/alexcrichton/filetime
 
 Copyright 2014 Alex Crichton
 
@@ -26344,7 +27162,7 @@ DEALINGS IN THE SOFTWARE.
 
 fill-range
 ----------
-Website: https://github.com/jonschlinkert/fill-range
+Source: https://github.com/jonschlinkert/fill-range
 
 Copyright 2014-present, Jon Schlinkert.
 Distributed under the MIT License
@@ -26376,7 +27194,7 @@ THE SOFTWARE.
 
 finalhandler
 ------------
-Website: https://github.com/pillarjs/finalhandler
+Source: https://github.com/pillarjs/finalhandler
 
 Copyright 2014-2022 Douglas Christopher Wilson <doug@somethingdoug.com>
 Distributed under the MIT License
@@ -26409,7 +27227,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 find-replace
 ------------
-Website: https://github.com/75lb/find-replace
+Source: https://github.com/75lb/find-replace
 
 Copyright 2015-19 Lloyd Brookes <75pound@gmail.com>
 Distributed under the MIT License
@@ -26441,7 +27259,7 @@ SOFTWARE.
 
 find-up
 -------
-Website: https://github.com/sindresorhus/find-up
+Source: https://github.com/sindresorhus/find-up
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -26461,7 +27279,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 find-yarn-workspace-root
 ------------------------
-Website: https://github.com/square/find-yarn-workspace-root
+Source: https://github.com/square/find-yarn-workspace-root
 
 Copyright 2017 Square, Inc.
 Distributed under the Apache License version 2.0
@@ -26675,7 +27493,7 @@ limitations under the License.
 
 fish shell
 ----------
-Website: https://github.com/fish-shell/fish-shell
+Source: https://github.com/fish-shell/fish-shell
 
 Copyright (C) 2005-2009 Axel Liljencrantz, Copyright (C) 2009- fish-shell contributors
 Distributed under the GNU General Public License version 2.0
@@ -26707,7 +27525,7 @@ more details.
 
 flatbuffers
 -----------
-Website: https://github.com/google/flatbuffers
+Source: https://github.com/google/flatbuffers
 
 Published by The FlatBuffers project
 Distributed under the Apache License version 2.0
@@ -26715,7 +27533,7 @@ Distributed under the Apache License version 2.0
 
 flate2
 ------
-Website: https://github.com/rust-lang/flate2-rs
+Source: https://github.com/rust-lang/flate2-rs
 
 Copyright 2014 Alex Crichton
 
@@ -26755,7 +27573,7 @@ DEALINGS IN THE SOFTWARE.
 
 fn.name
 -------
-Website: https://github.com/3rd-Eden/fn.name
+Source: https://github.com/3rd-Eden/fn.name
 
 Copyright 2015 Arnout Kazemier, Martijn Swaagman, the Contributors.
 Distributed under the MIT License
@@ -26787,7 +27605,7 @@ SOFTWARE.
 
 fnv
 ---
-Website: https://github.com/servo/rust-fnv
+Source: https://github.com/servo/rust-fnv
 
 Copyright 2017 Contributors
 
@@ -26827,7 +27645,7 @@ DEALINGS IN THE SOFTWARE.
 
 follow-redirects
 ----------------
-Website: https://github.com/follow-redirects/follow-redirects
+Source: https://github.com/follow-redirects/follow-redirects
 
 Copyright 2014–present Olivier Lalonde <olalonde@gmail.com>, James Talmage <james@talmage.io>, Ruben Verborgh
 Distributed under the MIT License
@@ -26856,7 +27674,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 font-finder
 -----------
-Website: https://github.com/princjef/font-finder
+Source: https://github.com/princjef/font-finder
 
 Copyright 2018 Jeffrey Principe
 Distributed under the MIT License
@@ -26888,7 +27706,7 @@ SOFTWARE.
 
 font-ligatures
 --------------
-Website: https://github.com/princjef/font-ligatures
+Source: https://github.com/princjef/font-ligatures
 
 Copyright 2018 Jeffrey Principe
 Distributed under the MIT License
@@ -26920,7 +27738,7 @@ SOFTWARE.
 
 foreground-child
 ----------------
-Website: https://github.com/tapjs/foreground-child
+Source: https://github.com/tapjs/foreground-child
 
 Copyright 2015-2023 Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -26946,7 +27764,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 foreign-types
 -------------
-Website: https://github.com/sfackler/foreign-types
+Source: https://github.com/sfackler/foreign-types
 
 Copyright 2017 The foreign-types Developers
 
@@ -26980,7 +27798,7 @@ SOFTWARE.
 
 form-data
 ---------
-Website: https://github.com/form-data/form-data
+Source: https://github.com/form-data/form-data
 
 Copyright 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
 Distributed under the MIT License
@@ -27010,7 +27828,7 @@ THE SOFTWARE.
 
 formdata-polyfill
 -----------------
-Website: https://jimmywarting@github.com/jimmywarting/FormData.git
+Source: https://jimmywarting@github.com/jimmywarting/FormData.git
 
 Copyright 2016 Jimmy Karl Roland Wärting
 Distributed under the MIT License
@@ -27042,7 +27860,7 @@ SOFTWARE.
 
 form_urlencoded
 ---------------
-Website: https://github.com/servo/rust-url
+Source: https://github.com/servo/rust-url
 
 Copyright 2013-2016 The rust-url developers
 
@@ -27082,7 +27900,7 @@ DEALINGS IN THE SOFTWARE.
 
 forwarded
 ---------
-Website: https://github.com/jshttp/forwarded
+Source: https://github.com/jshttp/forwarded
 
 Copyright 2014-2017 Douglas Christopher Wilson
 Distributed under the MIT License
@@ -27115,7 +27933,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 fresh
 -----
-Website: https://github.com/jshttp/fresh
+Source: https://github.com/jshttp/fresh
 
 Copyright 2012 TJ Holowaychuk <tj@vision-media.ca>
 Copyright 2016-2017 Douglas Christopher Wilson <doug@somethingdoug.com>
@@ -27151,7 +27969,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 frunk
 -----
-Website: https://github.com/lloydmeta/frunk
+Source: https://github.com/lloydmeta/frunk
 
 Published by Lloyd <lloydmeta@gmail.com>
 Distributed under the MIT License
@@ -27159,7 +27977,7 @@ Distributed under the MIT License
 
 frunk-enum
 ----------
-Website: https://github.com/Metaswitch/frunk-enum
+Source: https://github.com/Metaswitch/frunk-enum
 
 Copyright 2018 Metaswitch Networks
 
@@ -27210,7 +28028,7 @@ SOFTWARE.
 
 fs-constants
 ------------
-Website: https://github.com/mafintosh/fs-constants
+Source: https://github.com/mafintosh/fs-constants
 
 Copyright 2018 Mathias Buus
 Distributed under the MIT License
@@ -27242,7 +28060,7 @@ THE SOFTWARE.
 
 fs-extra
 --------
-Website: https://github.com/jprichardson/node-fs-extra
+Source: https://github.com/jprichardson/node-fs-extra
 
 Copyright 2011-2024 JP Richardson
 Distributed under the MIT License
@@ -27268,7 +28086,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEAL
 
 fs-minipass
 -----------
-Website: https://github.com/npm/fs-minipass
+Source: https://github.com/npm/fs-minipass
 
 Copyright Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -27294,7 +28112,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 fs.realpath
 -----------
-Website: https://github.com/isaacs/fs.realpath
+Source: https://github.com/isaacs/fs.realpath
 
 Copyright Isaac Z. Schlueter and Contributors
 Copyright Joyent, Inc. and other Node contributors.
@@ -27349,7 +28167,7 @@ DEALINGS IN THE SOFTWARE.
 
 fsevent-sys
 -----------
-Website: https://github.com/octplane/fsevent-rust
+Source: https://github.com/octplane/fsevent-rust
 
 Copyright 2015 Pierre Baillet
 Distributed under the MIT License
@@ -27381,7 +28199,7 @@ SOFTWARE.
 
 function-bind
 -------------
-Website: https://github.com/Raynos/function-bind
+Source: https://github.com/Raynos/function-bind
 
 Copyright 2013 Raynos.
 Distributed under the MIT License
@@ -27411,7 +28229,7 @@ THE SOFTWARE.
 
 futf
 ----
-Website: https://github.com/servo/futf
+Source: https://github.com/servo/futf
 
 Copyright 2015 Keegan McAllister
 
@@ -27451,7 +28269,7 @@ DEALINGS IN THE SOFTWARE.
 
 futures-rs
 ----------
-Website: https://github.com/rust-lang/futures-rs
+Source: https://github.com/rust-lang/futures-rs
 
 Copyright 2016 Alex Crichton
 Copyright 2017 The Tokio Authors
@@ -27703,7 +28521,7 @@ DEALINGS IN THE SOFTWARE.
 
 fxhash
 ------
-Website: https://github.com/cbreeden/fxhash
+Source: https://github.com/cbreeden/fxhash
 
 Published by cbreeden <github@u.breeden.cc>
 
@@ -27715,7 +28533,7 @@ Consult the documentation and source code of fxhash for more information.
 
 gaxios
 ------
-Website: https://github.com/googleapis/gaxios
+Source: https://github.com/googleapis/gaxios
 
 Published by Google, LLC
 Distributed under the Apache License version 2.0
@@ -27723,7 +28541,7 @@ Distributed under the Apache License version 2.0
 
 gcp-metadata
 ------------
-Website: https://github.com/googleapis/google-cloud-node-core
+Source: https://github.com/googleapis/google-cloud-node-core
 
 Published by Google LLC
 Distributed under the Apache License version 2.0
@@ -27731,7 +28549,7 @@ Distributed under the Apache License version 2.0
 
 generic-array
 -------------
-Website: https://github.com/fizyk20/generic-array
+Source: https://github.com/fizyk20/generic-array
 
 Copyright 2015 Bartłomiej Kamiński
 Distributed under the MIT License
@@ -27763,15 +28581,33 @@ SOFTWARE.
 
 generic-pool
 ------------
-Website: https://github.com/coopernurse/node-pool
+Source: https://github.com/coopernurse/node-pool
 
 Copyright 2010-2016 James Cooper <james@bitmechanic.com>
 Distributed under the MIT License
 
 
+get-caller-file
+---------------
+Source: https://github.com/stefanpenner/get-caller-file
+
+Copyright 2018 Stefan Penner
+Distributed under the ISC License
+
+ISC License text:
+
+ISC License (ISC)
+
+Copyright 2018 Stefan Penner
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
 get-intrinsic
 -------------
-Website: https://github.com/ljharb/get-intrinsic
+Source: https://github.com/ljharb/get-intrinsic
 
 Copyright 2020 Jordan Harband
 Distributed under the MIT License
@@ -27803,7 +28639,7 @@ SOFTWARE.
 
 get-proto
 ---------
-Website: https://github.com/ljharb/get-proto
+Source: https://github.com/ljharb/get-proto
 
 Copyright 2025 Jordan Harband
 Distributed under the MIT License
@@ -27835,7 +28671,7 @@ SOFTWARE.
 
 get-system-fonts
 ----------------
-Website: https://github.com/princjef/get-system-fonts
+Source: https://github.com/princjef/get-system-fonts
 
 Copyright 2018 Jeffrey Principe
 Distributed under the MIT License
@@ -27865,9 +28701,42 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+get-uri
+-------
+Source: https://github.com/TooTallNate/proxy-agents
+
+Copyright 2014 Nathan Rajlich <nathan@tootallnate.net>
+Distributed under the MIT License
+
+MIT License text:
+
+(The MIT License)
+
+Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 getopts
 -------
-Website: https://github.com/rust-lang/getopts
+Source: https://github.com/rust-lang/getopts
 
 Copyright 2014 The Rust Project Developers
 
@@ -27907,7 +28776,7 @@ DEALINGS IN THE SOFTWARE.
 
 getrandom
 ---------
-Website: https://github.com/rust-random/getrandom
+Source: https://github.com/rust-random/getrandom
 
 Copyright 2014 The Rust Project Developers
 Copyright 2018-2024 The rust-random Project Developers
@@ -27950,7 +28819,7 @@ DEALINGS IN THE SOFTWARE.
 
 gimli
 -----
-Website: https://github.com/gimli-rs/gimli
+Source: https://github.com/gimli-rs/gimli
 
 Copyright 2015 The Rust Project Developers
 
@@ -27990,7 +28859,7 @@ DEALINGS IN THE SOFTWARE.
 
 Git
 ---
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -27998,7 +28867,7 @@ Distributed under the MIT License
 
 Git Base
 --------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -28006,7 +28875,7 @@ Distributed under the MIT License
 
 Git Commit Message Plus
 -----------------------
-Website: https://github.com/walles/git-commit-message-plus
+Source: https://github.com/walles/git-commit-message-plus
 
 Copyright (c) 2023 Johan Walles <johan.walles@gmail.com>
 Distributed under the MIT License
@@ -28014,7 +28883,7 @@ Distributed under the MIT License
 
 git tmBundle
 ------------
-Website: https://github.com/textmate/git.tmbundle
+Source: https://github.com/textmate/git.tmbundle
 
 Copyright (c) 2008 Tim Harper
 Distributed under the MIT License
@@ -28022,7 +28891,7 @@ Distributed under the MIT License
 
 git2-rs
 -------
-Website: https://github.com/rust-lang/git2-rs
+Source: https://github.com/rust-lang/git2-rs
 
 Copyright 2014 Alex Crichton
 
@@ -28062,7 +28931,7 @@ DEALINGS IN THE SOFTWARE.
 
 GitHub
 ------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -28070,7 +28939,7 @@ Distributed under the MIT License
 
 GitHub Authentication
 ---------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -28078,7 +28947,7 @@ Distributed under the MIT License
 
 github-from-package
 -------------------
-Website: https://github.com/substack/github-from-package
+Source: https://github.com/substack/github-from-package
 
 Published by James Halliday
 Distributed under the MIT License
@@ -28086,7 +28955,7 @@ Distributed under the MIT License
 
 @github/copilot
 ---------------
-Website: https://github.com/github/copilot-cli
+Source: https://github.com/github/copilot-cli
 
 Copyright GitHub 2025. Use is subject to GitHub's Pre-release License Terms
 
@@ -28096,41 +28965,9 @@ SEE-LICENSE-IN-LICENSE.MD License text:
 Copyright (c) GitHub 2025. All rights reserved. Use is subject to GitHub's Pre-release License Terms
 
 
-@github/copilot-language-server
--------------------------------
-Website: https://github.com/github/copilot-language-server-release
-
-Copyright (c) 2025 GitHub
-Distributed under the MIT License
-
-MIT License text:
-
-MIT License
-
-Copyright (c) 2025 GitHub
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
 glob versions 10.4.5, 9.3.5
 ---------------------------
-Website: https://github.com/isaacs/node-glob
+Source: https://github.com/isaacs/node-glob
 
 Copyright 2009-2023 Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -28156,7 +28993,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 glob version 7.2.3
 ------------------
-Website: https://github.com/isaacs/node-glob
+Source: https://github.com/isaacs/node-glob
 
 Copyright Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -28188,7 +29025,7 @@ https://creativecommons.org/licenses/by-sa/4.0/
 
 globals
 -------
-Website: https://github.com/sindresorhus/globals
+Source: https://github.com/sindresorhus/globals
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -28208,7 +29045,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 globwalk
 --------
-Website: https://github.com/gilnaa/globwalk
+Source: https://github.com/gilnaa/globwalk
 
 Copyright 2017 Gilad Naaman
 Distributed under the MIT License
@@ -28238,7 +29075,7 @@ SOFTWARE.
 
 Go Language Basics
 ------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -28246,7 +29083,7 @@ Distributed under the MIT License
 
 go-syntax
 ---------
-Website: https://github.com/worlpaker/go-syntax
+Source: https://github.com/worlpaker/go-syntax
 
 Copyright (c) 2023 Furkan Ozalp
 Distributed under the MIT License
@@ -28254,7 +29091,7 @@ Distributed under the MIT License
 
 google-auth-library
 -------------------
-Website: https://github.com/googleapis/google-auth-library-nodejs
+Source: https://github.com/googleapis/google-auth-library-nodejs
 
 Published by Google Inc.
 Distributed under the Apache License version 2.0
@@ -28262,7 +29099,7 @@ Distributed under the Apache License version 2.0
 
 @google-cloud/paginator
 -----------------------
-Website: https://github.com/googleapis/nodejs-paginator
+Source: https://github.com/googleapis/nodejs-paginator
 
 Published by Google Inc.
 Distributed under the Apache License version 2.0
@@ -28270,7 +29107,7 @@ Distributed under the Apache License version 2.0
 
 @google-cloud/projectify
 ------------------------
-Website: https://github.com/googleapis/nodejs-projectify
+Source: https://github.com/googleapis/nodejs-projectify
 
 Published by Google Inc.
 Distributed under the Apache License version 2.0
@@ -28278,7 +29115,7 @@ Distributed under the Apache License version 2.0
 
 @google-cloud/promisify
 -----------------------
-Website: https://github.com/googleapis/nodejs-promisify
+Source: https://github.com/googleapis/nodejs-promisify
 
 Published by Google Inc.
 Distributed under the Apache License version 2.0
@@ -28286,7 +29123,7 @@ Distributed under the Apache License version 2.0
 
 @google-cloud/storage
 ---------------------
-Website: https://github.com/googleapis/nodejs-storage
+Source: https://github.com/googleapis/nodejs-storage
 
 Published by Google Inc.
 Distributed under the Apache License version 2.0
@@ -28294,7 +29131,7 @@ Distributed under the Apache License version 2.0
 
 google-logging-utils
 --------------------
-Website: https://github.com/googleapis/gax-nodejs
+Source: https://github.com/googleapis/gax-nodejs
 
 Published by Google API Authors
 Distributed under the Apache License version 2.0
@@ -28302,7 +29139,7 @@ Distributed under the Apache License version 2.0
 
 @google/genai
 -------------
-Website: https://github.com/googleapis/js-genai
+Source: https://github.com/googleapis/js-genai
 
 Copyright 2025 Google LLC
 Distributed under the Apache License version 2.0
@@ -28310,7 +29147,7 @@ Distributed under the Apache License version 2.0
 
 gopd
 ----
-Website: https://github.com/ljharb/gopd
+Source: https://github.com/ljharb/gopd
 
 Copyright 2022 Jordan Harband
 Distributed under the MIT License
@@ -28342,7 +29179,7 @@ SOFTWARE.
 
 graceful-fs
 -----------
-Website: https://github.com/isaacs/node-graceful-fs
+Source: https://github.com/isaacs/node-graceful-fs
 
 Copyright 2011-2022 Isaac Z. Schlueter, Ben Noordhuis, and Contributors
 Distributed under the ISC License
@@ -28368,7 +29205,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 graphql
 -------
-Website: https://github.com/graphql/graphql-js
+Source: https://github.com/graphql/graphql-js
 
 Copyright GraphQL Contributors
 Distributed under the MIT License
@@ -28400,7 +29237,7 @@ SOFTWARE.
 
 graphql-tag
 -----------
-Website: https://github.com/apollographql/graphql-tag
+Source: https://github.com/apollographql/graphql-tag
 
 Copyright 2021 Apollo Graph, Inc. (Formerly Meteor Development Group, Inc.)
 Distributed under the MIT License
@@ -28432,7 +29269,7 @@ SOFTWARE.
 
 Groovy Language Basics
 ----------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -28440,7 +29277,7 @@ Distributed under the MIT License
 
 Groovy tmBundle
 ---------------
-Website: https://github.com/textmate/groovy.tmbundle
+Source: https://github.com/textmate/groovy.tmbundle
 
 Copyright (c) textmate-groovy.tmbundle project authors
 
@@ -28464,7 +29301,7 @@ to the base-name name of the original file, and an extension of txt, html, or si
 
 gtoken
 ------
-Website: https://github.com/googleapis/node-gtoken
+Source: https://github.com/googleapis/node-gtoken
 
 Copyright 2014 Ryan Seys
 Distributed under the MIT License
@@ -28496,7 +29333,7 @@ THE SOFTWARE.
 
 Gulp support for VSCode
 -----------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -28504,7 +29341,7 @@ Distributed under the MIT License
 
 h2
 --
-Website: https://github.com/hyperium/h2
+Source: https://github.com/hyperium/h2
 
 Copyright 2017 h2 authors
 Distributed under the MIT License
@@ -28540,7 +29377,7 @@ DEALINGS IN THE SOFTWARE.
 
 hachure-fill
 ------------
-Website: https://github.com/pshihn/hachure-fill
+Source: https://github.com/pshihn/hachure-fill
 
 Copyright 2023 Preet Shihn
 Distributed under the MIT License
@@ -28572,7 +29409,7 @@ SOFTWARE.
 
 Handlebars
 ----------
-Website: https://github.com/daaain/Handlebars
+Source: https://github.com/daaain/Handlebars
 
 Copyright (c) Handlebars contributors
 Distributed under the MIT License
@@ -28580,7 +29417,7 @@ Distributed under the MIT License
 
 Handlebars Language Basics
 --------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -28588,7 +29425,7 @@ Distributed under the MIT License
 
 has-flag
 --------
-Website: https://github.com/sindresorhus/has-flag
+Source: https://github.com/sindresorhus/has-flag
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -28608,7 +29445,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 has-symbols
 -----------
-Website: https://github.com/inspect-js/has-symbols
+Source: https://github.com/inspect-js/has-symbols
 
 Copyright 2016 Jordan Harband
 Distributed under the MIT License
@@ -28640,7 +29477,7 @@ SOFTWARE.
 
 has-tostringtag
 ---------------
-Website: https://github.com/inspect-js/has-tostringtag
+Source: https://github.com/inspect-js/has-tostringtag
 
 Copyright 2021 Inspect JS
 Distributed under the MIT License
@@ -28672,7 +29509,7 @@ SOFTWARE.
 
 hashbrown
 ---------
-Website: https://github.com/rust-lang/hashbrown
+Source: https://github.com/rust-lang/hashbrown
 
 Copyright 2016 Amanieu d'Antras
 
@@ -28712,7 +29549,7 @@ DEALINGS IN THE SOFTWARE.
 
 hashes
 ------
-Website: https://github.com/RustCrypto/hashes
+Source: https://github.com/RustCrypto/hashes
 
 Copyright 2006-2009 Graydon Hoare
 Copyright 2009-2013 Mozilla Foundation
@@ -28758,7 +29595,7 @@ DEALINGS IN THE SOFTWARE.
 
 hasown
 ------
-Website: https://github.com/inspect-js/hasOwn
+Source: https://github.com/inspect-js/hasOwn
 
 Copyright Jordan Harband and contributors
 Distributed under the MIT License
@@ -28790,7 +29627,7 @@ SOFTWARE.
 
 he
 --
-Website: https://github.com/mathiasbynens/he
+Source: https://github.com/mathiasbynens/he
 
 Copyright Mathias Bynens <https:mathiasbynens.be/>
 Distributed under the MIT License
@@ -28821,7 +29658,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 heck
 ----
-Website: https://github.com/withoutboats/heck
+Source: https://github.com/withoutboats/heck
 
 Copyright 2015 The Rust Project Developers
 
@@ -28861,7 +29698,7 @@ DEALINGS IN THE SOFTWARE.
 
 hermit-abi
 ----------
-Website: https://github.com/hermit-os/hermit-rs
+Source: https://github.com/hermit-os/hermit-rs
 
 Published by Stefan Lankes
 
@@ -28873,7 +29710,7 @@ Consult the documentation and source code of hermit-abi for more information.
 
 hex
 ---
-Website: https://github.com/KokaKiwi/rust-hex
+Source: https://github.com/KokaKiwi/rust-hex
 
 Copyright 2013-2014 The Rust Project Developers.
 Copyright 2015-2020 The rust-hex Developers
@@ -28910,7 +29747,7 @@ SOFTWARE.
 
 highlight.js
 ------------
-Website: https://github.com/highlightjs/highlight.js
+Source: https://github.com/highlightjs/highlight.js
 
 Copyright 2006, Ivan Sagalaev.
 Distributed under the BSD 3-Clause license
@@ -28951,7 +29788,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 HLSL Language Basics
 --------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -28959,7 +29796,7 @@ Distributed under the MIT License
 
 hmac
 ----
-Website: https://github.com/RustCrypto/MACs
+Source: https://github.com/RustCrypto/MACs
 
 Copyright 2017 Artyom Pavlov
 
@@ -28999,7 +29836,7 @@ DEALINGS IN THE SOFTWARE.
 
 home
 ----
-Website: https://github.com/rust-lang/cargo
+Source: https://github.com/rust-lang/cargo
 
 Published by Brian Anderson <andersrb@gmail.com>
 
@@ -29011,7 +29848,7 @@ Consult the documentation and source code of home for more information.
 
 homedir-polyfill
 ----------------
-Website: https://github.com/doowb/homedir-polyfill
+Source: https://github.com/doowb/homedir-polyfill
 
 Copyright 2016 Brian Woodward
 Distributed under the MIT License
@@ -29043,7 +29880,7 @@ SOFTWARE.
 
 HTML 5.1 W3C Working Draft 08 October 2015
 ------------------------------------------
-Website: http://www.w3.org/TR/2015/WD-html51-20151008/
+Source: http://www.w3.org/TR/2015/WD-html51-20151008/
 
 Copyright (c) 2015 W3C(r) (MIT, ERCIM, Keio, Beihang).
 
@@ -29573,7 +30410,7 @@ dir="auto"
 
 HTML Language Basics
 --------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -29581,7 +30418,7 @@ Distributed under the MIT License
 
 HTML Language Features
 ----------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -29589,7 +30426,7 @@ Distributed under the MIT License
 
 HTML tmBundle
 -------------
-Website: https://github.com/textmate/html.tmbundle
+Source: https://github.com/textmate/html.tmbundle
 
 Copyright (c) textmate-html.tmbundle project authors
 
@@ -29613,7 +30450,7 @@ to the base-name name of the original file, and an extension of txt, html, or si
 
 html-entities
 -------------
-Website: https://github.com/mdevils/html-entities
+Source: https://github.com/mdevils/html-entities
 
 Copyright 2021 Dulin Marat
 Distributed under the MIT License
@@ -29643,7 +30480,7 @@ THE SOFTWARE.
 
 html5ever
 ---------
-Website: https://github.com/servo/html5ever
+Source: https://github.com/servo/html5ever
 
 Copyright 2014 The html5ever Project Developers
 
@@ -29683,7 +30520,7 @@ DEALINGS IN THE SOFTWARE.
 
 http
 ----
-Website: https://github.com/hyperium/http
+Source: https://github.com/hyperium/http
 
 Copyright 2017 http-rs authors
 
@@ -29930,7 +30767,7 @@ DEALINGS IN THE SOFTWARE.
 
 http-body
 ---------
-Website: https://github.com/hyperium/http-body
+Source: https://github.com/hyperium/http-body
 
 Copyright 2019-2024 Sean McArthur & Hyper Contributors
 Distributed under the MIT License
@@ -29966,7 +30803,7 @@ DEALINGS IN THE SOFTWARE.
 
 http-body-util
 --------------
-Website: https://github.com/hyperium/http-body
+Source: https://github.com/hyperium/http-body
 
 Copyright 2019 Hyper Contributors
 Distributed under the MIT License
@@ -30002,7 +30839,7 @@ DEALINGS IN THE SOFTWARE.
 
 http-errors
 -----------
-Website: https://github.com/jshttp/http-errors
+Source: https://github.com/jshttp/http-errors
 
 Copyright 2014 Jonathan Ong me@jongleberry.com
 Copyright 2016 Douglas Christopher Wilson doug@somethingdoug.com
@@ -30037,7 +30874,7 @@ THE SOFTWARE.
 
 http-proxy
 ----------
-Website: https://github.com/http-party/node-http-proxy
+Source: https://github.com/http-party/node-http-proxy
 
 Copyright 2010-2016 Charlie Robbins, Jarrett Cruger & the Contributors.
 Distributed under the MIT License
@@ -30070,7 +30907,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 http-proxy-agent
 ----------------
-Website: https://github.com/TooTallNate/proxy-agents
+Source: https://github.com/TooTallNate/proxy-agents
 
 Copyright 2013 Nathan Rajlich <nathan@tootallnate.net>
 Distributed under the MIT License
@@ -30103,7 +30940,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 http-proxy-middleware
 ---------------------
-Website: https://github.com/chimurai/http-proxy-middleware
+Source: https://github.com/chimurai/http-proxy-middleware
 
 Copyright 2015 Steven Chim
 Distributed under the MIT License
@@ -30135,7 +30972,7 @@ SOFTWARE.
 
 httparse
 --------
-Website: https://github.com/seanmonstar/httparse
+Source: https://github.com/seanmonstar/httparse
 
 Copyright 2015-2024 Sean McArthur
 
@@ -30169,7 +31006,7 @@ THE SOFTWARE.
 
 httpdate
 --------
-Website: https://github.com/pyfisch/httpdate
+Source: https://github.com/pyfisch/httpdate
 
 Copyright 2016 Pyfisch
 
@@ -30203,7 +31040,7 @@ THE SOFTWARE.
 
 https-proxy-agent
 -----------------
-Website: https://github.com/TooTallNate/proxy-agents
+Source: https://github.com/TooTallNate/proxy-agents
 
 Copyright 2013 Nathan Rajlich <nathan@tootallnate.net>
 Distributed under the MIT License
@@ -30236,7 +31073,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 humantime
 ---------
-Website: https://github.com/tailhook/humantime
+Source: https://github.com/tailhook/humantime
 
 Copyright 2016 Pyfisch
 Copyright 2016 The humantime Developers
@@ -30280,7 +31117,7 @@ SOFTWARE.
 
 @humanwhocodes/gitignore-to-minimatch
 -------------------------------------
-Website: https://github.com/humanwhocodes/gitignore-to-minimatch
+Source: https://github.com/humanwhocodes/gitignore-to-minimatch
 
 Published by Nicholas C. Zaks
 Distributed under the Apache License version 2.0
@@ -30288,7 +31125,7 @@ Distributed under the Apache License version 2.0
 
 hyper
 -----
-Website: https://github.com/hyperium/hyper
+Source: https://github.com/hyperium/hyper
 
 Copyright 2014-2021 Sean McArthur
 Distributed under the MIT License
@@ -30318,7 +31155,7 @@ THE SOFTWARE.
 
 hyper-old-types
 ---------------
-Website: https://github.com/hyperium/hyper-old-types
+Source: https://github.com/hyperium/hyper-old-types
 
 Copyright 2014 Sean McArthur
 Distributed under the MIT License
@@ -30348,7 +31185,7 @@ THE SOFTWARE.
 
 hyper-util
 ----------
-Website: https://github.com/hyperium/hyper-util
+Source: https://github.com/hyperium/hyper-util
 
 Copyright 2023 Sean McArthur
 Distributed under the MIT License
@@ -30378,7 +31215,7 @@ THE SOFTWARE.
 
 hyperlocal
 ----------
-Website: https://github.com/softprops/hyperlocal
+Source: https://github.com/softprops/hyperlocal
 
 Copyright 2015-2020 Doug Tangren
 Distributed under the MIT License
@@ -30409,7 +31246,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 iana-time-zone
 --------------
-Website: https://github.com/strawlab/iana-time-zone
+Source: https://github.com/strawlab/iana-time-zone
 
 Copyright 2020 Andrew D. Straw
 Copyright 2020 Andrew Straw
@@ -30657,7 +31494,7 @@ DEALINGS IN THE SOFTWARE.
 
 @iarna/toml
 -----------
-Website: https://github.com/iarna/iarna-toml
+Source: https://github.com/iarna/iarna-toml
 
 Copyright 2016, Rebecca Turner <me@re-becca.org>
 Distributed under the ISC License
@@ -30681,7 +31518,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 @iconify/types
 --------------
-Website: https://github.com/iconify/iconify
+Source: https://github.com/iconify/iconify
 
 Copyright 2021 - 2022 Vjacheslav Trushkin / Iconify OÜ
 Distributed under the MIT License
@@ -30713,7 +31550,7 @@ SOFTWARE.
 
 @iconify/utils
 --------------
-Website: https://github.com/iconify/iconify
+Source: https://github.com/iconify/iconify
 
 Copyright 2021-PRESENT Vjacheslav Trushkin
 Distributed under the MIT License
@@ -30745,7 +31582,7 @@ SOFTWARE.
 
 iconv-lite
 ----------
-Website: https://github.com/ashtuchkin/iconv-lite
+Source: https://github.com/ashtuchkin/iconv-lite
 
 Copyright 2011 Alexander Shtuchkin
 Distributed under the MIT License
@@ -30776,7 +31613,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 icu4x
 -----
-Website: https://github.com/unicode-org/icu4x
+Source: https://github.com/unicode-org/icu4x
 
 Copyright © 2020-2024 Unicode, Inc.
 Distributed under the Unicode License v3
@@ -30833,7 +31670,7 @@ ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation a
 
 id-arena
 --------
-Website: https://github.com/fitzgen/id-arena
+Source: https://github.com/fitzgen/id-arena
 
 Copyright 2014 Alex Crichton
 
@@ -30873,7 +31710,7 @@ DEALINGS IN THE SOFTWARE.
 
 ident_case
 ----------
-Website: https://github.com/TedDriggs/ident_case
+Source: https://github.com/TedDriggs/ident_case
 
 Published by Ted Driggs <ted.driggs@outlook.com>
 
@@ -30885,7 +31722,7 @@ Consult the documentation and source code of ident_case for more information.
 
 idna_adapter
 ------------
-Website: https://github.com/hsivonen/idna_adapter
+Source: https://github.com/hsivonen/idna_adapter
 
 Copyright The rust-url developers
 
@@ -30925,7 +31762,7 @@ DEALINGS IN THE SOFTWARE.
 
 ieee754
 -------
-Website: https://github.com/feross/ieee754
+Source: https://github.com/feross/ieee754
 
 Copyright 2008 Fair Oaks Labs, Inc.
 Distributed under the BSD 3-Clause license
@@ -30947,7 +31784,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 if_chain
 --------
-Website: https://github.com/lambda-fairy/if_chain
+Source: https://github.com/lambda-fairy/if_chain
 
 Copyright 2018 Chris Wong
 
@@ -30987,7 +31824,7 @@ DEALINGS IN THE SOFTWARE.
 
 ignore
 ------
-Website: https://github.com/kaelzhang/node-ignore
+Source: https://github.com/kaelzhang/node-ignore
 
 Copyright 2013 Kael Zhang <i@kael.me>, contributors http:kael.me/
 Distributed under the MIT License
@@ -31019,7 +31856,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 image-size
 ----------
-Website: https://github.com/image-size/image-size
+Source: https://github.com/image-size/image-size
 
 Copyright © 2017 Aditya Yadav, http:netroy.in
 Distributed under the MIT License
@@ -31039,7 +31876,7 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 
 impl-more
 ---------
-Website: https://github.com/robjtede/impl-more
+Source: https://github.com/robjtede/impl-more
 
 Copyright 2022-NOW Rob Ede
 
@@ -31286,7 +32123,7 @@ DEALINGS IN THE SOFTWARE.
 
 import-in-the-middle
 --------------------
-Website: https://github.com/nodejs/import-in-the-middle
+Source: https://github.com/nodejs/import-in-the-middle
 
 Published by Bryan English <bryan.english@datadoghq.com>
 Distributed under the Apache License version 2.0
@@ -31294,7 +32131,7 @@ Distributed under the Apache License version 2.0
 
 importlib-metadata
 ------------------
-Website: https://github.com/python/importlib_metadata
+Source: https://github.com/python/importlib_metadata
 
 Copyright (c) Jason R. Coombs
 Distributed under the Apache License version 2.0
@@ -31302,7 +32139,7 @@ Distributed under the Apache License version 2.0
 
 indexmap
 --------
-Website: https://github.com/indexmap-rs/indexmap
+Source: https://github.com/indexmap-rs/indexmap
 
 Copyright 2016--2017
 
@@ -31342,7 +32179,7 @@ DEALINGS IN THE SOFTWARE.
 
 inflight
 --------
-Website: https://github.com/npm/inflight
+Source: https://github.com/npm/inflight
 
 Copyright Isaac Z. Schlueter
 Distributed under the ISC License
@@ -31368,7 +32205,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 inherits
 --------
-Website: https://github.com/isaacs/inherits
+Source: https://github.com/isaacs/inherits
 
 Copyright Isaac Z. Schlueter
 Distributed under the ISC License
@@ -31394,7 +32231,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 ini
 ---
-Website: https://github.com/isaacs/ini
+Source: https://github.com/isaacs/ini
 
 Copyright Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -31420,7 +32257,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ini tmBundle
 ------------
-Website: https://github.com/textmate/ini.tmbundle
+Source: https://github.com/textmate/ini.tmbundle
 
 Copyright (c) textmate-ini.tmbundle project authors
 
@@ -31444,7 +32281,7 @@ to the base-name name of the original file, and an extension of txt, html, or si
 
 inotify
 -------
-Website: https://github.com/hannobraun/inotify
+Source: https://github.com/hannobraun/inotify
 
 Copyright Hanno Braun and contributors
 Distributed under the ISC License
@@ -31468,7 +32305,7 @@ THIS SOFTWARE.
 
 inotify-sys
 -----------
-Website: https://github.com/hannobraun/inotify-sys
+Source: https://github.com/hannobraun/inotify-sys
 
 Copyright Hanno Braun and contributors
 Distributed under the ISC License
@@ -31492,7 +32329,7 @@ THIS SOFTWARE.
 
 insta
 -----
-Website: https://github.com/mitsuhiko/insta
+Source: https://github.com/mitsuhiko/insta
 
 Published by Armin Ronacher <armin.ronacher@active-4.com>
 Distributed under the Apache License version 2.0
@@ -31500,7 +32337,7 @@ Distributed under the Apache License version 2.0
 
 instant
 -------
-Website: https://github.com/sebcrozet/instant
+Source: https://github.com/sebcrozet/instant
 
 Copyright 2019, Sébastien Crozet
 Distributed under the BSD 3-Clause license
@@ -31539,7 +32376,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 internmap
 ---------
-Website: https://github.com/mbostock/internmap
+Source: https://github.com/mbostock/internmap
 
 Copyright 2021 Mike Bostock
 Distributed under the ISC License
@@ -31563,7 +32400,7 @@ THIS SOFTWARE.
 
 inversify
 ---------
-Website: https://github.com/inversify/InversifyJS
+Source: https://github.com/inversify/InversifyJS
 
 Copyright 2015-2017 Remo H. Jansen
 Distributed under the MIT License
@@ -31595,7 +32432,7 @@ SOFTWARE.
 
 io-lifetimes
 ------------
-Website: https://github.com/sunfishcode/io-lifetimes
+Source: https://github.com/sunfishcode/io-lifetimes
 
 Published by Dan Gohman <dev@sunfishcode.online>
 
@@ -31607,7 +32444,7 @@ Consult the documentation and source code of io-lifetimes for more information.
 
 Ionic documentation
 -------------------
-Website: https://github.com/ionic-team/ionic-site
+Source: https://github.com/ionic-team/ionic-site
 
 Copyright 2016 Drifty Co.
 Distributed under the Apache License version 2.0
@@ -31615,7 +32452,7 @@ Distributed under the Apache License version 2.0
 
 Ionide FsGrammar
 ----------------
-Website: https://github.com/ionide/ionide-fsgrammar
+Source: https://github.com/ionide/ionide-fsgrammar
 
 Copyright (c) 2015 Krzysztof Cieslak
 Distributed under the MIT License
@@ -31623,7 +32460,7 @@ Distributed under the MIT License
 
 iovec
 -----
-Website: https://github.com/carllerche/iovec
+Source: https://github.com/carllerche/iovec
 
 Copyright 2017 Carl Lerche
 
@@ -31870,7 +32707,7 @@ DEALINGS IN THE SOFTWARE.
 
 ip-address
 ----------
-Website: https://github.com/beaugunderson/ip-address
+Source: https://github.com/beaugunderson/ip-address
 
 Copyright (C) 2011 by Beau Gunderson
 Distributed under the MIT License
@@ -31900,7 +32737,7 @@ THE SOFTWARE.
 
 ipaddr.js
 ---------
-Website: https://github.com/whitequark/ipaddr.js
+Source: https://github.com/whitequark/ipaddr.js
 
 Copyright (C) 2011-2017 whitequark <whitequark@whitequark.org>
 Distributed under the MIT License
@@ -31930,7 +32767,7 @@ THE SOFTWARE.
 
 ipnet
 -----
-Website: https://github.com/krisprice/ipnet
+Source: https://github.com/krisprice/ipnet
 
 Copyright 2017 Juniper Networks, Inc.
 
@@ -32159,7 +32996,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ipykernel
 ---------
-Website: https://github.com/ipython/ipykernel
+Source: https://github.com/ipython/ipykernel
 
 Copyright 2015, IPython Development Team
 Distributed under the BSD 3-Clause license
@@ -32200,7 +33037,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ipython
 -------
-Website: https://github.com/ipython/ipython
+Source: https://github.com/ipython/ipython
 
 Copyright 2001, Janko Hauser <jhauser@zscout.de> -
 Copyright 2001, Nathaniel Gray <n8gray@caltech.edu>
@@ -32247,7 +33084,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 is-core-module
 --------------
-Website: https://github.com/inspect-js/is-core-module
+Source: https://github.com/inspect-js/is-core-module
 
 Copyright 2014 Dave Justice
 Distributed under the MIT License
@@ -32278,7 +33115,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 is-docker
 ---------
-Website: https://github.com/sindresorhus/is-docker
+Source: https://github.com/sindresorhus/is-docker
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -32298,7 +33135,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 is-extglob
 ----------
-Website: https://github.com/micromatch/is-extglob
+Source: https://github.com/micromatch/is-extglob
 
 Copyright 2014-2016, Jon Schlinkert
 Distributed under the MIT License
@@ -32330,7 +33167,7 @@ THE SOFTWARE.
 
 is-fullwidth-code-point
 -----------------------
-Website: https://github.com/sindresorhus/is-fullwidth-code-point
+Source: https://github.com/sindresorhus/is-fullwidth-code-point
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -32350,7 +33187,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 is-glob
 -------
-Website: https://github.com/micromatch/is-glob
+Source: https://github.com/micromatch/is-glob
 
 Copyright 2014-2017, Jon Schlinkert.
 Distributed under the MIT License
@@ -32382,7 +33219,7 @@ THE SOFTWARE.
 
 is-inside-container
 -------------------
-Website: https://github.com/sindresorhus/is-inside-container
+Source: https://github.com/sindresorhus/is-inside-container
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -32402,7 +33239,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 is-number
 ---------
-Website: https://github.com/jonschlinkert/is-number
+Source: https://github.com/jonschlinkert/is-number
 
 Copyright 2014-present, Jon Schlinkert.
 Distributed under the MIT License
@@ -32434,7 +33271,7 @@ THE SOFTWARE.
 
 is-plain-object
 ---------------
-Website: https://github.com/jonschlinkert/is-plain-object
+Source: https://github.com/jonschlinkert/is-plain-object
 
 Copyright 2014-2017, Jon Schlinkert.
 Distributed under the MIT License
@@ -32466,7 +33303,7 @@ THE SOFTWARE.
 
 is-stream
 ---------
-Website: https://github.com/sindresorhus/is-stream
+Source: https://github.com/sindresorhus/is-stream
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -32486,7 +33323,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 is-terminal
 -----------
-Website: https://github.com/sunfishcode/is-terminal
+Source: https://github.com/sunfishcode/is-terminal
 
 Copyright 2015-2019 Doug Tangren
 Distributed under the MIT License
@@ -32494,7 +33331,7 @@ Distributed under the MIT License
 
 is-wsl
 ------
-Website: https://github.com/sindresorhus/is-wsl
+Source: https://github.com/sindresorhus/is-wsl
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -32514,7 +33351,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 @isaacs/balanced-match
 ----------------------
-Website: https://github.com/isaacs/balanced-match
+Source: https://github.com/isaacs/balanced-match
 
 Copyright (c) 2013 Julian Gruber <julian@juliangruber.com>
 Distributed under the MIT License
@@ -32522,7 +33359,7 @@ Distributed under the MIT License
 
 @isaacs/brace-expansion
 -----------------------
-Website: https://npmjs.com/package/@isaacs/brace-expansion/v/5.0.0
+Source: https://npmjs.com/package/@isaacs/brace-expansion/v/5.0.0
 
 Copyright Julian Gruber <julian@juliangruber.com>
 Distributed under the MIT License
@@ -32556,7 +33393,7 @@ SOFTWARE.
 
 @isaacs/cliui
 -------------
-Website: https://github.com/yargs/cliui
+Source: https://github.com/yargs/cliui
 
 Copyright 2015, Contributors
 Distributed under the ISC License
@@ -32581,7 +33418,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 isbinaryfile
 ------------
-Website: https://github.com/gjtorikian/isBinaryFile
+Source: https://github.com/gjtorikian/isBinaryFile
 
 Copyright 2019 Garen J. Torikian
 Distributed under the MIT License
@@ -32614,7 +33451,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 isexe
 -----
-Website: https://github.com/isaacs/isexe
+Source: https://github.com/isaacs/isexe
 
 Copyright 2016-2022 Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -32640,7 +33477,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 is_terminal_polyfill
 --------------------
-Website: https://github.com/polyfill-rs/is_terminal_polyfill
+Source: https://github.com/polyfill-rs/is_terminal_polyfill
 
 Copyright Individual contributors
 
@@ -32674,7 +33511,7 @@ SOFTWARE.
 
 itertools
 ---------
-Website: https://github.com/rust-itertools/itertools
+Source: https://github.com/rust-itertools/itertools
 
 Copyright 2015 bluss
 
@@ -32714,7 +33551,7 @@ DEALINGS IN THE SOFTWARE.
 
 itoa
 ----
-Website: https://github.com/dtolnay/itoa
+Source: https://github.com/dtolnay/itoa
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -32726,7 +33563,7 @@ Consult the documentation and source code of itoa for more information.
 
 jackspeak
 ---------
-Website: https://github.com/isaacs/jackspeak
+Source: https://github.com/isaacs/jackspeak
 
 Published by Isaac Z. Schlueter <i@izs.me>
 Distributed under the Blue Oak Model License version 1.0.0
@@ -32734,7 +33571,7 @@ Distributed under the Blue Oak Model License version 1.0.0
 
 Jake support for VS Code
 ------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -32742,7 +33579,7 @@ Distributed under the MIT License
 
 Java Language Basics
 --------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -32750,7 +33587,7 @@ Distributed under the MIT License
 
 JavaScript Language Basics
 --------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -32758,7 +33595,7 @@ Distributed under the MIT License
 
 JavaScript tmBundle
 -------------------
-Website: https://github.com/textmate/javascript.tmbundle
+Source: https://github.com/textmate/javascript.tmbundle
 
 Copyright (c) textmate-javascript.tmbundle project authors
 
@@ -32782,7 +33619,7 @@ to the base-name name of the original file, and an extension of txt, html, or si
 
 @jeanp413/ssh-config
 --------------------
-Website: https://github.com/cyjake/ssh-config
+Source: https://github.com/cyjake/ssh-config
 
 Copyright 2017 Chen Yangjian
 Distributed under the MIT License
@@ -32814,7 +33651,7 @@ SOFTWARE.
 
 jedi
 ----
-Website: https://github.com/davidhalter/jedi
+Source: https://github.com/davidhalter/jedi
 
 Published by David Halter
 Distributed under the MIT License
@@ -32822,7 +33659,7 @@ Distributed under the MIT License
 
 jedi-language-server
 --------------------
-Website: https://github.com/pappasam/jedi-language-server
+Source: https://github.com/pappasam/jedi-language-server
 
 Published by Sam Roeca
 Distributed under the MIT License
@@ -32830,7 +33667,7 @@ Distributed under the MIT License
 
 @joaomoreno/unique-names-generator
 ----------------------------------
-Website: https://github.com/joaomoreno/unique-names-generator
+Source: https://github.com/joaomoreno/unique-names-generator
 
 Copyright 2018-2022 AndreaSonny <andreasonny83@gmail.com> (https:github.com/andreasonny83)
 Copyright 2022 João Moreno <mail@joaomoreno.com> (https:github.com/joaomoreno)
@@ -32853,7 +33690,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 jobserver
 ---------
-Website: https://github.com/rust-lang/jobserver-rs
+Source: https://github.com/rust-lang/jobserver-rs
 
 Copyright 2014 Alex Crichton
 
@@ -32893,7 +33730,7 @@ DEALINGS IN THE SOFTWARE.
 
 js-base64
 ---------
-Website: https://github.com/dankogai/js-base64
+Source: https://github.com/dankogai/js-base64
 
 Copyright 2014, Dan Kogai
 Distributed under the BSD 3-Clause license
@@ -32932,7 +33769,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 js-beautify
 -----------
-Website: https://github.com/beautify-web/js-beautify
+Source: https://github.com/beautify-web/js-beautify
 
 Copyright (c) 2007-2018 Einar Lielmanis, Liam Newman, and contributors.
 Distributed under the MIT License
@@ -32940,7 +33777,7 @@ Distributed under the MIT License
 
 js-tokens
 ---------
-Website: https://github.com/lydell/js-tokens
+Source: https://github.com/lydell/js-tokens
 
 Copyright 2014, 2015, 2016, 2017, 2018 Simon Lydell
 Distributed under the MIT License
@@ -32972,7 +33809,7 @@ THE SOFTWARE.
 
 js-yaml
 -------
-Website: https://github.com/nodeca/js-yaml
+Source: https://github.com/nodeca/js-yaml
 
 Copyright (C) 2011-2015 by Vitaly Puzrin
 Distributed under the MIT License
@@ -33004,7 +33841,7 @@ THE SOFTWARE.
 
 jsbn
 ----
-Website: https://github.com/andyperlitch/jsbn
+Source: https://github.com/andyperlitch/jsbn
 
 Copyright 2003-2005 Tom Wu
 Distributed under the MIT License
@@ -33059,7 +33896,7 @@ tjw@cs.Stanford.EDU
 
 jschardet
 ---------
-Website: https://github.com/aadsm/jschardet
+Source: https://github.com/aadsm/jschardet
 
 Copyright (C) 1991, 1999 Free Software Foundation, Inc. 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 Distributed under the GNU Lesser General Public License version 2.1 or later
@@ -33578,7 +34415,7 @@ That's all there is to it!
 
 JSON Language Basics
 --------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -33586,7 +34423,7 @@ Distributed under the MIT License
 
 JSON Language Features
 ----------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -33594,7 +34431,7 @@ Distributed under the MIT License
 
 json-bigint
 -----------
-Website: https://github.com/sidorares/json-bigint
+Source: https://github.com/sidorares/json-bigint
 
 Copyright 2013 Andrey Sidorov
 Distributed under the MIT License
@@ -33625,7 +34462,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 json-bignum
 -----------
-Website: https://github.com/datalanche/json-bignum
+Source: https://github.com/datalanche/json-bignum
 
 Copyright 2012-2013 Datalanche, Inc.
 Distributed under the MIT License
@@ -33653,9 +34490,218 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
+json-schema
+-----------
+Source: https://github.com/kriszyp/json-schema
+
+Copyright 2005-2015, The Dojo Foundation
+
+Distributed under multiple software licenses, including:
+    Academic Free License version 2.1
+    BSD 3-Clause license
+Consult the documentation and source code of json-schema for more information.
+
+License text (Academic Free License version 2.1, BSD 3-Clause license):
+
+Dojo is available under **either** the terms of the BSD 3-Clause "New" License **or** the
+Academic Free License version 2.1. As a recipient of Dojo, you may choose which
+license to receive this code under (except as noted in per-module LICENSE
+files). Some modules may not be the copyright of the Dojo Foundation. These
+modules contain explicit declarations of copyright in both the LICENSE files in
+the directories in which they reside and in the code itself. No external
+contributions are allowed under licenses which are fundamentally incompatible
+with the AFL-2.1 OR and BSD-3-Clause licenses that Dojo is distributed under.
+
+The text of the AFL-2.1 and BSD-3-Clause licenses is reproduced below.
+
+-------------------------------------------------------------------------------
+BSD 3-Clause "New" License:
+
+Copyright (c) 2005-2015, The Dojo Foundation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the Dojo Foundation nor the names of its contributors
+  may be used to endorse or promote products derived from this software
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-------------------------------------------------------------------------------
+The Academic Free License, v. 2.1:
+
+This Academic Free License (the "License") applies to any original work of
+authorship (the "Original Work") whose owner (the "Licensor") has placed the
+following notice immediately following the copyright notice for the Original
+Work:
+
+Licensed under the Academic Free License version 2.1
+
+1) Grant of Copyright License. Licensor hereby grants You a world-wide,
+   royalty-free, non-exclusive, perpetual, sublicenseable license to do the
+   following:
+
+   a) to reproduce the Original Work in copies;
+
+   b) to prepare derivative works ("Derivative Works") based upon the Original
+      Work;
+
+   c) to distribute copies of the Original Work and Derivative Works to the
+      public;
+
+   d) to perform the Original Work publicly; and
+
+   e) to display the Original Work publicly.
+
+2) Grant of Patent License. Licensor hereby grants You a world-wide,
+   royalty-free, non-exclusive, perpetual, sublicenseable license, under patent
+   claims owned or controlled by the Licensor that are embodied in the Original
+   Work as furnished by the Licensor, to make, use, sell and offer for sale the
+   Original Work and Derivative Works.
+
+3) Grant of Source Code License. The term "Source Code" means the preferred
+   form of the Original Work for making modifications to it and all available
+   documentation describing how to modify the Original Work. Licensor hereby
+   agrees to provide a machine-readable copy of the Source Code of the Original
+   Work along with each copy of the Original Work that Licensor distributes.
+   Licensor reserves the right to satisfy this obligation by placing a
+   machine-readable copy of the Source Code in an information repository
+   reasonably calculated to permit inexpensive and convenient access by You for as
+   long as Licensor continues to distribute the Original Work, and by publishing
+   the address of that information repository in a notice immediately following
+   the copyright notice that applies to the Original Work.
+
+4) Exclusions From License Grant. Neither the names of Licensor, nor the names
+   of any contributors to the Original Work, nor any of their trademarks or
+   service marks, may be used to endorse or promote products derived from this
+   Original Work without express prior written permission of the Licensor. Nothing
+   in this License shall be deemed to grant any rights to trademarks, copyrights,
+   patents, trade secrets or any other intellectual property of Licensor except as
+   expressly stated herein. No patent license is granted to make, use, sell or
+   offer to sell embodiments of any patent claims other than the licensed claims
+   defined in Section 2. No right is granted to the trademarks of Licensor even if
+   such marks are included in the Original Work. Nothing in this License shall be
+   interpreted to prohibit Licensor from licensing under different terms from this
+   License any Original Work that Licensor otherwise would have a right to
+   license.
+
+5) This section intentionally omitted.
+
+6) Attribution Rights. You must retain, in the Source Code of any Derivative
+   Works that You create, all copyright, patent or trademark notices from the
+   Source Code of the Original Work, as well as any notices of licensing and any
+   descriptive text identified therein as an "Attribution Notice." You must cause
+   the Source Code for any Derivative Works that You create to carry a prominent
+   Attribution Notice reasonably calculated to inform recipients that You have
+   modified the Original Work.
+
+7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that
+   the copyright in and to the Original Work and the patent rights granted herein
+   by Licensor are owned by the Licensor or are sublicensed to You under the terms
+   of this License with the permission of the contributor(s) of those copyrights
+   and patent rights. Except as expressly stated in the immediately proceeding
+   sentence, the Original Work is provided under this License on an "AS IS" BASIS
+   and WITHOUT WARRANTY, either express or implied, including, without limitation,
+   the warranties of NON-INFRINGEMENT, MERCHANTABILITY or FITNESS FOR A PARTICULAR
+   PURPOSE. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK IS WITH YOU.
+   This DISCLAIMER OF WARRANTY constitutes an essential part of this License. No
+   license to Original Work is granted hereunder except under this disclaimer.
+
+8) Limitation of Liability. Under no circumstances and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise, shall the
+   Licensor be liable to any person for any direct, indirect, special, incidental,
+   or consequential damages of any character arising as a result of this License
+   or the use of the Original Work including, without limitation, damages for loss
+   of goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses. This limitation of liability shall not
+   apply to liability for death or personal injury resulting from Licensor's
+   negligence to the extent applicable law prohibits such limitation. Some
+   jurisdictions do not allow the exclusion or limitation of incidental or
+   consequential damages, so this exclusion and limitation may not apply to You.
+
+9) Acceptance and Termination. If You distribute copies of the Original Work or
+   a Derivative Work, You must make a reasonable effort under the circumstances to
+   obtain the express assent of recipients to the terms of this License. Nothing
+   else but this License (or another written agreement between Licensor and You)
+   grants You permission to create Derivative Works based upon the Original Work
+   or to exercise any of the rights granted in Section 1 herein, and any attempt
+   to do so except under the terms of this License (or another written agreement
+   between Licensor and You) is expressly prohibited by U.S. copyright law, the
+   equivalent laws of other countries, and by international treaty. Therefore, by
+   exercising any of the rights granted to You in Section 1 herein, You indicate
+   Your acceptance of this License and all of its terms and conditions.
+
+10) Termination for Patent Action. This License shall terminate automatically
+   and You may no longer exercise any of the rights granted to You by this License
+   as of the date You commence an action, including a cross-claim or counterclaim,
+   against Licensor or any licensee alleging that the Original Work infringes a
+   patent. This termination provision shall not apply for an action alleging
+   patent infringement by combinations of the Original Work with other software or
+   hardware.
+
+11) Jurisdiction, Venue and Governing Law. Any action or suit relating to this
+   License may be brought only in the courts of a jurisdiction wherein the
+   Licensor resides or in which Licensor conducts its primary business, and under
+   the laws of that jurisdiction excluding its conflict-of-law provisions. The
+   application of the United Nations Convention on Contracts for the International
+   Sale of Goods is expressly excluded. Any use of the Original Work outside the
+   scope of this License or after its termination shall be subject to the
+   requirements and penalties of the U.S. Copyright Act, 17 U.S.C. Â§ 101 et
+   seq., the equivalent laws of other countries, and international treaty. This
+   section shall survive the termination of this License.
+
+12) Attorneys Fees. In any action to enforce the terms of this License or
+   seeking damages relating thereto, the prevailing party shall be entitled to
+   recover its costs and expenses, including, without limitation, reasonable
+   attorneys' fees and costs incurred in connection with such action, including
+   any appeal of such action. This section shall survive the termination of this
+   License.
+
+13) Miscellaneous. This License represents the complete agreement concerning
+   the subject matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent necessary to
+   make it enforceable.
+
+14) Definition of "You" in This License. "You" throughout this License, whether
+   in upper or lower case, means an individual or a legal entity exercising rights
+   under, and complying with all of the terms of, this License. For legal
+   entities, "You" includes any entity that controls, is controlled by, or is
+   under common control with you. For purposes of this definition, "control" means (i)
+   the power, direct or indirect, to cause the direction or management of such
+   entity, whether by contract or otherwise, or (ii) ownership of fifty percent
+   (50%) or more of the outstanding shares, or (iii) beneficial ownership of such
+   entity.
+
+15) Right to Use. You may use the Original Work in all ways not otherwise
+   restricted or conditioned by this License or by law, and Licensor promises not
+   to interfere with or be responsible for such uses by You.
+
+   This license is Copyright (C) 2003-2004 Lawrence E. Rosen. All rights reserved.
+   Permission is hereby granted to copy and distribute this license without
+   modification. This license may not be modified without the express written
+   permission of its copyright owner.
+
+
 json-schema-to-ts
 -----------------
-Website: https://github.com/ThomasAribart/json-schema-to-ts
+Source: https://github.com/ThomasAribart/json-schema-to-ts
 
 Copyright 2020 Thomas Aribart
 Distributed under the MIT License
@@ -33687,7 +34733,7 @@ SOFTWARE.
 
 json-schema-traverse
 --------------------
-Website: https://github.com/epoberezkin/json-schema-traverse
+Source: https://github.com/epoberezkin/json-schema-traverse
 
 Copyright 2017 Evgeny Poberezkin
 Distributed under the MIT License
@@ -33719,7 +34765,7 @@ SOFTWARE.
 
 jsonc-parser
 ------------
-Website: https://github.com/microsoft/node-jsonc-parser
+Source: https://github.com/microsoft/node-jsonc-parser
 
 Copyright Microsoft
 Distributed under the MIT License
@@ -33751,7 +34797,7 @@ SOFTWARE.
 
 jsonfile
 --------
-Website: https://github.com/jprichardson/node-jsonfile
+Source: https://github.com/jprichardson/node-jsonfile
 
 Copyright 2012-2015, JP Richardson <jprichardson@gmail.com>
 Distributed under the MIT License
@@ -33775,9 +34821,9 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-jsonwebtoken version 9.0.2
---------------------------
-Website: https://github.com/auth0/node-jsonwebtoken
+jsonwebtoken versions 9.0.3, 9.0.2
+----------------------------------
+Source: https://github.com/auth0/node-jsonwebtoken
 
 Copyright 2015 Auth0, Inc. <support@auth0.com> (http:auth0.com)
 Distributed under the MIT License
@@ -33809,7 +34855,7 @@ SOFTWARE.
 
 jsonwebtoken version 9.3.1
 --------------------------
-Website: https://github.com/Keats/jsonwebtoken
+Source: https://github.com/Keats/jsonwebtoken
 
 Copyright 2015 Vincent Prouillet
 Distributed under the MIT License
@@ -33841,7 +34887,7 @@ SOFTWARE.
 
 Julia Language Basics
 ---------------------
-Website: https://npmjs.com/package/Julia Language Basics/v/1.0.0
+Source: https://npmjs.com/package/Julia Language Basics/v/1.0.0
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -33849,7 +34895,7 @@ Distributed under the MIT License
 
 jupyter-client
 --------------
-Website: https://github.com/jupyter/jupyter_client
+Source: https://github.com/jupyter/jupyter_client
 
 Copyright 2001-2015, IPython Development Team -
 Copyright 2015-, Jupyter Development Team
@@ -33892,7 +34938,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 jupyter-core
 ------------
-Website: https://github.com/jupyter/jupyter_core
+Source: https://github.com/jupyter/jupyter_core
 
 Copyright 2015-, Jupyter Development Team
 Distributed under the BSD 3-Clause license
@@ -33933,7 +34979,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 jwa
 ---
-Website: https://github.com/brianloveswords/node-jwa
+Source: https://github.com/brianloveswords/node-jwa
 
 Copyright 2013 Brian J. Brennan
 Distributed under the MIT License
@@ -33961,7 +35007,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEAL
 
 jwalk
 -----
-Website: https://github.com/byron/jwalk
+Source: https://github.com/byron/jwalk
 
 Copyright 2019 Jesse Grosjean
 Distributed under the MIT License
@@ -33993,7 +35039,7 @@ THE SOFTWARE.
 
 jws
 ---
-Website: https://github.com/brianloveswords/node-jws
+Source: https://github.com/brianloveswords/node-jws
 
 Copyright 2013 Brian J. Brennan
 Distributed under the MIT License
@@ -34021,7 +35067,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEAL
 
 Jxck/assert
 -----------
-Website: https://github.com/Jxck/assert
+Source: https://github.com/Jxck/assert
 
 Copyright (c) 2011 Jxck
 Distributed under the MIT License
@@ -34029,7 +35075,7 @@ Distributed under the MIT License
 
 katex
 -----
-Website: https://github.com/KaTeX/KaTeX
+Source: https://github.com/KaTeX/KaTeX
 
 Copyright 2013-2020 Khan Academy and other contributors
 Distributed under the MIT License
@@ -34061,7 +35107,7 @@ SOFTWARE.
 
 kerberos
 --------
-Website: https://github.com/mongodb-js/kerberos
+Source: https://github.com/mongodb-js/kerberos
 
 Published by The MongoDB NodeJS Team
 Distributed under the Apache License version 2.0
@@ -34069,7 +35115,7 @@ Distributed under the Apache License version 2.0
 
 khroma
 ------
-Website: https://github.com/fabiospampinato/khroma
+Source: https://github.com/fabiospampinato/khroma
 
 Copyright 2019-present Fabio Spampinato, Andrew Maney
 Distributed under the MIT License
@@ -34101,7 +35147,7 @@ DEALINGS IN THE SOFTWARE.
 
 Kimbie Dark Theme
 -----------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -34109,7 +35155,7 @@ Distributed under the MIT License
 
 kolorist
 --------
-Website: https://github.com/marvinhagemeister/kolorist
+Source: https://github.com/marvinhagemeister/kolorist
 
 Copyright 2020-present Marvin Hagemeister
 Distributed under the MIT License
@@ -34141,7 +35187,7 @@ SOFTWARE.
 
 kqueue
 ------
-Website: https://gitlab.com/rust-kqueue/rust-kqueue
+Source: https://gitlab.com/rust-kqueue/rust-kqueue
 
 Copyright 2016 William Orr <will@worrbase.com>
 Distributed under the MIT License
@@ -34171,7 +35217,7 @@ SOFTWARE.
 
 kqueue-sys
 ----------
-Website: https://gitlab.com/worr/rust-kqueue-sys
+Source: https://gitlab.com/worr/rust-kqueue-sys
 
 Copyright 2016 William Orr <will@worrbase.com>
 Distributed under the MIT License
@@ -34201,7 +35247,7 @@ SOFTWARE.
 
 kuler
 -----
-Website: https://github.com/3rd-Eden/kuler
+Source: https://github.com/3rd-Eden/kuler
 
 Copyright 2014 Arnout Kazemier
 Distributed under the MIT License
@@ -34219,7 +35265,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 langium
 -------
-Website: https://github.com/eclipse-langium/langium
+Source: https://github.com/eclipse-langium/langium
 
 Copyright 2021 TypeFox GmbH
 Distributed under the MIT License
@@ -34246,7 +35292,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 
 Language Windows batch file
 ---------------------------
-Website: https://github.com/mmims/language-batchfile
+Source: https://github.com/mmims/language-batchfile
 
 Copyright (c) 2021 Michael Mims
 Distributed under the MIT License
@@ -34254,7 +35300,7 @@ Distributed under the MIT License
 
 language-php
 ------------
-Website: https://github.com/KapitanOczywisty/language-php
+Source: https://github.com/KapitanOczywisty/language-php
 
 Copyright (c) 2014 GitHub Inc.
 Distributed under the MIT License
@@ -34296,7 +35342,7 @@ suitability for any purpose.
 
 language-tags
 -------------
-Website: https://github.com/pyfisch/rust-language-tags
+Source: https://github.com/pyfisch/rust-language-tags
 
 Copyright 2015 Pyfisch
 
@@ -34330,7 +35376,7 @@ THE SOFTWARE.
 
 LaTeX Language Basics
 ---------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright 2019 Jeff Hykin
 Copyright Microsoft 2018
@@ -34363,7 +35409,7 @@ SOFTWARE.
 
 LaTeX Workshop
 --------------
-Website: https://github.com/James-Yu/LaTeX-Workshop
+Source: https://github.com/James-Yu/LaTeX-Workshop
 
 Copyright (c) 2016 James Yu
 Distributed under the MIT License
@@ -34371,7 +35417,7 @@ Distributed under the MIT License
 
 layout-base
 -----------
-Website: https://github.com/iVis-at-Bilkent/layout-base
+Source: https://github.com/iVis-at-Bilkent/layout-base
 
 Copyright 2019 iVis@Bilkent
 Distributed under the MIT License
@@ -34403,7 +35449,7 @@ SOFTWARE.
 
 lazy_static
 -----------
-Website: https://github.com/rust-lang-nursery/lazy-static.rs
+Source: https://github.com/rust-lang-nursery/lazy-static.rs
 
 Copyright 2010 The Rust Project Developers
 
@@ -34443,7 +35489,7 @@ DEALINGS IN THE SOFTWARE.
 
 leb128
 ------
-Website: https://github.com/gimli-rs/leb128
+Source: https://github.com/gimli-rs/leb128
 
 Copyright 2015 The Rust Project Developers
 
@@ -34483,7 +35529,7 @@ DEALINGS IN THE SOFTWARE.
 
 Less Language Basics
 --------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -34491,7 +35537,7 @@ Distributed under the MIT License
 
 libc
 ----
-Website: https://github.com/rust-lang/libc
+Source: https://github.com/rust-lang/libc
 
 Copyright 2014-2020 The Rust Project Developers
 
@@ -34531,7 +35577,7 @@ DEALINGS IN THE SOFTWARE.
 
 libloading
 ----------
-Website: https://github.com/nagisa/rust_libloading/
+Source: https://github.com/nagisa/rust_libloading/
 
 Copyright © 2015, Simonas Kazlauskas
 Distributed under the ISC License
@@ -34554,7 +35600,7 @@ THIS SOFTWARE.
 
 libredox
 --------
-Website: https://gitlab.redox-os.org/redox-os/libredox.git
+Source: https://gitlab.redox-os.org/redox-os/libredox.git
 
 Copyright 2023 4lDO2
 Distributed under the MIT License
@@ -34586,7 +35632,7 @@ SOFTWARE.
 
 libz-sys
 --------
-Website: https://github.com/rust-lang/libz-sys
+Source: https://github.com/rust-lang/libz-sys
 
 Copyright 2014 Alex Crichton
 Copyright 2020 Josh Triplett
@@ -34629,7 +35675,7 @@ DEALINGS IN THE SOFTWARE.
 
 linked-hash-map
 ---------------
-Website: https://github.com/contain-rs/linked-hash-map
+Source: https://github.com/contain-rs/linked-hash-map
 
 Copyright 2015 The Rust Project Developers
 
@@ -34669,7 +35715,7 @@ DEALINGS IN THE SOFTWARE.
 
 linkify-it
 ----------
-Website: https://github.com/markdown-it/linkify-it
+Source: https://github.com/markdown-it/linkify-it
 
 Copyright 2015 Vitaly Puzrin.
 Distributed under the MIT License
@@ -34702,7 +35748,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 linux-raw-sys
 -------------
-Website: https://github.com/sunfishcode/linux-raw-sys
+Source: https://github.com/sunfishcode/linux-raw-sys
 
 Published by Dan Gohman <dev@sunfishcode.online>
 
@@ -34714,7 +35760,7 @@ Consult the documentation and source code of linux-raw-sys for more information.
 
 load-yaml-file
 --------------
-Website: https://github.com/LinusU/load-yaml-file
+Source: https://github.com/LinusU/load-yaml-file
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -34722,7 +35768,7 @@ Distributed under the MIT License
 
 Local Tunnel Port Forwarding
 ----------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -34730,7 +35776,7 @@ Distributed under the MIT License
 
 local-pkg
 ---------
-Website: https://github.com/antfu-collective/local-pkg
+Source: https://github.com/antfu-collective/local-pkg
 
 Copyright 2021 Anthony Fu <https:github.com/antfu>
 Distributed under the MIT License
@@ -34762,7 +35808,7 @@ SOFTWARE.
 
 locate-path
 -----------
-Website: https://github.com/sindresorhus/locate-path
+Source: https://github.com/sindresorhus/locate-path
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -34782,7 +35828,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 lodash
 ------
-Website: https://github.com/lodash/lodash
+Source: https://github.com/lodash/lodash
 
 Copyright 2012-2016 The Dojo Foundation <http:dojofoundation.org/>
 Copyright OpenJS Foundation and other contributors <https:openjsf.org/>
@@ -34842,7 +35888,7 @@ terms above.
 
 Log
 ---
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -34850,7 +35896,7 @@ Distributed under the MIT License
 
 log
 ---
-Website: https://github.com/rust-lang/log
+Source: https://github.com/rust-lang/log
 
 Copyright 2014 The Rust Project Developers
 
@@ -34890,7 +35936,7 @@ DEALINGS IN THE SOFTWARE.
 
 logform
 -------
-Website: https://github.com/winstonjs/logform
+Source: https://github.com/winstonjs/logform
 
 Copyright 2017 Charlie Robbins & the Contributors.
 Distributed under the MIT License
@@ -34920,9 +35966,43 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+looper
+------
+Source: https://github.com/dominictarr/looper
+
+Copyright 2013 Dominic Tarr
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2013 Dominic Tarr
+
+Permission is hereby granted, free of charge,
+to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to
+deal in the Software without restriction, including
+without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom
+the Software is furnished to do so,
+
+subject to the following conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 loose-envify
 ------------
-Website: https://github.com/zertosh/loose-envify
+Source: https://github.com/zertosh/loose-envify
 
 Copyright 2015 Andres Suarez <zertosh@gmail.com>
 Distributed under the MIT License
@@ -34954,7 +36034,7 @@ THE SOFTWARE.
 
 lru-cache
 ---------
-Website: https://github.com/isaacs/node-lru-cache
+Source: https://github.com/isaacs/node-lru-cache
 
 Copyright 2010-2023 Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -34980,7 +36060,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 lsp-types
 ---------
-Website: https://github.com/gluon-lang/lsp-types
+Source: https://github.com/gluon-lang/lsp-types
 
 Copyright 2016 Markus Westerlind
 Distributed under the MIT License
@@ -35012,7 +36092,7 @@ THE SOFTWARE.
 
 lsprotocol
 ----------
-Website: https://github.com/microsoft/lsprotocol
+Source: https://github.com/microsoft/lsprotocol
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -35044,7 +36124,7 @@ SOFTWARE
 
 Lua Language Basics
 -------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -35052,7 +36132,7 @@ Distributed under the MIT License
 
 Lua tmBundle
 ------------
-Website: https://github.com/sumneko/lua.tmbundle
+Source: https://github.com/sumneko/lua.tmbundle
 
 Copyright (c) sumneko-lua.tmbundle project authors
 
@@ -35076,7 +36156,7 @@ to the base-name name of the original file, and an extension of txt, html, or si
 
 mac
 ---
-Website: https://github.com/reem/rust-mac
+Source: https://github.com/reem/rust-mac
 
 Published by Jonathan Reem <jonathan.reem@gmail.com>
 
@@ -35088,7 +36168,7 @@ Consult the documentation and source code of mac for more information.
 
 Magic Python
 ------------
-Website: https://github.com/MagicStack/MagicPython
+Source: https://github.com/MagicStack/MagicPython
 
 Copyright (c) 2015-present MagicStack Inc. http://magic.io
 Distributed under the MIT License
@@ -35096,7 +36176,7 @@ Distributed under the MIT License
 
 Make Language Basics
 --------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -35104,7 +36184,7 @@ Distributed under the MIT License
 
 make tmbundle
 -------------
-Website: https://github.com/fadeevab/make.tmbundle
+Source: https://github.com/fadeevab/make.tmbundle
 
 Copyright (c) Microsoft
 Distributed under the MIT License
@@ -35112,7 +36192,7 @@ Distributed under the MIT License
 
 Markdown Language Basics
 ------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -35120,7 +36200,7 @@ Distributed under the MIT License
 
 Markdown Language Features
 --------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -35128,7 +36208,7 @@ Distributed under the MIT License
 
 Markdown Math
 -------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -35136,7 +36216,7 @@ Distributed under the MIT License
 
 Markdown tmBundle
 -----------------
-Website: https://github.com/textmate/markdown.tmbundle
+Source: https://github.com/textmate/markdown.tmbundle
 
 Copyright (c) markdown.tmbundle authors
 
@@ -35160,7 +36240,7 @@ to the base-name name of the original file, and an extension of txt, html, or si
 
 markdown-it
 -----------
-Website: https://github.com/markdown-it/markdown-it
+Source: https://github.com/markdown-it/markdown-it
 
 Copyright 2014 Vitaly Puzrin, Alex Kocharin.
 Distributed under the MIT License
@@ -35193,7 +36273,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 markdown-it-front-matter
 ------------------------
-Website: https://github.com/ParkSB/markdown-it-front-matter
+Source: https://github.com/ParkSB/markdown-it-front-matter
 
 Copyright 2016-2020 ParkSB.
 Distributed under the MIT License
@@ -35226,7 +36306,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 markdown-it-py
 --------------
-Website: https://github.com/executablebooks/markdown-it-py
+Source: https://github.com/executablebooks/markdown-it-py
 
 Copyright 2020 ExecutableBookProject
 Distributed under the MIT License
@@ -35258,7 +36338,7 @@ SOFTWARE.
 
 marked
 ------
-Website: https://github.com/markedjs/marked
+Source: https://github.com/markedjs/marked
 
 Copyright 2011-2018, Christopher Jeffrey (https:github.com/chjj/)
 Copyright 2018+, MarkedJS (https:github.com/markedjs/)
@@ -35319,7 +36399,7 @@ Redistribution and use in source and binary forms, with or without modification,
 
 Marked JS
 ---------
-Website: https://github.com/markedjs/marked
+Source: https://github.com/markedjs/marked
 
 Copyright (c) 2018+, MarkedJS (https://github.com/markedjs/) Copyright (c) 2011-2018, Christopher Jeffrey (https://github.com/chjj/)
 Distributed under the MIT License
@@ -35378,7 +36458,7 @@ Redistribution and use in source and binary forms, with or without modification,
 
 matchers
 --------
-Website: https://github.com/hawkw/matchers
+Source: https://github.com/hawkw/matchers
 
 Copyright 2019 Eliza Weisman
 Distributed under the MIT License
@@ -35408,7 +36488,7 @@ SOFTWARE.
 
 matches
 -------
-Website: https://github.com/SimonSapin/rust-std-candidates
+Source: https://github.com/SimonSapin/rust-std-candidates
 
 Copyright 2014-2016 Simon Sapin
 Distributed under the MIT License
@@ -35444,7 +36524,7 @@ DEALINGS IN THE SOFTWARE.
 
 math-intrinsics
 ---------------
-Website: https://github.com/es-shims/math-intrinsics
+Source: https://github.com/es-shims/math-intrinsics
 
 Copyright 2024 ECMAScript Shims
 Distributed under the MIT License
@@ -35476,7 +36556,7 @@ SOFTWARE.
 
 matplotlib-inline
 -----------------
-Website: https://github.com/ipython/matplotlib-inline
+Source: https://github.com/ipython/matplotlib-inline
 
 Copyright 2019-2022, IPython Development Team.
 Distributed under the BSD 3-Clause license
@@ -35516,7 +36596,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 mdurl versions 2.0.0, 1.0.1
 ---------------------------
-Website: https://github.com/markdown-it/mdurl
+Source: https://github.com/markdown-it/mdurl
 
 Copyright 2015 Vitaly Puzrin, Alex Kocharin.
 Copyright Joyent, Inc. and other Node contributors.
@@ -35573,7 +36653,7 @@ IN THE SOFTWARE.
 
 mdurl version 0.1.2
 -------------------
-Website: https://github.com/executablebooks/mdurl
+Source: https://github.com/executablebooks/mdurl
 
 Copyright 2015 Vitaly Puzrin, Alex Kocharin.
 Copyright 2021 Taneli Hukkinen
@@ -35633,7 +36713,7 @@ IN THE SOFTWARE.
 
 Media Preview
 -------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -35641,7 +36721,7 @@ Distributed under the MIT License
 
 media-typer
 -----------
-Website: https://github.com/jshttp/media-typer
+Source: https://github.com/jshttp/media-typer
 
 Copyright 2014 Douglas Christopher Wilson
 Distributed under the MIT License
@@ -35674,7 +36754,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 memchr
 ------
-Website: https://github.com/BurntSushi/memchr
+Source: https://github.com/BurntSushi/memchr
 
 Copyright 2015 Andrew Gallant
 
@@ -35686,7 +36766,7 @@ Consult the documentation and source code of memchr for more information.
 
 memoffset
 ---------
-Website: https://github.com/Gilnaa/memoffset
+Source: https://github.com/Gilnaa/memoffset
 
 Copyright 2017 Gilad Naaman
 Distributed under the MIT License
@@ -35716,7 +36796,7 @@ SOFTWARE.
 
 memoize-one
 -----------
-Website: https://github.com/alexreardon/memoize-one
+Source: https://github.com/alexreardon/memoize-one
 
 Copyright 2019 Alexander Reardon
 Distributed under the MIT License
@@ -35748,7 +36828,7 @@ SOFTWARE.
 
 Merge Conflict
 --------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -35756,7 +36836,7 @@ Distributed under the MIT License
 
 merge-descriptors
 -----------------
-Website: https://github.com/sindresorhus/merge-descriptors
+Source: https://github.com/sindresorhus/merge-descriptors
 
 Copyright 2013 Jonathan Ong <me@jongleberry.com>
 Copyright 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
@@ -35792,7 +36872,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 mermaid
 -------
-Website: https://github.com/mermaid-js/mermaid
+Source: https://github.com/mermaid-js/mermaid
 
 Copyright 2014 - 2022 Knut Sveidqvist
 Distributed under the MIT License
@@ -35824,7 +36904,7 @@ SOFTWARE.
 
 Mermaid Chat Features
 ---------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -35832,7 +36912,7 @@ Distributed under the MIT License
 
 @mermaid-js/parser
 ------------------
-Website: https://github.com/mermaid-js/mermaid
+Source: https://github.com/mermaid-js/mermaid
 
 Copyright 2023 Yokozuna59
 Distributed under the MIT License
@@ -35864,7 +36944,7 @@ SOFTWARE.
 
 methods
 -------
-Website: https://github.com/jshttp/methods
+Source: https://github.com/jshttp/methods
 
 Copyright 2013-2014 TJ Holowaychuk <tj@vision-media.ca>
 Copyright 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com>
@@ -35900,7 +36980,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 micromatch
 ----------
-Website: https://github.com/micromatch/micromatch
+Source: https://github.com/micromatch/micromatch
 
 Copyright 2014-present, Jon Schlinkert.
 Distributed under the MIT License
@@ -35932,7 +37012,7 @@ THE SOFTWARE.
 
 Microsoft Account
 -----------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -35940,7 +37020,7 @@ Distributed under the MIT License
 
 @microsoft/1ds-core-js
 ----------------------
-Website: https://github.com/microsoft/ApplicationInsights-JS
+Source: https://github.com/microsoft/ApplicationInsights-JS
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -35972,7 +37052,7 @@ SOFTWARE.
 
 @microsoft/1ds-post-js
 ----------------------
-Website: https://github.com/microsoft/ApplicationInsights-JS
+Source: https://github.com/microsoft/ApplicationInsights-JS
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -36004,7 +37084,7 @@ SOFTWARE.
 
 @microsoft/applicationinsights-channel-js
 -----------------------------------------
-Website: https://github.com/microsoft/ApplicationInsights-JS
+Source: https://github.com/microsoft/ApplicationInsights-JS
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -36036,7 +37116,7 @@ SOFTWARE.
 
 @microsoft/applicationinsights-common
 -------------------------------------
-Website: https://github.com/microsoft/ApplicationInsights-JS
+Source: https://github.com/microsoft/ApplicationInsights-JS
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -36068,7 +37148,7 @@ SOFTWARE.
 
 @microsoft/applicationinsights-core-js
 --------------------------------------
-Website: https://github.com/microsoft/ApplicationInsights-JS
+Source: https://github.com/microsoft/ApplicationInsights-JS
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -36100,7 +37180,7 @@ SOFTWARE.
 
 @microsoft/applicationinsights-shims
 ------------------------------------
-Website: https://github.com/microsoft/ApplicationInsights-JS
+Source: https://github.com/microsoft/ApplicationInsights-JS
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -36132,7 +37212,7 @@ SOFTWARE.
 
 @microsoft/applicationinsights-web-basic
 ----------------------------------------
-Website: https://github.com/microsoft/ApplicationInsights-JS
+Source: https://github.com/microsoft/ApplicationInsights-JS
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -36164,7 +37244,7 @@ SOFTWARE.
 
 @microsoft/applicationinsights-web-snippet
 ------------------------------------------
-Website: https://github.com/microsoft/ApplicationInsights-JS
+Source: https://github.com/microsoft/ApplicationInsights-JS
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -36196,7 +37276,7 @@ SOFTWARE
 
 @microsoft/dynamicproto-js
 --------------------------
-Website: https://github.com/microsoft/DynamicProto-JS
+Source: https://github.com/microsoft/DynamicProto-JS
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -36228,7 +37308,7 @@ SOFTWARE.
 
 @microsoft/fast-element
 -----------------------
-Website: https://github.com/Microsoft/fast
+Source: https://github.com/Microsoft/fast
 
 Published by Microsoft
 Distributed under the MIT License
@@ -36236,7 +37316,7 @@ Distributed under the MIT License
 
 @microsoft/fast-foundation
 --------------------------
-Website: https://github.com/Microsoft/fast
+Source: https://github.com/Microsoft/fast
 
 Published by Microsoft
 Distributed under the MIT License
@@ -36244,7 +37324,7 @@ Distributed under the MIT License
 
 @microsoft/fast-react-wrapper
 -----------------------------
-Website: https://github.com/Microsoft/fast
+Source: https://github.com/Microsoft/fast
 
 Published by Microsoft
 Distributed under the MIT License
@@ -36252,7 +37332,7 @@ Distributed under the MIT License
 
 @microsoft/fast-web-utilities
 -----------------------------
-Website: https://github.com/Microsoft/fast
+Source: https://github.com/Microsoft/fast
 
 Published by Microsoft
 Distributed under the MIT License
@@ -36260,7 +37340,7 @@ Distributed under the MIT License
 
 @microsoft/tiktokenizer
 -----------------------
-Website: https://github.com/Microsoft/Tokenizer
+Source: https://github.com/Microsoft/Tokenizer
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -36290,9 +37370,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE
 
 
+@midleman/playwright-reporter
+-----------------------------
+Source: https://npmjs.com/package/@midleman/playwright-reporter/v/0.27.0
+
+Copyright (c) playwright-reporter contributors
+Distributed under the MIT License
+
+
 mime versions 3.0.0, 1.6.0
 --------------------------
-Website: https://github.com/broofa/mime
+Source: https://github.com/broofa/mime
 
 Copyright 2010 Benjamin Thomas, Robert Kieffer
 Distributed under the MIT License
@@ -36324,7 +37412,7 @@ THE SOFTWARE.
 
 mime version 0.3.17
 -------------------
-Website: https://github.com/hyperium/mime
+Source: https://github.com/hyperium/mime
 
 Copyright 2014 Sean McArthur
 
@@ -36358,7 +37446,7 @@ THE SOFTWARE.
 
 mime-db
 -------
-Website: https://github.com/jshttp/mime-db
+Source: https://github.com/jshttp/mime-db
 
 Copyright 2014 Jonathan Ong <me@jongleberry.com>
 Copyright 2015-2022 Douglas Christopher Wilson <doug@somethingdoug.com>
@@ -36394,7 +37482,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 mime-types
 ----------
-Website: https://github.com/jshttp/mime-types
+Source: https://github.com/jshttp/mime-types
 
 Copyright 2014 Jonathan Ong <me@jongleberry.com>
 Copyright 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
@@ -36430,7 +37518,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 mime_guess
 ----------
-Website: https://github.com/abonander/mime_guess
+Source: https://github.com/abonander/mime_guess
 
 Copyright 2015 Austin Bonander
 Distributed under the MIT License
@@ -36462,7 +37550,7 @@ SOFTWARE.
 
 mimic-response
 --------------
-Website: https://github.com/sindresorhus/mimic-response
+Source: https://github.com/sindresorhus/mimic-response
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -36482,7 +37570,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 minimalistic-assert
 -------------------
-Website: https://github.com/calvinmetcalf/minimalistic-assert
+Source: https://github.com/calvinmetcalf/minimalistic-assert
 
 Copyright 2015 Calvin Metcalf
 Distributed under the ISC License
@@ -36506,7 +37594,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 minimatch
 ---------
-Website: https://github.com/isaacs/minimatch
+Source: https://github.com/isaacs/minimatch
 
 Copyright 2011-2023 Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -36532,15 +37620,15 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 minimist
 --------
-Website: https://github.com/minimistjs/minimist
+Source: https://github.com/minimistjs/minimist
 
 Published by James Halliday
 Distributed under the MIT License
 
 
-minipass versions 7.1.2, 5.0.0, 4.2.8
--------------------------------------
-Website: https://github.com/isaacs/minipass
+minipass versions 7.1.2, 5.0.0, 4.2.8, 3.3.6
+--------------------------------------------
+Source: https://github.com/isaacs/minipass
 
 Copyright 2017-2023 npm, Inc., Isaac Z. Schlueter, and Contributors
 Distributed under the ISC License
@@ -36566,7 +37654,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 minipass version 3.1.3
 ----------------------
-Website: https://github.com/isaacs/minipass
+Source: https://github.com/isaacs/minipass
 
 Copyright npm, Inc. and Contributors
 Distributed under the ISC License
@@ -36592,7 +37680,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 minizlib
 --------
-Website: https://github.com/isaacs/minizlib
+Source: https://github.com/isaacs/minizlib
 
 Copyright Isaac Z. Schlueter and Contributors
 Copyright Joyent, Inc. and other Node contributors.
@@ -36632,7 +37720,7 @@ It is a derivative work of the Node.js project.
 
 miniz_oxide
 -----------
-Website: https://github.com/Frommi/miniz_oxide
+Source: https://github.com/Frommi/miniz_oxide
 
 Copyright 2020 Frommi
 
@@ -36684,7 +37772,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 
 mio
 ---
-Website: https://github.com/tokio-rs/mio
+Source: https://github.com/tokio-rs/mio
 
 Copyright 2014 Carl Lerche and other MIO contributors
 Distributed under the MIT License
@@ -36714,7 +37802,7 @@ THE SOFTWARE.
 
 mkdirp
 ------
-Website: https://github.com/isaacs/node-mkdirp
+Source: https://github.com/isaacs/node-mkdirp
 
 Copyright James Halliday (mail@substack.net) and Isaac Z. Schlueter (i@izs.me)
 Distributed under the MIT License
@@ -36746,7 +37834,7 @@ THE SOFTWARE.
 
 mkdirp-classic
 --------------
-Website: https://github.com/mafintosh/mkdirp-classic
+Source: https://github.com/mafintosh/mkdirp-classic
 
 Copyright 2020 James Halliday (mail@substack.net) and Mathias Buus
 Distributed under the MIT License
@@ -36778,7 +37866,7 @@ THE SOFTWARE.
 
 mlly
 ----
-Website: https://github.com/unjs/mlly
+Source: https://github.com/unjs/mlly
 
 Copyright Pooya Parsa <pooya@pi0.io>
 Distributed under the MIT License
@@ -36810,7 +37898,7 @@ SOFTWARE.
 
 Moby Project Language Docker
 ----------------------------
-Website: https://github.com/moby/moby
+Source: https://github.com/moby/moby
 
 Copyright 2013-2018 Docker, Inc.
 Distributed under the Apache License version 2.0
@@ -36818,7 +37906,7 @@ Distributed under the Apache License version 2.0
 
 module-details-from-path
 ------------------------
-Website: https://github.com/watson/module-details-from-path
+Source: https://github.com/watson/module-details-from-path
 
 Copyright 2016 Thomas Watson Steen
 Distributed under the MIT License
@@ -36850,7 +37938,7 @@ SOFTWARE.
 
 moment
 ------
-Website: https://github.com/moment/moment
+Source: https://github.com/moment/moment
 
 Copyright JS Foundation and other contributors
 Distributed under the MIT License
@@ -36883,7 +37971,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 moment-timezone
 ---------------
-Website: https://github.com/moment/moment-timezone
+Source: https://github.com/moment/moment-timezone
 
 Copyright JS Foundation and other contributors
 Distributed under the MIT License
@@ -36914,7 +38002,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 monaco-editor-core
 ------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) 2016 - present Microsoft Corporation
 Distributed under the MIT License
@@ -36946,7 +38034,7 @@ SOFTWARE.
 
 Monokai Dimmed Theme
 --------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -36954,7 +38042,7 @@ Distributed under the MIT License
 
 Monokai Theme
 -------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -36962,7 +38050,7 @@ Distributed under the MIT License
 
 morphdom
 --------
-Website: https://github.com/patrick-steele-idem/morphdom
+Source: https://github.com/patrick-steele-idem/morphdom
 
 Copyright Patrick Steele-Idem <pnidem@gmail.com> (psteeleidem.com)
 Distributed under the MIT License
@@ -36994,7 +38082,7 @@ THE SOFTWARE.
 
 ms version 2.1.3
 ----------------
-Website: https://github.com/vercel/ms
+Source: https://github.com/vercel/ms
 
 Copyright 2020 Vercel, Inc.
 Distributed under the MIT License
@@ -37026,7 +38114,7 @@ SOFTWARE.
 
 ms version 2.0.0
 ----------------
-Website: https://github.com/vercel/ms
+Source: https://github.com/vercel/ms
 
 Copyright 2016 Zeit, Inc.
 Distributed under the MIT License
@@ -37058,7 +38146,7 @@ SOFTWARE.
 
 named-js-regexp
 ---------------
-Website: https://github.com/edvinv/named-js-regexp
+Source: https://github.com/edvinv/named-js-regexp
 
 Copyright 2015, @edvinv
 Distributed under the MIT License
@@ -37088,9 +38176,40 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
+nanoid
+------
+Source: https://github.com/ai/nanoid
+
+Copyright 2017 Andrey Sitnik <andrey@sitnik.ru>
+Distributed under the MIT License
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright 2017 Andrey Sitnik <andrey@sitnik.ru>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 napi-build-utils
 ----------------
-Website: https://github.com/inspiredware/napi-build-utils
+Source: https://github.com/inspiredware/napi-build-utils
 
 Copyright 2018 inspiredware
 Distributed under the MIT License
@@ -37122,7 +38241,7 @@ SOFTWARE.
 
 native-is-elevated
 ------------------
-Website: https://github.com/arkon/native-is-elevated
+Source: https://github.com/arkon/native-is-elevated
 
 Copyright 2016 Eugene Cheung
 Distributed under the MIT License
@@ -37154,7 +38273,7 @@ SOFTWARE.
 
 native-keymap
 -------------
-Website: https://github.com/Microsoft/node-native-keymap
+Source: https://github.com/Microsoft/node-native-keymap
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -37182,7 +38301,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 native-tls
 ----------
-Website: https://github.com/sfackler/rust-native-tls
+Source: https://github.com/sfackler/rust-native-tls
 
 Copyright 2016 The rust-native-tls Developers
 
@@ -37216,7 +38335,7 @@ SOFTWARE.
 
 native-watchdog
 ---------------
-Website: https://github.com/Microsoft/node-native-watchdog
+Source: https://github.com/Microsoft/node-native-watchdog
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -37246,9 +38365,41 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE
 
 
+ncp
+---
+Source: https://github.com/AvianFlu/ncp
+
+Copyright (C) 2011 by Charlie McConnell
+Distributed under the MIT License
+
+MIT License text:
+
+# MIT License
+
+###Copyright (C) 2011 by Charlie McConnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
 negotiator
 ----------
-Website: https://github.com/jshttp/negotiator
+Source: https://github.com/jshttp/negotiator
 
 Copyright 2012-2014 Federico Romero
 Copyright 2012-2014 Isaac Z. Schlueter
@@ -37287,7 +38438,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 nest-asyncio
 ------------
-Website: https://github.com/erdewit/nest_asyncio
+Source: https://github.com/erdewit/nest_asyncio
 
 Copyright 2018-2020, Ewald de Wit
 Distributed under the BSD 2-Clause license
@@ -37322,9 +38473,17 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+netmask
+-------
+Source: https://github.com/rs/node-netmask
+
+Copyright 2011 Olivier Poitrey <rs@rhapsodyk.net>
+Distributed under the MIT License
+
+
 @nevware21/ts-async
 -------------------
-Website: https://github.com/nevware21/ts-async
+Source: https://github.com/nevware21/ts-async
 
 Copyright 2022 NevWare21 Solutions LLC
 Distributed under the MIT License
@@ -37356,7 +38515,7 @@ SOFTWARE.
 
 @nevware21/ts-utils
 -------------------
-Website: https://github.com/nevware21/ts-utils
+Source: https://github.com/nevware21/ts-utils
 
 Copyright 2022 NevWare21 Solutions LLC
 Distributed under the MIT License
@@ -37388,7 +38547,7 @@ SOFTWARE.
 
 new_debug_unreachable
 ---------------------
-Website: https://github.com/mbrubeck/rust-debug-unreachable
+Source: https://github.com/mbrubeck/rust-debug-unreachable
 
 Copyright 2015 Jonathan Reem
 Distributed under the MIT License
@@ -37424,7 +38583,7 @@ DEALINGS IN THE SOFTWARE.
 
 nix
 ---
-Website: https://github.com/nix-rust/nix
+Source: https://github.com/nix-rust/nix
 
 Copyright 2015 Carl Lerche + nix-rust Authors
 Distributed under the MIT License
@@ -37456,7 +38615,7 @@ THE SOFTWARE.
 
 Node Debug Auto-attach
 ----------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -37464,7 +38623,7 @@ Distributed under the MIT License
 
 node-abi
 --------
-Website: https://github.com/lgeiger/node-abi
+Source: https://github.com/lgeiger/node-abi
 
 Copyright 2016 Lukas Geiger
 Distributed under the MIT License
@@ -37496,7 +38655,7 @@ SOFTWARE.
 
 node-addon-api
 --------------
-Website: https://github.com/nodejs/node-addon-api
+Source: https://github.com/nodejs/node-addon-api
 
 Copyright 2017 Node.js API collaborators
 Distributed under the MIT License
@@ -37516,7 +38675,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 node-domexception
 -----------------
-Website: https://github.com/jimmywarting/node-domexception
+Source: https://github.com/jimmywarting/node-domexception
 
 Copyright 2021 Jimmy Wärting
 Distributed under the MIT License
@@ -37548,7 +38707,7 @@ SOFTWARE.
 
 node-fetch version 3.3.2
 ------------------------
-Website: https://github.com/node-fetch/node-fetch
+Source: https://github.com/node-fetch/node-fetch
 
 Copyright 2016 - 2020 Node Fetch Team
 Distributed under the MIT License
@@ -37580,7 +38739,7 @@ SOFTWARE.
 
 node-fetch versions 2.7.0, 2.6.7
 --------------------------------
-Website: https://github.com/bitinn/node-fetch
+Source: https://github.com/bitinn/node-fetch
 
 Copyright 2016 David Frank
 Distributed under the MIT License
@@ -37612,7 +38771,7 @@ SOFTWARE.
 
 node-html-parser
 ----------------
-Website: https://github.com/taoqf/node-fast-html-parser
+Source: https://github.com/taoqf/node-fast-html-parser
 
 Copyright 2019 Tao Qiufeng
 Distributed under the MIT License
@@ -37630,7 +38789,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 node-pty
 --------
-Website: https://github.com/microsoft/node-pty
+Source: https://github.com/microsoft/node-pty
 
 Copyright 2012-2015, Christopher Jeffrey (https:github.com/chjj/)
 Copyright 2016, Daniel Imms (http:www.growingwiththeweb.com)
@@ -37708,7 +38867,7 @@ SOFTWARE.
 
 node-stream-zip
 ---------------
-Website: https://github.com/antelle/node-stream-zip
+Source: https://github.com/antelle/node-stream-zip
 
 Copyright 2012 Another-D-Mention Software and other contributors, http:www.another-d-mention.ro/
 Copyright 2021 Antelle https:github.com/antelle
@@ -37764,7 +38923,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 nodrop
 ------
-Website: https://github.com/bluss/arrayvec
+Source: https://github.com/bluss/arrayvec
 
 Copyright Ulrik Sverdrup "bluss" 2015-2017
 
@@ -37804,7 +38963,7 @@ DEALINGS IN THE SOFTWARE.
 
 notify
 ------
-Website: https://github.com/notify-rs/notify
+Source: https://github.com/notify-rs/notify
 
 Copyright 2000-2006, The Perl Foundation.
 Copyright Holder that are necessarily infringed by the Package. If you institute patent litigation (including a cross-claim or counterclaim) against any party alleging that the Package constitutes direct or contributory patent infringement, then this Artistic License to you shall terminate on the date that such litigation is filed.
@@ -38052,7 +39211,7 @@ For these and/or other purposes and motivations, and without any expectation of 
 
 ntapi
 -----
-Website: https://github.com/MSxDOS/ntapi
+Source: https://github.com/MSxDOS/ntapi
 
 Published by MSxDOS <melcodos@gmail.com>
 
@@ -38064,7 +39223,7 @@ Consult the documentation and source code of ntapi for more information.
 
 nth-check
 ---------
-Website: https://github.com/fb55/nth-check
+Source: https://github.com/fb55/nth-check
 
 Copyright Felix Böhm
 Distributed under the BSD 2-Clause license
@@ -38087,7 +39246,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 nu-ansi-term
 ------------
-Website: https://github.com/nushell/nu-ansi-term
+Source: https://github.com/nushell/nu-ansi-term
 
 Copyright 2014 Benjamin Sago
 Copyright 2021-2022 The Nushell Project Developers
@@ -38122,7 +39281,7 @@ SOFTWARE.
 
 num-bigint
 ----------
-Website: https://github.com/rust-num/num-bigint
+Source: https://github.com/rust-num/num-bigint
 
 Copyright 2014 The Rust Project Developers
 
@@ -38162,7 +39321,7 @@ DEALINGS IN THE SOFTWARE.
 
 num-conv
 --------
-Website: https://github.com/jhpratt/num-conv
+Source: https://github.com/jhpratt/num-conv
 
 Copyright 2023 Jacob Pratt
 
@@ -38403,7 +39562,7 @@ SOFTWARE.
 
 num-integer
 -----------
-Website: https://github.com/rust-num/num-integer
+Source: https://github.com/rust-num/num-integer
 
 Copyright 2014 The Rust Project Developers
 
@@ -38443,7 +39602,7 @@ DEALINGS IN THE SOFTWARE.
 
 num-traits
 ----------
-Website: https://github.com/rust-num/num-traits
+Source: https://github.com/rust-num/num-traits
 
 Copyright 2014 The Rust Project Developers
 
@@ -38483,7 +39642,7 @@ DEALINGS IN THE SOFTWARE.
 
 num_cpus
 --------
-Website: https://github.com/seanmonstar/num_cpus
+Source: https://github.com/seanmonstar/num_cpus
 
 Copyright 2015 Sean McArthur <sean@seanmonstar.com>
 
@@ -38517,7 +39676,7 @@ THE SOFTWARE.
 
 num_threads
 -----------
-Website: https://github.com/jhpratt/num_threads
+Source: https://github.com/jhpratt/num_threads
 
 Copyright 2021 Jacob Pratt
 
@@ -38758,7 +39917,7 @@ SOFTWARE.
 
 NVIDIA cuda-cpp-grammar
 -----------------------
-Website: https://github.com/NVIDIA/cuda-cpp-grammar
+Source: https://github.com/NVIDIA/cuda-cpp-grammar
 
 Copyright 2021 NVIDIA Corporation
 Distributed under the MIT License
@@ -38766,7 +39925,7 @@ Distributed under the MIT License
 
 oauth4webapi
 ------------
-Website: https://github.com/panva/oauth4webapi
+Source: https://github.com/panva/oauth4webapi
 
 Copyright 2022 Filip Skokan
 Distributed under the MIT License
@@ -38798,7 +39957,7 @@ SOFTWARE.
 
 object
 ------
-Website: https://github.com/gimli-rs/object
+Source: https://github.com/gimli-rs/object
 
 Copyright 2015 The Gimli Developers
 
@@ -38838,7 +39997,7 @@ DEALINGS IN THE SOFTWARE.
 
 object-inspect
 --------------
-Website: https://github.com/inspect-js/object-inspect
+Source: https://github.com/inspect-js/object-inspect
 
 Copyright 2013 James Halliday
 Distributed under the MIT License
@@ -38870,7 +40029,7 @@ SOFTWARE.
 
 Objective-C Language Basics
 ---------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -38878,7 +40037,7 @@ Distributed under the MIT License
 
 @octokit/auth-token
 -------------------
-Website: https://github.com/octokit/auth-token.js
+Source: https://github.com/octokit/auth-token.js
 
 Copyright 2019 Octokit contributors
 Distributed under the MIT License
@@ -38910,7 +40069,7 @@ THE SOFTWARE.
 
 @octokit/core
 -------------
-Website: https://github.com/octokit/core.js
+Source: https://github.com/octokit/core.js
 
 Copyright 2019 Octokit contributors
 Distributed under the MIT License
@@ -38942,7 +40101,7 @@ THE SOFTWARE.
 
 @octokit/endpoint
 -----------------
-Website: https://github.com/octokit/endpoint.js
+Source: https://github.com/octokit/endpoint.js
 
 Copyright 2018 Octokit contributors
 Distributed under the MIT License
@@ -38974,7 +40133,7 @@ THE SOFTWARE.
 
 @octokit/graphql
 ----------------
-Website: https://github.com/octokit/graphql.js
+Source: https://github.com/octokit/graphql.js
 
 Copyright 2018 Octokit contributors
 Distributed under the MIT License
@@ -39006,7 +40165,7 @@ THE SOFTWARE.
 
 @octokit/graphql-schema
 -----------------------
-Website: https://github.com/octokit/graphql-schema
+Source: https://github.com/octokit/graphql-schema
 
 Copyright 2017 Gregor Martynus
 Distributed under the MIT License
@@ -39037,7 +40196,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 @octokit/openapi-types version 25.0.0
 -------------------------------------
-Website: https://github.com/octokit/openapi-types.ts
+Source: https://github.com/octokit/openapi-types.ts
 
 Copyright GitHub 2025 - Licensed as MIT.
 Distributed under the MIT License
@@ -39055,7 +40214,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 @octokit/openapi-types versions 24.2.0, 23.0.1
 ----------------------------------------------
-Website: https://github.com/octokit/openapi-types.ts
+Source: https://github.com/octokit/openapi-types.ts
 
 Copyright 2020 Gregor Martynus
 Distributed under the MIT License
@@ -39073,7 +40232,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 @octokit/plugin-paginate-rest
 -----------------------------
-Website: https://github.com/octokit/plugin-paginate-rest.js
+Source: https://github.com/octokit/plugin-paginate-rest.js
 
 Copyright (c) 2019 Octokit contributors
 Distributed under the MIT License
@@ -39081,7 +40240,7 @@ Distributed under the MIT License
 
 @octokit/plugin-request-log
 ---------------------------
-Website: https://github.com/octokit/plugin-request-log.js
+Source: https://github.com/octokit/plugin-request-log.js
 
 Published by Gregor Martynus (https://twitter.com/gr2m)
 Distributed under the MIT License
@@ -39089,7 +40248,7 @@ Distributed under the MIT License
 
 @octokit/plugin-rest-endpoint-methods
 -------------------------------------
-Website: https://github.com/octokit/plugin-rest-endpoint-methods.js
+Source: https://github.com/octokit/plugin-rest-endpoint-methods.js
 
 Published by Gregor Martynus (https://twitter.com/gr2m)
 Distributed under the MIT License
@@ -39097,7 +40256,7 @@ Distributed under the MIT License
 
 @octokit/request
 ----------------
-Website: https://github.com/octokit/request.js
+Source: https://github.com/octokit/request.js
 
 Copyright 2018 Octokit contributors
 Distributed under the MIT License
@@ -39129,7 +40288,7 @@ THE SOFTWARE.
 
 @octokit/request-error
 ----------------------
-Website: https://github.com/octokit/request-error.js
+Source: https://github.com/octokit/request-error.js
 
 Copyright 2019 Octokit contributors
 Distributed under the MIT License
@@ -39161,7 +40320,7 @@ THE SOFTWARE.
 
 @octokit/rest
 -------------
-Website: https://github.com/octokit/rest.js
+Source: https://github.com/octokit/rest.js
 
 Copyright 2012 Cloud9 IDE, Inc. (Mike de Boer)
 Copyright 2017-2018 Octokit contributors
@@ -39196,7 +40355,7 @@ THE SOFTWARE.
 
 @octokit/types
 --------------
-Website: https://github.com/octokit/types.ts
+Source: https://github.com/octokit/types.ts
 
 Published by Gregor Martynus (https://twitter.com/gr2m)
 Distributed under the MIT License
@@ -39204,7 +40363,7 @@ Distributed under the MIT License
 
 on-finished
 -----------
-Website: https://github.com/jshttp/on-finished
+Source: https://github.com/jshttp/on-finished
 
 Copyright 2013 Jonathan Ong <me@jongleberry.com>
 Copyright 2014 Douglas Christopher Wilson <doug@somethingdoug.com>
@@ -39240,7 +40399,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 once
 ----
-Website: https://github.com/isaacs/once
+Source: https://github.com/isaacs/once
 
 Copyright Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -39266,7 +40425,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 once_cell
 ---------
-Website: https://github.com/matklad/once_cell
+Source: https://github.com/matklad/once_cell
 
 Published by Aleksey Kladov <aleksey.kladov@gmail.com>
 
@@ -39278,7 +40437,7 @@ Consult the documentation and source code of once_cell for more information.
 
 one-time
 --------
-Website: https://github.com/3rd-Eden/one-time
+Source: https://github.com/3rd-Eden/one-time
 
 Copyright 2015 Unshift.io, Arnout Kazemier, the Contributors.
 Distributed under the MIT License
@@ -39310,7 +40469,7 @@ SOFTWARE.
 
 open
 ----
-Website: https://github.com/sindresorhus/open
+Source: https://github.com/sindresorhus/open
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -39330,7 +40489,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 Open Remote - WSL
 -----------------
-Website: https://github.com/posit-dev/positron
+Source: https://github.com/posit-dev/positron
 
 Copyright License
 
@@ -39441,7 +40600,7 @@ these terms.
 
 Open Remote SSH
 ---------------
-Website: https://github.com/jeanp413/open-remote-ssh
+Source: https://github.com/jeanp413/open-remote-ssh
 
 Copyright (c) 2022 open-remote-ssh project authors
 Distributed under the MIT License
@@ -39449,7 +40608,7 @@ Distributed under the MIT License
 
 Open Remote WSL
 ---------------
-Website: https://github.com/jeanp413/open-remote-wsl
+Source: https://github.com/jeanp413/open-remote-wsl
 
 Copyright (c) 2023 open-remote-wsl project authors
 Distributed under the MIT License
@@ -39457,7 +40616,7 @@ Distributed under the MIT License
 
 open-remote-ssh
 ---------------
-Website: https://github.com/jeanp413/open-remote-ssh
+Source: https://github.com/jeanp413/open-remote-ssh
 
 Copyright 2022
 Distributed under the MIT License
@@ -39489,7 +40648,7 @@ SOFTWARE.
 
 openssl
 -------
-Website: https://github.com/sfackler/rust-openssl
+Source: https://github.com/sfackler/rust-openssl
 
 Copyright 2011-2017 Google Inc. 2013 Jack Lloyd 2013-2014 Steven Fackler
 Distributed under the Apache License version 2.0
@@ -39517,7 +40676,7 @@ limitations under the License.
 
 openssl-macros
 --------------
-Website: (Could not find homepage for package)
+Source: (Could not find homepage for package)
 
 Copyright 2022 Steven Fackler
 
@@ -39551,7 +40710,7 @@ SOFTWARE.
 
 openssl-probe
 -------------
-Website: https://github.com/alexcrichton/openssl-probe
+Source: https://github.com/alexcrichton/openssl-probe
 
 Copyright 2014 Alex Crichton
 
@@ -39591,7 +40750,7 @@ DEALINGS IN THE SOFTWARE.
 
 openssl-sys
 -----------
-Website: https://github.com/sfackler/rust-openssl
+Source: https://github.com/sfackler/rust-openssl
 
 Copyright 2014 Alex Crichton
 Distributed under the MIT License
@@ -39627,7 +40786,7 @@ DEALINGS IN THE SOFTWARE.
 
 @opentelemetry/api
 ------------------
-Website: https://github.com/open-telemetry/opentelemetry-js
+Source: https://github.com/open-telemetry/opentelemetry-js
 
 Published by OpenTelemetry Authors
 Distributed under the Apache License version 2.0
@@ -39635,7 +40794,7 @@ Distributed under the Apache License version 2.0
 
 @opentelemetry/api-logs
 -----------------------
-Website: https://github.com/open-telemetry/opentelemetry-js
+Source: https://github.com/open-telemetry/opentelemetry-js
 
 Published by OpenTelemetry Authors
 Distributed under the Apache License version 2.0
@@ -39643,7 +40802,7 @@ Distributed under the Apache License version 2.0
 
 @opentelemetry/core
 -------------------
-Website: https://github.com/open-telemetry/opentelemetry-js
+Source: https://github.com/open-telemetry/opentelemetry-js
 
 Published by OpenTelemetry Authors
 Distributed under the Apache License version 2.0
@@ -39651,7 +40810,7 @@ Distributed under the Apache License version 2.0
 
 @opentelemetry/instrumentation
 ------------------------------
-Website: https://github.com/open-telemetry/opentelemetry-js
+Source: https://github.com/open-telemetry/opentelemetry-js
 
 Published by OpenTelemetry Authors
 Distributed under the Apache License version 2.0
@@ -39659,7 +40818,7 @@ Distributed under the Apache License version 2.0
 
 @opentelemetry/resources
 ------------------------
-Website: https://github.com/open-telemetry/opentelemetry-js
+Source: https://github.com/open-telemetry/opentelemetry-js
 
 Published by OpenTelemetry Authors
 Distributed under the Apache License version 2.0
@@ -39667,7 +40826,7 @@ Distributed under the Apache License version 2.0
 
 @opentelemetry/sdk-trace-base
 -----------------------------
-Website: https://github.com/open-telemetry/opentelemetry-js
+Source: https://github.com/open-telemetry/opentelemetry-js
 
 Published by OpenTelemetry Authors
 Distributed under the Apache License version 2.0
@@ -39675,7 +40834,7 @@ Distributed under the Apache License version 2.0
 
 @opentelemetry/semantic-conventions
 -----------------------------------
-Website: https://github.com/open-telemetry/opentelemetry-js
+Source: https://github.com/open-telemetry/opentelemetry-js
 
 Published by OpenTelemetry Authors
 Distributed under the Apache License version 2.0
@@ -39683,7 +40842,7 @@ Distributed under the Apache License version 2.0
 
 opentype.js
 -----------
-Website: https://github.com/nodebox/opentype.js
+Source: https://github.com/nodebox/opentype.js
 
 Copyright 2017 Frederik De Bleser
 Distributed under the MIT License
@@ -39714,7 +40873,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 option-ext
 ----------
-Website: https://github.com/soc/option-ext
+Source: https://github.com/soc/option-ext
 
 Published by Simon Ochsenreither <simon@ochsenreither.de>
 Distributed under the Mozilla Public License version 2.0
@@ -40113,7 +41272,7 @@ defined by the Mozilla Public License, v. 2.0.
 
 ordered-float
 -------------
-Website: https://github.com/reem/rust-ordered-float
+Source: https://github.com/reem/rust-ordered-float
 
 Copyright 2015 Jonathan Reem
 Distributed under the MIT License
@@ -40149,7 +41308,7 @@ DEALINGS IN THE SOFTWARE.
 
 os-paths
 --------
-Website: https://github.com/rivy/js.os-paths
+Source: https://github.com/rivy/js.os-paths
 
 Copyright Roy Ivy III <rivy.dev@gmail.com>
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
@@ -40172,7 +41331,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 overload
 --------
-Website: https://github.com/danaugrs/overload
+Source: https://github.com/danaugrs/overload
 
 Copyright 2019 Daniel Augusto Rizzi Salvadori
 Distributed under the MIT License
@@ -40204,7 +41363,7 @@ SOFTWARE.
 
 p-finally
 ---------
-Website: https://github.com/sindresorhus/p-finally
+Source: https://github.com/sindresorhus/p-finally
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -40236,7 +41395,7 @@ THE SOFTWARE.
 
 p-limit
 -------
-Website: https://github.com/sindresorhus/p-limit
+Source: https://github.com/sindresorhus/p-limit
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -40256,7 +41415,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 p-locate
 --------
-Website: https://github.com/sindresorhus/p-locate
+Source: https://github.com/sindresorhus/p-locate
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -40276,7 +41435,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 p-queue
 -------
-Website: https://github.com/sindresorhus/p-queue
+Source: https://github.com/sindresorhus/p-queue
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -40296,7 +41455,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 p-timeout
 ---------
-Website: https://github.com/sindresorhus/p-timeout
+Source: https://github.com/sindresorhus/p-timeout
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -40314,9 +41473,75 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
+pac-proxy-agent
+---------------
+Source: https://github.com/TooTallNate/proxy-agents
+
+Copyright 2014 Nathan Rajlich <nathan@tootallnate.net>
+Distributed under the MIT License
+
+MIT License text:
+
+(The MIT License)
+
+Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+pac-resolver
+------------
+Source: https://github.com/TooTallNate/proxy-agents
+
+Copyright 2013 Nathan Rajlich <nathan@tootallnate.net>
+Distributed under the MIT License
+
+MIT License text:
+
+(The MIT License)
+
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 package-json-from-dist
 ----------------------
-Website: https://github.com/isaacs/package-json-from-dist
+Source: https://github.com/isaacs/package-json-from-dist
 
 Published by Isaac Z. Schlueter <i@izs.me> (https://izs.me)
 Distributed under the Blue Oak Model License version 1.0.0
@@ -40390,7 +41615,7 @@ software or this license, under any kind of legal claim.*****
 
 package-manager-detector
 ------------------------
-Website: https://github.com/antfu-collective/package-manager-detector
+Source: https://github.com/antfu-collective/package-manager-detector
 
 Copyright 2020-PRESENT Anthony Fu <https:github.com/antfu>
 Distributed under the MIT License
@@ -40422,7 +41647,7 @@ SOFTWARE.
 
 packaging
 ---------
-Website: https://github.com/pypa/packaging
+Source: https://github.com/pypa/packaging
 
 All rights reserved.
 Copyright (c) Donald Stufft and individual contributors.
@@ -40435,7 +41660,7 @@ Consult the documentation and source code of packaging for more information.
 
 @parcel/watcher
 ---------------
-Website: https://github.com/parcel-bundler/watcher
+Source: https://github.com/parcel-bundler/watcher
 
 Copyright 2017-present Devon Govett
 Distributed under the MIT License
@@ -40467,7 +41692,7 @@ SOFTWARE.
 
 parking
 -------
-Website: https://github.com/smol-rs/parking
+Source: https://github.com/smol-rs/parking
 
 Copyright 2014-2020 The Rust Project Developers
 
@@ -40479,7 +41704,7 @@ Consult the documentation and source code of parking for more information.
 
 parking_lot
 -----------
-Website: https://github.com/Amanieu/parking_lot
+Source: https://github.com/Amanieu/parking_lot
 
 Copyright 2016 The Rust Project Developers
 
@@ -40519,7 +41744,7 @@ DEALINGS IN THE SOFTWARE.
 
 parse-passwd
 ------------
-Website: https://github.com/doowb/parse-passwd
+Source: https://github.com/doowb/parse-passwd
 
 Copyright 2016 Brian Woodward
 Distributed under the MIT License
@@ -40551,7 +41776,7 @@ SOFTWARE.
 
 parse5
 ------
-Website: https://github.com/inikulin/parse5
+Source: https://github.com/inikulin/parse5
 
 Copyright 2013-2016 Ivan Nikulin (ifaaan@gmail.com, https:github.com/inikulin)
 Distributed under the MIT License
@@ -40581,7 +41806,7 @@ THE SOFTWARE.
 
 parseurl
 --------
-Website: https://github.com/pillarjs/parseurl
+Source: https://github.com/pillarjs/parseurl
 
 Copyright 2014 Jonathan Ong <me@jongleberry.com>
 Copyright 2014-2017 Douglas Christopher Wilson <doug@somethingdoug.com>
@@ -40617,7 +41842,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 parso
 -----
-Website: https://github.com/davidhalter/parso
+Source: https://github.com/davidhalter/parso
 
 Published by David Halter
 Distributed under the MIT License
@@ -40625,7 +41850,7 @@ Distributed under the MIT License
 
 paste
 -----
-Website: https://github.com/dtolnay/paste
+Source: https://github.com/dtolnay/paste
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -40637,7 +41862,7 @@ Consult the documentation and source code of paste for more information.
 
 path-absolutize
 ---------------
-Website: https://github.com/magiclen/path-absolutize
+Source: https://github.com/magiclen/path-absolutize
 
 Copyright 2018 magiclen.org (Ron Li)
 Distributed under the MIT License
@@ -40669,7 +41894,7 @@ SOFTWARE.
 
 path-data-parser
 ----------------
-Website: https://github.com/pshihn/path-data-parser
+Source: https://github.com/pshihn/path-data-parser
 
 Copyright 2020 Preet Shihn
 Distributed under the MIT License
@@ -40701,7 +41926,7 @@ SOFTWARE.
 
 path-dedot
 ----------
-Website: https://github.com/magiclen/path-dedot
+Source: https://github.com/magiclen/path-dedot
 
 Copyright 2018 magiclen.org (Ron Li)
 Distributed under the MIT License
@@ -40733,7 +41958,7 @@ SOFTWARE.
 
 path-exists
 -----------
-Website: https://github.com/sindresorhus/path-exists
+Source: https://github.com/sindresorhus/path-exists
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -40753,7 +41978,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 path-is-absolute
 ----------------
-Website: https://github.com/sindresorhus/path-is-absolute
+Source: https://github.com/sindresorhus/path-is-absolute
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -40785,7 +42010,7 @@ THE SOFTWARE.
 
 path-key
 --------
-Website: https://github.com/sindresorhus/path-key
+Source: https://github.com/sindresorhus/path-key
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -40805,7 +42030,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 path-parse
 ----------
-Website: https://github.com/jbgutierrez/path-parse
+Source: https://github.com/jbgutierrez/path-parse
 
 Copyright 2015 Javier Blanco
 Distributed under the MIT License
@@ -40837,7 +42062,7 @@ SOFTWARE.
 
 path-scurry
 -----------
-Website: https://github.com/isaacs/path-scurry
+Source: https://github.com/isaacs/path-scurry
 
 Published by Isaac Z. Schlueter <i@izs.me> (https://blog.izs.me)
 Distributed under the Blue Oak Model License version 1.0.0
@@ -40845,7 +42070,7 @@ Distributed under the Blue Oak Model License version 1.0.0
 
 path-to-regexp
 --------------
-Website: https://github.com/pillarjs/path-to-regexp
+Source: https://github.com/pillarjs/path-to-regexp
 
 Copyright 2014 Blake Embrey (hello@blakeembrey.com)
 Distributed under the MIT License
@@ -40877,7 +42102,7 @@ THE SOFTWARE.
 
 pathe
 -----
-Website: https://github.com/unjs/pathe
+Source: https://github.com/unjs/pathe
 
 Copyright 2023-present Fabio Spampinato
 Copyright Joyent, Inc. and other Node contributors.
@@ -40960,7 +42185,7 @@ DEALINGS IN THE SOFTWARE.
 
 peek-readable
 -------------
-Website: https://github.com/Borewit/peek-readable
+Source: https://github.com/Borewit/peek-readable
 
 Copyright 2010-2017 Borewit
 Distributed under the MIT License
@@ -40992,7 +42217,7 @@ THE SOFTWARE.
 
 pem
 ---
-Website: https://github.com/jcreekmore/pem-rs
+Source: https://github.com/jcreekmore/pem-rs
 
 Copyright 2016 Jonathan Creekmore
 Distributed under the MIT License
@@ -41024,7 +42249,7 @@ SOFTWARE.
 
 pend
 ----
-Website: https://github.com/andrewrk/node-pend
+Source: https://github.com/andrewrk/node-pend
 
 Copyright 2014 Andrew Kelley
 Distributed under the MIT License
@@ -41058,7 +42283,7 @@ SOFTWARE.
 
 Perl Language Basics
 --------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -41066,7 +42291,7 @@ Distributed under the MIT License
 
 Perl tmBundle
 -------------
-Website: https://github.com/textmate/perl.tmbundle
+Source: https://github.com/textmate/perl.tmbundle
 
 Copyright (c) textmate-perl.tmbundle project authors
 
@@ -41090,7 +42315,7 @@ to the base-name name of the original file, and an extension of txt, html, or si
 
 pexpect
 -------
-Website: https://pexpect.readthedocs.io/
+Source: https://pexpect.readthedocs.io/
 
 Copyright 2012, Noah Spurrier <noah@noah.org>
 Copyright 2013-2014, Pexpect development team
@@ -41122,7 +42347,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 PHP Language Basics
 -------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -41130,7 +42355,7 @@ Distributed under the MIT License
 
 PHP Language Features
 ---------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -41138,7 +42363,7 @@ Distributed under the MIT License
 
 picomatch
 ---------
-Website: https://github.com/micromatch/picomatch
+Source: https://github.com/micromatch/picomatch
 
 Copyright 2017-present, Jon Schlinkert.
 Distributed under the MIT License
@@ -41170,7 +42395,7 @@ THE SOFTWARE.
 
 pify
 ----
-Website: https://github.com/sindresorhus/pify
+Source: https://github.com/sindresorhus/pify
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -41190,7 +42415,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 pin-project
 -----------
-Website: https://github.com/taiki-e/pin-project
+Source: https://github.com/taiki-e/pin-project
 
 Published by Taiki Endo
 
@@ -41202,7 +42427,7 @@ Consult the documentation and source code of pin-project for more information.
 
 pin-project-lite
 ----------------
-Website: https://github.com/taiki-e/pin-project-lite
+Source: https://github.com/taiki-e/pin-project-lite
 
 Published by Taiki Endo
 
@@ -41214,7 +42439,7 @@ Consult the documentation and source code of pin-project-lite for more informati
 
 pin-utils
 ---------
-Website: https://github.com/rust-lang-nursery/pin-utils
+Source: https://github.com/rust-lang-nursery/pin-utils
 
 Copyright 2018 The pin-utils authors
 
@@ -41461,7 +42686,7 @@ DEALINGS IN THE SOFTWARE.
 
 pkg-config
 ----------
-Website: https://github.com/rust-lang/pkg-config-rs
+Source: https://github.com/rust-lang/pkg-config-rs
 
 Copyright 2014 Alex Crichton
 
@@ -41501,7 +42726,7 @@ DEALINGS IN THE SOFTWARE.
 
 pkg-types
 ---------
-Website: https://github.com/unjs/pkg-types
+Source: https://github.com/unjs/pkg-types
 
 Copyright Joyent, Inc. and other Node contributors.
 Copyright Pooya Parsa <pooya@pi0.io> - Daniel Roe <daniel@roe.dev>
@@ -41557,7 +42782,7 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 platformdirs
 ------------
-Website: https://github.com/tox-dev/platformdirs
+Source: https://github.com/tox-dev/platformdirs
 
 Copyright 2010-202x The platformdirs developers
 Distributed under the MIT License
@@ -41589,7 +42814,7 @@ SOFTWARE.
 
 points-on-curve
 ---------------
-Website: https://github.com/pshihn/bezier-points
+Source: https://github.com/pshihn/bezier-points
 
 Copyright 2020 Preet Shihn
 Distributed under the MIT License
@@ -41621,7 +42846,7 @@ SOFTWARE.
 
 points-on-path
 --------------
-Website: https://github.com/pshihn/points-on-path
+Source: https://github.com/pshihn/points-on-path
 
 Copyright 2020 Preet
 Distributed under the MIT License
@@ -41653,7 +42878,7 @@ SOFTWARE.
 
 portfinder
 ----------
-Website: https://github.com/http-party/node-portfinder
+Source: https://github.com/http-party/node-portfinder
 
 Copyright 2012 Charlie Robbins
 Distributed under the MIT License
@@ -41686,7 +42911,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 powerfmt
 --------
-Website: https://github.com/jhpratt/powerfmt
+Source: https://github.com/jhpratt/powerfmt
 
 Copyright 2023 Jacob Pratt et al.
 
@@ -41927,7 +43152,7 @@ SOFTWARE.
 
 PowerShell EditorSyntax
 -----------------------
-Website: https://github.com/PowerShell/EditorSyntax
+Source: https://github.com/PowerShell/EditorSyntax
 
 Copyright (c) Microsoft Corporation All rights reserved.
 Distributed under the MIT License
@@ -41935,7 +43160,7 @@ Distributed under the MIT License
 
 Powershell Language Basics
 --------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -41943,7 +43168,7 @@ Distributed under the MIT License
 
 PowerShell ReadLine
 -------------------
-Website: https://github.com/PowerShell/PSReadLine
+Source: https://github.com/PowerShell/PSReadLine
 
 Copyright (c) 2013, Jason Shirk. All rights reserved.
 Distributed under the BSD 2-Clause license
@@ -41951,7 +43176,7 @@ Distributed under the BSD 2-Clause license
 
 ppv-lite86
 ----------
-Website: https://github.com/cryptocorrosion/cryptocorrosion
+Source: https://github.com/cryptocorrosion/cryptocorrosion
 
 Copyright 2019 The CryptoCorrosion Contributors
 
@@ -42198,7 +43423,7 @@ DEALINGS IN THE SOFTWARE.
 
 prebuild-install
 ----------------
-Website: https://github.com/prebuild/prebuild-install
+Source: https://github.com/prebuild/prebuild-install
 
 Copyright 2015 Mathias Buus
 Distributed under the MIT License
@@ -42230,7 +43455,7 @@ THE SOFTWARE.
 
 precomputed-hash
 ----------------
-Website: https://github.com/emilio/precomputed-hash
+Source: https://github.com/emilio/precomputed-hash
 
 Copyright 2017 Emilio Cobos Álvarez
 Distributed under the MIT License
@@ -42262,7 +43487,7 @@ SOFTWARE.
 
 proc-macro-error
 ----------------
-Website: https://gitlab.com/CreepySkeleton/proc-macro-error
+Source: https://gitlab.com/CreepySkeleton/proc-macro-error
 
 Copyright 2019-2020 CreepySkeleton <creepy-skeleton@yandex.ru>
 
@@ -42505,7 +43730,7 @@ SOFTWARE.
 
 proc-macro-error-2
 ------------------
-Website: https://github.com/GnomedDev/proc-macro-error-2
+Source: https://github.com/GnomedDev/proc-macro-error-2
 
 Copyright 2019-2020 CreepySkeleton <creepy-skeleton@yandex.ru>
 
@@ -42748,7 +43973,7 @@ SOFTWARE.
 
 proc-macro-hack
 ---------------
-Website: https://github.com/dtolnay/proc-macro-hack
+Source: https://github.com/dtolnay/proc-macro-hack
 
 Copyright 2018 David Tolnay
 
@@ -42788,7 +44013,7 @@ DEALINGS IN THE SOFTWARE.
 
 proc-macro2
 -----------
-Website: https://github.com/dtolnay/proc-macro2
+Source: https://github.com/dtolnay/proc-macro2
 
 Published by David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>
 
@@ -42800,7 +44025,7 @@ Consult the documentation and source code of proc-macro2 for more information.
 
 promise-stream-reader
 ---------------------
-Website: https://github.com/princjef/promise-stream-reader
+Source: https://github.com/princjef/promise-stream-reader
 
 Copyright 2018 Jeffrey Principe
 Distributed under the MIT License
@@ -42832,7 +44057,7 @@ SOFTWARE.
 
 Prompt Language Basics
 ----------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -42840,7 +44065,7 @@ Distributed under the MIT License
 
 prompt-toolkit
 --------------
-Website: https://pypi.org/project/prompt-toolkit/
+Source: https://pypi.org/project/prompt-toolkit/
 
 Copyright 2014, Jonathan Slenders
 Distributed under the BSD 3-Clause license
@@ -42879,7 +44104,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 proxy-addr
 ----------
-Website: https://github.com/jshttp/proxy-addr
+Source: https://github.com/jshttp/proxy-addr
 
 Copyright 2014-2016 Douglas Christopher Wilson
 Distributed under the MIT License
@@ -42910,9 +44135,42 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
+proxy-agent
+-----------
+Source: https://github.com/TooTallNate/proxy-agents
+
+Copyright 2013 Nathan Rajlich <nathan@tootallnate.net>
+Distributed under the MIT License
+
+MIT License text:
+
+(The MIT License)
+
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 proxy-from-env
 --------------
-Website: https://github.com/Rob--W/proxy-from-env
+Source: https://github.com/Rob--W/proxy-from-env
 
 Copyright (C) 2016-2018 Rob Wu <rob@robwu.nl>
 Distributed under the MIT License
@@ -42943,7 +44201,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 psutil
 ------
-Website: https://github.com/giampaolo/psutil
+Source: https://github.com/giampaolo/psutil
 
 Copyright 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola
 Distributed under the BSD 3-Clause license
@@ -42983,7 +44241,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ptyprocess
 ----------
-Website: https://github.com/pexpect/ptyprocess
+Source: https://github.com/pexpect/ptyprocess
 
 Copyright 2012, Noah Spurrier <noah@noah.org>
 Copyright 2013-2014, Pexpect development team
@@ -43015,7 +44273,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 Pug Language Basics
 -------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -43023,15 +44281,49 @@ Distributed under the MIT License
 
 Pug.tmbundle
 ------------
-Website: https://github.com/davidrios/pug-tmbundle
+Source: https://github.com/davidrios/pug-tmbundle
 
 Copyright (c) 2016 David Rios
 Distributed under the MIT License
 
 
+pull-stream
+-----------
+Source: https://github.com/pull-stream/pull-stream
+
+Copyright 2013 Dominic Tarr
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2013 Dominic Tarr
+
+Permission is hereby granted, free of charge,
+to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to
+deal in the Software without restriction, including
+without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom
+the Software is furnished to do so,
+
+subject to the following conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 pump
 ----
-Website: https://github.com/mafintosh/pump
+Source: https://github.com/mafintosh/pump
 
 Copyright 2014 Mathias Buus
 Distributed under the MIT License
@@ -43063,7 +44355,7 @@ THE SOFTWARE.
 
 punycode
 --------
-Website: https://github.com/mathiasbynens/punycode.js
+Source: https://github.com/mathiasbynens/punycode.js
 
 Copyright Mathias Bynens <https:mathiasbynens.be/>
 Distributed under the MIT License
@@ -43094,7 +44386,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 punycode.js
 -----------
-Website: https://github.com/mathiasbynens/punycode.js
+Source: https://github.com/mathiasbynens/punycode.js
 
 Copyright Mathias Bynens <https:mathiasbynens.be/>
 Distributed under the MIT License
@@ -43125,7 +44417,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 pure-eval
 ---------
-Website: http://github.com/alexmojaki/pure_eval
+Source: http://github.com/alexmojaki/pure_eval
 
 Copyright 2019 Alex Hall
 Distributed under the MIT License
@@ -43157,7 +44449,7 @@ SOFTWARE.
 
 pycparser
 ---------
-Website: https://github.com/eliben/pycparser
+Source: https://github.com/eliben/pycparser
 
 Copyright 2008-2022, Eli Bendersky
 Distributed under the BSD 3-Clause license
@@ -43197,7 +44489,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 pydantic
 --------
-Website: https://github.com/pydantic/pydantic
+Source: https://github.com/pydantic/pydantic
 
 Copyright 2017 to present Pydantic Services Inc. and individual contributors.
 Distributed under the MIT License
@@ -43229,7 +44521,7 @@ SOFTWARE.
 
 pygls
 -----
-Website: https://github.com/openlawlibrary/pygls
+Source: https://github.com/openlawlibrary/pygls
 
 Published by Open Law Library
 Distributed under the Apache License version 2.0
@@ -43237,7 +44529,7 @@ Distributed under the Apache License version 2.0
 
 pygments
 --------
-Website: https://github.com/pygments/pygments
+Source: https://github.com/pygments/pygments
 
 Copyright 2006-2022 by the respective authors (see AUTHORS file).
 Distributed under the BSD 2-Clause license
@@ -43273,7 +44565,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Python
 ------
-Website: https://github.com/posit-dev/positron
+Source: https://github.com/posit-dev/positron
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -43305,7 +44597,7 @@ SOFTWARE.
 
 python-dateutil
 ---------------
-Website: https://github.com/dateutil/dateutil
+Source: https://github.com/dateutil/dateutil
 
 Copyright 2003-2011 - Gustavo Niemeyer <gustavo@niemeyer.net>
 Copyright 2012-2014 - Tomi Pieviläinen <tomi.pievilainen@iki.fi>
@@ -43384,7 +44676,7 @@ The above BSD License Applies to all code, even that also covered by Apache 2.0.
 
 pywin32
 -------
-Website: https://github.com/mhammond/pywin32
+Source: https://github.com/mhammond/pywin32
 
 Copyright 1994-2008, Mark Hammond
 Copyright 1996-2008, Greg Stein and Mark Hammond.
@@ -43602,7 +44894,7 @@ https://www.gnu.org/licenses/lgpl-2.1.txt
 
 pyzmq
 -----
-Website: https://github.com/zeromq/pyzmq
+Source: https://github.com/zeromq/pyzmq
 
 Copyright 2009-2012, Brian Granger, Min Ragan-Kelley
 Distributed under the BSD 3-Clause license
@@ -43643,7 +44935,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 qs
 --
-Website: https://github.com/ljharb/qs
+Source: https://github.com/ljharb/qs
 
 Copyright 2014, Nathan LaFreniere and other contributors
 Distributed under the BSD 3-Clause license
@@ -43683,7 +44975,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 quansync
 --------
-Website: https://github.com/quansync-dev/quansync
+Source: https://github.com/quansync-dev/quansync
 
 Copyright 2025-PRESENT Anthony Fu <https:github.com/antfu> and Kevin Deng <https:github.com/sxzz>
 Distributed under the MIT License
@@ -43715,7 +45007,7 @@ SOFTWARE.
 
 queue
 -----
-Website: https://github.com/jessetane/queue
+Source: https://github.com/jessetane/queue
 
 Copyright 2014 Jesse Tane <jesse.tane@gmail.com>
 Distributed under the MIT License
@@ -43735,7 +45027,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 Quiet Light Theme
 -----------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -43743,7 +45035,7 @@ Distributed under the MIT License
 
 quote
 -----
-Website: https://github.com/dtolnay/quote
+Source: https://github.com/dtolnay/quote
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -43755,7 +45047,7 @@ Consult the documentation and source code of quote for more information.
 
 R Language Basics
 -----------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -43763,7 +45055,7 @@ Distributed under the MIT License
 
 rand
 ----
-Website: https://github.com/rust-random/rand
+Source: https://github.com/rust-random/rand
 
 Copyright 2014 The Rust Project Developers
 Copyright 2018 Developers of the Rand project
@@ -43806,7 +45098,7 @@ DEALINGS IN THE SOFTWARE.
 
 rand_hc
 -------
-Website: https://github.com/rust-random/rand
+Source: https://github.com/rust-random/rand
 
 Copyright 2018 Developers of the Rand project
 
@@ -43846,7 +45138,7 @@ DEALINGS IN THE SOFTWARE.
 
 rand_pcg
 --------
-Website: https://github.com/rust-random/rand
+Source: https://github.com/rust-random/rand
 
 Copyright 2014-2017 Melissa O'Neill and PCG Project contributors
 Copyright 2018 Developers of the Rand project
@@ -43889,7 +45181,7 @@ DEALINGS IN THE SOFTWARE.
 
 range-parser
 ------------
-Website: https://github.com/jshttp/range-parser
+Source: https://github.com/jshttp/range-parser
 
 Copyright 2012-2014 TJ Holowaychuk <tj@vision-media.ca>
 Copyright 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com
@@ -43925,7 +45217,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 raw-body
 --------
-Website: https://github.com/stream-utils/raw-body
+Source: https://github.com/stream-utils/raw-body
 
 Copyright 2013-2014 Jonathan Ong <me@jongleberry.com>
 Copyright 2014-2022 Douglas Christopher Wilson <doug@somethingdoug.com>
@@ -43960,7 +45252,7 @@ THE SOFTWARE.
 
 rayon
 -----
-Website: https://github.com/rayon-rs/rayon
+Source: https://github.com/rayon-rs/rayon
 
 Copyright 2010 The Rust Project Developers
 
@@ -44000,7 +45292,7 @@ DEALINGS IN THE SOFTWARE.
 
 Razor Language Basics
 ---------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -44008,7 +45300,7 @@ Distributed under the MIT License
 
 rc
 --
-Website: https://github.com/dominictarr/rc
+Source: https://github.com/dominictarr/rc
 
 Copyright 2013, Dominic Tarr
 
@@ -44099,7 +45391,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 React
 -----
-Website: https://github.com/facebook/react
+Source: https://github.com/facebook/react
 
 Copyright Facebook, Inc. and its affiliates.
 Distributed under the MIT License
@@ -44131,7 +45423,7 @@ SOFTWARE.
 
 React DOM
 ---------
-Website: https://github.com/facebook/react
+Source: https://github.com/facebook/react
 
 Copyright Facebook, Inc. and its affiliates.
 Distributed under the MIT License
@@ -44163,7 +45455,7 @@ SOFTWARE.
 
 react-window
 ------------
-Website: https://github.com/bvaughn/react-window
+Source: https://github.com/bvaughn/react-window
 
 Copyright 2018 Brian Vaughn
 Distributed under the MIT License
@@ -44195,7 +45487,7 @@ SOFTWARE.
 
 readable-stream
 ---------------
-Website: https://github.com/nodejs/readable-stream
+Source: https://github.com/nodejs/readable-stream
 
 Copyright Joyent, Inc. and other Node contributors.
 Copyright Node.js contributors.
@@ -44252,15 +45544,47 @@ https://github.com/joyent/node repository:
 
 readable-web-to-node-stream
 ---------------------------
-Website: https://github.com/Borewit/readable-web-to-node-stream
+Source: https://github.com/Borewit/readable-web-to-node-stream
 
 Copyright 2019 Borewit
 Distributed under the MIT License
 
 
+recursive-readdir
+-----------------
+Source: https://github.com/jergason/recursive-readdir
+
+Copyright <year> <copyright holders>
+Distributed under the MIT License
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
 Red Theme
 ---------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -44268,7 +45592,7 @@ Distributed under the MIT License
 
 redox_syscall
 -------------
-Website: https://gitlab.redox-os.org/redox-os/syscall
+Source: https://gitlab.redox-os.org/redox-os/syscall
 
 Copyright 2017 Redox OS Developers
 Distributed under the MIT License
@@ -44301,7 +45625,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 redox_users
 -----------
-Website: https://gitlab.redox-os.org/redox-os/users
+Source: https://gitlab.redox-os.org/redox-os/users
 
 Copyright 2017 Jose Narvaez
 Distributed under the MIT License
@@ -44333,7 +45657,7 @@ SOFTWARE.
 
 ref-cast
 --------
-Website: https://github.com/dtolnay/ref-cast
+Source: https://github.com/dtolnay/ref-cast
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -44345,7 +45669,7 @@ Consult the documentation and source code of ref-cast for more information.
 
 Reference Search View
 ---------------------
-Website: https://github.com/Microsoft/vscode-references-view
+Source: https://github.com/Microsoft/vscode-references-view
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -44353,7 +45677,7 @@ Distributed under the MIT License
 
 reflect-metadata
 ----------------
-Website: https://github.com/rbuckton/reflect-metadata
+Source: https://github.com/rbuckton/reflect-metadata
 
 Published by Ron Buckton
 Distributed under the Apache License version 2.0
@@ -44361,7 +45685,7 @@ Distributed under the Apache License version 2.0
 
 regenerator-runtime
 -------------------
-Website: https://github.com/facebook/regenerator
+Source: https://github.com/facebook/regenerator
 
 Copyright 2014-present, Facebook, Inc.
 Distributed under the MIT License
@@ -44393,7 +45717,7 @@ SOFTWARE.
 
 regex
 -----
-Website: https://github.com/rust-lang/regex
+Source: https://github.com/rust-lang/regex
 
 Copyright 2014 The Rust Project Developers
 
@@ -44433,7 +45757,7 @@ DEALINGS IN THE SOFTWARE.
 
 request-light
 -------------
-Website: https://github.com/microsoft/node-request-light
+Source: https://github.com/microsoft/node-request-light
 
 Copyright Microsoft
 Distributed under the MIT License
@@ -44463,9 +45787,42 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+require-directory
+-----------------
+Source: https://github.com/troygoode/node-require-directory
+
+Copyright 2011 Troy Goode <troygoode@gmail.com>
+Distributed under the MIT License
+
+MIT License text:
+
+The MIT License (MIT)
+
+Copyright (c) 2011 Troy Goode <troygoode@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 require-from-string
 -------------------
-Website: https://github.com/floatdrop/require-from-string
+Source: https://github.com/floatdrop/require-from-string
 
 Copyright Vsevolod Strukchinsky <floatdrop@gmail.com> (github.com/floatdrop)
 Distributed under the MIT License
@@ -44497,7 +45854,7 @@ THE SOFTWARE.
 
 require-in-the-middle
 ---------------------
-Website: https://github.com/nodejs/require-in-the-middle
+Source: https://github.com/nodejs/require-in-the-middle
 
 Copyright 2016-2019, Thomas Watson Steen
 Copyright 2019-2025, Elasticsearch B.V.
@@ -44535,7 +45892,7 @@ SOFTWARE.
 
 requires-port
 -------------
-Website: https://github.com/unshiftio/requires-port
+Source: https://github.com/unshiftio/requires-port
 
 Copyright 2015 Unshift.io, Arnout Kazemier, the Contributors.
 Distributed under the MIT License
@@ -44567,7 +45924,7 @@ SOFTWARE.
 
 reqwest
 -------
-Website: https://github.com/seanmonstar/reqwest
+Source: https://github.com/seanmonstar/reqwest
 
 Copyright 2016 Sean McArthur
 
@@ -44808,7 +46165,7 @@ THE SOFTWARE.
 
 reqwest-middleware
 ------------------
-Website: https://github.com/TrueLayer/reqwest-middleware
+Source: https://github.com/TrueLayer/reqwest-middleware
 
 Copyright 2021 TrueLayer
 
@@ -44844,7 +46201,7 @@ SOFTWARE.
 
 resolve
 -------
-Website: https://github.com/browserify/resolve
+Source: https://github.com/browserify/resolve
 
 Copyright 2012 James Halliday
 Distributed under the MIT License
@@ -44876,7 +46233,7 @@ SOFTWARE.
 
 reStructuredText Language Basics
 --------------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -44884,7 +46241,7 @@ Distributed under the MIT License
 
 retry
 -----
-Website: https://github.com/tim-kos/node-retry
+Source: https://github.com/tim-kos/node-retry
 
 Copyright 2011: Tim Koschützki (tim@debuggable.com) Felix Geisendörfer (felix@debuggable.com)
 Distributed under the MIT License
@@ -44918,7 +46275,7 @@ THE SOFTWARE.
 
 retry-policies
 --------------
-Website: https://github.com/TrueLayer/retry-policies
+Source: https://github.com/TrueLayer/retry-policies
 
 Copyright 2021 TrueLayer
 
@@ -44954,7 +46311,7 @@ SOFTWARE.
 
 retry-request
 -------------
-Website: https://github.com/googleapis/retry-request
+Source: https://github.com/googleapis/retry-request
 
 Copyright 2015 Stephen Sawchuk
 Distributed under the MIT License
@@ -44985,7 +46342,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ring
 ----
-Website: https://github.com/briansmith/ring
+Source: https://github.com/briansmith/ring
 
 Copyright 2009 The Go Authors.
 Copyright 2015 The Chromium Authors.
@@ -45013,7 +46370,7 @@ for the license to code that was sourced from the once_cell project.
 
 ripgrep
 -------
-Website: https://github.com/BurntSushi/ripgrep
+Source: https://github.com/BurntSushi/ripgrep
 
 Copyright 2015 Andrew Gallant
 
@@ -45025,7 +46382,7 @@ Consult the documentation and source code of ripgrep for more information.
 
 robust-predicates
 -----------------
-Website: https://github.com/mourner/robust-predicates
+Source: https://github.com/mourner/robust-predicates
 
 Published by Vladimir Agafonkin
 Distributed under the Unlicense
@@ -45033,7 +46390,7 @@ Distributed under the Unlicense
 
 ropey
 -----
-Website: https://github.com/cessen/ropey
+Source: https://github.com/cessen/ropey
 
 Copyright 2017 Nathan Vegdahl
 Distributed under the MIT License
@@ -45063,7 +46420,7 @@ SOFTWARE.
 
 roughjs
 -------
-Website: https://github.com/pshihn/rough
+Source: https://github.com/pshihn/rough
 
 Copyright 2019 Preet Shihn
 Distributed under the MIT License
@@ -45095,7 +46452,7 @@ SOFTWARE.
 
 Ruby Language Basics
 --------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -45103,7 +46460,7 @@ Distributed under the MIT License
 
 Ruby LSP
 --------
-Website: https://github.com/Shopify/ruby-lsp
+Source: https://github.com/Shopify/ruby-lsp
 
 Copyright (c) 2022-present, Shopify Inc.
 Distributed under the MIT License
@@ -45161,7 +46518,7 @@ https://github.com/textmate/ruby.tmbundle#license
 
 run-applescript
 ---------------
-Website: https://github.com/sindresorhus/run-applescript
+Source: https://github.com/sindresorhus/run-applescript
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -45181,7 +46538,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 Rust Language Basics
 --------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -45189,7 +46546,7 @@ Distributed under the MIT License
 
 Rust standard libraries
 -----------------------
-Website: https://github.com/rust-lang/rust
+Source: https://github.com/rust-lang/rust
 
 Copyright (c) The Rust Project Contributors
 
@@ -45201,7 +46558,7 @@ Consult the documentation and source code of Rust standard libraries for more in
 
 Rust Syntax
 -----------
-Website: https://github.com/dustypomerleau/rust-syntax
+Source: https://github.com/dustypomerleau/rust-syntax
 
 Copyright (c) 2020 Dustin Pomerleau
 Distributed under the MIT License
@@ -45209,7 +46566,7 @@ Distributed under the MIT License
 
 rust-cssparser
 --------------
-Website: https://github.com/servo/rust-cssparser
+Source: https://github.com/servo/rust-cssparser
 
 Published by Simon Sapin <simon.sapin@exyr.org>
 Distributed under the Mozilla Public License version 2.0
@@ -45608,7 +46965,7 @@ defined by the Mozilla Public License, v. 2.0.
 
 rust-embed
 ----------
-Website: https://github.com/pyros2097/rust-embed
+Source: https://github.com/pyros2097/rust-embed
 
 Copyright 2018 pyros2097
 Distributed under the MIT License
@@ -45640,7 +46997,7 @@ SOFTWARE.
 
 rust-phf
 --------
-Website: https://github.com/sfackler/rust-phf
+Source: https://github.com/sfackler/rust-phf
 
 Published by Steven Fackler <sfackler@gmail.com>
 Distributed under the MIT License
@@ -45648,7 +47005,7 @@ Distributed under the MIT License
 
 rust-security-framework
 -----------------------
-Website: https://github.com/kornelski/rust-security-framework
+Source: https://github.com/kornelski/rust-security-framework
 
 Copyright 2015 Steven Fackler
 
@@ -45683,7 +47040,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 rust-url
 --------
-Website: https://github.com/servo/rust-url/
+Source: https://github.com/servo/rust-url/
 
 Copyright 2013-2022 The rust-url developers
 
@@ -45723,7 +47080,7 @@ DEALINGS IN THE SOFTWARE.
 
 rustc-demangle
 --------------
-Website: https://github.com/rust-lang/rustc-demangle
+Source: https://github.com/rust-lang/rustc-demangle
 
 Copyright 2014 Alex Crichton
 
@@ -45763,7 +47120,7 @@ DEALINGS IN THE SOFTWARE.
 
 rustc-hash
 ----------
-Website: https://github.com/rust-lang/rustc-hash
+Source: https://github.com/rust-lang/rustc-hash
 
 Published by The Rust Project Developers
 
@@ -45775,7 +47132,7 @@ Consult the documentation and source code of rustc-hash for more information.
 
 rustc_version
 -------------
-Website: https://github.com/Kimundi/rustc-version-rs
+Source: https://github.com/Kimundi/rustc-version-rs
 
 Copyright 2016 The Rust Project Developers
 
@@ -45815,7 +47172,7 @@ DEALINGS IN THE SOFTWARE.
 
 rustix
 ------
-Website: https://github.com/bytecodealliance/rustix
+Source: https://github.com/bytecodealliance/rustix
 
 Published by Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>
 
@@ -45827,7 +47184,7 @@ Consult the documentation and source code of rustix for more information.
 
 rustversion
 -----------
-Website: https://github.com/dtolnay/rustversion
+Source: https://github.com/dtolnay/rustversion
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -45839,7 +47196,7 @@ Consult the documentation and source code of rustversion for more information.
 
 rw
 --
-Website: https://github.com/mbostock/rw
+Source: https://github.com/mbostock/rw
 
 Copyright 2014-2016, Michael Bostock
 Distributed under the BSD 3-Clause license
@@ -45876,7 +47233,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 rxjs
 ----
-Website: https://github.com/reactivex/rxjs
+Source: https://github.com/reactivex/rxjs
 
 Copyright 2015-2018 Google, Inc., Netflix, Inc., Microsoft Corp. and contributors
 Distributed under the Apache License version 2.0
@@ -46090,7 +47447,7 @@ limitations under the License.
 
 rxjs-compat
 -----------
-Website: https://npmjs.com/package/rxjs-compat/v/6.6.7
+Source: https://npmjs.com/package/rxjs-compat/v/6.6.7
 
 Copyright 2015-2018 Google, Inc., Netflix, Inc., Microsoft Corp. and contributors
 Distributed under the Apache License version 2.0
@@ -46304,7 +47661,7 @@ limitations under the License.
 
 ryu
 ---
-Website: https://github.com/dtolnay/ryu
+Source: https://github.com/dtolnay/ryu
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -46342,7 +47699,7 @@ DEALINGS IN THE SOFTWARE.
 
 safe-buffer
 -----------
-Website: https://github.com/feross/safe-buffer
+Source: https://github.com/feross/safe-buffer
 
 Copyright Feross Aboukhadijeh
 Distributed under the MIT License
@@ -46374,7 +47731,7 @@ THE SOFTWARE.
 
 safe-stable-stringify
 ---------------------
-Website: https://github.com/BridgeAR/safe-stable-stringify
+Source: https://github.com/BridgeAR/safe-stable-stringify
 
 Copyright Ruben Bridgewater
 Distributed under the MIT License
@@ -46406,7 +47763,7 @@ SOFTWARE.
 
 safemem
 -------
-Website: https://github.com/abonander/safemem
+Source: https://github.com/abonander/safemem
 
 Copyright 2016 The `multipart` Crate Developers
 
@@ -46446,7 +47803,7 @@ DEALINGS IN THE SOFTWARE.
 
 safer-buffer
 ------------
-Website: https://github.com/ChALkeR/safer-buffer
+Source: https://github.com/ChALkeR/safer-buffer
 
 Copyright 2018 Nikita Skovoroda <chalkerx@gmail.com>
 Distributed under the MIT License
@@ -46478,7 +47835,7 @@ SOFTWARE.
 
 same-file
 ---------
-Website: https://github.com/BurntSushi/same-file
+Source: https://github.com/BurntSushi/same-file
 
 Copyright 2017 Andrew Gallant
 
@@ -46490,7 +47847,7 @@ Consult the documentation and source code of same-file for more information.
 
 sax
 ---
-Website: https://github.com/isaacs/sax-js
+Source: https://github.com/isaacs/sax-js
 
 Copyright 2010-2024 Isaac Z. Schlueter and Contributors
 Copyright 2010-2024 Mathias Bynens <https:mathiasbynens.be/>
@@ -46543,7 +47900,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 schannel
 --------
-Website: https://github.com/steffengy/schannel-rs
+Source: https://github.com/steffengy/schannel-rs
 
 Copyright 2015 steffengy
 Distributed under the MIT License
@@ -46561,7 +47918,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 scheduler
 ---------
-Website: https://github.com/facebook/react
+Source: https://github.com/facebook/react
 
 Copyright Facebook, Inc. and its affiliates.
 Distributed under the MIT License
@@ -46593,7 +47950,7 @@ SOFTWARE.
 
 schemars
 --------
-Website: https://github.com/GREsau/schemars
+Source: https://github.com/GREsau/schemars
 
 Copyright 2019 Graham Esau
 Distributed under the MIT License
@@ -46625,7 +47982,7 @@ SOFTWARE.
 
 scopeguard
 ----------
-Website: https://github.com/bluss/scopeguard
+Source: https://github.com/bluss/scopeguard
 
 Copyright 2016-2019 Ulrik Sverdrup "bluss" and scopeguard developers
 
@@ -46665,7 +48022,7 @@ DEALINGS IN THE SOFTWARE.
 
 scraper
 -------
-Website: https://github.com/causal-agent/scraper
+Source: https://github.com/causal-agent/scraper
 
 Copyright © 2016, June McEnroe <june@causal.agency>
 Copyright © 2017, Vivek Kushwaha <yoursvivek@gmail.com>
@@ -46692,7 +48049,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 SCSS Language Basics
 --------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -46700,15 +48057,45 @@ Distributed under the MIT License
 
 Search Result
 -------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
 
 
+secure-json-parse
+-----------------
+Source: https://github.com/fastify/secure-json-parse
+
+Copyright 2019 The Fastify Team
+Copyright 2019, Sideway Inc, and project contributors
+Distributed under the BSD 3-Clause license
+
+BSD 3-Clause license text:
+
+Copyright (c) 2019 The Fastify Team
+
+Copyright (c) 2019, Sideway Inc, and project contributors
+All rights reserved.
+
+The complete list of contributors can be found at:
+- https://github.com/hapijs/bourne/graphs/contributors
+- https://github.com/fastify/secure-json-parse/graphs/contributors
+
+  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
 selectors
 ---------
-Website: https://github.com/servo/servo
+Source: https://github.com/servo/servo
 
 Published by The Servo Project Developers
 Distributed under the Mozilla Public License version 2.0
@@ -47105,9 +48492,9 @@ This Source Code Form is "Incompatible With Secondary Licenses", as
 defined by the Mozilla Public License, v. 2.0.
 
 
-semver versions 7.7.2, 7.7.1, 7.6.3, 7.6.2, 7.5.4, 7.5.2, 5.7.2
+semver versions 7.7.3, 7.7.2, 7.7.1, 7.6.2, 7.5.4, 7.5.2, 5.7.2
 ---------------------------------------------------------------
-Website: https://github.com/npm/node-semver
+Source: https://github.com/npm/node-semver
 
 Copyright Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -47133,7 +48520,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 semver version 1.0.24
 ---------------------
-Website: https://github.com/dtolnay/semver
+Source: https://github.com/dtolnay/semver
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -47145,7 +48532,7 @@ Consult the documentation and source code of semver for more information.
 
 send
 ----
-Website: https://github.com/pillarjs/send
+Source: https://github.com/pillarjs/send
 
 Copyright 2012 TJ Holowaychuk
 Copyright 2014-2022 Douglas Christopher Wilson
@@ -47181,7 +48568,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 serde
 -----
-Website: https://github.com/serde-rs/serde
+Source: https://github.com/serde-rs/serde
 
 Published by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 
@@ -47193,7 +48580,7 @@ Consult the documentation and source code of serde for more information.
 
 serde-untagged
 --------------
-Website: https://github.com/dtolnay/serde-untagged
+Source: https://github.com/dtolnay/serde-untagged
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -47205,7 +48592,7 @@ Consult the documentation and source code of serde-untagged for more information
 
 serde-value
 -----------
-Website: https://github.com/arcnmx/serde-value
+Source: https://github.com/arcnmx/serde-value
 
 Copyright 2016 arcnmx
 Distributed under the MIT License
@@ -47235,7 +48622,7 @@ THE SOFTWARE.
 
 serde_ignored
 -------------
-Website: https://github.com/dtolnay/serde-ignored
+Source: https://github.com/dtolnay/serde-ignored
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -47247,7 +48634,7 @@ Consult the documentation and source code of serde_ignored for more information.
 
 serde_json
 ----------
-Website: https://github.com/serde-rs/json
+Source: https://github.com/serde-rs/json
 
 Published by Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 
@@ -47259,7 +48646,7 @@ Consult the documentation and source code of serde_json for more information.
 
 serde_repr
 ----------
-Website: https://github.com/dtolnay/serde-repr
+Source: https://github.com/dtolnay/serde-repr
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -47271,7 +48658,7 @@ Consult the documentation and source code of serde_repr for more information.
 
 serde_urlencoded
 ----------------
-Website: https://github.com/nox/serde_urlencoded
+Source: https://github.com/nox/serde_urlencoded
 
 Copyright 2016 Anthony Ramine
 
@@ -47311,7 +48698,7 @@ DEALINGS IN THE SOFTWARE.
 
 serde_with
 ----------
-Website: https://github.com/jonasbb/serde_with/
+Source: https://github.com/jonasbb/serde_with/
 
 Copyright 2015 Jonas Bushart, Marcin Kaźmierczak
 
@@ -47351,7 +48738,7 @@ DEALINGS IN THE SOFTWARE.
 
 serde_with_macros
 -----------------
-Website: https://github.com/jonasbb/serde_with/
+Source: https://github.com/jonasbb/serde_with/
 
 Copyright 2015 Jonas Bushart
 
@@ -47391,7 +48778,7 @@ DEALINGS IN THE SOFTWARE.
 
 serve-static
 ------------
-Website: https://github.com/expressjs/serve-static
+Source: https://github.com/expressjs/serve-static
 
 Copyright 2010 Sencha Inc.
 Copyright 2011 LearnBoost
@@ -47433,7 +48820,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Server Ready Action
 -------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -47441,7 +48828,7 @@ Distributed under the MIT License
 
 servo_arc
 ---------
-Website: https://github.com/servo/servo
+Source: https://github.com/servo/servo
 
 Published by The Servo Project Developers
 
@@ -47453,7 +48840,7 @@ Consult the documentation and source code of servo_arc for more information.
 
 Seti UI
 -------
-Website: https://github.com/jesseweed/seti-ui
+Source: https://github.com/jesseweed/seti-ui
 
 Copyright (c) 2014 Jesse Weed
 Distributed under the MIT License
@@ -47461,7 +48848,7 @@ Distributed under the MIT License
 
 setprototypeof
 --------------
-Website: https://github.com/wesleytodd/setprototypeof
+Source: https://github.com/wesleytodd/setprototypeof
 
 Copyright 2015, Wes Todd
 Distributed under the ISC License
@@ -47485,7 +48872,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 Shaderlab Language Basics
 -------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -47493,7 +48880,7 @@ Distributed under the MIT License
 
 Shaders tmLanguage
 ------------------
-Website: https://github.com/tgjones/shaders-tmLanguage
+Source: https://github.com/tgjones/shaders-tmLanguage
 
 Copyright (c) 2017 Tim Jones
 Distributed under the MIT License
@@ -47501,7 +48888,7 @@ Distributed under the MIT License
 
 sharded-slab
 ------------
-Website: https://github.com/hawkw/sharded-slab
+Source: https://github.com/hawkw/sharded-slab
 
 Copyright 2019 Eliza Weisman
 Distributed under the MIT License
@@ -47531,7 +48918,7 @@ THE SOFTWARE.
 
 shebang-command
 ---------------
-Website: https://github.com/kevva/shebang-command
+Source: https://github.com/kevva/shebang-command
 
 Copyright Kevin Mårtensson <kevinmartensson@gmail.com> (github.com/kevva)
 Distributed under the MIT License
@@ -47551,7 +48938,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 shebang-regex
 -------------
-Website: https://github.com/sindresorhus/shebang-regex
+Source: https://github.com/sindresorhus/shebang-regex
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -47571,15 +48958,51 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 Shell Script Language Basics
 ----------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
 
 
+shell-quote
+-----------
+Source: https://github.com/ljharb/shell-quote
+
+Copyright 2013 James Halliday (mail@substack.net)
+Distributed under the MIT License
+
+MIT License text:
+
+The MIT License
+
+Copyright (c) 2013 James Halliday (mail@substack.net)
+
+Permission is hereby granted, free of charge,
+to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to
+deal in the Software without restriction, including
+without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom
+the Software is furnished to do so,
+
+subject to the following conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 shimmer
 -------
-Website: https://github.com/othiym23/shimmer
+Source: https://github.com/othiym23/shimmer
 
 Copyright 2013-2019, Forrest L Norvell
 Distributed under the BSD 2-Clause license
@@ -47615,7 +49038,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 shlex
 -----
-Website: https://github.com/comex/rust-shlex
+Source: https://github.com/comex/rust-shlex
 
 Copyright 2015 Nicholas Allegra (comex).
 
@@ -47668,7 +49091,7 @@ THE SOFTWARE.
 
 side-channel
 ------------
-Website: https://github.com/ljharb/side-channel
+Source: https://github.com/ljharb/side-channel
 
 Copyright 2024 Jordan Harband
 Distributed under the MIT License
@@ -47700,7 +49123,7 @@ SOFTWARE.
 
 signal-exit
 -----------
-Website: https://github.com/tapjs/signal-exit
+Source: https://github.com/tapjs/signal-exit
 
 Copyright 2015-2023 Benjamin Coe, Isaac Z. Schlueter, and Contributors
 Distributed under the ISC License
@@ -47727,7 +49150,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 signal-hook-registry
 --------------------
-Website: https://github.com/vorner/signal-hook
+Source: https://github.com/vorner/signal-hook
 
 Copyright 2017 tokio-jsonrpc developers
 
@@ -47767,7 +49190,7 @@ DEALINGS IN THE SOFTWARE.
 
 similar
 -------
-Website: https://github.com/mitsuhiko/similar
+Source: https://github.com/mitsuhiko/similar
 
 Published by Armin Ronacher <armin.ronacher@active-4.com>, Pierre-Étienne Meunier <pe@pijul.org>, Brandon Williams <bwilliams.eng@gmail.com>
 Distributed under the Apache License version 2.0
@@ -47775,7 +49198,7 @@ Distributed under the Apache License version 2.0
 
 similar-asserts
 ---------------
-Website: https://github.com/mitsuhiko/similar-asserts
+Source: https://github.com/mitsuhiko/similar-asserts
 
 Published by Armin Ronacher <armin.ronacher@active-4.com>
 Distributed under the Apache License version 2.0
@@ -47783,7 +49206,7 @@ Distributed under the Apache License version 2.0
 
 Simple Browser
 --------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -47791,7 +49214,7 @@ Distributed under the MIT License
 
 simple-concat
 -------------
-Website: https://github.com/feross/simple-concat
+Source: https://github.com/feross/simple-concat
 
 Copyright Feross Aboukhadijeh
 Distributed under the MIT License
@@ -47822,7 +49245,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 simple-get
 ----------
-Website: https://github.com/feross/simple-get
+Source: https://github.com/feross/simple-get
 
 Copyright Feross Aboukhadijeh
 Distributed under the MIT License
@@ -47853,7 +49276,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 simple-lru-cache
 ----------------
-Website: https://npmjs.com/package/simple-lru-cache/v/0.0.2
+Source: https://npmjs.com/package/simple-lru-cache/v/0.0.2
 
 Copyright 2013 Mercadolibre.com
 Distributed under the MIT License
@@ -47883,7 +49306,7 @@ THE SOFTWARE.
 
 simple-socks
 ------------
-Website: https://github.com/brozeph/simple-socks
+Source: https://github.com/brozeph/simple-socks
 
 Published by https://github.com/brozeph
 Distributed under the MIT License
@@ -47891,7 +49314,7 @@ Distributed under the MIT License
 
 simplelog
 ---------
-Website: https://github.com/drakulix/simplelog.rs
+Source: https://github.com/drakulix/simplelog.rs
 
 Copyright 2015 Victor Brekenfeld
 
@@ -47927,7 +49350,7 @@ SOFTWARE.
 
 simple_asn1
 -----------
-Website: https://github.com/acw/simple_asn1
+Source: https://github.com/acw/simple_asn1
 
 Copyright 2017 Adam Wick
 Distributed under the ISC License
@@ -47951,7 +49374,7 @@ THIS SOFTWARE.
 
 simple_logger
 -------------
-Website: https://github.com/borntyping/rust-simple_logger
+Source: https://github.com/borntyping/rust-simple_logger
 
 Copyright 2015-2021 Sam Clements
 Distributed under the MIT License
@@ -47969,7 +49392,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 siphasher
 ---------
-Website: https://github.com/jedisct1/rust-siphash
+Source: https://github.com/jedisct1/rust-siphash
 
 Copyright 2012-2016 The Rust Project Developers.
 Copyright 2016-2021 Frank Denis.
@@ -47993,7 +49416,7 @@ option.
 
 six
 ---
-Website: https://github.com/benjaminp/six
+Source: https://github.com/benjaminp/six
 
 Published by Benjamin Peterson
 Distributed under the MIT License
@@ -48001,7 +49424,7 @@ Distributed under the MIT License
 
 slab
 ----
-Website: https://github.com/tokio-rs/slab
+Source: https://github.com/tokio-rs/slab
 
 Copyright 2019 Carl Lerche
 Distributed under the MIT License
@@ -48037,7 +49460,7 @@ DEALINGS IN THE SOFTWARE.
 
 slog
 ----
-Website: https://github.com/slog-rs/slog
+Source: https://github.com/slog-rs/slog
 
 Copyright 2014 The Rust Project Developers
 
@@ -48470,7 +49893,7 @@ defined by the Mozilla Public License, v. 2.0.
 
 smallvec
 --------
-Website: https://github.com/servo/rust-smallvec
+Source: https://github.com/servo/rust-smallvec
 
 Copyright 2018 The Servo Project Developers
 
@@ -48510,7 +49933,7 @@ DEALINGS IN THE SOFTWARE.
 
 smart-buffer
 ------------
-Website: https://github.com/JoshGlazebrook/smart-buffer
+Source: https://github.com/JoshGlazebrook/smart-buffer
 
 Copyright 2013-2017 Josh Glazebrook
 Distributed under the MIT License
@@ -48541,7 +49964,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 @smithy/abort-controller
 ------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -48755,7 +50178,7 @@ limitations under the License.
 
 @smithy/chunked-blob-reader
 ---------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -48969,7 +50392,7 @@ limitations under the License.
 
 @smithy/chunked-blob-reader-native
 ----------------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -49183,7 +50606,7 @@ limitations under the License.
 
 @smithy/config-resolver
 -----------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -49397,7 +50820,7 @@ limitations under the License.
 
 @smithy/core
 ------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -49611,7 +51034,7 @@ limitations under the License.
 
 @smithy/credential-provider-imds
 --------------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -49825,7 +51248,7 @@ limitations under the License.
 
 @smithy/eventstream-codec
 -------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -50039,7 +51462,7 @@ limitations under the License.
 
 @smithy/eventstream-serde-browser
 ---------------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -50253,7 +51676,7 @@ limitations under the License.
 
 @smithy/eventstream-serde-config-resolver
 -----------------------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -50467,7 +51890,7 @@ limitations under the License.
 
 @smithy/eventstream-serde-node
 ------------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -50681,7 +52104,7 @@ limitations under the License.
 
 @smithy/eventstream-serde-universal
 -----------------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -50895,7 +52318,7 @@ limitations under the License.
 
 @smithy/fetch-http-handler
 --------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -51109,7 +52532,7 @@ limitations under the License.
 
 @smithy/hash-blob-browser
 -------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -51323,7 +52746,7 @@ limitations under the License.
 
 @smithy/hash-node
 -----------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -51537,7 +52960,7 @@ limitations under the License.
 
 @smithy/hash-stream-node
 ------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -51751,7 +53174,7 @@ limitations under the License.
 
 @smithy/invalid-dependency
 --------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -51965,7 +53388,7 @@ limitations under the License.
 
 @smithy/is-array-buffer
 -----------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -52179,7 +53602,7 @@ limitations under the License.
 
 @smithy/md5-js
 --------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -52393,7 +53816,7 @@ limitations under the License.
 
 @smithy/middleware-content-length
 ---------------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -52607,7 +54030,7 @@ limitations under the License.
 
 @smithy/middleware-endpoint
 ---------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -52821,7 +54244,7 @@ limitations under the License.
 
 @smithy/middleware-retry
 ------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -53035,7 +54458,7 @@ limitations under the License.
 
 @smithy/middleware-serde
 ------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -53249,7 +54672,7 @@ limitations under the License.
 
 @smithy/middleware-stack
 ------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -53463,7 +54886,7 @@ limitations under the License.
 
 @smithy/node-config-provider
 ----------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -53677,7 +55100,7 @@ limitations under the License.
 
 @smithy/node-http-handler
 -------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -53891,7 +55314,7 @@ limitations under the License.
 
 @smithy/property-provider
 -------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -54105,7 +55528,7 @@ limitations under the License.
 
 @smithy/protocol-http
 ---------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -54319,7 +55742,7 @@ limitations under the License.
 
 @smithy/querystring-builder
 ---------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -54533,7 +55956,7 @@ limitations under the License.
 
 @smithy/querystring-parser
 --------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -54747,7 +56170,7 @@ limitations under the License.
 
 @smithy/service-error-classification
 ------------------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -54961,7 +56384,7 @@ limitations under the License.
 
 @smithy/shared-ini-file-loader
 ------------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -55175,7 +56598,7 @@ limitations under the License.
 
 @smithy/signature-v4
 --------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -55389,7 +56812,7 @@ limitations under the License.
 
 @smithy/smithy-client
 ---------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -55603,7 +57026,7 @@ limitations under the License.
 
 @smithy/types
 -------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2019 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -55817,7 +57240,7 @@ limitations under the License.
 
 @smithy/url-parser
 ------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -56031,7 +57454,7 @@ limitations under the License.
 
 @smithy/util-base64
 -------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -56245,7 +57668,7 @@ limitations under the License.
 
 @smithy/util-body-length-browser
 --------------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -56459,7 +57882,7 @@ limitations under the License.
 
 @smithy/util-body-length-node
 -----------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -56673,7 +58096,7 @@ limitations under the License.
 
 @smithy/util-buffer-from
 ------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -56887,7 +58310,7 @@ limitations under the License.
 
 @smithy/util-config-provider
 ----------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -57101,7 +58524,7 @@ limitations under the License.
 
 @smithy/util-defaults-mode-browser
 ----------------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -57315,7 +58738,7 @@ limitations under the License.
 
 @smithy/util-defaults-mode-node
 -------------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -57529,7 +58952,7 @@ limitations under the License.
 
 @smithy/util-endpoints
 ----------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2021 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -57743,7 +59166,7 @@ limitations under the License.
 
 @smithy/util-hex-encoding
 -------------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -57957,7 +59380,7 @@ limitations under the License.
 
 @smithy/util-middleware
 -----------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2021 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -58171,7 +59594,7 @@ limitations under the License.
 
 @smithy/util-retry
 ------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2021 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -58385,7 +59808,7 @@ limitations under the License.
 
 @smithy/util-stream
 -------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -58599,7 +60022,7 @@ limitations under the License.
 
 @smithy/util-uri-escape
 -----------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -58813,7 +60236,7 @@ limitations under the License.
 
 @smithy/util-utf8
 -----------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -59027,7 +60450,7 @@ limitations under the License.
 
 @smithy/util-waiter
 -------------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -59241,7 +60664,7 @@ limitations under the License.
 
 @smithy/uuid
 ------------
-Website: https://github.com/smithy-lang/smithy-typescript
+Source: https://github.com/smithy-lang/smithy-typescript
 
 Copyright 2018-2020 Amazon.com, Inc. or its affiliates.
 Distributed under the Apache License version 2.0
@@ -59455,7 +60878,7 @@ limitations under the License.
 
 snowflake-sdk
 -------------
-Website: https://github.com/snowflakedb/snowflake-connector-nodejs
+Source: https://github.com/snowflakedb/snowflake-connector-nodejs
 
 Copyright 2013-2019 Snowflake Computing, Inc.
 Distributed under the Apache License version 2.0
@@ -59669,7 +61092,7 @@ limitations under the License.
 
 @so-ric/colorspace
 ------------------
-Website: https://github.com/so-ric/colorspace
+Source: https://github.com/so-ric/colorspace
 
 Copyright 2015 Arnout Kazemier, Martijn Swaagman, the Contributors.
 Distributed under the MIT License
@@ -59700,7 +61123,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 socket2
 -------
-Website: https://github.com/rust-lang/socket2
+Source: https://github.com/rust-lang/socket2
 
 Copyright 2014 Alex Crichton
 
@@ -59740,7 +61163,7 @@ DEALINGS IN THE SOFTWARE.
 
 socks
 -----
-Website: https://github.com/JoshGlazebrook/socks
+Source: https://github.com/JoshGlazebrook/socks
 
 Copyright 2013 Josh Glazebrook
 Distributed under the MIT License
@@ -59771,7 +61194,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 socks-proxy-agent
 -----------------
-Website: https://github.com/TooTallNate/proxy-agents
+Source: https://github.com/TooTallNate/proxy-agents
 
 Copyright 2013 Nathan Rajlich <nathan@tootallnate.net>
 Distributed under the MIT License
@@ -59804,7 +61227,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Solarized Dark Theme
 --------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -59812,7 +61235,7 @@ Distributed under the MIT License
 
 Solarized Light Theme
 ---------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -59820,7 +61243,7 @@ Distributed under the MIT License
 
 spdx
 ----
-Website: https://github.com/EmbarkStudios/spdx
+Source: https://github.com/EmbarkStudios/spdx
 
 Copyright 2019 Embark Studios
 
@@ -59860,7 +61283,7 @@ DEALINGS IN THE SOFTWARE.
 
 split2
 ------
-Website: https://github.com/mcollina/split2
+Source: https://github.com/mcollina/split2
 
 Copyright 2014-2018, Matteo Collina <hello@matteocollina.com>
 Distributed under the ISC License
@@ -59884,7 +61307,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 sprintf-js version 1.1.3
 ------------------------
-Website: https://github.com/alexei/sprintf.js
+Source: https://github.com/alexei/sprintf.js
 
 Copyright 2007-present, Alexandru Mărășteanu <hello@alexei.ro>
 Distributed under the BSD 3-Clause license
@@ -59921,7 +61344,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 sprintf-js version 1.0.3
 ------------------------
-Website: https://github.com/alexei/sprintf.js
+Source: https://github.com/alexei/sprintf.js
 
 Copyright 2007-2014, Alexandru Marasteanu <hello [at) alexei (dot] ro>
 Distributed under the BSD 3-Clause license
@@ -59958,7 +61381,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 SQL Language Basics
 -------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -59966,7 +61389,7 @@ Distributed under the MIT License
 
 SQLite
 ------
-Website: https://sqlite.org/
+Source: https://sqlite.org/
 
 Dedicated to the public domain
 
@@ -59984,7 +61407,7 @@ a legal notice, here is a blessing:
 
 ssh2
 ----
-Website: https://github.com/mscdex/ssh2
+Source: https://github.com/mscdex/ssh2
 
 Copyright Brian White.
 Distributed under the MIT License
@@ -60014,7 +61437,7 @@ IN THE SOFTWARE.
 
 stable_deref_trait
 ------------------
-Website: https://github.com/storyyeller/stable_deref_trait
+Source: https://github.com/storyyeller/stable_deref_trait
 
 Copyright 2017 Robert Grosse
 
@@ -60054,7 +61477,7 @@ DEALINGS IN THE SOFTWARE.
 
 stack-chain
 -----------
-Website: https://github.com/AndreasMadsen/stack-chain
+Source: https://github.com/AndreasMadsen/stack-chain
 
 Copyright 2012 Andreas Madsen
 Distributed under the MIT License
@@ -60084,7 +61507,7 @@ THE SOFTWARE.
 
 stack-data
 ----------
-Website: http://github.com/alexmojaki/stack_data
+Source: http://github.com/alexmojaki/stack_data
 
 Copyright 2019 Alex Hall
 Distributed under the MIT License
@@ -60116,7 +61539,7 @@ SOFTWARE.
 
 stack-trace
 -----------
-Website: https://github.com/felixge/node-stack-trace
+Source: https://github.com/felixge/node-stack-trace
 
 Copyright 2011 Felix Geisendörfer (felix@debuggable.com)
 Distributed under the MIT License
@@ -60146,7 +61569,7 @@ THE SOFTWARE.
 
 static_assertions
 -----------------
-Website: https://github.com/nvzqz/static-assertions-rs
+Source: https://github.com/nvzqz/static-assertions-rs
 
 Copyright 2017 Nikolai Vazquez
 
@@ -60182,7 +61605,7 @@ SOFTWARE.
 
 statuses
 --------
-Website: https://github.com/jshttp/statuses
+Source: https://github.com/jshttp/statuses
 
 Copyright 2014 Jonathan Ong <me@jongleberry.com>
 Copyright 2016 Douglas Christopher Wilson <doug@somethingdoug.com>
@@ -60217,7 +61640,7 @@ THE SOFTWARE.
 
 stream-events
 -------------
-Website: https://github.com/stephenplusplus/stream-events
+Source: https://github.com/stephenplusplus/stream-events
 
 Published by Stephen Sawchuk
 Distributed under the MIT License
@@ -60225,7 +61648,7 @@ Distributed under the MIT License
 
 stream-shift
 ------------
-Website: https://github.com/mafintosh/stream-shift
+Source: https://github.com/mafintosh/stream-shift
 
 Copyright 2016 Mathias Buus
 Distributed under the MIT License
@@ -60255,9 +61678,43 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
+stream-to-pull-stream
+---------------------
+Source: https://github.com/dominictarr/stream-to-pull-stream
+
+Copyright 2013 Dominic Tarr
+Distributed under the MIT License
+
+MIT License text:
+
+Copyright (c) 2013 Dominic Tarr
+
+Permission is hereby granted, free of charge,
+to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to
+deal in the Software without restriction, including
+without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom
+the Software is furnished to do so,
+
+subject to the following conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 streaming-iterator
 ------------------
-Website: https://github.com/sfackler/streaming-iterator
+Source: https://github.com/sfackler/streaming-iterator
 
 Copyright 2016 Steven Fackler
 
@@ -60291,7 +61748,7 @@ SOFTWARE.
 
 string-cache
 ------------
-Website: https://github.com/servo/string-cache
+Source: https://github.com/servo/string-cache
 
 Copyright 2012-2013 Mozilla Foundation
 
@@ -60331,7 +61788,7 @@ DEALINGS IN THE SOFTWARE.
 
 string-width
 ------------
-Website: https://github.com/sindresorhus/string-width
+Source: https://github.com/sindresorhus/string-width
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -60351,7 +61808,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 string_decoder
 --------------
-Website: https://github.com/nodejs/string_decoder
+Source: https://github.com/nodejs/string_decoder
 
 Copyright Joyent, Inc. and other Node contributors.
 Copyright Node.js contributors.
@@ -60408,7 +61865,7 @@ https://github.com/joyent/node repository:
 
 strip-ansi
 ----------
-Website: https://github.com/chalk/strip-ansi
+Source: https://github.com/chalk/strip-ansi
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -60428,7 +61885,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 strip-bom
 ---------
-Website: https://github.com/sindresorhus/strip-bom
+Source: https://github.com/sindresorhus/strip-bom
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -60460,7 +61917,7 @@ THE SOFTWARE.
 
 strip-json-comments
 -------------------
-Website: https://github.com/sindresorhus/strip-json-comments
+Source: https://github.com/sindresorhus/strip-json-comments
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -60492,7 +61949,7 @@ THE SOFTWARE.
 
 strnum
 ------
-Website: https://github.com/NaturalIntelligence/strnum
+Source: https://github.com/NaturalIntelligence/strnum
 
 Copyright 2021 Natural Intelligence
 Distributed under the MIT License
@@ -60524,7 +61981,7 @@ SOFTWARE.
 
 strsim
 ------
-Website: https://github.com/rapidfuzz/strsim-rs
+Source: https://github.com/rapidfuzz/strsim-rs
 
 Copyright 2015 Danny Guo
 Copyright 2016 Titus Wormer <tituswormer@gmail.com>
@@ -60562,7 +62019,7 @@ SOFTWARE.
 
 strtok3
 -------
-Website: https://github.com/Borewit/strtok3
+Source: https://github.com/Borewit/strtok3
 
 Copyright 2017, Borewit
 Distributed under the MIT License
@@ -60589,7 +62046,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 
 structopt
 ---------
-Website: https://github.com/TeXitoi/structopt
+Source: https://github.com/TeXitoi/structopt
 
 Copyright 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>
 
@@ -60625,7 +62082,7 @@ SOFTWARE.
 
 structopt-derive
 ----------------
-Website: https://github.com/TeXitoi/structopt
+Source: https://github.com/TeXitoi/structopt
 
 Copyright 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>
 
@@ -60661,7 +62118,7 @@ SOFTWARE.
 
 struct_field_names_as_array
 ---------------------------
-Website: https://github.com/jofas/struct_field_names_as_array
+Source: https://github.com/jofas/struct_field_names_as_array
 
 Copyright 2021-22 Jonas Fassbender
 Distributed under the MIT License
@@ -60695,7 +62152,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 strum
 -----
-Website: https://github.com/Peternator7/strum
+Source: https://github.com/Peternator7/strum
 
 Copyright 2019 Peter Glotfelty
 Distributed under the MIT License
@@ -60727,7 +62184,7 @@ SOFTWARE.
 
 str_indices
 -----------
-Website: https://github.com/cessen/str_indices
+Source: https://github.com/cessen/str_indices
 
 Published by Nathan Vegdahl <cessen@cessen.com>
 
@@ -60739,7 +62196,7 @@ Consult the documentation and source code of str_indices for more information.
 
 stubs
 -----
-Website: https://github.com/stephenplusplus/stubs
+Source: https://github.com/stephenplusplus/stubs
 
 Published by Stephen Sawchuk
 Distributed under the MIT License
@@ -60747,7 +62204,7 @@ Distributed under the MIT License
 
 stylis
 ------
-Website: https://github.com/thysultan/stylis.js
+Source: https://github.com/thysultan/stylis.js
 
 Copyright 2016-present Sultan Tarimo
 Distributed under the MIT License
@@ -60779,7 +62236,7 @@ SOFTWARE.
 
 subtle
 ------
-Website: https://github.com/dalek-cryptography/subtle
+Source: https://github.com/dalek-cryptography/subtle
 
 Copyright 2016-2017 Isis Agora Lovecruft, Henry de Valence.
 Copyright 2016-2024 Isis Agora Lovecruft.
@@ -60821,7 +62278,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 sudo-prompt
 -----------
-Website: https://github.com/jorangreef/sudo-prompt
+Source: https://github.com/jorangreef/sudo-prompt
 
 Copyright 2015 Joran Dirk Greef
 Distributed under the MIT License
@@ -60853,7 +62310,7 @@ SOFTWARE.
 
 supports-color
 --------------
-Website: https://github.com/chalk/supports-color
+Source: https://github.com/chalk/supports-color
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Distributed under the MIT License
@@ -60873,7 +62330,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 supports-preserve-symlinks-flag
 -------------------------------
-Website: https://github.com/inspect-js/node-supports-preserve-symlinks-flag
+Source: https://github.com/inspect-js/node-supports-preserve-symlinks-flag
 
 Copyright 2022 Inspect JS
 Distributed under the MIT License
@@ -60905,7 +62362,7 @@ SOFTWARE.
 
 swagger
 -------
-Website: https://github.com/Metaswitch/swagger-rs
+Source: https://github.com/Metaswitch/swagger-rs
 
 Copyright 2017 libraries.core
 Distributed under the Apache License version 2.0
@@ -61119,7 +62576,7 @@ limitations under the License.
 
 @swc/helpers
 ------------
-Website: https://github.com/swc-project/swc
+Source: https://github.com/swc-project/swc
 
 Copyright 2024 SWC contributors.
 Distributed under the Apache License version 2.0
@@ -61333,7 +62790,7 @@ limitations under the License.
 
 Swift Language Basics
 ---------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -61341,7 +62798,7 @@ Distributed under the MIT License
 
 swift-tmlanguage
 ----------------
-Website: https://github.com/jtbandes/swift-tmlanguage
+Source: https://github.com/jtbandes/swift-tmlanguage
 
 Copyright 2023 Jacob Bandes-Storch
 Distributed under the MIT License
@@ -61349,7 +62806,7 @@ Distributed under the MIT License
 
 syn
 ---
-Website: https://github.com/dtolnay/syn
+Source: https://github.com/dtolnay/syn
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -61361,7 +62818,7 @@ Consult the documentation and source code of syn for more information.
 
 sync_wrapper
 ------------
-Website: https://github.com/Actyx/sync_wrapper
+Source: https://github.com/Actyx/sync_wrapper
 
 Published by Actyx AG <developer@actyx.io>
 Distributed under the Apache License version 2.0
@@ -61369,7 +62826,7 @@ Distributed under the Apache License version 2.0
 
 synstructure
 ------------
-Website: https://github.com/mystor/synstructure
+Source: https://github.com/mystor/synstructure
 
 Copyright 2016 Nika Layzell
 Distributed under the MIT License
@@ -61387,7 +62844,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 sysinfo
 -------
-Website: https://github.com/GuillaumeGomez/sysinfo
+Source: https://github.com/GuillaumeGomez/sysinfo
 
 Copyright 2015 Guillaume Gomez
 Distributed under the MIT License
@@ -61419,7 +62876,7 @@ SOFTWARE.
 
 system-deps
 -----------
-Website: https://github.com/gdesmott/system-deps
+Source: https://github.com/gdesmott/system-deps
 
 Published by Guillaume Desmottes <guillaume.desmottes@collabora.com>, Josh Triplett <josh@joshtriplett.org>
 
@@ -61431,7 +62888,7 @@ Consult the documentation and source code of system-deps for more information.
 
 tabbable
 --------
-Website: https://github.com/focus-trap/tabbable
+Source: https://github.com/focus-trap/tabbable
 
 Copyright 2015 David Clark
 Distributed under the MIT License
@@ -61463,7 +62920,7 @@ SOFTWARE.
 
 table-layout
 ------------
-Website: https://github.com/75lb/table-layout
+Source: https://github.com/75lb/table-layout
 
 Copyright 2015-24 Lloyd Brookes <75pound@gmail.com>
 Distributed under the MIT License
@@ -61495,7 +62952,7 @@ SOFTWARE.
 
 tail
 ----
-Website: https://github.com/lucagrulla/node-tail
+Source: https://github.com/lucagrulla/node-tail
 
 Copyright 2011 2012 2013 Forward
 Distributed under the MIT License
@@ -61527,7 +62984,7 @@ THE SOFTWARE.
 
 tar
 ---
-Website: https://github.com/isaacs/node-tar
+Source: https://github.com/isaacs/node-tar
 
 Copyright Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -61553,7 +63010,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 tar-fs
 ------
-Website: https://github.com/mafintosh/tar-fs
+Source: https://github.com/mafintosh/tar-fs
 
 Copyright 2014 Mathias Buus
 Distributed under the MIT License
@@ -61585,7 +63042,7 @@ THE SOFTWARE.
 
 tar-stream
 ----------
-Website: https://github.com/mafintosh/tar-stream
+Source: https://github.com/mafintosh/tar-stream
 
 Copyright 2014 Mathias Buus
 Distributed under the MIT License
@@ -61617,7 +63074,7 @@ THE SOFTWARE.
 
 target-lexicon
 --------------
-Website: https://github.com/bytecodealliance/target-lexicon
+Source: https://github.com/bytecodealliance/target-lexicon
 
 Published by Dan Gohman <sunfish@mozilla.com>
 Distributed under the Apache License version 2.0 with LLVM Exceptions
@@ -61625,7 +63082,7 @@ Distributed under the Apache License version 2.0 with LLVM Exceptions
 
 tas-client
 ----------
-Website: https://npmjs.com/package/tas-client/v/0.2.33
+Source: https://npmjs.com/package/tas-client/v/0.2.33
 
 Published by Microsoft
 Distributed under the MIT License
@@ -61633,7 +63090,7 @@ Distributed under the MIT License
 
 tas-client-umd
 --------------
-Website: https://npmjs.com/package/tas-client-umd/v/0.2.0
+Source: https://npmjs.com/package/tas-client-umd/v/0.2.0
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -61665,7 +63122,7 @@ SOFTWARE
 
 @techteamer/ocsp
 ----------------
-Website: https://github.com/TechTeamer/ocsp
+Source: https://github.com/TechTeamer/ocsp
 
 Copyright 2022 forkfork2
 Distributed under the MIT License
@@ -61697,7 +63154,7 @@ SOFTWARE.
 
 teeny-request
 -------------
-Website: https://github.com/googleapis/teeny-request
+Source: https://github.com/googleapis/teeny-request
 
 Published by fhinkel
 Distributed under the Apache License version 2.0
@@ -61705,7 +63162,7 @@ Distributed under the Apache License version 2.0
 
 tempfile
 --------
-Website: https://github.com/Stebalien/tempfile
+Source: https://github.com/Stebalien/tempfile
 
 Copyright 2015 Steven Allen
 
@@ -61745,7 +63202,7 @@ DEALINGS IN THE SOFTWARE.
 
 tendril
 -------
-Website: https://github.com/servo/tendril
+Source: https://github.com/servo/tendril
 
 Copyright 2015 Keegan McAllister
 
@@ -61785,7 +63242,7 @@ DEALINGS IN THE SOFTWARE.
 
 termcolor
 ---------
-Website: https://github.com/BurntSushi/termcolor
+Source: https://github.com/BurntSushi/termcolor
 
 Copyright 2015 Andrew Gallant
 
@@ -61797,7 +63254,7 @@ Consult the documentation and source code of termcolor for more information.
 
 terminal_size
 -------------
-Website: https://github.com/eminence/terminal-size
+Source: https://github.com/eminence/terminal-size
 
 Copyright 2015 The terminal-size Developers
 
@@ -61831,7 +63288,7 @@ SOFTWARE.
 
 testthat Test Reporter for R Test Explorer VSCode Extension
 -----------------------------------------------------------
-Website: https://github.com/meakbiyik/vscode-r-test-adapter/tree/master/src/testthat/reporter
+Source: https://github.com/meakbiyik/vscode-r-test-adapter/tree/master/src/testthat/reporter
 
 Copyright (c) 2021 vscodereporter authors, Copyright (c) 2013-2019 Hadley Wickham; RStudio
 Distributed under the MIT License
@@ -61839,7 +63296,7 @@ Distributed under the MIT License
 
 text-hex
 --------
-Website: https://github.com/3rd-Eden/text-hex
+Source: https://github.com/3rd-Eden/text-hex
 
 Copyright 2014-2015 Arnout Kazemier <opensource@3rd-Eden.com>
 Distributed under the MIT License
@@ -61869,9 +63326,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+text-table
+----------
+Source: https://github.com/substack/text-table
+
+Published by James Halliday
+Distributed under the MIT License
+
+
 textwrap
 --------
-Website: https://github.com/mgeisler/textwrap
+Source: https://github.com/mgeisler/textwrap
 
 Copyright 2016 Martin Geisler
 Distributed under the MIT License
@@ -61903,7 +63368,7 @@ SOFTWARE.
 
 thiserror
 ---------
-Website: https://github.com/dtolnay/thiserror
+Source: https://github.com/dtolnay/thiserror
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -61915,7 +63380,7 @@ Consult the documentation and source code of thiserror for more information.
 
 thread_local
 ------------
-Website: https://github.com/Amanieu/thread_local-rs
+Source: https://github.com/Amanieu/thread_local-rs
 
 Copyright 2016 The Rust Project Developers
 
@@ -61955,7 +63420,7 @@ DEALINGS IN THE SOFTWARE.
 
 time
 ----
-Website: https://github.com/time-rs/time
+Source: https://github.com/time-rs/time
 
 Copyright 2024 Jacob Pratt et al.
 
@@ -62196,7 +63661,7 @@ SOFTWARE.
 
 time-core
 ---------
-Website: https://github.com/time-rs/time
+Source: https://github.com/time-rs/time
 
 Copyright 2022 Jacob Pratt et al.
 
@@ -62437,7 +63902,7 @@ SOFTWARE.
 
 tiny-inflate
 ------------
-Website: https://github.com/devongovett/tiny-inflate
+Source: https://github.com/devongovett/tiny-inflate
 
 Copyright 2015-present Devon Govett
 Distributed under the MIT License
@@ -62469,7 +63934,7 @@ SOFTWARE.
 
 tinyexec
 --------
-Website: https://github.com/tinylibs/tinyexec
+Source: https://github.com/tinylibs/tinyexec
 
 Copyright 2024 Tinylibs
 Distributed under the MIT License
@@ -62501,7 +63966,7 @@ SOFTWARE.
 
 tinyvec
 -------
-Website: https://github.com/Lokathor/tinyvec
+Source: https://github.com/Lokathor/tinyvec
 
 Copyright 2019 Daniel "Lokathor" Gee.
 
@@ -62528,7 +63993,7 @@ Permission is granted to anyone to use this software for any purpose, including 
 
 tinyvec_macros
 --------------
-Website: https://github.com/Soveu/tinyvec_macros
+Source: https://github.com/Soveu/tinyvec_macros
 
 Copyright (C) 2020 Tomasz "Soveu" Marx
 Copyright 2020 Soveu
@@ -62797,7 +64262,7 @@ freely, subject to the following restrictions:
 
 tmp
 ---
-Website: https://github.com/raszi/node-tmp
+Source: https://github.com/raszi/node-tmp
 
 Copyright 2014 KARASZI István
 Distributed under the MIT License
@@ -62829,7 +64294,7 @@ SOFTWARE.
 
 to-regex-range
 --------------
-Website: https://github.com/micromatch/to-regex-range
+Source: https://github.com/micromatch/to-regex-range
 
 Copyright 2015-present, Jon Schlinkert.
 Distributed under the MIT License
@@ -62861,7 +64326,7 @@ THE SOFTWARE.
 
 toidentifier
 ------------
-Website: https://github.com/component/toidentifier
+Source: https://github.com/component/toidentifier
 
 Copyright 2016 Douglas Christopher Wilson <doug@somethingdoug.com>
 Distributed under the MIT License
@@ -62893,7 +64358,7 @@ SOFTWARE.
 
 token-types
 -----------
-Website: https://github.com/Borewit/token-types
+Source: https://github.com/Borewit/token-types
 
 Copyright 2017 Borewit
 Distributed under the MIT License
@@ -62911,7 +64376,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 @tokenizer/token
 ----------------
-Website: https://github.com/Borewit/tokenizer-token
+Source: https://github.com/Borewit/tokenizer-token
 
 Copyright 2020 Borewit
 Distributed under the MIT License
@@ -62919,7 +64384,7 @@ Distributed under the MIT License
 
 tokio
 -----
-Website: https://github.com/tokio-rs/tokio
+Source: https://github.com/tokio-rs/tokio
 
 Copyright Tokio Contributors
 Distributed under the MIT License
@@ -62951,7 +64416,7 @@ SOFTWARE.
 
 tokio-macros
 ------------
-Website: https://github.com/tokio-rs/tokio
+Source: https://github.com/tokio-rs/tokio
 
 Copyright 2019 Yoshua Wuyts
 Copyright Tokio Contributors
@@ -62986,7 +64451,7 @@ SOFTWARE.
 
 tokio-openssl
 -------------
-Website: https://github.com/tokio-rs/tokio-openssl
+Source: https://github.com/tokio-rs/tokio-openssl
 
 Copyright 2016 Tokio contributors
 
@@ -63233,7 +64698,7 @@ DEALINGS IN THE SOFTWARE.
 
 tokio-tungstenite
 -----------------
-Website: https://github.com/snapview/tokio-tungstenite
+Source: https://github.com/snapview/tokio-tungstenite
 
 Copyright 2017 Alexey Galakhov
 Copyright 2017 Daniel Abramov
@@ -63266,7 +64731,7 @@ THE SOFTWARE.
 
 toml version 3.0.0
 ------------------
-Website: https://github.com/BinaryMuse/toml-node
+Source: https://github.com/BinaryMuse/toml-node
 
 Copyright 2012 Michelle Tilley
 Distributed under the MIT License
@@ -63299,7 +64764,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 toml version 0.8.19
 -------------------
-Website: https://github.com/toml-rs/toml
+Source: https://github.com/toml-rs/toml
 
 Copyright Individual contributors
 
@@ -63333,7 +64798,7 @@ SOFTWARE.
 
 Tomorrow Night Blue Theme
 -------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -63341,7 +64806,7 @@ Distributed under the MIT License
 
 @tootallnate/once
 -----------------
-Website: https://github.com/TooTallNate/once
+Source: https://github.com/TooTallNate/once
 
 Copyright 2020 Nathan Rajlich
 Distributed under the MIT License
@@ -63371,9 +64836,17 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+@tootallnate/quickjs-emscripten
+-------------------------------
+Source: https://github.com/justjake/quickjs-emscripten
+
+Copyright (c) 2019-2024 Jake Teton-Landis
+Distributed under the MIT License
+
+
 tornado
 -------
-Website: https://github.com/tornadoweb/tornado
+Source: https://github.com/tornadoweb/tornado
 
 Published by Facebook
 Distributed under the Apache License version 2.0
@@ -63381,7 +64854,7 @@ Distributed under the Apache License version 2.0
 
 tower
 -----
-Website: https://github.com/tower-rs/tower
+Source: https://github.com/tower-rs/tower
 
 Copyright 2019 Tower Contributors
 Distributed under the MIT License
@@ -63417,7 +64890,7 @@ DEALINGS IN THE SOFTWARE.
 
 tower-lsp
 ---------
-Website: https://github.com/ebkalderon/tower-lsp
+Source: https://github.com/ebkalderon/tower-lsp
 
 Copyright 2023 Eyal Kalderon
 
@@ -63457,7 +64930,7 @@ DEALINGS IN THE SOFTWARE.
 
 tower-lsp-macros
 ----------------
-Website: https://github.com/ebkalderon/tower-lsp
+Source: https://github.com/ebkalderon/tower-lsp
 
 Published by Eyal Kalderon <ebkalderon@gmail.com>
 
@@ -63469,7 +64942,7 @@ Consult the documentation and source code of tower-lsp-macros for more informati
 
 tower-service
 -------------
-Website: https://github.com/tower-rs/tower
+Source: https://github.com/tower-rs/tower
 
 Copyright 2019 Tower Contributors
 Distributed under the MIT License
@@ -63505,7 +64978,7 @@ DEALINGS IN THE SOFTWARE.
 
 tr46
 ----
-Website: https://github.com/Sebmaster/tr46.js
+Source: https://github.com/Sebmaster/tr46.js
 
 Published by Sebastian Mayr <npm@smayr.name>
 Distributed under the MIT License
@@ -63513,7 +64986,7 @@ Distributed under the MIT License
 
 tracing
 -------
-Website: https://github.com/tokio-rs/tracing
+Source: https://github.com/tokio-rs/tracing
 
 Copyright 2019 Tokio Contributors
 Distributed under the MIT License
@@ -63549,7 +65022,7 @@ DEALINGS IN THE SOFTWARE.
 
 traitlets
 ---------
-Website: https://github.com/ipython/traitlets
+Source: https://github.com/ipython/traitlets
 
 Copyright 2001-, IPython Development Team
 Distributed under the BSD 3-Clause license
@@ -63590,7 +65063,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 traverse
 --------
-Website: https://github.com/substack/js-traverse
+Source: https://github.com/substack/js-traverse
 
 Copyright 2010 James Halliday (mail@substack.net)
 
@@ -63625,7 +65098,7 @@ THE SOFTWARE.
 
 tree-sitter
 -----------
-Website: https://github.com/tree-sitter/tree-sitter
+Source: https://github.com/tree-sitter/tree-sitter
 
 Published by Max Brunsfeld <maxbrunsfeld@gmail.com>
 Distributed under the MIT License
@@ -63633,7 +65106,7 @@ Distributed under the MIT License
 
 tree-sitter-r
 -------------
-Website: https://github.com/r-lib/tree-sitter-r
+Source: https://github.com/r-lib/tree-sitter-r
 
 Published by Kevin Ushey <kevin@posit.co>, Jim Hester <james.f.hester@gmail.com>, Davis Vaughan <davis@posit.co>
 Distributed under the MIT License
@@ -63641,7 +65114,7 @@ Distributed under the MIT License
 
 triple-beam
 -----------
-Website: https://github.com/winstonjs/triple-beam
+Source: https://github.com/winstonjs/triple-beam
 
 Copyright 2017 winstonjs
 Distributed under the MIT License
@@ -63673,7 +65146,7 @@ SOFTWARE.
 
 try-lock
 --------
-Website: https://github.com/seanmonstar/try-lock
+Source: https://github.com/seanmonstar/try-lock
 
 Copyright 2016 Alex Crichton
 Copyright 2018-2023 Sean McArthur
@@ -63706,7 +65179,7 @@ THE SOFTWARE.
 
 ts-algebra
 ----------
-Website: https://github.com/ThomasAribart/ts-algebra
+Source: https://github.com/ThomasAribart/ts-algebra
 
 Copyright 2020 Thomas Aribart
 Distributed under the MIT License
@@ -63738,7 +65211,7 @@ SOFTWARE.
 
 ts-dedent
 ---------
-Website: https://github.com/tamino-martinius/node-ts-dedent
+Source: https://github.com/tamino-martinius/node-ts-dedent
 
 Copyright 2018 Tamino Martinius
 Distributed under the MIT License
@@ -63770,7 +65243,7 @@ SOFTWARE.
 
 tslib
 -----
-Website: https://github.com/Microsoft/tslib
+Source: https://github.com/Microsoft/tslib
 
 Copyright Microsoft Corporation.
 Distributed under the 0BSD License
@@ -63793,7 +65266,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 tungstenite
 -----------
-Website: https://github.com/snapview/tungstenite-rs
+Source: https://github.com/snapview/tungstenite-rs
 
 Copyright 2016 Jason Housley
 Copyright 2017 Alexey Galakhov
@@ -63830,7 +65303,7 @@ THE SOFTWARE.
 
 tunnel
 ------
-Website: https://github.com/koichik/node-tunnel
+Source: https://github.com/koichik/node-tunnel
 
 Copyright 2012 Koichi Kobayashi
 Distributed under the MIT License
@@ -63862,7 +65335,7 @@ THE SOFTWARE.
 
 tunnel-agent
 ------------
-Website: https://npmjs.com/package/tunnel-agent/v/0.6.0
+Source: https://npmjs.com/package/tunnel-agent/v/0.6.0
 
 Published by Mikeal Rogers <mikeal.rogers@gmail.com> (http://www.futurealoof.com)
 Distributed under the Apache License version 2.0
@@ -63870,7 +65343,7 @@ Distributed under the Apache License version 2.0
 
 tweetnacl
 ---------
-Website: https://github.com/dchest/tweetnacl-js
+Source: https://github.com/dchest/tweetnacl-js
 
 Published by TweetNaCl-js contributors
 Distributed under the Unlicense
@@ -63878,7 +65351,7 @@ Distributed under the Unlicense
 
 type-is
 -------
-Website: https://github.com/jshttp/type-is
+Source: https://github.com/jshttp/type-is
 
 Copyright 2014 Jonathan Ong <me@jongleberry.com>
 Copyright 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
@@ -63914,7 +65387,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 typeid
 ------
-Website: https://github.com/dtolnay/typeid
+Source: https://github.com/dtolnay/typeid
 
 Published by David Tolnay <dtolnay@gmail.com>
 
@@ -63926,7 +65399,7 @@ Consult the documentation and source code of typeid for more information.
 
 typenum
 -------
-Website: https://github.com/paholg/typenum
+Source: https://github.com/paholg/typenum
 
 Copyright 2014 Paho Lurie-Gregg
 
@@ -63938,7 +65411,7 @@ Consult the documentation and source code of typenum for more information.
 
 TypeScript and JavaScript Language Features
 -------------------------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Published by vscode
 Distributed under the MIT License
@@ -63946,7 +65419,7 @@ Distributed under the MIT License
 
 TypeScript Language Basics
 --------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Published by vscode
 Distributed under the MIT License
@@ -63954,7 +65427,7 @@ Distributed under the MIT License
 
 TypeScript tmLanguage
 ---------------------
-Website: https://github.com/microsoft/TypeScript-TmLanguage
+Source: https://github.com/microsoft/TypeScript-TmLanguage
 
 Copyright (c) Microsoft Corporation All rights reserved.
 Distributed under the MIT License
@@ -63962,7 +65435,7 @@ Distributed under the MIT License
 
 @typespec/ts-http-runtime
 -------------------------
-Website: https://github.com/Azure/azure-sdk-for-js
+Source: https://github.com/Azure/azure-sdk-for-js
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -63994,7 +65467,7 @@ SOFTWARE.
 
 typical
 -------
-Website: https://github.com/75lb/typical
+Source: https://github.com/75lb/typical
 
 Copyright 2014-25 Lloyd Brookes <75pound@gmail.com>
 Distributed under the MIT License
@@ -64026,7 +65499,7 @@ SOFTWARE.
 
 typing-extensions
 -----------------
-Website: https://pypi.org/project/typing-extensions/
+Source: https://pypi.org/project/typing-extensions/
 
 Copyright 1991 - 1995, Stichting Mathematisch Centrum Amsterdam, The Netherlands.
 Distributed under the Python License version 2.0
@@ -64314,7 +65787,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 uc.micro
 --------
-Website: https://github.com/markdown-it/uc.micro
+Source: https://github.com/markdown-it/uc.micro
 
 Copyright Mathias Bynens <https:mathiasbynens.be/>
 Distributed under the MIT License
@@ -64345,7 +65818,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ufo
 ---
-Website: https://github.com/unjs/ufo
+Source: https://github.com/unjs/ufo
 
 Copyright Pooya Parsa <pooya@pi0.io>
 Distributed under the MIT License
@@ -64377,7 +65850,7 @@ SOFTWARE.
 
 uint64be
 --------
-Website: https://github.com/mafintosh/uint64be
+Source: https://github.com/mafintosh/uint64be
 
 Copyright 2015 Mathias Buus
 Distributed under the MIT License
@@ -64409,7 +65882,7 @@ THE SOFTWARE.
 
 undici
 ------
-Website: https://github.com/nodejs/undici
+Source: https://github.com/nodejs/undici
 
 Copyright Matteo Collina and Undici contributors
 Distributed under the MIT License
@@ -64441,7 +65914,7 @@ SOFTWARE.
 
 unicase
 -------
-Website: https://github.com/seanmonstar/unicase
+Source: https://github.com/seanmonstar/unicase
 
 Copyright 2014-2017 Sean McArthur
 
@@ -64475,7 +65948,7 @@ THE SOFTWARE.
 
 unicode
 -------
-Website: https://github.com/tdanecker/node-unicodetable
+Source: https://github.com/tdanecker/node-unicodetable
 
 Copyright 2014 ▟ ▖▟ ▖(dodo)
 Distributed under the MIT License
@@ -64493,7 +65966,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 Unicode 12.0.0
 --------------
-Website: https://home.unicode.org/
+Source: https://home.unicode.org/
 
 Copyright (c) 1991-2017 Unicode, Inc. All rights reserved.
 
@@ -64565,7 +66038,7 @@ b) this copyright and permission notice appear in associated
 
 unicode-bidi
 ------------
-Website: https://github.com/servo/unicode-bidi
+Source: https://github.com/servo/unicode-bidi
 
 Copyright 2015 The Rust Project Developers
 This project is copyright 2015, The Servo Project Developers (given in the file AUTHORS).
@@ -64606,7 +66079,7 @@ DEALINGS IN THE SOFTWARE.
 
 unicode-bom
 -----------
-Website: https://gitlab.com/philbooth/unicode-bom
+Source: https://gitlab.com/philbooth/unicode-bom
 
 Published by Phil Booth <pmbooth@gmail.com>
 Distributed under the Apache License version 2.0
@@ -64614,7 +66087,7 @@ Distributed under the Apache License version 2.0
 
 unicode-ident
 -------------
-Website: https://github.com/dtolnay/unicode-ident
+Source: https://github.com/dtolnay/unicode-ident
 
 Copyright © 1991-2022 Unicode, Inc.
 
@@ -64678,7 +66151,7 @@ b) this copyright and permission notice appear in associated
 
 unicode-normalization
 ---------------------
-Website: https://github.com/unicode-rs/unicode-normalization
+Source: https://github.com/unicode-rs/unicode-normalization
 
 Copyright 2015 The Rust Project Developers
 
@@ -64718,7 +66191,7 @@ DEALINGS IN THE SOFTWARE.
 
 unicode-segmentation
 --------------------
-Website: https://github.com/unicode-rs/unicode-segmentation
+Source: https://github.com/unicode-rs/unicode-segmentation
 
 Copyright 2015 The Rust Project Developers
 
@@ -64758,7 +66231,7 @@ DEALINGS IN THE SOFTWARE.
 
 unicode-width
 -------------
-Website: https://github.com/unicode-rs/unicode-width
+Source: https://github.com/unicode-rs/unicode-width
 
 Copyright 2015 The Rust Project Developers
 
@@ -64798,7 +66271,7 @@ DEALINGS IN THE SOFTWARE.
 
 unicode-xid
 -----------
-Website: https://github.com/unicode-rs/unicode-xid
+Source: https://github.com/unicode-rs/unicode-xid
 
 Copyright 2015 The Rust Project Developers
 
@@ -64838,7 +66311,7 @@ DEALINGS IN THE SOFTWARE.
 
 universal-user-agent
 --------------------
-Website: https://github.com/gr2m/universal-user-agent
+Source: https://github.com/gr2m/universal-user-agent
 
 Copyright 2018-2021, Gregor Martynus (https:github.com/gr2m)
 Distributed under the ISC License
@@ -64856,7 +66329,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 universalify
 ------------
-Website: https://github.com/RyanZim/universalify
+Source: https://github.com/RyanZim/universalify
 
 Copyright 2017, Ryan Zimmerman <opensrc@ryanzim.com>
 Distributed under the MIT License
@@ -64887,7 +66360,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 unpipe
 ------
-Website: https://github.com/stream-utils/unpipe
+Source: https://github.com/stream-utils/unpipe
 
 Copyright 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
 Distributed under the MIT License
@@ -64920,7 +66393,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 untrusted
 ---------
-Website: https://github.com/briansmith/untrusted
+Source: https://github.com/briansmith/untrusted
 
 Copyright 2015-2016 Brian Smith.
 Distributed under the ISC License
@@ -64944,7 +66417,7 @@ ISC License text:
 
 url
 ---
-Website: https://github.com/servo/rust-url
+Source: https://github.com/servo/rust-url
 
 Copyright 2013-2022 The rust-url developers
 
@@ -64984,7 +66457,7 @@ DEALINGS IN THE SOFTWARE.
 
 urlencoding
 -----------
-Website: https://github.com/kornelski/rust_urlencoding
+Source: https://github.com/kornelski/rust_urlencoding
 
 Copyright © 2016 Bertram Truong © 2021 Kornel Lesiński
 Distributed under the MIT License
@@ -65016,7 +66489,7 @@ THE SOFTWARE.
 
 utf-8
 -----
-Website: https://github.com/SimonSapin/rust-utf8
+Source: https://github.com/SimonSapin/rust-utf8
 
 Published by Simon Sapin <simon.sapin@exyr.org>
 
@@ -65028,7 +66501,7 @@ Consult the documentation and source code of utf-8 for more information.
 
 utf16_iter
 ----------
-Website: https://github.com/hsivonen/utf16_iter
+Source: https://github.com/hsivonen/utf16_iter
 
 Copyright Mozilla Foundation
 
@@ -65068,7 +66541,7 @@ DEALINGS IN THE SOFTWARE.
 
 utf8parse
 ---------
-Website: https://github.com/alacritty/vte
+Source: https://github.com/alacritty/vte
 
 Copyright 2016 Joe Wilm
 
@@ -65108,7 +66581,7 @@ DEALINGS IN THE SOFTWARE.
 
 utf8_iter
 ---------
-Website: https://github.com/hsivonen/utf8_iter
+Source: https://github.com/hsivonen/utf8_iter
 
 Copyright Mozilla Foundation
 
@@ -65148,7 +66621,7 @@ DEALINGS IN THE SOFTWARE.
 
 util-deprecate
 --------------
-Website: https://github.com/TooTallNate/util-deprecate
+Source: https://github.com/TooTallNate/util-deprecate
 
 Copyright 2014 Nathan Rajlich <nathan@tootallnate.net>
 Distributed under the MIT License
@@ -65183,7 +66656,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 utils-merge
 -----------
-Website: https://github.com/jaredhanson/utils-merge
+Source: https://github.com/jaredhanson/utils-merge
 
 Copyright 2013-2017 Jared Hanson
 Distributed under the MIT License
@@ -65214,7 +66687,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 uuid versions 11.1.0, 9.0.1, 8.3.2
 ----------------------------------
-Website: https://github.com/uuidjs/uuid
+Source: https://github.com/uuidjs/uuid
 
 Copyright 2010-2020 Robert Kieffer and other contributors
 Distributed under the MIT License
@@ -65234,7 +66707,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 uuid version 1.11.0
 -------------------
-Website: https://github.com/uuid-rs/uuid
+Source: https://github.com/uuid-rs/uuid
 
 Copyright 2014 The Rust Project Developers
 Copyright 2018 Ashley Mannix, Christopher Armstrong, Dylan DPC, Hunar Roop Kahlon
@@ -65277,7 +66750,7 @@ DEALINGS IN THE SOFTWARE.
 
 v8-inspect-profiler
 -------------------
-Website: https://github.com/jrieken/v8-inspect-profiler
+Source: https://github.com/jrieken/v8-inspect-profiler
 
 Copyright 2015 - present Microsoft Corporation
 Distributed under the MIT License
@@ -65311,7 +66784,7 @@ SOFTWARE.
 
 validator
 ---------
-Website: https://github.com/Keats/validator
+Source: https://github.com/Keats/validator
 
 Published by Vincent Prouillet <hello@vincentprouillet.com
 Distributed under the MIT License
@@ -65319,7 +66792,7 @@ Distributed under the MIT License
 
 valuable
 --------
-Website: https://github.com/tokio-rs/valuable
+Source: https://github.com/tokio-rs/valuable
 
 Copyright 2021 Valuable Contributors
 Distributed under the MIT License
@@ -65355,7 +66828,7 @@ DEALINGS IN THE SOFTWARE.
 
 vary
 ----
-Website: https://github.com/jshttp/vary
+Source: https://github.com/jshttp/vary
 
 Copyright 2014-2017 Douglas Christopher Wilson
 Distributed under the MIT License
@@ -65388,7 +66861,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 vcpkg
 -----
-Website: https://github.com/mcgoo/vcpkg-rs
+Source: https://github.com/mcgoo/vcpkg-rs
 
 Copyright 2017 Jim McGrath
 
@@ -65428,7 +66901,7 @@ DEALINGS IN THE SOFTWARE.
 
 VCSode JSON tmLanguage
 ----------------------
-Website: https://github.com/microsoft/vscode-css
+Source: https://github.com/microsoft/vscode-css
 
 Copyright (c) Microsoft Corporation.
 Distributed under the MIT License
@@ -65436,7 +66909,7 @@ Distributed under the MIT License
 
 vec_map
 -------
-Website: https://github.com/contain-rs/vec-map
+Source: https://github.com/contain-rs/vec-map
 
 Copyright 2015 The Rust Project Developers
 
@@ -65476,7 +66949,7 @@ DEALINGS IN THE SOFTWARE.
 
 version-compare
 ---------------
-Website: https://gitlab.com/timvisee/version-compare
+Source: https://gitlab.com/timvisee/version-compare
 
 Copyright 2017 Tim Visée
 Distributed under the MIT License
@@ -65506,7 +66979,7 @@ SOFTWARE.
 
 version_check
 -------------
-Website: https://github.com/SergioBenitez/version_check
+Source: https://github.com/SergioBenitez/version_check
 
 Copyright 2017-2018 Sergio Benitez
 
@@ -65541,7 +67014,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Visual Basic Language Basics
 ----------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -65549,7 +67022,7 @@ Distributed under the MIT License
 
 VSCode CSS
 ----------
-Website: https://github.com/microsoft/vscode-css
+Source: https://github.com/microsoft/vscode-css
 
 Copyright (c) Microsoft Corporation.
 Distributed under the MIT License
@@ -65557,7 +67030,7 @@ Distributed under the MIT License
 
 VSCode Java (tmLanguage)
 ------------------------
-Website: https://github.com/redhat-developer/vscode-java
+Source: https://github.com/redhat-developer/vscode-java
 
 Copyright (c) 2014 GitHub Inc.
 Distributed under the MIT License
@@ -65599,7 +67072,7 @@ suitability for any purpose.
 
 VSCode logfile highlighter
 --------------------------
-Website: https://github.com/emilast/vscode-logfile-highlighter
+Source: https://github.com/emilast/vscode-logfile-highlighter
 
 Copyright (c) 2015 emilast
 Distributed under the MIT License
@@ -65607,7 +67080,7 @@ Distributed under the MIT License
 
 VSCode Markdown tm grammar
 --------------------------
-Website: https://github.com/microsoft/vscode-markdown-tm-grammar
+Source: https://github.com/microsoft/vscode-markdown-tm-grammar
 
 Copyright (c) Microsoft 2018
 Distributed under the MIT License
@@ -65615,7 +67088,7 @@ Distributed under the MIT License
 
 VSCode MSSQL
 ------------
-Website: https://github.com/microsoft/vscode-mssql
+Source: https://github.com/microsoft/vscode-mssql
 
 Copyright (c) Microsoft Corporation All rights reserved.
 Distributed under the MIT License
@@ -65623,7 +67096,7 @@ Distributed under the MIT License
 
 VSCode Python
 -------------
-Website: https://github.com/microsoft/vscode-python
+Source: https://github.com/microsoft/vscode-python
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 Distributed under the MIT License
@@ -65631,7 +67104,7 @@ Distributed under the MIT License
 
 VSCode R Syntax
 ---------------
-Website: https://github.com/REditorSupport/vscode-R-syntax
+Source: https://github.com/REditorSupport/vscode-R-syntax
 
 Copyright (c) 2025 REditorSupport
 Distributed under the MIT License
@@ -65639,7 +67112,7 @@ Distributed under the MIT License
 
 VSCode R Test Adapter
 ---------------------
-Website: https://github.com/meakbiyik/vscode-r-test-adapter
+Source: https://github.com/meakbiyik/vscode-r-test-adapter
 
 Copyright (c) vscode-r-test-adapter project authors
 Distributed under the MIT License
@@ -65647,7 +67120,7 @@ Distributed under the MIT License
 
 VSCode reStructuredText
 -----------------------
-Website: https://github.com/trond-snekvik/vscode-rst
+Source: https://github.com/trond-snekvik/vscode-rst
 
 Copyright 2021 Trond Snekvik
 Distributed under the MIT License
@@ -65655,7 +67128,7 @@ Distributed under the MIT License
 
 VSCode Swift
 ------------
-Website: https://github.com/owensd/vscode-swift
+Source: https://github.com/owensd/vscode-swift
 
 Copyright (c) 2017 Kiad Studios, LLC.
 Distributed under the MIT License
@@ -65663,7 +67136,7 @@ Distributed under the MIT License
 
 VSCode win32-app-container-tokens
 ---------------------------------
-Website: https://github.com/microsoft/vscode-win32-app-container-tokens
+Source: https://github.com/microsoft/vscode-win32-app-container-tokens
 
 Copyright (c) Microsoft Corporation.
 Distributed under the MIT License
@@ -65671,7 +67144,7 @@ Distributed under the MIT License
 
 vscode-debugprotocol
 --------------------
-Website: https://github.com/microsoft/vscode-debugadapter-node
+Source: https://github.com/microsoft/vscode-debugadapter-node
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -65693,7 +67166,7 @@ THE SOFTWARE IS PROVIDED **AS IS**, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMP
 
 vscode-jsonrpc
 --------------
-Website: https://github.com/Microsoft/vscode-languageserver-node
+Source: https://github.com/Microsoft/vscode-languageserver-node
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -65715,7 +67188,7 @@ THE SOFTWARE IS PROVIDED **AS IS**, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMP
 
 vscode-languageclient
 ---------------------
-Website: https://github.com/Microsoft/vscode-languageserver-node
+Source: https://github.com/Microsoft/vscode-languageserver-node
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -65737,7 +67210,7 @@ THE SOFTWARE IS PROVIDED **AS IS**, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMP
 
 vscode-languageserver
 ---------------------
-Website: https://github.com/Microsoft/vscode-languageserver-node
+Source: https://github.com/Microsoft/vscode-languageserver-node
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -65759,7 +67232,7 @@ THE SOFTWARE IS PROVIDED **AS IS**, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMP
 
 vscode-languageserver-protocol
 ------------------------------
-Website: https://github.com/Microsoft/vscode-languageserver-node
+Source: https://github.com/Microsoft/vscode-languageserver-node
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -65781,7 +67254,7 @@ THE SOFTWARE IS PROVIDED **AS IS**, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMP
 
 vscode-languageserver-textdocument
 ----------------------------------
-Website: https://github.com/Microsoft/vscode-languageserver-node
+Source: https://github.com/Microsoft/vscode-languageserver-node
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -65803,7 +67276,7 @@ THE SOFTWARE IS PROVIDED **AS IS**, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMP
 
 vscode-languageserver-types
 ---------------------------
-Website: https://github.com/Microsoft/vscode-languageserver-node
+Source: https://github.com/Microsoft/vscode-languageserver-node
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -65825,7 +67298,7 @@ THE SOFTWARE IS PROVIDED **AS IS**, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMP
 
 vscode-latex-basics
 -------------------
-Website: https://github.com/jlelong/vscode-latex-basics
+Source: https://github.com/jlelong/vscode-latex-basics
 
 Copyright (c) vscode-latex-basics authors
 Distributed under the MIT License
@@ -65833,7 +67306,7 @@ Distributed under the MIT License
 
 vscode-markdown-languageserver
 ------------------------------
-Website: https://npmjs.com/package/vscode-markdown-languageserver/v/0.5.0-alpha.12
+Source: https://npmjs.com/package/vscode-markdown-languageserver/v/0.5.0-alpha.12
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -65865,7 +67338,7 @@ SOFTWARE
 
 vscode-markdown-languageservice
 -------------------------------
-Website: https://github.com/microsoft/vscode-markdown-languageservice
+Source: https://github.com/microsoft/vscode-markdown-languageservice
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -65897,7 +67370,7 @@ SOFTWARE
 
 vscode-oniguruma
 ----------------
-Website: https://github.com/microsoft/vscode-oniguruma
+Source: https://github.com/microsoft/vscode-oniguruma
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -65931,7 +67404,7 @@ SOFTWARE.
 
 vscode-regexpp
 --------------
-Website: https://github.com/mysticatea/regexpp
+Source: https://github.com/mysticatea/regexpp
 
 Copyright 2018 Toru Nagashima
 Distributed under the MIT License
@@ -65963,7 +67436,7 @@ SOFTWARE.
 
 vscode-tas-client
 -----------------
-Website: https://npmjs.com/package/vscode-tas-client/v/0.1.84
+Source: https://npmjs.com/package/vscode-tas-client/v/0.1.84
 
 Published by Microsoft
 Distributed under the MIT License
@@ -65971,7 +67444,7 @@ Distributed under the MIT License
 
 vscode-textmate
 ---------------
-Website: https://github.com/microsoft/vscode-textmate
+Source: https://github.com/microsoft/vscode-textmate
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -66003,7 +67476,7 @@ SOFTWARE.
 
 vscode-uri
 ----------
-Website: https://github.com/microsoft/vscode-uri
+Source: https://github.com/microsoft/vscode-uri
 
 Copyright Microsoft
 Distributed under the MIT License
@@ -66023,7 +67496,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 @vscode/codicons
 ----------------
-Website: https://github.com/microsoft/vscode-codicons
+Source: https://github.com/microsoft/vscode-codicons
 
 Copyright Microsoft Corporation.
 
@@ -66454,7 +67927,7 @@ SOFTWARE
 
 @vscode/copilot-api
 -------------------
-Website: https://github.com/Microsoft/vscode-extension-telemetry
+Source: https://github.com/Microsoft/vscode-extension-telemetry
 
 Published by Microsoft Corporation
 
@@ -66509,7 +67982,7 @@ IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW.
 
 @vscode/debugprotocol
 ---------------------
-Website: https://github.com/microsoft/vscode-debugadapter-node
+Source: https://github.com/microsoft/vscode-debugadapter-node
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -66531,7 +68004,7 @@ THE SOFTWARE IS PROVIDED **AS IS**, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMP
 
 @vscode/deviceid
 ----------------
-Website: https://npmjs.com/package/@vscode/deviceid/v/0.1.1
+Source: https://npmjs.com/package/@vscode/deviceid/v/0.1.1
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -66565,7 +68038,7 @@ SOFTWARE.
 
 @vscode/emmet-helper
 --------------------
-Website: https://github.com/Microsoft/vscode-emmet-helper
+Source: https://github.com/Microsoft/vscode-emmet-helper
 
 Copyright Microsoft
 Distributed under the MIT License
@@ -66597,7 +68070,7 @@ SOFTWARE.
 
 @vscode/extension-telemetry
 ---------------------------
-Website: https://github.com/Microsoft/vscode-extension-telemetry
+Source: https://github.com/Microsoft/vscode-extension-telemetry
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -66631,7 +68104,7 @@ SOFTWARE.
 
 @vscode/iconv-lite-umd
 ----------------------
-Website: https://github.com/Microsoft/vscode-iconv-lite-umd
+Source: https://github.com/Microsoft/vscode-iconv-lite-umd
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -66663,7 +68136,7 @@ SOFTWARE
 
 @vscode/l10n
 ------------
-Website: https://github.com/Microsoft/vscode-l10n
+Source: https://github.com/Microsoft/vscode-l10n
 
 Published by Microsoft Corporation
 Distributed under the MIT License
@@ -66671,7 +68144,7 @@ Distributed under the MIT License
 
 @vscode/markdown-it-katex
 -------------------------
-Website: https://github.com/microsoft/vscode-markdown-it-katex
+Source: https://github.com/microsoft/vscode-markdown-it-katex
 
 Copyright 2016 Waylon Flinn
 Copyright 2018 Takahiro Ethan Ikeuchi @iktakahiro
@@ -66749,7 +68222,7 @@ SOFTWARE.
 
 @vscode/policy-watcher
 ----------------------
-Website: https://github.com/microsoft/vscode-policy-watcher
+Source: https://github.com/microsoft/vscode-policy-watcher
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -66781,7 +68254,7 @@ SOFTWARE
 
 @vscode/prompt-tsx
 ------------------
-Website: https://github.com/microsoft/vscode-prompt-tsx
+Source: https://github.com/microsoft/vscode-prompt-tsx
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -66813,7 +68286,7 @@ SOFTWARE
 
 @vscode/proxy-agent
 -------------------
-Website: https://github.com/microsoft/vscode-proxy-agent
+Source: https://github.com/microsoft/vscode-proxy-agent
 
 Copyright 2014 Nathan Rajlich <nathan@tootallnate.net>
 Copyright 2015 Félicien François <felicien@tweakstyle.com>
@@ -66852,7 +68325,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 @vscode/ripgrep
 ---------------
-Website: https://github.com/microsoft/vscode-ripgrep
+Source: https://github.com/microsoft/vscode-ripgrep
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -66876,7 +68349,7 @@ THE SOFTWARE IS PROVIDED **AS IS**, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMP
 
 @vscode/spdlog
 --------------
-Website: https://github.com/microsoft/node-spdlog
+Source: https://github.com/microsoft/node-spdlog
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -66908,7 +68381,7 @@ SOFTWARE
 
 @vscode/sqlite3
 ---------------
-Website: https://github.com/microsoft/vscode-node-sqlite3
+Source: https://github.com/microsoft/vscode-node-sqlite3
 
 Copyright MapBox
 Distributed under the BSD 3-Clause license
@@ -66945,7 +68418,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 @vscode/sudo-prompt
 -------------------
-Website: https://github.com/bpasero/sudo-prompt
+Source: https://github.com/bpasero/sudo-prompt
 
 Copyright 2015 Joran Dirk Greef
 Distributed under the MIT License
@@ -66977,7 +68450,7 @@ SOFTWARE.
 
 @vscode/sync-api-client
 -----------------------
-Website: https://github.com/microsoft/vscode-wasm
+Source: https://github.com/microsoft/vscode-wasm
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -67009,7 +68482,7 @@ SOFTWARE
 
 @vscode/sync-api-common
 -----------------------
-Website: https://github.com/microsoft/vscode-wasm
+Source: https://github.com/microsoft/vscode-wasm
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -67041,7 +68514,7 @@ SOFTWARE
 
 @vscode/sync-api-service
 ------------------------
-Website: https://github.com/microsoft/vscode-wasm
+Source: https://github.com/microsoft/vscode-wasm
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -67073,7 +68546,7 @@ SOFTWARE
 
 @vscode/tree-sitter-wasm
 ------------------------
-Website: https://github.com/Microsoft/vscode-tree-sitter-wasm
+Source: https://github.com/Microsoft/vscode-tree-sitter-wasm
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -67105,7 +68578,7 @@ SOFTWARE
 
 @vscode/ts-package-manager
 --------------------------
-Website: https://npmjs.com/package/@vscode/ts-package-manager/v/0.0.2
+Source: https://npmjs.com/package/@vscode/ts-package-manager/v/0.0.2
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -67137,7 +68610,7 @@ SOFTWARE
 
 @vscode/vscode-languagedetection
 --------------------------------
-Website: https://github.com/microsoft/vscode-languagedetection
+Source: https://github.com/microsoft/vscode-languagedetection
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -67169,7 +68642,7 @@ SOFTWARE
 
 @vscode/webview-ui-toolkit
 --------------------------
-Website: https://github.com/microsoft/vscode-webview-ui-toolkit
+Source: https://github.com/microsoft/vscode-webview-ui-toolkit
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -67201,7 +68674,7 @@ SOFTWARE.
 
 @vscode/windows-mutex
 ---------------------
-Website: https://github.com/microsoft/node-windows-mutex
+Source: https://github.com/microsoft/node-windows-mutex
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -67235,7 +68708,7 @@ THE SOFTWARE.
 
 @vscode/windows-process-tree
 ----------------------------
-Website: https://github.com/microsoft/vscode-windows-process-tree
+Source: https://github.com/microsoft/vscode-windows-process-tree
 
 Copyright Microsoft Corporation.
 Distributed under the MIT License
@@ -67267,7 +68740,7 @@ SOFTWARE
 
 @vscode/windows-registry
 ------------------------
-Website: https://github.com/Microsoft/vscode-windows-registry
+Source: https://github.com/Microsoft/vscode-windows-registry
 
 Copyright Microsoft Corporation
 Distributed under the MIT License
@@ -67295,7 +68768,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 vswhom
 ------
-Website: https://github.com/nabijaczleweli/vswhom.rs
+Source: https://github.com/nabijaczleweli/vswhom.rs
 
 Copyright 2019 nabijaczleweli
 Distributed under the MIT License
@@ -67327,7 +68800,7 @@ SOFTWARE.
 
 vswhom-sys
 ----------
-Website: https://github.com/nabijaczleweli/vswhom-sys.rs
+Source: https://github.com/nabijaczleweli/vswhom-sys.rs
 
 Copyright 2019 nabijaczleweli
 Distributed under the MIT License
@@ -67359,7 +68832,7 @@ SOFTWARE.
 
 walkdir
 -------
-Website: https://github.com/BurntSushi/walkdir
+Source: https://github.com/BurntSushi/walkdir
 
 Copyright 2015 Andrew Gallant
 
@@ -67371,7 +68844,7 @@ Consult the documentation and source code of walkdir for more information.
 
 want
 ----
-Website: https://github.com/seanmonstar/want
+Source: https://github.com/seanmonstar/want
 
 Copyright 2018-2019 Sean McArthur
 Distributed under the MIT License
@@ -67401,7 +68874,7 @@ THE SOFTWARE.
 
 wasi
 ----
-Website: https://github.com/bytecodealliance/wasi
+Source: https://github.com/bytecodealliance/wasi
 
 Published by The Cranelift Project Developers
 
@@ -67413,7 +68886,7 @@ Consult the documentation and source code of wasi for more information.
 
 wasm-bindgen
 ------------
-Website: https://github.com/rustwasm/wasm-bindgen
+Source: https://github.com/rustwasm/wasm-bindgen
 
 Copyright 2014 Alex Crichton
 
@@ -67453,7 +68926,7 @@ DEALINGS IN THE SOFTWARE.
 
 wasm-encoder
 ------------
-Website: https://github.com/bytecodealliance/wasm-tools
+Source: https://github.com/bytecodealliance/wasm-tools
 
 Published by Nick Fitzgerald <fitzgen@gmail.com>
 Distributed under the Apache License version 2.0 with LLVM Exceptions
@@ -67461,7 +68934,7 @@ Distributed under the Apache License version 2.0 with LLVM Exceptions
 
 wasm-metadata
 -------------
-Website: https://github.com/bytecodealliance/wasm-tools
+Source: https://github.com/bytecodealliance/wasm-tools
 
 Published by Bytecode Alliance
 Distributed under the Apache License version 2.0 with LLVM Exceptions
@@ -67469,7 +68942,7 @@ Distributed under the Apache License version 2.0 with LLVM Exceptions
 
 wasm-timer
 ----------
-Website: https://github.com/tomaka/wasm-timer
+Source: https://github.com/tomaka/wasm-timer
 
 Copyright 2019 Pierre Krieger
 Copyright 2019 Tokio Contributors
@@ -67501,7 +68974,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 wasmparser
 ----------
-Website: https://github.com/bytecodealliance/wasm-tools
+Source: https://github.com/bytecodealliance/wasm-tools
 
 Published by Yury Delendik <ydelendik@mozilla.com>
 Distributed under the Apache License version 2.0 with LLVM Exceptions
@@ -67509,7 +68982,7 @@ Distributed under the Apache License version 2.0 with LLVM Exceptions
 
 wcwidth
 -------
-Website: https://github.com/jquast/wcwidth
+Source: https://github.com/jquast/wcwidth
 
 Published by Jeff Quast
 Distributed under the MIT License
@@ -67517,7 +68990,7 @@ Distributed under the MIT License
 
 Web Background Synchronization
 ------------------------------
-Website: https://github.com/WICG/background-sync
+Source: https://github.com/WICG/background-sync
 
 Copyright (c) 2021 the Contributors to the Web Background Synchronization Specification, published by the Web Platform Incubator Community Group under the W3C Community Contributor License Agreement (CLA).
 Distributed under the Apache License version 2.0
@@ -67525,7 +68998,7 @@ Distributed under the Apache License version 2.0
 
 web-streams-polyfill
 --------------------
-Website: https://github.com/MattiasBuelens/web-streams-polyfill
+Source: https://github.com/MattiasBuelens/web-streams-polyfill
 
 Copyright 2016 Diwank Singh Tomer
 Copyright 2024 Mattias Buelens
@@ -67560,7 +69033,7 @@ SOFTWARE.
 
 web-tree-sitter
 ---------------
-Website: https://github.com/tree-sitter/tree-sitter
+Source: https://github.com/tree-sitter/tree-sitter
 
 Copyright 2018-2024 Max Brunsfeld
 Distributed under the MIT License
@@ -67592,7 +69065,7 @@ SOFTWARE.
 
 web-worker
 ----------
-Website: https://github.com/developit/web-worker
+Source: https://github.com/developit/web-worker
 
 Copyright (c) Microsoft Corporation
 Distributed under the Apache License version 2.0
@@ -67600,7 +69073,7 @@ Distributed under the Apache License version 2.0
 
 webidl-conversions
 ------------------
-Website: https://github.com/jsdom/webidl-conversions
+Source: https://github.com/jsdom/webidl-conversions
 
 Copyright 2014, Domenic Denicola
 Distributed under the BSD 2-Clause license
@@ -67624,7 +69097,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 whatwg-url
 ----------
-Website: https://github.com/jsdom/whatwg-url
+Source: https://github.com/jsdom/whatwg-url
 
 Copyright 2015–2016 Sebastian Mayr
 Distributed under the MIT License
@@ -67656,7 +69129,7 @@ THE SOFTWARE.
 
 which
 -----
-Website: https://github.com/npm/node-which
+Source: https://github.com/npm/node-which
 
 Copyright Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -67682,7 +69155,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 which-pm
 --------
-Website: https://github.com/zkochan/packages
+Source: https://github.com/zkochan/packages
 
 Copyright 2017-2022 Zoltan Kochan <z@kochan.io>
 Distributed under the MIT License
@@ -67714,7 +69187,7 @@ SOFTWARE.
 
 winapi
 ------
-Website: https://github.com/retep998/winapi-rs
+Source: https://github.com/retep998/winapi-rs
 
 Copyright 2015-2018 The winapi-rs Developers
 
@@ -67748,7 +69221,7 @@ SOFTWARE.
 
 winapi-rs
 ---------
-Website: https://github.com/retep998/winapi-rs
+Source: https://github.com/retep998/winapi-rs
 
 Published by Peter Atashian <retep998@gmail.com>
 
@@ -67760,7 +69233,7 @@ Consult the documentation and source code of winapi-rs for more information.
 
 winapi-util
 -----------
-Website: https://github.com/BurntSushi/winapi-util
+Source: https://github.com/BurntSushi/winapi-util
 
 Copyright 2017 Andrew Gallant
 
@@ -67772,7 +69245,7 @@ Consult the documentation and source code of winapi-util for more information.
 
 Windows Bat Language Basics
 ---------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -67780,7 +69253,7 @@ Distributed under the MIT License
 
 windows-rs
 ----------
-Website: https://github.com/microsoft/windows-rs
+Source: https://github.com/microsoft/windows-rs
 
 Copyright Microsoft Corporation.
 
@@ -68023,7 +69496,7 @@ SOFTWARE
 
 winnow
 ------
-Website: https://github.com/winnow-rs/winnow
+Source: https://github.com/winnow-rs/winnow
 
 Copyrights in winnow are retained by their contributors.
 Distributed under the MIT License
@@ -68031,15 +69504,15 @@ Distributed under the MIT License
 
 winreg version 1.2.5
 --------------------
-Website: https://github.com/fresc81/node-winreg
+Source: https://github.com/fresc81/node-winreg
 
-Copyright 2016, Paul Bottin
+Copyright (C) 2012-2016 Yusuke Suzuki
 Distributed under the BSD 2-Clause license
 
 
 winreg version 0.52.0
 ---------------------
-Website: https://github.com/gentoo90/winreg-rs
+Source: https://github.com/gentoo90/winreg-rs
 
 Copyright 2015 Igor Shaula
 Distributed under the MIT License
@@ -68069,7 +69542,7 @@ THE SOFTWARE.
 
 winsafe
 -------
-Website: https://github.com/rodrigocfd/winsafe
+Source: https://github.com/rodrigocfd/winsafe
 
 Copyright 2019-present, Rodrigo Cesar de Freitas Dias
 Distributed under the MIT License
@@ -68099,7 +69572,7 @@ SOFTWARE.
 
 winston
 -------
-Website: https://github.com/winstonjs/winston
+Source: https://github.com/winstonjs/winston
 
 Copyright 2010 Charlie Robbins
 Distributed under the MIT License
@@ -68129,7 +69602,7 @@ THE SOFTWARE.
 
 winston-transport
 -----------------
-Website: https://github.com/winstonjs/winston-transport
+Source: https://github.com/winstonjs/winston-transport
 
 Copyright 2015 Charlie Robbins & the contributors.
 Distributed under the MIT License
@@ -68161,7 +69634,7 @@ SOFTWARE.
 
 wit-bindgen
 -----------
-Website: https://github.com/bytecodealliance/wit-bindgen
+Source: https://github.com/bytecodealliance/wit-bindgen
 
 Published by Alex Crichton <alex@alexcrichton.com>
 Distributed under the Apache License version 2.0 with LLVM Exceptions
@@ -68169,7 +69642,7 @@ Distributed under the Apache License version 2.0 with LLVM Exceptions
 
 wit-bindgen-rt
 --------------
-Website: https://github.com/bytecodealliance/wit-bindgen
+Source: https://github.com/bytecodealliance/wit-bindgen
 
 Published by Bytecode Alliance
 Distributed under the Apache License version 2.0 with LLVM Exceptions
@@ -68177,7 +69650,7 @@ Distributed under the Apache License version 2.0 with LLVM Exceptions
 
 wit-component
 -------------
-Website: https://github.com/bytecodealliance/wasm-tools
+Source: https://github.com/bytecodealliance/wasm-tools
 
 Published by Peter Huene <peter@huene.dev>
 Distributed under the Apache License version 2.0 with LLVM Exceptions
@@ -68185,7 +69658,7 @@ Distributed under the Apache License version 2.0 with LLVM Exceptions
 
 wit-parser
 ----------
-Website: https://github.com/bytecodealliance/wasm-tools
+Source: https://github.com/bytecodealliance/wasm-tools
 
 Published by Alex Crichton <alex@alexcrichton.com>
 Distributed under the Apache License version 2.0 with LLVM Exceptions
@@ -68193,7 +69666,7 @@ Distributed under the Apache License version 2.0 with LLVM Exceptions
 
 wordwrapjs
 ----------
-Website: https://github.com/75lb/wordwrapjs
+Source: https://github.com/75lb/wordwrapjs
 
 Copyright 2015-21 Lloyd Brookes <75pound@gmail.com>
 Distributed under the MIT License
@@ -68225,7 +69698,7 @@ SOFTWARE.
 
 wrap-ansi
 ---------
-Website: https://github.com/chalk/wrap-ansi
+Source: https://github.com/chalk/wrap-ansi
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -68245,7 +69718,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 wrappy
 ------
-Website: https://github.com/npm/wrappy
+Source: https://github.com/npm/wrappy
 
 Copyright Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -68271,7 +69744,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 write16
 -------
-Website: https://github.com/hsivonen/write16
+Source: https://github.com/hsivonen/write16
 
 Copyright Mozilla Foundation
 
@@ -68306,7 +69779,7 @@ the individual files for PD/CC0-dedicated sections).
 
 ws
 --
-Website: https://github.com/websockets/ws
+Source: https://github.com/websockets/ws
 
 Copyright 2011 Einar Otto Stangvik <einaros@gmail.com>
 Copyright 2013 Arnout Kazemier and contributors
@@ -68341,7 +69814,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 wsl-utils
 ---------
-Website: https://github.com/sindresorhus/wsl-utils
+Source: https://github.com/sindresorhus/wsl-utils
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -68361,7 +69834,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 xdg
 ---
-Website: https://github.com/whitequark/rust-xdg
+Source: https://github.com/whitequark/rust-xdg
 
 Copyright 2014 The Rust Project Developers
 
@@ -68401,7 +69874,7 @@ DEALINGS IN THE SOFTWARE.
 
 xdg-portable
 ------------
-Website: https://github.com/rivy/js.xdg-portable
+Source: https://github.com/rivy/js.xdg-portable
 
 Copyright Roy Ivy III <rivy.dev@gmail.com>
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
@@ -68424,7 +69897,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 XML Language Basics
 -------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -68432,7 +69905,7 @@ Distributed under the MIT License
 
 xml2js
 ------
-Website: https://github.com/Leonidas-from-XIV/node-xml2js
+Source: https://github.com/Leonidas-from-XIV/node-xml2js
 
 Copyright 2010, 2011, 2012, 2013.
 Distributed under the MIT License
@@ -68462,7 +69935,7 @@ IN THE SOFTWARE.
 
 xmlbuilder
 ----------
-Website: https://github.com/oozcitak/xmlbuilder-js
+Source: https://github.com/oozcitak/xmlbuilder-js
 
 Copyright 2013 Ozgur Ozcitak
 Distributed under the MIT License
@@ -68494,7 +69967,7 @@ THE SOFTWARE.
 
 @xterm/addon-clipboard
 ----------------------
-Website: https://github.com/xtermjs/xterm.js
+Source: https://github.com/xtermjs/xterm.js
 
 Copyright 2023, The xterm.js authors (https:github.com/xtermjs/xterm.js)
 Distributed under the MIT License
@@ -68524,7 +69997,7 @@ THE SOFTWARE.
 
 @xterm/addon-image
 ------------------
-Website: https://github.com/xtermjs/xterm.js
+Source: https://github.com/xtermjs/xterm.js
 
 Copyright 2019, 2020, 2021, 2022, 2023 The xterm.js authors (https:github.com/xtermjs/xterm.js)
 Distributed under the MIT License
@@ -68554,7 +70027,7 @@ THE SOFTWARE.
 
 @xterm/addon-ligatures
 ----------------------
-Website: https://github.com/xtermjs/xterm.js
+Source: https://github.com/xtermjs/xterm.js
 
 Copyright 2018 The xterm.js authors
 Distributed under the MIT License
@@ -68586,7 +70059,7 @@ SOFTWARE.
 
 @xterm/addon-progress
 ---------------------
-Website: https://github.com/xtermjs/xterm.js
+Source: https://github.com/xtermjs/xterm.js
 
 Copyright 2024, The xterm.js authors (https:github.com/xtermjs/xterm.js)
 Distributed under the MIT License
@@ -68616,7 +70089,7 @@ THE SOFTWARE.
 
 @xterm/addon-search
 -------------------
-Website: https://github.com/xtermjs/xterm.js
+Source: https://github.com/xtermjs/xterm.js
 
 Copyright 2017, The xterm.js authors (https:github.com/xtermjs/xterm.js)
 Distributed under the MIT License
@@ -68646,7 +70119,7 @@ THE SOFTWARE.
 
 @xterm/addon-serialize
 ----------------------
-Website: https://github.com/xtermjs/xterm.js
+Source: https://github.com/xtermjs/xterm.js
 
 Published by The xterm.js authors
 Distributed under the MIT License
@@ -68654,7 +70127,7 @@ Distributed under the MIT License
 
 @xterm/addon-unicode11
 ----------------------
-Website: https://github.com/xtermjs/xterm.js
+Source: https://github.com/xtermjs/xterm.js
 
 Copyright 2019, The xterm.js authors (https:github.com/xtermjs/xterm.js)
 Distributed under the MIT License
@@ -68684,7 +70157,7 @@ THE SOFTWARE.
 
 @xterm/addon-webgl
 ------------------
-Website: https://github.com/xtermjs/xterm.js
+Source: https://github.com/xtermjs/xterm.js
 
 Copyright 2018, The xterm.js authors (https:github.com/xtermjs/xterm.js)
 Distributed under the MIT License
@@ -68714,7 +70187,7 @@ THE SOFTWARE.
 
 @xterm/headless
 ---------------
-Website: https://github.com/xtermjs/xterm.js
+Source: https://github.com/xtermjs/xterm.js
 
 Copyright (c) 2012-2013, Christopher Jeffrey (MIT License)
 Copyright (c) The xterm.js authors
@@ -68723,7 +70196,7 @@ Distributed under the MIT License
 
 @xterm/xterm
 ------------
-Website: https://github.com/xtermjs/xterm.js
+Source: https://github.com/xtermjs/xterm.js
 
 Copyright 2012-2013, Christopher Jeffrey (https:github.com/chjj/)
 Copyright 2014-2016, SourceLair Private Company (https:www.sourcelair.com)
@@ -68757,9 +70230,33 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
+y18n
+----
+Source: https://github.com/yargs/y18n
+
+Copyright 2015, Contributors
+Distributed under the ISC License
+
+ISC License text:
+
+Copyright (c) 2015, Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+
 yallist
 -------
-Website: https://github.com/isaacs/yallist
+Source: https://github.com/isaacs/yallist
 
 Copyright Isaac Z. Schlueter and Contributors
 Distributed under the ISC License
@@ -68785,7 +70282,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 yaml version 2.8.1
 ------------------
-Website: https://github.com/eemeli/yaml
+Source: https://github.com/eemeli/yaml
 
 Copyright Eemeli Aro <eemeli@gmail.com>
 Distributed under the ISC License
@@ -68809,7 +70306,7 @@ THIS SOFTWARE.
 
 YAML Language Basics version 1.0.0
 ----------------------------------
-Website: https://github.com/microsoft/vscode
+Source: https://github.com/microsoft/vscode
 
 Copyright (c) Microsoft Corporation
 Distributed under the MIT License
@@ -68817,7 +70314,7 @@ Distributed under the MIT License
 
 YAML Syntax Highlighter
 -----------------------
-Website: https://github.com/RedCMD/YAML-Syntax-Highlighter
+Source: https://github.com/RedCMD/YAML-Syntax-Highlighter
 
 Copyright 2024 RedCMD
 Distributed under the MIT License
@@ -68825,7 +70322,7 @@ Distributed under the MIT License
 
 yaml-rust
 ---------
-Website: https://github.com/chyh1990/yaml-rust
+Source: https://github.com/chyh1990/yaml-rust
 
 Copyright 2015 Chen Yuheng
 
@@ -68859,9 +70356,67 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+yargs
+-----
+Source: https://github.com/yargs/yargs
+
+Copyright 2010 James Halliday (mail@substack.net); Modified work
+Copyright 2014 Contributors (ben@npmjs.com)
+Distributed under the MIT License
+
+MIT License text:
+
+MIT License
+
+Copyright 2010 James Halliday (mail@substack.net); Modified work Copyright 2014 Contributors (ben@npmjs.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+yargs-parser
+------------
+Source: https://github.com/yargs/yargs-parser
+
+Copyright 2016, Contributors
+Distributed under the ISC License
+
+ISC License text:
+
+Copyright (c) 2016, Contributors
+
+Permission to use, copy, modify, and/or distribute this software
+for any purpose with or without fee is hereby granted, provided
+that the above copyright notice and this permission notice
+appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE
+LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
 yauzl
 -----
-Website: https://github.com/thejoshwolfe/yauzl
+Source: https://github.com/thejoshwolfe/yauzl
 
 Copyright 2014 Josh Wolfe
 Distributed under the MIT License
@@ -68893,7 +70448,7 @@ SOFTWARE.
 
 yazl
 ----
-Website: https://github.com/thejoshwolfe/yazl
+Source: https://github.com/thejoshwolfe/yazl
 
 Copyright 2014 Josh Wolfe
 Distributed under the MIT License
@@ -68925,7 +70480,7 @@ SOFTWARE.
 
 yocto-queue
 -----------
-Website: https://github.com/sindresorhus/yocto-queue
+Source: https://github.com/sindresorhus/yocto-queue
 
 Copyright Sindre Sorhus <sindresorhus@gmail.com> (https:sindresorhus.com)
 Distributed under the MIT License
@@ -68945,7 +70500,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 zed_extension_api
 -----------------
-Website: https://github.com/zed-industries/zed
+Source: https://github.com/zed-industries/zed
 
 Copyright 2022 - 2024 Zed Industries, Inc.
 Distributed under the Apache License version 2.0
@@ -69148,7 +70703,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
 zerocopy
 --------
-Website: https://github.com/google/zerocopy
+Source: https://github.com/google/zerocopy
 
 Copyright 2023 The Fuchsia Authors
 
@@ -69425,7 +70980,7 @@ DEALINGS IN THE SOFTWARE.
 
 zeroize
 -------
-Website: https://github.com/RustCrypto/utils
+Source: https://github.com/RustCrypto/utils
 
 Copyright 2018-2021 The RustCrypto Project Developers
 
@@ -69461,7 +71016,7 @@ SOFTWARE.
 
 zeromq
 ------
-Website: https://github.com/zeromq/zmq.rs
+Source: https://github.com/zeromq/zmq.rs
 
 Copyright 2020 Alexei Kornienko
 Distributed under the MIT License
@@ -69493,7 +71048,7 @@ SOFTWARE.
 
 zeromq-src
 ----------
-Website: https://github.com/jean-airoldie/zeromq-src-rs
+Source: https://github.com/jean-airoldie/zeromq-src-rs
 
 Published by jean-airoldie <maxence.caron@protonmail.com>
 
@@ -69505,7 +71060,7 @@ Consult the documentation and source code of zeromq-src for more information.
 
 zipp
 ----
-Website: https://github.com/jaraco/zipp
+Source: https://github.com/jaraco/zipp
 
 Copyright (c) zipp contributors
 Distributed under the MIT License
@@ -69513,7 +71068,7 @@ Distributed under the MIT License
 
 zmq
 ---
-Website: https://github.com/erickt/rust-zmq
+Source: https://github.com/erickt/rust-zmq
 
 Copyright 2011-2014 Erick Tryzelaar
 
@@ -69553,7 +71108,7 @@ DEALINGS IN THE SOFTWARE.
 
 zmq-sys
 -------
-Website: https://github.com/erickt/rust-zmq
+Source: https://github.com/erickt/rust-zmq
 
 Published by a.rottmann@gmx.at, erick.tryzelaar@gmail.com
 
@@ -69563,9 +71118,41 @@ Distributed under multiple software licenses, including:
 Consult the documentation and source code of zmq-sys for more information.
 
 
+zod
+---
+Source: https://github.com/colinhacks/zod
+
+Copyright 2025 Colin McDonnell
+Distributed under the MIT License
+
+MIT License text:
+
+MIT License
+
+Copyright (c) 2025 Colin McDonnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
 zstd
 ----
-Website: https://github.com/gyscos/zstd-rs
+Source: https://github.com/gyscos/zstd-rs
 
 Copyright 2016 Alexandre Bury
 Distributed under the MIT License
@@ -69585,7 +71172,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 zstd-safe
 ---------
-Website: https://github.com/gyscos/zstd-rs
+Source: https://github.com/gyscos/zstd-rs
 
 Copyright 2016 Alexandre Bury
 
@@ -69597,7 +71184,7 @@ Consult the documentation and source code of zstd-safe for more information.
 
 zstd-sys
 --------
-Website: https://github.com/gyscos/zstd-rs
+Source: https://github.com/gyscos/zstd-rs
 
 Copyright 2016 Alexandre Bury
 Copyright 2016-present, Facebook, Inc.


### PR DESCRIPTION
Updating generated NOTICE file for third-party license and attribution information for the 2026.02 branch.

