### PR TITLE
Add user settings for file transfer restrictions

### DIFF
--- a/src/vs/workbench/browser/contextkeys.ts
+++ b/src/vs/workbench/browser/contextkeys.ts
@@ -13,11 +13,6 @@ import { IConfigurationService } from '../../platform/configuration/common/confi
 // Remove unused import
 // import { IWorkbenchEnvironmentService } from '../services/environment/common/environmentService.js';
 // --- End PWB ---
-// --- Start Positron ---
-import { Registry } from '../../platform/registry/common/platform.js';
-import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../platform/configuration/common/configurationRegistry.js';
-import { localize } from '../../nls.js';
-// --- End Positron ---
 import { WorkbenchState, IWorkspaceContextService, isTemporaryWorkspace } from '../../platform/workspace/common/workspace.js';
 import { IWorkbenchLayoutService, Parts, positionToString } from '../services/layout/browser/layoutService.js';
 import { getRemoteName } from '../../platform/remote/common/remoteHosts.js';
@@ -276,8 +271,8 @@ export class WorkbenchContextKeysHandler extends Disposable {
 			}
 
 			// --- Start Positron ---
-			if (e.affectsConfiguration('positron.fileTransfers.enableDownloads') ||
-				e.affectsConfiguration('positron.fileTransfers.enableUploads')) {
+			if (e.affectsConfiguration('files.enableDownloads') ||
+				e.affectsConfiguration('files.enableUploads')) {
 				this.updateFileTransferKeys();
 			}
 			// --- End Positron ---
@@ -399,42 +394,12 @@ export class WorkbenchContextKeysHandler extends Disposable {
 	// --- Start Positron ---
 	private updateFileTransferKeys(): void {
 		const cliDownloads = this.environmentService.isEnabledFileDownloads ?? true;
-		const settingDownloads = this.configurationService.getValue<boolean>('positron.fileTransfers.enableDownloads') ?? true;
+		const settingDownloads = this.configurationService.getValue<boolean>('files.enableDownloads') ?? true;
 		this.isEnabledFileDownloadsKey.set(cliDownloads && settingDownloads);
 
 		const cliUploads = this.environmentService.isEnabledFileUploads ?? true;
-		const settingUploads = this.configurationService.getValue<boolean>('positron.fileTransfers.enableUploads') ?? true;
+		const settingUploads = this.configurationService.getValue<boolean>('files.enableUploads') ?? true;
 		this.isEnabledFileUploadsKey.set(cliUploads && settingUploads);
 	}
 	// --- End Positron ---
 }
-
-// --- Start Positron ---
-Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
-	.registerConfiguration({
-		id: 'positron.fileTransfers',
-		order: 100,
-		title: localize('fileTransfersConfigurationTitle', "File Transfers"),
-		type: 'object',
-		properties: {
-			'positron.fileTransfers.enableDownloads': {
-				type: 'boolean',
-				default: true,
-				description: localize(
-					'positron.fileTransfers.enableDownloads',
-					"Enable file downloads via the browser UI. When false, download actions are hidden. If the server was started with --disable-file-downloads, downloads are disabled regardless of this setting."
-				),
-				restricted: true,
-			},
-			'positron.fileTransfers.enableUploads': {
-				type: 'boolean',
-				default: true,
-				description: localize(
-					'positron.fileTransfers.enableUploads',
-					"Enable file uploads via the browser UI. When false, upload actions are hidden. If the server was started with --disable-file-uploads, uploads are disabled regardless of this setting."
-				),
-				restricted: true,
-			},
-		}
-	});
-// --- End Positron ---

--- a/src/vs/workbench/browser/contextkeys.ts
+++ b/src/vs/workbench/browser/contextkeys.ts
@@ -13,6 +13,11 @@ import { IConfigurationService } from '../../platform/configuration/common/confi
 // Remove unused import
 // import { IWorkbenchEnvironmentService } from '../services/environment/common/environmentService.js';
 // --- End PWB ---
+// --- Start Positron ---
+import { Registry } from '../../platform/registry/common/platform.js';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../platform/configuration/common/configurationRegistry.js';
+import { localize } from '../../nls.js';
+// --- End Positron ---
 import { WorkbenchState, IWorkspaceContextService, isTemporaryWorkspace } from '../../platform/workspace/common/workspace.js';
 import { IWorkbenchLayoutService, Parts, positionToString } from '../services/layout/browser/layoutService.js';
 import { getRemoteName } from '../../platform/remote/common/remoteHosts.js';
@@ -83,6 +88,8 @@ export class WorkbenchContextKeysHandler extends Disposable {
 
 	// --- Start Positron ---
 	private positronTopActionBarVisibleContext: IContextKey<boolean>;
+	private isEnabledFileDownloadsKey: IContextKey<boolean>;
+	private isEnabledFileUploadsKey: IContextKey<boolean>;
 	// --- End Positron ---
 
 	constructor(
@@ -230,10 +237,13 @@ export class WorkbenchContextKeysHandler extends Disposable {
 		this.auxiliaryBarMaximizedContext = AuxiliaryBarMaximizedContext.bindTo(this.contextKeyService);
 		this.auxiliaryBarMaximizedContext.set(this.layoutService.isAuxiliaryBarMaximized());
 
-		// --- Start PWB: disable file downloads ---
-		IsEnabledFileDownloads.bindTo(this.contextKeyService).set(this.environmentService.isEnabledFileDownloads ?? true);
-		IsEnabledFileUploads.bindTo(this.contextKeyService).set(this.environmentService.isEnabledFileUploads ?? true);
-		// --- End PWB ---
+		// --- Start Positron ---
+		// Combine CLI flags with user settings using "most restrictive wins" logic:
+		// disabled if EITHER the CLI flag says disable OR the setting says disable.
+		this.isEnabledFileDownloadsKey = IsEnabledFileDownloads.bindTo(this.contextKeyService);
+		this.isEnabledFileUploadsKey = IsEnabledFileUploads.bindTo(this.contextKeyService);
+		this.updateFileTransferKeys();
+		// --- End Positron ---
 
 		this.registerListeners();
 	}
@@ -264,6 +274,13 @@ export class WorkbenchContextKeysHandler extends Disposable {
 			if (e.affectsConfiguration('workbench.editor.openSideBySideDirection')) {
 				this.updateSplitEditorsVerticallyContext();
 			}
+
+			// --- Start Positron ---
+			if (e.affectsConfiguration('positron.fileTransfers.enableDownloads') ||
+				e.affectsConfiguration('positron.fileTransfers.enableUploads')) {
+				this.updateFileTransferKeys();
+			}
+			// --- End Positron ---
 		}));
 
 		this._register(this.layoutService.onDidChangeZenMode(enabled => this.inZenModeContext.set(enabled)));
@@ -378,4 +395,46 @@ export class WorkbenchContextKeysHandler extends Disposable {
 		this.temporaryWorkspaceContext.set(isTemporaryWorkspace(this.contextService.getWorkspace()));
 		// --- End Positron ---
 	}
+
+	// --- Start Positron ---
+	private updateFileTransferKeys(): void {
+		const cliDownloads = this.environmentService.isEnabledFileDownloads ?? true;
+		const settingDownloads = this.configurationService.getValue<boolean>('positron.fileTransfers.enableDownloads') ?? true;
+		this.isEnabledFileDownloadsKey.set(cliDownloads && settingDownloads);
+
+		const cliUploads = this.environmentService.isEnabledFileUploads ?? true;
+		const settingUploads = this.configurationService.getValue<boolean>('positron.fileTransfers.enableUploads') ?? true;
+		this.isEnabledFileUploadsKey.set(cliUploads && settingUploads);
+	}
+	// --- End Positron ---
 }
