### PR TITLE
feat: add outline view support for Positron notebooks

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/outline/positronNotebookOutline.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/outline/positronNotebookOutline.contribution.ts
@@ -17,7 +17,6 @@ import {
 	IQuickPickDataSource, IQuickPickOutlineElement,
 	OutlineChangeEvent, OutlineConfigCollapseItemsValues, OutlineConfigKeys, OutlineTarget,
 } from '../../../../../services/outline/browser/outline.js';
-import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 import { NotebookOutlineConstants } from '../../../../notebook/browser/viewModel/notebookOutlineEntryFactory.js';
 import { getMarkdownHeadersInCell } from '../../../../notebook/browser/viewModel/foldingModel.js';
 import { NotebookCellsChangeType } from '../../../../notebook/common/notebookCommon.js';
@@ -393,7 +392,6 @@ export class PositronNotebookCellOutline extends Disposable implements IOutline<
 	constructor(
 		private readonly _editor: PositronNotebookEditor,
 		private readonly _target: OutlineTarget,
-		@IEditorService private readonly _editorService: IEditorService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IThemeService private readonly _themeService: IThemeService,

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/outline/positronNotebookOutline.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/outline/positronNotebookOutline.contribution.ts
@@ -561,7 +561,12 @@ export class PositronNotebookCellOutline extends Disposable implements IOutline<
 	}
 
 	preview(entry: PositronOutlineEntry): IDisposable {
-		entry.cell.reveal({ reason: 'programmatic' }).then(() => {
+		let disposed = false;
+		entry.cell.reveal({ reason: 'programmatic' }).then((revealed) => {
+			// Guard against stale previews: if disposed or reveal failed, skip.
+			if (disposed || !revealed) {
+				return;
+			}
 			// For markdown headers, scroll to the specific heading element
 			// so previewing between headings in the same cell works correctly.
 			if (entry.headingId && entry.cell.container) {
@@ -569,7 +574,7 @@ export class PositronNotebookCellOutline extends Disposable implements IOutline<
 				headingEl?.scrollIntoView({ block: 'nearest' });
 			}
 		});
-		return toDisposable(() => { });
+		return toDisposable(() => { disposed = true; });
 	}
 
 	captureViewState(): IDisposable {
@@ -587,27 +592,44 @@ export class PositronNotebookCellOutline extends Disposable implements IOutline<
 			if (scrollTop !== undefined && notebook.cellsContainer) {
 				notebook.cellsContainer.scrollTop = scrollTop;
 			}
+
+			// Verify captured cells still exist before restoring selection.
+			const currentCells = notebook.cells.get();
+			const cellStillExists = (cell: IPositronNotebookCell) => currentCells.includes(cell);
+
 			// Restore the full selection state (editing, multi-select, etc.).
 			switch (state.type) {
 				case SelectionState.NoCells:
 					break;
 				case SelectionState.SingleSelection:
-					state.active.select(CellSelectionType.Normal);
+					if (cellStillExists(state.active)) {
+						state.active.select(CellSelectionType.Normal);
+					}
 					break;
 				case SelectionState.EditingSelection:
-					state.active.select(CellSelectionType.Edit);
+					if (cellStillExists(state.active)) {
+						state.active.select(CellSelectionType.Edit);
+					}
 					break;
 				case SelectionState.MultiSelection: {
+					// Filter to cells that still exist in the notebook.
+					const validSelected = state.selected.filter(cellStillExists);
+					if (validSelected.length === 0) {
+						break;
+					}
 					// Rebuild multi-selection with the correct active cell.
 					// Add the active cell last since Add makes it active.
-					const nonActive = state.selected.filter(c => c !== state.active);
+					const activeExists = cellStillExists(state.active);
+					const nonActive = validSelected.filter(c => c !== state.active);
 					if (nonActive.length > 0) {
 						nonActive[0].select(CellSelectionType.Normal);
 						for (let i = 1; i < nonActive.length; i++) {
 							nonActive[i].select(CellSelectionType.Add);
 						}
-						state.active.select(CellSelectionType.Add);
-					} else {
+						if (activeExists) {
+							state.active.select(CellSelectionType.Add);
+						}
+					} else if (activeExists) {
 						state.active.select(CellSelectionType.Normal);
 					}
 					break;

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/outline/positronNotebookOutline.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/outline/positronNotebookOutline.contribution.ts
@@ -46,7 +46,7 @@ import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCom
 import { CellSelectionType, SelectionState, getActiveCell } from '../../selectionMachine.js';
 import { slugify } from '../../../../markdown/browser/markedGfmHeadingIdPlugin.js';
 
-// --- Section B: PositronOutlineEntry ---
+// --- PositronOutlineEntry ---
 
 /**
  * Custom outline entry for Positron notebooks. Holds a direct reference to the
@@ -86,7 +86,7 @@ export class PositronOutlineEntry {
 	}
 }
 
-// --- Section C: Pure functions (exported for testing) ---
+// --- Pure functions (exported for testing) ---
 
 /**
  * Extract markdown headers from cell content, with a fallback to HTML heading
@@ -230,7 +230,7 @@ function findElementById(root: HTMLElement, id: string): HTMLElement | null {
 	return null;
 }
 
-// --- Section D: Renderer, delegate, comparator, accessibility ---
+// --- Renderer, delegate, comparator, accessibility ---
 
 class PositronOutlineTemplate {
 	static readonly templateId = 'PositronNotebookOutlineRenderer';
@@ -319,7 +319,7 @@ class PositronOutlineComparator implements IOutlineComparator<PositronOutlineEnt
 	}
 }
 
-// --- Section E: Data sources (tree, quickpick, breadcrumbs) ---
+// --- Data sources (tree, quickpick, breadcrumbs) ---
 
 class PositronOutlinePaneProvider implements IDataSource<PositronNotebookCellOutline, PositronOutlineEntry> {
 
@@ -361,7 +361,7 @@ class PositronOutlineBreadcrumbsProvider implements IBreadcrumbsDataSource<Posit
 	}
 }
 
-// --- Section F: The IOutline implementation ---
+// --- The IOutline implementation ---
 
 export class PositronNotebookCellOutline extends Disposable implements IOutline<PositronOutlineEntry> {
 	readonly outlineKind = 'positronNotebookCells';
@@ -639,7 +639,7 @@ export class PositronNotebookCellOutline extends Disposable implements IOutline<
 	}
 }
 
-// --- Section G: The IOutlineCreator and registration ---
+// --- The IOutlineCreator and registration ---
 
 class PositronNotebookOutlineCreator implements IOutlineCreator<PositronNotebookEditor, PositronOutlineEntry> {
 	readonly dispose: () => void;

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/outline/positronNotebookOutline.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/outline/positronNotebookOutline.contribution.ts
@@ -1,0 +1,620 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isHTMLElement } from '../../../../../../base/browser/dom.js';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../../../../../base/common/lifecycle.js';
+import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { Registry } from '../../../../../../platform/registry/common/platform.js';
+import { LifecyclePhase } from '../../../../../services/lifecycle/common/lifecycle.js';
+import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from '../../../../../common/contributions.js';
+import { IEditorPane } from '../../../../../common/editor.js';
+import {
+	IBreadcrumbsDataSource, IBreadcrumbsOutlineElement,
+	IOutline, IOutlineComparator, IOutlineCreator, IOutlineListConfig, IOutlineService,
+	IQuickPickDataSource, IQuickPickOutlineElement,
+	OutlineChangeEvent, OutlineConfigCollapseItemsValues, OutlineConfigKeys, OutlineTarget,
+} from '../../../../../services/outline/browser/outline.js';
+import { IEditorService, SIDE_GROUP } from '../../../../../services/editor/common/editorService.js';
+import { NotebookOutlineConstants } from '../../../../notebook/browser/viewModel/notebookOutlineEntryFactory.js';
+import { getMarkdownHeadersInCell } from '../../../../notebook/browser/viewModel/foldingModel.js';
+import { NotebookCellsChangeType } from '../../../../notebook/common/notebookCommon.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { IEditorOptions } from '../../../../../../platform/editor/common/editor.js';
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { IListVirtualDelegate, IKeyboardNavigationLabelProvider } from '../../../../../../base/browser/ui/list/list.js';
+import { IListAccessibilityProvider } from '../../../../../../base/browser/ui/list/listWidget.js';
+import { IDataSource, ITreeNode, ITreeRenderer } from '../../../../../../base/browser/ui/tree/tree.js';
+import { FuzzyScore, createMatches } from '../../../../../../base/common/filters.js';
+import { IconLabel } from '../../../../../../base/browser/ui/iconLabel/iconLabel.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { IWorkbenchDataTreeOptions } from '../../../../../../platform/list/browser/listService.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
+import { getIconClassesForLanguageId } from '../../../../../../editor/common/services/getIconClasses.js';
+import { autorun } from '../../../../../../base/common/observable.js';
+import { renderAsPlaintext } from '../../../../../../base/browser/markdownRenderer.js';
+import { safeIntl } from '../../../../../../base/common/date.js';
+import { localize } from '../../../../../../nls.js';
+import { Delayer } from '../../../../../../base/common/async.js';
+import { CellKind, IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
+import { PositronNotebookInstance } from '../../PositronNotebookInstance.js';
+import { PositronNotebookEditor } from '../../PositronNotebookEditor.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
+import { CellSelectionType, getActiveCell } from '../../selectionMachine.js';
+import { slugify } from '../../../../markdown/browser/markedGfmHeadingIdPlugin.js';
+
+// --- Section B: PositronOutlineEntry ---
+
+/**
+ * Custom outline entry for Positron notebooks. Holds a direct reference to the
+ * Positron cell rather than the upstream ICellViewModel, giving full type safety
+ * and decoupling from upstream notebook internals.
+ */
+export class PositronOutlineEntry {
+	private _children: PositronOutlineEntry[] = [];
+	private _parent: PositronOutlineEntry | undefined;
+
+	get icon(): ThemeIcon {
+		return this.cell.kind === CellKind.Markup ? Codicon.markdown : Codicon.code;
+	}
+
+	get parent(): PositronOutlineEntry | undefined { return this._parent; }
+	get children(): readonly PositronOutlineEntry[] { return this._children; }
+
+	constructor(
+		readonly index: number,
+		readonly level: number,
+		readonly cell: IPositronNotebookCell,
+		readonly label: string,
+		readonly headingId: string | undefined,
+	) { }
+
+	addChild(entry: PositronOutlineEntry): void {
+		this._children.push(entry);
+		entry._parent = this;
+	}
+
+	/** Recursively flatten the tree into a list. */
+	asFlatList(bucket: PositronOutlineEntry[]): void {
+		bucket.push(this);
+		for (const child of this._children) {
+			child.asFlatList(bucket);
+		}
+	}
+}
+
+// --- Section C: Pure functions (exported for testing) ---
+
+/**
+ * Extract markdown headers from cell content, with a fallback to HTML heading
+ * tags when the marked lexer finds no headers. Matches upstream behavior from
+ * notebookOutlineEntryFactory.ts (getMarkdownHeadersInCellFallbackToHtmlTags).
+ */
+export function getMarkdownHeaders(content: string): { depth: number; text: string }[] {
+	const headers = Array.from(getMarkdownHeadersInCell(content));
+	if (headers.length > 0) {
+		return headers;
+	}
+	// Fallback: detect HTML heading tags
+	const match = content.match(/<h([1-6]).*?>(.*?)<\/h\1>/i);
+	if (match) {
+		headers.push({ depth: parseInt(match[1]), text: match[2].trim() });
+	}
+	return headers;
+}
+
+/** Return the first non-empty line from text, or empty string. */
+export function getFirstNonEmptyLine(text: string): string {
+	for (const line of text.split('\n')) {
+		const trimmed = line.trim();
+		if (trimmed.length > 0) {
+			return trimmed;
+		}
+	}
+	return '';
+}
+
+/**
+ * Build outline entries from Positron notebook cells.
+ *
+ * - Markdown cells: extract headers (h1-h6) with HTML fallback, with per-cell
+ *   slug de-duplication matching the renderer. Non-header markdown cells get
+ *   a first-line plaintext preview.
+ * - Code cells: first non-empty line as preview.
+ * - Raw cells: skipped.
+ *
+ * Returns a flat list. Use buildTree() to create the hierarchy.
+ */
+export function buildOutlineEntries(
+	cells: readonly IPositronNotebookCell[],
+): PositronOutlineEntry[] {
+	const entries: PositronOutlineEntry[] = [];
+	let index = 0;
+
+	for (const cell of cells) {
+		if (cell.isRawCell()) {
+			continue;
+		}
+
+		const content = cell.getContent();
+
+		if (cell.isMarkdownCell()) {
+			const headers = getMarkdownHeaders(content);
+			if (headers.length > 0) {
+				// Track slug duplicates per cell, matching the renderer's behavior.
+				const slugCounter = new Map<string, number>();
+				for (const { depth, text } of headers) {
+					let headingSlug = slugify(text);
+					const existing = slugCounter.get(headingSlug);
+					if (existing !== undefined) {
+						slugCounter.set(headingSlug, existing + 1);
+						headingSlug = headingSlug + '-' + (existing + 1);
+					} else {
+						slugCounter.set(headingSlug, 0);
+					}
+					entries.push(new PositronOutlineEntry(index++, depth, cell, text, headingSlug));
+				}
+			} else {
+				// Non-header markdown: first-line plaintext preview.
+				const firstLine = getFirstNonEmptyLine(content);
+				let preview = renderAsPlaintext({ value: firstLine }).trim();
+				if (preview.length === 0) {
+					preview = localize('positronNotebook.outline.emptyMarkdown', "empty markdown cell");
+				}
+				entries.push(new PositronOutlineEntry(index++, NotebookOutlineConstants.NonHeaderOutlineLevel, cell, preview, undefined));
+			}
+		} else if (cell.isCodeCell()) {
+			let preview = getFirstNonEmptyLine(content);
+			if (preview.length === 0) {
+				preview = localize('positronNotebook.outline.emptyCode', "empty cell");
+			}
+			entries.push(new PositronOutlineEntry(index++, NotebookOutlineConstants.NonHeaderOutlineLevel, cell, preview, undefined));
+		}
+	}
+	return entries;
+}
+
+/**
+ * Build a tree from a flat list of entries based on header levels.
+ * Returns the root-level entries with children nested appropriately.
+ */
+export function buildTree(flatEntries: PositronOutlineEntry[]): PositronOutlineEntry[] {
+	if (flatEntries.length === 0) {
+		return [];
+	}
+	const result: PositronOutlineEntry[] = [flatEntries[0]];
+	const parentStack: PositronOutlineEntry[] = [flatEntries[0]];
+
+	for (let i = 1; i < flatEntries.length; i++) {
+		const entry = flatEntries[i];
+		while (true) {
+			if (parentStack.length === 0) {
+				result.push(entry);
+				parentStack.push(entry);
+				break;
+			}
+			const parent = parentStack[parentStack.length - 1];
+			if (parent.level < entry.level) {
+				parent.addChild(entry);
+				parentStack.push(entry);
+				break;
+			} else {
+				parentStack.pop();
+			}
+		}
+	}
+	return result;
+}
+
+/**
+ * Walk the DOM subtree to find an element with the given ID.
+ * Avoids querySelector which is discouraged in this codebase.
+ */
+function findElementById(root: HTMLElement, id: string): HTMLElement | null {
+	if (root.id === id) {
+		return root;
+	}
+	const children = root.children;
+	for (let i = 0; i < children.length; i++) {
+		const child = children[i];
+		if (isHTMLElement(child)) {
+			const found = findElementById(child, id);
+			if (found) {
+				return found;
+			}
+		}
+	}
+	return null;
+}
+
+// --- Section D: Renderer, delegate, comparator, accessibility ---
+
+class PositronOutlineTemplate {
+	static readonly templateId = 'PositronNotebookOutlineRenderer';
+	constructor(
+		readonly container: HTMLElement,
+		readonly iconClass: HTMLElement,
+		readonly iconLabel: IconLabel,
+	) { }
+}
+
+class PositronOutlineRenderer implements ITreeRenderer<PositronOutlineEntry, FuzzyScore, PositronOutlineTemplate> {
+	readonly templateId = PositronOutlineTemplate.templateId;
+
+	constructor(
+		@IThemeService private readonly _themeService: IThemeService,
+	) { }
+
+	renderTemplate(container: HTMLElement): PositronOutlineTemplate {
+		container.classList.add('notebook-outline-element', 'show-file-icons');
+		const iconClass = document.createElement('div');
+		container.append(iconClass);
+		const iconLabel = new IconLabel(container, { supportHighlights: true });
+		return new PositronOutlineTemplate(container, iconClass, iconLabel);
+	}
+
+	renderElement(node: ITreeNode<PositronOutlineEntry, FuzzyScore>, _index: number, template: PositronOutlineTemplate): void {
+		const entry = node.element;
+		const extraClasses: string[] = [];
+
+		// Icon: use language file icon for code cells, theme icon for headers
+		const isCodeCell = entry.cell.kind === CellKind.Code;
+		if (isCodeCell && this._themeService.getFileIconTheme().hasFileIcons) {
+			template.iconClass.className = '';
+			extraClasses.push(...getIconClassesForLanguageId(entry.cell.model.language ?? ''));
+		} else {
+			template.iconClass.className = 'element-icon ' + ThemeIcon.asClassNameArray(entry.icon).join(' ');
+		}
+
+		template.iconLabel.setLabel(' ' + entry.label, undefined, {
+			matches: createMatches(node.filterData),
+			labelEscapeNewLines: true,
+			extraClasses,
+		});
+	}
+
+	disposeTemplate(template: PositronOutlineTemplate): void {
+		template.iconLabel.dispose();
+	}
+}
+
+class PositronOutlineVirtualDelegate implements IListVirtualDelegate<PositronOutlineEntry> {
+	getHeight(_element: PositronOutlineEntry): number {
+		return 22;
+	}
+	getTemplateId(_element: PositronOutlineEntry): string {
+		return PositronOutlineTemplate.templateId;
+	}
+}
+
+class PositronOutlineAccessibility implements IListAccessibilityProvider<PositronOutlineEntry> {
+	getAriaLabel(element: PositronOutlineEntry): string | null {
+		return element.label;
+	}
+	getWidgetAriaLabel(): string {
+		return '';
+	}
+}
+
+class PositronOutlineNavigationLabel implements IKeyboardNavigationLabelProvider<PositronOutlineEntry> {
+	getKeyboardNavigationLabel(element: PositronOutlineEntry): { toString(): string | undefined } | undefined {
+		return element.label;
+	}
+}
+
+class PositronOutlineComparator implements IOutlineComparator<PositronOutlineEntry> {
+	private readonly _collator = safeIntl.Collator(undefined, { numeric: true });
+
+	compareByPosition(a: PositronOutlineEntry, b: PositronOutlineEntry): number {
+		return a.index - b.index;
+	}
+	compareByType(a: PositronOutlineEntry, b: PositronOutlineEntry): number {
+		return a.cell.kind - b.cell.kind || this._collator.value.compare(a.label, b.label);
+	}
+	compareByName(a: PositronOutlineEntry, b: PositronOutlineEntry): number {
+		return this._collator.value.compare(a.label, b.label);
+	}
+}
+
+// --- Section E: Data sources (tree, quickpick, breadcrumbs) ---
+
+class PositronOutlinePaneProvider implements IDataSource<PositronNotebookCellOutline, PositronOutlineEntry> {
+
+	*getChildren(element: PositronNotebookCellOutline | PositronOutlineEntry): Iterable<PositronOutlineEntry> {
+		const entries = element instanceof PositronNotebookCellOutline
+			? element.entries
+			: element.children;
+		yield* entries;
+	}
+}
+
+class PositronOutlineQuickPickProvider implements IQuickPickDataSource<PositronOutlineEntry> {
+	constructor(private readonly _outline: PositronNotebookCellOutline) { }
+
+	getQuickPickElements(): IQuickPickOutlineElement<PositronOutlineEntry>[] {
+		const bucket: PositronOutlineEntry[] = [];
+		for (const entry of this._outline.entries) {
+			entry.asFlatList(bucket);
+		}
+		return bucket.map(element => ({
+			element,
+			label: `$(${element.icon.id}) ${element.label}`,
+			ariaLabel: element.label,
+		}));
+	}
+}
+
+class PositronOutlineBreadcrumbsProvider implements IBreadcrumbsDataSource<PositronOutlineEntry> {
+	constructor(private readonly _outline: PositronNotebookCellOutline) { }
+
+	getBreadcrumbElements(): readonly IBreadcrumbsOutlineElement<PositronOutlineEntry>[] {
+		const result: IBreadcrumbsOutlineElement<PositronOutlineEntry>[] = [];
+		let candidate = this._outline.activeElement;
+		while (candidate) {
+			result.unshift({ element: candidate, label: candidate.label });
+			candidate = candidate.parent;
+		}
+		return result;
+	}
+}
+
+// --- Section F: The IOutline implementation ---
+
+export class PositronNotebookCellOutline extends Disposable implements IOutline<PositronOutlineEntry> {
+	readonly outlineKind = 'positronNotebookCells';
+
+	private readonly _onDidChange = this._register(new Emitter<OutlineChangeEvent>());
+	readonly onDidChange: Event<OutlineChangeEvent> = this._onDidChange.event;
+
+	private readonly _modelDisposables = this._register(new DisposableStore());
+	private readonly _delayerRecomputeState: Delayer<void>;
+
+	readonly config: IOutlineListConfig<PositronOutlineEntry>;
+
+	private _entries: PositronOutlineEntry[] = [];
+	private _activeEntry: PositronOutlineEntry | undefined;
+
+	get entries(): PositronOutlineEntry[] { return this._entries; }
+	get activeElement(): PositronOutlineEntry | undefined { return this._activeEntry; }
+	get isEmpty(): boolean { return this._entries.length === 0; }
+
+	get uri(): URI | undefined {
+		return this._notebook?.uri;
+	}
+
+	private get _notebook(): PositronNotebookInstance | undefined {
+		return this._editor.notebookInstance;
+	}
+
+	constructor(
+		private readonly _editor: PositronNotebookEditor,
+		private readonly _target: OutlineTarget,
+		@IEditorService private readonly _editorService: IEditorService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IThemeService private readonly _themeService: IThemeService,
+	) {
+		super();
+
+		this._delayerRecomputeState = this._register(new Delayer<void>(300));
+
+		const treeDataSource = new PositronOutlinePaneProvider();
+		const quickPickDataSource = new PositronOutlineQuickPickProvider(this);
+		const breadcrumbsDataSource = new PositronOutlineBreadcrumbsProvider(this);
+		const delegate = new PositronOutlineVirtualDelegate();
+		const renderers = [this._instantiationService.createInstance(PositronOutlineRenderer)];
+		const comparator = new PositronOutlineComparator();
+		const options: IWorkbenchDataTreeOptions<PositronOutlineEntry, FuzzyScore> = {
+			collapseByDefault: this._target === OutlineTarget.Breadcrumbs ||
+				(this._target === OutlineTarget.OutlinePane &&
+					this._configurationService.getValue(OutlineConfigKeys.collapseItems) === OutlineConfigCollapseItemsValues.Collapsed),
+			expandOnlyOnTwistieClick: true,
+			multipleSelectionSupport: false,
+			accessibilityProvider: new PositronOutlineAccessibility(),
+			identityProvider: { getId: element => element.cell.uri.toString() + ':' + element.index },
+			keyboardNavigationLabelProvider: new PositronOutlineNavigationLabel(),
+		};
+
+		this.config = { treeDataSource, quickPickDataSource, breadcrumbsDataSource, delegate, renderers, comparator, options };
+
+		this._initListeners();
+		this._recomputeState();
+	}
+
+	private _initListeners(): void {
+		const notebook = this._notebook;
+		if (!notebook) {
+			return;
+		}
+
+		// Rebuild when cells are added/removed/reordered.
+		this._register(autorun(reader => {
+			notebook.cells.read(reader);
+			this._delayedRecomputeState();
+		}));
+
+		// Listen for cell content changes via the notebook text model.
+		this._setupModelListeners(notebook);
+		this._register(notebook.onDidChangeModel(() => {
+			this._setupModelListeners(notebook);
+		}));
+
+		// Update active element when selection changes.
+		this._register(autorun(reader => {
+			const state = notebook.selectionStateMachine.state.read(reader);
+			const activeCell = getActiveCell(state);
+			this._recomputeActive(activeCell);
+		}));
+
+		// Refresh icons on theme change.
+		this._register(this._themeService.onDidFileIconThemeChange(() => {
+			this._onDidChange.fire({});
+		}));
+	}
+
+	/**
+	 * Subscribe to text model content changes so the outline refreshes when
+	 * cell content is edited in place (not just when cells are added/removed).
+	 */
+	private _setupModelListeners(notebook: PositronNotebookInstance): void {
+		this._modelDisposables.clear();
+		const textModel = notebook.textModel;
+		if (!textModel) {
+			return;
+		}
+
+		this._modelDisposables.add(textModel.onDidChangeContent(contentChanges => {
+			if (contentChanges.rawEvents.some(c =>
+				c.kind === NotebookCellsChangeType.ChangeCellContent ||
+				c.kind === NotebookCellsChangeType.Move ||
+				c.kind === NotebookCellsChangeType.ModelChange)) {
+				this._delayedRecomputeState();
+			}
+		}));
+	}
+
+	private _delayedRecomputeState(): void {
+		this._delayerRecomputeState.trigger(() => this._recomputeState());
+	}
+
+	private _recomputeState(): void {
+		const notebook = this._notebook;
+		if (!notebook) {
+			this._entries = [];
+			this._onDidChange.fire({});
+			return;
+		}
+
+		const cells = notebook.cells.get();
+
+		// Build entries and tree.
+		const flatEntries = buildOutlineEntries(cells);
+		this._entries = buildTree(flatEntries);
+
+		// Recompute active after rebuilding entries.
+		const state = notebook.selectionStateMachine.state.get();
+		const activeCell = getActiveCell(state);
+		this._recomputeActive(activeCell);
+
+		this._onDidChange.fire({});
+	}
+
+	private _recomputeActive(activeCell: IPositronNotebookCell | null): void {
+		if (!activeCell) {
+			if (this._activeEntry) {
+				this._activeEntry = undefined;
+				this._onDidChange.fire({ affectOnlyActiveElement: true });
+			}
+			return;
+		}
+
+		// Find the first entry matching this cell (for multi-heading markdown
+		// cells, this is the first heading -- a documented v1 limitation).
+		const found = this._findEntryForCell(activeCell);
+		if (found !== this._activeEntry) {
+			this._activeEntry = found;
+			this._onDidChange.fire({ affectOnlyActiveElement: true });
+		}
+	}
+
+	private _findEntryForCell(cell: IPositronNotebookCell): PositronOutlineEntry | undefined {
+		for (const entry of this._entries) {
+			const found = this._findInTree(entry, cell);
+			if (found) {
+				return found;
+			}
+		}
+		return undefined;
+	}
+
+	private _findInTree(entry: PositronOutlineEntry, cell: IPositronNotebookCell): PositronOutlineEntry | undefined {
+		if (entry.cell === cell) {
+			return entry;
+		}
+		for (const child of entry.children) {
+			const found = this._findInTree(child, cell);
+			if (found) {
+				return found;
+			}
+		}
+		return undefined;
+	}
+
+	async reveal(entry: PositronOutlineEntry, options: IEditorOptions, sideBySide: boolean): Promise<void> {
+		// Open the notebook at this cell.
+		const notebookOptions = {
+			...options,
+			override: this._editor.input?.editorId,
+		};
+		await this._editorService.openEditor(
+			{ resource: entry.cell.uri, options: notebookOptions },
+			sideBySide ? SIDE_GROUP : undefined,
+		);
+
+		// Select and reveal the cell in the Positron notebook.
+		entry.cell.select(CellSelectionType.Normal);
+		await entry.cell.reveal({ reason: 'programmatic' });
+
+		// For markdown headers, scroll to the specific heading element
+		// using the entry's pre-computed heading DOM ID.
+		if (entry.headingId && entry.cell.container) {
+			const headingEl = findElementById(entry.cell.container, entry.headingId);
+			headingEl?.scrollIntoView({ block: 'nearest' });
+		}
+	}
+
+	preview(entry: PositronOutlineEntry): IDisposable {
+		entry.cell.reveal({ reason: 'programmatic' });
+		return toDisposable(() => { });
+	}
+
+	captureViewState(): IDisposable {
+		const notebook = this._notebook;
+		if (!notebook) {
+			return toDisposable(() => { });
+		}
+
+		// Capture scroll position and active cell for restore.
+		const scrollTop = notebook.cellsContainer?.scrollTop;
+		const state = notebook.selectionStateMachine.state.get();
+		const activeCell = getActiveCell(state);
+
+		return toDisposable(() => {
+			// Restore scroll position.
+			if (scrollTop !== undefined && notebook.cellsContainer) {
+				notebook.cellsContainer.scrollTop = scrollTop;
+			}
+			// Restore selection.
+			activeCell?.select(CellSelectionType.Normal);
+		});
+	}
+}
+
+// --- Section G: The IOutlineCreator and registration ---
+
+class PositronNotebookOutlineCreator implements IOutlineCreator<PositronNotebookEditor, PositronOutlineEntry> {
+	readonly dispose: () => void;
+
+	constructor(
+		@IOutlineService outlineService: IOutlineService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+	) {
+		const reg = outlineService.registerOutlineCreator(this);
+		this.dispose = () => reg.dispose();
+	}
+
+	matches(candidate: IEditorPane): candidate is PositronNotebookEditor {
+		return candidate.getId() === POSITRON_NOTEBOOK_EDITOR_ID;
+	}
+
+	async createOutline(editor: PositronNotebookEditor, target: OutlineTarget, _cancelToken: CancellationToken): Promise<IOutline<PositronOutlineEntry> | undefined> {
+		return this._instantiationService.createInstance(PositronNotebookCellOutline, editor, target);
+	}
+}
+
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
+	.registerWorkbenchContribution(PositronNotebookOutlineCreator, LifecyclePhase.Eventually);

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/outline/positronNotebookOutline.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/outline/positronNotebookOutline.contribution.ts
@@ -43,7 +43,7 @@ import { CellKind, IPositronNotebookCell } from '../../PositronNotebookCells/IPo
 import { PositronNotebookInstance } from '../../PositronNotebookInstance.js';
 import { PositronNotebookEditor } from '../../PositronNotebookEditor.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
-import { CellSelectionType, getActiveCell } from '../../selectionMachine.js';
+import { CellSelectionType, SelectionState, getActiveCell } from '../../selectionMachine.js';
 import { slugify } from '../../../../markdown/browser/markedGfmHeadingIdPlugin.js';
 
 // --- Section B: PositronOutlineEntry ---
@@ -469,7 +469,8 @@ export class PositronNotebookCellOutline extends Disposable implements IOutline<
 			if (contentChanges.rawEvents.some(c =>
 				c.kind === NotebookCellsChangeType.ChangeCellContent ||
 				c.kind === NotebookCellsChangeType.Move ||
-				c.kind === NotebookCellsChangeType.ModelChange)) {
+				c.kind === NotebookCellsChangeType.ModelChange ||
+				c.kind === NotebookCellsChangeType.ChangeCellLanguage)) {
 				this._delayedRecomputeState();
 			}
 		}));
@@ -560,7 +561,14 @@ export class PositronNotebookCellOutline extends Disposable implements IOutline<
 	}
 
 	preview(entry: PositronOutlineEntry): IDisposable {
-		entry.cell.reveal({ reason: 'programmatic' });
+		entry.cell.reveal({ reason: 'programmatic' }).then(() => {
+			// For markdown headers, scroll to the specific heading element
+			// so previewing between headings in the same cell works correctly.
+			if (entry.headingId && entry.cell.container) {
+				const headingEl = findElementById(entry.cell.container, entry.headingId);
+				headingEl?.scrollIntoView({ block: 'nearest' });
+			}
+		});
 		return toDisposable(() => { });
 	}
 
