### PR TITLE
Respect `containerEnv` in `devcontainer.json`

### DIFF
--- a/extensions/positron-dev-containers/src/container/terminalBuilder.ts
+++ b/extensions/positron-dev-containers/src/container/terminalBuilder.ts
@@ -311,7 +311,7 @@ export class TerminalBuilder {
 			workspaceFolder,
 			remoteWorkspaceFolder,
 			containerUser: devContainerConfig.remoteUser,
-			env: devContainerConfig.remoteEnv,
+			env: devContainerConfig.containerEnv,
 			mounts,
 			labels: {
 				'devcontainer.local_folder': workspaceFolder,

--- a/extensions/positron-dev-containers/src/container/terminalBuilder.ts
+++ b/extensions/positron-dev-containers/src/container/terminalBuilder.ts
@@ -11,7 +11,7 @@ import * as jsonc from 'jsonc-parser';
 import { getLogger } from '../common/logger';
 import { Configuration } from '../common/configuration';
 import { generateDockerBuildCommand, generateDockerCreateCommand } from '../spec/spec-node/devContainersSpecCLI';
-import { formatCommandWithEcho, escapeShellArg } from '../spec/spec-node/commandGeneration';
+import { formatCommandWithEcho, formatCommandForShell, escapeShellArg } from '../spec/spec-node/commandGeneration';
 import { prepareFeaturesInstallation, generateFeatureInstallScript, cleanupFeaturesDir } from './featuresInstaller';
 import { Mount } from '../spec/spec-configuration/containerFeaturesConfiguration';
 
@@ -347,7 +347,7 @@ export class TerminalBuilder {
 			scriptContent += '}\n\n';
 		} else {
 			scriptContent += 'echo "==> Creating container..."\n';
-			scriptContent += `CONTAINER_ID=$(${dockerPath} ${createCmd.args.join(' ')})\n`;
+			scriptContent += `CONTAINER_ID=$(${formatCommandForShell(createCmd)})\n`;
 			scriptContent += 'echo "Container ID: $CONTAINER_ID"\n\n';
 
 			scriptContent += 'echo "==> Starting container..."\n';

--- a/extensions/positron-dev-containers/src/remote/connectionManager.ts
+++ b/extensions/positron-dev-containers/src/remote/connectionManager.ts
@@ -5,8 +5,8 @@
 
 import * as vscode from 'vscode';
 import * as fs from 'fs';
-import * as path from 'path';
 import * as jsonc from 'jsonc-parser';
+import { URI } from 'vscode-uri';
 import { Logger } from '../common/logger';
 import { PortForwardingManager } from './portForwarding';
 import { installAndStartServer } from '../server/serverInstaller';
@@ -15,6 +15,8 @@ import { getDevContainerManager } from '../container/devContainerManager';
 import { decodeDevContainerAuthority } from '../common/authorityEncoding';
 import { WorkspaceMappingStorage } from '../common/workspaceMappingStorage';
 import { getConfiguration } from '../common/configuration';
+import { Workspace } from '../common/workspace';
+import { substitute } from '../spec/spec-common/variableSubstitution';
 
 /**
  * Connection state
@@ -510,19 +512,37 @@ export class ConnectionManager {
 	 */
 	private readRemoteEnv(workspacePath: string): Record<string, string> | undefined {
 		try {
-			// Check both standard devcontainer.json locations
-			let configPath = path.join(workspacePath, '.devcontainer', 'devcontainer.json');
-			if (!fs.existsSync(configPath)) {
-				configPath = path.join(workspacePath, '.devcontainer.json');
-				if (!fs.existsSync(configPath)) {
-					this.logger.debug('No devcontainer.json found for remoteEnv');
-					return undefined;
-				}
+			// Use Workspace helper to find the devcontainer.json path
+			const workspaceFolder: vscode.WorkspaceFolder = {
+				uri: vscode.Uri.file(workspacePath),
+				name: workspacePath.split(/[/\\]/).pop() || 'workspace',
+				index: 0
+			};
+			const paths = Workspace.getDevContainerPaths(workspaceFolder);
+			if (!paths) {
+				this.logger.debug('No devcontainer.json found for remoteEnv');
+				return undefined;
 			}
 
-			const config = jsonc.parse(fs.readFileSync(configPath, 'utf8'));
+			const config = jsonc.parse(fs.readFileSync(paths.devContainerJsonPath, 'utf8'));
 			if (config.remoteEnv && typeof config.remoteEnv === 'object') {
-				return config.remoteEnv;
+				// Validate that all values are strings
+				const result: Record<string, string> = {};
+				for (const [key, value] of Object.entries(config.remoteEnv)) {
+					if (typeof value === 'string') {
+						result[key] = value;
+					} else if (value !== null && value !== undefined) {
+						this.logger.debug(`Skipping non-string remoteEnv value for key "${key}"`);
+					}
+				}
+
+				// Expand variable references like ${localEnv:PATH}
+				return substitute({
+					platform: process.platform,
+					configFile: URI.file(paths.devContainerJsonPath),
+					localWorkspaceFolder: workspacePath,
+					env: process.env,
+				}, result);
 			}
 			return undefined;
 		} catch (error) {

--- a/extensions/positron-dev-containers/src/remote/connectionManager.ts
+++ b/extensions/positron-dev-containers/src/remote/connectionManager.ts
@@ -4,6 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as jsonc from 'jsonc-parser';
 import { Logger } from '../common/logger';
 import { PortForwardingManager } from './portForwarding';
 import { installAndStartServer } from '../server/serverInstaller';
@@ -161,6 +164,15 @@ export class ConnectionManager {
 				this.logger.debug(`Setting CONTAINER_WORKSPACE_FOLDER: ${remoteWorkspacePath}`);
 			} else {
 				this.logger.debug('No remoteWorkspacePath available');
+			}
+
+			// Add remoteEnv from devcontainer.json to the extension host environment
+			if (localWorkspacePath) {
+				const remoteEnv = this.readRemoteEnv(localWorkspacePath);
+				if (remoteEnv) {
+					Object.assign(extensionHostEnv, remoteEnv);
+					this.logger.debug(`Merged remoteEnv from devcontainer.json: ${Object.keys(remoteEnv).join(', ')}`);
+				}
 			}
 
 			// 3. Install Positron server with environment variables
@@ -490,6 +502,33 @@ export class ConnectionManager {
 			POSITRON_REMOTE_ENV: 'devcontainer',
 			// Add other environment variables as needed
 		};
+	}
+
+	/**
+	 * Read remoteEnv from the devcontainer.json for a workspace folder.
+	 * Returns the remoteEnv record, or undefined if the config cannot be read.
+	 */
+	private readRemoteEnv(workspacePath: string): Record<string, string> | undefined {
+		try {
+			// Check both standard devcontainer.json locations
+			let configPath = path.join(workspacePath, '.devcontainer', 'devcontainer.json');
+			if (!fs.existsSync(configPath)) {
+				configPath = path.join(workspacePath, '.devcontainer.json');
+				if (!fs.existsSync(configPath)) {
+					this.logger.debug('No devcontainer.json found for remoteEnv');
+					return undefined;
+				}
+			}
+
+			const config = jsonc.parse(fs.readFileSync(configPath, 'utf8'));
+			if (config.remoteEnv && typeof config.remoteEnv === 'object') {
+				return config.remoteEnv;
+			}
+			return undefined;
+		} catch (error) {
+			this.logger.debug('Failed to read remoteEnv from devcontainer.json', error);
+			return undefined;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Respects the `containerEnv` setting in `devcontainer.json`.

<img width="809" height="746" alt="image" src="https://github.com/user-attachments/assets/f2f34a20-ef37-450d-b264-7fe1dbb547a6" />

Formerly, we were incorrectly using `remoteEnv` here. Also moves `removeEnv` processing to the correct spot.

Addresses #11989.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Respect environment variables set in `containerEnv`  for Dev Containers (#11989). 


### QA Notes

The screenshot above shows an example usage.
