### PR TITLE
Remove 37MB of redundant PDF.js npm package

### DIFF
--- a/extensions/positron-pdf-server/package.json
+++ b/extensions/positron-pdf-server/package.json
@@ -40,12 +40,12 @@
 		"build-ext": "node ../../node_modules/gulp/bin/gulp.js --gulpfile ../../build/gulpfile.extensions.js compile-extension:positron-pdf-server ./tsconfig.json"
 	},
 	"dependencies": {
-		"express": "^4.22.0",
-		"pdfjs-dist": "^5.4.624"
+		"express": "^4.22.0"
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.17",
 		"@types/node": "22.x",
+		"pdfjs-dist": "^5.4.624",
 		"ts-node": "^10.9.1"
 	},
 	"repository": {

--- a/extensions/positron-pdf-server/scripts/download-pdfjs.ts
+++ b/extensions/positron-pdf-server/scripts/download-pdfjs.ts
@@ -37,7 +37,7 @@ if (fs.existsSync(viewerHtml)) {
 // Read version from package.json so we stay in sync with the installed version of pdfjs-dist.
 const packageJsonPath = path.join(extensionDir, 'package.json');
 const packageData = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-const version = packageData.dependencies['pdfjs-dist'].replace(/[^0-9.]/g, '');
+const version = packageData.devDependencies['pdfjs-dist'].replace(/[^0-9.]/g, '');
 
 // Log the version being downloaded for clarity.
 console.log(`Downloading PDF.js v${version} legacy viewer...`);


### PR DESCRIPTION
Addresses posit-dev/positron-builds#812

This PR reduces the positron-pdf-server extension bundle size by ~37MB by moving `pdfjs-dist` from `dependencies` to `devDependencies`. Turns out the npm package is only used for TypeScript types at compile time! The actual PDF.js viewer is downloaded separately by the postinstall script and served at runtime.

**Before:** Extension bundle ~63MB (included both npm package and downloaded viewer)
**After:** Extension bundle ~26MB (only downloaded viewer + express)

You really need to make a release build locally to make sure this is all working as expected.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:viewer

1. Open any PDF file in Positron
2. Verify the PDF viewer loads and displays correctly
3. Test scrolling, zooming, and page navigation

To verify bundle size reduction on macOS you can do this with a release build:                                                                                                       
                                                                                                                                                                                                                                                                        
```bash                                                                                                                                             
du -sh /Applications/Positron.app/Contents/Resources/app/extensions/positron-pdf-server/node_modules/                                               
# Should be ~3.7MB (just express), not ~40MB                                                                                                        
ls /Applications/Positron.app/Contents/Resources/app/extensions/positron-pdf-server/node_modules/ | grep pdf                                        
# Should return nothing                                      
```