### PR TITLE
e2e: fix flaky chat export test by closing specific toast

### DIFF
--- a/test/e2e/pages/dialog-toasts.ts
+++ b/test/e2e/pages/dialog-toasts.ts
@@ -56,6 +56,12 @@ export class Toasts {
 		}
 	}
 
+	async closeWithHeader(header: string | RegExp) {
+		const toast = this.toastNotification.filter({ hasText: header });
+		await toast.hover();
+		await toast.locator('.codicon-notifications-clear').click();
+	}
+
 	// --- Verifications ---
 
 	async expectToBeVisible(title?: string | RegExp, timeoutMs = 3000) {

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -1097,7 +1097,7 @@ export class Assistant {
 		await expect(async () => {
 			await this.quickaccess.runCommand(`positron-assistant.exportChatToFileInWorkspace`);
 			await this.toasts.waitForAppear('Chat log exported to:');
-			await this.toasts.closeAll();
+			await this.toasts.closeWithHeader('Chat log exported to:');
 			chatExportFile = await this.findChatExportFile(exportFolder);
 			expect(chatExportFile).not.toBeNull();
 		}).toPass({ timeout: 15000 });


### PR DESCRIPTION
## Summary
- Added `closeWithHeader()` method to `Toasts` class that correctly locates the close button within a filtered toast
- Updated `getChatResponseText()` to use `closeWithHeader()` instead of `closeAll()` which wasn't completely reliable

## QA Notes
@:assistant-eval

🤖 Generated with [Claude Code](https://claude.com/claude-code)