### PR TITLE
e2e: retry autocomplete after opening new Python and R files to prevent LSP sync issues

### DIFF
--- a/test/e2e/tests/autocomplete/autocomplete.test.ts
+++ b/test/e2e/tests/autocomplete/autocomplete.test.ts
@@ -226,7 +226,7 @@ async function triggerFirstAutocompleteInEditor({ app, session, expectedCount }:
 
 	await expect(async () => {
 		// Clear any previous attempt (Select All + Delete), no-op on empty file
-		await keyboard.press(`${process.platform === 'darwin' ? 'Meta' : 'Control'}+A`);
+		await hotKeys.selectAll();
 		await keyboard.press('Delete');
 		// Dismiss any stale suggestion widget
 		await keyboard.press('Escape');

--- a/test/e2e/tests/autocomplete/autocomplete.test.ts
+++ b/test/e2e/tests/autocomplete/autocomplete.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -44,8 +44,7 @@ test.describe('Autocomplete', {
 		await runCommand('Python: New Python File');
 
 		// Session 1 - trigger and verify editor autocomplete
-		await triggerAutocompleteInEditor({ app, session: pySession1, retrigger: false });
-		await editors.expectSuggestionListCount(1);
+		await triggerFirstAutocompleteInEditor({ app, session: pySession1, expectedCount: 1 });
 
 		// Session 2 - retrigger and verify editor autocomplete
 		await triggerAutocompleteInEditor({ app, session: pySession2, retrigger: true });
@@ -116,8 +115,7 @@ test.describe('Autocomplete', {
 		await runCommand('R: New R File');
 
 		// Session 1 - trigger and verify editor autocomplete
-		await triggerAutocompleteInEditor({ app, session: rSession1, retrigger: false });
-		await editors.expectSuggestionListCount(4);
+		await triggerFirstAutocompleteInEditor({ app, session: rSession1, expectedCount: 4 });
 
 		// Session 2 - retrigger and verify editor autocomplete
 		await triggerAutocompleteInEditor({ app, session: rSession2, retrigger: true });
@@ -204,4 +202,38 @@ async function triggerAutocompleteInEditor({ app, session, retrigger = false }: 
 			{ delay: 250 }
 		);
 	}
+}
+
+/**
+ * Triggers autocomplete in a newly opened editor file, retrying if the
+ * didOpen/didChange race causes the language server to miss the typed text.
+ * Each attempt clears the editor and retypes the trigger text.
+ */
+async function triggerFirstAutocompleteInEditor({ app, session, expectedCount }: {
+	app: Application;
+	session: SessionMetaData;
+	expectedCount: number;
+}) {
+	const { sessions, hotKeys, editors } = app.workbench;
+	const keyboard = app.code.driver.page.keyboard;
+	const triggerText = session.name.includes('Python') ? 'pd.DataF' : 'read_p';
+
+	// Select session and wait for editor focus once, before the retry loop
+	await sessions.select(session.id);
+	await hotKeys.firstTab();
+	const editorInput = app.code.driver.page.locator('.editor-instance .monaco-editor .native-edit-context');
+	await expect(editorInput).toBeFocused();
+
+	await expect(async () => {
+		// Clear any previous attempt (Select All + Delete), no-op on empty file
+		await keyboard.press(`${process.platform === 'darwin' ? 'Meta' : 'Control'}+A`);
+		await keyboard.press('Delete');
+		// Dismiss any stale suggestion widget
+		await keyboard.press('Escape');
+		// Type the trigger text
+		await keyboard.type(triggerText, { delay: 250 });
+		// Check for suggestions with a reduced timeout so failed attempts
+		// don't burn the full 15s default
+		await expect(editors.suggestionList).toHaveCount(expectedCount, { timeout: 5_000 });
+	}).toPass({ timeout: 30_000 });
 }


### PR DESCRIPTION
Addresses #12268. Fixes the flaky autocomplete e2e tests caused by an LSP didOpen/didChange race.

This PR retries the autocomplete tests immediately after after opening new Python and R files in the autocomplete tests, giving LSP clients time to flush the `didOpen` notification before any keystrokes trigger `didChange`.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:console @:win @:web

This is a test-only change.
