### PR TITLE
Support `Script` in r-versions config file

### DIFF
--- a/extensions/positron-r/src/kernel-spec.ts
+++ b/extensions/positron-r/src/kernel-spec.ts
@@ -13,7 +13,7 @@ import { JupyterKernelSpec } from './positron-supervisor';
 import { getArkKernelPath, getArkEnvironmentVariables } from './kernel';
 import { EXTENSION_ROOT_DIR } from './constants';
 import { findCondaExe } from './provider-conda';
-import { PackagerMetadata, isPixiMetadata, isCondaMetadata, isModuleMetadata } from './r-installation';
+import { PackagerMetadata, isPixiMetadata, isCondaMetadata, isModuleMetadata, isRVersionsMetadata } from './r-installation';
 import { findPixiExe } from './provider-pixi';
 import { LOGGER } from './extension';
 
@@ -377,6 +377,15 @@ export async function createJupyterKernelSpec(
 			// Use the pre-computed startup command from the module resolver
 			startup_command = packagerMetadata.startupCommand;
 			LOGGER.info(`Using module startup command: ${startup_command}`);
+		}
+	}
+
+	// If this R is from an r-versions entry with a script, source it before launching R
+	if (packagerMetadata && isRVersionsMetadata(packagerMetadata)) {
+		if (packagerMetadata.script) {
+			// Use POSIX-compatible source syntax (.) for portability
+			startup_command = `. ${packagerMetadata.script}`;
+			LOGGER.info(`Using r-versions startup script: ${packagerMetadata.script}`);
 		}
 	}
 

--- a/extensions/positron-r/src/provider-rversions.ts
+++ b/extensions/positron-r/src/provider-rversions.ts
@@ -218,7 +218,8 @@ export async function discoverRVersionsBinaries(): Promise<RBinary[]> {
 		const metadata: RVersionsMetadata = {
 			type: 'rversions',
 			label: entry.label,
-			// Future PRs will add: script, repo, library
+			script: entry.script,
+			// Future PRs will add: repo, library
 		};
 
 		binaries.push({

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -123,7 +123,9 @@ export interface RVersionsMetadata {
 	readonly type: 'rversions';
 	/** User-friendly display name from the Label field */
 	readonly label?: string;
-	// Future PRs will add: script, repo, library
+	/** Shell script to source before launching R */
+	readonly script?: string;
+	// Future PRs will add: repo, library
 }
 
 /**


### PR DESCRIPTION
Addresses #11426 with the next step

This PR adds support for the `Script` field from the r-versions configuration file, allowing administrators to specify a shell script that runs before launching R. This is commonly used on Posit Workbench to set environment variables or load modules before R starts:

<img width="1313" height="1049" alt="Screenshot 2026-02-27 at 10 10 22 AM" src="https://github.com/user-attachments/assets/f976c51e-6d1f-4914-b76f-2e67d4ca6316" />

This is the third PR in the r-versions implementation series:
- #12022
- #12101
- **This PR**: Script field support

When an r-versions entry includes a Script field (e.g., `Script: ~/setup-r.sh`), that script is sourced before starting the R session, making any environment changes available to R.

### Release Notes

#### New Features

- N/A for now!

#### Bug Fixes

- N/A

### QA Notes

@:interpreter

1. Create a test script that is something like `~/test-rversions-script.sh`:
   ```bash
   #!/bin/bash
   export RVERSIONS_TEST_VAR="Hello from r-versions script!"
   ```

2. Make it executable: `chmod +x ~/test-rversions-script.sh`

3. Create or update an r-versions file at `~/Library/Preferences/rstudio/r-versions` (macOS) or `/etc/rstudio/r-versions` (Linux):
   ```
   Path: /Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
   Label: R 4.3 (Is This Thing On?)
   Script: ~/test-rversions-script.sh
   ```

4. Restart Positron and start an R session using the labeled interpreter
5. Verify the environment variable is set:
   ```r
   Sys.getenv("RVERSIONS_TEST_VAR")
   # Should return: "Hello from r-versions script!"
   ```
