### PR TITLE
e2e: Add correct waits for responses and window reload

### DIFF
--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -702,17 +702,13 @@ export class Assistant {
 	 *
 	 * @param message The message to send
 	 */
-	async enterChatMessage(message: string, waitForResponse: boolean = true) {
+	async enterChatMessage(message: string) {
 		const chatInput = this.code.driver.page.locator(CHAT_INPUT);
 		await chatInput.waitFor({ state: 'visible' });
 		await chatInput.pressSequentially(message);
 		await this.code.driver.page.locator(SEND_MESSAGE_BUTTON).click();
 		// It can take a moment for the loading locator to become visible.
 		await this.code.driver.page.locator('.chat-most-recent-response.chat-response-loading').waitFor({ state: 'visible' });
-		// Optionally wait for any loading state on the most recent response to finish
-		if (waitForResponse) {
-			await this.waitForResponseComplete();
-		}
 	}
 
 	/**

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -702,13 +702,17 @@ export class Assistant {
 	 *
 	 * @param message The message to send
 	 */
-	async enterChatMessage(message: string) {
+	async enterChatMessage(message: string, waitForResponse: boolean = true) {
 		const chatInput = this.code.driver.page.locator(CHAT_INPUT);
 		await chatInput.waitFor({ state: 'visible' });
 		await chatInput.pressSequentially(message);
 		await this.code.driver.page.locator(SEND_MESSAGE_BUTTON).click();
 		// It can take a moment for the loading locator to become visible.
 		await this.code.driver.page.locator('.chat-most-recent-response.chat-response-loading').waitFor({ state: 'visible' });
+		// Optionally wait for any loading state on the most recent response to finish
+		if (waitForResponse) {
+			await this.waitForResponseComplete();
+		}
 	}
 
 	/**

--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -305,6 +305,9 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 		// Reload window if we manually signed in (not auto-signed-in)
 		if (!process.env.ANTHROPIC_API_KEY && process.env.ANTHROPIC_KEY) {
 			await runCommand('workbench.action.reloadWindow');
+			await app.code.driver.page.waitForTimeout(3000);
+			await app.code.driver.page.locator('.monaco-workbench').waitFor({ state: 'visible' });
+			await app.workbench.sessions.expectNoStartUpMessaging();
 		}
 
 		await expect(async () => {

--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -158,7 +158,7 @@ test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTAN
 	 */
 	// Skipping Console tests due to PR #10784
 	test.skip('Python: Verify running code in console from chat markdown response', { tag: [] }, async function ({ app, python }) {
-		await app.workbench.assistant.enterChatMessage('Send Python Code');
+		await app.workbench.assistant.sendChatMessageAndWait('Send Python Code');
 		await app.workbench.assistant.verifyCodeBlockActions();
 		await app.workbench.assistant.clickChatCodeRunButton('foo = 100');
 		await app.workbench.console.waitForConsoleContents('foo = 100');
@@ -174,7 +174,7 @@ test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTAN
 	 */
 	// Skipping Console tests due to PR #10784
 	test.skip('R: Verify running code in console from chat markdown response', { tag: [tags.CRITICAL] }, async function ({ app, r }) {
-		await app.workbench.assistant.enterChatMessage('Send R Code');
+		await app.workbench.assistant.sendChatMessageAndWait('Send R Code');
 		await app.workbench.assistant.verifyCodeBlockActions();
 		await app.workbench.assistant.clickChatCodeRunButton('foo <- 200');
 		await app.workbench.console.waitForConsoleContents('foo <- 200');
@@ -374,7 +374,7 @@ test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT
 
 	test('Token usage is displayed in chat response', async function ({ app }) {
 		const message = 'What is the meaning of life?';
-		await app.workbench.assistant.enterChatMessage(message);
+		await app.workbench.assistant.sendChatMessageAndWait(message);
 		await app.workbench.assistant.verifyTokenUsageVisible();
 		const tokenUsage = await app.workbench.assistant.getTokenUsage();
 		expect(tokenUsage).toMatchObject({
@@ -385,20 +385,20 @@ test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT
 
 	test('Token usage is not displayed when setting is disabled', async function ({ app, settings }) {
 		await settings.set({ 'positron.assistant.showTokenUsage.enable': false }, { reload: 'web' });
-		await app.workbench.assistant.enterChatMessage('What is the meaning of life?');
+		await app.workbench.assistant.sendChatMessageAndWait('What is the meaning of life?');
 
 		expect(await app.workbench.assistant.verifyTokenUsageNotVisible());
 	});
 
 	test('Token usage is not displayed for non-supported providers', async function ({ app, settings }) {
 		await settings.set({ 'positron.assistant.approximateTokenCount': [] }, { reload: 'web' });
-		await app.workbench.assistant.enterChatMessage('What is the meaning of life?');
+		await app.workbench.assistant.sendChatMessageAndWait('What is the meaning of life?');
 
 		expect(await app.workbench.assistant.verifyTokenUsageNotVisible());
 	});
 
 	test('Token usage updates when settings change', async function ({ app, settings }) {
-		await app.workbench.assistant.enterChatMessage('What is the meaning of life?');
+		await app.workbench.assistant.sendChatMessageAndWait('What is the meaning of life?');
 		await app.workbench.assistant.verifyTokenUsageVisible();
 
 		await settings.set({ 'positron.assistant.approximateTokenCount': [] }, { reload: 'web' });
@@ -419,11 +419,11 @@ test.describe('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSISTANT
 		const message1 = 'What is the meaning of life?';
 		const message2 = 'Forty-two';
 
-		await app.workbench.assistant.enterChatMessage(message1);
-		await app.workbench.assistant.waitForReadyToSend();
-		await app.workbench.assistant.enterChatMessage(message2);
+		await app.workbench.assistant.sendChatMessageAndWait(message1);
+		// await app.workbench.assistant.waitForReadyToSend();
+		await app.workbench.assistant.sendChatMessageAndWait(message2);
 
-		await app.workbench.assistant.waitForReadyToSend();
+		// await app.workbench.assistant.waitForReadyToSend();
 
 		const totalTokens = await app.workbench.assistant.getTotalTokenUsage();
 		expect(totalTokens).toBeDefined();


### PR DESCRIPTION
  Fix flaky assistant e2e tests by adding proper waits after window reload and when entering chat messages.

- Switched all the current tests to `sendChatMessageAndWait`. Some would go on too quickly and cause issue
- Added a check after reloading window in the default model test, sometimes it would timeout since the extensions hadn't finish reloading.


### QA Notes
@:assistant @:win @:web
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
