### PR TITLE
python LS: support completing integer keys

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_lsp.py
@@ -73,6 +73,11 @@ _RE_DOUBLE_BRACKET_KEY_ACCESS = re.compile(r'(\w[\w\.]*)\s*\[\s*\[\s*(?:.*,\s*)?
 
 Groups: (1) expression, (2) quote char, (3) optional key prefix"""
 
+_RE_INT_KEY_ACCESS = re.compile(r"(\w[\w\.]*)\s*\[\s*(\d*)$")
+"""Integer-key subscript access: e.g. `obj[` or `obj[12`
+
+Groups: (1) expression, (2) optional digit prefix"""
+
 _RE_DOTTED_IDENTIFIER = re.compile(r"([\w\.]+)$")
 """Trailing dotted identifier: e.g. `os.path.join`
 
@@ -615,21 +620,33 @@ def _handle_completion(
             )
         )
 
+    # Check for integer key access pattern (e.g., x[ or x[12)
+    int_key_match = _RE_INT_KEY_ACCESS.search(text_before_cursor)
+    if int_key_match and not dict_key_match:
+        items.extend(
+            _get_int_key_completions(
+                server,
+                expr=int_key_match.group(1),
+                prefix=int_key_match.group(2) or "",
+            )
+        )
+
     # Check for os.getenv() completions (e.g., os.getenv(" or os.getenv(key=")
     getenv_items = _get_getenv_completions(
         server, text_before_cursor, text_after_cursor, document=document
     )
     items.extend(getenv_items)
 
-    # Check for path completions in bare string literals (not dict access, not getenv)
-    if not dict_key_match and not getenv_items:
+    # Check for path completions in bare string literals (not dict/int key access, not getenv)
+    subscript_match = dict_key_match or int_key_match
+    if not subscript_match and not getenv_items:
         path_items = _get_path_completions(
             server, text_before_cursor, text_after_cursor, params.position
         )
         if path_items:
             return types.CompletionList(is_incomplete=False, items=path_items)
 
-    if not dict_key_match:
+    if not subscript_match:
         if "." in text_before_cursor and "(" not in text_before_cursor.split(".")[-1]:
             # Attribute completion (only if not inside a function call)
             items.extend(_get_attribute_completions(server, text_before_cursor))
@@ -830,9 +847,9 @@ def _get_dict_key_completions(
                 prefix, quote_char, has_closing_quote=has_closing_quote
             )
     elif _is_dataframe_like(obj):
-        # pandas/polars DataFrame
+        # pandas/polars DataFrame - only string columns for string key access
         with contextlib.suppress(Exception):
-            keys = list(obj.columns)
+            keys = [str(k) for k in obj.columns if isinstance(k, str)]
     elif _is_series_like(obj):
         # pandas Series with string index
         with contextlib.suppress(Exception):
