### PR TITLE
Claude rules for core tests and React tests

### DIFF
--- a/.claude/rules/core-tests.md
+++ b/.claude/rules/core-tests.md
@@ -1,0 +1,37 @@
+---
+paths:
+  - src/**/*.{test,integrationTest}.{ts,tsx}
+---
+
+# Core Tests
+
+Core Positron unit/integration tests in `src/`, run via `./scripts/test.sh`.
+
+## Disposables
+
+Every test suite must call `ensureNoDisposablesAreLeakedInTestSuite()`. Capture the return value if tests create disposables:
+
+```typescript
+const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+disposables.add(someDisposable);
+```
+
+## Services (prefer in this order)
+
+1. Real services directly (e.g. `new RuntimeStartupService(...)`).
+2. Existing `Test*` service classes - search from `src/vs/workbench/test/browser/positronWorkbenchTestServices.ts`.
+3. For many dependencies, use `positronWorkbenchInstantiationService`.
+
+## Mocking
+
+- Use `Partial<T>` with only the members your test needs, cast with `as T`.
+- For reusable mocks, create a test helper class implementing `Partial<T>`.
+
+## Sinon
+
+Prefer events/state to verify behavior (e.g. await `TestCommandService.onWillExecuteCommand` instead of stubbing `executeCommand`). Use sinon when no observable signal exists.
+
+## Async
+
+- Await events with `Event.toPromise(event)` instead of timeouts.
+- For debounce/throttle/scheduler logic, use `runWithFakedTimers`.

--- a/.claude/rules/react-tests.md
+++ b/.claude/rules/react-tests.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - src/**/*.test.tsx
+---
+
+# React Tests
+
+React component tests run in Electron (not browser). No React testing libraries are available - only `assert`, `sinon`, `react-dom`, and `react-dom/client`.
+
+## Constraints
+
+- Place tests in `test/browser/` adjacent to source: `feature/browser/components/foo.tsx` -> `feature/test/browser/foo.test.tsx`
+- Use `mainWindow.document` instead of `document` for DOM operations.
+- `querySelector` requires `/* eslint-disable no-restricted-syntax */` below the copyright header.
+- Render via a helper that wraps `root.render()` in `flushSync()` so React flushes synchronously.
+- Teardown order matters: (1) `root.unmount()`, (2) `container.remove()`, (3) `sinon.restore()`.

--- a/.vscode/extensions/vscode-selfhost-test-provider/src/extension.ts
+++ b/.vscode/extensions/vscode-selfhost-test-provider/src/extension.ts
@@ -24,7 +24,8 @@ import { ImportGraph } from './importGraph';
 
 // --- Start Positron ---
 // Add .tsx to the test file pattern to allow testing of React components
-const TEST_FILE_PATTERN = 'src/vs/**/*.{test,integrationTest}.{ts,tsx}';
+// VSCode only seems to support a single brace expansion
+const TEST_FILE_PATTERN = 'src/vs/**/*.{test.ts,test.tsx,integrationTest.ts,integrationTest.tsx}';
 // --- End Positron ---
 
 const getWorkspaceFolderForTestFile = (uri: vscode.Uri) =>

