### PR TITLE
React test helper: `setupReactRenderer()`

### DIFF
--- a/.claude/rules/core-tests.md
+++ b/.claude/rules/core-tests.md
@@ -18,13 +18,18 @@ disposables.add(someDisposable);
 
 ## Services (prefer in this order)
 
-1. Real services directly (e.g. `new RuntimeStartupService(...)`).
-2. Existing `Test*` service classes - search from `src/vs/workbench/test/browser/positronWorkbenchTestServices.ts`.
-3. For many dependencies, use `positronWorkbenchInstantiationService`.
+1. `{} as T` for services the code under test doesn't call (e.g. dependencies it only passes through to collaborators).
+2. Real services directly (e.g. `new RuntimeStartupService(...)`).
+3. Existing `Test*` service classes - search from `src/vs/workbench/test/browser/positronWorkbenchTestServices.ts`.
+4. For many dependencies, use `positronWorkbenchInstantiationService`.
+
+## Structure
+
+- Group related tests with nested `suite()` calls, not comment headers like `// --- Section ---`.
 
 ## Mocking
 
-- Use `Partial<T>` with only the members your test needs, cast with `as T`.
+- Use `Partial<T>` with only the members your test needs, cast with `as T`. This might trigger `local/code-no-dangerous-type-assertions`; add `/* eslint-disable local/code-no-dangerous-type-assertions */` below the copyright header.
 - For reusable mocks, create a test helper class implementing `Partial<T>`.
 
 ## Sinon

--- a/.claude/rules/react-tests.md
+++ b/.claude/rules/react-tests.md
@@ -7,10 +7,12 @@ paths:
 
 React component tests run in Electron (not browser). No React testing libraries are available - only `assert`, `sinon`, `react-dom`, and `react-dom/client`.
 
+## Setup
+
+Use `setupReactRenderer()` from `base/test/browser/react.js` for DOM/root lifecycle. Call it **before** `ensureNoDisposablesAreLeakedInTestSuite()` (mocha teardown is FIFO -- React must unmount before the leak checker runs).
+
 ## Constraints
 
-- Place tests in `test/browser/` adjacent to source: `feature/browser/components/foo.tsx` -> `feature/test/browser/foo.test.tsx`
-- Use `mainWindow.document` instead of `document` for DOM operations.
+- Place tests in `test/browser/` adjacent to source.
+- `container()` is a function -- call it inside tests, not at suite-definition time.
 - `querySelector` requires `/* eslint-disable no-restricted-syntax */` below the copyright header.
-- Render via a helper that wraps `root.render()` in `flushSync()` so React flushes synchronously.
-- Teardown order matters: (1) `root.unmount()`, (2) `container.remove()`, (3) `sinon.restore()`.

--- a/.claude/rules/react-tests.md
+++ b/.claude/rules/react-tests.md
@@ -5,13 +5,13 @@ paths:
 
 # React Tests
 
-React component tests run in Electron (not browser). No React testing libraries are available - only `assert`, `sinon`, `react-dom`, and `react-dom/client`.
+React component tests run in Electron with `assert`, `sinon`, and `react-dom`. No React testing libraries (Testing Library, Enzyme, etc.) are available.
 
 ## Setup
 
-Use `setupReactRenderer()` from `base/test/browser/react.js` for DOM/root lifecycle. Call it **before** `ensureNoDisposablesAreLeakedInTestSuite()` (mocha teardown is FIFO -- React must unmount before the leak checker runs).
+Use `setupReactRenderer()` from `base/test/browser/react.js` to manage the DOM container and React root. Call it **before** `ensureNoDisposablesAreLeakedInTestSuite()` -- mocha teardown is FIFO, so React must unmount before the leak checker runs.
 
-## Constraints
+## General
 
 - Place tests in `test/browser/` adjacent to source.
 - `container()` is a function -- call it inside tests, not at suite-definition time.

--- a/.claude/rules/react-tests.md
+++ b/.claude/rules/react-tests.md
@@ -14,5 +14,5 @@ Use `setupReactRenderer()` from `base/test/browser/react.js` to manage the DOM c
 ## General
 
 - Place tests in `test/browser/` adjacent to source.
-- `container()` is a function -- call it inside tests, not at suite-definition time.
-- `querySelector` requires `/* eslint-disable no-restricted-syntax */` below the copyright header.
+- `render()` returns the DOM container -- query it for assertions.
+- `querySelector<T>` requires `/* eslint-disable no-restricted-syntax */` below the copyright header.

--- a/.eslint-plugin-local/code-setup-react-renderer-before-disposables-check.ts
+++ b/.eslint-plugin-local/code-setup-react-renderer-before-disposables-check.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as eslint from 'eslint';
+import type * as estree from 'estree';
+import { TSESTree } from '@typescript-eslint/utils';
+
+export default new class SetupReactRendererBeforeDisposablesCheck implements eslint.Rule.RuleModule {
+
+	readonly meta: eslint.Rule.RuleMetaData = {
+		type: 'problem',
+		messages: {
+			order: '`setupReactRenderer()` must be called before `ensureNoDisposablesAreLeakedInTestSuite()`. ' +
+				'Mocha runs teardown hooks in FIFO order, so the React teardown must register first to unmount ' +
+				'components and dispose VS Code disposables before the leak checker inspects them.',
+		},
+		schema: false,
+	};
+
+	create(context: eslint.Rule.RuleContext): eslint.Rule.RuleListener {
+		return {
+			// Match setupReactRenderer() as a direct statement (expression or variable declaration) inside a suite callback.
+			['CallExpression[callee.name="suite"] > :function > BlockStatement > :matches(ExpressionStatement, VariableDeclaration) CallExpression[callee.name="setupReactRenderer"]']: (node: estree.CallExpression) => {
+				// Walk up to the BlockStatement to find sibling statements.
+				let stmt = node as TSESTree.Node;
+				while (stmt.parent && stmt.parent.type !== 'BlockStatement') {
+					stmt = stmt.parent;
+				}
+				const block = stmt.parent as TSESTree.BlockStatement;
+				const setupIdx = block.body.indexOf(stmt as TSESTree.Statement);
+
+				// Scan backward: if ensureNoDisposablesAreLeakedInTestSuite appears earlier, report it.
+				for (let i = setupIdx - 1; i >= 0; i--) {
+					if (isCallInStatement(block.body[i], 'ensureNoDisposablesAreLeakedInTestSuite')) {
+						context.report({ node: block.body[i] as estree.Node, messageId: 'order' });
+						return;
+					}
+				}
+			},
+		};
+	}
+};
+
+/** Check whether a statement contains a call to the given function name. */
+function isCallInStatement(node: TSESTree.Statement, name: string): boolean {
+	if (node.type === 'ExpressionStatement') {
+		return isCallTo(node.expression, name);
+	}
+	if (node.type === 'VariableDeclaration') {
+		return node.declarations.some(d => d.init && isCallTo(d.init, name));
+	}
+	return false;
+}
+
+function isCallTo(node: TSESTree.Expression, name: string): boolean {
+	return node.type === 'CallExpression'
+		&& node.callee.type === 'Identifier'
+		&& node.callee.name === name;
+}

