### PR TITLE
ci: switch windows e2e workflow from pip to uv for python deps

### DIFF
--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -327,6 +327,7 @@ jobs:
             ${{ runner.os }}-r-4.4.0-
 
       - name: Install R packages for 4.4.0
+        if: steps.cache-r.outputs.cache-hit != 'true'
         run: |
           Rscript -e "install.packages('pak')"
           Rscript -e "pak::local_install_dev_deps(ask = FALSE, upgrade = FALSE)"

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -265,7 +265,7 @@ jobs:
         id: cache-python
         uses: actions/cache/restore@v5
         with:
-          path: ~\AppData\Local\uv\cache
+          path: ${{ env.LOCALAPPDATA }}\uv\cache
           key: ${{ runner.os }}-uv-${{ steps.download-python-reqs.outputs.requirements-hash }}
           restore-keys: |
             ${{ runner.os }}-uv-
@@ -280,7 +280,7 @@ jobs:
         continue-on-error: true
         uses: actions/cache/save@v5
         with:
-          path: ~\AppData\Local\uv\cache
+          path: ${{ env.LOCALAPPDATA }}\uv\cache
           key: ${{ runner.os }}-uv-${{ steps.download-python-reqs.outputs.requirements-hash }}
 
       # Alternate python version

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -265,12 +265,14 @@ jobs:
         id: cache-python
         uses: actions/cache/restore@v5
         with:
-          path: ${{ env.LOCALAPPDATA }}\uv\cache
+          path: ${{ runner.temp }}\uv-cache
           key: ${{ runner.os }}-uv-${{ steps.download-python-reqs.outputs.requirements-hash }}
           restore-keys: |
             ${{ runner.os }}-uv-
 
       - name: Install python dependencies
+        env:
+          UV_CACHE_DIR: ${{ runner.temp }}\uv-cache
         run: |
           uv pip install --system -r requirements.txt
           uv pip install --system trcli
@@ -280,7 +282,7 @@ jobs:
         continue-on-error: true
         uses: actions/cache/save@v5
         with:
-          path: ${{ env.LOCALAPPDATA }}\uv\cache
+          path: ${{ runner.temp }}\uv-cache
           key: ${{ runner.os }}-uv-${{ steps.download-python-reqs.outputs.requirements-hash }}
 
       # Alternate python version
@@ -291,6 +293,8 @@ jobs:
 
       # Ensure Python 3.13.0 is used and only install ipykernel
       - name: Install ipykernel for Python 3.13.0
+        env:
+          UV_CACHE_DIR: ${{ runner.temp }}\uv-cache
         run: |
           python --version  # Verify it's 3.13.0
           uv pip install --system ipykernel

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -265,24 +265,23 @@ jobs:
         id: cache-python
         uses: actions/cache/restore@v5
         with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-pip-${{ steps.download-python-reqs.outputs.requirements-hash }}
+          path: ~\AppData\Local\uv\cache
+          key: ${{ runner.os }}-uv-${{ steps.download-python-reqs.outputs.requirements-hash }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-uv-
 
       - name: Install python dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-          python -m pip install trcli
+          uv pip install --system -r requirements.txt
+          uv pip install --system trcli
 
       - name: Save Python packages cache
         if: ${{ matrix.shard == 1 && steps.cache-python.outputs.cache-hit != 'true' }}
         continue-on-error: true
         uses: actions/cache/save@v5
         with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-pip-${{ steps.download-python-reqs.outputs.requirements-hash }}
+          path: ~\AppData\Local\uv\cache
+          key: ${{ runner.os }}-uv-${{ steps.download-python-reqs.outputs.requirements-hash }}
 
       # Alternate python version
       - name: Install Python 3.13.0
@@ -294,8 +293,7 @@ jobs:
       - name: Install ipykernel for Python 3.13.0
         run: |
           python --version  # Verify it's 3.13.0
-          python -m pip install --upgrade pip
-          python -m pip install ipykernel
+          uv pip install --system ipykernel
 
       # Install rig (R Installation Manager)
       - name: Install rig

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -327,7 +327,6 @@ jobs:
             ${{ runner.os }}-r-4.4.0-
 
       - name: Install R packages for 4.4.0
-        if: steps.cache-r.outputs.cache-hit != 'true'
         run: |
           Rscript -e "install.packages('pak')"
           Rscript -e "pak::local_install_dev_deps(ask = FALSE, upgrade = FALSE)"

--- a/test/e2e/tests/notebook/notebook-create.test.ts
+++ b/test/e2e/tests/notebook/notebook-create.test.ts
@@ -114,26 +114,6 @@ test.describe('Notebooks', {
 			}).toPass({ timeout: 15000 });
 		});
 
-		test.skip('Python - Ensure LSP works across cells', async function ({ app }) {
-			const { notebooks } = app.workbench;
-
-			await notebooks.insertNotebookCell('code');
-			await notebooks.addCodeToCellAtIndex(0, 'import torch');
-			await notebooks.insertNotebookCell('code');
-			await notebooks.addCodeToCellAtIndex(1, 'torch.rand(10)');
-
-			// toPass block seems to be needed on Ubuntu
-			await expect(async () => {
-				await app.workbench.notebooks.hoverCellText(1, 'torch');
-
-				const hoverTooltip = app.code.driver.page.getByRole('tooltip', {
-					name: /module torch/,
-				});
-
-				await expect(hoverTooltip).toBeVisible();
-				await expect(hoverTooltip).toContainText('The torch package contains');
-			}).toPass({ timeout: 60000 });
-		});
 	});
 
 	test.describe('R Notebooks', {


### PR DESCRIPTION
## Summary
- Use `uv` instead of `pip` for installing Python dependencies in the Windows e2e workflow
- `uv` is already installed in the workflow but wasn't being used for the main Python deps
- Expected to reduce Python dependency installation from ~4 minutes to ~30-60 seconds

## Changes
- Replace `python -m pip install` with `uv pip install --system`
- Update cache path from `~\AppData\Local\pip\Cache` to `~\AppData\Local\uv\cache`
- Update cache key prefix from `pip` to `uv`
- Remove unnecessary `pip install --upgrade pip` steps (uv doesn't need it)
- Removed `torch` dependency in qa-example-content and the related test here

## QA Notes

@:win

🤖 Generated with [Claude Code](https://claude.ai/code)