### PR TITLE
Support `POSITRON_DOCS_URL` env var for Workbench

### DIFF
--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -450,6 +450,13 @@ export class WebClientServer {
 			this._logService.info('[WebClientServer] No POSITRON_ENFORCED_SETTINGS environment variable found');
 		}
 
+		// --- Start Positron ---
+		const positronDocsUrl = process.env['POSITRON_DOCS_URL'];
+		if (positronDocsUrl) {
+			this._logService.info(`[WebClientServer] Using POSITRON_DOCS_URL: ${positronDocsUrl}`);
+		}
+		// --- End Positron ---
+
 		// --- Start PWB: Use secure auth cookie ---
 		const cookies = cookie.parse(req.headers.cookie || '');
 		const connectionTokenFromCookie = cookies[connectionTokenCookieName];
@@ -477,6 +484,7 @@ export class WebClientServer {
 			// --- Start Positron ---
 			disableExtension: this._environmentService.args['disable-extension'],
 			bootstrapExtensionsDir: this._environmentService.args['bootstrap-extensions-dir'],
+			positronDocsUrl,
 			// --- End Positron ---
 			productConfiguration,
 			callbackRoute: callbackRoute,

--- a/src/vs/workbench/browser/actions/helpActions.ts
+++ b/src/vs/workbench/browser/actions/helpActions.ts
@@ -17,6 +17,9 @@ import { KeybindingWeight } from '../../../platform/keybinding/common/keybinding
 import { Categories } from '../../../platform/action/common/actionCommonCategories.js';
 import { ICommandService } from '../../../platform/commands/common/commands.js';
 import { ContextKeyExpr } from '../../../platform/contextkey/common/contextkey.js';
+// --- Start Positron ---
+import { IBrowserWorkbenchEnvironmentService } from '../../services/environment/browser/environmentService.js';
+// --- End Positron ---
 
 class KeybindingsReferenceAction extends Action2 {
 
@@ -420,9 +423,10 @@ registerAction2(GetStartedWithAccessibilityFeatures);
 registerAction2(AskVSCodeCopilot);
 
 // --- Start Positron ---
+const POSITRON_DOCS_DEFAULT_URL = 'https://positron.posit.co/';
+
 registerAction2(class extends Action2 {
 	static readonly ID = 'workbench.action.openPositronDocumentation';
-	private readonly URL = 'https://positron.posit.co/';
 
 	constructor() {
 		super({
@@ -440,9 +444,9 @@ registerAction2(class extends Action2 {
 
 	run(accessor: ServicesAccessor): void {
 		const openerService = accessor.get(IOpenerService);
-		openerService.open(
-			URI.parse(this.URL)
-		);
+		const environmentService = accessor.get(IBrowserWorkbenchEnvironmentService);
+		const url = environmentService.positronDocsUrl ?? POSITRON_DOCS_DEFAULT_URL;
+		openerService.open(URI.parse(url));
 	}
 });
 

--- a/src/vs/workbench/browser/actions/helpActions.ts
+++ b/src/vs/workbench/browser/actions/helpActions.ts
@@ -18,7 +18,7 @@ import { Categories } from '../../../platform/action/common/actionCommonCategori
 import { ICommandService } from '../../../platform/commands/common/commands.js';
 import { ContextKeyExpr } from '../../../platform/contextkey/common/contextkey.js';
 // --- Start Positron ---
-import { IBrowserWorkbenchEnvironmentService } from '../../services/environment/browser/environmentService.js';
+import { IPositronDocsService } from '../../services/positronDocs/browser/positronDocsService.js';
 // --- End Positron ---
 
 class KeybindingsReferenceAction extends Action2 {
@@ -423,8 +423,6 @@ registerAction2(GetStartedWithAccessibilityFeatures);
 registerAction2(AskVSCodeCopilot);
 
 // --- Start Positron ---
-const POSITRON_DOCS_DEFAULT_URL = 'https://positron.posit.co/';
-
 registerAction2(class extends Action2 {
 	static readonly ID = 'workbench.action.openPositronDocumentation';
 
@@ -444,9 +442,8 @@ registerAction2(class extends Action2 {
 
 	run(accessor: ServicesAccessor): void {
 		const openerService = accessor.get(IOpenerService);
-		const environmentService = accessor.get(IBrowserWorkbenchEnvironmentService);
-		const url = environmentService.positronDocsUrl ?? POSITRON_DOCS_DEFAULT_URL;
-		openerService.open(URI.parse(url));
+		const docsService = accessor.get(IPositronDocsService);
+		openerService.open(URI.parse(docsService.baseUrl));
 	}
 });
 

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -331,6 +331,15 @@ export interface IWorkbenchConstructionOptions {
 	readonly isEnabledFileUploads?: boolean;
 	// --- End PWB ---
 
+	// --- Start Positron ---
+	/**
+	 * URL for Positron documentation. When set, the "Positron Documentation"
+	 * help menu item will open this URL instead of the default.
+	 * This is typically set by Posit Workbench to point to locally-hosted docs.
+	 */
+	readonly positronDocsUrl?: string;
+	// --- End Positron ---
+
 	//#endregion
 
 	//#region Profile options

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -82,7 +82,7 @@ import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js'
 import './media/positronChat.css';
 import { ILanguageModelsService } from '../../common/languageModels.js';
 import { IPositronAssistantConfigurationService } from '../../../positronAssistant/common/interfaces/positronAssistantService.js';
-import { IBrowserWorkbenchEnvironmentService } from '../../../../services/environment/browser/environmentService.js';
+import { IPositronDocsService } from '../../../../services/positronDocs/browser/positronDocsService.js';
 // --- End Positron ---
 
 const $ = dom.$;
@@ -369,7 +369,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		// --- Start Positron ---
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
 		@IPositronAssistantConfigurationService private readonly positronAssistantConfigurationService: IPositronAssistantConfigurationService,
-		@IBrowserWorkbenchEnvironmentService private readonly environmentService: IBrowserWorkbenchEnvironmentService,
+		@IPositronDocsService private readonly docsService: IPositronDocsService,
 		// --- End Positron ---
 		@IChatModeService private readonly chatModeService: IChatModeService,
 		@IChatLayoutService private readonly chatLayoutService: IChatLayoutService,
@@ -1048,8 +1048,7 @@ Click on $(attach) or type \`#\` to add context, such as files to your chat.
 
 Type \`/\` to use predefined commands such as \`/help\`.`,
 			), { supportThemeIcons: true, isTrusted: true });
-			const baseUrl = this.environmentService.positronDocsUrl ?? 'https://positron.posit.co/';
-			welcomeText = welcomeText.replace('{guide-link}', `[${guideLinkMessage}](${baseUrl}assistant)`);
+			welcomeText = welcomeText.replace('{guide-link}', `[${guideLinkMessage}](${this.docsService.getUrl('assistant')})`);
 		}
 		return {
 			title: welcomeTitle,

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -82,6 +82,7 @@ import { IAgentSessionsService } from '../agentSessions/agentSessionsService.js'
 import './media/positronChat.css';
 import { ILanguageModelsService } from '../../common/languageModels.js';
 import { IPositronAssistantConfigurationService } from '../../../positronAssistant/common/interfaces/positronAssistantService.js';
+import { IBrowserWorkbenchEnvironmentService } from '../../../../services/environment/browser/environmentService.js';
 // --- End Positron ---
 
 const $ = dom.$;
@@ -368,6 +369,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		// --- Start Positron ---
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
 		@IPositronAssistantConfigurationService private readonly positronAssistantConfigurationService: IPositronAssistantConfigurationService,
+		@IBrowserWorkbenchEnvironmentService private readonly environmentService: IBrowserWorkbenchEnvironmentService,
 		// --- End Positron ---
 		@IChatModeService private readonly chatModeService: IChatModeService,
 		@IChatLayoutService private readonly chatLayoutService: IChatLayoutService,
@@ -1046,7 +1048,8 @@ Click on $(attach) or type \`#\` to add context, such as files to your chat.
 
 Type \`/\` to use predefined commands such as \`/help\`.`,
 			), { supportThemeIcons: true, isTrusted: true });
-			welcomeText = welcomeText.replace('{guide-link}', `[${guideLinkMessage}](https://positron.posit.co/assistant)`);
+			const baseUrl = this.environmentService.positronDocsUrl ?? 'https://positron.posit.co/';
+			welcomeText = welcomeText.replace('{guide-link}', `[${guideLinkMessage}](${baseUrl}assistant)`);
 		}
 		return {
 			title: welcomeTitle,

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -24,6 +24,7 @@ import { IInstantiationService, createDecorator } from '../../../../platform/ins
 import { HelpClientInstance } from '../../../services/languageRuntime/common/languageRuntimeHelpClient.js';
 import { RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionService, RuntimeClientType } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { IBrowserWorkbenchEnvironmentService } from '../../../services/environment/browser/environmentService.js';
 
 /**
  * The help HTML file path.
@@ -210,6 +211,7 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
 		@IThemeService private readonly _themeService: IThemeService,
 		@IViewsService private readonly _viewsService: IViewsService,
+		@IBrowserWorkbenchEnvironmentService private readonly _environmentService: IBrowserWorkbenchEnvironmentService,
 
 	) {
 		// Call the base class's constructor.
@@ -245,6 +247,11 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 					html = html
 						.replace(placeholder, dataUrl);
 				}));
+
+				// Replace Positron docs URL with configured value or default
+				const positronDocsUrl = this._environmentService.positronDocsUrl ?? 'https://positron.posit.co/';
+				html = html.replace('__positronDocsUrl__', positronDocsUrl);
+
 				this._welcomeHTML = html;
 				this.showWelcomePage();
 			}).catch(error => {

--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -24,7 +24,7 @@ import { IInstantiationService, createDecorator } from '../../../../platform/ins
 import { HelpClientInstance } from '../../../services/languageRuntime/common/languageRuntimeHelpClient.js';
 import { RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionService, RuntimeClientType } from '../../../services/runtimeSession/common/runtimeSessionService.js';
-import { IBrowserWorkbenchEnvironmentService } from '../../../services/environment/browser/environmentService.js';
+import { IPositronDocsService } from '../../../services/positronDocs/browser/positronDocsService.js';
 
 /**
  * The help HTML file path.
@@ -211,7 +211,7 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
 		@IThemeService private readonly _themeService: IThemeService,
 		@IViewsService private readonly _viewsService: IViewsService,
-		@IBrowserWorkbenchEnvironmentService private readonly _environmentService: IBrowserWorkbenchEnvironmentService,
+		@IPositronDocsService private readonly _docsService: IPositronDocsService,
 
 	) {
 		// Call the base class's constructor.
@@ -249,8 +249,7 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 				}));
 
 				// Replace Positron docs URL with configured value or default
-				const positronDocsUrl = this._environmentService.positronDocsUrl ?? 'https://positron.posit.co/';
-				html = html.replace('__positronDocsUrl__', positronDocsUrl);
+				html = html.replace('__positronDocsUrl__', this._docsService.baseUrl);
 
 				this._welcomeHTML = html;
 				this.showWelcomePage();

--- a/src/vs/workbench/contrib/positronHelp/browser/resources/welcome.html
+++ b/src/vs/workbench/contrib/positronHelp/browser/resources/welcome.html
@@ -49,7 +49,7 @@
 
 			<div>
 				<ul>
-					<li><a href="https://positron.posit.co/">Positron Documentation</a></li>
+					<li><a href="__positronDocsUrl__">Positron Documentation</a></li>
 					<li><a href="https://github.com/posit-dev/positron/discussions">Positron Community Forum</a></li>
 					<li><a href="command:workbench.action.openIssueReporter">Report a Bug in Positron</a></li>
 					<li><a href="https://posit.co/positron-updates-signup/">Sign Up for Positron Updates</a></li>

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookPrompt.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookPrompt.ts
@@ -17,6 +17,7 @@ import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { POSITRON_NOTEBOOK_ENABLED_KEY } from '../common/positronNotebookConfig.js';
 import { URI } from '../../../../base/common/uri.js';
+import { IBrowserWorkbenchEnvironmentService } from '../../../services/environment/browser/environmentService.js';
 
 const NOTEBOOK_PROMPT_DISMISSED_KEY = 'positron.notebook.promptDismissed';
 
@@ -47,6 +48,7 @@ export class PositronNotebookPromptContribution extends Disposable implements IW
 		@INotificationService private readonly notificationService: INotificationService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IOpenerService private readonly openerService: IOpenerService,
+		@IBrowserWorkbenchEnvironmentService private readonly environmentService: IBrowserWorkbenchEnvironmentService,
 	) {
 		super();
 
@@ -94,7 +96,8 @@ export class PositronNotebookPromptContribution extends Disposable implements IW
 				{
 					label: localize('positron.notebook.prompt.learnMore', 'Learn more'),
 					run: () => {
-						this.openerService.open(URI.parse('https://positron.posit.co/positron-notebook-editor'));
+						const baseUrl = this.environmentService.positronDocsUrl ?? 'https://positron.posit.co/';
+						this.openerService.open(URI.parse(`${baseUrl}positron-notebook-editor`));
 					}
 				},
 				{

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookPrompt.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookPrompt.ts
@@ -17,7 +17,7 @@ import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { POSITRON_NOTEBOOK_ENABLED_KEY } from '../common/positronNotebookConfig.js';
 import { URI } from '../../../../base/common/uri.js';
-import { IBrowserWorkbenchEnvironmentService } from '../../../services/environment/browser/environmentService.js';
+import { IPositronDocsService } from '../../../services/positronDocs/browser/positronDocsService.js';
 
 const NOTEBOOK_PROMPT_DISMISSED_KEY = 'positron.notebook.promptDismissed';
 
@@ -48,7 +48,7 @@ export class PositronNotebookPromptContribution extends Disposable implements IW
 		@INotificationService private readonly notificationService: INotificationService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IOpenerService private readonly openerService: IOpenerService,
-		@IBrowserWorkbenchEnvironmentService private readonly environmentService: IBrowserWorkbenchEnvironmentService,
+		@IPositronDocsService private readonly docsService: IPositronDocsService,
 	) {
 		super();
 
@@ -96,8 +96,7 @@ export class PositronNotebookPromptContribution extends Disposable implements IW
 				{
 					label: localize('positron.notebook.prompt.learnMore', 'Learn more'),
 					run: () => {
-						const baseUrl = this.environmentService.positronDocsUrl ?? 'https://positron.posit.co/';
-						this.openerService.open(URI.parse(`${baseUrl}positron-notebook-editor`));
+						this.openerService.open(URI.parse(this.docsService.getUrl('positron-notebook-editor')));
 					}
 				},
 				{

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -78,7 +78,7 @@ import { ScrollbarVisibility } from '../../../../base/common/scrollable.js';
 import './media/positronGettingStarted.css';
 import { PositronReactRenderer } from '../../../../base/browser/positronReactRenderer.js';
 import { createWelcomePageLeft } from './positronWelcomePageLeft.js';
-import { IBrowserWorkbenchEnvironmentService } from '../../../services/environment/browser/environmentService.js';
+import { IPositronDocsService } from '../../../services/positronDocs/browser/positronDocsService.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { ILifecycleService, LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { isDark } from '../../../../platform/theme/common/theme.js';
@@ -230,7 +230,7 @@ export class GettingStartedPage extends EditorPane {
 		// --- Start Positron ---
 		@ILayoutService private readonly layoutService: ILayoutService,
 		@ILifecycleService private readonly lifecycleService: ILifecycleService,
-		@IBrowserWorkbenchEnvironmentService private readonly environmentService: IBrowserWorkbenchEnvironmentService,
+		@IPositronDocsService private readonly docsService: IPositronDocsService,
 		// --- End Positron ---
 		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
 	) {
@@ -1124,14 +1124,13 @@ export class GettingStartedPage extends EditorPane {
 				contextService: this.contextService
 			});
 
-		// --- Start Positron ---
-		const positronDocsUrl = this.environmentService.positronDocsUrl ?? 'https://positron.posit.co/';
-		// --- End Positron ---
 		const helpEntries: IWelcomePageHelpEntry[] = [
 			{
 				id: 'positron-documentation',
 				title: localize('positron.welcome.positronDocumentation', "Positron Documentation"),
-				href: positronDocsUrl
+				// --- Start Positron ---
+				href: this.docsService.baseUrl
+				// --- End Positron ---
 			},
 			{
 				id: 'positron-community',

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -78,6 +78,7 @@ import { ScrollbarVisibility } from '../../../../base/common/scrollable.js';
 import './media/positronGettingStarted.css';
 import { PositronReactRenderer } from '../../../../base/browser/positronReactRenderer.js';
 import { createWelcomePageLeft } from './positronWelcomePageLeft.js';
+import { IBrowserWorkbenchEnvironmentService } from '../../../services/environment/browser/environmentService.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { ILifecycleService, LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
 import { isDark } from '../../../../platform/theme/common/theme.js';
@@ -229,6 +230,7 @@ export class GettingStartedPage extends EditorPane {
 		// --- Start Positron ---
 		@ILayoutService private readonly layoutService: ILayoutService,
 		@ILifecycleService private readonly lifecycleService: ILifecycleService,
+		@IBrowserWorkbenchEnvironmentService private readonly environmentService: IBrowserWorkbenchEnvironmentService,
 		// --- End Positron ---
 		@IMarkdownRendererService private readonly markdownRendererService: IMarkdownRendererService,
 	) {
@@ -1122,11 +1124,14 @@ export class GettingStartedPage extends EditorPane {
 				contextService: this.contextService
 			});
 
+		// --- Start Positron ---
+		const positronDocsUrl = this.environmentService.positronDocsUrl ?? 'https://positron.posit.co/';
+		// --- End Positron ---
 		const helpEntries: IWelcomePageHelpEntry[] = [
 			{
 				id: 'positron-documentation',
 				title: localize('positron.welcome.positronDocumentation', "Positron Documentation"),
-				href: 'https://positron.posit.co/'
+				href: positronDocsUrl
 			},
 			{
 				id: 'positron-community',

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -1128,9 +1128,7 @@ export class GettingStartedPage extends EditorPane {
 			{
 				id: 'positron-documentation',
 				title: localize('positron.welcome.positronDocumentation', "Positron Documentation"),
-				// --- Start Positron ---
 				href: this.docsService.baseUrl
-				// --- End Positron ---
 			},
 			{
 				id: 'positron-community',

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -49,6 +49,13 @@ export interface IBrowserWorkbenchEnvironmentService extends IWorkbenchEnvironme
 	readonly isEnabledFileUploads?: boolean;
 	// --- End PWB ---
 
+	// --- Start Positron ---
+	/**
+	 * URL for Positron documentation, if provided by Posit Workbench.
+	 */
+	readonly positronDocsUrl?: string;
+	// --- End Positron ---
+
 	/**
 	 * Gets whether a resolver extension is expected for the environment.
 	 */
@@ -143,6 +150,12 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 		return this.options.isEnabledFileUploads;
 	}
 	// --- End PWB ---
+
+	// --- Start Positron ---
+	get positronDocsUrl(): string | undefined {
+		return this.options.positronDocsUrl;
+	}
+	// --- End Positron ---
 
 	@memoize
 	get argvResource(): URI { return joinPath(this.userRoamingDataHome, 'argv.json'); }

--- a/src/vs/workbench/services/environment/electron-browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/electron-browser/environmentService.ts
@@ -163,6 +163,11 @@ export class NativeWorkbenchEnvironmentService extends AbstractNativeEnvironment
 	get isEnabledFileUploads(): boolean {
 		return true;
 	}
+
+	// Positron docs URL is not used in desktop mode; returns undefined to use default.
+	get positronDocsUrl(): string | undefined {
+		return undefined;
+	}
 	// --- End Positron ---
 
 	constructor(

--- a/src/vs/workbench/services/positronDocs/browser/positronDocsService.ts
+++ b/src/vs/workbench/services/positronDocs/browser/positronDocsService.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
+import { IBrowserWorkbenchEnvironmentService } from '../../environment/browser/environmentService.js';
+
+/**
+ * The default Positron documentation URL.
+ */
+const POSITRON_DOCS_DEFAULT_URL = 'https://positron.posit.co/';
+
+/**
+ * Service identifier for the Positron docs service.
+ */
+export const IPositronDocsService = createDecorator<IPositronDocsService>('positronDocsService');
+
+/**
+ * Service that provides URLs for Positron documentation.
+ *
+ * When running inside Posit Workbench, the documentation may be hosted locally
+ * and configured via the POSITRON_DOCS_URL environment variable. This service
+ * centralizes the logic for determining the correct documentation URL.
+ */
+export interface IPositronDocsService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * The base URL for Positron documentation.
+	 * Returns the configured URL from POSITRON_DOCS_URL or the default public URL.
+	 */
+	readonly baseUrl: string;
+
+	/**
+	 * Gets the full URL for a documentation path.
+	 * @param path The path relative to the docs root (e.g., 'assistant', 'positron-notebook-editor')
+	 * @returns The full URL to the documentation page
+	 */
+	getUrl(path?: string): string;
+}
+
+/**
+ * Implementation of the Positron docs service.
+ */
+export class PositronDocsService implements IPositronDocsService {
+	readonly _serviceBrand: undefined;
+
+	readonly baseUrl: string;
+
+	constructor(
+		@IBrowserWorkbenchEnvironmentService environmentService: IBrowserWorkbenchEnvironmentService,
+	) {
+		this.baseUrl = environmentService.positronDocsUrl ?? POSITRON_DOCS_DEFAULT_URL;
+	}
+
+	getUrl(path?: string): string {
+		if (!path) {
+			return this.baseUrl;
+		}
+		// Ensure baseUrl ends with / and path doesn't start with /
+		const base = this.baseUrl.endsWith('/') ? this.baseUrl : `${this.baseUrl}/`;
+		const cleanPath = path.startsWith('/') ? path.slice(1) : path;
+		return `${base}${cleanPath}`;
+	}
+}
+
+registerSingleton(IPositronDocsService, PositronDocsService, InstantiationType.Delayed);


### PR DESCRIPTION
Addresses #12300

This PR adds support for the `POSITRON_DOCS_URL` environment variable, allowing Posit Workbench to direct documentation links to locally-hosted documentation instead of the public site. I started updating in a bunch of places and then decided to make a new `IPositronDocsService` to centralize documentation URL handling:
- Reads the configured URL from `POSITRON_DOCS_URL` (passed via `IBrowserWorkbenchEnvironmentService`)
- Falls back to `https://positron.posit.co/` when not set
- Provides `baseUrl` property and `getUrl(path)` method for clean URL construction

I updated the following location:
- Help menu _Positron Documentation_ command
- Help pane homepage
- _Help: Welcome_ page
- Notebook editor prompt "Learn more" link (`/positron-notebook-editor`)
- Assistant welcome message guide link (`/assistant`)

I do have a question for @zachhannum. If Workbench serves docs from a different origin than the main app, users may see an "external site" confirmation prompt. If docs are served from the same origin, this won't occur. What do we think is likely here? We could add the docs URL to `additionalTrustedDomains` if a really smooth experience with a different origin is required.

### Release Notes

#### New Features
- Workbench: added support for `POSITRON_DOCS_URL` environment variable to allow Workbench-hosted documentation (#12300)

#### Bug Fixes
- N/A

### QA Notes

@:help @:web

This feature is primarily for Posit Workbench integration. To test manually in a web server dev build:

1. Edit `.vscode/tasks.json` and add an `options.env` block to the "Run code server" task with a silly URL:
   ```json
   "options": {
       "env": {
           "POSITRON_DOCS_URL": "https://http.cat/"
       }
   },
   ```

2. Launch "Positron Server" from the debug panel

3. Open the Command Palette and run _Help: Positron Documentation_; you'll see an "external site" confirmation prompt but that will not happen on Workbench as long as the docs are served from the same origin

4. Verify it opens your configured URL instead of <https://positron.posit.co/>

5. Similarly, verify the links on the welcome page and the Help home page

6. **Important:** Revert the `tasks.json` change before committing! We don't want that in the long term, obviously. 😅 

The environment variable is read in the web server context only. Desktop builds will always use the default URL. I don't think we can verify this in a release build except for on Workbench with the env var set.