@@ -570,18 +578,41 @@ export class PositronNotebookCellOutline extends Disposable implements IOutline<
 			return toDisposable(() => { });
 		}
 
-		// Capture scroll position and active cell for restore.
+		// Capture scroll position and full selection state for restore.
 		const scrollTop = notebook.cellsContainer?.scrollTop;
 		const state = notebook.selectionStateMachine.state.get();
-		const activeCell = getActiveCell(state);
 
 		return toDisposable(() => {
 			// Restore scroll position.
 			if (scrollTop !== undefined && notebook.cellsContainer) {
 				notebook.cellsContainer.scrollTop = scrollTop;
 			}
-			// Restore selection.
-			activeCell?.select(CellSelectionType.Normal);
+			// Restore the full selection state (editing, multi-select, etc.).
+			switch (state.type) {
+				case SelectionState.NoCells:
+					break;
+				case SelectionState.SingleSelection:
+					state.active.select(CellSelectionType.Normal);
+					break;
+				case SelectionState.EditingSelection:
+					state.active.select(CellSelectionType.Edit);
+					break;
+				case SelectionState.MultiSelection: {
+					// Rebuild multi-selection with the correct active cell.
+					// Add the active cell last since Add makes it active.
+					const nonActive = state.selected.filter(c => c !== state.active);
+					if (nonActive.length > 0) {
+						nonActive[0].select(CellSelectionType.Normal);
+						for (let i = 1; i < nonActive.length; i++) {
+							nonActive[i].select(CellSelectionType.Add);
+						}
+						state.active.select(CellSelectionType.Add);
+					} else {
+						state.active.select(CellSelectionType.Normal);
+					}
+					break;
+				}
+			}
 		});
 	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/outline/positronNotebookOutline.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/outline/positronNotebookOutline.contribution.ts
