### PR TITLE
Fix ANSI color rendering in console and Quarto inline output

### DIFF
--- a/src/vs/base/common/ansiStyles.ts
+++ b/src/vs/base/common/ansiStyles.ts
@@ -61,9 +61,6 @@ export function computeAnsiStyles(styles: ANSIStyle[]): ANSICSSProperties {
  * @returns A CSS color string, or undefined if the color cannot be resolved.
  */
 export function resolveAnsiColor(color: ANSIColor | string): string | undefined {
-	if (typeof color === 'string') {
-		return color;
-	}
 	switch (color) {
 		case ANSIColor.Black:
 		case ANSIColor.Red:
@@ -83,6 +80,11 @@ export function resolveAnsiColor(color: ANSIColor | string): string | undefined 
 		case ANSIColor.BrightWhite:
 			return `var(--vscode-positronConsole-${color})`;
 		default:
+			// Note: ANSIColor is a string enum, so the typeof check must come
+			// after the switch cases, not before.
+			if (typeof color === 'string') {
+				return color;
+			}
 			return undefined;
 	}
 }

--- a/src/vs/base/test/common/ansiStyles.test.ts
+++ b/src/vs/base/test/common/ansiStyles.test.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
+import { ANSIColor } from '../../common/ansiOutput.js';
+import { resolveAnsiColor } from '../../common/ansiStyles.js';
+
+suite('resolveAnsiColor', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('maps standard ANSI colors to CSS variables', () => {
+		assert.strictEqual(
+			resolveAnsiColor(ANSIColor.Red),
+			'var(--vscode-positronConsole-ansiRed)'
+		);
+		assert.strictEqual(
+			resolveAnsiColor(ANSIColor.BrightCyan),
+			'var(--vscode-positronConsole-ansiBrightCyan)'
+		);
+	});
+
+	test('passes through RGB strings as-is', () => {
+		assert.strictEqual(resolveAnsiColor('#ff5f00'), '#ff5f00');
+		assert.strictEqual(resolveAnsiColor('rgb(255, 0, 0)'), 'rgb(255, 0, 0)');
+	});
+});


### PR DESCRIPTION
Addresses #12227

`ANSIColor` is a string enum, so those cases are matching `typeof color === 'string'`, causing them to be returned as raw enum strings instead of as CSS variables. Let's reorder things.

### QA Notes

Helpful R Code and screenshots are in #12227.