### PR TITLE
Update handling of R display name for `r-versions`, Homebrew

### DIFF
--- a/extensions/positron-r/src/provider-rversions.ts
+++ b/extensions/positron-r/src/provider-rversions.ts
@@ -6,7 +6,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { RBinary } from './provider.js';
-import { ReasonDiscovered } from './r-installation.js';
+import { ReasonDiscovered, RVersionsMetadata } from './r-installation.js';
 import { LOGGER } from './extension.js';
 
 /**
@@ -214,10 +214,17 @@ export async function discoverRVersionsBinaries(): Promise<RBinary[]> {
 			continue;
 		}
 
+		// Build metadata from r-versions entry fields
+		const metadata: RVersionsMetadata = {
+			type: 'rversions',
+			label: entry.label,
+			// Future PRs will add: script, repo, library
+		};
+
 		binaries.push({
 			path: binPath,
 			reasons: [ReasonDiscovered.RVERSIONS],
-			// Future PRs will add metadata for label, script, repo, library
+			packagerMetadata: metadata,
 		});
 
 		LOGGER.info(`Found R at ${binPath} from r-versions file`);

--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -12,7 +12,7 @@ import which from 'which';
 import * as positron from 'positron';
 import * as crypto from 'crypto';
 
-import { RInstallation, RMetadataExtra, getRHomePath, ReasonDiscovered, friendlyReason, PackagerMetadata, isPixiMetadata, isModuleMetadata, isCondaMetadata, ModuleMetadata } from './r-installation';
+import { RInstallation, RMetadataExtra, getRHomePath, ReasonDiscovered, friendlyReason, PackagerMetadata, isPixiMetadata, isModuleMetadata, isCondaMetadata, isRVersionsMetadata, ModuleMetadata } from './r-installation';
 import { LOGGER } from './extension';
 import { EXTENSION_ROOT_DIR, MINIMUM_R_VERSION } from './constants';
 import { getInterpreterOverridePaths, printInterpreterSettingsInfo, userRBinaries, userRHeadquarters } from './interpreter-settings.js';
@@ -231,6 +231,8 @@ async function getBinaries(): Promise<DiscoveredBinaries> {
 
 /**
  * Deduplicate a list of R binaries, merging the reasons for each binary.
+ * When the same binary is found via multiple sources, prefer r-versions metadata
+ * with a label since it provides a custom display name.
  * @param binaries Binaries to deduplicate
  * @returns Deduplicated binaries
  */
