### PR TITLE
auto-reload with snowflake configuration settings

### DIFF
--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -266,6 +266,24 @@ function registerAssistant(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('positron-assistant.selectGhostCellModel', selectGhostCellModel)
 	);
+	// Listen for configuration changes to enabledProviders
+	// This allows Snowflake and other providers to be enabled/disabled without reloading
+	context.subscriptions.push(
+		vscode.workspace.onDidChangeConfiguration(async (e) => {
+			if (e.affectsConfiguration('positron.assistant.enabledProviders')) {
+				await registerModels(context, storage);
+			}
+		})
+	);
+
+	// Listen for authentication session changes
+	// This handles the case where a user signs into Snowflake or other providers
+	// and enables features that depend on those credentials
+	context.subscriptions.push(
+		vscode.authentication.onDidChangeSessions(async () => {
+			await registerModels(context, storage);
+		})
+	);
 
 	// Dispose cleanup
 	context.subscriptions.push({

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -271,10 +271,9 @@ function registerAssistant(context: vscode.ExtensionContext) {
 	// Listen for configuration changes that affect model registration
 	context.subscriptions.push(
 		vscode.workspace.onDidChangeConfiguration(async (e) => {
-			// Enabled providers changed - re-register models
-			// This includes when Snowflake Cortex is enabled/disabled
-			if (e.affectsConfiguration('positron.assistant.enabledProviders')) {
-				log.info('[Assistant] Enabled providers changed, re-registering models');
+			// Individual provider enable settings (e.g., positron.assistant.provider.snowflakeCortex.enable)
+			if (e.affectsConfiguration('positron.assistant.provider')) {
+				log.info('[Assistant] Provider settings changed, re-registering models');
 				await registerModels(context);
 			}
 			// Snowflake provider variables changed (SNOWFLAKE_HOME, etc.)

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -171,6 +171,39 @@ function registerResetCommand(context: vscode.ExtensionContext) {
 	);
 }
 
+/**
+ * Listen for configuration changes that affect model registration.
+ */
+function registerConfigurationListener(context: vscode.ExtensionContext) {
+	context.subscriptions.push(
+		vscode.workspace.onDidChangeConfiguration(async (e) => {
+			// Individual provider enable settings (e.g., positron.assistant.provider.snowflakeCortex.enable)
+			if (e.affectsConfiguration('positron.assistant.provider')) {
+				log.info('[Assistant] Provider settings changed, re-registering models');
+				await registerModels(context);
+			}
+			// Snowflake provider variables changed (SNOWFLAKE_HOME, etc.)
+			if (e.affectsConfiguration('positron.assistant.providerVariables.snowflake')) {
+				log.info('[Assistant] Snowflake provider variables changed, re-registering models');
+				await registerModels(context);
+			}
+		})
+	);
+}
+
+/**
+ * Listen for authentication session changes (for OAuth-based providers).
+ * Note: This does NOT fire for file-based credentials like Snowflake's connections.toml
+ */
+function registerAuthenticationListener(context: vscode.ExtensionContext) {
+	context.subscriptions.push(
+		vscode.authentication.onDidChangeSessions(async () => {
+			log.info('[Assistant] Authentication sessions changed, re-registering models');
+			await registerModels(context);
+		})
+	);
+}
+
 async function toggleInlineCompletions() {
 	// Get the current value of the setting
 	const config = vscode.workspace.getConfiguration('positron.assistant');
@@ -262,10 +295,6 @@ function registerAssistant(context: vscode.ExtensionContext) {
 	// Register chat commands
 	registerAssistantCommands();
 
-	// Register ghost cell model picker command
-	context.subscriptions.push(
-		vscode.commands.registerCommand('positron-assistant.selectGhostCellModel', selectGhostCellModel)
-	);
 	// Listen for configuration changes to enabledProviders
 	// This allows Snowflake and other providers to be enabled/disabled without reloading
 	// Listen for configuration changes that affect model registration
@@ -291,7 +320,14 @@ function registerAssistant(context: vscode.ExtensionContext) {
 			log.info('[Assistant] Authentication sessions changed, re-registering models');
 			await registerModels(context);
 		})
-	);
+	// Register ghost cell model picker command
+	context.subscriptions.push(
+			vscode.commands.registerCommand('positron-assistant.selectGhostCellModel', selectGhostCellModel)
+		);
+
+	// Listeners for workbench/snowflake so that models can be registered without a reload
+	registerConfigurationListener(context);
+	registerAuthenticationListener(context);
 
 	// Dispose cleanup
 	context.subscriptions.push({

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -271,7 +271,7 @@ function registerAssistant(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.workspace.onDidChangeConfiguration(async (e) => {
 			if (e.affectsConfiguration('positron.assistant.enabledProviders')) {
-				await registerModels(context, storage);
+				await registerModels(context);
 			}
 		})
 	);
@@ -281,7 +281,7 @@ function registerAssistant(context: vscode.ExtensionContext) {
 	// and enables features that depend on those credentials
 	context.subscriptions.push(
 		vscode.authentication.onDidChangeSessions(async () => {
-			await registerModels(context, storage);
+			await registerModels(context);
 		})
 	);
 

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -268,19 +268,28 @@ function registerAssistant(context: vscode.ExtensionContext) {
 	);
 	// Listen for configuration changes to enabledProviders
 	// This allows Snowflake and other providers to be enabled/disabled without reloading
+	// Listen for configuration changes that affect model registration
 	context.subscriptions.push(
 		vscode.workspace.onDidChangeConfiguration(async (e) => {
+			// Enabled providers changed - re-register models
+			// This includes when Snowflake Cortex is enabled/disabled
 			if (e.affectsConfiguration('positron.assistant.enabledProviders')) {
+				log.info('[Assistant] Enabled providers changed, re-registering models');
+				await registerModels(context);
+			}
+			// Snowflake provider variables changed (SNOWFLAKE_HOME, etc.)
+			if (e.affectsConfiguration('positron.assistant.providerVariables.snowflake')) {
+				log.info('[Assistant] Snowflake provider variables changed, re-registering models');
 				await registerModels(context);
 			}
 		})
 	);
 
-	// Listen for authentication session changes
-	// This handles the case where a user signs into Snowflake or other providers
-	// and enables features that depend on those credentials
+	// Listen for authentication session changes (for OAuth-based providers)
+	// Note: This does NOT fire for file-based credentials like Snowflake's connections.toml
 	context.subscriptions.push(
 		vscode.authentication.onDidChangeSessions(async () => {
+			log.info('[Assistant] Authentication sessions changed, re-registering models');
 			await registerModels(context);
 		})
 	);

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -287,35 +287,10 @@ function registerAssistant(context: vscode.ExtensionContext) {
 	// Register chat commands
 	registerAssistantCommands();
 
-	// Listen for configuration changes to enabledProviders
-	// This allows Snowflake and other providers to be enabled/disabled without reloading
-	// Listen for configuration changes that affect model registration
-	context.subscriptions.push(
-		vscode.workspace.onDidChangeConfiguration(async (e) => {
-			// Individual provider enable settings (e.g., positron.assistant.provider.snowflakeCortex.enable)
-			if (e.affectsConfiguration('positron.assistant.provider')) {
-				log.info('[Assistant] Provider settings changed, re-registering models');
-				await registerModels(context);
-			}
-			// Snowflake provider variables changed (SNOWFLAKE_HOME, etc.)
-			if (e.affectsConfiguration('positron.assistant.providerVariables.snowflake')) {
-				log.info('[Assistant] Snowflake provider variables changed, re-registering models');
-				await registerModels(context);
-			}
-		})
-	);
-
-	// Listen for authentication session changes (for OAuth-based providers)
-	// Note: This does NOT fire for file-based credentials like Snowflake's connections.toml
-	context.subscriptions.push(
-		vscode.authentication.onDidChangeSessions(async () => {
-			log.info('[Assistant] Authentication sessions changed, re-registering models');
-			await registerModels(context);
-		})
 	// Register ghost cell model picker command
 	context.subscriptions.push(
-			vscode.commands.registerCommand('positron-assistant.selectGhostCellModel', selectGhostCellModel)
-		);
+		vscode.commands.registerCommand('positron-assistant.selectGhostCellModel', selectGhostCellModel)
+	);
 
 	// Listener for configuration changes so that models can be registered without a reload
 	// Note: Snowflake uses file-based credentials (connections.toml), handled via

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -27,8 +27,9 @@ import { collectDiagnostics } from './diagnostics.js';
 import { log } from './log.js';
 import { resetAssistantState } from './reset.js';
 import { performSettingsMigrations } from './providerMigration.js';
-import { disposeModels, registerModels } from './modelRegistration';
+import { disposeModels, registerModels, registerModelsForProvider } from './modelRegistration';
 import { registerPositAuthProvider } from './providers/posit/positProvider.js';
+import { PROVIDER_METADATA } from './providerMetadata.js';
 
 // (Authentication provider is registered via registerCopilotAuthProvider)
 
@@ -172,37 +173,28 @@ function registerResetCommand(context: vscode.ExtensionContext) {
 }
 
 /**
- * Listen for configuration changes that affect model registration.
+ * Listen for Snowflake configuration changes that affect model registration.
+ * Only re-registers Snowflake models when Snowflake-specific settings change.
  */
-function registerConfigurationListener(context: vscode.ExtensionContext) {
+function registerSnowflakeConfigurationListener(context: vscode.ExtensionContext) {
+	const snowflakeProviderId = PROVIDER_METADATA.snowflake.id;
+
 	context.subscriptions.push(
 		vscode.workspace.onDidChangeConfiguration(async (e) => {
-			// Individual provider enable settings (e.g., positron.assistant.provider.snowflakeCortex.enable)
-			if (e.affectsConfiguration('positron.assistant.provider')) {
-				log.info('[Assistant] Provider settings changed, re-registering models');
-				await registerModels(context);
+			// Snowflake provider enable setting changed
+			if (e.affectsConfiguration('positron.assistant.provider.snowflakeCortex.enable')) {
+				log.info('[Assistant] Snowflake provider enable setting changed, re-registering Snowflake models');
+				await registerModelsForProvider(context, snowflakeProviderId);
 			}
 			// Snowflake provider variables changed (SNOWFLAKE_HOME, etc.)
 			if (e.affectsConfiguration('positron.assistant.providerVariables.snowflake')) {
-				log.info('[Assistant] Snowflake provider variables changed, re-registering models');
-				await registerModels(context);
+				log.info('[Assistant] Snowflake provider variables changed, re-registering Snowflake models');
+				await registerModelsForProvider(context, snowflakeProviderId);
 			}
 		})
 	);
 }
 
-/**
- * Listen for authentication session changes (for OAuth-based providers).
- * Note: This does NOT fire for file-based credentials like Snowflake's connections.toml
- */
-function registerAuthenticationListener(context: vscode.ExtensionContext) {
-	context.subscriptions.push(
-		vscode.authentication.onDidChangeSessions(async () => {
-			log.info('[Assistant] Authentication sessions changed, re-registering models');
-			await registerModels(context);
-		})
-	);
-}
 
 async function toggleInlineCompletions() {
 	// Get the current value of the setting
@@ -325,9 +317,10 @@ function registerAssistant(context: vscode.ExtensionContext) {
 			vscode.commands.registerCommand('positron-assistant.selectGhostCellModel', selectGhostCellModel)
 		);
 
-	// Listeners for workbench/snowflake so that models can be registered without a reload
-	registerConfigurationListener(context);
-	registerAuthenticationListener(context);
+	// Listener for configuration changes so that models can be registered without a reload
+	// Note: Snowflake uses file-based credentials (connections.toml), handled via
+	// positron.assistant.providerVariables.snowflake configuration changes
+	registerSnowflakeConfigurationListener(context);
 
 	// Dispose cleanup
 	context.subscriptions.push({

--- a/extensions/positron-assistant/src/modelRegistration.ts
+++ b/extensions/positron-assistant/src/modelRegistration.ts
@@ -135,6 +135,7 @@ export async function registerModels(context: vscode.ExtensionContext) {
 
 		// Add any configs that should automatically work when the right conditions are met
 		autoModelConfigs = await createAutomaticModelConfigs();
+		log.info(`[Model Registration] Autoconfigured models: ${autoModelConfigs.map(c => c.provider).join(', ') || '(none)'}`);
 		// we add in the config if we don't already have it configured
 		for (const config of autoModelConfigs) {
 			if (!modelConfigs.find(c => c.provider === config.provider)) {
@@ -152,9 +153,12 @@ export async function registerModels(context: vscode.ExtensionContext) {
 	}
 
 	const registeredModels: ModelConfig[] = [];
+	log.info(`[Model Registration] Registering ${modelConfigs.length} models: ${modelConfigs.map(c => c.provider).join(', ')}`);
 	for (const config of modelConfigs) {
 		try {
+			log.info(`[Model Registration] Registering ${config.provider}...`);
 			await registerModelWithAPI(config, context);
+			log.info(`[Model Registration] Successfully registered ${config.provider}`);
 			registeredModels.push(config);
 			if (autoModelConfigs.includes(config)) {
 				// In addition, track auto-configured models separately
@@ -166,6 +170,7 @@ export async function registerModels(context: vscode.ExtensionContext) {
 				addAutoconfiguredModel(config);
 			}
 		} catch (e) {
+			log.error(`[Model Registration] Failed to register ${config.provider}:`, e);
 			if (!(e instanceof AssistantError) || e.display) {
 				vscode.window.showErrorMessage(`${e}`);
 			}

--- a/extensions/positron-assistant/src/modelRegistration.ts
+++ b/extensions/positron-assistant/src/modelRegistration.ts
@@ -190,6 +190,63 @@ export async function registerModels(context: vscode.ExtensionContext) {
 }
 
 /**
+ * Re-register models for a specific provider only.
+ * This is more efficient than registerModels(), but only one provider's state changes.
+ *
+ * @param context The extension context
+ * @param providerId The provider ID to re-register (e.g., 'snowflake-cortex')
+ */
+export async function registerModelsForProvider(context: vscode.ExtensionContext, providerId: string) {
+	// Dispose only models for this provider
+	disposeModels(providerId);
+	// Also remove from autoconfigured models list
+	removeAutoconfiguredModel(providerId);
+
+	try {
+		// Check if this provider is enabled
+		const enabledProviders = await positron.ai.getEnabledProviders();
+		const isEnabled = enabledProviders.length === 0 || enabledProviders.includes(providerId);
+
+		if (!isEnabled) {
+			log.info(`[Model Registration] Provider ${providerId} is disabled, skipping registration`);
+			return;
+		}
+
+		// Get stored model configurations for this provider
+		let modelConfigs = await getModelConfigurations(context);
+		modelConfigs = modelConfigs.filter(config => config.provider === providerId);
+
+		// Also check auto-configured models for this provider
+		const autoModelConfigs = await createAutomaticModelConfigs();
+		for (const config of autoModelConfigs) {
+			if (config.provider === providerId && !modelConfigs.find(c => c.provider === config.provider)) {
+				modelConfigs.push(config);
+			}
+		}
+
+		// Register models for this provider
+		for (const config of modelConfigs) {
+			try {
+				await registerModelWithAPI(config, context);
+				if (autoModelConfigs.includes(config)) {
+					addAutoconfiguredModel(config);
+				}
+				log.info(`[Model Registration] Re-registered model for provider: ${providerId}`);
+			} catch (e) {
+				if (!(e instanceof AssistantError) || e.display) {
+					vscode.window.showErrorMessage(`${e}`);
+				}
+			}
+		}
+	} catch (e) {
+		if (!(e instanceof AssistantError) || e.display) {
+			const failedMessage = vscode.l10n.t('Positron Assistant: Failed to re-register models for provider {0}.', providerId);
+			vscode.window.showErrorMessage(`${failedMessage} ${e}`);
+		}
+	}
+}
+
+/**
  * Registers the language model with the language model API.
  *
  * @param modelConfig the language model's config

--- a/extensions/positron-assistant/src/modelRegistration.ts
+++ b/extensions/positron-assistant/src/modelRegistration.ts
@@ -135,7 +135,6 @@ export async function registerModels(context: vscode.ExtensionContext) {
 
 		// Add any configs that should automatically work when the right conditions are met
 		autoModelConfigs = await createAutomaticModelConfigs();
-		log.info(`[Model Registration] Autoconfigured models: ${autoModelConfigs.map(c => c.provider).join(', ') || '(none)'}`);
 		// we add in the config if we don't already have it configured
 		for (const config of autoModelConfigs) {
 			if (!modelConfigs.find(c => c.provider === config.provider)) {
@@ -153,12 +152,9 @@ export async function registerModels(context: vscode.ExtensionContext) {
 	}
 
 	const registeredModels: ModelConfig[] = [];
-	log.info(`[Model Registration] Registering ${modelConfigs.length} models: ${modelConfigs.map(c => c.provider).join(', ')}`);
 	for (const config of modelConfigs) {
 		try {
-			log.info(`[Model Registration] Registering ${config.provider}...`);
 			await registerModelWithAPI(config, context);
-			log.info(`[Model Registration] Successfully registered ${config.provider}`);
 			registeredModels.push(config);
 			if (autoModelConfigs.includes(config)) {
 				// In addition, track auto-configured models separately
@@ -170,7 +166,6 @@ export async function registerModels(context: vscode.ExtensionContext) {
 				addAutoconfiguredModel(config);
 			}
 		} catch (e) {
-			log.error(`[Model Registration] Failed to register ${config.provider}:`, e);
 			if (!(e instanceof AssistantError) || e.display) {
 				vscode.window.showErrorMessage(`${e}`);
 			}

--- a/extensions/positron-catalog-explorer/src/catalog.ts
+++ b/extensions/positron-catalog-explorer/src/catalog.ts
@@ -103,18 +103,10 @@ export async function registerTreeViewProvider(
 		showCollapseAll: true,
 	});
 
-	// Listen for authentication session changes
-	// This handles the case where a user signs into Snowflake or other providers
-	// and expects the catalog explorer to update without reloading
-	const authListener = vscode.authentication.onDidChangeSessions(async () => {
-		await treeDataProvider.refreshProviders(context, registry);
-	});
-
-	context.subscriptions.push(treeView, authListener);
+	context.subscriptions.push(treeView);
 	return {
 		dispose: () => {
 			treeView.dispose();
-			authListener.dispose();
 		},
 	};
 }
@@ -173,24 +165,6 @@ class CatalogTreeDataProvider
 	}
 
 	onDidChangeTreeData = this.emitter.event;
-
-	/**
-	 * Refresh the list of providers and update the tree view.
-	 * This is called when authentication sessions change.
-	 */
-	async refreshProviders(
-		context: vscode.ExtensionContext,
-		registry: CatalogProviderRegistry,
-	): Promise<void> {
-		// Re-fetch all providers from the registry
-		const newProviders = await registry.listAllProviders(context);
-
-		// Update the providers list
-		this.providers = newProviders;
-
-		// Fire the change event to refresh the tree view
-		this.emitter.fire();
-	}
 
 	dispose() {
 		vscode.Disposable.from(...this.providers, ...this.listeners).dispose();

--- a/extensions/positron-catalog-explorer/src/catalogs/snowflake.ts
+++ b/extensions/positron-catalog-explorer/src/catalogs/snowflake.ts
@@ -58,10 +58,6 @@ export function registerSnowflakeProvider(
 		light: resourceUri('light', 'snowflake.png'),
 		dark: resourceUri('dark', 'snowflake.png'),
 	};
-	vscode.authentication.onDidChangeSessions((e) => {
-		if (e.provider.id === 'snowflake') {
-		}
-	});
 	return registry.register(registration);
 }
 
@@ -637,9 +633,9 @@ async function getRCodeForSnowflakeTable(
 	const varname = table?.replace('-', '_').toLowerCase();
 
 	const code = `conn <- DBI::dbConnect(
-	  odbc::snowflake(),
-	  account = "${account}"${warehouse ? `,
-	  warehouse = "${warehouse}"` : ''}
+		odbc::snowflake(),
+		account = "${account}"${warehouse ? `,
+		warehouse = "${warehouse}"` : ''}
 )
 ${table
 			? `${varname} <- dplyr::tbl(conn, I("${absoluteTablePath}"))

--- a/extensions/positron-catalog-explorer/src/credentials.ts
+++ b/extensions/positron-catalog-explorer/src/credentials.ts
@@ -153,7 +153,9 @@ export async function getSnowflakeConnectionOptions(): Promise<SnowflakeConnecti
 	// Try each path in order until we find a valid connections file
 	for (const pathToTry of pathsToTry) {
 		try {
-			if (fs.existsSync(pathToTry)) {
+			const exists = fs.existsSync(pathToTry);
+			traceInfo(`Checking path: ${pathToTry} - ${exists ? 'found' : 'not found'}`);
+			if (exists) {
 				traceInfo(`Loading Snowflake connections from: ${pathToTry}`);
 				const content = fs.readFileSync(pathToTry, 'utf8');
 				const rawConnections = toml.parse(content);

--- a/extensions/positron-catalog-explorer/src/extension.ts
+++ b/extensions/positron-catalog-explorer/src/extension.ts
@@ -17,14 +17,20 @@ import { registerSnowflakeProvider } from './catalogs/snowflake';
 import { setExtensionUri } from './resources';
 import { initializeLogging, traceInfo, traceWarn } from './logging';
 
-let catalogExplorerEnabled = false;
-
-/**
- * Initialize the catalog explorer with all providers and commands.
- */
-async function initializeCatalogExplorer(context: vscode.ExtensionContext): Promise<void> {
+export async function activate(context: vscode.ExtensionContext) {
+	// Check if the extension is enabled via configuration
 	const config = vscode.workspace.getConfiguration('catalogExplorer');
+	const isEnabled = config.get<boolean>('enabled', true);
 	const viewTestCatalog = config.get<boolean>('viewTestCatalog', false);
+
+	initializeLogging();
+	traceInfo('Catalog Explorer extension initializing');
+
+	// If the extension is disabled, return early without activating
+	if (!isEnabled) {
+		traceWarn('Catalog Explorer extension is disabled via configuration');
+		return;
+	}
 
 	setExtensionUri(context);
 	const registry = new CatalogProviderRegistry();
@@ -41,39 +47,6 @@ async function initializeCatalogExplorer(context: vscode.ExtensionContext): Prom
 		),
 	);
 	registerCatalogCommands(context, registry);
-
-	catalogExplorerEnabled = true;
-	traceInfo('Catalog Explorer initialized successfully');
-}
-
-export async function activate(context: vscode.ExtensionContext) {
-	initializeLogging();
-	traceInfo('Catalog Explorer extension initializing');
-
-	// Check if the extension is enabled via configuration
-	const config = vscode.workspace.getConfiguration('catalogExplorer');
-	const isEnabled = config.get<boolean>('enabled', true);
-
-	if (isEnabled) {
-		await initializeCatalogExplorer(context);
-	} else {
-		traceWarn('Catalog Explorer extension is disabled via configuration');
-
-		// Listen for configuration changes so we can enable without reloading
-		context.subscriptions.push(
-			vscode.workspace.onDidChangeConfiguration(async (e) => {
-				if (e.affectsConfiguration('catalogExplorer.enabled')) {
-					const enabled = vscode.workspace
-						.getConfiguration('catalogExplorer')
-						.get<boolean>('enabled', true);
-					if (enabled && !catalogExplorerEnabled) {
-						traceInfo('Catalog Explorer enabled via configuration change');
-						await initializeCatalogExplorer(context);
-					}
-				}
-			})
-		);
-	}
 }
 
 export function deactivate() { }

--- a/extensions/positron-catalog-explorer/src/extension.ts
+++ b/extensions/positron-catalog-explorer/src/extension.ts
@@ -17,20 +17,15 @@ import { registerSnowflakeProvider } from './catalogs/snowflake';
 import { setExtensionUri } from './resources';
 import { initializeLogging, traceInfo, traceWarn } from './logging';
 
-export async function activate(context: vscode.ExtensionContext) {
-	// Check if the extension is enabled via configuration
-	const config = vscode.workspace.getConfiguration('catalogExplorer');
-	const isEnabled = config.get<boolean>('enabled', true);
-	const viewTestCatalog = config.get<boolean>('viewTestCatalog', false);
+let catalogExplorerEnabled = false;
 
-	initializeLogging();
-	traceInfo('Catalog Explorer extension initializing');
-
-	// If the extension is disabled, return early without activating
-	if (!isEnabled) {
-		traceWarn('Catalog Explorer extension is disabled via configuration');
+async function initializeCatalogExplorer(context: vscode.ExtensionContext): Promise<void> {
+	if (catalogExplorerEnabled) {
 		return;
 	}
+
+	const config = vscode.workspace.getConfiguration('catalogExplorer');
+	const viewTestCatalog = config.get<boolean>('viewTestCatalog', false);
 
 	setExtensionUri(context);
 	const registry = new CatalogProviderRegistry();
@@ -47,6 +42,38 @@ export async function activate(context: vscode.ExtensionContext) {
 		),
 	);
 	registerCatalogCommands(context, registry);
+
+	catalogExplorerEnabled = true;
+	traceInfo('Catalog Explorer extension initialized');
+}
+
+export async function activate(context: vscode.ExtensionContext) {
+	initializeLogging();
+	traceInfo('Catalog Explorer extension activating');
+
+	// Check if the extension is enabled via configuration
+	const config = vscode.workspace.getConfiguration('catalogExplorer');
+	const isEnabled = config.get<boolean>('enabled', true);
+
+	// If the extension is disabled, set up a listener to initialize when enabled
+	if (!isEnabled) {
+		traceWarn('Catalog Explorer extension is disabled via configuration');
+		context.subscriptions.push(
+			vscode.workspace.onDidChangeConfiguration(async (e) => {
+				if (e.affectsConfiguration('catalogExplorer.enabled')) {
+					const newConfig = vscode.workspace.getConfiguration('catalogExplorer');
+					const newEnabled = newConfig.get<boolean>('enabled', false);
+					if (newEnabled && !catalogExplorerEnabled) {
+						traceInfo('Catalog Explorer enabled via configuration change');
+						await initializeCatalogExplorer(context);
+					}
+				}
+			})
+		);
+		return;
+	}
+
+	await initializeCatalogExplorer(context);
 }
 
 export function deactivate() { }


### PR DESCRIPTION
Adding listeners to settings so folks don't have to reload to connect to Snowflake. 

This PR is a recreation of #11935, but due to some git gymnastics was recreated instead 🤸‍♀️ 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- #10831 No longer have to reload Positron after enabling Catalog Explorer or Snowflake Cortex model provider.


### QA Notes

@:assistant

1. Run workbench docker container with user settings updated to NOT include cortex model provider or catalog explorer aka [delete these lines](https://github.com/posit-dev/positron-builds/blob/4c95d9a79976c7f5678fb36b547fa00c141d48e5/dev/workbench/rstudio/positron-user-settings.json#L15-L18) before you build the container
2. Sign into workbench using managed credentials. NOTE: if you do not see a notification like this when you open up Positron, your credentials did not load. I found sometimes I need to launch Positron twice to get the managed credentials to pick up.

<img width="494" height="86" alt="Screenshot 2026-02-18 at 2 34 43 PM" src="https://github.com/user-attachments/assets/e0c50de9-8ba0-4d51-9562-ac61c2ebd660" />

3. Enable Catalog Explorer setting -> see that you can immediately connect to Snowflake provider. Setting is: `"catalogExplorer.enabled": true`
4. Enable Snowflake Cortex -> see that you can immediately connect to Snowflake models. Setting is: `"positron.assistant.enabledProviders": ["snowflake-cortex"]` and `positron.assistant.provider.snowflakeCortex.enable`
