### PR TITLE
Fix assistant not using getTableSummary tool with Sonnet models

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -1109,7 +1109,7 @@
       {
         "name": "getTableSummary",
         "displayName": "Get Table Summary",
-        "modelDescription": "Get structured information about table variables in the current session.",
+        "modelDescription": "Retrieve summary statistics and structure of tabular data variables (DataFrames, tibbles, arrays) in the current session. Use when the user asks to summarize, describe, or inspect their data.",
         "canBeReferencedInPrompt": true,
         "toolReferenceName": "getTableSummary",
         "userDescription": "Get a summary of a table's data and structure.",

--- a/extensions/positron-assistant/src/md/prompts/chat/ask.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/ask.md
@@ -15,5 +15,5 @@ The code blocks are shown to the user, but the code is not executed unless the U
 If your response requires the results of executing a code block, STOP. Explain to the user what the code will do and end your response.
 Do not offer to run the code for the user.
 
-You NEVER try to summarise, present statistics or insights, or comment on the result of executing code blocks.
+You NEVER try to summarise or comment on the result of executing code blocks. You may present results from tool calls.
 </communication>

--- a/extensions/positron-assistant/src/md/prompts/chat/ask.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/ask.md
@@ -15,5 +15,7 @@ The code blocks are shown to the user, but the code is not executed unless the U
 If your response requires the results of executing a code block, STOP. Explain to the user what the code will do and end your response.
 Do not offer to run the code for the user.
 
-You NEVER try to summarise or comment on the result of executing code blocks. You may present results from tool calls.
+You NEVER try to summarise or comment on the result of executing code blocks.
+You may present information returned by tools you have invoked, but do not
+fabricate or extrapolate beyond the tool's output.
 </communication>

--- a/extensions/positron-assistant/src/md/prompts/chat/edit.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/edit.md
@@ -12,7 +12,9 @@ If you've suggested some code to run and writing further code would require the 
 
 Do not offer to run the code for the user.
 
-You NEVER try to summarise, present statistics or insights, or comment on the result of executing code blocks.
+You NEVER try to summarise or comment on the result of executing code blocks.
+You may present information returned by tools you have invoked, but do not
+fabricate or extrapolate beyond the tool's output.
 
 Prefer using the file editing tools to apply changes directly instead of showing code blocks.
 </communication>

--- a/extensions/positron-assistant/src/md/prompts/chat/tools.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/tools.md
@@ -11,5 +11,5 @@ We will provide you with a collection of tools to interact with the current Posi
 
 The USER can see when you invoke a tool, so you do not need to tell the user or mention the name of tools when you use them.
 
-You much prefer to respond to the USER with code to perform a data analysis, rather than directly trying to calculate summaries or statistics for your response.
+When a specialized tool can answer the user's question, prefer it over generating code.
 </tools>


### PR DESCRIPTION
Addresses #11575.

Updates the assistant prompts and tool description to guide Sonnet models toward using the `getTableSummary` tool when users ask to summarize or describe their data. Three changes:

1. **Improved `getTableSummary` model description** (`package.json`): Expanded from a generic description to explicitly mention summary statistics, data types (DataFrames, tibbles, arrays), and trigger phrases like "summarize", "describe", or "inspect".
2. **Relaxed ask-mode restriction** (`ask.md`): The prior prompt told the model to "NEVER try to summarise, present statistics or insights". This inadvertently discouraged tool use. Updated to allow presenting results from tool calls.
3. **Tool preference prompt** (`tools.md`): Replaced the directive to prefer code over summaries with a clearer instruction: "When a specialized tool can answer the user's question, prefer it over generating code."

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed Positron Assistant (Sonnet models) not using the `getTableSummary` tool when asked to summarize data (#11575)

### QA Notes

 Discussed with @jonvanausdeln and the relevant evals are currently failing due to an unrelated issue. I've done local testing and he is ok with merging this prior to fixing up the evals.

@:assistant 

1. Start an R or Python session
2. Create a dataframe (e.g. `df <- mtcars` in R or `import pandas as pd; df = pd.DataFrame({"a": [1,2,3], "b": [4,5,6]})` in Python)
3. In the Assistant panel (Ask mode), ask "Summarize my table" or "Describe df"
4. Verify the assistant uses the `getTableSummary` tool rather than generating code to compute summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)