### PR TITLE
hide advanced settings by default

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -7,7 +7,10 @@ import { isStandalone } from '../../base/browser/browser.js';
 import { isLinux, isMacintosh, isNative, isWeb, isWindows } from '../../base/common/platform.js';
 import { localize } from '../../nls.js';
 import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../platform/configuration/common/configurationRegistry.js';
-import product from '../../platform/product/common/product.js';
+// --- Start Positron ---
+// Unused after disabling alwaysShowAdvancedSettings default logic
+// import product from '../../platform/product/common/product.js';
+// --- End Positron ---
 import { Registry } from '../../platform/registry/common/platform.js';
 import { ConfigurationKeyValuePairs, ConfigurationMigrationWorkbenchContribution, DynamicWindowConfiguration, DynamicWorkbenchSecurityConfiguration, Extensions, IConfigurationMigrationRegistry, problemsConfigurationNodeBase, windowConfigurationNodeBase, workbenchConfigurationNodeBase } from '../common/configuration.js';
 import { WorkbenchPhase, registerWorkbenchContribution2 } from '../common/contributions.js';
@@ -545,7 +548,13 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.settings.alwaysShowAdvancedSettings': {
 				'type': 'boolean',
 				'description': localize('alwaysShowAdvancedSettings', "Controls whether advanced settings are always shown in the settings editor without requiring the `@tag:advanced` filter."),
+				// --- Start Positron ---
+				// Positron doesn't set product.quality, so default to false to hide advanced model providers
+				/*
 				'default': product.quality !== 'stable'
+				*/
+				'default': false
+				// --- End Positron ---
 			},
 			'workbench.sideBar.location': {
 				'type': 'string',


### PR DESCRIPTION
### Summmary

- addresses https://github.com/posit-dev/positron/issues/11900
- `alwaysShowAdvancedSettings` is a new setting from a recent upstream merge, but the default setting value needs to be updated as positron doesn't set `product.quality`



### QA Notes

- Settings tagged with `advanced` aren't visible in the Settings UI by default
- Advanced settings are visible in the Settings UI when the settings search includes `@tag:advanced` or when the advanced filter is applied
    - <img width="500" alt="image" src="https://github.com/user-attachments/assets/96ca2147-3c99-4ba5-9880-00ade6508a56" />