--- a/.vscode/extensions/vscode-selfhost-test-provider/src/extension.ts
+++ b/.vscode/extensions/vscode-selfhost-test-provider/src/extension.ts
@@ -22,10 +22,17 @@ import {
 import { BrowserTestRunner, PlatformTestRunner, VSCodeTestRunner } from './vscodeTestRunner';
 import { ImportGraph } from './importGraph';
 
-const TEST_FILE_PATTERN = 'src/vs/**/*.{test,integrationTest}.ts';
+// --- Start Positron ---
+// Add .tsx to the test file pattern to allow testing of React components
+const TEST_FILE_PATTERN = 'src/vs/**/*.{test,integrationTest}.{ts,tsx}';
+// --- End Positron ---
 
 const getWorkspaceFolderForTestFile = (uri: vscode.Uri) =>
-	(uri.path.endsWith('.test.ts') || uri.path.endsWith('.integrationTest.ts')) &&
+	// --- Start Positron ---
+	// Add .tsx to the test file pattern to allow testing of React components
+	(uri.path.endsWith('.test.ts') || uri.path.endsWith('.integrationTest.ts') ||
+		uri.path.endsWith('.test.tsx') || uri.path.endsWith('.integrationTest.tsx')) &&
+		// --- End Positron ---
 		uri.path.includes('/src/vs/')
 		? vscode.workspace.getWorkspaceFolder(uri)
 		: undefined;

--- a/.vscode/extensions/vscode-selfhost-test-provider/src/extension.ts
+++ b/.vscode/extensions/vscode-selfhost-test-provider/src/extension.ts
@@ -22,17 +22,10 @@ import {
 import { BrowserTestRunner, PlatformTestRunner, VSCodeTestRunner } from './vscodeTestRunner';
 import { ImportGraph } from './importGraph';
 
-// --- Start Positron ---
-// Add .tsx to the test file pattern to allow testing of React components
-const TEST_FILE_PATTERN = 'src/vs/**/*.{test,integrationTest}.{ts,tsx}';
-// --- End Positron ---
+const TEST_FILE_PATTERN = 'src/vs/**/*.{test,integrationTest}.ts';
 
 const getWorkspaceFolderForTestFile = (uri: vscode.Uri) =>
-	// --- Start Positron ---
-	// Add .tsx to the test file pattern to allow testing of React components
-	(uri.path.endsWith('.test.ts') || uri.path.endsWith('.integrationTest.ts') ||
-		uri.path.endsWith('.test.tsx') || uri.path.endsWith('.integrationTest.tsx')) &&
-		// --- End Positron ---
+	(uri.path.endsWith('.test.ts') || uri.path.endsWith('.integrationTest.ts')) &&
 		uri.path.includes('/src/vs/')
 		? vscode.workspace.getWorkspaceFolder(uri)
 		: undefined;

--- a/.vscode/extensions/vscode-selfhost-test-provider/src/testTree.ts
+++ b/.vscode/extensions/vscode-selfhost-test-provider/src/testTree.ts
@@ -88,17 +88,13 @@ export class TestFile {
 	) {
 		try {
 			const diagnostics: vscode.Diagnostic[] = [];
-			// --- Start Positron ---
-			// Add .tsx to the test file pattern to allow testing of React components
-			const fileName = this.uri.path.split('/').pop()!;
 			const ast = ts.createSourceFile(
-				fileName,
+				this.uri.path.split('/').pop()!,
 				content,
 				ts.ScriptTarget.ESNext,
 				false,
-				fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+				ts.ScriptKind.TS
 			);
-			// --- End Positron ---
 
 			const parents: { item: vscode.TestItem; children: vscode.TestItem[] }[] = [
 				{ item: file, children: [] },

--- a/.vscode/extensions/vscode-selfhost-test-provider/src/testTree.ts
+++ b/.vscode/extensions/vscode-selfhost-test-provider/src/testTree.ts
@@ -88,13 +88,17 @@ export class TestFile {
 	) {
 		try {
 			const diagnostics: vscode.Diagnostic[] = [];
+			// --- Start Positron ---
+			// Add .tsx to the test file pattern to allow testing of React components
+			const fileName = this.uri.path.split('/').pop()!;
 			const ast = ts.createSourceFile(
-				this.uri.path.split('/').pop()!,
+				fileName,
 				content,
 				ts.ScriptTarget.ESNext,
 				false,
-				ts.ScriptKind.TS
+				fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
 			);
+			// --- End Positron ---
 
 			const parents: { item: vscode.TestItem; children: vscode.TestItem[] }[] = [
 				{ item: file, children: [] },

--- a/src/vs/platform/positronActionBar/browser/components/actionBarWidget.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarWidget.tsx
@@ -96,16 +96,16 @@ export const ActionBarWidget = (props: ActionBarWidgetProps) => {
 	const WidgetComponent = props.descriptor.componentFactory(services);
 
 	// Handler for command execution (only used for command-driven widgets)
-	const handleClick = useCallback(() => {
+	const handleClick = useCallback(async () => {
 		if (props.descriptor.commandId) {
-			commandService.executeCommand(props.descriptor.commandId, props.descriptor.commandArgs);
+			await commandService.executeCommand(props.descriptor.commandId, props.descriptor.commandArgs);
 		}
 	}, [props.descriptor.commandId, props.descriptor.commandArgs, commandService]);
 
-	const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+	const handleKeyDown = useCallback(async (e: React.KeyboardEvent) => {
 		if ((e.key === 'Enter' || e.key === ' ') && props.descriptor.commandId) {
 			e.preventDefault();
-			commandService.executeCommand(props.descriptor.commandId, props.descriptor.commandArgs);
+			await commandService.executeCommand(props.descriptor.commandId, props.descriptor.commandArgs);
 		}
 	}, [props.descriptor.commandId, props.descriptor.commandArgs, commandService]);
 

--- a/src/vs/platform/positronActionBar/test/browser/actionBarWidget.test.tsx
+++ b/src/vs/platform/positronActionBar/test/browser/actionBarWidget.test.tsx
@@ -3,6 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/* eslint-disable no-restricted-syntax */
+
 import assert from 'assert';
 import sinon from 'sinon';
 import { flushSync } from 'react-dom';
@@ -10,53 +12,35 @@ import { createRoot, Root } from 'react-dom/client';
 import { ActionBarWidget } from '../../browser/components/actionBarWidget.js';
 import { IPositronActionBarWidgetDescriptor } from '../../browser/positronActionBarWidgetRegistry.js';
 import { MenuId } from '../../../actions/common/actions.js';
-import { ICommandService } from '../../../commands/common/commands.js';
-import { ServicesAccessor } from '../../../instantiation/common/instantiation.js';
+import { ICommandService, CommandsRegistry } from '../../../commands/common/commands.js';
+import { ServiceIdentifier, ServicesAccessor } from '../../../instantiation/common/instantiation.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
 import { PositronReactServicesContext } from '../../../../base/browser/positronReactRendererContext.js';
-
-/**
- * Creates a minimal mock ServicesAccessor for testing.
- */
-function createMockServicesAccessor(commandService?: ICommandService): ServicesAccessor {
-	const mockCommandService = commandService || {
-		executeCommand: sinon.stub().resolves()
-	} as any;
-
-	return {
-		get: (serviceId: any) => {
-			if (serviceId === ICommandService) {
-				return mockCommandService;
-			}
-			throw new Error(`Service ${serviceId} not mocked`);
-		}
-	} as any;
-}
-
-/**
- * Helper to render ActionBarWidget with context.
- */
-function renderWidget(
-	root: Root,
-	descriptor: IPositronActionBarWidgetDescriptor,
-	servicesAccessor: ServicesAccessor
-) {
-	// Render the widget and wait for React to flush
-	flushSync(() => {
-		root.render(
-			<PositronReactServicesContext.Provider value={servicesAccessor as any}>
-				<ActionBarWidget descriptor={descriptor} />
-			</PositronReactServicesContext.Provider>
-		);
-	});
-}
+import { PositronReactServices } from '../../../../base/browser/positronReactServices.js';
+import { TestCommandService } from '../../../../editor/test/browser/editorTestServices.js';
+import { TestInstantiationService } from '../../../instantiation/test/common/instantiationServiceMock.js';
+import { Event } from '../../../../base/common/event.js';
 
 suite('ActionBarWidget', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
 	let root: Root;
 	let container: HTMLElement;
-	let mockServicesAccessor: ServicesAccessor;
-	let commandService: ICommandService;
+	let mockServicesAccessor: PositronReactServices;
+	let commandService: TestCommandService;
+
+	/** Helper to render ActionBarWidget with context. */
+	function renderWidget(descriptor: IPositronActionBarWidgetDescriptor) {
+		// Render the widget and wait for React to flush
+		flushSync(() => {
+			root.render(
+				<PositronReactServicesContext.Provider value={mockServicesAccessor}>
+					<ActionBarWidget descriptor={descriptor} />
+				</PositronReactServicesContext.Provider>
+			);
+		});
+	}
 
 	setup(() => {
 		// Create a container element for React to render into
@@ -64,22 +48,24 @@ suite('ActionBarWidget', () => {
 		mainWindow.document.body.appendChild(container);
 		root = createRoot(container);
 
-		// Create mock command service
-		commandService = {
-			executeCommand: sinon.stub().resolves()
-		} as unknown as ICommandService;
-
-		mockServicesAccessor = createMockServicesAccessor(commandService);
+		// Create mock services
+		const instantiationService = disposables.add(new TestInstantiationService());
+		commandService = new TestCommandService(instantiationService);
+		mockServicesAccessor = ({
+			get<T>(serviceId: ServiceIdentifier<T>): T {
+				if (serviceId === ICommandService) {
+					return commandService as T;
+				}
+				throw new Error(`Service ${serviceId} not mocked`);
+			}
+		} satisfies Partial<PositronReactServices>) as PositronReactServices;
 	});
 
 	teardown(() => {
 		// Clean up the React root and container
-		if (root) {
-			root.unmount();
-		}
-		if (container && container.parentNode) {
-			container.parentNode.removeChild(container);
-		}
+		root.unmount();
+		container.remove();
+
 		// Restore spies and stubs
 		sinon.restore();
 	});
@@ -92,7 +78,7 @@ suite('ActionBarWidget', () => {
 			componentFactory: () => () => <span className='test-widget-content'>Test Widget</span>
 		};
 
-		renderWidget(root, descriptor, mockServicesAccessor);
+		renderWidget(descriptor);
 
 		const widgetContent = container.querySelector('.test-widget-content');
 		assert.ok(widgetContent, 'Expected to find widget content');
@@ -112,7 +98,7 @@ suite('ActionBarWidget', () => {
 			}
 		};
 
-		renderWidget(root, descriptor, mockServicesAccessor);
+		renderWidget(descriptor);
 
 		assert.ok(receivedAccessor, 'Widget should receive services accessor');
 		assert.strictEqual(receivedAccessor, mockServicesAccessor);
@@ -129,7 +115,7 @@ suite('ActionBarWidget', () => {
 			componentFactory: () => () => <span>Command Widget</span>
 		};
 
-		renderWidget(root, descriptor, mockServicesAccessor);
+		renderWidget(descriptor);
 
 		const button = container.querySelector('button.action-bar-widget');
 		assert.ok(button, 'Expected to find button element');
@@ -138,6 +124,9 @@ suite('ActionBarWidget', () => {
 	});
 
 	test('command-driven widget executes command on click', async () => {
+		// Register a test command
+		disposables.add(CommandsRegistry.registerCommand('test.click.command', () => { }));
+
 		const descriptor: IPositronActionBarWidgetDescriptor = {
 			id: 'test.clickable.widget',
 			menuId: MenuId.EditorActionsRight,
@@ -148,26 +137,25 @@ suite('ActionBarWidget', () => {
 			componentFactory: () => () => <span>Click Me</span>
 		};
 
-		renderWidget(root, descriptor, mockServicesAccessor);
+		renderWidget(descriptor);
 
 		const button = container.querySelector('button.action-bar-widget') as HTMLButtonElement;
 		assert.ok(button, 'Expected to find button');
 
 		// Simulate click
+		const commandPromise = Event.toPromise(commandService.onWillExecuteCommand);
 		button.click();
 
 		// Wait for click handler
-		await new Promise(resolve => setTimeout(resolve, 0));
-
-		const executeCommandStub = commandService.executeCommand as sinon.SinonStub;
-		assert.ok(executeCommandStub.calledOnce, 'Command should be executed once');
-		assert.ok(
-			executeCommandStub.calledWith('test.click.command', { arg1: 'value1' }),
-			'Command should be called with correct arguments'
-		);
+		const command = await commandPromise;
+		assert.strictEqual(command.commandId, 'test.click.command', 'Expected commandId to match');
+		assert.deepStrictEqual(command.args, [{ arg1: 'value1' }], 'Command should be called with correct arguments');
 	});
 
 	test('command-driven widget executes command on Enter key', async () => {
+		// Register a test command
+		disposables.add(CommandsRegistry.registerCommand('test.keyboard.command', () => { }));
+
 		const descriptor: IPositronActionBarWidgetDescriptor = {
 			id: 'test.keyboard.widget',
 			menuId: MenuId.EditorActionsRight,
@@ -177,23 +165,24 @@ suite('ActionBarWidget', () => {
 			componentFactory: () => () => <span>Press Enter</span>
 		};
 
-		renderWidget(root, descriptor, mockServicesAccessor);
+		renderWidget(descriptor);
 
 		const button = container.querySelector('button.action-bar-widget') as HTMLButtonElement;
 		assert.ok(button, 'Expected to find button');
 
 		// Simulate Enter key press
+		const commandPromise = Event.toPromise(commandService.onWillExecuteCommand);
 		const enterEvent = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true });
 		button.dispatchEvent(enterEvent);
 
-		// Wait for event handler
-		await new Promise(resolve => setTimeout(resolve, 0));
-
-		const executeCommandStub = commandService.executeCommand as sinon.SinonStub;
-		assert.ok(executeCommandStub.calledOnce, 'Command should be executed on Enter');
+		const command = await commandPromise;
+		assert.strictEqual(command.commandId, 'test.keyboard.command', 'Command should be executed on Enter');
 	});
 
 	test('command-driven widget executes command on Space key', async () => {
+		// Register a test command
+		disposables.add(CommandsRegistry.registerCommand('test.space.command', () => { }));
+
 		const descriptor: IPositronActionBarWidgetDescriptor = {
 			id: 'test.space.widget',
 			menuId: MenuId.EditorActionsRight,
@@ -203,20 +192,18 @@ suite('ActionBarWidget', () => {
 			componentFactory: () => () => <span>Press Space</span>
 		};
 
-		renderWidget(root, descriptor, mockServicesAccessor);
+		renderWidget(descriptor);
 
 		const button = container.querySelector('button.action-bar-widget') as HTMLButtonElement;
 		assert.ok(button, 'Expected to find button');
 
 		// Simulate Space key press
+		const commandPromise = Event.toPromise(commandService.onWillExecuteCommand);
 		const spaceEvent = new KeyboardEvent('keydown', { key: ' ', bubbles: true });
 		button.dispatchEvent(spaceEvent);
 
-		// Wait for event handler
-		await new Promise(resolve => setTimeout(resolve, 0));
-
-		const executeCommandStub = commandService.executeCommand as sinon.SinonStub;
-		assert.ok(executeCommandStub.calledOnce, 'Command should be executed on Space');
+		const command = await commandPromise;
+		assert.strictEqual(command.commandId, 'test.space.command', 'Command should be executed on Space');
 	});
 
 	test('self-contained widget renders as div (not button)', async () => {
@@ -228,7 +215,7 @@ suite('ActionBarWidget', () => {
 			componentFactory: () => () => <span>Self Contained</span>
 		};
 
-		renderWidget(root, descriptor, mockServicesAccessor);
+		renderWidget(descriptor);
 
 		const div = container.querySelector('div.action-bar-widget');
 		assert.ok(div, 'Expected to find div element');
@@ -246,7 +233,7 @@ suite('ActionBarWidget', () => {
 			componentFactory: () => () => <span>Legacy Widget</span>
 		};
 
-		renderWidget(root, descriptor, mockServicesAccessor);
+		renderWidget(descriptor);
 
 		const div = container.querySelector('div.action-bar-widget');
 		assert.ok(div, 'Expected to find div element for legacy widget');
@@ -271,7 +258,7 @@ suite('ActionBarWidget', () => {
 		// Suppress console.error for this test since we expect an error
 		const consoleErrorStub = sinon.stub(console, 'error');
 
-		renderWidget(root, descriptor, mockServicesAccessor);
+		renderWidget(descriptor);
 
 		const errorIndicator = container.querySelector('.action-bar-widget-error');
 		assert.ok(errorIndicator, 'Expected to find error indicator');
@@ -300,7 +287,7 @@ suite('ActionBarWidget', () => {
 		// Suppress console.error for this test
 		const consoleErrorStub = sinon.stub(console, 'error');
 
-		renderWidget(root, descriptor, mockServicesAccessor);
+		renderWidget(descriptor);
 
 		const errorIndicator = container.querySelector('.action-bar-widget-error') as HTMLElement;
 		assert.ok(errorIndicator, 'Expected to find error indicator');
@@ -311,7 +298,4 @@ suite('ActionBarWidget', () => {
 
 		consoleErrorStub.restore();
 	});
-
-	// Ensure that all disposables are cleaned up.
-	ensureNoDisposablesAreLeakedInTestSuite();
 });

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
@@ -3,6 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/* eslint-disable no-restricted-syntax */
+
 import assert from 'assert';
 import sinon from 'sinon';
 import { flushSync } from 'react-dom';
@@ -100,7 +102,6 @@ suite('ColumnSummaryCell', () => {
 	const columnSchema = getColumnSchema('test_column', 0, 'string', ColumnDisplayType.String);
 
 	function renderRoot(
-		root: Root,
 		mockTableSummaryDataGridInstance: TableSummaryDataGridInstance,
 	) {
 		// Render the widget and wait for React to flush
@@ -125,12 +126,8 @@ suite('ColumnSummaryCell', () => {
 
 	teardown(() => {
 		// Clean up the React root and container
-		if (root) {
-			root.unmount();
-		}
-		if (container && container.parentNode) {
-			container.parentNode.removeChild(container);
-		}
+		root.unmount();
+		container.remove();
 		// Restore spies and stubs
 		sinon.restore();
 	});
@@ -141,7 +138,7 @@ suite('ColumnSummaryCell', () => {
 			getColumnProfileNullCount: () => 0,
 		});
 
-		renderRoot(root, mockTableSummaryDataGridInstance);
+		renderRoot(mockTableSummaryDataGridInstance);
 
 		const nullPercentElement = container.querySelector('.text-percent');
 		assert.ok(nullPercentElement, 'Expected to find null percent element');
@@ -154,7 +151,7 @@ suite('ColumnSummaryCell', () => {
 			getColumnProfileNullCount: () => 1,
 		});
 
-		renderRoot(root, mockTableSummaryDataGridInstance);
+		renderRoot(mockTableSummaryDataGridInstance);
 
 		const nullPercentElement = container.querySelector('.text-percent');
 		assert.ok(nullPercentElement, 'Expected to find null percent element');
@@ -167,7 +164,7 @@ suite('ColumnSummaryCell', () => {
 			getColumnProfileNullCount: () => 999,
 		});
 
-		renderRoot(root, mockTableSummaryDataGridInstance);
+		renderRoot(mockTableSummaryDataGridInstance);
 
 		const nullPercentElement = container.querySelector('.text-percent');
 		assert.ok(nullPercentElement, 'Expected to find null percent element');
@@ -180,7 +177,7 @@ suite('ColumnSummaryCell', () => {
 			getColumnProfileNullCount: () => 1000,
 		});
 
-		renderRoot(root, mockTableSummaryDataGridInstance);
+		renderRoot(mockTableSummaryDataGridInstance);
 
 		const nullPercentElement = container.querySelector('.text-percent');
 		assert.ok(nullPercentElement, 'Expected to find null percent element');

--- a/test/unit/electron/renderer.js
+++ b/test/unit/electron/renderer.js
@@ -164,7 +164,10 @@ async function loadTestModules(opts) {
 		const files = Array.isArray(opts.run) ? opts.run : [opts.run];
 		const modules = files.map(file => {
 			file = file.replace(/^src[\\/]/, '');
-			return file.replace(/\.[jt]s$/, '');
+			// --- Start Positron ---
+			// Add support for React .tsx tests
+			return file.replace(/\.[jt]sx?$/, '');
+			// --- End Positron ---
 		});
 		return loadModules(modules);
 	}


### PR DESCRIPTION
Claude rules for core tests and React tests. I referenced @dhruvisompura's [documentation](https://github.com/posit-dev/positron-wiki/blob/main/react-unit-tests.qmd) from the wiki to write these. Also fixed eslint errors in the existing React tests and cleaned them up a bit.

Also updated the self-host test extension so that `.tsx` tests can be run/debugged directly from VSCode:

<img width="379" height="189" alt="image" src="https://github.com/user-attachments/assets/c9ebc4ef-d52d-4e06-8a30-d952af2ca51e" />

Related to #10000.

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

No behavior changes. Tests should continue to pass.