### PR TITLE
Use `.at(0)` not `[0]`

### DIFF
--- a/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
+++ b/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
@@ -926,7 +926,11 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 		if (!this._newFolderConfig) {
 			return false;
 		}
-		const currentFolderPath = this._contextService.getWorkspace().folders[0]?.uri;
+		const folder = this._contextService.getWorkspace().folders.at(0);
+		if (!folder) {
+			return false;
+		}
+		const currentFolderPath = folder.uri;
 		const newFolderPath = URI.from({
 			scheme: this._newFolderConfig.folderScheme,
 			authority: this._newFolderConfig.folderAuthority,


### PR DESCRIPTION
This way TypeScript infers `IWorkspaceFolder | undefined` rather than just `IWorkspaceFolder`, because at runtime we have seen that it is possible for there to be 0 workspace folders when Positron is not opened in any workspace

---

I cannot reproduce this in a dev build, but in my release build I currently have a general problem where:

* open to empty folder, it gets hung
* change to `dplyr/`, it works
* change back to empty folder, it gets hung

It looked like this

https://github.com/user-attachments/assets/4b61fdc9-08ac-4e33-a5aa-60e111659288

The Developer Tools logged revealed this

```
workbench.desktop.main.js:21698   ERR Cannot read properties of undefined (reading 'scheme'): TypeError: Cannot read properties of undefined (reading 'scheme')
    at ExtUri.relativePath (vscode-file://vscode-app/Applications/Positron.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:9367:14)
    at PositronNewFolderService2.isCurrentWindowNewFolder (vscode-file://vscode-app/Applications/Positron.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:743019:38)
    at new PositronNewFolderService2 (vscode-file://vscode-app/Applications/Positron.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:742438:15)
    at _InstantiationService._createInstance (vscode-file://vscode-app/Applications/Positron.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:385177:20)
    at vscode-file://vscode-app/Applications/Positron.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:385285:30
    at AbstractIdleValue._executor (vscode-file://vscode-app/Applications/Positron.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:10301:23)
    at get value (vscode-file://vscode-app/Applications/Positron.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:10316:12)
    at Object.get (vscode-file://vscode-app/Applications/Positron.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:385326:28)
    at RuntimeStartupService2.startupSequence (vscode-file://vscode-app/Applications/Positron.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:743679:34)
    at async RuntimeStartupService2.startupAfterTrust (vscode-file://vscode-app/Applications/Positron.app/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.js:744396:7)
```

Which points to `isCurrentWindowNewFolder()` and it looks like we unexpected had an `undefined` in here.

It does look like I have some global storage which I think _should_ have been cleaned up, but was not for some reason. It is not related to the project I am working on, but `2026-02-09_roundup/` was created with the New Folder Wizard with an "empty folder".

```
sqlite3 ~/Library/Application\ Support/Positron/User/globalStorage/state.vscdb "SELECT * FROM ItemTable WHERE
  key LIKE '%newFolder%';"
positron.newFolderConfig|{"folderScheme":"file","folderAuthority":"","folderTemplate":"Empty Project","folderPath":"/Users/davis/files/r/tidyverse-weekly-meetings/2026-02-09_roundup","folderName":"2026-02-09_roundup","initGitRepo":false,"openInNewWindow":true}
```

That global storage is what gets us by the `if (!this._newFolderConfig) {` check in that helper function.

I'm flying a bit blind, but it looks like `[0]` can return `undefined` at runtime if you are wrong about it, even though TypeScript infers the type to just `IWorkspaceFolder`. We can try to be a bit safer here by using `.at(0)` and bailing if we see that there isn't actually a workspace open. This feels like a pretty safe change even if I can't reproduce it in a dev build right now to check.