### PR TITLE
e2e: re-enable token count tests

### DIFF
--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -354,7 +354,7 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 
 // Skipping web. See https://github.com/posit-dev/positron/issues/8568
 // Skippig all due to https://github.com/posit-dev/positron/issues/9402
-test.describe.skip('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT, tags.CRITICAL] }, () => {
+test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT, tags.CRITICAL, tags.WEB] }, () => {
 	test.beforeAll('Enable Assistant', async function ({ app, settings }) {
 		await app.workbench.assistant.openPositronAssistantChat();
 		await app.workbench.assistant.loginModelProvider('echo');

--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -352,8 +352,7 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 	});
 });
 
-// Skipping web. See https://github.com/posit-dev/positron/issues/8568
-// Skippig all due to https://github.com/posit-dev/positron/issues/9402
+// Test suite for verifying token usage is displayed.
 test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
 	test.beforeAll('Enable Assistant', async function ({ app, settings }) {
 		await app.workbench.assistant.openPositronAssistantChat();

--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -354,7 +354,7 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 
 // Skipping web. See https://github.com/posit-dev/positron/issues/8568
 // Skippig all due to https://github.com/posit-dev/positron/issues/9402
-test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT, tags.CRITICAL, tags.WEB] }, () => {
+test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
 	test.beforeAll('Enable Assistant', async function ({ app, settings }) {
 		await app.workbench.assistant.openPositronAssistantChat();
 		await app.workbench.assistant.loginModelProvider('echo');

--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { web } from 'webpack';
 import { test, expect, tags } from '../_test.setup';
 import { join } from 'path';
 
@@ -361,9 +362,9 @@ test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT
 	});
 
 	test.beforeEach('Clear chat', async function ({ app, settings }) {
-		await settings.set({ 'positron.assistant.showTokenUsage.enable': true });
+		await settings.set({ 'positron.assistant.showTokenUsage.enable': true }, { reload: 'web' });
 		await app.workbench.assistant.clickNewChatButton();
-		await settings.set({ 'positron.assistant.approximateTokenCount': ['echo'] });
+		await settings.set({ 'positron.assistant.approximateTokenCount': ['echo'] }, { reload: 'web' });
 	});
 
 	test.afterAll('Sign out of Assistant', async function ({ app }) {
@@ -382,14 +383,14 @@ test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT
 	});
 
 	test('Token usage is not displayed when setting is disabled', async function ({ app, settings }) {
-		await settings.set({ 'positron.assistant.showTokenUsage.enable': false });
+		await settings.set({ 'positron.assistant.showTokenUsage.enable': false }, { reload: 'web' });
 		await app.workbench.assistant.enterChatMessage('What is the meaning of life?');
 
 		expect(await app.workbench.assistant.verifyTokenUsageNotVisible());
 	});
 
 	test('Token usage is not displayed for non-supported providers', async function ({ app, settings }) {
-		await settings.set({ 'positron.assistant.approximateTokenCount': [] });
+		await settings.set({ 'positron.assistant.approximateTokenCount': [] }, { reload: 'web' });
 		await app.workbench.assistant.enterChatMessage('What is the meaning of life?');
 
 		expect(await app.workbench.assistant.verifyTokenUsageNotVisible());
@@ -399,16 +400,16 @@ test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT
 		await app.workbench.assistant.enterChatMessage('What is the meaning of life?');
 		await app.workbench.assistant.verifyTokenUsageVisible();
 
-		await settings.set({ 'positron.assistant.approximateTokenCount': [] });
+		await settings.set({ 'positron.assistant.approximateTokenCount': [] }, { reload: 'web' });
 		expect(await app.workbench.assistant.verifyTokenUsageNotVisible());
 
-		await settings.set({ 'positron.assistant.approximateTokenCount': ['echo'] });
+		await settings.set({ 'positron.assistant.approximateTokenCount': ['echo'] }, { reload: 'web' });
 		await app.workbench.assistant.verifyTokenUsageVisible();
 
-		await settings.set({ 'positron.assistant.showTokenUsage.enable': false });
+		await settings.set({ 'positron.assistant.showTokenUsage.enable': false }, { reload: 'web' });
 		expect(await app.workbench.assistant.verifyTokenUsageNotVisible());
 
-		await settings.set({ 'positron.assistant.showTokenUsage.enable': true });
+		await settings.set({ 'positron.assistant.showTokenUsage.enable': true }, { reload: 'web' });
 		await app.workbench.assistant.verifyTokenUsageVisible();
 	});
 

--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -3,7 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { web } from 'webpack';
 import { test, expect, tags } from '../_test.setup';
 import { join } from 'path';
 


### PR DESCRIPTION
#9402 is no longer repro'ing, so turning back on these tests

- Un-skipped chat token tests
- Added reload after settings change on web


### QA Notes
@:assistant @:win @:web
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
