### PR TITLE
Assistant: Update Custom Agent directories

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -308,10 +308,10 @@ export class ActionList<T> extends Disposable {
 
 	private readonly _actionLineHeight = 28;
 	private readonly _headerLineHeight = 28;
+	private readonly _separatorLineHeight = 8;
 	// --- Start Positron ---
 	// Use a taller separator to accommodate provider logos
-	// private readonly _separatorLineHeight = 8;
-	private readonly _separatorLineHeight = 32;
+	private readonly _iconSeparatorLineHeight = 32;
 	// --- End Positron ---
 
 	private readonly _allMenuItems: readonly IActionListItem<T>[];
@@ -340,7 +340,11 @@ export class ActionList<T> extends Disposable {
 					case ActionListItemKind.Header:
 						return this._headerLineHeight;
 					case ActionListItemKind.Separator:
-						return this._separatorLineHeight;
+						// --- Start Positron ---
+						// Choose the separator height based on whether it has an icon
+						// return this._separatorLineHeight;
+						return !!element.group?.icon ? this._iconSeparatorLineHeight : this._separatorLineHeight;
+					// --- End Positron ---
 					default:
 						return this._actionLineHeight;
 				}
@@ -416,10 +420,22 @@ export class ActionList<T> extends Disposable {
 	layout(minWidth: number): number {
 		// Updating list height, depending on how many separators and headers there are.
 		const numHeaders = this._allMenuItems.filter(item => item.kind === 'header').length;
-		const numSeparators = this._allMenuItems.filter(item => item.kind === 'separator').length;
+		// --- Start Positron ---
+		// Create separate counts for icon vs. regular separators
+		// const numSeparators = this._allMenuItems.filter(item => item.kind === 'separator').length;
+		const numSeparators = this._allMenuItems.filter(item => item.kind === 'separator' && !item.group?.icon).length;
+		const numIconSeparators = this._allMenuItems.filter(item => item.kind === 'separator' && !!item.group?.icon).length;
+		// --- End Positron ---
 		const itemsHeight = this._allMenuItems.length * this._actionLineHeight;
 		const heightWithHeaders = itemsHeight + numHeaders * this._headerLineHeight - numHeaders * this._actionLineHeight;
-		const heightWithSeparators = heightWithHeaders + numSeparators * this._separatorLineHeight - numSeparators * this._actionLineHeight;
+		// --- Start Positron ---
+		// Adjust height calculation to account for icon vs. regular separators
+		// const heightWithSeparators = heightWithHeaders + numSeparators * this._separatorLineHeight - numSeparators * this._actionLineHeight;
+		const heightWithSeparators = heightWithHeaders +
+			numSeparators * this._separatorLineHeight +
+			numIconSeparators * this._iconSeparatorLineHeight -
+			(numSeparators + numIconSeparators) * this._actionLineHeight;
+		// --- End Positron ---
 		this._list.layout(heightWithSeparators);
 		let maxWidth = minWidth;
 

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -343,7 +343,7 @@ export class ActionList<T> extends Disposable {
 						// --- Start Positron ---
 						// Choose the separator height based on whether it has an icon
 						// return this._separatorLineHeight;
-						return !!element.group?.icon ? this._iconSeparatorLineHeight : this._separatorLineHeight;
+						return isTallSeparator(element) ? this._iconSeparatorLineHeight : this._separatorLineHeight;
 					// --- End Positron ---
 					default:
 						return this._actionLineHeight;
@@ -423,8 +423,8 @@ export class ActionList<T> extends Disposable {
 		// --- Start Positron ---
 		// Create separate counts for icon vs. regular separators
 		// const numSeparators = this._allMenuItems.filter(item => item.kind === 'separator').length;
-		const numSeparators = this._allMenuItems.filter(item => item.kind === 'separator' && !item.group?.icon).length;
-		const numIconSeparators = this._allMenuItems.filter(item => item.kind === 'separator' && !!item.group?.icon).length;
+		const numSeparators = this._allMenuItems.filter(item => item.kind === 'separator' && !isTallSeparator(item)).length;
+		const numIconSeparators = this._allMenuItems.filter(item => item.kind === 'separator' && isTallSeparator(item)).length;
 		// --- End Positron ---
 		const itemsHeight = this._allMenuItems.length * this._actionLineHeight;
 		const heightWithHeaders = itemsHeight + numHeaders * this._headerLineHeight - numHeaders * this._actionLineHeight;
@@ -586,3 +586,10 @@ export class ActionList<T> extends Disposable {
 function stripNewlines(str: string): string {
 	return str.replace(/\r\n|\r|\n/g, ' ');
 }
+
+// --- Start Positron ---
+// Helper to determine if a separator is "tall" (has icon or title)
+function isTallSeparator<T>(element: IActionListItem<T>): boolean {
+	return !!element.group?.icon || !!element.group?.title?.length || !!element.label?.length;
+}
+// --- End Positron ---

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -107,6 +107,8 @@ body .action-widget .monaco-scrollable-element .monaco-list-rows .monaco-list-ro
 	gap: 4px;
 	height: auto;
 	min-height: 20px;
+	/* Remove background color to avoid affordance on hover */
+	background-color: unset !important;
 }
 
 .action-widget .monaco-scrollable-element .monaco-list-rows .monaco-list-row.separator:not(:first-of-type) {

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -54,7 +54,7 @@ import { ILanguageModelToolsConfirmationService } from '../common/tools/language
 import { ILanguageModelToolsService } from '../common/tools/languageModelToolsService.js';
 import { ChatPromptFilesExtensionPointHandler } from '../common/promptSyntax/chatPromptFilesContribution.js';
 import { PromptsConfig } from '../common/promptSyntax/config/config.js';
-import { INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, INSTRUCTION_FILE_EXTENSION, LEGACY_MODE_DEFAULT_SOURCE_FOLDER, LEGACY_MODE_FILE_EXTENSION, PROMPT_DEFAULT_SOURCE_FOLDER, PROMPT_FILE_EXTENSION, DEFAULT_SKILL_SOURCE_FOLDERS, AGENTS_SOURCE_FOLDER, AGENT_FILE_EXTENSION, SKILL_FILENAME } from '../common/promptSyntax/config/promptFileLocations.js';
+import { INSTRUCTIONS_DEFAULT_SOURCE_FOLDER, INSTRUCTION_FILE_EXTENSION, LEGACY_MODE_DEFAULT_SOURCE_FOLDER, LEGACY_MODE_FILE_EXTENSION, PROMPT_DEFAULT_SOURCE_FOLDER, PROMPT_FILE_EXTENSION, DEFAULT_SKILL_SOURCE_FOLDERS, AGENTS_SOURCE_FOLDER, AGENT_FILE_EXTENSION, SKILL_FILENAME, AGENTS_POSITRON_SOURCE_FOLDER } from '../common/promptSyntax/config/promptFileLocations.js';
 import { PromptLanguageFeaturesProvider } from '../common/promptSyntax/promptFileContributions.js';
 import { AGENT_DOCUMENTATION_URL, INSTRUCTIONS_DOCUMENTATION_URL, PROMPT_DOCUMENTATION_URL, SKILL_DOCUMENTATION_URL } from '../common/promptSyntax/promptTypes.js';
 import { IPromptsService } from '../common/promptSyntax/service/promptsService.js';
@@ -831,6 +831,11 @@ configurationRegistry.registerConfiguration({
 			),
 			default: {
 				[AGENTS_SOURCE_FOLDER]: true,
+				// --- Start Positron ---
+				// Adds .vscode/positron/agents as a default location for agents
+				// Now togglable in settings UI
+				[AGENTS_POSITRON_SOURCE_FOLDER]: true
+				// --- End Positron ---
 			},
 			additionalProperties: { type: 'boolean' },
 			propertyNames: {


### PR DESCRIPTION
The 109 merge adds the `chat.agentFilesLocations` setting to allow users to customize built-in and custom agent directories. The Positron default agent directory (`.vscode/positron/agents`) was added to this list. Investigation shows that this setting is respected by Positron Assistant without any further edits necessary!

A minor rendering issue was also fixed up as a part of this PR, as shown in the screenshots below.

Old, demonstrating rendering bug:
<img width="227" height="302" alt="Screenshot 2026-03-09 at 10 50 54 AM" src="https://github.com/user-attachments/assets/44ebfc99-2bb9-4c85-979e-ac1af21e8914" />

New, showing fixed rendering & update
<img width="2168" height="1402" alt="Screenshot 2026-03-09 at 10 25 21 AM" src="https://github.com/user-attachments/assets/da00699a-191d-4476-bc40-54089f3cc197" />

File structure for "New" screenshot:
<img width="550" height="379" alt="Screenshot 2026-03-09 at 10 25 37 AM" src="https://github.com/user-attachments/assets/bc34e119-f0cb-450b-acb4-bec74b99f183" />

Addresses #12132 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Adds togglable option for `.vscode/positron/agents` directory in the `chat.agentFilesLocations` setting

#### Bug Fixes

- Adds `.vscode/positron/agents` back to the custom agent search list
- Fixes rendering bug in custom agents list


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

Agent logic:
- Ensure that agent files in Positron's location are displayed in the Agent picker (`.vscode/positron/agents/*.agent.md`)
- Ensure that agent files in a custom location are displayed in the Agent picker
  - Create custom agent directory (e.g., `custom-agents/*.agent.md`)
  - Add custom agent directory to settings (`chat.agentFilesLocations`)

Rendering:
- Ensure separator is correct height in the Agent picker within the chat pane
- Ensure the separator is the correct height in the model picker within the chat pane
  - Model picker separators have Icons within, so will be taller than in the Agent pane


e2e: @:assistant