### PR TITLE
Bundle Quarto for Windows ARM (to run under emulation)

### DIFF
--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -368,11 +368,9 @@ function packageTask(platform: string, arch: string, sourceFolderName: string, d
 		);
 
 		/// --- Start Positron ---
-		// The Quarto binaries are not available for Windows ARM builds, but are
-		// for all other platforms/architectures
-		if (!(platform === 'win32' && arch === 'arm64')) {
-			all = es.merge(all, getQuartoBinaries());
-		}
+		// Bundle Quarto binaries for all platforms. Windows ARM uses the x64
+		// Quarto binaries which run under emulation.
+		all = es.merge(all, getQuartoBinaries());
 		// --- End Positron ---
 
 		if (platform === 'win32') {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/12207

This is part of the work to make Windows ARM builds non-experimental. I'll follow up with some PRs in `positron-builds` and `positron-website` to update the release notes and the pages on the website.

We didn't discuss how prominently we want to tell people that they are using Quarto under emulation. I am already planning on adding documentation on our website in a few places, but do we think we need an in-app notification for folks? Like if they open a `.qmd` or similar? Or is that a bit much, given that we think this is working well for folks?

### Release Notes

#### New Features
- Windows ARM builds now include Quarto (running under x64 emulation) (#12207)

#### Bug Fixes
- N/A

### QA Notes

We are not yet running any tests yet on Windows ARM as described in https://github.com/posit-dev/positron/issues/10112.

- For a Windows ARM build, verify Quarto binaries are present in the app bundle at `resources/app/quarto/`
- On a Windows ARM device, test that Quarto renders work correctly