@@ -239,7 +241,14 @@ function deduplicateRBinaries(binaries: RBinary[]) {
 		if (acc.has(binary.path)) {
 			const existingBinary = acc.get(binary.path)!;
 			const mergedReasons = Array.from(new Set([...existingBinary.reasons, ...binary.reasons]));
-			acc.set(binary.path, { ...existingBinary, reasons: mergedReasons });
+
+			// Prefer r-versions metadata with a label over other metadata
+			let preferredMetadata = existingBinary.packagerMetadata;
+			if (binary.packagerMetadata && isRVersionsMetadata(binary.packagerMetadata) && binary.packagerMetadata.label) {
+				preferredMetadata = binary.packagerMetadata;
+			}
+
+			acc.set(binary.path, { ...existingBinary, reasons: mergedReasons, packagerMetadata: preferredMetadata });
 		} else {
 			acc.set(binary.path, binary);
 		}
@@ -295,15 +304,23 @@ export async function makeMetadata(
 	const runtimeShortName = includeArch ? `${rInst.version} (${rInst.arch})` : rInst.version;
 
 	// Full name shown to users
-	let packagerAmendment = '';
-	if (isModuleInstallation && rInst.packagerMetadata && isModuleMetadata(rInst.packagerMetadata)) {
-		packagerAmendment = ` (Module: ${rInst.packagerMetadata.environmentName})`;
-	} else if (isCondaInstallation && rInst.packagerMetadata && isCondaMetadata(rInst.packagerMetadata)) {
-		packagerAmendment = ` (Conda: ${path.basename(rInst.packagerMetadata.environmentPath)})`;
-	} else if (isPixiInstallation && rInst.packagerMetadata && isPixiMetadata(rInst.packagerMetadata)) {
-		packagerAmendment = ` (Pixi: ${rInst.packagerMetadata.environmentName || path.basename(rInst.packagerMetadata.environmentPath)})`;
+	// If r-versions metadata has a custom label, use it as the complete runtime name
+	let runtimeName: string;
+	if (rInst.packagerMetadata && isRVersionsMetadata(rInst.packagerMetadata) && rInst.packagerMetadata.label) {
+		runtimeName = rInst.packagerMetadata.label;
+	} else {
+		let packagerAmendment = '';
+		if (isModuleInstallation && rInst.packagerMetadata && isModuleMetadata(rInst.packagerMetadata)) {
+			packagerAmendment = ` (Module: ${rInst.packagerMetadata.environmentName})`;
+		} else if (isCondaInstallation && rInst.packagerMetadata && isCondaMetadata(rInst.packagerMetadata)) {
+			packagerAmendment = ` (Conda: ${path.basename(rInst.packagerMetadata.environmentPath)})`;
+		} else if (isPixiInstallation && rInst.packagerMetadata && isPixiMetadata(rInst.packagerMetadata)) {
+			packagerAmendment = ` (Pixi: ${rInst.packagerMetadata.environmentName || path.basename(rInst.packagerMetadata.environmentPath)})`;
+		} else if (isHomebrewInstallation) {
+			packagerAmendment = ' (Homebrew)';
+		}
+		runtimeName = `R ${runtimeShortName}${packagerAmendment}`;
 	}
-	const runtimeName = `R ${runtimeShortName}${packagerAmendment}`;
 
 	// Get the version of this extension from package.json so we can pass it
 	// to the adapter as the implementation version.

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -116,10 +116,21 @@ export interface ModuleMetadata {
 }
 
 /**
- * Packager metadata - Conda, Pixi, or Module.
- * Check ReasonDiscovered.CONDA, ReasonDiscovered.PIXI, or ReasonDiscovered.MODULE to determine which type.
+ * Metadata for an R installation from an r-versions configuration file.
  */
-export type PackagerMetadata = CondaMetadata | PixiMetadata | ModuleMetadata;
+export interface RVersionsMetadata {
+	/** Identifies this as an r-versions entry */
+	readonly type: 'rversions';
+	/** User-friendly display name from the Label field */
+	readonly label?: string;
+	// Future PRs will add: script, repo, library
+}
+
+/**
+ * Packager metadata - Conda, Pixi, Module, or RVersions.
+ * Check ReasonDiscovered.CONDA, ReasonDiscovered.PIXI, ReasonDiscovered.MODULE, or ReasonDiscovered.RVERSIONS to determine which type.
+ */
+export type PackagerMetadata = CondaMetadata | PixiMetadata | ModuleMetadata | RVersionsMetadata;
 
 /**
  * Type guard to check if packager metadata is from Pixi (has manifestPath).
@@ -140,6 +151,13 @@ export function isCondaMetadata(metadata: PackagerMetadata): metadata is CondaMe
  */
 export function isModuleMetadata(metadata: PackagerMetadata): metadata is ModuleMetadata {
 	return 'type' in metadata && metadata.type === 'module';
+}
+
+/**
+ * Type guard to check if packager metadata is from an r-versions configuration file (has type: 'rversions').
+ */
+export function isRVersionsMetadata(metadata: PackagerMetadata): metadata is RVersionsMetadata {
+	return 'type' in metadata && metadata.type === 'rversions';
 }
 
 export function friendlyReason(reason: ReasonDiscovered | ReasonRejected | null): string {

--- a/extensions/positron-r/src/runtime-manager.ts
+++ b/extensions/positron-r/src/runtime-manager.ts
@@ -185,9 +185,9 @@ export class RRuntimeManager implements positron.LanguageRuntimeManager {
 			// More thoughts in this issue:
 			// https://github.com/posit-dev/positron/issues/2659
 			curBin.reasons.unshift(ReasonDiscovered.affiliated);
-			inst = new RInstallation(curBin.path, true, curBin.reasons);
+			inst = new RInstallation(curBin.path, true, curBin.reasons, metadataExtra.packagerMetadata);
 		} else {
-			inst = new RInstallation(metadataExtra.binpath, curBin?.path === metadataExtra.binpath, [ReasonDiscovered.affiliated]);
+			inst = new RInstallation(metadataExtra.binpath, curBin?.path === metadataExtra.binpath, [ReasonDiscovered.affiliated], metadataExtra.packagerMetadata);
 		}
 
 		// Check the installation for validity


### PR DESCRIPTION
Addresses:

- #11426
- #6996

This PR adds support for the `Label` field from the r-versions configuration file, allowing administrators to specify custom display names for R installations in the interpreter picker. When an r-versions entry includes a Label field (e.g., `Label: R 4.3.0 (Production)`), that label is used as the runtime's display name in the UI.

This is the second PR in the r-versions implementation series! The first PR (#12022) added basic discovery of R installations from the r-versions file; this PR enables the custom labeling feature:

<img width="1443" height="1052" alt="Screenshot 2026-02-24 at 6 58 56 PM" src="https://github.com/user-attachments/assets/a91d479d-0a00-498a-9f1a-a7e6ff4aed18" />

Additionally, this PR adds "(Homebrew)" to the display name for Homebrew R installations, addressing what I believe is remaining for #6996. Things have changed since we wrote that issue and we already update the display name for many provider types, with results like "R 4.3.0 (Conda: envname)" and "R 4.3.0 (Module: envname)". I think adding Homebrew here will wrap that issue up.

### Release Notes

#### New Features

- N/A for now!

#### Bug Fixes

- N/A

### QA Notes

@:interpreter

- Create a test r-versions file at `~/Library/Preferences/rstudio/r-versions` (macOS) or `/etc/rstudio/r-versions` (Linux) with content like this (a real path to find R):

   ```
   Path: /Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
   Label: R 4.3.3 (Mashed Potatoes)
   ```

- Restart Positron and open the interpreter picker
- Verify the custom label appears instead of the auto-generated name
- If you have Homebrew R installed, verify it shows "(Homebrew)" in the display name
