### PR TITLE
Support Foundry deployment URLs in Assistant

### DIFF
--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -148,6 +148,7 @@ export async function showConfigurationDialog(
 									signedIn: result.configured,
 									defaults: {
 										...source.defaults,
+										...(result.configuration?.baseUrl && { baseUrl: result.configuration.baseUrl }),
 										autoconfigure: {
 											type: positron.ai.LanguageModelAutoconfigureType.Custom,
 											message: result.message ?? source.defaults.autoconfigure.message,
@@ -250,7 +251,9 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 			[...existingConfigs, newConfig]
 		);
 
-		positron.ai.addLanguageModelConfig(expandConfigToSource(newConfig));
+		const addedSource = expandConfigToSource(newConfig);
+		addedSource.signedIn = true;
+		positron.ai.addLanguageModelConfig(addedSource);
 
 		// Remember the base URL for this provider so it can be pre-populated after sign-out
 		if (baseUrl) {
@@ -398,7 +401,9 @@ export async function deleteConfiguration(context: vscode.ExtensionContext, id: 
 
 	clearTokenUsage(targetConfig.provider);
 
-	positron.ai.removeLanguageModelConfig(expandConfigToSource(targetConfig));
+	const removedSource = expandConfigToSource(targetConfig);
+	removedSource.signedIn = false;
+	positron.ai.removeLanguageModelConfig(removedSource);
 
 	// Refresh CopilotService signed-in state if this was a copilot model
 	if (targetConfig.provider === 'copilot-auth') {

--- a/extensions/positron-assistant/src/constants.ts
+++ b/extensions/positron-assistant/src/constants.ts
@@ -29,7 +29,7 @@ export const MIN_TOKEN_LIMIT = 512;
 export const TOOL_TAG_REQUIRES_WORKSPACE = 'requires-workspace';
 
 /** Default patterns for selectable models */
-export const DEFAULT_SELECTABLE_PATTERNS = ['claude', 'gpt'];
+export const DEFAULT_SELECTABLE_PATTERNS = ['claude', 'gpt', 'model-router'];
 
 /** Settings search string for provider enable settings */
 export const PROVIDER_ENABLE_SETTINGS_SEARCH = 'positron.assistant.provider enable';

--- a/extensions/positron-assistant/src/constants.ts
+++ b/extensions/positron-assistant/src/constants.ts
@@ -28,7 +28,11 @@ export const MIN_TOKEN_LIMIT = 512;
 /** Tag used by tools to indicate a workspace must be open in order to use the tool */
 export const TOOL_TAG_REQUIRES_WORKSPACE = 'requires-workspace';
 
-/** Default patterns for selectable models */
+/**
+ * Default patterns for selectable models
+ * model-router is a special value for Foundry that indicates the endpoint
+ * supports dynamic model selection that will be handled by Foundry
+ */
 export const DEFAULT_SELECTABLE_PATTERNS = ['claude', 'gpt', 'model-router'];
 
 /** Settings search string for provider enable settings */

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -298,6 +298,7 @@ function registerDeferredFoundryAutoconfigure(context: vscode.ExtensionContext) 
 				name: foundryProvider.source.provider.displayName,
 				model: foundryProvider.source.defaults.model,
 				apiKey: '',
+				baseUrl: result.configuration?.baseUrl,
 				toolCalls: foundryProvider.source.defaults.toolCalls,
 				completions: foundryProvider.source.defaults.completions,
 				autoconfigure: {

--- a/extensions/positron-assistant/src/providers/foundry/foundryProvider.ts
+++ b/extensions/positron-assistant/src/providers/foundry/foundryProvider.ts
@@ -16,9 +16,11 @@ import { log } from '../../log.js';
 /**
  * Microsoft Foundry model provider implementation.
  *
- * Uses the OpenAI v1 API (`{endpoint}/openai/v1/chat/completions`) which is
- * compatible with both `.openai.azure.com` and `.services.ai.azure.com` endpoints.
+ * Uses the OpenAI v1 API (`{endpoint}/openai/v1/chat/completions`)
  * The model is specified in the request body (no deployment-based URLs or api-version).
+ *
+ * If a user provides a deployment-based URL (containing `/openai/deployments/`),
+ * it is automatically converted to the v1 format by extracting the endpoint base.
  *
  * Supports two authentication paths within a single class:
  * - **API key** (manual): User configures via settings UI
@@ -68,15 +70,53 @@ export class FoundryModelProvider extends VercelModelProvider implements positro
 	/**
 	 * Gets the base URL for the Azure OpenAI v1 API.
 	 *
-	 * In managed mode, constructs from the Workbench endpoint setting.
-	 * In manual mode, uses the user-provided baseUrl.
+	 * Normalizes the raw URL from config (manual or Workbench) to the v1 format.
+	 * Deployment-based URLs are converted by extracting the endpoint base.
 	 */
 	get baseUrl(): string {
 		const rawUrl = this.isWorkbenchManaged
 			? FoundryModelProvider.getWorkbenchConfig().endpoint
 			: (this._config.baseUrl ?? '');
-		const url = rawUrl.replace(/\/+$/, '');
-		return url.endsWith('/openai/v1') ? url : `${url}/openai/v1`;
+		return FoundryModelProvider.normalizeToV1Url(rawUrl);
+	}
+
+	/**
+	 * Normalizes any Foundry URL to the v1 API format.
+	 *
+	 * Handles deployment URLs (e.g., `{endpoint}/openai/deployments/{name}/...?api-version=...`)
+	 * by extracting the endpoint base. Strips query parameters since the v1 API
+	 * rejects `api-version`. Appends `/openai/v1` if not already present.
+	 */
+	static normalizeToV1Url(rawUrl: string): string {
+		let url = rawUrl.trim();
+
+		// Strip query parameters (v1 API rejects api-version)
+		const queryIndex = url.indexOf('?');
+		if (queryIndex !== -1) {
+			url = url.substring(0, queryIndex);
+		}
+
+		url = url.replace(/\/+$/, '');
+
+		// Deployment URL: extract endpoint base before /openai/deployments/
+		const deploymentIndex = url.indexOf('/openai/deployments/');
+		if (deploymentIndex !== -1) {
+			url = url.substring(0, deploymentIndex);
+		}
+
+		if (url.endsWith('/openai/v1')) {
+			return url;
+		}
+
+		return `${url}/openai/v1`;
+	}
+
+	/**
+	 * Returns true if the URL is a deployment-based Azure OpenAI URL.
+	 * Used by the UI to show a warning when a deployment URL is entered.
+	 */
+	static isDeploymentUrl(rawUrl: string): boolean {
+		return /\/openai\/deployments\//.test(rawUrl);
 	}
 
 	/**
@@ -95,6 +135,14 @@ export class FoundryModelProvider extends VercelModelProvider implements positro
 			FoundryModelProvider.source.provider.id,
 			FoundryModelProvider.source.provider.displayName
 		);
+
+		if (result.configured) {
+			const endpoint = FoundryModelProvider.getWorkbenchConfig().endpoint;
+			result.configuration = {
+				baseUrl: FoundryModelProvider.normalizeToV1Url(endpoint),
+			};
+		}
+
 		return result;
 	}
 

--- a/extensions/positron-assistant/src/providers/foundry/foundryProvider.ts
+++ b/extensions/positron-assistant/src/providers/foundry/foundryProvider.ts
@@ -90,6 +90,11 @@ export class FoundryModelProvider extends VercelModelProvider implements positro
 	static normalizeToV1Url(rawUrl: string): string {
 		let url = rawUrl.trim();
 
+		// Early return for empty URL
+		if (!url) {
+			return '';
+		}
+
 		// Strip query parameters (v1 API rejects api-version)
 		const queryIndex = url.indexOf('?');
 		if (queryIndex !== -1) {
@@ -97,6 +102,11 @@ export class FoundryModelProvider extends VercelModelProvider implements positro
 		}
 
 		url = url.replace(/\/+$/, '');
+
+		// Early return if URL became empty after normalization
+		if (!url) {
+			return '';
+		}
 
 		// Deployment URL: extract endpoint base before /openai/deployments/
 		const deploymentIndex = url.indexOf('/openai/deployments/');

--- a/extensions/positron-assistant/src/test/foundryAutoconfigure.test.ts
+++ b/extensions/positron-assistant/src/test/foundryAutoconfigure.test.ts
@@ -150,7 +150,7 @@ suite('Foundry Autoconfigure', () => {
 		test('handles empty string', () => {
 			assert.strictEqual(
 				FoundryModelProvider.normalizeToV1Url(''),
-				'/openai/v1'
+				''
 			);
 		});
 	});

--- a/extensions/positron-assistant/src/test/foundryAutoconfigure.test.ts
+++ b/extensions/positron-assistant/src/test/foundryAutoconfigure.test.ts
@@ -97,6 +97,87 @@ suite('Foundry Autoconfigure', () => {
 		assert.strictEqual(result.message, 'Foundry managed credentials');
 	});
 
+	// --- URL normalization tests ---
+
+	suite('normalizeToV1Url', () => {
+		test('converts full deployment URL to v1', () => {
+			const input = 'https://r.azure.com/openai/deployments/m/chat/completions?api-version=2025-01-01-preview';
+			assert.strictEqual(FoundryModelProvider.normalizeToV1Url(input), 'https://r.azure.com/openai/v1');
+		});
+
+		test('converts partial deployment URL to v1', () => {
+			assert.strictEqual(
+				FoundryModelProvider.normalizeToV1Url('https://r.azure.com/openai/deployments/m'),
+				'https://r.azure.com/openai/v1'
+			);
+		});
+
+		test('preserves already-v1 URL', () => {
+			assert.strictEqual(
+				FoundryModelProvider.normalizeToV1Url('https://r.azure.com/openai/v1'),
+				'https://r.azure.com/openai/v1'
+			);
+		});
+
+		test('strips trailing slash from v1 URL', () => {
+			assert.strictEqual(
+				FoundryModelProvider.normalizeToV1Url('https://r.azure.com/openai/v1/'),
+				'https://r.azure.com/openai/v1'
+			);
+		});
+
+		test('appends /openai/v1 to bare endpoint with trailing slash', () => {
+			assert.strictEqual(
+				FoundryModelProvider.normalizeToV1Url('https://r.azure.com/'),
+				'https://r.azure.com/openai/v1'
+			);
+		});
+
+		test('appends /openai/v1 to bare endpoint', () => {
+			assert.strictEqual(
+				FoundryModelProvider.normalizeToV1Url('https://r.azure.com'),
+				'https://r.azure.com/openai/v1'
+			);
+		});
+
+		test('strips query params from bare endpoint', () => {
+			assert.strictEqual(
+				FoundryModelProvider.normalizeToV1Url('https://r.azure.com?api-version=x'),
+				'https://r.azure.com/openai/v1'
+			);
+		});
+
+		test('handles empty string', () => {
+			assert.strictEqual(
+				FoundryModelProvider.normalizeToV1Url(''),
+				'/openai/v1'
+			);
+		});
+	});
+
+	suite('isDeploymentUrl', () => {
+		test('detects full deployment URL', () => {
+			assert.strictEqual(
+				FoundryModelProvider.isDeploymentUrl('https://r.azure.com/openai/deployments/m/chat/completions'),
+				true
+			);
+		});
+
+		test('returns false for v1 URL', () => {
+			assert.strictEqual(
+				FoundryModelProvider.isDeploymentUrl('https://r.azure.com/openai/v1'),
+				false
+			);
+		});
+
+		test('returns false for bare endpoint', () => {
+			assert.strictEqual(
+				FoundryModelProvider.isDeploymentUrl('https://r.azure.com/'),
+				false
+			);
+		});
+	});
+
 	test('Existing providers (AWS/Snowflake) still work after Foundry addition', async () => {
 		// Re-enable AWS and Snowflake
 		AWSModelProvider.autoconfigure = async () => ({

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -186,7 +186,7 @@ const BaseUrl = (props: { baseUrl?: string; signedIn?: boolean; onChange: (newBa
 		</div>
 		{isDeploymentUrl &&
 			<div className='language-model-url-info'>
-				<span className='codicon codicon-warning' />
+				<span className='codicon codicon-info' />
 				<span>
 					{props.signedIn
 						? localize(

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -162,7 +162,7 @@ const DEPLOYMENT_URL_PATTERN = /\/openai\/deployments\//;
 
 const BaseUrl = (props: { baseUrl?: string; signedIn?: boolean; onChange: (newBaseUrl: string) => void; provider: IProvider }) => {
 	const baseUrlLabel = props.provider.id === 'openai-compatible' ? localize('positron.languageModelConfig.baseUrlOpenAICompatibleInputLabel', 'Base URL (must be OpenAI compatible)') : localize('positron.languageModelConfig.baseUrlInputLabel', 'Base URL');
-	const isDeploymentUrl = props.provider.id === 'foundry' && props.baseUrl ? DEPLOYMENT_URL_PATTERN.test(props.baseUrl) : false;
+	const isDeploymentUrl = props.provider.id === 'ms-foundry' && props.baseUrl ? DEPLOYMENT_URL_PATTERN.test(props.baseUrl) : false;
 
 	// When signed in with a deployment URL, show the normalized v1 URL
 	let displayUrl = props.baseUrl;
@@ -185,7 +185,7 @@ const BaseUrl = (props: { baseUrl?: string; signedIn?: boolean; onChange: (newBa
 			}
 		</div>
 		{isDeploymentUrl &&
-			<div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginTop: '4px', color: 'var(--vscode-editorWarning-foreground)', fontSize: '0.85em', wordBreak: 'break-word' }}>
+			<div className='language-model-url-info'>
 				<span className='codicon codicon-warning' />
 				<span>
 					{props.signedIn

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -162,7 +162,7 @@ const DEPLOYMENT_URL_PATTERN = /\/openai\/deployments\//;
 
 const BaseUrl = (props: { baseUrl?: string; signedIn?: boolean; onChange: (newBaseUrl: string) => void; provider: IProvider }) => {
 	const baseUrlLabel = props.provider.id === 'openai-compatible' ? localize('positron.languageModelConfig.baseUrlOpenAICompatibleInputLabel', 'Base URL (must be OpenAI compatible)') : localize('positron.languageModelConfig.baseUrlInputLabel', 'Base URL');
-	const isDeploymentUrl = props.baseUrl ? DEPLOYMENT_URL_PATTERN.test(props.baseUrl) : false;
+	const isDeploymentUrl = props.provider.id === 'foundry' && props.baseUrl ? DEPLOYMENT_URL_PATTERN.test(props.baseUrl) : false;
 
 	// When signed in with a deployment URL, show the normalized v1 URL
 	let displayUrl = props.baseUrl;
@@ -188,10 +188,16 @@ const BaseUrl = (props: { baseUrl?: string; signedIn?: boolean; onChange: (newBa
 			<div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginTop: '4px', color: 'var(--vscode-editorWarning-foreground)', fontSize: '0.85em', wordBreak: 'break-word' }}>
 				<span className='codicon codicon-warning' />
 				<span>
-					{localize(
-						'positron.languageModelConfig.deploymentUrlWarning',
-						"Deployment URL rewritten to use the OpenAI v1 endpoint."
-					)}
+					{props.signedIn
+						? localize(
+							'positron.languageModelConfig.deploymentUrlRewritten',
+							"Deployment URL rewritten to use the OpenAI v1 endpoint."
+						)
+						: localize(
+							'positron.languageModelConfig.deploymentUrlWillConvert',
+							"Deployment URL will be rewritten to use the OpenAI v1 endpoint."
+						)
+					}
 				</span>
 			</div>
 		}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -158,24 +158,45 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 	</>;
 }
 
-// Language config parts
-const BaseUrl = (props: { baseUrl?: string, signedIn?: boolean, onChange: (newBaseUrl: string) => void, provider: IProvider }) => {
+const DEPLOYMENT_URL_PATTERN = /\/openai\/deployments\//;
+
+const BaseUrl = (props: { baseUrl?: string; signedIn?: boolean; onChange: (newBaseUrl: string) => void; provider: IProvider }) => {
 	const baseUrlLabel = props.provider.id === 'openai-compatible' ? localize('positron.languageModelConfig.baseUrlOpenAICompatibleInputLabel', 'Base URL (must be OpenAI compatible)') : localize('positron.languageModelConfig.baseUrlInputLabel', 'Base URL');
+	const isDeploymentUrl = props.baseUrl ? DEPLOYMENT_URL_PATTERN.test(props.baseUrl) : false;
+
+	// When signed in with a deployment URL, show the normalized v1 URL
+	let displayUrl = props.baseUrl;
+	if (isDeploymentUrl && props.baseUrl) {
+		const deploymentIndex = props.baseUrl.indexOf('/openai/deployments/');
+		displayUrl = props.baseUrl.substring(0, deploymentIndex) + '/openai/v1';
+	}
+
 	return (<>
 		<div className='language-model-authentication-container' id='base-url-input'>
 			{
 				props.signedIn ?
-					<p>{localize('positron.languageModelConfig.baseUrlSignedIn', "Base URL: {0}", props.baseUrl)}</p>
+					<p>{localize('positron.languageModelConfig.baseUrlSignedIn', "Base URL: {0}", displayUrl)}</p>
 					:
 					<LabeledTextInput
 						label={baseUrlLabel}
 						type='text'
 						value={props.baseUrl ?? ''}
-						onChange={e => { props.onChange(e.currentTarget.value) }} />
+						onChange={e => { props.onChange(e.currentTarget.value); }} />
 			}
 		</div>
-	</>)
-}
+		{isDeploymentUrl &&
+			<div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginTop: '4px', color: 'var(--vscode-editorWarning-foreground)', fontSize: '0.85em', wordBreak: 'break-word' }}>
+				<span className='codicon codicon-warning' />
+				<span>
+					{localize(
+						'positron.languageModelConfig.deploymentUrlWarning',
+						"Deployment URL rewritten to use the OpenAI v1 endpoint."
+					)}
+				</span>
+			</div>
+		}
+	</>);
+};
 
 const ApiKey = (props: { apiKey?: string, onChange: (newApiKey: string) => void }) => {
 	return (<>

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -143,4 +143,13 @@
 	word-break: break-word;
 	margin-right: 90px;
 	padding-bottom: 10px;
+}
+
+.language-model-url-info {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	margin-top: 2px;
+	font-size: 0.85em;
+	word-break: break-word;
 }


### PR DESCRIPTION
Addresses #12377.

Adds support for deployment-based Azure OpenAI URLs (`{endpoint}/openai/deployments/{name}/...?api-version=...`) in the Foundry provider. These URLs are what admins see in the Foundry portal. The provider now automatically normalizes deployment URLs to the v1 format (`{endpoint}/openai/v1`). A message is displayed informing the user that the URL will be/has been modified.

When the user enters a deployment URL: 
<img width="600" height="495" alt="image" src="https://github.com/user-attachments/assets/93e22e1c-5d4c-462a-a110-b17eef00f8f0" />

After selecting Sign In:
<img width="587" height="491" alt="image" src="https://github.com/user-attachments/assets/91714e42-42c1-4a72-a458-fbe0144313a9" />

After selecting Sign Out: 
<img width="583" height="498" alt="image" src="https://github.com/user-attachments/assets/dc6f35cb-fe0e-4142-98f1-d04051908b64" />


While signed in, the base URL displayed will be the transformed openai/v1 URL, but if the user Signs Out, it will display the originally provided deployment URL.

Also fixes:
- Base URL showing "undefined" in the provider modal when Foundry is autoconfigured via Workbench
- `model-router` not appearing in the model picker due to the selectable model pattern filter

### Release Notes

#### New Features
- Positron Assistant Foundry provider now accepts deployment-based Azure OpenAI URLs and automatically converts them to the supported v1 format (#12377)

### QA Notes

@:assistant

**Deployment URL normalization:**
1. Open the Configure Language Model Providers modal
2. Select the Foundry provider
3. Paste a deployment URL like `https://example.openai.azure.com/openai/deployments/gpt-4/chat/completions?api-version=2025-01-01-preview`
4. Verify a warning appears indicating the URL will be rewritten
5. Sign in and verify the base URL displays as `https://example.openai.azure.com/openai/v1`

**Autoconfigured base URL (Workbench only):**
1. In a Workbench environment with Foundry autoconfigured, open the provider modal
2. Verify the base URL shows the configured endpoint (not "undefined")