### PR TITLE
e2e: Soft-fail databot test due to flakes

### DIFF
--- a/test/e2e/tests/databot/databot.test.ts
+++ b/test/e2e/tests/databot/databot.test.ts
@@ -10,7 +10,7 @@ test.use({
 });
 
 test.describe('Databot', {
-	tag: [tags.ASSISTANT, tags.DATABOT, tags.WEB, tags.WIN],
+	tag: [tags.ASSISTANT, tags.DATABOT, tags.WEB, tags.WIN, tags.SOFT_FAIL],
 }, () => {
 
 	let pySessionId: string;


### PR DESCRIPTION
New databot test fails sometimes due to databot not loading correctly. Changing to soft-fail for now and will investigate further.

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
