### PR TITLE
Add command for RStudio addins with installed packages

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -164,9 +164,9 @@
         "title": "%r.command.loadRDataFileWithPicker.title%"
       },
       {
-        "command": "r.browseAddins",
+        "command": "r.runAddin",
         "category": "R",
-        "title": "%r.command.browseAddins.title%"
+        "title": "%r.command.runAddin.title%"
       },
       {
         "command": "r.newRmdFromTemplate",

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -23,7 +23,7 @@
 	"r.command.loadRDataFile.title": "Load R Objects",
 	"r.command.loadRdsFile.title": "Load R Object",
 	"r.command.loadRDataFileWithPicker.title": "Load R Data File...",
-	"r.command.browseAddins.title": "Browse RStudio Addins",
+	"r.command.runAddin.title": "Run RStudio Addin",
 	"r.command.newRmdFromTemplate.title": "New R Markdown from Template",
 	"r.customEditor.rdataLoader.displayName": "R Workspace Loader",
 	"r.customEditor.rdsLoader.displayName": "R Object Loader",

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -561,46 +561,61 @@ interface AddinQuickPickItem extends vscode.QuickPickItem {
  * Shows a QuickPick with all addins found in installed packages.
  */
 async function browseAddins(): Promise<void> {
+	const session = await RSessionManager.instance.getConsoleSession();
+	if (!session) {
+		vscode.window.showErrorMessage(vscode.l10n.t('No R session available'));
+		return;
+	}
+
+	let addins: RStudioAddin[];
 	try {
-		const session = await RSessionManager.instance.getConsoleSession();
-		if (!session) {
-			vscode.window.showErrorMessage(vscode.l10n.t('No R session available'));
-			return;
+		addins = await session.getAddins();
+	} catch (err) {
+		vscode.window.showErrorMessage(vscode.l10n.t('Error loading addins: {0}', String(err)));
+		return;
+	}
+
+	if (addins.length === 0) {
+		vscode.window.showInformationMessage(
+			vscode.l10n.t('No RStudio Addins found. Install packages with addins (e.g., reprex, clipr).')
+		);
+		return;
+	}
+
+	// Sort addins by package name
+	addins.sort((a, b) => a.package.localeCompare(b.package));
+
+	// Group addins by package with separators
+	const items: (vscode.QuickPickItem | AddinQuickPickItem)[] = [];
+	let currentPackage = '';
+	for (const a of addins) {
+		if (a.package !== currentPackage) {
+			currentPackage = a.package;
+			items.push({
+				label: a.package,
+				kind: vscode.QuickPickItemKind.Separator
+			});
 		}
-
-		const addins = await session.getAddins();
-
-		if (addins.length === 0) {
-			vscode.window.showInformationMessage(
-				vscode.l10n.t('No RStudio Addins found. Install packages with addins (e.g., reprex, clipr).')
-			);
-			return;
-		}
-
-		const items: AddinQuickPickItem[] = addins.map(a => ({
+		items.push({
 			label: a.name,
-			description: `{${a.package}}`,
 			detail: a.description,
 			addin: a
-		}));
-
-		const selected = await vscode.window.showQuickPick(items, {
-			placeHolder: vscode.l10n.t('Select an RStudio Addin'),
-			matchOnDescription: true,
-			matchOnDetail: true
 		});
+	}
 
-		if (selected) {
-			// For now, just show the addin info. Full implementation in a later PR.
-			const a = selected.addin;
-			vscode.window.showInformationMessage(
-				vscode.l10n.t('Selected addin: {0} from {1} (binding: {2})',
-					a.name, a.package, a.binding)
-			);
+	const selected = await vscode.window.showQuickPick(items, {
+		placeHolder: vscode.l10n.t('Select an RStudio Addin'),
+		matchOnDetail: true
+	}) as AddinQuickPickItem | undefined;
+
+	if (selected) {
+		const addin = selected.addin;
+		const code = `${addin.package}:::${addin.binding}()`;
+		try {
+			await positron.runtime.executeCode('r', code, true);
+		} catch {
+			// R errors are already shown in the console
 		}
-	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		vscode.window.showErrorMessage(vscode.l10n.t('Error loading addins: {0}', message));
 	}
 }
 

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -637,58 +637,92 @@ async function newRmdFromTemplate(): Promise<void> {
 		return;
 	}
 
+	const session = await RSessionManager.instance.getConsoleSession();
+	if (!session) {
+		vscode.window.showErrorMessage(vscode.l10n.t('No R session available'));
+		return;
+	}
+
+	let templates: RmdTemplate[];
 	try {
-		const session = await RSessionManager.instance.getConsoleSession();
-		if (!session) {
-			vscode.window.showErrorMessage(vscode.l10n.t('No R session available'));
-			return;
+		templates = await session.getRmdTemplates(true);
+	} catch (err) {
+		vscode.window.showErrorMessage(vscode.l10n.t('Error loading R Markdown templates: {0}', String(err)));
+		return;
+	}
+
+	if (templates.length === 0) {
+		// The rmarkdown package itself has templates, so something must go really wrong to get here:
+		vscode.window.showInformationMessage(
+			vscode.l10n.t('No R Markdown templates found.')
+		);
+		return;
+	}
+
+	// Sort templates by package name
+	templates.sort((a, b) => a.package.localeCompare(b.package));
+
+	// Group templates by package with separators
+	const items: (vscode.QuickPickItem | TemplateQuickPickItem)[] = [];
+	let currentPackage = '';
+	for (const t of templates) {
+		if (t.package !== currentPackage) {
+			currentPackage = t.package;
+			items.push({
+				label: t.package,
+				kind: vscode.QuickPickItemKind.Separator
+			});
 		}
-
-		const templates = await session.getRmdTemplates(true);
-
-		if (templates.length === 0) {
-			// The rmarkdown package itself has templates, so something must go really wrong to get here:
-			vscode.window.showInformationMessage(
-				vscode.l10n.t('No R Markdown templates found.')
-			);
-			return;
-		}
-
-		const items: TemplateQuickPickItem[] = templates.map(t => ({
+		items.push({
 			label: t.name,
-			description: `{${t.package}}`,
 			detail: t.description,
 			template: t
-		}));
+		});
+	}
 
-		const selected = await vscode.window.showQuickPick(items, {
-			placeHolder: vscode.l10n.t('Select an R Markdown template'),
-			matchOnDescription: true,
-			matchOnDetail: true
+	const selected = await vscode.window.showQuickPick(items, {
+		placeHolder: vscode.l10n.t('Select an R Markdown template'),
+		matchOnDetail: true
+	}) as TemplateQuickPickItem | undefined;
+
+	if (selected) {
+		const t = selected.template;
+
+		// Get save location from user
+		const defaultDir = vscode.workspace.workspaceFolders?.[0]?.uri
+			?? vscode.Uri.file(os.homedir());
+
+		// Find an unused filename
+		let filename = 'Untitled.Rmd';
+		let counter = 1;
+		while (true) {
+			const candidate = vscode.Uri.joinPath(defaultDir, filename);
+			try {
+				await vscode.workspace.fs.stat(candidate);
+				// File exists, try next number
+				filename = `Untitled-${counter}.Rmd`;
+				counter++;
+			} catch {
+				// File doesn't exist, use this name
+				break;
+			}
+		}
+
+		const saveUri = await vscode.window.showSaveDialog({
+			defaultUri: vscode.Uri.joinPath(defaultDir, filename)
 		});
 
-		if (selected) {
-			const t = selected.template;
-
-			// Get save location from user
-			const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri
-				?? vscode.Uri.file(os.homedir());
-
-			const saveUri = await vscode.window.showSaveDialog({
-				defaultUri: vscode.Uri.joinPath(defaultUri, 'Untitled.Rmd')
-			});
-
-			if (!saveUri) {
-				return;
-			}
-
-			// Create document using rmarkdown::draft() and open via rstudioapi
-			const draftPath = saveUri.fsPath;
-			const code = `rmarkdown::draft(${JSON.stringify(draftPath)}, template = "${t.template}", package = "${t.package}")`;
-			await positron.runtime.executeCode('r', code, true);
+		if (!saveUri) {
+			return;
 		}
-	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		vscode.window.showErrorMessage(vscode.l10n.t('Error loading R Markdown templates: {0}', message));
+
+		// Create document using rmarkdown::draft() and open via rstudioapi
+		const draftPath = saveUri.fsPath;
+		const code = `rmarkdown::draft(${JSON.stringify(draftPath)}, template = "${t.template}", package = "${t.package}")`;
+		try {
+			await positron.runtime.executeCode('r', code, true);
+		} catch {
+			// R errors are already shown in the console
+		}
 	}
 }

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -266,8 +266,8 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 		}),
 
 		// Commands for RStudio addins
-		vscode.commands.registerCommand('r.browseAddins', async () => {
-			await browseAddins();
+		vscode.commands.registerCommand('r.runAddin', async () => {
+			await runAddin();
 		}),
 
 		// Commands for R Markdown templates
@@ -557,10 +557,10 @@ interface AddinQuickPickItem extends vscode.QuickPickItem {
 }
 
 /**
- * Browse installed RStudio addins.
- * Shows a QuickPick with all addins found in installed packages.
+ * Run an RStudio addin.
+ * Shows a QuickPick with all addins found in installed packages, then executes the selection.
  */
-async function browseAddins(): Promise<void> {
+async function runAddin(): Promise<void> {
 	const session = await RSessionManager.instance.getConsoleSession();
 	if (!session) {
 		vscode.window.showErrorMessage(vscode.l10n.t('No R session available'));


### PR DESCRIPTION
- Addresses #1313 mainly although I did apply some improvements to `.Rmd` templates i.e. #8762
- Addresses #12212 in that I grouped the templates and addins in the quickpick by package, but I did *not* add a button to the editor action bar (we do not want buttons for these somewhat legacy sets of functionality)

This PR completes the implementation for browsing and executing RStudio Addins and R Markdown templates. Users can now _Run RStudio Addin_ to select an addin from a quickpick grouped by package, and execute it directly.

I fixed up the error handling for both sets of R package goodies so that **loading** errors still show a dialog to alert users of issues fetching addins/templates, but R execution errors appear only in the console (no duplicate error dialogs).


### Release Notes

#### New Features

- Added support for browsing and executing RStudio Addins via Command Palette (#1313)

#### Bug Fixes

- N/A

### QA Notes

1. Install packages with addins (e.g., `reprex`, `blogdown`, `clipr`)
2. Run _R: Run RStudio Addin_ from Command Palette
3. Verify addins are grouped by package
4. Select an addin and verify it executes (e.g., `reprex` opens a gadget)

