### PR TITLE
Assistant: add back maxOutputTokens param to streamText options

### DIFF
--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -630,6 +630,8 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		const textResponses: vscode.LanguageModelTextPart[] = [];
 		const toolRequests: vscode.LanguageModelToolCallPart[] = [];
 		const toolResponses: Record<string, vscode.LanguageModelToolResult> = {};
+		let finishReason: string | undefined;
+		let maxOutputTokens: number | undefined;
 
 		// Create a streaming text processor to allow the model to stream to the chat
 		// response e.g. using a loose XML format.
@@ -646,6 +648,16 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 				await textProcessor.process(chunk.value);
 			} else if (chunk instanceof vscode.LanguageModelToolCallPart) {
 				toolRequests.push(chunk);
+			} else if (chunk instanceof vscode.LanguageModelDataPart) {
+				try {
+					const json = JSON.parse(new TextDecoder().decode(chunk.data));
+					if (json.type === 'finishReason') {
+						finishReason = json.data;
+						maxOutputTokens = json.maxOutputTokens;
+					}
+				} catch {
+					// Ignore data parts we can't parse
+				}
 			}
 		}
 
@@ -656,6 +668,22 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 
 		// Get actual token usage from the registry
 		const tokenUsage = getRequestTokenUsage(request.id);
