### PR TITLE
Add support for `Library` in r-versions configuration file

### DIFF
--- a/extensions/positron-r/src/kernel-spec.ts
+++ b/extensions/positron-r/src/kernel-spec.ts
@@ -387,6 +387,11 @@ export async function createJupyterKernelSpec(
 			startup_command = `. ${packagerMetadata.script}`;
 			LOGGER.info(`Using r-versions startup script: ${packagerMetadata.script}`);
 		}
+		// Set custom library paths via R_LIBS environment variable
+		if (packagerMetadata.library) {
+			env['R_LIBS'] = packagerMetadata.library;
+			LOGGER.info(`Using r-versions library paths: ${packagerMetadata.library}`);
+		}
 	}
 
 	// R script to run on session startup

--- a/extensions/positron-r/src/provider-rversions.ts
+++ b/extensions/positron-r/src/provider-rversions.ts
@@ -220,7 +220,7 @@ export async function discoverRVersionsBinaries(): Promise<RBinary[]> {
 			label: entry.label,
 			script: entry.script,
 			repo: entry.repo,
-			// Future PRs will add: library
+			library: entry.library,
 		};
 
 		binaries.push({

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -127,7 +127,8 @@ export interface RVersionsMetadata {
 	readonly script?: string;
 	/** CRAN repository URL or path to repos.conf file */
 	readonly repo?: string;
-	// Future PRs will add: library
+	/** Colon-separated list of R library directories */
+	readonly library?: string;
 }
 
 /**


### PR DESCRIPTION
Addresses #11426 with the fifth PR in the r-versions implementation series

This PR adds support for the `Library` field from the r-versions configuration file, allowing administrators to specify custom R library paths for specific R installations. The field accepts a colon-separated list of directory paths (e.g., `Library: /opt/R/4.3.0/site-library:/shared/r-libs`). When specified, the `R_LIBS` environment variable is set before launching R, which causes R to prepend these paths to `.libPaths()`.

I want to note that if you modify the r-versions file while an interpreter is already affiliated with the workspace, simply restarting Positron is not enough to pick up the changes. You need to **stop the interpreter first** (or explicitly clear the affiliation), then restart Positron, then start the interpreter again. This is consistent with how other packager metadata (conda, pixi, etc) works, but is that good for r-versions support? Should r-versions metadata be refreshed when starting a new session, rather than being cached via workspace affiliation? The behavior here matches other interpreter types, but means admin changes don't propagate automatically.

This is the fifth PR in the r-versions implementation series:
- #12022
- #12101
- #12169
- #12205
- **This PR:** `Library` field support

### Release Notes

#### New Features

- N/A for now!

#### Bug Fixes

- N/A

### QA Notes

@:interpreter

#### Testing with a single library path

1. Create a test library directory:
   ```bash
   mkdir -p /tmp/test-r-lib
   ```

> [!NOTE]
> R silently ignores library paths that don't exist. Make sure the directories really exist before testing.

2. Create or update r-versions file at `~/Library/Preferences/rstudio/r-versions` (macOS) or `/etc/rstudio/r-versions` (Linux):
   ```
   Path: /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources
   Label: R 4.4 (Test Library)
   Library: /tmp/test-r-lib
   ```

3. Restart Positron, start a session with the labeled interpreter, and verify:
   ```r
   Sys.getenv("R_LIBS")
   # Should show: /tmp/test-r-lib
   
   .libPaths()
   # Should show /tmp/test-r-lib (or /private/tmp/test-r-lib on macOS) at the front
   ```

#### Testing with multiple colon-separated paths

1. Create multiple test directories:
   ```bash
   mkdir -p /tmp/test-r-lib-1 /tmp/test-r-lib-2
   ```

2. Update r-versions to use multiple paths:
   ```
   Path: /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources
   Label: R 4.4 (Test Multiple Libraries)
   Library: /tmp/test-r-lib-1:/tmp/test-r-lib-2
   ```

3. Restart Positron, start a session, and verify:
   ```r
   .libPaths()
   # Should show both paths at the front of the list
   ```


