### PR TITLE
Remove Packages pane actions from File menu

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -78,11 +78,6 @@ class RefreshPackagesAction extends Action2 {
 			title: nls.localize2('refreshPackages', 'Refresh Packages'),
 			category: Categories.Developer,
 			f1: true,
-			menu: {
-				id: MenuId.MenubarFileMenu,
-				group: '1_newfolder',
-				order: 3,
-			},
 		});
 	}
 	override run(accessor: ServicesAccessor, ...args: unknown[]): Promise<ILanguageRuntimePackage[]> {
@@ -105,11 +100,6 @@ class InstallPackageAction extends Action2 {
 			title: nls.localize2('installPackage', 'Install Package'),
 			category: Categories.Developer,
 			f1: true,
-			menu: {
-				id: MenuId.MenubarFileMenu,
-				group: '1_newfolder',
-				order: 3,
-			},
 		});
 	}
 	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
@@ -172,11 +162,6 @@ class UninstallPackageAction extends Action2 {
 			title: nls.localize2('uninstallPackage', 'Uninstall Package'),
 			category: Categories.Developer,
 			f1: true,
-			menu: {
-				id: MenuId.MenubarFileMenu,
-				group: '1_newfolder',
-				order: 3,
-			},
 		});
 	}
 	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {


### PR DESCRIPTION
Relates #11829

The Install, Uninstall, and Refresh Package actions were incorrectly appearing in the File menu. These actions are still accessible via the Command Palette.

If we wanted to move them elsewhere, we could, but I am not sure where it would be appropriate.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

These options should now be gone.

<img width="431" height="302" alt="Screenshot 2026-02-12 at 4 03 55 PM" src="https://github.com/user-attachments/assets/40ec29cf-8f78-4af3-9552-e6ffae0dff4a" />