### PR TITLE
Fix "Working..." progress message during response streaming

### DIFF
--- a/extensions/positron-assistant/src/providers/test/echoProvider.ts
+++ b/extensions/positron-assistant/src/providers/test/echoProvider.ts
@@ -92,6 +92,17 @@ export class EchoModelProvider extends ModelProvider {
 		else if (inputText === 'Return model') {
 			response = model.id;
 		}
+		else if (inputText.startsWith('delay')) {
+			// Simulate a delayed response for testing cancellation and streaming, max 10s delay to prevent excessively long test runs
+			const delayMatch = inputText.match(/delay\s+(\d+)/);
+			const delay = Math.min(delayMatch ? parseInt(delayMatch[1]) : 1, 10);
+			await new Promise(resolve => setTimeout(resolve, delay * 1000));
+			response = `Responded after ${delay}s delay`;
+		}
+		else if (inputText === 'Long Response') {
+			// Simulate a long response to test streaming and cancellation
+			response = 'This is a long response. '.repeat(25);
+		}
 		else {
 			// Default case: echo back the input message
 			response = inputText;

--- a/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatListRenderer.ts
@@ -818,10 +818,11 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			lastPart.kind === 'references' ||
 			((lastPart.kind === 'toolInvocation' || lastPart.kind === 'toolInvocationSerialized') && (IChatToolInvocation.isComplete(lastPart) || lastPart.presentation === 'hidden')) ||
 			// --- Start Positron ---
-			// Show working progress if the last part is markdown content and the response is in progress
-			// This is especially helpful when running in Agent mode, when the executeCode code block is still being constructed
-			// This causes the in progress indicator to show in any mode, while markdown text is being rendered and the response is not complete
-			(lastPart.kind === 'markdownContent' && element.isComplete) ||
+			// Show working progress if the last part is markdown content and the response is in progress.
+			// The early return above already guarantees element.isComplete is false at this point.
+			// This is especially helpful when running in Agent mode, when the executeCode code block is still being constructed.
+			// This causes the in progress indicator to show in any mode, while markdown text is being rendered and the response is not complete.
+			lastPart.kind === 'markdownContent' ||
 			// --- End Positron ---
 			((lastPart.kind === 'textEditGroup' || lastPart.kind === 'notebookEditGroup') && lastPart.done && !partsToRender.some(part => part.kind === 'toolInvocation' && !IChatToolInvocation.isComplete(part))) ||
 			(lastPart.kind === 'progressTask' && lastPart.deferred.isSettled) ||

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -2278,7 +2278,12 @@ Type \`/\` to use predefined commands such as \`/help\`.`,
 			this.viewModel.resetInputPlaceholder();
 		}
 		this.inputEditor.updateOptions({ placeholder: undefined });
-		this.renderer.updateOptions({ restorable: true, editable: true, noFooter: false, progressMessageAtBottomOfResponse: mode => mode !== ChatModeKind.Ask });
+		// --- Start Positron ---
+		// Always show progress message at bottom of response in all modes,
+		// matching the initial widget creation override in chatViewPane.ts and chatEditor.ts.
+		// this.renderer.updateOptions({ restorable: true, editable: true, noFooter: false, progressMessageAtBottomOfResponse: mode => mode !== ChatModeKind.Ask });
+		this.renderer.updateOptions({ restorable: true, editable: true, noFooter: false, progressMessageAtBottomOfResponse: true });
+		// --- End Positron ---
 		if (this.visible) {
 			this.tree.rerender();
 		}


### PR DESCRIPTION
Address #11923

The `element.isComplete` would never be true because it would immediately return false on the first check above.

I've added a `delay <seconds>` and `Long Response` to the Echo model to simulate waiting for a response and a streaming response to help with testing.

<img width="464" height="336" alt="image" src="https://github.com/user-attachments/assets/07452f81-acf4-4676-b08c-4e2ba8bbc133" />


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix "Working..." progress message when streaming chat response


### QA Notes