### PR TITLE
Assistant: add Claude Opus 4.5 and 4.6 to Snowflake model listing

### DIFF
--- a/extensions/positron-assistant/src/modelDefinitions.ts
+++ b/extensions/positron-assistant/src/modelDefinitions.ts
@@ -70,16 +70,16 @@ const builtInModelDefinitions = new Map<string, ModelDefinition[]>([
 			maxOutputTokens: 8_192, // reference: https://ai.google.dev/gemini-api/docs/models#gemini-2.0-flash
 		},
 	]],
-	// Model listing reference: https://docs.snowflake.com/en/user-guide/snowflake-cortex/aisql#regional-availability
+	// Model listing reference: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api#model-availability
 	['snowflake-cortex', [
-		{
-			name: 'Claude Sonnet 4',
-			identifier: 'claude-4-sonnet',
-			maxInputTokens: 200_000, // Snowflake Cortex AI model context limit
-		},
 		{
 			name: 'Claude Sonnet 4.5',
 			identifier: 'claude-sonnet-4-5',
+			maxInputTokens: 200_000, // Snowflake Cortex AI model context limit
+		},
+		{
+			name: 'Claude Opus 4.5',
+			identifier: 'claude-opus-4-5',
 			maxInputTokens: 200_000, // Snowflake Cortex AI model context limit
 		},
 		{
@@ -88,14 +88,24 @@ const builtInModelDefinitions = new Map<string, ModelDefinition[]>([
 			maxInputTokens: 200_000, // Snowflake Cortex AI model context limit
 		},
 		{
-			name: 'GPT-5',
-			identifier: 'openai-gpt-5',
-			maxInputTokens: 128_000, // Typical GPT-5 context window
+			name: 'Claude Sonnet 4',
+			identifier: 'claude-4-sonnet',
+			maxInputTokens: 200_000, // Snowflake Cortex AI model context limit
+		},
+		{
+			name: 'Claude Opus 4',
+			identifier: 'claude-4-opus',
+			maxInputTokens: 200_000, // Snowflake Cortex AI model context limit
 		},
 		{
 			name: 'GPT-4.1',
 			identifier: 'openai-gpt-4.1',
-			maxInputTokens: 128_000, // Typical GPT-5 context window
+			maxInputTokens: 128_000, // Typical GPT context window
+		},
+		{
+			name: 'GPT-5',
+			identifier: 'openai-gpt-5',
+			maxInputTokens: 128_000, // Typical GPT context window
 		},
 	]]
 ]);

--- a/extensions/positron-assistant/src/modelDefinitions.ts
+++ b/extensions/positron-assistant/src/modelDefinitions.ts
@@ -73,8 +73,8 @@ const builtInModelDefinitions = new Map<string, ModelDefinition[]>([
 	// Model listing reference: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api#model-availability
 	['snowflake-cortex', [
 		{
-			name: 'Claude Sonnet 4.5',
-			identifier: 'claude-sonnet-4-5',
+			name: 'Claude Haiku 4.5',
+			identifier: 'claude-haiku-4-5',
 			maxInputTokens: 200_000, // Snowflake Cortex AI model context limit
 		},
 		{
@@ -83,8 +83,8 @@ const builtInModelDefinitions = new Map<string, ModelDefinition[]>([
 			maxInputTokens: 200_000, // Snowflake Cortex AI model context limit
 		},
 		{
-			name: 'Claude Haiku 4.5',
-			identifier: 'claude-haiku-4-5',
+			name: 'Claude Opus 4.6',
+			identifier: 'claude-opus-4-6',
 			maxInputTokens: 200_000, // Snowflake Cortex AI model context limit
 		},
 		{
@@ -93,8 +93,8 @@ const builtInModelDefinitions = new Map<string, ModelDefinition[]>([
 			maxInputTokens: 200_000, // Snowflake Cortex AI model context limit
 		},
 		{
-			name: 'Claude Opus 4.6',
-			identifier: 'claude-opus-4-6',
+			name: 'Claude Sonnet 4.5',
+			identifier: 'claude-sonnet-4-5',
 			maxInputTokens: 200_000, // Snowflake Cortex AI model context limit
 		},
 		{

--- a/extensions/positron-assistant/src/modelDefinitions.ts
+++ b/extensions/positron-assistant/src/modelDefinitions.ts
@@ -93,8 +93,8 @@ const builtInModelDefinitions = new Map<string, ModelDefinition[]>([
 			maxInputTokens: 200_000, // Snowflake Cortex AI model context limit
 		},
 		{
-			name: 'Claude Opus 4',
-			identifier: 'claude-4-opus',
+			name: 'Claude Opus 4.6',
+			identifier: 'claude-opus-4-6',
 			maxInputTokens: 200_000, // Snowflake Cortex AI model context limit
 		},
 		{


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/11645
- adds Claude Opus 4.5 and 4.6 models for Snowflake Cortex (Claude Opus 4 is getting deprecated for Snowflake, so we are instead including Claude Opus 4.6)
- reordered model listing config to be alphabetical

### Release Notes

#### New Features

- Assistant: added Claude Opus 4.5 and 4.6 models for Snowflake Cortex (#11645)

### QA Notes

1. Auth to Snowflake Cortex in Positron Assistant
2. Verify the model dropdown shows the updated list of models
3. Test that Claude Opus 4.5 and Claude Opus 4.6 models can be used for chat, tool calling, plot tool