### PR TITLE
Fix packages quick pick to not throw error on cancel

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
@@ -104,10 +104,9 @@ export const updatePackage = async (
 
 
 	const state = await collectInputs();
+	// If there is no selected package and version, it means the user canceled the QuickPick, so we should not perform the update.
 	if (state.selectedPackage && state.selectedVersion) {
 		await performUpdate(state.selectedPackage, state.selectedVersion);
-	} else {
-		throw new Error('Package or version not selected');
 	}
 };
 
@@ -253,7 +252,8 @@ export const installPackage = async (
 	}
 
 	const state = await collectInputs();
-	if (state.selectedPackage) {
+	// If there is no selected package and version, it means the user canceled the QuickPick, so we should not perform the update.
+	if (state.selectedPackage && state.selectedVersion) {
 		await performInstall(state.selectedPackage, state.selectedVersion);
 	}
 };

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
@@ -252,7 +252,7 @@ export const installPackage = async (
 	}
 
 	const state = await collectInputs();
-	// If there is no selected package and version, it means the user canceled the QuickPick, so we should not perform the update.
+	// If there is no selected package and version, it means the user canceled the QuickPick, so we should not perform the install.
 	if (state.selectedPackage && state.selectedVersion) {
 		await performInstall(state.selectedPackage, state.selectedVersion);
 	}


### PR DESCRIPTION
See #11833

### Release Notes

When the user cancels the package update or install quick pick, silently do nothing instead of throwing an error. Previously it would throw an error and show an alert dialog. Now, it should do nothing.

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

* Switch to an R project, but you can do similar in python:
* Open command palette.
* Choose Install Package
* Choose fortunes
* On the version picker, press `Esc`