### PR TITLE
e2e: fix data-explorer pins test failure due to viewport size

### DIFF
--- a/test/e2e/tests/data-explorer/data-explorer-pins.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-pins.test.ts
@@ -180,67 +180,67 @@ for (const { env, data, rowIndexOffset: indexOffset } of testCases) {
 			const { dataExplorer } = app.workbench;
 
 			// The Positron window size determines how many columns are visible in the DOM.
-			// When verifying the table data, we only check the data for the first 7 columns
+			// When verifying the table data, we only check the data for the first 6 columns
 			// because those are the only columns that get rendered based off the window size.
 			const dataPinRow5 = [
-				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78, 'column6': 35, 'column7': 13 },
-				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5, 'column6': 96, 'column7': 80 },
-				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83, 'column6': 21, 'column7': 76 },
-				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20, 'column6': 83, 'column7': 82 },
-				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85, 'column6': 82, 'column7': 36 },
-				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33, 'column6': 16, 'column7': 15 },
-				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61, 'column6': 33, 'column7': 21 },
-				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45, 'column6': 41, 'column7': 39 },
-				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73, 'column6': 79, 'column7': 98 },
-				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15, 'column6': 88, 'column7': 15 }
+				{ 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column4': 50, 'column5': 78 },
+				{ 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column4': 9, 'column5': 5 },
+				{ 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column4': 8, 'column5': 83 },
+				{ 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column4': 98, 'column5': 20 },
+				{ 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column4': 37, 'column5': 85 },
+				{ 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column4': 54, 'column5': 33 },
+				{ 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column4': 80, 'column5': 61 },
+				{ 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column4': 85, 'column5': 45 },
+				{ 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column4': 40, 'column5': 73 },
+				{ 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column4': 46, 'column5': 15 }
 			];
 			const dataPinRow5AndCol4 = [
-				{ 'column4': 50, 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column5': 78, 'column6': 35, 'column7': 13 },
-				{ 'column4': 9, 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column5': 5, 'column6': 96, 'column7': 80 },
-				{ 'column4': 8, 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column5': 83, 'column6': 21, 'column7': 76 },
-				{ 'column4': 98, 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column5': 20, 'column6': 83, 'column7': 82 },
-				{ 'column4': 37, 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column5': 85, 'column6': 82, 'column7': 36 },
-				{ 'column4': 54, 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column5': 33, 'column6': 16, 'column7': 15 },
-				{ 'column4': 80, 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column5': 61, 'column6': 33, 'column7': 21 },
-				{ 'column4': 85, 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column5': 45, 'column6': 41, 'column7': 39 },
-				{ 'column4': 40, 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column5': 73, 'column6': 79, 'column7': 98 },
-				{ 'column4': 46, 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column5': 15, 'column6': 88, 'column7': 15 }
+				{ 'column4': 50, 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column5': 78 },
+				{ 'column4': 9, 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column5': 5 },
+				{ 'column4': 8, 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column5': 83 },
+				{ 'column4': 98, 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column5': 20 },
+				{ 'column4': 37, 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column5': 85 },
+				{ 'column4': 54, 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column5': 33 },
+				{ 'column4': 80, 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column5': 61 },
+				{ 'column4': 85, 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column5': 45 },
+				{ 'column4': 40, 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column5': 73 },
+				{ 'column4': 46, 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column5': 15 }
 			];
 			const dataPinCol4SortCol4 = [
-				{ 'column4': 98, 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column5': 20, 'column6': 83, 'column7': 82 },
-				{ 'column4': 85, 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column5': 45, 'column6': 41, 'column7': 39 },
-				{ 'column4': 80, 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column5': 61, 'column6': 33, 'column7': 21 },
-				{ 'column4': 54, 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column5': 33, 'column6': 16, 'column7': 15 },
-				{ 'column4': 50, 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column5': 78, 'column6': 35, 'column7': 13 },
-				{ 'column4': 46, 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column5': 15, 'column6': 88, 'column7': 15 },
-				{ 'column4': 40, 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column5': 73, 'column6': 79, 'column7': 98 },
-				{ 'column4': 37, 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column5': 85, 'column6': 82, 'column7': 36 },
-				{ 'column4': 9, 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column5': 5, 'column6': 96, 'column7': 80 },
-				{ 'column4': 8, 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column5': 83, 'column6': 21, 'column7': 76 }
+				{ 'column4': 98, 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column5': 20 },
+				{ 'column4': 85, 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column5': 45 },
+				{ 'column4': 80, 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column5': 61 },
+				{ 'column4': 54, 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column5': 33 },
+				{ 'column4': 50, 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column5': 78 },
+				{ 'column4': 46, 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column5': 15 },
+				{ 'column4': 40, 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column5': 73 },
+				{ 'column4': 37, 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column5': 85 },
+				{ 'column4': 9, 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column5': 5 },
+				{ 'column4': 8, 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column5': 83 }
 			];
 			const dataSortCol4PinRow6 = [
-				{ 'column4': 40, 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column5': 73, 'column6': 79, 'column7': 98 },
-				{ 'column4': 98, 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column5': 20, 'column6': 83, 'column7': 82 },
-				{ 'column4': 85, 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column5': 45, 'column6': 41, 'column7': 39 },
-				{ 'column4': 80, 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column5': 61, 'column6': 33, 'column7': 21 },
-				{ 'column4': 54, 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column5': 33, 'column6': 16, 'column7': 15 },
-				{ 'column4': 50, 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column5': 78, 'column6': 35, 'column7': 13 },
-				{ 'column4': 46, 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column5': 15, 'column6': 88, 'column7': 15 },
-				{ 'column4': 37, 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column5': 85, 'column6': 82, 'column7': 36 },
-				{ 'column4': 9, 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column5': 5, 'column6': 96, 'column7': 80 },
-				{ 'column4': 8, 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column5': 83, 'column6': 21, 'column7': 76 }
+				{ 'column4': 40, 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column5': 73 },
+				{ 'column4': 98, 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column5': 20 },
+				{ 'column4': 85, 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column5': 45 },
+				{ 'column4': 80, 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column5': 61 },
+				{ 'column4': 54, 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column5': 33 },
+				{ 'column4': 50, 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column5': 78 },
+				{ 'column4': 46, 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column5': 15 },
+				{ 'column4': 37, 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column5': 85 },
+				{ 'column4': 9, 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column5': 5 },
+				{ 'column4': 8, 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column5': 83 }
 			];
 			const dataPinCol4 = [
-				{ 'column4': 9, 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column5': 5, 'column6': 96, 'column7': 80 },
-				{ 'column4': 8, 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column5': 83, 'column6': 21, 'column7': 76 },
-				{ 'column4': 98, 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column5': 20, 'column6': 83, 'column7': 82 },
-				{ 'column4': 37, 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column5': 85, 'column6': 82, 'column7': 36 },
-				{ 'column4': 54, 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column5': 33, 'column6': 16, 'column7': 15 },
-				{ 'column4': 50, 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column5': 78, 'column6': 35, 'column7': 13 },
-				{ 'column4': 80, 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column5': 61, 'column6': 33, 'column7': 21 },
-				{ 'column4': 85, 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column5': 45, 'column6': 41, 'column7': 39 },
-				{ 'column4': 40, 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column5': 73, 'column6': 79, 'column7': 98 },
-				{ 'column4': 46, 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column5': 15, 'column6': 88, 'column7': 15 }
+				{ 'column4': 9, 'column0': 82, 'column1': 69, 'column2': 75, 'column3': 56, 'column5': 5 },
+				{ 'column4': 8, 'column0': 8, 'column1': 79, 'column2': 99, 'column3': 13, 'column5': 83 },
+				{ 'column4': 98, 'column0': 75, 'column1': 71, 'column2': 52, 'column3': 41, 'column5': 20 },
+				{ 'column4': 37, 'column0': 52, 'column1': 48, 'column2': 14, 'column3': 12, 'column5': 85 },
+				{ 'column4': 54, 'column0': 7, 'column1': 3, 'column2': 75, 'column3': 17, 'column5': 33 },
+				{ 'column4': 50, 'column0': 41, 'column1': 42, 'column2': 47, 'column3': 99, 'column5': 78 },
+				{ 'column4': 80, 'column0': 97, 'column1': 79, 'column2': 8, 'column3': 89, 'column5': 61 },
+				{ 'column4': 85, 'column0': 38, 'column1': 91, 'column2': 5, 'column3': 33, 'column5': 45 },
+				{ 'column4': 40, 'column0': 22, 'column1': 9, 'column2': 4, 'column3': 43, 'column5': 73 },
+				{ 'column4': 46, 'column0': 30, 'column1': 8, 'column2': 19, 'column3': 47, 'column5': 15 }
 			];
 
 			// maximize to ensure all rows/columns are rendered and visible


### PR DESCRIPTION
## Summary

- Reduce expected columns from 8 to 6 in the "Column sorting removes pinned rows" test to account for Windows' smaller viewport after the React 19 upgrade
- The virtualized data grid only renders visible columns, and Windows CI has a smaller viewport that doesn't render column6 and column7

## QA Notes

@:win @:data-explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)