### PR TITLE
assistant: add user agent header to snowflake cortex reqs

### DIFF
--- a/extensions/positron-assistant/src/providers/openai/openaiCompatibleProvider.ts
+++ b/extensions/positron-assistant/src/providers/openai/openaiCompatibleProvider.ts
@@ -76,6 +76,14 @@ export class OpenAICompatibleModelProvider extends OpenAIModelProvider implement
 	}
 
 	/**
+	 * Returns custom headers to include in API requests.
+	 * Subclasses can override to add provider-specific headers (e.g. User-Agent).
+	 */
+	protected get customHeaders(): Record<string, string> | undefined {
+		return undefined;
+	}
+
+	/**
 	 * Initializes the OpenAI-compatible provider with chat wrapper.
 	 *
 	 * Creates an OpenAI provider that uses the `/v1/chat/completions` endpoint
@@ -90,6 +98,7 @@ export class OpenAICompatibleModelProvider extends OpenAIModelProvider implement
 		const baseProvider = createOpenAI({
 			apiKey: this._config.apiKey,
 			baseURL: this.baseUrl,
+			headers: this.customHeaders,
 			fetch: createOpenAICompatibleFetch(this.providerName)
 		});
 

--- a/extensions/positron-assistant/src/providers/snowflake/snowflakeProvider.ts
+++ b/extensions/positron-assistant/src/providers/snowflake/snowflakeProvider.ts
@@ -14,6 +14,7 @@ import {
 } from './snowflakeAuth';
 import { autoconfigureWithManagedCredentials, SNOWFLAKE_MANAGED_CREDENTIALS } from '../../pwb';
 import { OpenAICompatibleModelProvider } from '../openai/openaiCompatibleProvider.js';
+import { IS_RUNNING_ON_PWB } from '../../constants.js';
 import { PROVIDER_METADATA } from '../../providerMetadata.js';
 
 /**
@@ -37,6 +38,10 @@ export class SnowflakeModelProvider extends OpenAICompatibleModelProvider {
 			autoconfigure: { type: positron.ai.LanguageModelAutoconfigureType.Custom, message: 'Automatically configured using Snowflake credentials', signedIn: false },
 		}
 	};
+
+	protected override get customHeaders() {
+		return { 'User-Agent': IS_RUNNING_ON_PWB ? 'posit_workbench_positron' : 'posit_positron' };
+	}
 
 	/**
 	 * Gets the base URL for the Snowflake Cortex API.


### PR DESCRIPTION
- addresses https://github.com/posit-dev/positron/issues/11675

### Release Notes

#### New Features

- Assistant: include user agent for Snowflake Cortex requests (#11675)

### QA Notes

Chat message requests now indicate `posit_positron` in the user agent header. When Positron is run on Workbench, `posit_workbench_positron` is used.