### PR TITLE
e2e: fix flaky console-add test

### DIFF
--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -75,13 +75,20 @@ export class ContextMenu {
 				await this.nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel, menuTriggerButton });
 			} else {
 				this.code.logger.log(`Using web menu to select: ${menuItemLabel}`);
-				await this.triggerMenu(menuTrigger, menuTriggerButton);
 
-				// Retry hover+click to handle DOM detachment from menu re-renders
+				// Retry entire trigger+hover+click to handle menu closing unexpectedly
 				await expect(async () => {
+					// Dismiss any stale menu before re-triggering
+					await this.page.keyboard.press('Escape').catch(() => { });
+
+					// Trigger the menu
+					await menuTrigger.click({ button: menuTriggerButton });
+					await expect(this.contextMenu).toBeVisible({ timeout: 2000 });
+
 					const menuItem = menuItemType === 'menuitemcheckbox'
 						? this.getContextMenuCheckboxItem(menuItemLabel)
 						: this.getContextMenuItem(menuItemLabel);
+
 					await menuItem.hover({ timeout: 2000 });
 					await this.page.waitForTimeout(200);
 
@@ -91,7 +98,7 @@ export class ContextMenu {
 						// Tooltip must have been blocking and now we click
 						await menuItem.click();
 					}
-				}, 'hover and click menu item').toPass({ timeout: 5000 });
+				}, 'trigger, hover, and click menu item').toPass({ timeout: 10000 });
 			}
 		});
 	}


### PR DESCRIPTION
### Summary
Fixing the `console-add.test.ts > Validate can start a different runtime via Console + button` flake on Windows:
- Move menu trigger inside the `toPass()` retry block so that if the menu closes unexpectedly during interaction, the entire sequence (trigger, hover, click) is retried
- Add Escape key press before each retry to dismiss any stale menu state
- Add 2s timeouts for menu visibility and hover to fail fast and retry quickly

### QA Notes

@:console @:win