### PR TITLE
e2e: fix flaky basic dash app 

### DIFF
--- a/test/e2e/pages/editor.ts
+++ b/test/e2e/pages/editor.ts
@@ -28,6 +28,20 @@ export class Editor {
 	constructor(private code: Code) { }
 
 	/**
+	 * Wait for content to be visible in the editor viewer frame.
+	 */
+	async expectEditorViewerContentVisible(
+		getLocator: (frame: FrameLocator) => Locator,
+		options?: { timeout?: number }
+	): Promise<void> {
+		const { timeout = 30000 } = options ?? {};
+		const frame = !this.code.electronApp
+			? this.getEditorViewerFrame().frameLocator('iframe')
+			: this.getEditorViewerFrame();
+		await expect(getLocator(frame)).toBeVisible({ timeout });
+	}
+
+	/**
 	 * Action: Enter text in the editor
 	 * @param text the text to type into the editor
 	 * @param pressEnter whether to press Enter after typing the text
@@ -62,14 +76,16 @@ export class Editor {
 	}
 
 	async pressPlay(skipToastVerification: boolean = false): Promise<void> {
-		await this.code.driver.page.locator(PLAY_BUTTON).click();
+		await test.step('Press play button', async () => {
+			await this.code.driver.page.locator(PLAY_BUTTON).click();
 
-		if (!skipToastVerification) {
-			// await appearance and disappearance of the toast
-			const appRunningToast = this.code.driver.page.locator('.notifications-toasts').getByText(/Running.*application:/);
-			await expect(appRunningToast).toBeVisible({ timeout: 30000 });
-			await expect(appRunningToast).not.toBeVisible({ timeout: 45000 });
-		}
+			if (!skipToastVerification) {
+				// await appearance and disappearance of the toast
+				const appRunningToast = this.code.driver.page.locator('.notifications-toasts').getByText(/Running.*application:/);
+				await expect(appRunningToast).toBeVisible({ timeout: 30000 });
+				await expect(appRunningToast).not.toBeVisible({ timeout: 45000 });
+			}
+		});
 	}
 
 	async pressToLine(filename: string, lineNumber: number, press: string): Promise<void> {

--- a/test/e2e/pages/viewer.ts
+++ b/test/e2e/pages/viewer.ts
@@ -10,6 +10,7 @@ const OUTER_FRAME = '.webview';
 const INNER_FRAME = '#active-frame';
 const REFRESH_BUTTON = '.codicon-positron-refresh';
 const VIEWER_PANEL = '[id="workbench.panel.positronPreview"]';
+const ACTION_BAR = '.positron-action-bar';
 
 const FULL_APP = 'body';
 
@@ -17,6 +18,7 @@ export class Viewer {
 
 	get fullApp(): Locator { return this.code.driver.page.locator(FULL_APP); }
 	get viewerFrame(): FrameLocator { return this.code.driver.page.frameLocator(OUTER_FRAME).frameLocator(INNER_FRAME); }
+	get interruptButton(): Locator { return this.code.driver.page.locator(ACTION_BAR).getByRole('button', { name: 'Interrupt execution' }); }
 
 	constructor(private code: Code) { }
 
@@ -49,6 +51,43 @@ export class Viewer {
 	async expectViewerPanelVisible(timeout = 10000): Promise<void> {
 		await test.step('Expect viewer panel visible', async () => {
 			await expect(this.code.driver.page.locator(VIEWER_PANEL)).toBeVisible({ timeout });
+		});
+	}
+
+	/**
+	 * Wait for content to be visible in the viewer frame, with retry on failure.
+	 *
+	 * Dev servers (Flask, Dash, etc.) may report "running" before actually accepting
+	 * connections, causing ERR_CONNECTION_RESET. If content isn't visible, the onRetry
+	 * callback is called to allow restarting the server before the next attempt.
+	 */
+	async expectContentVisible(
+		getLocator: (frame: FrameLocator) => Locator,
+		options?: { timeout?: number; onRetry?: () => Promise<void> }
+	): Promise<void> {
+		const { timeout = 60000, onRetry } = options ?? {};
+
+		await test.step('Expect content visible in viewer frame', async () => {
+			await expect(async () => {
+				const frame = !this.code.electronApp
+					? this.viewerFrame.frameLocator('iframe')
+					: this.getViewerFrame();
+				const locator = getLocator(frame);
+
+				// Check if content is visible
+				let isVisible = false;
+				try {
+					isVisible = await locator.isVisible();
+				} catch {
+					// Frame might not be accessible after ERR_CONNECTION_RESET
+				}
+
+				if (!isVisible && onRetry) {
+					await onRetry();
+				}
+
+				await expect(locator).toBeVisible({ timeout: 5000 });
+			}).toPass({ timeout });
 		});
 	}
 }

