### PR TITLE
Bump Ark to 0.1.237

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -1089,7 +1089,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.236"
+      "ark": "0.1.237"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
- https://github.com/posit-dev/ark/pull/1084
  Addresses posit-dev/positron#12076
  Addresses posit-dev/positron#11842
  Related Positron PR: #12280

- https://github.com/posit-dev/ark/pull/1062

- https://github.com/posit-dev/ark/pull/1070

- Increase plot recv timeout


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

See linked PRs.

@:ark