### PR TITLE
e2e: fix flaky R interpreter test by waiting for reload

### DIFF
--- a/test/e2e/tests/interpreters/default-r-interpreter.test.ts
+++ b/test/e2e/tests/interpreters/default-r-interpreter.test.ts
@@ -43,9 +43,9 @@ test.describe('Default Interpreters - R', {
 
 	});
 
-	test('R - Add a default interpreter', async function ({ runCommand, sessions }) {
+	test('R - Add a default interpreter', async function ({ runCommand, sessions, hotKeys }) {
 
-		await runCommand('workbench.action.reloadWindow');
+		await hotKeys.reloadWindow(true);
 
 		const hiddenRVersion = process.env.POSITRON_HIDDEN_R;
 		if (!hiddenRVersion) {
@@ -69,7 +69,7 @@ test.describe('Default Interpreters - R', {
 				expect(path).toMatch(new RegExp(`R-${escapedVersion}\\/bin\\/R`));
 
 			} catch (error) {
-				await runCommand('workbench.action.reloadWindow');
+				await hotKeys.reloadWindow(true);
 				throw error;
 			}
 


### PR DESCRIPTION
## Summary
- Fix flaky `default-r-interpreter.test.ts` by using `hotKeys.reloadWindow(true)` which waits for the reload to complete instead of the fire-and-forget `runCommand('workbench.action.reloadWindow')`

## QA Notes

@:interpreter

🤖 Generated with [Claude Code](https://claude.com/claude-code)