### PR TITLE
e2e: fix summary panel test broken by Escape key press

### DIFF
--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -78,8 +78,10 @@ export class ContextMenu {
 
 				// Retry entire trigger+hover+click to handle menu closing unexpectedly
 				await expect(async () => {
-					// Dismiss any stale menu before re-triggering
-					await this.page.keyboard.press('Escape').catch(() => { });
+					// Dismiss any stale menu before re-triggering (only if menu is visible)
+					if (await this.contextMenu.isVisible()) {
+						await this.page.keyboard.press('Escape').catch(() => { });
+					}
 
 					// Trigger the menu
 					await menuTrigger.click({ button: menuTriggerButton });


### PR DESCRIPTION
## Summary
- Only press Escape to dismiss stale menus when a context menu is actually visible
- The unconditional Escape introduced in #12002 was clearing the Summary Panel search filter, causing the `data-explorer-summary-panel` test to fail

## QA Notes

@:data-explorer @:console

🤖 Generated with [Claude Code](https://claude.com/claude-code)