### PR TITLE
Fix bootstrap extensions packaging

### DIFF
--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -669,24 +669,14 @@ export function packageMarketplaceExtensionsStream(forWeb: boolean): Stream {
 
 // --- Start Positron ---
 export function packageBootstrapExtensionsStream(): Stream {
-	const bootstrapExtensionsStream = minifyExtensionResources(
-		es.merge(
-			...bootstrapExtensions
-				.map(extension => {
-					const src = getBootstrapExtensionStream(extension);
-					return updateExtensionPackageJSON(src, (data: any) => {
-						delete data.scripts;
-						delete data.dependencies;
-						delete data.devDependencies;
-						return data;
-					});
-				})
-		)
-	);
-
-	return (
-		bootstrapExtensionsStream
-			.pipe(util2.setExecutableBit(['**/*.sh']))
+	return es.merge(
+		...bootstrapExtensions
+			.map(extension => {
+				const src = getBootstrapExtensionStream(extension).pipe(rename(p => {
+					p.dirname = `extensions/bootstrap/${p.dirname}`;
+				}));
+				return src;
+			})
 	);
 }
 // --- End Positron ---


### PR DESCRIPTION
It looks like with the 1.109.0 this function got modified to stop saving the bootstrap extensions to the correct location. I suspect it was an unintentional copy of the `packageMarketplaceExtensionsStream` function.