### PR TITLE
e2e: Databot tests - removing posit-ai for now

### DIFF
--- a/test/e2e/tests/databot/databot.test.ts
+++ b/test/e2e/tests/databot/databot.test.ts
@@ -10,7 +10,7 @@ test.use({
 	suiteId: __filename
 });
 
-const DATABOT_PROVIDERS: ModelProvider[] = ['posit-ai', 'anthropic-api'];
+const DATABOT_PROVIDERS: ModelProvider[] = ['anthropic-api'];
 
 test.describe('Databot', {
 	tag: [tags.ASSISTANT, tags.DATABOT, tags.WEB, tags.WIN, tags.SOFT_FAIL],


### PR DESCRIPTION
There seems to be a case where posit-ai provider can hang in databot., so removing for now to get tests working correctly.

### QA Notes
@:databot
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
