### PR TITLE
E2E tests: extend notebook search tests with replace coverage

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -641,6 +641,61 @@ export class PositronNotebooks extends Notebooks {
 		});
 	}
 
+	/**
+	 * Action: Set replace text in the search widget.
+	 * @param text - The text to replace with.
+	 */
+	async searchSetReplaceText(text: string): Promise<void> {
+		await test.step(`Set replace text to: ${text}`, async () => {
+			await this.searchExpandReplace();
+			await this.replaceInput.fill(text);
+		});
+	}
+
+	/**
+	 * Action: Perform replace operation (single replace).
+	 */
+	async searchReplace(): Promise<void> {
+		await test.step('Replace current match', async () => {
+			await this.replaceButton.click();
+		});
+	}
+
+	/**
+	 * Action: Perform replace all operation.
+	 */
+	async searchReplaceAll(): Promise<void> {
+		await test.step('Replace all matches', async () => {
+			await this.replaceAllButton.click();
+		});
+	}
+
+	/**
+	 * Action: Toggle search case sensitivity.
+	 */
+	async searchToggleCaseSensitive(): Promise<void> {
+		await test.step('Toggle case sensitivity', async () => {
+			await this.searchWidget.getByRole('button', { name: 'Match Case' }).click();
+		});
+	}
+
+	/**
+	 * Action: Toggle whole word search.
+	 */
+	async searchToggleWholeWord(): Promise<void> {
+		await test.step('Toggle whole word', async () => {
+			await this.searchWidget.getByRole('button', { name: 'Match Whole Word' }).click();
+		});
+	}
+
+	/**
+	 * Action: Toggle regex search.
+	 */
+	async searchToggleRegex(): Promise<void> {
+		await test.step('Toggle regex search', async () => {
+			await this.searchWidget.getByRole('button', { name: 'Use Regular Expression' }).click();
+		});
+	}
 
 	// #endregion
 
