### PR TITLE
Bump Ark to 0.1.230

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -1078,7 +1078,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.229"
+      "ark": "0.1.230"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
- https://github.com/posit-dev/ark/pull/1039
  Addresses https://github.com/posit-dev/positron/issues/8939

- https://github.com/posit-dev/ark/pull/1044
  Closes https://github.com/posit-dev/positron/issues/11890

- https://github.com/posit-dev/ark/pull/1047
  Addresses posit-dev/positron#8979
  Addresses posit-dev/positron#12021

- https://github.com/posit-dev/ark/pull/1048
  Addresses posit-dev/positron#11889

### Release Notes

#### New Features

- Classed lists like data frames or model results can now be expanded in the debugger's variables pane (#8939).

- Virtual sources generated while stepping in the debugger now show the function name in the source to make where R is paused clearer (#11889).

#### Bug Fixes

- Fixed a debugger crash that occurred under some circumstances (#8979, #12021)

- The R debugger now disables the JIT compiler before executing the "stepping into" gesture. This prevents the debugger from confusingly pausing in the compiler's internal frames (#11890).


### QA Notes

See linked PRs.

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:ark