### PR TITLE
python: do not install uv prereleases

### DIFF
--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -545,15 +545,20 @@ export namespace CreateEnv {
         export const updatingUv = l10n.t('Updating uv...');
         export const updateUv = l10n.t('Update uv');
         export const proceedAnyway = l10n.t('Proceed Anyway');
-        export const prereleaseWarning = l10n.t(
-            'Your uv installation would use Python {0}, which is a pre-release version. Pre-release Python versions may cause compatibility issues. Run "uv self update" to get the latest stable Python versions.',
-        );
+        export const prereleaseWarning = (version: string) =>
+            l10n.t(
+                'Your uv installation would use Python {0}, which is a pre-release version. Pre-release Python versions may cause compatibility issues. Run "uv self update" to get the latest stable Python versions.',
+                version,
+            );
         export const errorUpdatingUv = l10n.t('Failed to update uv. See Output > Python for more info.');
-        export const stillPrereleaseWarning = l10n.t(
-            'After updating uv, Python {0} is still a pre-release. No stable version is available. Proceeding with environment creation.',
-        );
-        export const installingPython = l10n.t('Installing Python {0}...');
-        export const errorInstallingPython = l10n.t('Failed to install Python {0}. See Output > Python for more info.');
+        export const stillPrereleaseWarning = (version: string) =>
+            l10n.t(
+                'After updating uv, Python {0} is still a pre-release. No stable version is available. Proceeding with environment creation.',
+                version,
+            );
+        export const installingPython = (version: string) => l10n.t('Installing Python {0}...', version);
+        export const errorInstallingPython = (version: string) =>
+            l10n.t('Failed to install Python {0}. See Output > Python for more info.', version);
     }
     // --- End Positron ---
 

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -550,7 +550,7 @@ export namespace CreateEnv {
                 'Your uv installation would use Python {0}, which is a pre-release version. Pre-release Python versions may cause compatibility issues. Run "uv self update" to get the latest stable Python versions.',
                 version,
             );
-        export const errorUpdatingUv = l10n.t('Failed to update uv. See Output > Python for more info.');
+        export const errorUpdatingUv = l10n.t('Failed to update uv. See Output > Python Language Pack for more info.');
         export const stillPrereleaseWarning = (version: string) =>
             l10n.t(
                 'After updating uv, Python {0} is still a pre-release. No stable version is available. Proceeding with environment creation.',
@@ -558,7 +558,7 @@ export namespace CreateEnv {
             );
         export const installingPython = (version: string) => l10n.t('Installing Python {0}...', version);
         export const errorInstallingPython = (version: string) =>
-            l10n.t('Failed to install Python {0}. See Output > Python for more info.', version);
+            l10n.t('Failed to install Python {0}. See Output > Python Language Pack for more info.', version);
     }
     // --- End Positron ---
 

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -542,6 +542,16 @@ export namespace CreateEnv {
         export const providerDescription = l10n.t(
             'Use uv to find a Python version locally (or install it if needed) for the new environment',
         );
+        export const updatingUv = l10n.t('Updating uv...');
+        export const updateUv = l10n.t('Update uv');
+        export const proceedAnyway = l10n.t('Proceed Anyway');
+        export const prereleaseWarning = l10n.t(
+            'Your uv installation would use Python {0}, which is a pre-release version. Pre-release Python versions may cause compatibility issues. Run "uv self update" to get the latest stable Python versions.',
+        );
+        export const errorUpdatingUv = l10n.t('Failed to update uv. See Output > Python for more info.');
+        export const stillPrereleaseWarning = l10n.t(
+            'After updating uv, Python {0} is still a pre-release. Proceeding with environment creation.',
+        );
     }
     // --- End Positron ---
 

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -551,14 +551,14 @@ export namespace CreateEnv {
                 version,
             );
         export const errorUpdatingUv = l10n.t('Failed to update uv. See Output > Python Language Pack for more info.');
-        export const stillPrereleaseWarning = (version: string) =>
-            l10n.t(
-                'After updating uv, Python {0} is still a pre-release. No stable version is available. Proceeding with environment creation.',
-                version,
-            );
         export const installingPython = (version: string) => l10n.t('Installing Python {0}...', version);
         export const errorInstallingPython = (version: string) =>
             l10n.t('Failed to install Python {0}. See Output > Python Language Pack for more info.', version);
+        export const noStableVersionAvailable = (version: string) =>
+            l10n.t(
+                'No stable Python version is available for {0}. Only pre-release versions were found. Please try a different Python version.',
+                version,
+            );
     }
     // --- End Positron ---
 

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -550,8 +550,10 @@ export namespace CreateEnv {
         );
         export const errorUpdatingUv = l10n.t('Failed to update uv. See Output > Python for more info.');
         export const stillPrereleaseWarning = l10n.t(
-            'After updating uv, Python {0} is still a pre-release. Proceeding with environment creation.',
+            'After updating uv, Python {0} is still a pre-release. No stable version is available. Proceeding with environment creation.',
         );
+        export const installingPython = l10n.t('Installing Python {0}...');
+        export const errorInstallingPython = l10n.t('Failed to install Python {0}. See Output > Python for more info.');
     }
     // --- End Positron ---
 

--- a/extensions/positron-python/src/client/positron/runtime.ts
+++ b/extensions/positron-python/src/client/positron/runtime.ts
@@ -24,6 +24,7 @@ import {
 } from '../interpreter/configuration/environmentTypeComparer';
 import { getIpykernelBundle, IpykernelBundle } from './ipykernel';
 import { moduleMetadataMap } from '../pythonEnvironments/base/locators/lowLevel/moduleEnvironmentLocator';
+import { getShortVersionString, parseVersion } from '../pythonEnvironments/base/info/pythonVersion';
 
 /**
  * Module metadata for Python interpreters discovered via environment modules.
@@ -109,7 +110,9 @@ export async function createPythonRuntimeMetadata(
     traceInfo(`createPythonRuntime: startup behavior: ${startupBehavior}`);
 
     // Get the Python version from sysVersion since only that includes alpha/beta info (e.g '3.12.0b1')
-    const pythonVersion = interpreter.sysVersion?.split(' ')[0] || interpreter.version?.raw || '0.0.1';
+    // Use parseVersion + getShortVersionString to properly format the version (strips "final" suffix)
+    const rawVersion = interpreter.sysVersion?.split(' ')[0] || interpreter.version?.raw || '0.0.1';
+    const pythonVersion = getShortVersionString(parseVersion(rawVersion));
 
     // Get the environment name, using parent directory name for .venv/.conda folders (like uv does)
     let envName = interpreter.envName ?? '';

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -177,26 +177,35 @@ export async function getUvPythonVersionInfo(requestedVersion: string): Promise<
             return undefined;
         }
 
-        // Check if any version is already installed locally (has a path, not just "<download available>")
-        const hasLocalInstall = lines.some((line) => !line.includes('<download available>'));
-        if (hasLocalInstall) {
-            // Python is already installed locally, no need to warn about pre-release
+        // Find the first locally installed version or the first downloadable version
+        // A local install has a path (not just "<download available>")
+        const localLine = lines.find((line) => !line.includes('<download available>'));
+        const firstLine = localLine ?? lines[0];
+
+        // Format: "cpython-3.15.0a6-macos-aarch64-none    <download available>"
+        // or:     "cpython-3.13.7-macos-aarch64-none     /usr/local/bin/python3.13 -> ..."
+        const versionMatch = firstLine.match(/cpython-(\d+\.\d+\.\d+(?:a|b|rc)?\d*)/i);
+        if (!versionMatch) {
+            traceVerbose(`Could not parse version from uv python list output: ${firstLine}`);
             return undefined;
         }
-
-        // All versions are download-only. Get the version from the first line.
-        // Format: "cpython-3.15.0a6-macos-aarch64-none    <download available>"
-        const firstLine = lines[0];
-        const versionMatch = firstLine.match(/cpython-(\d+\.\d+\.\d+(?:a|b|rc)?\d*)/i);
-        const version = versionMatch ? versionMatch[1] : requestedVersion;
+        const version = versionMatch[1];
 
         // Check if it's a pre-release (contains 'a' for alpha, 'b' for beta, or 'rc' for release candidate)
         const isPrerelease = /\d+\.\d+\.\d+(a|b|rc)\d+/i.test(version);
 
+        // Extract path if this is a local install
+        let pythonPath: string | undefined;
+        if (localLine) {
+            // Extract path from format like "cpython-3.13.7-macos-aarch64-none     /usr/local/bin/python3.13 -> ..."
+            const pathMatch = localLine.match(/\s+(\/\S+)/);
+            pythonPath = pathMatch?.[1];
+        }
+
         return {
             version,
             isPrerelease,
-            path: undefined,
+            path: pythonPath,
         };
     } catch (ex) {
         traceVerbose(`Error checking uv Python version: ${ex}`);

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -166,7 +166,7 @@ export interface GetUvPythonVersionInfoOptions {
 
 /**
  * Checks what Python version uv would install for a given version request.
- * Uses `uv python find` to determine the version without actually installing.
+ * Uses `uv python list` to see available versions without actually installing.
  * @param requestedVersion The version requested (e.g., "3.14", "3.13")
  * @param options Options for version lookup
  * @returns Information about the Python version, or undefined if not found
@@ -243,8 +243,11 @@ export async function getUvPythonVersionInfo(
         // Extract path if this is a local install
         let pythonPath: string | undefined;
         if (isLocal) {
-            // Extract path from format like "cpython-3.13.7-macos-aarch64-none     /usr/local/bin/python3.13 -> ..."
-            const pathMatch = selectedLine.match(/\s+(\/\S+)/);
+            // Extract path from format like:
+            //   "cpython-3.13.7-macos-aarch64-none     /usr/local/bin/python3.13 -> ..."
+            //   "cpython-3.13.7-windows-x86_64-none   C:\Users\...\python.exe"
+            // Match Unix paths (starting with /) or Windows paths (starting with drive letter)
+            const pathMatch = selectedLine.match(/\s+(\/\S+|[A-Za-z]:\\\S+)/);
             pythonPath = pathMatch?.[1];
         }
 

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -11,6 +11,7 @@ import { exec, pathExists, readFile, resolveSymbolicLink } from '../externalDepe
 import { isTestExecution } from '../../../common/constants';
 import { getPyvenvConfigPathsFrom } from './simplevirtualenvs';
 import { splitLines } from '../../../common/stringUtils';
+import { CreateEnv } from '../../../common/utils/localize';
 
 /** Regex to extract version from uv python list output (e.g., "cpython-3.14.0a5-macos-aarch64-none") */
 const UV_VERSION_REGEX = /cpython-(\d+\.\d+\.\d+(?:a|b|rc)?\d*)/i;
