### PR TITLE
Add error boundaries to Positron notebook components

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/NotebookErrorBoundary.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/NotebookErrorBoundary.css
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.notebook-error-boundary {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 8px 12px;
+	border-radius: 4px;
+	background-color: var(--vscode-inputValidation-errorBackground, rgba(255, 0, 0, 0.1));
+	border: 1px solid var(--vscode-inputValidation-errorBorder, red);
+	font-size: 12px;
+}
+
+.notebook-error-boundary-header {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 6px;
+}
+
+.notebook-error-boundary-icon {
+	color: var(--vscode-editorError-foreground, red);
+}
+
+.notebook-error-boundary-actions {
+	display: flex;
+	flex-direction: row;
+	gap: 8px;
+}
+
+.notebook-error-boundary-action {
+	color: var(--vscode-textLink-foreground);
+	background: none;
+	border: none;
+	cursor: pointer;
+	padding: 0;
+	font-size: inherit;
+}
+
+.notebook-error-boundary-action:hover {
+	text-decoration: underline;
+}
+
+.notebook-error-boundary-details {
+	overflow-x: auto;
+}
+
+.notebook-error-boundary-details code {
+	white-space: pre-wrap;
+	font-size: 11px;
+	opacity: 0.8;
+}
+
+/* Level-specific styles */
+
+.notebook-error-boundary-output {
+	margin: 4px;
+}
+
+.notebook-error-boundary-cell {
+	margin: 4px;
+}
+
+.notebook-error-boundary-editor {
+	margin: 24px auto;
+	max-width: 600px;
+	padding: 16px 24px;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/NotebookErrorBoundary.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/NotebookErrorBoundary.css
@@ -66,6 +66,5 @@
 
 .notebook-error-boundary-editor {
 	margin: 24px auto;
-	max-width: 600px;
 	padding: 16px 24px;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/NotebookErrorBoundary.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/NotebookErrorBoundary.tsx
@@ -44,10 +44,20 @@ type NotebookErrorBoundaryProps = NotebookErrorBoundaryBaseProps & (
  */
 interface NotebookErrorBoundaryState {
 	hasError: boolean;
-	error?: Error;
+	errorMessage?: string;
 	componentStack?: string;
 	showDetails: boolean;
 	retryCount: number;
+}
+
+/**
+ * Safely extract a message from a thrown value, which may not be an Error.
+ */
+function getErrorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+	return String(error ?? 'Unknown error');
 }
 
 /**
@@ -84,7 +94,7 @@ export class NotebookErrorBoundary extends React.Component<
 	}
 
 	static getDerivedStateFromError(error: Error): Partial<NotebookErrorBoundaryState> {
-		return { hasError: true, error, componentStack: undefined, showDetails: false };
+		return { hasError: true, errorMessage: getErrorMessage(error), componentStack: undefined, showDetails: false };
 	}
 
 	override componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
@@ -93,7 +103,7 @@ export class NotebookErrorBoundary extends React.Component<
 		this.setState({ componentStack });
 
 		logService.error(
-			`Positron Notebook | ErrorBoundary (${level}) | Component "${componentName}" failed to render: ${error.message}`,
+			`Positron Notebook | ErrorBoundary (${level}) | Component "${componentName}" failed to render: ${getErrorMessage(error)}`,
 			componentStack
 		);
 	}
@@ -101,7 +111,7 @@ export class NotebookErrorBoundary extends React.Component<
 	private handleRetry = (): void => {
 		this.setState(prevState => ({
 			hasError: false,
-			error: undefined,
+			errorMessage: undefined,
 			componentStack: undefined,
 			showDetails: false,
 			retryCount: prevState.retryCount + 1,
@@ -124,7 +134,7 @@ export class NotebookErrorBoundary extends React.Component<
 	override render(): React.ReactNode {
 		if (this.state.hasError) {
 			const { level } = this.props;
-			const { error, componentStack, showDetails } = this.state;
+			const { errorMessage, componentStack, showDetails } = this.state;
 			const message = levelMessages[level];
 			const isEditorLevel = level === 'editor';
 
@@ -160,7 +170,7 @@ export class NotebookErrorBoundary extends React.Component<
 					{showDetails && (
 						<div className='notebook-error-boundary-details'>
 							<code>
-								{error?.message}
+								{errorMessage}
 								{componentStack && <>{'\n'}{componentStack}</>}
 							</code>
 						</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/NotebookErrorBoundary.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/NotebookErrorBoundary.tsx
@@ -11,7 +11,9 @@ import React from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../nls.js';
+import { Codicon } from '../../../../base/common/codicons.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { ThemeIcon } from '../../../../platform/positronActionBar/browser/components/icon.js';
 
 /**
  * The error boundary level determines the fallback UI style and message.
@@ -57,7 +59,7 @@ function getErrorMessage(error: unknown): string {
 	if (error instanceof Error) {
 		return error.message;
 	}
-	return String(error ?? 'Unknown error');
+	return String(error ?? localize('positron.notebook.errorBoundary.unknownError', "Unknown error"));
 }
 
 /**
@@ -141,7 +143,7 @@ export class NotebookErrorBoundary extends React.Component<
 			return (
 				<div className={`notebook-error-boundary notebook-error-boundary-${level}`} role='alert'>
 					<div className='notebook-error-boundary-header'>
-						<span className='notebook-error-boundary-icon codicon codicon-error'></span>
+						<ThemeIcon className='notebook-error-boundary-icon' icon={Codicon.error} />
 						<span>{message}</span>
 					</div>
 					<div className='notebook-error-boundary-actions'>

--- a/src/vs/workbench/contrib/positronNotebook/browser/NotebookErrorBoundary.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/NotebookErrorBoundary.tsx
@@ -59,12 +59,13 @@ function getErrorMessage(error: unknown): string {
 	if (error instanceof Error) {
 		return error.message;
 	}
-	return String(error ?? localize('positron.notebook.errorBoundary.unknownError', "Unknown error"));
+	return String(error ?? unknownErrorLabel);
 }
 
 /**
  * Localized strings.
  */
+const unknownErrorLabel = localize('positron.notebook.errorBoundary.unknownError', "Unknown error");
 const levelMessages: Record<ErrorBoundaryLevel, string> = {
 	output: localize('positron.notebook.errorBoundary.output', "Something went wrong rendering this output."),
 	cell: localize('positron.notebook.errorBoundary.cell', "Something went wrong rendering this cell."),

--- a/src/vs/workbench/contrib/positronNotebook/browser/NotebookErrorBoundary.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/NotebookErrorBoundary.tsx
@@ -1,0 +1,178 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './NotebookErrorBoundary.css';
+
+// React.
+import React from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../nls.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+
+/**
+ * The error boundary level determines the fallback UI style and message.
+ */
+type ErrorBoundaryLevel = 'output' | 'cell' | 'editor';
+
+/**
+ * Common props shared by all error boundary levels.
+ */
+interface NotebookErrorBoundaryBaseProps {
+	/** Descriptive name for logging. */
+	componentName: string;
+	/** Log service for error logging (class components cannot use hooks). */
+	logService: ILogService;
+	/** Child components to render. */
+	children: React.ReactNode;
+}
+
+/**
+ * Props for the NotebookErrorBoundary component.
+ * Uses a discriminated union so `onReload` is required at the editor level.
+ */
+type NotebookErrorBoundaryProps = NotebookErrorBoundaryBaseProps & (
+	| { level: 'output' | 'cell' }
+	| { level: 'editor'; onReload: () => void }
+);
+
+/**
+ * State for the NotebookErrorBoundary component.
+ */
+interface NotebookErrorBoundaryState {
+	hasError: boolean;
+	error?: Error;
+	componentStack?: string;
+	showDetails: boolean;
+	retryCount: number;
+}
+
+/**
+ * Localized strings.
+ */
+const levelMessages: Record<ErrorBoundaryLevel, string> = {
+	output: localize('positron.notebook.errorBoundary.output', "Something went wrong rendering this output."),
+	cell: localize('positron.notebook.errorBoundary.cell', "Something went wrong rendering this cell."),
+	editor: localize('positron.notebook.errorBoundary.editor', "Something went wrong rendering this notebook."),
+};
+const retryLabel = localize('positron.notebook.errorBoundary.retry', "Retry");
+const reloadLabel = localize('positron.notebook.errorBoundary.reload', "Reload");
+const showDetailsLabel = localize('positron.notebook.errorBoundary.showDetails', "Show Details");
+const hideDetailsLabel = localize('positron.notebook.errorBoundary.hideDetails', "Hide Details");
+
+/**
+ * Error boundary for Positron notebook components.
+ *
+ * Catches errors thrown during rendering of child components and displays a
+ * fallback UI with error details and retry/reload actions. Can be used at
+ * output, cell, or editor level with appropriate styling for each.
+ */
+export class NotebookErrorBoundary extends React.Component<
+	NotebookErrorBoundaryProps,
+	NotebookErrorBoundaryState
+> {
+	constructor(props: NotebookErrorBoundaryProps) {
+		super(props);
+		this.state = {
+			hasError: false,
+			showDetails: false,
+			retryCount: 0,
+		};
+	}
+
+	static getDerivedStateFromError(error: Error): Partial<NotebookErrorBoundaryState> {
+		return { hasError: true, error, componentStack: undefined, showDetails: false };
+	}
+
+	override componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+		const { level, componentName, logService } = this.props;
+		const componentStack = errorInfo.componentStack ?? '';
+		this.setState({ componentStack });
+
+		logService.error(
+			`Positron Notebook | ErrorBoundary (${level}) | Component "${componentName}" failed to render: ${error.message}`,
+			componentStack
+		);
+	}
+
+	private handleRetry = (): void => {
+		this.setState(prevState => ({
+			hasError: false,
+			error: undefined,
+			componentStack: undefined,
+			showDetails: false,
+			retryCount: prevState.retryCount + 1,
+		}));
+	};
+
+	private handleReload = (): void => {
+		// Only called when level === 'editor'; narrowing needed for TypeScript.
+		if (this.props.level === 'editor') {
+			this.props.onReload();
+		}
+	};
+
+	private toggleDetails = (): void => {
+		this.setState(prevState => ({
+			showDetails: !prevState.showDetails,
+		}));
+	};
+
+	override render(): React.ReactNode {
+		if (this.state.hasError) {
+			const { level } = this.props;
+			const { error, componentStack, showDetails } = this.state;
+			const message = levelMessages[level];
+			const isEditorLevel = level === 'editor';
+
+			return (
+				<div className={`notebook-error-boundary notebook-error-boundary-${level}`} role='alert'>
+					<div className='notebook-error-boundary-header'>
+						<span className='notebook-error-boundary-icon codicon codicon-error'></span>
+						<span>{message}</span>
+					</div>
+					<div className='notebook-error-boundary-actions'>
+						<button
+							className='notebook-error-boundary-action'
+							onClick={this.toggleDetails}
+						>
+							{showDetails ? hideDetailsLabel : showDetailsLabel}
+						</button>
+						{isEditorLevel ? (
+							<button
+								className='notebook-error-boundary-action'
+								onClick={this.handleReload}
+							>
+								{reloadLabel}
+							</button>
+						) : (
+							<button
+								className='notebook-error-boundary-action'
+								onClick={this.handleRetry}
+							>
+								{retryLabel}
+							</button>
+						)}
+					</div>
+					{showDetails && (
+						<div className='notebook-error-boundary-details'>
+							<code>
+								{error?.message}
+								{componentStack && <>{'\n'}{componentStack}</>}
+							</code>
+						</div>
+					)}
+				</div>
+			);
+		}
+
+		return (
+			<React.Fragment key={this.state.retryCount}>
+				{this.props.children}
+			</React.Fragment>
+		);
+	}
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -31,6 +31,7 @@ import { useContextKeyValue } from './useContextKeyValue.js';
 import { CONTEXT_FIND_WIDGET_VISIBLE } from '../../../../editor/contrib/find/browser/findModel.js';
 import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
 import { IDeletionSentinel } from './IPositronNotebookInstance.js';
+import { NotebookErrorBoundary } from './NotebookErrorBoundary.js';
 
 
 export function PositronNotebookComponent() {
@@ -158,7 +159,13 @@ function renderCellsAndSentinels(
 		// Render the cell
 		elements.push(
 			<React.Fragment key={cell.handle}>
-				<NotebookCell cell={cell as PositronNotebookCellGeneral} />
+				<NotebookErrorBoundary
+					componentName={`Cell[${cell.handle}]`}
+					level='cell'
+					logService={services.logService}
+				>
+					<NotebookCell cell={cell as PositronNotebookCellGeneral} />
+				</NotebookErrorBoundary>
 				<AddCellButtons index={cellArrayIndex + 1} />
 			</React.Fragment>
 		);

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -36,10 +36,18 @@ import { IDeletionSentinel } from './IPositronNotebookInstance.js';
 export function PositronNotebookComponent() {
 	const notebookInstance = useNotebookInstance();
 	const notebookCells = useObservedValue(notebookInstance.cells);
+
 	const deletionSentinels = useObservedValue(notebookInstance.deletionSentinels);
 	const fontStyles = useFontStyles();
 	const containerRef = React.useRef<HTMLDivElement>(null);
 	const services = usePositronReactServicesContext();
+
+	// Dev-only: throw to test the editor-level error boundary.
+	// Type "__positron_debug_throw_editor" in any cell to trigger.
+	if (!services.workbenchEnvironmentService.isBuilt &&
+		notebookCells.some(c => c.getContent().includes('__positron_debug_throw_editor'))) {
+		throw new Error('[dev] Error boundary test: editor rendering failure');
+	}
 
 	// Accessibility: Global announcements for notebook-level operations (cell add/delete).
 	// These are rendered in a ScreenReaderOnly ARIA live region for screen reader users.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -36,6 +36,12 @@ import { IDeletionSentinel } from './IPositronNotebookInstance.js';
 export function PositronNotebookComponent() {
 	const notebookInstance = useNotebookInstance();
 	const notebookCells = useObservedValue(notebookInstance.cells);
+
+	// TEMPORARY: error boundary test trigger - remove before merging
+	if (notebookCells.some(c => c.getContent().includes('__EDITOR_ERROR_TEST__'))) {
+		throw new Error('Test error: editor rendering failure');
+	}
+
 	const deletionSentinels = useObservedValue(notebookInstance.deletionSentinels);
 	const fontStyles = useFontStyles();
 	const containerRef = React.useRef<HTMLDivElement>(null);

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -36,12 +36,6 @@ import { IDeletionSentinel } from './IPositronNotebookInstance.js';
 export function PositronNotebookComponent() {
 	const notebookInstance = useNotebookInstance();
 	const notebookCells = useObservedValue(notebookInstance.cells);
-
-	// TEMPORARY: error boundary test trigger - remove before merging
-	if (notebookCells.some(c => c.getContent().includes('__EDITOR_ERROR_TEST__'))) {
-		throw new Error('Test error: editor rendering failure');
-	}
-
 	const deletionSentinels = useObservedValue(notebookInstance.deletionSentinels);
 	const fontStyles = useFontStyles();
 	const containerRef = React.useRef<HTMLDivElement>(null);

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -42,13 +42,6 @@ export function PositronNotebookComponent() {
 	const containerRef = React.useRef<HTMLDivElement>(null);
 	const services = usePositronReactServicesContext();
 
-	// Dev-only: throw to test the editor-level error boundary.
-	// Type "__positron_debug_throw_editor" in any cell to trigger.
-	if (!services.workbenchEnvironmentService.isBuilt &&
-		notebookCells.some(c => c.getContent().includes('__positron_debug_throw_editor'))) {
-		throw new Error('[dev] Error boundary test: editor rendering failure');
-	}
-
 	// Accessibility: Global announcements for notebook-level operations (cell add/delete).
 	// These are rendered in a ScreenReaderOnly ARIA live region for screen reader users.
 	const [globalAnnouncement, setGlobalAnnouncement] = React.useState<string>('');

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -30,6 +30,7 @@ import { EnvironentProvider } from './EnvironmentProvider.js';
 import { IEditorGroup, IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
 import { PositronNotebookEditorInput } from './PositronNotebookEditorInput.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { NotebookErrorBoundary } from './NotebookErrorBoundary.js';
 import { NotebookVisibilityProvider } from './NotebookVisibilityContext.js';
 import { observableValue } from '../../../../base/common/observable.js';
 import { PositronNotebookEditorControl } from './PositronNotebookEditorControl.js';
@@ -427,7 +428,17 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 						size: this._size,
 						scopedContextKeyProviderCallback: container => scopedContextKeyService.createScoped(container),
 					}}>
-						<PositronNotebookComponent />
+						<NotebookErrorBoundary
+							componentName='PositronNotebookComponent'
+							level='editor'
+							logService={this._logService}
+							onReload={() => {
+								this._disposeReactRenderer();
+								this._renderReact();
+							}}
+						>
+							<PositronNotebookComponent />
+						</NotebookErrorBoundary>
 					</EnvironentProvider>
 				</NotebookInstanceProvider>
 			</NotebookVisibilityProvider>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -21,6 +21,8 @@ import { NotebookCellActionBar } from './NotebookCellActionBar.js';
 import { useCellContextKeys } from './useCellContextKeys.js';
 import { CellScopedContextKeyServiceProvider } from './CellContextKeyServiceProvider.js';
 import { ScreenReaderOnly } from '../../../../../base/browser/ui/positronComponents/ScreenReaderOnly.js';
+import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { NotebookErrorBoundary } from '../NotebookErrorBoundary.js';
 import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED } from '../../../../../editor/contrib/find/browser/findModel.js';
 
 export function NotebookCellWrapper({ cell, children }: {
@@ -38,6 +40,7 @@ export function NotebookCellWrapper({ cell, children }: {
 	const [cellElement, setCellElement] = React.useState<HTMLDivElement | null>(null);
 	const cellRef = React.useCallback((node: HTMLDivElement | null) => { setCellElement(node); }, []);
 
+	const services = usePositronReactServicesContext();
 	const notebookInstance = useNotebookInstance();
 	const selectionStateMachine = notebookInstance.selectionStateMachine;
 	const environment = useEnvironment();
@@ -172,7 +175,13 @@ export function NotebookCellWrapper({ cell, children }: {
 	>
 		<CellScopedContextKeyServiceProvider service={scopedContextKeyService}>
 			<NotebookCellActionBar cell={cell} />
-			{children}
+			<NotebookErrorBoundary
+				componentName={`Cell[${cell.isCodeCell() ? 'code' : cell.isMarkdownCell() ? 'markdown' : 'raw'}]`}
+				level='cell'
+				logService={services.logService}
+			>
+				{children}
+			</NotebookErrorBoundary>
 		</CellScopedContextKeyServiceProvider>
 		<ScreenReaderOnly>
 			{announcement}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -29,6 +29,8 @@ import { Button } from '../../../../../base/browser/ui/positronComponents/button
 import { useCellContextMenu } from './useCellContextMenu.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
 import { DataExplorerCellOutput } from './DataExplorerCellOutput.js';
+import { NotebookErrorBoundary } from '../NotebookErrorBoundary.js';
+import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 
 
 interface CellOutputsSectionProps {
@@ -37,6 +39,7 @@ interface CellOutputsSectionProps {
 }
 
 const CellOutputsSection = React.memo(function CellOutputsSection({ cell, outputs }: CellOutputsSectionProps) {
+	const services = usePositronReactServicesContext();
 	const isCollapsed = useObservedValue(cell.outputIsCollapsed);
 	const { showContextMenu } = useCellContextMenu({
 		cell,
@@ -90,7 +93,14 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 						</Button>
 						: <>
 							{outputs?.map((output) => (
-								<CellOutput key={output.outputId} {...output} />
+								<NotebookErrorBoundary
+									key={output.outputId}
+									componentName={`CellOutput[${output.parsed.type}]`}
+									level='output'
+									logService={services.logService}
+								>
+									<CellOutput {...output} />
+								</NotebookErrorBoundary>
 							))}
 						</>
 					}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -114,16 +114,8 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 });
 
 export const NotebookCodeCell = React.memo(function NotebookCodeCell({ cell }: { cell: PositronNotebookCodeCell }) {
-	const services = usePositronReactServicesContext();
 	const outputContents = useObservedValue(cell.outputs);
 	const hasError = outputContents.some(o => o.parsed.type === 'error');
-
-	// Dev-only: throw to test the cell-level error boundary.
-	// Type "__positron_debug_throw_cell" in a code cell to trigger.
-	if (!services.workbenchEnvironmentService.isBuilt &&
-		cell.getContent().includes('__positron_debug_throw_cell')) {
-		throw new Error('[dev] Error boundary test: cell rendering failure');
-	}
 
 	return (
 		<NotebookCellWrapper
@@ -148,15 +140,6 @@ export const NotebookCodeCell = React.memo(function NotebookCodeCell({ cell }: {
 });
 
 const CellOutput = React.memo(function CellOutput(output: NotebookCellOutputs) {
-	const services = usePositronReactServicesContext();
-
-	// Dev-only: throw to test the output-level error boundary.
-	// Print "__positron_debug_throw_output" as cell output to trigger.
-	if (!services.workbenchEnvironmentService.isBuilt &&
-		'content' in output.parsed && String(output.parsed.content).includes('__positron_debug_throw_output')) {
-		throw new Error('[dev] Error boundary test: output rendering failure');
-	}
-
 	if (output.preloadMessageResult) {
 		return <PreloadMessageOutput preloadMessageResult={output.preloadMessageResult} />;
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -114,11 +114,6 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 });
 
 export const NotebookCodeCell = React.memo(function NotebookCodeCell({ cell }: { cell: PositronNotebookCodeCell }) {
-	// TEMPORARY: error boundary test trigger - remove before merging
-	if (cell.getContent().includes('__CELL_ERROR_TEST__')) {
-		throw new Error('Test error: cell rendering failure');
-	}
-
 	const outputContents = useObservedValue(cell.outputs);
 	const hasError = outputContents.some(o => o.parsed.type === 'error');
 
@@ -145,11 +140,6 @@ export const NotebookCodeCell = React.memo(function NotebookCodeCell({ cell }: {
 });
 
 const CellOutput = React.memo(function CellOutput(output: NotebookCellOutputs) {
-	// TEMPORARY: error boundary test trigger - remove before merging
-	if ('content' in output.parsed && String(output.parsed.content).includes('__OUTPUT_ERROR_TEST__')) {
-		throw new Error('Test error: output rendering failure');
-	}
-
 	if (output.preloadMessageResult) {
 		return <PreloadMessageOutput preloadMessageResult={output.preloadMessageResult} />;
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -114,8 +114,16 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 });
 
 export const NotebookCodeCell = React.memo(function NotebookCodeCell({ cell }: { cell: PositronNotebookCodeCell }) {
+	const services = usePositronReactServicesContext();
 	const outputContents = useObservedValue(cell.outputs);
 	const hasError = outputContents.some(o => o.parsed.type === 'error');
+
+	// Dev-only: throw to test the cell-level error boundary.
+	// Type "__positron_debug_throw_cell" in a code cell to trigger.
+	if (!services.workbenchEnvironmentService.isBuilt &&
+		cell.getContent().includes('__positron_debug_throw_cell')) {
+		throw new Error('[dev] Error boundary test: cell rendering failure');
+	}
 
 	return (
 		<NotebookCellWrapper
@@ -140,6 +148,15 @@ export const NotebookCodeCell = React.memo(function NotebookCodeCell({ cell }: {
 });
 
 const CellOutput = React.memo(function CellOutput(output: NotebookCellOutputs) {
+	const services = usePositronReactServicesContext();
+
+	// Dev-only: throw to test the output-level error boundary.
+	// Print "__positron_debug_throw_output" as cell output to trigger.
+	if (!services.workbenchEnvironmentService.isBuilt &&
+		'content' in output.parsed && String(output.parsed.content).includes('__positron_debug_throw_output')) {
+		throw new Error('[dev] Error boundary test: output rendering failure');
+	}
+
 	if (output.preloadMessageResult) {
 		return <PreloadMessageOutput preloadMessageResult={output.preloadMessageResult} />;
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -114,6 +114,11 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 });
 
 export const NotebookCodeCell = React.memo(function NotebookCodeCell({ cell }: { cell: PositronNotebookCodeCell }) {
+	// TEMPORARY: error boundary test trigger - remove before merging
+	if (cell.getContent().includes('__CELL_ERROR_TEST__')) {
+		throw new Error('Test error: cell rendering failure');
+	}
+
 	const outputContents = useObservedValue(cell.outputs);
 	const hasError = outputContents.some(o => o.parsed.type === 'error');
 
@@ -140,6 +145,11 @@ export const NotebookCodeCell = React.memo(function NotebookCodeCell({ cell }: {
 });
 
 const CellOutput = React.memo(function CellOutput(output: NotebookCellOutputs) {
+	// TEMPORARY: error boundary test trigger - remove before merging
+	if ('content' in output.parsed && String(output.parsed.content).includes('__OUTPUT_ERROR_TEST__')) {
+		throw new Error('Test error: output rendering failure');
+	}
+
 	if (output.preloadMessageResult) {
 		return <PreloadMessageOutput preloadMessageResult={output.preloadMessageResult} />;
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
@@ -20,6 +20,8 @@ import { MenuId } from '../../../../../platform/actions/common/actions.js';
 import { useCellContextMenu } from './useCellContextMenu.js';
 import { getActiveWindow } from '../../../../../base/browser/dom.js';
 import { IAction, Separator } from '../../../../../base/common/actions.js';
+import { NotebookErrorBoundary } from '../NotebookErrorBoundary.js';
+import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 
 // Localized strings.
 const copyLabel = localize('positron.notebook.copy', "Copy");
@@ -30,6 +32,7 @@ const renderedMarkdownContent = localize('positron.notebooks.markdownCell.render
 
 export function NotebookMarkdownCell({ cell }: { cell: PositronNotebookMarkdownCell }) {
 
+	const services = usePositronReactServicesContext();
 	const markdownString = useObservedValue(cell.markdownString);
 	const editorShown = useObservedValue(cell.editorShown);
 	const markdownContentRef = useRef<HTMLElement>(null);
@@ -109,14 +112,20 @@ export function NotebookMarkdownCell({ cell }: { cell: PositronNotebookMarkdownC
 						onContextMenu={handleContextMenu}
 						onDoubleClick={() => cell.toggleEditor()}
 					>
-						{
-							markdownString.length > 0
-								? <Markdown content={markdownString} />
-								: <div className='empty-output-msg'>
-									{emptyMarkdownCell}
-									{doubleClickToEdit}
-								</div>
-						}
+						<NotebookErrorBoundary
+							componentName='MarkdownOutput'
+							level='output'
+							logService={services.logService}
+						>
+							{
+								markdownString.length > 0
+									? <Markdown content={markdownString} />
+									: <div className='empty-output-msg'>
+										{emptyMarkdownCell}
+										{doubleClickToEdit}
+									</div>
+							}
+						</NotebookErrorBoundary>
 					</section>
 				)
 				: null

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookErrorBoundary.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookErrorBoundary.test.tsx
@@ -8,7 +8,6 @@
 
 import assert from 'assert';
 import sinon from 'sinon';
-import React from 'react';
 import { flushSync } from 'react-dom';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { setupReactRenderer } from '../../../../../base/test/browser/react.js';

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookErrorBoundary.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookErrorBoundary.test.tsx
@@ -1,0 +1,284 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable local/code-no-dangerous-type-assertions */
+
+import assert from 'assert';
+import sinon from 'sinon';
+import React from 'react';
+import { flushSync } from 'react-dom';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { setupReactRenderer } from '../../../../../base/test/browser/react.js';
+import { NotebookErrorBoundary } from '../../browser/NotebookErrorBoundary.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
+
+function ThrowingComponent({ error }: { error: Error }): never {
+	throw error;
+}
+
+function ThrowingNonErrorComponent({ value }: { value: unknown }): never {
+	throw value;
+}
+
+function GoodComponent() {
+	return <div className='good-component'>Hello</div>;
+}
+
+function createMockLogService() {
+	const errorSpy = sinon.spy();
+	const logService = { error: errorSpy } as unknown as ILogService;
+	return { logService, errorSpy };
+}
+
+/**
+ * The error fallback always renders exactly two .notebook-error-boundary-action
+ * buttons: [0] = toggle details, [1] = retry or reload.
+ */
+function getActionButtons(container: HTMLElement) {
+	const buttons = container.querySelectorAll<HTMLButtonElement>('.notebook-error-boundary-action');
+	return { toggleDetails: buttons[0], action: buttons[1] };
+}
+
+/** Click a button and flush React state updates synchronously. */
+function clickAndFlush(element: HTMLElement): void {
+	flushSync(() => { element.click(); });
+}
+
+suite('NotebookErrorBoundary', () => {
+	const { render } = setupReactRenderer();
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('when children render successfully', () => {
+		test('renders children', () => {
+			const { logService } = createMockLogService();
+			const container = render(
+				<NotebookErrorBoundary componentName='Test' level='cell' logService={logService}>
+					<GoodComponent />
+				</NotebookErrorBoundary>
+			);
+
+			assert.ok(container.querySelector<HTMLElement>('.good-component'));
+		});
+	});
+
+	suite('when children throw during render', () => {
+		// React logs console.error when an error boundary catches. The test
+		// runner treats unexpected console output as a failure.
+		let originalConsoleError: typeof console.error;
+		setup(() => {
+			originalConsoleError = console.error;
+			console.error = () => { };
+		});
+		teardown(() => {
+			console.error = originalConsoleError;
+		});
+
+		test('displays fallback error UI with role=alert', () => {
+			const { logService } = createMockLogService();
+			const container = render(
+				<NotebookErrorBoundary componentName='TestCell' level='cell' logService={logService}>
+					<ThrowingComponent error={new Error('render failed')} />
+				</NotebookErrorBoundary>
+			);
+
+			assert.ok(container.querySelector<HTMLElement>('[role="alert"]'));
+		});
+
+		test('applies level-specific CSS class and message', () => {
+			const cases: Array<{ level: 'output' | 'cell' | 'editor'; message: string }> = [
+				{ level: 'output', message: 'Something went wrong rendering this output.' },
+				{ level: 'cell', message: 'Something went wrong rendering this cell.' },
+				{ level: 'editor', message: 'Something went wrong rendering this notebook.' },
+			];
+
+			for (const { level, message } of cases) {
+				const { logService } = createMockLogService();
+				const container = level === 'editor'
+					? render(
+						<NotebookErrorBoundary componentName='Test' level='editor' logService={logService} onReload={() => { }}>
+							<ThrowingComponent error={new Error('fail')} />
+						</NotebookErrorBoundary>
+					)
+					: render(
+						<NotebookErrorBoundary componentName='Test' level={level} logService={logService}>
+							<ThrowingComponent error={new Error('fail')} />
+						</NotebookErrorBoundary>
+					);
+
+				assert.ok(
+					container.querySelector<HTMLElement>(`.notebook-error-boundary-${level}`),
+					`Expected CSS class for level "${level}"`
+				);
+
+				const header = container.querySelector<HTMLElement>('.notebook-error-boundary-header');
+				assert.ok(
+					header?.textContent?.includes(message),
+					`Expected message for level "${level}"`
+				);
+			}
+		});
+
+		test('logs error via logService', () => {
+			const { logService, errorSpy } = createMockLogService();
+			render(
+				<NotebookErrorBoundary componentName='MyCell' level='cell' logService={logService}>
+					<ThrowingComponent error={new Error('render failed')} />
+				</NotebookErrorBoundary>
+			);
+
+			sinon.assert.calledOnce(errorSpy);
+			const logMessage = errorSpy.firstCall.args[0] as string;
+			assert.ok(logMessage.includes('MyCell'), 'Log should include component name');
+			assert.ok(logMessage.includes('cell'), 'Log should include level');
+			assert.ok(logMessage.includes('render failed'), 'Log should include error message');
+		});
+
+		test('handles non-Error thrown values gracefully', () => {
+			const { logService, errorSpy } = createMockLogService();
+			const container = render(
+				<NotebookErrorBoundary componentName='Test' level='cell' logService={logService}>
+					<ThrowingNonErrorComponent value='string error' />
+				</NotebookErrorBoundary>
+			);
+
+			// Should still show error UI
+			assert.ok(container.querySelector<HTMLElement>('[role="alert"]'));
+
+			// Should log safely without crashing
+			sinon.assert.calledOnce(errorSpy);
+			const logMessage = errorSpy.firstCall.args[0] as string;
+			assert.ok(logMessage.includes('string error'), 'Log should include stringified thrown value');
+
+			// Details should show the stringified value
+			const { toggleDetails } = getActionButtons(container);
+			clickAndFlush(toggleDetails);
+			const details = container.querySelector<HTMLElement>('.notebook-error-boundary-details');
+			assert.ok(details?.textContent?.includes('string error'), 'Details should show stringified thrown value');
+		});
+	});
+
+	suite('Show Details toggle', () => {
+		let originalConsoleError: typeof console.error;
+		setup(() => {
+			originalConsoleError = console.error;
+			console.error = () => { };
+		});
+		teardown(() => {
+			console.error = originalConsoleError;
+		});
+
+		test('details are hidden by default', () => {
+			const { logService } = createMockLogService();
+			const container = render(
+				<NotebookErrorBoundary componentName='Test' level='cell' logService={logService}>
+					<ThrowingComponent error={new Error('fail')} />
+				</NotebookErrorBoundary>
+			);
+
+			assert.strictEqual(container.querySelector<HTMLElement>('.notebook-error-boundary-details'), null);
+		});
+
+		test('clicking toggle reveals error message then hides it', () => {
+			const { logService } = createMockLogService();
+			const container = render(
+				<NotebookErrorBoundary componentName='Test' level='cell' logService={logService}>
+					<ThrowingComponent error={new Error('specific error message')} />
+				</NotebookErrorBoundary>
+			);
+
+			const { toggleDetails } = getActionButtons(container);
+
+			// Show details
+			clickAndFlush(toggleDetails);
+			const details = container.querySelector<HTMLElement>('.notebook-error-boundary-details');
+			assert.ok(details, 'Details section should be visible after clicking');
+			assert.ok(details!.textContent?.includes('specific error message'), 'Details should contain the error message');
+
+			// Hide details
+			clickAndFlush(toggleDetails);
+			assert.strictEqual(container.querySelector<HTMLElement>('.notebook-error-boundary-details'), null);
+		});
+	});
+
+	suite('Retry (output and cell levels)', () => {
+		let originalConsoleError: typeof console.error;
+		setup(() => {
+			originalConsoleError = console.error;
+			console.error = () => { };
+		});
+		teardown(() => {
+			console.error = originalConsoleError;
+		});
+
+		test('shows Retry button for cell and output levels', () => {
+			for (const level of ['cell', 'output'] as const) {
+				const { logService } = createMockLogService();
+				const container = render(
+					<NotebookErrorBoundary componentName='Test' level={level} logService={logService}>
+						<ThrowingComponent error={new Error('fail')} />
+					</NotebookErrorBoundary>
+				);
+
+				const { action } = getActionButtons(container);
+				assert.ok(action, `Action button should exist for ${level} level`);
+			}
+		});
+
+		test('clicking Retry re-renders children', () => {
+			const { logService } = createMockLogService();
+			let shouldThrow = true;
+
+			function ConditionallyThrowingComponent() {
+				if (shouldThrow) {
+					throw new Error('fail');
+				}
+				return <div className='recovered'>Recovered</div>;
+			}
+
+			const container = render(
+				<NotebookErrorBoundary componentName='Test' level='cell' logService={logService}>
+					<ConditionallyThrowingComponent />
+				</NotebookErrorBoundary>
+			);
+
+			assert.ok(container.querySelector<HTMLElement>('[role="alert"]'));
+
+			// Fix the component and retry
+			shouldThrow = false;
+			const { action } = getActionButtons(container);
+			clickAndFlush(action);
+
+			assert.ok(container.querySelector<HTMLElement>('.recovered'), 'Children should re-render after retry');
+			assert.strictEqual(container.querySelector<HTMLElement>('[role="alert"]'), null, 'Error UI should be gone');
+		});
+	});
+
+	suite('Reload (editor level)', () => {
+		let originalConsoleError: typeof console.error;
+		setup(() => {
+			originalConsoleError = console.error;
+			console.error = () => { };
+		});
+		teardown(() => {
+			console.error = originalConsoleError;
+		});
+
+		test('clicking Reload calls onReload callback', () => {
+			const { logService } = createMockLogService();
+			const onReload = sinon.spy();
+			const container = render(
+				<NotebookErrorBoundary componentName='Test' level='editor' logService={logService} onReload={onReload}>
+					<ThrowingComponent error={new Error('fail')} />
+				</NotebookErrorBoundary>
+			);
+
+			const { action } = getActionButtons(container);
+			clickAndFlush(action);
+
+			sinon.assert.calledOnce(onReload);
+		});
+	});
+});


### PR DESCRIPTION
Addresses #11859.

### Summary

When a React component in the Positron notebook throws during rendering (e.g., a Plotly output error, malformed HTML, or data explorer failure), the entire React tree unmounts and the user sees a blank editor with no indication of what happened. The notebook content is still in memory but invisible.

This PR adds a reusable `NotebookErrorBoundary` class component (class required since React only supports error boundaries via `getDerivedStateFromError`/`componentDidCatch`) placed at three layers:

| Layer | Wraps | Fallback | Purpose |
|-------|-------|----------|---------|
| `output` | Each `CellOutput` / markdown render | Compact inline error + retry | Isolate bad outputs from the cell |
| `cell` | Each `NotebookCellWrapper` | Cell-shaped error card + retry | Isolate a broken cell from the notebook |
| `editor` | `PositronNotebookComponent` | Full-width error panel + reload | Prevent blank screen |

Component tree after changes:
```
PositronNotebookEditor._renderReact()
  NotebookVisibilityProvider
    NotebookInstanceProvider
      EnvironmentProvider
        NotebookErrorBoundary level="editor"           <-- NEW
          PositronNotebookComponent
            NotebookCellWrapper (per cell)
              NotebookErrorBoundary level="cell"        <-- NEW
                NotebookCodeCell / MarkdownCell
                  CellOutputsSection
                    NotebookErrorBoundary level="output" <-- NEW
                      CellOutput
```

The fallback UI at all levels shows a brief message, an expandable error details section with component stack, and an action button (Retry for output/cell, Reload for editor). Errors are logged via `ILogService` with boundary level, component name, and stack trace.

The `level` prop uses a discriminated union so that `onReload` is required only at the editor level, where it triggers a full React tree re-render via `PositronNotebookEditor`.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Notebook no longer goes blank when a single output or cell fails to render; errors are now caught and shown inline with retry/reload options (#11859)

### QA Notes

@:positron-notebooks @:notebooks

1. Open a Python notebook
2. Run a cell that produces output (e.g., a simple plot or data frame)
3. Verify the notebook renders normally -- error boundaries should be invisible when nothing goes wrong
4. To test error handling: if you can trigger a rendering failure (e.g., via a problematic Plotly output per #5311), verify that only the affected output/cell shows an error message rather than the entire notebook going blank
5. Verify the "Show Details" button expands to show the error message and component stack
6. Verify the "Retry" button re-attempts rendering the failed component