### PR TITLE
e2e: databot stablity fix and multi-model support

### DIFF
--- a/test/e2e/pages/databot.ts
+++ b/test/e2e/pages/databot.ts
@@ -51,9 +51,13 @@ const CODE_BLOCK_COPY_BUTTON = 'button[aria-label="Copy"]';
 const CODE_BLOCK_INSERT_CURSOR_BUTTON = 'button[aria-label="Insert At Cursor"]';
 const CODE_BLOCK_INSERT_FILE_BUTTON = 'button[aria-label="Insert into New File"]';
 const TOOL_CONFIRM_TITLE = 'h4.font-semibold';
-const TOOL_ALLOW_SESSION_BUTTON = 'button:has-text("Allow for session")';
-const TOOL_ALLOW_ONCE_BUTTON = 'button:has-text("Allow once")';
-const TOOL_DECLINE_BUTTON = 'button:has-text("Decline")';
+// The tool confirmation UI uses a split button: the main "Allow" button (left half)
+// executes the default allow-once action; the chevron (right half) opens a dropdown
+// with "Allow once", "Allow for session", and "Always allow for project" options.
+const TOOL_ALLOW_BUTTON = 'button.rounded-r-none:has-text("Allow")';
+const TOOL_ALLOW_DROPDOWN_TRIGGER = 'button[aria-label="More allow options"]';
+const TOOL_ALLOW_SESSION_MENU_ITEM = '[role="menuitem"]:has-text("for this session")';
+const TOOL_DECLINE_BUTTON = 'button.rounded-r-none:has-text("Decline")';
 
 /**
  * Page object for the Databot extension.
@@ -244,17 +248,18 @@ export class Databot {
 	}
 
 	/**
-	 * Clicks "Allow for session" on the tool confirmation dialog.
+	 * Selects "Allow for this session" from the tool confirmation dropdown.
 	 */
 	async allowToolForSession(): Promise<void> {
-		await this.frame.locator(TOOL_ALLOW_SESSION_BUTTON).click();
+		await this.frame.locator(TOOL_ALLOW_DROPDOWN_TRIGGER).click();
+		await this.frame.locator(TOOL_ALLOW_SESSION_MENU_ITEM).click();
 	}
 
 	/**
-	 * Clicks "Allow once" on the tool confirmation dialog.
+	 * Clicks the main "Allow" button on the tool confirmation dialog (allow once).
 	 */
 	async allowToolOnce(): Promise<void> {
-		await this.frame.locator(TOOL_ALLOW_ONCE_BUTTON).click();
+		await this.frame.locator(TOOL_ALLOW_BUTTON).click();
 	}
 
 	/**

--- a/test/e2e/tests/databot/databot.test.ts
+++ b/test/e2e/tests/databot/databot.test.ts
@@ -4,10 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test, tags } from '../_test.setup';
+import { ModelProvider } from '../../pages/positronAssistant';
 
 test.use({
 	suiteId: __filename
 });
+
+const DATABOT_PROVIDERS: ModelProvider[] = ['posit-ai', 'anthropic-api'];
 
 test.describe('Databot', {
 	tag: [tags.ASSISTANT, tags.DATABOT, tags.WEB, tags.WIN, tags.SOFT_FAIL],
@@ -15,88 +18,99 @@ test.describe('Databot', {
 
 	test.beforeAll(async function ({ app }) {
 		await app.workbench.extensions.installExtension('posit.databot', true);
-		await app.workbench.assistant.loginModelProvider('anthropic-api');
 	});
 
 	test.afterEach(async function ({ app }) {
 		await app.workbench.hotKeys.closeAllEditors();
 	});
 
-	test('Execute Python code via Databot', async function ({ app, sessions }) {
-		await sessions.start('python', { reuse: false });
-		await app.workbench.databot.open();
-		await app.workbench.databot.waitForReady();
+	for (const provider of DATABOT_PROVIDERS) {
+		test.describe(provider, () => {
+			test.beforeAll(async function ({ app }) {
+				await app.workbench.assistant.loginModelProvider(provider);
+			});
 
-		await app.workbench.databot.sendMessage('Print "hello world" in python', false);
-		await app.workbench.databot.expectToolConfirmVisible();
-		await app.workbench.databot.allowToolOnce();
-		await app.workbench.databot.waitForResponseComplete();
-		await app.workbench.console.waitForConsoleContents('hello world', { expectedCount: 2 });
-	});
+			test.afterAll(async function ({ app }) {
+				await app.workbench.assistant.logoutModelProvider(provider);
+			});
 
-	test('Execute R code via Databot', async function ({ app, sessions }) {
-		await sessions.start('r', { reuse: false });
-		await app.workbench.databot.open();
-		await app.workbench.databot.waitForReady();
+			test('Execute Python code via Databot', async function ({ app, sessions }) {
+				await sessions.start('python', { reuse: false });
+				await app.workbench.databot.open();
+				await app.workbench.databot.waitForReady();
 
-		await app.workbench.databot.sendMessage('Print "hello world" in R', false);
-		await app.workbench.databot.expectToolConfirmVisible();
-		await app.workbench.databot.allowToolOnce();
-		await app.workbench.databot.waitForResponseComplete();
-		await app.workbench.console.waitForConsoleContents('hello world', { expectedCount: 2 });
-	});
+				await app.workbench.databot.sendMessage('Print "hello world" in python', false);
+				await app.workbench.databot.expectToolConfirmVisible();
+				await app.workbench.databot.allowToolOnce();
+				await app.workbench.databot.waitForResponseComplete();
+				await app.workbench.console.waitForConsoleContents('hello world', { expectedCount: 2 });
+			});
 
-	test('Allow once prompts again on next tool call', async function ({ app, sessions }) {
-		await sessions.start('python', { reuse: false });
-		await app.workbench.databot.open();
-		await app.workbench.databot.waitForReady();
+			test('Execute R code via Databot', async function ({ app, sessions }) {
+				await sessions.start('r', { reuse: false });
+				await app.workbench.databot.open();
+				await app.workbench.databot.waitForReady();
 
-		// First tool call - allow once
-		await app.workbench.databot.sendMessage('Print "first" in python', false);
-		await app.workbench.databot.expectToolConfirmVisible();
-		await app.workbench.databot.allowToolOnce();
-		await app.workbench.databot.waitForResponseComplete();
+				await app.workbench.databot.sendMessage('Print "hello world" in R', false);
+				await app.workbench.databot.expectToolConfirmVisible();
+				await app.workbench.databot.allowToolOnce();
+				await app.workbench.databot.waitForResponseComplete();
+				await app.workbench.console.waitForConsoleContents('hello world', { expectedCount: 2 });
+			});
 
-		// Second tool call - should prompt again
-		await app.workbench.databot.sendMessage('Print "second" in python', false, { newConversation: false });
-		await app.workbench.databot.expectToolConfirmVisible();
-		await app.workbench.databot.allowToolOnce();
-		await app.workbench.databot.waitForResponseComplete();
-		await app.workbench.console.waitForConsoleContents('second', { expectedCount: 2 });
-	});
+			test('Allow once prompts again on next tool call', async function ({ app, sessions }) {
+				await sessions.start('python', { reuse: false });
+				await app.workbench.databot.open();
+				await app.workbench.databot.waitForReady();
 
-	test('Allow for session does not prompt again on next tool call', async function ({ app, sessions }) {
-		await sessions.start('python', { reuse: false });
-		await app.workbench.databot.open();
-		await app.workbench.databot.waitForReady();
+				// First tool call - allow once
+				await app.workbench.databot.sendMessage('Print "first" in python', false);
+				await app.workbench.databot.expectToolConfirmVisible();
+				await app.workbench.databot.allowToolOnce();
+				await app.workbench.databot.waitForResponseComplete();
 
-		// First tool call - allow for session
-		await app.workbench.databot.sendMessage('Print "first" in python', false);
-		await app.workbench.databot.expectToolConfirmVisible();
-		await app.workbench.databot.allowToolForSession();
-		await app.workbench.databot.waitForResponseComplete();
+				// Second tool call - should prompt again
+				await app.workbench.databot.sendMessage('Print "second" in python', false, { newConversation: false });
+				await app.workbench.databot.expectToolConfirmVisible();
+				await app.workbench.databot.allowToolOnce();
+				await app.workbench.databot.waitForResponseComplete();
+				await app.workbench.console.waitForConsoleContents('second', { expectedCount: 2 });
+			});
 
-		// Second tool call - should execute without prompting
-		await app.workbench.databot.sendMessage('Print "second" in python', true, { newConversation: false });
-		await app.workbench.console.waitForConsoleContents('second', { expectedCount: 2 });
-	});
+			test('Allow for session does not prompt again on next tool call', async function ({ app, sessions }) {
+				await sessions.start('python', { reuse: false });
+				await app.workbench.databot.open();
+				await app.workbench.databot.waitForReady();
 
-	test('Create data visualization via Databot', async function ({ app, sessions }) {
-		await sessions.start('r', { reuse: false });
-		await app.workbench.plots.clearPlots();
-		await app.workbench.databot.open();
-		await app.workbench.databot.waitForReady();
+				// First tool call - allow for session
+				await app.workbench.databot.sendMessage('Print "first" in python', false);
+				await app.workbench.databot.expectToolConfirmVisible();
+				await app.workbench.databot.allowToolForSession();
+				await app.workbench.databot.waitForResponseComplete();
 
-		await app.workbench.databot.sendMessage('Create a simple data visualization using base R plot()', false);
-		await app.workbench.databot.expectToolConfirmVisible();
-		await app.workbench.databot.allowToolForSession();
-		await app.workbench.databot.waitForResponseComplete();
+				// Second tool call - should execute without prompting
+				await app.workbench.databot.sendMessage('Print "second" in python', true, { newConversation: false });
+				await app.workbench.console.waitForConsoleContents('second', { expectedCount: 2 });
+			});
 
-		// Verify plot appears inline in the Databot chat
-		await app.workbench.databot.expectInlinePlotVisible();
+			test('Create data visualization via Databot', async function ({ app, sessions }) {
+				await sessions.start('r', { reuse: false });
+				await app.workbench.plots.clearPlots();
+				await app.workbench.databot.open();
+				await app.workbench.databot.waitForReady();
 
-		// Verify plot appears in the Positron plots pane
-		await app.workbench.plots.waitForCurrentPlot();
-	});
+				await app.workbench.databot.sendMessage('Create a simple data visualization using base R plot()', false);
+				await app.workbench.databot.expectToolConfirmVisible();
+				await app.workbench.databot.allowToolForSession();
+				await app.workbench.databot.waitForResponseComplete();
+
+				// Verify plot appears inline in the Databot chat
+				await app.workbench.databot.expectInlinePlotVisible();
+
+				// Verify plot appears in the Positron plots pane
+				await app.workbench.plots.waitForCurrentPlot();
+			});
+		});
+	}
 
 });

--- a/test/e2e/tests/databot/databot.test.ts
+++ b/test/e2e/tests/databot/databot.test.ts
@@ -35,7 +35,7 @@ test.describe('Databot', {
 			});
 
 			test('Execute Python code via Databot', async function ({ app, sessions }) {
-				await sessions.start('python', { reuse: false });
+				const session = await sessions.start('python', { reuse: false });
 				await app.workbench.databot.open();
 				await app.workbench.databot.waitForReady();
 
@@ -44,10 +44,11 @@ test.describe('Databot', {
 				await app.workbench.databot.allowToolOnce();
 				await app.workbench.databot.waitForResponseComplete();
 				await app.workbench.console.waitForConsoleContents('hello world', { expectedCount: 2 });
+				await sessions.delete(session.id);
 			});
 
 			test('Execute R code via Databot', async function ({ app, sessions }) {
-				await sessions.start('r', { reuse: false });
+				const session = await sessions.start('r', { reuse: false });
 				await app.workbench.databot.open();
 				await app.workbench.databot.waitForReady();
 
@@ -56,10 +57,11 @@ test.describe('Databot', {
 				await app.workbench.databot.allowToolOnce();
 				await app.workbench.databot.waitForResponseComplete();
 				await app.workbench.console.waitForConsoleContents('hello world', { expectedCount: 2 });
+				await sessions.delete(session.id);
 			});
 
 			test('Allow once prompts again on next tool call', async function ({ app, sessions }) {
-				await sessions.start('python', { reuse: false });
+				const session = await sessions.start('python', { reuse: false });
 				await app.workbench.databot.open();
 				await app.workbench.databot.waitForReady();
 
@@ -75,10 +77,11 @@ test.describe('Databot', {
 				await app.workbench.databot.allowToolOnce();
 				await app.workbench.databot.waitForResponseComplete();
 				await app.workbench.console.waitForConsoleContents('second', { expectedCount: 2 });
+				await sessions.delete(session.id);
 			});
 
 			test('Allow for session does not prompt again on next tool call', async function ({ app, sessions }) {
-				await sessions.start('python', { reuse: false });
+				const session = await sessions.start('python', { reuse: false });
 				await app.workbench.databot.open();
 				await app.workbench.databot.waitForReady();
 
@@ -91,10 +94,11 @@ test.describe('Databot', {
 				// Second tool call - should execute without prompting
 				await app.workbench.databot.sendMessage('Print "second" in python', true, { newConversation: false });
 				await app.workbench.console.waitForConsoleContents('second', { expectedCount: 2 });
+				await sessions.delete(session.id);
 			});
 
 			test('Create data visualization via Databot', async function ({ app, sessions }) {
-				await sessions.start('r', { reuse: false });
+				const session = await sessions.start('r', { reuse: false });
 				await app.workbench.plots.clearPlots();
 				await app.workbench.databot.open();
 				await app.workbench.databot.waitForReady();
@@ -109,6 +113,7 @@ test.describe('Databot', {
 
 				// Verify plot appears in the Positron plots pane
 				await app.workbench.plots.waitForCurrentPlot();
+				await sessions.delete(session.id);
 			});
 		});
 	}

--- a/test/e2e/tests/databot/databot.test.ts
+++ b/test/e2e/tests/databot/databot.test.ts
@@ -13,15 +13,9 @@ test.describe('Databot', {
 	tag: [tags.ASSISTANT, tags.DATABOT, tags.WEB, tags.WIN, tags.SOFT_FAIL],
 }, () => {
 
-	let pySessionId: string;
-	let rSessionId: string;
-
-	test.beforeAll(async function ({ app, sessions }) {
+	test.beforeAll(async function ({ app }) {
 		await app.workbench.extensions.installExtension('posit.databot', true);
 		await app.workbench.assistant.loginModelProvider('anthropic-api');
-		const [pySession, rSession] = await sessions.start(['python', 'r'], { reuse: true });
-		pySessionId = pySession.id;
-		rSessionId = rSession.id;
 	});
 
 	test.afterEach(async function ({ app }) {
@@ -29,7 +23,7 @@ test.describe('Databot', {
 	});
 
 	test('Execute Python code via Databot', async function ({ app, sessions }) {
-		await sessions.restart(pySessionId);
+		await sessions.start('python', { reuse: false });
 		await app.workbench.databot.open();
 		await app.workbench.databot.waitForReady();
 
@@ -41,7 +35,7 @@ test.describe('Databot', {
 	});
 
 	test('Execute R code via Databot', async function ({ app, sessions }) {
-		await sessions.restart(rSessionId);
+		await sessions.start('r', { reuse: false });
 		await app.workbench.databot.open();
 		await app.workbench.databot.waitForReady();
 
@@ -53,7 +47,7 @@ test.describe('Databot', {
 	});
 
 	test('Allow once prompts again on next tool call', async function ({ app, sessions }) {
-		await sessions.restart(pySessionId);
+		await sessions.start('python', { reuse: false });
 		await app.workbench.databot.open();
 		await app.workbench.databot.waitForReady();
 
@@ -72,7 +66,7 @@ test.describe('Databot', {
 	});
 
 	test('Allow for session does not prompt again on next tool call', async function ({ app, sessions }) {
-		await sessions.restart(pySessionId);
+		await sessions.start('python', { reuse: false });
 		await app.workbench.databot.open();
 		await app.workbench.databot.waitForReady();
 
@@ -88,7 +82,7 @@ test.describe('Databot', {
 	});
 
 	test('Create data visualization via Databot', async function ({ app, sessions }) {
-		await sessions.restart(rSessionId);
+		await sessions.start('r', { reuse: false });
 		await app.workbench.plots.clearPlots();
 		await app.workbench.databot.open();
 		await app.workbench.databot.waitForReady();


### PR DESCRIPTION
- Refactors the Databot e2e tests to run against multiple model providers. Tests are now wrapped in a for...of loop over a DATABOT_PROVIDERS array, with each provider getting its own test.describe block that handles login/logout. Adding a new provider is a one-line change.
- Each test now starts it's own console session. Re-using/restarting the same session was causing flakiness
- Updates the Allow button with the changes in latests databot release `0.0.41` that was causing failures.

### QA Notes
@:databot @:win @:web
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