+
+// --- Start Positron ---
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
+	.registerConfiguration({
+		id: 'positron.fileTransfers',
+		order: 100,
+		title: localize('fileTransfersConfigurationTitle', "File Transfers"),
+		type: 'object',
+		properties: {
+			'positron.fileTransfers.enableDownloads': {
+				type: 'boolean',
+				default: true,
+				description: localize(
+					'positron.fileTransfers.enableDownloads',
+					"Enable file downloads via the browser UI. When false, download actions are hidden. If the server was started with --disable-file-downloads, downloads are disabled regardless of this setting."
+				),
+				restricted: true,
+			},
+			'positron.fileTransfers.enableUploads': {
+				type: 'boolean',
+				default: true,
+				description: localize(
+					'positron.fileTransfers.enableUploads',
+					"Enable file uploads via the browser UI. When false, upload actions are hidden. If the server was started with --disable-file-uploads, uploads are disabled regardless of this setting."
+				),
+				restricted: true,
+			},
+		}
+	});
+// --- End Positron ---

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -676,3 +676,33 @@ ModesRegistry.registerLanguage({
 	aliases: ['Binary'],
 	mimetypes: ['text/x-code-binary']
 });
+
+// --- Start Positron ---
+// File transfer restriction settings, enforceable via POSITRON_ENFORCED_SETTINGS admin policy.
+configurationRegistry.registerConfiguration({
+	id: 'files',
+	order: 100,
+	title: nls.localize('filesConfigurationTitle', "Files"),
+	type: 'object',
+	properties: {
+		'files.enableDownloads': {
+			type: 'boolean',
+			default: true,
+			description: nls.localize(
+				'files.enableDownloads',
+				"Enable file downloads via the browser UI. When false, download actions are hidden. If the server was started with --disable-file-downloads, downloads are disabled regardless of this setting."
+			),
+			restricted: true,
+		},
+		'files.enableUploads': {
+			type: 'boolean',
+			default: true,
+			description: nls.localize(
+				'files.enableUploads',
+				"Enable file uploads via the browser UI. When false, upload actions are hidden. If the server was started with --disable-file-uploads, uploads are disabled regardless of this setting."
+			),
+			restricted: true,
+		},
+	}
+});
+// --- End Positron ---

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1832,7 +1832,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 				// --- Start Positron ---
 				// Combine CLI flag with user setting using "most restrictive wins" logic
 				const cliUploads = this.environmentService.isEnabledFileUploads;