@@ -334,7 +335,7 @@ export async function getStablePythonAfterUpdate(
     onProgress?: (message: string) => void,
 ): Promise<GetStablePythonResult> {
     // Update uv
-    onProgress?.('Updating uv...');
+    onProgress?.(CreateEnv.Uv.updatingUv);
     traceVerbose('Running uv self update...');
     const updateSuccess = await updateUv();
     if (!updateSuccess) {
@@ -360,7 +361,7 @@ export async function getStablePythonAfterUpdate(
 
     // Found a stable version - install it if not already local
     if (!stableVersionInfo.path) {
-        onProgress?.(`Installing Python ${stableVersionInfo.version}...`);
+        onProgress?.(CreateEnv.Uv.installingPython(stableVersionInfo.version));
         traceVerbose(`Installing stable Python ${stableVersionInfo.version}...`);
         const installSuccess = await installUvPython(stableVersionInfo.version);
         if (!installSuccess) {

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -16,7 +16,7 @@ import { splitLines } from '../../../common/stringUtils';
 class UvUtils {
     private static uvPromise: Promise<UvUtils | undefined>;
 
-    constructor(public readonly command: string) { }
+    constructor(public readonly command: string) {}
 
     public static async getUvUtils(): Promise<UvUtils | undefined> {
         if (UvUtils.uvPromise === undefined || isTestExecution()) {
@@ -169,7 +169,10 @@ export async function getUvPythonVersionInfo(requestedVersion: string): Promise<
             return undefined;
         }
 
-        const lines = output.split('\n').map((line) => line.trim()).filter((line) => line.length > 0);
+        const lines = output
+            .split('\n')
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0);
         if (lines.length === 0) {
             return undefined;
         }

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import { cache } from '../../../common/utils/decorators';
-import { traceVerbose } from '../../../logging';
+import { traceError, traceVerbose } from '../../../logging';
 import { exec, pathExists, readFile, resolveSymbolicLink } from '../externalDependencies';
 import { isTestExecution } from '../../../common/constants';
 import { getPyvenvConfigPathsFrom } from './simplevirtualenvs';
@@ -312,6 +312,67 @@ export async function installUvPython(version: string): Promise<boolean> {
         traceVerbose(`Error running uv python install: ${ex}`);
         return false;
     }
+}
+
+/**
+ * Result of attempting to get a stable Python version after updating uv.
+ */
+export type GetStablePythonResult =
+    | { success: true; version: string; wasInstalled: boolean }
+    | { success: false; error: 'update_failed' | 'install_failed' | 'no_stable_version'; version?: string };
+
+/**
+ * Updates uv and attempts to find/install a stable Python version.
+ * This handles the flow: update uv -> check for stable -> install if needed.
+ *
+ * @param requestedVersion The version requested (e.g., "3.14", "3.13")
+ * @param onProgress Optional callback for progress updates
+ * @returns Result indicating success with version info, or failure with error type
+ */
+export async function getStablePythonAfterUpdate(
+    requestedVersion: string,
+    onProgress?: (message: string) => void,
+): Promise<GetStablePythonResult> {
+    // Update uv
+    onProgress?.('Updating uv...');
+    traceVerbose('Running uv self update...');
+    const updateSuccess = await updateUv();
+    if (!updateSuccess) {
+        traceError('Failed to update uv');
+        return { success: false, error: 'update_failed' };
+    }
+    traceVerbose('uv updated successfully, checking for stable Python version...');
+
+    // Look for a stable version, skipping local pre-releases
+    const stableVersionInfo = await getUvPythonVersionInfo(requestedVersion, {
+        skipLocalPrereleases: true,
+    });
+
+    if (!stableVersionInfo || stableVersionInfo.isPrerelease) {
+        // No stable version available
+        traceError(
+            `No stable Python version available for ${requestedVersion}, only pre-release ${
+                stableVersionInfo?.version ?? 'unknown'
+            }`,
+        );
+        return { success: false, error: 'no_stable_version', version: stableVersionInfo?.version };
+    }
+
+    // Found a stable version - install it if not already local
+    if (!stableVersionInfo.path) {
+        onProgress?.(`Installing Python ${stableVersionInfo.version}...`);
+        traceVerbose(`Installing stable Python ${stableVersionInfo.version}...`);
+        const installSuccess = await installUvPython(stableVersionInfo.version);
+        if (!installSuccess) {
+            traceError(`Failed to install Python ${stableVersionInfo.version}`);
+            return { success: false, error: 'install_failed', version: stableVersionInfo.version };
+        }
+        traceVerbose(`Using stable Python ${stableVersionInfo.version}`);
+        return { success: true, version: stableVersionInfo.version, wasInstalled: true };
+    }
+
+    traceVerbose(`Using existing stable Python ${stableVersionInfo.version}`);
+    return { success: true, version: stableVersionInfo.version, wasInstalled: false };
 }
 
 /**

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -134,6 +134,76 @@ export async function isUvInstalled(): Promise<boolean> {
 }
 
 /**
+ * Information about a Python version that uv would install.
+ */
+export interface UvPythonVersionInfo {
+    /** The full version string (e.g., "3.14.0a5") */
+    version: string;
+    /** Whether this is a pre-release version (alpha, beta, or release candidate) */
+    isPrerelease: boolean;
+    /** The path to the Python executable */
+    path?: string;
+}
+
+/**
+ * Checks what Python version uv would install for a given version request.
+ * Uses `uv python find` to determine the version without actually installing.
+ * @param requestedVersion The version requested (e.g., "3.14", "3.13")
+ * @returns Information about the Python version, or undefined if not found
+ */
+export async function getUvPythonVersionInfo(requestedVersion: string): Promise<UvPythonVersionInfo | undefined> {
+    const uvUtils = await UvUtils.getUvUtils();
+    if (!uvUtils) {
+        return undefined;
+    }
+
+    try {
+        // Use `uv python find` to see what version would be used
+        const result = await exec(uvUtils.command, ['python', 'find', requestedVersion], { throwOnStdErr: false });
+        const pythonPath = result?.stdout.trim();
+
+        if (!pythonPath) {
+            return undefined;
+        }
+
+        // Extract version from the path (e.g., "cpython-3.14.0a5-macos-aarch64-none")
+        // The path typically contains the version in a format like:
+        // /Users/.../uv/python/cpython-3.14.0a5-macos-aarch64-none/bin/python
+        const versionMatch = pythonPath.match(/cpython-(\d+\.\d+\.\d+(?:a|b|rc)?\d*)/i);
+        let version = requestedVersion;
+
+        if (versionMatch) {
+            version = versionMatch[1];
+        } else {
+            // Try to get the version by running the Python executable
+            try {
+                const versionResult = await exec(pythonPath, ['--version'], { throwOnStdErr: false });
+                const versionOutput = versionResult?.stdout.trim() || versionResult?.stderr.trim();
+                // Output format: "Python 3.14.0a5"
+                const match = versionOutput?.match(/Python\s+(\d+\.\d+\.\d+(?:a|b|rc)?\d*)/i);
+                if (match) {
+                    version = match[1];
+                }
+            } catch (ex) {
+                traceVerbose(`Could not get Python version from executable: ${ex}`);
+            }
+        }
+
+        // Check if it's a pre-release (contains 'a' for alpha, 'b' for beta, or 'rc' for release candidate)
+        const isPrerelease = /\d+\.\d+\.\d+(a|b|rc)\d+/i.test(version);
+
+        return {
+            version,
+            isPrerelease,
+            path: pythonPath,
+        };
+    } catch (ex) {
+        traceVerbose(`Error checking uv Python version: ${ex}`);
+        return undefined;
+    }
+}
+
+/**
  * Find all places uv puts global interpreters. These can differ by OS and env vars.
  * @returns {Set<string>} Set of directories where uv interpreters are located.
  */

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -12,6 +12,17 @@ import { isTestExecution } from '../../../common/constants';
 import { getPyvenvConfigPathsFrom } from './simplevirtualenvs';
 import { splitLines } from '../../../common/stringUtils';
 
+/** Regex to extract version from uv python list output (e.g., "cpython-3.14.0a5-macos-aarch64-none") */
+const UV_VERSION_REGEX = /cpython-(\d+\.\d+\.\d+(?:a|b|rc)?\d*)/i;
+
+/** Regex to check if a version string is a pre-release (alpha, beta, or release candidate) */
+const PRERELEASE_REGEX = /\d+\.\d+\.\d+(a|b|rc)\d+/i;
+
+/** Check if a version string represents a pre-release version */
+function isVersionPrerelease(version: string): boolean {
+    return PRERELEASE_REGEX.test(version);
+}
+
 /** Wraps the "uv" utility, and exposes its functionality. */
 class UvUtils {
     private static uvPromise: Promise<UvUtils | undefined>;
@@ -146,12 +157,24 @@ export interface UvPythonVersionInfo {
 }
 
 /**
+ * Options for getUvPythonVersionInfo
+ */
+export interface GetUvPythonVersionInfoOptions {
+    /** If true, skip local pre-release versions and prefer downloadable stable versions */
+    skipLocalPrereleases?: boolean;
+}
+
+/**
  * Checks what Python version uv would install for a given version request.
  * Uses `uv python find` to determine the version without actually installing.
  * @param requestedVersion The version requested (e.g., "3.14", "3.13")
+ * @param options Options for version lookup
  * @returns Information about the Python version, or undefined if not found
  */
-export async function getUvPythonVersionInfo(requestedVersion: string): Promise<UvPythonVersionInfo | undefined> {
+export async function getUvPythonVersionInfo(
+    requestedVersion: string,
+    options?: GetUvPythonVersionInfoOptions,
+): Promise<UvPythonVersionInfo | undefined> {
     const uvUtils = await UvUtils.getUvUtils();
     if (!uvUtils) {
         return undefined;
@@ -177,28 +200,51 @@ export async function getUvPythonVersionInfo(requestedVersion: string): Promise<
             return undefined;
         }
 
-        // Find the first locally installed version or the first downloadable version
-        // A local install has a path (not just "<download available>")
-        const localLine = lines.find((line) => !line.includes('<download available>'));
-        const firstLine = localLine ?? lines[0];
+        // Helper to check if a line represents a pre-release version
+        const isLinePrerelease = (line: string): boolean => {
+            const match = line.match(UV_VERSION_REGEX);
+            return match ? isVersionPrerelease(match[1]) : false;
+        };
+
+        // Find the appropriate version based on options
+        let selectedLine: string;
+        if (options?.skipLocalPrereleases) {
+            // When skipping local pre-releases, prefer:
+            // 1. First local stable version
+            // 2. First downloadable stable version
+            // 3. Fall back to first line (may be pre-release)
+            const localStableLine = lines.find(
+                (line) => !line.includes('<download available>') && !isLinePrerelease(line),
+            );
+            const downloadableStableLine = lines.find(
+                (line) => line.includes('<download available>') && !isLinePrerelease(line),
+            );
+            selectedLine = localStableLine ?? downloadableStableLine ?? lines[0];
+        } else {
+            // Default behavior: prefer local versions
+            const localLine = lines.find((line) => !line.includes('<download available>'));
+            selectedLine = localLine ?? lines[0];
+        }
 
         // Format: "cpython-3.15.0a6-macos-aarch64-none    <download available>"
         // or:     "cpython-3.13.7-macos-aarch64-none     /usr/local/bin/python3.13 -> ..."
-        const versionMatch = firstLine.match(/cpython-(\d+\.\d+\.\d+(?:a|b|rc)?\d*)/i);
+        const versionMatch = selectedLine.match(UV_VERSION_REGEX);
         if (!versionMatch) {
-            traceVerbose(`Could not parse version from uv python list output: ${firstLine}`);
+            traceVerbose(`Could not parse version from uv python list output: ${selectedLine}`);
             return undefined;
         }
         const version = versionMatch[1];
 
-        // Check if it's a pre-release (contains 'a' for alpha, 'b' for beta, or 'rc' for release candidate)
-        const isPrerelease = /\d+\.\d+\.\d+(a|b|rc)\d+/i.test(version);
+        const isPrerelease = isVersionPrerelease(version);
+
+        // Check if this version is locally installed
+        const isLocal = !selectedLine.includes('<download available>');
 
         // Extract path if this is a local install
         let pythonPath: string | undefined;
-        if (localLine) {
+        if (isLocal) {
             // Extract path from format like "cpython-3.13.7-macos-aarch64-none     /usr/local/bin/python3.13 -> ..."
-            const pathMatch = localLine.match(/\s+(\/\S+)/);
+            const pathMatch = selectedLine.match(/\s+(\/\S+)/);
             pythonPath = pathMatch?.[1];
         }
 
@@ -230,6 +276,28 @@ export async function updateUv(): Promise<boolean> {
         return true;
     } catch (ex) {
         traceVerbose(`Error running uv self update: ${ex}`);
+        return false;
+    }
+}
+
+/**
+ * Installs a Python version using uv.
+ * @param version The version to install (e.g., "3.13.7", "3.14")
+ * @returns true if the installation succeeded, false otherwise
+ */
+export async function installUvPython(version: string): Promise<boolean> {
+    const uvUtils = await UvUtils.getUvUtils();
+    if (!uvUtils) {
+        return false;
+    }
+
+    try {
+        traceVerbose(`Running uv python install ${version}...`);
+        await exec(uvUtils.command, ['python', 'install', version], { throwOnStdErr: false });
+        traceVerbose(`uv python install ${version} completed successfully`);
+        return true;
+    } catch (ex) {
+        traceVerbose(`Error running uv python install: ${ex}`);
         return false;
     }
 }

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -245,10 +245,19 @@ export async function getUvPythonVersionInfo(
         if (isLocal) {
             // Extract path from format like:
             //   "cpython-3.13.7-macos-aarch64-none     /usr/local/bin/python3.13 -> ..."
-            //   "cpython-3.13.7-windows-x86_64-none   C:\Users\...\python.exe"
-            // Match Unix paths (starting with /) or Windows paths (starting with drive letter)
-            const pathMatch = selectedLine.match(/\s+(\/\S+|[A-Za-z]:\\\S+)/);
-            pythonPath = pathMatch?.[1];
+            //   "cpython-3.13.7-windows-x86_64-none   C:\Program Files\Python\python.exe"
+            // Split on 2+ spaces to separate columns, then strip " -> ..." suffix
+            const columns = selectedLine.split(/\s{2,}/);
+            if (columns.length >= 2) {
+                let pathColumn = columns[1].trim();
+                const arrowIndex = pathColumn.indexOf(' -> ');
+                if (arrowIndex !== -1) {
+                    pathColumn = pathColumn.substring(0, arrowIndex);
+                }
+                if (pathColumn.length > 0) {
+                    pythonPath = pathColumn;
+                }
+            }
         }
 
         return {

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -16,7 +16,7 @@ import { splitLines } from '../../../common/stringUtils';
 class UvUtils {
     private static uvPromise: Promise<UvUtils | undefined>;
 
-    constructor(public readonly command: string) {}
+    constructor(public readonly command: string) { }
 
     public static async getUvUtils(): Promise<UvUtils | undefined> {
         if (UvUtils.uvPromise === undefined || isTestExecution()) {
@@ -158,36 +158,34 @@ export async function getUvPythonVersionInfo(requestedVersion: string): Promise<
     }
 
     try {
-        // Use `uv python find` to see what version would be used
-        const result = await exec(uvUtils.command, ['python', 'find', requestedVersion], { throwOnStdErr: false });
-        const pythonPath = result?.stdout.trim();
+        // Use `uv python list VERSION` to see available versions
+        // Output format:
+        //   cpython-3.15.0a6-macos-aarch64-none    <download available>
+        //   cpython-3.13.7-macos-aarch64-none     /usr/local/bin/python3.13 -> ...
+        const result = await exec(uvUtils.command, ['python', 'list', requestedVersion], { throwOnStdErr: false });
+        const output = result?.stdout.trim();
 
-        if (!pythonPath) {
+        if (!output) {
             return undefined;
         }
 
-        // Extract version from the path (e.g., "cpython-3.14.0a5-macos-aarch64-none")
-        // The path typically contains the version in a format like:
-        // /Users/.../uv/python/cpython-3.14.0a5-macos-aarch64-none/bin/python
-        const versionMatch = pythonPath.match(/cpython-(\d+\.\d+\.\d+(?:a|b|rc)?\d*)/i);
-        let version = requestedVersion;
-
-        if (versionMatch) {
-            version = versionMatch[1];
-        } else {
-            // Try to get the version by running the Python executable
-            try {
-                const versionResult = await exec(pythonPath, ['--version'], { throwOnStdErr: false });
-                const versionOutput = versionResult?.stdout.trim() || versionResult?.stderr.trim();
-                // Output format: "Python 3.14.0a5"
-                const match = versionOutput?.match(/Python\s+(\d+\.\d+\.\d+(?:a|b|rc)?\d*)/i);
-                if (match) {
-                    version = match[1];
-                }
-            } catch (ex) {
-                traceVerbose(`Could not get Python version from executable: ${ex}`);
-            }
+        const lines = output.split('\n').map((line) => line.trim()).filter((line) => line.length > 0);
+        if (lines.length === 0) {
+            return undefined;
         }
+
+        // Check if any version is already installed locally (has a path, not just "<download available>")
+        const hasLocalInstall = lines.some((line) => !line.includes('<download available>'));
+        if (hasLocalInstall) {
+            // Python is already installed locally, no need to warn about pre-release
+            return undefined;
+        }
+
+        // All versions are download-only. Get the version from the first line.
+        // Format: "cpython-3.15.0a6-macos-aarch64-none    <download available>"
+        const firstLine = lines[0];
+        const versionMatch = firstLine.match(/cpython-(\d+\.\d+\.\d+(?:a|b|rc)?\d*)/i);
+        const version = versionMatch ? versionMatch[1] : requestedVersion;
 
         // Check if it's a pre-release (contains 'a' for alpha, 'b' for beta, or 'rc' for release candidate)
         const isPrerelease = /\d+\.\d+\.\d+(a|b|rc)\d+/i.test(version);
@@ -195,11 +193,32 @@ export async function getUvPythonVersionInfo(requestedVersion: string): Promise<
         return {
             version,
             isPrerelease,
-            path: pythonPath,
+            path: undefined,
         };
     } catch (ex) {
         traceVerbose(`Error checking uv Python version: ${ex}`);
         return undefined;
+    }
+}
+
+/**
+ * Runs `uv self update` to update uv to the latest version.
+ * @returns true if the update succeeded, false otherwise
+ */
+export async function updateUv(): Promise<boolean> {
+    const uvUtils = await UvUtils.getUvUtils();
+    if (!uvUtils) {
+        return false;
+    }
+
+    try {
+        traceVerbose('Running uv self update...');
+        await exec(uvUtils.command, ['self', 'update'], { throwOnStdErr: false });
+        traceVerbose('uv self update completed successfully');
+        return true;
+    } catch (ex) {
+        traceVerbose(`Error running uv self update: ${ex}`);
+        return false;
     }
 }
 

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
@@ -205,17 +205,11 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                 }
 
                 // Check if uv would install a pre-release version and warn the user
-                if (token.isCancellationRequested) {
-                    return undefined;
-                }
                 const versionInfo = await getUvPythonVersionInfo(version);
                 if (versionInfo?.isPrerelease) {
                     traceWarn(
                         `uv would install pre-release Python ${versionInfo.version} for requested version ${version}`,
                     );
-                    if (token.isCancellationRequested) {
-                        return undefined;
-                    }
                     const choice = await vscode.window.showWarningMessage(
                         CreateEnv.Uv.prereleaseWarning.replace('{0}', versionInfo.version),
                         { modal: false },
@@ -224,17 +218,11 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                         Common.cancel,
                     );
 
-                    if (token.isCancellationRequested) {
-                        return undefined;
-                    }
                     if (choice === CreateEnv.Uv.updateUv) {
                         // Run uv self update and wait for it to complete
                         progress.report({ message: CreateEnv.Uv.updatingUv });
                         traceInfo('Updating uv...');
                         const updateSuccess = await updateUv();
-                        if (token.isCancellationRequested) {
-                            return undefined;
-                        }
                         if (!updateSuccess) {
                             traceError('Failed to update uv');
                             throw new Error(CreateEnv.Uv.errorUpdatingUv);
@@ -245,9 +233,6 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                         const stableVersionInfo = await getUvPythonVersionInfo(version, {
                             skipLocalPrereleases: true,
                         });
-                        if (token.isCancellationRequested) {
-                            return undefined;
-                        }
 
                         if (stableVersionInfo && !stableVersionInfo.isPrerelease) {
                             // Found a stable version - install it if not already local
@@ -257,9 +242,6 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                                     message: CreateEnv.Uv.installingPython.replace('{0}', stableVersionInfo.version),
                                 });
                                 const installSuccess = await installUvPython(stableVersionInfo.version);
-                                if (token.isCancellationRequested) {
-                                    return undefined;
-                                }
                                 if (!installSuccess) {
                                     traceError(`Failed to install Python ${stableVersionInfo.version}`);
                                     throw new Error(
@@ -280,12 +262,10 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                                 CreateEnv.Uv.stillPrereleaseWarning.replace('{0}', fallbackInfo.version),
                             );
                         }
-                        // Continue with environment creation
                     } else if (choice !== CreateEnv.Uv.proceedAnyway) {
                         // User cancelled or closed the dialog
                         return undefined;
                     }
-                    // User chose to proceed anyway or update completed
                     traceInfo(`Proceeding with Python ${version}`);
                 }
 

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
@@ -244,9 +244,7 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                                 const installSuccess = await installUvPython(stableVersionInfo.version);
                                 if (!installSuccess) {
                                     traceError(`Failed to install Python ${stableVersionInfo.version}`);
-                                    throw new Error(
-                                        CreateEnv.Uv.errorInstallingPython(stableVersionInfo.version),
-                                    );
+                                    throw new Error(CreateEnv.Uv.errorInstallingPython(stableVersionInfo.version));
                                 }
                             }
                             traceInfo(`Using stable Python ${stableVersionInfo.version}`);
@@ -258,9 +256,7 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                             traceWarn(
                                 `No stable Python version available for ${version}, using pre-release ${fallbackInfo.version}`,
                             );
-                            vscode.window.showWarningMessage(
-                                CreateEnv.Uv.stillPrereleaseWarning(fallbackInfo.version),
-                            );
+                            vscode.window.showWarningMessage(CreateEnv.Uv.stillPrereleaseWarning(fallbackInfo.version));
                         }
                     } else if (choice !== CreateEnv.Uv.proceedAnyway) {
                         // User cancelled or closed the dialog

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
@@ -205,11 +205,17 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                 }
 
                 // Check if uv would install a pre-release version and warn the user
+                if (token.isCancellationRequested) {
+                    return undefined;
+                }
                 const versionInfo = await getUvPythonVersionInfo(version);
                 if (versionInfo?.isPrerelease) {
                     traceWarn(
                         `uv would install pre-release Python ${versionInfo.version} for requested version ${version}`,
                     );
+                    if (token.isCancellationRequested) {
+                        return undefined;
+                    }
                     const choice = await vscode.window.showWarningMessage(
                         CreateEnv.Uv.prereleaseWarning.replace('{0}', versionInfo.version),
                         { modal: false },
@@ -218,11 +224,17 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                         Common.cancel,
                     );
 
+                    if (token.isCancellationRequested) {
+                        return undefined;
+                    }
                     if (choice === CreateEnv.Uv.updateUv) {
                         // Run uv self update and wait for it to complete
                         progress.report({ message: CreateEnv.Uv.updatingUv });
                         traceInfo('Updating uv...');
                         const updateSuccess = await updateUv();
+                        if (token.isCancellationRequested) {
+                            return undefined;
+                        }
                         if (!updateSuccess) {
                             traceError('Failed to update uv');
                             throw new Error(CreateEnv.Uv.errorUpdatingUv);
@@ -231,6 +243,9 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
 
                         // Re-check if the version is still a pre-release after updating
                         const newVersionInfo = await getUvPythonVersionInfo(version);
+                        if (token.isCancellationRequested) {
+                            return undefined;
+                        }
                         if (newVersionInfo?.isPrerelease) {
                             // Still a pre-release after update - warn user but continue
                             traceWarn(`After uv update, still getting pre-release Python ${newVersionInfo.version}`);

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
@@ -21,12 +21,7 @@ import {
     CreateEnvironmentOptions,
     CreateEnvironmentResult,
 } from '../proposed.createEnvApis';
-import {
-    getUvPythonVersionInfo,
-    installUvPython,
-    isUvInstalled,
-    updateUv,
-} from '../../common/environmentManagers/uv';
+import { getUvPythonVersionInfo, installUvPython, isUvInstalled, updateUv } from '../../common/environmentManagers/uv';
 import { pickPythonVersion } from './uvUtils';
 
 export const UV_PROVIDER_ID = `${PVSC_EXTENSION_ID}:uv`;
@@ -291,7 +286,7 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                         return undefined;
                     }
                     // User chose to proceed anyway or update completed
-                    traceInfo(`Proceeding with Python ${versionInfo.version}`);
+                    traceInfo(`Proceeding with Python ${version}`);
                 }
 
                 envPath = await createUvVenv(workspace, version, progress, token, options?.envName);

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
@@ -21,7 +21,12 @@ import {
     CreateEnvironmentOptions,
     CreateEnvironmentResult,
 } from '../proposed.createEnvApis';
-import { getUvPythonVersionInfo, isUvInstalled, updateUv } from '../../common/environmentManagers/uv';
+import {
+    getUvPythonVersionInfo,
+    installUvPython,
+    isUvInstalled,
+    updateUv,
+} from '../../common/environmentManagers/uv';
 import { pickPythonVersion } from './uvUtils';
 
 export const UV_PROVIDER_ID = `${PVSC_EXTENSION_ID}:uv`;
@@ -239,22 +244,45 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                             traceError('Failed to update uv');
                             throw new Error(CreateEnv.Uv.errorUpdatingUv);
                         }
-                        traceInfo('uv updated successfully, re-checking Python version...');
+                        traceInfo('uv updated successfully, checking for stable Python version...');
 
-                        // Re-check if the version is still a pre-release after updating
-                        const newVersionInfo = await getUvPythonVersionInfo(version);
+                        // Look for a stable version, skipping local pre-releases
+                        const stableVersionInfo = await getUvPythonVersionInfo(version, {
+                            skipLocalPrereleases: true,
+                        });
                         if (token.isCancellationRequested) {
                             return undefined;
                         }
-                        if (newVersionInfo?.isPrerelease) {
-                            // Still a pre-release after update - warn user but continue
-                            traceWarn(`After uv update, still getting pre-release Python ${newVersionInfo.version}`);
-                            vscode.window.showWarningMessage(
-                                CreateEnv.Uv.stillPrereleaseWarning.replace('{0}', newVersionInfo.version),
-                            );
+
+                        if (stableVersionInfo && !stableVersionInfo.isPrerelease) {
+                            // Found a stable version - install it if not already local
+                            if (!stableVersionInfo.path) {
+                                traceInfo(`Installing stable Python ${stableVersionInfo.version}...`);
+                                progress.report({
+                                    message: CreateEnv.Uv.installingPython.replace('{0}', stableVersionInfo.version),
+                                });
+                                const installSuccess = await installUvPython(stableVersionInfo.version);
+                                if (token.isCancellationRequested) {
+                                    return undefined;
+                                }
+                                if (!installSuccess) {
+                                    traceError(`Failed to install Python ${stableVersionInfo.version}`);
+                                    throw new Error(
+                                        CreateEnv.Uv.errorInstallingPython.replace('{0}', stableVersionInfo.version),
+                                    );
+                                }
+                            }
+                            traceInfo(`Using stable Python ${stableVersionInfo.version}`);
+                            // Update version to use the specific stable version
+                            version = stableVersionInfo.version;
                         } else {
-                            traceInfo(
-                                `After uv update, now getting stable Python ${newVersionInfo?.version ?? version}`,
+                            // No stable version available - warn user but continue with pre-release
+                            const fallbackInfo = stableVersionInfo ?? versionInfo;
+                            traceWarn(
+                                `No stable Python version available for ${version}, using pre-release ${fallbackInfo.version}`,
+                            );
+                            vscode.window.showWarningMessage(
+                                CreateEnv.Uv.stillPrereleaseWarning.replace('{0}', fallbackInfo.version),
                             );
                         }
                         // Continue with environment creation

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
@@ -25,7 +25,7 @@ import {
     CreateEnvironmentOptions,
     CreateEnvironmentResult,
 } from '../proposed.createEnvApis';
-import { getUvPythonVersionInfo, installUvPython, isUvInstalled, updateUv } from '../../common/environmentManagers/uv';
+import { getStablePythonAfterUpdate, getUvPythonVersionInfo, isUvInstalled } from '../../common/environmentManagers/uv';
 import { pickPythonVersion } from './uvUtils';
 
 export const UV_PROVIDER_ID = `${PVSC_EXTENSION_ID}:uv`;
@@ -223,45 +223,22 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                     );
 
                     if (choice === CreateEnv.Uv.updateUv) {
-                        // Run uv self update and wait for it to complete
-                        progress.report({ message: CreateEnv.Uv.updatingUv });
-                        traceInfo('Updating uv...');
-                        const updateSuccess = await updateUv();
-                        if (!updateSuccess) {
-                            traceError('Failed to update uv');
-                            throw new Error(CreateEnv.Uv.errorUpdatingUv);
-                        }
-                        traceInfo('uv updated successfully, checking for stable Python version...');
-
-                        // Look for a stable version, skipping local pre-releases
-                        const stableVersionInfo = await getUvPythonVersionInfo(version, {
-                            skipLocalPrereleases: true,
+                        const result = await getStablePythonAfterUpdate(version, (message) => {
+                            progress.report({ message });
                         });
 
-                        if (stableVersionInfo && !stableVersionInfo.isPrerelease) {
-                            // Found a stable version - install it if not already local
-                            if (!stableVersionInfo.path) {
-                                traceInfo(`Installing stable Python ${stableVersionInfo.version}...`);
-                                progress.report({
-                                    message: CreateEnv.Uv.installingPython(stableVersionInfo.version),
-                                });
-                                const installSuccess = await installUvPython(stableVersionInfo.version);
-                                if (!installSuccess) {
-                                    traceError(`Failed to install Python ${stableVersionInfo.version}`);
-                                    throw new Error(CreateEnv.Uv.errorInstallingPython(stableVersionInfo.version));
-                                }
+                        if (!result.success) {
+                            if (result.error === 'update_failed') {
+                                throw new Error(CreateEnv.Uv.errorUpdatingUv);
+                            } else if (result.error === 'install_failed') {
+                                throw new Error(CreateEnv.Uv.errorInstallingPython(result.version ?? version));
+                            } else {
+                                throw new Error(CreateEnv.Uv.noStableVersionAvailable(version));
                             }
-                            traceInfo(`Using stable Python ${stableVersionInfo.version}`);
-                            // Update version to use the specific stable version
-                            version = stableVersionInfo.version;
-                        } else {
-                            // No stable version available - fail
-                            const fallbackInfo = stableVersionInfo ?? versionInfo;
-                            traceError(
-                                `No stable Python version available for ${version}, only pre-release ${fallbackInfo.version}`,
-                            );
-                            throw new Error(CreateEnv.Uv.noStableVersionAvailable(version));
                         }
+
+                        traceInfo(`Using stable Python ${result.version}`);
+                        version = result.version;
                     } else if (choice !== CreateEnv.Uv.proceedAnyway) {
                         // User cancelled or closed the dialog
                         return undefined;

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
@@ -21,7 +21,7 @@ import {
     CreateEnvironmentOptions,
     CreateEnvironmentResult,
 } from '../proposed.createEnvApis';
-import { getUvPythonVersionInfo, isUvInstalled } from '../../common/environmentManagers/uv';
+import { getUvPythonVersionInfo, isUvInstalled, updateUv } from '../../common/environmentManagers/uv';
 import { pickPythonVersion } from './uvUtils';
 
 export const UV_PROVIDER_ID = `${PVSC_EXTENSION_ID}:uv`;
@@ -48,9 +48,8 @@ async function createUvVenv(
         cwd: workspace.uri.fsPath,
     });
 
-    const venvPath = `${workspace.uri.fsPath}${
-        os.platform() === 'win32' ? `\\${targetDir}\\Scripts\\python.exe` : `/${targetDir}/bin/python`
-    }`;
+    const venvPath = `${workspace.uri.fsPath}${os.platform() === 'win32' ? `\\${targetDir}\\Scripts\\python.exe` : `/${targetDir}/bin/python`
+        }`;
 
     out.subscribe(
         (value) => {
@@ -210,33 +209,47 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                     traceWarn(
                         `uv would install pre-release Python ${versionInfo.version} for requested version ${version}`,
                     );
-                    const updateUv = 'Update uv';
-                    const proceedAnyway = 'Proceed Anyway';
-                    const cancel = 'Cancel';
                     const choice = await vscode.window.showWarningMessage(
-                        `Your uv installation would use Python ${versionInfo.version}, which is a pre-release version. ` +
-                            `Pre-release Python versions may cause compatibility issues. ` +
-                            `Run "uv self update" to get the latest stable Python versions.`,
+                        CreateEnv.Uv.prereleaseWarning.replace('{0}', versionInfo.version),
                         { modal: false },
-                        updateUv,
-                        proceedAnyway,
-                        cancel,
+                        CreateEnv.Uv.updateUv,
+                        CreateEnv.Uv.proceedAnyway,
+                        Common.cancel,
                     );
 
-                    if (choice === updateUv) {
-                        // Open a terminal and run uv self update
-                        const terminal = vscode.window.createTerminal('uv update');
-                        terminal.show();
-                        terminal.sendText('uv self update');
-                        // Return undefined to cancel the environment creation
-                        // User can retry after updating uv
-                        return undefined;
-                    } else if (choice !== proceedAnyway) {
+                    if (choice === CreateEnv.Uv.updateUv) {
+                        // Run uv self update and wait for it to complete
+                        progress.report({ message: CreateEnv.Uv.updatingUv });
+                        traceInfo('Updating uv...');
+                        const updateSuccess = await updateUv();
+                        if (!updateSuccess) {
+                            traceError('Failed to update uv');
+                            throw new Error(CreateEnv.Uv.errorUpdatingUv);
+                        }
+                        traceInfo('uv updated successfully, re-checking Python version...');
+
+                        // Re-check if the version is still a pre-release after updating
+                        const newVersionInfo = await getUvPythonVersionInfo(version);
+                        if (newVersionInfo?.isPrerelease) {
+                            // Still a pre-release after update - warn user but continue
+                            traceWarn(
+                                `After uv update, still getting pre-release Python ${newVersionInfo.version}`,
+                            );
+                            vscode.window.showWarningMessage(
+                                CreateEnv.Uv.stillPrereleaseWarning.replace('{0}', newVersionInfo.version),
+                            );
+                        } else {
+                            traceInfo(
+                                `After uv update, now getting stable Python ${newVersionInfo?.version ?? version}`,
+                            );
+                        }
+                        // Continue with environment creation
+                    } else if (choice !== CreateEnv.Uv.proceedAnyway) {
                         // User cancelled or closed the dialog
                         return undefined;
                     }
-                    // User chose to proceed anyway
-                    traceInfo(`User chose to proceed with pre-release Python ${versionInfo.version}`);
+                    // User chose to proceed anyway or update completed
+                    traceInfo(`Proceeding with Python ${versionInfo.version}`);
                 }
 
                 envPath = await createUvVenv(workspace, version, progress, token, options?.envName);

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
@@ -48,8 +48,9 @@ async function createUvVenv(
         cwd: workspace.uri.fsPath,
     });
 
-    const venvPath = `${workspace.uri.fsPath}${os.platform() === 'win32' ? `\\${targetDir}\\Scripts\\python.exe` : `/${targetDir}/bin/python`
-        }`;
+    const venvPath = `${workspace.uri.fsPath}${
+        os.platform() === 'win32' ? `\\${targetDir}\\Scripts\\python.exe` : `/${targetDir}/bin/python`
+    }`;
 
     out.subscribe(
         (value) => {
@@ -232,9 +233,7 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                         const newVersionInfo = await getUvPythonVersionInfo(version);
                         if (newVersionInfo?.isPrerelease) {
                             // Still a pre-release after update - warn user but continue
-                            traceWarn(
-                                `After uv update, still getting pre-release Python ${newVersionInfo.version}`,
-                            );
+                            traceWarn(`After uv update, still getting pre-release Python ${newVersionInfo.version}`);
                             vscode.window.showWarningMessage(
                                 CreateEnv.Uv.stillPrereleaseWarning.replace('{0}', newVersionInfo.version),
                             );

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as os from 'os';
-import * as vscode from 'vscode';
 import { CancellationToken, ProgressLocation, WorkspaceFolder } from 'vscode';
 import { Commands, PVSC_EXTENSION_ID } from '../../../common/constants';
 import { execObservable } from '../../../common/process/rawProcessApis';
@@ -13,7 +12,12 @@ import { Common, CreateEnv } from '../../../common/utils/localize';
 import { traceError, traceInfo, traceLog, traceWarn } from '../../../logging';
 import { CreateEnvironmentOptionsInternal, CreateEnvironmentProgress } from '../types';
 import { pickWorkspaceFolder } from '../common/workspaceSelection';
-import { MultiStepAction, MultiStepNode, withProgress } from '../../../common/vscodeApis/windowApis';
+import {
+    MultiStepAction,
+    MultiStepNode,
+    showWarningMessage,
+    withProgress,
+} from '../../../common/vscodeApis/windowApis';
 import { getVenvExecutable, showPositronErrorMessageWithLogs } from '../common/commonUtils';
 import { ExistingVenvAction, deleteEnvironment, pickExistingVenvAction } from './venvUtils';
 import {
@@ -210,7 +214,7 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                     traceWarn(
                         `uv would install pre-release Python ${versionInfo.version} for requested version ${version}`,
                     );
-                    const choice = await vscode.window.showWarningMessage(
+                    const choice = await showWarningMessage(
                         CreateEnv.Uv.prereleaseWarning(versionInfo.version),
                         { modal: false },
                         CreateEnv.Uv.updateUv,
@@ -251,12 +255,12 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                             // Update version to use the specific stable version
                             version = stableVersionInfo.version;
                         } else {
-                            // No stable version available - warn user but continue with pre-release
+                            // No stable version available - fail
                             const fallbackInfo = stableVersionInfo ?? versionInfo;
-                            traceWarn(
-                                `No stable Python version available for ${version}, using pre-release ${fallbackInfo.version}`,
+                            traceError(
+                                `No stable Python version available for ${version}, only pre-release ${fallbackInfo.version}`,
                             );
-                            vscode.window.showWarningMessage(CreateEnv.Uv.stillPrereleaseWarning(fallbackInfo.version));
+                            throw new Error(CreateEnv.Uv.noStableVersionAvailable(version));
                         }
                     } else if (choice !== CreateEnv.Uv.proceedAnyway) {
                         // User cancelled or closed the dialog

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
@@ -4,12 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as os from 'os';
+import * as vscode from 'vscode';
 import { CancellationToken, ProgressLocation, WorkspaceFolder } from 'vscode';
 import { Commands, PVSC_EXTENSION_ID } from '../../../common/constants';
 import { execObservable } from '../../../common/process/rawProcessApis';
 import { createDeferred } from '../../../common/utils/async';
 import { Common, CreateEnv } from '../../../common/utils/localize';
-import { traceError, traceInfo, traceLog } from '../../../logging';
+import { traceError, traceInfo, traceLog, traceWarn } from '../../../logging';
 import { CreateEnvironmentOptionsInternal, CreateEnvironmentProgress } from '../types';
 import { pickWorkspaceFolder } from '../common/workspaceSelection';
 import { MultiStepAction, MultiStepNode, withProgress } from '../../../common/vscodeApis/windowApis';
@@ -20,7 +21,7 @@ import {
     CreateEnvironmentOptions,
     CreateEnvironmentResult,
 } from '../proposed.createEnvApis';
-import { isUvInstalled } from '../../common/environmentManagers/uv';
+import { getUvPythonVersionInfo, isUvInstalled } from '../../common/environmentManagers/uv';
 import { pickPythonVersion } from './uvUtils';
 
 export const UV_PROVIDER_ID = `${PVSC_EXTENSION_ID}:uv`;
@@ -201,6 +202,41 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
 
                 if (!version) {
                     throw new Error('Failed to create uv environment. Python version is undefined.');
+                }
+
+                // Check if uv would install a pre-release version and warn the user
+                const versionInfo = await getUvPythonVersionInfo(version);
+                if (versionInfo?.isPrerelease) {
+                    traceWarn(
+                        `uv would install pre-release Python ${versionInfo.version} for requested version ${version}`,
+                    );
+                    const updateUv = 'Update uv';
+                    const proceedAnyway = 'Proceed Anyway';
+                    const cancel = 'Cancel';
+                    const choice = await vscode.window.showWarningMessage(
+                        `Your uv installation would use Python ${versionInfo.version}, which is a pre-release version. ` +
+                            `Pre-release Python versions may cause compatibility issues. ` +
+                            `Run "uv self update" to get the latest stable Python versions.`,
+                        { modal: false },
+                        updateUv,
+                        proceedAnyway,
+                        cancel,
+                    );
+
+                    if (choice === updateUv) {
+                        // Open a terminal and run uv self update
+                        const terminal = vscode.window.createTerminal('uv update');
+                        terminal.show();
+                        terminal.sendText('uv self update');
+                        // Return undefined to cancel the environment creation
+                        // User can retry after updating uv
+                        return undefined;
+                    } else if (choice !== proceedAnyway) {
+                        // User cancelled or closed the dialog
+                        return undefined;
+                    }
+                    // User chose to proceed anyway
+                    traceInfo(`User chose to proceed with pre-release Python ${versionInfo.version}`);
                 }
 
                 envPath = await createUvVenv(workspace, version, progress, token, options?.envName);

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvCreationProvider.ts
@@ -211,7 +211,7 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                         `uv would install pre-release Python ${versionInfo.version} for requested version ${version}`,
                     );
                     const choice = await vscode.window.showWarningMessage(
-                        CreateEnv.Uv.prereleaseWarning.replace('{0}', versionInfo.version),
+                        CreateEnv.Uv.prereleaseWarning(versionInfo.version),
                         { modal: false },
                         CreateEnv.Uv.updateUv,
                         CreateEnv.Uv.proceedAnyway,
@@ -239,13 +239,13 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                             if (!stableVersionInfo.path) {
                                 traceInfo(`Installing stable Python ${stableVersionInfo.version}...`);
                                 progress.report({
-                                    message: CreateEnv.Uv.installingPython.replace('{0}', stableVersionInfo.version),
+                                    message: CreateEnv.Uv.installingPython(stableVersionInfo.version),
                                 });
                                 const installSuccess = await installUvPython(stableVersionInfo.version);
                                 if (!installSuccess) {
                                     traceError(`Failed to install Python ${stableVersionInfo.version}`);
                                     throw new Error(
-                                        CreateEnv.Uv.errorInstallingPython.replace('{0}', stableVersionInfo.version),
+                                        CreateEnv.Uv.errorInstallingPython(stableVersionInfo.version),
                                     );
                                 }
                             }
@@ -259,7 +259,7 @@ export class UvCreationProvider implements CreateEnvironmentProvider {
                                 `No stable Python version available for ${version}, using pre-release ${fallbackInfo.version}`,
                             );
                             vscode.window.showWarningMessage(
-                                CreateEnv.Uv.stillPrereleaseWarning.replace('{0}', fallbackInfo.version),
+                                CreateEnv.Uv.stillPrereleaseWarning(fallbackInfo.version),
                             );
                         }
                     } else if (choice !== CreateEnv.Uv.proceedAnyway) {

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -4,7 +4,7 @@
 import * as path from 'path';
 import { Disposable, Event, EventEmitter, Uri, WorkspaceFoldersChangeEvent } from 'vscode';
 // eslint-disable-next-line import/no-duplicates
-import { PythonEnvInfo, PythonEnvKind, PythonEnvType, PythonVersion } from './base/info';
+import { PythonEnvInfo, PythonEnvKind, PythonEnvType, PythonReleaseLevel, PythonVersion } from './base/info';
 import {
     GetRefreshEnvironmentsOptions,
     IDiscoveryAPI,
@@ -123,7 +123,18 @@ function kindToShortString(kind: PythonEnvKind): string | undefined {
 }
 
 function toShortVersionString(version: PythonVersion): string {
-    return `${version.major}.${version.minor}.${version.micro}`.trim();
+    let verStr = `${version.major}.${version.minor}.${version.micro}`.trim();
+    // Include pre-release suffix (e.g., "a5" for alpha 5, "b2" for beta 2, "rc1" for release candidate 1)
+    if (version.release && version.release.level !== PythonReleaseLevel.Final) {
+        if (version.release.level === PythonReleaseLevel.Alpha) {
+            verStr = `${verStr}a${version.release.serial}`;
+        } else if (version.release.level === PythonReleaseLevel.Beta) {
+            verStr = `${verStr}b${version.release.serial}`;
+        } else if (version.release.level === PythonReleaseLevel.Candidate) {
+            verStr = `${verStr}rc${version.release.serial}`;
+        }
+    }
+    return verStr;
 }
 
 function getDisplayName(version: PythonVersion, kind: PythonEnvKind, arch: Architecture, name?: string): string {
@@ -278,6 +289,7 @@ async function toPythonEnvInfo(nativeEnv: NativeEnvInfo, condaEnvDirs: string[])
             major: version.major,
             minor: version.minor,
             micro: version.micro,
+            ...(version.release && { release: version.release }),
         },
         arch,
         distro: {

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -122,8 +122,20 @@ function kindToShortString(kind: PythonEnvKind): string | undefined {
     }
 }
 
+// --- Start Positron ---
+// @ts-ignore: Keeping original function for upstream compatibility
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function toShortVersionString(version: PythonVersion): string {
+    return `${version.major}.${version.minor}.${version.micro}`.trim();
+}
+// --- End Positron ---
+
 function getDisplayName(version: PythonVersion, kind: PythonEnvKind, arch: Architecture, name?: string): string {
+    // --- Start Positron ---
+    // use getShortVersionString instead of toShortVersionString
+    // to get all version info (e.g. for pre-releases, alpha)
     const versionStr = getShortVersionString(version);
+    // --- End Positron ---
     const kindStr = kindToShortString(kind);
     if (arch === Architecture.x86) {
         if (kindStr) {
@@ -274,7 +286,10 @@ async function toPythonEnvInfo(nativeEnv: NativeEnvInfo, condaEnvDirs: string[])
             major: version.major,
             minor: version.minor,
             micro: version.micro,
+            // --- Start Positron ---
+            // add info if this is a pre-release version (e.g. alpha, beta, rc)
             ...(version.release && { release: version.release }),
+            // --- End Positron ---
         },
         arch,
         distro: {

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -4,7 +4,7 @@
 import * as path from 'path';
 import { Disposable, Event, EventEmitter, Uri, WorkspaceFoldersChangeEvent } from 'vscode';
 // eslint-disable-next-line import/no-duplicates
-import { PythonEnvInfo, PythonEnvKind, PythonEnvType, PythonReleaseLevel, PythonVersion } from './base/info';
+import { PythonEnvInfo, PythonEnvKind, PythonEnvType, PythonVersion } from './base/info';
 import {
     GetRefreshEnvironmentsOptions,
     IDiscoveryAPI,
@@ -23,7 +23,7 @@ import {
 } from './base/locators/common/nativePythonFinder';
 import { createDeferred, Deferred } from '../common/utils/async';
 import { Architecture, getPathEnvVariable, getUserHomeDir } from '../common/utils/platform';
-import { parseVersion } from './base/info/pythonVersion';
+import { getShortVersionString, parseVersion } from './base/info/pythonVersion';
 import { cache } from '../common/utils/decorators';
 import { traceError, traceInfo, traceLog, traceVerbose, traceWarn } from '../logging';
 import { StopWatch } from '../common/utils/stopWatch';
@@ -122,23 +122,8 @@ function kindToShortString(kind: PythonEnvKind): string | undefined {
     }
 }
 
-function toShortVersionString(version: PythonVersion): string {
-    let verStr = `${version.major}.${version.minor}.${version.micro}`.trim();
-    // Include pre-release suffix (e.g., "a5" for alpha 5, "b2" for beta 2, "rc1" for release candidate 1)
-    if (version.release && version.release.level !== PythonReleaseLevel.Final) {
-        if (version.release.level === PythonReleaseLevel.Alpha) {
-            verStr = `${verStr}a${version.release.serial}`;
-        } else if (version.release.level === PythonReleaseLevel.Beta) {
-            verStr = `${verStr}b${version.release.serial}`;
-        } else if (version.release.level === PythonReleaseLevel.Candidate) {
-            verStr = `${verStr}rc${version.release.serial}`;
-        }
-    }
-    return verStr;
-}
-
 function getDisplayName(version: PythonVersion, kind: PythonEnvKind, arch: Architecture, name?: string): string {
-    const versionStr = toShortVersionString(version);
+    const versionStr = getShortVersionString(version);
     const kindStr = kindToShortString(kind);
     if (arch === Architecture.x86) {
         if (kindStr) {

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
@@ -10,6 +10,8 @@ import {
     isUvEnvironment,
     isUvInstalled,
     getUvDirs,
+    getUvPythonVersionInfo,
+    updateUv,
 } from '../../../../client/pythonEnvironments/common/environmentManagers/uv';
 import * as platformUtils from '../../../../client/common/utils/platform';
 import * as logging from '../../../../client/logging';
@@ -251,6 +253,193 @@ suite('UV Environment Tests', () => {
             assert.strictEqual(result.size, 2);
             assert.ok(result.has(uvDir));
             assert.ok(result.has(uvBinDir));
+        });
+    });
+
+    suite('getUvPythonVersionInfo Tests', () => {
+        test('Returns undefined when uv is not installed', async () => {
+            execStub.rejects(new Error('Command not found'));
+
+            const result = await getUvPythonVersionInfo('3.13');
+
+            assert.strictEqual(result, undefined);
+        });
+
+        test('Returns undefined when uv python list returns empty output', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({ stdout: '' });
+
+            const result = await getUvPythonVersionInfo('3.13');
+
+            assert.strictEqual(result, undefined);
+        });
+
+        test('Detects pre-release alpha version from download-only output', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['python', 'list', '3.15'], { throwOnStdErr: false }).resolves({
+                stdout: 'cpython-3.15.0a6-macos-aarch64-none    <download available>',
+            });
+
+            const result = await getUvPythonVersionInfo('3.15');
+
+            assert.ok(result);
+            assert.strictEqual(result.version, '3.15.0a6');
+            assert.strictEqual(result.isPrerelease, true);
+            assert.strictEqual(result.path, undefined);
+        });
+
+        test('Detects pre-release beta version', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['python', 'list', '3.14'], { throwOnStdErr: false }).resolves({
+                stdout: 'cpython-3.14.0b2-linux-x86_64-gnu    <download available>',
+            });
+
+            const result = await getUvPythonVersionInfo('3.14');
+
+            assert.ok(result);
+            assert.strictEqual(result.version, '3.14.0b2');
+            assert.strictEqual(result.isPrerelease, true);
+        });
+
+        test('Detects pre-release candidate version', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
+                stdout: 'cpython-3.13.0rc1-macos-aarch64-none    <download available>',
+            });
+
+            const result = await getUvPythonVersionInfo('3.13');
+
+            assert.ok(result);
+            assert.strictEqual(result.version, '3.13.0rc1');
+            assert.strictEqual(result.isPrerelease, true);
+        });
+
+        test('Detects stable version as non-prerelease', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['python', 'list', '3.12'], { throwOnStdErr: false }).resolves({
+                stdout: 'cpython-3.12.5-macos-aarch64-none    <download available>',
+            });
+
+            const result = await getUvPythonVersionInfo('3.12');
+
+            assert.ok(result);
+            assert.strictEqual(result.version, '3.12.5');
+            assert.strictEqual(result.isPrerelease, false);
+        });
+
+        test('Returns local install info including path when version is pre-release', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['python', 'list', '3.14'], { throwOnStdErr: false }).resolves({
+                stdout: 'cpython-3.14.0a5-macos-aarch64-none    /usr/local/bin/python3.14',
+            });
+
+            const result = await getUvPythonVersionInfo('3.14');
+
+            assert.ok(result);
+            assert.strictEqual(result.version, '3.14.0a5');
+            assert.strictEqual(result.isPrerelease, true);
+            assert.strictEqual(result.path, '/usr/local/bin/python3.14');
+        });
+
+        test('Returns local install info for stable version', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
+                stdout: 'cpython-3.13.7-macos-aarch64-none     /usr/local/bin/python3.13 -> python3.13.real',
+            });
+
+            const result = await getUvPythonVersionInfo('3.13');
+
+            assert.ok(result);
+            assert.strictEqual(result.version, '3.13.7');
+            assert.strictEqual(result.isPrerelease, false);
+            assert.strictEqual(result.path, '/usr/local/bin/python3.13');
+        });
+
+        test('Prefers local install over download when both available', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
+                stdout: [
+                    'cpython-3.13.8-macos-aarch64-none    <download available>',
+                    'cpython-3.13.7-macos-aarch64-none    /usr/local/bin/python3.13',
+                ].join('\n'),
+            });
+
+            const result = await getUvPythonVersionInfo('3.13');
+
+            assert.ok(result);
+            // Should use the local install (3.13.7), not the download (3.13.8)
+            assert.strictEqual(result.version, '3.13.7');
+            assert.strictEqual(result.path, '/usr/local/bin/python3.13');
+        });
+
+        test('Returns undefined when version cannot be parsed from output', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
+                stdout: 'unexpected format that does not match',
+            });
+
+            const result = await getUvPythonVersionInfo('3.13');
+
+            assert.strictEqual(result, undefined);
+            assert.ok(traceVerboseStub.calledWith(sinon.match(/Could not parse version/)));
+        });
+
+        test('Handles multiple lines of output', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['python', 'list', '3.12'], { throwOnStdErr: false }).resolves({
+                stdout: [
+                    'cpython-3.12.9-macos-aarch64-none    <download available>',
+                    'cpython-3.12.8-macos-aarch64-none    <download available>',
+                    'cpython-3.12.7-macos-aarch64-none    <download available>',
+                ].join('\n'),
+            });
+
+            const result = await getUvPythonVersionInfo('3.12');
+
+            assert.ok(result);
+            // Should use the first line (highest version) when all are downloads
+            assert.strictEqual(result.version, '3.12.9');
+            assert.strictEqual(result.isPrerelease, false);
+        });
+    });
+
+    suite('updateUv Tests', () => {
+        test('Returns false when uv is not installed', async () => {
+            execStub.rejects(new Error('Command not found'));
+
+            const result = await updateUv();
+
+            assert.strictEqual(result, false);
+        });
+
+        test('Returns true when uv self update succeeds', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['self', 'update'], { throwOnStdErr: false }).resolves({ stdout: 'Updated' });
+
+            const result = await updateUv();
+
+            assert.strictEqual(result, true);
+            assert.ok(execStub.calledWith('uv', ['self', 'update'], { throwOnStdErr: false }));
+        });
+
+        test('Returns false when uv self update fails', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['self', 'update'], { throwOnStdErr: false }).rejects(new Error('Update failed'));
+
+            const result = await updateUv();
+
+            assert.strictEqual(result, false);
+            assert.ok(traceVerboseStub.calledWith(sinon.match(/Error running uv self update/)));
+        });
+
+        test('Logs success message on successful update', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['self', 'update'], { throwOnStdErr: false }).resolves({ stdout: 'Updated' });
+
+            await updateUv();
+
+            assert.ok(traceVerboseStub.calledWith('Running uv self update...'));
+            assert.ok(traceVerboseStub.calledWith('uv self update completed successfully'));
         });
     });
 });

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
@@ -12,6 +12,7 @@ import {
     getUvDirs,
     getUvPythonVersionInfo,
     updateUv,
+    installUvPython,
 } from '../../../../client/pythonEnvironments/common/environmentManagers/uv';
 import * as platformUtils from '../../../../client/common/utils/platform';
 import * as logging from '../../../../client/logging';
