### PR TITLE
e2e: databot test robustness fix, waiting for databot to load

### DIFF
--- a/test/e2e/infra/electron.ts
+++ b/test/e2e/infra/electron.ts
@@ -34,7 +34,8 @@ export async function resolveElectronConfiguration(options: LaunchOptions): Prom
 		'--disable-updates',
 		`--crash-reporter-directory=${crashesPath}`,
 		'--disable-workspace-trust',
-		`--logsPath=${logsPath}`
+		`--logsPath=${logsPath}`,
+		`--log=trace`,
 	];
 	if (options.useInMemorySecretStorage) {
 		args.push('--use-inmemory-secretstorage');

--- a/test/e2e/pages/databot.ts
+++ b/test/e2e/pages/databot.ts
@@ -87,6 +87,8 @@ export class Databot {
 	 */
 	async waitForReady(timeout: number = 30000): Promise<void> {
 		await expect(this.frame.locator(CHAT_INPUT)).toBeVisible({ timeout });
+		await expect(this.frame.locator(SEND_BUTTON)).toBeVisible({ timeout });
+		await expect(this.frame.locator(STOP_BUTTON)).not.toBeVisible({ timeout });
 	}
 
 	/**
@@ -274,7 +276,7 @@ export class Databot {
 			return;
 		}
 		await button.click();
-		await expect(this.frame.locator(CHAT_INPUT)).toBeVisible();
+		await this.waitForReady();
 	}
 
 	/**


### PR DESCRIPTION
Databot tests occasionally failed due to some timing issues, this shouls make it a littel more robuts

- waitForReady now also checks that the send button is visible and the stop button is hidden, ensuring Databot is
  fully idle before tests proceed
- startNewConversation reuses waitForReady instead of duplicating a partial check

I also changed the default logging to trace. As this test sometimes fails and we need the databot trace logs to investigate. If this proves to slow things down, we can pull it out.

##  QA Notes
@:databot
