### PR TITLE
fix: auto-scroll notebook cells into view on keyboard navigation

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -601,7 +601,7 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 			) ?? true;
 
 			if (autoFollow) {
-				await cell.reveal();
+				await cell.reveal({ reason: 'programmatic' });
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -14,6 +14,7 @@ import { NotebookPreloadOutputResults } from '../../../../services/positronWebvi
 import { CellSelectionType } from '../selectionMachine.js';
 import { IOutputItemDto } from '../../../notebook/common/notebookCommon.js';
 import { IPositronCellViewModel } from '../IPositronNotebookEditor.js';
+import { ICellRevealOptions } from './PositronNotebookCell.js';
 
 export type ExecutionStatus = 'running' | 'pending' | 'idle';
 
@@ -190,10 +191,10 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 
 	/**
 	 * Reveal the cell in the viewport
-	 * @param type Reveal type.
+	 * @param typeOrOptions Reveal type (for backward compatibility) or reveal options with reason-aware behavior
 	 * @returns Promise that resolves to true if the cell was successfully revealed, false otherwise.
 	 */
-	reveal(type?: CellRevealType): Promise<boolean>;
+	reveal(typeOrOptions?: CellRevealType | ICellRevealOptions): Promise<boolean>;
 
 	/**
 	 * Temporarily highlight the cell with a flash animation to draw attention.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -9,7 +9,7 @@ import { IObservable, IObservableSignal, ISettableObservable } from '../../../..
 import { URI } from '../../../../../base/common/uri.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
-import { CellRevealType, INotebookEditorOptions } from '../../../notebook/browser/notebookBrowser.js';
+import { INotebookEditorOptions } from '../../../notebook/browser/notebookBrowser.js';
 import { NotebookPreloadOutputResults } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
 import { CellSelectionType } from '../selectionMachine.js';
 import { IOutputItemDto } from '../../../notebook/common/notebookCommon.js';
@@ -191,10 +191,10 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 
 	/**
 	 * Reveal the cell in the viewport
-	 * @param typeOrOptions Reveal type (for backward compatibility) or reveal options with reason-aware behavior
+	 * @param options Reveal options controlling scroll behavior based on reason (keyboard navigation vs programmatic).
 	 * @returns Promise that resolves to true if the cell was successfully revealed, false otherwise.
 	 */
-	reveal(typeOrOptions?: CellRevealType | ICellRevealOptions): Promise<boolean>;
+	reveal(options?: ICellRevealOptions): Promise<boolean>;
 
 	/**
 	 * Temporarily highlight the cell with a flash animation to draw attention.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -194,7 +194,7 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	 * @param options Reveal options controlling scroll behavior based on reason (keyboard navigation vs programmatic).
 	 * @returns Promise that resolves to true if the cell was successfully revealed, false otherwise.
 	 */
-	reveal(options?: ICellRevealOptions): Promise<boolean>;
+	reveal(options: ICellRevealOptions): Promise<boolean>;
 
 	/**
 	 * Temporarily highlight the cell with a flash animation to draw attention.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -53,10 +53,6 @@ export interface ICellRevealOptions {
 	 * The direction of keyboard navigation (only applicable when reason is 'keyboardNavigation')
 	 */
 	direction?: CellNavigationDirection;
-	/**
-	 * Optional cell reveal type for programmatic reveals (backward compatibility)
-	 */
-	type?: CellRevealType;
 }
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { ITextEditorOptions } from '../../../../../platform/editor/common/editor.js';
@@ -320,7 +316,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		// Handle backward compatibility - if just a CellRevealType is passed, treat as programmatic
 		const options: ICellRevealOptions = typeOrOptions !== null && typeof typeOrOptions === 'object'
 			? typeOrOptions
-			: { reason: 'programmatic', type: typeOrOptions };
+			: { reason: 'programmatic' };
 
 		// Capture per-notebook generation so we can bail if a newer reveal starts while we await
 		const genMap = PositronNotebookCellGeneral._revealGenerationByInstance;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -332,9 +332,18 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 			return false;
 		}
 
