### PR TITLE
Fix packages pane horizontal scrolling

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -37,6 +37,23 @@
 	display: flex;
 	align-items: center;
 	cursor: pointer;
+	overflow: hidden;
+}
+
+.packages-list-item-name {
+	flex: 0 0 auto;
+	white-space: nowrap;
+}
+
+.packages-list-item-version {
+	flex: 0 1 auto;
+	min-width: 0;
+	opacity: 0.7;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	font-size: 0.9em;
+	margin-left: 0.5em;
 }
 
 .packages-list-item:hover {
@@ -53,11 +70,4 @@
 .positron-packages-list.focused .packages-list-item.selected {
 	color: var(--vscode-list-activeSelectionForeground);
 	background: var(--vscode-list-activeSelectionBackground);
-}
-
-.packages-list-item .description {
-	opacity: 0.7;
-	white-space: nowrap;
-	font-size: 0.9em;
-	margin-left: 0.5em;
 }

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -269,8 +269,8 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 					}
 				}}
 			>
-				<div>{displayName}</div>
-				<div className='description'>{version}</div>
+				<div className='packages-list-item-name'>{displayName}</div>
+				<div className='packages-list-item-version'>{version}</div>
 			</div >
 		);
 	};


### PR DESCRIPTION
Prevent horizontal scrolling in the packages pane by:
- Adding overflow: hidden to the list item container
- Keeping package name at full width (never truncates)
- Allowing version to shrink and truncate with ellipsis
- Using explicit class names for name and version elements

See #11929 

<img width="228" height="173" alt="Screenshot 2026-02-18 at 4 45 08 PM" src="https://github.com/user-attachments/assets/bcb5c184-b7f1-407c-ba2f-443fcd1587ff" />
<img width="225" height="303" alt="Screenshot 2026-02-18 at 4 45 00 PM" src="https://github.com/user-attachments/assets/1e329447-9070-4e25-b473-6c3a6a618826" />
