### PR TITLE
dev: enforce strict error handling in build scripts

### DIFF
--- a/scripts/build-check.sh
+++ b/scripts/build-check.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Waits for all three build daemons (watch-client, watch-extensions, watch-e2e) to reach idle state.
 # Exits 0 if all daemons are idle, non-zero if any daemon fails.
+set -euo pipefail
 
 node scripts/deemon-status.mjs \
 	--name watch-client \
@@ -22,11 +23,9 @@ node scripts/deemon-status.mjs \
 	--command "npm run watch-e2e" &
 pid3=$!
 
-wait $pid1
-r1=$?
-wait $pid2
-r2=$?
-wait $pid3
-r3=$?
+r1=0; r2=0; r3=0
+wait $pid1 || r1=$?
+wait $pid2 || r2=$?
+wait $pid3 || r3=$?
 
 exit $((r1 || r2 || r3))

--- a/scripts/build-ps.sh
+++ b/scripts/build-ps.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 # Shows the status of Positron build daemons (watch-clientd, watch-extensionsd, watch-e2ed)
+set -euo pipefail
 
 DAEMONS=("watch-client" "watch-extensions" "watch-e2e")
 PS_OUTPUT=$(ps aux)
 
 printf "%-20s %-10s %-10s %s\n" "DAEMON" "STATUS" "PID" "STARTED"
 for daemon in "${DAEMONS[@]}"; do
-	line=$(echo "$PS_OUTPUT" | grep "$PWD/node_modules/.bin/deemon --daemon npm run ${daemon}" | head -1)
+	line=$(echo "$PS_OUTPUT" | grep -F "$PWD/node_modules/.bin/deemon --daemon npm run ${daemon}" | head -1 || true)
 	if [ -n "$line" ]; then
 		pid=$(echo "$line" | awk '{print $2}')
 		started=$(echo "$line" | awk '{print $9}')

--- a/scripts/build-start.sh
+++ b/scripts/build-start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 run() {
 	local name=$1

--- a/scripts/build-stop.sh
+++ b/scripts/build-stop.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 run() {
 	local name=$1

--- a/scripts/file-origin.sh
+++ b/scripts/file-origin.sh
@@ -5,9 +5,9 @@
 #
 # Usage: ./scripts/file-origin.sh <file>
 #
-set -e
+set -euo pipefail
 
-file="$1"
+file="${1:-}"
 
 if [ -z "$file" ]; then
 	echo "Usage: $0 <file>"


### PR DESCRIPTION
I encountered a weird bug during a Claude session where build-ps.sh reported that the daemons weren't running when they were. Turns out I was running in a sandboxed mode where `/bin/ps` wasn't allowed, and that error wasn't failing the bash script.

This PR adds `set -euo pipefail` to the top of the Claude build helper scripts to help with things like that.