### PR TITLE
Bump Ark to 0.1.231

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -1078,7 +1078,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.230"
+      "ark": "0.1.231"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
- https://github.com/posit-dev/ark/pull/1041
  Addresses https://github.com/posit-dev/ark/issues/1035
  Addresses #11784

- https://github.com/posit-dev/ark/pull/1042
  Addresses #11891

- https://github.com/posit-dev/ark/pull/1043
  Addresses #11892

- https://github.com/posit-dev/ark/pull/1036
  Addresses #11797
  Addresses #11799
  Addresses #12085


### Release Notes

#### New Features

- Shiny is now fully supported by the R debugger (#11784). Please update to the latest version of the `shiny` package to get full support.

- The R debugger now supports error and warning breakpoints (#11797). Set these in the Breakpoints pane to drop in the debugger as soon as an error or warning is emitted.

- The R debugger can now be invoked while R code is running (#11799). You can either run the command "Debug: Pause", or check the Interrupt breakpoint option in the Breakpoints pane and interrupt R. This feature allows you to peak at what R is doing while running long computations or stucked in an infinite loop. You can even resume the computation by clicking on Continue in the Debug Toolbar.

- Shiny internals are now excluded from call stack by default (#11892). Set the global option `"ark.debugger.show_hidden_frames"` to `"fenced"` to show them (or to `TRUE` to show all hidden frames).


#### Bug Fixes

- Long call stacks in the debugger are no longer truncated (#11891).

- The debugger's `source()` hook now returns the last value, consistently with `base::source()` (https://github.com/posit-dev/ark/issues/1035).

- Backtraces of errors emitted while in the debugger are now properly stored in the Console (#12085).



### QA Notes

See notes in linked PRs

@:ark