### PR TITLE
e2e test - notebook console interactions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -226,5 +226,5 @@
 	],
 	"azureMcp.serverMode": "all",
 	"azureMcp.readOnly": true,
-	"chat.tools.terminal.outputLocation": "none"
+	"chat.tools.terminal.outputLocation": "chat"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -226,5 +226,5 @@
 	],
 	"azureMcp.serverMode": "all",
 	"azureMcp.readOnly": true,
-	"chat.tools.terminal.outputLocation": "chat"
+	"chat.tools.terminal.outputLocation": "none"
 }

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -58,6 +58,14 @@ export class Console {
 	}
 
 	/**
+	 * Gets the console input editor locator.
+	 * Useful for verifying console input is visible and editable.
+	 */
+	get inputEditor() {
+		return this.activeConsole.locator('.console-input');
+	}
+
+	/**
 	 * Action: Start a new session via the `+ v` button in the console.
 	 *
 	 * @param contextMenu

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -62,7 +62,7 @@ export class Console {
 	 * Useful for verifying console input is visible and editable.
 	 */
 	get inputEditor() {
-		return this.activeConsole.locator('.console-input');
+		return this.activeConsole.locator('.console-input').first();
 	}
 
 	/**

--- a/test/e2e/tests/console/console-notebook.test.ts
+++ b/test/e2e/tests/console/console-notebook.test.ts
@@ -1,0 +1,437 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { tags } from '../_test.setup';
+import { test } from '../notebooks-positron/_test.setup';
+import { expect } from '@playwright/test';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Notebook → Console Interaction (no shared state assumed)', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.CONSOLE, tags.CRITICAL]
+}, () => {
+
+	test.afterEach(async ({ app, settings }, testInfo) => {
+		const { notebooksPositron, console } = app.workbench;
+
+		// Log console contents on failure for debugging
+		if (testInfo.status !== 'passed') {
+			await console.logConsoleContents();
+		}
+
+		await notebooksPositron.expectNoActiveSpinners();
+		await settings.remove(['console.showNotebookConsoleActions']);
+	});
+
+	/**
+	 * Wait until console is actually ready for typing
+	 * (prompt visible != input ready)
+	 */
+	async function prepareConsoleForUse(console: any, prompt: string) {
+		await test.step('Prepare console for use', async () => {
+			await console.waitForReady(prompt, 30000);
+
+			// Verify input accepts keystrokes with retry logic
+			await expect(async () => {
+				const input = console.inputEditor;
+				await expect(input).toBeVisible();
+
+				await input.click();
+				await input.type('1');
+				await input.press('Backspace');
+			}).toPass({ timeout: 15000 });
+		});
+	}
+
+	async function openNotebookConsoleAndFocus(
+		notebooksPositron: any,
+		console: any,
+		prompt: string,
+		sessions: any
+	) {
+		await test.step('Open notebook console and focus', async () => {
+			const sessionCountBefore = await sessions.getSessionCount();
+
+			await notebooksPositron.kernel.openNotebookConsole();
+
+			// Verify new session was created
+			await sessions.expectSessionCountToBe(sessionCountBefore + 1, 'all');
+
+			await prepareConsoleForUse(console, prompt);
+		});
+	}
+
+	/**
+	 * Self-contained REPL execution probe
+	 * Verifies console can execute code without relying on notebook variables
+	 */
+	async function verifyConsoleExec(console: any, lang: 'python' | 'r') {
+		await test.step('Verify console can execute code', async () => {
+			await console.focus();
+			await console.typeToConsole('print(6 * 7)');
+			await console.sendEnterKey();
+			await console.waitForConsoleExecution();
+
+			if (lang === 'python') {
+				// Note: expectedCount accounts for console buffer accumulation
+				await console.waitForConsoleContents(/\b42\b/, { expectedCount: 2 });
+			} else {
+				await console.waitForConsoleContents('[1] 42', { expectedCount: 2 });
+			}
+		});
+	}
+
+	test.skip('Console remains usable after notebook cell execution (Python)',
+		async ({ app, sessions, settings }) => {
+			const { notebooksPositron, console } = app.workbench;
+
+			await test.step('Setup: Enable notebook console actions', async () => {
+				await settings.set({ 'console.showNotebookConsoleActions': true });
+			});
+
+			await test.step('Create notebook and select kernel', async () => {
+				await notebooksPositron.newNotebook();
+				await notebooksPositron.kernel.select('Python');
+			});
+
+			await test.step('Open notebook console', async () => {
+				await openNotebookConsoleAndFocus(notebooksPositron, console, '>>>', sessions);
+			});
+
+			await test.step('Execute notebook cell', async () => {
+				await notebooksPositron.addCodeToCell(0, 'x = 42', {
+					run: true,
+					waitForSpinner: true
+				});
+				await notebooksPositron.expectExecutionStatusToBe(0, 'idle', 30000);
+			});
+
+			await test.step('Verify console remains usable', async () => {
+				await prepareConsoleForUse(console, '>>>');
+				await verifyConsoleExec(console, 'python');
+			});
+		}
+	);
+
+	test.skip('Console remains usable after executing multiple notebook cells',
+		async ({ app, sessions, settings }) => {
+			const { notebooksPositron, console } = app.workbench;
+
+			await test.step('Setup: Enable notebook console actions', async () => {
+				await settings.set({ 'console.showNotebookConsoleActions': true });
+			});
+
+			await test.step('Create notebook and select kernel', async () => {
+				await notebooksPositron.newNotebook();
+				await notebooksPositron.kernel.select('Python');
+			});
+
+			await test.step('Open notebook console', async () => {
+				await openNotebookConsoleAndFocus(notebooksPositron, console, '>>>', sessions);
+			});
+
+			await test.step('Execute multiple notebook cells', async () => {
+				await notebooksPositron.addCodeToCell(0, 'a = 10', {
+					run: true,
+					waitForSpinner: true
+				});
+				await notebooksPositron.expectExecutionStatusToBe(0, 'idle', 30000);
+
+				await notebooksPositron.addCell('code');
+				await notebooksPositron.addCodeToCell(1, 'b = 20', {
+					run: true,
+					waitForSpinner: true
+				});
+				await notebooksPositron.expectExecutionStatusToBe(1, 'idle', 30000);
+
+				await notebooksPositron.addCell('code');
+				await notebooksPositron.addCodeToCell(2, 'c = a + b', {
+					run: true,
+					waitForSpinner: true
+				});
+				await notebooksPositron.expectExecutionStatusToBe(2, 'idle', 30000);
+			});
+
+			await test.step('Verify console remains usable', async () => {
+				await prepareConsoleForUse(console, '>>>');
+				await verifyConsoleExec(console, 'python');
+			});
+		}
+	);
+
+	test.skip('Console usable after large notebook output',
+		async ({ app, sessions, settings }) => {
+			const { notebooksPositron, console } = app.workbench;
+
+			await test.step('Setup: Enable notebook console actions', async () => {
+				await settings.set({ 'console.showNotebookConsoleActions': true });
+			});
+
+			await test.step('Create notebook and select kernel', async () => {
+				await notebooksPositron.newNotebook();
+				await notebooksPositron.kernel.select('Python');
+			});
+
+			await test.step('Open notebook console', async () => {
+				await openNotebookConsoleAndFocus(notebooksPositron, console, '>>>', sessions);
+			});
+
+			await test.step('Execute cell with large output', async () => {
+				await notebooksPositron.addCodeToCell(
+					0,
+					`
+for i in range(200):
+    print(i)
+`,
+					{
+						run: true,
+						waitForSpinner: true
+					}
+				);
+				await notebooksPositron.expectExecutionStatusToBe(0, 'idle', 30000);
+
+				const output = notebooksPositron.cell.nth(0).getByTestId('cell-output');
+				await output.evaluate((node) => { node.scrollTop = node.scrollHeight; });
+			});
+
+			await test.step('Verify console remains usable', async () => {
+				await prepareConsoleForUse(console, '>>>');
+				await verifyConsoleExec(console, 'python');
+			});
+		}
+	);
+
+	test.skip('Console usable after busy → idle kernel transition',
+		async ({ app, sessions, settings }) => {
+			const { notebooksPositron, console } = app.workbench;
+
+			await test.step('Setup: Enable notebook console actions', async () => {
+				await settings.set({ 'console.showNotebookConsoleActions': true });
+			});
+
+			await test.step('Create notebook and select kernel', async () => {
+				await notebooksPositron.newNotebook();
+				await notebooksPositron.kernel.select('Python');
+			});
+
+			await test.step('Open notebook console', async () => {
+				await openNotebookConsoleAndFocus(notebooksPositron, console, '>>>', sessions);
+			});
+
+			await test.step('Execute long-running cell', async () => {
+				await notebooksPositron.addCodeToCell(
+					0,
+					`
+import time
+time.sleep(2)
+`,
+					{
+						run: true,
+						waitForSpinner: true
+					}
+				);
+				await notebooksPositron.expectExecutionStatusToBe(0, 'idle', 30000);
+			});
+
+			await test.step('Verify console remains usable', async () => {
+				await prepareConsoleForUse(console, '>>>');
+				await verifyConsoleExec(console, 'python');
+			});
+		}
+	);
+
+	test.skip('Console usable after Run button execution',
+		async ({ app, sessions, settings }) => {
+			const { notebooksPositron, console } = app.workbench;
+
+			await test.step('Setup: Enable notebook console actions', async () => {
+				await settings.set({ 'console.showNotebookConsoleActions': true });
+			});
+
+			await test.step('Create notebook and select kernel', async () => {
+				await notebooksPositron.newNotebook();
+				await notebooksPositron.kernel.select('Python');
+			});
+
+			await test.step('Open notebook console', async () => {
+				await openNotebookConsoleAndFocus(notebooksPositron, console, '>>>', sessions);
+			});
+
+			await test.step('Execute cell via Run button', async () => {
+				await notebooksPositron.addCodeToCell(0, 'y = 5');
+				await notebooksPositron.runCellButtonAtIndex(0).click();
+				await notebooksPositron.expectExecutionStatusToBe(0, 'idle', 30000);
+			});
+
+			await test.step('Verify console remains usable', async () => {
+				await prepareConsoleForUse(console, '>>>');
+				await verifyConsoleExec(console, 'python');
+			});
+		}
+	);
+
+	test.skip('R console remains usable after notebook execution',
+		async ({ app, sessions, settings }) => {
+			const { notebooksPositron, console } = app.workbench;
+
+			await test.step('Setup: Enable notebook console actions', async () => {
+				await settings.set({ 'console.showNotebookConsoleActions': true });
+			});
+
+			await test.step('Create notebook and select R kernel', async () => {
+				await notebooksPositron.newNotebook();
+				await expect(async () => {
+					await notebooksPositron.kernel.select('R');
+				}).toPass({ timeout: 30000 });
+			});
+
+			await test.step('Open notebook console', async () => {
+				await openNotebookConsoleAndFocus(notebooksPositron, console, '>', sessions);
+			});
+
+			await test.step('Execute notebook cell', async () => {
+				await notebooksPositron.addCodeToCell(0, 'x <- 100', {
+					run: true,
+					waitForSpinner: true
+				});
+				await notebooksPositron.expectExecutionStatusToBe(0, 'idle', 30000);
+			});
+
+			await test.step('Verify console remains usable', async () => {
+				await prepareConsoleForUse(console, '>');
+				await verifyConsoleExec(console, 'r');
+			});
+		}
+	);
+
+	test.skip('Console can access variables defined in notebook',
+		async ({ app, sessions, settings }) => {
+			const { notebooksPositron, console } = app.workbench;
+
+			await test.step('Setup', async () => {
+				await settings.set({ 'console.showNotebookConsoleActions': true });
+				await notebooksPositron.newNotebook();
+				await notebooksPositron.kernel.select('Python');
+				await openNotebookConsoleAndFocus(notebooksPositron, console, '>>>', sessions);
+			});
+
+			await test.step('Define variable in notebook', async () => {
+				await notebooksPositron.addCodeToCell(0, 'notebook_var = "from notebook"', {
+					run: true,
+					waitForSpinner: true
+				});
+				await notebooksPositron.expectExecutionStatusToBe(0, 'idle', 30000);
+			});
+
+			await test.step('Access variable from console', async () => {
+				await console.focus();
+				await console.typeToConsole('print(notebook_var)');
+				await console.sendEnterKey();
+				await console.waitForConsoleExecution();
+				await console.waitForConsoleContents('from notebook', {});
+			});
+		}
+	);
+
+	test.skip('Console usable after notebook cell raises exception',
+		async ({ app, sessions, settings }) => {
+			const { notebooksPositron, console } = app.workbench;
+
+			await test.step('Setup', async () => {
+				await settings.set({ 'console.showNotebookConsoleActions': true });
+				await notebooksPositron.newNotebook();
+				await notebooksPositron.kernel.select('Python');
+				await openNotebookConsoleAndFocus(notebooksPositron, console, '>>>', sessions);
+			});
+
+			await test.step('Execute cell with error', async () => {
+				await notebooksPositron.addCodeToCell(0, 'raise ValueError("test error")', {
+					run: true,
+					waitForSpinner: true
+				});
+
+				// Wait for execution to complete (spinner disappears even with error)
+				await notebooksPositron.expectSpinnerAtIndex(0, false);
+			});
+
+			await test.step('Verify console remains usable', async () => {
+				await prepareConsoleForUse(console, '>>>');
+				await verifyConsoleExec(console, 'python');
+			});
+		}
+	);
+
+	test.skip('Console reconnects after notebook kernel restart',
+		async ({ app, sessions, settings }) => {
+			const { notebooksPositron, console } = app.workbench;
+
+			await test.step('Setup', async () => {
+				await settings.set({ 'console.showNotebookConsoleActions': true });
+				await notebooksPositron.newNotebook();
+				await notebooksPositron.kernel.select('Python');
+				await openNotebookConsoleAndFocus(notebooksPositron, console, '>>>', sessions);
+			});
+
+			await test.step('Define variable before restart', async () => {
+				await notebooksPositron.addCodeToCell(0, 'x = 100', {
+					run: true,
+					waitForSpinner: true
+				});
+				await notebooksPositron.expectExecutionStatusToBe(0, 'idle', 30000);
+			});
+
+			await test.step('Restart kernel', async () => {
+				await notebooksPositron.kernel.restart({ waitForRestart: true });
+				await notebooksPositron.kernel.expectStatusToBe('idle', 30000);
+			});
+
+			await test.step('Verify console reconnected and state cleared', async () => {
+				await console.waitForReady('>>>', 30000);
+				await console.focus();
+
+				// Verify variable no longer exists (fresh interpreter)
+				await console.typeToConsole('print(x)');
+				await console.sendEnterKey();
+				await console.waitForConsoleExecution();
+				await console.waitForConsoleContents(/NameError.*'x'/, {});
+			});
+		}
+	);
+
+	test.skip('R console handles data frames after notebook execution', {
+		tag: [tags.ARK]
+	}, async ({ app, sessions, settings }) => {
+		const { notebooksPositron, console } = app.workbench;
+
+		await test.step('Setup', async () => {
+			await settings.set({ 'console.showNotebookConsoleActions': true });
+			await notebooksPositron.newNotebook();
+			await expect(async () => {
+				await notebooksPositron.kernel.select('R');
+			}).toPass({ timeout: 30000 });
+			await openNotebookConsoleAndFocus(notebooksPositron, console, '>', sessions);
+		});
+
+		await test.step('Create data frame in notebook', async () => {
+			const dfCode = 'df <- data.frame(x = 1:3, y = c("a", "b", "c"))';
+			await notebooksPositron.addCodeToCell(0, dfCode, {
+				run: true,
+				waitForSpinner: true
+			});
+			await notebooksPositron.expectExecutionStatusToBe(0, 'idle', 30000);
+		});
+
+		await test.step('Access data frame from console', async () => {
+			await console.focus();
+			await console.typeToConsole('print(df)');
+			await console.sendEnterKey();
+			await console.waitForConsoleExecution();
+			await console.waitForConsoleContents('1 a', { expectedCount: 2 });
+		});
+	});
+
+});

