### PR TITLE
Fix title case for packages pane action bar menu items

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -38,27 +38,32 @@ import { PackagesInstanceMenuButton } from './packagesInstanceMenuButton.js';
 
 const positronRefreshPackages = localize(
 	'positronRefreshPackages',
-	'Refresh packages',
+	'Refresh Packages',
 );
 
 const positronInstallPackage = localize(
 	'positronInstallPackage',
-	'Install package',
+	'Install Package',
 );
 
 const positronUninstallPackage = localize(
 	'positronUninstallPackage',
-	'Uninstall package',
+	'Uninstall Package',
 );
 
 const positronUpdatePackage = localize(
 	'positronUpdatePackage',
-	'Update package',
+	'Update Package',
 );
 
 const positronUpdateAllPackages = localize(
 	'positronUpdateAllPackages',
-	'Update all packages',
+	'Update All Packages',
+);
+
+const positronPackageActions = localize(
+	'positronPackageActions',
+	'Package Actions',
 );
 
 export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
@@ -87,7 +92,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 			return;
 		}
 
-		setPackages(activeInstance.packages)
+		setPackages(activeInstance.packages);
 		const disposables = new DisposableStore();
 		disposables.add(activeInstance.onDidRefreshPackagesInstance((packages) => {
 			setPackages(packages);
@@ -97,19 +102,19 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 		}));
 		disposables.add(activeInstance.onDidChangeInstallState((isLoading) => {
 			setInstallLoading(isLoading);
-		}))
+		}));
 		disposables.add(activeInstance.onDidChangeUpdateState((isLoading) => {
 			setUpdateLoading(isLoading);
-		}))
+		}));
 		disposables.add(activeInstance.onDidChangeUpdateAllState((isLoading) => {
 			setUpdateAllLoading(isLoading);
-		}))
+		}));
 		disposables.add(activeInstance.onDidChangeUninstallState((isLoading) => {
 			setUninstallLoading(isLoading);
 		}));
 
 		return () => disposables.dispose();
-	}, [activeInstance])
+	}, [activeInstance]);
 
 	useEffect(() => {
 		let progressBar: ProgressBar | undefined;
@@ -170,7 +175,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 
 	// Load packages when the active session changes
 	useEffect(() => {
-		services.commandService.executeCommand('positronPackages.refreshPackages')
+		services.commandService.executeCommand('positronPackages.refreshPackages');
 	}, [activeInstance, services.commandService]);
 
 	// We're required to save the scroll state because browsers will automatically
@@ -296,14 +301,14 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 				onUninstallPackage={() => {
 					const packageName = getSelectedItemPackageName(selectedItem);
 					if (packageName) {
-						services.commandService.executeCommand('positronPackages.uninstallPackage', packageName)
+						services.commandService.executeCommand('positronPackages.uninstallPackage', packageName);
 					}
 				}}
 				onUpdateAllPackages={() => services.commandService.executeCommand('positronPackages.updateAllPackages')}
 				onUpdatePackage={() => {
 					const packageName = getSelectedItemPackageName(selectedItem);
 					if (packageName) {
-						services.commandService.executeCommand('positronPackages.updatePackage', packageName)
+						services.commandService.executeCommand('positronPackages.updatePackage', packageName);
 					}
 				}}
 			></ActionBar>
@@ -328,7 +333,7 @@ const ACTION_BAR_PADDING_RIGHT = 8;
 const ACTION_BAR_HEIGHT = 28;
 
 interface ActionBarProps {
-	busy: boolean,
+	busy: boolean;
 	activeSession?: ILanguageRuntimeSession;
 	selectedItem?: string;
 	onInstallPackage: () => void;
@@ -406,11 +411,11 @@ const ActionBar = ({
 								},
 							]}
 							align='right'
-							ariaLabel={localize('positronPackageActions', 'Package actions')}
+							ariaLabel={positronPackageActions}
 							disabled={!activeSession}
 							dropdownIndicator='disabled'
 							icon={ThemeIcon.fromId('ellipsis')}
-							tooltip={localize('positronPackageActions', 'Package actions')}
+							tooltip={positronPackageActions}
 						/>
 					</ActionBarRegion>
 				</PositronActionBar>


### PR DESCRIPTION
Related #11832

### Release Notes

Changes tooltips from sentence case to Title Case to match VS Code conventions: "Refresh Packages", "Install Package", "Update Package", "Update All Packages", "Uninstall Package", "Package Actions".

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

You can see by hovering the action bar items.