--- a/test/e2e/pages/viewer.ts
+++ b/test/e2e/pages/viewer.ts
@@ -69,6 +69,7 @@ export class Viewer {
 
 		await test.step('Expect content visible in viewer frame', async () => {
 			await expect(async () => {
+				// Get the frame and locator for the content
 				const frame = !this.code.electronApp
 					? this.viewerFrame.frameLocator('iframe')
 					: this.getViewerFrame();
@@ -82,10 +83,12 @@ export class Viewer {
 					// Frame might not be accessible after ERR_CONNECTION_RESET
 				}
 
+				// If content isn't visible, call onRetry to allow restarting the server
 				if (!isVisible && onRetry) {
 					await onRetry();
 				}
 
+				// Expect the content to be visible
 				await expect(locator).toBeVisible({ timeout: 5000 });
 			}).toPass({ timeout });
 		});

--- a/test/e2e/tests/apps/python-apps.test.ts
+++ b/test/e2e/tests/apps/python-apps.test.ts
@@ -73,10 +73,7 @@ test.describe('Python Applications', {
 
 			await openFile(join('workspaces', 'python_apps', appTest.filePath));
 
-			// Press play and verify the content is visible in the viewer frame.
-			// If content isn't visible (e.g., due to ERR_CONNECTION_RESET), interrupt
-			// the server and restart it - the second attempt usually succeeds since
-			// Python/packages are already loaded.
+			// Press play and verify the content is visible in the viewer frame
 			await editor.pressPlay();
 			await viewer.expectContentVisible(appTest.locator, {
 				onRetry: async () => {

--- a/test/e2e/tests/apps/python-apps.test.ts
+++ b/test/e2e/tests/apps/python-apps.test.ts
@@ -73,10 +73,7 @@ test.describe('Python Applications', {
 
 			await openFile(join('workspaces', 'python_apps', appTest.filePath));
 
-			// Press play and verify the content is visible in the viewer frame.
-			// If content isn't visible (e.g., due to ERR_CONNECTION_RESET), interrupt
-			// the server and restart it - the second attempt usually succeeds since
-			// Python/packages are already loaded.
+			// Press play and verify the content is visible in the viewer frame
 			await editor.pressPlay();
 			await viewer.expectContentVisible(appTest.locator, {
 				onRetry: async () => {
@@ -86,7 +83,7 @@ test.describe('Python Applications', {
 				}
 			});
 
-			// Verify the content is also visible in the editor viewer frame
+			// Click the "Open in Editor" button and verify the content is visible in the editor viewer frame
 			await viewer.openViewerToEditor();
 			await viewer.clearViewer();
 			await editor.expectEditorViewerContentVisible(appTest.locator);

--- a/test/e2e/tests/apps/python-apps.test.ts
+++ b/test/e2e/tests/apps/python-apps.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { FrameLocator, Locator } from '@playwright/test';
 import { test, expect, tags } from '../_test.setup';
 import { join } from 'path';
 
@@ -10,193 +11,114 @@ test.use({
 	suiteId: __filename
 });
 
+interface AppTestConfig {
+	name: string;
+	tags: string[];
+	filePath: string;
+	locator: (frame: FrameLocator) => Locator;
+}
+
+const appTests: AppTestConfig[] = [
+	{
+		name: 'Dash',
+		tags: [tags.WIN, tags.WORKBENCH],
+		filePath: 'dash_example/dash_example.py',
+		locator: frame => frame.getByText('Hello World'),
+	},
+	{
+		name: 'FastAPI',
+		tags: [tags.WIN],
+		filePath: 'fastapi_example/fastapi_example.py',
+		locator: frame => frame.getByText('FastAPI'),
+	},
+	{
+		name: 'Gradio',
+		tags: [tags.WIN],
+		filePath: 'gradio_example/gradio_example.py',
+		locator: frame => frame.getByRole('button', { name: 'Submit' }),
+	},
+	{
+		name: 'Streamlit',
+		tags: [tags.WEB, tags.WIN],
+		filePath: 'streamlit_example/streamlit_example.py',
+		locator: frame => frame.getByRole('button', { name: 'Deploy' }),
+	},
+	{
+		name: 'Flask',
+		tags: [tags.WEB, tags.WIN],
+		filePath: 'flask_example/__init__.py',
+		locator: frame => frame.getByText('Log In'),
+	},
+];
+
 test.describe('Python Applications', {
 	tag: [tags.CRITICAL, tags.APPS, tags.VIEWER, tags.EDITOR, tags.WEB]
 }, () => {
 
 	test.afterEach(async function ({ app, hotKeys }) {
+		const { terminal, viewer } = app.workbench;
+
 		await hotKeys.closeAllEditors();
 		await hotKeys.focusConsole();
-		await app.workbench.terminal.clickTerminalTab(); // ensure we are in the terminal tab for cleanup
-		await app.workbench.terminal.sendKeysToTerminal('Control+C');
-		await app.workbench.viewer.clearViewer();
+		await terminal.clickTerminalTab();
+		await terminal.sendKeysToTerminal('Control+C');
+		await viewer.clearViewer();
 	});
 
-	test('Python - Verify Basic Dash App', { tag: [tags.WIN, tags.WORKBENCH] }, async function ({ app, openFile, python }) {
-		const viewer = app.workbench.viewer;
+	for (const appTest of appTests) {
+		test(`Python - Verify Basic ${appTest.name} App`, {
+			tag: appTest.tags
+		}, async function ({ app, openFile, python }) {
+			const { viewer, editor, terminal } = app.workbench;
 
-		await openFile(join('workspaces', 'python_apps', 'dash_example', 'dash_example.py'));
-		await app.workbench.editor.pressPlay();
+			await openFile(join('workspaces', 'python_apps', appTest.filePath));
 
-		await expect(
-			app.web
-				? viewer.viewerFrame.frameLocator('iframe').getByText('Hello World')
-				: viewer.getViewerFrame().getByText('Hello World')
-		).toBeVisible({ timeout: 30000 });
+			// Press play and verify the content is visible in the viewer frame.
+			// If content isn't visible (e.g., due to ERR_CONNECTION_RESET), interrupt
+			// the server and restart it - the second attempt usually succeeds since
+			// Python/packages are already loaded.
+			await editor.pressPlay();
+			await viewer.expectContentVisible(appTest.locator, {
+				onRetry: async () => {
+					await terminal.clickTerminalTab();
+					await terminal.sendKeysToTerminal('Control+C');
+					await editor.pressPlay();
+				}
+			});
 
-		await test.step('Verify app can be opened in editor', async () => {
-			await app.workbench.viewer.openViewerToEditor();
-			await app.workbench.viewer.clearViewer();
-
-			const editorFrameLocator = app.workbench.editor.getEditorViewerFrame();
-
-			await expect(
-				app.web
-					? editorFrameLocator.frameLocator('iframe').getByText('Hello World')
-					: editorFrameLocator.getByText('Hello World')
-			).toBeVisible({ timeout: 30000 });
+			// Verify the content is also visible in the editor viewer frame
+			await viewer.openViewerToEditor();
+			await viewer.clearViewer();
+			await editor.expectEditorViewerContentVisible(appTest.locator);
 		});
-	});
-
-	test('Python - Verify Basic FastAPI App', {
-		tag: [tags.WIN]
-	}, async function ({ app, openFile, python }) {
-		const viewer = app.workbench.viewer;
-
-		await openFile(join('workspaces', 'python_apps', 'fastapi_example', 'fastapi_example.py'));
-		await app.workbench.editor.pressPlay();
-
-		await expect(
-			app.web
-				? viewer.viewerFrame.frameLocator('iframe').getByText('FastAPI')
-				: viewer.getViewerFrame().getByText('FastAPI')
-		).toBeVisible({ timeout: 30000 });
-
-		await test.step('Verify app can be opened in editor', async () => {
-			await app.workbench.viewer.openViewerToEditor();
-			await app.workbench.viewer.clearViewer();
-
-			const editorHeaderLocator = app.web
-				? app.workbench.editor.viewerFrame.frameLocator('iframe').getByRole('heading', { name: 'FastAPI' })
-				: app.workbench.editor.viewerFrame.getByRole('heading', { name: 'FastAPI' });
-
-			await expect(editorHeaderLocator).toBeVisible({ timeout: 30000 });
-		});
-	});
-
-	test('Python - Verify Basic Gradio App', {
-		tag: [tags.WIN],
-	}, async function ({ app, openFile, python }) {
-		const viewer = app.workbench.viewer;
-
-		await openFile(join('workspaces', 'python_apps', 'gradio_example', 'gradio_example.py'));
-		await app.workbench.editor.pressPlay();
-
-		await expect(
-			app.web
-				? viewer.viewerFrame.frameLocator('iframe').getByRole('button', { name: 'Submit' })
-				: viewer.getViewerFrame().getByRole('button', { name: 'Submit' })
-		).toBeVisible({ timeout: 45000 });
-
-		await test.step('Verify app can be opened in editor', async () => {
-			await app.workbench.viewer.openViewerToEditor();
-			await app.workbench.viewer.clearViewer();
-
-			const editorFrameLocator = app.workbench.editor.getEditorViewerFrame();
-
-			await expect(
-				app.web
-					? editorFrameLocator.frameLocator('iframe').getByRole('button', { name: 'Submit' })
-					: editorFrameLocator.getByRole('button', { name: 'Submit' })
-			).toBeVisible({ timeout: 30000 });
-		});
-
-	});
-
-	test('Python - Verify Basic Streamlit App', {
-		tag: [tags.WEB, tags.WIN]
-	}, async function ({ app, openFile, python }) {
-		const viewer = app.workbench.viewer;
-
-		await openFile(join('workspaces', 'python_apps', 'streamlit_example', 'streamlit_example.py'));
-		await app.workbench.editor.pressPlay();
-
-		const viewerFrame = viewer.getViewerFrame();
-
-		await expect(async () => {
-			const headerLocator = app.web
-				? viewerFrame.frameLocator('iframe').getByRole('button', { name: 'Deploy' })
-				: viewerFrame.getByRole('button', { name: 'Deploy' });
-
-			await expect(headerLocator).toBeVisible({ timeout: 30000 });
-		}).toPass({ timeout: 60000 });
-
-		await test.step('Verify app can be opened in editor', async () => {
-			await app.workbench.viewer.openViewerToEditor();
-			await app.workbench.viewer.clearViewer();
-
-			const editor = app.workbench.editor;
-			const editorFrame = editor.getEditorViewerFrame();
-
-			const headerLocator = app.web
-				? editorFrame.frameLocator('iframe').getByRole('button', { name: 'Deploy' })
-				: editorFrame.getByRole('button', { name: 'Deploy' });
-
-			await expect(headerLocator).toBeVisible({ timeout: 30000 });
-		});
-	});
-
-	test('Python - Verify Basic Flask App', {
-		tag: [tags.WEB, tags.WIN]
-	}, async function ({ app, openFile, python }) {
-		const viewer = app.workbench.viewer;
-
-		await openFile(join('workspaces', 'python_apps', 'flask_example', '__init__.py'));
-
-		await app.workbench.editor.pressPlay();
-		const viewerFrame = viewer.getViewerFrame();
-		const loginLocator = app.web
-			? viewerFrame.frameLocator('iframe').getByText('Log In')
-			: viewerFrame.getByText('Log In');
-
-		await expect(loginLocator).toBeVisible({ timeout: 60000 });
-
-		await test.step('Verify app can be opened in editor', async () => {
-			await app.workbench.viewer.openViewerToEditor();
-			await app.workbench.viewer.clearViewer();
-
-			const editor = app.workbench.editor;
-			const editorFrame = editor.getEditorViewerFrame();
-
-			const loginLocator = app.web
-				? editorFrame.frameLocator('iframe').getByText('Log In')
-				: editorFrame.getByText('Log In');
-
-			await expect(loginLocator).toBeVisible({ timeout: 30000 });
-		});
-	});
+	}
 
 	test('Python - Verify Viewer interrupt button for Streamlit app', {
 		tag: [tags.WEB, tags.WIN]
-	}, async function ({ app, openFile, page, python }) {
-		const viewer = app.workbench.viewer;
-		const interruptButton = page.locator('.positron-action-bar').getByRole('button', { name: 'Interrupt execution' });
+	}, async function ({ app, openFile, python }) {
+		const { viewer, editor, terminal } = app.workbench;
 
-		await test.step('Launch Streamlit app', async () => {
-			await openFile(join('workspaces', 'python_apps', 'streamlit_example', 'streamlit_example.py'));
-			await app.workbench.editor.pressPlay();
-
-			const viewerFrame = viewer.getViewerFrame();
-
-			await expect(async () => {
-				const headerLocator = app.web
-					? viewerFrame.frameLocator('iframe').getByRole('button', { name: 'Deploy' })
-					: viewerFrame.getByRole('button', { name: 'Deploy' });
-
-				await expect(headerLocator).toBeVisible({ timeout: 30000 });
-			}).toPass({ timeout: 60000 });
-		});
+		// Open the Streamlit app file and press play
+		await openFile(join('workspaces', 'python_apps', 'streamlit_example', 'streamlit_example.py'));
+		await editor.pressPlay();
+		await viewer.expectContentVisible(
+			frame => frame.getByRole('button', { name: 'Deploy' }),
+			{
+				onRetry: async () => {
+					await terminal.clickTerminalTab();
+					await terminal.sendKeysToTerminal('Control+C');
+					await editor.pressPlay();
+				}
+			}
+		);
 
 		await test.step('Verify interrupt button is visible', async () => {
-			await expect(interruptButton).toBeVisible({ timeout: 10000 });
+			await expect(viewer.interruptButton).toBeVisible({ timeout: 10000 });
 		});
 
 		await test.step('Click interrupt button and verify it disappears', async () => {
-			await interruptButton.click();
-
-			// Button should disappear immediately after clicking
-			await expect(interruptButton).not.toBeVisible({ timeout: 5000 });
+			await viewer.interruptButton.click();
+			await expect(viewer.interruptButton).not.toBeVisible({ timeout: 5000 });
 		});
 	});
 });
-


### PR DESCRIPTION
 ### Summary

Fixes flaky Basic Dash app test on Windows caused by ERR_CONNECTION_RESET when the viewer tries to load the app URL before the dev server is actually accepting connections.

### Root Cause

Dev servers (Dash, Flask, etc.) report "running" before they're fully ready to accept connections. On Windows CI, the viewer loads the URL almost immediately after the server prints its startup message, resulting in ERR_CONNECTION_RESET. The iframe fails to load and won't auto-retry.

###  Changes
  - Added onRetry callback to viewer.expectContentVisible() that gets called when content isn't visible
  - Tests now interrupt the server (Ctrl+C) and restart it on failure - the second attempt succeeds since Python/packages are already loaded
- Added POM helpers
- Refactored tests to be a lot more DRY for easier maintainabilty

  QA Notes

  @:win @:web