### PR TITLE
Fix PositronModalPopup laying out at 0,0 after resize

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -432,6 +432,14 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 
 		// Add the onResize event handler.
 		disposableStore.add(props.renderer.onResize(e => {
+			// If there's an anchor point, or if there's an anchor element and it has been removed from the DOM,
+			// the popup cannot be laid out accurately because we don't know enough about what has changed in the
+			// DOM as a result of the resize. In this case, dispose the renderer and return.
+			if (props.anchorPoint || (props.anchorElement && !props.anchorElement.isConnected)) {
+				props.renderer.dispose();
+				return;
+			}
+
 			// On resize, update the layout.
 			updatePopupLayout();
 		}));


### PR DESCRIPTION
# Fix PositronModalPopup laying out at 0,0 after resize

## Issue

When the anchor element for a `PositronModalPopup` is removed from the DOM, subsequent resize events caused the popup to attempt layout calculations with a detached element, resulting in the popup appearing at coordinates 0,0.

## Fix

Add logic to the `onResize` handler to dispose the popup when the anchor element is no longer in the DOM and when an `anchorPoint` is specified.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #12159 Fix modal popups laying out at 0,0 after resize.

### QA Notes

- N/A

Tests:
@:critical
@:modal