### PR TITLE
Fix E2E tests awaiting startup

### DIFF
--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -228,7 +228,7 @@ export class HotKeys {
 		await this.code.driver.page.waitForTimeout(3000);
 		await this.code.driver.page.locator('.monaco-workbench').waitFor({ state: 'visible' });
 		if (waitForReady) {
-			await expect(this.code.driver.page.locator('text=/^Starting up|^Starting|^Preparing|^Reconnecting|^Reactivating|^Discovering( \\w+)? interpreters|starting\\.$/i')).toHaveCount(0, { timeout: 90000 });
+			await expect(this.code.driver.page.locator('text=/^Waiting for extensions|^Starting|^Preparing|^Reconnecting|^Reactivating|^Discovering( \\w+)? interpreters|starting\\.$/i')).toHaveCount(0, { timeout: 90000 });
 		}
 	}
 

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -525,7 +525,7 @@ export class Sessions {
 			await expect(this.code.driver.page.locator('[id="workbench.parts.titlebar"]')).toBeVisible({ timeout: 30000 });
 			await this.console.focus();
 			await this.code.driver.page.mouse.move(0, 0);
-			await expect(this.page.locator('text=/^Starting up|^Starting|^Preparing|^Reconnecting|^Discovering( \\w+)? interpreters|starting\\.$/i')).toHaveCount(0, { timeout: 90000 });
+			await expect(this.page.locator('text=/^Waiting for extensions|^Starting|^Preparing|^Reconnecting|^Discovering( \\w+)? interpreters|starting\\.$/i')).toHaveCount(0, { timeout: 90000 });
 		});
 	}
 


### PR DESCRIPTION
Many E2E tests determine Positron to be ready when the text in the console doesn't match any known "startup messages". PR #12063 regressed these tests by adding a new startup message, _Waiting for extensions_, which replaces the more generic _Starting up_.

Because this message wasn't listed, the tests presumed startup to be complete when they saw it and proceeded to try to run code before anything was actually ready. This is particularly pronounced on Chromium where startup is slower.

The fix is to replace the old _Starting up_ with _Waiting for extensions_.