@@ -250,7 +250,7 @@ class PositronOutlineRenderer implements ITreeRenderer<PositronOutlineEntry, Fuz
 	) { }
 
 	renderTemplate(container: HTMLElement): PositronOutlineTemplate {
-		container.classList.add('notebook-outline-element', 'show-file-icons');
+		container.classList.add('outline-element', 'notebook-outline-element', 'show-file-icons');
 		const iconClass = document.createElement('div');
 		container.append(iconClass);
 		const iconLabel = new IconLabel(container, { supportHighlights: true });

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/outline/positronNotebookOutline.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/outline/positronNotebookOutline.contribution.ts
@@ -17,7 +17,7 @@ import {
 	IQuickPickDataSource, IQuickPickOutlineElement,
 	OutlineChangeEvent, OutlineConfigCollapseItemsValues, OutlineConfigKeys, OutlineTarget,
 } from '../../../../../services/outline/browser/outline.js';
-import { IEditorService, SIDE_GROUP } from '../../../../../services/editor/common/editorService.js';
+import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 import { NotebookOutlineConstants } from '../../../../notebook/browser/viewModel/notebookOutlineEntryFactory.js';
 import { getMarkdownHeadersInCell } from '../../../../notebook/browser/viewModel/foldingModel.js';
 import { NotebookCellsChangeType } from '../../../../notebook/common/notebookCommon.js';
@@ -545,17 +545,11 @@ export class PositronNotebookCellOutline extends Disposable implements IOutline<
 	}
 
 	async reveal(entry: PositronOutlineEntry, options: IEditorOptions, sideBySide: boolean): Promise<void> {
-		// Open the notebook at this cell.
-		const notebookOptions = {
-			...options,
-			override: this._editor.input?.editorId,
-		};
-		await this._editorService.openEditor(
-			{ resource: entry.cell.uri, options: notebookOptions },
-			sideBySide ? SIDE_GROUP : undefined,
-		);
-
 		// Select and reveal the cell in the Positron notebook.
+		// We navigate directly via cell methods rather than openEditor because
+		// the Positron notebook does not have cell-URI-to-notebook resolution.
+		// Using openEditor with a cell URI would cause the editor to be
+		// replaced/reopened instead of navigating within the notebook.
 		entry.cell.select(CellSelectionType.Normal);
 		await entry.cell.reveal({ reason: 'programmatic' });
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -7,6 +7,7 @@
 import './contrib/find/positronNotebookFind.contribution.js';
 import './contrib/assistant/positronNotebookAssistant.contribution.js';
 import './contrib/ghostCell/positronNotebookGhostCell.contribution.js';
+import './contrib/outline/positronNotebookOutline.contribution.js';
 
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookOutline.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookOutline.test.ts
@@ -1,0 +1,229 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { CellKind } from '../../../notebook/common/notebookCommon.js';
+import { createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
+import {
+	buildOutlineEntries,
+	buildTree,
+	getMarkdownHeaders,
+	getFirstNonEmptyLine,
+} from '../../browser/contrib/outline/positronNotebookOutline.contribution.js';
+
+suite('PositronNotebookOutline', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('getFirstNonEmptyLine', () => {
+		test('returns first non-empty line', () => {
+			assert.strictEqual(getFirstNonEmptyLine('hello\nworld'), 'hello');
+		});
+
+		test('skips blank lines', () => {
+			assert.strictEqual(getFirstNonEmptyLine('\n\n  \nhello'), 'hello');
+		});
+
+		test('returns empty string for empty input', () => {
+			assert.strictEqual(getFirstNonEmptyLine(''), '');
+		});
+
+		test('returns empty string for whitespace-only input', () => {
+			assert.strictEqual(getFirstNonEmptyLine('   \n  \n  '), '');
+		});
+	});
+
+	suite('getMarkdownHeaders', () => {
+		test('extracts markdown headers', () => {
+			const headers = getMarkdownHeaders('# Title\nsome text\n## Subtitle');
+			assert.strictEqual(headers.length, 2);
+			assert.strictEqual(headers[0].depth, 1);
+			assert.strictEqual(headers[0].text, 'Title');
+			assert.strictEqual(headers[1].depth, 2);
+			assert.strictEqual(headers[1].text, 'Subtitle');
+		});
+
+		test('returns empty for no headers', () => {
+			const headers = getMarkdownHeaders('just some text\nno headers here');
+			assert.strictEqual(headers.length, 0);
+		});
+
+		test('falls back to HTML heading tags', () => {
+			const headers = getMarkdownHeaders('<h2>HTML Heading</h2>');
+			assert.strictEqual(headers.length, 1);
+			assert.strictEqual(headers[0].depth, 2);
+			assert.strictEqual(headers[0].text, 'HTML Heading');
+		});
+
+		test('prefers markdown headers over HTML tags', () => {
+			const headers = getMarkdownHeaders('# Markdown\n<h2>HTML</h2>');
+			assert.strictEqual(headers.length, 1);
+			assert.strictEqual(headers[0].text, 'Markdown');
+		});
+	});
+
+	suite('buildOutlineEntries', () => {
+		test('builds entries from markdown headers', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['# Title\n## Section', 'markdown', CellKind.Markup]],
+				disposables,
+			);
+			const cells = notebook.cells.get();
+			const entries = buildOutlineEntries(cells);
+
+			assert.strictEqual(entries.length, 2);
+			assert.strictEqual(entries[0].label, 'Title');
+			assert.strictEqual(entries[0].level, 1);
+			assert.strictEqual(entries[1].label, 'Section');
+			assert.strictEqual(entries[1].level, 2);
+		});
+
+		test('builds entries from code cells', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]],
+				disposables,
+			);
+			const cells = notebook.cells.get();
+			const entries = buildOutlineEntries(cells);
+
+			assert.strictEqual(entries.length, 1);
+			assert.strictEqual(entries[0].label, 'print("hello")');
+			assert.strictEqual(entries[0].level, 7); // NonHeaderOutlineLevel
+		});
+
+		test('skips raw cells', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['raw content', 'raw', CellKind.Code]],
+				disposables,
+			);
+			const cells = notebook.cells.get();
+			const entries = buildOutlineEntries(cells);
+
+			assert.strictEqual(entries.length, 0);
+		});
+
+		test('handles mixed cell types', () => {
+			const notebook = createTestPositronNotebookInstance([
+				['# Introduction', 'markdown', CellKind.Markup],
+				['x = 1', 'python', CellKind.Code],
+				['## Analysis', 'markdown', CellKind.Markup],
+				['plot(x)', 'python', CellKind.Code],
+			], disposables);
+			const cells = notebook.cells.get();
+			const entries = buildOutlineEntries(cells);
+
+			assert.strictEqual(entries.length, 4);
+			assert.strictEqual(entries[0].label, 'Introduction');
+			assert.strictEqual(entries[1].label, 'x = 1');
+			assert.strictEqual(entries[2].label, 'Analysis');
+			assert.strictEqual(entries[3].label, 'plot(x)');
+		});
+
+		test('empty markdown cell shows fallback label', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['', 'markdown', CellKind.Markup]],
+				disposables,
+			);
+			const cells = notebook.cells.get();
+			const entries = buildOutlineEntries(cells);
+
+			assert.strictEqual(entries.length, 1);
+			assert.ok(entries[0].label.length > 0, 'Should have a fallback label');
+		});
+
+		test('non-header markdown uses first-line preview', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['Some paragraph text\nMore text here', 'markdown', CellKind.Markup]],
+				disposables,
+			);
+			const cells = notebook.cells.get();
+			const entries = buildOutlineEntries(cells);
+
+			assert.strictEqual(entries.length, 1);
+			assert.strictEqual(entries[0].level, 7); // NonHeaderOutlineLevel
+		});
+	});
+
+	suite('duplicate heading IDs', () => {
+		test('de-duplicates heading IDs within a cell', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['## Details\n## Details\n## Details', 'markdown', CellKind.Markup]],
+				disposables,
+			);
+			const cells = notebook.cells.get();
+			const entries = buildOutlineEntries(cells);
+
+			assert.strictEqual(entries.length, 3);
+			assert.strictEqual(entries[0].headingId, 'details');
+			assert.strictEqual(entries[1].headingId, 'details-1');
+			assert.strictEqual(entries[2].headingId, 'details-2');
+		});
+
+		test('resets slug counter between cells', () => {
+			const notebook = createTestPositronNotebookInstance([
+				['## Details', 'markdown', CellKind.Markup],
+				['## Details', 'markdown', CellKind.Markup],
+			], disposables);
+			const cells = notebook.cells.get();
+			const entries = buildOutlineEntries(cells);
+
+			assert.strictEqual(entries.length, 2);
+			// Each cell gets its own slug counter, so both are "details"
+			assert.strictEqual(entries[0].headingId, 'details');
+			assert.strictEqual(entries[1].headingId, 'details');
+		});
+	});
+
+	suite('buildTree', () => {
+		test('nests entries by header level', () => {
+			const notebook = createTestPositronNotebookInstance([
+				['# H1\n## H2\n### H3', 'markdown', CellKind.Markup],
+			], disposables);
+			const cells = notebook.cells.get();
+			const flatEntries = buildOutlineEntries(cells);
+			const tree = buildTree(flatEntries);
+
+			assert.strictEqual(tree.length, 1, 'Should have 1 root entry');
+			assert.strictEqual(tree[0].label, 'H1');
+			const h2Children = Array.from(tree[0].children);
+			assert.strictEqual(h2Children.length, 1);
+			assert.strictEqual(h2Children[0].label, 'H2');
+			const h3Children = Array.from(h2Children[0].children);
+			assert.strictEqual(h3Children.length, 1);
+			assert.strictEqual(h3Children[0].label, 'H3');
+		});
+
+		test('code cells nest under preceding header', () => {
+			const notebook = createTestPositronNotebookInstance([
+				['# Title', 'markdown', CellKind.Markup],
+				['x = 1', 'python', CellKind.Code],
+			], disposables);
+			const cells = notebook.cells.get();
+			const flatEntries = buildOutlineEntries(cells);
+			const tree = buildTree(flatEntries);
+
+			assert.strictEqual(tree.length, 1);
+			const children = Array.from(tree[0].children);
+			assert.strictEqual(children.length, 1);
+			assert.strictEqual(children[0].label, 'x = 1');
+		});
+
+		test('sibling headers stay at same level', () => {
+			const notebook = createTestPositronNotebookInstance([
+				['## A\n## B\n## C', 'markdown', CellKind.Markup],
+			], disposables);
+			const cells = notebook.cells.get();
+			const flatEntries = buildOutlineEntries(cells);
+			const tree = buildTree(flatEntries);
+
+			assert.strictEqual(tree.length, 3, 'All h2s should be roots');
+		});
+
+		test('returns empty array for empty input', () => {
+			const tree = buildTree([]);
+			assert.strictEqual(tree.length, 0);
+		});
+	});
+});

