### PR TITLE
Add 'Clear Output' to notebook cell output context menu

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -229,6 +229,11 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	runAllCells(): Promise<void>;
 
 	/**
+	 * Clears the output of a specific cell, or the active cell if none is provided.
+	 */
+	clearCellOutput(cell?: IPositronNotebookCell, skipContentEvent?: boolean): void;
+
+	/**
 	 * Clears all output from all cells in the notebook.
 	 */
 	clearAllCellOutputs(): void;

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1577,7 +1577,11 @@ registerAction2(class extends NotebookAction2 {
 	}
 
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor): void {
-		notebook.clearCellOutput();
+		const state = notebook.selectionStateMachine.state.get();
+		const cell = getActiveCell(state);
+		if (cell) {
+			notebook.clearCellOutput(cell);
+		}
 	}
 });
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1579,7 +1579,7 @@ registerAction2(class extends NotebookAction2 {
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor): void {
 		const state = notebook.selectionStateMachine.state.get();
 		const cell = getActiveCell(state);
-		if (cell) {
+		if (cell?.isCodeCell()) {
 			notebook.clearCellOutput(cell);
 		}
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1515,7 +1515,7 @@ registerAction2(class extends NotebookAction2 {
 			title: localize2('positronNotebook.cell.collapseOutput', "Collapse Output"),
 			menu: {
 				id: MenuId.PositronNotebookCellOutputActionLeft,
-				group: PositronNotebookCellOutputActionGroup.Collapse,
+				group: PositronNotebookCellOutputActionGroup.Visibility,
 				order: 1,
 				when: ContextKeyExpr.and(
 					POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
@@ -1542,7 +1542,7 @@ registerAction2(class extends NotebookAction2 {
 			title: localize2('positronNotebook.cell.expandOutput', "Expand Output"),
 			menu: {
 				id: MenuId.PositronNotebookCellOutputActionLeft,
-				group: PositronNotebookCellOutputActionGroup.Collapse,
+				group: PositronNotebookCellOutputActionGroup.Visibility,
 				order: 2,
 				when: ContextKeyExpr.and(
 					POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
@@ -1569,8 +1569,8 @@ registerAction2(class extends NotebookAction2 {
 			title: localize2('positronNotebook.cell.clearOutput', "Clear Output"),
 			menu: {
 				id: MenuId.PositronNotebookCellOutputActionLeft,
-				group: PositronNotebookCellOutputActionGroup.Clear,
-				order: 1,
+				group: PositronNotebookCellOutputActionGroup.Visibility,
+				order: 3,
 				when: POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS
 			}
 		});

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1561,6 +1561,26 @@ registerAction2(class extends NotebookAction2 {
 	}
 });
 
+// Clear output for a cell
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.clearOutput',
+			title: localize2('positronNotebook.cell.clearOutput', "Clear Output"),
+			menu: {
+				id: MenuId.PositronNotebookCellOutputActionLeft,
+				group: PositronNotebookCellOutputActionGroup.Clear,
+				order: 1,
+				when: POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS
+			}
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor): void {
+		notebook.clearCellOutput();
+	}
+});
+
 //#endregion Cell Commands
 
 //#region Notebook Header Actions

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
@@ -30,4 +30,5 @@ export enum PositronNotebookCellActionBarLeftGroup {
 // Group IDs for output actions menu
 export enum PositronNotebookCellOutputActionGroup {
 	Collapse = '0_collapse',
+	Clear = '1_clear',
 }

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
@@ -29,6 +29,5 @@ export enum PositronNotebookCellActionBarLeftGroup {
 
 // Group IDs for output actions menu
 export enum PositronNotebookCellOutputActionGroup {
-	Collapse = '0_collapse',
-	Clear = '1_clear',
+	Visibility = '0_visibility',
 }


### PR DESCRIPTION
Addresses #10489.

Adds a "Clear Output" action to the Positron notebook cell output right-click context menu, allowing users to clear individual cell outputs without clearing all notebook outputs. The action appears in the output action menu for code cells that have outputs.

In the `...` menu:
<img width="281" height="203" alt="image" src="https://github.com/user-attachments/assets/489c7e07-54d9-469c-9ada-a0ba1e00025f" />

On right-click:
<img width="518" height="236" alt="image" src="https://github.com/user-attachments/assets/fb412756-e754-40b9-a8e9-e4e3d21fa1c9" />


### Release Notes

#### New Features
- Added "Clear Output" option to the notebook cell output context menu for clearing individual cell outputs (#10489)

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks

1. Open a Python or R notebook with multiple cells
2. Run several cells so they have output
3. Right-click on a cell's output area
4. Verify "Clear Output" appears in the context menu
5. Click "Clear Output" and verify only that cell's output is cleared while other cells retain their outputs