### PR TITLE
E2E test: monitor load avg and CPU usage on OSX, too

### DIFF
--- a/test/e2e/infra/systemDiagnostics.ts
+++ b/test/e2e/infra/systemDiagnostics.ts
@@ -17,13 +17,13 @@ export function getFreeMemory(): string {
 }
 
 /**
- * Get load average and CPU usage information (Linux only)
+ * Get load average and CPU usage information (Unix-like systems)
  *
  * @returns The load average and CPU usage string, or a message indicating it's not available
  */
 export function getLoadAverageAndCpuUsage(): string {
-	if (process.platform !== 'linux') {
-		return 'Load average and CPU usage information is only available on Linux systems.';
+	if (process.platform === 'win32') {
+		return 'Load average and CPU usage information is not available on Windows.';
 	}
 
 	try {


### PR DESCRIPTION
We previously erroneously skipped on OSX. We need this diagnostic info in positron-builds repo.

### QA Notes