--- a/test/e2e/tests/notebooks-positron/notebook-outline.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-outline.test.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Positron Notebooks: Outline', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.OUTLINE]
+}, () => {
+
+	test('Outline displays markdown headers from notebook cells', async function ({ app, hotKeys }) {
+		const { notebooksPositron, outline } = app.workbench;
+
+		await test.step('Create notebook with markdown header cells', async () => {
+			await notebooksPositron.newNotebook();
+			await hotKeys.notebookLayout();
+
+			// Add a markdown cell with a level-1 header
+			await notebooksPositron.addCell('markdown');
+			await notebooksPositron.addCodeToCell(1, '# Introduction');
+
+			// Add a code cell between the markdown cells
+			await notebooksPositron.addCodeToCell(2, 'x = 1');
+
+			// Add another markdown cell with a level-2 header
+			await notebooksPositron.addCell('markdown');
+			await notebooksPositron.addCodeToCell(3, '## Analysis');
+		});
+
+		await test.step('Open Outline pane and verify entries', async () => {
+			await outline.focus();
+
+			// The outline should contain entries for each markdown header
+			await outline.expectOutlineElementToBeVisible('Introduction');
+			await outline.expectOutlineElementToBeVisible('Analysis');
+		});
+	});
+
+	test('Clicking an outline entry navigates to the corresponding cell', async function ({ app, hotKeys }) {
+		const { notebooksPositron, outline } = app.workbench;
+
+		await test.step('Create notebook with multiple markdown header cells', async () => {
+			await notebooksPositron.newNotebook();
+			await hotKeys.notebookLayout();
+
+			// Cell 0: default empty code cell (from newNotebook)
+			// Cell 1: markdown header "# First Section"
+			await notebooksPositron.addCell('markdown');
+			await notebooksPositron.addCodeToCell(1, '# First Section');
+
+			// Cell 2: code cell
+			await notebooksPositron.addCodeToCell(2, 'x = 1');
+
+			// Cell 3: code cell
+			await notebooksPositron.addCodeToCell(3, 'y = 2');
+
+			// Cell 4: markdown header "# Second Section"
+			await notebooksPositron.addCell('markdown');
+			await notebooksPositron.addCodeToCell(4, '# Second Section');
+
+			// Cell 5: code cell
+			await notebooksPositron.addCodeToCell(5, 'z = 3');
+		});
+
+		await test.step('Open Outline and click second header entry', async () => {
+			await outline.focus();
+
+			// Verify both headers appear in the outline
+			await outline.expectOutlineElementToBeVisible('First Section');
+			await outline.expectOutlineElementToBeVisible('Second Section');
+
+			// Click the "Second Section" entry to navigate
+			const secondSectionEntry = outline.outlineElement.filter({ hasText: 'Second Section' });
+			await secondSectionEntry.click();
+		});
+
+		await test.step('Verify notebook navigated to the correct cell', async () => {
+			// After clicking "Second Section" in the outline, the notebook
+			// should select cell 4 (the markdown cell with "# Second Section")
+			await notebooksPositron.expectCellIndexToBeSelected(4, { isSelected: true });
+		});
+	});
+});

