### PR TITLE
Fixup React loading and CSS imports

### DIFF
--- a/extensions/positron-assistant/package-lock.json
+++ b/extensions/positron-assistant/package-lock.json
@@ -4610,6 +4610,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/src/vs/code/electron-browser/workbench/workbench-dev.html
+++ b/src/vs/code/electron-browser/workbench/workbench-dev.html
@@ -71,6 +71,20 @@
 					positronHistoryEntry
 				;
 		"/>
+
+		<script type="importmap" nonce="0c6a828f1297">
+			{
+				"imports": {
+					"he": "../../../../esm-package-dependencies/he.js",
+					"react": "../../../../esm-package-dependencies/react.js",
+					"react/jsx-runtime": "../../../../esm-package-dependencies/jsx-runtime.js",
+					"react-dom": "../../../../esm-package-dependencies/react-dom.js",
+					"react-dom/client": "../../../../esm-package-dependencies/client.js",
+					"react-window": "../../../../esm-package-dependencies/react-window.js"
+				}
+			}
+		</script>
+
 	</head>
 
 	<body aria-label="">

--- a/src/vs/code/electron-browser/workbench/workbench.ts
+++ b/src/vs/code/electron-browser/workbench/workbench.ts
@@ -291,11 +291,8 @@
 		const baseUrl = new URL(`${fileUriFromPath(configuration.appRoot, { isWindows: safeProcess.platform === 'win32', scheme: 'vscode-file', fallbackAuthority: 'vscode-app' })}/out/`);
 		globalThis._VSCODE_FILE_ROOT = baseUrl.toString();
 
-		// --- Start Positron ---
 		// Dev only: CSS import map tricks
-		// setupCSSImportMaps<T>(configuration, baseUrl);
-		setupImportMaps<T>(configuration, baseUrl);
-		// --- End Positron ---
+		setupCSSImportMaps<T>(configuration, baseUrl);
 
 		// ESM Import
 		try {
@@ -450,8 +447,6 @@
 		return uri.replace(/#/g, '%23');
 	}
 
-	// --- Start Positron ---
-	/*
 	function setupCSSImportMaps<T extends ISandboxConfiguration>(configuration: T, baseUrl: URL) {
 
 		// DEV ---------------------------------------------------------------------------------------
@@ -496,65 +491,6 @@
 			performance.mark('code/didAddCssLoader');
 		}
 	}
-	*/
-
-	function setupImportMaps<T extends ISandboxConfiguration>(configuration: T, baseUrl: URL) {
-		// Only set up import maps if we have CSS modules. These only exist in
-		// development configurations.
-		if (Array.isArray(configuration.cssModules) && configuration.cssModules.length > 0) {
-
-			// Create import maps for React and other dependencies. This is for
-			// development mode only; for release builds, the importmap is inlined
-			// in workbench.html.
-			const style = document.createElement('style');
-			style.type = 'text/css';
-			style.media = 'screen';
-			style.id = 'vscode-css-loading';
-			document.head.appendChild(style);
-
-			const importMap: { imports: Record<string, string> } = { imports: {} };
-			const addModule = (packageName: string) => {
-				const packageNamePath = packageName.split('/');
-				const module = `esm-package-dependencies/${packageNamePath[packageNamePath.length - 1]}.js`;
-				const url = new URL(module, baseUrl).href;
-				importMap.imports[packageName] = url;
-			};
-
-			addModule('he');
-			addModule('react');
-			addModule('react/jsx-runtime');
-			addModule('react-dom');
-			addModule('react-dom/client');
-			addModule('react-window');
-
-			// DEV ---------------------------------------------------------------------------------------
-			// DEV: This is for development and enables loading CSS via import-statements via import-maps.
-			// DEV: For each CSS modules that we have we defined an entry in the import map that maps to
-			// DEV: a blob URL that loads the CSS via a dynamic @import-rule.
-			// DEV ---------------------------------------------------------------------------------------
-			globalThis._VSCODE_CSS_LOAD = function (url) {
-				style.textContent += `@import url(${url});\n`;
-			};
-
-			for (const cssModule of configuration.cssModules) {
-				const cssUrl = new URL(cssModule, baseUrl).href;
-				const jsSrc = `globalThis._VSCODE_CSS_LOAD('${cssUrl}');\n`;
-				const blob = new Blob([jsSrc], { type: 'application/javascript' });
-				importMap.imports[cssUrl] = URL.createObjectURL(blob);
-			}
-
-			const ttp = window.trustedTypes?.createPolicy('vscode-bootstrapImportMap', { createScript(value) { return value; }, });
-			const importMapSrc = JSON.stringify(importMap, undefined, 2);
-			const importMapScript = document.createElement('script');
-			importMapScript.type = 'importmap';
-			importMapScript.setAttribute('nonce', '0c6a828f1297');
-			// @ts-ignore
-			importMapScript.textContent = ttp?.createScript(importMapSrc) ?? importMapSrc;
-			document.head.appendChild(importMapScript);
-		}
-	}
-
-	// --- End Positron ---
 
 	//#endregion
 


### PR DESCRIPTION
# Fix React 19 rendering race condition in dev builds

## Problem
After updating to React 19.2.4, React components would intermittently (or often, always) fail to render on first launch in development builds. Reloading the window would fix the issue, indicating a timing/race condition during initialization.

## Solution
Move React module dependencies from dynamic JavaScript creation to static HTML import maps (like we do everywhere else) and revert to using VS Code's `setupCSSImportMaps` function.

## Changes

**1. Static React Import Map ([workbench-dev.html](src/vs/code/electron-browser/workbench/workbench-dev.html#L75-L86) & [workbench.html](src/vs/code/electron-browser/workbench/workbench.html))**
- Added static `<script type="importmap">` in HTML with React dependencies:
  - `he`
  - `react`
  - `react/jsx-runtime`
  - `react-dom`
  - `react-dom/client`
  - `react-window`

**2. Revert to `setupCSSImportMaps` ([workbench.ts:295](src/vs/code/electron-browser/workbench/workbench.ts#L295))**
- Use VS Code's original `setupCSSImportMaps` function for CSS-only import maps
- Remove `setupImportMaps` function that attempted to handle both React and CSS dynamically

## Why This Works
- **Static import maps** are parsed immediately when the HTML loads, before any JavaScript executes
- **Dynamic CSS import maps** are created synchronously by `setupCSSImportMaps` without import map timing delays
- **Separating React (static) from CSS (dynamic)** eliminates the race condition where both were being created at the same time
- The browser can now reliably resolve React imports without waiting for JavaScript execution

## Testing
Verified that React components render correctly on first launch in development builds without requiring window reload.

## Bonus!

Loading Positron in development builds is now significantly faster.

### Release Notes

- N/A

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes
