### PR TITLE
Fix SVG plot output rendering in Positron notebooks

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/notebookOutputUtils.ts
@@ -27,6 +27,7 @@ function getMimeTypePriority(mime: string): number | null {
 		case 'text/markdown':
 			return 2.5;
 		case 'image/png':
+		case 'image/svg+xml':
 			return 3;
 		case 'text/plain':
 			return 4;

--- a/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
@@ -170,6 +170,13 @@ export function parseOutputData(outputItem: IOutputItemDto): ParsedOutput {
 		};
 	}
 
+	if (mime === 'image/svg+xml') {
+		return {
+			type: 'image',
+			dataUrl: `data:image/svg+xml,${encodeURIComponent(message)}`
+		};
+	}
+
 	return {
 		type: 'unknown',
 		content: localize('cellExecutionUnknownMimeType', 'Can\'t handle mime type "{0}" yet', mime)

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputUtils.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputUtils.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { parseOutputData } from '../../browser/getOutputContents.js';
+import { pickPreferredOutputItem } from '../../browser/PositronNotebookCells/notebookOutputUtils.js';
+
+function makeOutputItem(mime: string, text: string) {
+	return { mime, data: VSBuffer.fromString(text) };
+}
+
+suite('Notebook Output Utils', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('parseOutputData: parses image/svg+xml into an image with a data URL', () => {
+		const svg = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>';
+		const result = parseOutputData(makeOutputItem('image/svg+xml', svg));
+
+		assert.strictEqual(result.type, 'image');
+		const { dataUrl } = result as { type: 'image'; dataUrl: string };
+		assert.ok(
+			dataUrl.startsWith('data:image/svg+xml,'),
+			'data URL should use the svg+xml MIME type'
+		);
+		assert.ok(
+			dataUrl.includes(encodeURIComponent(svg)),
+			'data URL should contain the URI-encoded SVG markup'
+		);
+	});
+
+	test('pickPreferredOutputItem: prefers image/svg+xml over text/plain', () => {
+		const items = [
+			makeOutputItem('text/plain', 'fallback text'),
+			makeOutputItem('image/svg+xml', '<svg></svg>'),
+		];
+
+		const preferred = pickPreferredOutputItem(items);
+		assert.strictEqual(preferred?.mime, 'image/svg+xml');
+	});
+});


### PR DESCRIPTION
Addresses #10785.

When using `%matplotlib inline` with `figure_format = 'svg'` in Positron's notebook frontend, plots fail to render -- the user sees `<Figure size 800x500 with 1 Axes>` instead of the plot image. The `display_data` message arrives with valid `image/svg+xml` data, but two gaps in the output pipeline prevent it from rendering:

1. **MIME priority selection** (`notebookOutputUtils.ts`): `getMimeTypePriority()` returned `null` for `image/svg+xml`, so the selection logic fell back to `text/plain`.
2. **Output parser** (`getOutputContents.ts`): `parseOutputData()` had no case for `image/svg+xml`, so even if SVG won priority selection it would display "Can't handle mime type."

This PR adds `image/svg+xml` at the same priority as `image/png` and adds parsing support that encodes the SVG as a data URL.

### Screenshots

SVG mode works
<img width="1055" height="867" alt="image" src="https://github.com/user-attachments/assets/ca1954a3-a49b-44b1-8046-b893134fdd19" />


PNG (default) still works
<img width="1008" height="868" alt="image" src="https://github.com/user-attachments/assets/50741866-e0be-4e9a-8f21-b10db652e95d" />


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed SVG plot output not rendering in Positron notebooks when using `%matplotlib inline` with SVG figure format (#10785)

### QA Notes

`@:positron-notebooks` `@:plots`

1. Open a new Positron notebook with a Python kernel
2. Run the following in a cell:

```python
import matplotlib.pyplot as plt
import numpy as np

%matplotlib inline
%config InlineBackend.figure_format = 'svg'

x = np.linspace(0, 2*np.pi, 100)
plt.figure(figsize=(8, 5))
plt.plot(x, np.sin(x))
plt.title('Sine Wave')
plt.show()
```

3. Verify the sine wave plot renders inline in the cell output (not just `<Figure size 800x500 with 1 Axes>`)
4. Also verify that the default PNG format still works by removing the `figure_format = 'svg'` config line and re-running