--- a/test/e2e/tests/notebooks-positron/notebook-outline.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-outline.test.ts
@@ -14,64 +14,43 @@ test.describe('Positron Notebooks: Outline', {
 	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.OUTLINE]
 }, () => {
 
-	test('Outline displays markdown headers from notebook cells', async function ({ app, hotKeys }) {
+	test('Outline displays markdown headers from notebook cells', async function ({ app }) {
 		const { notebooksPositron, outline } = app.workbench;
 
-		await test.step('Create notebook with markdown header cells', async () => {
+		await test.step('Create notebook with markdown header cell', async () => {
 			await notebooksPositron.newNotebook();
-			await hotKeys.notebookLayout();
-
-			// Add a markdown cell with a level-1 header
 			await notebooksPositron.addCell('markdown');
-			await notebooksPositron.addCodeToCell(1, '# Introduction');
-
-			// Add a code cell between the markdown cells
-			await notebooksPositron.addCodeToCell(2, 'x = 1');
-
-			// Add another markdown cell with a level-2 header
-			await notebooksPositron.addCell('markdown');
-			await notebooksPositron.addCodeToCell(3, '## Analysis');
+			await notebooksPositron.addCodeToCell(1, '# Introduction\n## Analysis');
 		});
 
 		await test.step('Open Outline pane and verify entries', async () => {
 			await outline.focus();
-
-			// The outline should contain entries for each markdown header
 			await outline.expectOutlineElementToBeVisible('Introduction');
 			await outline.expectOutlineElementToBeVisible('Analysis');
 		});
 	});
 
-	test('Clicking an outline entry navigates to the corresponding cell', async function ({ app, hotKeys }) {
+	test('Clicking an outline entry navigates to the corresponding cell', async function ({ app }) {
 		const { notebooksPositron, outline } = app.workbench;
 
-		await test.step('Create notebook with multiple markdown header cells', async () => {
+		await test.step('Create notebook with multiple sections', async () => {
 			await notebooksPositron.newNotebook();
-			await hotKeys.notebookLayout();
 
-			// Cell 0: default empty code cell (from newNotebook)
-			// Cell 1: markdown header "# First Section"
+			// Cell 1: markdown with "# First Section"
 			await notebooksPositron.addCell('markdown');
 			await notebooksPositron.addCodeToCell(1, '# First Section');
 
 			// Cell 2: code cell
+			await notebooksPositron.addCell('code');
 			await notebooksPositron.addCodeToCell(2, 'x = 1');
 
-			// Cell 3: code cell
-			await notebooksPositron.addCodeToCell(3, 'y = 2');
-
-			// Cell 4: markdown header "# Second Section"
+			// Cell 3: markdown with "# Second Section"
 			await notebooksPositron.addCell('markdown');
-			await notebooksPositron.addCodeToCell(4, '# Second Section');
-
-			// Cell 5: code cell
-			await notebooksPositron.addCodeToCell(5, 'z = 3');
+			await notebooksPositron.addCodeToCell(3, '# Second Section');
 		});
 
 		await test.step('Open Outline and click second header entry', async () => {
 			await outline.focus();
-
-			// Verify both headers appear in the outline
 			await outline.expectOutlineElementToBeVisible('First Section');
 			await outline.expectOutlineElementToBeVisible('Second Section');
 
@@ -82,8 +61,8 @@ test.describe('Positron Notebooks: Outline', {
 
 		await test.step('Verify notebook navigated to the correct cell', async () => {
 			// After clicking "Second Section" in the outline, the notebook
-			// should select cell 4 (the markdown cell with "# Second Section")
-			await notebooksPositron.expectCellIndexToBeSelected(4, { isSelected: true });
+			// should select cell 3 (the markdown cell with "# Second Section")
+			await notebooksPositron.expectCellIndexToBeSelected(3, { isSelected: true });
 		});
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-outline.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-outline.test.ts
@@ -14,23 +14,33 @@ test.describe('Positron Notebooks: Outline', {
 	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.OUTLINE]
 }, () => {
 
-	test('Outline displays markdown headers from notebook cells', async function ({ app }) {
+	test('Outline displays markdown headers and code cell previews', async function ({ app }) {
 		const { notebooksPositron, outline } = app.workbench;
 
-		await test.step('Create notebook with markdown header cell', async () => {
+		await test.step('Create notebook with markdown and code cells', async () => {
 			await notebooksPositron.newNotebook();
+
+			// Cell 0: default empty code cell
+			await notebooksPositron.addCodeToCell(0, 'x = 1');
+
+			// Cell 1: markdown with headers
 			await notebooksPositron.addCell('markdown');
 			await notebooksPositron.addCodeToCell(1, '# Introduction\n## Analysis');
 		});
 
 		await test.step('Open Outline pane and verify entries', async () => {
 			await outline.focus();
+
+			// Markdown headers should appear
 			await outline.expectOutlineElementToBeVisible('Introduction');
 			await outline.expectOutlineElementToBeVisible('Analysis');
+
+			// Code cell preview should appear
+			await outline.expectOutlineElementToBeVisible('x = 1');
 		});
 	});
 
-	test('Clicking an outline entry navigates to the corresponding cell', async function ({ app }) {
+	test('Clicking outline entries navigates to the corresponding cell', async function ({ app }) {
 		const { notebooksPositron, outline } = app.workbench;
 
 		await test.step('Create notebook with multiple sections', async () => {
@@ -49,20 +59,19 @@ test.describe('Positron Notebooks: Outline', {
 			await notebooksPositron.addCodeToCell(3, '# Second Section');
 		});
 
-		await test.step('Open Outline and click second header entry', async () => {
+		await test.step('Click markdown header entry and verify navigation', async () => {
 			await outline.focus();
-			await outline.expectOutlineElementToBeVisible('First Section');
 			await outline.expectOutlineElementToBeVisible('Second Section');
 
-			// Click the "Second Section" entry to navigate
 			const secondSectionEntry = outline.outlineElement.filter({ hasText: 'Second Section' });
 			await secondSectionEntry.click();
+			await notebooksPositron.expectCellIndexToBeSelected(3, { isSelected: true });
 		});
 
-		await test.step('Verify notebook navigated to the correct cell', async () => {
-			// After clicking "Second Section" in the outline, the notebook
-			// should select cell 3 (the markdown cell with "# Second Section")
-			await notebooksPositron.expectCellIndexToBeSelected(3, { isSelected: true });
+		await test.step('Click code cell entry and verify navigation', async () => {
+			const codeCellEntry = outline.outlineElement.filter({ hasText: 'x = 1' });
+			await codeCellEntry.click();
+			await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true });
 		});
 	});
 });


### PR DESCRIPTION
Addresses #9638.

### Summary

Adds an Outline (Table of Contents) pane for Positron notebooks. The upstream VS Code notebook outline cannot be reused because the Positron notebook editor does not implement `INotebookEditor` (see #9440), so this registers a standalone `IOutlineCreator` with the upstream `IOutlineService`, following the same pattern as the built-in `NotebookOutlineCreator`. This enables the standard VS Code outline pane (Explorer sidebar), breadcrumbs, and Go to Symbol when a Positron notebook is the active editor.

https://github.com/user-attachments/assets/23cb4d63-1f9b-42e0-990a-8356301ff173

### Key design decisions

- **Custom `PositronOutlineEntry` instead of reusing upstream `OutlineEntry`**: The upstream entry class is tightly coupled to `ICellViewModel`. A custom entry holds a direct `IPositronNotebookCell` reference, avoiding `as any` casts, storing the heading slug directly on the entry (no side map), and decoupling from upstream type changes. This also positions us for a future custom Positron outline pane.

- **Direct cell navigation for reveal**: `reveal()` uses `cell.select()` + `cell.reveal()` rather than `openEditor` with a cell URI. The Positron notebook lacks cell-URI-to-notebook resolution, so `openEditor` would replace/reopen the editor instead of navigating within it. For markdown headers, the entry's pre-computed heading slug is used to scroll to the specific DOM element.

- **Reusing upstream markdown parsing**: Header extraction uses the upstream `getMarkdownHeadersInCell()` from `foldingModel.ts` (both share the same `marked` v14.0.0), with an inline HTML `<h1>`-`<h6>` fallback matching upstream behavior. Slug de-duplication is per-cell, matching the renderer.

- **Debounced refresh (300ms)**: Matches the upstream notebook outline behavior. Rebuilds on structural changes (cell add/remove/reorder via `autorun` on `notebook.cells`), content edits (`onDidChangeContent` for `ChangeCellContent`/`Move`/`ModelChange`/`ChangeCellLanguage`), and re-subscribes on model swap via `onDidChangeModel`.

- **View state capture**: `captureViewState()` saves scroll position and full selection state (single, editing, multi-select) so Go to Symbol preview navigation is reversible when the picker is cancelled.

### Known v1 limitations

- No cursor-accurate heading tracking within multi-heading markdown cells (highlights the first heading)
- No code cell symbols (functions, classes) -- only first-line preview
- No problem markers, toolbar actions, or configuration settings

### Release Notes

#### New Features
- Added Outline pane support for Positron notebooks, showing markdown headers and code cell previews with click-to-navigate (#9638)

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks @:outline

1. Open a new Positron notebook
2. Add a code cell with some code (e.g., `x = 1`)
3. Add a markdown cell with headers (e.g., `# Introduction\n## Analysis`)
4. Open the Outline pane (View > Outline or the sidebar)
5. Verify:
   - Markdown headers ("Introduction", "Analysis") appear in the outline with proper nesting
   - Code cell shows its first line as a preview (e.g., "x = 1")
   - Clicking an outline entry navigates to and selects the corresponding cell
   - Editing cell content updates the outline after a brief delay
   - Adding/removing cells updates the outline
   - Breadcrumbs update to reflect the active cell's heading path