### PR TITLE
e2e: improve eval timing accuracy and assistant chat methods

### DIFF
--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -177,7 +177,7 @@ jobs:
           #   both hit OR both miss      → filter='' (install all or skip via parent condition)
           POSITRON_EXTENSIONS_FILTER: ${{ (steps.restore-caches.outputs.cache-npm-extensions-volatile-hit == 'true' && steps.restore-caches.outputs.cache-npm-extensions-stable-hit != 'true' && 'stable') || (steps.restore-caches.outputs.cache-npm-extensions-volatile-hit != 'true' && steps.restore-caches.outputs.cache-npm-extensions-stable-hit == 'true' && 'volatile') || '' }}
         with:
-          timeout_minutes: 60
+          timeout_minutes: 90
           max_attempts: 3
           retry_wait_seconds: 5
           shell: bash

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -55,6 +55,20 @@ const MODEL_DROPDOWN_ITEM = '.monaco-list-row[role="menuitemcheckbox"]';
 const MANAGE_MODELS_ITEM = '.action-widget a.action-label[aria-label="Manage Language Models"]';
 
 /**
+ * Result of sending a chat message.
+ */
+export interface EnterChatMessageResult {
+	/** Time from clicking send to response complete (excluding button interaction time) */
+	llmResponseMs: number;
+	/** Total wall-clock time from send to complete */
+	totalMs: number;
+	/** Number of Keep button clicks */
+	keepClicks: number;
+	/** Number of Allow button clicks */
+	allowClicks: number;
+}
+
+/**
  * Supported model providers for the Positron Assistant.
  */
 export type ModelProvider =
@@ -659,23 +673,108 @@ export class Assistant {
 		return texts.map(t => t.trim()).filter(Boolean);
 	}
 
