### PR TITLE
Add support for submenus in our custom context menus

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -35,7 +35,7 @@ export interface KeyboardModifiers {
  * ButtonProps interface.
  */
 export interface ButtonProps {
-	readonly ariaHaspopup?: 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog' | 'true' | 'false';
+	readonly ariaHaspopup?: React.AriaAttributes['aria-haspopup'];
 	readonly ariaLabel?: string;
 	readonly className?: string;
 	readonly disabled?: boolean;

--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -35,6 +35,7 @@ export interface KeyboardModifiers {
  * ButtonProps interface.
  */
 export interface ButtonProps {
+	readonly ariaHaspopup?: 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog' | 'true' | 'false';
 	readonly ariaLabel?: string;
 	readonly className?: string;
 	readonly disabled?: boolean;
@@ -45,6 +46,7 @@ export interface ButtonProps {
 	readonly tooltip?: string | (() => string | undefined);
 	readonly onBlur?: () => void;
 	readonly onFocus?: () => void;
+	readonly onKeyDown?: (e: KeyboardEvent<HTMLButtonElement>) => void;
 	readonly onMouseEnter?: () => void;
 	readonly onMouseLeave?: () => void;
 	readonly onPressed?: (e: KeyboardModifiers) => void;
@@ -94,10 +96,18 @@ export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProp
 
 	/**
 	 * onKeyDown event handler.
-	 * @param e A KeyboardEvent<HTMLDivElement> that describes a user interaction with the keyboard.
+	 * @param e A KeyboardEvent<HTMLButtonElement> that describes a user interaction with the keyboard.
 	 */
 	const keyDownHandler = (e: KeyboardEvent<HTMLButtonElement>) => {
-		// Process the key down event.
+		// Call the external onKeyDown handler first if provided.
+		props.onKeyDown?.(e);
+
+		// If the event was handled (preventDefault called), don't process further.
+		if (e.defaultPrevented) {
+			return;
+		}
+
+		// Process the key down event for Enter/Space.
 		switch (e.code) {
 			case 'Enter':
 			case 'Space':
@@ -165,6 +175,7 @@ export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProp
 		<button
 			ref={buttonRef}
 			aria-disabled={props.disabled ? 'true' : undefined}
+			aria-haspopup={props.ariaHaspopup}
 			aria-label={props.ariaLabel}
 			className={positronClassNames(
 				'positron-button',

--- a/src/vs/platform/positronActionBar/browser/positronDynamicActionBar.tsx
+++ b/src/vs/platform/positronActionBar/browser/positronDynamicActionBar.tsx
@@ -19,19 +19,26 @@ import { usePositronActionBarContext } from './positronActionBarContext.js';
 import { DisposableStore, toDisposable } from '../../../base/common/lifecycle.js';
 import { optionalValue, positronClassNames } from '../../../base/common/positronUtilities.js';
 import { CustomContextMenuSeparator } from '../../../workbench/browser/positronComponents/customContextMenu/customContextMenuSeparator.js';
-import { CustomContextMenuEntry, showCustomContextMenu } from '../../../workbench/browser/positronComponents/customContextMenu/customContextMenu.js';
+import { CustomContextMenuEntry, CustomContextMenuSubmenu, CustomContextMenuSubmenuOptions, showCustomContextMenu } from '../../../workbench/browser/positronComponents/customContextMenu/customContextMenu.js';
 import { CustomContextMenuItem, CustomContextMenuItemOptions } from '../../../workbench/browser/positronComponents/customContextMenu/customContextMenuItem.js';
 
 /**
  * Constants.
  */
 export const DEFAULT_ACTION_BAR_BUTTON_WIDTH = 24;
+export const DEFAULT_ACTION_BAR_DROPDOWN_BUTTON_WIDTH = 36;
 export const DEFAULT_ACTION_BAR_SEPARATOR_WIDTH = 7;
 
 /**
  * OverflowContextMenuItem interface.
  */
 export interface OverflowContextMenuItem extends CustomContextMenuItemOptions {
+}
+
+/**
+ * OverflowContextMenuSubmenu interface.
+ */
+export interface OverflowContextMenuSubmenu extends CustomContextMenuSubmenuOptions {
 }
 
 /**
@@ -63,6 +70,12 @@ export interface DynamicActionBarAction {
 	 * The overflow custom context menu item.
 	 */
 	overflowContextMenuItem?: OverflowContextMenuItem;
+
+	/**
+	 * The overflow custom context menu submenu. Use this for actions that
+	 * should appear as a submenu in the overflow menu.
+	 */
+	overflowContextMenuSubmenu?: OverflowContextMenuSubmenu;
 }
 
 /**
@@ -245,6 +258,16 @@ export const PositronDynamicActionBar = (props: PositronDynamicActionBarProps) =
 		}
 
 		/**
+		 * Checks if an action has an overflow menu entry (either item or submenu).
+		 * This means this action is allowed to overflow into the overflow menu if we run out of space.
+		 *
+		 * @param action The action to check.
+		 * @returns True if the action has an overflow menu entry.
+		 */
+		const hasOverflowEntry = (action: DynamicActionBarAction) =>
+			action.overflowContextMenuItem || action.overflowContextMenuSubmenu;
+
+		/**
 		 * Lays out the specified actions.
 		 * @param actions The actions to layout.
 		 * @param gridEntries The grid entries.
@@ -253,7 +276,7 @@ export const PositronDynamicActionBar = (props: PositronDynamicActionBarProps) =
 		const layoutActions = (actions: DynamicActionBarAction[], gridEntries: GridEntry[], overflowActions: DynamicActionBarAction[]) => {
 			// Handle overflowing.
 			if (overflowing) {
-				overflowActions.push(...actions.filter(action => action.overflowContextMenuItem));
+				overflowActions.push(...actions.filter(hasOverflowEntry));
 				return;
 			}
 
@@ -278,7 +301,7 @@ export const PositronDynamicActionBar = (props: PositronDynamicActionBarProps) =
 				// Handle overflowing.
 				if (separatorWidth + width > layoutWidth) {
 					overflowing = true;
-					overflowActions.push(...actions.slice(i).filter(action => action.overflowContextMenuItem));
+					overflowActions.push(...actions.slice(i).filter(hasOverflowEntry));
 					return;
 				}
 
@@ -357,6 +380,19 @@ export const PositronDynamicActionBar = (props: PositronDynamicActionBarProps) =
 
 		// If there are overflow actions, add the overflow button.
 		if (overflowActions.length) {
+			/**
+			 * Creates a custom context menu entry from an overflow action.
+			 *
+			 * @param overflowAction The overflow action.
+			 * @returns The custom context menu entry.
+			 */
+			const createOverflowEntry = (overflowAction: DynamicActionBarAction): CustomContextMenuEntry => {
+				if (overflowAction.overflowContextMenuSubmenu) {
+					return new CustomContextMenuSubmenu(overflowAction.overflowContextMenuSubmenu);
+				}
+				return new CustomContextMenuItem(overflowAction.overflowContextMenuItem!);
+			};
+
 			rightGridColumns.push(`${DEFAULT_ACTION_BAR_BUTTON_WIDTH}px`);
 			rightGridElements.push(
 				<div style={{ display: 'flex', width: `${DEFAULT_ACTION_BAR_BUTTON_WIDTH}px` }}>
@@ -371,9 +407,9 @@ export const PositronDynamicActionBar = (props: PositronDynamicActionBarProps) =
 							const customContextMenuEntries: CustomContextMenuEntry[] = [];
 
 							// Build the left custom context menu entries for the overflow context menu
-							leftOverflowActions.filter(overflowAction => overflowAction.overflowContextMenuItem).forEach((overflowAction, index, overflowActions) => {
+							leftOverflowActions.filter(hasOverflowEntry).forEach((overflowAction, index, overflowActions) => {
 								// Add the custom context menu entry.
-								customContextMenuEntries.push(new CustomContextMenuItem(overflowAction.overflowContextMenuItem!));
+								customContextMenuEntries.push(createOverflowEntry(overflowAction));
 
 								// Add the custom context menu separator, if needed.
 								if (overflowAction.separator && index < overflowActions.length - 1) {
@@ -382,14 +418,14 @@ export const PositronDynamicActionBar = (props: PositronDynamicActionBarProps) =
 							});
 
 							// Build the right custom context menu entries for the overflow context menu
-							rightOverflowActions.filter(overflowAction => overflowAction.overflowContextMenuItem).forEach((overflowAction, index, overflowActions) => {
+							rightOverflowActions.filter(hasOverflowEntry).forEach((overflowAction, index, overflowActions) => {
 								// Add a separator between the left custom context menu entries and the right custom context menu entries.
 								if (!index && customContextMenuEntries.length) {
 									customContextMenuEntries.push(new CustomContextMenuSeparator());
 								}
 
 								// Add the custom context menu entry.
-								customContextMenuEntries.push(new CustomContextMenuItem(overflowAction.overflowContextMenuItem!));
+								customContextMenuEntries.push(createOverflowEntry(overflowAction));
 
 								// Add the custom context menu separator, if needed.
 								if (overflowAction.separator && index < overflowActions.length - 1) {
@@ -398,7 +434,7 @@ export const PositronDynamicActionBar = (props: PositronDynamicActionBarProps) =
 							});
 
 							// Show the custom context.
-							await showCustomContextMenu({
+							showCustomContextMenu({
 								anchorElement: refOverflowButton.current,
 								popupPosition: 'auto',
 								popupAlignment: 'auto',

--- a/src/vs/platform/positronActionBar/browser/positronDynamicActionBar.tsx
+++ b/src/vs/platform/positronActionBar/browser/positronDynamicActionBar.tsx
@@ -390,7 +390,11 @@ export const PositronDynamicActionBar = (props: PositronDynamicActionBarProps) =
 				if (overflowAction.overflowContextMenuSubmenu) {
 					return new CustomContextMenuSubmenu(overflowAction.overflowContextMenuSubmenu);
 				}
-				return new CustomContextMenuItem(overflowAction.overflowContextMenuItem!);
+				if (overflowAction.overflowContextMenuItem) {
+					return new CustomContextMenuItem(overflowAction.overflowContextMenuItem);
+				}
+
+				throw new Error('Overflow action must define an overflow context menu item or submenu.');
 			};
 
 			rightGridColumns.push(`${DEFAULT_ACTION_BAR_BUTTON_WIDTH}px`);

--- a/src/vs/platform/positronActionBar/browser/positronDynamicActionBar.tsx
+++ b/src/vs/platform/positronActionBar/browser/positronDynamicActionBar.tsx
@@ -441,7 +441,13 @@ export const PositronDynamicActionBar = (props: PositronDynamicActionBarProps) =
 	return (
 		<>
 			<div ref={refExemplar} className='exemplar' />
-			<div ref={refActionBar} className={classNames} style={style} onKeyDown={keyDownHandler}>
+			<div
+				ref={refActionBar}
+				className={classNames}
+				role='toolbar'
+				style={style}
+				onKeyDown={keyDownHandler}
+			>
 				{gridComponents}
 			</div>
 		</>

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.css
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.css
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -84,7 +84,21 @@
 }
 
 .custom-context-menu-item .shortcut {
-	padding-inline: 10px; /* Vertical padding can cause overflow and supurious scrollbars. */
+	padding-inline: 10px; /* Vertical padding can cause overflow and spurious scrollbars. */
 	white-space: nowrap;
 	grid-column: shortcut / end;
+}
+
+/* The submenu chevron indicator uses the shortcut column slot */
+.custom-context-menu-item .submenu-indicator {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding-right: 4px;
+	grid-column: shortcut / end;
+}
+
+/* Make the submenu chevron indicator look disabled */
+.custom-context-menu-item .submenu-indicator.disabled {
+	opacity: 50%;
 }

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -6,6 +6,9 @@
 // CSS.
 import './customContextMenu.css';
 
+// React.
+import React, { useRef } from 'react';
+
 // Other dependencies.
 import * as DOM from '../../../../base/browser/dom.js';
 import { isMacintosh } from '../../../../base/common/platform.js';
@@ -21,7 +24,45 @@ import { AnchorPoint, PopupAlignment, PopupPosition, PositronModalPopup } from '
 /**
  * CustomContextMenuEntry type.
  */
-export type CustomContextMenuEntry = CustomContextMenuItem | CustomContextMenuSeparator;
+export type CustomContextMenuEntry = CustomContextMenuItem | CustomContextMenuSeparator | CustomContextMenuSubmenu;
+
+/**
+ * CustomContextMenuSubmenuOptions interface.
+ */
+export interface CustomContextMenuSubmenuOptions {
+	/**
+	 * Optional icon to display before the label.
+	 */
+	readonly icon?: string;
+
+	/**
+	 * The label text for the submenu item.
+	 */
+	readonly label: string;
+
+	/**
+	 * Whether the submenu item is disabled.
+	 */
+	readonly disabled?: boolean;
+
+	/**
+	 * Function that returns the entries to display in the submenu. Evaluated when the submenu
+	 * is opened to ensure properties like checked state are up to date in the submenu when it opens.
+	 */
+	readonly entries: () => CustomContextMenuEntry[];
+}
+
+/**
+ * CustomContextMenuSubmenu class.
+ */
+export class CustomContextMenuSubmenu {
+	/**
+	 * Constructor.
+	 * @param options A CustomContextMenuSubmenuOptions that contains the submenu options.
+	 */
+	constructor(readonly options: CustomContextMenuSubmenuOptions) {
+	}
+}
 
 /**
  * CustomContextMenuProps interface.
@@ -209,6 +250,93 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 		);
 	};
 
+	/**
+	 * MenuSubmenuItem component.
+	 *
+	 * A component that renders a menu item that opens a submenu when hovered or clicked.
+	 * The submenu is another custom context menu that is positioned relative to the parent menu item.
+	 *
+	 * @param options A CustomContextMenuSubmenuOptions that contains the options.
+	 * @returns The rendered component.
+	 */
+	const MenuSubmenuItem = (options: CustomContextMenuSubmenuOptions) => {
+		// Reference to the submenu item that will be used to position the actual submenu popup.
+		const buttonRef = useRef<HTMLButtonElement>(null);
+
+		/**
+		 * Opens the submenu (another custom context menu) positioned relative to this menu item.
+		 */
+		const openSubmenu = () => {
+			if (options.disabled || !buttonRef.current) {
+				return;
+			}
+
+			// Get the anchor point to position the submenu to the top right of the parent menu item.
+			const rect = buttonRef.current.getBoundingClientRect();
+			const anchorPoint: AnchorPoint = {
+				clientX: rect.right,
+				clientY: rect.top
+			};
+
+			// Show the submenu by creating a new custom context menu instance.
+			// Use 'auto' positioning to let the popup system determine the best placement.
+			showCustomContextMenu({
+				anchorElement: buttonRef.current,
+				anchorPoint,
+				popupPosition: 'auto',
+				popupAlignment: 'auto',
+				// Evaluate the entries now to ensure things like the checked state is up to date when submenu opens.
+				entries: options.entries(),
+				onClose: () => {
+					// When submenu closes, focus returns to parent menu item.
+					buttonRef.current?.focus();
+				}
+			});
+		};
+
+		// Render.
+		return (
+			<Button
+				ref={buttonRef}
+				ariaHaspopup='menu'
+				className='custom-context-menu-item'
+				disabled={options.disabled}
+				onPressed={openSubmenu}
+			>
+				{options.icon &&
+					<div
+						aria-hidden='true'
+						className={positronClassNames(
+							'icon',
+							'codicon',
+							`codicon-${options.icon}`,
+							{ 'disabled': options.disabled }
+						)}
+					/>
+				}
+
+				<div
+					className={positronClassNames(
+						'title',
+						{ 'disabled': options.disabled }
+					)}
+				>
+					{options.label}
+				</div>
+
+				<div
+					aria-hidden='true'
+					className={positronClassNames(
+						'submenu-indicator',
+						'codicon',
+						'codicon-chevron-right',
+						{ 'disabled': options.disabled }
+					)}
+				/>
+			</Button>
+		);
+	};
+
 	// Render.
 	return (
 		<PositronModalPopup
@@ -228,6 +356,8 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 						return <MenuItem key={index} {...entry.options} />;
 					} else if (entry instanceof CustomContextMenuSeparator) {
 						return <MenuSeparator key={index} />;
+					} else if (entry instanceof CustomContextMenuSubmenu) {
+						return <MenuSubmenuItem key={index} {...entry.options} />;
 					} else {
 						// This indicates a bug.
 						return null;

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -114,7 +114,7 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 	const services = usePositronReactServicesContext();
 
 	/**
-	 * Dismisses the  modal popup.
+	 * Dismisses the modal popup.
 	 */
 	const dismiss = () => {
 		props.renderer.dispose();
@@ -122,15 +122,23 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 
 	/**
 	 * MenuSeparator component.
+	 *
+	 * A component that renders a separator line between menu items.
+	 * It is used to visually group related menu items together.
+	 *
 	 * @returns The rendered component.
 	 */
 	const MenuSeparator = () => {
 		// Render.
-		return <div className='custom-context-menu-separator' />;
+		return <div className='custom-context-menu-separator' role='separator' />;
 	};
 
 	/**
 	 * MenuItem component.
+	 *
+	 * A component that renders a single menu item in the context menu.
+	 * It can display an optional icon, a label, and an optional checkmark for checkable items.
+	 *
 	 * @param options A CustomContextMenuItemOptions that contains the options.
 	 * @returns The rendered component.
 	 */
@@ -214,7 +222,7 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 			renderer={props.renderer}
 			width={props.width}
 		>
-			<div className='custom-context-menu-items'>
+			<div className='custom-context-menu-items' role='menu'>
 				{props.entries.map((entry, index) => {
 					if (entry instanceof CustomContextMenuItem) {
 						return <MenuItem key={index} {...entry.options} />;

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -288,10 +288,30 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 				// Evaluate the entries now to ensure things like the checked state is up to date when submenu opens.
 				entries: options.entries(),
 				onClose: () => {
-					// When submenu closes, focus returns to parent menu item.
+					// When submenu closes, focus returns to parent menu item that opened the submenu.
 					buttonRef.current?.focus();
 				}
 			});
+		};
+
+		/**
+		 * Handles keyboard events for submenu navigation.
+		 * ArrowRight opens the submenu, and ArrowLeft is handled by the parent menu to close the submenu.
+		 *
+		 * @param e The keyboard event.
+		 */
+		const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+			// Do nothing if the submenu item is disabled.
+			if (options.disabled) {
+				return;
+			}
+
+			// Arrow Right opens the submenu.
+			if (e.key === 'ArrowRight') {
+				e.preventDefault();
+				e.stopPropagation();
+				openSubmenu();
+			}
 		};
 
 		// Render.
@@ -301,6 +321,7 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 				ariaHaspopup='menu'
 				className='custom-context-menu-item'
 				disabled={options.disabled}
+				onKeyDown={handleKeyDown}
 				onPressed={openSubmenu}
 			>
 				{options.icon &&
@@ -337,6 +358,21 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 		);
 	};
 
+	/**
+	 * Handles keyboard events for the custom context menu.
+	 *
+	 * ArrowLeft support added to allow closing submenus which are context menus themselves.
+	 * Without this, once a submenu is open, the user would have to use the mouse to close
+	 * the submenu.
+	 */
+	const handleKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === 'ArrowLeft') {
+			e.preventDefault();
+			e.stopPropagation();
+			dismiss();
+		}
+	};
+
 	// Render.
 	return (
 		<PositronModalPopup
@@ -350,7 +386,7 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 			renderer={props.renderer}
 			width={props.width}
 		>
-			<div className='custom-context-menu-items' role='menu'>
+			<div className='custom-context-menu-items' role='menu' onKeyDown={handleKeyDown}>
 				{props.entries.map((entry, index) => {
 					if (entry instanceof CustomContextMenuItem) {
 						return <MenuItem key={index} {...entry.options} />;


### PR DESCRIPTION
Follow up to #11995 that partially addresses #6292

This PR adds support for rendering submenus in `CustomContextMenu` (our custom context menu component) and `PositronDynamicActionBar` (our action bar component that supports overflowing actions into a dropdown menu).

To fully address #6292, we need to be able to take the dropdown menu buttons from the plots pane and convert them to submenus/cascading menus. This gets us this missing piece.

I do want to point out that the submenu mouse and keyboard support isn't perfect. The `CustomContextMenu` doesn't support showing submenus on hover yet (I started going down this path but realized its going to be its own standalone effort). Keyboard functionality with left/right arrow keys has been added but it's not following accessibility guidelines because part of that effort requires re-writing the component which I didn't want to do in this pass. I did try and improve the semantics and markup a bit.

Note: I do feel like one thing that is missing in the `PositronDynamicActionBar`/`CustomContextMenu` is support for the `IAction` type. This type is used by our `ActionBarButton` and `ActionBarMenuButton` components in our action bars and if we extended that support, we could make it easier to create the submenus. This is something I'll try and resolve in the next PR that fixes the plots pane action bar.

### Screenshots

Breakdown of the new menu UI:

https://github.com/user-attachments/assets/8771d47e-2ae2-4968-bb06-3886239df73e

Video example with checkmark state:

https://github.com/user-attachments/assets/94e781c0-d464-4c9e-a614-aad67ef5730d

### Dev Testing

Note: this PR doesn't introduce a use case of the submenu feature yet, that will come in a follow-up PR. I know its not ideal to review unused code so along with the screenshots I've got some code you can paste into the Console Action Bar (`src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx`) to test the changes locally:

```
        // TEST: paste this at Line 460 
	const testSubmenuActions = (): IAction[] => [
		{ id: 'test1', label: 'Test Option 1', tooltip: '', class: '', enabled: true, run: () => console.log('Test 1') },
		{ id: 'test2', label: 'Test Option 2', tooltip: '', class: '', enabled: true, run: () => console.log('Test 2') },
		{ id: 'test3', label: 'Test Option 3', tooltip: '', class: '', enabled: true, run: () => console.log('Test 3') },
	];
	rightActions.push({
		fixedWidth: DEFAULT_ACTION_BAR_DROPDOWN_BUTTON_WIDTH,
		separator: false,
		component: (
			<ActionBarMenuButton
				actions={testSubmenuActions}
				icon={ThemeIcon.fromId('beaker')}
				tooltip='Test Submenu'
			/>
		),
		overflowContextMenuSubmenu: {
			icon: 'beaker',
			label: 'Test Submenu',
			entries: () => [
				new CustomContextMenuItem({ label: 'Submenu Option 1', onSelected: () => console.log('Submenu 1') }),
				new CustomContextMenuItem({ label: 'Submenu Option 2', onSelected: () => console.log('Submenu 2') }),
				new CustomContextMenuItem({ label: 'Submenu Option 3', onSelected: () => console.log('Submenu 3') }),
			]
		}
	});
```

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:console
@:modal
@:plots

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
