### PR TITLE
Fix broken language features for new notebooks

### DIFF
--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -450,6 +450,16 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		runtimeMetadata: ILanguageRuntimeMetadata,
 		sessionMetadata: IRuntimeSessionMetadata,
 		sessionName: string): Promise<extHostProtocol.RuntimeInitialState> {
+		// Revive the notebook URI if it exists. The URI is serialized as a
+		// plain UriComponents object when crossing the IPC boundary and needs
+		// to be revived into a proper URI instance.
+		if (sessionMetadata.notebookUri) {
+			sessionMetadata = {
+				...sessionMetadata,
+				notebookUri: URI.revive(sessionMetadata.notebookUri)
+			};
+		}
+
 		// Look up the session manager responsible for restoring this session
 		console.debug(`[Reconnect ${sessionMetadata.sessionId}]: Await runtime manager for runtime ${runtimeMetadata.extensionId.value}...`);
 		const sessionManager = await this.runtimeManagerForRuntime(runtimeMetadata, true);


### PR DESCRIPTION
Addresses #9070.

When restoring a language runtime session, the `notebookUri` in `sessionMetadata` was not being revived from its serialized `UriComponents` form back into a proper `URI` instance. This caused `toString()` to produce `"[object Object]"` instead of a valid URI string, silently breaking notebook document sync and leaving language features (completions, hover, etc.) non-functional in notebook cells.

The fix adds `URI.revive()` for `notebookUri` in `$restoreLanguageRuntimeSession`, matching the existing pattern already used in `$createLanguageRuntimeSession`.

### Screenshot of language features now working
<img width="947" height="565" alt="image" src="https://github.com/user-attachments/assets/3971af6b-4410-4d5d-bd23-4fb608131cae" />


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed notebook language features (code completions, hover, etc.) not working after restoring a session (#9070)

### QA Notes

@:notebooks @:positron-notebooks

1. Open a Python notebook (or create a new one)
2. Start or restart the Python interpreter so the session is restored
3. In a cell, type `import os` and run it
4. In the next cell, type `os.` and press Ctrl+Space
5. Verify that completions appear (e.g., `os.path`, `os.getcwd`, etc.)