-		// Apply scroll behavior based on reason
+		// Two scroll strategies depending on how the reveal was triggered:
+		//
+		// Keyboard navigation uses an instant jump. The user is driving the
+		// navigation themselves so each step moves at most one cell -- the
+		// scroll distance is small and predictable, and an instant snap keeps
+		// repeated key-presses feeling responsive without disorienting the user.
+		//
+		// Programmatic reveals (e.g. an agent editing a cell elsewhere in the
+		// notebook) use a smooth, centered scroll. The destination may be far
+		// from the current viewport, so the animation gives the user a sense of
+		// direction and helps them re-orient spatially within the document.
 		if (resolvedOptions.reason === 'keyboardNavigation') {
-			// Keyboard navigation: instant scroll ensuring full cell visibility.
 			// We always call scrollIntoView here (skipping isInViewport()) because
 			// the 50% visibility threshold used by isInViewport() would leave
 			// partially-visible cells un-scrolled. scrollIntoView with 'nearest'
@@ -352,7 +361,6 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 				this._container.scrollIntoView({ behavior: 'instant', block: 'nearest' });
 			}
 		} else {
-			// Programmatic reveal: only scroll if cell is not sufficiently visible
 			if (!this.isInViewport()) {
 				this._container.scrollIntoView({ behavior: 'smooth', block: 'center' });
 			}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -18,6 +18,13 @@ import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEdito
 import { CellSelectionType } from '../selectionMachine.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
 import { derived, IObservable, IObservableSignal, observableFromEvent, observableSignal, observableValue } from '../../../../../base/common/observable.js';
+import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
+import { ITextEditorOptions } from '../../../../../platform/editor/common/editor.js';
+import { applyTextEditorOptions } from '../../../../common/editor/editorOptions.js';
+import { ScrollType } from '../../../../../editor/common/editorCommon.js';
+import { INotebookEditorOptions } from '../../../notebook/browser/notebookBrowser.js';
+import { INotebookCellExecution, INotebookExecutionStateService, NotebookExecutionType } from '../../../notebook/common/notebookExecutionStateService.js';
+import { IContextKeysCellOutputViewModel } from '../IPositronNotebookEditor.js';
 
 /**
  * Minimum visibility ratio required for a cell to be considered visible in the viewport.
@@ -54,13 +61,6 @@ export interface ICellRevealOptions {
 	 */
 	direction?: CellNavigationDirection;
 }
