### PR TITLE
Add links for email newsletter signup

### DIFF
--- a/src/vs/workbench/browser/actions/helpActions.ts
+++ b/src/vs/workbench/browser/actions/helpActions.ts
@@ -445,4 +445,25 @@ registerAction2(class extends Action2 {
 		);
 	}
 });
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.openPositronNewsletterSignup',
+			title: localize2('openPositronNewsletterSignup', 'Sign Up for Positron Updates'),
+			category: Categories.Help,
+			f1: true,
+			menu: {
+				id: MenuId.MenubarHelpMenu,
+				group: '1_welcome',
+				order: 8
+			}
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		const openerService = accessor.get(IOpenerService);
+		openerService.open(URI.parse('https://posit.co/positron-updates-signup/'));
+	}
+});
 // --- End Positron ---

--- a/src/vs/workbench/contrib/positronHelp/browser/resources/welcome.html
+++ b/src/vs/workbench/contrib/positronHelp/browser/resources/welcome.html
@@ -51,7 +51,8 @@
 				<ul>
 					<li><a href="https://positron.posit.co/">Positron Documentation</a></li>
 					<li><a href="https://github.com/posit-dev/positron/discussions">Positron Community Forum</a></li>
-					<li><a href="command:workbench.action.openIssueReporter">Report a bug in Positron</a></li>
+					<li><a href="command:workbench.action.openIssueReporter">Report a Bug in Positron</a></li>
+					<li><a href="https://posit.co/positron-updates-signup/">Sign Up for Positron Updates</a></li>
 					<br />
 					<li><a href="https://posit.co/resources/cheatsheets/">Posit Cheat Sheets</a></li>
 					<li><a href="https://posit.co/products/">Posit Products</a></li>

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -1130,8 +1130,13 @@ export class GettingStartedPage extends EditorPane {
 			},
 			{
 				id: 'report-bug',
-				title: 'Report a bug',
+				title: 'Report a Bug',
 				href: 'https://github.com/posit-dev/positron/issues'
+			},
+			{
+				id: 'positron-newsletter',
+				title: localize('positron.welcome.newsletter', "Sign Up for Positron Updates"),
+				href: 'https://posit.co/positron-updates-signup/'
 			}
 		];
 

--- a/test/e2e/tests/help/help.test.ts
+++ b/test/e2e/tests/help/help.test.ts
@@ -26,6 +26,11 @@ test.describe('Help', { tag: [tags.HELP, tags.WEB] }, () => {
 		const docLink = helpFrame.getByRole('link', { name: 'Positron Documentation' });
 		await expect(docLink).toBeVisible();
 		await expect(docLink).toHaveAttribute('href', 'https://positron.posit.co/');
+
+		const newsletterLink = helpFrame.getByRole('link', { name: 'Sign Up for Positron Updates' });
+		await expect(newsletterLink).toBeVisible();
+		await expect(newsletterLink).toHaveAttribute('href', 'https://posit.co/positron-updates-signup/');
+
 		await app.workbench.layouts.enterLayout('stacked');
 	});
 

--- a/test/e2e/tests/welcome/welcome.test.ts
+++ b/test/e2e/tests/welcome/welcome.test.ts
@@ -31,7 +31,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 			await welcome.expectFooterToBeVisible();
 			await welcome.expectTabTitleToBe('Welcome');
 			await welcome.expectStartToContain(['New Notebook', 'New File']);
-			await welcome.expectHelpToContain(['Positron Documentation', 'Positron Community Forum', 'Report a bug']);
+			await welcome.expectHelpToContain(['Positron Documentation', 'Positron Community Forum', 'Report a Bug', 'Sign Up for Positron Updates']);
 			await welcome.expectRecentToContain([]);
 			app.web
 				? await welcome.expectConnectToBeVisible(false)
@@ -109,7 +109,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 			await welcome.expectFooterToBeVisible();
 
 			await welcome.expectStartToContain(['Open Folder...', 'New Folder...', 'New from Git...']);
-			await welcome.expectHelpToContain(['Positron Documentation', 'Positron Community Forum', 'Report a bug']);
+			await welcome.expectHelpToContain(['Positron Documentation', 'Positron Community Forum', 'Report a Bug', 'Sign Up for Positron Updates']);
 			await welcome.expectRecentToContain(['qa-example-content']);
 		});
 


### PR DESCRIPTION
Addresses #11854.

This PR adds a newsletter signup link in multiple locations to make Positron email updates more discoverable:
- New Help menu command "Sign Up for Positron Updates"
- Help pane welcome page
- Getting Started page links

<img width="1295" height="899" alt="Screenshot 2026-03-02 at 11 59 12 AM" src="https://github.com/user-attachments/assets/9dd0efd9-c220-4c0c-864b-ce724426d477" />

I am leaning away from adding a new popup notification for now, because we've gotten feedback from customers that Positron already has notifications that can feel overwhelming. Customers are looking for ways to reduce distracting popups so it doesn't seem like a great moment for adding an additional one.

### Release Notes

#### New Features

- Added "Sign Up for Positron Updates" link to the Help menu, Help pane, and Getting Started page (#11854)

#### Bug Fixes

- N/A

### QA Notes

@:help @:welcome

1. Open the Help menu and verify "Sign Up for Positron Updates" appears
2. Click it and verify it opens https://posit.co/positron-updates-signup/
3. Open the Help pane (the welcome page) and verify the signup link appears in the resources list
4. Open the Getting Started tab and verify the signup link appears
