### PR TITLE
e2e test - additional pyrefly coverage

### DIFF
--- a/test/e2e/pages/problems.ts
+++ b/test/e2e/pages/problems.ts
@@ -50,7 +50,7 @@ export class Problems {
 
 	/**
 	 * Verify: Expect the number of problems, errors, and warnings to be as specified
-	 * @param problemCount - The expected problem count shown in the Problems tab badge
+	 * @param badgeCount - The expected problem count shown in the Problems tab badge (total)
 	 * @param errorCount - The expected error count shown in the Problems view
 	 * @param warningCount - The expected warning count shown in the Problems view
 	 */

--- a/test/e2e/tests/lsp/lsp-diagnostics.test.ts
+++ b/test/e2e/tests/lsp/lsp-diagnostics.test.ts
@@ -15,7 +15,10 @@ test.describe('Diagnostics', {
 }, () => {
 
 	test.beforeAll(async function ({ settings }) {
-		await settings.set({ 'python.pyrefly.displayTypeErrors': 'force-on' });
+		await settings.set({
+			'python.pyrefly.displayTypeErrors': 'force-on',
+			'positron.notebook.enabled': true
+		});
 	});
 
 	test.afterEach(async function ({ runCommand }) {
@@ -68,6 +71,7 @@ test.describe('Diagnostics', {
 	// Adding these additional tests to ensure a more robust coverage
 	// The idea is to use different scenarios as a proxy for potential pyrefly issues/delays/halts
 	// Some tests may appear redundant, but they are designed to catch potential breakages in pyrefly functionality
+	// NOTE: Check on maintenance over time - if pyrefly changes warning text too often, we may want to consider removing that line.
 
 	test('Python - File shows diagnostic for non-existent module import', async function ({ app, runCommand, sessions, python }) {
 		const { problems, editor } = app.workbench;
@@ -153,17 +157,17 @@ test.describe('Diagnostics', {
 		await problems.expectDiagnosticsToBe({ badgeCount: 0, warningCount: 0, errorCount: 0 });
 	});
 
-	test.skip('Python - Notebook shows diagnostic for undefined variable', async function ({ app, runCommand, hotKeys }) {
-		const { problems, notebooks } = app.workbench;
+	test('Python - Notebook shows diagnostic for undefined variable', async function ({ app, hotKeys }) {
+		const { problems, notebooksPositron } = app.workbench;
 
-		await test.step('Create notebook', async () => {
-			await runCommand('Python: Create New Notebook');
-			await notebooks.selectCellAtIndex(0);
+		await test.step('Create notebook and select Python kernel', async () => {
+			await notebooksPositron.newNotebook();
+			await notebooksPositron.kernel.select('Python');
 		});
 
 		await test.step('Add code with undefined variable', async () => {
-			await notebooks.typeInEditor('x = 1\nprint(xx)');
-			await notebooks.waitForActiveCellEditorContents('x = 1 print(xx)');
+			await notebooksPositron.addCodeToCell(0, 'x = 1\nprint(xx)');
+			await notebooksPositron.expectCellContentAtIndexToBe(0, ['x = 1', 'print(xx)']);
 		});
 
 		await test.step('Verify diagnostic appears', async () => {
@@ -171,9 +175,10 @@ test.describe('Diagnostics', {
 		});
 
 		await test.step('Fix the error', async () => {
+			await notebooksPositron.selectCellAtIndex(0, { editMode: true });
 			await hotKeys.selectAll();
-			await notebooks.typeInEditor('x = 1\nprint(x)');
-			await notebooks.waitForActiveCellEditorContents('x = 1 print(x)');
+			await notebooksPositron.editorAtIndex(0).pressSequentially('x = 1\nprint(x)');
+			await notebooksPositron.expectCellContentAtIndexToBe(0, ['x = 1', 'print(x)']);
 		});
 
 		await test.step('Verify diagnostic is cleared', async () => {

--- a/test/e2e/tests/lsp/lsp-diagnostics.test.ts
+++ b/test/e2e/tests/lsp/lsp-diagnostics.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import path from 'path';
 import { test, tags } from '../_test.setup.js';
 
 test.use({
@@ -62,6 +63,122 @@ test.describe('Diagnostics', {
 		await problems.expectDiagnosticsToBe({ badgeCount: 0, warningCount: 0, errorCount: 0 });
 		await problems.expectSquigglyCountToBe('warning', 0);
 		*/
+	});
+
+	// Adding these additional tests to ensure a more robust coverage
+	// The idea is to use different scenarios as a proxy for potential pyrefly issues/delays/halts
+	// Some tests may appear redundant, but they are designed to catch potential breakages in pyrefly functionality
+
+	test('Python - File shows diagnostic for non-existent module import', async function ({ app, runCommand, sessions, python }) {
+		const { problems, editor } = app.workbench;
+		await runCommand('Python: New File');
+		await editor.type('import bad_module\n');
+		await problems.expectDiagnosticsToBe({ badgeCount: 2, warningCount: 1, errorCount: 1 });
+		await problems.expectWarningText('Cannot find module `bad_module`');
+	});
+
+	test('Python - File shows diagnostic for missing attribute on module', async function ({ app, runCommand }) {
+		const { problems, editor } = app.workbench;
+		await runCommand('Python: New File');
+		await editor.type('import math\nmath.not_a_real_attr\n');
+		await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 0, errorCount: 1 });
+		await problems.expectWarningText('No attribute');
+	});
+
+	test('Python - File shows diagnostic for calling non-callable', async function ({ app, runCommand }) {
+		const { problems, editor } = app.workbench;
+		await runCommand('Python: New File');
+		await editor.type('x = 1\nx()\n');
+		await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 0, errorCount: 1 });
+		await problems.expectWarningText('Expected a callable');
+	});
+
+	test('Python - File shows diagnostic for incompatible assignment (annotated int)', async function ({ app, runCommand }) {
+		const { problems, editor } = app.workbench;
+		await runCommand('Python: New File');
+		await editor.type('x: int = "hello"\n');
+		await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 0, errorCount: 1 });
+		await problems.expectWarningText('not assignable');
+	});
+
+	test('Python - File shows diagnostic for wrong return type', async function ({ app, runCommand }) {
+		const { problems, editor } = app.workbench;
+		await runCommand('Python: New File');
+		await editor.type('def f() -> int:\n\treturn "nope"\n');
+		await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 0, errorCount: 1 });
+		await problems.expectWarningText('Return type');
+	});
+
+	test('Python - File shows diagnostic for list element type mismatch', async function ({ app, runCommand }) {
+		const { problems, editor } = app.workbench;
+		await runCommand('Python: New File');
+		await editor.type('xs: list[int] = [1, "a"]\n');
+		await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 0, errorCount: 1 });
+		await problems.expectWarningText('not assignable');
+	});
+
+	test('Python - File shows diagnostic for dict value type mismatch', async function ({ app, runCommand }) {
+		const { problems, editor } = app.workbench;
+		await runCommand('Python: New File');
+		await editor.type('m: dict[str, int] = {"a": 1, "b": "x"}\n');
+		await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 0, errorCount: 1 });
+		await problems.expectWarningText('not assignable');
+	});
+
+	test('Python - File shows type errors when indentation error is present', async function ({ app, runCommand, sessions, python }) {
+		const { problems, editor } = app.workbench;
+		await runCommand('Python: New File');
+		await editor.type('def greet(name: str) -> str:\n\treturn f"Hello, {name}"\n\n# Type error: passing int instead of str\nresult = greet(123)\n');
+		await problems.expectDiagnosticsToBe({ badgeCount: 6, warningCount: 0, errorCount: 6 });
+	});
+
+	// NOTE[RSF]: Unskip/fix tests for QMD and Notebook files
+	// Currently skipping due to pyrefly not working with .qmd and .ipynb
+
+	test.skip('Python - QMD file shows diagnostic for undefined variable', async function ({ app, runCommand }) {
+		const { problems, editor, quickInput, hotKeys } = app.workbench;
+		await runCommand('workbench.action.files.newUntitledFile');
+		await editor.type('---\ntitle: "Test"\n---\n\n```{python}\nprint(does_not_exist)\n```\n');
+
+		await runCommand('workbench.action.files.saveAs', { keepOpen: true });
+		await quickInput.waitForQuickInputOpened();
+		await quickInput.type(path.join(app.workspacePathOrFolder, 'smoke.qmd'));
+		await app.code.driver.page.keyboard.press('Enter');
+		await quickInput.waitForQuickInputClosed();
+		await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 0, errorCount: 1 });
+
+		await hotKeys.selectAll();
+		await editor.type('---\ntitle: "Test"\n---\n\n```{python}\nx = 1\nprint(x)\n```\n');
+
+		await problems.expectDiagnosticsToBe({ badgeCount: 0, warningCount: 0, errorCount: 0 });
+	});
+
+	test.skip('Python - Notebook shows diagnostic for undefined variable', async function ({ app, runCommand, hotKeys }) {
+		const { problems, notebooks } = app.workbench;
+
+		await test.step('Create notebook', async () => {
+			await runCommand('Python: Create New Notebook');
+			await notebooks.selectCellAtIndex(0);
+		});
+
+		await test.step('Add code with undefined variable', async () => {
+			await notebooks.typeInEditor('x = 1\nprint(xx)');
+			await notebooks.waitForActiveCellEditorContents('x = 1 print(xx)');
+		});
+
+		await test.step('Verify diagnostic appears', async () => {
+			await problems.expectDiagnosticsToBe({ badgeCount: 1, warningCount: 0, errorCount: 1 });
+		});
+
+		await test.step('Fix the error', async () => {
+			await hotKeys.selectAll();
+			await notebooks.typeInEditor('x = 1\nprint(x)');
+			await notebooks.waitForActiveCellEditorContents('x = 1 print(x)');
+		});
+
+		await test.step('Verify diagnostic is cleared', async () => {
+			await problems.expectDiagnosticsToBe({ badgeCount: 0, warningCount: 0, errorCount: 0 });
+		});
 	});
 
 });


### PR DESCRIPTION
This pull request expands the test coverage for Python diagnostics in the LSP integration tests, aiming to catch potential issues and breakages in diagnostic functionality. It introduces several new test cases for common Python errors and edge cases, and prepares groundwork for future tests on QMD and Notebook files. Additionally, a minor documentation update clarifies a parameter name in the `Problems` page object (`badgeCount`).

Expanded Python diagnostics test coverage:

* Added multiple new tests to `lsp-diagnostics.test.ts` to verify diagnostics for scenarios such as non-existent module imports, missing attributes, calling non-callables, incompatible assignments, wrong return types, list/dict element type mismatches, and type errors with indentation issues. These tests improve robustness and help detect pyrefly-related issues or delays.
* Added skipped tests for QMD and Notebook files, noting current limitations due to pyrefly not supporting `.qmd` and `.ipynb` files. These are placeholders for future diagnostic coverage.

Test infrastructure improvement:

* Imported `path` module in `lsp-diagnostics.test.ts` to support file path operations for future and existing tests.

Documentation update:

* Clarified the parameter name from `problemCount` to `badgeCount` in the `Problems` page object, making the expected badge count meaning more explicit.

@:pyrefly @:web