### PR TITLE
build: update x64archfiles for snowflake-sdk

### DIFF
--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -64,6 +64,8 @@ const stashPatterns = [
 	'**/node_modules/@napi-rs/canvas-darwin-arm64/skia.darwin-arm64.node',
 	// Exclusions from positron-assistant
 	'**/resources/copilot/**',  // Copilot language server binary
+	// Exclusions from Snowflake SQL client
+	'**/node_modules/snowflake-sdk/dist/lib/minicore/binaries/**',
 ];
 
 // Some generated files may end up being different in both distributions.
@@ -230,8 +232,7 @@ async function origMain(
 		// Add to the list of x64-only files
 		// **/node_modules/fsevents/fsevents.node
 		// **/node_modules/@napi-rs/canvas-darwin-x64/skia.darwin-x64.node
-		// **/node_modules/snowflake-sdk/dist/lib/minicore/binaries/*.darwin-x64.node
-		x64ArchFiles: '{*/kerberos.node,**/extensions/microsoft-authentication/dist/libmsalruntime.dylib,**/extensions/microsoft-authentication/dist/msal-node-runtime.node,**/node_modules/fsevents/fsevents.node,**/node_modules/@napi-rs/canvas-darwin-x64/skia.darwin-x64.node,**/node_modules/snowflake-sdk/dist/lib/minicore/binaries/*.darwin-x64.node}',
+		x64ArchFiles: '{*/kerberos.node,**/extensions/microsoft-authentication/dist/libmsalruntime.dylib,**/extensions/microsoft-authentication/dist/msal-node-runtime.node,**/node_modules/fsevents/fsevents.node,**/node_modules/@napi-rs/canvas-darwin-x64/skia.darwin-x64.node}',
 		// --- End Positron ---
 		filesToSkipComparison: (file: string) => {
 			for (const expected of filesToSkip) {

--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -230,7 +230,8 @@ async function origMain(
 		// Add to the list of x64-only files
 		// **/node_modules/fsevents/fsevents.node
 		// **/node_modules/@napi-rs/canvas-darwin-x64/skia.darwin-x64.node
-		x64ArchFiles: '{*/kerberos.node,**/extensions/microsoft-authentication/dist/libmsalruntime.dylib,**/extensions/microsoft-authentication/dist/msal-node-runtime.node,**/node_modules/fsevents/fsevents.node,**/node_modules/@napi-rs/canvas-darwin-x64/skia.darwin-x64.node}',
+		// **/node_modules/snowflake-sdk/dist/lib/minicore/binaries/*.darwin-x64.node
+		x64ArchFiles: '{*/kerberos.node,**/extensions/microsoft-authentication/dist/libmsalruntime.dylib,**/extensions/microsoft-authentication/dist/msal-node-runtime.node,**/node_modules/fsevents/fsevents.node,**/node_modules/@napi-rs/canvas-darwin-x64/skia.darwin-x64.node,**/node_modules/snowflake-sdk/dist/lib/minicore/binaries/*.darwin-x64.node}',
 		// --- End Positron ---
 		filesToSkipComparison: (file: string) => {
 			for (const expected of filesToSkip) {


### PR DESCRIPTION
Unblocks macos build by adding more architecture specific files after `snowflake-sdk` was updated🕺 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

macos build should succeed