--- a/test/e2e/tests/console/console-notebook.test.ts
+++ b/test/e2e/tests/console/console-notebook.test.ts
@@ -85,6 +85,7 @@ test.describe('Notebook → Console Interaction (no shared state assumed)', {
 		});
 	}
 
+	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console remains usable after notebook cell execution (Python)',
 		async ({ app, sessions, settings }) => {
 			const { notebooksPositron, console } = app.workbench;
@@ -117,6 +118,7 @@ test.describe('Notebook → Console Interaction (no shared state assumed)', {
 		}
 	);
 
+	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console remains usable after executing multiple notebook cells',
 		async ({ app, sessions, settings }) => {
 			const { notebooksPositron, console } = app.workbench;
@@ -163,6 +165,7 @@ test.describe('Notebook → Console Interaction (no shared state assumed)', {
 		}
 	);
 
+	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console usable after large notebook output',
 		async ({ app, sessions, settings }) => {
 			const { notebooksPositron, console } = app.workbench;
@@ -185,7 +188,7 @@ test.describe('Notebook → Console Interaction (no shared state assumed)', {
 					0,
 					`
 for i in range(200):
-    print(i)
+	print(i)
 `,
 					{
 						run: true,
@@ -205,6 +208,7 @@ for i in range(200):
 		}
 	);
 
+	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console usable after busy → idle kernel transition',
 		async ({ app, sessions, settings }) => {
 			const { notebooksPositron, console } = app.workbench;
@@ -244,6 +248,7 @@ time.sleep(2)
 		}
 	);
 
+	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console usable after Run button execution',
 		async ({ app, sessions, settings }) => {
 			const { notebooksPositron, console } = app.workbench;
@@ -274,6 +279,7 @@ time.sleep(2)
 		}
 	);
 
+	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('R console remains usable after notebook execution',
 		async ({ app, sessions, settings }) => {
 			const { notebooksPositron, console } = app.workbench;
@@ -308,6 +314,7 @@ time.sleep(2)
 		}
 	);
 
+	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console can access variables defined in notebook',
 		async ({ app, sessions, settings }) => {
 			const { notebooksPositron, console } = app.workbench;
@@ -337,6 +344,7 @@ time.sleep(2)
 		}
 	);
 
+	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console usable after notebook cell raises exception',
 		async ({ app, sessions, settings }) => {
 			const { notebooksPositron, console } = app.workbench;
@@ -365,6 +373,7 @@ time.sleep(2)
 		}
 	);
 
