### PR TITLE
e2e: fix Windows path escaping in R plot save test

### DIFF
--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -764,10 +764,15 @@ fig`;
 const rTwoPlots = `plot(1:10)
 plot(1:100)`;
 
-const rPlotAndSave = (filePath: string) => `plot(1:10)
-grDevices::png(filename = "${filePath}")
+const rPlotAndSave = (filePath: string) => {
+	// Convert backslashes to forward slashes for R compatibility on Windows
+	// (R interprets \U as unicode escape sequence)
+	const safePath = filePath.replace(/\\/g, '/');
+	return `plot(1:10)
+grDevices::png(filename = "${safePath}")
 plot(1:20)
 dev.off()`;
+};
 
 async function dismissPlotZoomTooltip(page: Page) {
 	const plotZoomTooltip = page.getByText('Set the plot zoom');


### PR DESCRIPTION
## Summary

- Fixes the `R - plot and save in one block` test failing on Windows
- The `\U` in Windows paths like `C:\Users\...` was being interpreted as a Unicode escape sequence in R, causing a syntax error
- Convert backslashes to forward slashes which R handles correctly on all platforms

## Test plan

@:win

🤖 Generated with [Claude Code](https://claude.com/claude-code)