### PR TITLE
Skip architecture mismatch check for remote sessions

### DIFF
--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -25,6 +25,7 @@ import { IWorkspaceTrustManagementService } from '../../../../platform/workspace
 import { URI } from '../../../../base/common/uri.js';
 import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 import { IPositronNewFolderService } from '../../positronNewFolder/common/positronNewFolder.js';
+import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
 import { isWeb } from '../../../../base/common/platform.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Barrier } from '../../../../base/common/async.js';
@@ -144,6 +145,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		@IStorageService private readonly _storageService: IStorageService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
+		@IWorkbenchEnvironmentService private readonly _environmentService: IWorkbenchEnvironmentService,
 	) {
 
 		super();
@@ -1741,6 +1743,12 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		// Skip on web - the browser's architecture doesn't relate to where
 		// the interpreter is running
 		if (isWeb) {
+			return;
+		}
+
+		// Skip on remote sessions - Linux remotes don't have architecture emulation,
+		// and comparing interpreter arch against the local client arch is meaningless
+		if (this._environmentService.remoteAuthority) {
 			return;
 		}
 

--- a/src/vs/workbench/services/runtimeStartup/test/common/runtimeStartup.test.ts
+++ b/src/vs/workbench/services/runtimeStartup/test/common/runtimeStartup.test.ts
@@ -18,76 +18,127 @@ import { IEphemeralStateService } from '../../../../../platform/ephemeralState/c
 import { BeforeShutdownEvent, ILifecycleService, WillShutdownEvent } from '../../../lifecycle/common/lifecycle.js';
 import { IPositronNewFolderService, NewFolderStartupPhase } from '../../../positronNewFolder/common/positronNewFolder.js';
 import { IProgressService } from '../../../../../platform/progress/common/progress.js';
+import { IWorkbenchEnvironmentService } from '../../../environment/common/environmentService.js';
+
+/**
+ * Helper to create common service stubs for RuntimeStartupService tests.
+ */
+function createCommonStubs(
+	instantiationService: TestInstantiationService,
+	notificationService: MockNotificationService,
+	remoteAuthority?: string
+): void {
+	instantiationService.stub(INotificationService, notificationService);
+	instantiationService.stub(IEphemeralStateService, {
+		getItem: () => Promise.resolve(undefined),
+		setItem: () => Promise.resolve(),
+	});
+	instantiationService.stub(ILifecycleService, {
+		onBeforeShutdown: new Emitter<BeforeShutdownEvent>().event,
+		onWillShutdown: new Emitter<WillShutdownEvent>().event,
+	});
+	instantiationService.stub(IPositronNewFolderService, {
+		onDidChangeNewFolderStartupPhase: new Emitter<NewFolderStartupPhase>().event,
+		startupPhase: NewFolderStartupPhase.Complete,
+	});
+	instantiationService.stub(IProgressService, {});
+	instantiationService.stub(IWorkbenchEnvironmentService, {
+		remoteAuthority,
+	});
+}
 
 suite('Positron - RuntimeStartupService Architecture Mismatch', () => {
-	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	let instantiationService: TestInstantiationService;
-	let notificationService: MockNotificationService;
-	let runtimeStartupService: RuntimeStartupService;
+	suite('Local sessions', () => {
+		const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	setup(() => {
-		instantiationService = disposables.add(new TestInstantiationService());
-		createRuntimeServices(instantiationService, disposables);
+		let instantiationService: TestInstantiationService;
+		let notificationService: MockNotificationService;
+		let runtimeStartupService: RuntimeStartupService;
 
-		notificationService = new MockNotificationService();
-		instantiationService.stub(INotificationService, notificationService);
-
-		instantiationService.stub(IEphemeralStateService, {
-			getItem: () => Promise.resolve(undefined),
-			setItem: () => Promise.resolve(),
+		setup(() => {
+			instantiationService = disposables.add(new TestInstantiationService());
+			createRuntimeServices(instantiationService, disposables);
+			notificationService = new MockNotificationService();
+			createCommonStubs(instantiationService, notificationService, undefined);
+			runtimeStartupService = disposables.add(instantiationService.createInstance(RuntimeStartupService));
 		});
-		instantiationService.stub(ILifecycleService, {
-			onBeforeShutdown: new Emitter<BeforeShutdownEvent>().event,
-			onWillShutdown: new Emitter<WillShutdownEvent>().event,
-		});
-		instantiationService.stub(IPositronNewFolderService, {
-			onDidChangeNewFolderStartupPhase: new Emitter<NewFolderStartupPhase>().event,
-			startupPhase: NewFolderStartupPhase.Complete,
-		});
-		instantiationService.stub(IProgressService, {});
 
-		runtimeStartupService = disposables.add(instantiationService.createInstance(RuntimeStartupService));
+		// Architecture mismatch checks are skipped on web since the browser's
+		// architecture doesn't relate to where the interpreter is running
+		(isWeb ? test.skip : test)('no notification when architectures match', () => {
+			// Use the same architecture as the system
+			const matchingArch = systemArch === 'arm64'
+				? LanguageRuntimeArchitecture.Arm64
+				: LanguageRuntimeArchitecture.X64;
+
+			const mockSession = {
+				runtimeMetadata: { languageId: 'python', runtimeName: 'Python 3.12.0' }
+			} as unknown as ILanguageRuntimeSession;
+			const mockRuntimeInfo = { interpreterArch: matchingArch };
+
+			runtimeStartupService['checkArchitectureMismatch'](mockSession, mockRuntimeInfo);
+
+			assert.strictEqual(notificationService.promptCalls.length, 0, 'Should not show notification when architectures match');
+		});
+
+		(isWeb ? test.skip : test)('notification shown with correct message when architectures mismatch', () => {
+			// Use a different architecture than the system
+			const mismatchedArch = systemArch === 'arm64'
+				? LanguageRuntimeArchitecture.X64
+				: LanguageRuntimeArchitecture.Arm64;
+			const mismatchedArchStr = systemArch === 'arm64' ? 'x64' : 'arm64';
+
+			const mockSession = {
+				runtimeMetadata: { languageId: 'python', runtimeName: 'Python 3.12.0 (x64)' }
+			} as unknown as ILanguageRuntimeSession;
+			const mockRuntimeInfo = { interpreterArch: mismatchedArch };
+
+			runtimeStartupService['checkArchitectureMismatch'](mockSession, mockRuntimeInfo);
+
+			assert.strictEqual(notificationService.promptCalls.length, 1, 'Should show notification when architectures mismatch');
+
+			const call = notificationService.promptCalls[0];
+			assert.strictEqual(call.severity, Severity.Warning);
+			const expectedMessage = `The interpreter "Python 3.12.0 (x64)" has a different architecture (${mismatchedArchStr}) than your system (${systemArch}). This may cause problems with performance and package compatibility.`;
+			assert.strictEqual(call.message, expectedMessage);
+		});
 	});
 
-	// Architecture mismatch checks are skipped on web since the browser's
-	// architecture doesn't relate to where the interpreter is running
-	(isWeb ? test.skip : test)('no notification when architectures match', () => {
-		// Use the same architecture as the system
-		const matchingArch = systemArch === 'arm64'
-			? LanguageRuntimeArchitecture.Arm64
-			: LanguageRuntimeArchitecture.X64;
+	suite('Remote SSH sessions', () => {
+		const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-		const mockSession = {
-			runtimeMetadata: { languageId: 'python', runtimeName: 'Python 3.12.0' }
-		} as unknown as ILanguageRuntimeSession;
-		const mockRuntimeInfo = { interpreterArch: matchingArch };
+		let instantiationService: TestInstantiationService;
+		let notificationService: MockNotificationService;
+		let runtimeStartupService: RuntimeStartupService;
 
-		runtimeStartupService['checkArchitectureMismatch'](mockSession, mockRuntimeInfo);
+		setup(() => {
+			instantiationService = disposables.add(new TestInstantiationService());
+			createRuntimeServices(instantiationService, disposables);
+			notificationService = new MockNotificationService();
+			createCommonStubs(instantiationService, notificationService, 'ssh-remote+myserver');
+			runtimeStartupService = disposables.add(instantiationService.createInstance(RuntimeStartupService));
+		});
 
-		assert.strictEqual(notificationService.promptCalls.length, 0, 'Should not show notification when architectures match');
-	});
+		test('no notification even when architectures mismatch', () => {
+			// Use a different architecture than the system (would normally trigger warning)
+			const mismatchedArch = systemArch === 'arm64'
+				? LanguageRuntimeArchitecture.X64
+				: LanguageRuntimeArchitecture.Arm64;
 
-	(isWeb ? test.skip : test)('notification shown with correct message when architectures mismatch', () => {
-		// Use a different architecture than the system
-		const mismatchedArch = systemArch === 'arm64'
-			? LanguageRuntimeArchitecture.X64
-			: LanguageRuntimeArchitecture.Arm64;
-		const mismatchedArchStr = systemArch === 'arm64' ? 'x64' : 'arm64';
+			const mockSession = {
+				runtimeMetadata: { languageId: 'python', runtimeName: 'Python 3.12.0 (x64)' }
+			} as unknown as ILanguageRuntimeSession;
+			const mockRuntimeInfo = { interpreterArch: mismatchedArch };
 
-		const mockSession = {
-			runtimeMetadata: { languageId: 'python', runtimeName: 'Python 3.12.0 (x64)' }
-		} as unknown as ILanguageRuntimeSession;
-		const mockRuntimeInfo = { interpreterArch: mismatchedArch };
+			runtimeStartupService['checkArchitectureMismatch'](mockSession, mockRuntimeInfo);
 
-		runtimeStartupService['checkArchitectureMismatch'](mockSession, mockRuntimeInfo);
-
-		assert.strictEqual(notificationService.promptCalls.length, 1, 'Should show notification when architectures mismatch');
-
-		const call = notificationService.promptCalls[0];
-		assert.strictEqual(call.severity, Severity.Warning);
-		const expectedMessage = `The interpreter "Python 3.12.0 (x64)" has a different architecture (${mismatchedArchStr}) than your system (${systemArch}). This may cause problems with performance and package compatibility.`;
-		assert.strictEqual(call.message, expectedMessage);
+			assert.strictEqual(
+				notificationService.promptCalls.length,
+				0,
+				'Should not show notification in remote SSH sessions'
+			);
+		});
 	});
 });
 


### PR DESCRIPTION
- Addresses #12405
- Related to #12047, if you want to see some background

This PR skips the architecture mismatch warning when connected to a remote session (such as via SSH). The warning was incorrectly comparing the remote interpreter's architecture against the local client machine's architecture, causing false positives (e.g., x64 Python on a remote x64 Linux server triggering a warning because the local machine is an ARM Mac).

Since all our remote session support requires Linux as the remote OS, and Linux has no architecture emulation layer anyway, this check is not meaningful for remote sessions.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed architecture mismatch warning incorrectly appearing in remote SSH sessions (#12405)

### QA Notes

@:interpreter @:remote-ssh

#### No warning 🚫 

1. From an ARM Mac or Windows machine, connect to a remote x64 Linux VM via Remote SSH
2. Start a Python or R interpreter on the remote
3. Verify no architecture mismatch warning appears

#### Yes warning ✅ 

- On an ARM Mac or Windows with an x64 Python installed, start the x64 interpreter
- Verify the architecture mismatch warning still appears as expected
