### PR TITLE
Assistant: Fixes Quarto prompting

### DIFF
--- a/extensions/positron-assistant/src/md/prompts/chat/quarto.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/quarto.md
@@ -9,21 +9,19 @@ description: Prompting related to Quarto
 <quarto>
 When the USER asks a question about Quarto, you attempt to respond as normal in the first instance.
 
-When you respond with Quarto document examples (.qmd files), use standard triple-backtick code fences with the `qmd` language identifier:
+When you respond with Quarto document examples (.qmd files), use at least five backticks with the `quarto` language identifier for the outer code fence. This prevents conflicts with the triple-backtick code blocks that appear inside Quarto documents:
 
-```qmd
+`````quarto
 ---
 title: "Example"
 ---
 
 ## Hello World
+
+```{r}
+# R code here
 ```
-
-When you respond with Quarto-flavored markdown code blocks that would appear inside a .qmd file (such as executable R or Python code chunks), use at least four tildes to avoid conflicts with the outer code fence:
-
-````python
-print("Hello from Python")
-````
+`````
 
 If you find you cannot complete the USER’s Quarto request, or don’t know the answer to their Quarto question, direct the USER to the user guides provided online at <https://quarto.org/docs/guide/>.
 </quarto>

--- a/extensions/positron-assistant/src/md/prompts/chat/quarto.md
+++ b/extensions/positron-assistant/src/md/prompts/chat/quarto.md
@@ -9,7 +9,21 @@ description: Prompting related to Quarto
 <quarto>
 When the USER asks a question about Quarto, you attempt to respond as normal in the first instance.
 
-When you respond with Quarto examples, you use at least four tildes (`~~~~quarto`) to create the surrounding codeblock.
+When you respond with Quarto document examples (.qmd files), use standard triple-backtick code fences with the `qmd` language identifier:
+
+```qmd
+---
+title: "Example"
+---
+
+## Hello World
+```
+
+When you respond with Quarto-flavored markdown code blocks that would appear inside a .qmd file (such as executable R or Python code chunks), use at least four tildes to avoid conflicts with the outer code fence:
+
+````python
+print("Hello from Python")
+````
 
 If you find you cannot complete the USER’s Quarto request, or don’t know the answer to their Quarto question, direct the USER to the user guides provided online at <https://quarto.org/docs/guide/>.
 </quarto>


### PR DESCRIPTION
This PR fixes Quarto prompting from using tildes for code fencing, to backticks.

<img width="2168" height="1402" alt="Screenshot 2026-03-09 at 1 50 10 PM" src="https://github.com/user-attachments/assets/5ae4459d-41cf-4185-af7c-81b76a2b70f4" />

Address #11919

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Assistant now correctly fences Quarto code


### QA Notes

Ensure quarto docs use backticks for fences on Sonnet 4.5 models.

e2e: @:assistant