### PR TITLE
python: make UvInstaller respect http.proxy setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,8 @@ Positron forks VSCode. Minimize merge conflicts by isolating Positron code.
 ## Testing
 
 - Ensure build daemons are running before testing
-- Extension tests (preferred for extension development): `npm run test-extension -- -l <extension-name> --grep <pattern>`
+- Extension tests (preferred for extension development except positron-python): `npm run test-extension -- -l <extension-name> --grep <pattern>`
+	- For positron-python, see that extension's CLAUDE.md
 - E2E tests (for UI integration testing): `npx playwright test test/e2e/tests/<test-name>.test.ts --project e2e-electron --reporter list --grep '<pattern>'`
 - Core tests (for core IDE unit/integration testing): `./scripts/test.sh --grep <pattern> --run <file>`
 

--- a/extensions/positron-python/CLAUDE.md
+++ b/extensions/positron-python/CLAUDE.md
@@ -19,7 +19,7 @@ Python language support for the Positron IDE. Fork of Microsoft's Python extensi
 
 - Before running Python-related commands, if a virtual environment exists at `extensions/positron-python/.venv`, activate it
 - **Python**: Run pytest from `extensions/positron-python/python_files/posit`
-- **TypeScript**: `npm run test-extension -- -l positron-python --grep "pattern"`
+- **TypeScript**: `npm run test:unittests -- --grep "pattern"`
 - Never use `if __name__ == "__main__"` in test files
 - Use parametrized tests (`@pytest.mark.parametrize`) for comprehensive coverage
 

--- a/extensions/positron-python/src/client/common/installer/moduleInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/moduleInstaller.ts
@@ -155,6 +155,9 @@ export abstract class ModuleInstaller implements IModuleInstaller {
                     executionInfoArgs,
                     token,
                     executionInfo.useShell,
+                    // --- Start Positron ---
+                    executionInfo.envVars,
+                    // --- End Positron ---
                 );
             }
         };