@@ -401,6 +402,98 @@ suite('UV Environment Tests', () => {
             assert.strictEqual(result.version, '3.12.9');
             assert.strictEqual(result.isPrerelease, false);
         });
+
+        suite('skipLocalPrereleases option', () => {
+            test('Skips local pre-release and returns downloadable stable version', async () => {
+                execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+                execStub.withArgs('uv', ['python', 'list', '3.14'], { throwOnStdErr: false }).resolves({
+                    stdout: [
+                        'cpython-3.14.0a5-macos-aarch64-none    /usr/local/bin/python3.14',
+                        'cpython-3.14.0-macos-aarch64-none    <download available>',
+                    ].join('\n'),
+                });
+
+                const result = await getUvPythonVersionInfo('3.14', { skipLocalPrereleases: true });
+
+                assert.ok(result);
+                // Should skip the local pre-release and return the downloadable stable version
+                assert.strictEqual(result.version, '3.14.0');
+                assert.strictEqual(result.isPrerelease, false);
+                assert.strictEqual(result.path, undefined);
+            });
+
+            test('Returns local stable version when available', async () => {
+                execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+                execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
+                    stdout: [
+                        'cpython-3.13.8-macos-aarch64-none    <download available>',
+                        'cpython-3.13.7-macos-aarch64-none    /usr/local/bin/python3.13',
+                    ].join('\n'),
+                });
+
+                const result = await getUvPythonVersionInfo('3.13', { skipLocalPrereleases: true });
+
+                assert.ok(result);
+                // Should return the local stable version
+                assert.strictEqual(result.version, '3.13.7');
+                assert.strictEqual(result.isPrerelease, false);
+                assert.strictEqual(result.path, '/usr/local/bin/python3.13');
+            });
+
+            test('Falls back to pre-release when no stable version available', async () => {
+                execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+                execStub.withArgs('uv', ['python', 'list', '3.15'], { throwOnStdErr: false }).resolves({
+                    stdout: [
+                        'cpython-3.15.0a6-macos-aarch64-none    /usr/local/bin/python3.15',
+                        'cpython-3.15.0a5-macos-aarch64-none    <download available>',
+                    ].join('\n'),
+                });
+
+                const result = await getUvPythonVersionInfo('3.15', { skipLocalPrereleases: true });
+
+                assert.ok(result);
+                // No stable version available, falls back to first line (local pre-release)
+                assert.strictEqual(result.version, '3.15.0a6');
+                assert.strictEqual(result.isPrerelease, true);
+            });
+
+            test('Prefers local stable over downloadable stable', async () => {
+                execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+                execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({
+                    stdout: [
+                        'cpython-3.13.0a5-macos-aarch64-none    /usr/local/bin/python3.13a',
+                        'cpython-3.13.8-macos-aarch64-none    <download available>',
+                        'cpython-3.13.7-macos-aarch64-none    /usr/local/bin/python3.13',
+                    ].join('\n'),
+                });
+
+                const result = await getUvPythonVersionInfo('3.13', { skipLocalPrereleases: true });
+
+                assert.ok(result);
+                // Should prefer local stable (3.13.7) over downloadable stable (3.13.8)
+                assert.strictEqual(result.version, '3.13.7');
+                assert.strictEqual(result.isPrerelease, false);
+                assert.strictEqual(result.path, '/usr/local/bin/python3.13');
+            });
+
+            test('Default behavior (no option) prefers local pre-release', async () => {
+                execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+                execStub.withArgs('uv', ['python', 'list', '3.14'], { throwOnStdErr: false }).resolves({
+                    stdout: [
+                        'cpython-3.14.0a5-macos-aarch64-none    /usr/local/bin/python3.14',
+                        'cpython-3.14.0-macos-aarch64-none    <download available>',
+                    ].join('\n'),
+                });
+
+                const result = await getUvPythonVersionInfo('3.14');
+
+                assert.ok(result);
+                // Default behavior: prefer local version (even if pre-release)
+                assert.strictEqual(result.version, '3.14.0a5');
+                assert.strictEqual(result.isPrerelease, true);
+                assert.strictEqual(result.path, '/usr/local/bin/python3.14');
+            });
+        });
     });
 
     suite('updateUv Tests', () => {
@@ -440,6 +533,52 @@ suite('UV Environment Tests', () => {
 
             assert.ok(traceVerboseStub.calledWith('Running uv self update...'));
             assert.ok(traceVerboseStub.calledWith('uv self update completed successfully'));
+        });
+    });
+
+    suite('installUvPython Tests', () => {
+        test('Returns false when uv is not installed', async () => {
+            execStub.rejects(new Error('Command not found'));
+
+            const result = await installUvPython('3.13.7');
+
+            assert.strictEqual(result, false);
+        });
+
+        test('Returns true when uv python install succeeds', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub
+                .withArgs('uv', ['python', 'install', '3.13.7'], { throwOnStdErr: false })
+                .resolves({ stdout: 'Installed' });
+
+            const result = await installUvPython('3.13.7');
+
+            assert.strictEqual(result, true);
+            assert.ok(execStub.calledWith('uv', ['python', 'install', '3.13.7'], { throwOnStdErr: false }));
+        });
+
+        test('Returns false when uv python install fails', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub
+                .withArgs('uv', ['python', 'install', '3.13.7'], { throwOnStdErr: false })
+                .rejects(new Error('Install failed'));
+
+            const result = await installUvPython('3.13.7');
+
+            assert.strictEqual(result, false);
+            assert.ok(traceVerboseStub.calledWith(sinon.match(/Error running uv python install/)));
+        });
+
+        test('Logs success message on successful install', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub
+                .withArgs('uv', ['python', 'install', '3.14.0'], { throwOnStdErr: false })
+                .resolves({ stdout: 'Installed' });
+
+            await installUvPython('3.14.0');
+
+            assert.ok(traceVerboseStub.calledWith('Running uv python install 3.14.0...'));
+            assert.ok(traceVerboseStub.calledWith('uv python install 3.14.0 completed successfully'));
         });
     });
 });

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
@@ -370,6 +370,20 @@ suite('UV Environment Tests', () => {
             assert.strictEqual(result.path, 'C:\\Users\\test\\AppData\\Local\\uv\\python\\python.exe');
         });
 
