### PR TITLE
Do not sync Variables pane for a Data Explorer "editor"

### DIFF
--- a/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
+++ b/src/vs/workbench/services/positronVariables/common/positronVariablesService.ts
@@ -24,6 +24,7 @@ import { PositronNotebookEditorInput } from '../../../contrib/positronNotebook/b
 import { IRuntimeNotebookKernelService } from '../../../contrib/runtimeNotebookKernel/common/interfaces/runtimeNotebookKernelService.js';
 import { ILanguageRuntimeCodeExecutedEvent } from '../../positronConsole/common/positronConsoleCodeExecution.js';
 import { IQuartoExecutionManager } from '../../../contrib/positronQuarto/common/quartoExecutionTypes.js';
+import { PositronDataExplorerEditorInput } from '../../../contrib/positronDataExplorerEditor/browser/positronDataExplorerEditorInput.js';
 
 /**
  * PositronVariablesService class.
@@ -304,6 +305,14 @@ export class PositronVariablesService extends Disposable implements IPositronVar
 		}
 
 		const editorInput = this._editorService.activeEditor;
+
+		// If a data explorer is opened, don't change the Variables pane session.
+		// The data explorer should not impact session following, keeping the
+		// Variables pane on whichever session spawned the data being viewed.
+		if (editorInput instanceof PositronDataExplorerEditorInput) {
+			return;
+		}
+
 		if (editorInput instanceof NotebookEditorInput || editorInput instanceof PositronNotebookEditorInput) {
 			// If this is a notebook editor try and set the active variables session to the one
 			// that corresponds with it.

--- a/test/e2e/tests/variables/variables-notebook.test.ts
+++ b/test/e2e/tests/variables/variables-notebook.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -87,6 +87,29 @@ test.describe('Variables Pane - Notebook', {
 		await notebooks.assertCellOutput('Hello from first cell', 0);
 		await notebooks.assertCellOutput('Sum of numbers: 15');
 		await notebooks.assertCellOutput('Modified numbers: [1, 2, 3, 4, 5, 6]');
+	});
+
+	test('Python - Verify Variables pane stays on notebook session after opening Data Explorer', {
+		tag: [tags.DATA_EXPLORER]
+	}, async function ({ app, hotKeys }) {
+		const { notebooks, variables, editors } = app.workbench;
+
+		// Create a dataframe in a notebook
+		await notebooks.createNewNotebook();
+		await notebooks.selectInterpreter('Python');
+		await notebooks.addCodeToCellAtIndex(0, 'import pandas as pd\ndf = pd.DataFrame({"a": [1, 2, 3]})');
+		await notebooks.executeCodeInCell();
+
+		// Verify we're on the notebook session
+		await hotKeys.fullSizeSecondarySidebar();
+		await variables.expectSessionToBe(FILENAME);
+
+		// Open the Data Explorer by double-clicking the variable
+		await variables.doubleClickVariableRow('df');
+		await editors.verifyTab('Data: df', { isVisible: true });
+
+		// Verify Variables pane stayed on the notebook session (regression test for #7539)
+		await variables.expectSessionToBe(FILENAME);
 	});
 });
 


### PR DESCRIPTION
Addresses #7539

When a user opens the Data Explorer from a notebook's Variables pane, the Variables pane would incorrectly switch to the foreground console session instead of staying on the notebook session. This happened because the `_syncToActiveEditor()` method thought the Data Explorer "editor" was just a regular old editor, causing it to fall through to the default behavior of switching to the foreground console session.

This PR makes the Data Explorer "transparent" to session following; when a Data Explorer editor becomes active, the Variables pane now stays on whichever session it was showing. This preserves the context for users working in a notebook.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed Variables pane navigating away from the correct notebook session when opening the Data Explorer (#7539)

### QA Notes

@:variables @:data-explorer @:notebooks

1. Open a Jupyter notebook
2. Create a dataframe:
```python
import pandas as pd
df = pd.DataFrame({"a": [1, 2, 3]})
```
3. Execute the cell
4. In the Variables pane, verify the session shows the notebook name
5. Click the data viewer icon on the `df` variable to open it
6. Verify the Variables pane still shows the notebook session (not the console)
