### PR TITLE
Remove agent type selector for non-copilot models

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -500,6 +500,10 @@ export class OpenSessionTargetPickerAction extends Action2 {
 						ChatContextKeys.enabled,
 						ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 						ChatContextKeys.inQuickChat.negate(),
+						// --- Start Positron ---
+						// Only show session target picker when the current provider is Copilot Chat
+						ChatContextKeys.chatCurrentProvider.isEqualTo('copilot'),
+						// --- End Positron ---
 						ChatContextKeys.chatSessionIsEmpty),
 					group: 'navigation',
 				},
@@ -535,6 +539,10 @@ export class OpenDelegationPickerAction extends Action2 {
 						ChatContextKeys.enabled,
 						ChatContextKeys.location.isEqualTo(ChatAgentLocation.Chat),
 						ChatContextKeys.inQuickChat.negate(),
+						// --- Start Positron ---
+						// Only show delegation picker when the current provider is Copilot Chat
+						ChatContextKeys.chatCurrentProvider.isEqualTo('copilot'),
+						// --- End Positron ---
 						ChatContextKeys.chatSessionIsEmpty.negate()),
 					group: 'navigation',
 				},

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1088,8 +1088,15 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this._currentLanguageModel.set(model, undefined);
 
 		// --- Start Positron ---
-		// 1.109.0: currentProvider and getLanguageModelProviders were removed upstream.
-		// Provider switching is now implicit through model selection.
+		// Update the current provider when the model vendor changes, so that
+		// the chatCurrentProvider context key stays in sync and picker
+		// visibility is re-evaluated (e.g. session target picker is only
+		// shown for the copilot provider).
+		const newVendor = model.metadata.vendor;
+		if (this.languageModelsService.currentProvider?.id !== newVendor) {
+			const knownProvider = this.languageModelsService.getLanguageModelProviders().find(p => p.id === newVendor);
+			this.languageModelsService.currentProvider = knownProvider ?? { id: newVendor, displayName: newVendor };
+		}
 		// --- End Positron ---
 
 		if (this.cachedWidth) {


### PR DESCRIPTION
Address #12346 

Sets an enablement on the picker so it depends on the current provider. An update to the context key had to be added so the state can be updated when the model selection changes.

<img width="325" height="122" alt="image" src="https://github.com/user-attachments/assets/7b294377-7b91-48a3-8e43-2f16a3d4dd82" />

<img width="325" height="120" alt="image" src="https://github.com/user-attachments/assets/f9d53ef4-b6c9-4774-91c5-ac7e3c546df9" />


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Remove agent type selector when a non-Copilot model is selected


### QA Notes