@@ -858,7 +875,59 @@ def _get_dict_key_completions(
     return items
 
 
-def _get_dict_value_detail(obj: Any, key: str) -> tuple[str | None, types.MarkupContent | None]:
+def _get_int_key_completions(
+    server: PositronLanguageServer,
+    *,
+    expr: str,
+    prefix: str,
+) -> list[types.CompletionItem]:
+    """Get integer key completions for dict-like objects.
+
+    Handles dict with int keys, DataFrame with int columns, pandas
+    Series with int index, and polars Series (positional index).
+    """
+    if server.shell is None:
+        return []
+
+    obj = _safe_resolve_expression(server.shell.user_ns, expr)
+    if obj is None:
+        return []
+
+    int_keys: list[int] = []
+
+    with contextlib.suppress(Exception):
+        if isinstance(obj, dict):
+            int_keys = [k for k in obj if isinstance(k, int) and not isinstance(k, bool)]
+        elif _is_dataframe_like(obj):
+            int_keys = [k for k in obj.columns if isinstance(k, int)]
+        elif _is_series_like(obj):
+            module = type(obj).__module__
+            if "polars" in module:
+                int_keys = list(range(len(obj)))
+            else:
+                int_keys = [k for k in obj.index if isinstance(k, int)]
+
+    items: list[types.CompletionItem] = []
+    for key in int_keys:
+        label = str(key)
+        if not label.startswith(prefix):
+            continue
+        items.append(
+            types.CompletionItem(
+                label=label,
+                kind=types.CompletionItemKind.Field,
+                sort_text=f"a{label}",
+                insert_text=label,
+                data={"type": "int_key", "expr": expr, "key": key},
+            )
+        )
+
+    return items
+
+
+def _get_dict_value_detail(
+    obj: Any, key: str | int
+) -> tuple[str | None, types.MarkupContent | None]:
     """Get the detail string and documentation for a dict-like key's value.
 
     Args:
@@ -1437,6 +1506,17 @@ def _handle_completion_resolve(
         expr = params.data.get("expr")
         key = params.data.get("key")
         if expr and key and server.shell:
+            obj = _safe_resolve_expression(server.shell.user_ns, expr)
+            if obj is not None:
+                params.detail, params.documentation = _get_dict_value_detail(obj, key)
+        return params
+
+    # Handle integer key completions
+    if params.data and isinstance(params.data, dict) and params.data.get("type") == "int_key":
+        expr = params.data.get("expr")
+        key = params.data.get("key")
+        # Use `key is not None` because integer 0 is falsy
+        if expr and key is not None and server.shell:
             obj = _safe_resolve_expression(server.shell.user_ns, expr)
             if obj is not None:
                 params.detail, params.documentation = _get_dict_value_detail(obj, key)

--- a/extensions/positron-python/python_files/posit/positron/tests/test_lsp_patterns.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_lsp_patterns.py
@@ -15,6 +15,7 @@ from positron.positron_lsp import (
     _RE_DOTTED_IDENTIFIER,
     _RE_DOTTED_IDENTIFIER_WS,
     _RE_DOUBLE_BRACKET_KEY_ACCESS,
+    _RE_INT_KEY_ACCESS,
     _RE_KWARG_NAME,
     _RE_KWARG_TRAILING,
     _RE_KWARG_VALUE,
@@ -124,6 +125,43 @@ class TestDoubleBracketKeyAccess:
     )
     def test_no_match(self, text: str) -> None:
         assert _RE_DOUBLE_BRACKET_KEY_ACCESS.search(text) is None
+
+
+class TestIntKeyAccess:
+    """Match integer-key subscript access like obj[ or obj[12."""
+
+    @pytest.mark.parametrize(
+        ("text", "expr", "prefix"),
+        [
+            ("x[", "x", ""),
+            ("x[0", "x", "0"),
+            ("x[12", "x", "12"),
+            ("obj.attr[", "obj.attr", ""),
+            ("obj.attr[3", "obj.attr", "3"),
+            ("x  [", "x", ""),
+            ("x[ 1", "x", "1"),
+        ],
+    )
+    def test_match(self, text: str, expr: str, prefix: str) -> None:
+        m = _RE_INT_KEY_ACCESS.search(text)
+        assert m is not None
+        assert m.group(1) == expr
+        assert m.group(2) == prefix
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            'x["',
+            "x['",
+            'x["abc',
+            "",
+            "x",
+            "['",
+            "[",
+        ],
+    )
+    def test_no_match(self, text: str) -> None:
+        assert _RE_INT_KEY_ACCESS.search(text) is None
 
 
 class TestDottedIdentifier:

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
@@ -450,7 +450,6 @@ class TestCompletions:
                 None,
                 ["0"],
                 id="pandas_dataframe_int_dict_key",
-                marks=pytest.mark.xfail(reason="Completing integer dict keys not supported"),
             ),
             pytest.param(
                 'x["',
@@ -465,7 +464,27 @@ class TestCompletions:
                 None,
                 ["0"],
                 id="polars_series_dict_key",
-                marks=pytest.mark.xfail(reason="Completing integer dict keys not supported"),
+            ),
+            pytest.param(
+                "x[",
+                {"x": {0: "zero", 1: "one", 2: "two"}},
+                None,
+                ["0", "1", "2"],
+                id="dict_int_keys",
+            ),
+            pytest.param(
+                "x[1",
+                {"x": pd.DataFrame({0: [], 10: [], 11: [], 20: []})},
+                None,
+                ["10", "11"],
+                id="pandas_dataframe_int_key_prefix_filter",
+            ),
+            pytest.param(
+                "x[",
+                {"x": pd.Series({"a": 0}, dtype="int64")},
+                None,
+                [],
+                id="pandas_series_string_index_no_int_keys",
             ),
             # Double-bracket (multi-column) DataFrame access
             pytest.param(
@@ -1053,6 +1072,20 @@ class TestCompletionItemResolve:
                 id="polars_dataframe_dict_key",
             ),
             pytest.param(
+                "x[",
+                {"x": {0: "hello"}},
+                "str",
+                None,
+                id="dict_int_key_resolve",
+            ),
+            pytest.param(
+                "x[",
+                {"x": pd.DataFrame({0: [1, 2, 3]})},
+                "int64 (3)",
+                "dtype: int64",
+                id="pandas_dataframe_int_key_resolve",
+            ),
+            pytest.param(
                 "x",
                 {"x": pl.Series([1, 2, 3])},
                 "Int64 (3)",
@@ -1087,13 +1120,13 @@ class TestCompletionItemResolve:
 
         item = completion_list.items[0]
 
-        # Dict key completions defer detail to resolve for performance
-        is_dict_key_completion = '["' in source or "['" in source
-        if is_dict_key_completion:
+        # Dict/int key completions defer detail to resolve for performance
+        is_subscript_completion = '["' in source or "['" in source or source.endswith("[")
+        if is_subscript_completion:
             # Verify detail is not set initially and data has expected structure
             assert item.detail is None
             assert item.data is not None
-            assert item.data.get("type") == "dict_key"
+            assert item.data.get("type") in ("dict_key", "int_key")
             assert "expr" in item.data
             assert "key" in item.data
 


### PR DESCRIPTION
Addresses #11542. This PR adds integer key completions for dict/DataFrame/Series subscript access in the python language server. Previously, only string keys were completed (e.g. `x["key`). Now `x[` also offers integer keys like `0`, `1`, etc.

### Release Notes

#### New Features
- Python autocomplete now suggests integer keys when accessing dicts, DataFrames, and Series with bracket notation (#11542)

#### Bug Fixes
- N/A

### QA Notes

@:console @:editor

1. Open a Python console and create objects with integer keys:

```python
d = {0: "zero", 1: "one", 2: "two"}
import pandas as pd
df = pd.DataFrame({0: [1, 2], 10: [3, 4], 11: [5, 6]})
```

2. In the editor or console, type `d[` and verify completions `0`, `1`, `2` appear
3. Type `df[` and verify completions `0`, `10`, `11` appear
4. Type `df[1` and verify only `10` and `11` appear (prefix filtering)
5. Verify string key completions still work: `df2 = pd.DataFrame({"a": []}); df2["` should complete `a`
6. Verify hovering/resolving an integer key completion shows type info
