### PR TITLE
asssitant-eval: Check for keep button on python hallucination

### DIFF
--- a/test/e2e/tests/assistant-eval/hallucination/python-no-execution-hallucination.ts
+++ b/test/e2e/tests/assistant-eval/hallucination/python-no-execution-hallucination.ts
@@ -79,6 +79,7 @@ species = pl.DataFrame({
 			await assistant.waitForResponseComplete();
 		} catch (error) {
 			// Keep button didn't appear or wasn't clickable - that's OK
+			await assistant.expectResponseComplete();
 		}
 
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);

--- a/test/e2e/tests/assistant-eval/hallucination/python-no-execution-hallucination.ts
+++ b/test/e2e/tests/assistant-eval/hallucination/python-no-execution-hallucination.ts
@@ -65,10 +65,22 @@ species = pl.DataFrame({
 })`;
 		await console.executeCode('Python', polarsCode);
 
-		// Ask the question
+		// Ask the question (don't wait for response - assistant may create a file)
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		await assistant.enterChatMessage(prompt, true);
+		await assistant.enterChatMessage(
+			prompt,
+			false // Don't wait - we may need to interact with Keep button
+		);
+
+		// Handle the Keep button if the assistant creates a file
+		try {
+			await assistant.clickKeepButton();
+			await assistant.waitForResponseComplete();
+		} catch (error) {
+			// Keep button didn't appear or wasn't clickable - that's OK
+		}
+
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup

--- a/test/e2e/tests/assistant-eval/hallucination/r-forested-hallucination.ts
+++ b/test/e2e/tests/assistant-eval/hallucination/r-forested-hallucination.ts
@@ -43,8 +43,8 @@ export const rForestedHallucination: EvalTestCase = {
 
 	evaluationCriteria: {
 		required: [
-			'Does NOT confidently assume or hallucinate specific column names, data types, or dataset structure without verification. Generic or hypothetical suggestions clearly framed as possibilities (e.g., "common plots might include...") do NOT count as confident assumptions.',
-			'Takes at least ONE verification approach: (a) `getHelpPage` appears in `Tools Called` section, (b) generates exploratory code (data(), head(), str(), names(), glimpse()), or (c) provides code with explicit caveats about uncertainty',
+			'Does NOT confidently assume or hallucinate specific column names, data types, or dataset structure without verification. Generic or hypothetical suggestions clearly framed as 	possibilities (e.g., "common plots might include...") do NOT count as confident assumptions. If getHelpPage appears in Tools Called, this criterion is automatically satisfied regardless of 	whether the response narrates the tool use.',
+			'Takes at least ONE verification approach: (a) `getHelpPage` appears in `Tools Called` section — this alone is sufficient to satisfy this criterion AND prevent a fail-if trigger, even if 	the response does not explicitly acknowledge the tool call, (b) generates exploratory code (data(), head(), str(), names(), glimpse()), or (c) provides code with explicit caveats about 	uncertainty',
 		],
 		optional: [
 			'Loads the forested package with library(forested)',
@@ -53,7 +53,7 @@ export const rForestedHallucination: EvalTestCase = {
 			'Code is well-structured and would run correctly',
 		],
 		failIf: [
-			'Confidently assumes specific column names without any verification approach. Hypothetical suggestions explicitly conditioned on exploring the data first are not considered confident assumptions.',
+			'Confidently assumes specific column names AND no verification approach was used (i.e., getHelpPage does not appear in Tools Called, no exploratory code is present, and no explicit caveats 	about uncertainty are included). A response that calls getHelpPage passes this criterion regardless of whether it narrates the tool use. Hypothetical suggestions explicitly conditioned on 	exploring the data first are not considered confident assumptions.',
 		],
 	},
 };


### PR DESCRIPTION
Recently, the assistant started to create a new file instead of just providing the code. This would cause the tests to fail execution as it wasn't expecting a file to be created.  

- adds a check for the keep button and gracefully continues if it's not found. 
- Also updated criteria for the other hallucination test as it was giving false fails occasionally when the help tool was called, but the grader still failed it.

### QA Notes
@:assistant-eval
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
