### PR TITLE
python: fix Windows conda DLL loading

### DIFF
--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -35,6 +35,7 @@ import { shouldIncludeInterpreter, getUserDefaultInterpreter } from './interpret
 import { hasFiles } from './util';
 import { isProblematicCondaEnvironment } from '../interpreter/configuration/environmentTypeComparer';
 import { EnvironmentType } from '../pythonEnvironments/info';
+import { isCondaEnvironment } from '../pythonEnvironments/common/environmentManagers/conda';
 import { IApplicationShell } from '../common/application/types';
 import { Interpreters } from '../common/utils/localize';
 import { untildify } from '../common/helpers';
@@ -326,6 +327,22 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
         // only provided for new sessions; existing (restored) sessions already
         // have one.
         const env = await environmentVariablesProvider.getEnvironmentVariables();
+
+        // On Windows, conda environments need additional library paths (Library/bin, etc.)
+        // for DLL loading. Without these, Python could crash with STATUS_FATAL_USER_CALLBACK_EXCEPTION
+        // when importing packages with native dependencies like numpy, matplotlib, etc.
+        // See: https://github.com/posit-dev/positron/issues/9740
+        if (os.platform() === 'win32' && (await isCondaEnvironment(extraData.pythonPath))) {
+            const root = path.dirname(extraData.pythonPath);
+            const condaPaths = [
+                path.join(root, 'Library', 'bin'),
+                path.join(root, 'Library', 'mingw-w64', 'bin'),
+                path.join(root, 'Library', 'usr', 'bin'),
+                path.join(root, 'bin'),
+                path.join(root, 'Scripts'),
+            ].join(path.delimiter);
+            env.PATH = env.PATH ? condaPaths + path.delimiter + env.PATH : condaPaths;
+        }
         if (sessionMetadata.sessionMode === positron.LanguageRuntimeSessionMode.Console) {
             // Workaround to use Plotly's browser renderer. Ensures the plot is
             // displayed to fill the webview.


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/9740 and https://github.com/posit-dev/positron/issues/11221. Adds certain directories containing important conda libraries to the PATH when on Windows using a conda session.

This allows for you to import libraries like numpy without a crash.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed Python console crashes on Windows when using conda environments with packages that have native dependencies (numpy, matplotlib, scipy, etc.) (https://github.com/posit-dev/positron/issues/9740)


### QA Notes

On a Windows machine:

1. Create a conda environment with native packages:
   ```
   conda create -n test_crash python=3.10 pandas matplotlib numpy
   conda activate test_crash
   ```

2. Start Positron and select the `test_crash` conda environment

3. Open a Python console and run:
   ```python
   import pandas as pd
   import matplotlib.pyplot as plt
   
   s = pd.Series([1, 2, 3, 4])
   s.plot()
   plt.show()
   ```

4. Verify the plot displays without crashing (previously would crash with exit code -1066598273)

5. If possible, test with the scanpy reproduction case from the issue comments.
