### PR TITLE
Remove 'auto' model and clear model picker if previous model is unavailable

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1177,6 +1177,13 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const defaultModel = allModels.find(m => m.metadata.isDefault) || allModels.find(m => m.metadata.isUserSelectable);
 		if (defaultModel) {
 			this.setCurrentLanguageModel(defaultModel);
+			// --- Start Positron ---
+		} else {
+			// No models available - clear the stale model so the picker
+			// shows a placeholder instead of the last-selected model name
+			this._currentLanguageModel = undefined;
+			this._onDidChangeModelList.fire();
+			// --- End Positron ---
 		}
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -17,7 +17,11 @@ import { IContextKeyService } from '../../../../../../platform/contextkey/common
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
+// --- Start Positron ---
+/*
 import { DEFAULT_MODEL_PICKER_CATEGORY } from '../../../common/widget/input/modelPickerWidget.js';
+*/
+// --- End Positron ---
 import { IActionProvider } from '../../../../../../base/browser/ui/dropdown/dropdown.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
@@ -60,7 +64,9 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 			const models = delegate.getModels();
 			const actions: IActionWidgetDropdownAction[] = [];
 
+			// Disable fake "Auto" entry since it won't work with Positron Assistant
 			// --- Start CodeOSS ---
+			/*
 			if (models.length === 0) {
 				// Show a fake "Auto" entry when no models are available
 				return [{
@@ -74,6 +80,7 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 					run: () => { }
 				} satisfies IActionWidgetDropdownAction];
 			}
+			*/
 			// --- End CodeOSS ---
 
 			// Group models by vendor
@@ -277,7 +284,10 @@ export class ModelPickerActionItem extends ActionWidgetDropdownActionViewItem {
 		// Modify the original action with a different label and make it show the current model
 		const actionWithLabel: IAction = {
 			...action,
-			label: currentModel?.metadata.name ?? localize('chat.modelPicker.auto', "Auto"),
+			// --- Start Positron ---
+			// Change "Auto" to "Pick Model"
+			label: currentModel?.metadata.name ?? localize('chat.modelPicker.label', "Pick Model"),
+			// --- End Positron ---
 			run: () => { }
 		};
 
@@ -300,6 +310,8 @@ export class ModelPickerActionItem extends ActionWidgetDropdownActionViewItem {
 		// --- Start Positron ---
 		// Listen for model list changes (e.g., when provider settings change)
 		this._register(delegate.onDidChangeModelList(() => {
+			// Sync current model from delegate in case it was cleared
+			this.currentModel = delegate.getCurrentModel();
 			// Update the label in case the current model changed
 			if (this.element) {
 				this.renderLabel(this.element);
@@ -344,7 +356,10 @@ export class ModelPickerActionItem extends ActionWidgetDropdownActionViewItem {
 			domChildren.push(iconElement);
 		}
 
-		domChildren.push(dom.$('span.chat-model-label', undefined, name ?? localize('chat.modelPicker.auto', "Auto")));
+		// --- Start Positron ---
+		// Change "Auto" to "Pick Model"
+		domChildren.push(dom.$('span.chat-model-label', undefined, name ?? localize('chat.modelPicker.label', "Pick Model")));
+		// --- End Positron ---
 		domChildren.push(...renderLabelWithIcons(`$(chevron-down)`));
 
 		dom.reset(element, ...domChildren);


### PR DESCRIPTION
Address #11845 

Changes "Auto" to "Pick Model". Added an event trigger and clearing the state so that a previously selected model that is unavailable will be cleared.

<img width="435" height="134" alt="image" src="https://github.com/user-attachments/assets/7fa07425-4fdc-4ac1-b782-b5b61b23a847" />

Attempting to chat will display an error that a model provider must be configured.

<img width="428" height="189" alt="image" src="https://github.com/user-attachments/assets/136709ba-4f5b-499a-acab-a1ab5d31838a" />


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix Assistant model picker when no models are available


### QA Notes