### PR TITLE
e2e: refactor plot file attribution tests and add POM helpers

### DIFF
--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -60,6 +60,11 @@ export class HotKeys {
 		await this.pressHotKeys('Cmd+Shift+Enter', 'Run file in console');
 	}
 
+	public async runLineOfCode() {
+		await this.pressHotKeys('Cmd+Enter', 'Run line of code');
+		await this.code.driver.page.waitForTimeout(500); // Wait for the console to process the command
+	}
+
 	public async selectNotebookKernel() {
 		await this.pressHotKeys('Cmd+J D', 'Select notebook kernel');
 	}

--- a/test/e2e/pages/plots.ts
+++ b/test/e2e/pages/plots.ts
@@ -21,6 +21,7 @@ const COPY_PLOT_BUTTON = '.positron-plots-container .positron-dynamic-action-bar
 const ZOOM_PLOT_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Fit"]';
 const OPEN_IN_EDITOR_DROPDOWN_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Select where to open plot"]';
 const OVERFLOW_MENU_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="overflow"]';
+const ORIGIN_FILE_BUTTON = '.plot-origin-file';
 const OUTER_WEBVIEW_FRAME = '.webview';
 const INNER_WEBVIEW_FRAME = '#active-frame';
 
@@ -39,6 +40,7 @@ export class Plots {
 	copyPlotButton: Locator;
 	zoomPlotButton: Locator;
 	currentPlot: Locator;
+	originFileButton: Locator;
 	savePlotModal: Locator;
 	overwriteModal: Locator;
 
@@ -53,16 +55,39 @@ export class Plots {
 		this.copyPlotButton = this.code.driver.page.locator(COPY_PLOT_BUTTON);
 		this.zoomPlotButton = this.code.driver.page.locator(ZOOM_PLOT_BUTTON);
 		this.currentPlot = this.code.driver.page.locator(CURRENT_PLOT);
+		this.originFileButton = this.code.driver.page.locator(ORIGIN_FILE_BUTTON);
 		this.savePlotModal = this.code.driver.page.locator('.positron-modal-dialog-box').filter({ hasText: 'Save Plot' });
 		this.overwriteModal = this.code.driver.page.locator('.positron-modal-dialog-box').filter({ hasText: 'The file already exists' });
 	}
 
+	async clickOriginFileButton() {
+		await test.step('Click origin file button', async () => {
+			await this.originFileButton.click();
+		});
+	}
+
 	async waitForCurrentPlot() {
-		await expect(this.code.driver.page.locator(CURRENT_PLOT)).toBeVisible({ timeout: 30000 });
+		await test.step('Wait for current plot to be visible', async () => {
+			await expect(this.code.driver.page.locator(CURRENT_PLOT)).toBeVisible({ timeout: 30000 });
+		});
 	}
 
 	async waitForCurrentStaticPlot() {
-		await expect(this.code.driver.page.locator(CURRENT_STATIC_PLOT)).toBeVisible({ timeout: 30000 });
+		await test.step('Wait for current static plot to be visible', async () => {
+			await expect(this.code.driver.page.locator(CURRENT_STATIC_PLOT)).toBeVisible({ timeout: 30000 });
+		});
+	}
+
+	async expectOriginButtonVisible() {
+		await test.step('Expect origin file button to be visible', async () => {
+			await expect(this.originFileButton).toBeVisible({ timeout: 30000 });
+		});
+	}
+
+	async expectOriginButtonContain(text: string) {
+		await test.step(`Expect origin file button to contain text: ${text}`, async () => {
+			await expect(this.originFileButton).toContainText(text);
+		});
 	}
 
 	getWebviewPlotLocator(selector: string): Locator {

--- a/test/e2e/tests/plots/plot-file-attribution.test.ts
+++ b/test/e2e/tests/plots/plot-file-attribution.test.ts
@@ -5,193 +5,101 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
-import { test, expect, tags } from '../_test.setup';
+import { test, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
 });
 
-test.describe('Plot File Attribution', { tag: [tags.PLOTS] }, () => {
+interface LanguageConfig {
+	session: 'r' | 'python';
+	fileName: string;
+	fileContent: string;
+	runFileCommand: string;
+	tags: string[];
+}
 
-	test.describe('R Plot File Attribution', { tag: [tags.ARK] }, () => {
+const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+const countLines = (content: string) => content.split('\n').filter(line => line.trim()).length;
 
-		const R_PLOT_FILE = 'plot-attribution-test.R';
+const languageConfigs: LanguageConfig[] = [
+	{
+		session: 'r',
+		fileName: 'plot-attribution-test.R',
+		fileContent: 'plot(1:10)\n',
+		tags: [tags.ARK],
+		runFileCommand: 'r.sourceCurrentFile',
+	},
+	{
+		session: 'python',
+		fileName: 'plot-attribution-test.py',
+		fileContent: [
+			'import matplotlib.pyplot as plt',
+			'plt.plot([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])',
+			'plt.show()',
+			''
+		].join('\n'),
+		tags: [],
+		runFileCommand: 'python.execInConsole',
+	},
+];
 
-		test.beforeEach(async function ({ app, sessions, hotKeys }) {
-			await sessions.start('r');
-			await hotKeys.stackedLayout();
+for (const config of languageConfigs) {
+	test.describe(`Plot File Attribution`, { tag: [tags.PLOTS, ...config.tags] }, () => {
 
-			// Create the R script file in the workspace
-			const filePath = path.join(app.workspacePathOrFolder, R_PLOT_FILE);
-			fs.writeFileSync(filePath, 'plot(1:10)\n');
+		test.beforeEach(async function ({ app, sessions }) {
+			const filePath = path.join(app.workspacePathOrFolder, config.fileName);
+			fs.writeFileSync(filePath, config.fileContent);
+
+			await sessions.start(config.session);
 		});
 
 		test.afterEach(async function ({ app, hotKeys }) {
-			await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
-			await expect(async () => {
-				await hotKeys.clearPlots();
-				await app.workbench.plots.waitForNoPlots({ timeout: 3000 });
-			}).toPass({ timeout: 15000 });
+			await hotKeys.closeAllEditors();
+			await hotKeys.clearPlots();
+			await app.workbench.plots.waitForNoPlots({ timeout: 3000 });
 		});
 
 		test.afterAll(async function ({ cleanup }) {
-			await cleanup.removeTestFiles([R_PLOT_FILE]);
+			await cleanup.removeTestFiles([config.fileName]);
 		});
 
-		test('R - Plot origin shows source file after line execution', async function ({ app, page, openFile }) {
+		test(`${capitalize(config.session)} - Plot origin shows source file after line execution`, async function ({ app, openFile, hotKeys }) {
+			const { plots, editors } = app.workbench;
 
-			await test.step('Open R file and execute line with Cmd+Enter', async () => {
-				await openFile(R_PLOT_FILE);
-				await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter');
-			});
+			// Open the file and run each line of code to generate a plot
+			await openFile(config.fileName);
+			for (let i = 0; i < countLines(config.fileContent); i++) {
+				await hotKeys.runLineOfCode();
+			}
 
-			await test.step('Wait for plot to appear', async () => {
-				await app.workbench.plots.waitForCurrentPlot();
-			});
+			// Wait for the plot to appear and verify the origin button
+			await plots.waitForCurrentPlot();
+			await plots.expectOriginButtonVisible();
+			await plots.expectOriginButtonContain(config.fileName);
 
-			await test.step('Verify origin file button shows correct filename', async () => {
-				const originButton = page.locator('.plot-origin-file');
-				await expect(originButton).toBeVisible({ timeout: 30000 });
-				await expect(originButton).toHaveText(R_PLOT_FILE);
-			});
-
-			await test.step('Click origin button and verify editor opens the file', async () => {
-				// Close the editor first so we can verify the click opens it
-				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
-
-				const originButton = page.locator('.plot-origin-file');
-				await originButton.click();
-
-				// Verify the editor opened the correct file
-				const tab = page.getByRole('tab', { name: R_PLOT_FILE });
-				await expect(tab).toBeVisible({ timeout: 15000 });
-			});
+			// Close the editor and click the origin button to verify it opens the correct file
+			await hotKeys.closeAllEditors();
+			await plots.clickOriginFileButton();
+			await editors.verifyTab(config.fileName, { isVisible: true, isSelected: true });
 		});
 
-		test('R - Plot origin shows source file after source() command', async function ({ app, page, openFile, runCommand }) {
+		test(`${capitalize(config.session)} - Plot origin shows source file after run file command`, async function ({ app, openFile, runCommand, hotKeys }) {
+			const { plots, editors } = app.workbench;
 
-			await test.step('Open R file and source it', async () => {
-				await openFile(R_PLOT_FILE);
-				await runCommand('r.sourceCurrentFile');
-			});
+			// Open the file and run the command to execute the entire file
+			await openFile(config.fileName);
+			await runCommand(config.runFileCommand);
 
-			await test.step('Wait for plot to appear', async () => {
-				await app.workbench.plots.waitForCurrentPlot();
-			});
+			// Wait for the plot to appear and verify the origin button
+			await plots.waitForCurrentPlot();
+			await plots.expectOriginButtonVisible();
+			await plots.expectOriginButtonContain(config.fileName);
 
-			await test.step('Verify origin file button shows correct filename', async () => {
-				const originButton = page.locator('.plot-origin-file');
-				await expect(originButton).toBeVisible({ timeout: 30000 });
-				await expect(originButton).toHaveText(R_PLOT_FILE);
-			});
-
-			await test.step('Click origin button and verify editor opens the file', async () => {
-				// Close the editor first so we can verify the click opens it
-				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
-
-				const originButton = page.locator('.plot-origin-file');
-				await originButton.click();
-
-				// Verify the editor opened the correct file
-				const tab = page.getByRole('tab', { name: R_PLOT_FILE });
-				await expect(tab).toBeVisible({ timeout: 15000 });
-			});
+			// Close the editor and click the origin button to verify it opens the correct file
+			await hotKeys.closeAllEditors();
+			await plots.clickOriginFileButton();
+			await editors.verifyTab(config.fileName, { isVisible: true, isSelected: true });
 		});
 	});
-
-	test.describe('Python Plot File Attribution', () => {
-
-		const PY_PLOT_FILE = 'plot-attribution-test.py';
-
-		test.beforeEach(async function ({ app, sessions, hotKeys }) {
-			await sessions.start('python');
-			await hotKeys.stackedLayout();
-
-			// Create the Python script file in the workspace
-			const filePath = path.join(app.workspacePathOrFolder, PY_PLOT_FILE);
-			fs.writeFileSync(filePath, [
-				'import matplotlib.pyplot as plt',
-				'plt.plot([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])',
-				'plt.show()',
-				''
-			].join('\n'));
-		});
-
-		test.afterEach(async function ({ app, hotKeys }) {
-			await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
-			await expect(async () => {
-				await hotKeys.clearPlots();
-				await app.workbench.plots.waitForNoPlots({ timeout: 3000 });
-			}).toPass({ timeout: 15000 });
-		});
-
-		test.afterAll(async function ({ cleanup }) {
-			await cleanup.removeTestFiles([PY_PLOT_FILE]);
-		});
-
-		test('Python - Plot origin shows source file after line execution', async function ({ app, page, openFile }) {
-
-			await test.step('Open Python file and execute lines with Cmd+Enter', async () => {
-				await openFile(PY_PLOT_FILE);
-				// Execute each line: import, plot, show
-				for (let i = 0; i < 3; i++) {
-					await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter');
-					// Wait briefly for each line to be sent
-					await page.waitForTimeout(500);
-				}
-			});
-
-			await test.step('Wait for plot to appear', async () => {
-				await app.workbench.plots.waitForCurrentPlot();
-			});
-
-			await test.step('Verify origin file button shows correct filename', async () => {
-				const originButton = page.locator('.plot-origin-file');
-				await expect(originButton).toBeVisible({ timeout: 30000 });
-				await expect(originButton).toHaveText(PY_PLOT_FILE);
-			});
-
-			await test.step('Click origin button and verify editor opens the file', async () => {
-				// Close the editor first so we can verify the click opens it
-				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
-
-				const originButton = page.locator('.plot-origin-file');
-				await originButton.click();
-
-				// Verify the editor opened the correct file
-				const tab = page.getByRole('tab', { name: PY_PLOT_FILE });
-				await expect(tab).toBeVisible({ timeout: 15000 });
-			});
-		});
-
-		test('Python - Plot origin shows source file after Run Python File in Console', async function ({ app, page, openFile, runCommand }) {
-
-			await test.step('Open Python file and run it in console', async () => {
-				await openFile(PY_PLOT_FILE);
-				await runCommand('python.execInConsole');
-			});
-
-			await test.step('Wait for plot to appear', async () => {
-				await app.workbench.plots.waitForCurrentPlot();
-			});
-
-			await test.step('Verify origin file button shows correct filename', async () => {
-				const originButton = page.locator('.plot-origin-file');
-				await expect(originButton).toBeVisible({ timeout: 30000 });
-				await expect(originButton).toHaveText(PY_PLOT_FILE);
-			});
-
-			await test.step('Click origin button and verify editor opens the file', async () => {
-				// Close the editor first so we can verify the click opens it
-				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
-
-				const originButton = page.locator('.plot-origin-file');
-				await originButton.click();
-
-				// Verify the editor opened the correct file
-				const tab = page.getByRole('tab', { name: PY_PLOT_FILE });
-				await expect(tab).toBeVisible({ timeout: 15000 });
-			});
-		});
-	});
-});
+}


### PR DESCRIPTION
## Summary

- Add origin file button locator and methods to Plots POM (`clickOriginFileButton`, `expectOriginButtonVisible`, `expectOriginButtonContain`)
- Add `runLineOfCode()` hotkey helper for Cmd+Enter
- Refactor tests to use parameterized config for R and Python, reducing duplication

## QA Notes

@:plots @:web

🤖 Generated with [Claude Code](https://claude.com/claude-code)