+	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console reconnects after notebook kernel restart',
 		async ({ app, sessions, settings }) => {
 			const { notebooksPositron, console } = app.workbench;
@@ -402,6 +411,7 @@ time.sleep(2)
 		}
 	);
 
+	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('R console handles data frames after notebook execution', {
 		tag: [tags.ARK]
 	}, async ({ app, sessions, settings }) => {

--- a/test/e2e/tests/console/console-notebook.test.ts
+++ b/test/e2e/tests/console/console-notebook.test.ts
@@ -12,8 +12,13 @@ test.use({
 });
 
 test.describe('Notebook → Console Interaction (no shared state assumed)', {
-	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.CONSOLE, tags.CRITICAL]
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.CONSOLE]
 }, () => {
+
+	test.beforeAll(async ({ settings }) => {
+		// Enable notebook console actions for all tests
+		await settings.set({ 'console.showNotebookConsoleActions': true });
+	});
 
 	test.afterEach(async ({ app, settings }, testInfo) => {
 		const { notebooksPositron, console } = app.workbench;
@@ -36,6 +41,7 @@ test.describe('Notebook → Console Interaction (no shared state assumed)', {
 			await console.waitForReady(prompt, 30000);
 
 			// Verify input accepts keystrokes with retry logic
+			// Type '1' then backspace to ensure input is truly interactive (not just visible)
 			await expect(async () => {
 				const input = console.inputEditor;
 				await expect(input).toBeVisible();
@@ -87,12 +93,8 @@ test.describe('Notebook → Console Interaction (no shared state assumed)', {
 
 	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console remains usable after notebook cell execution (Python)',
-		async ({ app, sessions, settings }) => {
+		async ({ app, sessions }) => {
 			const { notebooksPositron, console } = app.workbench;
-
-			await test.step('Setup: Enable notebook console actions', async () => {
-				await settings.set({ 'console.showNotebookConsoleActions': true });
-			});
 
 			await test.step('Create notebook and select kernel', async () => {
 				await notebooksPositron.newNotebook();
@@ -120,12 +122,8 @@ test.describe('Notebook → Console Interaction (no shared state assumed)', {
 
 	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console remains usable after executing multiple notebook cells',
-		async ({ app, sessions, settings }) => {
+		async ({ app, sessions }) => {
 			const { notebooksPositron, console } = app.workbench;
-
-			await test.step('Setup: Enable notebook console actions', async () => {
-				await settings.set({ 'console.showNotebookConsoleActions': true });
-			});
 
 			await test.step('Create notebook and select kernel', async () => {
 				await notebooksPositron.newNotebook();
@@ -167,12 +165,8 @@ test.describe('Notebook → Console Interaction (no shared state assumed)', {
 
 	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console usable after large notebook output',
-		async ({ app, sessions, settings }) => {
+		async ({ app, sessions }) => {
 			const { notebooksPositron, console } = app.workbench;
-
-			await test.step('Setup: Enable notebook console actions', async () => {
-				await settings.set({ 'console.showNotebookConsoleActions': true });
-			});
 
 			await test.step('Create notebook and select kernel', async () => {
 				await notebooksPositron.newNotebook();
@@ -210,12 +204,8 @@ for i in range(200):
 
 	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console usable after busy → idle kernel transition',
-		async ({ app, sessions, settings }) => {
+		async ({ app, sessions }) => {
 			const { notebooksPositron, console } = app.workbench;
-
-			await test.step('Setup: Enable notebook console actions', async () => {
-				await settings.set({ 'console.showNotebookConsoleActions': true });
-			});
 
 			await test.step('Create notebook and select kernel', async () => {
 				await notebooksPositron.newNotebook();
@@ -250,12 +240,8 @@ time.sleep(2)
 
 	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console usable after Run button execution',
-		async ({ app, sessions, settings }) => {
+		async ({ app, sessions }) => {
 			const { notebooksPositron, console } = app.workbench;
-
-			await test.step('Setup: Enable notebook console actions', async () => {
-				await settings.set({ 'console.showNotebookConsoleActions': true });
-			});
 
 			await test.step('Create notebook and select kernel', async () => {
 				await notebooksPositron.newNotebook();
@@ -281,12 +267,8 @@ time.sleep(2)
 
 	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('R console remains usable after notebook execution',
-		async ({ app, sessions, settings }) => {
+		async ({ app, sessions }) => {
 			const { notebooksPositron, console } = app.workbench;
-
-			await test.step('Setup: Enable notebook console actions', async () => {
-				await settings.set({ 'console.showNotebookConsoleActions': true });
-			});
 
 			await test.step('Create notebook and select R kernel', async () => {
 				await notebooksPositron.newNotebook();
@@ -316,11 +298,10 @@ time.sleep(2)
 
 	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console can access variables defined in notebook',
-		async ({ app, sessions, settings }) => {
+		async ({ app, sessions }) => {
 			const { notebooksPositron, console } = app.workbench;
 
 			await test.step('Setup', async () => {
-				await settings.set({ 'console.showNotebookConsoleActions': true });
 				await notebooksPositron.newNotebook();
 				await notebooksPositron.kernel.select('Python');
 				await openNotebookConsoleAndFocus(notebooksPositron, console, '>>>', sessions);
@@ -346,11 +327,10 @@ time.sleep(2)
 
 	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console usable after notebook cell raises exception',
-		async ({ app, sessions, settings }) => {
+		async ({ app, sessions }) => {
 			const { notebooksPositron, console } = app.workbench;
 
 			await test.step('Setup', async () => {
-				await settings.set({ 'console.showNotebookConsoleActions': true });
 				await notebooksPositron.newNotebook();
 				await notebooksPositron.kernel.select('Python');
 				await openNotebookConsoleAndFocus(notebooksPositron, console, '>>>', sessions);
@@ -375,11 +355,10 @@ time.sleep(2)
 
 	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('Console reconnects after notebook kernel restart',
-		async ({ app, sessions, settings }) => {
+		async ({ app, sessions }) => {
 			const { notebooksPositron, console } = app.workbench;
 
 			await test.step('Setup', async () => {
-				await settings.set({ 'console.showNotebookConsoleActions': true });
 				await notebooksPositron.newNotebook();
 				await notebooksPositron.kernel.select('Python');
 				await openNotebookConsoleAndFocus(notebooksPositron, console, '>>>', sessions);
@@ -414,11 +393,10 @@ time.sleep(2)
 	// TODO: Unskip when #11704 is resolved (console focus preservation after notebook cell execution)
 	test.skip('R console handles data frames after notebook execution', {
 		tag: [tags.ARK]
-	}, async ({ app, sessions, settings }) => {
+	}, async ({ app, sessions }) => {
 		const { notebooksPositron, console } = app.workbench;
 
 		await test.step('Setup', async () => {
-			await settings.set({ 'console.showNotebookConsoleActions': true });
 			await notebooksPositron.newNotebook();
 			await expect(async () => {
 				await notebooksPositron.kernel.select('R');


### PR DESCRIPTION
This pull request introduces a minor configuration update to the VS Code workspace settings and enhances the test automation code for the console page. The most significant changes are grouped below:

**Developer Experience:**

* Changed the VS Code setting for terminal output location so that chat tool terminal output now appears in the chat interface instead of being hidden. (`.vscode/settings.json`)

**Test Automation Improvements:**

* Added a new `inputEditor` getter to the `Console` page object, making it easier to verify that the console input is visible and editable in end-to-end tests. (`test/e2e/pages/console.ts`)

@:web @:win @:positron-notebooks