### PR TITLE
Use lowercase "uv" in UI display strings per uv style guide

### DIFF
--- a/extensions/positron-python/src/client/api/types.ts
+++ b/extensions/positron-python/src/client/api/types.ts
@@ -269,7 +269,7 @@ export type KnownEnvironmentTools =
     | 'Pyenv'
     | 'Hatch'
     // --- Start Positron ---
-    | 'Uv'
+    | 'uv'
     // --- End Positron ---
     | 'Unknown';
 

--- a/extensions/positron-python/src/client/common/installer/uvInstaller.ts
+++ b/extensions/positron-python/src/client/common/installer/uvInstaller.ts
@@ -26,7 +26,7 @@ export class UVInstaller extends ModuleInstaller {
     }
 
     public get name(): string {
-        return 'Uv';
+        return 'uv';
     }
 
     public get displayName(): string {

--- a/extensions/positron-python/src/client/environmentApi.ts
+++ b/extensions/positron-python/src/client/environmentApi.ts
@@ -401,7 +401,7 @@ function convertKind(kind: PythonEnvKind): EnvironmentTools | undefined {
             return 'Pyenv';
         // --- Start Positron ---
         case PythonEnvKind.Uv:
-            return 'Uv';
+            return 'uv';
         // --- End Positron ---
         default:
             return undefined;

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -95,7 +95,7 @@ export namespace EnvGroups {
     export const Hatch = 'Hatch';
     export const Pixi = 'Pixi';
     // --- Start Positron ---
-    export const Uv = 'Uv';
+    export const Uv = 'uv';
     export const Module = 'Module';
     export const Unsupported = 'Unsupported';
     // --- End Positron ---
@@ -781,6 +781,8 @@ function getGroup(item: IInterpreterQuickPickItem, workspacePath?: string) {
             return EnvGroups.Global;
         case EnvironmentType.Module:
             return EnvGroups.Module;
+        case EnvironmentType.Uv:
+            return EnvGroups.Uv;
         // --- End Positron ---
         case EnvironmentType.Global:
         case EnvironmentType.System:

--- a/extensions/positron-python/src/client/positron/packages/packageManagerFactory.ts
+++ b/extensions/positron-python/src/client/positron/packages/packageManagerFactory.ts
@@ -20,7 +20,7 @@ export class PackageManagerFactory {
     /**
      * Create the appropriate package manager for the given environment.
      *
-     * @param runtimeSource The environment type (e.g., 'Venv', 'Conda', 'Global', 'Uv')
+     * @param runtimeSource The environment type (e.g., 'Venv', 'Conda', 'Global', 'uv')
      * @param pythonPath The path to the Python interpreter
      * @param messageEmitter The emitter for runtime messages
      * @param serviceContainer The service container for dependency injection

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -23,7 +23,7 @@ interface MessageEmitter {
 }
 
 /**
- * UV Package Manager
+ * uv Package Manager
  *
  * Provides package management functionality for Python sessions using uv.
  * Supports two workflows:

--- a/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonUtils.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/base/locators/common/nativePythonUtils.ts
@@ -15,7 +15,7 @@ export enum NativePythonEnvironmentKind {
     Pipenv = 'Pipenv',
     Poetry = 'Poetry',
     // --- Start Positron ---
-    Uv = 'Uv',
+    Uv = 'uv',
     Custom = 'Custom',
     // --- End Positron ---
     MacPythonOrg = 'MacPythonOrg',

--- a/extensions/positron-python/src/client/pythonEnvironments/info/index.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/info/index.ts
@@ -22,7 +22,7 @@ export enum EnvironmentType {
     Hatch = 'Hatch',
     Pixi = 'Pixi',
     // --- Start Positron ---
-    Uv = 'Uv',
+    Uv = 'uv',
     Custom = 'Custom',
     Module = 'Module',
     // --- End Positron ---
@@ -64,7 +64,7 @@ export enum ModuleInstallerType {
     Pipenv = 'Pipenv',
     Pixi = 'Pixi',
     // --- Start Positron ---
-    Uv = 'Uv',
+    Uv = 'uv',
     // --- End Positron ---
 }
 

--- a/extensions/positron-python/src/test/common/installer/uvInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/common/installer/uvInstaller.unit.test.ts
@@ -89,7 +89,7 @@ suite('UV Installer Tests', () => {
 
     suite('Basic Properties', () => {
         test('Should have correct name', () => {
-            expect(uvInstaller.name).to.equal('Uv');
+            expect(uvInstaller.name).to.equal('uv');
         });
 
         test('Should have correct display name', () => {

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
@@ -15,7 +15,7 @@ import * as platformUtils from '../../../../client/common/utils/platform';
 import * as logging from '../../../../client/logging';
 import * as simplevenv from '../../../../client/pythonEnvironments/common/environmentManagers/simplevirtualenvs';
 
-suite('UV Environment Tests', () => {
+suite('uv Environment Tests', () => {
     let resolveSymbolicLinkStub: sinon.SinonStub;
     let getOSTypeStub: sinon.SinonStub;
     let getEnvironmentVariableStub: sinon.SinonStub;

--- a/extensions/positron-python/src/test/pythonEnvironments/creation/provider/uvCreationProvider.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/creation/provider/uvCreationProvider.unit.test.ts
@@ -29,7 +29,7 @@ import {
 
 chaiUse(chaiAsPromised.default);
 
-suite('UV Creation provider tests', () => {
+suite('uv Creation provider tests', () => {
     let uvProvider: CreateEnvironmentProvider;
     let progressMock: typemoq.IMock<CreateEnvironmentProgress>;
     let isUvInstalledStub: sinon.SinonStub;

--- a/extensions/positron-python/src/test/pythonEnvironments/creation/provider/uvUtils.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/creation/provider/uvUtils.unit.test.ts
@@ -9,7 +9,7 @@ import { CancellationTokenSource } from 'vscode';
 import * as windowApis from '../../../../client/common/vscodeApis/windowApis';
 import { pickPythonVersion } from '../../../../client/pythonEnvironments/creation/provider/uvUtils';
 
-suite('UV Utils test', () => {
+suite('uv Utils test', () => {
     let showQuickPickWithBackStub: sinon.SinonStub;
 
     setup(() => {

--- a/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
@@ -347,10 +347,10 @@ suite('Native Python API', () => {
     });
 
     // --- Start Positron ---
-    test('Uv environment detected and converted during addEnv via triggerRefresh', async () => {
+    test('uv environment detected and converted during addEnv via triggerRefresh', async () => {
         // Create a test environment that looks like a regular VirtualEnv initially
         const uvEnv: NativeEnvInfo = {
-            displayName: 'UV Environment',
+            displayName: 'uv environment',
             name: 'my_uv_env',
             executable: '/home/user/.local/share/uv/python/cpython-3.11.5/bin/python',
             kind: NativePythonEnvironmentKind.VirtualEnv, // Initially detected as VirtualEnv
@@ -388,10 +388,10 @@ suite('Native Python API', () => {
         assert.isTrue(isUvEnvironmentStub.calledWith('/home/user/.local/share/uv/python/cpython-3.11.5/bin/python'));
     });
 
-    test('Uv environment detected and converted during resolveEnv', async () => {
+    test('uv environment detected and converted during resolveEnv', async () => {
         // Create a test environment
         const uvEnv: NativeEnvInfo = {
-            displayName: 'UV Python',
+            displayName: 'uv Python',
             name: 'uv_python',
             executable: '/home/user/.local/share/uv/python/cpython-3.10',
             kind: NativePythonEnvironmentKind.VirtualEnv, // Initially recognized as VirtualEnv

--- a/test/e2e/tests/interpreters/new-uv-project.test.ts
+++ b/test/e2e/tests/interpreters/new-uv-project.test.ts
@@ -12,7 +12,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('New UV Environment', {
+test.describe('New uv Environment', {
 	tag: [tags.INTERPRETER]
 }, () => {
 
@@ -30,7 +30,7 @@ test.describe('New UV Environment', {
 		}
 	});
 	// This is skipped for windows because we can't get the text from the Terminal
-	test('Python - Add new UV environment', async function ({ app, openFolder }) {
+	test('Python - Add new uv environment', async function ({ app, openFolder }) {
 
 		test.skip(process.env.IS_OPENSUSE === 'true', 'Skip on openSuse');
 
@@ -54,7 +54,7 @@ test.describe('New UV Environment', {
 
 		const metadata = await app.workbench.sessions.getMetadata();
 
-		expect(metadata.source).toBe('Uv');
+		expect(metadata.source).toBe('uv');
 		expect(metadata.path).toContain('qa-example-content/proj/.venv/bin/python');
 
 	});

--- a/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
+++ b/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
@@ -79,7 +79,7 @@ export async function verifyUvEnvStarts(app: Application) {
 		if (/(8080)/.test(app.code.driver.page.url())) {
 			app.code.driver.page.getByRole('button', { name: 'Yes' }).click();
 		}
-		await app.workbench.console.waitForConsoleContents(/\(Uv: .+\) started/);
+		await app.workbench.console.waitForConsoleContents(/\(uv: .+\) started/);
 	});
 }
 


### PR DESCRIPTION
## Summary

Closes #12176

The uv tool's [style guide](https://github.com/astral-sh/uv/blob/main/STYLE.md#styling-uv) requires it always be written as lowercase "uv". Positron was displaying "Uv" in session names (e.g., "Python 3.12.0 (Uv: project-name)"), interpreter group labels, and other UI surfaces because enum string values like `EnvironmentType.Uv = 'Uv'` flowed directly into display text.

- Change string values of display-facing enums/constants from `'Uv'` to `'uv'`
- Add explicit switch case in `getInterpreterGroupLabel` to avoid broken dynamic property lookup
- Leave `NativePythonEnvironmentKind.Uv = 'Uv'` unchanged (value comes from external Python Environment Tool)

## Screenshot

All five occurrences of "uv" in the session name across the UI are now lowercased:
<img width="1416" height="1000" alt="Screenshot 2026-02-27 at 3 44 08 PM" src="https://github.com/user-attachments/assets/51054c25-fb13-437d-a27d-cd2b3a992ca1" />


## Test plan

- [x] Unit tests pass: `npm run test:unittests -- --grep "uv"` (64 passing)
- [x] TypeScript compiles with 0 errors (`watch-client`, `watch-extensions`)
- [ ] QA: Open a uv-managed Python project and verify:
  - Session name shows "Python 3.x.x (uv: project-name)" (lowercase)
  - Interpreter picker group label shows "uv"
  - New Folder flow interpreter dropdown shows "uv" group label