--- a/.eslint-plugin-local/tests/code-setup-react-renderer-before-disposables-check-test.tsx
+++ b/.eslint-plugin-local/tests/code-setup-react-renderer-before-disposables-check-test.tsx
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Test file to verify the code-setup-react-renderer-before-disposables-check ESLint rule.
+
+import { setupReactRenderer } from '../../src/vs/base/test/browser/react.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../src/vs/base/test/common/utils.js';
+
+// -----
+// Valid
+// -----
+
+suite('correct order - destructured', () => {
+	const { render } = setupReactRenderer();
+	ensureNoDisposablesAreLeakedInTestSuite();
+});
+
+suite('correct order - expression statement', () => {
+	setupReactRenderer();
+	ensureNoDisposablesAreLeakedInTestSuite();
+});
+
+suite('correct order - ensureNoDisposables assigned to variable', () => {
+	setupReactRenderer();
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+});
+
+suite('only setupReactRenderer - no ensureNoDisposables', () => {
+	setupReactRenderer();
+});
+
+suite('only ensureNoDisposables - no setupReactRenderer', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+});
+
+suite('neither function present', () => {
+});
+
+// -------
+// Invalid
+// -------
+
+suite('wrong order - destructured', () => {
+	// eslint-disable-next-line local/code-setup-react-renderer-before-disposables-check
+	ensureNoDisposablesAreLeakedInTestSuite();
+	const { render } = setupReactRenderer();
+});
+
+suite('wrong order - expression statement', () => {
+	// eslint-disable-next-line local/code-setup-react-renderer-before-disposables-check
+	ensureNoDisposablesAreLeakedInTestSuite();
+	setupReactRenderer();
+});
+
+suite('wrong order - ensureNoDisposables assigned to variable', () => {
+	// eslint-disable-next-line local/code-setup-react-renderer-before-disposables-check
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+	setupReactRenderer();
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -176,6 +176,16 @@ export default tseslint.config(
 			'jsx-a11y/no-static-element-interactions': 'error',
 		},
 	},
+	// React Tests
+	{
+		files: [
+			'src/vs/**/*.test.tsx',
+			'.eslint-plugin-local/**/*.tsx',
+		],
+		rules: {
+			'local/code-setup-react-renderer-before-disposables-check': 'error',
+		}
+	},
 	// --- End Positron ---
 	// TS
 	{

--- a/src/vs/base/test/browser/react.tsx
+++ b/src/vs/base/test/browser/react.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/src/vs/base/test/browser/react.tsx
+++ b/src/vs/base/test/browser/react.tsx
@@ -20,12 +20,12 @@ import { mainWindow } from '../../browser/window.js';
  * @example
  * ```ts
  * suite('MyWidget', () => {
- *     const { render, container } = setupReactRenderer();
+ *     const { render } = setupReactRenderer();
  *     ensureNoDisposablesAreLeakedInTestSuite();
  *
  *     test('renders', () => {
- *         render(<MyWidget />);
- *         assert.ok(container().querySelector('.my-widget'));
+ *         const container = render(<MyWidget />);
+ *         assert.ok(container.querySelector('.my-widget'));
  *     });
  * });
  * ```
@@ -47,19 +47,16 @@ export function setupReactRenderer() {
 
 	return {
 		/**
-		 * Render a React element synchronously via `flushSync`.
+		 * Render a React element synchronously via `flushSync` and return the
+		 * DOM container the React root is mounted into.
 		 */
-		render(element: ReactElement) {
+		render(element: ReactElement): HTMLElement {
+			if (root === undefined) {
+				throw new Error('React root is not initialized. Did you try to render before setup?');
+			}
 			flushSync(() => {
 				root.render(element);
 			});
-		},
-
-		/**
-		 * Returns the DOM container the React root is mounted into.
-		 * Call inside tests (after `setup` has run), not at suite-definition time.
-		 */
-		container(): HTMLElement {
 			return el;
 		},
 	};

--- a/src/vs/base/test/browser/react.tsx
+++ b/src/vs/base/test/browser/react.tsx
@@ -25,7 +25,7 @@ function EffectGate({ onCleanup, children }: PropsWithChildren<{ onCleanup: () =
  * Sets up a React render root for component tests. Registers mocha `setup` and
  * `teardown` hooks that create/destroy the DOM container and React root.
  *
- * **Must be called before `ensureNoDisposablesAreLeakedInTestSuite()`** because
+ * Must be called before `ensureNoDisposablesAreLeakedInTestSuite()` because
  * mocha runs teardown hooks in FIFO order. The React teardown must run first so
  * that deferred `useEffect` cleanups dispose VS Code disposables before the leak
  * checker inspects them.

--- a/src/vs/base/test/browser/react.tsx
+++ b/src/vs/base/test/browser/react.tsx
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { PropsWithChildren, ReactElement, useEffect } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, Root } from 'react-dom/client';
+import { mainWindow } from '../../browser/window.js';
+
+/**
+ * Wrapper component that resolves a promise when its useEffect cleanup runs.
+ * React fires cleanup effects bottom-up (children before parent), so by the
+ * time this parent's cleanup fires, all child effects -- including those that
+ * create VS Code disposables -- have already been disposed.
+ */
+function EffectGate({ onCleanup, children }: PropsWithChildren<{ onCleanup: () => void }>) {
+	useEffect(() => {
+		return onCleanup;
+	}, [onCleanup]);
+	return <>{children}</>;
+}
+
+/**
+ * Sets up a React render root for component tests. Registers mocha `setup` and
+ * `teardown` hooks that create/destroy the DOM container and React root.
+ *
+ * **Must be called before `ensureNoDisposablesAreLeakedInTestSuite()`** because
+ * mocha runs teardown hooks in FIFO order. The React teardown must run first so
+ * that deferred `useEffect` cleanups dispose VS Code disposables before the leak
+ * checker inspects them.
+ *
+ * @example
+ * ```ts
+ * suite('MyWidget', () => {
+ *     const { render, container } = setupReactRenderer();
+ *     ensureNoDisposablesAreLeakedInTestSuite();
+ *
+ *     test('renders', () => {
+ *         render(<MyWidget />);
+ *         assert.ok(container().querySelector('.my-widget'));
+ *     });
+ * });
+ * ```
+ */
+export function setupReactRenderer() {
+	let root: Root;
+	let el: HTMLElement;
+	let cleanupPromise: Promise<void>;
+	let resolveCleanup: () => void;
+
+	setup(() => {
+		el = mainWindow.document.createElement('div');
+		mainWindow.document.body.appendChild(el);
+		root = createRoot(el);
+		cleanupPromise = new Promise<void>(r => { resolveCleanup = r; });
+	});
+
+	teardown(async () => {
+		root.unmount();
+		await cleanupPromise;
+		el.remove();
+	});
+
+	return {
+		/**
+		 * Render a React element synchronously via `flushSync`, wrapped in an
+		 * `EffectGate` that enables awaiting deferred cleanup effects on unmount.
+		 */
+		render(element: ReactElement) {
+			flushSync(() => {
+				root.render(
+					<EffectGate onCleanup={resolveCleanup}>
+						{element}
+					</EffectGate>
+				);
+			});
+		},
+
+		/**
+		 * Returns the DOM container the React root is mounted into.
+		 * Call inside tests (after `setup` has run), not at suite-definition time.
+		 */
+		container(): HTMLElement {
+			return el;
+		},
+	};
+}

--- a/src/vs/base/test/browser/react.tsx
+++ b/src/vs/base/test/browser/react.tsx
@@ -3,23 +3,10 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { PropsWithChildren, ReactElement, useEffect } from 'react';
+import { ReactElement } from 'react';
 import { flushSync } from 'react-dom';
 import { createRoot, Root } from 'react-dom/client';
 import { mainWindow } from '../../browser/window.js';
-
-/**
- * Wrapper component that resolves a promise when its useEffect cleanup runs.
- * React fires cleanup effects bottom-up (children before parent), so by the
- * time this parent's cleanup fires, all child effects -- including those that
- * create VS Code disposables -- have already been disposed.
- */
-function EffectGate({ onCleanup, children }: PropsWithChildren<{ onCleanup: () => void }>) {
-	useEffect(() => {
-		return onCleanup;
-	}, [onCleanup]);
-	return <>{children}</>;
-}
 
 /**
  * Sets up a React render root for component tests. Registers mocha `setup` and
@@ -46,34 +33,25 @@ function EffectGate({ onCleanup, children }: PropsWithChildren<{ onCleanup: () =
 export function setupReactRenderer() {
 	let root: Root;
 	let el: HTMLElement;
-	let cleanupPromise: Promise<void>;
-	let resolveCleanup: () => void;
 
 	setup(() => {
 		el = mainWindow.document.createElement('div');
 		mainWindow.document.body.appendChild(el);
 		root = createRoot(el);
-		cleanupPromise = new Promise<void>(r => { resolveCleanup = r; });
 	});
 
 	teardown(async () => {
 		root.unmount();
-		await cleanupPromise;
 		el.remove();
 	});
 
 	return {
 		/**
-		 * Render a React element synchronously via `flushSync`, wrapped in an
-		 * `EffectGate` that enables awaiting deferred cleanup effects on unmount.
+		 * Render a React element synchronously via `flushSync`.
 		 */
 		render(element: ReactElement) {
 			flushSync(() => {
-				root.render(
-					<EffectGate onCleanup={resolveCleanup}>
-						{element}
-					</EffectGate>
-				);
+				root.render(element);
 			});
 		},
 

--- a/src/vs/platform/positronActionBar/test/browser/actionBarWidget.test.tsx
+++ b/src/vs/platform/positronActionBar/test/browser/actionBarWidget.test.tsx
@@ -21,7 +21,7 @@ import { TestInstantiationService } from '../../../instantiation/test/common/ins
 import { Event } from '../../../../base/common/event.js';
 
 suite('ActionBarWidget', () => {
-	const { render, container } = setupReactRenderer();
+	const { render } = setupReactRenderer();
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	let mockServicesAccessor: PositronReactServices;
@@ -29,7 +29,7 @@ suite('ActionBarWidget', () => {
 
 	/** Helper to render ActionBarWidget with context. */
 	function renderWidget(descriptor: IPositronActionBarWidgetDescriptor) {
-		render(
+		return render(
 			<PositronReactServicesContext.Provider value={mockServicesAccessor}>
 				<ActionBarWidget descriptor={descriptor} />
 			</PositronReactServicesContext.Provider>
@@ -61,9 +61,9 @@ suite('ActionBarWidget', () => {
 			componentFactory: () => () => <span className='test-widget-content'>Test Widget</span>
 		};
 
-		renderWidget(descriptor);
+		const container = renderWidget(descriptor);
 
-		const widgetContent = container().querySelector('.test-widget-content');
+		const widgetContent = container.querySelector('.test-widget-content');
 		assert.ok(widgetContent, 'Expected to find widget content');
 		assert.strictEqual(widgetContent.textContent, 'Test Widget');
 	});
@@ -98,9 +98,9 @@ suite('ActionBarWidget', () => {
 			componentFactory: () => () => <span>Command Widget</span>
 		};
 
-		renderWidget(descriptor);
+		const container = renderWidget(descriptor);
 
-		const button = container().querySelector('button.action-bar-widget');
+		const button = container.querySelector('button.action-bar-widget');
 		assert.ok(button, 'Expected to find button element');
 		assert.strictEqual(button.getAttribute('aria-label'), 'Test Command');
 		assert.strictEqual(button.getAttribute('title'), 'Execute test command');
@@ -120,9 +120,9 @@ suite('ActionBarWidget', () => {
 			componentFactory: () => () => <span>Click Me</span>
 		};
 
-		renderWidget(descriptor);
+		const container = renderWidget(descriptor);
 
-		const button = container().querySelector('button.action-bar-widget') as HTMLButtonElement;
+		const button = container.querySelector<HTMLButtonElement>('button.action-bar-widget');
 		assert.ok(button, 'Expected to find button');
 
 		// Simulate click
@@ -148,9 +148,9 @@ suite('ActionBarWidget', () => {
 			componentFactory: () => () => <span>Press Enter</span>
 		};
 
-		renderWidget(descriptor);
+		const container = renderWidget(descriptor);
 
-		const button = container().querySelector('button.action-bar-widget') as HTMLButtonElement;
+		const button = container.querySelector<HTMLButtonElement>('button.action-bar-widget');
 		assert.ok(button, 'Expected to find button');
 
 		// Simulate Enter key press
@@ -175,9 +175,9 @@ suite('ActionBarWidget', () => {
 			componentFactory: () => () => <span>Press Space</span>
 		};
 
-		renderWidget(descriptor);
+		const container = renderWidget(descriptor);
 
-		const button = container().querySelector('button.action-bar-widget') as HTMLButtonElement;
+		const button = container.querySelector<HTMLButtonElement>('button.action-bar-widget');
 		assert.ok(button, 'Expected to find button');
 
 		// Simulate Space key press
@@ -198,12 +198,12 @@ suite('ActionBarWidget', () => {
 			componentFactory: () => () => <span>Self Contained</span>
 		};
 
-		renderWidget(descriptor);
+		const container = renderWidget(descriptor);
 
-		const div = container().querySelector('div.action-bar-widget');
+		const div = container.querySelector('div.action-bar-widget');
 		assert.ok(div, 'Expected to find div element');
 
-		const button = container().querySelector('button.action-bar-widget');
+		const button = container.querySelector('button.action-bar-widget');
 		assert.strictEqual(button, null, 'Should not render as button when self-contained');
 	});
 
@@ -216,12 +216,12 @@ suite('ActionBarWidget', () => {
 			componentFactory: () => () => <span>Legacy Widget</span>
 		};
 
-		renderWidget(descriptor);
+		const container = renderWidget(descriptor);
 
-		const div = container().querySelector('div.action-bar-widget');
+		const div = container.querySelector('div.action-bar-widget');
 		assert.ok(div, 'Expected to find div element for legacy widget');
 
-		const button = container().querySelector('button.action-bar-widget');
+		const button = container.querySelector('button.action-bar-widget');
 		assert.strictEqual(button, null, 'Legacy widget should not render as button');
 	});
 
@@ -241,9 +241,9 @@ suite('ActionBarWidget', () => {
 		// Suppress console.error for this test since we expect an error
 		const consoleErrorStub = sinon.stub(console, 'error');
 
-		renderWidget(descriptor);
+		const container = renderWidget(descriptor);
 
-		const errorIndicator = container().querySelector('.action-bar-widget-error');
+		const errorIndicator = container.querySelector('.action-bar-widget-error');
 		assert.ok(errorIndicator, 'Expected to find error indicator');
 
 		const errorIcon = errorIndicator.querySelector('.codicon-error');
@@ -270,9 +270,9 @@ suite('ActionBarWidget', () => {
 		// Suppress console.error for this test
 		const consoleErrorStub = sinon.stub(console, 'error');
 
-		renderWidget(descriptor);
+		const container = renderWidget(descriptor);
 
-		const errorIndicator = container().querySelector('.action-bar-widget-error') as HTMLElement;
+		const errorIndicator = container.querySelector<HTMLElement>('.action-bar-widget-error');
 		assert.ok(errorIndicator, 'Expected to find error indicator');
 
 		const title = errorIndicator.getAttribute('title');

--- a/src/vs/platform/positronActionBar/test/browser/actionBarWidget.test.tsx
+++ b/src/vs/platform/positronActionBar/test/browser/actionBarWidget.test.tsx
@@ -7,15 +7,13 @@
 
 import assert from 'assert';
 import sinon from 'sinon';
-import { flushSync } from 'react-dom';
-import { createRoot, Root } from 'react-dom/client';
 import { ActionBarWidget } from '../../browser/components/actionBarWidget.js';
 import { IPositronActionBarWidgetDescriptor } from '../../browser/positronActionBarWidgetRegistry.js';
 import { MenuId } from '../../../actions/common/actions.js';
 import { ICommandService, CommandsRegistry } from '../../../commands/common/commands.js';
 import { ServiceIdentifier, ServicesAccessor } from '../../../instantiation/common/instantiation.js';
-import { mainWindow } from '../../../../base/browser/window.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { setupReactRenderer } from '../../../../base/test/browser/react.js';
 import { PositronReactServicesContext } from '../../../../base/browser/positronReactRendererContext.js';
 import { PositronReactServices } from '../../../../base/browser/positronReactServices.js';
 import { TestCommandService } from '../../../../editor/test/browser/editorTestServices.js';
@@ -23,32 +21,22 @@ import { TestInstantiationService } from '../../../instantiation/test/common/ins
 import { Event } from '../../../../base/common/event.js';
 
 suite('ActionBarWidget', () => {
+	const { render, container } = setupReactRenderer();
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	let root: Root;
-	let container: HTMLElement;
 	let mockServicesAccessor: PositronReactServices;
 	let commandService: TestCommandService;
 
 	/** Helper to render ActionBarWidget with context. */
 	function renderWidget(descriptor: IPositronActionBarWidgetDescriptor) {
-		// Render the widget and wait for React to flush
-		flushSync(() => {
-			root.render(
-				<PositronReactServicesContext.Provider value={mockServicesAccessor}>
-					<ActionBarWidget descriptor={descriptor} />
-				</PositronReactServicesContext.Provider>
-			);
-		});
+		render(
+			<PositronReactServicesContext.Provider value={mockServicesAccessor}>
+				<ActionBarWidget descriptor={descriptor} />
+			</PositronReactServicesContext.Provider>
+		);
 	}
 
 	setup(() => {
-		// Create a container element for React to render into
-		container = mainWindow.document.createElement('div');
-		mainWindow.document.body.appendChild(container);
-		root = createRoot(container);
-
-		// Create mock services
 		const instantiationService = disposables.add(new TestInstantiationService());
 		commandService = new TestCommandService(instantiationService);
 		mockServicesAccessor = ({
@@ -62,11 +50,6 @@ suite('ActionBarWidget', () => {
 	});
 
 	teardown(() => {
-		// Clean up the React root and container
-		root.unmount();
-		container.remove();
-
-		// Restore spies and stubs
 		sinon.restore();
 	});
 
@@ -80,7 +63,7 @@ suite('ActionBarWidget', () => {
 
 		renderWidget(descriptor);
 
-		const widgetContent = container.querySelector('.test-widget-content');
+		const widgetContent = container().querySelector('.test-widget-content');
 		assert.ok(widgetContent, 'Expected to find widget content');
 		assert.strictEqual(widgetContent.textContent, 'Test Widget');
 	});
@@ -117,7 +100,7 @@ suite('ActionBarWidget', () => {
 
 		renderWidget(descriptor);
 
-		const button = container.querySelector('button.action-bar-widget');
+		const button = container().querySelector('button.action-bar-widget');
 		assert.ok(button, 'Expected to find button element');
 		assert.strictEqual(button.getAttribute('aria-label'), 'Test Command');
 		assert.strictEqual(button.getAttribute('title'), 'Execute test command');
@@ -139,7 +122,7 @@ suite('ActionBarWidget', () => {
 
 		renderWidget(descriptor);
 
-		const button = container.querySelector('button.action-bar-widget') as HTMLButtonElement;
+		const button = container().querySelector('button.action-bar-widget') as HTMLButtonElement;
 		assert.ok(button, 'Expected to find button');
 
 		// Simulate click
@@ -167,7 +150,7 @@ suite('ActionBarWidget', () => {
 
 		renderWidget(descriptor);
 
-		const button = container.querySelector('button.action-bar-widget') as HTMLButtonElement;
+		const button = container().querySelector('button.action-bar-widget') as HTMLButtonElement;
 		assert.ok(button, 'Expected to find button');
 
 		// Simulate Enter key press
@@ -194,7 +177,7 @@ suite('ActionBarWidget', () => {
 
 		renderWidget(descriptor);
 
-		const button = container.querySelector('button.action-bar-widget') as HTMLButtonElement;
+		const button = container().querySelector('button.action-bar-widget') as HTMLButtonElement;
 		assert.ok(button, 'Expected to find button');
 
 		// Simulate Space key press
@@ -217,10 +200,10 @@ suite('ActionBarWidget', () => {
 
 		renderWidget(descriptor);
 
-		const div = container.querySelector('div.action-bar-widget');
+		const div = container().querySelector('div.action-bar-widget');
 		assert.ok(div, 'Expected to find div element');
 
-		const button = container.querySelector('button.action-bar-widget');
+		const button = container().querySelector('button.action-bar-widget');
 		assert.strictEqual(button, null, 'Should not render as button when self-contained');
 	});
 
@@ -235,10 +218,10 @@ suite('ActionBarWidget', () => {
 
 		renderWidget(descriptor);
 
-		const div = container.querySelector('div.action-bar-widget');
+		const div = container().querySelector('div.action-bar-widget');
 		assert.ok(div, 'Expected to find div element for legacy widget');
 
-		const button = container.querySelector('button.action-bar-widget');
+		const button = container().querySelector('button.action-bar-widget');
 		assert.strictEqual(button, null, 'Legacy widget should not render as button');
 	});
 
@@ -260,7 +243,7 @@ suite('ActionBarWidget', () => {
 
 		renderWidget(descriptor);
 
-		const errorIndicator = container.querySelector('.action-bar-widget-error');
+		const errorIndicator = container().querySelector('.action-bar-widget-error');
 		assert.ok(errorIndicator, 'Expected to find error indicator');
 
 		const errorIcon = errorIndicator.querySelector('.codicon-error');
@@ -289,7 +272,7 @@ suite('ActionBarWidget', () => {
 
 		renderWidget(descriptor);
 
-		const errorIndicator = container.querySelector('.action-bar-widget-error') as HTMLElement;
+		const errorIndicator = container().querySelector('.action-bar-widget-error') as HTMLElement;
 		assert.ok(errorIndicator, 'Expected to find error indicator');
 
 		const title = errorIndicator.getAttribute('title');

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/PositronFindInput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/PositronFindInput.tsx
@@ -205,4 +205,4 @@ export const PositronFindInput = ({
 	}, [findInput, focus]);
 
 	return <div ref={containerRef} className='find-input-container' />;
-}
+};

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
@@ -10,7 +10,7 @@ import assert from 'assert';
 import sinon from 'sinon';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { setupReactRenderer } from '../../../../../../../base/test/browser/react.js';
-import { ISettableObservable, observableValue } from '../../../../../../../base/common/observableInternal/index.js';
+import { ISettableObservable, observableValue } from '../../../../../../../base/common/observable.js';
 import { MockContextKeyService } from '../../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { IContextViewService } from '../../../../../../../platform/contextview/browser/contextView.js';
 import { unthemedInboxStyles } from '../../../../../../../base/browser/ui/inputbox/inputBox.js';
@@ -35,25 +35,25 @@ suite('PositronFindWidget', () => {
 	function renderWidget() {
 		render(
 			<PositronFindWidget
-				findText={findText}
 				contextKeyService={new MockContextKeyService()}
 				// ContextViewService is only used by FindInput for validation message
 				// popups, which these tests don't trigger.
 				contextViewService={{} as IContextViewService}
-				matchCase={matchCase}
-				matchWholeWord={matchWholeWord}
-				useRegex={useRegex}
-				matchIndex={matchIndex}
-				matchCount={matchCount}
 				findInputOptions={{
 					label: 'Find',
 					inputBoxStyles: unthemedInboxStyles,
 					toggleStyles: unthemedToggleStyles,
 				}}
-				isVisible={isVisible}
+				findText={findText}
 				inputFocused={inputFocused}
-				onPreviousMatch={onPreviousMatch}
+				isVisible={isVisible}
+				matchCase={matchCase}
+				matchCount={matchCount}
+				matchIndex={matchIndex}
+				matchWholeWord={matchWholeWord}
+				useRegex={useRegex}
 				onNextMatch={onNextMatch}
+				onPreviousMatch={onPreviousMatch}
 			/>
 		);
 	}

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
@@ -8,17 +8,58 @@
 
 import assert from 'assert';
 import sinon from 'sinon';
+import { flushSync } from 'react-dom';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { setupReactRenderer } from '../../../../../../../base/test/browser/react.js';
-import { ISettableObservable, observableValue, transaction } from '../../../../../../../base/common/observable.js';
+import { ISettableObservable, observableValue } from '../../../../../../../base/common/observable.js';
 import { MockContextKeyService } from '../../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { IContextViewService } from '../../../../../../../platform/contextview/browser/contextView.js';
 import { unthemedInboxStyles } from '../../../../../../../base/browser/ui/inputbox/inputBox.js';
 import { unthemedToggleStyles } from '../../../../../../../base/browser/ui/toggle/toggle.js';
 import { PositronFindWidget } from '../../../../browser/contrib/find/PositronFindWidget.js';
 
+class PositronFindWidgetFixture {
+	constructor(public readonly container: HTMLDivElement) { }
+
+	get results() {
+		const el = this.container.querySelector('.results');
+		assert.ok(el, 'Expected results element to exist');
+		return el;
+	}
+
+	get navigationButtons() {
+		return this.container.querySelectorAll<HTMLButtonElement>('.navigation-buttons button');
+	}
+
+	get previousButton() {
+		const button = this.navigationButtons[0];
+		assert.ok(button, 'Expected previous button to exist');
+		return button;
+	}
+
+	get nextButton() {
+		const button = this.navigationButtons[1];
+		assert.ok(button, 'Expected next button to exist');
+		return button;
+	}
+
+	get closeButton() {
+		const button = this.container.querySelector<HTMLButtonElement>('button.close-button');
+		assert.ok(button, 'Expected close button to exist');
+		return button;
+	}
+
+	get isVisible() {
+		return this.container.classList.contains('visible');
+	}
+
+	get hasErrorStyling() {
+		return this.container.classList.contains('no-results');
+	}
+}
+
 suite('PositronFindWidget', () => {
-	const { render, container } = setupReactRenderer();
+	const { render } = setupReactRenderer();
 	ensureNoDisposablesAreLeakedInTestSuite();
 
 	let findText: ISettableObservable<string>;
@@ -33,7 +74,7 @@ suite('PositronFindWidget', () => {
 	let onNextMatch: sinon.SinonStub;
 
 	function renderWidget() {
-		render(
+		const container = render(
 			<PositronFindWidget
 				contextKeyService={new MockContextKeyService()}
 				// ContextViewService is only used by FindInput for validation message
@@ -56,6 +97,9 @@ suite('PositronFindWidget', () => {
 				onPreviousMatch={onPreviousMatch}
 			/>
 		);
+		const widgetContainer = container.querySelector<HTMLDivElement>('.positron-find-widget');
+		assert.ok(widgetContainer, 'Expected PositronFindWidget to be rendered');
+		return new PositronFindWidgetFixture(widgetContainer);
 	}
 
 	setup(() => {
@@ -75,217 +119,92 @@ suite('PositronFindWidget', () => {
 		sinon.restore();
 	});
 
-	suite('Rendering & Visibility', () => {
-		test('renders when visible', () => {
-			renderWidget();
+	test('is visible after first render', () => {
+		const widget = renderWidget();
 
-			const widget = container().querySelector('.positron-find-widget.visible');
-			assert.ok(widget, 'Expected PositronFindWidget to exist');
-		});
-
-		test('hidden when not visible', () => {
-			isVisible.set(false, undefined);
-			renderWidget();
-
-			const widget = container().querySelector('.positron-find-widget');
-			assert.ok(widget, 'Expected .positron-find-widget to exist');
-			assert.ok(
-				!widget.classList.contains('visible'),
-				'Expected PositronFindWidget to not exist'
-			);
-		});
-
+		assert.ok(widget.isVisible, 'Expected find widget to be visible');
 	});
 
-	suite('FindResult display', () => {
-		test('shows "No results" when find text is empty', () => {
-			renderWidget();
+	test('hides when close button is clicked', () => {
+		const widget = renderWidget();
 
-			const results = container().querySelector('.positron-find-widget .results');
-			assert.ok(results, 'Expected to find results');
-			assert.strictEqual(results.textContent, 'No results');
-		});
+		flushSync(() => widget.closeButton.click());
 
-		test('shows empty results when matchCount is undefined', () => {
-			findText.set('foo', undefined);
-			renderWidget();
-
-			const results = container().querySelector('.positron-find-widget .results');
-			assert.ok(results, 'Expected .results to exist');
-			assert.strictEqual(results.textContent, '');
-		});
-
-		test('shows "No results" with error styling when no matches', () => {
-			findText.set('foo', undefined);
-			matchCount.set(0, undefined);
-			renderWidget();
-
-			const results = container().querySelector('.positron-find-widget .results');
-			assert.ok(results, 'Expected .results to exist');
-			assert.strictEqual(results.textContent, 'No results');
-
-			const widget = container().querySelector('.positron-find-widget.no-results');
-			assert.ok(widget, 'Expected widget to have .no-results class');
-		});
-
-		test('shows match count when matches exist', () => {
-			findText.set('foo', undefined);
-			matchCount.set(5, undefined);
-			matchIndex.set(2, undefined);
-			renderWidget();
-
-			const results = container().querySelector('.positron-find-widget .results');
-			assert.ok(results, 'Expected .results to exist');
-			assert.strictEqual(results.textContent, '3 of 5');
-		});
-
-		test('shows "1 of N" when matchIndex is undefined', () => {
-			findText.set('foo', undefined);
-			matchCount.set(3, undefined);
-			renderWidget();
-
-			const results = container().querySelector('.positron-find-widget .results');
-			assert.ok(results, 'Expected .results to exist');
-			assert.strictEqual(results.textContent, '1 of 3');
-		});
+		assert.ok(!widget.isVisible, 'Expected find widget to be hidden after close');
+		assert.ok(!isVisible.get(), 'Expected isVisible observable to be false after close');
 	});
 
-	suite('Navigation buttons', () => {
-		test('previous match button disabled when no matches', () => {
-			matchCount.set(0, undefined);
-			renderWidget();
+	test('hides when isVisible changes', () => {
+		const widget = renderWidget();
 
-			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
-			const buttons = container().querySelectorAll<HTMLButtonElement>('.navigation-buttons button');
-			const prevButton = buttons[0];
-			assert.ok(prevButton, 'Expected previous button to exist');
-			assert.strictEqual(prevButton.disabled, true, 'Expected previous button to be disabled');
-		});
+		flushSync(() => isVisible.set(false, undefined));
 
-		test('next match button disabled when no matches', () => {
-			matchCount.set(0, undefined);
-			renderWidget();
-
-			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
-			const nextButton = buttons[1] as HTMLButtonElement;
-			assert.ok(nextButton, 'Expected next button to exist');
-			assert.strictEqual(nextButton.disabled, true, 'Expected next button to be disabled');
-		});
-
-		test('previous match button enabled when matches exist', () => {
-			matchCount.set(3, undefined);
-			renderWidget();
-
-			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
-			const prevButton = buttons[0] as HTMLButtonElement;
-			assert.ok(prevButton, 'Expected previous button to exist');
-			assert.strictEqual(prevButton.disabled, false, 'Expected previous button to be enabled');
-		});
-
-		test('next match button enabled when matches exist', () => {
-			matchCount.set(3, undefined);
-			renderWidget();
-
-			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
-			const nextButton = buttons[1] as HTMLButtonElement;
-			assert.ok(nextButton, 'Expected next button to exist');
-			assert.strictEqual(nextButton.disabled, false, 'Expected next button to be enabled');
-		});
-
-		test('previous match button calls onPreviousMatch', () => {
-			matchCount.set(3, undefined);
-			renderWidget();
-
-			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
-			const prevButton = buttons[0] as HTMLButtonElement;
-			prevButton.click();
-
-			assert.ok(onPreviousMatch.calledOnce, 'Expected onPreviousMatch to be called once');
-		});
-
-		test('next match button calls onNextMatch', () => {
-			matchCount.set(3, undefined);
-			renderWidget();
-
-			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
-			const nextButton = buttons[1] as HTMLButtonElement;
-			nextButton.click();
-
-			assert.ok(onNextMatch.calledOnce, 'Expected onNextMatch to be called once');
-		});
+		assert.ok(!widget.isVisible, 'Expected find widget to be hidden');
 	});
 
-	suite('Close button', () => {
-		test('sets isVisible to false', () => {
-			renderWidget();
+	test('has no error styling when there is no query', () => {
+		const widget = renderWidget();
 
-			const closeButton = container().querySelector('.positron-find-widget button.close-button') as HTMLButtonElement;
-			assert.ok(closeButton, 'Expected close button to exist');
-			closeButton.click();
-
-			assert.strictEqual(isVisible.get(), false, 'Expected isVisible to be false after close');
-		});
+		assert.strictEqual(widget.results.textContent, 'No results');
+		assert.ok(!widget.hasErrorStyling, 'Expected find widget to have no error styling without a query');
 	});
 
-	suite('Tab order', () => {
-		test('disabled navigation buttons are excluded from tab order', () => {
-			matchCount.set(0, undefined);
-			renderWidget();
+	test('has error styling when there is a query but no matches', () => {
+		findText.set('foo', undefined);
+		matchCount.set(0, undefined);
+		const widget = renderWidget();
 
-			const navButtons = container().querySelectorAll<HTMLButtonElement>('.positron-find-widget .navigation-buttons button');
-			for (const btn of navButtons) {
-				assert.strictEqual(btn.disabled, true, `Expected navigation button "${btn.ariaLabel}" to be disabled`);
-			}
-
-			// Close button should still be enabled
-			const closeButton = container().querySelector('.positron-find-widget button.close-button') as HTMLButtonElement;
-			assert.strictEqual(closeButton.disabled, false, 'Expected close button to remain enabled');
-		});
+		assert.strictEqual(widget.results.textContent, 'No results');
+		assert.ok(widget.hasErrorStyling, 'Expected find widget to indicate no results found');
 	});
 
-	suite('Reactivity', () => {
-		test('re-renders when matchCount changes', () => {
-			transaction((tx) => {
-				findText.set('foo', tx);
-				matchCount.set(3, tx);
-				matchIndex.set(0, tx);
-			});
-			renderWidget();
+	test('shows empty results while matchCount is loading', () => {
+		findText.set('foo', undefined);
+		const widget = renderWidget();
 
-			let results = container().querySelector('.positron-find-widget .results');
-			assert.strictEqual(results?.textContent, '1 of 3');
+		assert.strictEqual(widget.results.textContent, '');
+	});
 
-			matchCount.set(5, undefined);
-			renderWidget();
+	test('navigation buttons are disabled when there are no matches', () => {
+		matchCount.set(0, undefined);
+		const widget = renderWidget();
 
-			results = container().querySelector('.positron-find-widget .results');
-			assert.strictEqual(results?.textContent, '1 of 5');
-		});
+		assert.ok(widget.previousButton.disabled, 'Expected previous button to be disabled');
+		assert.ok(widget.nextButton.disabled, 'Expected next button to be disabled');
+	});
 
-		test('re-renders when findText changes', () => {
-			renderWidget();
+	test('previous match button calls onPreviousMatch', () => {
+		matchCount.set(3, undefined);
+		const widget = renderWidget();
 
-			let results = container().querySelector('.positron-find-widget .results');
-			assert.strictEqual(results?.textContent, 'No results');
+		widget.previousButton.click();
 
-			findText.set('foo', undefined);
-			renderWidget();
+		assert.ok(onPreviousMatch.calledOnce, 'Expected onPreviousMatch to be called once');
+	});
 
-			results = container().querySelector('.positron-find-widget .results');
-			assert.strictEqual(results?.textContent, '');
-		});
+	test('next match button calls onNextMatch', () => {
+		matchCount.set(3, undefined);
+		const widget = renderWidget();
 
-		test('re-renders when visibility changes', () => {
-			renderWidget();
+		widget.nextButton.click();
 
-			let widget = container().querySelector('.positron-find-widget');
-			assert.ok(widget?.classList.contains('visible'), 'Expected widget to be visible');
+		assert.ok(onNextMatch.calledOnce, 'Expected onNextMatch to be called once');
+	});
 
-			isVisible.set(false, undefined);
-			renderWidget();
+	test('shows "1 of N" when matchIndex is undefined', () => {
+		findText.set('foo', undefined);
+		matchCount.set(3, undefined);
+		const widget = renderWidget();
 
-			widget = container().querySelector('.positron-find-widget');
-			assert.ok(widget?.classList.contains('visible') === false, 'Expected widget to not be visible');
-		});
+		assert.strictEqual(widget.results.textContent, '1 of 3');
+	});
+
+	test('shows match index and count', () => {
+		findText.set('foo', undefined);
+		matchCount.set(5, undefined);
+		matchIndex.set(2, undefined);
+		const widget = renderWidget();
+
+		assert.strictEqual(widget.results.textContent, '3 of 5');
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -10,42 +10,66 @@ import assert from 'assert';
 import sinon from 'sinon';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { setupReactRenderer } from '../../../../../../../base/test/browser/react.js';
-import { observableValue } from '../../../../../../../base/common/observable.js';
+import { ISettableObservable, observableValue } from '../../../../../../../base/common/observableInternal/index.js';
 import { MockContextKeyService } from '../../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { IContextViewService } from '../../../../../../../platform/contextview/browser/contextView.js';
 import { unthemedInboxStyles } from '../../../../../../../base/browser/ui/inputbox/inputBox.js';
 import { unthemedToggleStyles } from '../../../../../../../base/browser/ui/toggle/toggle.js';
-import { PositronFindWidget, PositronFindWidgetProps } from '../../../../browser/contrib/find/PositronFindWidget.js';
+import { PositronFindWidget } from '../../../../browser/contrib/find/PositronFindWidget.js';
 
 suite('PositronFindWidget', () => {
 	const { render, container } = setupReactRenderer();
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	function renderWidget(overrides?: Partial<PositronFindWidgetProps>) {
-		const props: PositronFindWidgetProps = {
-			findText: observableValue('findText', ''),
-			contextKeyService: new MockContextKeyService(),
-			// ContextViewService is only used by FindInput for validation message
-			// popups, which these tests don't trigger.
-			contextViewService: {} as IContextViewService,
-			matchCase: observableValue('matchCase', false),
-			matchWholeWord: observableValue('matchWholeWord', false),
-			useRegex: observableValue('useRegex', false),
-			matchIndex: observableValue<number | undefined>('matchIndex', undefined),
-			matchCount: observableValue<number | undefined>('matchCount', undefined),
-			findInputOptions: {
-				label: 'Find',
-				inputBoxStyles: unthemedInboxStyles,
-				toggleStyles: unthemedToggleStyles,
-			},
-			isVisible: observableValue('isVisible', true),
-			inputFocused: observableValue('inputFocused', false),
-			onPreviousMatch: sinon.stub(),
-			onNextMatch: sinon.stub(),
-			...overrides,
-		};
-		render(<PositronFindWidget {...props} />);
+	let findText: ISettableObservable<string>;
+	let matchCase: ISettableObservable<boolean>;
+	let matchWholeWord: ISettableObservable<boolean>;
+	let useRegex: ISettableObservable<boolean>;
+	let matchIndex: ISettableObservable<number | undefined>;
+	let matchCount: ISettableObservable<number | undefined>;
+	let isVisible: ISettableObservable<boolean>;
+	let inputFocused: ISettableObservable<boolean>;
+	let onPreviousMatch: sinon.SinonStub;
+	let onNextMatch: sinon.SinonStub;
+
+	function renderWidget() {
+		render(
+			<PositronFindWidget
+				findText={findText}
+				contextKeyService={new MockContextKeyService()}
+				// ContextViewService is only used by FindInput for validation message
+				// popups, which these tests don't trigger.
+				contextViewService={{} as IContextViewService}
+				matchCase={matchCase}
+				matchWholeWord={matchWholeWord}
+				useRegex={useRegex}
+				matchIndex={matchIndex}
+				matchCount={matchCount}
+				findInputOptions={{
+					label: 'Find',
+					inputBoxStyles: unthemedInboxStyles,
+					toggleStyles: unthemedToggleStyles,
+				}}
+				isVisible={isVisible}
+				inputFocused={inputFocused}
+				onPreviousMatch={onPreviousMatch}
+				onNextMatch={onNextMatch}
+			/>
+		);
 	}
+
+	setup(() => {
+		findText = observableValue('findText', '');
+		matchCase = observableValue('matchCase', false);
+		matchWholeWord = observableValue('matchWholeWord', false);
+		useRegex = observableValue('useRegex', false);
+		matchIndex = observableValue<number | undefined>('matchIndex', undefined);
+		matchCount = observableValue<number | undefined>('matchCount', undefined);
+		isVisible = observableValue('isVisible', true);
+		inputFocused = observableValue('inputFocused', false);
+		onPreviousMatch = sinon.stub();
+		onNextMatch = sinon.stub();
+	});
 
 	teardown(() => {
 		sinon.restore();
@@ -60,8 +84,8 @@ suite('PositronFindWidget', () => {
 		});
 
 		test('hidden when not visible', () => {
-			const isVisible = observableValue('isVisible', false);
-			renderWidget({ isVisible });
+			isVisible.set(false, undefined);
+			renderWidget();
 
 			const widget = container().querySelector('.positron-find-widget');
 			assert.ok(widget, 'Expected .positron-find-widget to exist');
@@ -106,9 +130,8 @@ suite('PositronFindWidget', () => {
 		});
 
 		test('shows empty results when matchCount is undefined', () => {
-			const findText = observableValue('findText', 'foo');
-			const matchCount = observableValue<number | undefined>('matchCount', undefined);
-			renderWidget({ findText, matchCount });
+			findText.set('foo', undefined);
+			renderWidget();
 
 			const results = container().querySelector('.positron-find-widget .results');
 			assert.ok(results, 'Expected .results to exist');
@@ -116,9 +139,9 @@ suite('PositronFindWidget', () => {
 		});
 
 		test('shows "No results" with error styling when no matches', () => {
-			const findText = observableValue('findText', 'foo');
-			const matchCount = observableValue<number | undefined>('matchCount', 0);
-			renderWidget({ findText, matchCount });
+			findText.set('foo', undefined);
+			matchCount.set(0, undefined);
+			renderWidget();
 
 			const results = container().querySelector('.positron-find-widget .results');
 			assert.ok(results, 'Expected .results to exist');
@@ -129,10 +152,10 @@ suite('PositronFindWidget', () => {
 		});
 
 		test('shows match count when matches exist', () => {
-			const findText = observableValue('findText', 'foo');
-			const matchCount = observableValue<number | undefined>('matchCount', 5);
-			const matchIndex = observableValue<number | undefined>('matchIndex', 2);
-			renderWidget({ findText, matchCount, matchIndex });
+			findText.set('foo', undefined);
+			matchCount.set(5, undefined);
+			matchIndex.set(2, undefined);
+			renderWidget();
 
 			const results = container().querySelector('.positron-find-widget .results');
 			assert.ok(results, 'Expected .results to exist');
@@ -140,10 +163,9 @@ suite('PositronFindWidget', () => {
 		});
 
 		test('shows "1 of N" when matchIndex is undefined', () => {
-			const findText = observableValue('findText', 'foo');
-			const matchCount = observableValue<number | undefined>('matchCount', 3);
-			const matchIndex = observableValue<number | undefined>('matchIndex', undefined);
-			renderWidget({ findText, matchCount, matchIndex });
+			findText.set('foo', undefined);
+			matchCount.set(3, undefined);
+			renderWidget();
 
 			const results = container().querySelector('.positron-find-widget .results');
 			assert.ok(results, 'Expected .results to exist');
@@ -153,8 +175,8 @@ suite('PositronFindWidget', () => {
 
 	suite('Navigation buttons', () => {
 		test('previous match button disabled when no matches', () => {
-			const matchCount = observableValue<number | undefined>('matchCount', 0);
-			renderWidget({ matchCount });
+			matchCount.set(0, undefined);
+			renderWidget();
 
 			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
 			const prevButton = buttons[0] as HTMLButtonElement;
@@ -163,8 +185,8 @@ suite('PositronFindWidget', () => {
 		});
 
 		test('next match button disabled when no matches', () => {
-			const matchCount = observableValue<number | undefined>('matchCount', 0);
-			renderWidget({ matchCount });
+			matchCount.set(0, undefined);
+			renderWidget();
 
 			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
 			const nextButton = buttons[1] as HTMLButtonElement;
@@ -173,8 +195,8 @@ suite('PositronFindWidget', () => {
 		});
 
 		test('previous match button enabled when matches exist', () => {
-			const matchCount = observableValue<number | undefined>('matchCount', 3);
-			renderWidget({ matchCount });
+			matchCount.set(3, undefined);
+			renderWidget();
 
 			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
 			const prevButton = buttons[0] as HTMLButtonElement;
@@ -183,8 +205,8 @@ suite('PositronFindWidget', () => {
 		});
 
 		test('next match button enabled when matches exist', () => {
-			const matchCount = observableValue<number | undefined>('matchCount', 3);
-			renderWidget({ matchCount });
+			matchCount.set(3, undefined);
+			renderWidget();
 
 			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
 			const nextButton = buttons[1] as HTMLButtonElement;
@@ -193,9 +215,8 @@ suite('PositronFindWidget', () => {
 		});
 
 		test('previous match button calls onPreviousMatch', () => {
-			const matchCount = observableValue<number | undefined>('matchCount', 3);
-			const onPreviousMatch = sinon.stub();
-			renderWidget({ matchCount, onPreviousMatch });
+			matchCount.set(3, undefined);
+			renderWidget();
 
 			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
 			const prevButton = buttons[0] as HTMLButtonElement;
@@ -205,9 +226,8 @@ suite('PositronFindWidget', () => {
 		});
 
 		test('next match button calls onNextMatch', () => {
-			const matchCount = observableValue<number | undefined>('matchCount', 3);
-			const onNextMatch = sinon.stub();
-			renderWidget({ matchCount, onNextMatch });
+			matchCount.set(3, undefined);
+			renderWidget();
 
 			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
 			const nextButton = buttons[1] as HTMLButtonElement;
@@ -219,8 +239,7 @@ suite('PositronFindWidget', () => {
 
 	suite('Close button', () => {
 		test('sets isVisible to false', () => {
-			const isVisible = observableValue('isVisible', true);
-			renderWidget({ isVisible });
+			renderWidget();
 
 			const closeButton = container().querySelector('.positron-find-widget button.close-button') as HTMLButtonElement;
 			assert.ok(closeButton, 'Expected close button to exist');
@@ -232,8 +251,8 @@ suite('PositronFindWidget', () => {
 
 	suite('Tab order', () => {
 		test('disabled navigation buttons are excluded from tab order', () => {
-			const matchCount = observableValue<number | undefined>('matchCount', 0);
-			renderWidget({ matchCount });
+			matchCount.set(0, undefined);
+			renderWidget();
 
 			const navButtons = container().querySelectorAll('.positron-find-widget .navigation-buttons button') as NodeListOf<HTMLButtonElement>;
 			for (const btn of navButtons) {
@@ -248,44 +267,42 @@ suite('PositronFindWidget', () => {
 
 	suite('Reactivity', () => {
 		test('re-renders when matchCount changes', () => {
-			const findText = observableValue('findText', 'foo');
-			const matchCount = observableValue<number | undefined>('matchCount', 3);
-			const matchIndex = observableValue<number | undefined>('matchIndex', 0);
-			renderWidget({ findText, matchCount, matchIndex });
+			findText.set('foo', undefined);
+			matchCount.set(3, undefined);
+			matchIndex.set(0, undefined);
+			renderWidget();
 
 			let results = container().querySelector('.positron-find-widget .results');
 			assert.strictEqual(results?.textContent, '1 of 3');
 
 			matchCount.set(5, undefined);
-			renderWidget({ findText, matchCount, matchIndex });
+			renderWidget();
 
 			results = container().querySelector('.positron-find-widget .results');
 			assert.strictEqual(results?.textContent, '1 of 5');
 		});
 
 		test('re-renders when findText changes', () => {
-			const findText = observableValue('findText', '');
-			renderWidget({ findText });
+			renderWidget();
 
 			let results = container().querySelector('.positron-find-widget .results');
 			assert.strictEqual(results?.textContent, 'No results');
 
 			findText.set('foo', undefined);
-			renderWidget({ findText });
+			renderWidget();
 
 			results = container().querySelector('.positron-find-widget .results');
 			assert.strictEqual(results?.textContent, '');
 		});
 
 		test('re-renders when visibility changes', () => {
-			const isVisible = observableValue('isVisible', true);
-			renderWidget({ isVisible });
+			renderWidget();
 
 			let widget = container().querySelector('.positron-find-widget');
 			assert.ok(widget?.classList.contains('visible'), 'Expected widget to be visible');
 
 			isVisible.set(false, undefined);
-			renderWidget({ isVisible });
+			renderWidget();
 
 			widget = container().querySelector('.positron-find-widget');
 			assert.ok(!widget?.classList.contains('visible'), 'Expected widget to not be visible');

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
@@ -1,0 +1,302 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* eslint-disable no-restricted-syntax */
+
+import assert from 'assert';
+import sinon from 'sinon';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
+import { setupReactRenderer } from '../../../../../../../base/test/browser/react.js';
+import { observableValue } from '../../../../../../../base/common/observable.js';
+import { MockContextKeyService } from '../../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { IContextViewService } from '../../../../../../../platform/contextview/browser/contextView.js';
+import { unthemedInboxStyles } from '../../../../../../../base/browser/ui/inputbox/inputBox.js';
+import { unthemedToggleStyles } from '../../../../../../../base/browser/ui/toggle/toggle.js';
+import { PositronFindWidget, PositronFindWidgetProps } from '../../../../browser/contrib/find/PositronFindWidget.js';
+import { IFindInputOptions } from '../../../../../../../base/browser/ui/findinput/findInput.js';
+
+suite('PositronFindWidget', () => {
+	const { render, container } = setupReactRenderer();
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	let defaultProps: PositronFindWidgetProps;
+
+	const findInputOptions: IFindInputOptions = {
+		label: 'Find',
+		inputBoxStyles: unthemedInboxStyles,
+		toggleStyles: unthemedToggleStyles,
+	};
+
+	function renderWidget(overrides?: Partial<PositronFindWidgetProps>) {
+		const props: PositronFindWidgetProps = { ...defaultProps, ...overrides };
+		render(<PositronFindWidget {...props} />);
+	}
+
+	setup(() => {
+		defaultProps = {
+			findText: observableValue('findText', ''),
+			contextKeyService: new MockContextKeyService(),
+			contextViewService: {} as IContextViewService,
+			matchCase: observableValue('matchCase', false),
+			matchWholeWord: observableValue('matchWholeWord', false),
+			useRegex: observableValue('useRegex', false),
+			matchIndex: observableValue<number | undefined>('matchIndex', undefined),
+			matchCount: observableValue<number | undefined>('matchCount', undefined),
+			findInputOptions,
+			isVisible: observableValue('isVisible', true),
+			inputFocused: observableValue('inputFocused', false),
+			onPreviousMatch: sinon.stub(),
+			onNextMatch: sinon.stub(),
+		};
+	});
+
+	teardown(() => {
+		sinon.restore();
+	});
+
+	// --- Rendering & Visibility ---
+
+	test('renders when visible', () => {
+		renderWidget();
+
+		const widget = container().querySelector('.positron-find-widget.visible');
+		assert.ok(widget, 'Expected .positron-find-widget.visible to exist');
+	});
+
+	test('hidden when not visible', () => {
+		const isVisible = observableValue('isVisible', false);
+		renderWidget({ isVisible });
+
+		const widget = container().querySelector('.positron-find-widget');
+		assert.ok(widget, 'Expected .positron-find-widget to exist');
+		assert.ok(
+			!widget.classList.contains('visible'),
+			'Expected widget to lack .visible class'
+		);
+	});
+
+	test('contains find input container', () => {
+		renderWidget();
+
+		const findInput = container().querySelector('.positron-find-widget .find-input-container');
+		assert.ok(findInput, 'Expected .find-input-container to exist');
+	});
+
+	test('contains navigation buttons', () => {
+		renderWidget();
+
+		const navButtons = container().querySelector('.positron-find-widget .navigation-buttons');
+		assert.ok(navButtons, 'Expected .navigation-buttons to exist');
+
+		const buttons = navButtons.querySelectorAll('button.action-button');
+		assert.strictEqual(buttons.length, 2, 'Expected 2 navigation buttons');
+	});
+
+	test('contains close button', () => {
+		renderWidget();
+
+		const closeButton = container().querySelector('.positron-find-widget button.close-button');
+		assert.ok(closeButton, 'Expected close button to exist');
+	});
+
+	// --- FindResult display ---
+
+	test('shows "No results" when find text is empty', () => {
+		renderWidget();
+
+		const results = container().querySelector('.positron-find-widget .results');
+		assert.ok(results, 'Expected .results to exist');
+		assert.strictEqual(results.textContent, 'No results');
+	});
+
+	test('shows empty results when matchCount is undefined', () => {
+		const findText = observableValue('findText', 'foo');
+		const matchCount = observableValue<number | undefined>('matchCount', undefined);
+		renderWidget({ findText, matchCount });
+
+		const results = container().querySelector('.positron-find-widget .results');
+		assert.ok(results, 'Expected .results to exist');
+		assert.strictEqual(results.textContent, '');
+	});
+
+	test('shows "No results" with error styling when no matches', () => {
+		const findText = observableValue('findText', 'foo');
+		const matchCount = observableValue<number | undefined>('matchCount', 0);
+		renderWidget({ findText, matchCount });
+
+		const results = container().querySelector('.positron-find-widget .results');
+		assert.ok(results, 'Expected .results to exist');
+		assert.strictEqual(results.textContent, 'No results');
+
+		const widget = container().querySelector('.positron-find-widget.no-results');
+		assert.ok(widget, 'Expected widget to have .no-results class');
+	});
+
+	test('shows match count when matches exist', () => {
+		const findText = observableValue('findText', 'foo');
+		const matchCount = observableValue<number | undefined>('matchCount', 5);
+		const matchIndex = observableValue<number | undefined>('matchIndex', 2);
+		renderWidget({ findText, matchCount, matchIndex });
+
+		const results = container().querySelector('.positron-find-widget .results');
+		assert.ok(results, 'Expected .results to exist');
+		assert.strictEqual(results.textContent, '3 of 5');
+	});
+
+	test('shows "1 of N" when matchIndex is undefined', () => {
+		const findText = observableValue('findText', 'foo');
+		const matchCount = observableValue<number | undefined>('matchCount', 3);
+		const matchIndex = observableValue<number | undefined>('matchIndex', undefined);
+		renderWidget({ findText, matchCount, matchIndex });
+
+		const results = container().querySelector('.positron-find-widget .results');
+		assert.ok(results, 'Expected .results to exist');
+		assert.strictEqual(results.textContent, '1 of 3');
+	});
+
+	// --- Navigation buttons ---
+
+	test('previous match button disabled when no matches', () => {
+		const matchCount = observableValue<number | undefined>('matchCount', 0);
+		renderWidget({ matchCount });
+
+		const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
+		const prevButton = buttons[0] as HTMLButtonElement;
+		assert.ok(prevButton, 'Expected previous button to exist');
+		assert.strictEqual(prevButton.disabled, true, 'Expected previous button to be disabled');
+	});
+
+	test('next match button disabled when no matches', () => {
+		const matchCount = observableValue<number | undefined>('matchCount', 0);
+		renderWidget({ matchCount });
+
+		const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
+		const nextButton = buttons[1] as HTMLButtonElement;
+		assert.ok(nextButton, 'Expected next button to exist');
+		assert.strictEqual(nextButton.disabled, true, 'Expected next button to be disabled');
+	});
+
+	test('previous match button enabled when matches exist', () => {
+		const matchCount = observableValue<number | undefined>('matchCount', 3);
+		renderWidget({ matchCount });
+
+		const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
+		const prevButton = buttons[0] as HTMLButtonElement;
+		assert.ok(prevButton, 'Expected previous button to exist');
+		assert.strictEqual(prevButton.disabled, false, 'Expected previous button to be enabled');
+	});
+
+	test('next match button enabled when matches exist', () => {
+		const matchCount = observableValue<number | undefined>('matchCount', 3);
+		renderWidget({ matchCount });
+
+		const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
+		const nextButton = buttons[1] as HTMLButtonElement;
+		assert.ok(nextButton, 'Expected next button to exist');
+		assert.strictEqual(nextButton.disabled, false, 'Expected next button to be enabled');
+	});
+
+	test('previous match button calls onPreviousMatch', () => {
+		const matchCount = observableValue<number | undefined>('matchCount', 3);
+		const onPreviousMatch = sinon.stub();
+		renderWidget({ matchCount, onPreviousMatch });
+
+		const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
+		const prevButton = buttons[0] as HTMLButtonElement;
+		prevButton.click();
+
+		assert.ok(onPreviousMatch.calledOnce, 'Expected onPreviousMatch to be called once');
+	});
+
+	test('next match button calls onNextMatch', () => {
+		const matchCount = observableValue<number | undefined>('matchCount', 3);
+		const onNextMatch = sinon.stub();
+		renderWidget({ matchCount, onNextMatch });
+
+		const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
+		const nextButton = buttons[1] as HTMLButtonElement;
+		nextButton.click();
+
+		assert.ok(onNextMatch.calledOnce, 'Expected onNextMatch to be called once');
+	});
+
+	// --- Close button ---
+
+	test('close button sets isVisible to false', () => {
+		const isVisible = observableValue('isVisible', true);
+		renderWidget({ isVisible });
+
+		const closeButton = container().querySelector('.positron-find-widget button.close-button') as HTMLButtonElement;
+		assert.ok(closeButton, 'Expected close button to exist');
+		closeButton.click();
+
+		assert.strictEqual(isVisible.get(), false, 'Expected isVisible to be false after close');
+	});
+
+	// --- Tab order ---
+
+	test('disabled navigation buttons are excluded from tab order', () => {
+		const matchCount = observableValue<number | undefined>('matchCount', 0);
+		renderWidget({ matchCount });
+
+		const navButtons = container().querySelectorAll('.positron-find-widget .navigation-buttons button') as NodeListOf<HTMLButtonElement>;
+		for (const btn of navButtons) {
+			assert.strictEqual(btn.disabled, true, `Expected navigation button "${btn.ariaLabel}" to be disabled`);
+		}
+
+		// Close button should still be enabled
+		const closeButton = container().querySelector('.positron-find-widget button.close-button') as HTMLButtonElement;
+		assert.strictEqual(closeButton.disabled, false, 'Expected close button to remain enabled');
+	});
+
+	// --- Reactivity (observable updates) ---
+
+	test('re-renders when matchCount changes', () => {
+		const findText = observableValue('findText', 'foo');
+		const matchCount = observableValue<number | undefined>('matchCount', 3);
+		const matchIndex = observableValue<number | undefined>('matchIndex', 0);
+		renderWidget({ findText, matchCount, matchIndex });
+
+		let results = container().querySelector('.positron-find-widget .results');
+		assert.strictEqual(results?.textContent, '1 of 3');
+
+		// Update matchCount and re-render
+		matchCount.set(5, undefined);
+		renderWidget({ findText, matchCount, matchIndex });
+
+		results = container().querySelector('.positron-find-widget .results');
+		assert.strictEqual(results?.textContent, '1 of 5');
+	});
+
+	test('re-renders when findText changes', () => {
+		const findText = observableValue('findText', '');
+		renderWidget({ findText });
+
+		let results = container().querySelector('.positron-find-widget .results');
+		assert.strictEqual(results?.textContent, 'No results');
+
+		// Update findText - with no matchCount set, should show empty
+		findText.set('foo', undefined);
+		renderWidget({ findText });
+
+		results = container().querySelector('.positron-find-widget .results');
+		assert.strictEqual(results?.textContent, '');
+	});
+
+	test('re-renders when visibility changes', () => {
+		const isVisible = observableValue('isVisible', true);
+		renderWidget({ isVisible });
+
+		let widget = container().querySelector('.positron-find-widget');
+		assert.ok(widget?.classList.contains('visible'), 'Expected widget to be visible');
+
+		// Toggle visibility
+		isVisible.set(false, undefined);
+		renderWidget({ isVisible });
+
+		widget = container().querySelector('.positron-find-widget');
+		assert.ok(!widget?.classList.contains('visible'), 'Expected widget to not be visible');
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
@@ -80,7 +80,7 @@ suite('PositronFindWidget', () => {
 			renderWidget();
 
 			const widget = container().querySelector('.positron-find-widget.visible');
-			assert.ok(widget, 'Expected .positron-find-widget.visible to exist');
+			assert.ok(widget, 'Expected PositronFindWidget to exist');
 		});
 
 		test('hidden when not visible', () => {
@@ -91,7 +91,7 @@ suite('PositronFindWidget', () => {
 			assert.ok(widget, 'Expected .positron-find-widget to exist');
 			assert.ok(
 				!widget.classList.contains('visible'),
-				'Expected widget to lack .visible class'
+				'Expected PositronFindWidget to not exist'
 			);
 		});
 
@@ -102,7 +102,7 @@ suite('PositronFindWidget', () => {
 			renderWidget();
 
 			const results = container().querySelector('.positron-find-widget .results');
-			assert.ok(results, 'Expected .results to exist');
+			assert.ok(results, 'Expected to find results');
 			assert.strictEqual(results.textContent, 'No results');
 		});
 
@@ -156,7 +156,8 @@ suite('PositronFindWidget', () => {
 			renderWidget();
 
 			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
-			const prevButton = buttons[0] as HTMLButtonElement;
+			const buttons = container().querySelectorAll<HTMLButtonElement>('.navigation-buttons button');
+			const prevButton = buttons[0];
 			assert.ok(prevButton, 'Expected previous button to exist');
 			assert.strictEqual(prevButton.disabled, true, 'Expected previous button to be disabled');
 		});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
@@ -10,7 +10,7 @@ import assert from 'assert';
 import sinon from 'sinon';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../../base/test/common/utils.js';
 import { setupReactRenderer } from '../../../../../../../base/test/browser/react.js';
-import { ISettableObservable, observableValue } from '../../../../../../../base/common/observable.js';
+import { ISettableObservable, observableValue, transaction } from '../../../../../../../base/common/observable.js';
 import { MockContextKeyService } from '../../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { IContextViewService } from '../../../../../../../platform/contextview/browser/contextView.js';
 import { unthemedInboxStyles } from '../../../../../../../base/browser/ui/inputbox/inputBox.js';
@@ -95,29 +95,6 @@ suite('PositronFindWidget', () => {
 			);
 		});
 
-		test('contains find input container', () => {
-			renderWidget();
-
-			const findInput = container().querySelector('.positron-find-widget .find-input-container');
-			assert.ok(findInput, 'Expected .find-input-container to exist');
-		});
-
-		test('contains navigation buttons', () => {
-			renderWidget();
-
-			const navButtons = container().querySelector('.positron-find-widget .navigation-buttons');
-			assert.ok(navButtons, 'Expected .navigation-buttons to exist');
-
-			const buttons = navButtons.querySelectorAll('button.action-button');
-			assert.strictEqual(buttons.length, 2, 'Expected 2 navigation buttons');
-		});
-
-		test('contains close button', () => {
-			renderWidget();
-
-			const closeButton = container().querySelector('.positron-find-widget button.close-button');
-			assert.ok(closeButton, 'Expected close button to exist');
-		});
 	});
 
 	suite('FindResult display', () => {
@@ -267,9 +244,11 @@ suite('PositronFindWidget', () => {
 
 	suite('Reactivity', () => {
 		test('re-renders when matchCount changes', () => {
-			findText.set('foo', undefined);
-			matchCount.set(3, undefined);
-			matchIndex.set(0, undefined);
+			transaction((tx) => {
+				findText.set('foo', tx);
+				matchCount.set(3, tx);
+				matchIndex.set(0, tx);
+			})
 			renderWidget();
 
 			let results = container().querySelector('.positron-find-widget .results');
@@ -305,7 +284,7 @@ suite('PositronFindWidget', () => {
 			renderWidget();
 
 			widget = container().querySelector('.positron-find-widget');
-			assert.ok(!widget?.classList.contains('visible'), 'Expected widget to not be visible');
+			assert.ok(widget?.classList.contains('visible') === false, 'Expected widget to not be visible');
 		});
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 /* eslint-disable no-restricted-syntax */
+/* eslint-disable local/code-no-dangerous-type-assertions */
 
 import assert from 'assert';
 import sinon from 'sinon';
@@ -15,288 +16,279 @@ import { IContextViewService } from '../../../../../../../platform/contextview/b
 import { unthemedInboxStyles } from '../../../../../../../base/browser/ui/inputbox/inputBox.js';
 import { unthemedToggleStyles } from '../../../../../../../base/browser/ui/toggle/toggle.js';
 import { PositronFindWidget, PositronFindWidgetProps } from '../../../../browser/contrib/find/PositronFindWidget.js';
-import { IFindInputOptions } from '../../../../../../../base/browser/ui/findinput/findInput.js';
 
 suite('PositronFindWidget', () => {
 	const { render, container } = setupReactRenderer();
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	let defaultProps: PositronFindWidgetProps;
-
-	const findInputOptions: IFindInputOptions = {
-		label: 'Find',
-		inputBoxStyles: unthemedInboxStyles,
-		toggleStyles: unthemedToggleStyles,
-	};
-
 	function renderWidget(overrides?: Partial<PositronFindWidgetProps>) {
-		const props: PositronFindWidgetProps = { ...defaultProps, ...overrides };
-		render(<PositronFindWidget {...props} />);
-	}
-
-	setup(() => {
-		defaultProps = {
+		const props: PositronFindWidgetProps = {
 			findText: observableValue('findText', ''),
 			contextKeyService: new MockContextKeyService(),
+			// ContextViewService is only used by FindInput for validation message
+			// popups, which these tests don't trigger.
 			contextViewService: {} as IContextViewService,
 			matchCase: observableValue('matchCase', false),
 			matchWholeWord: observableValue('matchWholeWord', false),
 			useRegex: observableValue('useRegex', false),
 			matchIndex: observableValue<number | undefined>('matchIndex', undefined),
 			matchCount: observableValue<number | undefined>('matchCount', undefined),
-			findInputOptions,
+			findInputOptions: {
+				label: 'Find',
+				inputBoxStyles: unthemedInboxStyles,
+				toggleStyles: unthemedToggleStyles,
+			},
 			isVisible: observableValue('isVisible', true),
 			inputFocused: observableValue('inputFocused', false),
 			onPreviousMatch: sinon.stub(),
 			onNextMatch: sinon.stub(),
+			...overrides,
 		};
-	});
+		render(<PositronFindWidget {...props} />);
+	}
 
 	teardown(() => {
 		sinon.restore();
 	});
 
-	// --- Rendering & Visibility ---
+	suite('Rendering & Visibility', () => {
+		test('renders when visible', () => {
+			renderWidget();
 
-	test('renders when visible', () => {
-		renderWidget();
+			const widget = container().querySelector('.positron-find-widget.visible');
+			assert.ok(widget, 'Expected .positron-find-widget.visible to exist');
+		});
 
-		const widget = container().querySelector('.positron-find-widget.visible');
-		assert.ok(widget, 'Expected .positron-find-widget.visible to exist');
+		test('hidden when not visible', () => {
+			const isVisible = observableValue('isVisible', false);
+			renderWidget({ isVisible });
+
+			const widget = container().querySelector('.positron-find-widget');
+			assert.ok(widget, 'Expected .positron-find-widget to exist');
+			assert.ok(
+				!widget.classList.contains('visible'),
+				'Expected widget to lack .visible class'
+			);
+		});
+
+		test('contains find input container', () => {
+			renderWidget();
+
+			const findInput = container().querySelector('.positron-find-widget .find-input-container');
+			assert.ok(findInput, 'Expected .find-input-container to exist');
+		});
+
+		test('contains navigation buttons', () => {
+			renderWidget();
+
+			const navButtons = container().querySelector('.positron-find-widget .navigation-buttons');
+			assert.ok(navButtons, 'Expected .navigation-buttons to exist');
+
+			const buttons = navButtons.querySelectorAll('button.action-button');
+			assert.strictEqual(buttons.length, 2, 'Expected 2 navigation buttons');
+		});
+
+		test('contains close button', () => {
+			renderWidget();
+
+			const closeButton = container().querySelector('.positron-find-widget button.close-button');
+			assert.ok(closeButton, 'Expected close button to exist');
+		});
 	});
 
-	test('hidden when not visible', () => {
-		const isVisible = observableValue('isVisible', false);
-		renderWidget({ isVisible });
+	suite('FindResult display', () => {
+		test('shows "No results" when find text is empty', () => {
+			renderWidget();
 
-		const widget = container().querySelector('.positron-find-widget');
-		assert.ok(widget, 'Expected .positron-find-widget to exist');
-		assert.ok(
-			!widget.classList.contains('visible'),
-			'Expected widget to lack .visible class'
-		);
+			const results = container().querySelector('.positron-find-widget .results');
+			assert.ok(results, 'Expected .results to exist');
+			assert.strictEqual(results.textContent, 'No results');
+		});
+
+		test('shows empty results when matchCount is undefined', () => {
+			const findText = observableValue('findText', 'foo');
+			const matchCount = observableValue<number | undefined>('matchCount', undefined);
+			renderWidget({ findText, matchCount });
+
+			const results = container().querySelector('.positron-find-widget .results');
+			assert.ok(results, 'Expected .results to exist');
+			assert.strictEqual(results.textContent, '');
+		});
+
+		test('shows "No results" with error styling when no matches', () => {
+			const findText = observableValue('findText', 'foo');
+			const matchCount = observableValue<number | undefined>('matchCount', 0);
+			renderWidget({ findText, matchCount });
+
+			const results = container().querySelector('.positron-find-widget .results');
+			assert.ok(results, 'Expected .results to exist');
+			assert.strictEqual(results.textContent, 'No results');
+
+			const widget = container().querySelector('.positron-find-widget.no-results');
+			assert.ok(widget, 'Expected widget to have .no-results class');
+		});
+
+		test('shows match count when matches exist', () => {
+			const findText = observableValue('findText', 'foo');
+			const matchCount = observableValue<number | undefined>('matchCount', 5);
+			const matchIndex = observableValue<number | undefined>('matchIndex', 2);
+			renderWidget({ findText, matchCount, matchIndex });
+
+			const results = container().querySelector('.positron-find-widget .results');
+			assert.ok(results, 'Expected .results to exist');
+			assert.strictEqual(results.textContent, '3 of 5');
+		});
+
+		test('shows "1 of N" when matchIndex is undefined', () => {
+			const findText = observableValue('findText', 'foo');
+			const matchCount = observableValue<number | undefined>('matchCount', 3);
+			const matchIndex = observableValue<number | undefined>('matchIndex', undefined);
+			renderWidget({ findText, matchCount, matchIndex });
+
+			const results = container().querySelector('.positron-find-widget .results');
+			assert.ok(results, 'Expected .results to exist');
+			assert.strictEqual(results.textContent, '1 of 3');
+		});
 	});
 
-	test('contains find input container', () => {
-		renderWidget();
+	suite('Navigation buttons', () => {
+		test('previous match button disabled when no matches', () => {
+			const matchCount = observableValue<number | undefined>('matchCount', 0);
+			renderWidget({ matchCount });
 
-		const findInput = container().querySelector('.positron-find-widget .find-input-container');
-		assert.ok(findInput, 'Expected .find-input-container to exist');
+			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
+			const prevButton = buttons[0] as HTMLButtonElement;
+			assert.ok(prevButton, 'Expected previous button to exist');
+			assert.strictEqual(prevButton.disabled, true, 'Expected previous button to be disabled');
+		});
+
+		test('next match button disabled when no matches', () => {
+			const matchCount = observableValue<number | undefined>('matchCount', 0);
+			renderWidget({ matchCount });
+
+			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
+			const nextButton = buttons[1] as HTMLButtonElement;
+			assert.ok(nextButton, 'Expected next button to exist');
+			assert.strictEqual(nextButton.disabled, true, 'Expected next button to be disabled');
+		});
+
+		test('previous match button enabled when matches exist', () => {
+			const matchCount = observableValue<number | undefined>('matchCount', 3);
+			renderWidget({ matchCount });
+
+			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
+			const prevButton = buttons[0] as HTMLButtonElement;
+			assert.ok(prevButton, 'Expected previous button to exist');
+			assert.strictEqual(prevButton.disabled, false, 'Expected previous button to be enabled');
+		});
+
+		test('next match button enabled when matches exist', () => {
+			const matchCount = observableValue<number | undefined>('matchCount', 3);
+			renderWidget({ matchCount });
+
+			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
+			const nextButton = buttons[1] as HTMLButtonElement;
+			assert.ok(nextButton, 'Expected next button to exist');
+			assert.strictEqual(nextButton.disabled, false, 'Expected next button to be enabled');
+		});
+
+		test('previous match button calls onPreviousMatch', () => {
+			const matchCount = observableValue<number | undefined>('matchCount', 3);
+			const onPreviousMatch = sinon.stub();
+			renderWidget({ matchCount, onPreviousMatch });
+
+			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
+			const prevButton = buttons[0] as HTMLButtonElement;
+			prevButton.click();
+
+			assert.ok(onPreviousMatch.calledOnce, 'Expected onPreviousMatch to be called once');
+		});
+
+		test('next match button calls onNextMatch', () => {
+			const matchCount = observableValue<number | undefined>('matchCount', 3);
+			const onNextMatch = sinon.stub();
+			renderWidget({ matchCount, onNextMatch });
+
+			const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
+			const nextButton = buttons[1] as HTMLButtonElement;
+			nextButton.click();
+
+			assert.ok(onNextMatch.calledOnce, 'Expected onNextMatch to be called once');
+		});
 	});
 
-	test('contains navigation buttons', () => {
-		renderWidget();
+	suite('Close button', () => {
+		test('sets isVisible to false', () => {
+			const isVisible = observableValue('isVisible', true);
+			renderWidget({ isVisible });
 
-		const navButtons = container().querySelector('.positron-find-widget .navigation-buttons');
-		assert.ok(navButtons, 'Expected .navigation-buttons to exist');
+			const closeButton = container().querySelector('.positron-find-widget button.close-button') as HTMLButtonElement;
+			assert.ok(closeButton, 'Expected close button to exist');
+			closeButton.click();
 
-		const buttons = navButtons.querySelectorAll('button.action-button');
-		assert.strictEqual(buttons.length, 2, 'Expected 2 navigation buttons');
+			assert.strictEqual(isVisible.get(), false, 'Expected isVisible to be false after close');
+		});
 	});
 
-	test('contains close button', () => {
-		renderWidget();
+	suite('Tab order', () => {
+		test('disabled navigation buttons are excluded from tab order', () => {
+			const matchCount = observableValue<number | undefined>('matchCount', 0);
+			renderWidget({ matchCount });
 
-		const closeButton = container().querySelector('.positron-find-widget button.close-button');
-		assert.ok(closeButton, 'Expected close button to exist');
+			const navButtons = container().querySelectorAll('.positron-find-widget .navigation-buttons button') as NodeListOf<HTMLButtonElement>;
+			for (const btn of navButtons) {
+				assert.strictEqual(btn.disabled, true, `Expected navigation button "${btn.ariaLabel}" to be disabled`);
+			}
+
+			// Close button should still be enabled
+			const closeButton = container().querySelector('.positron-find-widget button.close-button') as HTMLButtonElement;
+			assert.strictEqual(closeButton.disabled, false, 'Expected close button to remain enabled');
+		});
 	});
 
-	// --- FindResult display ---
+	suite('Reactivity', () => {
+		test('re-renders when matchCount changes', () => {
+			const findText = observableValue('findText', 'foo');
+			const matchCount = observableValue<number | undefined>('matchCount', 3);
+			const matchIndex = observableValue<number | undefined>('matchIndex', 0);
+			renderWidget({ findText, matchCount, matchIndex });
 
-	test('shows "No results" when find text is empty', () => {
-		renderWidget();
+			let results = container().querySelector('.positron-find-widget .results');
+			assert.strictEqual(results?.textContent, '1 of 3');
 
-		const results = container().querySelector('.positron-find-widget .results');
-		assert.ok(results, 'Expected .results to exist');
-		assert.strictEqual(results.textContent, 'No results');
-	});
+			matchCount.set(5, undefined);
+			renderWidget({ findText, matchCount, matchIndex });
 
-	test('shows empty results when matchCount is undefined', () => {
-		const findText = observableValue('findText', 'foo');
-		const matchCount = observableValue<number | undefined>('matchCount', undefined);
-		renderWidget({ findText, matchCount });
+			results = container().querySelector('.positron-find-widget .results');
+			assert.strictEqual(results?.textContent, '1 of 5');
+		});
 
-		const results = container().querySelector('.positron-find-widget .results');
-		assert.ok(results, 'Expected .results to exist');
-		assert.strictEqual(results.textContent, '');
-	});
+		test('re-renders when findText changes', () => {
+			const findText = observableValue('findText', '');
+			renderWidget({ findText });
 
-	test('shows "No results" with error styling when no matches', () => {
-		const findText = observableValue('findText', 'foo');
-		const matchCount = observableValue<number | undefined>('matchCount', 0);
-		renderWidget({ findText, matchCount });
+			let results = container().querySelector('.positron-find-widget .results');
+			assert.strictEqual(results?.textContent, 'No results');
 
-		const results = container().querySelector('.positron-find-widget .results');
-		assert.ok(results, 'Expected .results to exist');
-		assert.strictEqual(results.textContent, 'No results');
+			findText.set('foo', undefined);
+			renderWidget({ findText });
 
-		const widget = container().querySelector('.positron-find-widget.no-results');
-		assert.ok(widget, 'Expected widget to have .no-results class');
-	});
+			results = container().querySelector('.positron-find-widget .results');
+			assert.strictEqual(results?.textContent, '');
+		});
 
-	test('shows match count when matches exist', () => {
-		const findText = observableValue('findText', 'foo');
-		const matchCount = observableValue<number | undefined>('matchCount', 5);
-		const matchIndex = observableValue<number | undefined>('matchIndex', 2);
-		renderWidget({ findText, matchCount, matchIndex });
+		test('re-renders when visibility changes', () => {
+			const isVisible = observableValue('isVisible', true);
+			renderWidget({ isVisible });
 
-		const results = container().querySelector('.positron-find-widget .results');
-		assert.ok(results, 'Expected .results to exist');
-		assert.strictEqual(results.textContent, '3 of 5');
-	});
+			let widget = container().querySelector('.positron-find-widget');
+			assert.ok(widget?.classList.contains('visible'), 'Expected widget to be visible');
 
-	test('shows "1 of N" when matchIndex is undefined', () => {
-		const findText = observableValue('findText', 'foo');
-		const matchCount = observableValue<number | undefined>('matchCount', 3);
-		const matchIndex = observableValue<number | undefined>('matchIndex', undefined);
-		renderWidget({ findText, matchCount, matchIndex });
+			isVisible.set(false, undefined);
+			renderWidget({ isVisible });
 
-		const results = container().querySelector('.positron-find-widget .results');
-		assert.ok(results, 'Expected .results to exist');
-		assert.strictEqual(results.textContent, '1 of 3');
-	});
-
-	// --- Navigation buttons ---
-
-	test('previous match button disabled when no matches', () => {
-		const matchCount = observableValue<number | undefined>('matchCount', 0);
-		renderWidget({ matchCount });
-
-		const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
-		const prevButton = buttons[0] as HTMLButtonElement;
-		assert.ok(prevButton, 'Expected previous button to exist');
-		assert.strictEqual(prevButton.disabled, true, 'Expected previous button to be disabled');
-	});
-
-	test('next match button disabled when no matches', () => {
-		const matchCount = observableValue<number | undefined>('matchCount', 0);
-		renderWidget({ matchCount });
-
-		const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
-		const nextButton = buttons[1] as HTMLButtonElement;
-		assert.ok(nextButton, 'Expected next button to exist');
-		assert.strictEqual(nextButton.disabled, true, 'Expected next button to be disabled');
-	});
-
-	test('previous match button enabled when matches exist', () => {
-		const matchCount = observableValue<number | undefined>('matchCount', 3);
-		renderWidget({ matchCount });
-
-		const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
-		const prevButton = buttons[0] as HTMLButtonElement;
-		assert.ok(prevButton, 'Expected previous button to exist');
-		assert.strictEqual(prevButton.disabled, false, 'Expected previous button to be enabled');
-	});
-
-	test('next match button enabled when matches exist', () => {
-		const matchCount = observableValue<number | undefined>('matchCount', 3);
-		renderWidget({ matchCount });
-
-		const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
-		const nextButton = buttons[1] as HTMLButtonElement;
-		assert.ok(nextButton, 'Expected next button to exist');
-		assert.strictEqual(nextButton.disabled, false, 'Expected next button to be enabled');
-	});
-
-	test('previous match button calls onPreviousMatch', () => {
-		const matchCount = observableValue<number | undefined>('matchCount', 3);
-		const onPreviousMatch = sinon.stub();
-		renderWidget({ matchCount, onPreviousMatch });
-
-		const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
-		const prevButton = buttons[0] as HTMLButtonElement;
-		prevButton.click();
-
-		assert.ok(onPreviousMatch.calledOnce, 'Expected onPreviousMatch to be called once');
-	});
-
-	test('next match button calls onNextMatch', () => {
-		const matchCount = observableValue<number | undefined>('matchCount', 3);
-		const onNextMatch = sinon.stub();
-		renderWidget({ matchCount, onNextMatch });
-
-		const buttons = container().querySelectorAll('.positron-find-widget .navigation-buttons button');
-		const nextButton = buttons[1] as HTMLButtonElement;
-		nextButton.click();
-
-		assert.ok(onNextMatch.calledOnce, 'Expected onNextMatch to be called once');
-	});
-
-	// --- Close button ---
-
-	test('close button sets isVisible to false', () => {
-		const isVisible = observableValue('isVisible', true);
-		renderWidget({ isVisible });
-
-		const closeButton = container().querySelector('.positron-find-widget button.close-button') as HTMLButtonElement;
-		assert.ok(closeButton, 'Expected close button to exist');
-		closeButton.click();
-
-		assert.strictEqual(isVisible.get(), false, 'Expected isVisible to be false after close');
-	});
-
-	// --- Tab order ---
-
-	test('disabled navigation buttons are excluded from tab order', () => {
-		const matchCount = observableValue<number | undefined>('matchCount', 0);
-		renderWidget({ matchCount });
-
-		const navButtons = container().querySelectorAll('.positron-find-widget .navigation-buttons button') as NodeListOf<HTMLButtonElement>;
-		for (const btn of navButtons) {
-			assert.strictEqual(btn.disabled, true, `Expected navigation button "${btn.ariaLabel}" to be disabled`);
-		}
-
-		// Close button should still be enabled
-		const closeButton = container().querySelector('.positron-find-widget button.close-button') as HTMLButtonElement;
-		assert.strictEqual(closeButton.disabled, false, 'Expected close button to remain enabled');
-	});
-
-	// --- Reactivity (observable updates) ---
-
-	test('re-renders when matchCount changes', () => {
-		const findText = observableValue('findText', 'foo');
-		const matchCount = observableValue<number | undefined>('matchCount', 3);
-		const matchIndex = observableValue<number | undefined>('matchIndex', 0);
-		renderWidget({ findText, matchCount, matchIndex });
-
-		let results = container().querySelector('.positron-find-widget .results');
-		assert.strictEqual(results?.textContent, '1 of 3');
-
-		// Update matchCount and re-render
-		matchCount.set(5, undefined);
-		renderWidget({ findText, matchCount, matchIndex });
-
-		results = container().querySelector('.positron-find-widget .results');
-		assert.strictEqual(results?.textContent, '1 of 5');
-	});
-
-	test('re-renders when findText changes', () => {
-		const findText = observableValue('findText', '');
-		renderWidget({ findText });
-
-		let results = container().querySelector('.positron-find-widget .results');
-		assert.strictEqual(results?.textContent, 'No results');
-
-		// Update findText - with no matchCount set, should show empty
-		findText.set('foo', undefined);
-		renderWidget({ findText });
-
-		results = container().querySelector('.positron-find-widget .results');
-		assert.strictEqual(results?.textContent, '');
-	});
-
-	test('re-renders when visibility changes', () => {
-		const isVisible = observableValue('isVisible', true);
-		renderWidget({ isVisible });
-
-		let widget = container().querySelector('.positron-find-widget');
-		assert.ok(widget?.classList.contains('visible'), 'Expected widget to be visible');
-
-		// Toggle visibility
-		isVisible.set(false, undefined);
-		renderWidget({ isVisible });
-
-		widget = container().querySelector('.positron-find-widget');
-		assert.ok(!widget?.classList.contains('visible'), 'Expected widget to not be visible');
+			widget = container().querySelector('.positron-find-widget');
+			assert.ok(!widget?.classList.contains('visible'), 'Expected widget to not be visible');
+		});
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
@@ -248,7 +248,7 @@ suite('PositronFindWidget', () => {
 				findText.set('foo', tx);
 				matchCount.set(3, tx);
 				matchIndex.set(0, tx);
-			})
+			});
 			renderWidget();
 
 			let results = container().querySelector('.positron-find-widget .results');

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.test.tsx
@@ -232,7 +232,7 @@ suite('PositronFindWidget', () => {
 			matchCount.set(0, undefined);
 			renderWidget();
 
-			const navButtons = container().querySelectorAll('.positron-find-widget .navigation-buttons button') as NodeListOf<HTMLButtonElement>;
+			const navButtons = container().querySelectorAll<HTMLButtonElement>('.positron-find-widget .navigation-buttons button');
 			for (const btn of navButtons) {
 				assert.strictEqual(btn.disabled, true, `Expected navigation button "${btn.ariaLabel}" to be disabled`);
 			}

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
@@ -7,15 +7,12 @@
 
 import assert from 'assert';
 import sinon from 'sinon';
-import { flushSync } from 'react-dom';
-import { createRoot, Root } from 'react-dom/client';
-import { mainWindow } from '../../../../../base/browser/window.js';
-
 import { ColumnSummaryCell } from '../../browser/components/columnSummaryCell.js';
 import { getColumnSchema } from '../../common/positronDataExplorerMocks.js';
 import { ColumnDisplayType, SupportStatus, ColumnProfileType, SupportedFeatures } from '../../../languageRuntime/common/positronDataExplorerComm.js';
 import { TableSummaryDataGridInstance } from '../../browser/tableSummaryDataGridInstance.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { setupReactRenderer } from '../../../../../base/test/browser/react.js';
 import { PositronActionBarHoverManager } from '../../../../../platform/positronActionBar/browser/positronActionBarHoverManager.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 
@@ -97,38 +94,25 @@ function createMockTableSummaryDataGridInstance(overrides: Partial<TableSummaryD
 }
 
 suite('ColumnSummaryCell', () => {
-	let root: Root;
-	let container: HTMLElement;
+	const { render, container } = setupReactRenderer();
+	ensureNoDisposablesAreLeakedInTestSuite();
+
 	const columnSchema = getColumnSchema('test_column', 0, 'string', ColumnDisplayType.String);
 
 	function renderRoot(
 		mockTableSummaryDataGridInstance: TableSummaryDataGridInstance,
 	) {
-		// Render the widget and wait for React to flush
-		flushSync(() => {
-			root.render(
-				<ColumnSummaryCell
-					columnIndex={0}
-					columnSchema={columnSchema}
-					instance={mockTableSummaryDataGridInstance}
-					onDoubleClick={() => { }}
-				/>
-			);
-		});
+		render(
+			<ColumnSummaryCell
+				columnIndex={0}
+				columnSchema={columnSchema}
+				instance={mockTableSummaryDataGridInstance}
+				onDoubleClick={() => { }}
+			/>
+		);
 	}
 
-	setup(() => {
-		// Create a container element for React to render into
-		container = mainWindow.document.createElement('div');
-		mainWindow.document.body.appendChild(container);
-		root = createRoot(container);
-	});
-
 	teardown(() => {
-		// Clean up the React root and container
-		root.unmount();
-		container.remove();
-		// Restore spies and stubs
 		sinon.restore();
 	});
 
@@ -140,7 +124,7 @@ suite('ColumnSummaryCell', () => {
 
 		renderRoot(mockTableSummaryDataGridInstance);
 
-		const nullPercentElement = container.querySelector('.text-percent');
+		const nullPercentElement = container().querySelector('.text-percent');
 		assert.ok(nullPercentElement, 'Expected to find null percent element');
 		assert.strictEqual(nullPercentElement.textContent, '0%', 'Expected to find 0% for 0% input');
 	});
@@ -153,7 +137,7 @@ suite('ColumnSummaryCell', () => {
 
 		renderRoot(mockTableSummaryDataGridInstance);
 
-		const nullPercentElement = container.querySelector('.text-percent');
+		const nullPercentElement = container().querySelector('.text-percent');
 		assert.ok(nullPercentElement, 'Expected to find null percent element');
 		assert.strictEqual(nullPercentElement.textContent, '<1%', 'Expected to find <1% for 0.5% input');
 	});
@@ -166,7 +150,7 @@ suite('ColumnSummaryCell', () => {
 
 		renderRoot(mockTableSummaryDataGridInstance);
 
-		const nullPercentElement = container.querySelector('.text-percent');
+		const nullPercentElement = container().querySelector('.text-percent');
 		assert.ok(nullPercentElement, 'Expected to find null percent element');
 		assert.strictEqual(nullPercentElement.textContent, '99%', 'Expected to find 99% for 99.9% input');
 	});
@@ -179,11 +163,9 @@ suite('ColumnSummaryCell', () => {
 
 		renderRoot(mockTableSummaryDataGridInstance);
 
-		const nullPercentElement = container.querySelector('.text-percent');
+		const nullPercentElement = container().querySelector('.text-percent');
 		assert.ok(nullPercentElement, 'Expected to find null percent element');
 		assert.strictEqual(nullPercentElement.textContent, '100%', 'Expected to find 100% for 100% input');
 	});
 
-	// Ensure that all disposables are cleaned up.
-	ensureNoDisposablesAreLeakedInTestSuite();
 });

--- a/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/test/browser/columnSummaryCell.test.tsx
@@ -94,7 +94,7 @@ function createMockTableSummaryDataGridInstance(overrides: Partial<TableSummaryD
 }
 
 suite('ColumnSummaryCell', () => {
-	const { render, container } = setupReactRenderer();
+	const { render } = setupReactRenderer();
 	ensureNoDisposablesAreLeakedInTestSuite();
 
 	const columnSchema = getColumnSchema('test_column', 0, 'string', ColumnDisplayType.String);
@@ -102,7 +102,7 @@ suite('ColumnSummaryCell', () => {
 	function renderRoot(
 		mockTableSummaryDataGridInstance: TableSummaryDataGridInstance,
 	) {
-		render(
+		return render(
 			<ColumnSummaryCell
 				columnIndex={0}
 				columnSchema={columnSchema}
@@ -122,9 +122,9 @@ suite('ColumnSummaryCell', () => {
 			getColumnProfileNullCount: () => 0,
 		});
 
-		renderRoot(mockTableSummaryDataGridInstance);
+		const container = renderRoot(mockTableSummaryDataGridInstance);
 
-		const nullPercentElement = container().querySelector('.text-percent');
+		const nullPercentElement = container.querySelector('.text-percent');
 		assert.ok(nullPercentElement, 'Expected to find null percent element');
 		assert.strictEqual(nullPercentElement.textContent, '0%', 'Expected to find 0% for 0% input');
 	});
@@ -135,9 +135,9 @@ suite('ColumnSummaryCell', () => {
 			getColumnProfileNullCount: () => 1,
 		});
 
-		renderRoot(mockTableSummaryDataGridInstance);
+		const container = renderRoot(mockTableSummaryDataGridInstance);
 
-		const nullPercentElement = container().querySelector('.text-percent');
+		const nullPercentElement = container.querySelector('.text-percent');
 		assert.ok(nullPercentElement, 'Expected to find null percent element');
 		assert.strictEqual(nullPercentElement.textContent, '<1%', 'Expected to find <1% for 0.5% input');
 	});
@@ -148,9 +148,9 @@ suite('ColumnSummaryCell', () => {
 			getColumnProfileNullCount: () => 999,
 		});
 
-		renderRoot(mockTableSummaryDataGridInstance);
+		const container = renderRoot(mockTableSummaryDataGridInstance);
 
-		const nullPercentElement = container().querySelector('.text-percent');
+		const nullPercentElement = container.querySelector('.text-percent');
 		assert.ok(nullPercentElement, 'Expected to find null percent element');
 		assert.strictEqual(nullPercentElement.textContent, '99%', 'Expected to find 99% for 99.9% input');
 	});
@@ -161,9 +161,9 @@ suite('ColumnSummaryCell', () => {
 			getColumnProfileNullCount: () => 1000,
 		});
 
-		renderRoot(mockTableSummaryDataGridInstance);
+		const container = renderRoot(mockTableSummaryDataGridInstance);
 
-		const nullPercentElement = container().querySelector('.text-percent');
+		const nullPercentElement = container.querySelector('.text-percent');
 		assert.ok(nullPercentElement, 'Expected to find null percent element');
 		assert.strictEqual(nullPercentElement.textContent, '100%', 'Expected to find 100% for 100% input');
 	});


### PR DESCRIPTION
Adds shared React test infrastructure and an ESLint rule to enforce correct usage. Related to #10000.

- New `setupReactRenderer()` helper manages the React root lifecycle via mocha `setup`/`teardown` hooks.
- New ESLint rule to enforce that `setupReactRenderer()` is called before `ensureNoDisposablesAreLeakedInTestSuite()` in test suites. Mocha teardown is FIFO, so the React teardown must unmount components (and cleanup effects which often cleans up disposables) before the leak checker inspects disposables.
- Updated Claude rules given above
- Added `PositronFindWidget` tests and refactored action bar widget and column summary cell tests to test everything out

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

No user-facing changes. All changes are to test infrastructure and developer tooling.