### PR TITLE
new folder: suppress session creation during init tasks

### DIFF
--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -135,7 +135,9 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 				if (newKernel) {
 					// Kernel is registered, start the session
 					this.updateNotebookLanguage(e.notebook, newKernel.runtime.languageId);
-					await newKernel.ensureSessionStarted(e.notebook, `Runtime kernel ${newKernel.id} selected for notebook`);
+					if (!this._runtimeSessionService.implicitStartupSuppressed) {
+						await newKernel.ensureSessionStarted(e.notebook, `Runtime kernel ${newKernel.id} selected for notebook`);
+					}
 				} else {
 					// Our kernel but not registered yet - defer processing until runtime registers
 					this._logService.info(
@@ -412,7 +414,7 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 		// Get the selected kernel
 		const kernel = instance.kernel.get();
 
-		if (kernel) {
+		if (kernel && !this._runtimeSessionService.implicitStartupSuppressed) {
 			// Ensure a session is started for the kernel
 			await kernel.ensureSessionStarted(instance.uri, `Positron notebook editor opened`);
 		}

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
@@ -78,7 +78,9 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 						`[RuntimeNotebookKernelService] Processing deferred kernel selection for ${kernelId}`
 					);
 					this._pendingKernelSelections.delete(notebookUri);
-					await kernel.ensureSessionStarted(notebookUri, 'Deferred kernel selection after runtime registration');
+					if (!this._runtimeSessionService.implicitStartupSuppressed) {
+						await kernel.ensureSessionStarted(notebookUri, 'Deferred kernel selection after runtime registration');
+					}
 				}
 			}
 		}));

