### PR TITLE
e2e: Skip R breakpoint tests

### DIFF
--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -214,7 +214,8 @@ test.describe('R Debugging', {
 
 // R Breakpoints - Tests for gutter-click breakpoints feature (#1766)
 // These tests verify the new R breakpoint support added in PR #11407
-test.describe('R Breakpoints', {
+// skipping for now as they are failing in e2e tests, but not manually. We are investigating.
+test.describe.skip('R Breakpoints', {
 	tag: [tags.DEBUG, tags.WIN, tags.ARK]
 }, () => {
 	let breakpointSession: SessionMetaData;


### PR DESCRIPTION
Skipping R breakpoint tests while we investigate why they are failing in automated tests, but not manually.

### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
