### PR TITLE
ci: fix checkout of specific commit SHA in test workflows

### DIFF
--- a/.github/workflows/test-e2e-debian.yml
+++ b/.github/workflows/test-e2e-debian.yml
@@ -134,9 +134,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.commit || github.ref }}
           fetch-depth: 0
           submodules: recursive
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - name: Load secret
         uses: 1password/load-secrets-action@v3

--- a/.github/workflows/test-e2e-rhel.yml
+++ b/.github/workflows/test-e2e-rhel.yml
@@ -134,9 +134,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.commit || github.ref }}
           fetch-depth: 0
           submodules: recursive
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - name: Load secret
         uses: 1password/load-secrets-action@v3

--- a/.github/workflows/test-e2e-sles.yml
+++ b/.github/workflows/test-e2e-sles.yml
@@ -134,9 +134,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.commit || github.ref }}
           fetch-depth: 0
           submodules: recursive
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - name: Load secret
         uses: 1password/load-secrets-action@v3

--- a/.github/workflows/test-e2e-suse.yml
+++ b/.github/workflows/test-e2e-suse.yml
@@ -134,9 +134,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.commit || github.ref }}
           fetch-depth: 0
           submodules: recursive
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - name: Load secret
         uses: 1password/load-secrets-action@v3

--- a/.github/workflows/test-e2e-ubuntu-build.yml
+++ b/.github/workflows/test-e2e-ubuntu-build.yml
@@ -67,9 +67,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.commit || github.ref }}
           fetch-depth: 0
           submodules: recursive
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - name: Ensure Docker config dir is writable
         run: |

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -112,9 +112,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.commit || github.ref }}
           fetch-depth: 0
           submodules: recursive
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - name: Load secret
         uses: 1password/load-secrets-action@v3
@@ -484,8 +487,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.commit || github.ref }}
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -36,8 +36,10 @@ jobs:
       _R_CHECK_SYSTEM_CLOCK_: false
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.commit || github.ref }}
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -40,8 +40,10 @@ jobs:
       _R_CHECK_SYSTEM_CLOCK_: false
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.commit || github.ref }}
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- Fix test-full-suite workflow failing when testing a specific commit SHA
- `actions/checkout@v6` interprets the `ref` parameter as a branch/tag name first, causing errors like: `Error: A branch or tag with the name 'a0eca0eae3' could not be found`
- Solution: checkout default branch first, then `git checkout` to the specific commit

## Test plan
- [x] Trigger test-full-suite workflow with a commit SHA to verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)