### PR TITLE
e2e: implement retry logic for quick pick interaction to handle race conditions

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -428,31 +428,38 @@ export class Sessions {
 			// Don't try to start a new runtime if one is currently starting up
 			await this.expectAllSessionsToBeReady();
 
-			// Start the runtime via the session picker button, quickaccess or console session button
-			if (triggerMode === 'quickaccess') {
-				const command = language === 'Python' ? 'python.setInterpreter' : 'r.selectInterpreter';
-				await this.quickaccess.runCommand(command, { keepOpen: true });
-			} else if (triggerMode === 'session-picker') {
-				await this.quickPick.openSessionQuickPickMenu();
-			} else {
-				await this.page.keyboard.press('Control+Shift+/');
-			}
+			// Retry the quick pick interaction to handle race conditions where the
+			// picker may not open or populate correctly on the first attempt.
+			await expect(async () => {
+				// Dismiss any stale quick input from a previous attempt
+				await this.quickinput.closeQuickInput().catch(() => { });
 
-			let input = language;
-			if (version) {
-				input += ` ${version}`;
-			}
-			if (options.disambiguator) {
-				input += ` ${options.disambiguator}`;
-			}
+				// Start the runtime via the session picker button, quickaccess or console session button
+				if (triggerMode === 'quickaccess') {
+					const command = language === 'Python' ? 'python.setInterpreter' : 'r.selectInterpreter';
+					await this.quickaccess.runCommand(command, { keepOpen: true });
+				} else if (triggerMode === 'session-picker') {
+					await this.quickPick.openSessionQuickPickMenu();
+				} else {
+					await this.page.keyboard.press('Control+Shift+/');
+				}
 
-			await this.quickinput.type(input);
+				let input = language;
+				if (version) {
+					input += ` ${version}`;
+				}
+				if (options.disambiguator) {
+					input += ` ${options.disambiguator}`;
+				}
 
-			// Wait until the desired runtime appears in the list and select it.
-			// We need to click instead of using 'enter' because the Python select interpreter command
-			// may include additional items above the desired interpreter string.
-			await this.quickinput.selectQuickInputElementContaining(`${language} ${version}`);
-			await this.quickinput.waitForQuickInputClosed();
+				await this.quickinput.type(input);
+
+				// Wait until the desired runtime appears in the list and select it.
+				// We need to click instead of using 'enter' because the Python select interpreter command
+				// may include additional items above the desired interpreter string.
+				await this.quickinput.selectQuickInputElementContaining(`${language} ${version}`, { timeout: 2000 });
+				await this.quickinput.waitForQuickInputClosed();
+			}, 'Select runtime from quick pick').toPass({ timeout: 30000 });
 
 			// Move mouse to prevent tooltip hover
 			await this.code.driver.page.mouse.move(0, 0);


### PR DESCRIPTION
Adds a retry mechanism to startAndSkipMetadata in the e2e sessions page object. 
Instead of failing immediately on the first attempt, the interaction now retries for up to 30 seconds with a 2 second timeout on each attempt, dismissing any stale quick input between retries.


### QA Notes
@:interpreter @:sessions
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
