### PR TITLE
ci: fail e2e merge job when shard reports are missing

### DIFF
--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -375,29 +375,41 @@ jobs:
 
       - name: Verify all shard reports received
         id: verify-reports
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           EXPECTED_SHARDS=${{ inputs.shards }}
+          PROJECT="${{ inputs.project }}"
           echo "Expected shard count: $EXPECTED_SHARDS"
 
-          # Count the number of blob report artifacts that were downloaded
-          # Each shard produces a report.zip file in the blob-report directory
-          REPORT_COUNT=$(find all-blob-reports -name "report-*.zip" 2>/dev/null | wc -l)
-          echo "Found $REPORT_COUNT blob report(s)"
+          # Query GitHub API for artifacts in this run matching our pattern
+          # This is more reliable than counting files since artifact names are deterministic
+          ARTIFACTS=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts --jq '.artifacts[].name' | grep "^blob-report-${PROJECT}-" || true)
+          ARTIFACT_COUNT=$(echo "$ARTIFACTS" | grep -c . || echo 0)
 
-          if [ "$REPORT_COUNT" -lt "$EXPECTED_SHARDS" ]; then
-            echo "::warning::Missing blob reports! Expected $EXPECTED_SHARDS but found $REPORT_COUNT"
-            echo "This typically means one or more shards crashed before uploading their results."
+          echo "Found artifacts:"
+          echo "$ARTIFACTS"
+          echo ""
+          echo "Artifact count: $ARTIFACT_COUNT"
+
+          # Check which shards are missing
+          MISSING_SHARDS=""
+          for i in $(seq 1 $EXPECTED_SHARDS); do
+            if ! echo "$ARTIFACTS" | grep -q "^blob-report-${PROJECT}-${i}$"; then
+              MISSING_SHARDS="$MISSING_SHARDS $i"
+            fi
+          done
+
+          if [ -n "$MISSING_SHARDS" ]; then
+            echo "::warning::Missing blob reports for shards:$MISSING_SHARDS"
+            echo "This typically means these shards crashed before uploading their results."
             echo "missing_reports=true" >> $GITHUB_OUTPUT
-            echo "report_count=$REPORT_COUNT" >> $GITHUB_OUTPUT
+            echo "missing_shards=$MISSING_SHARDS" >> $GITHUB_OUTPUT
           else
             echo "All $EXPECTED_SHARDS shard reports received"
             echo "missing_reports=false" >> $GITHUB_OUTPUT
-            echo "report_count=$REPORT_COUNT" >> $GITHUB_OUTPUT
+            echo "missing_shards=" >> $GITHUB_OUTPUT
           fi
-
-          # List what we have for debugging
-          echo "Contents of all-blob-reports:"
-          ls -la all-blob-reports/ || true
 
       - name: Merge Playwright Blob Reports, Generate HTML and JSON Reports
         working-directory: playwright-merge
@@ -448,8 +460,8 @@ jobs:
           if [[ "${{ steps.verify-reports.outputs.missing_reports }}" == "true" ]]; then
             echo ""
             echo "::error::Missing shard reports detected!"
-            echo "Expected ${{ inputs.shards }} shard reports but only received ${{ steps.verify-reports.outputs.report_count }}."
-            echo "One or more shards likely crashed or timed out before uploading results."
+            echo "Missing reports from shards:${{ steps.verify-reports.outputs.missing_shards }}"
+            echo "These shards likely crashed or timed out before uploading results."
             echo "Check the individual shard jobs above for errors."
             exit 1
           fi

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -373,6 +373,32 @@ jobs:
           pattern: blob-report-${{ inputs.project }}-*
           merge-multiple: true
 
