### PR TITLE
Fix notebook multiselect leaving cell in edit mode

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -179,6 +179,15 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 		const cellEditorFocusedKey = POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.bindTo(editor.contextKeyService);
 
 		disposables.add(editor.onDidFocusEditorWidget(() => {
+			// If the user shift/ctrl/cmd-clicked to multi-select, the click handler
+			// already transitioned to MultiSelection. Don't override that by entering
+			// edit mode just because the editor received focus.
+			const currentState = instance.selectionStateMachine.state.get();
+			if (currentState.type === SelectionState.MultiSelection) {
+				cellEditorFocusedKey.set(true);
+				return;
+			}
+
 			// enterEditor() automatically detects that editor has focus and skips focus management
 			instance.selectionStateMachine.enterEditor(cell);
 			cellEditorFocusedKey.set(true);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -21,13 +21,14 @@ import { FloatingEditorClickMenu } from '../../../../browser/codeeditor.js';
 import { CellEditorOptions } from '../../../notebook/browser/view/cellParts/cellEditorOptions.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { useEnvironment } from '../EnvironmentProvider.js';
+import { addDisposableListener } from '../../../../../base/browser/dom.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { PositronNotebookCellGeneral } from '../PositronNotebookCells/PositronNotebookCell.js';
 import { useObservedValue } from '../useObservedValue.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { autorun, autorunDelta } from '../../../../../base/common/observable.js';
 import { POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED } from '../ContextKeysManager.js';
-import { SelectionState } from '../selectionMachine.js';
+import { CellSelectionType, SelectionState } from '../selectionMachine.js';
 import { InQuickPickContextKey } from '../../../../browser/quickaccess.js';
 import { EditorContextKeys } from '../../../../../editor/common/editorContextKeys.js';
 import { CTX_INLINE_CHAT_FOCUSED } from '../../../../contrib/inlineChat/common/inlineChat.js';
@@ -178,22 +179,51 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 		// (CodeEditorWidget creates this synchronously in its constructor)
 		const cellEditorFocusedKey = POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.bindTo(editor.contextKeyService);
 
+		// Track whether the most recent mousedown had modifier keys held.
+		// Monaco's _onMouseDown calls focus() BEFORE emitting onMouseDown,
+		// so editor.onMouseDown fires AFTER onDidFocusEditorWidget. We use a
+		// native DOM capture-phase listener which fires before Monaco's
+		// handler to detect modifier keys early enough.
+		let hadModifierMouseDown = false;
+		const editorContainer = editor.getContainerDomNode();
+		const nativeMouseDownHandler = (e: MouseEvent) => {
+			hadModifierMouseDown = e.shiftKey || e.ctrlKey || e.metaKey;
+		};
+		disposables.add(addDisposableListener(editorContainer, 'mousedown', nativeMouseDownHandler, true));
+
+		// Also handle multi-selection from editor.onMouseDown (fires after
+		// focus) as a secondary path for cases where the focus handler
+		// couldn't prevent enterEditor in time.
+		disposables.add(editor.onMouseDown((e) => {
+			if (e.event.shiftKey || e.event.ctrlKey || e.event.metaKey) {
+				instance.selectionStateMachine.selectCell(cell, CellSelectionType.Add);
+			}
+		}));
+
 		disposables.add(editor.onDidFocusEditorWidget(() => {
-			// If the user shift/ctrl/cmd-clicked to multi-select, the click handler
-			// already transitioned to MultiSelection. Don't override that by entering
-			// edit mode just because the editor received focus.
-			const currentState = instance.selectionStateMachine.state.get();
-			if (currentState.type === SelectionState.MultiSelection) {
+			// Consume and reset the modifier flag so it doesn't affect
+			// subsequent programmatic focus calls.
+			const wasModifierClick = hadModifierMouseDown;
+			hadModifierMouseDown = false;
+
+			// If the user shift/ctrl/cmd-clicked, the wrapper's onClick handler
+			// will handle multi-selection. Don't override that by entering edit mode.
+			if (wasModifierClick) {
 				cellEditorFocusedKey.set(true);
 				return;
 			}
 
-			// enterEditor() automatically detects that editor has focus and skips focus management
+			// enterEditor() automatically detects that editor has focus and skips focus management.
+			// This also handles plain clicks during MultiSelection, collapsing the selection
+			// into EditingSelection for this cell.
 			instance.selectionStateMachine.enterEditor(cell);
 			cellEditorFocusedKey.set(true);
 		}));
 
 		disposables.add(editor.onDidBlurEditorWidget(() => {
+			// Clear any stale modifier flag so it doesn't incorrectly suppress
+			// enterEditor() on a later keyboard/programmatic focus.
+			hadModifierMouseDown = false;
 			cellEditorFocusedKey.set(false);
 
 			// Check where focus moved to - don't exit edit mode if focus moved to VS Code overlays

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
 import { CellSelectionStatus, IPositronNotebookCell } from '../PositronNotebookCells/IPositronNotebookCell.js';
-import { CellSelectionType } from '../selectionMachine.js';
+import { CellSelectionType, SelectionState } from '../selectionMachine.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { useEnvironment } from '../EnvironmentProvider.js';
 import { useObservedValue } from '../useObservedValue.js';
@@ -148,7 +148,16 @@ export function NotebookCellWrapper({ cell, children }: {
 			// where in the cell the click landed (including inside the editor).
 			const addMode = e.shiftKey || e.ctrlKey || e.metaKey;
 			if (addMode) {
+				const stateBefore = selectionStateMachine.state.get();
 				selectionStateMachine.selectCell(cell, CellSelectionType.Add);
+				const stateAfter = selectionStateMachine.state.get();
+				// The mousedown that preceded this click gave the editor DOM focus.
+				// Move focus to the cell wrapper so no editor appears active during
+				// multi-selection. Only do this when the state actually changed
+				// (e.g., skip when shift-clicking the same cell you're editing).
+				if (stateBefore !== stateAfter) {
+					cellElement?.focus();
+				}
 				return;
 			}
 
@@ -172,9 +181,13 @@ export function NotebookCellWrapper({ cell, children }: {
 				return;
 			}
 
-			// If already selected, do nothing - maintain selection invariant
+			// In single selection, clicking the already-selected cell's non-editor
+			// area is a no-op. In multi-selection, collapse to single selection.
 			if (selectionStatus === CellSelectionStatus.Selected) {
-				return;
+				const currentState = selectionStateMachine.state.get();
+				if (currentState.type !== SelectionState.MultiSelection) {
+					return;
+				}
 			}
 
 			selectionStateMachine.selectCell(cell, CellSelectionType.Normal);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -144,6 +144,14 @@ export function NotebookCellWrapper({ cell, children }: {
 		role='article'
 		tabIndex={0}
 		onClick={(e) => {
+			// If a modifier key is held, treat as multi-select regardless of
+			// where in the cell the click landed (including inside the editor).
+			const addMode = e.shiftKey || e.ctrlKey || e.metaKey;
+			if (addMode) {
+				selectionStateMachine.selectCell(cell, CellSelectionType.Add);
+				return;
+			}
+
 			const clickTarget = e.nativeEvent.target as HTMLElement;
 			// If any of the element or its parents have the class
 			// 'positron-cell-editor-monaco-widget' then don't run the select code as the editor
@@ -169,8 +177,7 @@ export function NotebookCellWrapper({ cell, children }: {
 				return;
 			}
 
-			const addMode = e.shiftKey || e.ctrlKey || e.metaKey;
-			selectionStateMachine.selectCell(cell, addMode ? CellSelectionType.Add : CellSelectionType.Normal);
+			selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
 		}}
 	>
 		<CellScopedContextKeyServiceProvider service={scopedContextKeyService}>

--- a/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/selectionMachine.ts
@@ -69,6 +69,7 @@ const ValidSelectionStateTransitions: Record<SelectionState, SelectionState[]> =
 	],
 	[SelectionState.EditingSelection]: [
 		SelectionState.EditingSelection, // Can stay in editing (same cell)
+		SelectionState.MultiSelection,   // Modified click exits edit mode and grows the selection
 		SelectionState.SingleSelection,  // Exit editor
 		SelectionState.NoCells,          // Cell being edited removed
 	],
@@ -407,8 +408,15 @@ export class SelectionStateMachine extends Disposable {
 		}
 
 		if (state.type === SelectionState.EditingSelection) {
-			// Cannot add to selection while editing
-			this._logService.warn('SelectionMachine: Cannot add cell selection in EditingSelection state');
+			if (state.active === cell) {
+				return;
+			}
+
+			this._setState({
+				type: SelectionState.MultiSelection,
+				selected: verifyNonEmptyArray([state.active, cell]),
+				active: cell
+			});
 			return;
 		}
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookInstance.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookInstance.test.ts
@@ -6,6 +6,8 @@ import * as assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
+import { CellSelectionStatus } from '../../browser/PositronNotebookCells/IPositronNotebookCell.js';
+import { CellSelectionType, getSelectedCells, SelectionState } from '../../browser/selectionMachine.js';
 
 suite('PositronNotebookInstance', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
@@ -30,6 +32,31 @@ suite('PositronNotebookInstance', () => {
 			assert.ok(textModel, 'Notebook should have a text model');
 			assert.strictEqual(textModel.cells[0].getValue(), 'print("hello")', 'Unexpected content for text model cell 0');
 			assert.strictEqual(textModel.cells[1].getValue(), 'print("world")', 'Unexpected content for text model cell 1');
+		});
+	});
+
+	suite('selectionStateMachine', () => {
+		test('multi-selection clears editing state from the previously edited cell', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[
+					['print("code")', 'python', CellKind.Code],
+					['# markdown', 'markdown', CellKind.Markup],
+				],
+				disposables,
+			);
+
+			const [codeCell, markdownCell] = notebook.cells.get();
+
+			notebook.selectionStateMachine.selectCell(codeCell, CellSelectionType.Edit);
+			notebook.selectionStateMachine.selectCell(markdownCell, CellSelectionType.Add);
+
+			const state = notebook.selectionStateMachine.state.get();
+			assert.strictEqual(state.type, SelectionState.MultiSelection);
+			assert.deepStrictEqual(getSelectedCells(state), [codeCell, markdownCell]);
+			assert.strictEqual(state.active, markdownCell);
+			assert.notStrictEqual(codeCell.selectionStatus.get(), CellSelectionStatus.Editing);
+			assert.strictEqual(codeCell.selectionStatus.get(), CellSelectionStatus.Selected);
+			assert.strictEqual(markdownCell.selectionStatus.get(), CellSelectionStatus.Selected);
 		});
 	});
 });

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -29,6 +29,8 @@ export class PositronNotebooks extends Notebooks {
 	private newCellButton = this.code.driver.page.getByLabel(/new code cell/i);
 	private spinner = this.code.driver.page.getByLabel(/cell is executing/i);
 	editorAtIndex = (index: number) => this.cell.nth(index).locator('.monaco-editor :is(.native-edit-context, .inputarea)');
+	/** The visible editor code area -- clickable even when the editor is not focused. */
+	editorWidgetAtIndex = (index: number) => this.cell.nth(index).locator('.positron-cell-editor-monaco-widget .view-lines');
 	cell = this.code.driver.page.locator('[data-testid="notebook-cell"]');
 	codeCell = this.code.driver.page.locator('[data-testid="notebook-cell"][aria-label="Code cell"]');
 	markdownCell = this.code.driver.page.locator(`[data-testid="notebook-cell"][aria-label="${MARKDOWN_ARIA_LABEL}"]`);

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -183,6 +183,151 @@ test.describe('Notebook Focus and Selection', {
 		await notebooksPositron.expectCellContentAtIndexToBe(3, '# Heading 1');
 	});
 
+	// --- Selection state transition tests ---
+	// These tests cover all click-based transitions between selection states:
+	//   SingleSelection, EditingSelection, MultiSelection
+
+	// From EditingSelection: plain click another cell's editor enters edit mode there
+	test('From edit mode: click another cell editor switches edit target', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		await notebooksPositron.newNotebook({ codeCells: 3 });
+
+		await notebooksPositron.selectCellAtIndex(0, { editMode: true });
+		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: true });
+
+		// Use editorWidgetAtIndex for non-focused editors (editorAtIndex targets
+		// .native-edit-context which is only visible when the editor has focus)
+		await notebooksPositron.editorWidgetAtIndex(2).click();
+
+		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false, inEditMode: false });
+		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: true, isActive: true });
+	});
+
+	// From EditingSelection: plain click another cell's non-editor area selects without editing
+	test('From edit mode: click another cell non-editor area exits edit and selects', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		await notebooksPositron.newNotebook({ codeCells: 1, markdownCells: 2 });
+
+		await notebooksPositron.selectCellAtIndex(0, { editMode: true });
+		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: true });
+
+		// Click on markdown cell (rendered content, not an editor)
+		await notebooksPositron.cell.nth(2).click();
+
+		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false });
+		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: false, isActive: true });
+	});
+
+	// From EditingSelection: shift-click on the SAME cell is a no-op (preserves edit mode)
+	test('From edit mode: shift-click same cell editor preserves edit mode', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		await notebooksPositron.newNotebook({ codeCells: 3 });
+
+		await notebooksPositron.selectCellAtIndex(0, { editMode: true });
+		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: true });
+
+		await notebooksPositron.editorWidgetAtIndex(0).click({ modifiers: ['Shift'] });
+
+		// Should remain in edit mode on the same cell -- not multi-select
+		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: true, inEditMode: true, isActive: true });
+	});
+
+	// From EditingSelection: shift-click creates multi-selection without editing
+	test('From edit mode: shift-click editor creates multi-selection', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		await notebooksPositron.newNotebook({ codeCells: 3 });
+
+		await notebooksPositron.selectCellAtIndex(0, { editMode: true });
+		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: true });
+
+		await notebooksPositron.editorWidgetAtIndex(1).click({ modifiers: ['Shift'] });
+
+		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: true, inEditMode: false });
+		await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: true, inEditMode: false, isActive: true });
+	});
+
+	// From MultiSelection: plain click on editor collapses to edit mode
+	test('From multi-selection: click editor collapses to edit mode', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+		await notebooksPositron.newNotebook({ codeCells: 3 });
+
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+		await keyboard.press('Shift+ArrowDown');
+		await keyboard.press('Shift+ArrowDown');
+		await notebooksPositron.expectCellsToBeSelected([0, 1, 2]);
+
+		await notebooksPositron.editorWidgetAtIndex(1).click();
+
+		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false });
+		await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: true, inEditMode: true, isActive: true });
+		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: false });
+	});
+
+	// From MultiSelection: plain click on non-editor area collapses to single-select
+	test('From multi-selection: click non-editor area collapses to single-select', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+		await notebooksPositron.newNotebook({ codeCells: 1, markdownCells: 2 });
+
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+		await keyboard.press('Shift+ArrowDown');
+		await keyboard.press('Shift+ArrowDown');
+		await notebooksPositron.expectCellsToBeSelected([0, 1, 2]);
+
+		// Click on markdown cell (rendered content, not an editor)
+		await notebooksPositron.cell.nth(2).click();
+
+		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false });
+		await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: false });
+		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: false, isActive: true });
+	});
+
+	// From MultiSelection: shift-click adds to selection
+	test('From multi-selection: shift-click adds cell to selection', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
+		await notebooksPositron.newNotebook({ codeCells: 4 });
+
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+		await keyboard.press('Shift+ArrowDown');
+		await notebooksPositron.expectCellsToBeSelected([0, 1]);
+
+		await notebooksPositron.editorWidgetAtIndex(3).click({ modifiers: ['Shift'] });
+
+		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: true });
+		await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: true });
+		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: false });
+		await notebooksPositron.expectCellIndexToBeSelected(3, { isSelected: true, inEditMode: false, isActive: true });
+	});
+
+	// From SingleSelection: click another cell's editor enters edit mode
+	test('From single-select: click another cell editor enters edit mode', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		await notebooksPositron.newNotebook({ codeCells: 3 });
+
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: false });
+
+		await notebooksPositron.editorWidgetAtIndex(2).click();
+
+		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false });
+		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: true, isActive: true });
+	});
+
+	// From SingleSelection: shift-click creates multi-selection
+	test('From single-select: shift-click creates multi-selection', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		await notebooksPositron.newNotebook({ codeCells: 3 });
+
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+
+		await notebooksPositron.editorWidgetAtIndex(2).click({ modifiers: ['Shift'] });
+
+		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: true, inEditMode: false });
+		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: false, isActive: true });
+	});
+
 	test('Multi-select and deselect retains anchor/active cell', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;


### PR DESCRIPTION
Addresses #12342.

Fixes the notebook selection state machine to handle shift+click (add to selection) while a cell is in edit mode. Previously, `_selectCellAdd` rejected this transition with a warning, leaving the state machine stuck in `EditingSelection`. Now it correctly transitions to `MultiSelection`.

This matters when shift+clicking a markdown cell from an editing code cell -- markdown cells don't steal DOM focus, so the focus-based `exitEditor` path never fires.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed notebook selection state machine getting stuck in edit mode during multi-select (#12342)

### QA Notes

@:notebooks @:positron-notebooks

1. Open a notebook with a code cell and a markdown cell
2. Click into the code cell to enter edit mode
3. Shift+click the markdown cell
4. Verify both cells are selected (blue border) and the code cell is no longer in edit mode