+        test('Extracts Windows path with spaces correctly', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['python', 'list', '3.12'], { throwOnStdErr: false }).resolves({
+                stdout: 'cpython-3.12.5-windows-x86_64-none    C:\\Program Files\\Python312\\python.exe',
+            });
+
+            const result = await getUvPythonVersionInfo('3.12');
+
+            assert.ok(result);
+            assert.strictEqual(result.version, '3.12.5');
+            assert.strictEqual(result.isPrerelease, false);
+            assert.strictEqual(result.path, 'C:\\Program Files\\Python312\\python.exe');
+        });
+
         test('Prefers local install over download when both available', async () => {
             execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
             execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uv.unit.test.ts
@@ -356,6 +356,20 @@ suite('UV Environment Tests', () => {
             assert.strictEqual(result.path, '/usr/local/bin/python3.13');
         });
 
+        test('Extracts Windows path correctly', async () => {
+            execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
+            execStub.withArgs('uv', ['python', 'list', '3.12'], { throwOnStdErr: false }).resolves({
+                stdout: 'cpython-3.12.5-windows-x86_64-none    C:\\Users\\test\\AppData\\Local\\uv\\python\\python.exe',
+            });
+
+            const result = await getUvPythonVersionInfo('3.12');
+
+            assert.ok(result);
+            assert.strictEqual(result.version, '3.12.5');
+            assert.strictEqual(result.isPrerelease, false);
+            assert.strictEqual(result.path, 'C:\\Users\\test\\AppData\\Local\\uv\\python\\python.exe');
+        });
+
         test('Prefers local install over download when both available', async () => {
             execStub.withArgs('uv', ['python', 'dir'], { throwOnStdErr: true }).resolves({ stdout: customDir });
             execStub.withArgs('uv', ['python', 'list', '3.13'], { throwOnStdErr: false }).resolves({

--- a/extensions/positron-python/src/test/pythonEnvironments/creation/provider/uvCreationProvider.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/creation/provider/uvCreationProvider.unit.test.ts
@@ -19,7 +19,7 @@ import * as rawProcessApis from '../../../../client/common/process/rawProcessApi
 import { Output } from '../../../../client/common/process/types';
 import { createDeferred } from '../../../../client/common/utils/async';
 import * as commonUtils from '../../../../client/pythonEnvironments/creation/common/commonUtils';
-import { CreateEnv } from '../../../../client/common/utils/localize';
+import { Common, CreateEnv } from '../../../../client/common/utils/localize';
 import * as uv from '../../../../client/pythonEnvironments/common/environmentManagers/uv';
 import * as venvUtils from '../../../../client/pythonEnvironments/creation/provider/venvUtils';
 import {
@@ -354,5 +354,173 @@ suite('UV Creation provider tests', () => {
         });
         assert.isTrue(showErrorMessageWithLogsStub.notCalled);
         assert.isTrue(pickExistingVenvActionStub.calledOnce);
+    });
+
+    suite('Pre-release version handling', () => {
+        let showWarningMessageStub: sinon.SinonStub;
+        let updateUvStub: sinon.SinonStub;
+        let installUvPythonStub: sinon.SinonStub;
+
+        const workspace1 = {
+            uri: Uri.file(path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src', 'testMultiRootWkspc', 'workspace1')),
+            name: 'workspace1',
+            index: 0,
+        };
+
+        setup(() => {
+            showWarningMessageStub = sinon.stub(windowApis, 'showWarningMessage');
+            updateUvStub = sinon.stub(uv, 'updateUv');
+            installUvPythonStub = sinon.stub(uv, 'installUvPython');
+
+            pickWorkspaceFolderStub.resolves(workspace1);
+            pickPythonVersionStub.resolves('3.14');
+
+            withProgressStub.callsFake(
+                (
+                    _options: ProgressOptions,
+                    task: (
+                        progress: CreateEnvironmentProgress,
+                        token?: CancellationToken,
+                    ) => Thenable<CreateEnvironmentResult>,
+                ) => task(progressMock.object),
+            );
+        });
+
+        test('User cancels when prerelease warning appears', async () => {
+            getUvPythonVersionInfoStub.resolves({ version: '3.14.0a5', isPrerelease: true, path: undefined });
+            showWarningMessageStub.resolves(Common.cancel);
+
+            const result = await uvProvider.createEnvironment();
+
+            assert.isUndefined(result);
+            assert.isTrue(showWarningMessageStub.calledOnce);
+            assert.isTrue(execObservableStub.notCalled);
+        });
+
+        test('User closes dialog (undefined) when prerelease warning appears', async () => {
+            getUvPythonVersionInfoStub.resolves({ version: '3.14.0a5', isPrerelease: true, path: undefined });
+            showWarningMessageStub.resolves(undefined);
+
+            const result = await uvProvider.createEnvironment();
+
+            assert.isUndefined(result);
+            assert.isTrue(showWarningMessageStub.calledOnce);
+            assert.isTrue(execObservableStub.notCalled);
+        });
+
+        test('User chooses Proceed Anyway with prerelease version', async () => {
+            getUvPythonVersionInfoStub.resolves({ version: '3.14.0a5', isPrerelease: true, path: undefined });
+            showWarningMessageStub.resolves(CreateEnv.Uv.proceedAnyway);
+
+            const deferred = createDeferred();
+            let _next: undefined | ((value: Output<string>) => void);
+            let _complete: undefined | (() => void);
+            execObservableStub.callsFake(() => {
+                deferred.resolve();
+                return {
+                    proc: { exitCode: 0 },
+                    out: {
+                        subscribe: (
+                            next?: (value: Output<string>) => void,
+                            _error?: (error: unknown) => void,
+                            complete?: () => void,
+                        ) => {
+                            _next = next;
+                            _complete = complete;
+                        },
+                    },
+                    dispose: () => undefined,
+                };
+            });
+
+            const promise = uvProvider.createEnvironment();
+            await deferred.promise;
+
+            _next!({ out: 'Created virtual environment', source: 'stdout' });
+            _complete!();
+
+            const result = await promise;
+            assert.isDefined(result?.path);
+            assert.isTrue(showWarningMessageStub.calledOnce);
+            assert.isTrue(updateUvStub.notCalled);
+        });
+
+        test('User chooses Update uv and stable version becomes available', async () => {
+            // First call returns prerelease, second call (after update) returns stable
+            getUvPythonVersionInfoStub
+                .onFirstCall()
+                .resolves({ version: '3.14.0a5', isPrerelease: true, path: undefined });
+            getUvPythonVersionInfoStub
+                .onSecondCall()
+                .resolves({ version: '3.14.0', isPrerelease: false, path: undefined });
+
+            showWarningMessageStub.resolves(CreateEnv.Uv.updateUv);
+            updateUvStub.resolves(true);
+            installUvPythonStub.resolves(true);
+
+            const deferred = createDeferred();
+            let _next: undefined | ((value: Output<string>) => void);
+            let _complete: undefined | (() => void);
+            execObservableStub.callsFake(() => {
+                deferred.resolve();
+                return {
+                    proc: { exitCode: 0 },
+                    out: {
+                        subscribe: (
+                            next?: (value: Output<string>) => void,
+                            _error?: (error: unknown) => void,
+                            complete?: () => void,
+                        ) => {
+                            _next = next;
+                            _complete = complete;
+                        },
+                    },
+                    dispose: () => undefined,
+                };
+            });
+
+            const promise = uvProvider.createEnvironment();
+            await deferred.promise;
+
+            _next!({ out: 'Created virtual environment', source: 'stdout' });
+            _complete!();
+
+            const result = await promise;
+            assert.isDefined(result?.path);
+            assert.isTrue(updateUvStub.calledOnce);
+            assert.isTrue(installUvPythonStub.calledOnce);
+        });
+
+        test('User chooses Update uv but only prerelease still available - fails', async () => {
+            getUvPythonVersionInfoStub
+                .onFirstCall()
+                .resolves({ version: '3.14.0a5', isPrerelease: true, path: undefined });
+            getUvPythonVersionInfoStub
+                .onSecondCall()
+                .resolves({ version: '3.14.0a6', isPrerelease: true, path: undefined });
+
+            showWarningMessageStub.resolves(CreateEnv.Uv.updateUv);
+            updateUvStub.resolves(true);
+
+            const result = await uvProvider.createEnvironment();
+
+            assert.isDefined(result?.error);
+            assert.isTrue(updateUvStub.calledOnce);
+            assert.isTrue(execObservableStub.notCalled);
+            assert.isTrue(showErrorMessageWithLogsStub.calledOnce);
+        });
+
+        test('User chooses Update uv but update fails', async () => {
+            getUvPythonVersionInfoStub.resolves({ version: '3.14.0a5', isPrerelease: true, path: undefined });
+            showWarningMessageStub.resolves(CreateEnv.Uv.updateUv);
+            updateUvStub.resolves(false);
+
+            const result = await uvProvider.createEnvironment();
+
+            assert.isDefined(result?.error);
+            assert.isTrue(updateUvStub.calledOnce);
+            assert.isTrue(execObservableStub.notCalled);
+            assert.isTrue(showErrorMessageWithLogsStub.calledOnce);
+        });
     });
 });

--- a/extensions/positron-python/src/test/pythonEnvironments/creation/provider/uvCreationProvider.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/creation/provider/uvCreationProvider.unit.test.ts
@@ -33,6 +33,7 @@ suite('UV Creation provider tests', () => {
     let uvProvider: CreateEnvironmentProvider;
     let progressMock: typemoq.IMock<CreateEnvironmentProgress>;
     let isUvInstalledStub: sinon.SinonStub;
+    let getUvPythonVersionInfoStub: sinon.SinonStub;
     let pickPythonVersionStub: sinon.SinonStub;
     let pickWorkspaceFolderStub: sinon.SinonStub;
     let execObservableStub: sinon.SinonStub;
@@ -45,6 +46,9 @@ suite('UV Creation provider tests', () => {
         pickWorkspaceFolderStub = sinon.stub(wsSelect, 'pickWorkspaceFolder');
         isUvInstalledStub = sinon.stub(uv, 'isUvInstalled');
         isUvInstalledStub.resolves(true);
+        // Return a stable (non-prerelease) version to avoid triggering the prerelease warning flow
+        getUvPythonVersionInfoStub = sinon.stub(uv, 'getUvPythonVersionInfo');
+        getUvPythonVersionInfoStub.resolves({ version: '3.12.5', isPrerelease: false, path: undefined });
         pickPythonVersionStub = sinon.stub(uvUtils, 'pickPythonVersion');
         execObservableStub = sinon.stub(rawProcessApis, 'execObservable');
         withProgressStub = sinon.stub(windowApis, 'withProgress');

--- a/extensions/positron-python/src/test/pythonEnvironments/creation/provider/uvCreationProvider.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/creation/provider/uvCreationProvider.unit.test.ts
@@ -358,8 +358,7 @@ suite('UV Creation provider tests', () => {
 
     suite('Pre-release version handling', () => {
         let showWarningMessageStub: sinon.SinonStub;
-        let updateUvStub: sinon.SinonStub;
-        let installUvPythonStub: sinon.SinonStub;
+        let getStablePythonAfterUpdateStub: sinon.SinonStub;
 
         const workspace1 = {
             uri: Uri.file(path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src', 'testMultiRootWkspc', 'workspace1')),
@@ -369,8 +368,7 @@ suite('UV Creation provider tests', () => {
 
         setup(() => {
             showWarningMessageStub = sinon.stub(windowApis, 'showWarningMessage');
-            updateUvStub = sinon.stub(uv, 'updateUv');
-            installUvPythonStub = sinon.stub(uv, 'installUvPython');
+            getStablePythonAfterUpdateStub = sinon.stub(uv, 'getStablePythonAfterUpdate');
 
             pickWorkspaceFolderStub.resolves(workspace1);
             pickPythonVersionStub.resolves('3.14');
@@ -442,21 +440,13 @@ suite('UV Creation provider tests', () => {
             const result = await promise;
             assert.isDefined(result?.path);
             assert.isTrue(showWarningMessageStub.calledOnce);
-            assert.isTrue(updateUvStub.notCalled);
+            assert.isTrue(getStablePythonAfterUpdateStub.notCalled);
         });
 
         test('User chooses Update uv and stable version becomes available', async () => {
-            // First call returns prerelease, second call (after update) returns stable
-            getUvPythonVersionInfoStub
-                .onFirstCall()
-                .resolves({ version: '3.14.0a5', isPrerelease: true, path: undefined });
-            getUvPythonVersionInfoStub
-                .onSecondCall()
-                .resolves({ version: '3.14.0', isPrerelease: false, path: undefined });
-
+            getUvPythonVersionInfoStub.resolves({ version: '3.14.0a5', isPrerelease: true, path: undefined });
             showWarningMessageStub.resolves(CreateEnv.Uv.updateUv);
-            updateUvStub.resolves(true);
-            installUvPythonStub.resolves(true);
+            getStablePythonAfterUpdateStub.resolves({ success: true, version: '3.14.0', wasInstalled: true });
 
             const deferred = createDeferred();
             let _next: undefined | ((value: Output<string>) => void);
@@ -487,25 +477,59 @@ suite('UV Creation provider tests', () => {
 
             const result = await promise;
             assert.isDefined(result?.path);
-            assert.isTrue(updateUvStub.calledOnce);
-            assert.isTrue(installUvPythonStub.calledOnce);
+            assert.isTrue(getStablePythonAfterUpdateStub.calledOnce);
+        });
+
+        test('User chooses Update uv and stable version is already local', async () => {
+            getUvPythonVersionInfoStub.resolves({ version: '3.14.0a5', isPrerelease: true, path: undefined });
+            showWarningMessageStub.resolves(CreateEnv.Uv.updateUv);
+            getStablePythonAfterUpdateStub.resolves({ success: true, version: '3.14.0', wasInstalled: false });
+
+            const deferred = createDeferred();
+            let _next: undefined | ((value: Output<string>) => void);
+            let _complete: undefined | (() => void);
+            execObservableStub.callsFake(() => {
+                deferred.resolve();
+                return {
+                    proc: { exitCode: 0 },
+                    out: {
+                        subscribe: (
+                            next?: (value: Output<string>) => void,
+                            _error?: (error: unknown) => void,
+                            complete?: () => void,
+                        ) => {
+                            _next = next;
+                            _complete = complete;
+                        },
+                    },
+                    dispose: () => undefined,
+                };
+            });
+
+            const promise = uvProvider.createEnvironment();
+            await deferred.promise;
+
+            _next!({ out: 'Created virtual environment', source: 'stdout' });
+            _complete!();
+
+            const result = await promise;
+            assert.isDefined(result?.path);
+            assert.isTrue(getStablePythonAfterUpdateStub.calledOnce);
         });
 
         test('User chooses Update uv but only prerelease still available - fails', async () => {
-            getUvPythonVersionInfoStub
-                .onFirstCall()
-                .resolves({ version: '3.14.0a5', isPrerelease: true, path: undefined });
-            getUvPythonVersionInfoStub
-                .onSecondCall()
-                .resolves({ version: '3.14.0a6', isPrerelease: true, path: undefined });
-
+            getUvPythonVersionInfoStub.resolves({ version: '3.14.0a5', isPrerelease: true, path: undefined });
             showWarningMessageStub.resolves(CreateEnv.Uv.updateUv);
-            updateUvStub.resolves(true);
+            getStablePythonAfterUpdateStub.resolves({
+                success: false,
+                error: 'no_stable_version',
+                version: '3.14.0a6',
+            });
 
             const result = await uvProvider.createEnvironment();
 
             assert.isDefined(result?.error);
-            assert.isTrue(updateUvStub.calledOnce);
+            assert.isTrue(getStablePythonAfterUpdateStub.calledOnce);
             assert.isTrue(execObservableStub.notCalled);
             assert.isTrue(showErrorMessageWithLogsStub.calledOnce);
         });
@@ -513,12 +537,25 @@ suite('UV Creation provider tests', () => {
         test('User chooses Update uv but update fails', async () => {
             getUvPythonVersionInfoStub.resolves({ version: '3.14.0a5', isPrerelease: true, path: undefined });
             showWarningMessageStub.resolves(CreateEnv.Uv.updateUv);
-            updateUvStub.resolves(false);
+            getStablePythonAfterUpdateStub.resolves({ success: false, error: 'update_failed' });
 
             const result = await uvProvider.createEnvironment();
 
             assert.isDefined(result?.error);
-            assert.isTrue(updateUvStub.calledOnce);
+            assert.isTrue(getStablePythonAfterUpdateStub.calledOnce);
+            assert.isTrue(execObservableStub.notCalled);
+            assert.isTrue(showErrorMessageWithLogsStub.calledOnce);
+        });
+
+        test('User chooses Update uv but Python install fails', async () => {
+            getUvPythonVersionInfoStub.resolves({ version: '3.14.0a5', isPrerelease: true, path: undefined });
+            showWarningMessageStub.resolves(CreateEnv.Uv.updateUv);
+            getStablePythonAfterUpdateStub.resolves({ success: false, error: 'install_failed', version: '3.14.0' });
+
+            const result = await uvProvider.createEnvironment();
+
+            assert.isDefined(result?.error);
+            assert.isTrue(getStablePythonAfterUpdateStub.calledOnce);
             assert.isTrue(execObservableStub.notCalled);
             assert.isTrue(showErrorMessageWithLogsStub.calledOnce);
         });

--- a/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
@@ -419,5 +419,46 @@ suite('Native Python API', () => {
         assert.isTrue(isUvEnvironmentStub.calledTwice);
         assert.isTrue(isUvEnvironmentStub.calledWith('/home/user/.local/share/uv/python/cpython-3.10'));
     });
+
+    test('Pre-release version (alpha) is included in display name', async () => {
+        // Create a test environment with an alpha version (e.g., Python 3.14.0a5)
+        const alphaEnv: NativeEnvInfo = {
+            displayName: 'Alpha Python',
+            name: 'alpha_python',
+            executable: '/usr/bin/python3.14',
+            kind: NativePythonEnvironmentKind.LinuxGlobal,
+            version: '3.14.0a5', // Alpha version
+            prefix: '/usr/bin',
+        };
+
+        mockFinder
+            .setup((f) => f.refresh())
+            .returns(() => {
+                async function* generator() {
+                    yield* [alphaEnv];
+                }
+                return generator();
+            })
+            .verifiable(typemoq.Times.once());
+
+        mockFinder.setup((f) => f.resolve(typemoq.It.isAny())).verifiable(typemoq.Times.never());
+
+        await api.triggerRefresh();
+        const envs = api.getEnvs();
+        assert.equal(envs.length, 1);
+
+        const addedEnv = envs[0];
+        assert.isDefined(addedEnv);
+        // Verify that the display name includes the alpha suffix
+        assert.include(addedEnv.display ?? '', '3.14.0a5');
+        assert.include(addedEnv.detailedDisplayName ?? '', '3.14.0a5');
+        // Verify version info
+        assert.equal(addedEnv.version.major, 3);
+        assert.equal(addedEnv.version.minor, 14);
+        assert.equal(addedEnv.version.micro, 0);
+        assert.isDefined(addedEnv.version.release);
+        assert.equal(addedEnv.version.release?.level, 'alpha');
+        assert.equal(addedEnv.version.release?.serial, 5);
+    });
     // --- End Positron ---
 });


### PR DESCRIPTION
Previously, when using `uv` to download Python, you might get a pre-release Python (like 3.15.0a6) if you haven't updated `uv` in a while.

Now: 
- check if we will use a pre-releas
- if so, show warning dialog with three options: "Update uv", "Proceed Anyway", or  "Cancel". 
- "Update uv" ->  run the command via `exec`, and we automatically re-check whether a stable Python is now available. 
- If the version is still a pre-release (maybe it's genuinely the latest like for 3.15), we show a brief notice and proceed anyway.

Also: Python version strings in the Console now display pre-release suffixes (3.14.0a5) instead of just the base version ‼️ 

<img width="491" height="110" alt="Screenshot 2026-03-05 at 2 40 14 PM" src="https://github.com/user-attachments/assets/3fda23c1-a99f-4d4a-aab2-7cbcb7ec6243" />


### Release Notes


#### New Features

- N/A

#### Bug Fixes

- #11787 Do not install Python pre-releases if possible with uv.
- #10758 Show full version of Python in the console, including alpha/beta/pre-release.


### QA Notes

@:new-folder-flow

this is a bit awkward to check.

to check the "only prereleases available for this version" flow, i added 3.15 to this line of code and tried to create a new python project.

https://github.com/posit-dev/positron/blob/fd70f3f2b1b54bc9eb45522ede9113215cec121a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/uvUtils.ts#L10

To test out the "older version of uv that only has pre-releases of a version available", run this to get an old-enough version of `uv`

```bash
curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.8.19/uv-installer.sh | sh;
```

this `uv` version only includes rc versions of 3.14. use it to try to make a 3.14 project, like so.


https://github.com/user-attachments/assets/8402490b-8200-4e60-b7b6-88abf4ee3190

please ignore the breakpoint moments 😂 