### PR TITLE
Data Explorer: Increase GetDataValues timeout

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
+++ b/src/vs/workbench/services/positronDataExplorer/browser/positronDataExplorerService.ts
@@ -18,7 +18,7 @@ import { PositronDataExplorerInstance } from './positronDataExplorerInstance.js'
 import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionService, RuntimeClientType } from '../../runtimeSession/common/runtimeSessionService.js';
 import { IPositronDataExplorerService } from './interfaces/positronDataExplorerService.js';
 import { IPositronDataExplorerInstance } from './interfaces/positronDataExplorerInstance.js';
-import { PositronDataExplorerComm } from '../../languageRuntime/common/positronDataExplorerComm.js';
+import { DataExplorerBackendRequest, PositronDataExplorerComm } from '../../languageRuntime/common/positronDataExplorerComm.js';
 import { PositronDataExplorerDuckDBBackend } from '../common/positronDataExplorerDuckDBBackend.js';
 import { ServicesAccessor } from '../../../../editor/browser/editorExtensions.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -91,7 +91,11 @@ class DataExplorerRuntime extends Disposable {
 				}
 
 				// Create and register the DataExplorerClientInstance for the client instance.
-				const commInstance = new PositronDataExplorerComm(e.client);
+				const commInstance = new PositronDataExplorerComm(e.client, {
+					[DataExplorerBackendRequest.GetDataValues]: {
+						timeout: 10000, // 10 seconds instead of the default 5
+					},
+				});
 				const dataExplorerClientInstance = new DataExplorerClientInstance(commInstance);
 				this._register(dataExplorerClientInstance);
 
@@ -395,7 +399,11 @@ class PositronDataExplorerService extends Disposable implements IPositronDataExp
 				const existingInstance = this.getInstance(client.getClientId());
 				// If we don't have a Data Explorer client instance, create one and open the editor.
 				if (!existingInstance) {
-					const commInstance = new PositronDataExplorerComm(client);
+					const commInstance = new PositronDataExplorerComm(client, {
+						[DataExplorerBackendRequest.GetDataValues]: {
+							timeout: 10000, // 10 seconds instead of the default 5
+						},
+					});
 					const dataExplorerClientInstance = new DataExplorerClientInstance(commInstance);
 					this.openEditor(session.runtimeMetadata.languageName, dataExplorerClientInstance);
 				}


### PR DESCRIPTION
Attempt at fixing the `get_data_values` rpc timeout issue we have been seeing for tests.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:data-explorer
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