+      - name: Verify all shard reports received
+        id: verify-reports
+        run: |
+          EXPECTED_SHARDS=${{ inputs.shards }}
+          echo "Expected shard count: $EXPECTED_SHARDS"
+
+          # Count the number of blob report artifacts that were downloaded
+          # Each shard produces a report.zip file in the blob-report directory
+          REPORT_COUNT=$(find all-blob-reports -name "report-*.zip" 2>/dev/null | wc -l)
+          echo "Found $REPORT_COUNT blob report(s)"
+
+          if [ "$REPORT_COUNT" -lt "$EXPECTED_SHARDS" ]; then
+            echo "::warning::Missing blob reports! Expected $EXPECTED_SHARDS but found $REPORT_COUNT"
+            echo "This typically means one or more shards crashed before uploading their results."
+            echo "missing_reports=true" >> $GITHUB_OUTPUT
+            echo "report_count=$REPORT_COUNT" >> $GITHUB_OUTPUT
+          else
+            echo "All $EXPECTED_SHARDS shard reports received"
+            echo "missing_reports=false" >> $GITHUB_OUTPUT
+            echo "report_count=$REPORT_COUNT" >> $GITHUB_OUTPUT
+          fi
+
+          # List what we have for debugging
+          echo "Contents of all-blob-reports:"
+          ls -la all-blob-reports/ || true
+
       - name: Merge Playwright Blob Reports, Generate HTML and JSON Reports
         working-directory: playwright-merge
         run: |
@@ -417,6 +443,16 @@ jobs:
           fi
 
           node scripts/check-soft-fail-failures.js "$JSON_REPORT" $EXTRA_ARGS
+
+          # Fail if we're missing reports from any shards (even if all available tests passed)
+          if [[ "${{ steps.verify-reports.outputs.missing_reports }}" == "true" ]]; then
+            echo ""
+            echo "::error::Missing shard reports detected!"
+            echo "Expected ${{ inputs.shards }} shard reports but only received ${{ steps.verify-reports.outputs.report_count }}."
+            echo "One or more shards likely crashed or timed out before uploading results."
+            echo "Check the individual shard jobs above for errors."
+            exit 1
+          fi
 
       - name: Clean up blob report artifacts
         if: success()

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -521,29 +521,41 @@ jobs:
       - name: Verify all shard reports received
         id: verify-reports
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           EXPECTED_SHARDS=${{ inputs.shards }}
+          PROJECT="${{ inputs.project }}"
           echo "Expected shard count: $EXPECTED_SHARDS"
 
-          # Count the number of blob report artifacts that were downloaded
-          # Each shard produces a report.zip file in the blob-report directory
-          REPORT_COUNT=$(find all-blob-reports -name "report-*.zip" 2>/dev/null | wc -l)
-          echo "Found $REPORT_COUNT blob report(s)"
+          # Query GitHub API for artifacts in this run matching our pattern
+          # This is more reliable than counting files since artifact names are deterministic
+          ARTIFACTS=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts --jq '.artifacts[].name' | grep "^blob-report-${PROJECT}-" || true)
+          ARTIFACT_COUNT=$(echo "$ARTIFACTS" | grep -c . || echo 0)
 
-          if [ "$REPORT_COUNT" -lt "$EXPECTED_SHARDS" ]; then
-            echo "::warning::Missing blob reports! Expected $EXPECTED_SHARDS but found $REPORT_COUNT"
-            echo "This typically means one or more shards crashed before uploading their results."
+          echo "Found artifacts:"
+          echo "$ARTIFACTS"
+          echo ""
+          echo "Artifact count: $ARTIFACT_COUNT"
+
+          # Check which shards are missing
+          MISSING_SHARDS=""
+          for i in $(seq 1 $EXPECTED_SHARDS); do
+            if ! echo "$ARTIFACTS" | grep -q "^blob-report-${PROJECT}-${i}$"; then
+              MISSING_SHARDS="$MISSING_SHARDS $i"
+            fi
+          done
+
+          if [ -n "$MISSING_SHARDS" ]; then
+            echo "::warning::Missing blob reports for shards:$MISSING_SHARDS"
+            echo "This typically means these shards crashed before uploading their results."
             echo "missing_reports=true" >> $GITHUB_OUTPUT
-            echo "report_count=$REPORT_COUNT" >> $GITHUB_OUTPUT
+            echo "missing_shards=$MISSING_SHARDS" >> $GITHUB_OUTPUT
           else
             echo "All $EXPECTED_SHARDS shard reports received"
             echo "missing_reports=false" >> $GITHUB_OUTPUT
-            echo "report_count=$REPORT_COUNT" >> $GITHUB_OUTPUT
+            echo "missing_shards=" >> $GITHUB_OUTPUT
           fi
-
-          # List what we have for debugging
-          echo "Contents of all-blob-reports:"
-          ls -la all-blob-reports/ || true
 
       - name: Merge Playwright Blob Reports, Generate HTML and JSON Reports
         shell: bash
