### PR TITLE
Rename some language runtime commands

### DIFF
--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.tsx
@@ -16,7 +16,7 @@ import { ActionBarCommandButton } from '../../../../../platform/positronActionBa
 import { CommandCenter } from '../../../../../platform/commandCenter/common/commandCenter.js';
 import { ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { localize } from '../../../../../nls.js';
-import { LANGUAGE_RUNTIME_SELECT_SESSION_ID, LANGUAGE_RUNTIME_START_NEW_SESSION_ID } from '../../../../contrib/languageRuntime/browser/languageRuntimeActions.js';
+import { LANGUAGE_RUNTIME_SELECT_SESSION_ID, LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID } from '../../../../contrib/languageRuntime/browser/languageRuntimeActions.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 
 const startSession = localize('positron.console.startSession', "Start Session");
@@ -40,7 +40,7 @@ export const TopActionBarSessionManager = () => {
 		session => session.metadata.sessionMode === LanguageRuntimeSessionMode.Console);
 	const command = hasActiveConsoleSessions
 		? LANGUAGE_RUNTIME_SELECT_SESSION_ID
-		: LANGUAGE_RUNTIME_START_NEW_SESSION_ID;
+		: LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID;
 
 	// Main useEffect.
 	useEffect(() => {

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -170,7 +170,7 @@ const selectLanguageRuntimeSession = async (
 	// Show quick pick to select an active runtime or show all runtimes.
 	const quickPickItems: QuickPickItem[] = [
 		{
-			label: localize('positron.languageRuntime.activeSessions', 'Active Interpreter Sessions'),
+			label: localize('positron.languageRuntime.activeSessions', 'Console Sessions'),
 			type: 'separator',
 		},
 		...activeRuntimeItems,
@@ -181,13 +181,13 @@ const selectLanguageRuntimeSession = async (
 
 	if (options?.allowStartSession) {
 		quickPickItems.push({
-			label: localize('positron.languageRuntime.newSession', 'New Interpreter Session...'),
+			label: localize('positron.languageRuntime.newSession', 'New Console Session...'),
 			id: startNewRuntimeId,
 			alwaysShow: true
 		});
 	}
 	const result = await quickInputService.pick(quickPickItems, {
-		title: options?.title || localize('positron.languageRuntime.selectSession', 'Select Interpreter Session'),
+		title: options?.title || localize('positron.languageRuntime.selectSession.quickPickTitle', 'Select Interpreter Session'),
 		canPickMany: false,
 		activeItem: activeRuntimeItems.filter(item => item.picked)[0]
 	});
@@ -566,7 +566,7 @@ export function registerLanguageRuntimeActions() {
 	 */
 	registerLanguageRuntimeAction(
 		LANGUAGE_RUNTIME_SELECT_SESSION_ID,
-		localize2('positron.languageRuntime.selectInterpreterSession', 'Select Interpreter Session'),
+		localize2('positron.languageRuntime.selectInterpreterSession', 'Select Console Session'),
 		async accessor => {
 			// Access services.
 			const commandService = accessor.get(ICommandService);
@@ -594,7 +594,7 @@ export function registerLanguageRuntimeActions() {
 			super({
 				icon: Codicon.plus,
 				id: LANGUAGE_RUNTIME_START_NEW_SESSION_ID,
-				title: localize2('positron.languageRuntime.startSession', 'Start New Interpreter Session'),
+				title: localize2('positron.languageRuntime.startSession', 'Start New Console Session'),
 				category,
 				f1: true,
 				menu: [{
@@ -724,7 +724,7 @@ export function registerLanguageRuntimeActions() {
 
 			// Prompt the user to select a session they want to rename.
 			const session = await selectLanguageRuntimeSession(
-				accessor, { title: 'Select Interpreter Session To Rename' });
+				accessor, { title: localize('positron.languageRuntime.selectSessionToRename', 'Select Session To Rename') });
 			if (!session) {
 				return;
 			}

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -43,7 +43,7 @@ export const LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID = 'workbench.action.l
 export const LANGUAGE_RUNTIME_RESTART_ACTIVE_SESSION_ID = 'workbench.action.language.runtime.restartActiveSession';
 export const LANGUAGE_RUNTIME_RENAME_SESSION_ID = 'workbench.action.language.runtime.renameSession';
 export const LANGUAGE_RUNTIME_RENAME_ACTIVE_SESSION_ID = 'workbench.action.language.runtime.renameActiveSession';
-export const LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_SESSION_ID = 'workbench.action.language.runtime.duplicateActiveSession';
+export const LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_CONSOLE_SESSION_ID = 'workbench.action.language.runtime.duplicateActiveConsoleSession';
 export const LANGUAGE_RUNTIME_SELECT_RUNTIME_ID = 'workbench.action.languageRuntime.selectRuntime';
 export const LANGUAGE_RUNTIME_DISCOVER_RUNTIMES_ID = 'workbench.action.language.runtime.discoverAllRuntimes';
 
@@ -642,15 +642,15 @@ export function registerLanguageRuntimeActions() {
 	});
 
 	/**
-	 * Action that allows the user to create a new session based off the current active session.
+	 * Action that allows the user to create a new console session based off the current active console session.
 	 * This utilizes the runtime data from the current session to create a new session.
 	 */
 	registerAction2(class extends Action2 {
 		constructor() {
 			super({
 				icon: Codicon.plus,
-				id: LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_SESSION_ID,
-				title: localize2('positron.languageRuntime.duplicateSession.title', 'Duplicate Active Interpreter Session'),
+				id: LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_CONSOLE_SESSION_ID,
+				title: localize2('positron.languageRuntime.duplicateActiveConsoleSession.title', 'Duplicate Active Console Session'),
 				category,
 				f1: true,
 				menu: [{

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -18,7 +18,7 @@ import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionService
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
 import { dispose } from '../../../../base/common/lifecycle.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ExplorerFolderContext } from '../../files/common/files.js';
@@ -1310,3 +1310,16 @@ registerAction2(class extends Action2 {
 		notificationService.info(localize('positron.interpreter.archMismatchReset', 'Architecture mismatch warning has been reset. The warning will appear the next time you start an interpreter with a different architecture than your system.'));
 	}
 });
+
+CommandsRegistry.registerCommandAlias(
+	'workbench.action.language.runtime.startNewSession',
+	LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID
+);
+CommandsRegistry.registerCommandAlias(
+	'workbench.action.language.runtime.duplicateActiveSession',
+	LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_CONSOLE_SESSION_ID
+);
+CommandsRegistry.registerCommandAlias(
+	'workbench.action.languageRuntime.selectRuntime',
+	LANGUAGE_RUNTIME_SELECT_LEGACY_NOTEBOOK_RUNTIME_ID
+);

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -49,7 +49,7 @@ export const LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID = 'workbench.action.l
 export const LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_CONSOLE_SESSION_ID = 'workbench.action.language.runtime.duplicateActiveConsoleSession';
 
 // Notebook Session Specific Action IDs
-export const LANGUAGE_RUNTIME_SELECT_RUNTIME_ID = 'workbench.action.languageRuntime.selectRuntime';
+export const LANGUAGE_RUNTIME_SELECT_LEGACY_NOTEBOOK_RUNTIME_ID = 'workbench.action.languageRuntime.selectLegacyNotebookRuntime';
 
 /**
  * Helper function that askses the user to select a language from the list of registered language
@@ -512,7 +512,7 @@ export function registerLanguageRuntimeActions() {
 	registerAction2(class PickInterpreterAction extends Action2 {
 		constructor() {
 			super({
-				id: LANGUAGE_RUNTIME_SELECT_RUNTIME_ID,
+				id: LANGUAGE_RUNTIME_SELECT_LEGACY_NOTEBOOK_RUNTIME_ID,
 				title: localize2('positron.command.selectInterpreter', "Select Interpreter"),
 				f1: false,
 				category,

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -278,8 +278,10 @@ const createInterpreterGroups = (
  * @returns
  */
 const selectNewLanguageRuntime = async (
-	accessor: ServicesAccessor
-): Promise<ILanguageRuntimeMetadata | undefined> => {
+	accessor: ServicesAccessor,
+	options?: {
+		title?: string;
+	}): Promise<ILanguageRuntimeMetadata | undefined> => {
 	// Access services.
 	const quickInputService = accessor.get(IQuickInputService);
 	const runtimeSessionService = accessor.get(IRuntimeSessionService);
@@ -408,7 +410,7 @@ const selectNewLanguageRuntime = async (
 	const selectedRuntime = await quickInputService.pick(
 		runtimeItems,
 		{
-			title: localize('positron.languageRuntime.startSession', 'Start New Interpreter Session'),
+			title: options?.title || localize('positron.languageRuntime.startSession', 'Start New Interpreter Session'),
 			canPickMany: false
 		}
 	);
@@ -501,7 +503,7 @@ export function registerLanguageRuntimeActions() {
 	/**
 	 * Action used to select a registered language runtime (aka interpreter).
 	 *
-	 * NOTE: This is a convenience action that is used by the notebook services
+	 * NOTE: This is a convenience action that is used by the legacy notebook service
 	 */
 	registerAction2(class PickInterpreterAction extends Action2 {
 		constructor() {
@@ -626,7 +628,10 @@ export function registerLanguageRuntimeActions() {
 			const runtimeSessionService = accessor.get(IRuntimeSessionService);
 
 			// Prompt the user to select a runtime to start
-			const selectedRuntime = await selectNewLanguageRuntime(accessor);
+			const selectedRuntime = await selectNewLanguageRuntime(
+				accessor,
+				{ title: localize('positron.languageRuntime.startConsoleSession', 'Start New Console Session') }
+			);
 
 			// If the user selected a runtime, set it as the active runtime
 			if (selectedRuntime?.runtimeId) {

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -39,13 +39,17 @@ interface RuntimeClientInstanceQuickPickItem extends IQuickPickItem { runtimeCli
 
 // Action IDs
 export const LANGUAGE_RUNTIME_SELECT_SESSION_ID = 'workbench.action.language.runtime.selectSession';
-export const LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID = 'workbench.action.language.runtime.startNewConsoleSession';
 export const LANGUAGE_RUNTIME_RESTART_ACTIVE_SESSION_ID = 'workbench.action.language.runtime.restartActiveSession';
 export const LANGUAGE_RUNTIME_RENAME_SESSION_ID = 'workbench.action.language.runtime.renameSession';
 export const LANGUAGE_RUNTIME_RENAME_ACTIVE_SESSION_ID = 'workbench.action.language.runtime.renameActiveSession';
-export const LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_CONSOLE_SESSION_ID = 'workbench.action.language.runtime.duplicateActiveConsoleSession';
-export const LANGUAGE_RUNTIME_SELECT_RUNTIME_ID = 'workbench.action.languageRuntime.selectRuntime';
 export const LANGUAGE_RUNTIME_DISCOVER_RUNTIMES_ID = 'workbench.action.language.runtime.discoverAllRuntimes';
+
+// Console Session Specific Action IDs
+export const LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID = 'workbench.action.language.runtime.startNewConsoleSession';
+export const LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_CONSOLE_SESSION_ID = 'workbench.action.language.runtime.duplicateActiveConsoleSession';
+
+// Notebook Session Specific Action IDs
+export const LANGUAGE_RUNTIME_SELECT_RUNTIME_ID = 'workbench.action.languageRuntime.selectRuntime';
 
 /**
  * Helper function that askses the user to select a language from the list of registered language

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -582,7 +582,7 @@ export function registerLanguageRuntimeActions() {
 			const newActiveSession = await selectLanguageRuntimeSession(accessor,
 				{
 					allowStartSession: true,
-					title: localize('positron.languageRuntime.changeForegroundSession.quickPickTitle', 'Running Interpreter Sessions')
+					title: localize('positron.languageRuntime.changeForegroundSession.quickPickTitle', 'Interpreter Sessions')
 				}
 			);
 

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -573,7 +573,12 @@ export function registerLanguageRuntimeActions() {
 			const runtimeSessionService = accessor.get(IRuntimeSessionService);
 
 			// Prompt the user to select a runtime to use.
-			const newActiveSession = await selectLanguageRuntimeSession(accessor, { allowStartSession: true });
+			const newActiveSession = await selectLanguageRuntimeSession(accessor,
+				{
+					allowStartSession: true,
+					title: localize('positron.languageRuntime.changeForegroundSession.quickPickTitle', 'Running Interpreter Sessions')
+				}
+			);
 
 			// If the user selected a specific session, set it as the active session if it still exists
 			if (newActiveSession) {
@@ -581,7 +586,8 @@ export function registerLanguageRuntimeActions() {
 				commandService.executeCommand('workbench.panel.positronConsole.focus');
 				runtimeSessionService.foregroundSession = newActiveSession;
 			}
-		});
+		}
+	);
 
 	/**
 	 * Action that allows the user to create a new console session from a list of registered runtimes.

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -170,7 +170,7 @@ const selectLanguageRuntimeSession = async (
 	// Show quick pick to select an active runtime or show all runtimes.
 	const quickPickItems: QuickPickItem[] = [
 		{
-			label: localize('positron.languageRuntime.activeSessions', 'Console Sessions'),
+			label: localize('positron.languageRuntime.activeConsoleSessions', 'Console Sessions'),
 			type: 'separator',
 		},
 		...activeRuntimeItems,
@@ -181,7 +181,7 @@ const selectLanguageRuntimeSession = async (
 
 	if (options?.allowStartSession) {
 		quickPickItems.push({
-			label: localize('positron.languageRuntime.newSession', 'New Console Session...'),
+			label: localize('positron.languageRuntime.newConsoleSession', 'New Console Session...'),
 			id: startNewRuntimeId,
 			alwaysShow: true
 		});

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -437,7 +437,7 @@ const renameLanguageRuntimeSession = async (
 	const sessionName = await quickInputService.input({
 		value: '',
 		placeHolder: '',
-		prompt: localize('positron.console.renameSession.prompt', "Enter the new session name"),
+		prompt: localize('positron.languageRuntime.renameSession.prompt', "Enter the new session name"),
 	});
 
 	// Validate the new session name
@@ -451,7 +451,7 @@ const renameLanguageRuntimeSession = async (
 		sessionService.updateSessionName(sessionId, newSessionName);
 	} catch (error) {
 		notificationService.error(
-			localize('positron.console.renameSession.error',
+			localize('positron.languageRuntime.renameSession.error',
 				"Failed to rename session {0}: {1}",
 				sessionId,
 				error
@@ -705,7 +705,7 @@ export function registerLanguageRuntimeActions() {
 		constructor() {
 			super({
 				id: LANGUAGE_RUNTIME_RENAME_SESSION_ID,
-				title: localize2('positron.console.renameSesison', "Rename Interpreter Session"),
+				title: localize2('positron.languageRuntime.renameSession', "Rename Interpreter Session"),
 				category,
 				f1: true,
 			});
@@ -748,7 +748,7 @@ export function registerLanguageRuntimeActions() {
 		constructor() {
 			super({
 				id: LANGUAGE_RUNTIME_RENAME_ACTIVE_SESSION_ID,
-				title: localize2('positron.console.renameActiveSesison', "Rename Active Interpreter Session"),
+				title: localize2('positron.languageRuntime.renameActiveSession', "Rename Active Interpreter Session"),
 				category,
 				f1: true,
 				keybinding: {

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -566,7 +566,7 @@ export function registerLanguageRuntimeActions() {
 	 */
 	registerLanguageRuntimeAction(
 		LANGUAGE_RUNTIME_SELECT_SESSION_ID,
-		localize2('positron.languageRuntime.selectInterpreterSession', 'Select Console Session'),
+		localize2('positron.languageRuntime.selectSession.commandTitle', 'Select Session'),
 		async accessor => {
 			// Access services.
 			const commandService = accessor.get(ICommandService);

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -39,7 +39,7 @@ interface RuntimeClientInstanceQuickPickItem extends IQuickPickItem { runtimeCli
 
 // Action IDs
 export const LANGUAGE_RUNTIME_SELECT_SESSION_ID = 'workbench.action.language.runtime.selectSession';
-export const LANGUAGE_RUNTIME_START_NEW_SESSION_ID = 'workbench.action.language.runtime.startNewSession';
+export const LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID = 'workbench.action.language.runtime.startNewConsoleSession';
 export const LANGUAGE_RUNTIME_RESTART_ACTIVE_SESSION_ID = 'workbench.action.language.runtime.restartActiveSession';
 export const LANGUAGE_RUNTIME_RENAME_SESSION_ID = 'workbench.action.language.runtime.renameSession';
 export const LANGUAGE_RUNTIME_RENAME_ACTIVE_SESSION_ID = 'workbench.action.language.runtime.renameActiveSession';
@@ -194,8 +194,8 @@ const selectLanguageRuntimeSession = async (
 
 	// Handle the user's selection.
 	if (result?.id === startNewRuntimeId) {
-		// If the user selected "All Runtimes...", execute the command to show all runtimes.
-		const sessionId: string | undefined = await commandService.executeCommand(LANGUAGE_RUNTIME_START_NEW_SESSION_ID);
+		// If the user selected "New Console Session...", execute the command to start a new console session.
+		const sessionId: string | undefined = await commandService.executeCommand(LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID);
 		if (sessionId) {
 			return runtimeSessionService.activeSessions.find(session => session.sessionId === sessionId);
 		}
@@ -584,7 +584,7 @@ export function registerLanguageRuntimeActions() {
 		});
 
 	/**
-	 * Action that allows the user to create a new session from a list of registered runtimes.
+	 * Action that allows the user to create a new console session from a list of registered runtimes.
 	 */
 	registerAction2(class extends Action2 {
 		/**
@@ -593,8 +593,8 @@ export function registerLanguageRuntimeActions() {
 		constructor() {
 			super({
 				icon: Codicon.plus,
-				id: LANGUAGE_RUNTIME_START_NEW_SESSION_ID,
-				title: localize2('positron.languageRuntime.startSession', 'Start New Console Session'),
+				id: LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID,
+				title: localize2('positron.languageRuntime.startConsoleSession', 'Start New Console Session'),
 				category,
 				f1: true,
 				menu: [{

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
@@ -40,7 +40,7 @@ import { areSameExtensions } from '../../../../../platform/extensionManagement/c
 // eslint-disable-next-line no-duplicate-imports
 import { DeferredPromise } from '../../../../../base/common/async.js';
 import { POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID } from '../../../runtimeNotebookKernel/common/runtimeNotebookKernelConfig.js';
-import { LANGUAGE_RUNTIME_SELECT_RUNTIME_ID } from '../../../languageRuntime/browser/languageRuntimeActions.js';
+import { LANGUAGE_RUNTIME_SELECT_LEGACY_NOTEBOOK_RUNTIME_ID } from '../../../languageRuntime/browser/languageRuntimeActions.js';
 // --- End Positron ---
 type KernelPick = IQuickPickItem & { kernel: INotebookKernel };
 function isKernelPick(item: QuickPickInput<IQuickPickItem>): item is KernelPick {
@@ -568,7 +568,7 @@ export class KernelPickerMRUStrategy extends KernelPickerStrategyBase {
 		// 	return this.displaySelectAnotherQuickPick(editor, items.length === 1 && items[0] === pick);
 		// }
 
-		if (pick.id === LANGUAGE_RUNTIME_SELECT_RUNTIME_ID) {
+		if (pick.id === LANGUAGE_RUNTIME_SELECT_LEGACY_NOTEBOOK_RUNTIME_ID) {
 			this._handleKernelQuickPick(pick, editor);
 		}
 		// --- End Positron ---

--- a/src/vs/workbench/contrib/positronConsole/browser/components/emptyConsole.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/emptyConsole.tsx
@@ -9,7 +9,7 @@ import './emptyConsole.css';
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
 import { PositronButton } from '../../../../../base/browser/ui/positronComponents/button/positronButton.js';
-import { LANGUAGE_RUNTIME_START_NEW_SESSION_ID } from '../../../languageRuntime/browser/languageRuntimeActions.js';
+import { LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID } from '../../../languageRuntime/browser/languageRuntimeActions.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 
 // Load localized copy for control.
@@ -27,7 +27,7 @@ export const EmptyConsole = () => {
 	const services = usePositronReactServicesContext();
 
 	const handlePressed = () => {
-		services.commandService.executeCommand(LANGUAGE_RUNTIME_START_NEW_SESSION_ID);
+		services.commandService.executeCommand(LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID);
 	};
 
 	// Render.

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -32,7 +32,7 @@ import { IAccessibilityService } from '../../../../platform/accessibility/common
 import { IActionViewItem } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { IDropdownMenuActionViewItemOptions } from '../../../../base/browser/ui/dropdown/dropdownActionViewItem.js';
 import { Action, IAction } from '../../../../base/common/actions.js';
-import { LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_SESSION_ID, LANGUAGE_RUNTIME_START_NEW_SESSION_ID } from '../../languageRuntime/browser/languageRuntimeActions.js';
+import { LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_SESSION_ID, LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID } from '../../languageRuntime/browser/languageRuntimeActions.js';
 import { DropdownWithPrimaryActionViewItem } from '../../../../platform/actions/browser/dropdownWithPrimaryActionViewItem.js';
 import { MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { localize } from '../../../../nls.js';
@@ -389,7 +389,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 			undefined,
 			true,
 			() => {
-				this.commandService.executeCommand(LANGUAGE_RUNTIME_START_NEW_SESSION_ID);
+				this.commandService.executeCommand(LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID);
 			})
 		);
 

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleView.tsx
@@ -32,7 +32,7 @@ import { IAccessibilityService } from '../../../../platform/accessibility/common
 import { IActionViewItem } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { IDropdownMenuActionViewItemOptions } from '../../../../base/browser/ui/dropdown/dropdownActionViewItem.js';
 import { Action, IAction } from '../../../../base/common/actions.js';
-import { LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_SESSION_ID, LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID } from '../../languageRuntime/browser/languageRuntimeActions.js';
+import { LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_CONSOLE_SESSION_ID, LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID } from '../../languageRuntime/browser/languageRuntimeActions.js';
 import { DropdownWithPrimaryActionViewItem } from '../../../../platform/actions/browser/dropdownWithPrimaryActionViewItem.js';
 import { MenuItemAction } from '../../../../platform/actions/common/actions.js';
 import { localize } from '../../../../nls.js';
@@ -310,7 +310,7 @@ export class PositronConsoleViewPane extends PositronViewPane implements IReactC
 
 	override createActionViewItem(action: IAction, options?: IDropdownMenuActionViewItemOptions): IActionViewItem | undefined {
 		// Do not create the session dropdown if there are no Positron console instances.
-		if (action.id === LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_SESSION_ID && this.positronConsoleService.positronConsoleInstances.length > 0) {
+		if (action.id === LANGUAGE_RUNTIME_DUPLICATE_ACTIVE_CONSOLE_SESSION_ID && this.positronConsoleService.positronConsoleInstances.length > 0) {
 			if (action instanceof MenuItemAction) {
 				const dropdownAction = new Action('console.session.quickLaunch', localize('console.session.quickLaunch', 'Quick Launch Session...'), 'codicon-chevron-down', true);
 				this._register(dropdownAction);

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
@@ -24,7 +24,7 @@ import { NotebookExecutionStatus } from './notebookExecutionStatus.js';
 import { RuntimeNotebookKernel } from './runtimeNotebookKernel.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { ILanguageRuntimeCodeExecutedEvent } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
-import { LANGUAGE_RUNTIME_SELECT_RUNTIME_ID } from '../../languageRuntime/browser/languageRuntimeActions.js';
+import { LANGUAGE_RUNTIME_SELECT_LEGACY_NOTEBOOK_RUNTIME_ID } from '../../languageRuntime/browser/languageRuntimeActions.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { isNotebookRuntimeSessionMetadata } from '../../../services/runtimeSession/common/runtimeSession.js';
 import { IPositronNotebookService } from '../../positronNotebook/browser/positronNotebookService.js';
@@ -193,7 +193,7 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 					{
 						label: 'Select Environment...',
 						command: {
-							id: LANGUAGE_RUNTIME_SELECT_RUNTIME_ID,
+							id: LANGUAGE_RUNTIME_SELECT_LEGACY_NOTEBOOK_RUNTIME_ID,
 							title: 'Select Environment',
 						},
 					}

--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -47,7 +47,7 @@ export class Console {
 		this.trashButton = this.code.driver.page.getByTestId('trash-session');
 
 		// `+` Add Session Split Button Locators
-		this.addSessionDuplicateButton = this.code.driver.page.getByLabel('Duplicate Active Interpreter');
+		this.addSessionDuplicateButton = this.code.driver.page.getByLabel('Duplicate Active Console Session');
 		this.addSessionExpandMenuButton = this.code.driver.page.getByLabel('Quick Launch Session...');
 
 		// Misc

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -1043,8 +1043,8 @@ export class Sessions {
  */
 export class SessionQuickPick {
 	private get quickInputTitleBar(): Locator { return this.code.driver.page.locator('.quick-input-titlebar'); }
-	private get sessionQuickMenu(): Locator { return this.quickInputTitleBar.getByText(/(Select Interpreter Session)|(Start New Interpreter Session)/); }
-	get allSessionsMenu(): Locator { return this.quickInputTitleBar.getByText(/Start New Interpreter Session/); }
+	private get sessionQuickMenu(): Locator { return this.quickInputTitleBar.getByText(/(Running Interpreter Sessions)|(Start New Console Session)/); }
+	get allSessionsMenu(): Locator { return this.quickInputTitleBar.getByText(/Start New Console Session/); }
 
 	constructor(private code: Code, private sessions: Sessions) { }
 
@@ -1063,9 +1063,9 @@ export class SessionQuickPick {
 				}
 
 				if (viewAllRuntimes) {
-					await this.code.driver.page.getByRole('textbox', { name: /(Select Interpreter Session|New Interpreter Session)/ }).fill('New Session');
+					await this.code.driver.page.getByRole('textbox', { name: /(Running Interpreter Sessions|New Console Session)/ }).fill('New Session');
 					await this.code.driver.page.keyboard.press('Enter');
-					await expect(this.code.driver.page.getByText(/Start New Interpreter Session/)).toBeVisible({ timeout: 1000 });
+					await expect(this.code.driver.page.getByText(/Start New Console Session/)).toBeVisible({ timeout: 1000 });
 				}
 			}, 'Open Session QuickPick Menu').toPass({ intervals: [500], timeout: 10000 });
 		});
@@ -1111,7 +1111,7 @@ export class SessionQuickPick {
 
 			// Filter out the one with "New Session..."
 			const filteredSessions = activeSessions
-				.filter(session => !session.name.includes('New Interpreter Session...'));
+				.filter(session => !session.name.includes('New Console Session...'));
 
 			await this.closeSessionQuickPickMenu();
 			return filteredSessions;

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -19,6 +19,15 @@ export const ACTIVE_STATUS_ICON = '.codicon-positron-runtime-status-active';
 export const IDLE_STATUS_ICON = '.codicon-positron-runtime-status-idle';
 export const DISCONNECTED_STATUS_ICON = '.codicon-positron-runtime-status-disconnected';
 
+// Quickpick labels - keep in sync with languageRuntimeActions.ts
+const INTERPRETER_SESSIONS_LABEL = 'Interpreter Sessions';
+const START_NEW_CONSOLE_SESSION_LABEL = 'Start New Console Session';
+const NEW_CONSOLE_SESSION_ITEM_LABEL = 'New Console Session...';
+
+// Quickpick label regex patterns used in SessionQuickPick
+const SESSION_QUICK_MENU_PATTERN = new RegExp(`(${INTERPRETER_SESSIONS_LABEL})|(${START_NEW_CONSOLE_SESSION_LABEL})`);
+const START_NEW_CONSOLE_SESSION_PATTERN = new RegExp(START_NEW_CONSOLE_SESSION_LABEL);
+
 /**
  * Class to manage console sessions
  */
@@ -1043,8 +1052,8 @@ export class Sessions {
  */
 export class SessionQuickPick {
 	private get quickInputTitleBar(): Locator { return this.code.driver.page.locator('.quick-input-titlebar'); }
-	private get sessionQuickMenu(): Locator { return this.quickInputTitleBar.getByText(/(Interpreter Sessions)|(Start New Console Session)/); }
-	get allSessionsMenu(): Locator { return this.quickInputTitleBar.getByText(/Start New Console Session/); }
+	private get sessionQuickMenu(): Locator { return this.quickInputTitleBar.getByText(SESSION_QUICK_MENU_PATTERN); }
+	get allSessionsMenu(): Locator { return this.quickInputTitleBar.getByText(START_NEW_CONSOLE_SESSION_PATTERN); }
 
 	constructor(private code: Code, private sessions: Sessions) { }
 
@@ -1063,9 +1072,9 @@ export class SessionQuickPick {
 				}
 
 				if (viewAllRuntimes) {
-					await this.code.driver.page.getByRole('textbox', { name: /(Interpreter Sessions|New Console Session)/ }).fill('New Session');
+					await this.code.driver.page.getByRole('textbox', { name: SESSION_QUICK_MENU_PATTERN }).fill('New Session');
 					await this.code.driver.page.keyboard.press('Enter');
-					await expect(this.code.driver.page.getByText(/Start New Console Session/)).toBeVisible({ timeout: 1000 });
+					await expect(this.code.driver.page.getByText(START_NEW_CONSOLE_SESSION_PATTERN)).toBeVisible({ timeout: 1000 });
 				}
 			}, 'Open Session QuickPick Menu').toPass({ intervals: [500], timeout: 10000 });
 		});
@@ -1111,7 +1120,7 @@ export class SessionQuickPick {
 
 			// Filter out the one with "New Session..."
 			const filteredSessions = activeSessions
-				.filter(session => !session.name.includes('New Console Session...'));
+				.filter(session => !session.name.includes(NEW_CONSOLE_SESSION_ITEM_LABEL));
 
 			await this.closeSessionQuickPickMenu();
 			return filteredSessions;

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -1043,7 +1043,7 @@ export class Sessions {
  */
 export class SessionQuickPick {
 	private get quickInputTitleBar(): Locator { return this.code.driver.page.locator('.quick-input-titlebar'); }
-	private get sessionQuickMenu(): Locator { return this.quickInputTitleBar.getByText(/(Running Interpreter Sessions)|(Start New Console Session)/); }
+	private get sessionQuickMenu(): Locator { return this.quickInputTitleBar.getByText(/(Interpreter Sessions)|(Start New Console Session)/); }
 	get allSessionsMenu(): Locator { return this.quickInputTitleBar.getByText(/Start New Console Session/); }
 
 	constructor(private code: Code, private sessions: Sessions) { }
@@ -1063,7 +1063,7 @@ export class SessionQuickPick {
 				}
 
 				if (viewAllRuntimes) {
-					await this.code.driver.page.getByRole('textbox', { name: /(Running Interpreter Sessions|New Console Session)/ }).fill('New Session');
+					await this.code.driver.page.getByRole('textbox', { name: /(Interpreter Sessions|New Console Session)/ }).fill('New Session');
 					await this.code.driver.page.keyboard.press('Enter');
 					await expect(this.code.driver.page.getByText(/Start New Console Session/)).toBeVisible({ timeout: 1000 });
 				}

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
@@ -47,7 +47,7 @@ async function verifyNotebookEditorVisible(app: Application) {
 }
 
 async function verifyNotebookAndConsolePythonVersion(app: Application) {
-	const sessionSelectorButton = app.code.driver.page.getByRole('button', { name: 'Select Interpreter Session' });
+	const sessionSelectorButton = app.code.driver.page.getByRole('button', { name: 'Select Session' });
 	const sessionSelectorText = await sessionSelectorButton.textContent();
 
 	// Extract the version number (e.g., '3.10.12') from the button text


### PR DESCRIPTION
Addresses #11898

As we work towards making notebook sessions first-class citizens, we need to clearly communicate:
  1. Which commands work with any session type (console or notebook or quarto)
  2. Which commands are specific to a session type and only work with that type

This PR renames things such that:
- console specific commands and quickpicks clearly state "Console" in the command ID and title
- commands that work with any session type use the term "Interpreter" or just "Session".

To help track all of the changes, I've created a table below that show you what has changed and what the session type support expectation is.

#### Command Title Changes

| Command ID | Old Command Title | New Command Title | Quick Pick Title | Supports Console | Supports Notebook |
|------------|-----------|-----------|------------------|---------|----------|
| `workbench.action.language.runtime.selectSession` | Select Interpreter Session | Select Session | Interpreter Sessions | Yes | Yes (future) |
| `workbench.action.language.runtime.startNewConsoleSession` (was `...startNewSession`) | Start New Interpreter Session | Start New Console Session | Start New Console Session | Yes | No |
| `workbench.action.language.runtime.duplicateActiveConsoleSession` (was `...duplicateActiveSession`) | Duplicate Active Interpreter Session | Duplicate Active Console Session | N/A | Yes | No |
| `workbench.action.language.runtime.renameSession` | Rename Interpreter Session | N/A | Select Session To Rename | Yes | Yes (future) |
| `workbench.action.languageRuntime.selectLegacyNotebookRuntime` (was `... selectRuntime`) | Select Interpreter | N/A | N/A | No | Yes (legacy) |

#### Interpreter Picker Label Changes

I also updated some of the labels in the quickpick shown when you click on the interpreter picker. 

| Old Label | New Label |
|-----------|-----------|
| Active Interpreter Sessions | Console Sessions |
| New Interpreter Session... | New Console Session... |

### Screenshots

NOTE: the title "Running Interpreter Sessions" was changed to "Interpreter Sessions" based off PR feedback but the videos/screenshots were taken prior to that change and don't reflect this update in the title!

**BEFORE**

<img width="1828" height="1072" alt="before-select-session-quickpick" src="https://github.com/user-attachments/assets/1b254b29-35b3-4195-a87e-1e62a718602b" />

**AFTER**

<img width="1840" height="1072" alt="after-rename-select-session-quickpick-labels" src="https://github.com/user-attachments/assets/5e5bef70-a878-49ac-8ef8-cf64922b4ccd" />


**Legacy Notebook -> "Select Environment" quickpick flow unchanged**

https://github.com/user-attachments/assets/72984fcb-c41f-49f3-aa55-f60964934981

**Duplicate Console Session**

https://github.com/user-attachments/assets/71195d64-0cd8-4f40-a760-9cb3b8a134d1

**Start New Console Session**

https://github.com/user-attachments/assets/91bcb5ed-143f-4b12-b0f3-12f42003981e


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Rename some language runtime commands (#11898)

#### Bug Fixes

- N/A


### QA Notes

@:console
@:critical
@:interpreter
@:notebooks
@:sessions

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
