### PR TITLE
assistant eval: Change the logic order of keep button check

### DIFF
--- a/test/e2e/tests/assistant-eval/hallucination/python-no-execution-hallucination.ts
+++ b/test/e2e/tests/assistant-eval/hallucination/python-no-execution-hallucination.ts
@@ -75,10 +75,9 @@ species = pl.DataFrame({
 
 		// Handle the Keep button if the assistant creates a file
 		try {
-			await assistant.clickKeepButton();
 			await assistant.waitForResponseComplete();
 		} catch (error) {
-			// Keep button didn't appear or wasn't clickable - that's OK
+			await assistant.clickKeepButton(20000);
 			await assistant.expectResponseComplete();
 		}
 


### PR DESCRIPTION
This eval was still a little flakey as the response sometimes takes longer than expected.

- Re-ordered the catch of the keep button. No need to wait for the keep button when response is quicker and doesn't create files.
- Increased the timeout for the keep button appear


### QA Notes
@:assistant-eval
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
