### PR TITLE
Fixes a React 19 rendering issue during Electron's cold startup

### DIFF
--- a/src/vs/code/electron-browser/workbench/workbench.ts
+++ b/src/vs/code/electron-browser/workbench/workbench.ts
@@ -294,6 +294,21 @@
 		// Dev only: CSS import map tricks
 		setupCSSImportMaps<T>(configuration, baseUrl);
 
+		/// --- Start Positron ---
+		// In development mode, setupCSSImportMaps() creates import map entries for 500+ CSS files.
+		// When the ESM imports below execute, they trigger a massive cascade of CSS loads that
+		// overwhelms the event loop. Under this pressure, React's queueMicrotask() calls get dropped,
+		// causing React to hang permanently. A 1-second delay before the cascade gives the event loop
+		// breathing room, preventing microtasks from being dropped.
+		//
+		// Note: Countless alternatives were tried (testing microtask reliability, monitoring CSS load
+		// progress, RAF-based yielding, batched CSS loading), but nothing works as reliably as a
+		// simple 1-second yeld before the cascade starts.
+		if (Array.isArray(configuration.cssModules) && configuration.cssModules.length > 0) {
+			await new Promise(resolve => setTimeout(resolve, 1000));
+		}
+		// --- End Positron ---
+
 		// ESM Import
 		try {
 			let workbenchUrl: string;


### PR DESCRIPTION
## Fix React Hang in Development Mode

**Problem:** In development mode, React will sometimes hang permanently after initially working. This only affected the first cold start in Electron dev mode.

**Root Cause:** `setupCSSImportMaps()` creates import map entries for 500+ CSS files. When ESM imports execute, they trigger a massive cascade of CSS loads that overwhelms the event loop. Under this pressure, React 19's `queueMicrotask()` calls get dropped, causing React's scheduler to hang permanently (`didScheduleMicrotask` stays `true` forever, no future renders occur).

**Solution:** Add a 1-second delay after `setupCSSImportMaps()` and before ESM imports. This gives the event loop breathing room before the CSS cascade begins, preventing microtasks from being dropped.

**Alternatives Considered:** Tested microtask reliability, monitored CSS load progress, RAF-based yielding, and batched CSS loading. None proved as reliable as a simple 1-second yield.

**Impact:** Development mode only. Production builds use bundled CSS and are unaffected.

### Release Notes

- N/A

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

Tests:
@:console
@:critical
@:data-explorer
@:editor-action-bar
@:viewer
@:modal
@:plots
@:top-action-bar
@:variables
