### PR TITLE
e2e: Enable bedrock sign-in

### DIFF
--- a/extensions/positron-assistant/src/providers/aws/awsBedrockProvider.ts
+++ b/extensions/positron-assistant/src/providers/aws/awsBedrockProvider.ts
@@ -160,8 +160,9 @@ export class AWSModelProvider extends VercelModelProvider implements positron.ai
 		};
 
 		const region = AWS_REGION ?? 'us-east-1';
-		const profile = AWS_PROFILE ?? 'default';
-		const credentials = fromNodeProviderChain({ profile });
+		// Only use profile if explicitly configured; omit for OIDC/environment credentials
+		const profile = AWS_PROFILE;
+		const credentials = fromNodeProviderChain(profile ? { profile } : {});
 
 		const inferenceProfileRegion = vscode.workspace
 			.getConfiguration('positron.assistant.bedrock')
@@ -173,7 +174,7 @@ export class AWSModelProvider extends VercelModelProvider implements positron.ai
 			this._inferenceProfileRegion = AWSModelProvider.deriveInferenceProfileRegion(region);
 		}
 		this.logger.info(
-			`Using AWS region: ${region}, profile: ${profile}, ` +
+			`Using AWS region: ${region}, profile: ${profile ?? '(default chain)'}, ` +
 			`inference profile region: ${this._inferenceProfileRegion}`
 		);
 
@@ -185,7 +186,7 @@ export class AWSModelProvider extends VercelModelProvider implements positron.ai
 
 		// Initialize Bedrock SDK client for model listing
 		this.bedrockClient = new BedrockClient({
-			profile,
+			...(profile && { profile }),
 			region,
 			credentials: credentials
 		});

--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -80,7 +80,7 @@ test.describe('Positron Assistant Setup', { tag: [tags.WIN, tags.ASSISTANT, tags
 	 * @param app - Application fixture providing access to UI elements
 	 * currently skipped as a TODO to finsih implementation of bedrock auth
 	 */
-	test.skip('Amazon Bedrock: Verify Successful Sign in and Sign Out', async function ({ app }) {
+	test('Amazon Bedrock: Verify Successful Sign in and Sign Out', async function ({ app }) {
 		await app.workbench.assistant.openPositronAssistantChat();
 		await app.workbench.assistant.loginModelProvider('amazon-bedrock');
 		await app.workbench.assistant.logoutModelProvider('amazon-bedrock');


### PR DESCRIPTION
The IAM role we use in our workflows as updated to include bedrock access. This enables that to be use in our positron assistant tests.

- Adds the amazon-bedrock sign-in test for assistant
- Enables OIDC (and similar) auth in Positron Assistant (see https://github.com/posit-dev/positron/pull/11874#issuecomment-3893621739)


### QA Notes
@:assistant @:win @:web
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
