### PR TITLE
If we already have a `parentPath` when setting up to clone, go straight to cloning

### DIFF
--- a/extensions/git/src/cloneManager.ts
+++ b/extensions/git/src/cloneManager.ts
@@ -48,6 +48,17 @@ export class CloneManager {
 
 		url = url.trim().replace(/^git\s+clone\s+/, '');
 
+		// --- Start Positron ---
+		// When a parentPath is explicitly provided (e.g., from Positron's "New Folder from Git"
+		// dialog), skip the cache check and clone directly. This ensures the user's explicit
+		// folder choice is respected. The cloneRepository function handles conflicts by
+		// appending "-1", "-2", etc. to the folder name if needed.
+		// See: https://github.com/posit-dev/positron/issues/11585
+		if (options.parentPath) {
+			return this.cloneRepository(url, options.parentPath, options);
+		}
+		// --- End Positron ---
+
 		const cachedRepository = this.repositoryCache.get(url);
 		if (cachedRepository && (cachedRepository.length > 0)) {
 			return this.tryOpenExistingRepository(cachedRepository, url, options.postCloneAction, options.parentPath, options.ref);


### PR DESCRIPTION
Addresses #11585

When using our Positron-specific _New Folder from Git_ command/dialog to clone a repository that was previously cloned, Positron would open the existing clone instead of creating a new one in the user's chosen location. This happened because VS Code's git extension caches cloned repository URLs and opens the cached location instead of cloning.

The fix here that I am proposing is in the upstream git extension rather than the Positron-specific _New Folder from Git_ dialog because the cache check happens inside the `git.clone` command before the actual clone logic runs, and there's no option to bypass it. The fix is pretty minimal, though! When a `parentPath` is explicitly provided (as Positron's dialog does), skip the cache and proceed directly to cloning. This also enables the existing "-1", "-2" suffix behavior when cloning to a folder where a copy of this repo already exists.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed issue where cloning the same repository to a different directory via "New Folder from Git" would open the first clone instead of creating a new one (#11585)

### QA Notes

1. Clone a repository via File > New Folder from Git or _Workspaces: New Folder from Template..._ from the command palette
2. Close then reopen Positron
3. Use one of the same gestures to clone the same repository to a different parent folder
4. Verify a new clone is created in the new location
5. Now clone the same repository to the same parent folder
6. Verify a new clone is created with "-1" suffix
