### PR TITLE
notebooks: skip updates when language is unchanged

### DIFF
--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
@@ -303,6 +303,15 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 			}
 		}
 
+		// Skip if nothing would change, to avoid spurious DidChangeNotebookDocument
+		// notifications that can disrupt language server initialization (e.g. Pyrefly).
+		// eslint-disable-next-line local/code-no-any-casts, @typescript-eslint/no-explicit-any
+		const existingMetadata = notebook.metadata?.metadata as any;
+		const existingLanguage = existingMetadata?.language_info?.name;
+		if (existingLanguage === languageId && cellEdits.length === 0) {
+			return;
+		}
+
 		// Apply the edits.
 		notebook.applyEdits(
 			[documentMetadataEdit, ...cellEdits],


### PR DESCRIPTION
Addresses #12161.

When opening an `.ipynb` file, `updateNotebookLanguage()` unconditionally calls `applyEdits()` even when the notebook metadata and cell languages already match the kernel's language. This fires a spurious `DidChangeNotebookDocument` LSP notification immediately after `DidOpenNotebookDocument`, which disrupts Pyrefly's initialization and prevents semantic highlighting, hover, and completions from working until reload.

This adds an early return in `updateNotebookLanguage()` when `language_info.name` already matches the target language and no cell language changes are needed.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed Pyrefly static analysis features (semantic highlighting, hover, completions) not working when first opening a `.ipynb` file (#12161)

### QA Notes

@:notebooks @:pyrefly

1. Open an existing `.ipynb` file with Python cells
2. Verify semantic highlighting, hover, and completions from Pyrefly work on first open without having to reload