+
+		// Warn if the response was truncated due to max output tokens
+		if (finishReason === 'length' || finishReason === 'max_tokens') {
+			const maxTokensArg = encodeURIComponent(JSON.stringify(['positron.assistant.maxOutputTokens']));
+			const maxTokensUri = `command:workbench.action.openSettings?${maxTokensArg}`;
+			const overridesArg = encodeURIComponent(JSON.stringify(['positron.assistant.models.overrides']));
+			const overridesUri = `command:workbench.action.openSettings?${overridesArg}`;
+			const tokenLimit = maxOutputTokens ?? tokenUsage?.tokens.outputTokens;
+			const message = new vscode.MarkdownString(
+				`This response may be incomplete because it reached the maximum output token limit (${tokenLimit} tokens). ` +
+				`To allow longer responses, increase [Max Output Tokens](${maxTokensUri}) or ` +
+				`configure [Model Overrides](${overridesUri}) in Settings.`
+			);
+			message.isTrusted = { enabledCommands: ['workbench.action.openSettings'] };
+			response.warning(message);
+		}
 
 		// If we do have tool requests to follow up on, use vscode.lm.invokeTool recursively
 		if (toolRequests.length > 0) {

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -675,9 +675,9 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 			const maxTokensUri = `command:workbench.action.openSettings?${maxTokensArg}`;
 			const overridesArg = encodeURIComponent(JSON.stringify(['positron.assistant.models.overrides']));
 			const overridesUri = `command:workbench.action.openSettings?${overridesArg}`;
-			const tokenLimit = maxOutputTokens ?? tokenUsage?.tokens.outputTokens;
+			const tokenLimitSuffix = maxOutputTokens ? ` (${maxOutputTokens} tokens)` : '';
 			const message = new vscode.MarkdownString(
-				`This response may be incomplete because it reached the maximum output token limit (${tokenLimit} tokens). ` +
+				`This response may be incomplete because it reached the maximum output token limit${tokenLimitSuffix}. ` +
 				`To allow longer responses, increase [Max Output Tokens](${maxTokensUri}) or ` +
 				`configure [Model Overrides](${overridesUri}) in Settings.`
 			);

--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import * as xml from './xml.js';
 
 import { MARKDOWN_DIR, MAX_CONTEXT_VARIABLES } from './constants';
-import { isChatImageMimeType, isTextEditRequest, languageModelCacheBreakpointPart, toLanguageModelChatMessage, uriToString, isRuntimeSessionReference, isPromptInstructionsReference } from './utils';
+import { isChatImageMimeType, isMaxTokensFinishReason, isTextEditRequest, languageModelCacheBreakpointPart, toLanguageModelChatMessage, uriToString, isRuntimeSessionReference, isPromptInstructionsReference } from './utils';
 import { ContextInfo, PositronAssistantToolName } from './types.js';
 import { DefaultTextProcessor } from './defaultTextProcessor.js';
 import { ReplaceStringProcessor } from './replaceStringProcessor.js';
@@ -670,7 +670,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 		const tokenUsage = getRequestTokenUsage(request.id);
 
 		// Warn if the response was truncated due to max output tokens
-		if (finishReason === 'length' || finishReason === 'max_tokens') {
+		if (isMaxTokensFinishReason(finishReason)) {
 			const maxTokensArg = encodeURIComponent(JSON.stringify(['positron.assistant.maxOutputTokens']));
 			const maxTokensUri = `command:workbench.action.openSettings?${maxTokensArg}`;
 			const overridesArg = encodeURIComponent(JSON.stringify(['positron.assistant.models.overrides']));

--- a/extensions/positron-assistant/src/providers/anthropic/anthropicProvider.ts
+++ b/extensions/positron-assistant/src/providers/anthropic/anthropicProvider.ts
@@ -260,6 +260,15 @@ export class AnthropicModelProvider extends ModelProvider implements positron.ai
 			this.logger.info(`Finished request ${stream.request_id}; usage: ${JSON.stringify(message.usage)}`);
 		}
 
+		// Report finish reason so consumers can detect truncated responses
+		if (message.stop_reason) {
+			progress.report(vscode.LanguageModelDataPart.json({
+				type: 'finishReason',
+				data: message.stop_reason,
+				maxOutputTokens: body.max_tokens,
+			}));
+		}
+
 		// Record token usage
 		if (message.usage) {
 			const tokens = toTokenUsage(message.usage);

--- a/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
+++ b/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
@@ -195,6 +195,7 @@ export abstract class VercelModelProvider extends ModelProvider {
 			messages: aiMessages,
 			tools: modelTools,
 			abortSignal: signal,
+			maxOutputTokens: options.modelOptions?.maxTokens ?? model.maxOutputTokens,
 		});
 
 		try {

--- a/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
+++ b/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
@@ -190,16 +190,17 @@ export abstract class VercelModelProvider extends ModelProvider {
 		this.logger.debug(`[${model.name}] SEND ${aiMessages.length} messages, ${modelTools ? Object.keys(modelTools).length : 0} tools`);
 
 		// Stream the response
+		const maxOutputTokens = options.modelOptions?.maxTokens ?? model.maxOutputTokens;
 		const result = ai.streamText({
 			model: aiModel,
 			messages: aiMessages,
 			tools: modelTools,
 			abortSignal: signal,
-			maxOutputTokens: options.modelOptions?.maxTokens ?? model.maxOutputTokens,
+			maxOutputTokens,
 		});
 
 		try {
-			await this.handleStreamResponse(result, model, progress, token, requestId);
+			await this.handleStreamResponse(result, model, progress, token, requestId, maxOutputTokens);
 		} catch (error) {
 			// Allow subclasses to handle provider-specific errors
 			this.handleStreamError(error);
@@ -291,7 +292,8 @@ export abstract class VercelModelProvider extends ModelProvider {
 		model: vscode.LanguageModelChatInformation,
 		progress: vscode.Progress<vscode.LanguageModelResponsePart2>,
 		token: vscode.CancellationToken,
-		requestId?: string
+		requestId?: string,
+		maxOutputTokens?: number
 	): Promise<void> {
 		// Set chat context for error handling
 		const errorContext = {
@@ -346,6 +348,24 @@ export abstract class VercelModelProvider extends ModelProvider {
 				this.logger.warn(`[${model.id}] ${warning}`);
 			}
 		}
+
+		// Report finish reason so consumers can detect truncated responses.
+		// Some providers (e.g. Snowflake Cortex) return 'unknown' as the finish reason
+		// even when truncated, so we also check if outputTokens hit the configured limit.
+		const finishReason = await result.finishReason;
+		const usage = await result.usage;
+		const wasTruncated = finishReason === 'length' ||
+			(finishReason === 'unknown' && maxOutputTokens !== undefined && usage.outputTokens >= maxOutputTokens);
+		if (wasTruncated) {
+			this.logger.info(`[${model.name}] Response may be incomplete because it reached the maximum output token limit (finish reason: '${finishReason}', output tokens: ${usage.outputTokens}, max: ${maxOutputTokens})`);
+		} else {
+			this.logger.debug(`[${model.name}] Finish reason: ${finishReason}`);
+		}
+		progress.report(vscode.LanguageModelDataPart.json({
+			type: 'finishReason',
+			data: wasTruncated ? 'length' : finishReason,
+			maxOutputTokens,
+		}));
 
 		// Handle token usage
 		await this.handleTokenUsage(result, model, progress, requestId);

--- a/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
+++ b/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
@@ -355,7 +355,8 @@ export abstract class VercelModelProvider extends ModelProvider {
 		const finishReason = await result.finishReason;
 		const usage = await result.usage;
 		const wasTruncated = finishReason === 'length' ||
-			(finishReason === 'unknown' && maxOutputTokens !== undefined && usage.outputTokens >= maxOutputTokens);
+			(finishReason === 'unknown' && maxOutputTokens !== undefined &&
+				usage?.outputTokens !== undefined && usage.outputTokens >= maxOutputTokens);
 		if (wasTruncated) {
 			this.logger.info(`[${model.name}] Response may be incomplete because it reached the maximum output token limit (finish reason: '${finishReason}', output tokens: ${usage.outputTokens}, max: ${maxOutputTokens})`);
 		} else {

--- a/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
+++ b/extensions/positron-assistant/src/providers/base/vercelModelProvider.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as ai from 'ai';
 import { ModelProvider } from './modelProvider';
-import { CacheBreakpointProvider, processMessages, toAIMessage } from '../../utils';
+import { CacheBreakpointProvider, isMaxTokensFinishReason, processMessages, toAIMessage } from '../../utils';
 import { getProviderTimeoutMs } from '../../providerConfig.js';
 import { TokenUsage, recordRequestTokenUsage, recordTokenUsage } from '../../tokens';
 import { createModelInfo, markDefaultModel } from '../../modelResolutionHelpers';
@@ -354,7 +354,7 @@ export abstract class VercelModelProvider extends ModelProvider {
 		// even when truncated, so we also check if outputTokens hit the configured limit.
 		const finishReason = await result.finishReason;
 		const usage = await result.usage;
-		const wasTruncated = finishReason === 'length' ||
+		const wasTruncated = isMaxTokensFinishReason(finishReason) ||
 			(finishReason === 'unknown' && maxOutputTokens !== undefined &&
 				usage?.outputTokens !== undefined && usage.outputTokens >= maxOutputTokens);
 		if (wasTruncated) {

--- a/extensions/positron-assistant/src/utils.ts
+++ b/extensions/positron-assistant/src/utils.ts
@@ -643,6 +643,14 @@ export function isAuthorizationError(error: any): boolean {
 }
 
 /**
+ * Check if a finish reason indicates the response was truncated due to the max output token limit.
+ * Vercel AI SDK providers use 'length'; native Anthropic SDK uses 'max_tokens'.
+ */
+export function isMaxTokensFinishReason(finishReason: string | undefined): boolean {
+	return finishReason === 'length' || finishReason === 'max_tokens';
+}
+
+/**
  * Handle getPlot tool results for OpenAI-compatible providers (chat completions endpoint).
  *
  * This creates both:


### PR DESCRIPTION
### Summary

- addresses https://github.com/posit-dev/positron/issues/12214
- the AI SDK 5 migration (#10903) dropped the `maxTokens` parameter from the `streamText()` call in the Vercel base provider
    - when this param is not set, providers default to low output token limits (like Snowflake Cortex, which defaults to 4096) and may silently truncate responses
- this re-adds the parameter `maxOutputTokens` so that custom max output tokens are applied to the requests

#### Preview

<img width="1032" height="611" alt="image" src="https://github.com/user-attachments/assets/61182012-42b0-4c7c-b889-e9c33f3d7174" />

- ^ this is with the following setting configured:

    ```json
        "positron.assistant.models.overrides.snowflakeCortex": [
            {
                "name": "Claude Haiku 4.5",
                "identifier": "claude-haiku-4-5",
                "maxInputTokens": 200000,
                "maxOutputTokens": 512,
            },
        ],
    ```

### Release Notes

#### New Features

- Assistant: show warning in chat when output token limit reached (#12214)

#### Bug Fixes

- Assistant: fixed issue where custom max output tokens were not being applied to requests (#12214)

### QA Notes

#### Setup

1. Set a custom max output tokens amount, such as 512, using `positron.assistant.maxOutputTokens` or the `positron.assistant.models.overrides.<provider>` setting, e.g. `positron.assistant.models.overrides.snowflakeCortex`
1. Sign in to the corresponding model provider
1. Send a prompt in chat which generates long output, like "Create a numbered list of 200 creative R package names with descriptions"

#### Expected results

- the Assistant output pane should show something like `[info] [Snowflake Cortex] [vercel]: End request request_ff128385-cfba-4dc8-bc93-e90497298f0f; usage: 14363 input tokens (+0 cached), <THE_MAX_OUTPUT_TOKENS_YOU_SET> output tokens` instead of the default (e.g. 4096 output tokens for Snowflake)
- we now indicate in the chat when the max output tokens has been exceeded
