### PR TITLE
Add notebook session/kernel management tools to assistant

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -1206,10 +1206,10 @@
         ]
       },
       {
-        "name": "runNotebookCells",
-        "displayName": "Run Notebook Cells",
+        "name": "executeNotebook",
+        "displayName": "Execute Notebook",
         "modelDescription": "Execute one or more cells in the active notebook and return their outputs. Use this when the user wants to run code cells or see the results of cell execution.",
-        "toolReferenceName": "runNotebookCells",
+        "toolReferenceName": "executeNotebook",
         "canBeReferencedInPrompt": true,
         "tags": [
           "positron-assistant",
@@ -1232,10 +1232,10 @@
         }
       },
       {
-        "name": "editNotebookCells",
-        "displayName": "Edit Notebook Cells",
+        "name": "editNotebook",
+        "displayName": "Edit Notebook",
         "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content). Code cells are executed by default after adding (set run=false to skip execution). Use operation='update' to modify existing cells (requires cellIndex and content), operation='delete' to remove cells (requires cellIndices array, e.g., [0] for single cell or [0,1,2] for multiple), or operation='reorder' to reorganize cells. For reorder, either use fromIndex and toIndex to move a single cell, or provide newOrder array (a permutation where newOrder[i] is the original index of the cell that should be at position i) to reorder all cells at once. Use index=-1 to append cells at the end when adding.",
-        "toolReferenceName": "editNotebookCells",
+        "toolReferenceName": "editNotebook",
         "canBeReferencedInPrompt": true,
         "tags": [
           "positron-assistant"
@@ -1306,10 +1306,10 @@
         }
       },
       {
-        "name": "getNotebookCells",
-        "displayName": "Get Notebook Cells",
+        "name": "getNotebookInfo",
+        "displayName": "Get Notebook Info",
         "modelDescription": "Retrieve information about notebook cells with flexible operations. Use operation='get' to fetch specific cells by index or all cells if cellIndices is omitted, operation='getSelected' to get only selected cells, operation='getOutputs' to retrieve cell execution outputs (requires cellIndices), or operation='getMetadata' to get only cell status information without content.",
-        "toolReferenceName": "getNotebookCells",
+        "toolReferenceName": "getNotebookInfo",
         "canBeReferencedInPrompt": true,
         "tags": [
           "positron-assistant"
@@ -1343,7 +1343,7 @@
       {
         "name": "createNotebook",
         "displayName": "Create Notebook",
-        "modelDescription": "Create a new Jupyter notebook with the specified language kernel (Python or R). Use when the user wants to start a new notebook. After creation, use EditNotebookCells to add content.",
+        "modelDescription": "Create a new Jupyter notebook with the specified language kernel (Python or R). Use when the user wants to start a new notebook. After creation, use editNotebook to add content.",
         "toolReferenceName": "createNotebook",
         "canBeReferencedInPrompt": true,
         "tags": [

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -1208,7 +1208,7 @@
       {
         "name": "executeNotebook",
         "displayName": "Execute Notebook",
-        "modelDescription": "Execute one or more cells in the active notebook and return their outputs. Use this when the user wants to run code cells or see the results of cell execution.",
+        "modelDescription": "Manage notebook execution lifecycle. Use operation='run' to execute specific cells by index and return their outputs. Use operation='runAll' to execute all cells in order. Use operation='interrupt' to cancel a running execution. Use operation='restartKernel' to restart the kernel (optionally with runAll=true to run all cells after restart).",
         "toolReferenceName": "executeNotebook",
         "canBeReferencedInPrompt": true,
         "tags": [
@@ -1218,23 +1218,37 @@
         "inputSchema": {
           "type": "object",
           "properties": {
+            "operation": {
+              "type": "string",
+              "enum": [
+                "run",
+                "runAll",
+                "interrupt",
+                "restartKernel"
+              ],
+              "description": "Type of execution operation. 'run' executes specific cells by index, 'runAll' executes all cells in order, 'interrupt' cancels running execution, 'restartKernel' restarts the kernel."
+            },
             "cellIndices": {
               "type": "array",
-              "description": "Array of cell indices to execute. Each index is a 0-based position of the cell in the notebook.",
+              "description": "Array of cell indices to execute (0-based). Required when operation is 'run'.",
               "items": {
                 "type": "number"
               }
+            },
+            "runAll": {
+              "type": "boolean",
+              "description": "When true with operation='restartKernel', run all cells after the kernel restarts. Defaults to false."
             }
           },
           "required": [
-            "cellIndices"
+            "operation"
           ]
         }
       },
       {
         "name": "editNotebook",
         "displayName": "Edit Notebook",
-        "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content). Code cells are executed by default after adding (set run=false to skip execution). Use operation='update' to modify existing cells (requires cellIndex and content), operation='delete' to remove cells (requires cellIndices array, e.g., [0] for single cell or [0,1,2] for multiple), or operation='reorder' to reorganize cells. For reorder, either use fromIndex and toIndex to move a single cell, or provide newOrder array (a permutation where newOrder[i] is the original index of the cell that should be at position i) to reorder all cells at once. Use index=-1 to append cells at the end when adding.",
+        "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content). Code cells are executed by default after adding (set run=false to skip execution). Use operation='update' to modify existing cells (requires cellIndex and content), operation='delete' to remove cells (requires cellIndices array, e.g., [0] for single cell or [0,1,2] for multiple), operation='reorder' to reorganize cells, or operation='clearOutputs' to clear cell outputs (optional cellIndices to clear specific cells, omit to clear all). For reorder, either use fromIndex and toIndex to move a single cell, or provide newOrder array (a permutation where newOrder[i] is the original index of the cell that should be at position i) to reorder all cells at once. Use index=-1 to append cells at the end when adding.",
         "toolReferenceName": "editNotebook",
         "canBeReferencedInPrompt": true,
         "tags": [
@@ -1249,9 +1263,10 @@
                 "add",
                 "update",
                 "delete",
-                "reorder"
+                "reorder",
+                "clearOutputs"
               ],
-              "description": "Type of edit operation to perform. 'add' creates a new cell, 'update' modifies existing cell content, 'delete' removes a cell, 'reorder' moves cells to new positions."
+              "description": "Type of edit operation to perform. 'add' creates a new cell, 'update' modifies existing cell content, 'delete' removes a cell, 'reorder' moves cells to new positions, 'clearOutputs' clears cell outputs."
             },
             "cellType": {
               "type": "string",
@@ -1278,7 +1293,7 @@
               "items": {
                 "type": "number"
               },
-              "description": "Array of cell indices to delete (0-based). Required when operation is 'delete'. Use [0] for single cell or [0,1,2] for multiple cells."
+              "description": "Array of cell indices (0-based). Required for 'delete'. Optional for 'clearOutputs' (omit to clear all). Use [0] for single cell or [0,1,2] for multiple."
             },
             "run": {
               "type": "boolean",
@@ -1308,7 +1323,7 @@
       {
         "name": "getNotebookInfo",
         "displayName": "Get Notebook Info",
-        "modelDescription": "Retrieve information about notebook cells with flexible operations. Use operation='get' to fetch specific cells by index or all cells if cellIndices is omitted, operation='getSelected' to get only selected cells, operation='getOutputs' to retrieve cell execution outputs (requires cellIndices), or operation='getMetadata' to get only cell status information without content.",
+        "modelDescription": "Retrieve information about notebook cells and kernel status. Use operation='get' to fetch specific cells by index or all cells if cellIndices is omitted, operation='getSelected' to get only selected cells, operation='getOutputs' to retrieve cell execution outputs (requires cellIndices), operation='getMetadata' to get only cell status information without content, or operation='getKernelStatus' to get kernel state and session metadata.",
         "toolReferenceName": "getNotebookInfo",
         "canBeReferencedInPrompt": true,
         "tags": [
@@ -1323,9 +1338,10 @@
                 "get",
                 "getSelected",
                 "getOutputs",
-                "getMetadata"
+                "getMetadata",
+                "getKernelStatus"
               ],
-              "description": "Type of read operation. 'get' retrieves cell info, 'getSelected' gets only selected cells, 'getOutputs' retrieves cell execution outputs, 'getMetadata' gets only status/execution info without content."
+              "description": "Type of read operation. 'get' retrieves cell info, 'getSelected' gets only selected cells, 'getOutputs' retrieves cell execution outputs, 'getMetadata' gets only status/execution info without content, 'getKernelStatus' gets kernel state and session metadata."
             },
             "cellIndices": {
               "type": "array",

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -1248,7 +1248,7 @@
       {
         "name": "editNotebook",
         "displayName": "Edit Notebook",
-        "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content). Code cells are executed by default after adding (set run=false to skip execution). Use operation='update' to modify existing cells (requires cellIndex and content), operation='delete' to remove cells (requires cellIndices array, e.g., [0] for single cell or [0,1,2] for multiple), operation='reorder' to reorganize cells, or operation='clearOutputs' to clear cell outputs (optional cellIndices to clear specific cells, omit to clear all). For reorder, either use fromIndex and toIndex to move a single cell, or provide newOrder array (a permutation where newOrder[i] is the original index of the cell that should be at position i) to reorder all cells at once. Use index=-1 to append cells at the end when adding.",
+        "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content). Code cells are executed by default after adding (set run=false to skip execution). Use operation='update' to modify existing cells (requires cellIndex and content), operation='delete' to remove cells (requires cellIndices array, e.g., [0] for single cell or [0,1,2] for multiple), operation='reorder' to reorganize cells, or operation='clearOutputs' to clear all cell outputs. For reorder, either use fromIndex and toIndex to move a single cell, or provide newOrder array (a permutation where newOrder[i] is the original index of the cell that should be at position i) to reorder all cells at once. Use index=-1 to append cells at the end when adding.",
         "toolReferenceName": "editNotebook",
         "canBeReferencedInPrompt": true,
         "tags": [
@@ -1266,7 +1266,7 @@
                 "reorder",
                 "clearOutputs"
               ],
-              "description": "Type of edit operation to perform. 'add' creates a new cell, 'update' modifies existing cell content, 'delete' removes a cell, 'reorder' moves cells to new positions, 'clearOutputs' clears cell outputs."
+              "description": "Type of edit operation to perform. 'add' creates a new cell, 'update' modifies existing cell content, 'delete' removes a cell, 'reorder' moves cells to new positions, 'clearOutputs' clears all cell outputs."
             },
             "cellType": {
               "type": "string",
@@ -1293,7 +1293,7 @@
               "items": {
                 "type": "number"
               },
-              "description": "Array of cell indices (0-based). Required for 'delete'. Optional for 'clearOutputs' (omit to clear all). Use [0] for single cell or [0,1,2] for multiple."
+              "description": "Array of cell indices (0-based). Required for 'delete'. Use [0] for single cell or [0,1,2] for multiple."
             },
             "run": {
               "type": "boolean",

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -1248,7 +1248,7 @@
       {
         "name": "editNotebook",
         "displayName": "Edit Notebook",
-        "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content). Code cells are executed by default after adding (set run=false to skip execution). Use operation='update' to modify existing cells (requires cellIndex and content), operation='delete' to remove cells (requires cellIndices array, e.g., [0] for single cell or [0,1,2] for multiple), operation='reorder' to reorganize cells, or operation='clearOutputs' to clear all cell outputs. For reorder, either use fromIndex and toIndex to move a single cell, or provide newOrder array (a permutation where newOrder[i] is the original index of the cell that should be at position i) to reorder all cells at once. Use index=-1 to append cells at the end when adding.",
+        "modelDescription": "Perform edit operations on notebook cells. Use operation='add' to create new cells (requires cellType, index, and content). Code cells are executed by default after adding (set run=false to skip execution). Use operation='update' to modify existing cells (requires cellIndex and content), operation='delete' to remove cells (requires cellIndices array, e.g., [0] for single cell or [0,1,2] for multiple), operation='reorder' to reorganize cells, or operation='clearOutputs' to clear cell outputs (optionally pass cellIndices to clear specific cells, or omit to clear all). For reorder, either use fromIndex and toIndex to move a single cell, or provide newOrder array (a permutation where newOrder[i] is the original index of the cell that should be at position i) to reorder all cells at once. Use index=-1 to append cells at the end when adding.",
         "toolReferenceName": "editNotebook",
         "canBeReferencedInPrompt": true,
         "tags": [
@@ -1266,7 +1266,7 @@
                 "reorder",
                 "clearOutputs"
               ],
-              "description": "Type of edit operation to perform. 'add' creates a new cell, 'update' modifies existing cell content, 'delete' removes a cell, 'reorder' moves cells to new positions, 'clearOutputs' clears all cell outputs."
+              "description": "Type of edit operation to perform. 'add' creates a new cell, 'update' modifies existing cell content, 'delete' removes a cell, 'reorder' moves cells to new positions, 'clearOutputs' clears cell outputs (optionally for specific cells via cellIndices)."
             },
             "cellType": {
               "type": "string",
@@ -1293,7 +1293,7 @@
               "items": {
                 "type": "number"
               },
-              "description": "Array of cell indices (0-based). Required for 'delete'. Use [0] for single cell or [0,1,2] for multiple."
+              "description": "Array of cell indices (0-based). Required for 'delete'. Optional for 'clearOutputs' (omit to clear all). Use [0] for single cell or [0,1,2] for multiple."
             },
             "run": {
               "type": "boolean",

--- a/extensions/positron-assistant/src/api.ts
+++ b/extensions/positron-assistant/src/api.ts
@@ -299,17 +299,17 @@ export function getEnabledTools(
 				break;
 			// Notebook tools require both a notebook attached as context AND an active notebook editor.
 			// Tool availability varies by mode:
-			// - Execution tools (RunNotebookCells): Agent mode only
-			// - Modification tools (EditNotebookCells): Edit and Agent modes
-			// - Read-only tools (GetNotebookCells): All modes (Ask, Edit, Agent)
-			case PositronAssistantToolName.RunNotebookCells:
+			// - Execution tools (ExecuteNotebook): Agent mode only
+			// - Modification tools (EditNotebook): Edit and Agent modes
+			// - Read-only tools (GetNotebookInfo): All modes (Ask, Edit, Agent)
+			case PositronAssistantToolName.ExecuteNotebook:
 				// Execution requires Agent mode
 				if (!(inChatPane && hasActiveNotebook && isAgentMode)) {
 					disabledTools.push({ name: tool.name, reason: 'Requires chat pane, active notebook, and agent mode' });
 					continue;
 				}
 				break;
-			case PositronAssistantToolName.EditNotebookCells:
+			case PositronAssistantToolName.EditNotebook:
 				// Modification requires Edit or Agent mode
 				// Available when notebook mode is enabled (not just when notebook is active)
 				// so it can be used immediately after CreateNotebook in the same turn
@@ -318,7 +318,7 @@ export function getEnabledTools(
 					continue;
 				}
 				break;
-			case PositronAssistantToolName.GetNotebookCells:
+			case PositronAssistantToolName.GetNotebookInfo:
 				// Read-only tools available in all modes when notebook mode is enabled
 				// Available without active notebook so it can be used after CreateNotebook
 				if (!(inChatPane && isNotebookModeEnabled())) {

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
@@ -11,19 +11,19 @@ You MUST use notebook-specific tools. NEVER use file tools.
 
 - NEVER read .ipynb files directly (breaks notebook state sync)
 - NEVER parse notebook JSON manually (causes sync issues)
-- DO NOT use grep/search tools - use GetNotebookCells instead
+- DO NOT use grep/search tools - use getNotebookInfo instead
 - DO NOT manually parse or construct notebook formats
 </tool-usage-protocol>
 
 <anti-patterns>
 ❌ Read `/path/to/notebook.ipynb` → parse JSON → extract cells
-✓ Use GetNotebookCells with cellIndices
+✓ Use getNotebookInfo with cellIndices
 
 ❌ Use grep/search tools to find cell content
-✓ Use GetNotebookCells to inspect specific cells
+✓ Use getNotebookInfo to inspect specific cells
 
 ❌ Edit .ipynb file directly
-✓ Use EditNotebookCells tool
+✓ Use editNotebook tool
 </anti-patterns>
 
 <notebook-context-instructions>
@@ -32,15 +32,15 @@ The current notebook state (kernel info, cell contents, selection) is provided i
 </notebook-context-instructions>
 
 <workflows>
-**Analyze/explain:** Reference cells by **index** ("cell 0", "cell 3"). Use GetNotebookCells with `cellIndices` for additional cells. Check execution order [N], status, and success/failure.
+**Analyze/explain:** Reference cells by **index** ("cell 0", "cell 3"). Use getNotebookInfo with `cellIndices` for additional cells. Check execution order [N], status, and success/failure.
 
-**Modify cells:** Use EditNotebookCells with `operation: 'update'`, `cellIndex`, and `content`. Explain changes before applying.
+**Modify cells:** Use editNotebook with `operation: 'update'`, `cellIndex`, and `content`. Explain changes before applying.
 
-**Add cells:** Use EditNotebookCells with `operation: 'add'`. Code cells are run by default (set `run: false` to skip execution). Returns outputs for code cells. When you add cell at index N, cells N+ shift to N+1, N+2, etc.
+**Add cells:** Use editNotebook with `operation: 'add'`. Code cells are run by default (set `run: false` to skip execution). Returns outputs for code cells. When you add cell at index N, cells N+ shift to N+1, N+2, etc.
 
-**Delete cells:** Use EditNotebookCells with `operation: 'delete'` and `cellIndices` array (e.g., `[0]` for single cell, `[0,2,3]` for multiple). When you delete cells, higher indices shift down.
+**Delete cells:** Use editNotebook with `operation: 'delete'` and `cellIndices` array (e.g., `[0]` for single cell, `[0,2,3]` for multiple). When you delete cells, higher indices shift down.
 
-**Execute cells:** Use RunNotebookCells with `cellIndices` (array). Consider cell dependencies and execution order. Example: `cellIndices: [0, 1, 3]`.
+**Execute cells:** Use executeNotebook with `cellIndices` (array). Consider cell dependencies and execution order. Example: `cellIndices: [0, 1, 3]`.
 
 **Debug issues:** Check cell execution status, order, success/failure. Use GetCellOutputs with `operation: 'getOutputs'` and `cellIndices` to inspect errors/outputs. Consider cell dependencies and sequence.
 </workflows>

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-agent.md
@@ -40,9 +40,19 @@ The current notebook state (kernel info, cell contents, selection) is provided i
 
 **Delete cells:** Use editNotebook with `operation: 'delete'` and `cellIndices` array (e.g., `[0]` for single cell, `[0,2,3]` for multiple). When you delete cells, higher indices shift down.
 
-**Execute cells:** Use executeNotebook with `cellIndices` (array). Consider cell dependencies and execution order. Example: `cellIndices: [0, 1, 3]`.
+**Execute cells:** Use executeNotebook with `operation: 'run'` and `cellIndices` (array). Consider cell dependencies and execution order. Example: `operation: 'run', cellIndices: [0, 1, 3]`.
 
-**Debug issues:** Check cell execution status, order, success/failure. Use GetCellOutputs with `operation: 'getOutputs'` and `cellIndices` to inspect errors/outputs. Consider cell dependencies and sequence.
+**Run all cells:** Use executeNotebook with `operation: 'runAll'` to execute all cells in order.
+
+**Interrupt execution:** Use executeNotebook with `operation: 'interrupt'` to cancel running execution.
+
+**Restart kernel:** Use executeNotebook with `operation: 'restartKernel'`. Add `runAll: true` to run all cells after restart.
+
+**Clear outputs:** Use editNotebook with `operation: 'clearOutputs'`. Optionally pass `cellIndices` to clear specific cells.
+
+**Check kernel status:** Use getNotebookInfo with `operation: 'getKernelStatus'` to get kernel state and session metadata.
+
+**Debug issues:** Check cell execution status, order, success/failure. Use getNotebookInfo with `operation: 'getOutputs'` and `cellIndices` to inspect errors/outputs. Consider cell dependencies and sequence.
 </workflows>
 
 <data-verification>

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
@@ -47,6 +47,8 @@ The current notebook state (kernel info, cell contents, selection) is provided i
 <workflows>
 **Analyze/explain:** Reference cells by **index** ("cell 0", "cell 3"). Use getNotebookInfo with `cellIndices` for additional cells. Check execution order [N], status, and success/failure.
 
-**Debug issues:** Check cell execution status, order, success/failure. Use GetCellOutputs with `cellIndex` to inspect errors/outputs. Consider cell dependencies and sequence.
+**Debug issues:** Check cell execution status, order, success/failure. Use getNotebookInfo with `operation: 'getOutputs'` and `cellIndices` to inspect errors/outputs. Consider cell dependencies and sequence.
+
+**Check kernel status:** Use getNotebookInfo with `operation: 'getKernelStatus'` to get kernel state and session metadata.
 </workflows>
 {{/if}}

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-ask.md
@@ -11,7 +11,7 @@ You MUST use notebook-specific tools. NEVER use file tools.
 
 - NEVER read .ipynb files directly (breaks notebook state sync)
 - NEVER parse notebook JSON manually (causes sync issues)
-- DO NOT use grep/search tools - use GetNotebookCells instead
+- DO NOT use grep/search tools - use getNotebookInfo instead
 - DO NOT manually parse or construct notebook formats
 
 If the user requests cell modifications or execution, explain that these require switching to Edit mode (for modifications) or Agent mode (for execution) using the mode selector in the chat panel.
@@ -19,13 +19,13 @@ If the user requests cell modifications or execution, explain that these require
 
 <anti-patterns>
 ❌ Read `/path/to/notebook.ipynb` → parse JSON → extract cells
-✓ Use GetNotebookCells with cellIndices
+✓ Use getNotebookInfo with cellIndices
 
 ❌ Use grep/search tools to find cell content
-✓ Use GetNotebookCells to inspect specific cells
+✓ Use getNotebookInfo to inspect specific cells
 
 ❌ Edit .ipynb file directly
-✓ Use EditNotebookCells tool
+✓ Use editNotebook tool
 </anti-patterns>
 
 <notebook-context-instructions>
@@ -45,7 +45,7 @@ The current notebook state (kernel info, cell contents, selection) is provided i
 </critical-rules>
 
 <workflows>
-**Analyze/explain:** Reference cells by **index** ("cell 0", "cell 3"). Use GetNotebookCells with `cellIndices` for additional cells. Check execution order [N], status, and success/failure.
+**Analyze/explain:** Reference cells by **index** ("cell 0", "cell 3"). Use getNotebookInfo with `cellIndices` for additional cells. Check execution order [N], status, and success/failure.
 
 **Debug issues:** Check cell execution status, order, success/failure. Use GetCellOutputs with `cellIndex` to inspect errors/outputs. Consider cell dependencies and sequence.
 </workflows>

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-edit.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-edit.md
@@ -14,8 +14,9 @@ You MUST use notebook-specific tools. NEVER use file tools.
 - DO NOT use grep/search tools - use getNotebookInfo instead
 - DO NOT manually parse or construct notebook formats
 - DO NOT attempt to execute cells (executeNotebook not available in Edit mode)
+- DO NOT attempt to restart or interrupt kernel (executeNotebook not available in Edit mode)
 
-If the user requests cell execution, suggest switching to Agent mode for execution capabilities.
+If the user requests cell execution or kernel management, suggest switching to Agent mode.
 </tool-usage-protocol>
 
 <anti-patterns>
@@ -45,7 +46,11 @@ The current notebook state (kernel info, cell contents, selection) is provided i
 
 **Delete:** Use editNotebook with `operation: 'delete'` and `cellIndices` array (e.g., `[0]`). Confirm deletion clearly. When you delete cells, higher indices shift down.
 
-**Debug:** Check cell execution status, order, success/failure. Use GetCellOutputs with `cellIndex` to inspect errors/outputs. Consider cell dependencies and sequence. If fix requires running cells, suggest Agent mode.
+**Clear outputs:** Use editNotebook with `operation: 'clearOutputs'`. Optionally pass `cellIndices` to clear specific cells.
+
+**Debug:** Check cell execution status, order, success/failure. Use getNotebookInfo with `operation: 'getOutputs'` and `cellIndices` to inspect errors/outputs. Consider cell dependencies and sequence. If fix requires running cells, suggest Agent mode.
+
+**Check kernel status:** Use getNotebookInfo with `operation: 'getKernelStatus'` to get kernel state and session metadata.
 
 **Execution requested:** Prepare cells with editNotebook. State execution requires Agent mode.
 </workflows>

--- a/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-edit.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/notebook-mode-edit.md
@@ -11,22 +11,22 @@ You MUST use notebook-specific tools. NEVER use file tools.
 
 - NEVER read .ipynb files directly (breaks notebook state sync)
 - NEVER parse notebook JSON manually (causes sync issues)
-- DO NOT use grep/search tools - use GetNotebookCells instead
+- DO NOT use grep/search tools - use getNotebookInfo instead
 - DO NOT manually parse or construct notebook formats
-- DO NOT attempt to execute cells (RunNotebookCells not available in Edit mode)
+- DO NOT attempt to execute cells (executeNotebook not available in Edit mode)
 
 If the user requests cell execution, suggest switching to Agent mode for execution capabilities.
 </tool-usage-protocol>
 
 <anti-patterns>
 ❌ Read `/path/to/notebook.ipynb` → parse JSON → extract cells
-✓ Use GetNotebookCells with cellIndices
+✓ Use getNotebookInfo with cellIndices
 
 ❌ Use grep/search tools to find cell content
-✓ Use GetNotebookCells to inspect specific cells
+✓ Use getNotebookInfo to inspect specific cells
 
 ❌ Edit .ipynb file directly
-✓ Use EditNotebookCells tool
+✓ Use editNotebook tool
 </anti-patterns>
 
 <notebook-context-instructions>
@@ -37,17 +37,17 @@ The current notebook state (kernel info, cell contents, selection) is provided i
 <workflows>
 **Mode capabilities:** View, modify, add, delete cells. Cannot execute (Agent mode only). If execution requested: "Cannot execute in Edit mode. Switch to Agent mode to run cells."
 
-**Analyze/explain:** Reference cells by **index** ("cell 0", "cell 3"). Use GetNotebookCells with `cellIndices` for additional cells. Check execution order [N], status, and success/failure.
+**Analyze/explain:** Reference cells by **index** ("cell 0", "cell 3"). Use getNotebookInfo with `cellIndices` for additional cells. Check execution order [N], status, and success/failure.
 
-**Modify:** Use EditNotebookCells with `cellIndex` and new content. Explain changes before applying. If user wants execution, suggest Agent mode.
+**Modify:** Use editNotebook with `cellIndex` and new content. Explain changes before applying. If user wants execution, suggest Agent mode.
 
-**Add:** Use EditNotebookCells with `cellType`, `index`, and `content`. Choose position respecting logical flow. When you add cell at index N, cells N+ shift to N+1, N+2, etc. If user wants execution, suggest Agent mode.
+**Add:** Use editNotebook with `cellType`, `index`, and `content`. Choose position respecting logical flow. When you add cell at index N, cells N+ shift to N+1, N+2, etc. If user wants execution, suggest Agent mode.
 
-**Delete:** Use EditNotebookCells with `operation: 'delete'` and `cellIndices` array (e.g., `[0]`). Confirm deletion clearly. When you delete cells, higher indices shift down.
+**Delete:** Use editNotebook with `operation: 'delete'` and `cellIndices` array (e.g., `[0]`). Confirm deletion clearly. When you delete cells, higher indices shift down.
 
 **Debug:** Check cell execution status, order, success/failure. Use GetCellOutputs with `cellIndex` to inspect errors/outputs. Consider cell dependencies and sequence. If fix requires running cells, suggest Agent mode.
 
-**Execution requested:** Prepare cells with EditNotebookCells. State execution requires Agent mode.
+**Execution requested:** Prepare cells with editNotebook. State execution requires Agent mode.
 </workflows>
 
 <critical-rules>

--- a/extensions/positron-assistant/src/test/tools/createNotebook.test.ts
+++ b/extensions/positron-assistant/src/test/tools/createNotebook.test.ts
@@ -104,7 +104,7 @@ suite('CreateNotebook Tool', () => {
 			assert.ok(executeCommandStub.calledWith('ipynb.newUntitledIpynb', 'python'));
 		});
 
-		test('includes EditNotebookCells guidance when no prior notebook exists', async () => {
+		test('includes editNotebook guidance when no prior notebook exists', async () => {
 			sandbox.stub(vscode.commands, 'executeCommand').resolves();
 			mockNotebookEditorActivation();
 
@@ -120,8 +120,8 @@ suite('CreateNotebook Tool', () => {
 			);
 
 			const textPart = result.content[0] as vscode.LanguageModelTextPart;
-			// Should include detailed EditNotebookCells guidance
-			assert.ok(textPart.value.includes('EditNotebookCells'));
+			// Should include detailed editNotebook guidance
+			assert.ok(textPart.value.includes('editNotebook'));
 			assert.ok(textPart.value.includes('operation'));
 			assert.ok(textPart.value.includes('cellType'));
 		});

--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -444,10 +444,9 @@ export function registerAssistantTools(
 
 	// Register notebook-specific tools for notebook participant
 	// These tools enable the assistant to interact with Jupyter notebooks:
-	// - RunNotebookCells: Execute cells and retrieve outputs
-	// - AddNotebookCell: Add new code or markdown cells
-	// - UpdateNotebookCell: Update existing cell content
-	// - GetCellOutputs: Retrieve outputs from executed cells
+	// - ExecuteNotebook: Execute cells and retrieve outputs
+	// - EditNotebook: Add, update, delete, or reorder cells
+	// - GetNotebookInfo: Retrieve cell info, outputs, and kernel status
 	registerNotebookTools(context, participantService);
 
 	// Register the CreateNotebook tool for creating new notebooks

--- a/extensions/positron-assistant/src/tools/createNotebook.ts
+++ b/extensions/positron-assistant/src/tools/createNotebook.ts
@@ -100,7 +100,7 @@ export const createNotebookToolImpl = {
 			if (hadNotebookBefore) {
 				return new vscode.LanguageModelToolResult([
 					new vscode.LanguageModelTextPart(
-						`Created new ${lang} notebook. Use EditNotebookCells to add content.`
+						`Created new ${lang} notebook. Use editNotebook to add content.`
 					)
 				]);
 			}
@@ -110,7 +110,7 @@ export const createNotebookToolImpl = {
 			return new vscode.LanguageModelToolResult([
 				new vscode.LanguageModelTextPart(
 					`Created new ${lang} notebook.\n\n` +
-					`To add cells, use EditNotebookCells with:\n` +
+					`To add cells, use editNotebook with:\n` +
 					`- operation: 'add'\n` +
 					`- cellType: 'code' or 'markdown'\n` +
 					`- index: -1 (append to end) or specific position\n` +

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -507,7 +507,14 @@ function createEditNotebookTool(participantService: ParticipantService) {
 
 				case 'clearOutputs': {
 					const { cellIndices: clearIndices } = options.input;
-					if (clearIndices && clearIndices.length > 0) {
+					if (clearIndices !== undefined) {
+						if (clearIndices.length === 0) {
+							// Empty array -- invoke will reject; skip confirmation
+							return {
+								invocationMessage: vscode.l10n.t('Clearing notebook outputs'),
+								pastTenseMessage: vscode.l10n.t('Cleared notebook outputs'),
+							};
+						}
 						const message = clearIndices.length === 1
 							? vscode.l10n.t('Clear outputs for cell {0}?', clearIndices[0])
 							: vscode.l10n.t('Clear outputs for cells {0}?', clearIndices.join(', '));

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { PositronAssistantToolName } from '../types.js';
 import { log } from '../log.js';
-import { convertOutputsToLanguageModelParts, formatCells, validateCellIndices, validatePermutation, MAX_CELL_CONTENT_LENGTH, isErrorMime, isTextMime, isImageMime } from './notebookUtils.js';
+import { convertOutputsToLanguageModelParts, formatCells, validateCellIndices, validatePermutation, MAX_CELL_CONTENT_LENGTH, isErrorMime, isTextMime } from './notebookUtils.js';
 import { getChatRequestData } from '../tools.js';
 import type { ParticipantService } from '../participants.js';
 import { resolveShowDiff } from '../notebookAssistantMetadata.js';
@@ -320,7 +320,7 @@ async function runAllCells(
 				const status = hasError ? 'Error' : 'OK';
 				// Show first line of first text output or indicator for non-text types
 				const firstOutput = cellOutputs[0];
-				if (isImageMime(firstOutput.mimeType)) {
+				if (firstOutput.mimeType.startsWith('image/')) {
 					resultParts.push(
 						new vscode.LanguageModelTextPart(`Cell ${cell.index}: [${status}] [Image output]\n`)
 					);

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -201,14 +201,15 @@ export const ExecuteNotebookTool = vscode.lm.registerTool<ExecuteNotebookInput>(
 				}
 
 				case 'interrupt': {
-					// Verify the active notebook matches the target to avoid interrupting the wrong notebook
-					const activeEditor = vscode.window.activeNotebookEditor;
-					if (!activeEditor || activeEditor.notebook.uri.toString() !== context.uri) {
+					const notebookUri = vscode.Uri.parse(context.uri);
+					const session = await positron.runtime.getNotebookSession(notebookUri);
+					if (!session) {
 						return new vscode.LanguageModelToolResult([
-							new vscode.LanguageModelTextPart('Cannot interrupt: the active notebook has changed. Please ensure the target notebook is focused.')
+							new vscode.LanguageModelTextPart('No active kernel session found for this notebook. The kernel may not be started.')
 						]);
 					}
-					await vscode.commands.executeCommand('notebook.cancelExecution');
+
+					await positron.runtime.interruptSession(session.metadata.sessionId);
 					return new vscode.LanguageModelToolResult([
 						new vscode.LanguageModelTextPart('Successfully interrupted notebook execution.')
 					]);

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -320,9 +320,9 @@ async function runAllCells(
 				const status = hasError ? 'Error' : 'OK';
 				// Show first line of first text output or indicator for non-text types
 				const firstOutput = cellOutputs[0];
-				// Intentionally uses startsWith rather than isImageMime() so that
-				// SVG (image/svg+xml) is treated as an image here. The helper
-				// classifies SVG as text, which will be corrected in #12096.
+				// SVG (image/svg+xml) classification is inconsistent -- isTextMime
+				// treats it as text, but we want it as an image here. Uses
+				// startsWith as a workaround; proper fix deferred to #12096.
 				if (firstOutput.mimeType.startsWith('image/')) {
 					resultParts.push(
 						new vscode.LanguageModelTextPart(`Cell ${cell.index}: [${status}] [Image output]\n`)

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -201,6 +201,13 @@ export const ExecuteNotebookTool = vscode.lm.registerTool<ExecuteNotebookInput>(
 				}
 
 				case 'interrupt': {
+					// Verify the active notebook matches the target to avoid interrupting the wrong notebook
+					const activeEditor = vscode.window.activeNotebookEditor;
+					if (!activeEditor || activeEditor.notebook.uri.toString() !== context.uri) {
+						return new vscode.LanguageModelToolResult([
+							new vscode.LanguageModelTextPart('Cannot interrupt: the active notebook has changed. Please ensure the target notebook is focused.')
+						]);
+					}
 					await vscode.commands.executeCommand('notebook.cancelExecution');
 					return new vscode.LanguageModelToolResult([
 						new vscode.LanguageModelTextPart('Successfully interrupted notebook execution.')
@@ -308,21 +315,23 @@ async function runAllCells(
 					new vscode.LanguageModelTextPart(`Cell ${cell.index}: No output\n`)
 				);
 			} else {
+				// Determine error status from all outputs, not just the first
+				const hasError = cellOutputs.some(o => isErrorMime(o.mimeType));
+				const status = hasError ? 'Error' : 'OK';
 				// Show first line of first text output or indicator for non-text types
 				const firstOutput = cellOutputs[0];
 				if (isImageMime(firstOutput.mimeType)) {
 					resultParts.push(
-						new vscode.LanguageModelTextPart(`Cell ${cell.index}: [OK] [Image output]\n`)
+						new vscode.LanguageModelTextPart(`Cell ${cell.index}: [${status}] [Image output]\n`)
 					);
 				} else if (isTextMime(firstOutput.mimeType)) {
 					const firstLine = (firstOutput.data?.split('\n')[0] ?? '').slice(0, 200);
-					const status = isErrorMime(firstOutput.mimeType) ? 'Error' : 'OK';
 					resultParts.push(
 						new vscode.LanguageModelTextPart(`Cell ${cell.index}: [${status}] ${firstLine}\n`)
 					);
 				} else {
 					resultParts.push(
-						new vscode.LanguageModelTextPart(`Cell ${cell.index}: [OK] [${firstOutput.mimeType} output]\n`)
+						new vscode.LanguageModelTextPart(`Cell ${cell.index}: [${status}] [${firstOutput.mimeType} output]\n`)
 					);
 				}
 			}
@@ -819,8 +828,10 @@ function createEditNotebookTool(participantService: ParticipantService) {
 
 							// Clear outputs for specific cells by selecting each and clearing
 							const notebookEditor = vscode.window.activeNotebookEditor;
-							if (!notebookEditor) {
-								return createNoActiveNotebookErrorResult();
+							if (!notebookEditor || notebookEditor.notebook.uri.toString() !== context.uri) {
+								return new vscode.LanguageModelToolResult([
+									new vscode.LanguageModelTextPart('Cannot clear outputs: the active notebook has changed. Please ensure the target notebook is focused.')
+								]);
 							}
 							const notebook = notebookEditor.notebook;
 
@@ -863,6 +874,13 @@ function createEditNotebookTool(participantService: ParticipantService) {
 								)
 							]);
 						} else {
+							// Verify the active notebook matches the target to avoid clearing the wrong notebook
+							const activeEditor = vscode.window.activeNotebookEditor;
+							if (!activeEditor || activeEditor.notebook.uri.toString() !== context.uri) {
+								return new vscode.LanguageModelToolResult([
+									new vscode.LanguageModelTextPart('Cannot clear outputs: the active notebook has changed. Please ensure the target notebook is focused.')
+								]);
+							}
 							// Clear all outputs using the built-in command
 							await vscode.commands.executeCommand('notebook.clearAllCellsOutputs');
 							return new vscode.LanguageModelToolResult([

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { PositronAssistantToolName } from '../types.js';
 import { log } from '../log.js';
-import { convertOutputsToLanguageModelParts, formatCells, validateCellIndices, validatePermutation, MAX_CELL_CONTENT_LENGTH } from './notebookUtils.js';
+import { convertOutputsToLanguageModelParts, formatCells, validateCellIndices, validatePermutation, MAX_CELL_CONTENT_LENGTH, isErrorMime, isTextMime, isImageMime } from './notebookUtils.js';
 import { getChatRequestData } from '../tools.js';
 import type { ParticipantService } from '../participants.js';
 import { resolveShowDiff } from '../notebookAssistantMetadata.js';
@@ -52,48 +52,105 @@ const CELL_TYPE_MAP: Record<string, positron.notebooks.NotebookCellType> = {
 };
 
 /**
+ * Maximum number of cells for which runAll returns full outputs.
+ * Beyond this threshold, runAll returns per-cell summaries instead.
+ */
+const MAX_CELLS_FOR_FULL_RUN_ALL_OUTPUT = 10;
+
+/**
+ * Input type for the ExecuteNotebook tool.
+ */
+interface ExecuteNotebookInput {
+	operation: 'run' | 'runAll' | 'interrupt' | 'restartKernel';
+	cellIndices?: number[];
+	runAll?: boolean;
+}
+
+/**
  * Tool: Execute Notebook
  *
- * Executes one or more cells in the active notebook and returns their outputs.
- * Supports both text and image outputs.
+ * Manages the notebook execution lifecycle: run specific cells, run all cells,
+ * interrupt execution, or restart the kernel.
  */
-export const ExecuteNotebookTool = vscode.lm.registerTool<{
-	cellIndices: number[];
-}>(PositronAssistantToolName.ExecuteNotebook, {
+export const ExecuteNotebookTool = vscode.lm.registerTool<ExecuteNotebookInput>(PositronAssistantToolName.ExecuteNotebook, {
 	prepareInvocation: async (options, _token) => {
-		const cellIndices = options.input.cellIndices;
+		const { operation, cellIndices } = options.input;
 
-		// Get the active notebook context to fetch cell previews
-		const context = await positron.notebooks.getContext();
-		if (!context) {
-			// If no notebook is active, we still need to return a PreparedToolInvocation
-			// The actual error will be shown during invoke()
-			return {
-				invocationMessage: vscode.l10n.t('Running notebook cells'),
-				pastTenseMessage: vscode.l10n.t('Ran notebook cells'),
-			};
+		switch (operation) {
+			case 'run': {
+				if (!cellIndices || cellIndices.length === 0) {
+					return {
+						invocationMessage: vscode.l10n.t('Running notebook cells'),
+						pastTenseMessage: vscode.l10n.t('Ran notebook cells'),
+					};
+				}
+
+				// Build simple confirmation message
+				const cellList = cellIndices.length <= 5
+					? cellIndices.join(', ')
+					: `${cellIndices.slice(0, 5).join(', ')}, and ${cellIndices.length - 5} more`;
+
+				const message = cellIndices.length === 1
+					? vscode.l10n.t('Execute cell {0}?', cellIndices[0])
+					: vscode.l10n.t('Execute {0} cells ({1})?', cellIndices.length, cellList);
+
+				return {
+					invocationMessage: vscode.l10n.t('Running notebook cells'),
+					confirmationMessages: {
+						title: vscode.l10n.t('Run Notebook Cells'),
+						message: message
+					},
+					pastTenseMessage: vscode.l10n.t('Ran notebook cells'),
+				};
+			}
+
+			case 'runAll': {
+				const context = await positron.notebooks.getContext();
+				const cellCount = context?.cellCount ?? 0;
+				return {
+					invocationMessage: vscode.l10n.t('Running all notebook cells'),
+					confirmationMessages: {
+						title: vscode.l10n.t('Run All Cells'),
+						message: vscode.l10n.t('Execute all {0} cells in the notebook?', cellCount)
+					},
+					pastTenseMessage: vscode.l10n.t('Ran all notebook cells'),
+				};
+			}
+
+			case 'interrupt':
+				return {
+					invocationMessage: vscode.l10n.t('Interrupting notebook execution'),
+					pastTenseMessage: vscode.l10n.t('Interrupted notebook execution'),
+				};
+
+			case 'restartKernel': {
+				const willRunAll = options.input.runAll === true;
+				const message = willRunAll
+					? vscode.l10n.t('Restart the kernel and run all cells?')
+					: vscode.l10n.t('Restart the kernel?');
+				return {
+					invocationMessage: willRunAll
+						? vscode.l10n.t('Restarting kernel and running all cells')
+						: vscode.l10n.t('Restarting kernel'),
+					confirmationMessages: {
+						title: vscode.l10n.t('Restart Kernel'),
+						message: message
+					},
+					pastTenseMessage: willRunAll
+						? vscode.l10n.t('Restarted kernel and ran all cells')
+						: vscode.l10n.t('Restarted kernel'),
+				};
+			}
+
+			default:
+				return {
+					invocationMessage: vscode.l10n.t('Executing notebook operation'),
+					pastTenseMessage: vscode.l10n.t('Executed notebook operation'),
+				};
 		}
-
-		// Build simple confirmation message
-		const cellList = cellIndices.length <= 5
-			? cellIndices.join(', ')
-			: `${cellIndices.slice(0, 5).join(', ')}, and ${cellIndices.length - 5} more`;
-
-		const message = cellIndices.length === 1
-			? vscode.l10n.t('Execute cell {0}?', cellIndices[0])
-			: vscode.l10n.t('Execute {0} cells ({1})?', cellIndices.length, cellList);
-
-		return {
-			invocationMessage: vscode.l10n.t('Running notebook cells'),
-			confirmationMessages: {
-				title: vscode.l10n.t('Run Notebook Cells'),
-				message: message
-			},
-			pastTenseMessage: vscode.l10n.t('Ran notebook cells'),
-		};
 	},
 	invoke: async (options, token) => {
-		const cellIndices = options.input.cellIndices;
+		const { operation } = options.input;
 
 		try {
 			const context = await positron.notebooks.getContext();
@@ -101,50 +158,190 @@ export const ExecuteNotebookTool = vscode.lm.registerTool<{
 				return createNoActiveNotebookErrorResult();
 			}
 
-			// Validate cell indices
-			const validation = validateCellIndices(cellIndices, context.cellCount);
-			if (!validation.valid) {
-				return new vscode.LanguageModelToolResult([
-					new vscode.LanguageModelTextPart(validation.error!)
-				]);
-			}
+			switch (operation) {
+				case 'run': {
+					const cellIndices = options.input.cellIndices;
+					if (!cellIndices || cellIndices.length === 0) {
+						return new vscode.LanguageModelToolResult([
+							new vscode.LanguageModelTextPart('Missing required parameter: cellIndices (required for run operation)')
+						]);
+					}
 
-			await positron.notebooks.runCells(context.uri, cellIndices);
+					// Validate cell indices
+					const validation = validateCellIndices(cellIndices, context.cellCount);
+					if (!validation.valid) {
+						return new vscode.LanguageModelToolResult([
+							new vscode.LanguageModelTextPart(validation.error!)
+						]);
+					}
 
-			// Build mixed content response with support for images
-			const resultParts: (vscode.LanguageModelTextPart | vscode.LanguageModelDataPart)[] = [];
-			resultParts.push(
-				new vscode.LanguageModelTextPart(`Successfully executed ${cellIndices.length} cell(s).\n\nOutputs:\n`)
-			);
+					await positron.notebooks.runCells(context.uri, cellIndices);
 
-			for (const cellIndex of cellIndices) {
-				const cellOutputs = await positron.notebooks.getCellOutputs(context.uri, cellIndex);
+					// Build mixed content response with support for images
+					const resultParts: (vscode.LanguageModelTextPart | vscode.LanguageModelDataPart)[] = [];
+					resultParts.push(
+						new vscode.LanguageModelTextPart(`Successfully executed ${cellIndices.length} cell(s).\n\nOutputs:\n`)
+					);
 
-				if (cellOutputs.length > 0) {
-					resultParts.push(new vscode.LanguageModelTextPart(`\nCell ${cellIndex}:\n`));
-					// Convert outputs to LanguageModel parts using shared helper
-					const outputParts = convertOutputsToLanguageModelParts(cellOutputs);
-					resultParts.push(...outputParts);
+					for (const cellIndex of cellIndices) {
+						const cellOutputs = await positron.notebooks.getCellOutputs(context.uri, cellIndex);
+
+						if (cellOutputs.length > 0) {
+							resultParts.push(new vscode.LanguageModelTextPart(`\nCell ${cellIndex}:\n`));
+							const outputParts = convertOutputsToLanguageModelParts(cellOutputs);
+							resultParts.push(...outputParts);
+						}
+					}
+
+					return new vscode.LanguageModelToolResult2(resultParts);
 				}
-			}
 
-			return new vscode.LanguageModelToolResult2(resultParts);
+				case 'runAll': {
+					return await runAllCells(context);
+				}
+
+				case 'interrupt': {
+					await vscode.commands.executeCommand('notebook.cancelExecution');
+					return new vscode.LanguageModelToolResult([
+						new vscode.LanguageModelTextPart('Successfully interrupted notebook execution.')
+					]);
+				}
+
+				case 'restartKernel': {
+					const notebookUri = vscode.Uri.parse(context.uri);
+					const session = await positron.runtime.getNotebookSession(notebookUri);
+					if (!session) {
+						return new vscode.LanguageModelToolResult([
+							new vscode.LanguageModelTextPart('No active kernel session found for this notebook. The kernel may not be started.')
+						]);
+					}
+
+					await positron.runtime.restartSession(session.metadata.sessionId);
+
+					if (options.input.runAll === true) {
+						// Re-fetch context after restart to get fresh state
+						const freshContext = await positron.notebooks.getContext();
+						if (!freshContext) {
+							return new vscode.LanguageModelToolResult([
+								new vscode.LanguageModelTextPart('Kernel restarted successfully, but notebook context became unavailable. Could not run all cells.')
+							]);
+						}
+						// Verify the active notebook hasn't changed during restart
+						if (freshContext.uri !== context.uri) {
+							return new vscode.LanguageModelToolResult([
+								new vscode.LanguageModelTextPart('Kernel restarted successfully, but the active notebook changed. Run all cells skipped to avoid executing the wrong notebook.')
+							]);
+						}
+						return await runAllCells(freshContext);
+					}
+
+					return new vscode.LanguageModelToolResult([
+						new vscode.LanguageModelTextPart('Successfully restarted the kernel.')
+					]);
+				}
+
+				default:
+					return new vscode.LanguageModelToolResult([
+						new vscode.LanguageModelTextPart(
+							`Unknown operation: ${operation}. Must be "run", "runAll", "interrupt", or "restartKernel".`
+						)
+					]);
+			}
 		} catch (error: unknown) {
-			return createNotebookToolErrorResult(error, PositronAssistantToolName.ExecuteNotebook, 'execute cells');
+			return createNotebookToolErrorResult(error, PositronAssistantToolName.ExecuteNotebook, `${operation}`);
 		}
 	}
 });
 
 /**
+ * Runs all cells in a notebook and returns results.
+ * For small notebooks (<= MAX_CELLS_FOR_FULL_RUN_ALL_OUTPUT cells),
+ * returns full outputs. For larger notebooks, returns per-cell summaries.
+ */
+async function runAllCells(
+	context: positron.notebooks.NotebookContext
+): Promise<vscode.LanguageModelToolResult | vscode.LanguageModelToolResult2> {
+	const allCells = await positron.notebooks.getCells(context.uri);
+	// Run all cell indices (the execution service handles skipping non-executable cells)
+	const allIndices = allCells.map(c => c.index);
+	// Track code cells separately for accurate reporting
+	const codeCells = allCells.filter(c => c.type === 'code');
+
+	if (allIndices.length === 0) {
+		return new vscode.LanguageModelToolResult([
+			new vscode.LanguageModelTextPart('The notebook has no cells to execute.')
+		]);
+	}
+
+	await positron.notebooks.runCells(context.uri, allIndices);
+
+	const resultParts: (vscode.LanguageModelTextPart | vscode.LanguageModelDataPart)[] = [];
+
+	if (codeCells.length <= MAX_CELLS_FOR_FULL_RUN_ALL_OUTPUT) {
+		// Small notebook: return full outputs for code cells
+		resultParts.push(
+			new vscode.LanguageModelTextPart(
+				`Successfully executed all ${allIndices.length} cell(s) (${codeCells.length} code cell(s)).\n\nOutputs:\n`
+			)
+		);
+
+		for (const cell of codeCells) {
+			const cellOutputs = await positron.notebooks.getCellOutputs(context.uri, cell.index);
+			if (cellOutputs.length > 0) {
+				resultParts.push(new vscode.LanguageModelTextPart(`\nCell ${cell.index}:\n`));
+				const outputParts = convertOutputsToLanguageModelParts(cellOutputs);
+				resultParts.push(...outputParts);
+			}
+		}
+	} else {
+		// Large notebook: return per-cell summaries for code cells
+		resultParts.push(
+			new vscode.LanguageModelTextPart(
+				`Successfully executed all ${allIndices.length} cell(s) (${codeCells.length} code cell(s)). Per-cell summary:\n\n`
+			)
+		);
+
+		for (const cell of codeCells) {
+			const cellOutputs = await positron.notebooks.getCellOutputs(context.uri, cell.index);
+			if (cellOutputs.length === 0) {
+				resultParts.push(
+					new vscode.LanguageModelTextPart(`Cell ${cell.index}: No output\n`)
+				);
+			} else {
+				// Show first line of first text output or indicator for non-text types
+				const firstOutput = cellOutputs[0];
+				if (isImageMime(firstOutput.mimeType)) {
+					resultParts.push(
+						new vscode.LanguageModelTextPart(`Cell ${cell.index}: [OK] [Image output]\n`)
+					);
+				} else if (isTextMime(firstOutput.mimeType)) {
+					const firstLine = (firstOutput.data?.split('\n')[0] ?? '').slice(0, 200);
+					const status = isErrorMime(firstOutput.mimeType) ? 'Error' : 'OK';
+					resultParts.push(
+						new vscode.LanguageModelTextPart(`Cell ${cell.index}: [${status}] ${firstLine}\n`)
+					);
+				} else {
+					resultParts.push(
+						new vscode.LanguageModelTextPart(`Cell ${cell.index}: [OK] [${firstOutput.mimeType} output]\n`)
+					);
+				}
+			}
+		}
+	}
+
+	return new vscode.LanguageModelToolResult2(resultParts);
+}
+
+/**
  * Input type for the EditNotebook tool.
  */
 interface EditNotebookInput {
-	operation: 'add' | 'update' | 'delete' | 'reorder';
+	operation: 'add' | 'update' | 'delete' | 'reorder' | 'clearOutputs';
 	cellType?: 'code' | 'markdown';
 	index?: number;
 	content?: string;
 	cellIndex?: number;           // For update operation
-	cellIndices?: number[];        // For delete operation (array)
+	cellIndices?: number[];        // For delete and clearOutputs operations
 	run?: boolean;
 	fromIndex?: number;
 	toIndex?: number;
@@ -186,6 +383,10 @@ function createEditNotebookTool(participantService: ParticipantService) {
 					reorder: {
 						invocationMessage: vscode.l10n.t('Reordering notebook cells'),
 						pastTenseMessage: vscode.l10n.t('Reordered notebook cells'),
+					},
+					clearOutputs: {
+						invocationMessage: vscode.l10n.t('Clearing notebook outputs'),
+						pastTenseMessage: vscode.l10n.t('Cleared notebook outputs'),
 					},
 				};
 				return messages[operation];
@@ -290,6 +491,21 @@ function createEditNotebookTool(participantService: ParticipantService) {
 							pastTenseMessage: vscode.l10n.t('Moved notebook cell'),
 						};
 					}
+				}
+
+				case 'clearOutputs': {
+					const { cellIndices } = options.input;
+					const message = cellIndices && cellIndices.length > 0
+						? vscode.l10n.t('Clear outputs from {0} cell(s)?', cellIndices.length)
+						: vscode.l10n.t('Clear all cell outputs?');
+					return {
+						invocationMessage: vscode.l10n.t('Clearing notebook outputs'),
+						confirmationMessages: {
+							title: vscode.l10n.t('Clear Outputs'),
+							message: message
+						},
+						pastTenseMessage: vscode.l10n.t('Cleared notebook outputs'),
+					};
 				}
 
 				default:
@@ -589,10 +805,76 @@ function createEditNotebookTool(participantService: ParticipantService) {
 						}
 					}
 
+					case 'clearOutputs': {
+						const { cellIndices } = options.input;
+
+						if (cellIndices && cellIndices.length > 0) {
+							// Validate specified indices
+							const validation = validateCellIndices(cellIndices, context.cellCount);
+							if (!validation.valid) {
+								return new vscode.LanguageModelToolResult([
+									new vscode.LanguageModelTextPart(validation.error!)
+								]);
+							}
+
+							// Clear outputs for specific cells by selecting each and clearing
+							const notebookEditor = vscode.window.activeNotebookEditor;
+							if (!notebookEditor) {
+								return createNoActiveNotebookErrorResult();
+							}
+							const notebook = notebookEditor.notebook;
+
+							// Build a WorkspaceEdit that replaces each target code cell
+							// with a copy that has no outputs. Accumulate all edits
+							// before calling set() so earlier entries are not replaced.
+							const edit = new vscode.WorkspaceEdit();
+							const notebookEdits: vscode.NotebookEdit[] = [];
+							let clearedCount = 0;
+							const uniqueIndices = [...new Set(cellIndices)].sort((a, b) => a - b);
+							for (const idx of uniqueIndices) {
+								const cell = notebook.cellAt(idx);
+								if (cell.kind === vscode.NotebookCellKind.Code) {
+									const cellData = new vscode.NotebookCellData(
+										cell.kind,
+										cell.document.getText(),
+										cell.document.languageId
+									);
+									cellData.metadata = cell.metadata;
+									cellData.outputs = []; // Empty outputs
+									const range = new vscode.NotebookRange(idx, idx + 1);
+									notebookEdits.push(vscode.NotebookEdit.replaceCells(range, [cellData]));
+									clearedCount++;
+								}
+							}
+
+							if (notebookEdits.length > 0) {
+								edit.set(notebook.uri, notebookEdits);
+								const success = await vscode.workspace.applyEdit(edit);
+								if (!success) {
+									return new vscode.LanguageModelToolResult([
+										new vscode.LanguageModelTextPart('Failed to apply edit to clear cell outputs.')
+									]);
+								}
+							}
+
+							return new vscode.LanguageModelToolResult([
+								new vscode.LanguageModelTextPart(
+									`Successfully cleared outputs from ${clearedCount} code cell(s) (${cellIndices.length} cell(s) specified).`
+								)
+							]);
+						} else {
+							// Clear all outputs using the built-in command
+							await vscode.commands.executeCommand('notebook.clearAllCellsOutputs');
+							return new vscode.LanguageModelToolResult([
+								new vscode.LanguageModelTextPart('Successfully cleared all cell outputs.')
+							]);
+						}
+					}
+
 					default:
 						return new vscode.LanguageModelToolResult([
 							new vscode.LanguageModelTextPart(
-								`Unknown operation: ${operation}. Must be "add", "update", "delete", or "reorder".`
+								`Unknown operation: ${operation}. Must be "add", "update", "delete", "reorder", or "clearOutputs".`
 							)
 						]);
 				}
@@ -600,7 +882,7 @@ function createEditNotebookTool(participantService: ParticipantService) {
 				return createNotebookToolErrorResult(
 					error,
 					PositronAssistantToolName.EditNotebook,
-					`${operation} cell`
+					`${operation}`
 				);
 			}
 		}
@@ -614,13 +896,19 @@ function createEditNotebookTool(participantService: ParticipantService) {
  * Supports getting specific cells, all cells, selected cells, outputs, or metadata only.
  */
 export const GetNotebookInfoTool = vscode.lm.registerTool<{
-	operation: 'get' | 'getSelected' | 'getOutputs' | 'getMetadata';
+	operation: 'get' | 'getSelected' | 'getOutputs' | 'getMetadata' | 'getKernelStatus';
 	cellIndices?: number[];
 }>(PositronAssistantToolName.GetNotebookInfo, {
 	prepareInvocation: async (options, _token) => {
+		if (options.input.operation === 'getKernelStatus') {
+			return {
+				invocationMessage: vscode.l10n.t('Getting kernel status'),
+				pastTenseMessage: vscode.l10n.t('Retrieved kernel status'),
+			};
+		}
 		return {
-			invocationMessage: vscode.l10n.t('Getting notebook cells'),
-			pastTenseMessage: vscode.l10n.t('Retrieved notebook cells'),
+			invocationMessage: vscode.l10n.t('Getting notebook info'),
+			pastTenseMessage: vscode.l10n.t('Retrieved notebook info'),
 		};
 	},
 	invoke: async (options, token) => {
@@ -777,10 +1065,38 @@ export const GetNotebookInfoTool = vscode.lm.registerTool<{
 					]);
 				}
 
+				case 'getKernelStatus': {
+					const statusInfo: Record<string, string | undefined> = {
+						kernelLanguage: context.kernelLanguage,
+						kernelId: context.kernelId,
+						runtimeState: context.runtimeState ?? 'unknown',
+					};
+
+					// Try to get additional session metadata
+					const notebookUri = vscode.Uri.parse(context.uri);
+					const session = await positron.runtime.getNotebookSession(notebookUri);
+					if (session) {
+						const metadata = session.runtimeMetadata;
+						statusInfo.runtimeName = metadata.runtimeName;
+						statusInfo.languageVersion = metadata.languageVersion;
+						statusInfo.runtimeVersion = metadata.runtimeVersion;
+						statusInfo.runtimeSource = metadata.runtimeSource;
+
+						const dynState = await session.getDynState();
+						statusInfo.sessionName = dynState.sessionName;
+					}
+
+					return new vscode.LanguageModelToolResult([
+						new vscode.LanguageModelTextPart(
+							`Kernel status:\n${JSON.stringify(statusInfo, null, 2)}`
+						)
+					]);
+				}
+
 				default:
 					return new vscode.LanguageModelToolResult([
 						new vscode.LanguageModelTextPart(
-							`Unknown operation: ${operation}. Must be "get", "getSelected", "getOutputs", or "getMetadata".`
+							`Unknown operation: ${operation}. Must be "get", "getSelected", "getOutputs", "getMetadata", or "getKernelStatus".`
 						)
 					]);
 			}
@@ -788,7 +1104,7 @@ export const GetNotebookInfoTool = vscode.lm.registerTool<{
 			return createNotebookToolErrorResult(
 				error,
 				PositronAssistantToolName.GetNotebookInfo,
-				`${operation} cells`
+				`${operation}`
 			);
 		}
 	}

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -814,6 +814,17 @@ function createEditNotebookTool(participantService: ParticipantService) {
 					}
 
 					case 'clearOutputs': {
+						const { cellIndices: clearCellIndices } = options.input;
+						if (clearCellIndices && clearCellIndices.length > 0) {
+							return new vscode.LanguageModelToolResult([
+								new vscode.LanguageModelTextPart(
+									'The clearOutputs operation clears all cell outputs. ' +
+									'Selecting specific cells via cellIndices is not supported. ' +
+									'Omit cellIndices to clear all outputs.'
+								)
+							]);
+						}
+
 						// Ensure the notebook is the active editor so
 						// notebook.clearAllCellsOutputs resolves its context.
 						// The chat panel may have stolen focus.

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -320,6 +320,9 @@ async function runAllCells(
 				const status = hasError ? 'Error' : 'OK';
 				// Show first line of first text output or indicator for non-text types
 				const firstOutput = cellOutputs[0];
+				// Intentionally uses startsWith rather than isImageMime() so that
+				// SVG (image/svg+xml) is treated as an image here. The helper
+				// classifies SVG as text, which will be corrected in #12096.
 				if (firstOutput.mimeType.startsWith('image/')) {
 					resultParts.push(
 						new vscode.LanguageModelTextPart(`Cell ${cell.index}: [${status}] [Image output]\n`)

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -503,15 +503,11 @@ function createEditNotebookTool(participantService: ParticipantService) {
 				}
 
 				case 'clearOutputs': {
-					const { cellIndices } = options.input;
-					const message = cellIndices && cellIndices.length > 0
-						? vscode.l10n.t('Clear outputs from {0} cell(s)?', cellIndices.length)
-						: vscode.l10n.t('Clear all cell outputs?');
 					return {
 						invocationMessage: vscode.l10n.t('Clearing notebook outputs'),
 						confirmationMessages: {
 							title: vscode.l10n.t('Clear Outputs'),
-							message: message
+							message: vscode.l10n.t('Clear all cell outputs?'),
 						},
 						pastTenseMessage: vscode.l10n.t('Cleared notebook outputs'),
 					};
@@ -815,78 +811,17 @@ function createEditNotebookTool(participantService: ParticipantService) {
 					}
 
 					case 'clearOutputs': {
-						const { cellIndices } = options.input;
+						// Ensure the notebook is the active editor so
+						// notebook.clearAllCellsOutputs resolves its context.
+						// The chat panel may have stolen focus.
+						const notebookUri = vscode.Uri.parse(context.uri);
+						const notebookDoc = await vscode.workspace.openNotebookDocument(notebookUri);
+						await vscode.window.showNotebookDocument(notebookDoc, { preserveFocus: false });
 
-						if (cellIndices && cellIndices.length > 0) {
-							// Validate specified indices
-							const validation = validateCellIndices(cellIndices, context.cellCount);
-							if (!validation.valid) {
-								return new vscode.LanguageModelToolResult([
-									new vscode.LanguageModelTextPart(validation.error!)
-								]);
-							}
-
-							// Clear outputs for specific cells by selecting each and clearing
-							const notebookEditor = vscode.window.activeNotebookEditor;
-							if (!notebookEditor || notebookEditor.notebook.uri.toString() !== context.uri) {
-								return new vscode.LanguageModelToolResult([
-									new vscode.LanguageModelTextPart('Cannot clear outputs: the active notebook has changed. Please ensure the target notebook is focused.')
-								]);
-							}
-							const notebook = notebookEditor.notebook;
-
-							// Build a WorkspaceEdit that replaces each target code cell
-							// with a copy that has no outputs. Accumulate all edits
-							// before calling set() so earlier entries are not replaced.
-							const edit = new vscode.WorkspaceEdit();
-							const notebookEdits: vscode.NotebookEdit[] = [];
-							let clearedCount = 0;
-							const uniqueIndices = [...new Set(cellIndices)].sort((a, b) => a - b);
-							for (const idx of uniqueIndices) {
-								const cell = notebook.cellAt(idx);
-								if (cell.kind === vscode.NotebookCellKind.Code) {
-									const cellData = new vscode.NotebookCellData(
-										cell.kind,
-										cell.document.getText(),
-										cell.document.languageId
-									);
-									cellData.metadata = cell.metadata;
-									cellData.outputs = []; // Empty outputs
-									const range = new vscode.NotebookRange(idx, idx + 1);
-									notebookEdits.push(vscode.NotebookEdit.replaceCells(range, [cellData]));
-									clearedCount++;
-								}
-							}
-
-							if (notebookEdits.length > 0) {
-								edit.set(notebook.uri, notebookEdits);
-								const success = await vscode.workspace.applyEdit(edit);
-								if (!success) {
-									return new vscode.LanguageModelToolResult([
-										new vscode.LanguageModelTextPart('Failed to apply edit to clear cell outputs.')
-									]);
-								}
-							}
-
-							return new vscode.LanguageModelToolResult([
-								new vscode.LanguageModelTextPart(
-									`Successfully cleared outputs from ${clearedCount} code cell(s) (${cellIndices.length} cell(s) specified).`
-								)
-							]);
-						} else {
-							// Verify the active notebook matches the target to avoid clearing the wrong notebook
-							const activeEditor = vscode.window.activeNotebookEditor;
-							if (!activeEditor || activeEditor.notebook.uri.toString() !== context.uri) {
-								return new vscode.LanguageModelToolResult([
-									new vscode.LanguageModelTextPart('Cannot clear outputs: the active notebook has changed. Please ensure the target notebook is focused.')
-								]);
-							}
-							// Clear all outputs using the built-in command
-							await vscode.commands.executeCommand('notebook.clearAllCellsOutputs');
-							return new vscode.LanguageModelToolResult([
-								new vscode.LanguageModelTextPart('Successfully cleared all cell outputs.')
-							]);
-						}
+						await vscode.commands.executeCommand('notebook.clearAllCellsOutputs');
+						return new vscode.LanguageModelToolResult([
+							new vscode.LanguageModelTextPart('Successfully cleared all cell outputs.')
+						]);
 					}
 
 					default:

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -52,14 +52,14 @@ const CELL_TYPE_MAP: Record<string, positron.notebooks.NotebookCellType> = {
 };
 
 /**
- * Tool: Run Notebook Cells
+ * Tool: Execute Notebook
  *
  * Executes one or more cells in the active notebook and returns their outputs.
  * Supports both text and image outputs.
  */
-export const RunNotebookCellsTool = vscode.lm.registerTool<{
+export const ExecuteNotebookTool = vscode.lm.registerTool<{
 	cellIndices: number[];
-}>(PositronAssistantToolName.RunNotebookCells, {
+}>(PositronAssistantToolName.ExecuteNotebook, {
 	prepareInvocation: async (options, _token) => {
 		const cellIndices = options.input.cellIndices;
 
@@ -130,15 +130,15 @@ export const RunNotebookCellsTool = vscode.lm.registerTool<{
 
 			return new vscode.LanguageModelToolResult2(resultParts);
 		} catch (error: unknown) {
-			return createNotebookToolErrorResult(error, PositronAssistantToolName.RunNotebookCells, 'execute cells');
+			return createNotebookToolErrorResult(error, PositronAssistantToolName.ExecuteNotebook, 'execute cells');
 		}
 	}
 });
 
 /**
- * Input type for the EditNotebookCells tool.
+ * Input type for the EditNotebook tool.
  */
-interface EditNotebookCellsInput {
+interface EditNotebookInput {
 	operation: 'add' | 'update' | 'delete' | 'reorder';
 	cellType?: 'code' | 'markdown';
 	index?: number;
@@ -152,7 +152,7 @@ interface EditNotebookCellsInput {
 }
 
 /**
- * Creates the Edit Notebook Cells tool.
+ * Creates the Edit Notebook tool.
  *
  * Performs edit operations on notebook cells: add, update, delete, or reorder.
  * Uses a simple enum-based operation parameter for flexibility.
@@ -160,8 +160,8 @@ interface EditNotebookCellsInput {
  * @param participantService The participant service for accessing the chat response stream
  * @returns The registered tool disposable
  */
-function createEditNotebookCellsTool(participantService: ParticipantService) {
-	return vscode.lm.registerTool<EditNotebookCellsInput>(PositronAssistantToolName.EditNotebookCells, {
+function createEditNotebookTool(participantService: ParticipantService) {
+	return vscode.lm.registerTool<EditNotebookInput>(PositronAssistantToolName.EditNotebook, {
 		prepareInvocation: async (options, _token) => {
 			const { operation, cellType, cellIndex, run } = options.input;
 
@@ -599,7 +599,7 @@ function createEditNotebookCellsTool(participantService: ParticipantService) {
 			} catch (error: unknown) {
 				return createNotebookToolErrorResult(
 					error,
-					PositronAssistantToolName.EditNotebookCells,
+					PositronAssistantToolName.EditNotebook,
 					`${operation} cell`
 				);
 			}
@@ -608,15 +608,15 @@ function createEditNotebookCellsTool(participantService: ParticipantService) {
 }
 
 /**
- * Tool: Get Notebook Cells
+ * Tool: Get Notebook Info
  *
  * Retrieves information about notebook cells with flexible operation modes.
  * Supports getting specific cells, all cells, selected cells, outputs, or metadata only.
  */
-export const GetNotebookCellsTool = vscode.lm.registerTool<{
+export const GetNotebookInfoTool = vscode.lm.registerTool<{
 	operation: 'get' | 'getSelected' | 'getOutputs' | 'getMetadata';
 	cellIndices?: number[];
-}>(PositronAssistantToolName.GetNotebookCells, {
+}>(PositronAssistantToolName.GetNotebookInfo, {
 	prepareInvocation: async (options, _token) => {
 		return {
 			invocationMessage: vscode.l10n.t('Getting notebook cells'),
@@ -787,7 +787,7 @@ export const GetNotebookCellsTool = vscode.lm.registerTool<{
 		} catch (error: unknown) {
 			return createNotebookToolErrorResult(
 				error,
-				PositronAssistantToolName.GetNotebookCells,
+				PositronAssistantToolName.GetNotebookInfo,
 				`${operation} cells`
 			);
 		}
@@ -807,8 +807,8 @@ export function registerNotebookTools(
 	participantService: ParticipantService
 ): void {
 	context.subscriptions.push(
-		RunNotebookCellsTool,
-		createEditNotebookCellsTool(participantService),
-		GetNotebookCellsTool
+		ExecuteNotebookTool,
+		createEditNotebookTool(participantService),
+		GetNotebookInfoTool
 	);
 }

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -506,6 +506,20 @@ function createEditNotebookTool(participantService: ParticipantService) {
 				}
 
 				case 'clearOutputs': {
+					const { cellIndices: clearIndices } = options.input;
+					if (clearIndices && clearIndices.length > 0) {
+						const message = clearIndices.length === 1
+							? vscode.l10n.t('Clear outputs for cell {0}?', clearIndices[0])
+							: vscode.l10n.t('Clear outputs for cells {0}?', clearIndices.join(', '));
+						return {
+							invocationMessage: vscode.l10n.t('Clearing notebook outputs'),
+							confirmationMessages: {
+								title: vscode.l10n.t('Clear Outputs'),
+								message: message,
+							},
+							pastTenseMessage: vscode.l10n.t('Cleared notebook outputs'),
+						};
+					}
 					return {
 						invocationMessage: vscode.l10n.t('Clearing notebook outputs'),
 						confirmationMessages: {
@@ -816,23 +830,24 @@ function createEditNotebookTool(participantService: ParticipantService) {
 					case 'clearOutputs': {
 						const { cellIndices: clearCellIndices } = options.input;
 						if (clearCellIndices && clearCellIndices.length > 0) {
+							// Validate cell indices
+							const validation = validateCellIndices(clearCellIndices, context.cellCount);
+							if (!validation.valid) {
+								return new vscode.LanguageModelToolResult([
+									new vscode.LanguageModelTextPart(validation.error!)
+								]);
+							}
+
+							await positron.notebooks.clearCellOutputs(context.uri, clearCellIndices);
+							const message = clearCellIndices.length === 1
+								? `Successfully cleared outputs for cell ${clearCellIndices[0]}.`
+								: `Successfully cleared outputs for cells ${clearCellIndices.join(', ')}.`;
 							return new vscode.LanguageModelToolResult([
-								new vscode.LanguageModelTextPart(
-									'The clearOutputs operation clears all cell outputs. ' +
-									'Selecting specific cells via cellIndices is not supported. ' +
-									'Omit cellIndices to clear all outputs.'
-								)
+								new vscode.LanguageModelTextPart(message)
 							]);
 						}
 
-						// Ensure the notebook is the active editor so
-						// notebook.clearAllCellsOutputs resolves its context.
-						// The chat panel may have stolen focus.
-						const notebookUri = vscode.Uri.parse(context.uri);
-						const notebookDoc = await vscode.workspace.openNotebookDocument(notebookUri);
-						await vscode.window.showNotebookDocument(notebookDoc, { preserveFocus: false });
-
-						await vscode.commands.executeCommand('notebook.clearAllCellsOutputs');
+						await positron.notebooks.clearCellOutputs(context.uri);
 						return new vscode.LanguageModelToolResult([
 							new vscode.LanguageModelTextPart('Successfully cleared all cell outputs.')
 						]);

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -829,7 +829,13 @@ function createEditNotebookTool(participantService: ParticipantService) {
 
 					case 'clearOutputs': {
 						const { cellIndices: clearCellIndices } = options.input;
-						if (clearCellIndices && clearCellIndices.length > 0) {
+						if (clearCellIndices !== undefined) {
+							if (clearCellIndices.length === 0) {
+								return new vscode.LanguageModelToolResult([
+									new vscode.LanguageModelTextPart('No cell indices specified. Provide cell indices to clear specific cells, or omit cellIndices to clear all.')
+								]);
+							}
+
 							// Validate cell indices
 							const validation = validateCellIndices(clearCellIndices, context.cellCount);
 							if (!validation.valid) {

--- a/extensions/positron-assistant/src/tools/notebookTools.ts
+++ b/extensions/positron-assistant/src/tools/notebookTools.ts
@@ -272,7 +272,7 @@ async function runAllCells(
 	// Run all cell indices (the execution service handles skipping non-executable cells)
 	const allIndices = allCells.map(c => c.index);
 	// Track code cells separately for accurate reporting
-	const codeCells = allCells.filter(c => c.type === 'code');
+	const codeCells = allCells.filter(c => c.type === positron.notebooks.NotebookCellType.Code);
 
 	if (allIndices.length === 0) {
 		return new vscode.LanguageModelToolResult([

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -13,6 +13,11 @@ import { log } from '../log.js';
 /**
  * MIME types for notebook cell output classification.
  * Matches the canonical types from the ipynb extension and VS Code notebook renderer.
+ *
+ * NOTE: The core browser layer has similar utilities in
+ * `src/vs/workbench/contrib/positronNotebook/browser/notebookMimeUtils.ts`
+ * (isImageMimeType, isTextBasedMimeType). Extensions cannot import from core,
+ * so these are maintained separately. Keep them aligned when adding new types.
  */
 const ERROR_MIME_TYPES = new Set([
 	'application/vnd.code.notebook.error',
@@ -24,12 +29,18 @@ const ERROR_MIME_TYPES = new Set([
 const TEXT_MIME_TYPES = new Set([
 	'application/vnd.code.notebook.stdout',
 	'application/x.notebook.stdout',
+	'application/x.notebook.stream',
 	'application/json',
+	'application/xml',
 	'image/svg+xml',
 ]);
 
 /**
  * Strips MIME parameters (e.g., `; charset=utf-8`) to get the base type.
+ *
+ * Differs from `normalizeMimeType` in `src/vs/base/common/mime.ts` which
+ * preserves parameters and only lowercases. This variant strips parameters
+ * entirely for Set-based lookups.
  */
 function normalizeMime(mimeType: string): string {
 	const semicolonIndex = mimeType.indexOf(';');

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -11,6 +11,48 @@ import { isRuntimeSessionReference } from '../utils.js';
 import { log } from '../log.js';
 
 /**
+ * MIME types for notebook cell output classification.
+ * Matches the canonical types from the ipynb extension and VS Code notebook renderer.
+ */
+const ERROR_MIME_TYPES = new Set([
+	'application/vnd.code.notebook.error',
+	'application/vnd.code.notebook.stderr',
+	'application/x.notebook.error',
+	'application/x.notebook.stderr',
+]);
+
+const TEXT_MIME_TYPES = new Set([
+	'application/vnd.code.notebook.stdout',
+	'application/x.notebook.stdout',
+	'application/json',
+]);
+
+/**
+ * Returns true if the MIME type represents an error or stderr output.
+ */
+export function isErrorMime(mimeType: string): boolean {
+	return ERROR_MIME_TYPES.has(mimeType);
+}
+
+/**
+ * Returns true if the MIME type represents text-based output
+ * (including stdout, stderr, error, text/*, and structured text like JSON).
+ */
+export function isTextMime(mimeType: string): boolean {
+	return mimeType.startsWith('text/') ||
+		TEXT_MIME_TYPES.has(mimeType) ||
+		ERROR_MIME_TYPES.has(mimeType);
+}
+
+/**
+ * Returns true if the MIME type represents an image output.
+ * Excludes image/svg+xml which is text-based XML.
+ */
+export function isImageMime(mimeType: string): boolean {
+	return mimeType.startsWith('image/') && mimeType !== 'image/svg+xml';
+}
+
+/**
  * Maximum preview length per cell for confirmations (characters)
  */
 const MAX_CELL_PREVIEW_LENGTH = 500;

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -333,9 +333,9 @@ export function convertOutputsToLanguageModelParts(
 
 	// Convert each output to appropriate LanguageModel part
 	for (const output of outputs) {
-		// Intentionally uses startsWith rather than isImageMime() so that
-		// SVG (image/svg+xml) is treated as an image here. The helper
-		// classifies SVG as text, which will be corrected in #12096.
+		// SVG (image/svg+xml) classification is inconsistent -- isTextMime
+		// treats it as text, but we want it as an image here. Uses
+		// startsWith as a workaround; proper fix deferred to #12096.
 		if (output.mimeType.startsWith('image/')) {
 			// Handle image outputs - convert base64 to binary
 			if (!output.data) {

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -443,10 +443,10 @@ export function serializeNotebookContext(
 		if (canIncludeFullNotebook) {
 			contextNote = xml.node('note', 'All cells are provided above because this notebook has fewer than 20 cells.');
 		} else {
-			contextNote = xml.node('note', 'A context window around the selected/recent cells is provided above. Use the GetNotebookCells tool to retrieve additional cells by index when needed.');
+			contextNote = xml.node('note', 'A context window around the selected/recent cells is provided above. Use the getNotebookInfo tool to retrieve additional cells by index when needed.');
 		}
 	} else {
-		contextNote = xml.node('note', 'Only selected cells are shown above to conserve tokens. Use the GetNotebookCells tool to retrieve additional cells by index when needed.');
+		contextNote = xml.node('note', 'Only selected cells are shown above to conserve tokens. Use the getNotebookInfo tool to retrieve additional cells by index when needed.');
 	}
 
 	// Build result
@@ -716,7 +716,7 @@ export function serializeNotebookContextAsUserMessage(
 			: 'Context window around selected/recent cells (notebook has 20+ cells)';
 		parts.push(xml.node('context-mode', contextMode));
 	} else {
-		parts.push(xml.node('context-mode', 'Selected cells only (use GetNotebookCells for other cells)'));
+		parts.push(xml.node('context-mode', 'Selected cells only (use getNotebookInfo for other cells)'));
 	}
 	parts.push('</notebook-info>');
 

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -25,6 +25,7 @@ const TEXT_MIME_TYPES = new Set([
 	'application/vnd.code.notebook.stdout',
 	'application/x.notebook.stdout',
 	'application/json',
+	'image/svg+xml',
 ]);
 
 /**

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -33,8 +33,8 @@ const TEXT_MIME_TYPES = new Set([
  */
 function normalizeMime(mimeType: string): string {
 	const semicolonIndex = mimeType.indexOf(';');
-	const base = semicolonIndex >= 0 ? mimeType.slice(0, semicolonIndex).trim() : mimeType;
-	return base.toLowerCase();
+	const base = semicolonIndex >= 0 ? mimeType.slice(0, semicolonIndex) : mimeType;
+	return base.trim().toLowerCase();
 }
 
 /**

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -33,7 +33,8 @@ const TEXT_MIME_TYPES = new Set([
  */
 function normalizeMime(mimeType: string): string {
 	const semicolonIndex = mimeType.indexOf(';');
-	return semicolonIndex >= 0 ? mimeType.slice(0, semicolonIndex).trim() : mimeType;
+	const base = semicolonIndex >= 0 ? mimeType.slice(0, semicolonIndex).trim() : mimeType;
+	return base.toLowerCase();
 }
 
 /**

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -29,10 +29,18 @@ const TEXT_MIME_TYPES = new Set([
 ]);
 
 /**
+ * Strips MIME parameters (e.g., `; charset=utf-8`) to get the base type.
+ */
+function normalizeMime(mimeType: string): string {
+	const semicolonIndex = mimeType.indexOf(';');
+	return semicolonIndex >= 0 ? mimeType.slice(0, semicolonIndex).trim() : mimeType;
+}
+
+/**
  * Returns true if the MIME type represents an error or stderr output.
  */
 export function isErrorMime(mimeType: string): boolean {
-	return ERROR_MIME_TYPES.has(mimeType);
+	return ERROR_MIME_TYPES.has(normalizeMime(mimeType));
 }
 
 /**
@@ -40,9 +48,10 @@ export function isErrorMime(mimeType: string): boolean {
  * (including stdout, stderr, error, text/*, and structured text like JSON).
  */
 export function isTextMime(mimeType: string): boolean {
-	return mimeType.startsWith('text/') ||
-		TEXT_MIME_TYPES.has(mimeType) ||
-		ERROR_MIME_TYPES.has(mimeType);
+	const normalized = normalizeMime(mimeType);
+	return normalized.startsWith('text/') ||
+		TEXT_MIME_TYPES.has(normalized) ||
+		ERROR_MIME_TYPES.has(normalized);
 }
 
 /**
@@ -50,7 +59,8 @@ export function isTextMime(mimeType: string): boolean {
  * Excludes image/svg+xml which is text-based XML.
  */
 export function isImageMime(mimeType: string): boolean {
-	return mimeType.startsWith('image/') && mimeType !== 'image/svg+xml';
+	const normalized = normalizeMime(mimeType);
+	return normalized.startsWith('image/') && normalized !== 'image/svg+xml';
 }
 
 /**

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -67,15 +67,6 @@ export function isTextMime(mimeType: string): boolean {
 }
 
 /**
- * Returns true if the MIME type represents an image output.
- * Excludes image/svg+xml which is text-based XML.
- */
-export function isImageMime(mimeType: string): boolean {
-	const normalized = normalizeMime(mimeType);
-	return normalized.startsWith('image/') && normalized !== 'image/svg+xml';
-}
-
-/**
  * Maximum preview length per cell for confirmations (characters)
  */
 const MAX_CELL_PREVIEW_LENGTH = 500;

--- a/extensions/positron-assistant/src/tools/notebookUtils.ts
+++ b/extensions/positron-assistant/src/tools/notebookUtils.ts
@@ -342,6 +342,9 @@ export function convertOutputsToLanguageModelParts(
 
 	// Convert each output to appropriate LanguageModel part
 	for (const output of outputs) {
+		// Intentionally uses startsWith rather than isImageMime() so that
+		// SVG (image/svg+xml) is treated as an image here. The helper
+		// classifies SVG as text, which will be corrected in #12096.
 		if (output.mimeType.startsWith('image/')) {
 			// Handle image outputs - convert base64 to binary
 			if (!output.data) {

--- a/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
+++ b/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
@@ -273,7 +273,7 @@ Notebook instructions are split into mode-specific prompt files following the es
 - **Content:**
   - **Tool usage protocol** with brief "why" explanations for constraints
   - **Anti-pattern examples** showing common mistakes and correct approaches
-  - Read and modification tools (GetNotebookInfo, GetCellOutputs, AddNotebookCell, UpdateNotebookCell)
+  - Read and modification tools (GetNotebookInfo, GetCellOutputs, EditNotebook)
   - **Workflows section** includes mode capabilities as first item, followed by concise workflows:
     - Analyze/explain, Modify, Add, Delete, Debug, Execution requested
   - **Exact response template** for execution requests: "Cannot execute in Edit mode. Switch to Agent mode to run cells."
@@ -287,7 +287,7 @@ Notebook instructions are split into mode-specific prompt files following the es
 - **Content:**
   - **Tool usage protocol** with brief "why" explanations (e.g., "causes sync issues")
   - **Anti-pattern examples** demonstrating wrong approaches (file tools) vs. correct approaches (notebook tools)
-  - Complete tool list (all 5 tools: GetNotebookInfo, GetCellOutputs, ExecuteNotebook, AddNotebookCell, UpdateNotebookCell)
+  - Complete tool list (all 4 tools: GetNotebookInfo, GetCellOutputs, ExecuteNotebook, EditNotebook)
   - Concise workflows covering all operations: analyze, modify, add, delete, execute, debug
   - Critical rules with:
     - Zero-based index referencing

--- a/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
+++ b/extensions/positron-assistant/src/tools/positron-assistant-notebook-mode.md
@@ -122,26 +122,26 @@ The `hasActiveNotebook` flag determines which tools are available. Each notebook
 Notebook tools are conditionally available based on the assistant mode, with filtering implemented in switch-case logic:
 
 **Execution Tools (Agent mode only):**
-- `RunNotebookCells` - Execute cells in the kernel using `cellIndices` parameter
+- `ExecuteNotebook` - Execute cells in the kernel using `cellIndices` parameter
 
 **Modification Tools (Edit and Agent modes):**
-- `EditNotebookCells` - Unified tool for adding, modifying, or deleting cells using `operation` parameter ('add', 'update', 'delete'). Code cells added with 'add' are executed by default (set `run: false` to skip execution).
+- `EditNotebook` - Unified tool for adding, modifying, or deleting cells using `operation` parameter ('add', 'update', 'delete'). Code cells added with 'add' are executed by default (set `run: false` to skip execution).
 
 **Read-Only Tools (Available in all modes - Ask, Edit, Agent):**
-- `GetNotebookCells` - Read cell contents with status information using `cellIndices` parameter
+- `GetNotebookInfo` - Read cell contents with status information using `cellIndices` parameter
 - `GetCellOutputs` - Retrieve cell execution outputs using `cellIndices` parameter
 
 Tool filtering in `extensions/positron-assistant/src/api.ts`:
 ```typescript
 // Notebook execution tools are only available in Agent mode.
 // Notebook modification tools are available in Edit and Agent modes.
-// Read-only tools (GetNotebookCells, GetCellOutputs) are available in all modes.
-case PositronAssistantToolName.RunNotebookCells:
+// Read-only tools (GetNotebookInfo, GetCellOutputs) are available in all modes.
+case PositronAssistantToolName.ExecuteNotebook:
 	if (!(inChatPane && hasActiveNotebook && isAgentMode)) {
 		continue;
 	}
 	break;
-case PositronAssistantToolName.EditNotebookCells:
+case PositronAssistantToolName.EditNotebook:
 	if (!(inChatPane && hasActiveNotebook && (isEditMode || isAgentMode))) {
 		continue;
 	}
@@ -156,8 +156,8 @@ All notebook tools can be explicitly referenced by users in chat prompts. This a
 
 1. **Using `#` syntax in the prompt:**
    - Type `#` followed by the tool reference name directly in the chat prompt
-   - Example: `#runNotebookCells execute the first cell`
-   - Example: `#getNotebookCells show me all cells`
+   - Example: `#executeNotebook execute the first cell`
+   - Example: `#getNotebookInfo show me all cells`
 
 2. **Via the attachment button (paperclip):**
    - Tools appear as attachable options in the chat UI
@@ -167,10 +167,10 @@ All notebook tools can be explicitly referenced by users in chat prompts. This a
 
 All notebook tools have `canBeReferencedInPrompt: true` and can be referenced using their `toolReferenceName`:
 
-- **`#runNotebookCells`** - Execute cells in the kernel using `cellIndices` (Agent mode only)
-- **`#editNotebookCells`** - Add, modify, or delete cells using `operation` parameter (Edit and Agent modes)
+- **`#executeNotebook`** - Execute cells in the kernel using `cellIndices` (Agent mode only)
+- **`#editNotebook`** - Add, modify, or delete cells using `operation` parameter (Edit and Agent modes)
 - **`#getCellOutputs`** - Retrieve cell execution outputs using `cellIndices` (All modes)
-- **`#getNotebookCells`** - Read cell contents with status information using `cellIndices` (All modes)
+- **`#getNotebookInfo`** - Read cell contents with status information using `cellIndices` (All modes)
 
 **Important Notes:**
 
@@ -191,7 +191,7 @@ All notebook tools have `canBeReferencedInPrompt: true` and can be referenced us
 **With notebook mode in Ask mode (notebook attached + active editor + Ask mode):**
 - Notebook-aware assistant with **read-only access**
 - Access to read-only tools:
-  - `GetNotebookCells` - Read cell contents with status information (selection status, execution status, execution order, run success/failure, duration)
+  - `GetNotebookInfo` - Read cell contents with status information (selection status, execution status, execution order, run success/failure, duration)
   - `GetCellOutputs` - Retrieve cell execution outputs
 - Can view notebook context, analyze code, explain cells, and inspect outputs
 - References cells by zero-based index in responses (e.g., "cell 0", "cell 3")
@@ -204,9 +204,9 @@ All notebook tools have `canBeReferencedInPrompt: true` and can be referenced us
 **With notebook mode in Edit mode (notebook attached + active editor + Edit mode):**
 - Notebook-aware assistant with **modification access**
 - Access to read and modification tools:
-  - `GetNotebookCells` - Read cell contents with status information
+  - `GetNotebookInfo` - Read cell contents with status information
   - `GetCellOutputs` - Retrieve cell execution outputs
-  - `EditNotebookCells` - Add, modify, or delete cells (replaces AddNotebookCell and UpdateNotebookCell)
+  - `EditNotebook` - Add, modify, or delete cells (replaces AddNotebookCell and UpdateNotebookCell)
 - Can view, analyze, and modify notebook cells
 - Can add new code or markdown cells
 - References cells by zero-based index in responses (e.g., "cell 0", "cell 3")
@@ -219,10 +219,10 @@ All notebook tools have `canBeReferencedInPrompt: true` and can be referenced us
 **With notebook mode in Agent mode (notebook attached + active editor + Agent mode):**
 - Notebook-aware assistant with **full manipulation capabilities**
 - Access to all notebook tools:
-  - `GetNotebookCells` - Read cell contents with status information
+  - `GetNotebookInfo` - Read cell contents with status information
   - `GetCellOutputs` - Retrieve cell execution outputs
-  - `RunNotebookCells` - Execute cells in the kernel
-  - `EditNotebookCells` - Add, modify, or delete cells
+  - `ExecuteNotebook` - Execute cells in the kernel
+  - `EditNotebook` - Add, modify, or delete cells
 - Can perform all operations: view, analyze, modify, execute, and create cells
 - References cells by zero-based index in responses (e.g., "cell 0", "cell 3")
 - Understands index shifting when adding/deleting cells
@@ -259,7 +259,7 @@ Notebook instructions are split into mode-specific prompt files following the es
 - **Content:**
   - **Tool usage protocol** with brief "why" explanations (e.g., "breaks notebook state sync")
   - **Anti-pattern examples** showing wrong vs. right approaches using visual symbols (❌/✓)
-  - Read-only tools only (GetNotebookCells, GetCellOutputs)
+  - Read-only tools only (GetNotebookInfo, GetCellOutputs)
   - Concise, action-oriented workflows for analysis and debugging
   - **Exact response templates** for mode handoff:
     - When modifications requested: "I cannot modify cells in Ask mode. Switch to Edit mode to modify cells."
@@ -273,7 +273,7 @@ Notebook instructions are split into mode-specific prompt files following the es
 - **Content:**
   - **Tool usage protocol** with brief "why" explanations for constraints
   - **Anti-pattern examples** showing common mistakes and correct approaches
-  - Read and modification tools (GetNotebookCells, GetCellOutputs, AddNotebookCell, UpdateNotebookCell)
+  - Read and modification tools (GetNotebookInfo, GetCellOutputs, AddNotebookCell, UpdateNotebookCell)
   - **Workflows section** includes mode capabilities as first item, followed by concise workflows:
     - Analyze/explain, Modify, Add, Delete, Debug, Execution requested
   - **Exact response template** for execution requests: "Cannot execute in Edit mode. Switch to Agent mode to run cells."
@@ -287,7 +287,7 @@ Notebook instructions are split into mode-specific prompt files following the es
 - **Content:**
   - **Tool usage protocol** with brief "why" explanations (e.g., "causes sync issues")
   - **Anti-pattern examples** demonstrating wrong approaches (file tools) vs. correct approaches (notebook tools)
-  - Complete tool list (all 5 tools: GetNotebookCells, GetCellOutputs, RunNotebookCells, AddNotebookCell, UpdateNotebookCell)
+  - Complete tool list (all 5 tools: GetNotebookInfo, GetCellOutputs, ExecuteNotebook, AddNotebookCell, UpdateNotebookCell)
   - Concise workflows covering all operations: analyze, modify, add, delete, execute, debug
   - Critical rules with:
     - Zero-based index referencing
@@ -354,7 +354,7 @@ if (!context) {
   - Adding cell at index N: cells N+ shift to N+1, N+2, etc.
   - Deleting cell at index N: cells N+1+ shift down to N, N+1, etc.
 
-The `GetNotebookCells` tool returns cells with complete status information:
+The `GetNotebookInfo` tool returns cells with complete status information:
 - **Index**: Zero-based position in the notebook
 - **Selection status**: 'unselected' | 'selected' | 'active' (where 'active' indicates editing mode)
 - **Execution status**: 'running' | 'pending' | 'idle' (code cells only)
@@ -412,13 +412,13 @@ The chosen approach (attached context detection) provides the cleanest implement
 
 | Scenario | Notebook Attached? | Notebook Active Editor? | Mode | Notebook Mode? | Available Tools |
 |----------|-------------------|------------------------|------|----------------|-----------------|
-| 1 | ✅ Yes | ✅ Yes (same file) | Ask | ✅ ON (Read-only) | GetNotebookCells, GetCellOutputs |
-| 2 | ✅ Yes | ✅ Yes (same file) | Edit | ✅ ON (Modification) | GetNotebookCells, GetCellOutputs, EditNotebookCells |
+| 1 | ✅ Yes | ✅ Yes (same file) | Ask | ✅ ON (Read-only) | GetNotebookInfo, GetCellOutputs |
+| 2 | ✅ Yes | ✅ Yes (same file) | Edit | ✅ ON (Modification) | GetNotebookInfo, GetCellOutputs, EditNotebook |
 | 3 | ✅ Yes | ✅ Yes (same file) | Agent | ✅ ON (Full access) | All 4 tools |
 | 4 | ✅ Yes | ❌ No (different file active) | Any | ❌ OFF | None |
 | 5 | ❌ No | ✅ Yes | Any | ❌ OFF | None |
-| 6 | ✅ Multiple notebooks | ✅ Yes (one is active) | Ask | ✅ ON (Read-only) | GetNotebookCells, GetCellOutputs |
-| 7 | ✅ Multiple notebooks | ✅ Yes (one is active) | Edit | ✅ ON (Modification) | GetNotebookCells, GetCellOutputs, EditNotebookCells |
+| 6 | ✅ Multiple notebooks | ✅ Yes (one is active) | Ask | ✅ ON (Read-only) | GetNotebookInfo, GetCellOutputs |
+| 7 | ✅ Multiple notebooks | ✅ Yes (one is active) | Edit | ✅ ON (Modification) | GetNotebookInfo, GetCellOutputs, EditNotebook |
 | 8 | ✅ Multiple notebooks | ✅ Yes (one is active) | Agent | ✅ ON (Full access) | All 4 tools |
 | 9 | ✅ Multiple notebooks | ❌ No (none active) | Any | ❌ OFF | None |
 
@@ -429,29 +429,29 @@ The chosen approach (attached context detection) provides the cleanest implement
 2. **Open notebook** in Positron notebook editor
 3. **Switch to Ask mode** in the mode selector
 4. **Verify behavior**:
-   - Only read-only tools appear in tool list: `GetNotebookCells`, `GetCellOutputs`
-   - Modification tools do NOT appear: `RunNotebookCells`, `EditNotebookCells`
-   - Read-only tools can be referenced using `#getNotebookCells` and `#getCellOutputs`
+   - Only read-only tools appear in tool list: `GetNotebookInfo`, `GetCellOutputs`
+   - Modification tools do NOT appear: `ExecuteNotebook`, `EditNotebook`
+   - Read-only tools can be referenced using `#getNotebookInfo` and `#getCellOutputs`
    - System prompt includes selected cell information with status
-   - Ask "What does cell 0 do?" → Should work using GetNotebookCells
+   - Ask "What does cell 0 do?" → Should work using GetNotebookInfo
    - Ask "Modify cell 2" → Should respond: "I cannot modify cells in Ask mode. Switch to Edit mode to modify cells."
    - Ask "Run cell 1" → Should respond: "I cannot execute cells in Ask mode. Switch to Agent mode to run cells."
-   - Try referencing: `#getNotebookCells show me all cells` → Should work
+   - Try referencing: `#getNotebookInfo show me all cells` → Should work
 
 #### Test 2: Edit Mode - Modification Access
 1. **Attach notebook file** using `@filename.ipynb` in chat
 2. **Open notebook** in Positron notebook editor
 3. **Switch to Edit mode** in the mode selector
 4. **Verify behavior**:
-   - Modification tools appear in tool list: `GetNotebookCells`, `GetCellOutputs`, `EditNotebookCells`
-   - Execution tools do NOT appear: `RunNotebookCells`
-   - All available tools can be referenced using `#getNotebookCells`, `#getCellOutputs`, `#editNotebookCells`
+   - Modification tools appear in tool list: `GetNotebookInfo`, `GetCellOutputs`, `EditNotebook`
+   - Execution tools do NOT appear: `ExecuteNotebook`
+   - All available tools can be referenced using `#getNotebookInfo`, `#getCellOutputs`, `#editNotebook`
    - Ask "Show me the output of cell 2" → Should use GetCellOutputs
-  - Ask "Update cell 3 to add error handling" → Should use EditNotebookCells with `operation: 'update'`
-  - Ask "Add a new cell after cell 2" → Should use EditNotebookCells with `operation: 'add'` (code cells run by default)
+  - Ask "Update cell 3 to add error handling" → Should use EditNotebook with `operation: 'update'`
+  - Ask "Add a new cell after cell 2" → Should use EditNotebook with `operation: 'add'` (code cells run by default)
    - Ask "Run cell 1" → Should respond: "Cannot execute in Edit mode. Switch to Agent mode to run cells."
-   - Try referencing: `#editNotebookCells modify cell 3` → Should work
-   - Try referencing: `#editNotebookCells add a markdown cell` → Should work
+   - Try referencing: `#editNotebook modify cell 3` → Should work
+   - Try referencing: `#editNotebook add a markdown cell` → Should work
 
 #### Test 3: Agent Mode - Full Access
 1. **Attach notebook file** using `@filename.ipynb` in chat
@@ -459,14 +459,14 @@ The chosen approach (attached context detection) provides the cleanest implement
 3. **Switch to Agent mode** in the mode selector
 4. **Verify behavior**:
    - All 4 notebook tools appear in tool list
-   - All tools can be referenced: `#runNotebookCells`, `#editNotebookCells`, `#getCellOutputs`, `#getNotebookCells`
-  - Request cell modification → Should use EditNotebookCells with `operation: 'update'`
-  - Request cell execution → Should use RunNotebookCells with `cellIndices`
-  - Request adding new cell → Should use EditNotebookCells with `operation: 'add'` (code cells run by default, returns outputs)
+   - All tools can be referenced: `#executeNotebook`, `#editNotebook`, `#getCellOutputs`, `#getNotebookInfo`
+  - Request cell modification → Should use EditNotebook with `operation: 'update'`
+  - Request cell execution → Should use ExecuteNotebook with `cellIndices`
+  - Request adding new cell → Should use EditNotebook with `operation: 'add'` (code cells run by default, returns outputs)
    - Assistant can perform all notebook operations
    - Assistant understands index shifting when adding/deleting cells
-   - Try referencing: `#runNotebookCells execute cell 0` → Should work
-   - Try referencing: `#editNotebookCells add a new markdown cell at the end` → Should work
+   - Try referencing: `#executeNotebook execute cell 0` → Should work
+   - Try referencing: `#editNotebook add a new markdown cell at the end` → Should work
 
 #### Test 4: Without Attached Notebook
 1. **Do NOT attach any notebook file**
@@ -511,17 +511,17 @@ The chosen approach (attached context detection) provides the cleanest implement
 1. **Attach notebook file** using `@filename.ipynb` in chat
 2. **Open notebook** in Positron notebook editor
 3. **Test `#` syntax referencing:**
-   - In Ask mode: Try `#getNotebookCells show all cells` → Should work
+   - In Ask mode: Try `#getNotebookInfo show all cells` → Should work
    - In Ask mode: Try `#getCellOutputs show outputs` → Should work
-   - In Ask mode: Try `#editNotebookCells add cell` → Should suggest switching to Edit mode (tool not available)
-   - In Ask mode: Try `#runNotebookCells execute cell` → Should suggest switching to Agent mode (tool not available)
-   - In Edit mode: Try `#getNotebookCells show all cells` → Should work
-   - In Edit mode: Try `#editNotebookCells add markdown cell` → Should work
-   - In Edit mode: Try `#editNotebookCells update cell 2` → Should work
-   - In Edit mode: Try `#runNotebookCells execute cell` → Should respond: "Cannot execute in Edit mode. Switch to Agent mode to run cells."
-   - In Agent mode: Try `#runNotebookCells execute cell 0` → Should work
-   - In Agent mode: Try `#editNotebookCells add markdown cell` → Should work
-   - In Agent mode: Try `#editNotebookCells update cell 2` → Should work
+   - In Ask mode: Try `#editNotebook add cell` → Should suggest switching to Edit mode (tool not available)
+   - In Ask mode: Try `#executeNotebook execute cell` → Should suggest switching to Agent mode (tool not available)
+   - In Edit mode: Try `#getNotebookInfo show all cells` → Should work
+   - In Edit mode: Try `#editNotebook add markdown cell` → Should work
+   - In Edit mode: Try `#editNotebook update cell 2` → Should work
+   - In Edit mode: Try `#executeNotebook execute cell` → Should respond: "Cannot execute in Edit mode. Switch to Agent mode to run cells."
+   - In Agent mode: Try `#executeNotebook execute cell 0` → Should work
+   - In Agent mode: Try `#editNotebook add markdown cell` → Should work
+   - In Agent mode: Try `#editNotebook update cell 2` → Should work
 4. **Test attachment button:**
    - Click paperclip button in chat
    - Verify notebook tools appear in the attachment list (only available ones based on mode)

--- a/extensions/positron-assistant/src/types.ts
+++ b/extensions/positron-assistant/src/types.ts
@@ -19,9 +19,9 @@ export enum PositronAssistantToolName {
 	DocumentCreate = 'documentCreate',
 	TextSearch = 'positron_findTextInProject_internal',
 	FileContents = 'positron_getFileContents_internal',
-	RunNotebookCells = 'runNotebookCells',
-	EditNotebookCells = 'editNotebookCells',
-	GetNotebookCells = 'getNotebookCells',
+	ExecuteNotebook = 'executeNotebook',
+	EditNotebook = 'editNotebook',
+	GetNotebookInfo = 'getNotebookInfo',
 	CreateNotebook = 'createNotebook',
 }
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2140,6 +2140,13 @@ declare module 'positron' {
 			notebookUri?: vscode.Uri): Thenable<LanguageRuntimeSession>;
 
 		/**
+		 * Interrupt a running session.
+		 *
+		 * @param sessionId The ID of the session to interrupt.
+		 */
+		export function interruptSession(sessionId: string): Thenable<void>;
+
+		/**
 		 * Restart a running session.
 		 *
 		 * @param sessionId The ID of the session to restart.

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2929,5 +2929,12 @@ declare module 'positron' {
 		 * @param cellIndex The index of the cell to scroll to
 		 */
 		export function scrollToCellIfNeeded(notebookUri: string, cellIndex: number): Thenable<void>;
+
+		/**
+		 * Clear cell outputs in a notebook.
+		 * @param notebookUri URI of the notebook
+		 * @param cellIndices Optional array of cell indices to clear. If omitted, clears all cells.
+		 */
+		export function clearCellOutputs(notebookUri: string, cellIndices?: number[]): Thenable<void>;
 	}
 }

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2732,6 +2732,12 @@ declare module 'positron' {
 			 * to fit without taking too much context.
 			 */
 			allCells?: NotebookCell[];
+
+			/**
+			 * The current state of the runtime session (e.g. 'idle', 'busy', 'restarting').
+			 * Undefined if no runtime session is associated with this notebook.
+			 */
+			runtimeState?: string;
 		}
 
 		/**

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -615,6 +615,43 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 	}
 
 	/**
+	 * Clears cell outputs in a notebook.
+	 * If cellIndices is provided, clears only those cells. Otherwise clears all.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param cellIndices Optional array of cell indices to clear.
+	 */
+	async $clearCellOutputs(notebookUri: string, cellIndices?: number[]): Promise<void> {
+		const instance = this._getInstanceByUri(notebookUri);
+		if (!instance) {
+			throw new Error(`No notebook found with URI: ${notebookUri}`);
+		}
+
+		if (cellIndices === undefined) {
+			// Clear all cell outputs
+			instance.clearAllCellOutputs();
+		} else {
+			if (cellIndices.length === 0) {
+				return;
+			}
+
+			const cells = instance.cells.get();
+			const cellCount = cells.length;
+
+			// De-duplicate and sort ascending
+			const uniqueIndices = [...new Set(cellIndices)].sort((a, b) => a - b);
+
+			// Validate all indices
+			for (const idx of uniqueIndices) {
+				if (!Number.isInteger(idx) || idx < 0 || idx >= cellCount) {
+					throw new Error(`Invalid cell index: ${idx}. Must be between 0 and ${cellCount - 1}`);
+				}
+			}
+
+			instance.clearCellOutputsByIndex(uniqueIndices);
+		}
+	}
+
+	/**
 	 * Helper method to ensure and return a notebook's text model.
 	 * Asserts the text model is defined and narrows the type for TypeScript.
 	 * @param instance The notebook instance.

--- a/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadNotebookFeatures.ts
@@ -21,6 +21,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { isImageMimeType, isTextBasedMimeType } from '../../../contrib/positronNotebook/browser/notebookMimeUtils.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY } from '../../../contrib/positronNotebook/common/positronNotebookConfig.js';
+import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 
 /**
  * Main thread implementation of notebook features for extension host communication.
@@ -36,6 +37,7 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		@IPositronNotebookService private readonly _positronNotebookService: IPositronNotebookService,
 		@ILogService private readonly _logService: ILogService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
 	) {
 		// No initialization needed
 	}
@@ -112,13 +114,19 @@ export class MainThreadNotebookFeatures implements MainThreadNotebookFeaturesSha
 		// Include all cells - filtering will be done on the extension side
 		const allCells = cells.map(cell => this.mapCellToDTO(cell));
 
+		// Get runtime state from the session service
+		const notebookUri = instance.uri;
+		const session = this._runtimeSessionService.getNotebookSessionForNotebookUri(notebookUri);
+		const runtimeState = session?.getRuntimeState();
+
 		return {
-			uri: instance.uri.toString(),
+			uri: notebookUri.toString(),
 			kernelId: kernel?.id,
 			kernelLanguage: kernel?.runtime.languageId,
 			cellCount: cells.length,
 			selectedCells,
-			allCells
+			allCells,
+			runtimeState: runtimeState ?? undefined,
 		};
 	}
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -508,6 +508,10 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 			async scrollToCellIfNeeded(notebookUri: string, cellIndex: number): Promise<void> {
 				return extHostNotebookFeatures.scrollToCellIfNeeded(notebookUri, cellIndex);
+			},
+
+			async clearCellOutputs(notebookUri: string, cellIndices?: number[]): Promise<void> {
+				return extHostNotebookFeatures.clearCellOutputs(notebookUri, cellIndices);
 			}
 		};
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -142,6 +142,9 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 					sessionMode,
 					notebookUri);
 			},
+			interruptSession(sessionId: string): Thenable<void> {
+				return extHostLanguageRuntime.interruptSession(sessionId);
+			},
 			restartSession(sessionId: string): Thenable<void> {
 				return extHostLanguageRuntime.restartSession(sessionId);
 			},

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -437,7 +437,8 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 					kernelLanguage: context.kernelLanguage,
 					cellCount: context.cellCount,
 					selectedCells: context.selectedCells,
-					allCells: context.allCells
+					allCells: context.allCells,
+					runtimeState: context.runtimeState
 				};
 			},
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -234,6 +234,7 @@ export interface MainThreadNotebookFeaturesShape extends IDisposable {
 	$moveCell(notebookUri: string, fromIndex: number, toIndex: number): Promise<void>;
 	$reorderCells(notebookUri: string, newOrder: number[]): Promise<void>;
 	$scrollToCellIfNeeded(notebookUri: string, cellIndex: number): Promise<void>;
+	$clearCellOutputs(notebookUri: string, cellIndices?: number[]): Promise<void>;
 }
 
 /**

--- a/src/vs/workbench/api/common/positron/extHostNotebookFeatures.ts
+++ b/src/vs/workbench/api/common/positron/extHostNotebookFeatures.ts
@@ -133,5 +133,14 @@ export class ExtHostNotebookFeatures implements extHostProtocol.ExtHostNotebookF
 	async scrollToCellIfNeeded(notebookUri: string, cellIndex: number): Promise<void> {
 		return this._proxy.$scrollToCellIfNeeded(notebookUri, cellIndex);
 	}
+
+	/**
+	 * Clears cell outputs in a notebook.
+	 * @param notebookUri The URI of the notebook as a string.
+	 * @param cellIndices Optional array of cell indices to clear. If omitted, clears all cells.
+	 */
+	async clearCellOutputs(notebookUri: string, cellIndices?: number[]): Promise<void> {
+		return this._proxy.$clearCellOutputs(notebookUri, cellIndices);
+	}
 }
 

--- a/src/vs/workbench/common/positron/notebookAssistant.ts
+++ b/src/vs/workbench/common/positron/notebookAssistant.ts
@@ -87,4 +87,6 @@ export interface INotebookContextDTO {
 	cellCount: number;
 	selectedCells: INotebookCellDTO[];
 	allCells?: INotebookCellDTO[];
+	/** The current state of the runtime session (e.g. 'idle', 'busy', 'restarting') */
+	runtimeState?: string;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -239,6 +239,12 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	clearAllCellOutputs(): void;
 
 	/**
+	 * Clears outputs from specific cells in the notebook by index.
+	 * @param cellIndices Array of cell indices whose outputs should be cleared.
+	 */
+	clearCellOutputsByIndex(cellIndices: number[]): void;
+
+	/**
 	 * Creates and inserts a new cell into the notebook.
 	 *
 	 * @param type The kind of cell to create (e.g., code, markdown)

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -2152,53 +2152,8 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Clears the outputs of all cells in the notebook.
 	 */
 	clearAllCellOutputs(): void {
-		this._assertTextModel();
-
-		try {
-			const computeUndoRedo = !this.isReadOnly;
-
-			// Clear outputs from all cells
-			this.textModel.cells.forEach((cell, index) => {
-				this.clearCellOutput(this.cells.get()[index], true);
-			});
-
-			// Clear execution metadata for non-executing cells
-			const clearExecutionMetadataEdits = this.textModel.cells.map((cell, index) => {
-				const runState = this.notebookExecutionStateService.getCellExecution(cell.uri)?.state;
-				if (runState !== NotebookCellExecutionState.Executing) {
-					return {
-						editType: CellEditType.PartialInternalMetadata,
-						index,
-						internalMetadata: {
-							runStartTime: null,
-							runStartTimeAdjustment: null,
-							runEndTime: null,
-							executionOrder: null,
-							lastRunSuccess: null
-						}
-					};
-				}
-				return undefined;
-			}).filter((edit): edit is ICellEditOperation & {
-				editType: CellEditType.PartialInternalMetadata;
-				index: number;
-				internalMetadata: {
-					runStartTime: null;
-					runStartTimeAdjustment: null;
-					runEndTime: null;
-					executionOrder: null;
-					lastRunSuccess: null;
-				};
-			} => !!edit);
-
-			if (clearExecutionMetadataEdits.length) {
-				this.textModel.applyEdits(clearExecutionMetadataEdits, true, undefined, () => undefined, undefined, computeUndoRedo);
-			}
-
-		} finally {
-			// Fire a single content change event
-			this._onDidChangeContent.fire();
-		}
+		const allIndices = this.cells.get().map((_, i) => i);
+		this.clearCellOutputsByIndex(allIndices);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -2152,7 +2152,13 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Clears the outputs of all cells in the notebook.
 	 */
 	clearAllCellOutputs(): void {
+		this._assertTextModel();
 		const allIndices = this.cells.get().map((_, i) => i);
+		if (allIndices.length === 0) {
+			// Preserve legacy behavior: always fire content-change even on empty notebooks
+			this._onDidChangeContent.fire();
+			return;
+		}
 		this.clearCellOutputsByIndex(allIndices);
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -2201,6 +2201,56 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		}
 	}
 
+	/**
+	 * Clears outputs from specific cells in the notebook by index.
+	 * @param cellIndices Array of cell indices whose outputs should be cleared.
+	 */
+	clearCellOutputsByIndex(cellIndices: number[]): void {
+		this._assertTextModel();
+
+		if (cellIndices.length === 0) {
+			return;
+		}
+
+		try {
+			const computeUndoRedo = !this.isReadOnly;
+			const cells = this.cells.get();
+
+			// Clear outputs from specified cells
+			for (const idx of cellIndices) {
+				this.clearCellOutput(cells[idx], true);
+			}
+
+			// Clear execution metadata for non-executing cells at specified indices
+			const clearExecutionMetadataEdits: ICellEditOperation[] = [];
+			for (const idx of cellIndices) {
+				const cellModel = this.textModel.cells[idx];
+				const runState = this.notebookExecutionStateService.getCellExecution(cellModel.uri)?.state;
+				if (runState !== NotebookCellExecutionState.Executing) {
+					clearExecutionMetadataEdits.push({
+						editType: CellEditType.PartialInternalMetadata,
+						index: idx,
+						internalMetadata: {
+							runStartTime: null,
+							runStartTimeAdjustment: null,
+							runEndTime: null,
+							executionOrder: null,
+							lastRunSuccess: null
+						}
+					});
+				}
+			}
+
+			if (clearExecutionMetadataEdits.length) {
+				this.textModel.applyEdits(clearExecutionMetadataEdits, true, undefined, () => undefined, undefined, computeUndoRedo);
+			}
+
+		} finally {
+			// Fire a single content change event
+			this._onDidChangeContent.fire();
+		}
+	}
+
 
 	// #endregion
 


### PR DESCRIPTION
Addresses #12094


## Summary

- Rename and expand the three existing notebook assistant tools to cover session-level operations in addition to cell-level operations:
  - `runNotebookCells` -> `executeNotebook`: adds `runAll`, `interrupt`, `restartKernel` operations
  - `getNotebookCells` -> `getNotebookInfo`: adds `getKernelStatus` operation
  - `editNotebookCells` -> `editNotebook`: adds `clearOutputs` operation
- Extend `positron.notebooks.getContext()` with `runtimeState` so extensions can check kernel state (idle, busy, restarting, etc.)
- Filter Jupyter extension notebook tools (`configure_notebook`, `notebook_list_packages`, `notebook_install_packages`, etc.) when Positron notebook mode is active (fixes #12087)

The goal was to keep the tool number small while adding features in an obvious path. In manual testing the model (sonnet 4.6) seems to be pretty good at knowing what to use. 

<img width="519" height="802" alt="image" src="https://github.com/user-attachments/assets/178327f7-cdae-4b36-9483-f9abb7bf26fb" />
<img width="509" height="735" alt="image" src="https://github.com/user-attachments/assets/2a52c811-0c17-4ba7-86fa-bd988c821f87" />

## Details

### New operations

| Tool | Operation | What it does |
|---|---|---|
| `executeNotebook` | `runAll` | Run all cells with output heuristic for large notebooks |
| `executeNotebook` | `interrupt` | Cancel running cell executions |
| `executeNotebook` | `restartKernel` | Restart kernel session, optionally run all cells after |
| `getNotebookInfo` | `getKernelStatus` | Returns kernel language, runtime state, session metadata |
| `editNotebook` | `clearOutputs` | Clear outputs from specific cells or all cells |

### Large notebook output heuristic

`runAll` and `restartKernel` with `runAll: true` use a cell-count threshold: small notebooks return full outputs, large notebooks return per-cell summaries (success/failure, first line of output). The model can drill into specific cells with `getNotebookInfo` if needed.

## Test plan

- [ ] Open a Python notebook, verify `executeNotebook` `run` operation works (existing behavior)
- [ ] Run all cells via assistant in a small notebook (<10 cells), verify full outputs returned
- [ ] Run all cells in a large notebook (>10 cells), verify summary outputs returned
- [ ] Interrupt a long-running cell via assistant
- [ ] Restart kernel via assistant, verify kernel reaches ready state
- [ ] Restart kernel with `runAll: true`, verify cells execute after restart
- [ ] Get kernel status via assistant, verify runtime state is accurate
- [ ] Clear all outputs via assistant
- [ ] Clear specific cell outputs by index via assistant
- [ ] Verify Jupyter extension tools do not appear when Positron notebook mode is active
- [ ] Verify renamed tools appear correctly in tool picker and assistant responses

### e2e test tags
`@:critical @:positron-notebooks @:assistant`