### PR TITLE
Add engines.positron compatibility check for extension installs and updates

### DIFF
--- a/product.json
+++ b/product.json
@@ -3,7 +3,7 @@
 	"nameShort": "Positron",
 	"nameLong": "Positron",
 	"version": "",
-	"positronVersion": "2026.04.0",
+	"positronVersion": "2025.06.0",
 	"positronBuildNumber": 0,
 	"applicationName": "positron",
 	"dataFolderName": ".positron",

--- a/product.json
+++ b/product.json
@@ -3,7 +3,7 @@
 	"nameShort": "Positron",
 	"nameLong": "Positron",
 	"version": "",
-	"positronVersion": "2025.06.0",
+	"positronVersion": "2026.04.0",
 	"positronBuildNumber": 0,
 	"applicationName": "positron",
 	"dataFolderName": ".positron",

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -1019,7 +1019,7 @@ export class ExtensionEditor extends EditorPane {
 		// Pass the compatible gallery version so the Marketplace panel shows
 		// the correct version instead of the unfiltered latest.
 		additionalDetailsWidget.positronCompatibleGallery = template.positronCompatibleGallery;
-		// --- End Positron ---
+		// --- Start Positron ---
 		this.contentDisposables.add(additionalDetailsWidget);
 		// --- End Positron ---
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -1374,7 +1374,10 @@ class AdditionalDetailsWidget extends Disposable {
 				append(moreInfo,
 					$('.more-info-entry', undefined,
 						$('div.more-info-entry-name', undefined, localize('Version', "Version")),
+						// --- Start Positron ---
+						// $('code', undefined, gallery.version)
 						$('code', undefined, displayVersion)
+						// --- End Positron ---
 					)
 				);
 			}

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -1013,9 +1013,9 @@ export class ExtensionEditor extends EditorPane {
 		this.contentDisposables.add(toDisposable(removeLayoutParticipant));
 		this.contentDisposables.add(scrollableContent);
 
-		/// --- Start Positron ---
-		const additionalDetailsWidget = this.instantiationService.createInstance(AdditionalDetailsWidget, content, extension);
 		// --- Start Positron ---
+		const additionalDetailsWidget = this.instantiationService.createInstance(AdditionalDetailsWidget, content, extension);
+		// --- End Positron ---
 		// Pass the compatible gallery version so the Marketplace panel shows
 		// the correct version instead of the unfiltered latest.
 		additionalDetailsWidget.positronCompatibleGallery = template.positronCompatibleGallery;

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -91,6 +91,11 @@ import { ShowCurrentReleaseNotesActionId } from '../../update/common/update.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { fromNow } from '../../../../base/common/date.js';
+// --- Start Positron ---
+import { IProductService } from '../../../../platform/product/common/productService.js'; // --- Positron ---
+import { ILogService } from '../../../../platform/log/common/log.js'; // --- Positron ---
+import { getLatestPositronCompatibleVersion } from './positronCompatibleVersion.js'; // --- Positron ---
+// --- End Positron ---
 
 class NavBar extends Disposable {
 
@@ -165,6 +170,10 @@ interface IExtensionEditorTemplate {
 	extension: IExtension;
 	gallery: IGalleryExtension | null;
 	manifest: IExtensionManifest | null;
+	// --- Start Positron ---
+	positronCompatibilityPending: boolean;
+	positronCompatibleGallery: IGalleryExtension | null;
+	// --- End Positron ---
 }
 
 const enum WebviewIndex {
@@ -248,6 +257,10 @@ export class ExtensionEditor extends EditorPane {
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IHoverService private readonly hoverService: IHoverService,
+		// --- Start Positron ---
+		@IProductService private readonly productService: IProductService,
+		@ILogService private readonly logService: ILogService,
+		// --- End Positron ---
 	) {
 		super(ExtensionEditor.ID, group, telemetryService, themeService, storageService);
 		this.extensionReadme = null;
@@ -323,11 +336,16 @@ export class ExtensionEditor extends EditorPane {
 
 		const description = append(details, $('.description'));
 
+		// --- Start Positron ---
+		const updateAction = this.instantiationService.createInstance(UpdateAction, true); // --- Positron ---
+		// --- End Positron ---
 		const installAction = this.instantiationService.createInstance(InstallDropdownAction);
 		const actions = [
 			this.instantiationService.createInstance(ExtensionRuntimeStateAction),
 			this.instantiationService.createInstance(ExtensionStatusLabelAction),
-			this.instantiationService.createInstance(UpdateAction, true),
+			// --- Start Positron ---
+			updateAction,
+			// --- End Positron ---
 			this.instantiationService.createInstance(SetColorThemeAction),
 			this.instantiationService.createInstance(SetFileIconThemeAction),
 			this.instantiationService.createInstance(SetProductIconThemeAction),
@@ -452,7 +470,15 @@ export class ExtensionEditor extends EditorPane {
 			},
 			set manifest(manifest: IExtensionManifest | null) {
 				installAction.manifest = manifest;
-			}
+			},
+			// --- Start Positron ---
+			set positronCompatibilityPending(pending: boolean) {
+				updateAction.positronCompatibilityPending = pending;
+			},
+			set positronCompatibleGallery(gallery: IGalleryExtension | null) {
+				updateAction.positronCompatibleGallery = gallery;
+			},
+			// --- End Positron ---
 		};
 	}
 
@@ -538,6 +564,11 @@ export class ExtensionEditor extends EditorPane {
 		this.extensionChangelog = new Cache(() => gallery ? this.extensionGalleryService.getChangelog(gallery, token) : extension.getChangelog(token));
 		this.extensionManifest = new Cache(() => gallery ? this.extensionGalleryService.getManifest(gallery, token) : extension.getManifest(token));
 
+		// --- Start Positron ---
+		// Set positronCompatibilityPending to true to hide the Update button until the engines.positron compatibility check completes,
+		// so we don't briefly show an incompatible version.
+		template.positronCompatibilityPending = true;
+		// --- End Positron ---
 		template.extension = extension;
 		template.gallery = gallery;
 		template.manifest = null;
@@ -554,10 +585,59 @@ export class ExtensionEditor extends EditorPane {
 			this.transientDisposables.add(onClick(template.name, () => this.openerService.open(URI.parse(extension.url!))));
 		}
 
-		const manifest = await this.extensionManifest.get().promise;
+		// --- Start Positron ---
+		// Allow manifest to be updated below.
+		let manifest = await this.extensionManifest.get().promise;
+		// --- End Positron ---
 		if (token.isCancellationRequested) {
 			return;
 		}
+
+		// --- Start Positron ---
+		// Check engines.positron compatibility. If the current gallery version
+		// is incompatible, find the latest compatible version and swap out the
+		// manifest and gallery references used by the editor.
+		const galleryToCheck = gallery ?? extension.gallery;
+		if (manifest && galleryToCheck) {
+			// Fetch all versions and find the latest one whose engines.positron
+			// is satisfied by the running Positron version.
+			const compatibleGallery = await getLatestPositronCompatibleVersion(
+				galleryToCheck,
+				this.extensionGalleryService,
+				this.productService,
+				this.logService,
+				token,
+			);
+
+			// Check for cancellation again before proceeding, since fetching all versions and checking compatibility could take some time.
+			if (token.isCancellationRequested) {
+				return;
+			}
+
+			// If we found a compatible version that is different from the currently shown version, update the editor to show the compatible
+			// version instead.
+			if (compatibleGallery && compatibleGallery.version !== galleryToCheck.version) {
+				// Re-fetch resources for the compatible version.
+				manifest = await this.extensionGalleryService.getManifest(compatibleGallery, token);
+
+				// Check for cancellation again before proceeding, since fetching the manifest could take some time.
+				if (token.isCancellationRequested) {
+					return;
+				}
+
+				// Update the caches to fetch the readme, changelog, and manifest for the compatible version from the
+				// gallery instead of the currently shown version (which may be incompatible).
+				this.extensionReadme = new Cache(() => this.extensionGalleryService.getReadme(compatibleGallery, token));
+				this.extensionChangelog = new Cache(() => this.extensionGalleryService.getChangelog(compatibleGallery, token));
+				this.extensionManifest = new Cache(() => this.extensionGalleryService.getManifest(compatibleGallery, token));
+				template.gallery = compatibleGallery;
+				template.positronCompatibleGallery = compatibleGallery;
+			}
+		}
+
+		// Allow the Update button to render now that we know the correct version.
+		template.positronCompatibilityPending = false;
+		// --- End Positron ---
 
 		if (manifest) {
 			template.manifest = manifest;

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -337,7 +337,7 @@ export class ExtensionEditor extends EditorPane {
 		const description = append(details, $('.description'));
 
 		// --- Start Positron ---
-		const updateAction = this.instantiationService.createInstance(UpdateAction, true); // --- Positron ---
+		const updateAction = this.instantiationService.createInstance(UpdateAction, true);
 		// --- End Positron ---
 		const installAction = this.instantiationService.createInstance(InstallDropdownAction);
 		const actions = [

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -442,6 +442,11 @@ export class ExtensionEditor extends EditorPane {
 		const content = append(body, $('.content'));
 		content.id = generateUuid(); // An id is needed for the webview parent flow to
 
+		// --- Start Positron ---
+		// Backing store for the positronCompatibleGallery getter/setter on the template.
+		let positronCompatibleGalleryValue: IGalleryExtension | null = null;
+		// --- End Positron ---
+
 		this.template = {
 			builtin,
 			content,
@@ -475,8 +480,13 @@ export class ExtensionEditor extends EditorPane {
 			set positronCompatibilityPending(pending: boolean) {
 				updateAction.positronCompatibilityPending = pending;
 			},
+			get positronCompatibleGallery(): IGalleryExtension | null {
+				return positronCompatibleGalleryValue;
+			},
 			set positronCompatibleGallery(gallery: IGalleryExtension | null) {
+				positronCompatibleGalleryValue = gallery;
 				updateAction.positronCompatibleGallery = gallery;
+				installAction.positronCompatibleGallery = gallery;
 			},
 			// --- End Positron ---
 		};
@@ -754,7 +764,10 @@ export class ExtensionEditor extends EditorPane {
 		this.contentDisposables.add(toDisposable(arrays.insert(this.layoutParticipants, { layout })));
 
 		// Render additional details synchronously to avoid flicker
-		this.renderAdditionalDetails(additionalDetailsContainer, extension);
+		// --- Start Positron ---
+		// Pass the template so the Marketplace version reflects the Positron-compatible version.
+		this.renderAdditionalDetails(additionalDetailsContainer, extension, template);
+		// --- End Positron ---
 
 		switch (id) {
 			case ExtensionEditorTab.Readme: return this.openDetails(extension, contentContainer, token);
@@ -992,7 +1005,7 @@ export class ExtensionEditor extends EditorPane {
 		return { focus: () => extensionPackContent.focus() };
 	}
 
-	private renderAdditionalDetails(container: HTMLElement, extension: IExtension): void {
+	private renderAdditionalDetails(container: HTMLElement, extension: IExtension, template: IExtensionEditorTemplate): void {
 		const content = $('div', { class: 'additional-details-content', tabindex: '0' });
 		const scrollableContent = new DomScrollableElement(content, {});
 		const layout = () => scrollableContent.scanDomNode();
@@ -1000,7 +1013,15 @@ export class ExtensionEditor extends EditorPane {
 		this.contentDisposables.add(toDisposable(removeLayoutParticipant));
 		this.contentDisposables.add(scrollableContent);
 
-		this.contentDisposables.add(this.instantiationService.createInstance(AdditionalDetailsWidget, content, extension));
+		/// --- Start Positron ---
+		const additionalDetailsWidget = this.instantiationService.createInstance(AdditionalDetailsWidget, content, extension);
+		// --- Start Positron ---
+		// Pass the compatible gallery version so the Marketplace panel shows
+		// the correct version instead of the unfiltered latest.
+		additionalDetailsWidget.positronCompatibleGallery = template.positronCompatibleGallery;
+		// --- End Positron ---
+		this.contentDisposables.add(additionalDetailsWidget);
+		// --- End Positron ---
 
 		append(container, scrollableContent.getDomNode());
 		scrollableContent.scanDomNode();
@@ -1130,6 +1151,20 @@ class AdditionalDetailsWidget extends Disposable {
 
 	private readonly disposables = this._register(new DisposableStore());
 
+	// --- Start Positron ---
+	// When set, the Marketplace version display uses this gallery object
+	// instead of extension.gallery.
+	private _positronCompatibleGallery: IGalleryExtension | null = null;
+	private _lastExtension: IExtension | null = null;
+	set positronCompatibleGallery(gallery: IGalleryExtension | null) {
+		this._positronCompatibleGallery = gallery;
+		// Re-render to update the Marketplace version display.
+		if (this._lastExtension) {
+			this.render(this._lastExtension);
+		}
+	}
+	// --- End Positron ---
+
 	constructor(
 		private readonly container: HTMLElement,
 		extension: IExtension,
@@ -1152,6 +1187,9 @@ class AdditionalDetailsWidget extends Disposable {
 	}
 
 	private render(extension: IExtension): void {
+		// --- Start Positron ---
+		this._lastExtension = extension;
+		// --- End Positron ---
 		this.container.innerText = '';
 		this.disposables.clear();
 
@@ -1324,6 +1362,10 @@ class AdditionalDetailsWidget extends Disposable {
 		const moreInfo = append(moreInfoContainer, $('.more-info'));
 		if (gallery) {
 			if (!extension.local) {
+				// --- Start Positron ---
+				// Show the compatible version if available, otherwise the gallery version.
+				const displayVersion = this._positronCompatibleGallery?.version ?? gallery.version;
+				// --- End Positron ---
 				append(moreInfo,
 					$('.more-info-entry', undefined,
 						$('div.more-info-entry-name', undefined, localize('id', "Identifier")),
@@ -1332,7 +1374,7 @@ class AdditionalDetailsWidget extends Disposable {
 				append(moreInfo,
 					$('.more-info-entry', undefined,
 						$('div.more-info-entry-name', undefined, localize('Version', "Version")),
-						$('code', undefined, gallery.version)
+						$('code', undefined, displayVersion)
 					)
 				);
 			}

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -92,9 +92,9 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { fromNow } from '../../../../base/common/date.js';
 // --- Start Positron ---
-import { IProductService } from '../../../../platform/product/common/productService.js'; // --- Positron ---
-import { ILogService } from '../../../../platform/log/common/log.js'; // --- Positron ---
-import { getLatestPositronCompatibleVersion } from './positronCompatibleVersion.js'; // --- Positron ---
+import { IProductService } from '../../../../platform/product/common/productService.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { getLatestPositronCompatibleVersion } from './positronCompatibleVersion.js';
 // --- End Positron ---
 
 class NavBar extends Disposable {

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -672,7 +672,7 @@ export class InstallAction extends ExtensionAction {
 			);
 			if (!compatibleGallery) {
 				this.dialogService.info(
-					localize('positronIncompatibleExtension', "No version of '{0}' is compatible with this version of Positron.", extension.displayName || extension.identifier.id),
+					localize('positronIncompatibleExtensionInstall', "No version of '{0}' is compatible with this version of Positron (v{1}).", extension.displayName || extension.identifier.id, this.productService.positronVersion),
 				);
 				return undefined;
 			}
@@ -1149,13 +1149,13 @@ export class UpdateAction extends ExtensionAction {
 			);
 			if (!compatibleGallery) {
 				this.dialogService.info(
-					localize('positronIncompatibleExtension', "No version of '{0}' is compatible with this version of Positron.", this.extension.displayName || this.extension.identifier.id),
+					localize('positronIncompatibleExtensionUpdate', "No update for '{0}' is compatible with this version of Positron (v{1}).", this.extension.displayName || this.extension.identifier.id, this.productService.positronVersion),
 				);
 				return;
 			}
 			if (compatibleGallery.version === this.extension.version) {
 				this.dialogService.info(
-					localize('positronAlreadyCompatible', "'{0}' is already at the latest version compatible with this version of Positron (v{1}).", this.extension.displayName || this.extension.identifier.id, this.extension.version),
+					localize('positronAlreadyCompatible', "'{0}' v{1} is already at the latest version compatible with this version of Positron (v{2}).", this.extension.displayName || this.extension.identifier.id, this.extension.version, this.productService.positronVersion),
 				);
 				return;
 			}

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -682,9 +682,15 @@ export class InstallAction extends ExtensionAction {
 		}
 		// --- End Positron ---
 		try {
+			// --- Start Positron ---
+			// return await this.extensionsWorkbenchService.install(extension, this.options);
 			return await this.extensionsWorkbenchService.install(extension, installOptions);
+			// --- End Positron ---
 		} catch (error) {
+			// --- Start Positron ---
+			// await this.instantiationService.createInstance(PromptExtensionInstallFailureAction, extension, this.options, extension.latestVersion, InstallOperation.Install, error).run();
 			await this.instantiationService.createInstance(PromptExtensionInstallFailureAction, extension, installOptions, extension.latestVersion, InstallOperation.Install, error).run();
+			// --- End Positron ---
 			return undefined;
 		}
 	}

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -75,6 +75,12 @@ import { IAuthenticationUsageService } from '../../../services/authentication/br
 import { IExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { IWorkbenchIssueService } from '../../issue/common/issue.js';
 import { IUserDataProfilesService } from '../../../../platform/userDataProfile/common/userDataProfile.js';
+// --- Start Positron ---
+import { getLatestPositronCompatibleVersion } from './positronCompatibleVersion.js';
+// eslint-disable-next-line no-duplicate-imports
+import { InstallExtensionOptions } from '../common/extensions.js';
+// --- End Positron ---
+
 
 export class PromptExtensionInstallFailureAction extends Action {
 
@@ -959,12 +965,35 @@ export class UpdateAction extends ExtensionAction {
 
 	private readonly updateThrottler = new Throttler();
 
+	// --- Start Positron ---
+	// When set, overrides the version shown in the "Update to" label and
+	// the version installed when the user clicks the button. While
+	// _positronCompatibilityPending is true, the button is hidden to avoid
+	// briefly showing an incompatible version.
+	private _positronCompatibilityPending = false;
+	private _positronCompatibleGallery: IGalleryExtension | null = null;
+	set positronCompatibilityPending(pending: boolean) {
+		this._positronCompatibilityPending = pending;
+		this.update();
+	}
+	set positronCompatibleGallery(gallery: IGalleryExtension | null) {
+		this._positronCompatibleGallery = gallery;
+		this._positronCompatibilityPending = false;
+		this.update();
+	}
+	// --- End Positron ---
+
 	constructor(
 		private readonly verbose: boolean,
 		@IExtensionsWorkbenchService private readonly extensionsWorkbenchService: IExtensionsWorkbenchService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		// --- Start Positron ---
+		@IExtensionGalleryService private readonly galleryService: IExtensionGalleryService,
+		@IProductService private readonly productService: IProductService,
+		@ILogService private readonly logService: ILogService,
+		// --- End Positron ---
 	) {
 		super(`extensions.update`, localize('update', "Update"), UpdateAction.DisabledClass, false);
 		this.update();
@@ -973,7 +1002,10 @@ export class UpdateAction extends ExtensionAction {
 	update(): void {
 		this.updateThrottler.queue(() => this.computeAndUpdateEnablement());
 		if (this.extension) {
-			this.label = this.verbose ? localize('update to', "Update to v{0}", this.extension.latestVersion) : localize('update', "Update");
+			// --- Start Positron ---
+			const version = this._positronCompatibleGallery?.version ?? this.extension.latestVersion;
+			// --- End Positron ---
+			this.label = this.verbose ? localize('update to', "Update to v{0}", version) : localize('update', "Update");
 		}
 	}
 
@@ -985,6 +1017,12 @@ export class UpdateAction extends ExtensionAction {
 			return;
 		}
 
+		// --- Start Positron ---
+		if (this._positronCompatibilityPending) {
+			return;
+		}
+		// --- End Positron ---
+
 		if (this.extension.deprecationInfo) {
 			return;
 		}
@@ -993,6 +1031,13 @@ export class UpdateAction extends ExtensionAction {
 		const isInstalled = this.extension.state === ExtensionState.Installed;
 
 		this.enabled = canInstall === true && isInstalled && this.extension.outdated;
+		// --- Start Positron ---
+		// If we resolved a compatible version that matches the installed
+		// version, there is no update to offer.
+		if (this.enabled && this._positronCompatibleGallery && this.extension.version === this._positronCompatibleGallery.version) {
+			this.enabled = false;
+		}
+		// --- End Positron ---
 		this.class = this.enabled ? UpdateAction.EnabledClass : UpdateAction.DisabledClass;
 	}
 
@@ -1032,19 +1077,57 @@ export class UpdateAction extends ExtensionAction {
 			}
 		}
 
-		const installOptions: InstallOptions = {};
+		const installOptions: InstallExtensionOptions = {};
 		if (this.extension.local?.source === 'vsix' && this.extension.local.pinned) {
 			installOptions.pinned = false;
 		}
 		if (this.extension.local?.preRelease) {
 			installOptions.installPreReleaseVersion = true;
 		}
+
+		// --- Start Positron ---
+		// Check engines.positron compatibility before updating. The gallery
+		// service only checks engines.vscode; engines.positron is only
+		// available in the full manifest, not in the Open VSX metadata.
+		// If the extension editor already resolved a compatible version, use
+		// it directly to avoid redundant manifest fetches.
+		let targetVersion = this.extension.latestVersion;
+		if (this._positronCompatibleGallery) {
+			targetVersion = this._positronCompatibleGallery.version;
+			installOptions.version = this._positronCompatibleGallery.version;
+		} else if (this.extension.gallery) {
+			const compatibleGallery = await getLatestPositronCompatibleVersion(
+				this.extension.gallery,
+				this.galleryService,
+				this.productService,
+				this.logService,
+				CancellationToken.None,
+			);
+			if (!compatibleGallery) {
+				this.dialogService.info(
+					localize('positronIncompatibleExtension', "No version of '{0}' is compatible with this version of Positron.", this.extension.displayName || this.extension.identifier.id),
+				);
+				return;
+			}
+			if (compatibleGallery.version === this.extension.version) {
+				this.dialogService.info(
+					localize('positronAlreadyCompatible', "'{0}' is already at the latest version compatible with this version of Positron (v{1}).", this.extension.displayName || this.extension.identifier.id, this.extension.version),
+				);
+				return;
+			}
+			if (compatibleGallery.version !== this.extension.gallery.version) {
+				targetVersion = compatibleGallery.version;
+				installOptions.version = compatibleGallery.version;
+			}
+		}
+		// --- End Positron ---
+
 		try {
-			alert(localize('updateExtensionStart', "Updating extension {0} to version {1} started.", this.extension.displayName, this.extension.latestVersion));
+			alert(localize('updateExtensionStart', "Updating extension {0} to version {1} started.", this.extension.displayName, targetVersion));
 			await this.extensionsWorkbenchService.install(this.extension, installOptions);
-			alert(localize('updateExtensionComplete', "Updating extension {0} to version {1} completed.", this.extension.displayName, this.extension.latestVersion));
+			alert(localize('updateExtensionComplete', "Updating extension {0} to version {1} completed.", this.extension.displayName, targetVersion));
 		} catch (err) {
-			this.instantiationService.createInstance(PromptExtensionInstallFailureAction, this.extension, installOptions, this.extension.latestVersion, InstallOperation.Update, err).run();
+			this.instantiationService.createInstance(PromptExtensionInstallFailureAction, this.extension, installOptions, targetVersion, InstallOperation.Update, err).run();
 		}
 	}
 }

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1127,7 +1127,10 @@ export class UpdateAction extends ExtensionAction {
 			}
 		}
 
+		// --- Start Positron ---
+		// const installOptions: InstallOptions = {};
 		const installOptions: InstallExtensionOptions = {};
+		// --- End Positron ---
 		if (this.extension.local?.source === 'vsix' && this.extension.local.pinned) {
 			installOptions.pinned = false;
 		}
@@ -1173,11 +1176,20 @@ export class UpdateAction extends ExtensionAction {
 		// --- End Positron ---
 
 		try {
+			// --- Start Positron ---
+			// alert(localize('updateExtensionStart', "Updating extension {0} to version {1} started.", this.extension.displayName, this.extension.latestVersion));
 			alert(localize('updateExtensionStart', "Updating extension {0} to version {1} started.", this.extension.displayName, targetVersion));
+			// --- End Positron ---
 			await this.extensionsWorkbenchService.install(this.extension, installOptions);
+			// --- Start Positron ---
+			// alert(localize('updateExtensionComplete', "Updating extension {0} to version {1} completed.", this.extension.displayName, this.extension.latestVersion));
 			alert(localize('updateExtensionComplete', "Updating extension {0} to version {1} completed.", this.extension.displayName, targetVersion));
+			// --- End Positron ---
 		} catch (err) {
+			// --- Start Positron ---
+			// this.instantiationService.createInstance(PromptExtensionInstallFailureAction, this.extension, installOptions, this.extension.latestVersion, InstallOperation.Update, err).run();
 			this.instantiationService.createInstance(PromptExtensionInstallFailureAction, this.extension, installOptions, targetVersion, InstallOperation.Update, err).run();
+			// --- End Positron ---
 		}
 	}
 }

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -444,6 +444,14 @@ export class InstallAction extends ExtensionAction {
 	private readonly updateThrottler = new Throttler();
 	public readonly options: InstallOptions;
 
+	// --- Start Positron ---
+	// The compatible gallery version resolved by the extension editor, if any.
+	private _positronCompatibleGallery: IGalleryExtension | null = null;
+	set positronCompatibleGallery(gallery: IGalleryExtension | null) {
+		this._positronCompatibleGallery = gallery;
+	}
+	// --- End Positron ---
+
 	constructor(
 		options: InstallOptions,
 		@IExtensionsWorkbenchService private readonly extensionsWorkbenchService: IExtensionsWorkbenchService,
@@ -457,6 +465,11 @@ export class InstallAction extends ExtensionAction {
 		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
 		@IAllowedExtensionsService private readonly allowedExtensionsService: IAllowedExtensionsService,
 		@IExtensionGalleryManifestService private readonly extensionGalleryManifestService: IExtensionGalleryManifestService,
+		// --- Start Positron ---
+		@IExtensionGalleryService private readonly galleryService: IExtensionGalleryService,
+		@IProductService private readonly productService: IProductService,
+		@ILogService private readonly logService: ILogService,
+		// --- End Positron ---
 	) {
 		super('extensions.install', localize('install', "Install"), InstallAction.CLASS, false);
 		this.hideOnDisabled = false;
@@ -643,10 +656,35 @@ export class InstallAction extends ExtensionAction {
 	}
 
 	private async install(extension: IExtension): Promise<IExtension | undefined> {
+		// --- Start Positron ---
+		// If the extension editor resolved a compatible version, install that
+		// specific version. Otherwise, check compatibility on the fly.
+		const installOptions: InstallExtensionOptions = { ...this.options };
+		if (this._positronCompatibleGallery) {
+			installOptions.version = this._positronCompatibleGallery.version;
+		} else if (extension.gallery) {
+			const compatibleGallery = await getLatestPositronCompatibleVersion(
+				extension.gallery,
+				this.galleryService,
+				this.productService,
+				this.logService,
+				CancellationToken.None,
+			);
+			if (!compatibleGallery) {
+				this.dialogService.info(
+					localize('positronIncompatibleExtension', "No version of '{0}' is compatible with this version of Positron.", extension.displayName || extension.identifier.id),
+				);
+				return undefined;
+			}
+			if (compatibleGallery.version !== extension.gallery.version) {
+				installOptions.version = compatibleGallery.version;
+			}
+		}
+		// --- End Positron ---
 		try {
-			return await this.extensionsWorkbenchService.install(extension, this.options);
+			return await this.extensionsWorkbenchService.install(extension, installOptions);
 		} catch (error) {
-			await this.instantiationService.createInstance(PromptExtensionInstallFailureAction, extension, this.options, extension.latestVersion, InstallOperation.Install, error).run();
+			await this.instantiationService.createInstance(PromptExtensionInstallFailureAction, extension, installOptions, extension.latestVersion, InstallOperation.Install, error).run();
 			return undefined;
 		}
 	}
@@ -697,6 +735,12 @@ export class InstallDropdownAction extends ButtonWithDropDownExtensionAction {
 		this.extensionActions.forEach(a => (<InstallAction>a).manifest = manifest);
 		this.update();
 	}
+
+	// --- Start Positron ---
+	set positronCompatibleGallery(gallery: IGalleryExtension | null) {
+		this.extensionActions.forEach(a => (<InstallAction>a).positronCompatibleGallery = gallery);
+	}
+	// --- End Positron ---
 
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,

--- a/src/vs/workbench/contrib/extensions/browser/positronCompatibleVersion.ts
+++ b/src/vs/workbench/contrib/extensions/browser/positronCompatibleVersion.ts
@@ -1,0 +1,143 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../base/common/cancellation.js';
+import { IExtensionGalleryService, IGalleryExtension } from '../../../../platform/extensionManagement/common/extensionManagement.js';
+import { IExtensionManifest } from '../../../../platform/extensions/common/extensions.js';
+import { isValidPositronExtensionVersion } from '../../../../platform/extensions/common/positronExtensionValidator.js';
+import { IProductService } from '../../../../platform/product/common/productService.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+
+/**
+ * Given a gallery extension (typically the latest version), checks whether its
+ * engines.positron requirement is compatible with the running Positron version.
+ * If not, walks back through older versions to find the latest compatible one.
+ *
+ * Returns the compatible gallery extension, or null if no compatible version exists.
+ * Returns the original gallery extension unchanged if it has no engines.positron
+ * requirement or if it is already compatible.
+ */
+export async function getLatestPositronCompatibleVersion(
+	gallery: IGalleryExtension,
+	galleryService: IExtensionGalleryService,
+	productService: IProductService,
+	logService: ILogService,
+	token: CancellationToken,
+): Promise<IGalleryExtension | null> {
+	// Sanity check: if we are not running in Positron, skip the check entirely.
+	const positronVersion = productService.positronVersion;
+	if (!positronVersion) {
+		return gallery;
+	}
+
+	// Fetch the manifest for the candidate version to check engines.positron.
+	const manifest = await galleryService.getManifest(gallery, token);
+
+	// Check for cancellation again before proceeding.
+	if (token.isCancellationRequested) {
+		return null;
+	}
+
+	// If the manifest is unavailable, assume compatible rather than blocking
+	// the update entirely.
+	if (!manifest) {
+		return gallery;
+	}
+
+	// If the candidate version is already compatible, return it immediately.
+	if (isPositronCompatible(manifest, positronVersion, productService)) {
+		return gallery;
+	}
+
+	// The latest version is incompatible. Walk back through older versions.
+	logService.info(
+		`Extension '${gallery.identifier.id}' v${gallery.version} requires ` +
+		`engines.positron '${manifest.engines?.positron}' but Positron version is ` +
+		`'${positronVersion}'. Searching for a compatible older version.`
+	);
+
+	// Fetch all published versions.
+	const allVersions = await galleryService.getAllVersions(gallery.identifier);
+
+	// Check for cancellation again before proceeding.
+	if (token.isCancellationRequested) {
+		return null;
+	}
+
+	// Versions are returned newest-first.
+	for (const versionEntry of allVersions) {
+		// Skip the version we already checked.
+		if (versionEntry.version === gallery.version) {
+			continue;
+		}
+
+		// Fetch the gallery extension object for this specific version.
+		const olderGalleryExtensions = await galleryService.getExtensions(
+			[{ ...gallery.identifier, version: versionEntry.version }],
+			token,
+		);
+
+		// Check for cancellation again before proceeding.
+		if (token.isCancellationRequested) {
+			return null;
+		}
+
+		// getExtensions may return empty if the version was yanked or unavailable.
+		const olderGallery = olderGalleryExtensions[0];
+		if (!olderGallery) {
+			continue;
+		}
+
+		// Fetch the full manifest to inspect engines.positron for this version.
+		const olderManifest = await galleryService.getManifest(olderGallery, token);
+
+		// Check for cancellation again before proceeding.
+		if (token.isCancellationRequested) {
+			return null;
+		}
+
+		// Skip versions whose manifest cannot be fetched.
+		if (!olderManifest) {
+			continue;
+		}
+
+		// If a compatible version is found, return it.
+		if (isPositronCompatible(olderManifest, positronVersion, productService)) {
+			logService.info(
+				`Found compatible version v${versionEntry.version} for extension ` +
+				`'${gallery.identifier.id}'.`
+			);
+			return olderGallery;
+		}
+	}
+
+	// No compatible version was found.
+	logService.info(
+		`No compatible version found for extension '${gallery.identifier.id}' ` +
+		`with Positron ${positronVersion}.`
+	);
+	return null;
+}
+
+function isPositronCompatible(
+	manifest: IExtensionManifest,
+	positronVersion: string,
+	productService: IProductService,
+): boolean {
+	// No positron engine requirement; compatible with any version.
+	if (!manifest.engines?.positron) {
+		return true;
+	}
+
+	// Validate the engines.positron semver range against the running version.
+	const notices: string[] = [];
+	return isValidPositronExtensionVersion(
+		positronVersion,
+		productService.date,
+		manifest,
+		false,
+		notices,
+	);
+}


### PR DESCRIPTION
## Summary

Adds `engines.positron` version compatibility checking to extension installs and updates. The Open VSX gallery service only checks `engines.vscode` -- `engines.positron` is not part of the Open VSX metadata and can only be read from the full extension manifest. This PR intercepts at three user-facing points to ensure users never install an incompatible extension version:

- **Install button**: For uninstalled extensions, installs the compatible version rather than the latest. Falls back to an on-the-fly compatibility check if the extension editor hasn't pre-resolved a version.

- **Update button**: Uses the resolved compatible version when the user clicks Update. If already at the latest compatible version, shows an informational dialog. If no compatible version exists, informs the user.

- **Extension editor**: When opened, checks the latest gallery version's manifest for `engines.positron` compatibility. If incompatible, walks back through older versions to find the latest compatible one and updates the UI (version labels, readme, changelog, manifest) accordingly.

## Changes

**New file: `positronCompatibleVersion.ts`**
- `getLatestPositronCompatibleVersion()` -- given a gallery extension, fetches its manifest and checks `engines.positron` against the running Positron version. If incompatible, iterates through older versions (newest-first) to find the latest compatible one. Returns null if none exists.

**`extensionEditor.ts`**
- Added `positronCompatibilityPending` and `positronCompatibleGallery` to the editor template with a closure-backed getter/setter that propagates to the Update and Install actions
- In `render()`, sets `positronCompatibilityPending = true` before rendering, runs the compatibility check, swaps gallery/manifest/caches if a different compatible version is found, then sets `positronCompatibilityPending = false`
- `AdditionalDetailsWidget` stores the compatible gallery and re-renders when set, so the Marketplace panel shows the correct version
- `renderAdditionalDetails` passes the template to the widget so it can read `positronCompatibleGallery`

**`extensionsActions.ts`**
- `UpdateAction`: Added `_positronCompatibilityPending` (hides button during check) and `_positronCompatibleGallery` (overrides version label and install target). Disables the button when the compatible version matches the installed version. Shows dialogs when already up-to-date or no compatible version exists.
- `InstallAction`: Added `_positronCompatibleGallery` to install the compatible version. Falls back to on-the-fly check via `getLatestPositronCompatibleVersion` if no cached value. Shows dialog if no compatible version exists.
- `InstallDropdownAction`: Propagates `positronCompatibleGallery` to child `InstallAction` instances.

## Test plan

- [ ] Open extension editor for an extension with `engines.positron` set to a range incompatible with the current Positron version -- verify the editor shows the latest compatible version (not the latest gallery version) in the header, Marketplace panel, and Update button label
- [ ] Click Update when already at the latest compatible version -- verify an informational dialog appears
- [ ] Click Update from the extensions list for an extension with an incompatible latest version -- verify the correct compatible version is installed, or a dialog appears if already up-to-date
- [ ] Install an uninstalled extension with an incompatible latest version -- verify the compatible version is installed
- [ ] Open extension editor for an extension without `engines.positron` -- verify normal behavior (latest version shown, installs/updates work as before)
- [ ] Open extension editor for an extension where the latest version IS compatible -- verify no change in behavior

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #11321 Add engines.positron compatibility check for extension updates.

### QA Notes

If there is an update available, regardless of whether or not it is compatible, the user will see the Update button in the installed extensions:

<p>
<img width="404" height="87" alt="image" src="https://github.com/user-attachments/assets/503add38-b748-484b-a178-13b0d3f243c3" />
</p>

This cannot be helped because we do not have access to the `engines.positron` metadata at this stage. Also, it is _factually correct_, even though it's not always optimal.

If the user clicks the Update button, and it turns out that they are already at the latest version of the extension they can install based on the Positron version that is installed, the following error will be displayed.

<p>
<img width="1625" height="1185" alt="image" src="https://github.com/user-attachments/assets/81908b14-3439-4206-bae1-588dfbd76499" />
</p>

The best way to test this PR is in a dev build running locally.

First, "Disable Auto Update for All Extensions":

<p>
<img width="333" height="270" alt="image" src="https://github.com/user-attachments/assets/de57f497-a55c-41b8-87c4-f5dd59619fd5" />
</p>

Next:

- Manually vary `positronVersion` in `product.json` to older version numbers and re-run Positron to check the Extensions panel / Quarto extension to see what versions are suggested for installs and updates.

For example:

- Install an old version of the Quarto extension (`1.111.0` is a good one to use)

`positronVersion: "2024.06.0"` will result in being prompted to update Quarto to `v1.222.0`:

<p>
<img width="1530" height="1240" alt="image" src="https://github.com/user-attachments/assets/c250b7b0-d715-4b8e-b925-18cd77fcbd6c" />
</p>

`positronVersion: "2025.06.0"` will result in being prompted to update Quarto to `v1.226.0`:

<p>
<img width="1530" height="1240" alt="image" src="https://github.com/user-attachments/assets/e45b0e4b-0e21-40b0-b287-ef1daf429b3a" />
</p>

`positronVersion: "2025.12.0"` (and later) will, today, anyway, result in being prompted to update Quarto to `v1.130.0`:

<p>
<img width="1530" height="1240" alt="image" src="https://github.com/user-attachments/assets/b682ce07-95ee-4e11-9cec-311f9efe82a1" />
</p>