### PR TITLE
python LS: add column completions for double-bracket DataFrame access

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_lsp.py
@@ -805,7 +805,7 @@ def _get_dict_key_completions(
     obj = _safe_resolve_expression(server.shell.user_ns, expr)
     if obj is None:
         # Try static analysis fallback for os.environ
-        if document is not None:
+        if not exclude_dicts and document is not None:
             os_imports = _parse_os_imports(document.source)
             # Check if expr is "<alias>.environ" where alias maps to "os"
             match = _RE_ALIAS_ENVIRON.match(expr)

--- a/extensions/positron-python/python_files/posit/positron/positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_lsp.py
@@ -68,6 +68,11 @@ _RE_DICT_KEY_ACCESS = re.compile(r'(\w[\w\.]*)\s*\[\s*(["\'])([^"\']*)?$')
 
 Groups: (1) expression, (2) quote char, (3) optional key prefix"""
 
+_RE_DOUBLE_BRACKET_KEY_ACCESS = re.compile(r'(\w[\w\.]*)\s*\[\s*\[\s*(?:.*,\s*)?(["\'])([^"\']*)?$')
+"""DataFrame multi-column select: e.g. `df[["col` or `df[["a", "col`
+
+Groups: (1) expression, (2) quote char, (3) optional key prefix"""
+
 _RE_DOTTED_IDENTIFIER = re.compile(r"([\w\.]+)$")
 """Trailing dotted identifier: e.g. `os.path.join`
 
@@ -590,6 +595,10 @@ def _handle_completion(
     # Check for dict key access pattern (e.g., x[" or x[')
     # This includes DataFrame column access and environment variables
     dict_key_match = _RE_DICT_KEY_ACCESS.search(text_before_cursor)
+    is_double_bracket = False
+    if not dict_key_match:
+        dict_key_match = _RE_DOUBLE_BRACKET_KEY_ACCESS.search(text_before_cursor)
+        is_double_bracket = dict_key_match is not None
     if dict_key_match:
         quote_char = dict_key_match.group(2)
         # Check if there's already a closing quote after cursor
@@ -602,6 +611,7 @@ def _handle_completion(
                 quote_char=quote_char,
                 has_closing_quote=has_closing_quote,
                 document=document,
+                exclude_dicts=is_double_bracket,
             )
         )
 
@@ -785,6 +795,7 @@ def _get_dict_key_completions(
     quote_char: str,
     has_closing_quote: bool,
     document: TextDocument | None = None,
+    exclude_dicts: bool = False,
 ) -> list[types.CompletionItem]:
     """Get dict key completions for dict-like objects (dict, DataFrame, Series, os.environ)."""
     if server.shell is None:
@@ -807,12 +818,17 @@ def _get_dict_key_completions(
     items = []
     keys: list[str] = []
 
-    # Get keys based on the type of object
+    # Get keys based on the type of object.
+    # Double-bracket access (df[["col"]]) only makes sense for DataFrames/Series,
+    # not plain dicts or environ (which would raise TypeError on list keys).
     if isinstance(obj, dict):
-        keys = [str(k) for k in obj if isinstance(k, str)]
+        if not exclude_dicts:
+            keys = [str(k) for k in obj if isinstance(k, str)]
     elif _is_environ_like(obj):
-        # os.environ or similar - use shared helper
-        return _make_env_var_completions(prefix, quote_char, has_closing_quote=has_closing_quote)
+        if not exclude_dicts:
+            return _make_env_var_completions(
+                prefix, quote_char, has_closing_quote=has_closing_quote
+            )
     elif _is_dataframe_like(obj):
         # pandas/polars DataFrame
         with contextlib.suppress(Exception):

--- a/extensions/positron-python/python_files/posit/positron/tests/test_lsp_patterns.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_lsp_patterns.py
@@ -14,6 +14,7 @@ from positron.positron_lsp import (
     _RE_DICT_KEY_ACCESS,
     _RE_DOTTED_IDENTIFIER,
     _RE_DOTTED_IDENTIFIER_WS,
+    _RE_DOUBLE_BRACKET_KEY_ACCESS,
     _RE_KWARG_NAME,
     _RE_KWARG_TRAILING,
     _RE_KWARG_VALUE,
@@ -80,6 +81,49 @@ class TestDictKeyAccess:
     )
     def test_no_match(self, text: str) -> None:
         assert _RE_DICT_KEY_ACCESS.search(text) is None
+
+
+class TestDoubleBracketKeyAccess:
+    """Match DataFrame multi-column select like df[["col."""
+
+    @pytest.mark.parametrize(
+        ("text", "expr", "quote", "prefix"),
+        [
+            ('x[["', "x", '"', ""),
+            ("x[['", "x", "'", ""),
+            ('x[["abc', "x", '"', "abc"),
+            ("df[['col", "df", "'", "col"),
+            ('obj.attr[["key', "obj.attr", '"', "key"),
+            ('x  [["', "x", '"', ""),
+            ('x[["a", "', "x", '"', ""),
+            ('x[["a", "bc', "x", '"', "bc"),
+            ("x[['a', 'b', '", "x", "'", ""),
+            ('x[[ "', "x", '"', ""),
+            ('x[[ "a",  "bc', "x", '"', "bc"),
+        ],
+    )
+    def test_match(self, text: str, expr: str, quote: str, prefix: str) -> None:
+        m = _RE_DOUBLE_BRACKET_KEY_ACCESS.search(text)
+        assert m is not None
+        assert m.group(1) == expr
+        assert m.group(2) == quote
+        assert m.group(3) == prefix
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            'x["',
+            "x['",
+            "x[[",
+            "x[[1",
+            "x",
+            "",
+            '[["',
+            "[['",
+        ],
+    )
+    def test_no_match(self, text: str) -> None:
+        assert _RE_DOUBLE_BRACKET_KEY_ACCESS.search(text) is None
 
 
 class TestDottedIdentifier:

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
@@ -518,6 +518,20 @@ class TestCompletions:
                 id="os_environ_double_bracket_no_completions",
             ),
             pytest.param(
+                'import os; os.environ[["',
+                {},
+                None,
+                [],
+                id="os_environ_double_bracket_from_source_no_completions",
+            ),
+            pytest.param(
+                'x[["',
+                {"x": pd.Series({"a": 1, "b": 2})},
+                None,
+                ['a"', 'b"'],
+                id="pandas_series_double_bracket",
+            ),
+            pytest.param(
                 'os.environ["',
                 {"os": os},
                 None,

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
@@ -352,19 +352,29 @@ class TestCompletions:
         assert labels == {expected_label}
 
     @pytest.mark.parametrize(
-        ("source", "character", "expected_labels"),
+        ("source", "namespace", "character", "expected_labels"),
         [
-            ("x['']", 3, {"a", "b"}),
-            ('x[""]', 3, {"a", "b"}),
-            ("x['", None, {"a'", "b'"}),
-            ('x["', None, {'a"', 'b"'}),
+            ("x['']", {"x": {"a": 0, "b": 1}}, 3, {"a", "b"}),
+            ('x[""]', {"x": {"a": 0, "b": 1}}, 3, {"a", "b"}),
+            ("x['", {"x": {"a": 0, "b": 1}}, None, {"a'", "b'"}),
+            ('x["', {"x": {"a": 0, "b": 1}}, None, {'a"', 'b"'}),
+            ('x[[""]', {"x": pd.DataFrame({"a": [], "b": []})}, 4, {"a", "b"}),
+            ("x[['']", {"x": pd.DataFrame({"a": [], "b": []})}, 4, {"a", "b"}),
+            ('x[["', {"x": pd.DataFrame({"a": [], "b": []})}, None, {'a"', 'b"'}),
+            ("x[['", {"x": pd.DataFrame({"a": [], "b": []})}, None, {"a'", "b'"}),
+            ('x[[""]', {"x": {"a": 0, "b": 1}}, 4, set()),
+            ("x[['']", {"x": {"a": 0, "b": 1}}, 4, set()),
         ],
     )
     def test_dict_key_completion_with_closing_quote(
-        self, source: str, character: Optional[int], expected_labels: set[str]
+        self,
+        source: str,
+        namespace: Dict[str, Any],
+        character: Optional[int],
+        expected_labels: set[str],
     ) -> None:
         """Test that dict key completions don't duplicate closing quote when it already exists."""
-        server = create_test_server(namespace={"x": {"a": 0, "b": 1}})
+        server = create_test_server(namespace=namespace)
 
         text_document = create_text_document(server, TEST_DOCUMENT_URI, source)
         completions = self._completions(server, text_document, character=character)
@@ -456,6 +466,56 @@ class TestCompletions:
                 ["0"],
                 id="polars_series_dict_key",
                 marks=pytest.mark.xfail(reason="Completing integer dict keys not supported"),
+            ),
+            # Double-bracket (multi-column) DataFrame access
+            pytest.param(
+                'x[["',
+                {"x": pd.DataFrame({"a": [], "b": []})},
+                None,
+                ['a"', 'b"'],
+                id="pandas_dataframe_double_bracket",
+            ),
+            pytest.param(
+                "x[['",
+                {"x": pd.DataFrame({"a": [], "b": []})},
+                None,
+                ["a'", "b'"],
+                id="pandas_dataframe_double_bracket_single_quote",
+            ),
+            pytest.param(
+                'x[["a", "',
+                {"x": pd.DataFrame({"a": [], "b": []})},
+                None,
+                ['a"', 'b"'],
+                id="pandas_dataframe_double_bracket_second_col",
+            ),
+            pytest.param(
+                'x[["',
+                {"x": pl.DataFrame({"a": []})},
+                None,
+                ['a"'],
+                id="polars_dataframe_double_bracket",
+            ),
+            pytest.param(
+                'x[[ "',
+                {"x": pd.DataFrame({"a": [], "b": []})},
+                None,
+                ['a"', 'b"'],
+                id="pandas_dataframe_double_bracket_whitespace",
+            ),
+            pytest.param(
+                'x[["',
+                {"x": {"a": 0, "b": 1}},
+                None,
+                [],
+                id="dict_double_bracket_no_completions",
+            ),
+            pytest.param(
+                'os.environ[["',
+                {"os": os},
+                None,
+                [],
+                id="os_environ_double_bracket_no_completions",
             ),
             pytest.param(
                 'os.environ["',


### PR DESCRIPTION
Addresses #11553. This PR adds column name completions when you do e.g. `df[["` in addition to existing behavior with `df["`.

It adds a new double-bracket-matching regex with the same group structure as the single-bracket-matching one, used as a fallback when the single-bracket pattern doesn't match.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed Python column name completions not appearing for multi-column DataFrame selection with `df[["` syntax (#11553)

### QA Notes

@:console @:editor

```python
import pandas as pd
x = {"alpha": [1, 2], "beta": [3, 4], "gamma": [5, 6]}
df = pd.DataFrame(x)

# Make sure to run the above first, so we don't rely on static analysis

# All of these should show column name completions:
df[["  # first column
df[["alpha", "  # second column
df[['  # single quotes

# This should not!
x[['
```