### PR TITLE
ci: Auto-invalidate cache when postinstall behavior changes

### DIFF
--- a/.github/cache-scripts/cache-paths.sh
+++ b/.github/cache-scripts/cache-paths.sh
@@ -64,13 +64,16 @@ fi
 # ----------------------------------------------------------------------------
 # npm-core: Core build dependencies (~500MB-1GB)
 # ----------------------------------------------------------------------------
-# What: Root node_modules, build tools, test dependencies, npm/node-gyp caches
+# What: Root node_modules, build tools, test dependencies, npm/node-gyp caches,
+#       and artifacts generated during postinstall (e.g., ESM dependencies)
 # Invalidates: When any core package-lock.json changes OR Node.js major version changes
+#              OR postinstall scripts change (see generate-package-locks-hash.sh)
 # Why cache node-gyp: Avoids downloading Node.js headers (saves 10-30s, more reliable)
 # Node.js version: Major version included in cache key (ABI is stable within major versions)
 read -r -d '' NPM_CORE_PATHS << EOF || true
 .npm-cache
 $NODE_GYP_CACHE
+.build/esm-package-dependencies
 node_modules
 build/node_modules
 remote/node_modules

--- a/.github/cache-scripts/check-uncached-artifacts.sh
+++ b/.github/cache-scripts/check-uncached-artifacts.sh
@@ -198,7 +198,7 @@ if [[ $UNCACHED_COUNT -gt 0 ]]; then
 			echo ""
 			echo "npm install created **$UNCACHED_COUNT files** outside node_modules/ that aren't cached."
 			echo ""
-			echo "See the \"Check for uncached postinstall artifacts\" step for details and next steps."
+			echo "**Where to look:** In the \`${GITHUB_JOB:-unit}\` job, expand the \"🔍 Check for uncached postinstall artifacts\" step for details and next steps."
 		} >> "$GITHUB_STEP_SUMMARY"
 	fi
 

--- a/.github/cache-scripts/generate-package-locks-hash.sh
+++ b/.github/cache-scripts/generate-package-locks-hash.sh
@@ -103,10 +103,11 @@ lockFiles.forEach(f => console.error('  → ' + f));
 // generated. Changes to these should invalidate the cache even if package-lock
 // files haven't changed.
 //
-// NOTE: If you add a new script that runs during postinstall, add it here!
+// NOTE: If you add a new script that runs during install, add it here!
 const buildScripts = [
-  'build/npm/postinstall.ts',  // Main postinstall script
-  'build/npm/dirs.ts',         // Controls which directories get npm install
+  'build/npm/preinstall.ts',   // Preinstall script - installs build/ dependencies
+  'build/npm/postinstall.ts',  // Postinstall script - runs npm install in all dirs
+  'build/npm/dirs.ts',         // List of directories that get npm install
 ].sort();
 
 console.error('');

--- a/.github/cache-scripts/generate-package-locks-hash.sh
+++ b/.github/cache-scripts/generate-package-locks-hash.sh
@@ -5,7 +5,21 @@
 #
 # WHAT THIS DOES:
 # Creates a deterministic hash used as the cache key for npm-core cache.
-# When any core package-lock.json changes, the hash changes and cache invalidates.
+# The hash includes:
+# 1. All core package-lock.json files (dependency versions)
+# 2. Build scripts that affect postinstall behavior (what gets generated)
+#
+# When any of these change, the hash changes and cache invalidates.
+#
+# WHY INCLUDE BUILD SCRIPTS?
+# The postinstall script runs during `npm install` and generates artifacts
+# beyond just node_modules (e.g., ESM dependencies, compiled assets). When
+# the cache is restored, npm skips postinstall because deps appear installed,
+# but new/changed build steps won't run. Including these scripts in the hash
+# ensures cache invalidation when postinstall behavior changes.
+#
+# See: https://github.com/posit-dev/positron/pull/11873 for context on why
+# this was needed (ESM build step added to postinstall required manual bump).
 #
 # WHAT IS "CORE"?
 # Core = Non-extension directories that need npm install:
@@ -38,9 +52,10 @@
 set -euo pipefail
 
 # ============================================================================
-# SECTION 1: Generate Hash from dirs.ts
+# SECTION 1: Generate Hash from dirs.ts and build scripts
 # ============================================================================
-# Use Node.js to read dirs.ts and hash all core package-lock.json files.
+# Use Node.js to read dirs.ts and hash all core package-lock.json files
+# plus critical build scripts that affect postinstall behavior.
 # Why Node.js? dirs.ts is a TS module, easier to read with require().
 
 echo "Generating package-locks hash for npm-core cache..."
@@ -82,12 +97,28 @@ console.error('Hashing ' + lockFiles.length + ' package-lock.json files:');
 lockFiles.forEach(f => console.error('  → ' + f));
 
 // ----------------------------------------------------------------------------
-// Step 3: Hash all files together
+// Step 3: Collect build scripts that affect postinstall behavior
 // ----------------------------------------------------------------------------
-// Read each file and update the running hash
-// Sort order ensures deterministic hash
+// These scripts control what runs during npm install and what artifacts are
+// generated. Changes to these should invalidate the cache even if package-lock
+// files haven't changed.
+//
+// NOTE: If you add a new script that runs during postinstall, add it here!
+const buildScripts = [
+  'build/npm/postinstall.ts',  // Main postinstall script
+  'build/npm/dirs.ts',         // Controls which directories get npm install
+].sort();
+
+console.error('');
+console.error('Hashing ' + buildScripts.length + ' build scripts:');
+buildScripts.forEach(f => console.error('  → ' + f));
+
+// ----------------------------------------------------------------------------
+// Step 4: Hash all files together
+// ----------------------------------------------------------------------------
+// Read each file and update the running hash. Sort order ensures deterministic hash.
 const hash = crypto.createHash('sha256');
-for (const file of lockFiles) {
+for (const file of [...lockFiles, ...buildScripts]) {
   hash.update(fs.readFileSync(file));
 }
 


### PR DESCRIPTION
## Summary

Include `postinstall.ts` and `dirs.ts` in the npm-core cache key hash so the cache automatically invalidates when postinstall behavior changes. Also add `.build/esm-package-dependencies` to cached paths.

## Problem

When `postinstall.ts` is modified to add new build steps (like the ESM build in #11873), the cache key doesn't change because no `package-lock.json` files changed. npm skips postinstall when restoring from cache, causing missing artifacts and requiring manual cache version bumps.

## Solution

Hash the postinstall scripts alongside package-lock files:

```javascript
const buildScripts = [
  'build/npm/postinstall.ts',
  'build/npm/dirs.ts',
].sort();

for (const file of [...lockFiles, ...buildScripts]) {
  hash.update(fs.readFileSync(file));
}
```

## Changes

- **generate-package-locks-hash.sh**: Include `postinstall.ts` and `dirs.ts` in cache key hash
- **cache-paths.sh**: Add `.build/esm-package-dependencies` to `NPM_CORE_PATHS`

## QA Notes
n/a

🤖 Generated with [Claude Code](https://claude.ai/code)