### PR TITLE
Add support for `uv` to the packages pane

### DIFF
--- a/extensions/positron-python/src/client/positron/packages/packageManagerFactory.ts
+++ b/extensions/positron-python/src/client/positron/packages/packageManagerFactory.ts
@@ -7,6 +7,7 @@ import { IServiceContainer } from '../../ioc/types';
 import { EnvironmentType } from '../../pythonEnvironments/info';
 import { PipPackageManager } from './pipPackageManager';
 import { IPackageManager, MessageEmitter } from './types';
+import { UvPackageManager } from './uvPackageManager';
 
 /**
  * Package manager types for Python environments.
@@ -15,19 +16,22 @@ import { IPackageManager, MessageEmitter } from './types';
 export enum PackageManagerType {
     Pip = 'Pip',
     Venv = 'Venv',
+    Uv = 'Uv',
 }
 
 /**
  * Factory for creating the appropriate package manager based on environment type.
  *
  * This factory examines the Python environment type and returns the corresponding
- * package manager implementation, with a fallback to PipPackageManager.
+ * package manager implementation:
+ * - Uv environments use UvPackageManager
+ * - All other environments use PipPackageManager as the default
  */
 export class PackageManagerFactory {
     /**
      * Create the appropriate package manager for the given environment.
      *
-     * @param runtimeSource The environment type (e.g., 'Venv', 'Conda', 'Global')
+     * @param runtimeSource The environment type (e.g., 'Venv', 'Conda', 'Global', 'Uv')
      * @param pythonPath The path to the Python interpreter
      * @param messageEmitter The emitter for runtime messages
      * @param serviceContainer The service container for dependency injection
@@ -39,8 +43,10 @@ export class PackageManagerFactory {
         messageEmitter: MessageEmitter,
         serviceContainer: IServiceContainer,
     ): IPackageManager {
-        // Check if the environment is a venv
-        if (runtimeSource === EnvironmentType.Venv) {
+        // Check if the environment is a uv-managed environment
+        if (runtimeSource === EnvironmentType.Uv) {
+            return new UvPackageManager(pythonPath, messageEmitter, serviceContainer);
+        } else if (runtimeSource === EnvironmentType.Venv) {
             return new PipPackageManager(pythonPath, messageEmitter, serviceContainer);
         }
 

--- a/extensions/positron-python/src/client/positron/packages/packageManagerFactory.ts
+++ b/extensions/positron-python/src/client/positron/packages/packageManagerFactory.ts
@@ -10,16 +10,6 @@ import { IPackageManager, MessageEmitter } from './types';
 import { UvPackageManager } from './uvPackageManager';
 
 /**
- * Package manager types for Python environments.
- * Used to identify which package manager is handling package operations.
- */
-export enum PackageManagerType {
-    Pip = 'Pip',
-    Venv = 'Venv',
-    Uv = 'Uv',
-}
-
-/**
  * Factory for creating the appropriate package manager based on environment type.
  *
  * This factory examines the Python environment type and returns the corresponding

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -38,10 +38,6 @@ export class PipPackageManager implements IPackageManager {
         }
     }
 
-    /**
-     * Install one or more packages.
-     * @param packages Array of package install requests with name and optional version
-     */
     async installPackages(packages: positron.PackageSpec[]): Promise<void> {
         if (packages.length === 0) {
             return;
@@ -56,9 +52,6 @@ export class PipPackageManager implements IPackageManager {
         await this._executePipInTerminal(args);
     }
 
-    /**
-     * Uninstall one or more packages.
-     */
     async uninstallPackages(packages: string[]): Promise<void> {
         if (packages.length === 0) {
             return;
@@ -71,10 +64,6 @@ export class PipPackageManager implements IPackageManager {
         await this._executePipInTerminal(args);
     }
 
-    /**
-     * Update specific packages to latest versions.
-     * @param packages Array of package install requests with name and optional version
-     */
     async updatePackages(packages: positron.PackageSpec[]): Promise<void> {
         if (packages.length === 0) {
             return;
@@ -89,9 +78,6 @@ export class PipPackageManager implements IPackageManager {
         await this._executePipInTerminal(args);
     }
 
-    /**
-     * Update all installed packages to their latest versions.
-     */
     async updateAllPackages(): Promise<void> {
         await this._ensurePip();
 

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -223,16 +223,14 @@ export class UvPackageManager {
     private async _getOutdatedPackages(): Promise<Array<{ name: string }>> {
         const processServiceFactory = this._serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
         const processService = await processServiceFactory.create();
+        const proxyEnv = this._getProxyEnv();
 
         try {
-            const result = await processService.exec('uv', [
-                'pip',
-                'list',
-                '--outdated',
-                '--format=json',
-                '--python',
-                this._pythonPath,
-            ]);
+            const result = await processService.exec(
+                'uv',
+                ['pip', 'list', '--outdated', '--format=json', '--python', this._pythonPath],
+                { extraVariables: proxyEnv },
+            );
 
             if (result.stdout) {
                 return JSON.parse(result.stdout);
@@ -253,12 +251,28 @@ export class UvPackageManager {
     }
 
     /**
+     * Get proxy environment variables if a proxy is configured in VS Code settings.
+     * uv uses standard HTTP_PROXY/HTTPS_PROXY environment variables.
+     */
+    private _getProxyEnv(): Record<string, string> | undefined {
+        const proxy = vscode.workspace.getConfiguration('http').get<string>('proxy', '');
+        if (proxy) {
+            return {
+                HTTP_PROXY: proxy,
+                HTTPS_PROXY: proxy,
+            };
+        }
+        return undefined;
+    }
+
+    /**
      * Execute a uv command in the terminal (visible to user).
      */
     private async _executeUvInTerminal(args: string[]): Promise<void> {
+        const proxyEnv = this._getProxyEnv();
         const terminalService = this._serviceContainer
             .get<ITerminalServiceFactory>(ITerminalServiceFactory)
-            .getTerminalService({});
+            .getTerminalService({ env: proxyEnv });
         // Ensure terminal is created and ready before sending command
         await terminalService.show();
         const tokenSource = new vscode.CancellationTokenSource();

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -7,12 +7,12 @@ import { randomUUID } from 'crypto';
 import * as path from 'path';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
-import { IWorkspaceService } from '../common/application/types';
-import { IFileSystem } from '../common/platform/types';
-import { IProcessServiceFactory } from '../common/process/types';
-import { ITerminalServiceFactory } from '../common/terminal/types';
-import { IServiceContainer } from '../ioc/types';
-import { isUvInstalled } from '../pythonEnvironments/common/environmentManagers/uv';
+import { IWorkspaceService } from '../../common/application/types';
+import { IFileSystem } from '../../common/platform/types';
+import { IProcessServiceFactory } from '../../common/process/types';
+import { ITerminalServiceFactory } from '../../common/terminal/types';
+import { IServiceContainer } from '../../ioc/types';
+import { isUvInstalled } from '../../pythonEnvironments/common/environmentManagers/uv';
 
 /**
  * Interface for emitting messages to the Positron console
@@ -85,8 +85,8 @@ export class UvPackageManager {
         const useProjectWorkflow = await this._shouldUseProjectWorkflow();
 
         if (useProjectWorkflow) {
-            // Project workflow: uv remove --active <packages>
-            const args = ['remove', '--active', ...packages];
+            // Project workflow: uv remove --active --python <path> <packages>
+            const args = ['remove', '--active', '--python', this._pythonPath, ...packages];
             await this._executeUvInTerminal(args);
         } else {
             // Environment workflow: uv pip uninstall --python <path> <packages>
@@ -129,8 +129,8 @@ export class UvPackageManager {
         const useProjectWorkflow = await this._shouldUseProjectWorkflow();
 
         if (useProjectWorkflow) {
-            // Project workflow: uv sync --upgrade
-            const args = ['sync', '--upgrade'];
+            // Project workflow: uv sync --upgrade --active --python <path>
+            const args = ['sync', '--upgrade', '--active', '--python', this._pythonPath];
             await this._executeUvInTerminal(args);
         } else {
             // Environment workflow: get outdated packages and upgrade them

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -1,0 +1,285 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { randomUUID } from 'crypto';
+import * as path from 'path';
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+import { IWorkspaceService } from '../common/application/types';
+import { IFileSystem } from '../common/platform/types';
+import { IProcessServiceFactory } from '../common/process/types';
+import { ITerminalServiceFactory } from '../common/terminal/types';
+import { IServiceContainer } from '../ioc/types';
+import { isUvInstalled } from '../pythonEnvironments/common/environmentManagers/uv';
+
+/**
+ * Interface for emitting messages to the Positron console
+ */
+interface MessageEmitter {
+    fire(message: positron.LanguageRuntimeMessage): void;
+}
+
+/**
+ * UV Package Manager
+ *
+ * Provides package management functionality for Python sessions using uv.
+ * Supports two workflows:
+ * - Project workflow: Uses `uv add`/`uv remove` when a valid pyproject.toml exists
+ * - Environment workflow: Uses `uv pip install`/`uv pip uninstall` otherwise
+ */
+export class UvPackageManager {
+    constructor(
+        private readonly _pythonPath: string,
+        private readonly _messageEmitter: MessageEmitter,
+        private readonly _serviceContainer: IServiceContainer,
+    ) {}
+
+    /**
+     * Check if uv is available.
+     */
+    async isUvAvailable(): Promise<boolean> {
+        try {
+            return await isUvInstalled();
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Install one or more packages.
+     * @param packages Array of package install requests with name and optional version
+     */
+    async installPackages(packages: positron.PackageSpec[]): Promise<void> {
+        if (packages.length === 0) {
+            return;
+        }
+
+        await this._ensureUv();
+
+        const packageSpecs = this._formatPackageSpecs(packages);
+        const useProjectWorkflow = await this._shouldUseProjectWorkflow();
+
+        if (useProjectWorkflow) {
+            // Project workflow: uv add --active --python <path> <packages>
+            const args = ['add', '--active', '--python', this._pythonPath, ...packageSpecs];
+            await this._executeUvInTerminal(args);
+        } else {
+            // Environment workflow: uv pip install --python <path> <packages>
+            const args = ['pip', 'install', '--python', this._pythonPath, ...packageSpecs];
+            await this._executeUvInTerminal(args);
+        }
+    }
+
+    /**
+     * Uninstall one or more packages.
+     */
+    async uninstallPackages(packages: string[]): Promise<void> {
+        if (packages.length === 0) {
+            return;
+        }
+
+        await this._ensureUv();
+
+        const useProjectWorkflow = await this._shouldUseProjectWorkflow();
+
+        if (useProjectWorkflow) {
+            // Project workflow: uv remove --active <packages>
+            const args = ['remove', '--active', ...packages];
+            await this._executeUvInTerminal(args);
+        } else {
+            // Environment workflow: uv pip uninstall --python <path> <packages>
+            const args = ['pip', 'uninstall', '--python', this._pythonPath, ...packages];
+            await this._executeUvInTerminal(args);
+        }
+    }
+
+    /**
+     * Update specific packages to latest versions.
+     * @param packages Array of package install requests with name and optional version
+     */
+    async updatePackages(packages: positron.PackageSpec[]): Promise<void> {
+        if (packages.length === 0) {
+            return;
+        }
+
+        await this._ensureUv();
+
+        const packageSpecs = this._formatPackageSpecs(packages);
+        const useProjectWorkflow = await this._shouldUseProjectWorkflow();
+
+        if (useProjectWorkflow) {
+            // Project workflow: uv add --upgrade --active --python <path> <packages>
+            const args = ['add', '--upgrade', '--active', '--python', this._pythonPath, ...packageSpecs];
+            await this._executeUvInTerminal(args);
+        } else {
+            // Environment workflow: uv pip install --upgrade --python <path> <packages>
+            const args = ['pip', 'install', '--upgrade', '--python', this._pythonPath, ...packageSpecs];
+            await this._executeUvInTerminal(args);
+        }
+    }
+
+    /**
+     * Update all installed packages to their latest versions.
+     */
+    async updateAllPackages(): Promise<void> {
+        await this._ensureUv();
+
+        const useProjectWorkflow = await this._shouldUseProjectWorkflow();
+
+        if (useProjectWorkflow) {
+            // Project workflow: uv sync --upgrade
+            const args = ['sync', '--upgrade'];
+            await this._executeUvInTerminal(args);
+        } else {
+            // Environment workflow: get outdated packages and upgrade them
+            const outdatedPackages = await this._getOutdatedPackages();
+
+            if (outdatedPackages.length === 0) {
+                this._emitMessage('All packages are up to date.\n');
+                return;
+            }
+
+            const packageNames = outdatedPackages.map((pkg) => pkg.name);
+            const args = ['pip', 'install', '--upgrade', '--python', this._pythonPath, ...packageNames];
+            await this._executeUvInTerminal(args);
+        }
+    }
+
+    // =========================================================================
+    // Private helper methods
+    // =========================================================================
+
+    /**
+     * Ensure uv is available, throwing an error if not.
+     */
+    private async _ensureUv(): Promise<void> {
+        const hasUv = await this.isUvAvailable();
+        if (!hasUv) {
+            throw new Error(
+                'uv is not available. ' +
+                    'Please install uv to use package management features: https://docs.astral.sh/uv/',
+            );
+        }
+    }
+
+    /**
+     * Determine whether to use the project-based workflow (uv add) or
+     * environment-based workflow (uv pip install).
+     *
+     * Uses project workflow when:
+     * - pyproject.toml exists with a valid [project] section (name + version)
+     * - requirements.txt does NOT exist (to avoid sync issues)
+     */
+    private async _shouldUseProjectWorkflow(): Promise<boolean> {
+        const workspaceService = this._serviceContainer.get<IWorkspaceService>(IWorkspaceService);
+        const fileSystem = this._serviceContainer.get<IFileSystem>(IFileSystem);
+
+        // Get workspace folder
+        let workspaceFolder = workspaceService.workspaceFolders?.[0];
+        if (!workspaceFolder) {
+            return false;
+        }
+
+        const workspacePath = workspaceFolder.uri.fsPath;
+
+        // Check if pyproject.toml exists
+        const pyprojectPath = path.join(workspacePath, 'pyproject.toml');
+        const pyprojectExists = await fileSystem.fileExists(pyprojectPath);
+        if (!pyprojectExists) {
+            return false;
+        }
+
+        // Check if pyproject.toml has a valid [project] section
+        let hasValidProjectSection = false;
+        try {
+            const pyprojectContent = await fileSystem.readFile(pyprojectPath);
+            const hasProjectSection = /^\[project\]/m.test(pyprojectContent);
+            const hasName = /^name\s*=/m.test(pyprojectContent);
+            const hasVersion = /^version\s*=/m.test(pyprojectContent);
+            hasValidProjectSection = hasProjectSection && hasName && hasVersion;
+        } catch {
+            return false;
+        }
+
+        if (!hasValidProjectSection) {
+            return false;
+        }
+
+        // Check if requirements.txt exists (if so, use pip workflow to avoid sync issues)
+        const requirementsPath = path.join(workspacePath, 'requirements.txt');
+        const requirementsExists = await fileSystem.fileExists(requirementsPath);
+        if (requirementsExists) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get list of outdated packages using uv pip list.
+     */
+    private async _getOutdatedPackages(): Promise<Array<{ name: string }>> {
+        const processServiceFactory = this._serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
+        const processService = await processServiceFactory.create();
+
+        try {
+            const result = await processService.exec('uv', [
+                'pip',
+                'list',
+                '--outdated',
+                '--format=json',
+                '--python',
+                this._pythonPath,
+            ]);
+
+            if (result.stdout) {
+                return JSON.parse(result.stdout);
+            }
+        } catch {
+            throw new Error('Failed to get outdated packages list');
+        }
+
+        return [];
+    }
+
+    /**
+     * Format package install requests into package specifiers.
+     * e.g., { name: "requests", version: "2.28.0" } becomes "requests==2.28.0"
+     */
+    private _formatPackageSpecs(packages: positron.PackageSpec[]): string[] {
+        return packages.map((pkg) => (pkg.version ? `${pkg.name}==${pkg.version}` : pkg.name));
+    }
+
+    /**
+     * Execute a uv command in the terminal (visible to user).
+     */
+    private async _executeUvInTerminal(args: string[]): Promise<void> {
+        const terminalService = this._serviceContainer
+            .get<ITerminalServiceFactory>(ITerminalServiceFactory)
+            .getTerminalService({});
+        // Ensure terminal is created and ready before sending command
+        await terminalService.show();
+        const tokenSource = new vscode.CancellationTokenSource();
+        try {
+            await terminalService.sendCommand('uv', args, tokenSource.token);
+        } finally {
+            tokenSource.dispose();
+        }
+    }
+
+    /**
+     * Emit a stream message to the console.
+     */
+    private _emitMessage(text: string, parentId?: string): void {
+        this._messageEmitter.fire({
+            id: randomUUID(),
+            parent_id: parentId ?? '',
+            when: new Date().toISOString(),
+            type: positron.LanguageRuntimeMessageType.Stream,
+            name: positron.LanguageRuntimeStreamName.Stdout,
+            text,
+        } as positron.LanguageRuntimeStream);
+    }
+}

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -47,10 +47,6 @@ export class UvPackageManager {
         }
     }
 
-    /**
-     * Install one or more packages.
-     * @param packages Array of package install requests with name and optional version
-     */
     async installPackages(packages: positron.PackageSpec[]): Promise<void> {
         if (packages.length === 0) {
             return;
@@ -72,9 +68,6 @@ export class UvPackageManager {
         }
     }
 
-    /**
-     * Uninstall one or more packages.
-     */
     async uninstallPackages(packages: string[]): Promise<void> {
         if (packages.length === 0) {
             return;
@@ -95,10 +88,6 @@ export class UvPackageManager {
         }
     }
 
-    /**
-     * Update specific packages to latest versions.
-     * @param packages Array of package install requests with name and optional version
-     */
     async updatePackages(packages: positron.PackageSpec[]): Promise<void> {
         if (packages.length === 0) {
             return;
@@ -120,9 +109,6 @@ export class UvPackageManager {
         }
     }
 
-    /**
-     * Update all installed packages to their latest versions.
-     */
     async updateAllPackages(): Promise<void> {
         await this._ensureUv();
 

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -1,0 +1,243 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { expect } from 'chai';
+import * as path from 'path';
+import * as sinon from 'sinon';
+// eslint-disable-next-line import/no-unresolved
+import * as positron from 'positron';
+import { Uri } from 'vscode';
+import { IWorkspaceService } from '../../client/common/application/types';
+import { IFileSystem } from '../../client/common/platform/types';
+import { IServiceContainer } from '../../client/ioc/types';
+import { UvPackageManager } from '../../client/positron/packages/uvPackageManager';
+
+/**
+ * Interface for emitting messages to the Positron console (matches the one in uvPackageManager.ts)
+ */
+interface MessageEmitter {
+	fire(message: positron.LanguageRuntimeMessage): void;
+}
+
+// Test class to expose protected methods
+class UvPackageManagerTest extends UvPackageManager {
+	public async shouldUseProjectWorkflow(): Promise<boolean> {
+		// Access private method via bracket notation for testing
+		return (this as any)._shouldUseProjectWorkflow();
+	}
+}
+
+suite('UvPackageManager Tests', () => {
+	let uvPackageManager: UvPackageManagerTest;
+	let serviceContainer: IServiceContainer;
+	let workspaceService: IWorkspaceService;
+	let fileSystem: IFileSystem;
+	let messageEmitter: MessageEmitter;
+
+	setup(() => {
+		// Create mocks for services
+		fileSystem = {
+			fileExists: sinon.stub().resolves(false),
+			readFile: sinon.stub().resolves(''),
+		} as any;
+
+		workspaceService = {
+			getWorkspaceFolder: sinon.stub().returns(undefined),
+			get workspaceFolders() {
+				return undefined;
+			},
+		} as any;
+
+		// Create service container mock
+		serviceContainer = {
+			get: sinon.stub(),
+		} as any;
+
+		// Configure service container to return the appropriate services
+		(serviceContainer.get as sinon.SinonStub)
+			.withArgs(IWorkspaceService)
+			.returns(workspaceService)
+			.withArgs(IFileSystem)
+			.returns(fileSystem);
+
+		// Create message emitter mock
+		messageEmitter = {
+			fire: sinon.stub(),
+		};
+
+		// Create package manager instance
+		uvPackageManager = new UvPackageManagerTest('/path/to/python', messageEmitter, serviceContainer);
+	});
+
+	teardown(() => {
+		sinon.restore();
+	});
+
+	suite('_shouldUseProjectWorkflow Method', () => {
+		test('Should return true when pyproject.toml exists with [project] section and requirements.txt does not', async () => {
+			const workspaceFolder = {
+				uri: Uri.file('/workspace'),
+				name: 'test',
+				index: 0,
+			};
+
+			const pyprojectContent = `[project]
+name = "test-project"
+version = "0.1.0"`;
+
+			sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+			const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
+			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
+			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
+			(fileSystem.readFile as sinon.SinonStub)
+				.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
+				.resolves(pyprojectContent);
+
+			const result = await uvPackageManager.shouldUseProjectWorkflow();
+
+			expect(result).to.be.true;
+		});
+
+		test('Should return false when pyproject.toml exists without [project] section', async () => {
+			const workspaceFolder = {
+				uri: Uri.file('/workspace'),
+				name: 'test',
+				index: 0,
+			};
+
+			const pyprojectContent = `[build-system]
+requires = ["setuptools"]`;
+
+			sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+			const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
+			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
+			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
+			(fileSystem.readFile as sinon.SinonStub)
+				.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
+				.resolves(pyprojectContent);
+
+			const result = await uvPackageManager.shouldUseProjectWorkflow();
+
+			expect(result).to.be.false;
+		});
+
+		test('Should return false when pyproject.toml has [project] section but missing name', async () => {
+			const workspaceFolder = {
+				uri: Uri.file('/workspace'),
+				name: 'test',
+				index: 0,
+			};
+
+			const pyprojectContent = `[project]
+version = "0.1.0"`;
+
+			sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+			const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
+			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
+			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
+			(fileSystem.readFile as sinon.SinonStub)
+				.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
+				.resolves(pyprojectContent);
+
+			const result = await uvPackageManager.shouldUseProjectWorkflow();
+
+			expect(result).to.be.false;
+		});
+
+		test('Should return false when pyproject.toml has [project] section but missing version', async () => {
+			const workspaceFolder = {
+				uri: Uri.file('/workspace'),
+				name: 'test',
+				index: 0,
+			};
+
+			const pyprojectContent = `[project]
+name = "test-project"`;
+
+			sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+			const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
+			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
+			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
+			(fileSystem.readFile as sinon.SinonStub)
+				.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
+				.resolves(pyprojectContent);
+
+			const result = await uvPackageManager.shouldUseProjectWorkflow();
+
+			expect(result).to.be.false;
+		});
+
+		test('Should return false when pyproject.toml readFile throws error', async () => {
+			const workspaceFolder = {
+				uri: Uri.file('/workspace'),
+				name: 'test',
+				index: 0,
+			};
+
+			sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+			const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
+			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
+			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
+			(fileSystem.readFile as sinon.SinonStub)
+				.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
+				.rejects(new Error('Permission denied'));
+
+			const result = await uvPackageManager.shouldUseProjectWorkflow();
+
+			expect(result).to.be.false;
+		});
+
+		test('Should return false when both pyproject.toml and requirements.txt exist', async () => {
+			const workspaceFolder = {
+				uri: Uri.file('/workspace'),
+				name: 'test',
+				index: 0,
+			};
+
+			const pyprojectContent = `[project]
+name = "test-project"
+version = "0.1.0"`;
+
+			sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+			const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
+			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
+			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(true);
+			(fileSystem.readFile as sinon.SinonStub)
+				.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
+				.resolves(pyprojectContent);
+
+			const result = await uvPackageManager.shouldUseProjectWorkflow();
+
+			expect(result).to.be.false;
+		});
+
+		test('Should return false when pyproject.toml does not exist', async () => {
+			const workspaceFolder = {
+				uri: Uri.file('/workspace'),
+				name: 'test',
+				index: 0,
+			};
+
+			sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+			const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
+			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(false);
+			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
+
+			const result = await uvPackageManager.shouldUseProjectWorkflow();
+
+			expect(result).to.be.false;
+		});
+
+		test('Should return false when no workspace folder is available', async () => {
+			sinon.stub(workspaceService, 'workspaceFolders').value(undefined);
+
+			const result = await uvPackageManager.shouldUseProjectWorkflow();
+
+			expect(result).to.be.false;
+		});
+	});
+});

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -20,224 +20,224 @@ import { UvPackageManager } from '../../client/positron/packages/uvPackageManage
  * Interface for emitting messages to the Positron console (matches the one in uvPackageManager.ts)
  */
 interface MessageEmitter {
-	fire(message: positron.LanguageRuntimeMessage): void;
+    fire(message: positron.LanguageRuntimeMessage): void;
 }
 
 // Test class to expose protected methods
 class UvPackageManagerTest extends UvPackageManager {
-	public async shouldUseProjectWorkflow(): Promise<boolean> {
-		// Access private method via bracket notation for testing
-		return (this as any)._shouldUseProjectWorkflow();
-	}
+    public async shouldUseProjectWorkflow(): Promise<boolean> {
+        // Access private method via bracket notation for testing
+        return (this as any)._shouldUseProjectWorkflow();
+    }
 }
 
 suite('UvPackageManager Tests', () => {
-	let uvPackageManager: UvPackageManagerTest;
-	let serviceContainer: IServiceContainer;
-	let workspaceService: IWorkspaceService;
-	let fileSystem: IFileSystem;
-	let messageEmitter: MessageEmitter;
+    let uvPackageManager: UvPackageManagerTest;
+    let serviceContainer: IServiceContainer;
+    let workspaceService: IWorkspaceService;
+    let fileSystem: IFileSystem;
+    let messageEmitter: MessageEmitter;
 
-	setup(() => {
-		// Create mocks for services
-		fileSystem = {
-			fileExists: sinon.stub().resolves(false),
-			readFile: sinon.stub().resolves(''),
-		} as any;
+    setup(() => {
+        // Create mocks for services
+        fileSystem = {
+            fileExists: sinon.stub().resolves(false),
+            readFile: sinon.stub().resolves(''),
+        } as any;
 
-		workspaceService = {
-			getWorkspaceFolder: sinon.stub().returns(undefined),
-			get workspaceFolders() {
-				return undefined;
-			},
-		} as any;
+        workspaceService = {
+            getWorkspaceFolder: sinon.stub().returns(undefined),
+            get workspaceFolders() {
+                return undefined;
+            },
+        } as any;
 
-		// Create service container mock
-		serviceContainer = {
-			get: sinon.stub(),
-		} as any;
+        // Create service container mock
+        serviceContainer = {
+            get: sinon.stub(),
+        } as any;
 
-		// Configure service container to return the appropriate services
-		(serviceContainer.get as sinon.SinonStub)
-			.withArgs(IWorkspaceService)
-			.returns(workspaceService)
-			.withArgs(IFileSystem)
-			.returns(fileSystem);
+        // Configure service container to return the appropriate services
+        (serviceContainer.get as sinon.SinonStub)
+            .withArgs(IWorkspaceService)
+            .returns(workspaceService)
+            .withArgs(IFileSystem)
+            .returns(fileSystem);
 
-		// Create message emitter mock
-		messageEmitter = {
-			fire: sinon.stub(),
-		};
+        // Create message emitter mock
+        messageEmitter = {
+            fire: sinon.stub(),
+        };
 
-		// Create package manager instance
-		uvPackageManager = new UvPackageManagerTest('/path/to/python', messageEmitter, serviceContainer);
-	});
+        // Create package manager instance
+        uvPackageManager = new UvPackageManagerTest('/path/to/python', messageEmitter, serviceContainer);
+    });
 
-	teardown(() => {
-		sinon.restore();
-	});
+    teardown(() => {
+        sinon.restore();
+    });
 
-	suite('_shouldUseProjectWorkflow Method', () => {
-		test('Should return true when pyproject.toml exists with [project] section and requirements.txt does not', async () => {
-			const workspaceFolder = {
-				uri: Uri.file('/workspace'),
-				name: 'test',
-				index: 0,
-			};
+    suite('_shouldUseProjectWorkflow Method', () => {
+        test('Should return true when pyproject.toml exists with [project] section and requirements.txt does not', async () => {
+            const workspaceFolder = {
+                uri: Uri.file('/workspace'),
+                name: 'test',
+                index: 0,
+            };
 
-			const pyprojectContent = `[project]
+            const pyprojectContent = `[project]
 name = "test-project"
 version = "0.1.0"`;
 
-			sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
-			const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
-			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
-			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
-			(fileSystem.readFile as sinon.SinonStub)
-				.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
-				.resolves(pyprojectContent);
+            sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+            const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
+            fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
+            fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
+            (fileSystem.readFile as sinon.SinonStub)
+                .withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
+                .resolves(pyprojectContent);
 
-			const result = await uvPackageManager.shouldUseProjectWorkflow();
+            const result = await uvPackageManager.shouldUseProjectWorkflow();
 
-			expect(result).to.be.true;
-		});
+            expect(result).to.be.true;
+        });
 
-		test('Should return false when pyproject.toml exists without [project] section', async () => {
-			const workspaceFolder = {
-				uri: Uri.file('/workspace'),
-				name: 'test',
-				index: 0,
-			};
+        test('Should return false when pyproject.toml exists without [project] section', async () => {
+            const workspaceFolder = {
+                uri: Uri.file('/workspace'),
+                name: 'test',
+                index: 0,
+            };
 
-			const pyprojectContent = `[build-system]
+            const pyprojectContent = `[build-system]
 requires = ["setuptools"]`;
 
-			sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
-			const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
-			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
-			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
-			(fileSystem.readFile as sinon.SinonStub)
-				.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
-				.resolves(pyprojectContent);
+            sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+            const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
+            fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
+            fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
+            (fileSystem.readFile as sinon.SinonStub)
+                .withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
+                .resolves(pyprojectContent);
 
-			const result = await uvPackageManager.shouldUseProjectWorkflow();
+            const result = await uvPackageManager.shouldUseProjectWorkflow();
 
-			expect(result).to.be.false;
-		});
+            expect(result).to.be.false;
+        });
 
-		test('Should return false when pyproject.toml has [project] section but missing name', async () => {
-			const workspaceFolder = {
-				uri: Uri.file('/workspace'),
-				name: 'test',
-				index: 0,
-			};
+        test('Should return false when pyproject.toml has [project] section but missing name', async () => {
+            const workspaceFolder = {
+                uri: Uri.file('/workspace'),
+                name: 'test',
+                index: 0,
+            };
 
-			const pyprojectContent = `[project]
+            const pyprojectContent = `[project]
 version = "0.1.0"`;
 
-			sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
-			const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
-			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
-			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
-			(fileSystem.readFile as sinon.SinonStub)
-				.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
-				.resolves(pyprojectContent);
+            sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+            const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
+            fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
+            fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
+            (fileSystem.readFile as sinon.SinonStub)
+                .withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
+                .resolves(pyprojectContent);
 
-			const result = await uvPackageManager.shouldUseProjectWorkflow();
+            const result = await uvPackageManager.shouldUseProjectWorkflow();
 
-			expect(result).to.be.false;
-		});
+            expect(result).to.be.false;
+        });
 
-		test('Should return false when pyproject.toml has [project] section but missing version', async () => {
-			const workspaceFolder = {
-				uri: Uri.file('/workspace'),
-				name: 'test',
-				index: 0,
-			};
+        test('Should return false when pyproject.toml has [project] section but missing version', async () => {
+            const workspaceFolder = {
+                uri: Uri.file('/workspace'),
+                name: 'test',
+                index: 0,
+            };
 
-			const pyprojectContent = `[project]
+            const pyprojectContent = `[project]
 name = "test-project"`;
 
-			sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
-			const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
-			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
-			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
-			(fileSystem.readFile as sinon.SinonStub)
-				.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
-				.resolves(pyprojectContent);
+            sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+            const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
+            fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
+            fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
+            (fileSystem.readFile as sinon.SinonStub)
+                .withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
+                .resolves(pyprojectContent);
 
-			const result = await uvPackageManager.shouldUseProjectWorkflow();
+            const result = await uvPackageManager.shouldUseProjectWorkflow();
 
-			expect(result).to.be.false;
-		});
+            expect(result).to.be.false;
+        });
 
-		test('Should return false when pyproject.toml readFile throws error', async () => {
-			const workspaceFolder = {
-				uri: Uri.file('/workspace'),
-				name: 'test',
-				index: 0,
-			};
+        test('Should return false when pyproject.toml readFile throws error', async () => {
+            const workspaceFolder = {
+                uri: Uri.file('/workspace'),
+                name: 'test',
+                index: 0,
+            };
 
-			sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
-			const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
-			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
-			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
-			(fileSystem.readFile as sinon.SinonStub)
-				.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
-				.rejects(new Error('Permission denied'));
+            sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+            const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
+            fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
+            fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
+            (fileSystem.readFile as sinon.SinonStub)
+                .withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
+                .rejects(new Error('Permission denied'));
 
-			const result = await uvPackageManager.shouldUseProjectWorkflow();
+            const result = await uvPackageManager.shouldUseProjectWorkflow();
 
-			expect(result).to.be.false;
-		});
+            expect(result).to.be.false;
+        });
 
-		test('Should return false when both pyproject.toml and requirements.txt exist', async () => {
-			const workspaceFolder = {
-				uri: Uri.file('/workspace'),
-				name: 'test',
-				index: 0,
-			};
+        test('Should return false when both pyproject.toml and requirements.txt exist', async () => {
+            const workspaceFolder = {
+                uri: Uri.file('/workspace'),
+                name: 'test',
+                index: 0,
+            };
 
-			const pyprojectContent = `[project]
+            const pyprojectContent = `[project]
 name = "test-project"
 version = "0.1.0"`;
 
-			sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
-			const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
-			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
-			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(true);
-			(fileSystem.readFile as sinon.SinonStub)
-				.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
-				.resolves(pyprojectContent);
+            sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+            const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
+            fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(true);
+            fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(true);
+            (fileSystem.readFile as sinon.SinonStub)
+                .withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
+                .resolves(pyprojectContent);
 
-			const result = await uvPackageManager.shouldUseProjectWorkflow();
+            const result = await uvPackageManager.shouldUseProjectWorkflow();
 
-			expect(result).to.be.false;
-		});
+            expect(result).to.be.false;
+        });
 
-		test('Should return false when pyproject.toml does not exist', async () => {
-			const workspaceFolder = {
-				uri: Uri.file('/workspace'),
-				name: 'test',
-				index: 0,
-			};
+        test('Should return false when pyproject.toml does not exist', async () => {
+            const workspaceFolder = {
+                uri: Uri.file('/workspace'),
+                name: 'test',
+                index: 0,
+            };
 
-			sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
-			const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
-			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(false);
-			fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
+            sinon.stub(workspaceService, 'workspaceFolders').value([workspaceFolder]);
+            const fileExistsStub = fileSystem.fileExists as sinon.SinonStub;
+            fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml')).resolves(false);
+            fileExistsStub.withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt')).resolves(false);
 
-			const result = await uvPackageManager.shouldUseProjectWorkflow();
+            const result = await uvPackageManager.shouldUseProjectWorkflow();
 
-			expect(result).to.be.false;
-		});
+            expect(result).to.be.false;
+        });
 
-		test('Should return false when no workspace folder is available', async () => {
-			sinon.stub(workspaceService, 'workspaceFolders').value(undefined);
+        test('Should return false when no workspace folder is available', async () => {
+            sinon.stub(workspaceService, 'workspaceFolders').value(undefined);
 
-			const result = await uvPackageManager.shouldUseProjectWorkflow();
+            const result = await uvPackageManager.shouldUseProjectWorkflow();
 
-			expect(result).to.be.false;
-		});
-	});
+            expect(result).to.be.false;
+        });
+    });
 });


### PR DESCRIPTION
This is based off PR #12029 so we should merge that first.

See #11663

Adds support for uv-managed Python environments in the packages pane:

- Create UvPackageManager class with dual workflow support:
  - Project workflow (uv add/remove) when valid pyproject.toml exists
  - Environment workflow (uv pip install/uninstall) otherwise
- Add IPackageManager interface for common package manager operations
- Add PackageManagerType.Uv to the enum
- Update PackageManagerFactory to return UvPackageManager for uv environments
- Rename _pipPackageManager to _packageManager in session.ts

### Release Notes

#### New Features

- Add support for `uv` to the packages pane

#### Bug Fixes

- N/A


### QA Notes

I created a new UV environment using the New Folder from Template menu.