### PR TITLE
Fix import statements in PipPackageManager

### DIFF
--- a/extensions/positron-python/src/client/positron/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/pipPackageManager.ts
@@ -7,7 +7,7 @@ import { randomUUID } from 'crypto';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { IPythonExecutionFactory, IPythonExecutionService } from '../common/process/types';
-import { ITerminalServiceFactory } from '../common/terminal/types.js';
+import { ITerminalServiceFactory } from '../common/terminal/types';
 import { IServiceContainer } from '../ioc/types';
 
 /**


### PR DESCRIPTION
We had included an accidental `.js` in the import, which is not necessary.
