### PR TITLE
Fix superscript and subscript rendering in Positron notebooks

### DIFF
--- a/src/vs/workbench/contrib/markdown/common/markedSuperSubExtension.ts
+++ b/src/vs/workbench/contrib/markdown/common/markedSuperSubExtension.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/workbench/contrib/markdown/common/markedSuperSubExtension.ts
+++ b/src/vs/workbench/contrib/markdown/common/markedSuperSubExtension.ts
@@ -19,6 +19,7 @@ export namespace MarkedSuperSubExtension {
 		type: 'superscript' | 'subscript';
 		raw: string;
 		text: string;
+		tokens: marked.Token[];
 	}
 
 	// Match ^text^ for superscript. Text cannot contain ^ or newlines or spaces at boundaries.
@@ -44,19 +45,23 @@ export namespace MarkedSuperSubExtension {
 			start(src: string) {
 				return src.indexOf('^');
 			},
-			tokenizer(src: string) {
+			tokenizer(this: { lexer: marked.Lexer }, src: string) {
 				const match = src.match(superscriptRule);
 				if (match) {
-					return {
+					const token: SuperSubToken = {
 						type: 'superscript',
 						raw: match[0],
 						text: match[1],
+						tokens: [],
 					};
+					this.lexer.inline(token.text, token.tokens);
+					return token;
 				}
 				return undefined;
 			},
+			childTokens: ['tokens'],
 			renderer(token: marked.Tokens.Generic) {
-				return `<sup>${token.text}</sup>`;
+				return `<sup>${this.parser.parseInline(token.tokens ?? [])}</sup>`;
 			},
 		};
 	}
@@ -82,19 +87,23 @@ export namespace MarkedSuperSubExtension {
 				}
 				return -1;
 			},
-			tokenizer(src: string) {
+			tokenizer(this: { lexer: marked.Lexer }, src: string) {
 				const match = src.match(subscriptRule);
 				if (match) {
-					return {
+					const token: SuperSubToken = {
 						type: 'subscript',
 						raw: match[0],
 						text: match[1],
+						tokens: [],
 					};
+					this.lexer.inline(token.text, token.tokens);
+					return token;
 				}
 				return undefined;
 			},
+			childTokens: ['tokens'],
 			renderer(token: marked.Tokens.Generic) {
-				return `<sub>${token.text}</sub>`;
+				return `<sub>${this.parser.parseInline(token.tokens ?? [])}</sub>`;
 			},
 		};
 	}

--- a/src/vs/workbench/contrib/markdown/common/markedSuperSubExtension.ts
+++ b/src/vs/workbench/contrib/markdown/common/markedSuperSubExtension.ts
@@ -22,12 +22,12 @@ export namespace MarkedSuperSubExtension {
 		tokens: marked.Token[];
 	}
 
-	// Match ^text^ for superscript. Text cannot contain ^ or newlines or spaces at boundaries.
-	const superscriptRule = /^\^(?!\^)(\S(?:[^^]*?\S)?)\^(?!\^)/;
+	// Match ^text^ for superscript. Text cannot contain ^, newlines, or spaces at boundaries.
+	const superscriptRule = /^\^(?!\^)(\S(?:[^^\n]*?\S)?)\^(?!\^)/;
 
-	// Match ~text~ for subscript. Text cannot contain ~ or newlines or spaces at boundaries.
+	// Match ~text~ for subscript. Text cannot contain ~, newlines, or spaces at boundaries.
 	// Must not match ~~text~~ (which is strikethrough).