@@ -597,8 +609,8 @@ jobs:
           if [[ "${{ steps.verify-reports.outputs.missing_reports }}" == "true" ]]; then
             echo ""
             echo "::error::Missing shard reports detected!"
-            echo "Expected ${{ inputs.shards }} shard reports but only received ${{ steps.verify-reports.outputs.report_count }}."
-            echo "One or more shards likely crashed or timed out before uploading results."
+            echo "Missing reports from shards:${{ steps.verify-reports.outputs.missing_shards }}"
+            echo "These shards likely crashed or timed out before uploading results."
             echo "Check the individual shard jobs above for errors."
             exit 1
           fi

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -518,6 +518,33 @@ jobs:
           pattern: blob-report-${{ inputs.project }}-*
           merge-multiple: true
 
+      - name: Verify all shard reports received
+        id: verify-reports
+        shell: bash
+        run: |
+          EXPECTED_SHARDS=${{ inputs.shards }}
+          echo "Expected shard count: $EXPECTED_SHARDS"
+
+          # Count the number of blob report artifacts that were downloaded
+          # Each shard produces a report.zip file in the blob-report directory
+          REPORT_COUNT=$(find all-blob-reports -name "report-*.zip" 2>/dev/null | wc -l)
+          echo "Found $REPORT_COUNT blob report(s)"
+
+          if [ "$REPORT_COUNT" -lt "$EXPECTED_SHARDS" ]; then
+            echo "::warning::Missing blob reports! Expected $EXPECTED_SHARDS but found $REPORT_COUNT"
+            echo "This typically means one or more shards crashed before uploading their results."
+            echo "missing_reports=true" >> $GITHUB_OUTPUT
+            echo "report_count=$REPORT_COUNT" >> $GITHUB_OUTPUT
+          else
+            echo "All $EXPECTED_SHARDS shard reports received"
+            echo "missing_reports=false" >> $GITHUB_OUTPUT
+            echo "report_count=$REPORT_COUNT" >> $GITHUB_OUTPUT
+          fi
+
+          # List what we have for debugging
+          echo "Contents of all-blob-reports:"
+          ls -la all-blob-reports/ || true
+
       - name: Merge Playwright Blob Reports, Generate HTML and JSON Reports
         shell: bash
         working-directory: playwright-merge
@@ -565,6 +592,16 @@ jobs:
           fi
 
           node scripts/check-soft-fail-failures.js "$JSON_REPORT" $EXTRA_ARGS
+
+          # Fail if we're missing reports from any shards (even if all available tests passed)
+          if [[ "${{ steps.verify-reports.outputs.missing_reports }}" == "true" ]]; then
+            echo ""
+            echo "::error::Missing shard reports detected!"
+            echo "Expected ${{ inputs.shards }} shard reports but only received ${{ steps.verify-reports.outputs.report_count }}."
+            echo "One or more shards likely crashed or timed out before uploading results."
+            echo "Check the individual shard jobs above for errors."
+            exit 1
+          fi
 
       - name: Clean up blob report artifacts
         if: success()


### PR DESCRIPTION
## Summary
- Add verification in merge-reports job that all expected shard artifacts exist
- Fail the job if any shard crashed or timed out before uploading its blob report
- Partial reports are still merged and uploaded to S3 for debugging

## Problem
When a shard fails completely (crashes, times out, etc.) before uploading its blob report, the merge-reports job only sees reports from successful shards. If all tests in those available reports passed, the workflow incorrectly reports success.

The Slack status reporter monitors the final merged job names (`e2e-windows`, `e2e-electron`, etc.), not individual shard jobs (`e2e-windows-1`, `e2e-windows-2`, etc.). This means a crashed shard can go unnoticed if the merge job doesn't explicitly detect the missing report.

Example: https://github.com/posit-dev/positron/actions/runs/22355981083

## Solution
Query the GitHub Actions artifacts API to verify all expected shard artifacts exist (`blob-report-<project>-1` through `blob-report-<project>-N`). This approach is more robust than counting files because:
- Artifact names are deterministic and under our control
- Not dependent on Playwright's internal blob report file naming conventions
- Reports exactly which shards are missing for easier debugging

## QA Notes
Monitoring full suite run here: https://github.com/posit-dev/positron/actions/workflows/test-full-suite.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)