### PR TITLE
fix: prevent ghost cell suggestions from hanging on stalled streams and model selection

### DIFF
--- a/extensions/positron-assistant/src/ghostCellSuggestions.ts
+++ b/extensions/positron-assistant/src/ghostCellSuggestions.ts
@@ -110,22 +110,15 @@ export async function generateGhostCellSuggestion(
 	// lets getModel() bail out between API calls when the timeout fires,
 	// avoiding stale work in the background.
 	let modelSelectionTimedOut = false;
-	let modelSelectionTimer: ReturnType<typeof setTimeout> | undefined;
 	const modelSelectionCts = new vscode.CancellationTokenSource();
-	let modelSelection: ModelSelectionResult | null;
+	let modelSelection: ModelSelectionResult | null | undefined;
 	try {
-		modelSelection = await Promise.race([
+		modelSelection = await raceTimeout(
 			getModel(participantService, log, modelSelectionCts.token),
-			new Promise<null>(resolve => {
-				modelSelectionTimer = setTimeout(() => {
-					modelSelectionTimedOut = true;
-					modelSelectionCts.cancel();
-					resolve(null);
-				}, MODEL_SELECTION_TIMEOUT_MS);
-			})
-		]);
+			MODEL_SELECTION_TIMEOUT_MS,
+			() => { modelSelectionTimedOut = true; modelSelectionCts.cancel(); }
+		);
 	} finally {
-		clearTimeout(modelSelectionTimer);
 		modelSelectionCts.dispose();
 	}
 	if (!modelSelection) {
@@ -180,7 +173,6 @@ export async function generateGhostCellSuggestion(
 	// cancels, so we don't leave stalled streams alive in the background.
 	const generationCts = new vscode.CancellationTokenSource();
 	const parentCancelListener = token.onCancellationRequested(() => generationCts.cancel());
-	let generationTimer: ReturnType<typeof setTimeout> | undefined;
 
 	try {
 		// Construct messages for the request
@@ -193,20 +185,18 @@ export async function generateGhostCellSuggestion(
 		// Timeout covers the entire generation process (request + streaming).
 		// Previously the timeout only covered sendRequest(), so a stalled
 		// stream from the model provider could hang indefinitely.
-		const timeoutMs = GENERATION_TIMEOUT_MS;
 		const generationPromise = (async () => {
 			const response = await model.sendRequest([systemMessage, userMessage], {}, generationCts.token);
 			return parseStreamingXML(response.text, log, generationCts.token, language, onProgress);
 		})();
-		const result = await Promise.race([
+		const result = await raceTimeout(
 			generationPromise,
-			new Promise<never>((_, reject) => {
-				generationTimer = setTimeout(() => {
-					generationCts.cancel();
-					reject(new Error('Ghost cell suggestion timed out'));
-				}, timeoutMs);
-			})
-		]);
+			GENERATION_TIMEOUT_MS,
+			() => generationCts.cancel()
+		);
+		if (result === undefined) {
+			throw new Error('Ghost cell suggestion timed out');
+		}
 		if (result) {
 			result.modelName = modelName;
 			result.usedFallback = usedFallback;
@@ -223,7 +213,6 @@ export async function generateGhostCellSuggestion(
 		log.error(`[ghost-cell] Error generating suggestion: ${errorMessage}`);
 		return null;
 	} finally {
-		clearTimeout(generationTimer);
 		parentCancelListener.dispose();
 		generationCts.dispose();
 	}
@@ -399,10 +388,7 @@ async function parseStreamingXML(
 		// that motivated the cancellation racing above).
 		const returnPromise = iterator.return?.();
 		if (returnPromise) {
-			await Promise.race([
-				returnPromise,
-				new Promise<void>(resolve => setTimeout(resolve, ITERATOR_CLEANUP_TIMEOUT_MS))
-			]);
+			await raceTimeout(returnPromise, ITERATOR_CLEANUP_TIMEOUT_MS);
 		}
 	}
 
@@ -528,6 +514,32 @@ async function fetchVariablesFromSession(
  */
 function escapeRegExp(s: string): string {
 	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Race a promise against a timeout. Returns the promise result, or
+ * `undefined` if the timeout fires first. The timer is cleaned up
+ * internally. An optional `onTimeout` callback runs when the timeout fires.
+ */
+async function raceTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+	onTimeout?: () => void
+): Promise<T | undefined> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<undefined>(resolve => {
+				timer = setTimeout(() => {
+					onTimeout?.();
+					resolve(undefined);
+				}, timeoutMs);
+			})
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
 }
 
 /**

--- a/extensions/positron-assistant/src/ghostCellSuggestions.ts
+++ b/extensions/positron-assistant/src/ghostCellSuggestions.ts
@@ -96,10 +96,28 @@ export async function generateGhostCellSuggestion(
 	// Start variable fetch concurrently with model selection
 	const variablesSummaryPromise = fetchSessionVariablesSummary(uri, log);
 
-	// Get the model to use for generation
-	const modelSelection = await getModel(participantService, log);
+	// Get the model to use for generation (with timeout to prevent hanging
+	// if a VS Code API call stalls)
+	let modelSelectionTimedOut = false;
+	let modelSelectionTimer: ReturnType<typeof setTimeout> | undefined;
+	let modelSelection: ModelSelectionResult | null;
+	try {
+		modelSelection = await Promise.race([
+			getModel(participantService, log),
+			new Promise<null>(resolve => {
+				modelSelectionTimer = setTimeout(() => {
+					modelSelectionTimedOut = true;
+					resolve(null);
+				}, 10000);
+			})
+		]);
+	} finally {
+		clearTimeout(modelSelectionTimer);
+	}
 	if (!modelSelection) {
-		log.warn('[ghost-cell] No language model available');
+		log.warn(modelSelectionTimedOut
+			? '[ghost-cell] Model selection timed out'
+			: '[ghost-cell] No language model available');
 		return null;
 	}
 	const { model, usedFallback } = modelSelection;
@@ -144,6 +162,12 @@ export async function generateGhostCellSuggestion(
 		'utf8'
 	);
 
+	// Cancel in-flight generation work if the timeout fires or the caller
+	// cancels, so we don't leave stalled streams alive in the background.
+	const generationCts = new vscode.CancellationTokenSource();
+	const parentCancelListener = token.onCancellationRequested(() => generationCts.cancel());
+	let generationTimer: ReturnType<typeof setTimeout> | undefined;
+
 	try {
 		// Construct messages for the request
 		const systemMessage = new vscode.LanguageModelChatMessage(
@@ -152,17 +176,23 @@ export async function generateGhostCellSuggestion(
 		);
 		const userMessage = vscode.LanguageModelChatMessage.User(contextMessage);
 
-		// Send request to LLM with timeout
+		// Timeout covers the entire generation process (request + streaming).
+		// Previously the timeout only covered sendRequest(), so a stalled
+		// stream from the model provider could hang indefinitely.
 		const timeoutMs = 30000;
-		const timeoutPromise = new Promise<never>((_, reject) => {
-			setTimeout(() => reject(new Error('Ghost cell suggestion timed out')), timeoutMs);
-		});
-
-		const responsePromise = model.sendRequest([systemMessage, userMessage], {}, token);
-		const response = await Promise.race([responsePromise, timeoutPromise]);
-
-		// Parse streaming XML response
-		const result = await parseStreamingXML(response.text, log, token, language, onProgress);
+		const generationPromise = (async () => {
+			const response = await model.sendRequest([systemMessage, userMessage], {}, generationCts.token);
+			return parseStreamingXML(response.text, log, generationCts.token, language, onProgress);
+		})();
+		const result = await Promise.race([
+			generationPromise,
+			new Promise<never>((_, reject) => {
+				generationTimer = setTimeout(() => {
+					generationCts.cancel();
+					reject(new Error('Ghost cell suggestion timed out'));
+				}, timeoutMs);
+			})
+		]);
 		if (result) {
 			result.modelName = modelName;
 			result.usedFallback = usedFallback;
@@ -178,6 +208,10 @@ export async function generateGhostCellSuggestion(
 		const errorMessage = error instanceof Error ? error.message : String(error);
 		log.error(`[ghost-cell] Error generating suggestion: ${errorMessage}`);
 		return null;
+	} finally {
+		clearTimeout(generationTimer);
+		parentCancelListener.dispose();
+		generationCts.dispose();
 	}
 }
 
@@ -313,20 +347,39 @@ async function parseStreamingXML(
 		}
 	});
 
-	// Stream the response through the lexer
+	// Stream the response through the lexer, racing each chunk against
+	// cancellation so we can break out of a stalled stream promptly.
+	// The original for-await loop only checked cancellation between
+	// chunks, so a blocked iterator would never reach the check.
+	let rejectOnCancel!: (error: Error) => void;
+	const cancelledPromise = new Promise<never>((_, reject) => {
+		rejectOnCancel = reject;
+	});
+	const cancelListener = token.onCancellationRequested(() => {
+		rejectOnCancel(new Error('Cancelled'));
+	});
+
+	const iterator = textStream[Symbol.asyncIterator]();
 	try {
-		for await (const delta of textStream) {
-			if (token.isCancellationRequested) {
+		while (true) {
+			const iterResult = await Promise.race([iterator.next(), cancelledPromise]);
+			if (iterResult.done) {
 				break;
 			}
-			await lexer.process(delta);
+			await lexer.process(iterResult.value);
 		}
 
 		// Flush any remaining content
 		await lexer.flush();
 	} catch (error) {
+		if (token.isCancellationRequested) {
+			return null;
+		}
 		log.error(`[ghost-cell] Error during XML streaming: ${error}`);
 		return null;
+	} finally {
+		cancelListener.dispose();
+		await iterator.return?.();
 	}
 
 	// Validate result

--- a/extensions/positron-assistant/src/ghostCellSuggestions.ts
+++ b/extensions/positron-assistant/src/ghostCellSuggestions.ts
@@ -97,22 +97,27 @@ export async function generateGhostCellSuggestion(
 	const variablesSummaryPromise = fetchSessionVariablesSummary(uri, log);
 
 	// Get the model to use for generation (with timeout to prevent hanging
-	// if a VS Code API call stalls)
+	// if a VS Code API call stalls). A dedicated CancellationTokenSource
+	// lets getModel() bail out between API calls when the timeout fires,
+	// avoiding stale work in the background.
 	let modelSelectionTimedOut = false;
 	let modelSelectionTimer: ReturnType<typeof setTimeout> | undefined;
+	const modelSelectionCts = new vscode.CancellationTokenSource();
 	let modelSelection: ModelSelectionResult | null;
 	try {
 		modelSelection = await Promise.race([
-			getModel(participantService, log),
+			getModel(participantService, log, modelSelectionCts.token),
 			new Promise<null>(resolve => {
 				modelSelectionTimer = setTimeout(() => {
 					modelSelectionTimedOut = true;
+					modelSelectionCts.cancel();
 					resolve(null);
 				}, 10000);
 			})
 		]);
 	} finally {
 		clearTimeout(modelSelectionTimer);
+		modelSelectionCts.dispose();
 	}
 	if (!modelSelection) {
 		log.warn(modelSelectionTimedOut
@@ -379,7 +384,16 @@ async function parseStreamingXML(
 		return null;
 	} finally {
 		cancelListener.dispose();
-		await iterator.return?.();
+		// Clean up the iterator, but don't block indefinitely if the
+		// provider's iterator.return() is stalled (mirrors the same concern
+		// that motivated the cancellation racing above).
+		const returnPromise = iterator.return?.();
+		if (returnPromise) {
+			await Promise.race([
+				returnPromise,
+				new Promise<void>(resolve => setTimeout(resolve, 1000))
+			]);
+		}
 	}
 
 	// Validate result
@@ -521,10 +535,12 @@ interface ModelSelectionResult {
  */
 async function getModel(
 	participantService: ParticipantService,
-	log: vscode.LogOutputChannel
+	log: vscode.LogOutputChannel,
+	token?: vscode.CancellationToken
 ): Promise<ModelSelectionResult | null> {
 	// Log all available models for debugging
 	const allModels = await vscode.lm.selectChatModels();
+	if (token?.isCancellationRequested) { return null; }
 	log.debug(`[ghost-cell] Available models: ${allModels.length} total`);
 
 	// Check configuration setting first (highest priority)
@@ -559,6 +575,8 @@ async function getModel(
 		log.warn(`[ghost-cell] Configured model patterns not found: ${JSON.stringify(configuredPatterns)}`);
 	}
 
+	if (token?.isCancellationRequested) { return null; }
+
 	// Check for the latest chat session and use its model
 	const sessionModelId = participantService.getCurrentSessionModel();
 	if (sessionModelId) {
@@ -569,8 +587,11 @@ async function getModel(
 		}
 	}
 
+	if (token?.isCancellationRequested) { return null; }
+
 	// Fall back to the first model for the currently selected provider
 	const currentProvider = await positron.ai.getCurrentProvider();
+	if (token?.isCancellationRequested) { return null; }
 	if (currentProvider) {
 		const models = await vscode.lm.selectChatModels({ vendor: currentProvider.id });
 		if (models && models.length > 0) {
@@ -578,6 +599,8 @@ async function getModel(
 			return { model: models[0], usedFallback: hasConfiguredModel };
 		}
 	}
+
+	if (token?.isCancellationRequested) { return null; }
 
 	// Fall back to any available model
 	const [firstModel] = await vscode.lm.selectChatModels();

--- a/extensions/positron-assistant/src/ghostCellSuggestions.ts
+++ b/extensions/positron-assistant/src/ghostCellSuggestions.ts
@@ -111,6 +111,7 @@ export async function generateGhostCellSuggestion(
 	// avoiding stale work in the background.
 	let modelSelectionTimedOut = false;
 	const modelSelectionCts = new vscode.CancellationTokenSource();
+	const tokenListener = token.onCancellationRequested(() => modelSelectionCts.cancel());
 	let modelSelection: ModelSelectionResult | null | undefined;
 	try {
 		modelSelection = await raceTimeout(
@@ -119,6 +120,7 @@ export async function generateGhostCellSuggestion(
 			() => { modelSelectionTimedOut = true; modelSelectionCts.cancel(); }
 		);
 	} finally {
+		tokenListener.dispose();
 		modelSelectionCts.dispose();
 	}
 	if (!modelSelection) {

--- a/extensions/positron-assistant/src/ghostCellSuggestions.ts
+++ b/extensions/positron-assistant/src/ghostCellSuggestions.ts
@@ -594,6 +594,7 @@ async function getModel(
 	if (token?.isCancellationRequested) { return null; }
 	if (currentProvider) {
 		const models = await vscode.lm.selectChatModels({ vendor: currentProvider.id });
+		if (token?.isCancellationRequested) { return null; }
 		if (models && models.length > 0) {
 			log.debug(`[ghost-cell] Using provider model: ${models[0].name}`);
 			return { model: models[0], usedFallback: hasConfiguredModel };
@@ -604,6 +605,7 @@ async function getModel(
 
 	// Fall back to any available model
 	const [firstModel] = await vscode.lm.selectChatModels();
+	if (token?.isCancellationRequested) { return null; }
 	if (firstModel) {
 		log.debug(`[ghost-cell] Using fallback model: ${firstModel.name}`);
 		return { model: firstModel, usedFallback: hasConfiguredModel };

--- a/extensions/positron-assistant/src/ghostCellSuggestions.ts
+++ b/extensions/positron-assistant/src/ghostCellSuggestions.ts
@@ -306,7 +306,7 @@ function buildContextMessage(
 /**
  * Parse streaming XML response and build the suggestion result
  */
-async function parseStreamingXML(
+export async function parseStreamingXML(
 	textStream: AsyncIterable<string>,
 	log: vscode.LogOutputChannel,
 	token: vscode.CancellationToken,

--- a/extensions/positron-assistant/src/ghostCellSuggestions.ts
+++ b/extensions/positron-assistant/src/ghostCellSuggestions.ts
@@ -37,6 +37,15 @@ export type GhostCellProgressCallback = (partial: Partial<GhostCellSuggestionRes
 /** Timeout for fetching session variables (ms) */
 const VARIABLE_FETCH_TIMEOUT_MS = 3000;
 
+/** Timeout for model selection (ms) */
+const MODEL_SELECTION_TIMEOUT_MS = 10000;
+
+/** Timeout for the entire generation process including streaming (ms) */
+const GENERATION_TIMEOUT_MS = 30000;
+
+/** Timeout for iterator cleanup on cancellation (ms) */
+const ITERATOR_CLEANUP_TIMEOUT_MS = 1000;
+
 /**
  * Valid XML tag names for parsing ghost cell suggestions
  */
@@ -112,7 +121,7 @@ export async function generateGhostCellSuggestion(
 					modelSelectionTimedOut = true;
 					modelSelectionCts.cancel();
 					resolve(null);
-				}, 10000);
+				}, MODEL_SELECTION_TIMEOUT_MS);
 			})
 		]);
 	} finally {
@@ -184,7 +193,7 @@ export async function generateGhostCellSuggestion(
 		// Timeout covers the entire generation process (request + streaming).
 		// Previously the timeout only covered sendRequest(), so a stalled
 		// stream from the model provider could hang indefinitely.
-		const timeoutMs = 30000;
+		const timeoutMs = GENERATION_TIMEOUT_MS;
 		const generationPromise = (async () => {
 			const response = await model.sendRequest([systemMessage, userMessage], {}, generationCts.token);
 			return parseStreamingXML(response.text, log, generationCts.token, language, onProgress);
@@ -360,6 +369,7 @@ async function parseStreamingXML(
 	const cancelledPromise = new Promise<never>((_, reject) => {
 		rejectOnCancel = reject;
 	});
+	cancelledPromise.catch(() => { });
 	const cancelListener = token.onCancellationRequested(() => {
 		rejectOnCancel(new Error('Cancelled'));
 	});
@@ -371,7 +381,7 @@ async function parseStreamingXML(
 			if (iterResult.done) {
 				break;
 			}
-			await lexer.process(iterResult.value);
+			await Promise.race([lexer.process(iterResult.value), cancelledPromise]);
 		}
 
 		// Flush any remaining content
@@ -391,7 +401,7 @@ async function parseStreamingXML(
 		if (returnPromise) {
 			await Promise.race([
 				returnPromise,
-				new Promise<void>(resolve => setTimeout(resolve, 1000))
+				new Promise<void>(resolve => setTimeout(resolve, ITERATOR_CLEANUP_TIMEOUT_MS))
 			]);
 		}
 	}

--- a/extensions/positron-assistant/src/test/ghostCellSuggestions.test.ts
+++ b/extensions/positron-assistant/src/test/ghostCellSuggestions.test.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { parseStreamingXML } from '../ghostCellSuggestions.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockLog(): vscode.LogOutputChannel {
+	return {
+		debug: () => { },
+		info: () => { },
+		warn: () => { },
+		error: () => { },
+		trace: () => { },
+	} as unknown as vscode.LogOutputChannel;
+}
+
+function iterableFrom(chunks: string[]): AsyncIterable<string> {
+	return {
+		[Symbol.asyncIterator]: async function* () {
+			for (const chunk of chunks) {
+				yield chunk;
+			}
+		}
+	};
+}
+
+/**
+ * Create an async iterable that yields some chunks then stalls forever.
+ * Call `cleanup` to unblock so the iterator can be garbage-collected.
+ */
+function stallingIterable(chunks: string[]): { iterable: AsyncIterable<string>; cleanup: () => void } {
+	let unblock: () => void;
+	const blockForever = new Promise<string>((resolve) => {
+		unblock = () => resolve('');
+	});
+	return {
+		iterable: {
+			[Symbol.asyncIterator]: async function* () {
+				for (const chunk of chunks) {
+					yield chunk;
+				}
+				yield await blockForever;
+			}
+		},
+		cleanup: () => unblock!()
+	};
+}
+
+// ---------------------------------------------------------------------------
+// parseStreamingXML
+// ---------------------------------------------------------------------------
+
+suite('parseStreamingXML', () => {
+	const log = mockLog();
+
+	test('parses a complete suggestion', async () => {
+		const xml = '<suggestion><explanation>Load the data</explanation><code>import pandas as pd\ndf = pd.read_csv("data.csv")</code></suggestion>';
+		const stream = iterableFrom([xml]);
+		const cts = new vscode.CancellationTokenSource();
+
+		const result = await parseStreamingXML(stream, log, cts.token, 'python');
+		cts.dispose();
+
+		assert.ok(result);
+		assert.strictEqual(result.code, 'import pandas as pd\ndf = pd.read_csv("data.csv")');
+		assert.strictEqual(result.explanation, 'Load the data');
+		assert.strictEqual(result.language, 'python');
+	});
+
+	test('cancellation unblocks a stalled iterator', async () => {
+		// Key behavioral test for the PR fix: if the iterator stalls
+		// (never yields), cancellation should still return promptly.
+		const { iterable, cleanup } = stallingIterable([]);
+		const cts = new vscode.CancellationTokenSource();
+
+		const start = Date.now();
+		setTimeout(() => cts.cancel(), 50);
+
+		const result = await parseStreamingXML(iterable, log, cts.token, 'python');
+		const elapsed = Date.now() - start;
+		cleanup();
+		cts.dispose();
+
+		assert.strictEqual(result, null);
+		assert.ok(elapsed < 2000, `Expected prompt return after cancellation but took ${elapsed}ms`);
+	});
+
+	test('handles iterator whose return() stalls', async () => {
+		// If iterator.return() hangs, parseStreamingXML should not
+		// block indefinitely thanks to the cleanup timeout.
+		let returnCalled = false;
+		const iterable: AsyncIterable<string> = {
+			[Symbol.asyncIterator]() {
+				let done = false;
+				return {
+					async next() {
+						if (!done) {
+							done = true;
+							return { value: '<suggestion><code>x</code></suggestion>', done: false };
+						}
+						return { value: undefined, done: true };
+					},
+					return() {
+						returnCalled = true;
+						return new Promise<IteratorResult<string>>(() => { });
+					}
+				};
+			}
+		};
+
+		const cts = new vscode.CancellationTokenSource();
+		const start = Date.now();
+		setTimeout(() => cts.cancel(), 50);
+
+		const result = await parseStreamingXML(iterable, log, cts.token, 'python');
+		const elapsed = Date.now() - start;
+		cts.dispose();
+
+		assert.strictEqual(returnCalled, true, 'iterator.return() should have been called');
+		// The 1000ms ITERATOR_CLEANUP_TIMEOUT_MS + some margin
+		assert.ok(elapsed < 3000, `Expected cleanup timeout to fire but took ${elapsed}ms`);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes several robustness issues in ghost cell suggestions that caused the feature to hang or get stuck in a loading state. These fixes also unblock investigation and closure of related ghost cell issues.

Addresses #11413.
Closes #12024, #12025.

### Changes

**Ghost cell suggestion robustness** (`ghostCellSuggestions.ts`):
- Wrap model selection in a timeout with a dedicated `CancellationTokenSource` so a stalled VS Code API call cannot hang the feature indefinitely
- Check cancellation tokens between each async step in `getModel()` to bail out promptly on cancellation
- Replace the old timeout (which only covered `sendRequest()`) with a `raceTimeout` that covers the entire generation process including streaming
- Race each iterator chunk against cancellation so a blocked async iterator cannot prevent cleanup
- Add a bounded timeout on `iterator.return()` during cleanup to prevent hanging on stalled providers


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed ghost cell suggestions getting stuck in a loading state when model selection or streaming stalls (#11413)
- Fixed ghost cell cleanup hanging indefinitely on stalled stream iterators (#11413)

### QA Notes

@:assistant @:positron-notebooks

1. Open a Python notebook with ghost cell suggestions enabled
2. Add a few code cells and run them
3. Trigger a ghost cell suggestion (automatic or via Cmd+Shift+G)
4. Verify the suggestion appears without getting stuck in loading
5. Cancel/dismiss the suggestion and verify the UI returns to normal promptly
6. Verify the keyboard shortcut Cmd+Shift+G works to trigger suggestions on demand