### PR TITLE
e2e: Assistant flake fix - remove reload after signin

### DIFF
--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -303,12 +303,12 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 		await app.workbench.assistant.loginModelProvider('anthropic-api');
 
 		// Reload window if we manually signed in (not auto-signed-in)
-		if (!process.env.ANTHROPIC_API_KEY && process.env.ANTHROPIC_KEY) {
-			await runCommand('workbench.action.reloadWindow');
-			await app.code.driver.page.waitForTimeout(3000);
-			await app.code.driver.page.locator('.monaco-workbench').waitFor({ state: 'visible' });
-			await app.workbench.sessions.expectNoStartUpMessaging();
-		}
+		// if (!process.env.ANTHROPIC_API_KEY && process.env.ANTHROPIC_KEY) {
+		// 	await runCommand('workbench.action.reloadWindow');
+		// 	await app.code.driver.page.waitForTimeout(3000);
+		// 	await app.code.driver.page.locator('.monaco-workbench').waitFor({ state: 'visible' });
+		// 	await app.workbench.sessions.expectNoStartUpMessaging();
+		// }
 
 		await expect(async () => {
 			try {

--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -302,14 +302,6 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 		// Sign in to Anthropic (method handles auto-sign-in detection)
 		await app.workbench.assistant.loginModelProvider('anthropic-api');
 
-		// Reload window if we manually signed in (not auto-signed-in)
-		// if (!process.env.ANTHROPIC_API_KEY && process.env.ANTHROPIC_KEY) {
-		// 	await runCommand('workbench.action.reloadWindow');
-		// 	await app.code.driver.page.waitForTimeout(3000);
-		// 	await app.code.driver.page.locator('.monaco-workbench').waitFor({ state: 'visible' });
-		// 	await app.workbench.sessions.expectNoStartUpMessaging();
-		// }
-
 		await expect(async () => {
 			try {
 				await app.workbench.assistant.pickModel();


### PR DESCRIPTION
The reload after anthropic sign-in is now not needed. It was also causing some race conditions.

See: https://github.com/posit-dev/positron/actions/runs/22321721600 ..  Ran each assistant test 5x.  Databot & Eval fails can be ignored, they can't run in a loop like this.

### QA Notes
@:assistant
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
