### PR TITLE
e2e: fix LSP test filtering for e2e-electron project

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -82,12 +82,20 @@ export default defineConfig<CustomTestOptions>({
 	projects: [
 		{
 			name: 'e2e-electron',
-			testIgnore: [
-				'example.test.ts',
-				'**/workbench/**',
-				'**/remote-ssh/**',
-				// Note: assistant-eval NOT ignored here - runs on e2e-electron only
-			],
+			testIgnore: process.env.ALLOW_PYREFLY === 'true'
+				? [
+					'example.test.ts',
+					'**/workbench/**',
+					'**/remote-ssh/**',
+					// Note: assistant-eval NOT ignored here - runs on e2e-electron only
+				]
+				: [
+					'example.test.ts',
+					'**/workbench/**',
+					'**/remote-ssh/**',
+					'**/lsp/**',
+					// Note: assistant-eval NOT ignored here - runs on e2e-electron only
+				],
 			use: {
 				artifactDir: 'e2e-electron'
 			},


### PR DESCRIPTION
### Summary

The project-level testIgnore was overriding the top-level config, causing LSP tests to run in e2e-electron when they should be excluded (unless ALLOW_PYREFLY=true).

### QA Notes

n/a