### PR TITLE
Improve modal dialog spacing and remove action bar separators

### DIFF
--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okActionBar.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okActionBar.css
@@ -8,7 +8,7 @@
 	right: 0;
 	bottom: 0;
 	gap: 10px;
-	height: 64px;
+	height: var(--_positron-modal-action-bar-height);
 	display: flex;
 	margin: 0 16px;
 	padding: 0 0px;

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okActionBar.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okActionBar.css
@@ -17,10 +17,6 @@
 	justify-content: end;
 }
 
-.positron-modal-dialog-box .ok-action-bar.top-separator {
-	border-top: 1px solid var(--vscode-positronModalDialog-separator);
-}
-
 .positron-modal-dialog-box .ok-action-bar .action-bar-button {
 	width: 80px;
 	height: 32px;

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okActionBar.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okActionBar.tsx
@@ -26,7 +26,7 @@ interface OKActionBarProps {
 export const OKActionBar = (props: OKActionBarProps) => {
 	// Render.
 	return (
-		<div className='ok-action-bar top-separator'>
+		<div className='ok-action-bar'>
 			<Button className='action-bar-button default' onPressed={props.onAccept}>
 				{props.okButtonTitle ?? localize('positronOK', "OK")}
 			</Button>

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelActionBar.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelActionBar.css
@@ -17,10 +17,6 @@
 	justify-content: end;
 }
 
-.positron-modal-dialog-box .ok-cancel-action-bar.top-separator {
-	border-top: 1px solid var(--vscode-positronModalDialog-separator);
-}
-
 .positron-modal-dialog-box .ok-cancel-action-bar .action-bar-button {
 	width: 80px;
 	height: 32px;

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelActionBar.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelActionBar.css
@@ -8,7 +8,7 @@
 	right: 0;
 	bottom: 0;
 	gap: 10px;
-	height: 64px;
+	height: var(--_positron-modal-action-bar-height);
 	display: flex;
 	margin: 0 16px;
 	padding: 0 0px;

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelActionBar.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelActionBar.tsx
@@ -50,7 +50,7 @@ export const OKCancelActionBar = (props: OKCancelActionBarProps) => {
 
 	// Render.
 	return (
-		<div className='ok-cancel-action-bar top-separator'>
+		<div className='ok-cancel-action-bar'>
 			{preActions}
 			<PlatformNativeDialogActionBar primaryButton={okButton} secondaryButton={cancelButton} />
 		</div>

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelBackNextActionBar.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelBackNextActionBar.css
@@ -8,7 +8,7 @@
 	right: 0;
 	bottom: 0;
 	gap: 10px;
-	height: 64px;
+	height: var(--_positron-modal-action-bar-height);
 	display: flex;
 	margin: 0 16px;
 	padding: 0 0px;

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelBackNextActionBar.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelBackNextActionBar.css
@@ -17,10 +17,6 @@
 	justify-content: space-between;
 }
 
-.positron-modal-dialog-box .ok-cancel-back-action-bar .top-separator {
-	border-top: 1px solid var(--vscode-positronModalDialog-separator);
-}
-
 .positron-modal-dialog-box .ok-cancel-back-action-bar .action-bar-button {
 	width: 80px;
 	height: 32px;

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelBackNextActionBar.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/components/okCancelBackNextActionBar.tsx
@@ -51,7 +51,7 @@ export const OKCancelBackNextActionBar = ({ okButtonConfig, cancelButtonConfig, 
 
 	// Render.
 	return (
-		<div className='ok-cancel-back-action-bar top-separator'>
+		<div className='ok-cancel-back-action-bar'>
 			<div className='left-actions'>
 				{backButtonConfig ?
 					<Button className='action-bar-button' disabled={backButtonConfig.disable ?? false} onPressed={backButtonConfig.onClick}>

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.css
@@ -11,6 +11,7 @@
 }
 
 .positron-modal-dialog-box {
+	--_positron-modal-action-bar-height: 64px;
 	display: flex;
 	overflow: hidden;
 	position: absolute;

--- a/src/vs/workbench/browser/positronNewFolderFlow/components/flowStep.css
+++ b/src/vs/workbench/browser/positronNewFolderFlow/components/flowStep.css
@@ -9,6 +9,7 @@
 	right: 0;
 	bottom: 0;
 	padding: 16px;
+	padding-bottom: 80px;
 	position: absolute;
 }
 

--- a/src/vs/workbench/browser/positronNewFolderFlow/components/flowStep.css
+++ b/src/vs/workbench/browser/positronNewFolderFlow/components/flowStep.css
@@ -8,8 +8,7 @@
 	left: 0;
 	right: 0;
 	bottom: 0;
-	padding: 16px;
-	padding-bottom: 80px;
+	padding: 16px 16px calc(var(--_positron-modal-action-bar-height) + 16px);
 	position: absolute;
 }
 

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -128,13 +128,6 @@
 	color: var(--vscode-textLink-foreground);
 }
 
-.language-model-modal-dialog .ok-action-bar.top-separator {
-	border-top: none;
-	padding-bottom: 16px;
-	padding-top: 0px;
-	height: 32px;
-}
-
 .language-model-modal-dialog .content-area {
 	padding: 16px 16px 0 16px;
 }


### PR DESCRIPTION
Addresses #12113.

This PR fixes the "No interpreters available" and other similar warnings overflowing the content area in the New Folder from Template dialog. The fix adds some additional space to the flow step container to leave room. I did not add the ability to scroll or anything like that.

I also would like to propose removing the non-functional horizontal rule separator above the action bar buttons, because I think it looked pretty weird with the additional space we are adding here. Thoughts?

With these changes:

<img width="1509" height="1076" alt="Screenshot 2026-03-08 at 6 07 53 PM" src="https://github.com/user-attachments/assets/ce44d19f-b8f4-438f-825c-e9dca990ff23" />

<img width="1509" height="1076" alt="Screenshot 2026-03-08 at 6 07 05 PM" src="https://github.com/user-attachments/assets/428e0fa0-125c-481c-b1b2-4ffea0ca81e5" />


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed warning messages overflowing the content area in the New Folder from Template dialog (#12113)

### QA Notes

@:new-folder-flow

1. Open New Folder from Template dialog (File > New Folder from Template or via Welcome tab)
2. Select Python Project
3. Select Conda (if not installed) or any configuration that triggers a warning message
4. Verify the warning message does not overflow into the button area

