### PR TITLE
Remove orphaned import from #12064

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/actions.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/actions.tsx
@@ -13,7 +13,7 @@ import { PositronModalReactRenderer } from '../../../../../../base/browser/posit
 import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 import { NotebookAction2 } from '../../NotebookAction2.js';
 import { POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../ContextKeysManager.js';
-import { GhostCellController, POSITRON_NOTEBOOK_GHOST_CELL_AWAITING_REQUEST } from './controller.js';
+import { GhostCellController } from './controller.js';
 import { REQUEST_GHOST_CELL_SUGGESTION_COMMAND_ID, SHOW_GHOST_CELL_INFO_COMMAND_ID } from './config.js';
 import { GhostCellInfoModalDialog } from './GhostCellInfoModalDialog.js';
 


### PR DESCRIPTION
A stale build daemon caused me to miss this error from removing an import on a rebase conflict. 
