### PR TITLE
Bump Publisher extension version

### DIFF
--- a/product.json
+++ b/product.json
@@ -230,7 +230,7 @@
 		},
 		{
 			"name": "posit.publisher",
-			"version": "1.30.0",
+			"version": "1.31.8",
 			"repo": "https://github.com/posit-dev/publisher",
 			"metadata": {
 				"id": "ccc4be7e-a835-4fcf-b439-79c25a0ae11e",


### PR DESCRIPTION
Bumps the version of the Publisher extension to a new release that includes Windows ARM64 binaries. This is needed to unblock our Windows ARM64 builds.

Addresses https://github.com/posit-dev/positron/issues/11952. 



