### PR TITLE
e2e: fix welcome test flake

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "extensions-ci": "npm run gulp extensions-ci",
     "extensions-ci-pr": "npm run gulp extensions-ci-pr",
     "perf": "node scripts/code-perf.js",
-    "rebuild": ". $NVM_DIR/nvm.sh && nvm use && ./rebuild.sh",
+    "nuke": ". $NVM_DIR/nvm.sh && nvm use && ./rebuild.sh && npm run prelaunch",
     "update-build-ts-version": "npm install -D typescript@next && npm install -D @typescript/native-preview && (cd build && npm run typecheck)",
     "build-ps": "./scripts/build-ps.sh",
     "build-check": "./scripts/build-check.sh",

--- a/test/e2e/tests/assistant-eval/README.md
+++ b/test/e2e/tests/assistant-eval/README.md
@@ -1,6 +1,6 @@
 # Positron: LLM Eval Test Catalog
 
-> 9 test cases · Auto-generated on 2026-02-20T17:23:18.628Z
+> 9 test cases · Auto-generated on 2026-03-04T17:56:14.438Z
 
 ## Hallucination
 
@@ -123,7 +123,6 @@ What is the total revenue shown in my notebook? Just tell me the answer, don't a
 
 #### Nice to have
 
-- References the DataFrame "df" by name or describes the data structure
 - Provides a clear, accurate calculation or explanation showing how the total was derived
 - Does not hallucinate columns or values not present in the notebook
 

--- a/test/e2e/tests/assistant-eval/notebooks/r-notebook-automatic-context.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/r-notebook-automatic-context.ts
@@ -63,7 +63,6 @@ export const rNotebookAutomaticContext: EvalTestCase = {
 			'The `editNotebookCells` tool must NOT appear in "Tools Called:" (we asked NOT to edit)',
 		],
 		optional: [
-			'References the DataFrame "df" by name or describes the data structure',
 			'Provides a clear, accurate calculation or explanation showing how the total was derived',
 			'Does not hallucinate columns or values not present in the notebook',
 		],