--- a/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
+++ b/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -115,6 +115,7 @@ class TestRuntimeSessionService implements IRuntimeSessionService {
 	readonly onDidStartUiClient = this._onDidStartUiClient.event;
 
 	foregroundSession: ILanguageRuntimeSession | undefined;
+	implicitStartupSuppressed = false;
 
 	async updateNotebookSessionUri(oldUri: URI, newUri: URI): Promise<string | undefined> {
 		return undefined;

--- a/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
+++ b/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
@@ -258,15 +258,17 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 	private async _runExtensionTasks() {
 		// TODO: it would be nice to run these tasks in parallel!
 
-		// Run git init first if needed.
+		// First, create the new empty file since this is a quick task.
+		if (this.pendingInitTasks.has(NewFolderTask.CreateNewFile)) {
+			await this._runCreateNewFile();
+		}
+
+		// Next, run git init if needed.
 		if (this.pendingInitTasks.has(NewFolderTask.Git)) {
 			await this._runGitInit();
 		}
 
-		// Run language-specific tasks (e.g. creating venvs) before opening
-		// any files. Opening a language file triggers implicit runtime
-		// auto-start via onDidRequestRichLanguageFeatures, so the
-		// environment must exist first.
+		// Next, run language-specific tasks which may take a bit more time.
 		if (this.pendingInitTasks.has(NewFolderTask.Python)) {
 			await this._runPythonTasks();
 		}
@@ -275,11 +277,6 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 		}
 		if (this.pendingInitTasks.has(NewFolderTask.R)) {
 			await this._runRTasks();
-		}
-
-		// Create the new file last, after the environment is ready.
-		if (this.pendingInitTasks.has(NewFolderTask.CreateNewFile)) {
-			await this._runCreateNewFile();
 		}
 	}
 

--- a/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
+++ b/src/vs/workbench/services/positronNewFolder/common/positronNewFolderService.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -86,6 +86,7 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 			this.onDidChangeNewFolderStartupPhase((phase) => {
 				switch (phase) {
 					case NewFolderStartupPhase.RuntimeStartup:
+						this._runtimeSessionService.implicitStartupSuppressed = false;
 						this.initTasksComplete.open();
 						break;
 					case NewFolderStartupPhase.PostInitialization:
@@ -94,6 +95,7 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 					case NewFolderStartupPhase.Complete:
 						// Open both the init and post-init task barriers because some new folders
 						// do not have a runtime startup phase (e.g. Empty Project).
+						this._runtimeSessionService.implicitStartupSuppressed = false;
 						this.initTasksComplete.open();
 						this.postInitTasksComplete.open();
 						break;
@@ -116,6 +118,10 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 			// If new folder configuration is found, save the runtime metadata.
 			// This metadata will be overwritten if a new environment is created.
 			this._runtimeMetadata = this._newFolderConfig?.runtimeMetadata;
+
+			// Suppress implicit auto-start to prevent starting the wrong
+			// runtime before the new folder's environment is ready.
+			this._runtimeSessionService.implicitStartupSuppressed = true;
 		}
 
 		// Initialize the pending tasks observable.
@@ -212,7 +218,19 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 			undefined
 		);
 		if (this._newFolderConfig) {
-			await this._runExtensionTasks();
+			try {
+				await this._runExtensionTasks();
+			} catch (error) {
+				this._logService.error(
+					'[New folder startup] Error running extension tasks:',
+					error
+				);
+				this._startupPhase.set(
+					NewFolderStartupPhase.Complete,
+					undefined
+				);
+				return;
+			}
 
 			// For folders that do not require a runtime startup phase, we set the startup phase to Complete.
 			if (this._newFolderConfig.folderTemplate === FolderTemplate.EmptyProject ||
@@ -240,17 +258,15 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 	private async _runExtensionTasks() {
 		// TODO: it would be nice to run these tasks in parallel!
 
-		// First, create the new empty file since this is a quick task.
-		if (this.pendingInitTasks.has(NewFolderTask.CreateNewFile)) {
-			await this._runCreateNewFile();
-		}
-
-		// Next, run git init if needed.
+		// Run git init first if needed.
 		if (this.pendingInitTasks.has(NewFolderTask.Git)) {
 			await this._runGitInit();
 		}
 
-		// Next, run language-specific tasks which may take a bit more time.
+		// Run language-specific tasks (e.g. creating venvs) before opening
+		// any files. Opening a language file triggers implicit runtime
+		// auto-start via onDidRequestRichLanguageFeatures, so the
+		// environment must exist first.
 		if (this.pendingInitTasks.has(NewFolderTask.Python)) {
 			await this._runPythonTasks();
 		}
@@ -259,6 +275,11 @@ export class PositronNewFolderService extends Disposable implements IPositronNew
 		}
 		if (this.pendingInitTasks.has(NewFolderTask.R)) {
 			await this._runRTasks();
+		}
+
+		// Create the new file last, after the environment is ready.
+		if (this.pendingInitTasks.has(NewFolderTask.CreateNewFile)) {
+			await this._runCreateNewFile();
 		}
 	}
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -149,6 +149,9 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		this._register(new Emitter<{ sessionId: string; uiClient: UiClientInstance }>());
 
 
+	// When true, suppresses implicit runtime auto-start from file-open events.
+	private _implicitStartupSuppressed = false;
+
 	// The dialog prompt instance for the modal wait prompt.
 	private _modalWaitPrompt: IModalDialogPromptInstance | undefined = undefined;
 
@@ -184,6 +187,17 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			// If a runtime for the language is already starting or running,
 			// there is no need to check for implicit startup below.
 			if (this.hasStartingOrRunningConsole(languageId)) {
+				return;
+			}
+
+			// Don't auto-start a runtime when implicit startup is suppressed.
+			// This prevents starting the wrong runtime during new folder
+			// initialization, before the intended environment is ready.
+			if (this._implicitStartupSuppressed) {
+				this._logService.debug(
+					`Skipping implicit auto-start for language '${languageId}' ` +
+					`because implicit startup is suppressed.`
+				);
 				return;
 			}
 
@@ -831,6 +845,14 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 */
 	get foregroundSession(): ILanguageRuntimeSession | undefined {
 		return this._foregroundSession;
+	}
+
+	get implicitStartupSuppressed(): boolean {
+		return this._implicitStartupSuppressed;
+	}
+
+	set implicitStartupSuppressed(value: boolean) {
+		this._implicitStartupSuppressed = value;
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -619,6 +619,14 @@ export interface IRuntimeSessionService {
 	 * @returns An `IDisposable` to clean up the event handler.
 	 */
 	watchUiClient(sessionId: string, handler: (uiClient: UiClientInstance) => void): IDisposable;
+
+	/**
+	 * When true, suppresses implicit runtime auto-start triggered by
+	 * opening files with a matching language ID. Used during new folder
+	 * initialization to prevent starting the wrong runtime before the
+	 * intended environment is ready.
+	 */
+	implicitStartupSuppressed: boolean;
 }
 
 export { RuntimeClientType };

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -325,11 +325,13 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			// - The runtime has implicit startup behavior.
 			// - There's no runtime affiliated with the current workspace for this
 			//   language (if there is, we want that runtime to start, not this one)
+			// - Implicit startup is not suppressed (e.g. during new folder init)
 			else if (this._encounteredLanguagesByLanguageId.has(runtime.languageId) &&
 				this._startupPhase === RuntimeStartupPhase.Complete &&
 				!this._runtimeSessionService.hasStartingOrRunningConsole(runtime.languageId) &&
 				runtime.startupBehavior === LanguageRuntimeStartupBehavior.Implicit &&
-				!this.getAffiliatedRuntimeMetadata(runtime.languageId)) {
+				!this.getAffiliatedRuntimeMetadata(runtime.languageId) &&
+				!this._runtimeSessionService.implicitStartupSuppressed) {
 
 				this.autoStartRuntime(runtime,
 					`A file with the language ID ${runtime.languageId} was open ` +

--- a/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
+++ b/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -64,13 +64,13 @@ export async function verifyCondaFilesArePresent(app: Application) {
 
 export async function verifyCondaEnvStarts(app: Application) {
 	await test.step('Verify conda environment starts', async () => {
-		await app.workbench.console.waitForConsoleContents(/(Conda).*started/);
+		await app.workbench.console.waitForConsoleContents(/\(Conda: .+\) started/);
 	});
 }
 
 export async function verifyVenvEnvStarts(app: Application) {
 	await test.step('Verify venv environment starts', async () => {
-		await app.workbench.console.waitForConsoleContents('(Venv: .venv) started.');
+		await app.workbench.console.waitForConsoleContents(/\(Venv: .+\) started/);
 	});
 }
 
@@ -79,7 +79,7 @@ export async function verifyUvEnvStarts(app: Application) {
 		if (/(8080)/.test(app.code.driver.page.url())) {
 			app.code.driver.page.getByRole('button', { name: 'Yes' }).click();
 		}
-		await app.workbench.console.waitForConsoleContents(/(Uv: .+) started./);
+		await app.workbench.console.waitForConsoleContents(/\(Uv: .+\) started/);
 	});
 }
 

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts
@@ -13,7 +13,6 @@ test.use({
 
 // Not running conda test on windows because conda reeks havoc on selecting the correct python interpreter
 test.describe('New Folder Flow: Python Project', {
-	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/9999' }],
 	tag: [tags.MODAL, tags.NEW_FOLDER_FLOW, tags.WEB]
 }, () => {
 	const folderTemplate = FolderTemplate.PYTHON_PROJECT;

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-python.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -12,7 +12,7 @@ test.use({
 });
 
 // Not running conda test on windows because conda reeks havoc on selecting the correct python interpreter
-test.describe.skip('New Folder Flow: Python Project', {
+test.describe('New Folder Flow: Python Project', {
 	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/9999' }],
 	tag: [tags.MODAL, tags.NEW_FOLDER_FLOW, tags.WEB]
 }, () => {


### PR DESCRIPTION
Addresses #9999.

This PR fixes a race condition where the wrong Python runtime could start during new folder initialization. Opening a `.py` file triggers implicit runtime auto-start via `onDidRequestRichLanguageFeatures`, but this was happening before the intended environment was ready.

In addition to #9999, in recent months I feel like I've sometimes been seeing two Python consoles open during the New Folder flow. I never opened an issue for it. But this PR seems to fix that too. I think it was another symptom of this race condition, honestly.

### Changes

1. Add `implicitStartupSuppressed` flag to `RuntimeSessionService` to temporarily block implicit runtime auto-start
2. Suppress implicit startup during new folder initialization until the environment is ready
3. Unskip and fix the Python new folder flow e2e tests

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix condition where wrong Python runtime could start during new folder initialization (#9999)

### QA Notes

@:new-folder-flow @:web

1. Create a new Python folder from template
2. Select "Create new venv" (or conda/uv)
3. Verify that the console starts with the correct environment interpreter, not a system Python

The venv should be fully created before the console starts.
