### PR TITLE
Suppress automatic suggestion of the REditorSupport.r extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,5 +10,11 @@
 		"jrieken.vscode-pr-pinger",
 		"typescriptteam.native-preview",
 		"ms-vscode.ts-customized-language-service"
+	],
+	// --- Start Positron ---
+	// Suppress automatic suggestion of the REditorSupport.r extension
+	"unwantedRecommendations": [
+		"REditorSupport.r"
 	]
+	// --- End Positron ---
 }


### PR DESCRIPTION
Just a little dev hangnail. `REditorSupport.r` is not among the concrete extension recommendations for VS Code itself. We just see this pop-up because positron-r has some `.R` files. I'd love to prevent this automatic suggestion for all of us, for all time.

<img width="465" height="122" alt="Screenshot 2026-03-04 at 11 18 52 AM" src="https://github.com/user-attachments/assets/b104312e-c7c8-43f5-b1fb-d00a07cbcf14" />
