### PR TITLE
Set trustedTypes policy in dev

### DIFF
--- a/src/vs/code/electron-browser/workbench/workbench-dev.html
+++ b/src/vs/code/electron-browser/workbench/workbench-dev.html
@@ -72,6 +72,7 @@
 				;
 		"/>
 
+		<!--- --- Start Positron --- -->
 		<script type="importmap" nonce="0c6a828f1297">
 			{
 				"imports": {
@@ -84,6 +85,19 @@
 				}
 			}
 		</script>
+
+		<!-- Pre-create the amdLoader TrustedType policy in the original page context.
+		When two import maps are present (static React + dynamic CSS), the V8 context
+		in which later module scripts create TrustedType policies can become invalid,
+		causing "callback is no longer runnable" errors. By creating the policy here
+		in an inline script, amdX.ts will use it via globalThis._VSCODE_WEB_PACKAGE_TTP
+		instead of creating its own. -->
+		<script nonce="0c6a828f1297">
+			globalThis._VSCODE_WEB_PACKAGE_TTP = window.trustedTypes?.createPolicy('amdLoader', {
+				createScriptURL(value) { return value; }
+			});
+		</script>
+		<!-- --- End Positron --- -->
 
 	</head>
 


### PR DESCRIPTION
I have a hard time reproducing this now but this fixed the `Failed to execute 'createScriptURL' on 'TrustedTypePolicy'` for me that only seemed to affect dev instances.

It seemed to be a combination of the new way of loading modules that we inherited from upstream and needing to statically load our additional modules for React and such.