### PR TITLE
Support `Repo` in r-versions config file

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -1089,7 +1089,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.234"
+      "ark": "0.1.235"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/extensions/positron-r/src/kernel-spec.ts
+++ b/extensions/positron-r/src/kernel-spec.ts
@@ -7,6 +7,7 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 import { execSync } from 'child_process';
 
 import { JupyterKernelSpec } from './positron-supervisor';
@@ -419,9 +420,15 @@ export async function createJupyterKernelSpec(
 	}
 
 	// Set the default repositories
+	// Check if r-versions entry specifies a repo (takes precedence over settings)
+	const rVersionsRepoArgs = getRVersionsRepoArgs(packagerMetadata);
+	if (rVersionsRepoArgs) {
+		argv.push(...rVersionsRepoArgs);
+	}
+
 	const defaultRepos = config.get<string>('defaultRepositories') ?? 'auto';
 	const ppmRepo = config.get<string>('packageManagerRepository');
-	if (defaultRepos === 'auto') {
+	if (!rVersionsRepoArgs && defaultRepos === 'auto') {
 		const reposConf = findReposConf();
 		if (reposConf) {
 			// If there's a `repos.conf` file in a well-known directory, use
@@ -440,7 +447,7 @@ export async function createJupyterKernelSpec(
 		// In all other cases when `auto` is set, we don't specify
 		// `--default-repos` at all, and let Ark choose an appropriate
 		// repository (usually `cran.rstudio.com)
-	} else {
+	} else if (!rVersionsRepoArgs) {
 		// Warn the user about inconsistent PPM settings.
 		if (ppmRepo) {
 			const openSettings = vscode.l10n.t('Open Settings');
@@ -510,7 +517,7 @@ export async function createJupyterKernelSpec(
  * Attempt to find a `repos.conf` file in Positron or RStudio XDG
  * configuration directories.
  *
- * Returns the path to the file if found, or `undefined` if no
+ * Returns the path to the file if found, or `undefined` if not.
  */
 function findReposConf(): string | undefined {
 	const xdg = require('xdg-portable/cjs');
@@ -529,4 +536,52 @@ function findReposConf(): string | undefined {
 		}
 	}
 	return;
+}
+
+/**
+ * Cache for temporary repos.conf files created from r-versions URLs.
+ * Maps URL -> temp file path. Reused across sessions during extension lifetime.
+ */
+const rVersionsReposConfCache = new Map<string, string>();
+
+/**
+ * Get repository configuration args from r-versions metadata.
+ *
+ * The Repo field can be either a file path to a repos.conf file or a URL.
+ * For URLs, a temporary repos.conf file is created and cached for reuse.
+ * Returns the appropriate argv entries, or `undefined` if no repo is specified.
+ */
+function getRVersionsRepoArgs(packagerMetadata?: PackagerMetadata): string[] | undefined {
+	if (!packagerMetadata || !isRVersionsMetadata(packagerMetadata) || !packagerMetadata.repo) {
+		return undefined;
+	}
+
+	const repo = packagerMetadata.repo;
+
+	// Check if this is a URL
+	if (repo.startsWith('http://') || repo.startsWith('https://')) {
+		// Check cache first
+		const cachedPath = rVersionsReposConfCache.get(repo);
+		if (cachedPath && fs.existsSync(cachedPath)) {
+			LOGGER.info(`Using cached repos.conf for r-versions URL: ${cachedPath}`);
+			return ['--repos-conf', cachedPath];
+		}
+
+		// Create a temporary repos.conf file for the URL
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'positron-r-repos-'));
+		const tempReposConf = path.join(tempDir, 'repos.conf');
+		fs.writeFileSync(tempReposConf, `CRAN=${repo}\n`);
+		rVersionsReposConfCache.set(repo, tempReposConf);
+		LOGGER.info(`Created temporary repos.conf for r-versions URL: ${tempReposConf}`);
+		return ['--repos-conf', tempReposConf];
+	}
+
+	// Treat as a file path
+	if (fs.existsSync(repo) && fs.statSync(repo).isFile()) {
+		LOGGER.info(`Using r-versions repos.conf: ${repo}`);
+		return ['--repos-conf', repo];
+	}
+
+	LOGGER.warn(`r-versions Repo field is not a valid URL or file path: ${repo}`);
+	return undefined;
 }

--- a/extensions/positron-r/src/kernel-spec.ts
+++ b/extensions/positron-r/src/kernel-spec.ts
@@ -7,7 +7,6 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import * as os from 'os';
 import { execSync } from 'child_process';
 
 import { JupyterKernelSpec } from './positron-supervisor';
@@ -539,16 +538,11 @@ function findReposConf(): string | undefined {
 }
 
 /**
- * Cache for temporary repos.conf files created from r-versions URLs.
- * Maps URL -> temp file path. Reused across sessions during extension lifetime.
- */
-const rVersionsReposConfCache = new Map<string, string>();
-
-/**
  * Get repository configuration args from r-versions metadata.
  *
  * The Repo field can be either a file path to a repos.conf file or a URL.
- * For URLs, a temporary repos.conf file is created and cached for reuse.
+ * For URLs, use ark's --default-cran-repo.
+ * For file paths, use ark's --repos-conf.
  * Returns the appropriate argv entries, or `undefined` if no repo is specified.
  */
 function getRVersionsRepoArgs(packagerMetadata?: PackagerMetadata): string[] | undefined {
@@ -558,25 +552,13 @@ function getRVersionsRepoArgs(packagerMetadata?: PackagerMetadata): string[] | u
 
 	const repo = packagerMetadata.repo;
 
-	// Check if this is a URL
+	// Check if this is a URL, to pass directly to ark's --default-cran-repo
 	if (repo.startsWith('http://') || repo.startsWith('https://')) {
-		// Check cache first
-		const cachedPath = rVersionsReposConfCache.get(repo);
-		if (cachedPath && fs.existsSync(cachedPath)) {
-			LOGGER.info(`Using cached repos.conf for r-versions URL: ${cachedPath}`);
-			return ['--repos-conf', cachedPath];
-		}
-
-		// Create a temporary repos.conf file for the URL
-		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'positron-r-repos-'));
-		const tempReposConf = path.join(tempDir, 'repos.conf');
-		fs.writeFileSync(tempReposConf, `CRAN=${repo}\n`);
-		rVersionsReposConfCache.set(repo, tempReposConf);
-		LOGGER.info(`Created temporary repos.conf for r-versions URL: ${tempReposConf}`);
-		return ['--repos-conf', tempReposConf];
+		LOGGER.info(`Using r-versions repo URL: ${repo}`);
+		return ['--default-cran-repo', repo];
 	}
 
-	// Treat as a file path
+	// Otherwise treat as a file path, to use with --repos-conf
 	if (fs.existsSync(repo) && fs.statSync(repo).isFile()) {
 		LOGGER.info(`Using r-versions repos.conf: ${repo}`);
 		return ['--repos-conf', repo];

--- a/extensions/positron-r/src/provider-rversions.ts
+++ b/extensions/positron-r/src/provider-rversions.ts
@@ -219,7 +219,8 @@ export async function discoverRVersionsBinaries(): Promise<RBinary[]> {
 			type: 'rversions',
 			label: entry.label,
 			script: entry.script,
-			// Future PRs will add: repo, library
+			repo: entry.repo,
+			// Future PRs will add: library
 		};
 
 		binaries.push({

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -125,7 +125,9 @@ export interface RVersionsMetadata {
 	readonly label?: string;
 	/** Shell script to source before launching R */
 	readonly script?: string;
-	// Future PRs will add: repo, library
+	/** CRAN repository URL or path to repos.conf file */
+	readonly repo?: string;
+	// Future PRs will add: library
 }
 
 /**


### PR DESCRIPTION
Addresses #11426 with the fourth PR in the r-versions implementation series

This PR adds support for the `Repo` field from the r-versions configuration file, allowing administrators to specify default CRAN repositories for specific R installations. The field can be either:
- A URL (e.g., `Repo: https://cran.rstudio.com/`)
- A path to a repos.conf file (e.g., `Repo: /etc/rstudio/repos.conf`)

For URLs, a temporary `repos.conf` file is created and cached for the extension lifetime, avoiding repeated file creation across R sessions.

This is the fourth PR in the r-versions implementation series:
- #12022 
- #12101 
- #12169 
- **This PR:** `Repo` field support

### Release Notes

#### New Features

- N/A for now!

#### Bug Fixes

- N/A

### QA Notes

> [!NOTE]
> R installations managed by rig will likely have a line in their Rprofile (`options(repos = c(CRAN = "..."))`) that overrides repository settings configured via r-versions. If when you are trying this out, it shows the default `cloud.r-project.org` instead of the expected repo, check the R installation's Rprofile at `<R_HOME>/library/base/R/Rprofile`.

@:interpreter

**Testing with a repos.conf file path:**

1. Create a repos.conf file with a non-default repo:
   ```bash
   mkdir -p ~/Library/Preferences/positron
   echo "CRAN=https://cran.case.edu/" > ~/Library/Preferences/positron/repos.conf
   ```

2. Create or update r-versions file at `~/Library/Preferences/rstudio/r-versions` (macOS) or `/etc/rstudio/r-versions` (Linux):
   ```
   Path: /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources
   Label: R 4.4 (Test Repos File)
   Repo: /Users/yourusername/Library/Preferences/positron/repos.conf
   ```

3. Restart Positron, start a session with the labeled interpreter, and verify:
   ```r
   getOption("repos")
   # Should show: https://cran.case.edu/
   ```

**Testing with a URL:**

1. Update r-versions to use a URL directly:
   ```
   Path: /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources
   Label: R 4.4 (Test Repos URL)
   Repo: https://cran.rstudio.com/
   ```

2. Restart Positron, start a session, and verify:
   ```r
   getOption("repos")
   # Should show: https://cran.rstudio.com/
   ```


