### PR TITLE
Filter Jupyter extension notebook tools in Positron notebook mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ pwb-version
 !.claude/hooks/
 !.claude/settings.json
 .claude/skills/positron-qa-verify/output/
+# Often used for agent and personal notes
+/thoughts
 
 .Rproj.user
 /playwright-report/

--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -152,6 +152,12 @@ const EXTERNAL_NOTEBOOK_TOOLS = new Set([
 	'configure_notebook',
 	'notebook_list_packages',
 	'notebook_install_packages',
+	// Jupyter extension kernel management tools (ms-toolsai.jupyter)
+	// These are hidden via when: "false" but can be dynamically activated
+	// via the extension_installed_by_tool tag mechanism.
+	'configure_python_notebook',
+	'configure_non_python_notebook',
+	'restart_notebook_kernel',
 ]);
 
 /**

--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -134,15 +134,24 @@ export class PositronAssistantApi {
 }
 
 /**
- * Copilot notebook tool names that should be disabled when Positron notebook mode is active.
+ * External notebook tool names that should be disabled when Positron notebook mode is active.
  * These tools conflict with Positron's specialized notebook tools.
+ *
+ * Includes tools from both Copilot (copilot_* prefix) and the Jupyter extension
+ * (ms-toolsai.jupyter), which registers configure_notebook, notebook_list_packages,
+ * and notebook_install_packages.
  */
-const COPILOT_NOTEBOOK_TOOLS = new Set([
+const EXTERNAL_NOTEBOOK_TOOLS = new Set([
+	// Copilot notebook tools
 	'copilot_editNotebook',
 	'copilot_getNotebookSummary',
 	'copilot_runNotebookCell',
 	'copilot_readNotebookCellOutput',
 	'copilot_createNewJupyterNotebook',
+	// Jupyter extension notebook tools (ms-toolsai.jupyter)
+	'configure_notebook',
+	'notebook_list_packages',
+	'notebook_install_packages',
 ]);
 
 /**
@@ -381,9 +390,9 @@ export function getEnabledTools(
 		// Check if the tool is provided by Copilot.
 		const copilotTool = tool.name.startsWith('copilot_');
 
-		// Disable Copilot notebook tools when Positron notebook mode is active
+		// Disable external notebook tools when Positron notebook mode is active
 		// to avoid conflicts with Positron's specialized notebook tools.
-		if (copilotTool && COPILOT_NOTEBOOK_TOOLS.has(tool.name)) {
+		if (EXTERNAL_NOTEBOOK_TOOLS.has(tool.name)) {
 			// For most tools, this means an active notebook is attached
 			// For createNotebook specifically, we disable when our CreateNotebook tool would be available
 			if (hasActiveNotebook ||

--- a/test/e2e/tests/assistant/positron-assistant-tool-calls.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant-tool-calls.test.ts
@@ -120,13 +120,12 @@ test.describe('Positron Assistant Tool Scoping', { tag: [tags.WIN, tags.ASSISTAN
 		];
 
 		// Tools that don't require any session (always available in Agent mode)
+		// Note: configure_notebook, notebook_list_packages, and notebook_install_packages
+		// are excluded here because they are filtered out when Positron notebook mode is active.
 		const NON_SESSION_TOOLS = [
 			'documentCreate',
 			'getProjectTree',
 			'getChangedFiles',
-			'configure_notebook',
-			'notebook_list_packages',
-			'notebook_install_packages',
 			'inline_chat_exit',
 			'get_terminal_output',
 			'terminal_selection',


### PR DESCRIPTION
Addresses #12087.

The assistant was using `configure_notebook`, `notebook_list_packages`, and `notebook_install_packages` from the Jupyter extension (`ms-toolsai.jupyter`) instead of Positron's specialized notebook tools. The existing filter only caught `copilot_*` prefixed tools, missing all 6 Jupyter extension notebook tools.

This PR renames `COPILOT_NOTEBOOK_TOOLS` to `EXTERNAL_NOTEBOOK_TOOLS`, adds all 6 Jupyter extension tools to the filter set, and removes the `copilot_` prefix requirement from the filter condition so all external notebook tools are caught regardless of naming convention.

I also added a thing for thoughts/ to gitignore as it was annoying me to keep manually ignoring these files. 

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed assistant using wrong notebook tools for package management when Positron notebook mode is active (#12087)

### QA Notes

@:assistant @:notebooks @:positron-notebooks

1. Open a Python notebook in Positron
2. Ask the assistant to install a package (e.g. "install pandas")
3. Verify the assistant does NOT use `configure_notebook` or `notebook_install_packages`
4. Verify the assistant uses Positron's own notebook tools instead