### PR TITLE
New ESLint Rule: PositronActionBar

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1269,7 +1269,13 @@ export default tseslint.config(
 				{
 					'selector': 'CallExpression[callee.property.name=\'getElementsByTagNameNS\']',
 					'message': 'getElementsByTagNameNS should not be used as relying on selectors is very fragile. Use dom.ts h() to build your elements and access them directly.'
+				},
+				// --- Start Positron ---
+				{
+					'selector': 'JSXOpeningElement > JSXIdentifier[name="PositronActionBar"]',
+					'message': 'PositronActionBar does not display actions at narrow widths gracefully. The action buttons will get cut off at narrower widths. Use PositronDynamicActionBar instead and configure overflowContextMenuItem on actions to allow them to move to an overflow menu when space is limited.'
 				}
+				// --- End Positron ---
 			],
 			'no-restricted-globals': [
 				'warn',

--- a/src/vs/platform/positronActionBar/browser/positronDynamicActionBar.tsx
+++ b/src/vs/platform/positronActionBar/browser/positronDynamicActionBar.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -81,11 +81,11 @@ interface CommonPositronDynamicActionBarProps {
 type NestedPositronDynamicActionBarProps = | {
 	nestedActionBar?: true;
 	borderTop?: never;
-	borderBottom?: never
+	borderBottom?: never;
 } | {
 	nestedActionBar?: false | undefined;
 	borderTop?: boolean;
-	borderBottom?: boolean
+	borderBottom?: boolean;
 };
 
 /**
@@ -239,7 +239,10 @@ export const PositronDynamicActionBar = (props: PositronDynamicActionBarProps) =
 		let overflowing = layoutWidth === 0;
 
 		// Grid entry interface.
-		interface GridEntry { width: number; action: DynamicActionBarAction; }
+		interface GridEntry {
+			width: number;
+			action: DynamicActionBarAction;
+		}
 
 		/**
 		 * Lays out the specified actions.
@@ -288,7 +291,7 @@ export const PositronDynamicActionBar = (props: PositronDynamicActionBarProps) =
 				// Set the append separator flag for the next iteration.
 				appendSeparator = action.separator;
 			}
-		}
+		};
 
 		// Layout the right actions.
 		const rightGridEntries: GridEntry[] = [];

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/summaryRowActionBar/summaryRowActionBar.tsx
@@ -22,7 +22,7 @@ import { MAX_ADVANCED_LAYOUT_ENTRY_COUNT } from '../../../../../positronDataGrid
 const SEARCH_DEBOUNCE_TIMEOUT = 500;
 
 export interface SummaryRowActionBarProps {
-	instance: TableSummaryDataGridInstance
+	instance: TableSummaryDataGridInstance;
 }
 
 export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
@@ -138,4 +138,4 @@ export const SummaryRowActionBar = ({ instance }: SummaryRowActionBarProps) => {
 			</PositronActionBarContextProvider>
 		</div>
 	);
-}
+};

--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -456,7 +456,7 @@ export const ActionBar = (props: ActionBarProps) => {
 		fixedWidth: DEFAULT_ACTION_BAR_BUTTON_WIDTH,
 		separator: true,
 		component: <ConsoleInstanceInfoButton />,
-	})
+	});
 
 
 	// Toggle trace action.
@@ -479,7 +479,7 @@ export const ActionBar = (props: ActionBarProps) => {
 				label: positronToggleTrace,
 				onSelected: toggleTraceHandler
 			}
-		})
+		});
 	}
 
 	// Toggle word wrap action.
@@ -501,7 +501,7 @@ export const ActionBar = (props: ActionBarProps) => {
 			label: positronToggleWordWrap,
 			onSelected: toggleWordWrapHandler
 		}
-	})
+	});
 
 	// Open in editor action.
 	rightActions.push({

--- a/src/vs/workbench/contrib/positronHistory/browser/components/positronHistoryPanel.tsx
+++ b/src/vs/workbench/contrib/positronHistory/browser/components/positronHistoryPanel.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -419,7 +419,7 @@ export const PositronHistoryPanel = (props: PositronHistoryPanelProps) => {
 				if (index === 0) {
 					return true;
 				}
-				return entry.input !== arr[index - 1].input
+				return entry.input !== arr[index - 1].input;
 			});
 
 			// Apply search filter

--- a/src/vs/workbench/contrib/positronHistory/browser/components/positronHistoryPanel.tsx
+++ b/src/vs/workbench/contrib/positronHistory/browser/components/positronHistoryPanel.tsx
@@ -1178,8 +1178,8 @@ export const PositronHistoryPanel = (props: PositronHistoryPanelProps) => {
 								} else {
 									return (
 										<HistoryEntry
-											historyItem={item}
 											fontInfo={props.fontInfo}
+											historyItem={item}
 											instantiationService={instantiationService}
 											isSelected={index === selectedIndex}
 											languageId={currentLanguage || ''}

--- a/src/vs/workbench/contrib/positronVariables/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/actionBars.tsx
@@ -76,7 +76,7 @@ export const ActionBars = (props: PropsWithChildren<{}>) => {
 			}, kFilterTimeout);
 
 			// Clear the find timeout.
-			return () => clearTimeout(filterTimeout)
+			return () => clearTimeout(filterTimeout);
 		}
 	}, [filterText, positronVariablesContext.activePositronVariablesInstance]);
 


### PR DESCRIPTION
Partially addresses #6292 

This PR is the first step in helping us address the issue with our action bars that cause actions to become clipped. We have two action bar components: `PositronActionBar` and `PositronDynamicActionBar`. The `PositronDynamicActionBar` component is newer and used in the Console pane which elegantly moves actions into an overflow menu when there isn't space in the window for the actions.

When we added `PositronDynamicActionBar`, we didn't have time to convert all the other use cases of `PositronActionBar` over. 

We need to be using the `PositronDynamicActionBar` instead of the `PositronActionBar`. To prevent newer instances of `PositronActionBar` from being used and added, I've added a new ESLint rule that warns a user that they should be using the newer component.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

You should be able to test this by pulling down the dev build and opening to a file that is using the `PositronActionBar` component.

You should see the warning in the Problems pane, and a yellow squiggly under the component that shows the linting rule on hover.

<img width="1576" height="842" alt="Screenshot 2026-02-17 at 6 24 10 PM" src="https://github.com/user-attachments/assets/f1ab7527-0cb0-4974-a315-1c14b9c2a623" />

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
