### PR TITLE
assistant: report token usage in progress data part

### DIFF
--- a/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
+++ b/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
@@ -390,7 +390,7 @@ export abstract class VercelModelProvider extends ModelProvider {
 		}
 
 		// Report token usage information
-		const part: any = vscode.LanguageModelDataPart.json({ type: 'usage', data: tokens });
+		const part = vscode.LanguageModelDataPart.json({ type: 'usage', data: tokens });
 		progress.report(part);
 
 		if (requestId) {

--- a/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
+++ b/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
@@ -339,7 +339,7 @@ export abstract class VercelModelProvider extends ModelProvider {
 		}
 
 		// Handle token usage
-		await this.handleTokenUsage(result, model, requestId);
+		await this.handleTokenUsage(result, model, progress, requestId);
 	}
 
 	/**
@@ -359,6 +359,7 @@ export abstract class VercelModelProvider extends ModelProvider {
 	protected async handleTokenUsage(
 		result: ReturnType<typeof ai.streamText>,
 		model: vscode.LanguageModelChatInformation,
+		progress: vscode.Progress<vscode.LanguageModelResponsePart2>,
 		requestId?: string
 	): Promise<void> {
 		const usage = await result.usage;
@@ -376,12 +377,6 @@ export abstract class VercelModelProvider extends ModelProvider {
 			tokens.inputTokens += metaUsage.cacheWriteInputTokens || 0;
 			tokens.cachedTokens += metaUsage.cacheReadInputTokens || 0;
 
-			// Report token usage information
-			const part: any = vscode.LanguageModelDataPart.json({ type: 'usage', data: tokens });
-			if (part.report) {
-				part.report(part);
-			}
-
 			this.logger.debug(`[${model.name}]: Bedrock usage: ${JSON.stringify(usage, null, 2)}`);
 		}
 
@@ -393,6 +388,10 @@ export abstract class VercelModelProvider extends ModelProvider {
 
 			this.logger.debug(`[${model.name}]: Anthropic usage: ${JSON.stringify(anthropicMeta, null, 2)}`);
 		}
+
+		// Report token usage information
+		const part: any = vscode.LanguageModelDataPart.json({ type: 'usage', data: tokens });
+		progress.report(part);
 
 		if (requestId) {
 			recordRequestTokenUsage(requestId, this.providerId, tokens);


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/12070

### Release Notes

#### Bug Fixes

- Assistant: fixed issue where token usage was not being reported in progress data part (#12070)

### QA Notes

Databot's conversation log should now contain token usage information in the assistant message's `providerOptions` when Bedrock is used.