### PR TITLE
Show workspace trust status properly in the Console

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/startupStatus.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/startupStatus.tsx
@@ -20,7 +20,7 @@ import { usePositronReactServicesContext } from '../../../../../base/browser/pos
 
 // Load localized copy for control.
 const initalizing = localize('positron.console.initializing', "Waiting for extensions");
-const awaitingTrust = localize('positron.console.awaitingTrust', "Consoles cannot start until the workspace is trusted");
+const awaitingTrust = localize('positron.console.awaitingTrust', "Cannot start consoles in Restricted Mode. Trust this folder to enable consoles.");
 const newFolderTasks = localize('positron.console.newFolderTasks', "Setting up workspace");
 const reconnecting = localize('positron.console.reconnecting', "Reconnecting");
 const starting = localize('positron.console.starting', "Starting");
@@ -93,6 +93,15 @@ export const StartupStatus = () => {
 		};
 	}, [services.languageRuntimeService, services.runtimeStartupService]);
 
+	// When awaiting trust, show a static message without a progress bar.
+	if (startupPhase === RuntimeStartupPhase.AwaitingTrust) {
+		return (
+			<div className='startup-status'>
+				<div className='awaiting'>{awaitingTrust}</div>
+			</div>
+		);
+	}
+
 	// Render.
 	return (
 		<div className='startup-status'>
@@ -105,9 +114,6 @@ export const StartupStatus = () => {
 			}
 			{startupPhase === RuntimeStartupPhase.Reconnecting && !runtimeStartupEvent &&
 				<div className='reconnecting'>{reconnecting}...</div>
-			}
-			{startupPhase === RuntimeStartupPhase.AwaitingTrust &&
-				<div className='awaiting'>{awaitingTrust}...</div>
 			}
 			{startupPhase === RuntimeStartupPhase.NewFolderTasks &&
 				<div className='new-folder-tasks'>{newFolderTasks}...</div>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/startupStatus.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/startupStatus.tsx
@@ -17,10 +17,11 @@ import { ProgressBar } from '../../../../../base/browser/ui/progressbar/progress
 import { RuntimeStartupPhase } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IRuntimeAutoStartEvent } from '../../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { EmbeddedLink } from '../../../../../base/browser/ui/positronComponents/embeddedLink/EmbeddedLink.js';
 
 // Load localized copy for control.
 const initalizing = localize('positron.console.initializing', "Waiting for extensions");
-const awaitingTrust = localize('positron.console.awaitingTrust', "Cannot start consoles in Restricted Mode. Trust this folder to enable consoles.");
+const awaitingTrust = localize('positron.console.awaitingTrust', "Cannot start consoles in Restricted Mode. [Trust this folder](command:workbench.trust.manage) to enable consoles.");
 const newFolderTasks = localize('positron.console.newFolderTasks', "Setting up workspace");
 const reconnecting = localize('positron.console.reconnecting', "Reconnecting");
 const starting = localize('positron.console.starting', "Starting");
@@ -114,7 +115,7 @@ export const StartupStatus = () => {
 				<div className='reconnecting'>{reconnecting}...</div>
 			}
 			{isAwaitingTrust &&
-				<div className='awaiting'>{awaitingTrust}</div>
+				<div className='awaiting'><EmbeddedLink>{awaitingTrust}</EmbeddedLink></div>
 			}
 			{startupPhase === RuntimeStartupPhase.NewFolderTasks &&
 				<div className='new-folder-tasks'>{newFolderTasks}...</div>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/startupStatus.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/startupStatus.tsx
@@ -93,19 +93,17 @@ export const StartupStatus = () => {
 		};
 	}, [services.languageRuntimeService, services.runtimeStartupService]);
 
-	// When awaiting trust, show a static message without a progress bar.
-	if (startupPhase === RuntimeStartupPhase.AwaitingTrust) {
-		return (
-			<div className='startup-status'>
-				<div className='awaiting'>{awaitingTrust}</div>
-			</div>
-		);
-	}
+	// Whether we are awaiting workspace trust. In this state we show a
+	// static message and hide the progress bar.
+	const isAwaitingTrust = startupPhase === RuntimeStartupPhase.AwaitingTrust;
 
