### PR TITLE
Remember choice in plot 'open in editor' action

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -457,7 +457,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	// Open in editor actions builder.
 	const openInEditorActions = (): IAction[] => {
 		return openInEditorCommands.map(command => ({
-			id: PlotsEditorAction.ID,
+			id: `${PlotsEditorAction.ID}.${command.editorTarget}`,
 			label: command.label,
 			tooltip: '',
 			class: undefined,

--- a/test/e2e/pages/plots.ts
+++ b/test/e2e/pages/plots.ts
@@ -19,6 +19,7 @@ const PLOT_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .pos
 const SAVE_PLOT_FROM_PLOTS_PANE_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Save plot"]';
 const COPY_PLOT_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Copy plot to clipboard"]';
 const ZOOM_PLOT_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Fit"]';
+const OPEN_IN_EDITOR_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Open in editor tab"]';
 const OPEN_IN_EDITOR_DROPDOWN_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Select where to open plot"]';
 const OVERFLOW_MENU_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="overflow"]';
 const ORIGIN_FILE_BUTTON = '.plot-origin-file';
@@ -233,6 +234,31 @@ export class Plots {
 			} else {
 				throw new Error('Could not find "Open in Editor" button in action bar or overflow menu');
 			}
+		});
+	}
+
+	async clickOpenInEditorButton() {
+		await test.step('Click the main Open in Editor button', async () => {
+			const openInEditorButton = this.code.driver.page.locator(OPEN_IN_EDITOR_BUTTON);
+			await openInEditorButton.click();
+		});
+	}
+
+	async verifyOpenPlotDropdownCheckedOption(expectedOption: PlotLocations) {
+		const menuItemLabels: Record<PlotLocations, string> = {
+			'editor': 'Open in editor tab',
+			'new window': 'Open in new window',
+			'editor tab to the side': 'Open in editor tab to the Side'
+		};
+		await test.step(`Verify dropdown checked option is: ${expectedOption}`, async () => {
+			const openInEditorButton = this.code.driver.page.locator(OPEN_IN_EDITOR_DROPDOWN_BUTTON);
+			await this.contextMenu.triggerAndVerifyMenuItems({
+				menuTrigger: openInEditorButton,
+				menuItemStates: Object.entries(menuItemLabels).map(([key, label]) => ({
+					label,
+					checked: key === expectedOption
+				}))
+			});
 		});
 	}
 

--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -153,6 +153,37 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await expect(plots.plotSizeButton).not.toBeDisabled();
 		});
 
+		test('Python - Verify open plot dropdown remembers selection', {
+			tag: [tags.WEB, tags.WIN, tags.PLOTS]
+		}, async function ({ app, page }) {
+			const plots = app.workbench.plots;
+
+			await test.step('Create a plot', async () => {
+				await app.workbench.console.executeCode('Python', pythonDynamicPlot);
+				await plots.waitForCurrentPlot();
+				await app.workbench.layouts.enterLayout('fullSizedAuxBar');
+			});
+
+			await test.step('Select "Open in editor tab" from dropdown', async () => {
+				await plots.openPlotIn('editor');
+				await plots.waitForPlotInEditor();
+				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
+			});
+
+			await test.step('Click main button and verify it opens in editor tab', async () => {
+				// Clicking the main (non-dropdown) part of the split button should
+				// repeat the last selected action ("Open in editor tab").
+				await plots.clickOpenInEditorButton();
+				await plots.waitForPlotInEditor();
+
+				// Verify there is exactly one editor group (not side-by-side),
+				// confirming the action was "editor tab" not "new window"
+				const editorGroups = page.locator('.editor-group-container');
+				await expect(editorGroups).toHaveCount(1);
+				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
+			});
+		});
+
 		test('Python - Verify opening plot in new window', { tag: [tags.WEB, tags.WIN, tags.PLOTS] }, async function ({ app }) {
 			await verifyPlotInNewWindow(app, 'Python', pythonDynamicPlot);
 		});


### PR DESCRIPTION
Fixes persistence of the user's choice in the Open in Editor action in the Plots pane. The problem was pretty simple; all the commands were mapped to the same ID.

Also adds a test to protect this code path going forward.

Addresses https://github.com/posit-dev/positron/issues/11654.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix issue persisting selection in the Open in Editor menu in the Plots pane (#11654)


### QA Notes

Easy to repro using notes in #11654. 

Test tags: `@:plots`
