### PR TITLE
Ensure that extension updates are compatible with the running Positron version

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -31,6 +31,9 @@ import { StopWatch } from '../../../base/common/stopwatch.js';
 import { format2 } from '../../../base/common/strings.js';
 import { ExtensionGalleryResourceType, Flag, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService, ExtensionGalleryManifestStatus } from './extensionGalleryManifest.js';
 import { TelemetryTrustedValue } from '../../telemetry/common/telemetryUtils.js';
+// --- Start Positron ---
+import { isValidPositronExtensionVersion } from '../../extensions/common/positronExtensionValidator.js';
+// --- End Positron ---
 
 const CURRENT_TARGET_PLATFORM = isWeb ? TargetPlatform.WEB : getTargetPlatform(platform, arch);
 const SEARCH_ACTIVITY_HEADER_NAME = 'X-Market-Search-Activity-Id';
@@ -1030,6 +1033,13 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 			if (!(await this.isEngineValid(extension.id, extension.version, extension.engine, extension.manifestAsset, productVersion))) {
 				return false;
 			}
+
+			// --- Start Positron ---
+			// Check Positron engine compatibility (requires manifest fetch since Open VSX doesn't expose engines.positron).
+			if (!(await this.isPositronEngineValid(extension.id, extension.version, extension.manifestAsset, productVersion))) {
+				return false;
+			}
+			// --- End Positron ---
 		}
 
 		return true;
@@ -1062,6 +1072,58 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 
 		return isEngineValid(engine, productVersion.version, productVersion.date);
 	}