-	// Render.
+	// Render. The progress bar div must always be in the DOM so that the
+	// ref is available when the useEffect creates the ProgressBar instance;
+	// it is hidden during the AwaitingTrust phase via display:none.
 	return (
 		<div className='startup-status'>
-			<div ref={progressRef} className='progress'></div>
+			<div ref={progressRef} className='progress'
+				style={isAwaitingTrust ? { display: 'none' } : undefined}></div>
 			{runtimeStartupEvent &&
 				<RuntimeStartupProgress evt={runtimeStartupEvent} />
 			}
@@ -114,6 +112,9 @@ export const StartupStatus = () => {
 			}
 			{startupPhase === RuntimeStartupPhase.Reconnecting && !runtimeStartupEvent &&
 				<div className='reconnecting'>{reconnecting}...</div>
+			}
+			{isAwaitingTrust &&
+				<div className='awaiting'>{awaitingTrust}</div>
 			}
 			{startupPhase === RuntimeStartupPhase.NewFolderTasks &&
 				<div className='new-folder-tasks'>{newFolderTasks}...</div>

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -405,12 +405,13 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				}
 			}
 
-			// If we were awaiting trust, and we now have language packs, move on
-			// to the discovery phase if we haven't already and there are now registered
-			// language packs.
+			// If we were awaiting trust, and we now have language packs, the
+			// workspace has been trusted and extensions have been activated.
+			// Run the full startup sequence (not just discovery) so that
+			// session restoration, affiliated runtimes, etc. are handled.
 			if (this._startupPhase === RuntimeStartupPhase.AwaitingTrust) {
 				if (this._languagePacks.size > 0) {
-					this.discoverAllRuntimes();
+					this.startupSequence();
 				} else {
 					this._logService.debug(`[Runtime startup] No language packs were found.`);
 					this.setStartupPhase(RuntimeStartupPhase.Complete);
@@ -462,6 +463,29 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				}
 			}
 		}));
+
+		// If the workspace is not trusted, immediately transition to the
+		// AwaitingTrust phase so the console shows the correct message
+		// (rather than "Waiting for extensions", which is misleading since
+		// extensions won't activate until the workspace is trusted).
+		if (!this._workspaceTrustManagementService.isWorkspaceTrusted()) {
+			this.setStartupPhase(RuntimeStartupPhase.AwaitingTrust);
+			this._register(this._workspaceTrustManagementService.onDidChangeTrust((trusted) => {
+				if (!trusted) {
+					return;
+				}
+				// When the workspace becomes trusted while we are still
+				// awaiting trust, the extension host will restart and the
+				// ext point handler will fire with language packs, which
+				// drives the startup sequence forward. However, if no
+				// language packs arrive (e.g. no extensions contribute
+				// runtimes), we need a fallback to avoid hanging forever
+				// in the AwaitingTrust phase.
+				if (this._startupPhase === RuntimeStartupPhase.AwaitingTrust) {
+					this.discoverAllRuntimes();
+				}
+			}));
+		}
 
 		// Find all the sessions that need to be restored.
 		this.findRestoredSessions().then(() => {

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -480,9 +480,11 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				// drives the startup sequence forward. However, if no
 				// language packs arrive (e.g. no extensions contribute
 				// runtimes), we need a fallback to avoid hanging forever
-				// in the AwaitingTrust phase.
+				// in the AwaitingTrust phase. Route through the full
+				// startup sequence so session restore, new-folder tasks,
+				// and affiliated/recommended startup are not skipped.
 				if (this._startupPhase === RuntimeStartupPhase.AwaitingTrust) {
-					this.discoverAllRuntimes();
+					this.startupSequence();
 				}
 			}));
 		}
@@ -606,6 +608,17 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 	 * The main entry point for the runtime startup service.
 	 */
 	private async startupSequence() {
+
+		// Guard against double entry. Both the ext-point handler and the
+		// onDidChangeTrust handler can call startupSequence() when the
+		// workspace transitions from untrusted to trusted. Setting the
+		// phase synchronously before the first await ensures only the
+		// first caller proceeds.
+		if (this._startupPhase !== RuntimeStartupPhase.AwaitingTrust &&
+			this._startupPhase !== RuntimeStartupPhase.Initializing) {
+			return;
+		}
+		this.setStartupPhase(RuntimeStartupPhase.Starting);
 
 		// Attempt to reconnect to any active sessions first.
 		await this.restoreSessions();


### PR DESCRIPTION
This change fixes the display of trust status in the Console.

<img width="1300" height="911" alt="image" src="https://github.com/user-attachments/assets/8ea4b9cd-3c37-492b-ad44-72eabc9c8d37" />

This appears to be a regression from a change in upstream behavior; now, likely for security reasons, the extensions that supply language runtimes don't even register until after the workspace is trusted. That means that we need to wait for the workspace to be trusted before doing anything else.

I've also removed the progress bar when awaiting trust, as otherwise you're stuck with an infinite spinner in Restricted Mode. 

Addresses #11828. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix display of workbench trust status in the Console (#11828)

