### PR TITLE
python LS: more tiny speedups

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_lsp.py
@@ -508,9 +508,12 @@ def _handle_completion(
     text_after_cursor = line[params.position.character :]
 
     # Check for parameter completion first (e.g., inside a function call like "f(")
-    param_items, inside_function_call = _get_parameter_completions(server, text_before_cursor)
-    if param_items:
-        items.extend(param_items)
+    if "(" in text_before_cursor:
+        param_items, inside_function_call = _get_parameter_completions(server, text_before_cursor)
+        if param_items:
+            items.extend(param_items)
+    else:
+        inside_function_call = False
 
     # Check for dict key access pattern (e.g., x[" or x[')
     # This includes DataFrame column access and environment variables

--- a/extensions/positron-python/python_files/posit/positron/positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_lsp.py
@@ -32,6 +32,7 @@ import re
 import threading
 from functools import lru_cache
 from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Callable, Generator, Optional
 
 from ._vendor import attrs, cattrs
@@ -142,7 +143,8 @@ def _safe_resolve_expression(namespace: dict[str, Any], expr: str) -> Any | None
         return None
 
 
-def _parse_os_imports(source: str) -> dict[str, str]:
+@lru_cache(maxsize=32)
+def _parse_os_imports(source: str) -> MappingProxyType[str, str]:
     """
     Parse import statements to find os module imports.
 
@@ -150,10 +152,12 @@ def _parse_os_imports(source: str) -> dict[str, str]:
     Only supports `import os` and `import os as <alias>` forms.
     Does NOT support `from os import ...` (out of scope).
 
-    Returns empty dict if source is empty, invalid, or has no os imports.
+    Returns empty mapping if source is empty, invalid, or has no os imports.
+
+    The return value is immutable (MappingProxyType) since results are cached.
     """
     if not source or not source.strip():
-        return {}
+        return MappingProxyType({})
 
     imports: dict[str, str] = {}
 
@@ -166,7 +170,7 @@ def _parse_os_imports(source: str) -> dict[str, str]:
                     if alias.name == "os":
                         key = alias.asname or "os"
                         imports[key] = "os"
-        return imports
+        return MappingProxyType(imports)
     except SyntaxError:
         pass
 
@@ -188,7 +192,7 @@ def _parse_os_imports(source: str) -> dict[str, str]:
         except SyntaxError:
             continue
 
-    return imports
+    return MappingProxyType(imports)
 
 
 def _get_expression_at_position(line: str, character: int) -> str:

--- a/extensions/positron-python/python_files/posit/positron/positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_lsp.py
@@ -1518,6 +1518,7 @@ def _handle_signature_help(
 
     # Get signature - handle builtins which may not have introspectable signatures
     sig_str = None
+    doc = None
     params_list = []
     try:
         sig = inspect.signature(obj)
@@ -1552,7 +1553,8 @@ def _handle_signature_help(
         if not sig_str:
             return None
 
-    doc = inspect.getdoc(obj)
+    if doc is None:
+        doc = inspect.getdoc(obj)
     signature_info = types.SignatureInformation(
         label=f"{func_name}{sig_str}",
         documentation=doc,

--- a/extensions/positron-python/python_files/posit/positron/positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_lsp.py
@@ -508,12 +508,9 @@ def _handle_completion(
     text_after_cursor = line[params.position.character :]
 
     # Check for parameter completion first (e.g., inside a function call like "f(")
-    param_items = _get_parameter_completions(server, text_before_cursor)
+    param_items, inside_function_call = _get_parameter_completions(server, text_before_cursor)
     if param_items:
         items.extend(param_items)
-
-    # Determine if we're inside a function call
-    inside_function_call = bool(param_items) or _is_inside_function_call(text_before_cursor)
 
     # Check for dict key access pattern (e.g., x[" or x[')
     # This includes DataFrame column access and environment variables
@@ -573,55 +570,47 @@ def _handle_completion(
     return types.CompletionList(is_incomplete=False, items=items) if items else None
 
 
-def _is_inside_function_call(text_before_cursor: str) -> bool:
-    """Check if the cursor is inside a function call (after an opening parenthesis)."""
-    # Count unmatched opening parentheses
-    paren_depth = 0
-    for c in text_before_cursor:
-        if c == "(":
-            paren_depth += 1
-        elif c == ")":
-            paren_depth -= 1
-    return paren_depth > 0
-
-
 def _get_parameter_completions(
     server: PositronLanguageServer, text_before_cursor: str
-) -> list[types.CompletionItem]:
-    """Get parameter completions when inside a function call."""
+) -> tuple[list[types.CompletionItem], bool]:
+    """Get parameter completions when inside a function call.
+
+    Returns (items, inside_function_call) where inside_function_call
+    indicates whether the cursor is inside an enclosing parenthesis.
+    """
     if server.shell is None:
-        return []
+        return [], False
 
     # Find if we're inside a function call
     func_end = _find_enclosing_paren(text_before_cursor)
     if func_end < 0:
-        return []
+        return [], False
 
     # Extract function name/expression
     func_expr = text_before_cursor[:func_end].rstrip()
     match = re.search(r"([\w\.]+)$", func_expr)
     if not match:
-        return []
+        return [], True
 
     func_name = match.group(1)
 
     # Safely resolve the callable
     obj = _safe_resolve_expression(server.shell.user_ns, func_name)
     if obj is None or not callable(obj):
-        return []
+        return [], True
 
     # Parse arguments section to understand context
     args_text = text_before_cursor[func_end + 1 :]
 
     # Skip parameter completions if we're inside a string literal
     if _is_inside_string(args_text):
-        return []
+        return [], True
 
     # Check if cursor is right after an "=" sign (meaning we're typing a value, not a parameter name)
     # Pattern: look for "word=" at the end, possibly with a value started
     if re.search(r"\w+\s*=\s*[^\s,]*$", args_text) and not args_text.rstrip().endswith(","):
         # Cursor is positioned after "=" where a value should go, don't suggest parameters
-        return []
+        return [], True
 
     # Find all keyword arguments already provided (param=value)
     already_provided = set()
@@ -669,7 +658,7 @@ def _get_parameter_completions(
         # Can't get signature for this callable
         pass
 
-    return items
+    return items, True
 
 
 def _get_namespace_completions(


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11550. Here are 4 more small speedups:

1. `_parse_os_imports()` calls `ast.parse()` on the full document source, which used to happen up to twice per keystroke (from `_get_dict_key_completions()` and `_get_getenv_completions()`). I added a `lru_cache` decorator, and made its return value immutable for safety.
2. During completions, skip the `_get_parameter_completions()` check if there's no `(` character before the cursor.
3. Changed `_get_parameter_completions()` to also return whether we're inside parentheses, so we only have to scan the line once instead of twice.
4. Only call `inspect.getdoc()` once instead of twice when e.g. requesting signature help for builtins.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Existing LSP completions (dict key access, attribute access, parameter completions, magic commands, path completions, signature help) should all work identically. Hopefully a bit faster too.