### PR TITLE
Add check before restoring persisted model

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -992,7 +992,21 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			// Sync selected model
 			if (state?.selectedModel) {
 				if (!this._currentLanguageModel || this._currentLanguageModel.identifier !== state.selectedModel.identifier) {
-					this.setCurrentLanguageModel(state.selectedModel);
+					// --- Start Positron ---
+					// Validate that the persisted model is still available from
+					// an enabled provider before restoring it. Without this
+					// check, stale session state (e.g. a Copilot "Auto" model
+					// from a previous session) can be blindly applied even when
+					// no providers are configured, causing the model picker to
+					// show a stale label.
+					const availableModels = this.getModels();
+					const isModelAvailable = availableModels.some(m => m.identifier === state.selectedModel!.identifier);
+					if (isModelAvailable) {
+						this.setCurrentLanguageModel(state.selectedModel);
+					} else {
+						this.setCurrentLanguageModelToDefault();
+					}
+					// --- End Positron ---
 				}
 			}
 


### PR DESCRIPTION
Address #11845 

Add another check when restoring the persisted model so it doesn't restore an unavailable model.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes