### PR TITLE
Notebook unit testing infrastructure

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -8,7 +8,6 @@ import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { IObservable, IObservableSignal, ISettableObservable } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
-import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
 import { INotebookEditorOptions } from '../../../notebook/browser/notebookBrowser.js';
 import { NotebookPreloadOutputResults } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
 import { CellSelectionType } from '../selectionMachine.js';
@@ -238,7 +237,7 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	 *
 	 * @param editor Code editor widget associated with cell.
 	 */
-	attachEditor(editor: CodeEditorWidget): void;
+	attachEditor(editor: ICodeEditor): void;
 
 	/**
 	 * Detach the editor from the cell

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -14,7 +14,6 @@ import { NotebookCellTextModel } from '../../../notebook/common/model/notebookCe
 import { CellDecorationManager } from './CellDecorationManager.js';
 import { CellKind, NotebookCellExecutionState } from '../../../notebook/common/notebookCommon.js';
 import { IPositronNotebookCodeCell, IPositronNotebookCell, IPositronNotebookMarkdownCell, IPositronNotebookRawCell, CellSelectionStatus, ExecutionStatus, NotebookCellOutputs } from './IPositronNotebookCell.js';
-import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
 import { CellSelectionType } from '../selectionMachine.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
 import { derived, IObservable, IObservableSignal, observableFromEvent, observableSignal, observableValue } from '../../../../../base/common/observable.js';
@@ -226,7 +225,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		return this._container;
 	}
 
-	attachEditor(editor: CodeEditorWidget): void {
+	attachEditor(editor: ICodeEditor): void {
 		this._editor.set(editor, undefined);
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -34,10 +34,10 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 		cellModel: NotebookCellTextModel,
 		private instance: PositronNotebookInstance,
 		@INotebookExecutionStateService _executionStateService: INotebookExecutionStateService,
-		@ITextModelService _textModelResolverService: ITextModelService,
+		@ITextModelService _textModelService: ITextModelService,
 		@IPositronWebviewPreloadService private _webviewPreloadService: IPositronWebviewPreloadService,
 	) {
-		super(cellModel, instance, _executionStateService, _textModelResolverService);
+		super(cellModel, instance, _executionStateService, _textModelService);
 
 		// Initialize output collapse state from cell model if available
 		this._outputIsCollapsed = observableValue<boolean>(

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -276,7 +276,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 */
 	private _currentOperation: NotebookOperationType | undefined = undefined;
 
