### PR TITLE
Handle more kinds of shells in supervisor startup

### DIFF
--- a/extensions/positron-supervisor/resources/supervisor-wrapper.sh
+++ b/extensions/positron-supervisor/resources/supervisor-wrapper.sh
@@ -58,9 +58,9 @@ fi
 SHELL_NAME=$(basename "$DEFAULT_SHELL")
 
 # Check if the shell is one we know how to work with. If not, fall back to
-# bash or sh so that we don't break on exotic shells (e.g. fish, elvish, etc.)
+# bash or sh so that we don't break on exotic shells (e.g. nushell, elvish, etc.)
 case "$SHELL_NAME" in
-	bash|zsh|dash|sh|ksh|ash|csh|tcsh|nu|nushell)
+	bash|zsh|dash|sh|ksh|ash|csh|tcsh|fish)
 		# Known shell; use it as-is
 		;;
 	*)
@@ -81,27 +81,12 @@ fi
 # Print the command line to the log file
 echo "$DEFAULT_SHELL" $SHELL_FLAGS "$@" >> "$output_file"
 
-# Determine if we need to prefix the command with ^ for nushell.
-# In nushell, external commands must be prefixed with ^ so that the shell
-# does not try to parse the command name as a nushell expression.
-IS_NUSHELL=false
-if [ "$SHELL_NAME" = "nu" ] || [ "$SHELL_NAME" = "nushell" ]; then
-	IS_NUSHELL=true
-fi
-
 # Quote the arguments to handle single quotes and spaces correctly.
 QUOTED_ARGS=""
-first=true
 for arg in "$@"; do
 	# Escape any single quotes in the argument
 	escaped_arg=$(printf "%s" "$arg" | sed "s/'/'\\\\''/g")
-	# Prefix the first argument (the command) with ^ when running under nushell
-	if [ "$first" = true ] && [ "$IS_NUSHELL" = true ]; then
-		QUOTED_ARGS=" ^'${escaped_arg}'"
-	else
-		QUOTED_ARGS="${QUOTED_ARGS} '${escaped_arg}'"
-	fi
-	first=false
+	QUOTED_ARGS="${QUOTED_ARGS} '${escaped_arg}'"
 done
 
 # Run the program with its arguments, redirecting stdout and stderr to the output file

--- a/extensions/positron-supervisor/resources/supervisor-wrapper.sh
+++ b/extensions/positron-supervisor/resources/supervisor-wrapper.sh
@@ -44,36 +44,64 @@ DEFAULT_SHELL=$SHELL
 
 # If $SHELL is not set, try to use the environment
 if [ -z "$DEFAULT_SHELL" ]; then
-    # Fall back to bash as a reasonable default
-    DEFAULT_SHELL=$(which bash 2>/dev/null || which sh)
+	# Fall back to bash as a reasonable default
+	DEFAULT_SHELL=$(which bash 2>/dev/null || which sh)
 fi
 
 # Ensure we have a valid shell
 if [ -z "$DEFAULT_SHELL" ] || [ ! -x "$DEFAULT_SHELL" ]; then
-    echo "Error: Could not determine a valid shell." >&2
-    exit 1
+	echo "Error: Could not determine a valid shell." >&2
+	exit 1
 fi
 
 # Determine shell flags based on shell type
+SHELL_NAME=$(basename "$DEFAULT_SHELL")
+
+# Check if the shell is one we know how to work with. If not, fall back to
+# bash or sh so that we don't break on exotic shells (e.g. fish, elvish, etc.)
+case "$SHELL_NAME" in
+	bash|zsh|dash|sh|ksh|ash|csh|tcsh|nu|nushell)
+		# Known shell; use it as-is
+		;;
+	*)
+		# Unknown shell; fall back to bash or sh
+		DEFAULT_SHELL=$(which bash 2>/dev/null || which sh)
+		SHELL_NAME=$(basename "$DEFAULT_SHELL")
+		;;
+esac
+
 # csh and tcsh don't support -l and -c together; use -d instead of -l
 # (in csh, -d loads the directory stack even in non-login shells)
-SHELL_NAME=$(basename "$DEFAULT_SHELL")
 if [ "$SHELL_NAME" = "csh" ] || [ "$SHELL_NAME" = "tcsh" ]; then
-    SHELL_FLAGS="-d -c"
+	SHELL_FLAGS="-d -c"
 else
-    SHELL_FLAGS="-l -c"
+	SHELL_FLAGS="-l -c"
 fi
 
 # Print the command line to the log file
 echo "$DEFAULT_SHELL" $SHELL_FLAGS "$@" >> "$output_file"
 
-# Quote the arguments to handle single quotes and spaces correctly
+# Determine if we need to prefix the command with ^ for nushell.
+# In nushell, external commands must be prefixed with ^ so that the shell
+# does not try to parse the command name as a nushell expression.
+IS_NUSHELL=false
+if [ "$SHELL_NAME" = "nu" ] || [ "$SHELL_NAME" = "nushell" ]; then
+	IS_NUSHELL=true
+fi
+
+# Quote the arguments to handle single quotes and spaces correctly.
 QUOTED_ARGS=""
+first=true
 for arg in "$@"; do
-    # Escape any single quotes in the argument
-    escaped_arg=$(printf "%s" "$arg" | sed "s/'/'\\\\''/g")
-    # Add the escaped argument with single quotes
-    QUOTED_ARGS="${QUOTED_ARGS} '${escaped_arg}'"
+	# Escape any single quotes in the argument
+	escaped_arg=$(printf "%s" "$arg" | sed "s/'/'\\\\''/g")
+	# Prefix the first argument (the command) with ^ when running under nushell
+	if [ "$first" = true ] && [ "$IS_NUSHELL" = true ]; then
+		QUOTED_ARGS=" ^'${escaped_arg}'"
+	else
+		QUOTED_ARGS="${QUOTED_ARGS} '${escaped_arg}'"
+	fi
+	first=false
 done
 
 # Run the program with its arguments, redirecting stdout and stderr to the output file


### PR DESCRIPTION
This change addresses an issue starting the kernel supervisor when `nushell` is the default shell.

<img width="1323" height="864" alt="image" src="https://github.com/user-attachments/assets/62b3eb9e-d891-47dd-b9ec-e4dea5505df0" />

The problem is that nushell requires us to specify the launch command a little differently, which this PR does.

Additionally, it contains a defense mechanism against other "exotic" shells: if the shell command is not on a list of recognized shells, then instead of just hoping for the best (current behavior) it falls back to `bash` so we can be certain the startup arguments we're using will work correctly.

Addresses #12156.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix error starting kernels when using exotic shells (#12156)


### QA Notes

`chsh` is useful when testing this change.