@@ -260,6 +263,9 @@ export abstract class ModuleInstaller implements IModuleInstaller {
         args: string[],
         token: CancellationToken | undefined,
         useShell: boolean | undefined,
+        // --- Start Positron ---
+        envVars?: Record<string, string>,
+        // --- End Positron ---
     ) {
         const options: TerminalCreationOptions = {};
         if (isResource(resource)) {
@@ -311,7 +317,10 @@ export abstract class ModuleInstaller implements IModuleInstaller {
             } else {
                 // Pass the cancellation token through so that users can cancel installs via the UI
                 // when executeInTerminal is false
-                const spawnOptions: SpawnOptions = { token };
+                const spawnOptions: SpawnOptions = {
+                    token,
+                    ...(envVars && Object.keys(envVars).length > 0 ? { extraVariables: envVars } : {}),
+                };
                 executionResult = await processService.exec(command, args, spawnOptions);
             }
             if (executionResult.stderr?.includes('error: externally-managed-environment')) {

--- a/extensions/positron-python/src/client/common/installer/moduleInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/moduleInstaller.ts
@@ -273,6 +273,13 @@ export abstract class ModuleInstaller implements IModuleInstaller {
         } else {
             options.interpreter = resource;
         }
+        // --- Start Positron ---
+        // Pass env vars (e.g. HTTP_PROXY/HTTPS_PROXY for uv) to the terminal
+        // so they're available in the terminal's environment.
+        if (envVars && Object.keys(envVars).length > 0) {
+            options.env = envVars;
+        }
+        // --- End Positron ---
         if (executeInTerminal) {
             const terminalService = this.serviceContainer
                 .get<ITerminalServiceFactory>(ITerminalServiceFactory)

--- a/extensions/positron-python/src/client/common/installer/uvInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/uvInstaller.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -144,9 +144,19 @@ export class UVInstaller extends ModuleInstaller {
         }
         args.push('--upgrade', '--python', pythonPath);
 
+        // Read the http.proxy setting and pass it as env vars for uv,
+        // which uses HTTP_PROXY/HTTPS_PROXY (not a CLI flag like pip).
+        const proxy = workspaceService.getConfiguration('http').get<string>('proxy', '');
+        const envVars: Record<string, string> = {};
+        if (proxy) {
+            envVars.HTTP_PROXY = proxy;
+            envVars.HTTPS_PROXY = proxy;
+        }
+
         return {
             args: [...args, moduleName],
             execPath,
+            ...(Object.keys(envVars).length > 0 ? { envVars } : {}),
         };
     }
 }

--- a/extensions/positron-python/src/client/common/terminal/service.ts
+++ b/extensions/positron-python/src/client/common/terminal/service.ts
@@ -219,6 +219,9 @@ export class TerminalService implements ITerminalService, Disposable {
             this.terminal = await ensureTerminalLegacy(this.options?.resource, {
                 name: this.options?.title || 'Python',
                 hideFromUser: this.options?.hideFromUser,
+                // --- Start Positron ---
+                env: this.options?.env,
+                // --- End Positron ---
             });
             return;
         } else {
@@ -226,6 +229,9 @@ export class TerminalService implements ITerminalService, Disposable {
             this.terminal = this.terminalManager.createTerminal({
                 name: this.options?.title || 'Python',
                 hideFromUser: this.options?.hideFromUser,
+                // --- Start Positron ---
+                env: this.options?.env,
+                // --- End Positron ---
             });
             this.terminalAutoActivator.disableAutoActivation(this.terminal);
 

--- a/extensions/positron-python/src/client/common/types.ts
+++ b/extensions/positron-python/src/client/common/types.ts
@@ -65,6 +65,9 @@ export type ExecutionInfo = {
     args: string[];
     product?: Product;
     useShell?: boolean;
+    // --- Start Positron ---
+    envVars?: Record<string, string>;
+    // --- End Positron ---
 };
 
 export enum InstallerResponse {

--- a/extensions/positron-python/src/test/common/installer/uvInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/common/installer/uvInstaller.unit.test.ts
@@ -680,4 +680,123 @@ version = "0.1.0"`;
             });
         });
     });
+
+    suite('http.proxy support', () => {
+        function setupWithProxy(proxyUrl: string) {
+            const getConfigStub = workspaceService.getConfiguration as sinon.SinonStub;
+            getConfigStub.reset();
+
+            const httpGet = sinon.stub();
+            httpGet.withArgs('proxy', '').returns(proxyUrl);
+            getConfigStub.withArgs('http').returns({ get: httpGet });
+
+            // Default for any other section (shouldn't be needed, but safe)
+            getConfigStub.callsFake((_section: string) => ({
+                get: sinon.stub().returns(''),
+            }));
+        }
+
+        function setupInterpreter(pythonPath: string, _resource?: Uri) {
+            const settings: IPythonSettings = { pythonPath } as IPythonSettings;
+            (configurationService.getSettings as sinon.SinonStub).returns(settings);
+            (interpreterService.getActiveInterpreter as sinon.SinonStub).resolves({ path: pythonPath });
+        }
+
+        test('Should set HTTP_PROXY and HTTPS_PROXY when http.proxy is configured', async () => {
+            const resource = Uri.file('/test/path');
+            const pythonPath = '/path/to/python';
+            const proxyUrl = 'http://proxy.example.com:8080';
+
+            setupInterpreter(pythonPath);
+            setupWithProxy(proxyUrl);
+
+            const result = await uvInstaller.getExecutionInfo('numpy', resource);
+
+            expect(result.envVars).to.deep.equal({
+                HTTP_PROXY: proxyUrl,
+                HTTPS_PROXY: proxyUrl,
+            });
+        });
+
+        test('Should not include envVars when http.proxy is empty', async () => {
+            const resource = Uri.file('/test/path');
+            const pythonPath = '/path/to/python';
+
+            setupInterpreter(pythonPath);
+            setupWithProxy('');
+
+            const result = await uvInstaller.getExecutionInfo('numpy', resource);
+
+            expect(result.envVars).to.be.undefined;
+        });
+
+        test('Should not include envVars with default mock (no proxy configured)', async () => {
+            const resource = Uri.file('/test/path');
+            const pythonPath = '/path/to/python';
+
+            setupInterpreter(pythonPath);
+            // Use the default mock from setup() which returns '' for all config gets
+
+            const result = await uvInstaller.getExecutionInfo('numpy', resource);
+
+            expect(result.envVars).to.be.undefined;
+        });
+
+        test('Should include envVars alongside correct args for pip install', async () => {
+            const resource = Uri.file('/test/path');
+            const pythonPath = '/path/to/python';
+            const proxyUrl = 'http://corp-proxy:3128';
+
+            setupInterpreter(pythonPath);
+            setupWithProxy(proxyUrl);
+
+            const result = await uvInstaller.getExecutionInfo('pandas', resource);
+
+            expect(result).to.deep.equal({
+                args: ['pip', 'install', '--upgrade', '--python', pythonPath, 'pandas'],
+                execPath: 'uv',
+                envVars: {
+                    HTTP_PROXY: proxyUrl,
+                    HTTPS_PROXY: proxyUrl,
+                },
+            });
+        });
+
+        test('Should include envVars alongside correct args for uv add', async () => {
+            const resource = Uri.file('/test/path');
+            const pythonPath = '/path/to/python';
+            const proxyUrl = 'https://secure-proxy.internal:443';
+
+            const workspaceFolder = {
+                uri: Uri.file('/workspace'),
+                name: 'test',
+                index: 0,
+            };
+
+            const pyprojectContent = `[project]\nname = "test-project"\nversion = "0.1.0"`;
+
+            setupInterpreter(pythonPath);
+            setupWithProxy(proxyUrl);
+            (workspaceService.getWorkspaceFolder as sinon.SinonStub).returns(workspaceFolder);
+            (fileSystem.fileExists as sinon.SinonStub)
+                .withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
+                .resolves(true)
+                .withArgs(path.join(workspaceFolder.uri.fsPath, 'requirements.txt'))
+                .resolves(false);
+            (fileSystem.readFile as sinon.SinonStub)
+                .withArgs(path.join(workspaceFolder.uri.fsPath, 'pyproject.toml'))
+                .resolves(pyprojectContent);
+
+            const result = await uvInstaller.getExecutionInfo('numpy', resource);
+
+            expect(result).to.deep.equal({
+                args: ['add', '--active', '--upgrade', '--python', pythonPath, 'numpy'],
+                execPath: 'uv',
+                envVars: {
+                    HTTP_PROXY: proxyUrl,
+                    HTTPS_PROXY: proxyUrl,
+                },
+            });
+        });
+    });
 });


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11270. Adds support for the `http.proxy` VS Code setting in `UvInstaller` and passes it as `HTTP_PROXY`/`HTTPS_PROXY` environment variables, which `uv` respects.

To plumb env vars through the install pipeline, the PR adds an `envVars` field to `ExecutionInfo` and threads it through `ModuleInstaller` into both the terminal service (for interactive installs) and `SpawnOptions` (for background installs).

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed `uv` package installs not respecting the `http.proxy` setting (#11270)

### QA Notes

@:interpreter

1. Configure a proxy in VS Code settings: `"http.proxy": "http://your-proxy:port"`
2. Open a Python project and install a package via `uv` (e.g. ask Assistant to install a package for you)
3. Verify the install succeeds through the proxy
4. Without the proxy setting, verify installs still work normally

I set up a little server to block only traffic from PyPI and used that as my proxy. Then I confirmed Assistant's uv tool wasn't able to install.

<details><summary>code for that (click to expand)</summary>
<p>

```py
import http.server
import socket
import socketserver
import ssl
import threading

# Block only PyPI hosts; tunnel everything else through.
BLOCKED_HOSTS = {"pypi.org", "files.pythonhosted.org"}


class ProxyHandler(http.server.BaseHTTPRequestHandler):
    def do_CONNECT(self):
        host = self.path.split(":")[0]
        port = int(self.path.split(":")[1]) if ":" in self.path else 443

        if host in BLOCKED_HOSTS:
            print(f"\n>>> BLOCKED CONNECT: {self.path}")
            self.send_error(
                502, f"Proxy test: {host} intentionally blocked"
            )
            return

        # Tunnel non-blocked traffic through transparently
        print(f"    (tunneling {self.path})")
        try:
            remote = socket.create_connection((host, port), timeout=10)
        except Exception as e:
            self.send_error(502, f"Failed to connect to {host}: {e}")
            return

        self.send_response(200, "Connection Established")
        self.end_headers()

        # Shuttle bytes between client and remote in both directions
        client = self.connection

        def forward(src, dst):
            try:
                while True:
                    data = src.recv(4096)
                    if not data:
                        break
                    dst.sendall(data)
            except Exception:
                pass
            finally:
                try:
                    dst.shutdown(socket.SHUT_WR)
                except Exception:
                    pass

        t1 = threading.Thread(
            target=forward, args=(client, remote), daemon=True
        )
        t2 = threading.Thread(
            target=forward, args=(remote, client), daemon=True
        )
        t1.start()
        t2.start()
        t1.join()
        t2.join()
        remote.close()

    def do_GET(self):
        print(f"\n>>> PROXY GET: {self.path}")
        self.send_error(502, "Proxy test: plain HTTP blocked")


PORT = 9999
with socketserver.ThreadingTCPServer(("", PORT), ProxyHandler) as httpd:
    print(f"Test proxy listening on http://127.0.0.1:{PORT}")
    print(f"Blocking: {', '.join(BLOCKED_HOSTS)}")
    print("Tunneling all other HTTPS traffic through.")
    httpd.serve_forever()
```

</p>
</details> 