### PR TITLE
Fixes a React 19 rendering issue during Electron's cold startup

### DIFF
--- a/src/vs/base/browser/positronModalReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalReactRenderer.tsx
@@ -234,6 +234,12 @@ export class PositronModalReactRenderer extends Disposable {
 			this._root = createRoot(this._overlay);
 
 			// Render the ReactElement that was supplied.
+			// Unlike PositronReactRenderer, we don't need flushSync here because modal popups
+			// are user-triggered (context menus, dropdowns, dialogs) and occur well after the
+			// critical Electron startup window (~t=2800-2930ms) where microtasks are dropped.
+			// By the time a user interacts with the UI, the event loop is "warm" and React 19's
+			// microtask-based scheduling works normally. Note: If we ever show programmatic modal
+			// dialogs automatically during the critical startup window, we would need flushSync.
 			this._root.render(
 				<PositronReactServicesContext.Provider value={PositronReactServices.services}>
 					{reactElement}

--- a/src/vs/base/browser/positronReactRenderer.tsx
+++ b/src/vs/base/browser/positronReactRenderer.tsx
@@ -5,6 +5,7 @@
 
 // React.
 import { ReactElement } from 'react';
+import { flushSync } from 'react-dom';
 import { createRoot, Root } from 'react-dom/client';
 
 // Other dependencies.
@@ -146,11 +147,20 @@ export class PositronReactRenderer extends Disposable {
 	 */
 	public render(reactElement: ReactElement) {
 		if (this._root) {
-			this._root.render(
-				<PositronReactServicesContext.Provider value={PositronReactServices.services}>
-					{reactElement}
-				</PositronReactServicesContext.Provider>
-			);
+			// React 19 changed to use microtask-based scheduling for root.render(). During the
+			// first ~150ms of Electron renderer startup (specifically around t=2800-2930ms), the
+			// event loop silently drops queueMicrotask callbacks. If React's scheduling microtask
+			// is dropped, the render never completes (didScheduleMicrotask stays true forever).
+			// flushSync forces synchronous rendering, bypassing the microtask queue entirely.
+			// This issue only occurs on the first cold startup; subsequent reloads work fine
+			// because the event loop is already "warm" and microtasks fire normally.
+			flushSync(() => {
+				this._root!.render(
+					<PositronReactServicesContext.Provider value={PositronReactServices.services}>
+						{reactElement}
+					</PositronReactServicesContext.Provider>
+				);
+			});
 		}
 	}
 


### PR DESCRIPTION
## What changed

Commit (`ddf480634`) fixes a React 19 rendering issue during Electron's cold startup.

**positronReactRenderer.tsx:** Wrapped `root.render()` in `flushSync()` to force synchronous rendering. This bypasses React 19's microtask-based scheduling, which fails during a narrow window of Electron's first renderer startup (~t=2800-2930ms) when `queueMicrotask` callbacks are silently dropped.

**positronModalReactRenderer.tsx:** Added a comment explaining why `flushSync` is *not* needed here -- modal popups are user-triggered and occur well after the critical startup window, so the event loop is already "warm" and microtask scheduling works normally.

## Root cause

React 19 changed `ensureRootIsScheduled` to use a single `queueMicrotask` to bridge `root.render()` to the scheduler. During Electron's cold startup, that microtask gets dropped, leaving `didScheduleMicrotask` permanently `true` and all roots stuck with `pendingLanes=32` and `callbackNode=null`. The issue doesn't reproduce on reload because the event loop is already warm.

### Release Notes

- N/A

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

This appears to fix the issue that causes some or all React rendering to fail during launch.

Tests:
@:console
@:critical
@:data-explorer
@:editor-action-bar
@:viewer
@:modal
@:plots
@:top-action-bar
@:variables