### PR TITLE
Bump Ark to 0.1.234

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -1089,7 +1089,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.233"
+      "ark": "0.1.234"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -186,7 +186,7 @@ test.describe('R Debugging', {
 		await console.waitForConsoleContents('Found 2 fruits!');
 	});
 
-	test.skip('R - Verify debugging with `debugonce()` pauses only once', async ({ app, page, executeCode, openFile, runCommand }) => {
+	test('R - Verify debugging with `debugonce()` pauses only once', async ({ app, page, executeCode, openFile, runCommand }) => {
 		const { debug, console } = app.workbench;
 
 		await openFile('workspaces/r-debugging/fruit_avg.r');

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -144,12 +144,12 @@ test.describe('R Debugging', {
 		// Step into the next line using 's'
 		await page.keyboard.type('s');
 		await page.keyboard.press('Enter');
-		await console.waitForConsoleContents(/debug at .*#3: cols <- grep\(pattern, names\(dat\)\)/);
+		await debug.expectCurrentLineToBe(3);
 
 		// Step over to next line using 'n'
 		await page.keyboard.type('n');
 		await page.keyboard.press('Enter');
-		await console.waitForConsoleContents(/debug at .*#4: mini_dat <- dat\[, cols\]/);
+		await debug.expectCurrentLineToBe(4);
 
 		// Continue execution with 'c'
 		await page.keyboard.type('c');
@@ -175,11 +175,11 @@ test.describe('R Debugging', {
 
 		// Step into using the debugger UI controls
 		await debug.stepInto();
-		await console.waitForConsoleContents(/debug at .*#3: cols <- grep\(pattern, names\(dat\)\)/);
+		await debug.expectCurrentLineToBe(3);
 
 		// Step over using the debugger UI controls
 		await debug.stepOver();
-		await console.waitForConsoleContents(/debug at .*#4: mini_dat <- dat\[, cols\]/);
+		await debug.expectCurrentLineToBe(4);
 
 		// Continue execution and check final message
 		await debug.continue();


### PR DESCRIPTION
- https://github.com/posit-dev/ark/pull/1065
- https://github.com/posit-dev/ark/pull/1068
  Addresses https://github.com/posit-dev/positron/issues/12230

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Noisy messages emitted by R during debugging are now filtered out from the Console (#12230).

#### Bug Fixes

- Fixed a rare bug that caused Console output to be temporarily swallowed (https://github.com/posit-dev/ark/pull/1065#issuecomment-3977280275).


### QA Notes

See linked PRs.

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:ark