### PR TITLE
Add command for `rmarkdown::draft()` with installed `.Rmd` templates

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -1089,7 +1089,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.233"
+      "ark": "0.1.236"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -169,9 +169,9 @@
         "title": "%r.command.browseAddins.title%"
       },
       {
-        "command": "r.browseRmdTemplates",
+        "command": "r.newRmdFromTemplate",
         "category": "R",
-        "title": "%r.command.browseRmdTemplates.title%"
+        "title": "%r.command.newRmdFromTemplate.title%"
       }
     ],
     "configuration": [

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -24,7 +24,7 @@
 	"r.command.loadRdsFile.title": "Load R Object",
 	"r.command.loadRDataFileWithPicker.title": "Load R Data File...",
 	"r.command.browseAddins.title": "Browse RStudio Addins",
-	"r.command.browseRmdTemplates.title": "Browse R Markdown Templates",
+	"r.command.newRmdFromTemplate.title": "New R Markdown from Template",
 	"r.customEditor.rdataLoader.displayName": "R Workspace Loader",
 	"r.customEditor.rdsLoader.displayName": "R Object Loader",
 	"r.menu.createNewFile.title": "R File",

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -653,12 +653,24 @@ async function browseRmdTemplates(): Promise<void> {
 		});
 
 		if (selected) {
-			// For now, just show the template info. Full implementation in a later PR.
 			const t = selected.template;
-			vscode.window.showInformationMessage(
-				vscode.l10n.t('Selected template: {0} from {1} (template dir: {2})',
-					t.name, t.package, t.template)
-			);
+
+			// Get save location from user
+			const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri
+				?? vscode.Uri.file(os.homedir());
+
+			const saveUri = await vscode.window.showSaveDialog({
+				defaultUri: vscode.Uri.joinPath(defaultUri, 'Untitled.Rmd')
+			});
+
+			if (!saveUri) {
+				return;
+			}
+
+			// Create document using rmarkdown::draft() and open via rstudioapi
+			const draftPath = saveUri.fsPath;
+			const code = `rmarkdown::draft(${JSON.stringify(draftPath)}, template = "${t.template}", package = "${t.package}")`;
+			await positron.runtime.executeCode('r', code, true);
 		}
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -629,7 +629,7 @@ async function newRmdFromTemplate(): Promise<void> {
 			return;
 		}
 
-		const templates = await session.getRmdTemplates();
+		const templates = await session.getRmdTemplates(true);
 
 		if (templates.length === 0) {
 			// The rmarkdown package itself has templates, so something must go really wrong to get here:

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -271,8 +271,8 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 		}),
 
 		// Commands for R Markdown templates
-		vscode.commands.registerCommand('r.browseRmdTemplates', async () => {
-			await browseRmdTemplates();
+		vscode.commands.registerCommand('r.newRmdFromTemplate', async () => {
+			await newRmdFromTemplate();
 		}),
 	);
 }
@@ -612,10 +612,10 @@ interface TemplateQuickPickItem extends vscode.QuickPickItem {
 }
 
 /**
- * Browse installed R Markdown templates.
- * Shows a QuickPick with all templates found in installed packages.
+ * Create a new R Markdown document from an installed template.
+ * Shows a QuickPick to select a template, then a save dialog for the destination.
  */
-async function browseRmdTemplates(): Promise<void> {
+async function newRmdFromTemplate(): Promise<void> {
 	// Check that rmarkdown is installed first
 	const isInstalled = await checkInstalled('rmarkdown');
 	if (!isInstalled) {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/8762
Related to https://github.com/posit-dev/ark/pull/1063 and https://github.com/posit-dev/positron/pull/12160

This PR completes the `.Rmd` template browsing feature by adding file creation after template selection. When users select a template from the _R: New R Markdown from Template_ command, they now get a native save dialog to choose the destination, and `rmarkdown::draft()` creates and opens the file.

I want to point out that unlike _R: New R File_ which creates an empty in-memory document, R Markdown templates require a real file path because:

- `rmarkdown::draft()` writes the file to disk directly
- Templates with `create_dir: true` create a directory structure with supporting files (CSS, images, LaTeX style files, etc.)
- The template's skeleton files get copied alongside the .Rmd

### Release Notes

#### New Features

- Use the new command _R: New R Markdown from Template_ to discover all `.Rmd` templates in your installed R packages and create a new file using your chosen option (#8762)

#### Bug Fixes

- N/A

### QA Notes

@:r-markdown @:interpreter

Make sure you have both the rmarkdown and rticles packages installed.

**Test 1: Regular template**

1. Open Command Palette > _R: New R Markdown from Template_
2. Select "GitHub Document (Markdown)" from `{rmarkdown}`
3. Save dialog should appear with `Untitled.Rmd` as default filename
4. Choose a location and filename
5. Verify:
   - File is created at chosen location
   - File opens in editor
   - Contains GitHub document YAML front matter

**Test 2: Template with directory creation (`create_dir: true`)**

1. Open Command Palette > _R: New R Markdown from Template_
2. Select "Journal of Statistical Software" from `{rticles}`
3. Save as `my-article.Rmd` at some path
4. Verify:
   - A `my-article/` directory is created at your chosen path
   - `my-article/my-article.Rmd` exists inside it
   - Supporting files (e.g., `.bib`, style files) are present in the directory
   - The .Rmd file opens in editor

**Test 3: Cancel behavior**

1. Open Command Palette > _R: New R Markdown from Template_
2. Select any template
3. Press Escape on save dialog
4. Verify no file is created and no error appears
