### PR TITLE
python LS: add DataFrame colname completions in method string arguments

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_lsp.py
@@ -33,7 +33,7 @@ import threading
 from functools import lru_cache
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Callable, Generator, Optional
+from typing import TYPE_CHECKING, Any, Callable, Generator, NamedTuple, Optional
 
 from ._vendor import attrs, cattrs
 from ._vendor.lsprotocol import types
@@ -140,6 +140,78 @@ _RE_LEADING_PERCENT = re.compile(r"^(%*)")
 """Leading percent signs for magic commands
 
 Group: (1) percent characters"""
+
+_ANY_POSITIONAL = -1
+"""Sentinel for variadic positional parameters (e.g., polars `select(*exprs)`)."""
+
+
+class _ColParam(NamedTuple):
+    """Parameter that accepts column names in a DataFrame method."""
+
+    name: str
+    pos: int | None
+
+
+_PANDAS_COLUMN_METHODS: dict[str, list[_ColParam]] = {
+    "groupby": [_ColParam("by", 0)],
+    "sort_values": [_ColParam("by", 0)],
+    "drop": [_ColParam("labels", 0), _ColParam("columns", None)],
+    "set_index": [_ColParam("keys", 0)],
+    "merge": [
+        _ColParam("on", None),
+        _ColParam("left_on", None),
+        _ColParam("right_on", None),
+    ],
+    "drop_duplicates": [_ColParam("subset", 0)],
+    "duplicated": [_ColParam("subset", 0)],
+    "pivot": [
+        _ColParam("index", None),
+        _ColParam("columns", None),
+        _ColParam("values", None),
+    ],
+    "pivot_table": [
+        _ColParam("values", 0),
+        _ColParam("index", None),
+        _ColParam("columns", None),
+    ],
+    "melt": [_ColParam("id_vars", 0), _ColParam("value_vars", 1)],
+    "nlargest": [_ColParam("columns", 1)],
+    "nsmallest": [_ColParam("columns", 1)],
+    "explode": [_ColParam("column", 0)],
+    "value_counts": [_ColParam("subset", 0)],
+    "get": [_ColParam("key", 0)],
+    "pop": [_ColParam("item", 0)],
+    "join": [_ColParam("on", None)],
+    "resample": [_ColParam("on", None)],
+    "filter": [_ColParam("items", None)],
+}
+"""Pandas DataFrame methods whose string arguments are column names."""
+
+_POLARS_COLUMN_METHODS: dict[str, list[_ColParam]] = {
+    "select": [_ColParam("exprs", _ANY_POSITIONAL)],
+    "group_by": [_ColParam("by", _ANY_POSITIONAL)],
+    "sort": [_ColParam("by", 0)],
+    "drop": [_ColParam("columns", _ANY_POSITIONAL)],
+    "join": [
+        _ColParam("on", None),
+        _ColParam("left_on", None),
+        _ColParam("right_on", None),
+    ],
+    "unique": [_ColParam("subset", 0)],
+    "explode": [_ColParam("columns", 0)],
+    "unpivot": [_ColParam("on", 0), _ColParam("index", None)],
+    "melt": [_ColParam("id_vars", 0), _ColParam("value_vars", 1)],
+    "pivot": [
+        _ColParam("on", 0),
+        _ColParam("index", None),
+        _ColParam("values", None),
+    ],
+    "partition_by": [_ColParam("by", _ANY_POSITIONAL)],
+    "get_column": [_ColParam("name", 0)],
+    "with_columns": [_ColParam("exprs", _ANY_POSITIONAL)],
+    "filter": [_ColParam("predicates", _ANY_POSITIONAL)],
+}
+"""Polars DataFrame/LazyFrame methods whose string arguments are column names."""
 
 
 @enum.unique
@@ -637,9 +709,13 @@ def _handle_completion(
     )
     items.extend(getenv_items)
 
-    # Check for path completions in bare string literals (not dict/int key access, not getenv)
+    # Check for DataFrame column name completions in method calls
+    col_name_items = _get_column_name_completions(server, text_before_cursor, text_after_cursor)
+    items.extend(col_name_items)
+
+    # Check for path completions in bare string literals (not subscript access, not getenv, not columns)
     subscript_match = dict_key_match or int_key_match