-	const subscriptRule = /^~(?!~)(\S(?:[^~]*?\S)?)~(?!~)/;
+	const subscriptRule = /^~(?!~)(\S(?:[^~\n]*?\S)?)~(?!~)/;
 
 	export function extension(): marked.MarkedExtension {
 		return {

--- a/src/vs/workbench/contrib/markdown/common/markedSuperSubExtension.ts
+++ b/src/vs/workbench/contrib/markdown/common/markedSuperSubExtension.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as marked from '../../../../base/common/marked/marked.js';
+
+/**
+ * Marked extension for superscript (^text^) and subscript (~text~) syntax.
+ *
+ * Superscript: `^text^` renders as <sup>text</sup>
+ * Subscript: `~text~` renders as <sub>text</sub>
+ *
+ * Note: Single `~text~` is subscript, while double `~~text~~` remains strikethrough (del).
+ */
+export namespace MarkedSuperSubExtension {
+
+	export interface SuperSubToken {
+		type: 'superscript' | 'subscript';
+		raw: string;
+		text: string;
+	}
+
+	// Match ^text^ for superscript. Text cannot contain ^ or newlines or spaces at boundaries.
+	const superscriptRule = /^\^(?!\^)(\S(?:[^^]*?\S)?)\^(?!\^)/;
+
+	// Match ~text~ for subscript. Text cannot contain ~ or newlines or spaces at boundaries.
+	// Must not match ~~text~~ (which is strikethrough).
+	const subscriptRule = /^~(?!~)(\S(?:[^~]*?\S)?)~(?!~)/;
+
+	export function extension(): marked.MarkedExtension {
+		return {
+			extensions: [
+				superscript(),
+				subscript(),
+			],
+		};
+	}
+
+	function superscript(): marked.TokenizerAndRendererExtension {
+		return {
+			name: 'superscript',
+			level: 'inline',
+			start(src: string) {
+				return src.indexOf('^');
+			},
+			tokenizer(src: string) {
+				const match = src.match(superscriptRule);
+				if (match) {
+					return {
+						type: 'superscript',
+						raw: match[0],
+						text: match[1],
+					};
+				}
+				return undefined;
+			},
+			renderer(token: marked.Tokens.Generic) {
+				return `<sup>${token.text}</sup>`;
+			},
+		};
+	}
+
+	function subscript(): marked.TokenizerAndRendererExtension {
+		return {
+			name: 'subscript',
+			level: 'inline',
+			start(src: string) {
+				// Find a single ~ that is not part of ~~ (strikethrough)
+				let index = 0;
+				while (index < src.length) {
+					const pos = src.indexOf('~', index);
+					if (pos === -1) {
+						return -1;
+					}
+					// Skip ~~ (strikethrough)
+					if (src[pos + 1] === '~') {
+						index = pos + 2;
+						continue;
+					}
+					return pos;
+				}
+				return -1;
+			},
+			tokenizer(src: string) {
+				const match = src.match(subscriptRule);
+				if (match) {
+					return {
+						type: 'subscript',
+						raw: match[0],
+						text: match[1],
+					};
+				}
+				return undefined;
+			},
+			renderer(token: marked.Tokens.Generic) {
+				return `<sub>${token.text}</sub>`;
+			},
+		};
+	}
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.tsx
@@ -536,7 +536,12 @@ export class TokenMarkdownRenderer {
 			} else if (token.type === 'code' || token.type === 'codespan') {
 				parts.push((token as marked.Tokens.Code | marked.Tokens.Codespan).text);
 			} else if (token.type === 'superscript' || token.type === 'subscript') {
-				parts.push((token as MarkedSuperSubExtension.SuperSubToken).text);
+				const supSubToken = token as MarkedSuperSubExtension.SuperSubToken;
+				if (supSubToken.tokens && supSubToken.tokens.length > 0) {
+					parts.push(this.extractTextFromTokens(supSubToken.tokens));
+				} else {
+					parts.push(supSubToken.text);
+				}
 			} else if ('tokens' in token && Array.isArray(token.tokens)) {
 				parts.push(this.extractTextFromTokens(token.tokens));
 			}

--- a/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -528,7 +528,7 @@ export class TokenMarkdownRenderer {
 	/**
 	 * Extracts plain text from tokens (used for generating heading IDs)
 	 */
-	private extractTextFromTokens(tokens: (marked.Token | MarkedSuperSubExtension.SuperSubToken)[]): string {
+	private extractTextFromTokens(tokens: ExtendedToken[]): string {
 		const parts: string[] = [];
 		for (const token of tokens) {
 			if (token.type === 'text') {

--- a/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.tsx
@@ -339,9 +339,9 @@ export class TokenMarkdownRenderer {
 				return this.renderDel(token as marked.Tokens.Del, key);
 			// Custom superscript/subscript tokens
 			case 'superscript':
-				return <sup key={key}>{(token as MarkedSuperSubExtension.SuperSubToken).text}</sup>;
+				return <sup key={key}>{this.renderInlineTokens((token as MarkedSuperSubExtension.SuperSubToken).tokens)}</sup>;
 			case 'subscript':
-				return <sub key={key}>{(token as MarkedSuperSubExtension.SuperSubToken).text}</sub>;
+				return <sub key={key}>{this.renderInlineTokens((token as MarkedSuperSubExtension.SuperSubToken).tokens)}</sub>;
 			// Custom KaTeX tokens
 			case 'inlineKatex':
 			case 'blockKatex':
@@ -528,13 +528,15 @@ export class TokenMarkdownRenderer {
 	/**
 	 * Extracts plain text from tokens (used for generating heading IDs)
 	 */
-	private extractTextFromTokens(tokens: marked.Token[]): string {
+	private extractTextFromTokens(tokens: (marked.Token | MarkedSuperSubExtension.SuperSubToken)[]): string {
 		const parts: string[] = [];
 		for (const token of tokens) {
 			if (token.type === 'text') {
-				parts.push(token.text);
+				parts.push((token as marked.Tokens.Text).text);
 			} else if (token.type === 'code' || token.type === 'codespan') {
 				parts.push((token as marked.Tokens.Code | marked.Tokens.Codespan).text);
+			} else if (token.type === 'superscript' || token.type === 'subscript') {
+				parts.push((token as MarkedSuperSubExtension.SuperSubToken).text);
 			} else if ('tokens' in token && Array.isArray(token.tokens)) {
 				parts.push(this.extractTextFromTokens(token.tokens));
 			}

--- a/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.tsx
@@ -22,6 +22,7 @@ import { allowedMarkdownHtmlTags, allowedMarkdownHtmlAttributes } from '../../..
 import { importAMDNodeModule } from '../../../../amdX.js';
 import { convertDomChildrenToReact } from './domToReact.js';
 import { MarkedKatexExtension } from '../../markdown/common/markedKatexExtension.js';
+import { MarkedSuperSubExtension } from '../../markdown/common/markedSuperSubExtension.js';
 
 /**
  * Decodes HTML entities in a string
@@ -67,7 +68,7 @@ function decodeHtmlEntities(text: string): string {
  * KatexToken is created by MarkedKatexExtension.ts which
  * parses LaTeX math expressions and creates these tokens.
  */
-type ExtendedToken = marked.Token | MarkedKatexExtension.KatexToken;
+type ExtendedToken = marked.Token | MarkedKatexExtension.KatexToken | MarkedSuperSubExtension.SuperSubToken;
 
 /**
  * Component that renders LaTeX expressions.
@@ -336,6 +337,11 @@ export class TokenMarkdownRenderer {
 				return <code key={key}>{decodeHtmlEntities((token as marked.Tokens.Codespan).text)}</code>;
 			case 'del':
 				return this.renderDel(token as marked.Tokens.Del, key);
+			// Custom superscript/subscript tokens
+			case 'superscript':
+				return <sup key={key}>{(token as MarkedSuperSubExtension.SuperSubToken).text}</sup>;
+			case 'subscript':
+				return <sub key={key}>{(token as MarkedSuperSubExtension.SuperSubToken).text}</sub>;
 			// Custom KaTeX tokens
 			case 'inlineKatex':
 			case 'blockKatex':
@@ -565,8 +571,10 @@ export async function renderNotebookMarkdown(
 		{ throwOnError: false }
 	);
 
-	// Create Marked instance with KaTeX extension which handles LaTeX
-	const markedInstance = new marked.Marked().use(katexExtension);
+	// Create Marked instance with KaTeX and superscript/subscript extensions
+	const markedInstance = new marked.Marked()
+		.use(katexExtension)
+		.use(MarkedSuperSubExtension.extension());
 
 	// Tokenize markdown (KaTeX extension creates custom tokens)
 	const tokens = markedInstance.lexer(content) as ExtendedToken[];


### PR DESCRIPTION
Addresses #10600.

Positron notebooks use Marked (not markdown-it) for markdown rendering, which lacks built-in support for superscript (`^text^`) and subscript (`~text~`) syntax. This PR adds a custom Marked extension to handle both, following the same pattern as the existing KaTeX extension.

__Before__
<img width="388" height="317" alt="image" src="https://github.com/user-attachments/assets/d4d3e1f2-aad7-4940-9c39-8a854c1e3fcc" />

__After__
<img width="424" height="336" alt="image" src="https://github.com/user-attachments/assets/26c5ae32-710a-4e34-acd4-2c16bd78fb18" />


### Changes

- **New file**: `src/vs/workbench/contrib/markdown/common/markedSuperSubExtension.ts` -- Custom Marked tokenizer/renderer extension for `^text^` (superscript) and `~text~` (subscript) syntax
- **Modified**: `src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.tsx` -- Registers the extension and adds React rendering for the new token types

The subscript tokenizer is careful to not match `~~text~~`, which should remain as strikethrough. Both extensions support nested inline tokens (e.g., bold inside superscript).

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed superscript (`^text^`) and subscript (`~text~`) syntax not rendering in Positron notebooks (#10600)

### QA Notes

@:positron-notebooks

1. Open a Positron notebook
2. Add a markdown cell with:
```markdown
## Superscript and Subscript
^superscript^ ~subscript~

H~2~O is water. E = mc^2^.

~~strikethrough~~ should still work.

^**bold superscript**^ and ~*italic subscript*~
```
3. Verify superscript renders as raised text and subscript renders as lowered text
4. Verify `~~strikethrough~~` still renders as strikethrough (not subscript)
5. Verify nested formatting (bold/italic inside super/subscript) works
6. Verify headings containing super/subscript generate correct anchor IDs
