### PR TITLE
Send selected frame notification to interested debuggers

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -794,7 +794,8 @@
         "languages": ["r"],
         "supportsUiLaunch": false,
         "sendBreakpointsOnAllSaves": true,
-        "verifyBreakpointsInDirtyDocuments": true
+        "verifyBreakpointsInDirtyDocuments": true,
+        "supportsFrameSelection": true
       }
     ],
     "customEditors": [

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -1078,7 +1078,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.231"
+      "ark": "0.1.232"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -159,9 +159,23 @@ export class DebugService implements IDebugService {
 			}
 		}));
 
-		this.disposables.add(this.viewModel.onDidFocusStackFrame(() => {
+		// --- Start Positron ---
+		this.disposables.add(this.viewModel.onDidFocusStackFrame(e => {
+			// Original handler code:
 			this.onStateChange();
+
+			// Notify the DAP server which frame is selected by sending a sentinel evaluate request.
+			// Only do this if the debugger has opted in via `supportsFrameSelection`.
+			if (e.stackFrame && e.session) {
+				const dbgr = this.adapterManager.getDebugger(e.session.configuration.type);
+				if (dbgr?.supportsFrameSelection) {
+					e.session.evaluate('.positron_selected_frame', e.stackFrame.frameId, 'watch').catch(_err => {
+						// Ignore errors: the DAP server may not handle this sentinel
+					});
+				}
+			}
 		}));
+		// --- End Positron ---
 		this.disposables.add(this.viewModel.onDidFocusSession((session: IDebugSession | undefined) => {
 			this.onStateChange();
 

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -241,6 +241,8 @@ export interface IDebuggerMetadata {
 	// --- Start Positron ---
 	// Whether this debugger can verify breakpoints in dirty (unsaved) documents
 	verifyBreakpointsInDirtyDocuments?: boolean;
+	// Whether this debugger wants to be notified when the user selects a stack frame
+	supportsFrameSelection?: boolean;
 	// --- End Positron ---
 }
 
@@ -1010,6 +1012,9 @@ export interface IDebuggerContribution extends IPlatformSpecificAdapterContribut
 
 	// Whether this debugger can verify breakpoints in dirty (unsaved) documents
 	verifyBreakpointsInDirtyDocuments?: boolean;
+
+	// Whether this debugger wants to be notified when the user selects a stack frame
+	supportsFrameSelection?: boolean;
 	// --- End Positron ---
 
 	// debug configuration support

--- a/src/vs/workbench/contrib/debug/common/debugSchemas.ts
+++ b/src/vs/workbench/contrib/debug/common/debugSchemas.ts
@@ -80,6 +80,11 @@ export const debuggersExtPoint = extensionsRegistry.ExtensionsRegistry.registerE
 					type: 'boolean',
 					default: false
 				},
+				supportsFrameSelection: {
+					description: nls.localize('positron.extension.contributes.debuggers.supportsFrameSelection', "Whether this debugger wants to be notified when the user selects a stack frame. When true, a sentinel evaluate request is sent to the DAP server on frame selection. Defaults to false."),
+					type: 'boolean',
+					default: false
+				},
 				// --- End Positron ---
 				configurationSnippets: {
 					description: nls.localize('vscode.extension.contributes.debuggers.configurationSnippets', "Snippets for adding new configurations in \'launch.json\'."),

--- a/src/vs/workbench/contrib/debug/common/debugger.ts
+++ b/src/vs/workbench/contrib/debug/common/debugger.ts
@@ -159,6 +159,10 @@ export class Debugger implements IDebugger, IDebuggerMetadata {
 	get verifyBreakpointsInDirtyDocuments(): boolean {
 		return this.debuggerContribution.verifyBreakpointsInDirtyDocuments === true; // Defaults to false
 	}
+
+	get supportsFrameSelection(): boolean {
+		return this.debuggerContribution.supportsFrameSelection === true; // Defaults to false
+	}
 	// --- End Positron ---
 
 	get when(): ContextKeyExpression | undefined {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/3078
Frontend-side of https://github.com/posit-dev/ark/pull/1046

This PR adds an opt-in debugger capability that allows debug adapters to be notified when the user selects a stack frame in the UI.

When a debugger sets `supportsFrameSelection: true` in its contribution, the debug service sends a sentinel evaluate request (`.positron.selectedFrame`) to the DAP server whenever the user focuses a different stack frame. This allows the backend to update its internal state to match the user's selection.

This is needed for R debugging where the Variables pane needs to reflect the currently selected frame. Without this notification, the backend has no way to know which frame the user is viewing.

Extensions opt in by adding the capability to their debugger contribution:

```json
{
    "type": "ark",
    "label": "R Debugger",
    "supportsFrameSelection": true
}
```

The DAP server should then watch for evaluate requests with the expression `.positron.selectedFrame` and use the `frameId` to update its notion of the "current" frame.


### Release Notes

#### New Features

- The Console is now synchronised with the selected stack frame when debugging R (https://github.com/posit-dev/positron/issues/3078). Selecting a frame in the Call Stack view updates the evaluation context in the Console, providing a GUI replacement for `base::recover()`.

#### Bug Fixes

- N/A


### QA Notes

This is tested on the backend-side but it would be nice to add basic E2E tests for the action of changing the selected frame and evaluating a local variable that only exists there. For instance with the following, you should be able to evaluate `my_g_local` when the top frame is selected (the default). After selecting `f`, `my_f_local` is now in scope in the Console.

```r
f <- function(my_f_local = "f") {
	g()
}
g <- function(my_g_local = "g") {
	browser()
}
f()
```

@:ark