+
+	// --- Start Positron ---
+	private async isPositronEngineValid(extensionId: string, version: string, manifestAsset: IGalleryExtensionAsset | null, productVersion: IProductVersion): Promise<boolean> {
+		// No manifest means no Positron requirement - assume compatible.
+		if (!manifestAsset) {
+			return true;
+		}
+
+		// Fetch the manifest to check for engines.positron. On error, assume compatible.
+		let positronEngine: string | undefined;
+		try {
+			// Load the manifest for the extension.
+			const headers = { 'Accept-Encoding': 'gzip' };
+			const context = await this.getAsset(extensionId, manifestAsset, AssetType.Manifest, version, { headers });
+			const manifest = await asJson<IExtensionManifest>(context);
+
+			// If manifest parsing failed, assume compatible rather than blocking the extension.
+			if (!manifest) {
+				this.logService.warn(`Manifest was not found for the extension ${extensionId} with version ${version}`);
+				return true;
+			}
+
+			// No Positron engine requirement means the extension is compatible with any Positron version.
+			positronEngine = manifest.engines?.positron;
+			if (!positronEngine) {
+				return true;
+			}
+		} catch (error) {
+			this.logService.error(`Error while getting the Positron engine for the version ${version}.`, getErrorMessage(error));
+			return true;
+		}
+
+		// Build a minimal manifest to validate the Positron engine requirement.
+		const notices: string[] = [];
+		const manifest: IExtensionManifest = {
+			name: extensionId,
+			publisher: '',
+			version: version,
+			engines: { vscode: '*', positron: positronEngine },
+			main: './main.js' // Required to trigger version validation.
+		};
+
+		// Check if the extension's Positron version requirement is compatible with the current Positron version.
+		return isValidPositronExtensionVersion(
+			this.productService.positronVersion,
+			productVersion.date,
+			manifest,
+			false,
+			notices
+		);
+	}
+	// --- End Positron ---
 
 	private async getEngine(extensionId: string, version: string, manifestAsset: IGalleryExtensionAsset | null): Promise<string | undefined> {
 		if (!manifestAsset) {
@@ -1156,7 +1218,11 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		}
 
 		const runQuery = async (query: Query, token: CancellationToken) => {
-			const { extensions, total } = await this.queryGalleryExtensions(query, { targetPlatform: CURRENT_TARGET_PLATFORM, compatible: false, includePreRelease: !!options.includePreRelease, productVersion: options.productVersion ?? { version: this.productService.version, date: this.productService.date } }, extensionGalleryManifest, token);
+			// --- Start Positron ---
+			// Set compatible: true to enable engine compatibility filtering.
+			// This will fetch manifests to check Positron engine requirements via isPositronEngineValid().
+			const { extensions, total } = await this.queryGalleryExtensions(query, { targetPlatform: CURRENT_TARGET_PLATFORM, compatible: true, includePreRelease: !!options.includePreRelease, productVersion: options.productVersion ?? { version: this.productService.version, date: this.productService.date } }, extensionGalleryManifest, token);
+			// --- End Positron ---
 
 			const result: IGalleryExtension[] = [];
 			let defaultChatAgentExtension: IGalleryExtension | undefined;

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -613,6 +613,12 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 
 	private readonly commonHeadersPromise: Promise<IHeaders>;
 	private readonly extensionsEnabledWithApiProposalVersion: string[];
+	// --- Start Positron ---
+	// Caches Positron engine compatibility check results to avoid re-fetching and re-validating
+	// extension manifests. Keyed by `extensionId@version`, stores whether the extension version
+	// is compatible with the current Positron version.
+	private readonly positronEngineValidityCache = new Map<string, boolean>();
+	// --- End Positron ---
 
 	constructor(
 		storageService: IStorageService | undefined,
@@ -1075,53 +1081,75 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 
 	// --- Start Positron ---
 	private async isPositronEngineValid(extensionId: string, version: string, manifestAsset: IGalleryExtensionAsset | null, productVersion: IProductVersion): Promise<boolean> {
-		// No manifest means no Positron requirement - assume compatible.
+		// When the manifest asset is not available, we cannot check the Positron engine requirement.
+		// Assume compatible.
 		if (!manifestAsset) {
 			return true;
 		}
 
-		// Fetch the manifest to check for engines.positron. On error, assume compatible.
-		let positronEngine: string | undefined;
+		// Check the Positron engine validity cache for this extension version. If we have a cached
+		// result, return it to avoid unnecessary manifest fetches and Positron engine validations
+		// for extension versions we've already checked.
+		const cacheKey = `${extensionId}@${version}`;
+		const cachedResult = this.positronEngineValidityCache.get(cacheKey);
+		if (cachedResult !== undefined) {
+			return cachedResult;
+		}
+
+		// Fetch the manifest and check for engines.positron.
 		try {
-			// Load the manifest for the extension.
+			// Fetch the manifest with gzip encoding to reduce the payload size.
 			const headers = { 'Accept-Encoding': 'gzip' };
 			const context = await this.getAsset(extensionId, manifestAsset, AssetType.Manifest, version, { headers });
 			const manifest = await asJson<IExtensionManifest>(context);
 
-			// If manifest parsing failed, assume compatible rather than blocking the extension.
+			// If manifest parsing failed, assume compatible but do not cache the result.
 			if (!manifest) {
 				this.logService.warn(`Manifest was not found for the extension ${extensionId} with version ${version}`);
 				return true;
 			}
 
-			// No Positron engine requirement means the extension is compatible with any Positron version.
-			positronEngine = manifest.engines?.positron;
+			// Check if the manifest has a Positron engine requirement. If not, the extension is compatible with any
+			// Positron version. If it does, validate the requirement against the current Positron version.
+			const positronEngine = manifest.engines?.positron;
+			let isValid: boolean;
 			if (!positronEngine) {
-				return true;
+				isValid = true;
+			} else {
+				// Build a minimal manifest to validate the Positron engine requirement.
+				const validationManifest: IExtensionManifest = {
+					name: extensionId,
+					publisher: '',
+					version: version,
+					engines: { vscode: '*', positron: positronEngine },
+					main: './main.js' // Required to trigger version validation.
+				};
+
+				// Check if the extension's Positron version requirement is compatible with the current Positron version.
+				isValid = isValidPositronExtensionVersion(
+					this.productService.positronVersion,
+					productVersion.date,
+					validationManifest,
+					false,
+					[]
+				);
 			}
+
+			// Log incompatible extensions so users understand what's being filtered out.
+			if (!isValid) {
+				const extensionName = manifest.displayName || manifest.name || extensionId;
+				this.logService.info(`${extensionName} version ${version} is incompatible with Positron ${this.productService.positronVersion} (requires Positron ${positronEngine})`);
+			}
+
+			// Cache and return the result.
+			this.positronEngineValidityCache.set(cacheKey, isValid);
+			return isValid;
 		} catch (error) {
+			// Log the error but return true without caching to avoid blocking extensions due to transient errors (e.g., network issues)
+			// or issues with manifest parsing that may not be related to Positron compatibility.
 			this.logService.error(`Error while getting the Positron engine for the version ${version}.`, getErrorMessage(error));
 			return true;
 		}
-
-		// Build a minimal manifest to validate the Positron engine requirement.
-		const notices: string[] = [];
-		const manifest: IExtensionManifest = {
-			name: extensionId,
-			publisher: '',
-			version: version,
-			engines: { vscode: '*', positron: positronEngine },
-			main: './main.js' // Required to trigger version validation.
-		};
-
-		// Check if the extension's Positron version requirement is compatible with the current Positron version.
-		return isValidPositronExtensionVersion(
-			this.productService.positronVersion,
-			productVersion.date,
-			manifest,
-			false,
-			notices
-		);
 	}
 	// --- End Positron ---
 


### PR DESCRIPTION
## Overview

This implementation requires setting `compatible: true` in the gallery query, which triggers manifest fetching for extension compatibility validation. This is necessary because the Open VSX marketplace does not expose `engines.positron` as a gallery metadata property (unlike `engines.vscode`, which is exposed via the `Microsoft.VisualStudio.Code.Engine` property).

Without access to `engines.positron` in the marketplace metadata, we must fetch the full extension manifest to read the Positron engine requirement during the browse/query flow. This ensures extensions with incompatible Positron version requirements are filtered out before being presented to users.

Trade-off: While this approach increases network overhead due to manifest fetches, it provides consistent version compatibility filtering for Positron extensions, matching the behavior users expect from VS Code's engine validation.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #11321 Ensures that extension updates are compatible with the running Positron version.

### QA Notes

The best way to test this PR is in a dev build running locally.

First, "Disable Auto Update for All Extensions":

<p>
<img width="333" height="270" alt="image" src="https://github.com/user-attachments/assets/de57f497-a55c-41b8-87c4-f5dd59619fd5" />
</p>

Next:

- Install an old version of the Quarto extension (`1.111.0` is a good one to use)
- Manually vary `positronVersion` in `product.json` to older version numbers and re-run Positron to check the Extensions panel / Quarto extension to see what update is suggested.

For example:

`positronVersion: "2024.06.0"` will result in being prompted to update Quarto to `v1.222.0`:

<p>
<img width="1530" height="1240" alt="image" src="https://github.com/user-attachments/assets/c250b7b0-d715-4b8e-b925-18cd77fcbd6c" />
</p>

`positronVersion: "2025.06.0"` will result in being prompted to update Quarto to `v1.226.0`:

<p>
<img width="1530" height="1240" alt="image" src="https://github.com/user-attachments/assets/e45b0e4b-0e21-40b0-b287-ef1daf429b3a" />
</p>

`positronVersion: "2025.12.0"` (and later) will, today, anyway, result in being prompted to update Quarto to `v1.130.0`:

<p>
<img width="1530" height="1240" alt="image" src="https://github.com/user-attachments/assets/b682ce07-95ee-4e11-9cec-311f9efe82a1" />
</p>