### PR TITLE
Fix autoscroll when moving notebook cells with keyboard shortcuts

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1326,6 +1326,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		);
 
 		this._onDidChangeContent.fire();
+
+		// Reveal the active cell at its new position so the viewport follows the move
+		const activeCell = getActiveCell(this.selectionStateMachine.state.get());
+		activeCell?.reveal({ reason: 'keyboardNavigation', direction: 'up' });
 	}
 
 	/**
@@ -1376,6 +1380,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		);
 
 		this._onDidChangeContent.fire();
+
+		// Reveal the active cell at its new position so the viewport follows the move
+		const activeCell = getActiveCell(this.selectionStateMachine.state.get());
+		activeCell?.reveal({ reason: 'keyboardNavigation', direction: 'down' });
 	}
 
 	/**


### PR DESCRIPTION
Addresses #11611
## Summary

- Fixes the viewport not following the active cell when using Alt+Up/Down to move cells in Positron Notebooks
- Adds a `reveal()` call after each move operation so the viewport scrolls to keep the moved cell visible, matching the existing behavior for arrow-key navigation


## QA Notes

@:positron-notebooks

1. Open a notebook with enough cells to require scrolling
2. Select a cell near the bottom of the viewport
3. Press Alt+Down repeatedly -- the viewport should scroll to keep the cell visible
4. Select a cell near the top and press Alt+Up repeatedly -- same behavior
5. Verify normal arrow-key navigation (Up/Down without Alt) still works as before