-				const settingUploads = this.configurationService.getValue<boolean>('positron.fileTransfers.enableUploads') ?? true;
+				const settingUploads = this.configurationService.getValue<boolean>('files.enableUploads') ?? true;
 				if (cliUploads && settingUploads) {
 					// Use local file import when supported
 					if (!isWeb || (isTemporaryWorkspace(this.contextService.getWorkspace()) && WebFileSystemAccess.supported(mainWindow))) {

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1829,8 +1829,11 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 
 			// External file DND (Import/Upload file)
 			if (data instanceof NativeDragAndDropData) {
-				// --- Start PWB: disable file downloads ---
-				if (this.environmentService.isEnabledFileUploads) {
+				// --- Start Positron ---
+				// Combine CLI flag with user setting using "most restrictive wins" logic
+				const cliUploads = this.environmentService.isEnabledFileUploads;
+				const settingUploads = this.configurationService.getValue<boolean>('positron.fileTransfers.enableUploads') ?? true;
+				if (cliUploads && settingUploads) {
 					// Use local file import when supported
 					if (!isWeb || (isTemporaryWorkspace(this.contextService.getWorkspace()) && WebFileSystemAccess.supported(mainWindow))) {
 						const fileImport = this.instantiationService.createInstance(ExternalFileImport);
@@ -1841,8 +1844,8 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 						const browserUpload = this.instantiationService.createInstance(BrowserFileUpload);
 						await browserUpload.upload(target, originalEvent);
 					}
-					// --- End PWB ---
 				}
+				// --- End Positron ---
 			}
 
 			// In-Explorer DND (Move/Copy file)

--- a/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
+++ b/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
@@ -326,8 +326,8 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 			// Combine CLI flags with user settings using "most restrictive wins" logic.
 			// Keep the inner block unindented to avoid merge conflicts:
 			// prettier-ignore
-			const isDownloadEnabled = (this.environmentService.isEnabledFileDownloads) && (this.configurationService.getValue<boolean>('positron.fileTransfers.enableDownloads') ?? true);
-			const isUploadEnabled = (this.environmentService.isEnabledFileUploads) && (this.configurationService.getValue<boolean>('positron.fileTransfers.enableUploads') ?? true);
+			const isDownloadEnabled = (this.environmentService.isEnabledFileDownloads) && (this.configurationService.getValue<boolean>('files.enableDownloads') ?? true);
+			const isUploadEnabled = (this.environmentService.isEnabledFileUploads) && (this.configurationService.getValue<boolean>('files.enableUploads') ?? true);
 			if ((isSave && isDownloadEnabled) || (!isSave && isUploadEnabled)) {
 				if ((this.scheme !== Schemas.file) && this.options && this.options.availableFileSystems && (this.options.availableFileSystems.length > 1) && (this.options.availableFileSystems.indexOf(Schemas.file) > -1)) {
 					this.filePickBox.customButton = true;

--- a/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
+++ b/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
@@ -43,9 +43,10 @@ import { Codicon } from '../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 
-// --- Start PWB: disable file downloads ---
+// --- Start Positron ---
 import { IBrowserWorkbenchEnvironmentService } from '../../environment/browser/environmentService.js';
-// --- End PWB ---
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+// --- End Positron ---
 
 export namespace OpenLocalFileCommand {
 	export const ID = 'workbench.action.files.openLocalFile';
@@ -151,9 +152,10 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@IModelService private readonly modelService: IModelService,
 		@ILanguageService private readonly languageService: ILanguageService,
-		// --- Start PWB: disable file downloads ---
+		// --- Start Positron ---
 		@IBrowserWorkbenchEnvironmentService protected readonly environmentService: IBrowserWorkbenchEnvironmentService,
-		// --- End PWB ---
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		// --- End Positron ---
 		@IRemoteAgentService private readonly remoteAgentService: IRemoteAgentService,
 		@IPathService protected readonly pathService: IPathService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
@@ -320,11 +322,13 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 			this.filePickBox.placeholder = nls.localize('remoteFileDialog.placeholder', "Folder path");
 			this.filePickBox.ok = true;
 			this.filePickBox.okLabel = typeof this.options.openLabel === 'string' ? this.options.openLabel : this.options.openLabel?.withoutMnemonic;
-			// --- Start PWB: disable file downloads ---
-			// We just wrapped the whole block in this outer if statement.
+			// --- Start Positron ---
+			// Combine CLI flags with user settings using "most restrictive wins" logic.
 			// Keep the inner block unindented to avoid merge conflicts:
 			// prettier-ignore
-			if ((isSave && this.environmentService.isEnabledFileDownloads) || (!isSave && this.environmentService.isEnabledFileUploads)) {
+			const isDownloadEnabled = (this.environmentService.isEnabledFileDownloads) && (this.configurationService.getValue<boolean>('positron.fileTransfers.enableDownloads') ?? true);
+			const isUploadEnabled = (this.environmentService.isEnabledFileUploads) && (this.configurationService.getValue<boolean>('positron.fileTransfers.enableUploads') ?? true);
+			if ((isSave && isDownloadEnabled) || (!isSave && isUploadEnabled)) {
 				if ((this.scheme !== Schemas.file) && this.options && this.options.availableFileSystems && (this.options.availableFileSystems.length > 1) && (this.options.availableFileSystems.indexOf(Schemas.file) > -1)) {
 					this.filePickBox.customButton = true;
 					this.filePickBox.customLabel = nls.localize('remoteFileDialog.local', 'Show Local');
@@ -344,7 +348,7 @@ export class SimpleFileDialog extends Disposable implements ISimpleFileDialog {
 					}
 				}
 			}
-			// --- End PWB ---
+			// --- End Positron ---
 
 			this.setButtons();
 			this._register(this.filePickBox.onDidTriggerButton(e => {


### PR DESCRIPTION
Addresses #11816 

Add `positron.fileTransfers.enableDownloads` and `positron.fileTransfers.enableUploads` configuration settings so that Positron Workbench admins can enforce file transfer restrictions per user and group via the existing `POSITRON_ENFORCED_SETTINGS` mechanism.
These settings only exist in server mode because they are irrelevant when Positron is running locally.

### Summary

Currently file transfer restrictions (`--disable-file-downloads`, `--disable-file-uploads`) can only be set as server-wide CLI flags. This PR adds user settings that complement the CLI flags with "most restrictive wins" logic: transfers are disabled if **either** the CLI flag or the user setting says to disable.

**Changes:**
- Register `files.enableDownloads` and `files.enableUploads` settings (boolean, default `true`, `restricted: true`)
- Update context key binding in `WorkbenchContextKeysHandler` to combine CLI flags with settings and listen for dynamic changes
- Update `FileDragAndDrop` drop handler to check both CLI flag and setting
- Update `SimpleFileDialog` "Show Local" button to check both CLI flag and setting

### Release Notes

#### New Features
- Added `files.enableDownloads` and `files.enableUploads` settings for file transfer restrictions

### QA Notes

@:web

**Test 1: Settings disable file transfers**
1. Launch Positron Server (web mode)
2. Open Settings, search for `positron.fileTransfers`
3. Set `enableDownloads` to `false`
4. Verify the "Download..." option is not present  when right clicking a file in the file explorer
5. Set `enableUploads` to `false`
6. Verify the "Upload..." option is not present when right clicking a folder in the file explorer
7. Verify drag-and-drop file upload is blocked

There's an existing Workbench issue to add automation for the CLI feature https://github.com/rstudio/rstudio-ide-automation/issues/1876
