### PR TITLE
Bump Ark to 0.1.232

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -1078,7 +1078,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.231"
+      "ark": "0.1.232"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
- https://github.com/posit-dev/ark/pull/1037
  Addresses posit-dev/positron#1765

- https://github.com/posit-dev/ark/pull/1046
  Addresses posit-dev/positron#3078 (in conjunction with https://github.com/posit-dev/positron/pull/11941)
  Addresses posit-dev/positron#7667
  Addresses posit-dev/positron#11604

- https://github.com/posit-dev/ark/pull/1049
  Addresses posit-dev/positron#11780

- https://github.com/posit-dev/ark/pull/1050
  Addresses posit-dev/positron#11050

- https://github.com/posit-dev/ark/pull/1052
  Addresses posit-dev/positron#12131


### Release Notes

#### New Features

- The R debugger now has support for the Watch Pane (#1765). This is especially useful for tracking variables that do not show in the Debug Variables pane, or the result of computations. If you prefix expressions with `/print`, the result shows the R output instead of a structured variable.

- The Console is now synchronized with the frame environment selected in the Call Stack view of the debugger pane (#3078). You can now interact with local objects higher up in the call stack, just like you would with `base::recover()`.

- Dynamic completions (e.g. for data frame columns) are now sensitive to which call frame is selected in the debugger (#11050).

- Positron's Variable pane is now synchronized with the frame selected in the call stack (#12131).

#### Bug Fixes

- Fixed focus issues when evaluating code in the Console while the debugger is active (#7667, #11604).

- Fixed a regression when stepping through certain calls like `tryCatch()` (#11780). Console evaluations are now evaluated in the expected environment.


### QA Notes

See linked PRs.

@:ark