-import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
-import { ITextEditorOptions } from '../../../../../platform/editor/common/editor.js';
-import { applyTextEditorOptions } from '../../../../common/editor/editorOptions.js';
-import { ScrollType } from '../../../../../editor/common/editorCommon.js';
-import { INotebookEditorOptions } from '../../../notebook/browser/notebookBrowser.js';
-import { INotebookCellExecution, INotebookExecutionStateService, NotebookExecutionType } from '../../../notebook/common/notebookExecutionStateService.js';
-import { IContextKeysCellOutputViewModel } from '../IPositronNotebookEditor.js';
 
 export abstract class PositronNotebookCellGeneral extends Disposable implements IPositronNotebookCell {
 	abstract readonly kind: CellKind;
@@ -312,8 +312,8 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	 */
 	private static _revealGenerationByInstance = new WeakMap<object, number>();
 
-	async reveal(options?: ICellRevealOptions): Promise<boolean> {
-		const resolvedOptions = options ?? { reason: 'programmatic' };
+	async reveal(options: ICellRevealOptions): Promise<boolean> {
+		const resolvedOptions = options;
 
 		// Capture per-notebook generation so we can bail if a newer reveal starts while we await
 		const genMap = PositronNotebookCellGeneral._revealGenerationByInstance;
@@ -399,7 +399,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		}
 
 		// Scroll the cell into view
-		await this.reveal();
+		await this.reveal({ reason: 'programmatic' });
 
 		// Select the cell in edit mode
 		this.select(CellSelectionType.Edit);

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -11,7 +11,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IContextKeyService, IScopedContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { CellRevealType, IActiveNotebookEditorDelegate, IBaseCellEditorOptions, ICellViewModel, INotebookCellOverlayChangeAccessor, INotebookDeltaDecoration, INotebookEditorCreationOptions, INotebookEditorOptions, INotebookEditorViewState, INotebookViewZoneChangeAccessor } from '../../notebook/browser/notebookBrowser.js';
+import { IActiveNotebookEditorDelegate, IBaseCellEditorOptions, ICellViewModel, INotebookCellOverlayChangeAccessor, INotebookDeltaDecoration, INotebookEditorCreationOptions, INotebookEditorOptions, INotebookEditorViewState, INotebookViewZoneChangeAccessor } from '../../notebook/browser/notebookBrowser.js';
 import { NotebookLayoutInfo } from '../../notebook/browser/notebookViewEvents.js';
 import { NotebookOptions } from '../../notebook/browser/notebookOptions.js';
 import { NotebookTextModel } from '../../notebook/common/model/notebookTextModel.js';
@@ -873,7 +873,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @param cell The cell to reveal
 	 */
 	async revealInCenterIfOutsideViewport(cell: IExtensionApiCellViewModel): Promise<void> {
-		this._revealCell(cell, CellRevealType.CenterIfOutsideViewport);
+		this._revealCell(cell);
 	}
 
 	/**
@@ -881,7 +881,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @param cell The cell to reveal
 	 */
 	async revealInCenter(cell: IExtensionApiCellViewModel): Promise<void> {
-		await this._revealCell(cell, CellRevealType.Center);
+		await this._revealCell(cell);
 	}
 
 	/**
@@ -889,7 +889,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @param cell The cell to reveal
 	 */
 	async revealInViewAtTop(cell: IExtensionApiCellViewModel): Promise<void> {
-		await this._revealCell(cell, CellRevealType.Top);
+		await this._revealCell(cell);
 	}
 
 	private _toPositronCell(cell: IExtensionApiCellViewModel): IPositronNotebookCell {
@@ -904,9 +904,8 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	/**
 	 * @param cell The cell to reveal
 	 */
-	private async _revealCell(cell: IExtensionApiCellViewModel, type?: CellRevealType): Promise<void> {
-		// Pass the type parameter to reveal method - it will handle backward compatibility
-		await this._toPositronCell(cell).reveal(type);
+	private async _revealCell(cell: IExtensionApiCellViewModel): Promise<void> {
+		await this._toPositronCell(cell).reveal();
 	}
 	//#endregion INotebookEditor
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -905,6 +905,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @param cell The cell to reveal
 	 */
 	private async _revealCell(cell: IExtensionApiCellViewModel, type?: CellRevealType): Promise<void> {
+		// Pass the type parameter to reveal method - it will handle backward compatibility
 		await this._toPositronCell(cell).reveal(type);
 	}
 	//#endregion INotebookEditor
@@ -2046,7 +2047,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 		if (autoFollow) {
 			// Reveal (scroll to) and highlight
-			if (!(await cell.reveal())) {
+			if (!(await cell.reveal({ reason: 'programmatic' }))) {
 				this._logService.debug('[PositronNotebookInstance] handleAssistantModification: cell.reveal() returned false');
 			}
 			if (!(await cell.highlightTemporarily(operationType, maxWaitMs))) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -905,7 +905,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @param cell The cell to reveal
 	 */
 	private async _revealCell(cell: IExtensionApiCellViewModel): Promise<void> {
-		await this._toPositronCell(cell).reveal();
+		await this._toPositronCell(cell).reveal({ reason: 'programmatic' });
 	}
 	//#endregion INotebookEditor
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.css
@@ -8,4 +8,8 @@
 	margin-left: 12px;
 
 	border-radius: var(--vscode-positronNotebook-cell-radius);
+
+	/* Ensure the action bar (which overlaps above the cell by half its height)
+	 * is not clipped when scrollIntoView aligns the cell to the viewport top. */
+	scroll-margin-top: var(--vscode-positronNotebook-action-bar-inset);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
@@ -8,6 +8,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
 import { ICellRange } from '../../notebook/common/notebookRange.js';
+import { CellNavigationDirection } from './PositronNotebookCells/PositronNotebookCell.js';
 
 /**
  * Represents the possible selection states for the notebook.
@@ -708,6 +709,8 @@ export class SelectionStateMachine extends Disposable {
 			return;
 		}
 
+		const direction: CellNavigationDirection = up ? 'up' : 'down';
+
 		if (addMode) {
 			// If the edge cell is at the top or bottom of the cells, and the up or down arrow key is pressed, respectively, do nothing.
 			if (indexOfReferenceCell <= 0 && up || indexOfReferenceCell >= cells.length - 1 && !up) {
@@ -742,6 +745,7 @@ export class SelectionStateMachine extends Disposable {
 						active: nextCell  // nextCell becomes the new active cell
 					});
 				}
+				void nextCell.reveal({ reason: 'keyboardNavigation', direction });
 				return;
 			}
 
@@ -753,11 +757,13 @@ export class SelectionStateMachine extends Disposable {
 				selected: newSelection,
 				active: nextCell
 			});
+			void nextCell.reveal({ reason: 'keyboardNavigation', direction });
 			return;
 		}
 
 		if (state.type === SelectionState.MultiSelection) {
 			this.selectCell(nextCell, CellSelectionType.Normal);
+			void nextCell.reveal({ reason: 'keyboardNavigation', direction });
 			return;
 		}
 
@@ -769,8 +775,7 @@ export class SelectionStateMachine extends Disposable {
 
 		// If meta is not held down, we're in single selection mode.
 		this.selectCell(nextCell, CellSelectionType.Normal);
-
-		// React will handle focus based on selection state change
+		void nextCell.reveal({ reason: 'keyboardNavigation', direction });
 	}
 
 	//#endregion Private Methods

--- a/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
@@ -745,36 +745,30 @@ export class SelectionStateMachine extends Disposable {
 						active: nextCell  // nextCell becomes the new active cell
 					});
 				}
-				void nextCell.reveal({ reason: 'keyboardNavigation', direction });
+			} else {
+				// Expanding the selection
+				const newSelection = verifyNonEmptyArray(up ? [nextCell, ...currentSelection] : [...currentSelection, nextCell]);
+				// The newly added cell becomes the active cell
+				this._setState({
+					type: SelectionState.MultiSelection,
+					selected: newSelection,
+					active: nextCell
+				});
+			}
+		} else if (state.type === SelectionState.MultiSelection) {
+			this.selectCell(nextCell, CellSelectionType.Normal);
+		} else {
+			// If the reference cell is at the top or bottom of the cells, and the up or down arrow key is pressed, respectively, do nothing.
+			if (indexOfReferenceCell <= 0 && up || indexOfReferenceCell >= cells.length - 1 && !up) {
+				// Already at the edge of the cells.
 				return;
 			}
 
-			// Otherwise, we're expanding the selection
-			const newSelection = verifyNonEmptyArray(up ? [nextCell, ...currentSelection] : [...currentSelection, nextCell]);
-			// The newly added cell becomes the active cell
-			this._setState({
-				type: SelectionState.MultiSelection,
-				selected: newSelection,
-				active: nextCell
-			});
-			void nextCell.reveal({ reason: 'keyboardNavigation', direction });
-			return;
-		}
-
-		if (state.type === SelectionState.MultiSelection) {
+			// Single selection mode.
 			this.selectCell(nextCell, CellSelectionType.Normal);
-			void nextCell.reveal({ reason: 'keyboardNavigation', direction });
-			return;
 		}
 
-		// If the reference cell is at the top or bottom of the cells, and the up or down arrow key is pressed, respectively, do nothing.
-		if (indexOfReferenceCell <= 0 && up || indexOfReferenceCell >= cells.length - 1 && !up) {
-			// Already at the edge of the cells.
-			return;
-		}
-
-		// If meta is not held down, we're in single selection mode.
-		this.selectCell(nextCell, CellSelectionType.Normal);
+		// Reveal the newly active cell
 		void nextCell.reveal({ reason: 'keyboardNavigation', direction });
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
@@ -769,7 +769,9 @@ export class SelectionStateMachine extends Disposable {
 		}
 
 		// Reveal the newly active cell
-		void nextCell.reveal({ reason: 'keyboardNavigation', direction });
+		nextCell.reveal({ reason: 'keyboardNavigation', direction }).catch(err => {
+			this._logService.error('SelectionMachine: Failed to reveal cell during keyboard navigation', err);
+		});
 	}
 
 	//#endregion Private Methods

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -1078,6 +1078,25 @@ export class PositronNotebooks extends Notebooks {
 	}
 
 	/**
+	 * Verify: the action bar for the cell at the specified index is not clipped
+	 * by the notebook scroll container (its top edge is within the viewport).
+	 */
+	async expectActionBarVisibleInViewport(cellIndex: number): Promise<void> {
+		await test.step(`Verify action bar for cell ${cellIndex} is visible in viewport`, async () => {
+			await expect(async () => {
+				const actionBar = this.cell.nth(cellIndex).locator('.positron-notebooks-cell-action-bar');
+				const actionBarBox = await actionBar.boundingBox();
+				const containerBox = await this.cellsContainer.boundingBox();
+				expect(actionBarBox, `Action bar for cell ${cellIndex} has no bounding box`).not.toBeNull();
+				expect(containerBox, 'Cells container has no bounding box').not.toBeNull();
+
+				// The action bar's top edge should not be above the scroll container
+				expect(actionBarBox!.y).toBeGreaterThanOrEqual(containerBox!.y - 1);
+			}).toPass({ timeout: DEFAULT_TIMEOUT });
+		});
+	}
+
+	/**
 	 * Get the current scroll position of the notebook cells container.
 	 */
 	async getScrollTop(): Promise<number> {

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -241,4 +241,109 @@ test.describe('Notebook Focus and Selection', {
 		await keyboard.type('print("New Below")');
 		await notebooksPositron.expectCellContentAtIndexToBe(1, 'print("New Below")');
 	});
+
+	test.describe('Auto-scroll on keyboard navigation', () => {
+
+		test('Navigating down scrolls off-screen cell into view', async function ({ app }) {
+			const { notebooksPositron } = app.workbench;
+			const keyboard = app.code.driver.page.keyboard;
+			await notebooksPositron.newNotebook({ codeCells: 15 });
+
+			// Start at the first cell in command mode
+			await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+
+			// Navigate down through all cells - each active cell should remain visible
+			for (let i = 0; i < 14; i++) {
+				await keyboard.press('ArrowDown');
+				await notebooksPositron.expectCellIndexToBeSelected(i + 1, { inEditMode: false });
+				await notebooksPositron.expectCellToBeVisibleInViewport(i + 1);
+			}
+		});
+
+		test('Navigating up scrolls off-screen cell into view', async function ({ app }) {
+			const { notebooksPositron } = app.workbench;
+			const keyboard = app.code.driver.page.keyboard;
+			await notebooksPositron.newNotebook({ codeCells: 15 });
+
+			// Navigate to the last cell
+			await notebooksPositron.selectCellAtIndex(14, { editMode: false });
+
+			// Navigate up through all cells - each active cell should remain visible
+			for (let i = 14; i > 0; i--) {
+				await keyboard.press('ArrowUp');
+				await notebooksPositron.expectCellIndexToBeSelected(i - 1, { inEditMode: false });
+				await notebooksPositron.expectCellToBeVisibleInViewport(i - 1);
+			}
+		});
+
+		test('No scroll when target cell is already fully visible', async function ({ app }) {
+			const { notebooksPositron } = app.workbench;
+			const keyboard = app.code.driver.page.keyboard;
+			await notebooksPositron.newNotebook({ codeCells: 3 });
+
+			// Select cell 0 and navigate to cell 1 (both should be visible)
+			await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+			const scrollBefore = await notebooksPositron.getScrollTop();
+			await keyboard.press('ArrowDown');
+			await notebooksPositron.expectCellIndexToBeSelected(1, { inEditMode: false });
+			const scrollAfter = await notebooksPositron.getScrollTop();
+
+			expect(Math.abs(scrollAfter - scrollBefore)).toBeLessThanOrEqual(1);
+		});
+
+		test('Boundary: no scroll at first/last cell', async function ({ app }) {
+			const { notebooksPositron } = app.workbench;
+			const keyboard = app.code.driver.page.keyboard;
+			await notebooksPositron.newNotebook({ codeCells: 15 });
+
+			// At first cell, pressing ArrowUp should not scroll
+			await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+			const scrollTopBefore = await notebooksPositron.getScrollTop();
+			await keyboard.press('ArrowUp');
+			await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: false });
+			expect(Math.abs(await notebooksPositron.getScrollTop() - scrollTopBefore)).toBeLessThanOrEqual(1);
+
+			// Navigate to last cell
+			await notebooksPositron.selectCellAtIndex(14, { editMode: false });
+			const scrollBottomBefore = await notebooksPositron.getScrollTop();
+			await keyboard.press('ArrowDown');
+			await notebooksPositron.expectCellIndexToBeSelected(14, { inEditMode: false });
+			expect(Math.abs(await notebooksPositron.getScrollTop() - scrollBottomBefore)).toBeLessThanOrEqual(1);
+		});
+
+		test('Shift+navigation keeps active cell visible', async function ({ app }) {
+			const { notebooksPositron } = app.workbench;
+			const keyboard = app.code.driver.page.keyboard;
+			await notebooksPositron.newNotebook({ codeCells: 15 });
+
+			// Start at cell 0, shift-select down through cells
+			await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+			for (let i = 0; i < 14; i++) {
+				await keyboard.press('Shift+ArrowDown');
+				// The active cell (newest in selection) should be selected and visible
+				await notebooksPositron.expectCellIndexToBeSelected(i + 1, { isActive: true, inEditMode: false });
+				await notebooksPositron.expectCellToBeVisibleInViewport(i + 1);
+			}
+		});
+
+		test('Enter/Escape mode transitions do not scroll', async function ({ app }) {
+			const { notebooksPositron } = app.workbench;
+			const keyboard = app.code.driver.page.keyboard;
+			await notebooksPositron.newNotebook({ codeCells: 15 });
+
+			// Navigate to a cell in the middle
+			await notebooksPositron.selectCellAtIndex(7, { editMode: false });
+			const scrollBefore = await notebooksPositron.getScrollTop();
+
+			// Enter edit mode - should not scroll
+			await keyboard.press('Enter');
+			await notebooksPositron.expectCellIndexToBeSelected(7, { inEditMode: true });
+			expect(Math.abs(await notebooksPositron.getScrollTop() - scrollBefore)).toBeLessThanOrEqual(1);
+
+			// Exit edit mode - should not scroll
+			await keyboard.press('Escape');
+			await notebooksPositron.expectCellIndexToBeSelected(7, { inEditMode: false });
+			expect(Math.abs(await notebooksPositron.getScrollTop() - scrollBefore)).toBeLessThanOrEqual(1);
+		});
+	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path from 'path';
-import { tags } from '../_test.setup';
+import { expect, tags } from '../_test.setup';
 import { test } from './_test.setup.js';
 
 test.use({

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -326,6 +326,29 @@ test.describe('Notebook Focus and Selection', {
 			}
 		});
 
+		test('Action bar is not clipped when scrolling to oversized cell', async function ({ app }) {
+			const { notebooksPositron } = app.workbench;
+			const keyboard = app.code.driver.page.keyboard;
+			await notebooksPositron.newNotebook({ codeCells: 5 });
+
+			// Make cell 3 taller than the viewport by adding many lines
+			await notebooksPositron.selectCellAtIndex(3, { editMode: true });
+			for (let i = 0; i < 50; i++) {
+				await keyboard.press('Enter');
+			}
+			await keyboard.press('Escape');
+
+			// Navigate from cell 2 down to the oversized cell 3.
+			// This triggers scrollIntoView({ block: 'start' }) for oversized cells,
+			// which would clip the action bar without scroll-margin-top.
+			await notebooksPositron.selectCellAtIndex(2, { editMode: false });
+			await keyboard.press('ArrowDown');
+			await notebooksPositron.expectCellIndexToBeSelected(3, { inEditMode: false });
+
+			// Verify the action bar is not clipped by the scroll container
+			await notebooksPositron.expectActionBarVisibleInViewport(3);
+		});
+
 		test('Enter/Escape mode transitions do not scroll', async function ({ app }) {
 			const { notebooksPositron } = app.workbench;
 			const keyboard = app.code.driver.page.keyboard;


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11611.

### Summary

When navigating notebook cells with keyboard shortcuts (Arrow Up/Down in command mode, Shift+Arrow for multi-select), the active cell now automatically scrolls into view. Previously, focus could move to off-screen cells without any scroll adjustment, forcing users to manually scroll to find the active cell.

Key behaviors:
- **Normal cells**: scrolls the minimum distance to make the cell fully visible (`scrollIntoView({ block: 'nearest' })`)
- **Oversized cells** (taller than viewport): shows the top when navigating down, bottom when navigating up
- **Already-visible cells**: no scroll change
- **Keyboard navigation only**: programmatic reveals retain existing smooth/center behavior
- Uses a per-notebook generation counter to cancel stale reveals during rapid key presses
- Adds `scroll-margin-top` to prevent action bar clipping when a cell is aligned to the viewport top

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Notebook cells now auto-scroll into view during keyboard navigation (Arrow Up/Down, Shift+Arrow) so the active cell is always visible (#11611)


### QA Notes

@:positron-notebooks

1. Open a notebook with enough cells to require scrolling (15+ cells)
2. Click the first cell, press `Escape` to enter command mode
3. Press `ArrowDown` repeatedly -- each newly selected cell should scroll into view
4. At the last cell, press `ArrowDown` -- nothing should change
5. Press `ArrowUp` repeatedly back to the first cell -- same scroll behavior
6. At the first cell, press `ArrowUp` -- nothing should change
7. From cell 0, hold `Shift` and press `ArrowDown` repeatedly -- multi-select should work and the active cell should stay visible
8. Make one cell very tall (50+ lines), navigate into it from above -- the top of the cell should be visible; navigate into it from below -- the bottom should be visible
9. When navigating to a tall cell from above, verify the action bar (above the cell) is not clipped by the scroll container