### PR TITLE
Fix spacing/padding in runtime session attachment icon

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/media/positronChat.css
+++ b/src/vs/workbench/contrib/chat/browser/widget/media/positronChat.css
@@ -1,13 +1,29 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
+/* Specificity must beat (0,3,0) from upstream chat.css. */
+.interactive-session .chat-attached-context .chat-attached-context-attachment.runtime-session-context-attachment {
+	align-items: center;
+	gap: 4px;
+	padding-inline: 4px;
+	/* Prevent the text wrapping in narrow contexts */
+	white-space: nowrap;
+}
 
+/* Reset margin-right since .monaco-icon-label already has gap: 4px. */
 .runtime-session-context-attachment .monaco-icon-label-iconpath {
 	width: 14px;
 	height: 14px;
-	padding-left: 2px;
-	margin-top: 2px;
+	margin: 0;
+	padding: 0;
+	align-self: center;
+}
+
+/* Specificity must beat (0,4,0) from upstream. */
+.interactive-session .chat-attached-context .chat-attached-context-attachment.runtime-session-context-attachment .monaco-button {
+	margin-top: 0;
+	height: 100%;
 }
 
 .chat-token-usage-status {


### PR DESCRIPTION
I noticed that our button/pill for attached runtime sessions was a bit funky with spacing and often looked bad when the session name was long (something that happens often in notebooks where the session is named the notebook file name). 

The fix was to just readjust some of the spacing and gaps in the content. 

### Old view 
_Note the lack of inline padding for icon and the lack of space between the session name and type-hint._
<img width="346" height="124" alt="image" src="https://github.com/user-attachments/assets/ee090ee3-809b-4b88-ace5-6a97502ecfdf" />


### New view
<img width="282" height="32" alt="image" src="https://github.com/user-attachments/assets/594c0b88-f0f1-4391-aa11-9db70a4e2e34" />


### Super narrow 
<img width="194" height="120" alt="image" src="https://github.com/user-attachments/assets/9683f791-f5ed-47b3-b07b-b4f83f887911" />