-    if not subscript_match and not getenv_items:
+    if not subscript_match and not getenv_items and not col_name_items:
         path_items = _get_path_completions(
             server, text_before_cursor, text_after_cursor, params.position
         )
@@ -1413,6 +1489,138 @@ def _get_dataframe_column_completions(obj: Any, prefix: str) -> list[types.Compl
         pass
 
     return items
+
+
+def _dataframe_library(obj: Any) -> str | None:
+    """Return 'pandas' or 'polars' based on the object's module, or None."""
+    module = type(obj).__module__
+    if "pandas" in module:
+        return "pandas"
+    if "polars" in module:
+        return "polars"
+    return None
+
+
+def _col_param_matches(
+    params: list[_ColParam],
+    kwarg_name: str | None,
+    positional_index: int,
+) -> bool:
+    """Check if any _ColParam matches the current argument position."""
+    for param in params:
+        if kwarg_name is not None:
+            if param.name == kwarg_name:
+                return True
+        elif param.pos == positional_index or param.pos == _ANY_POSITIONAL:
+            return True
+    return False
+
+
+def _make_column_completions(
+    obj: Any,
+    prefix: str,
+    quote_char: str,
+    *,
+    has_closing_quote: bool,
+) -> list[types.CompletionItem]:
+    """Create column name completion items for a DataFrame."""
+    items: list[types.CompletionItem] = []
+    try:
+        # Polars LazyFrame: use collect_schema().names() to avoid PerformanceWarning
+        if hasattr(obj, "collect_schema"):
+            columns = obj.collect_schema().names()
+        else:
+            columns = list(obj.columns)
+    except Exception:
+        return []
+
+    for col in columns:
+        if col is None:
+            continue
+        col_str = str(col)
+        if not col_str.startswith(prefix):
+            continue
+        insert_text = col_str if has_closing_quote else f"{col_str}{quote_char}"
+        items.append(
+            types.CompletionItem(
+                label=col_str,
+                kind=types.CompletionItemKind.Field,
+                sort_text=f"0{col_str}",
+                detail="column",
+                insert_text=insert_text,
+            )
+        )
+    return items
+
+
+def _get_column_name_completions(
+    server: PositronLanguageServer,
+    text_before_cursor: str,
+    text_after_cursor: str,
+) -> list[types.CompletionItem]:
+    """Get column name completions for DataFrame method calls.
+
+    Detects patterns like `df.groupby("col")` or `df.sort_values(by="col")`
+    and provides column name completions from the DataFrame.
+    """
+    if server.shell is None or "(" not in text_before_cursor or "." not in text_before_cursor:
+        return []
+
+    # Check if cursor is inside a string literal
+    string_match = _RE_STRING_LITERAL.search(text_before_cursor)
+    if not string_match:
+        return []
+
+    quote_char = string_match.group(1)
+    prefix = string_match.group(2) or ""
+    before_string = text_before_cursor[: string_match.start()]
+
+    # Check for keyword argument (e.g., "by=")
+    keyword_match = _RE_KWARG_TRAILING.search(before_string)
+    kwarg_name = keyword_match.group(1) if keyword_match else None
+
+    # Find the enclosing function call's opening parenthesis
+    func_paren_pos = _find_enclosing_paren(before_string)
+    if func_paren_pos < 0:
+        return []
+
+    # Extract receiver.method before the opening paren
+    func_match = _RE_DOTTED_IDENTIFIER_WS.search(before_string[:func_paren_pos])
+    if not func_match:
+        return []
+
+    dotted_name = func_match.group(1)
+    last_dot = dotted_name.rfind(".")
+    if last_dot < 0:
+        return []
+
+    receiver_expr = dotted_name[:last_dot]
+    method_name = dotted_name[last_dot + 1 :]
+
+    # Resolve the receiver object
+    obj = _safe_resolve_expression(server.shell.user_ns, receiver_expr)
+    if obj is None:
+        return []
+
+    # Check if it's a DataFrame and get the library
+    library = _dataframe_library(obj)
+    if library is None or not _is_dataframe_like(obj):
+        return []
+
+    # Look up the method in the library-specific dict
+    method_dict = _PANDAS_COLUMN_METHODS if library == "pandas" else _POLARS_COLUMN_METHODS
+    col_params = method_dict.get(method_name)
+    if col_params is None:
+        return []
+
+    # Determine positional index and check parameter match
+    args_text = before_string[func_paren_pos + 1 :]
+    positional_index = _count_arg_commas(args_text)
+    if not _col_param_matches(col_params, kwarg_name, positional_index):
+        return []
+
+    has_closing_quote = text_after_cursor.lstrip().startswith(quote_char)
+    return _make_column_completions(obj, prefix, quote_char, has_closing_quote=has_closing_quote)
 
 
 def _get_magic_completions(

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
@@ -721,6 +721,182 @@ class TestCompletions:
                 [TEST_ENVIRONMENT_VARIABLE],
                 id="os_getenv_alias_with_os_in_namespace",
             ),
+            # --- DataFrame column name completions in method calls ---
+            # Pandas positional
+            pytest.param(
+                'x.drop("")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="pandas_drop_positional",
+            ),
+            pytest.param(
+                'x.groupby("")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="pandas_groupby_positional",
+            ),
+            pytest.param(
+                'x.sort_values("")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="pandas_sort_values_positional",
+            ),
+            pytest.param(
+                'x.set_index("")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="pandas_set_index_positional",
+            ),
+            pytest.param(
+                'x.nlargest(5, "")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="pandas_nlargest_positional",
+            ),
+            # Pandas keyword
+            pytest.param(
+                'x.filter(items="")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="pandas_filter_keyword",
+            ),
+            pytest.param(
+                'x.drop(columns="")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="pandas_drop_keyword",
+            ),
+            pytest.param(
+                'x.groupby(by="")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="pandas_groupby_keyword",
+            ),
+            pytest.param(
+                'x.sort_values(by="")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="pandas_sort_values_keyword",
+            ),
+            pytest.param(
+                'x.set_index(keys="")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="pandas_set_index_keyword",
+            ),
+            pytest.param(
+                'x.merge(other, on="")',
+                {"x": pd.DataFrame({"col1": [], "col2": []}), "other": pd.DataFrame()},
+                -2,
+                ["col1", "col2"],
+                id="pandas_merge_on_keyword",
+            ),
+            pytest.param(
+                'x.merge(other, left_on="")',
+                {"x": pd.DataFrame({"col1": [], "col2": []}), "other": pd.DataFrame()},
+                -2,
+                ["col1", "col2"],
+                id="pandas_merge_left_on_keyword",
+            ),
+            # Pandas out-of-order keywords
+            pytest.param(
+                'x.groupby(axis="columns", by="")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="pandas_groupby_out_of_order_keyword",
+            ),
+            pytest.param(
+                'x.sort_values(axis="columns", by="")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="pandas_sort_values_out_of_order_keyword",
+            ),
+            # Pandas prefix and quote variants
+            pytest.param(
+                'x.groupby("col")',
+                {"x": pd.DataFrame({"col1": [], "col2": [], "other": []})},
+                -2,
+                ["col1", "col2"],
+                id="pandas_groupby_prefix_filter",
+            ),
+            pytest.param(
+                "x.groupby('')",
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="pandas_groupby_single_quote",
+            ),
+            # Polars positional
+            pytest.param(
+                'x.sort("")',
+                {"x": pl.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="polars_sort_positional",
+            ),
+            pytest.param(
+                'x.select("")',
+                {"x": pl.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="polars_select_positional",
+            ),
+            pytest.param(
+                'x.select("x", "")',
+                {"x": pl.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="polars_select_variadic_second",
+            ),
+            pytest.param(
+                'x.group_by("")',
+                {"x": pl.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="polars_group_by_positional",
+            ),
+            pytest.param(
+                'x.drop("")',
+                {"x": pl.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="polars_drop_positional",
+            ),
+            pytest.param(
+                'x.explode("")',
+                {"x": pl.DataFrame({"col1": [], "col2": []})},
+                -2,
+                ["col1", "col2"],
+                id="polars_explode_positional",
+            ),
+            # Polars keyword
+            pytest.param(
+                'x.join(other, on="")',
+                {"x": pl.DataFrame({"col1": [], "col2": []}), "other": pl.DataFrame()},
+                -2,
+                ["col1", "col2"],
+                id="polars_join_on_keyword",
+            ),
+            # Polars LazyFrame
+            pytest.param(
+                'lf.sort("")',
+                {"lf": pl.DataFrame({"col1": [], "col2": []}).lazy()},
+                -2,
+                ["col1", "col2"],
+                id="polars_lazyframe_sort",
+            ),
         ],
     )
     def test_completions(
@@ -1007,6 +1183,57 @@ class TestCompletions:
         labels = [c.label for c in completions]
 
         assert set(labels) == {"%%timeit", "%%time"}
+
+    @pytest.mark.parametrize(
+        ("source", "namespace", "character"),
+        [
+            pytest.param(
+                'x.nlargest(5, 3, "")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                id="pandas_nlargest_wrong_positional",
+            ),
+            pytest.param(
+                'x.unknown_method("")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                id="unknown_method",
+            ),
+            pytest.param(
+                'mydict.groupby("")',
+                {"mydict": {"col1": 0}},
+                -2,
+                id="not_a_dataframe",
+            ),
+            pytest.param(
+                'x.merge("")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                id="pandas_merge_positional_not_column",
+            ),
+            pytest.param(
+                'x.filter("")',
+                {"x": pd.DataFrame({"col1": [], "col2": []})},
+                -2,
+                id="pandas_filter_positional_keyword_only",
+            ),
+        ],
+    )
+    def test_no_column_completions(
+        self,
+        source: str,
+        namespace: Dict[str, Any],
+        character: int,
+        tmp_path: Path,
+    ) -> None:
+        """Test that column completions are NOT returned for invalid contexts."""
+        server = create_test_server(namespace, root_path=tmp_path)
+        text_document = create_text_document(server, TEST_DOCUMENT_URI, source)
+        completions = self._completions(server, text_document, character)
+        column_completions = [c for c in completions if c.detail == "column"]
+        assert column_completions == [], (
+            f"Expected no column completions, got {[c.label for c in column_completions]}"
+        )
 
 
 class TestCompletionItemResolve:


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/5436. This PR adds column name completions inside method string arguments like `df.groupby("col")` or `df.sort_values(by="col")`.

This adds column name completions for 19 pandas and 14 polars DataFrame methods. Some features I chose to defer for now; see below.

As usual it makes me a little uncomfortable to shove all this in one file. I promise to come back and reorganize soon in https://github.com/posit-dev/positron/issues/12014.

Supported argument styles:
- Positional: `df.groupby("")`, `df.nlargest(5, "")`
- Keyword: `df.sort_values(by="")`, `df.merge(other, on="")`
- Out-of-order keyword: `df.groupby(axis="columns", by="")`
- Polars variadic: `pl_df.select("")`, `pl_df.select("a", "")`
- Polars LazyFrame: `lf.sort("")`
- Prefix filtering and single/double quote support, as usual

Out of scope! For now...
 - For list arguments, e.g. `df.groupby(["col1", "col2"])`, only the first element's completions will work
 - Subscript-based column selection: `df.loc[:, "col"]`, `df.loc[:, ["col1", "col2"]]`
 - Dict-keyed params: `rename(columns={"old": "new"})`, `agg({"col": "sum"})`
 - Top-level function, not a method on a DataFrame: `pl.col("col1")`

And we'll probably never do these:
 - Column names inside expression strings: `query("col1 > col2")`/`eval("...")`
 - Chained receivers: `df.reset_index().groupby("col")`

### Release Notes

#### New Features

- Column name completions now appear inside pandas and polars DataFrame method string arguments such as `groupby()`, `sort_values()`, `select()`, `merge()`, and others (#5436)

#### Bug Fixes

- N/A

### QA Notes

@:console @:notebooks

In the Console or a notebook with a Python interpreter, create a DataFrame and verify column completions appear:

```python
import pandas as pd
df = pd.DataFrame({"price": [1, 2], "quantity": [3, 4], "name": ["a", "b"]})

# All of these should show price, quantity, name completions:
df.groupby("")          # positional
df.sort_values(by="")   # keyword
df.drop(columns="")     # keyword-only param
df.nlargest(5, "")      # second positional
```

```python
import polars as pl
pldf = pl.DataFrame({"price": [1, 2], "quantity": [3, 4]})

# These should also complete:
pldf.select("")
pldf.group_by("")
pldf.sort("")
```

Verify that completions do NOT appear for:
- Non-DataFrame receivers: `mydict.groupby("")`
- Unknown methods: `df.unknown("")`
- Wrong positional slots: `df.merge("")` (first arg is another DataFrame, not a column)