@@ -725,6 +780,24 @@ export class PositronNotebooks extends Notebooks {
 	async expectSearchDecorationCountToBe(expectedCount: number): Promise<void> {
 		await test.step(`Expect search decoration count to be: ${expectedCount}`, async () => {
 			await expect(this.searchDecoration).toHaveCount(expectedCount, { timeout: DEFAULT_TIMEOUT });
+		});
+	}
+
+	/**
+	 * Verify: Replace button is disabled.
+	 */
+	async expectReplaceButtonToBeDisabled(): Promise<void> {
+		await test.step('Expect Replace button to be disabled', async () => {
+			await expect(this.replaceButton).toBeDisabled({ timeout: DEFAULT_TIMEOUT });
+		});
+	}
+
+	/**
+	 * Verify: Replace All button is disabled.
+	 */
+	async expectReplaceAllButtonToBeDisabled(): Promise<void> {
+		await test.step('Expect Replace All button to be disabled', async () => {
+			await expect(this.replaceAllButton).toBeDisabled({ timeout: DEFAULT_TIMEOUT });
 		});
 	}
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -676,6 +676,8 @@ export class PositronNotebooks extends Notebooks {
 	async searchToggleCaseSensitive(): Promise<void> {
 		await test.step('Toggle case sensitivity', async () => {
 			await this.searchWidget.getByRole('button', { name: 'Match Case' }).click();
+			// Wait for search to re-execute after toggle
+			await this.code.driver.page.waitForTimeout(500);
 		});
 	}
 
@@ -685,6 +687,8 @@ export class PositronNotebooks extends Notebooks {
 	async searchToggleWholeWord(): Promise<void> {
 		await test.step('Toggle whole word', async () => {
 			await this.searchWidget.getByRole('button', { name: 'Match Whole Word' }).click();
+			// Wait for search to re-execute after toggle
+			await this.code.driver.page.waitForTimeout(500);
 		});
 	}
 
@@ -694,6 +698,8 @@ export class PositronNotebooks extends Notebooks {
 	async searchToggleRegex(): Promise<void> {
 		await test.step('Toggle regex search', async () => {
 			await this.searchWidget.getByRole('button', { name: 'Use Regular Expression' }).click();
+			// Wait for search to re-execute after toggle
+			await this.code.driver.page.waitForTimeout(500);
 		});
 	}
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -675,7 +675,9 @@ export class PositronNotebooks extends Notebooks {
 	 */
 	async searchToggleCaseSensitive(): Promise<void> {
 		await test.step('Toggle case sensitivity', async () => {
-			await this.searchWidget.getByRole('button', { name: 'Match Case' }).click();
+			const caseButton = this.searchWidget.getByRole('button', { name: 'Match Case' });
+			await expect(caseButton).toBeVisible({ timeout: 5000 });
+			await caseButton.click();
 			// Wait for search to re-execute after toggle
 			await this.code.driver.page.waitForTimeout(500);
 		});
@@ -686,7 +688,9 @@ export class PositronNotebooks extends Notebooks {
 	 */
 	async searchToggleWholeWord(): Promise<void> {
 		await test.step('Toggle whole word', async () => {
-			await this.searchWidget.getByRole('button', { name: 'Match Whole Word' }).click();
+			const wholeWordButton = this.searchWidget.getByRole('button', { name: 'Match Whole Word' });
+			await expect(wholeWordButton).toBeVisible({ timeout: 5000 });
+			await wholeWordButton.click();
 			// Wait for search to re-execute after toggle
 			await this.code.driver.page.waitForTimeout(500);
 		});
@@ -794,6 +798,8 @@ export class PositronNotebooks extends Notebooks {
 	 */
 	async expectReplaceButtonToBeDisabled(): Promise<void> {
 		await test.step('Expect Replace button to be disabled', async () => {
+			// Wait a moment for the UI to update after search completes
+			await this.code.driver.page.waitForTimeout(500);
 			await expect(this.replaceButton).toBeDisabled({ timeout: DEFAULT_TIMEOUT });
 		});
 	}
@@ -803,6 +809,8 @@ export class PositronNotebooks extends Notebooks {
 	 */
 	async expectReplaceAllButtonToBeDisabled(): Promise<void> {
 		await test.step('Expect Replace All button to be disabled', async () => {
+			// Wait a moment for the UI to update after search completes
+			await this.code.driver.page.waitForTimeout(500);
 			await expect(this.replaceAllButton).toBeDisabled({ timeout: DEFAULT_TIMEOUT });
 		});
 	}

--- a/test/e2e/tests/notebooks-positron/notebook-search.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-search.test.ts
@@ -84,12 +84,19 @@ test.describe('Positron Notebooks: Search & Replace', {
 		});
 	});
 
-	test('Verify replace in markdown cells', async function ({ app }) {
+	test('Verify replace in markdown cells', async function ({ app, page }) {
 		const { notebooksPositron } = app.workbench;
 
-		await notebooksPositron.newNotebook({ codeCells: 1, markdownCells: 1 });
+		await notebooksPositron.newNotebook();
 		await notebooksPositron.addCodeToCell(0, 'x = 1');
-		await notebooksPositron.addCodeToCell(1, '# Heading with test\nParagraph with test content');
+
+		// Add markdown cell and enter content manually
+		await notebooksPositron.addCell('markdown');
+		await notebooksPositron.selectCellAtIndex(1, { editMode: true });
+		await page.keyboard.type('# Heading with test');
+		await page.keyboard.press('Enter');
+		await page.keyboard.type('Paragraph with test content');
+		await notebooksPositron.viewMarkdown.click();
 
 		await test.step('Replace in markdown cell', async () => {
 			await notebooksPositron.search('test');
@@ -114,23 +121,24 @@ test.describe('Positron Notebooks: Search & Replace', {
 		await notebooksPositron.search('test');
 		await notebooksPositron.expectSearchCountToBe({ total: 5 });
 
-		await test.step('Replace first match, skip second, replace third', async () => {
+		await test.step('Replace last match, skip first, replace second', async () => {
 			await notebooksPositron.searchSetReplaceText('pass');
 
-			// Replace first occurrence
+			// Replace current match (last occurrence in cell 2)
 			await notebooksPositron.searchReplace();
 			await notebooksPositron.expectSearchCountToBe({ total: 4 });
 
-			// Skip second occurrence (advance without replacing)
+			// Skip next occurrence (advances to position 2)
 			await notebooksPositron.searchNext();
 			await notebooksPositron.expectSearchCountToBe({ current: 2, total: 4 });
 
-			// Replace third occurrence
+			// Replace at position 2 (middle occurrence in cell 1)
 			await notebooksPositron.searchReplace();
 			await notebooksPositron.expectSearchCountToBe({ current: 2, total: 3 });
 
-			// Verify partial replacement
-			await notebooksPositron.expectCellContentAtIndexToBe(0, 'pass test pass');
+			// Verify partial replacements
+			await notebooksPositron.expectCellContentAtIndexToBe(0, 'test pass test');
+			await notebooksPositron.expectCellContentAtIndexToBe(1, 'test pass');
 		});
 
 		await notebooksPositron.searchClose();

--- a/test/e2e/tests/notebooks-positron/notebook-search.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-search.test.ts
@@ -83,4 +83,166 @@ test.describe('Positron Notebooks: Search & Replace', {
 			await notebooksPositron.expectCellContentAtIndexToBe(0, '# Cell 0');
 		});
 	});
+
+	test('Verify replace in markdown cells', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		await notebooksPositron.newNotebook({ codeCells: 1, markdownCells: 1 });
+		await notebooksPositron.addCodeToCell(0, 'x = 1');
+		await notebooksPositron.addCodeToCell(1, '# Heading with test\nParagraph with test content');
+
+		await test.step('Replace in markdown cell', async () => {
+			await notebooksPositron.search('test');
+			await notebooksPositron.expectSearchCountToBe({ total: 2 });
+			await notebooksPositron.searchSetReplaceText('example');
+			await notebooksPositron.searchReplaceAll();
+			await notebooksPositron.expectSearchCountToBe({ total: 0 });
+			await notebooksPositron.expectCellContentAtIndexToBe(1, '# Heading with example\nParagraph with example content');
+		});
+
+		await notebooksPositron.searchClose();
+	});
+
+	test('Verify step-through replace and skip functionality', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.addCodeToCell(0, 'test test test');
+		await notebooksPositron.addCell('code');
+		await notebooksPositron.addCodeToCell(1, 'test test');
+
+		await notebooksPositron.search('test');
+		await notebooksPositron.expectSearchCountToBe({ total: 5 });
+
+		await test.step('Replace first match, skip second, replace third', async () => {
+			await notebooksPositron.searchSetReplaceText('pass');
+
+			// Replace first occurrence
+			await notebooksPositron.searchReplace();
+			await notebooksPositron.expectSearchCountToBe({ total: 4 });
+
+			// Skip second occurrence (advance without replacing)
+			await notebooksPositron.searchNext();
+			await notebooksPositron.expectSearchCountToBe({ current: 2, total: 4 });
+
+			// Replace third occurrence
+			await notebooksPositron.searchReplace();
+			await notebooksPositron.expectSearchCountToBe({ current: 2, total: 3 });
+
+			// Verify partial replacement
+			await notebooksPositron.expectCellContentAtIndexToBe(0, 'pass test pass');
+		});
+
+		await notebooksPositron.searchClose();
+	});
+
+	test('Verify match counter updates correctly', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		await notebooksPositron.newNotebook({ codeCells: 1 });
+		await notebooksPositron.addCodeToCell(0, 'item item item item item');
+
+		await notebooksPositron.search('item');
+		await notebooksPositron.expectSearchCountToBe({ total: 5 });
+
+		await test.step('Counter updates after each replace', async () => {
+			await notebooksPositron.searchSetReplaceText('thing');
+
+			await notebooksPositron.searchReplace();
+			await notebooksPositron.expectSearchCountToBe({ total: 4 });
+
+			await notebooksPositron.searchReplace();
+			await notebooksPositron.expectSearchCountToBe({ total: 3 });
+
+			await notebooksPositron.searchReplace();
+			await notebooksPositron.expectSearchCountToBe({ total: 2 });
+		});
+
+		await notebooksPositron.searchClose();
+	});
+
+	test('Verify case sensitivity toggle', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		await notebooksPositron.newNotebook({ codeCells: 1 });
+		await notebooksPositron.addCodeToCell(0, 'Test test TEST tEsT');
+
+		await test.step('Case-insensitive search matches all variations', async () => {
+			await notebooksPositron.search('test');
+			await notebooksPositron.expectSearchCountToBe({ total: 4 });
+			await notebooksPositron.searchClose();
+		});
+
+		await test.step('Case-sensitive search matches only exact case', async () => {
+			await notebooksPositron.search('test');
+			await notebooksPositron.searchToggleCaseSensitive();
+			await notebooksPositron.expectSearchCountToBe({ total: 1 });
+			await notebooksPositron.searchClose();
+		});
+
+		await test.step('Case-sensitive "Test" matches only "Test"', async () => {
+			await notebooksPositron.search('Test');
+			await notebooksPositron.searchToggleCaseSensitive();
+			await notebooksPositron.expectSearchCountToBe({ total: 1 });
+		});
+
+		await notebooksPositron.searchClose();
+	});
+
+	test('Verify whole word toggle', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		await notebooksPositron.newNotebook({ codeCells: 1 });
+		await notebooksPositron.addCodeToCell(0, 'test testing tested tester');
+
+		await test.step('Without whole word, matches partial words', async () => {
+			await notebooksPositron.search('test');
+			await notebooksPositron.expectSearchCountToBe({ total: 4 });
+			await notebooksPositron.searchClose();
+		});
+
+		await test.step('With whole word, matches only complete word', async () => {
+			await notebooksPositron.search('test');
+			await notebooksPositron.searchToggleWholeWord();
+			await notebooksPositron.expectSearchCountToBe({ total: 1 });
+		});
+
+		await notebooksPositron.searchClose();
+	});
+
+	test('Verify no matches state and disabled buttons', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		await notebooksPositron.newNotebook({ codeCells: 1 });
+		await notebooksPositron.addCodeToCell(0, 'hello world');
+
+		await test.step('No matches shows "No results" and disables replace buttons', async () => {
+			await notebooksPositron.search('nonexistent');
+			await notebooksPositron.expectSearchCountToBe({ total: 0 });
+			await notebooksPositron.searchSetReplaceText('something');
+			await notebooksPositron.expectReplaceButtonToBeDisabled();
+			await notebooksPositron.expectReplaceAllButtonToBeDisabled();
+		});
+
+		await notebooksPositron.searchClose();
+	});
+
+	test('Verify empty replace string (deletion)', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		await notebooksPositron.newNotebook({ codeCells: 1 });
+		await notebooksPositron.addCodeToCell(0, 'remove remove keep');
+
+		await test.step('Replace with empty string deletes matches', async () => {
+			await notebooksPositron.search('remove ');
+			await notebooksPositron.expectSearchCountToBe({ total: 2 });
+
+			await notebooksPositron.searchSetReplaceText('');
+			await notebooksPositron.searchReplaceAll();
+			await notebooksPositron.expectSearchCountToBe({ total: 0 });
+			await notebooksPositron.expectCellContentAtIndexToBe(0, 'keep');
+		});
+
+		await notebooksPositron.searchClose();
+	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-search.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-search.test.ts
@@ -104,7 +104,7 @@ test.describe('Positron Notebooks: Search & Replace', {
 			await notebooksPositron.searchSetReplaceText('example');
 			await notebooksPositron.searchReplaceAll();
 			await notebooksPositron.expectSearchCountToBe({ total: 0 });
-			await notebooksPositron.expectCellContentAtIndexToBe(1, '# Heading with example\nParagraph with example content');
+			await notebooksPositron.expectCellContentAtIndexToBe(1, ['# Heading with example', 'Paragraph with example content']);
 		});
 
 		await notebooksPositron.searchClose();
@@ -147,7 +147,7 @@ test.describe('Positron Notebooks: Search & Replace', {
 	test('Verify match counter updates correctly', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 
-		await notebooksPositron.newNotebook({ codeCells: 1 });
+		await notebooksPositron.newNotebook();
 		await notebooksPositron.addCodeToCell(0, 'item item item item item');
 
 		await notebooksPositron.search('item');
@@ -172,7 +172,7 @@ test.describe('Positron Notebooks: Search & Replace', {
 	test('Verify case sensitivity toggle', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 
-		await notebooksPositron.newNotebook({ codeCells: 1 });
+		await notebooksPositron.newNotebook();
 		await notebooksPositron.addCodeToCell(0, 'Test test TEST tEsT');
 
 		await test.step('Case-insensitive search matches all variations', async () => {
@@ -200,7 +200,7 @@ test.describe('Positron Notebooks: Search & Replace', {
 	test('Verify whole word toggle', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 
-		await notebooksPositron.newNotebook({ codeCells: 1 });
+		await notebooksPositron.newNotebook();
 		await notebooksPositron.addCodeToCell(0, 'test testing tested tester');
 
 		await test.step('Without whole word, matches partial words', async () => {
@@ -221,7 +221,7 @@ test.describe('Positron Notebooks: Search & Replace', {
 	test('Verify no matches state and disabled buttons', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 
-		await notebooksPositron.newNotebook({ codeCells: 1 });
+		await notebooksPositron.newNotebook();
 		await notebooksPositron.addCodeToCell(0, 'hello world');
 
 		await test.step('No matches shows "No results" and disables replace buttons', async () => {
@@ -238,7 +238,7 @@ test.describe('Positron Notebooks: Search & Replace', {
 	test('Verify empty replace string (deletion)', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 
-		await notebooksPositron.newNotebook({ codeCells: 1 });
+		await notebooksPositron.newNotebook();
 		await notebooksPositron.addCodeToCell(0, 'remove remove keep');
 
 		await test.step('Replace with empty string deletes matches', async () => {


### PR DESCRIPTION
## Summary

Extend existing `notebook-search.test.ts` with comprehensive test coverage for the notebook find & replace feature implemented in PR #12102.

## New Test Coverage

This PR adds **7 new test cases** to the existing search test file:

1. **Replace in markdown cells** - Verify replace works in markdown content
2. **Step-through replace** - Selective replacement with skip functionality
3. **Match counter updates** - Verify counter accuracy after each operation
4. **Case sensitivity toggle** - Test case-sensitive vs case-insensitive matching
5. **Whole word toggle** - Test whole word vs partial word matching  
6. **No matches state** - Verify disabled buttons when no results found
7. **Empty replace string** - Test deletion by replacing with empty string

Combined with the existing basic replace tests (already existing), this provides comprehensive coverage of the find & replace functionality.

## Page Object Enhancements

Enhanced `notebooksPositron.ts` page object with:
- `searchSetReplaceText(text)` - Set replacement text (auto-expands replace row)
- `searchReplace()` - Replace current match
- `searchReplaceAll()` - Replace all matches
- `searchToggleCaseSensitive()` - Toggle case sensitivity
- `searchToggleWholeWord()` - Toggle whole word matching
- `searchToggleRegex()` - Toggle regex mode
- `expectReplaceButtonToBeDisabled()` - Verify button state
- `expectReplaceAllButtonToBeDisabled()` - Verify button state

## Test Design

Tests follow Positron E2E best practices:
- Consolidated into existing `notebook-search.test.ts` to avoid duplication
- Proper test structure with `test.use({ suiteId: __filename })`
- Appropriate tags (`@:positron-notebooks`, `@:web`, `@:win`)
- Test steps for better reporting
- Lean assertions without repetition

## QA Notes

@:positron-notebooks @:web @:win

## Related Issues

- Addresses #12321 (test automation request)
- Tests implementation from #12102 
- Related to #10756 (original feature request)