### PR TITLE
plots: pass format to render and save

### DIFF
--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -214,6 +214,7 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 					uri,
 					size: preRender.settings.size,
 					pixel_ratio: preRender.settings.pixel_ratio,
+					format: preRender.settings.format,
 					renderTimeMs: 0,
 				};
 			}
@@ -271,6 +272,7 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 					uri,
 					size: preRender.settings.size,
 					pixel_ratio: preRender.settings.pixel_ratio,
+					format: preRender.settings.format,
 					renderTimeMs: 0,
 				};
 
@@ -374,6 +376,9 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 			return false;
 		}
 		if (left.pixel_ratio !== right.pixel_ratio) {
+			return false;
+		}
+		if (left.format !== right.format) {
 			return false;
 		}
 		return true;

--- a/src/vs/workbench/services/languageRuntime/common/positronPlotRenderQueue.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronPlotRenderQueue.ts
@@ -36,6 +36,9 @@ export interface IRenderedPlot {
 	/** The pixel ratio of the device for which the plot was rendered */
 	pixel_ratio: number;
 
+	/** The format of the rendered plot */
+	format?: PlotRenderFormat;
+
 	/** The plot's image URI. The URI includes the plot itself as a base64-encoded string. */
 	uri: string;
 
@@ -417,6 +420,7 @@ export class PositronPlotRenderQueue extends Disposable {
 					const renderResult: IRenderedPlot = {
 						size: operationRequest.size,
 						pixel_ratio: operationRequest.pixel_ratio!,
+						format: operationRequest.format,
 						uri,
 						renderTimeMs
 					};


### PR DESCRIPTION
When saving plots from the Plots Panel, users could select any format, but the saved files always contained PNG data since `settingsEqual()` did not include the format parameter.


NOTE: this exposes a bug where SVGs can't be saved without XQuartz installed. We didn't see this before since the data was always in PNG form, whereas now we get an RPC error.

```
Error saving plot: {"code":-32603,"data":null,"message":"Failed to process positron.plot request: No such file or directory (os error 2) (request: {\"id\":\"5a9cdddf-184f-4dc4-a058-1d77a1393513\",\"jsonrpc\":\"2.0\",\"method\":\"render\",\"params\":{\"format\":\"svg\",\"pixel_ratio\":1,\"size\":{\"height\":531,\"width\":709}}})","name":"RPC Error -32603"}
```

After I downloaded XQuartz, SVGs saved as expected!

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #11137 R plots no longer always saved as PNG in plots pane.


### QA Notes

@:plots

the original issue has a good example:

```r
library(ggplot2)
p <- ggplot(mtcars, aes(x = wt, y = mpg, color = factor(cyl))) +
  geom_point(size = 3) +
  labs(
    title = "Car Weight vs. MPG",
    x = "Weight (1000 lbs)",
    y = "Miles Per Gallon (mpg)",
    color = "Cylinders"
  ) +
  theme_minimal()
```

use UI to save as PDF, this should work as expected