### PR TITLE
Inject package management scripts when enabling the packages pane

### DIFF
--- a/extensions/positron-r/src/extension.ts
+++ b/extensions/positron-r/src/extension.ts
@@ -12,6 +12,7 @@ import { setContexts } from './contexts';
 import { setupTestExplorer, refreshTestExplorer } from './testing/testing';
 import { RRuntimeManager } from './runtime-manager';
 import { RSessionManager } from './session-manager';
+import { getActiveRSessions } from './session';
 import { registerUriHandler } from './uri-handler';
 import { registerRLanguageModelTools } from './llm-tools.js';
 import { registerFileAssociations } from './file-associations.js';
@@ -71,7 +72,44 @@ export function activate(context: vscode.ExtensionContext) {
 		if (event.affectsConfiguration('positron.r.testing')) {
 			refreshTestExplorer(context);
 		}
+		if (event.affectsConfiguration('positron.environments.enable')) {
+			await sourcePackagesScriptForActiveSessions();
+		}
 	});
+}
+
+/**
+ * Source the packages script for active R sessions when the environments
+ * feature is enabled mid-session. Only sources for the first session per
+ * unique R interpreter to avoid redundant calls.
+ */
+async function sourcePackagesScriptForActiveSessions(): Promise<void> {
+	// Check if the feature is now enabled
+	const environmentsEnabled = vscode.workspace
+		.getConfiguration('positron.environments')
+		.get<boolean>('enable', false);
+
+	if (!environmentsEnabled) {
+		return;
+	}
+
+	const sessions = await getActiveRSessions();
+
+	// Track which interpreters we've already processed
+	const processedInterpreters = new Set<string>();
+
+	for (const session of sessions) {
+		const interpreterPath = session.runtimeMetadata.runtimePath;
+
+		// Only process the first session per interpreter
+		if (processedInterpreters.has(interpreterPath)) {
+			continue;
+		}
+		processedInterpreters.add(interpreterPath);
+
+		// Source the packages script (fails silently if already sourced or errors)
+		await session.sourcePackagesScriptIfNeeded();
+	}
 }
 
 export async function supervisorApi(): Promise<PositronSupervisorApi> {

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -107,9 +107,6 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	/** Package manager for this session */
 	private _packageManager?: RPackageManager;
 
-	/** Whether the packages script has been sourced for this session */
-	private _packagesScriptSourced: boolean = false;
-
 	/** Disposables. Disposed of after main resources (LSP, kernel, etc) */
 	private _disposables: vscode.Disposable[] = [];
 
@@ -764,14 +761,11 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	}
 
 	/**
-	 * Source the packages script if it hasn't been sourced yet.
+	 * Source the packages script for this session.
 	 * Called when the environments feature is enabled mid-session.
+	 * Safe to call multiple times since sourcing is idempotent.
 	 */
 	async sourcePackagesScriptIfNeeded(): Promise<void> {
-		if (this._packagesScriptSourced) {
-			return;
-		}
-
 		if (!this._packageManager) {
 			return;
 		}
@@ -783,9 +777,8 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 
 		try {
 			await this._packageManager.sourcePackagesScript();
-			this._packagesScriptSourced = true;
 		} catch {
-			// Fail silently as requested
+			// Fail silently
 		}
 	}
 
@@ -1093,9 +1086,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 				.get<boolean>('enable', false);
 
 			if (environmentsEnabled) {
-				promises.push(this._packageManager!.sourcePackagesScript().then(() => {
-					this._packagesScriptSourced = true;
-				}));
+				promises.push(this._packageManager!.sourcePackagesScript());
 			}
 
 			await Promise.all(promises);

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -107,6 +107,9 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	/** Package manager for this session */
 	private _packageManager?: RPackageManager;
 
+	/** Whether the packages script has been sourced for this session */
+	private _packagesScriptSourced: boolean = false;
+
 	/** Disposables. Disposed of after main resources (LSP, kernel, etc) */
 	private _disposables: vscode.Disposable[] = [];
 
@@ -760,6 +763,32 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		return this._packageManager.searchPackageVersions(name);
 	}
 
+	/**
+	 * Source the packages script if it hasn't been sourced yet.
+	 * Called when the environments feature is enabled mid-session.
+	 */
+	async sourcePackagesScriptIfNeeded(): Promise<void> {
+		if (this._packagesScriptSourced) {
+			return;
+		}
+
+		if (!this._packageManager) {
+			return;
+		}
+
+		// Only source if the session is ready
+		if (this._state !== positron.RuntimeState.Ready) {
+			return;
+		}
+
+		try {
+			await this._packageManager.sourcePackagesScript();
+			this._packagesScriptSourced = true;
+		} catch {
+			// Fail silently as requested
+		}
+	}
+
 	private async createKernel(): Promise<JupyterLanguageRuntimeSession> {
 		this.adapterApi = await supervisorApi();
 
@@ -1064,7 +1093,9 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 				.get<boolean>('enable', false);
 
 			if (environmentsEnabled) {
-				promises.push(this._packageManager!.sourcePackagesScript());
+				promises.push(this._packageManager!.sourcePackagesScript().then(() => {
+					this._packagesScriptSourced = true;
+				}));
 			}
 
 			await Promise.all(promises);

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -770,11 +770,6 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 			return;
 		}
 
-		// Only source if the session is ready
-		if (this._state !== positron.RuntimeState.Ready) {
-			return;
-		}
-
 		try {
 			await this._packageManager.sourcePackagesScript();
 		} catch {


### PR DESCRIPTION
See #12076 

This injects the package management scripts into R sessions when the setting is enabled.

Without this PR, users might enable the feature but when interacting with R sessions the called functions will not have been declared yet. This PR adds a listener for when the setting is changed and injects the code.

I have chosen to execute the code regardless of whether it has been called before since the code should be idempotent. This avoids having to deal with managing state and tracking lifecycle events and managing restarts that might eliminate its state.

### QA Notes

Disable the setting

```
"positron.environments.enable": false,
```

1. Kill all your consoles.
1. Reload the window
1. This is basically a clean setup now
1. Enable the setting
1. The R packages pane should refresh and show packages.

If you are having trouble having a selected session show up, try selecting another interpreter like Zed and switching back. There is a known bug fixed here https://github.com/posit-dev/positron/issues/12090