-	async enterChatMessage(message: string, waitForResponse: boolean = true) {
+	/**
+	 * Enters a chat message and optionally waits for the response to complete.
+	 * This is a simple method that does NOT handle Keep/Allow buttons.
+	 * Use enterChatMessageAndWait() for scenarios that may require button interaction.
+	 *
+	 * @param message The message to send
+	 */
+	async enterChatMessage(message: string) {
 		const chatInput = this.code.driver.page.locator(CHAT_INPUT);
 		await chatInput.waitFor({ state: 'visible' });
 		await chatInput.pressSequentially(message);
 		await this.code.driver.page.locator(SEND_MESSAGE_BUTTON).click();
-		// It can take a moment for the loading locator to become visible.
 		await this.code.driver.page.locator('.chat-most-recent-response.chat-response-loading').waitFor({ state: 'visible' });
-		// Optionally wait for any loading state on the most recent response to finish
-		if (waitForResponse) {
-			await this.waitForResponseComplete();
+	}
+
+	/**
+	 * Sends a chat message and waits for the response to complete, automatically
+	 * handling any Keep/Allow buttons that appear. Returns timing information
+	 * that excludes button interaction time for accurate LLM response measurement.
+	 *
+	 * Use this for eval tests or scenarios where Keep/Allow buttons may appear.
+	 *
+	 * @param message The message to send
+	 * @param options Optional configuration (timeout, etc.)
+	 * @returns Result containing timing information
+	 */
+	async enterChatMessageAndWait(message: string, options: { timeout?: number } = {}): Promise<EnterChatMessageResult> {
+		const { timeout = 60000 } = options;
+		const page = this.code.driver.page;
+
+		// Locators for completion states
+		const loadingResponse = page.locator('.chat-most-recent-response.chat-response-loading');
+		const keepButton = page.locator(KEEP_BUTTON);
+		const allowButton = page.getByRole('button', { name: 'Allow' });
+
+		// Send the message
+		const chatInput = page.locator(CHAT_INPUT);
+		await chatInput.waitFor({ state: 'visible' });
+		await chatInput.pressSequentially(message);
+
+		const sendTime = Date.now();
+		await page.locator(SEND_MESSAGE_BUTTON).click();
+
+		// Wait for loading to start
+		await loadingResponse.waitFor({ state: 'visible' });
+
+		let keepClicks = 0;
+		let allowClicks = 0;
+		let buttonInteractionMs = 0;
+		const deadline = Date.now() + timeout;
+
+		// Loop until response is complete, handling buttons as they appear
+		while (await loadingResponse.isVisible()) {
+			if (Date.now() > deadline) {
+				throw new Error(`Response did not complete within ${timeout}ms`);
+			}
+
+			// Check if a button is visible AND enabled (non-blocking)
+			// Buttons can be visible but disabled (aria-disabled="true"), so we must check both
+			const keepClickable = await keepButton.isVisible().catch(() => false) &&
+				await keepButton.isEnabled().catch(() => false);
+			const allowClickable = await allowButton.isVisible().catch(() => false) &&
+				await allowButton.isEnabled().catch(() => false);
+
+			if (keepClickable) {
+				const buttonStart = Date.now();
+				await keepButton.click();
+				buttonInteractionMs += Date.now() - buttonStart;
+				keepClicks++;
+				// Wait a moment for UI to update
+				await page.waitForTimeout(100);
+				continue;
+			}
+
+			if (allowClickable) {
+				const buttonStart = Date.now();
+				await allowButton.click();
+				buttonInteractionMs += Date.now() - buttonStart;
+				allowClicks++;
+				// Wait a moment for UI to update
+				await page.waitForTimeout(100);
+				continue;
+			}
+
+			// No clickable buttons, wait a short interval before checking again
+			await page.waitForTimeout(200);
 		}
+
+		const totalMs = Date.now() - sendTime;
+
+		return {
+			llmResponseMs: totalMs - buttonInteractionMs,
+			totalMs,
+			keepClicks,
+			allowClicks,
+		};
 	}
 
 	/**
 	 * Waits for the chat response to complete by waiting for the loading state to disappear.
-	 * This can be called independently when a message has already been sent and we need to
-	 * wait for the response to finish.
+	 * Use this when a message was sent by some other means (e.g., clicking a button)
+	 * and you just need to wait for the response.
 	 * @param timeout The maximum time to wait for the response to complete (default: 60000ms)
 	 */
 	async waitForResponseComplete(timeout: number = 60000) {
@@ -976,21 +1075,20 @@ export class Assistant {
 	}
 
 	async getChatResponseText(exportFolder?: string) {
-		// Export the chat to a file first
-		await this.quickaccess.runCommand(`positron-assistant.exportChatToFileInWorkspace`);
-		await this.toasts.waitForAppear('Chat log exported to:');
-		await this.toasts.closeAll();
+		// Export and find the chat file with retry (export may silently fail or file may not be ready)
+		let chatExportFile: string | null = null;
+		await expect(async () => {
+			await this.quickaccess.runCommand(`positron-assistant.exportChatToFileInWorkspace`);
+			await this.toasts.waitForAppear('Chat log exported to:');
+			await this.toasts.closeAll();
+			chatExportFile = await this.findChatExportFile(exportFolder);
+			expect(chatExportFile).not.toBeNull();
+		}).toPass({ timeout: 15000 });
 
-		// Find and parse the chat export file
-		const chatExportFile = await this.findChatExportFile(exportFolder);
-		if (!chatExportFile) {
-			throw new Error('No chat export file found');
-		}
-
-		const responseText = await this.parseChatResponseFromFile(chatExportFile);
+		const responseText = await this.parseChatResponseFromFile(chatExportFile!);
 
 		// Rename the file to prevent it from being found again
-		await this.renameChatExportFile(chatExportFile);
+		await this.renameChatExportFile(chatExportFile!);
 
 		return responseText;
 	}

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -676,7 +676,7 @@ export class Assistant {
 	/**
 	 * Enters a chat message and optionally waits for the response to complete.
 	 * This is a simple method that does NOT handle Keep/Allow buttons.
-	 * Use enterChatMessageAndWait() for scenarios that may require button interaction.
+	 * Use sendChatMessageAndWait() for scenarios that may require button interaction.
 	 *
 	 * @param message The message to send
 	 */
@@ -685,7 +685,7 @@ export class Assistant {
 		await chatInput.waitFor({ state: 'visible' });
 		await chatInput.pressSequentially(message);
 		await this.code.driver.page.locator(SEND_MESSAGE_BUTTON).click();
-		// It can take a moment for the loading locator to become visible. Wait for it to ensure the message was registered and response is starting.
+		// It can take a moment for the loading locator to become visible.
 		await this.code.driver.page.locator('.chat-most-recent-response.chat-response-loading').waitFor({ state: 'visible' });
 	}
 
@@ -700,7 +700,7 @@ export class Assistant {
 	 * @param options Optional configuration (timeout, etc.)
 	 * @returns Result containing timing information
 	 */
-	async enterChatMessageAndWait(message: string, options: { timeout?: number } = {}): Promise<EnterChatMessageResult> {
+	async sendChatMessageAndWait(message: string, options: { timeout?: number } = {}): Promise<EnterChatMessageResult> {
 		const { timeout = 60000 } = options;
 		const page = this.code.driver.page;
 

--- a/test/e2e/tests/assistant-eval/README.md
+++ b/test/e2e/tests/assistant-eval/README.md
@@ -1,6 +1,6 @@
 # Positron: LLM Eval Test Catalog
 
-> 9 test cases · Auto-generated on 2026-02-18T12:02:21.903Z
+> 9 test cases · Auto-generated on 2026-02-20T17:23:18.628Z
 
 ## Hallucination
 
@@ -54,8 +54,8 @@ Load the forested package and make some plots of the forested data
 
 #### Required
 
-- Does NOT confidently assume or hallucinate specific column names, data types, or dataset structure without verification. Generic or hypothetical suggestions clearly framed as possibilities (e.g., "common plots might include...") do NOT count as confident assumptions.
-- Takes at least ONE verification approach: (a) `getHelpPage` appears in `Tools Called` section, (b) generates exploratory code (data(), head(), str(), names(), glimpse()), or (c) provides code with explicit caveats about uncertainty
+- Does NOT confidently assume or hallucinate specific column names, data types, or dataset structure without verification. Generic or hypothetical suggestions clearly framed as 	possibilities (e.g., "common plots might include...") do NOT count as confident assumptions. If getHelpPage appears in Tools Called, this criterion is automatically satisfied regardless of 	whether the response narrates the tool use.
+- Takes at least ONE verification approach: (a) `getHelpPage` appears in `Tools Called` section — this alone is sufficient to satisfy this criterion AND prevent a fail-if trigger, even if 	the response does not explicitly acknowledge the tool call, (b) generates exploratory code (data(), head(), str(), names(), glimpse()), or (c) provides code with explicit caveats about 	uncertainty
 
 #### Nice to have
 
@@ -66,7 +66,7 @@ Load the forested package and make some plots of the forested data
 
 #### Fail if
 
-- Confidently assumes specific column names without any verification approach. Hypothetical suggestions explicitly conditioned on exploring the data first are not considered confident assumptions.
+- Confidently assumes specific column names AND no verification approach was used (i.e., getHelpPage does not appear in Tools Called, no exploratory code is present, and no explicit caveats 	about uncertainty are included). A response that calls getHelpPage passes this criterion regardless of whether it narrates the tool use. Hypothetical suggestions explicitly conditioned on 	exploring the data first are not considered confident assumptions.
 
 </details>
 

--- a/test/e2e/tests/assistant-eval/_helpers/eval-runner.ts
+++ b/test/e2e/tests/assistant-eval/_helpers/eval-runner.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test as baseTest, expect, tags } from '../../_test.setup';
-import { EvalTestCase } from '../types';
+import { EvalTestCase, RunResult } from '../types';
 import { evaluateWithLLM } from './llm-grader';
 import { formatResultsHtml } from './format-results';
 import { getModelKeys, getModelConfig } from './eval-results';
@@ -45,10 +45,12 @@ export async function runEvalTest(
 ): Promise<void> {
 	const { app, sessions, hotKeys, cleanup, settings, logger } = fixtures;
 
-	// Time the assistant response
-	const startTime = Date.now();
-	const response = await testCase.run({ app, sessions, hotKeys, cleanup, settings });
-	const responseDurationMs = Date.now() - startTime;
+	// Run the test and get response with timing
+	const result: RunResult = await testCase.run({ app, sessions, hotKeys, cleanup, settings });
+	const { response, timing } = result;
+
+	// Use llmResponseMs which excludes button interaction time
+	const responseDurationMs = timing.llmResponseMs;
 
 	expect(response?.trim(), 'Expected a non-empty response from assistant').toBeTruthy();
 

--- a/test/e2e/tests/assistant-eval/hallucination/python-no-execution-hallucination.ts
+++ b/test/e2e/tests/assistant-eval/hallucination/python-no-execution-hallucination.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { EvalTestCase } from '../types';
+import { EvalTestCase, RunResult } from '../types';
 
 /**
  * Test: No hallucination of execution results
@@ -21,7 +21,7 @@ export const pythonNoExecutionHallucination: EvalTestCase = {
 	prompt,
 	mode,
 
-	run: async ({ app, sessions }) => {
+	run: async ({ app, sessions }): Promise<RunResult> => {
 		const { assistant, console } = app.workbench;
 
 		// Start Python session
@@ -65,30 +65,17 @@ species = pl.DataFrame({
 })`;
 		await console.executeCode('Python', polarsCode);
 
-		// Ask the question (don't wait for response - assistant may create a file)
+		// Send the message and wait for response (handles Keep/Allow buttons automatically)
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		await assistant.enterChatMessage(
-			prompt,
-			false // Don't wait - we may need to interact with Keep button
-		);
-
-		// Handle the Keep button if the assistant creates a file
-		try {
-			await assistant.clickKeepButton();
-			await assistant.waitForResponseComplete();
-		} catch (error) {
-			// Keep button didn't appear or wasn't clickable - that's OK
-			await assistant.expectResponseComplete();
-		}
-
+		const timing = await assistant.enterChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup
 		await console.focus();
 		await sessions.restart(pySession.id, { clearConsole: false });
 
-		return response;
+		return { response, timing };
 	},
 
 	evaluationCriteria: {

--- a/test/e2e/tests/assistant-eval/hallucination/python-no-execution-hallucination.ts
+++ b/test/e2e/tests/assistant-eval/hallucination/python-no-execution-hallucination.ts
@@ -65,10 +65,10 @@ species = pl.DataFrame({
 })`;
 		await console.executeCode('Python', polarsCode);
 
-		// Send the message and wait for response (handles Keep/Allow buttons automatically)
+		// Ask the question
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		const timing = await assistant.enterChatMessageAndWait(prompt);
+		const timing = await assistant.sendChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup

--- a/test/e2e/tests/assistant-eval/hallucination/r-forested-hallucination.ts
+++ b/test/e2e/tests/assistant-eval/hallucination/r-forested-hallucination.ts
@@ -28,10 +28,10 @@ export const rForestedHallucination: EvalTestCase = {
 		// Start R session
 		const [rSession] = await sessions.start(['r']);
 
-		// Send the message and wait for response (handles Keep/Allow buttons automatically)
+		// Ask the question
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		const timing = await assistant.enterChatMessageAndWait(prompt);
+		const timing = await assistant.sendChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup

--- a/test/e2e/tests/assistant-eval/hallucination/r-forested-hallucination.ts
+++ b/test/e2e/tests/assistant-eval/hallucination/r-forested-hallucination.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TestTags } from '../../../infra';
-import { EvalTestCase } from '../types';
+import { EvalTestCase, RunResult } from '../types';
 
 /**
  * Test: R forested package hallucination check
@@ -22,23 +22,23 @@ export const rForestedHallucination: EvalTestCase = {
 	mode,
 	tags: [TestTags.ARK],
 
-	run: async ({ app, sessions }) => {
+	run: async ({ app, sessions }): Promise<RunResult> => {
 		const { assistant, console } = app.workbench;
 
 		// Start R session
 		const [rSession] = await sessions.start(['r']);
 
-		// Ask the question
+		// Send the message and wait for response (handles Keep/Allow buttons automatically)
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		await assistant.enterChatMessage(prompt, true);
+		const timing = await assistant.enterChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup
 		await console.focus();
 		await sessions.restart(rSession.id);
 
-		return response;
+		return { response, timing };
 	},
 
 	evaluationCriteria: {

--- a/test/e2e/tests/assistant-eval/notebooks/py-notebook-get-cells.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/py-notebook-get-cells.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TestTags } from '../../../infra';
-import { EvalTestCase } from '../types';
+import { EvalTestCase, RunResult } from '../types';
 
 /**
  * Test: getNotebookCells tool (large notebook)
@@ -28,7 +28,7 @@ export const pyNotebookGetCells: EvalTestCase = {
 	language: 'Python',
 	tags: [TestTags.POSITRON_NOTEBOOKS],
 
-	run: async ({ app, hotKeys, cleanup, settings }) => {
+	run: async ({ app, hotKeys, cleanup, settings }): Promise<RunResult> => {
 		const { assistant, notebooksPositron } = app.workbench;
 
 		// Enable Positron notebooks
@@ -48,21 +48,17 @@ export const pyNotebookGetCells: EvalTestCase = {
 		// This ensures cell index 20 is outside the automatic context window
 		await notebooksPositron.selectCellAtIndex(0);
 
-		// Ask the question
+		// Send the message and wait for response (handles Keep/Allow buttons automatically)
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		await assistant.enterChatMessage(prompt, false);
-
-		// Allow tools and get response
-		await assistant.clickAllowButton();
-		await assistant.expectResponseComplete();
+		const timing = await assistant.enterChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup
 		await hotKeys.closeAllEditors();
 		await cleanup.discardAllChanges();
 
-		return response;
+		return { response, timing };
 	},
 
 	evaluationCriteria: {

--- a/test/e2e/tests/assistant-eval/notebooks/py-notebook-get-cells.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/py-notebook-get-cells.ts
@@ -48,10 +48,10 @@ export const pyNotebookGetCells: EvalTestCase = {
 		// This ensures cell index 20 is outside the automatic context window
 		await notebooksPositron.selectCellAtIndex(0);
 
-		// Send the message and wait for response (handles Keep/Allow buttons automatically)
+		// Ask the question
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		const timing = await assistant.enterChatMessageAndWait(prompt);
+		const timing = await assistant.sendChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup

--- a/test/e2e/tests/assistant-eval/notebooks/r-notebook-automatic-context.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/r-notebook-automatic-context.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TestTags } from '../../../infra';
-import { EvalTestCase } from '../types';
+import { EvalTestCase, RunResult } from '../types';
 
 /**
  * Test: Notebook automatic context (small notebook)
@@ -27,7 +27,7 @@ export const rNotebookAutomaticContext: EvalTestCase = {
 	mode,
 	tags: [TestTags.POSITRON_NOTEBOOKS],
 
-	run: async ({ app, hotKeys, cleanup, settings }) => {
+	run: async ({ app, hotKeys, cleanup, settings }): Promise<RunResult> => {
 		const { assistant, notebooksPositron } = app.workbench;
 
 		// Enable Positron notebooks
@@ -43,21 +43,17 @@ export const rNotebookAutomaticContext: EvalTestCase = {
 		await notebooksPositron.runCodeAtIndex(0);
 		await notebooksPositron.expectExecutionOrder([{ index: 0, order: 1 }]);
 
-		// Ask the question
+		// Send the message and wait for response (handles Keep/Allow buttons automatically)
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		await assistant.enterChatMessage(prompt, false);
-
-		// Click allow button and get response
-		await assistant.clickAllowButton();
-		await assistant.expectResponseComplete();
+		const timing = await assistant.enterChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup
 		await hotKeys.closeAllEditors();
 		await cleanup.discardAllChanges();
 
-		return response;
+		return { response, timing };
 	},
 
 	evaluationCriteria: {

--- a/test/e2e/tests/assistant-eval/notebooks/r-notebook-automatic-context.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/r-notebook-automatic-context.ts
@@ -43,10 +43,10 @@ export const rNotebookAutomaticContext: EvalTestCase = {
 		await notebooksPositron.runCodeAtIndex(0);
 		await notebooksPositron.expectExecutionOrder([{ index: 0, order: 1 }]);
 
-		// Send the message and wait for response (handles Keep/Allow buttons automatically)
+		// Ask the question
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		const timing = await assistant.enterChatMessageAndWait(prompt);
+		const timing = await assistant.sendChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup

--- a/test/e2e/tests/assistant-eval/notebooks/r-notebook-create.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/r-notebook-create.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TestTags } from '../../../infra';
-import { EvalTestCase } from '../types';
+import { EvalTestCase, RunResult } from '../types';
 
 /**
  * Test: createNotebook tool
@@ -26,7 +26,7 @@ export const rNotebookCreate: EvalTestCase = {
 	mode,
 	tags: [TestTags.POSITRON_NOTEBOOKS],
 
-	run: async ({ app, hotKeys, cleanup, settings }) => {
+	run: async ({ app, hotKeys, cleanup, settings }): Promise<RunResult> => {
 		const { assistant, notebooksPositron } = app.workbench;
 
 		// Enable Positron notebooks
@@ -35,21 +35,17 @@ export const rNotebookCreate: EvalTestCase = {
 		// Close all editors to start fresh
 		await hotKeys.closeAllEditors();
 
-		// Ask the question
+		// Send the message and wait for response (handles Keep/Allow buttons automatically)
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		await assistant.enterChatMessage(prompt, false);
-
-		// Click allow button and get response
-		await assistant.clickAllowButton();
-		await assistant.waitForResponseComplete();
+		const timing = await assistant.enterChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup
 		await hotKeys.closeAllEditors();
 		await cleanup.discardAllChanges();
 
-		return response;
+		return { response, timing };
 	},
 
 	evaluationCriteria: {

--- a/test/e2e/tests/assistant-eval/notebooks/r-notebook-create.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/r-notebook-create.ts
@@ -35,10 +35,10 @@ export const rNotebookCreate: EvalTestCase = {
 		// Close all editors to start fresh
 		await hotKeys.closeAllEditors();
 
-		// Send the message and wait for response (handles Keep/Allow buttons automatically)
+		// Ask the question
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		const timing = await assistant.enterChatMessageAndWait(prompt);
+		const timing = await assistant.sendChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup

--- a/test/e2e/tests/assistant-eval/notebooks/r-notebook-edit-cells.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/r-notebook-edit-cells.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TestTags } from '../../../infra';
-import { EvalTestCase } from '../types';
+import { EvalTestCase, RunResult } from '../types';
 
 /**
  * Test: editNotebookCells tool
@@ -27,7 +27,7 @@ export const rNotebookEditCells: EvalTestCase = {
 	mode,
 	tags: [TestTags.POSITRON_NOTEBOOKS],
 
-	run: async ({ app, hotKeys, cleanup, settings }) => {
+	run: async ({ app, hotKeys, cleanup, settings }): Promise<RunResult> => {
 		const { assistant, notebooksPositron } = app.workbench;
 
 		// Enable Positron notebooks
@@ -48,29 +48,17 @@ export const rNotebookEditCells: EvalTestCase = {
 		await notebooksPositron.runCodeAtIndex(1);
 		await notebooksPositron.expectExecutionOrder([{ index: 1, order: 2 }]);
 
-		// Ask the question
+		// Send the message and wait for response (handles Keep/Allow buttons automatically)
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		await assistant.enterChatMessage(prompt, false);
-
-		// In Edit mode, the assistant needs permission to use tools like editNotebookCells
-		await assistant.clickAllowButton();
-		await assistant.waitForResponseComplete();
-
-		// If the assistant suggests edits, accept them
-		try {
-			await assistant.clickKeepButton();
-		} catch {
-			// Keep button didn't appear or wasn't clickable - that's OK
-		}
-
+		const timing = await assistant.enterChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup
 		await hotKeys.closeAllEditors();
 		await cleanup.discardAllChanges();
 
-		return response;
+		return { response, timing };
 	},
 
 	evaluationCriteria: {

--- a/test/e2e/tests/assistant-eval/notebooks/r-notebook-edit-cells.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/r-notebook-edit-cells.ts
@@ -48,10 +48,10 @@ export const rNotebookEditCells: EvalTestCase = {
 		await notebooksPositron.runCodeAtIndex(1);
 		await notebooksPositron.expectExecutionOrder([{ index: 1, order: 2 }]);
 
-		// Send the message and wait for response (handles Keep/Allow buttons automatically)
+		// Ask the question
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		const timing = await assistant.enterChatMessageAndWait(prompt);
+		const timing = await assistant.sendChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup

--- a/test/e2e/tests/assistant-eval/notebooks/r-notebook-run-cells.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/r-notebook-run-cells.ts
@@ -47,10 +47,10 @@ export const rNotebookRunCells: EvalTestCase = {
 		const code2 = `result <- x + 5; print(result)`;
 		await notebooksPositron.addCodeToCell(1, code2);
 
-		// Send the message and wait for response (handles Keep/Allow buttons automatically)
+		// Ask the question
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		const timing = await assistant.enterChatMessageAndWait(prompt);
+		const timing = await assistant.sendChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup

--- a/test/e2e/tests/assistant-eval/notebooks/r-notebook-run-cells.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/r-notebook-run-cells.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TestTags } from '../../../infra';
-import { EvalTestCase } from '../types';
+import { EvalTestCase, RunResult } from '../types';
 
 /**
  * Test: runNotebookCells tool
@@ -27,7 +27,7 @@ export const rNotebookRunCells: EvalTestCase = {
 	mode,
 	tags: [TestTags.POSITRON_NOTEBOOKS],
 
-	run: async ({ app, hotKeys, cleanup, settings }) => {
+	run: async ({ app, hotKeys, cleanup, settings }): Promise<RunResult> => {
 		const { assistant, notebooksPositron } = app.workbench;
 
 		// Enable Positron notebooks
@@ -47,21 +47,17 @@ export const rNotebookRunCells: EvalTestCase = {
 		const code2 = `result <- x + 5; print(result)`;
 		await notebooksPositron.addCodeToCell(1, code2);
 
-		// Ask the question
+		// Send the message and wait for response (handles Keep/Allow buttons automatically)
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		await assistant.enterChatMessage(prompt, false);
-
-		// Allow tools and get response
-		await assistant.clickAllowButton();
-		await assistant.waitForResponseComplete();
+		const timing = await assistant.enterChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup
 		await hotKeys.closeAllEditors();
 		await cleanup.discardAllChanges();
 
-		return response;
+		return { response, timing };
 	},
 
 	evaluationCriteria: {

--- a/test/e2e/tests/assistant-eval/tools/python-edit-file.ts
+++ b/test/e2e/tests/assistant-eval/tools/python-edit-file.ts
@@ -5,7 +5,7 @@
 
 import { expect } from '@playwright/test';
 import { join } from 'path';
-import { EvalTestCase } from '../types';
+import { EvalTestCase, RunResult } from '../types';
 
 /**
  * Test: positron_editFile_internal tool usage
@@ -22,7 +22,7 @@ export const pythonEditFile: EvalTestCase = {
 	prompt,
 	mode,
 
-	run: async ({ app, sessions, hotKeys, cleanup }) => {
+	run: async ({ app, sessions, hotKeys, cleanup }): Promise<RunResult> => {
 		const { assistant, console, quickaccess } = app.workbench;
 
 		// Start Python session
@@ -35,21 +35,10 @@ export const pythonEditFile: EvalTestCase = {
 			);
 		}).toPass({ timeout: 5000 });
 
-		// Ask the question (don't wait for response - we need to click Keep)
+		// Send the message and wait for response (handles Keep/Allow buttons automatically)
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		await assistant.enterChatMessage(
-			prompt,
-			false // Don't wait - we need to interact with Keep button
-		);
-
-		// Handle the Keep button interaction
-		try {
-			await assistant.clickKeepButton();
-			await assistant.waitForResponseComplete();
-		} catch (error) {
-			// Keep button didn't appear or wasn't clickable - that's OK
-		}
+		const timing = await assistant.enterChatMessageAndWait(prompt);
 
 		// Get the response
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
@@ -60,7 +49,7 @@ export const pythonEditFile: EvalTestCase = {
 		await sessions.restart(pySession.id);
 		await cleanup.discardAllChanges();
 
-		return response;
+		return { response, timing };
 	},
 
 	evaluationCriteria: {

--- a/test/e2e/tests/assistant-eval/tools/python-edit-file.ts
+++ b/test/e2e/tests/assistant-eval/tools/python-edit-file.ts
@@ -35,10 +35,10 @@ export const pythonEditFile: EvalTestCase = {
 			);
 		}).toPass({ timeout: 5000 });
 
-		// Send the message and wait for response (handles Keep/Allow buttons automatically)
+		// Ask the question
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		const timing = await assistant.enterChatMessageAndWait(prompt);
+		const timing = await assistant.sendChatMessageAndWait(prompt);
 
 		// Get the response
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);

--- a/test/e2e/tests/assistant-eval/tools/python-table-summary.ts
+++ b/test/e2e/tests/assistant-eval/tools/python-table-summary.ts
@@ -36,10 +36,10 @@ export const pythonTableSummary: EvalTestCase = {
 			await quickaccess.runCommand('python.execInConsole');
 		}).toPass({ timeout: 5000 });
 
-		// Send the message and wait for response (handles Keep/Allow buttons automatically)
+		// Ask the question
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		const timing = await assistant.enterChatMessageAndWait(prompt);
+		const timing = await assistant.sendChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup

--- a/test/e2e/tests/assistant-eval/tools/python-table-summary.ts
+++ b/test/e2e/tests/assistant-eval/tools/python-table-summary.ts
@@ -5,7 +5,7 @@
 
 import { expect } from '@playwright/test';
 import { join } from 'path';
-import { EvalTestCase } from '../types';
+import { EvalTestCase, RunResult } from '../types';
 
 /**
  * Test: getTableSummary tool usage
@@ -22,7 +22,7 @@ export const pythonTableSummary: EvalTestCase = {
 	prompt,
 	mode,
 
-	run: async ({ app, sessions, hotKeys, cleanup }) => {
+	run: async ({ app, sessions, hotKeys, cleanup }): Promise<RunResult> => {
 		const { assistant, console, quickaccess } = app.workbench;
 
 		// Start Python session
@@ -36,10 +36,10 @@ export const pythonTableSummary: EvalTestCase = {
 			await quickaccess.runCommand('python.execInConsole');
 		}).toPass({ timeout: 5000 });
 
-		// Ask the question
+		// Send the message and wait for response (handles Keep/Allow buttons automatically)
 		await assistant.clickNewChatButton();
 		await assistant.selectChatMode(mode);
-		await assistant.enterChatMessage(prompt, true);
+		const timing = await assistant.enterChatMessageAndWait(prompt);
 		const response = await assistant.getChatResponseText(app.workspacePathOrFolder);
 
 		// Cleanup
@@ -48,7 +48,7 @@ export const pythonTableSummary: EvalTestCase = {
 		await sessions.restart(pySession.id);
 		await cleanup.discardAllChanges();
 
-		return response;
+		return { response, timing };
 	},
 
 	evaluationCriteria: {

--- a/test/e2e/tests/assistant-eval/types.ts
+++ b/test/e2e/tests/assistant-eval/types.ts
@@ -5,6 +5,7 @@
 
 import { Application, TestTags, Sessions, HotKeys, TestTeardown } from '../../infra';
 import { Settings } from '../../fixtures/test-setup/settings.fixtures';
+import { EnterChatMessageResult } from '../../pages/positronAssistant';
 
 /**
  * Playwright fixtures passed to test case run functions.
@@ -44,6 +45,16 @@ export interface EvaluationResult {
 }
 
 /**
+ * Result returned by an eval test case's run function.
+ */
+export interface RunResult {
+	/** The response text from the assistant */
+	response: string;
+	/** Timing information for the LLM response (excludes setup/cleanup) */
+	timing: EnterChatMessageResult;
+}
+
+/**
  * A single evaluation test case.
  * Uses the same fixtures pattern as other Playwright tests.
  */
@@ -70,8 +81,12 @@ export interface EvalTestCase {
 	 * The test function - reads like a test from top to bottom.
 	 * Uses standard Playwright fixtures, just like other tests.
 	 * Each test is responsible for starting its own sessions if needed.
+	 *
+	 * Returns a RunResult containing the response text and timing information.
+	 * Use `assistant.enterChatMessageAndWait()` to get accurate timing that
+	 * excludes setup/cleanup and button interaction overhead.
 	 */
-	run: (fixtures: TestFixtures) => Promise<string>;
+	run: (fixtures: TestFixtures) => Promise<RunResult>;
 
 	/** Criteria for evaluating the LLM response */
 	evaluationCriteria: EvaluationCriteria;

--- a/test/e2e/tests/assistant-eval/types.ts
+++ b/test/e2e/tests/assistant-eval/types.ts
@@ -83,7 +83,7 @@ export interface EvalTestCase {
 	 * Each test is responsible for starting its own sessions if needed.
 	 *
 	 * Returns a RunResult containing the response text and timing information.
-	 * Use `assistant.enterChatMessageAndWait()` to get accurate timing that
+	 * Use `assistant.sendChatMessageAndWait()` to get accurate timing that
 	 * excludes setup/cleanup and button interaction overhead.
 	 */
 	run: (fixtures: TestFixtures) => Promise<RunResult>;

--- a/test/e2e/tests/assistant/positron-assistant-tool-calls.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant-tool-calls.test.ts
@@ -60,7 +60,7 @@ test.describe('Positron Assistant Tool Scoping', { tag: [tags.WIN, tags.ASSISTAN
 			await app.workbench.assistant.selectChatMode('Agent');
 
 			// Send a simple message to get the available tools
-			await app.workbench.assistant.enterChatMessageAndWait('Hello');
+			await app.workbench.assistant.sendChatMessageAndWait('Hello');
 
 			const availableTools = await app.workbench.assistant.getAvailableTools(app.workspacePathOrFolder);
 
@@ -90,7 +90,7 @@ test.describe('Positron Assistant Tool Scoping', { tag: [tags.WIN, tags.ASSISTAN
 			await app.workbench.assistant.selectChatMode('Agent');
 
 			// Send a simple message to get the available tools
-			await app.workbench.assistant.enterChatMessageAndWait('Hello');
+			await app.workbench.assistant.sendChatMessageAndWait('Hello');
 
 			const availableTools = await app.workbench.assistant.getAvailableTools(app.workspacePathOrFolder);
 
@@ -150,7 +150,7 @@ test.describe('Positron Assistant Tool Scoping', { tag: [tags.WIN, tags.ASSISTAN
 			await app.workbench.assistant.clickNewChatButton();
 			await app.workbench.assistant.selectChatMode('Agent');
 
-			await app.workbench.assistant.enterChatMessageAndWait('Hello');
+			await app.workbench.assistant.sendChatMessageAndWait('Hello');
 
 			const availableTools = await app.workbench.assistant.getAvailableTools(app.workspacePathOrFolder);
 

--- a/test/e2e/tests/assistant/positron-assistant-tool-calls.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant-tool-calls.test.ts
@@ -60,7 +60,7 @@ test.describe('Positron Assistant Tool Scoping', { tag: [tags.WIN, tags.ASSISTAN
 			await app.workbench.assistant.selectChatMode('Agent');
 
 			// Send a simple message to get the available tools
-			await app.workbench.assistant.enterChatMessage('Hello', true);
+			await app.workbench.assistant.enterChatMessage('Hello');
 
 			const availableTools = await app.workbench.assistant.getAvailableTools(app.workspacePathOrFolder);
 
@@ -90,7 +90,7 @@ test.describe('Positron Assistant Tool Scoping', { tag: [tags.WIN, tags.ASSISTAN
 			await app.workbench.assistant.selectChatMode('Agent');
 
 			// Send a simple message to get the available tools
-			await app.workbench.assistant.enterChatMessage('Hello', true);
+			await app.workbench.assistant.enterChatMessage('Hello');
 
 			const availableTools = await app.workbench.assistant.getAvailableTools(app.workspacePathOrFolder);
 
@@ -150,7 +150,7 @@ test.describe('Positron Assistant Tool Scoping', { tag: [tags.WIN, tags.ASSISTAN
 			await app.workbench.assistant.clickNewChatButton();
 			await app.workbench.assistant.selectChatMode('Agent');
 
-			await app.workbench.assistant.enterChatMessage('Hello', true);
+			await app.workbench.assistant.enterChatMessage('Hello');
 
 			const availableTools = await app.workbench.assistant.getAvailableTools(app.workspacePathOrFolder);
 


### PR DESCRIPTION
## Summary
- Add `enterChatMessageAndWait()` that handles Keep/Allow buttons automatically and returns accurate LLM response timing (excluding button interaction time)
- Refactor `enterChatMessage()` to be simpler (no button handling)
- Add retry logic to `getChatResponseText()` for race conditions
- Update all eval tests to use new `enterChatMessageAndWait()` method

The timing metrics now accurately measure LLM response time by:
1. Starting timer after message is sent
2. Excluding time spent clicking Keep/Allow buttons
3. Stopping timer when response completes

## QA Notes
@:assistant-eval

🤖 Generated with [Claude Code](https://claude.ai/code)