--- a/test/e2e/tests/lsp/lsp-outline.test.ts
+++ b/test/e2e/tests/lsp/lsp-outline.test.ts
@@ -83,7 +83,7 @@ test.describe('Outline', { tag: [tags.WEB, tags.PYREFLY] }, () => {
 
 		test.skip('Verify outline after reload with Python in foreground and R in background', {
 			tag: [tags.ARK],
-		}, async function ({ app, runCommand, sessions }) {
+		}, async function ({ app, hotKeys, sessions }) {
 			const { outline, editor } = app.workbench;
 
 			// Start sessions
@@ -99,7 +99,7 @@ test.describe('Outline', { tag: [tags.WEB, tags.PYREFLY] }, () => {
 
 			// Reload window
 			await sessions.expectSessionCountToBe(2);
-			await runCommand('workbench.action.reloadWindow');
+			await hotKeys.reloadWindow(true);
 			await sessions.expectSessionCountToBe(2);
 
 			// Verify outlines for both file types
@@ -112,7 +112,7 @@ test.describe('Outline', { tag: [tags.WEB, tags.PYREFLY] }, () => {
 
 		test.skip('Verify outline after reload with R in foreground and Python in background', {
 			tag: [tags.ARK],
-		}, async function ({ app, runCommand, sessions }) {
+		}, async function ({ app, hotKeys, sessions }) {
 			const { outline, editor } = app.workbench;
 
 			// Start sessions
@@ -127,7 +127,7 @@ test.describe('Outline', { tag: [tags.WEB, tags.PYREFLY] }, () => {
 			await verifyPythonOutline(outline);
 
 			// Reload window
-			await runCommand('workbench.action.reloadWindow');
+			await hotKeys.reloadWindow(true);
 
 			// Verify outlines for both file types
 			await editor.selectTab(R_FILE);

--- a/test/e2e/tests/sessions/session-mgmt.test.ts
+++ b/test/e2e/tests/sessions/session-mgmt.test.ts
@@ -56,7 +56,7 @@ test.describe('Sessions: Management', {
 				{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6036' },
 				{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/6843' } // <-- main issue for the test, session do not consistently restore
 			]
-		}, async function ({ app, sessions, runCommand }) {
+		}, async function ({ app, sessions, hotKeys }) {
 			const { console, plots, variables } = app.workbench;
 
 			// Ensure sessions exist and are idle
@@ -85,7 +85,7 @@ test.describe('Sessions: Management', {
 			await variables.expectVariableToBe('test', '3');
 
 			// Reload app
-			await runCommand('workbench.action.reloadWindow');
+			await hotKeys.reloadWindow(true);
 
 			// Verify all sessions reload and are idle
 			await sessions.expectSessionCountToBe(3);

--- a/test/e2e/tests/sessions/session-rename.test.ts
+++ b/test/e2e/tests/sessions/session-rename.test.ts
@@ -23,7 +23,7 @@ test.describe('Sessions: Rename', {
 
 	test('Validate can rename sessions and name persists', {
 		tag: process.platform === 'win32' ? [tags.SOFT_FAIL] : [] //only soft fail on windows since this is marked as critical and only flakey on windows.
-	}, async function ({ sessions, runCommand }) {
+	}, async function ({ sessions, hotKeys }) {
 		const [pySession, pySessionAlt, rSession, rSessionAlt] = await sessions.start(['python', 'pythonAlt', 'r', 'rAlt']);
 
 		// Rename sessions
@@ -40,7 +40,7 @@ test.describe('Sessions: Rename', {
 
 		// Test may be flaky due to issue 6843
 		// Reload window
-		await runCommand('workbench.action.reloadWindow');
+		await hotKeys.reloadWindow(true);
 		await sessions.expectAllSessionsToBeReady();
 
 		// Verify session names persist

--- a/test/e2e/tests/welcome/welcome.test.ts
+++ b/test/e2e/tests/welcome/welcome.test.ts
@@ -72,7 +72,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 			await editors.expectActiveEditorIconClassToMatch(/python-lang-file-icon/);
 		});
 
-		test('R - Verify clicking on `new notebook` from the Welcome page opens notebook and sets kernel', async function ({ app, r }) {
+		test('R - Verify clicking on `new notebook` from the Welcome page opens notebook and sets kernel', async function ({ app, sessions, r }) {
 			const { welcome, popups, editors, notebooks } = app.workbench;
 
 			await welcome.newNotebookButton.click();
@@ -80,6 +80,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 
 			await editors.expectActiveEditorIconClassToMatch(/ipynb-ext-file-icon/);
 			await notebooks.expectKernelToBe(availableRuntimes['r'].name);
+			await sessions.deleteAll();
 		});
 
 		test('R - Verify clicking on `new file` from the Welcome page opens editor', async function ({ app, r }) {

--- a/test/e2e/tests/welcome/welcome.test.ts
+++ b/test/e2e/tests/welcome/welcome.test.ts
@@ -6,9 +6,6 @@
 import { availableRuntimes } from '../../infra';
 import { test, tags } from '../_test.setup';
 
-const pythonRuntime = availableRuntimes['python'];
-const rRuntime = availableRuntimes['r'];
-
 test.use({
 	suiteId: __filename
 });
@@ -19,7 +16,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 	});
 
 	test.describe('Workspace', () => {
-		test.beforeEach(async function ({ hotKeys, sessions, app }) {
+		test.beforeEach(async function ({ hotKeys, sessions }) {
 			await sessions.expectNoStartUpMessaging();
 			await hotKeys.openWelcomeWalkthrough();
 		});
@@ -41,7 +38,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 		test('Verify limited walkthroughs on Welcome page and full list in `More...`', async function ({ app, hotKeys }) {
 			const { welcome, quickInput } = app.workbench;
 			await hotKeys.resetWelcomeWalkthrough();
-			await hotKeys.reloadWindow();
+			await hotKeys.reloadWindow(true);
 
 			await welcome.expectWalkthroughsToHaveCount(3);
 			await welcome.expectWalkthroughsToContain(['Migrating from VSCode to Positron', 'Migrating from RStudio to Positron', 'Explore the Positron Notebook Editor in Alpha']);
@@ -64,7 +61,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 			await welcome.newNotebookButton.click();
 			await popups.clickItem('Python Notebook');
 			await editors.expectActiveEditorIconClassToMatch(/ipynb-ext-file-icon/);
-			await notebooks.expectKernelToBe(pythonRuntime.name);
+			await notebooks.expectKernelToBe(availableRuntimes['python'].name);
 		});
 
 		test('Python - Verify clicking on `new file` from the Welcome page opens editor', async function ({ app, python }) {
@@ -82,7 +79,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 			await popups.clickItem('R Notebook');
 
 			await editors.expectActiveEditorIconClassToMatch(/ipynb-ext-file-icon/);
-			await notebooks.expectKernelToBe(rRuntime.name);
+			await notebooks.expectKernelToBe(availableRuntimes['r'].name);
 		});
 
 		test('R - Verify clicking on `new file` from the Welcome page opens editor', async function ({ app, r }) {
@@ -139,5 +136,4 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 			await modals.expectToBeVisible('New Folder from Git');
 		});
 	});
-
 });


### PR DESCRIPTION

## Summary
`welcome.test.ts`
- Move `availableRuntimes` access from module-level consts to inside tests, which fixes flaky test failures where `rRuntime.name` was `"R undefined"` because env vars weren't set at module import time
- Deleted previous session and test was often hanging on this session for some reason

miscellaneous
- Updated tests to use `hotKeys.reload()` over the command for reliability
- Updated ~build~ nuke script to also run prelaunch.
- Removed optional condition from an eval as not needed

## QA Notes

@:welcome @:web

🤖 Generated with [Claude Code](https://claude.com/claude-code)