### PR TITLE
Address EPIPE issues on macOS

### DIFF
--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -993,9 +993,22 @@ export class KCApi implements PositronSupervisorApi {
 					}
 				}
 
-				// Rethrow the error for the caller to handle. Use a summary to
-				// unroll AggregateErrors.
-				throw new Error(summarizeError(err));
+				// Log the error; use a summary to unroll aggregate errors like
+				// AggregateError
+				const errorSummary = summarizeError(err);
+				this.log(`Failed to create session '${sessionMetadata.sessionId}': ${errorSummary}`);
+				if (err.stack) {
+					this.log(`Stack trace: ${err.stack}`);
+				}
+				if (err.cause) {
+					this.log(`Caused by: ${summarizeError(err.cause)}`);
+					if (err.cause.stack) {
+						this.log(`Stack trace: ${err.cause.stack}`);
+					}
+				}
+
+				// Rethrow the error for the caller to handle.
+				throw new Error(errorSummary);
 			}
 		}
 

--- a/extensions/positron-supervisor/src/KallichoreApiInstance.ts
+++ b/extensions/positron-supervisor/src/KallichoreApiInstance.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/extensions/positron-supervisor/src/KallichoreApiInstance.ts
+++ b/extensions/positron-supervisor/src/KallichoreApiInstance.ts
@@ -9,7 +9,6 @@ import { createHttpAgent } from './NamedPipeHttpAgent.js';
 import { KallichoreServerState } from './ServerState.js';
 import axios, { AxiosInstance } from 'axios';
 
-import * as http from 'http';
 import * as os from 'os';
 
 export enum KallichoreTransport {
@@ -87,6 +86,12 @@ export class KallichoreApiInstance {
 			// revisited in the future if we support remote connections.
 			proxy: false as const,
 
+			// Disable redirects. Kallichore is a local server that never
+			// redirects, and this bypasses the follow-redirects middleware
+			// in axios, avoiding extra buffering and potential write
+			// errors on the underlying socket.
+			maxRedirects: 0,
+
 			// Include the bearer token auth on each request
 			headers: {
 				Authorization: `Bearer ${state.bearer_token}`
@@ -95,21 +100,6 @@ export class KallichoreApiInstance {
 
 		let basePath = state.base_path;
 		let axiosInstance: AxiosInstance | undefined;
-
-		// Handle Unix domain socket connections on non-Windows platforms
-		// We need to create a custom HTTP agent with keepAlive disabled to ensure
-		// connections are properly closed after each request. This prevents
-		// "error shutting down connection" errors on the server side when using
-		// the default keep-alive behavior.
-		if (this._transport === KallichoreTransport.UnixSocket && state.socket_path) {
-			const httpAgent = new http.Agent({
-				keepAlive: false
-			});
-			axiosInstance = axios.create({
-				httpAgent: httpAgent,
-				...baseOptions
-			});
-		}
 
 		// Handle named pipe connections specially on Windows
 		if (this._transport === KallichoreTransport.NamedPipe && state.named_pipe && os.platform() === 'win32') {

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -711,10 +711,15 @@ class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILangua
 				this._startupEmitter.fire(info);
 				resolve(info);
 			}).catch((err) => {
+				// Combine error details and stack trace if both are present
+				const errorDetails = `${err.details ? err.details : ''}${err.stack ? '\n\n' + err.stack : ''}`;
 				// Examine the error object to see what kind of failure it is
-				if (err.message && err.details) {
+				if (err.message && errorDetails) {
 					// We have an error message and details; use both
-					this._startupFailureEmitter.fire(err satisfies ILanguageRuntimeStartupFailure);
+					this._startupFailureEmitter.fire({
+						message: err.message,
+						details: errorDetails
+					} satisfies ILanguageRuntimeStartupFailure);
 					reject(err.message);
 				} else if (err.message && err.errors) {
 					// There are multiple errors (AggregateError)
@@ -728,21 +733,21 @@ class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILangua
 					// We have a name and a message.
 					this._startupFailureEmitter.fire({
 						message: err.name,
-						details: err.message
+						details: err.message + (errorDetails ? '\n\n' + errorDetails : '')
 					} satisfies ILanguageRuntimeStartupFailure);
 					reject(err.message);
 				} else if (err.message) {
 					// We only have a message.
 					this._startupFailureEmitter.fire({
 						message: err.message,
-						details: ''
+						details: errorDetails
 					} satisfies ILanguageRuntimeStartupFailure);
 					reject(err.message);
 				} else {
 					// Not an error object, or it doesn't have a message; just use the string
 					this._startupFailureEmitter.fire({
 						message: err.toString(),
-						details: ''
+						details: errorDetails
 					} satisfies ILanguageRuntimeStartupFailure);
 					reject(err);
 				}


### PR DESCRIPTION
This change fixes the `EPIPE` errors that can happen when starting the first Python session in a macOS build.

Addresses https://github.com/posit-dev/positron/issues/11936. 

The problem was introduced by some subtle changes to Axios in 1.13.5 (and is therefore a regression from #11872). 

  1. Client connects to Unix socket
  2. Client starts writing the PUT /sessions request (headers + JSON body)
  3. The server reads the full request, processes it successfully (hence the log new_session("python-e024f191") succeeds)
  4. The server sends the HTTP response and, because of Connection: close, immediately closes its end of the socket
  5. Before the client's TCP stack receives and processes the FIN/RST from the server, the client attempts the `req.end()` call (in 1.13.5)
  6. The socket write fails with `EPIPE` because the remote end is already closed

There are 3 changes in this PR:

- Disable the redirect-following middleware in Axios; we don't need it and it is responsible for this new wrinkle.
- Remove our `keep-alive: false` setting. This setting was introduced to address https://github.com/posit-dev/positron/issues/11004, but setting `keep-alive: false` causes the connection to be closed so aggressively that it can be detected as an error. Unfortunately there appears to be no combination of options that keeps both Axios and Tokio happy on domain sockets, so we're just gonna live with some ignorable errors being logged (I moved them to the debug level as part of a prior update, so at least they won't look scary any more). 
- Add stack information and better error logging when failing to create sessions. This will result in errors in the supervisor output logs if this happens again, and more info displayed in the Console.