-	private _contributions = new Map<string, IPositronNotebookContribution>();
+	private readonly _contributions = this._register(new DisposableMap<string, IPositronNotebookContribution>());
 
 	/**
 	 * Observable list of deletion sentinels.

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.test.ts
@@ -26,8 +26,6 @@ suite('PositronNotebookCell', () => {
 
 			assert.strictEqual(cell.getContent(), editorModel.getValue(), 'Cell content should match editor model value');
 			assert.strictEqual(cell.model.textModel, editorModel, 'Cell model should be the editor model');
-			// eslint-disable-next-line local/code-no-any-casts
-			assert.strictEqual(cell.model.textBuffer, (editorModel as any)._buffer, 'Cell model should share text buffer with editor model');
 		});
 
 		test('setValue propagates through the content change event chain', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.test.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { CellKind, NotebookCellsChangeType } from '../../../notebook/common/notebookCommon.js';
+import { createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
+
+suite('PositronNotebookCell', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	/** Tests to ensure that the test harness is correctly setup, useful for debugging the test harness */
+	suite('Test Harness', () => {
+		test('cells have editors auto-attached', () => {
+			const notebook = disposables.add(createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]],
+			));
+
+			const cell = notebook.cells.get()[0];
+			assert.ok(cell.currentEditor, 'Cell should have an auto-attached editor');
+
+			const editorModel = cell.currentEditor.getModel();
+			assert.ok(editorModel, 'Cell editor should have a model');
+
+			assert.strictEqual(cell.getContent(), editorModel.getValue(), 'Cell content should match editor model value');
+			assert.strictEqual(cell.model.textModel, editorModel, 'Cell model should be the editor model');
+			// eslint-disable-next-line local/code-no-any-casts
+			assert.strictEqual(cell.model.textBuffer, (editorModel as any)._buffer, 'Cell model should share text buffer with editor model');
+		});
+
+		test('setValue propagates through the content change event chain', () => {
+			const notebook = disposables.add(createTestPositronNotebookInstance(
+				[['original content', 'python', CellKind.Code]],
+			));
+
+			const cell = notebook.cells.get()[0];
+			const notebookModel = notebook.textModel!;
+
+			// Link 1: NotebookCellTextModel fires onDidChangeContent when textModel changes
+			let cellContentFired = false;
+			disposables.add(cell.model.onDidChangeContent((e) => {
+				if (e === 'content' || (typeof e === 'object' && e.type === 'model')) {
+					cellContentFired = true;
+				}
+			}));
+
+			// Link 2: NotebookTextModel fires onDidChangeContent with ChangeCellContent
+			let notebookModelFired = false;
+			disposables.add(notebookModel.onDidChangeContent((e) => {
+				if (e.rawEvents.some(
+					event => event.kind === NotebookCellsChangeType.ChangeCellContent ||
+						event.kind === NotebookCellsChangeType.ModelChange)) {
+					notebookModelFired = true;
+				}
+			}));
+
+			cell.model.textModel!.setValue('new content');
+
+			assert.ok(cellContentFired, 'NotebookCellTextModel.onDidChangeContent should fire when textModel.setValue() is called');
+			assert.ok(notebookModelFired, 'NotebookTextModel.onDidChangeContent should fire when textModel.setValue() is called');
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookInstance.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookInstance.test.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
+import { CellKind } from '../../../notebook/common/notebookCommon.js';
+
+suite('PositronNotebookInstance', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	/** Tests to ensure that the test harness is correctly setup, useful for debugging the test harness */
+	suite('Test Harness', () => {
+		test('notebook has cells from notebook text model', () => {
+			const notebook = disposables.add(createTestPositronNotebookInstance(
+				[
+					['print("hello")', 'python', CellKind.Code],
+					['print("world")', 'python', CellKind.Code],
+				],
+			));
+
+			const cells = notebook.cells.get();
+			assert.strictEqual(cells.length, 2, 'Unexpected number of cells in notebook');
+			assert.strictEqual(cells[0].model.getValue(), 'print("hello")', 'Unexpected content for notebook cell 0');
+			assert.strictEqual(cells[1].model.getValue(), 'print("world")', 'Unexpected content for notebook cell 1');
+
+			const { textModel } = notebook;
+			assert.ok(textModel, 'Notebook should have a text model');
+			assert.strictEqual(textModel.cells[0].getValue(), 'print("hello")', 'Unexpected content for text model cell 0');
+			assert.strictEqual(textModel.cells[1].getValue(), 'print("world")', 'Unexpected content for text model cell 1');
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/testPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/testPositronNotebookInstance.ts
@@ -1,0 +1,196 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, DisposableStore, IDisposable } from '../../../../../base/common/lifecycle.js';
+import { autorun } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { ICellDto2 } from '../../../notebook/common/notebookCommon.js';
+import { NotebookTextModel } from '../../../notebook/common/model/notebookTextModel.js';
+import { MockNotebookCell } from '../../../notebook/test/browser/testNotebookEditor.js';
+import { IPositronNotebookCell } from '../../browser/PositronNotebookCells/IPositronNotebookCell.js';
+import { PositronNotebookInstance } from '../../browser/PositronNotebookInstance.js';
+import { positronWorkbenchInstantiationService } from '../../../../test/browser/positronWorkbenchTestServices.js';
+import { instantiateTestCodeEditor } from '../../../../../editor/test/browser/testCodeEditor.js';
+import { ITextBuffer, ITextBufferFactory, ITextModel } from '../../../../../editor/common/model.js';
+import { ICodeEditorService } from '../../../../../editor/browser/services/codeEditorService.js';
+import { TestCodeEditorService } from '../../../../../editor/test/browser/editorTestServices.js';
+import { IEditorWorkerService } from '../../../../../editor/common/services/editorWorker.js';
+import { TestEditorWorkerService } from '../../../../../editor/test/common/services/testEditorWorkerService.js';
+import { ILanguageFeatureDebounceService, LanguageFeatureDebounceService } from '../../../../../editor/common/services/languageFeatureDebounce.js';
+import { ILanguageFeaturesService } from '../../../../../editor/common/services/languageFeatures.js';
+import { LanguageFeaturesService } from '../../../../../editor/common/services/languageFeaturesService.js';
+import { ITreeSitterLibraryService } from '../../../../../editor/common/services/treeSitter/treeSitterLibraryService.js';
+import { TestTreeSitterLibraryService } from '../../../../../editor/test/common/services/testTreeSitterLibraryService.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { IModelService } from '../../../../../editor/common/services/model.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { PLAINTEXT_LANGUAGE_ID } from '../../../../../editor/common/languages/modesRegistry.js';
+
+/**
+ * Test subclass of PositronNotebookInstance that exposes disposable registration.
+ * This allows test infrastructure to register disposables (editors, text models, etc.)
+ * with the notebook's lifecycle.
+ */
+export class TestPositronNotebookInstance extends PositronNotebookInstance {
+	testInstantiationService!: TestInstantiationService;
+
+	registerDisposable(disposable: IDisposable): void {
+		this._register(disposable);
+	}
+}
+
+/**
+ * Creates an instantiation service for Positron notebook tests.
+ * Extends positronWorkbenchInstantiationService with editor services
+ * required for attaching TestCodeEditor instances to cells.
+ *
+ * Exported so that multi-instance tests can share a single service
+ * (avoiding disposable-tracking conflicts from duplicate global singletons).
+ */
+export function positronNotebookInstantiationService(
+	disposables: DisposableStore
+): TestInstantiationService {
+	const instantiationService = positronWorkbenchInstantiationService(disposables);
+
+	// Add editor services required for TestCodeEditor
+	instantiationService.stub(ICodeEditorService, disposables.add(instantiationService.createInstance(TestCodeEditorService)));
+	instantiationService.stub(IEditorWorkerService, new TestEditorWorkerService());
+	instantiationService.stub(ILanguageFeatureDebounceService, instantiationService.createInstance(LanguageFeatureDebounceService));
+	instantiationService.stub(ILanguageFeaturesService, new LanguageFeaturesService());
+	instantiationService.stub(ITreeSitterLibraryService, new TestTreeSitterLibraryService());
+
+	return instantiationService;
+}
+
+let nextInstanceId = 0;
+
+/**
+ * Converts a MockNotebookCell tuple to ICellDto2 format for NotebookTextModel.
+ */
+function cellToDto(cell: MockNotebookCell): ICellDto2 {
+	const [source, language, cellKind, outputs, metadata] = cell;
+	return {
+		source,
+		mime: undefined,
+		language,
+		cellKind,
+		outputs: outputs || [],
+		metadata: metadata || {},
+		internalMetadata: {},
+	};
+}
+
+/**
+ * Convenience function: creates both the instantiation service and the notebook
+ * instance. Use this for single-instance tests.
+ *
+ * For multi-instance tests (where two notebooks must coexist), create a shared
+ * service with {@link positronNotebookInstantiationService} and call
+ * {@link instantiateTestNotebookInstance} directly.
+ */
+export function createTestPositronNotebookInstance(
+	cells: MockNotebookCell[],
+): TestPositronNotebookInstance {
+	const disposables = new DisposableStore();
+	const instantiationService = positronNotebookInstantiationService(disposables);
+	const notebook = instantiateTestNotebookInstance(cells, instantiationService, disposables);
+	return notebook;
+}
+
+/**
+ * Lower-level factory: creates a PositronNotebookInstance using an existing
+ * instantiation service. Editors are automatically attached to all cells
+ * (initial and dynamically added).
+ *
+ * @param cells Array of cell data in shorthand format
+ * @param instantiationService Pre-built service (from {@link positronNotebookInstantiationService})
+ * @param disposables Store that owns service-lifetime disposables; the notebook
+ *                    takes ownership via {@link TestPositronNotebookInstance.registerDisposable}.
+ */
+export function instantiateTestNotebookInstance(
+	cells: MockNotebookCell[],
+	instantiationService: TestInstantiationService,
+	disposables: DisposableStore,
+): TestPositronNotebookInstance {
+	// Create the notebook instance with a unique ID and URI so multiple
+	// instances can coexist in the same ModelService without collisions.
+	const id = nextInstanceId++;
+	const viewType = 'jupyter-notebook';
+	const uri = URI.parse(`test:///test/notebook-${id}.ipynb`);
+	const notebook = instantiationService.createInstance(
+		TestPositronNotebookInstance,
+		`test-instance-${id}`,
+		uri,
+		viewType,
+		undefined, // creationOptions
+	);
+	notebook.testInstantiationService = instantiationService;
+	notebook.registerDisposable(disposables);
+
+	// Attach view with DOM containers
+	const editorContainer = document.createElement('div');
+	const notebookContainer = document.createElement('div');
+	const overlayContainer = document.createElement('div');
+	editorContainer.appendChild(notebookContainer);
+	editorContainer.appendChild(overlayContainer);
+	const scopedContextKeyService = instantiationService.get(IContextKeyService).createScoped(editorContainer);
+	notebook.attachView(editorContainer, scopedContextKeyService, notebookContainer, overlayContainer);
+
+	// Create the notebook text model directly
+	const cellDtos = cells.map((cell) => cellToDto(cell));
+	const model = disposables.add(instantiationService.createInstance(
+		NotebookTextModel,
+		viewType,
+		uri,
+		cellDtos,
+		{}, // metadata
+		{
+			transientCellMetadata: {},
+			transientDocumentMetadata: {},
+			cellContentMetadata: {},
+			transientOutputs: false,
+		}
+	));
+	notebook.setModel(model);
+
+	// Auto-attach test editors to all cells (initial and dynamically added).
+	// This mirrors what React's CellEditorMonacoWidget does in production.
+	const attachedCells = new WeakSet<IPositronNotebookCell>();
+	notebook.registerDisposable(autorun(reader => {
+		const currentCells = notebook.cells.read(reader);
+		for (const cell of currentCells) {
+			if (!attachedCells.has(cell)) {
+				attachedCells.add(cell);
+				const textModel = disposables.add(instantiationService.invokeFunction(createTestNotebookCellTextModel, cell));
+				const editor = disposables.add(instantiateTestCodeEditor(instantiationService, textModel));
+				cell.attachEditor(editor);
+				// NotebookTextModel.onModelAdded automatically sets cell.model.textModel = textModel
+			}
+		}
+	}));
+
+	return notebook;
+}
+
+function createTestNotebookCellTextModel(accessor: ServicesAccessor, cell: IPositronNotebookCell): ITextModel {
+	// Create text model directly from cell's textBuffer.
+	const modelService = accessor.get(IModelService);
+	const languageService = accessor.get(ILanguageService);
+	const languageSelection = languageService.createById(
+		languageService.getLanguageIdByLanguageName(cell.model.language) ?? PLAINTEXT_LANGUAGE_ID
+	);
+
+	const bufferFactory: ITextBufferFactory = {
+		create: (_defaultEOL) => ({
+			textBuffer: cell.model.textBuffer as ITextBuffer,
+			disposable: Disposable.None,
+		}),
+		getFirstLineText: (limit: number) =>
+			cell.model.textBuffer.getLineContent(1).substring(0, limit),
+	};
+	return modelService.createModel(bufferFactory, languageSelection, cell.uri);
+}

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -74,6 +74,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 		super.dispose();
 		// Clean up disposables linked to any connected sessions
 		this._sessionToDisposablesMap.forEach(disposables => disposables.dispose());
+		this._notebookToDisposablesMap.forEach(disposables => disposables.dispose());
 	}
 
 	sessionInfo(sessionId: string) {

--- a/src/vs/workbench/test/browser/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/positronWorkbenchTestServices.ts
@@ -55,6 +55,8 @@ import { ILanguageService } from '../../../editor/common/languages/language.js';
 import { IRuntimeNotebookKernelService } from '../../contrib/runtimeNotebookKernel/common/interfaces/runtimeNotebookKernelService.js';
 import { RuntimeNotebookKernelService } from '../../contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.js';
 import { IPositronNotebookService, PositronNotebookService } from '../../contrib/positronNotebook/browser/positronNotebookService.js';
+import { INotebookLoggingService } from '../../contrib/notebook/common/notebookLoggingService.js';
+import { NotebookLoggingService } from '../../contrib/notebook/browser/services/notebookLoggingServiceImpl.js';
 
 export function positronWorkbenchInstantiationService(
 	disposables: Pick<DisposableStore, 'add'> = new DisposableStore(),
@@ -80,6 +82,7 @@ export function positronWorkbenchInstantiationService(
 	instantiationService.stub(INotebookDocumentService, new NotebookDocumentWorkbenchService());
 	instantiationService.stub(INotebookService, disposables.add(instantiationService.createInstance(NotebookService)));
 	instantiationService.stub(INotebookKernelService, disposables.add(instantiationService.createInstance(NotebookKernelService)));
+	instantiationService.stub(INotebookLoggingService, disposables.add(instantiationService.createInstance(NotebookLoggingService)));
 
 	// Positron services.
 	instantiationService.stub(IEphemeralStateService, instantiationService.createInstance(EphemeralStateService));


### PR DESCRIPTION
This PR adds a test harness for `PositronNotebookInstance` and a few initial tests that were useful to debug the test harness. Addresses #10000.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:positron-notebooks @:web

Nothing should break. Unit tests should pass:

```sh
./scripts/test.sh --runGlob '**/positronNotebook/**/*.test.js'
```