### PR TITLE
Fix scrollable notebook cell output nesting

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -729,6 +729,7 @@
 		"--vscode-positronNotebook-foreground",
 		"--vscode-positronNotebook-img-placeholder-background",
 		"--vscode-positronNotebook-output-background",
+		"--vscode-positronNotebook-output-max-height",
 		"--vscode-positronNotebook-text-output-font-family",
 		"--vscode-positronNotebook-text-output-font-size",
 		"--vscode-positronPackages-background",

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 
 // Other dependencies.
 import * as DOM from '../../../../base/browser/dom.js';
-import { useNotebookInstance } from './NotebookInstanceProvider.js';
+import { useNotebookInstance, useNotebookOptions } from './NotebookInstanceProvider.js';
 import { AddCellButtons } from './AddCellButtons.js';
 import { useObservedValue } from './useObservedValue.js';
 import { NotebookCodeCell } from './notebookCells/NotebookCodeCell.js';
@@ -186,15 +186,19 @@ function renderCellsAndSentinels(
  */
 function useFontStyles(): React.CSSProperties {
 	const services = usePositronReactServicesContext();
+	const notebookOptions = useNotebookOptions();
+	const layout = notebookOptions.getLayoutConfiguration();
 
 	const editorOptions = services.configurationService.getValue<IEditorOptions>('editor');
 	const targetWindow = DOM.getActiveWindow();
 	const fontInfo = FontMeasurements.readFontInfo(targetWindow, createBareFontInfoFromRawSettings(editorOptions, PixelRatio.getInstance(targetWindow).value));
 	const family = fontInfo.fontFamily ?? `"SF Mono", Monaco, Menlo, Consolas, "Ubuntu Mono", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace`;
+	const outputMaxHeight = layout.outputLineHeight * layout.outputLineLimit;
 
 	return {
 		['--vscode-positronNotebook-text-output-font-family' as string]: family,
-		['--vscode-positronNotebook-text-output-font-size' as string]: `${fontInfo.fontSize}px`,
+		['--vscode-positronNotebook-text-output-font-size' as string]: `${layout.outputFontSize}px`,
+		['--vscode-positronNotebook-output-max-height' as string]: `${outputMaxHeight}px`,
 	};
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
@@ -12,17 +12,6 @@
 	white-space: pre-wrap;
 }
 
-.positron-notebook-text-output.long-output-scroll {
-	/* TODO: This should match the height of the output if truncated */
-	max-height: 400px;
-	overflow: scroll;
-	border: var(--vscode-positronNotebook-border);
-	border-radius: var(--vscode-positronNotebook-cell-radius);
-	padding: 0.15rem 0.25rem;
-	position: relative;
-}
-
-
 .notebook-output-truncation-message {
 	display: block;
 	font-size: 0.95em;
@@ -37,13 +26,3 @@
 .notebook-output-truncation-message a:active {
 	color: var(--vscode-textLink-activeForeground);
 }
-
-.positron-notebook-text-output.long-output-scroll + .notebook-output-truncation-message {
-	text-align: right;
-}
-
-/* Hide the truncation message when were not showing scrollbars. */
-.positron-notebook-text-output:not(.long-output-scroll) + .notebook-output-truncation-message {
-	display: none;
-}
-

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -6,6 +6,9 @@
 // CSS.
 import './CellTextOutput.css';
 
+// React.
+import React from 'react';
+
 // Other dependencies.
 import { ANSIOutput } from '../../../../../base/common/ansiOutput.js';
 import { OutputLines } from '../../../../browser/positronAnsiRenderer/outputLines.js';
@@ -16,7 +19,7 @@ import { NotebookDisplayOptions } from '../../../notebook/browser/notebookOption
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { NotebookCellQuickFix } from './NotebookCellQuickFix.js';
 
-type LongOutputOptions = Pick<NotebookDisplayOptions, 'outputLineLimit' | 'outputScrolling'>;
+export type LongOutputOptions = Pick<NotebookDisplayOptions, 'outputLineLimit' | 'outputScrolling'>;
 
 type TruncationResult =
 	{ content: string } & (
@@ -80,7 +83,10 @@ const TruncationMessage = ({ numLinesTruncated, commandService }: {
 	numLinesTruncated: number;
 	commandService: ICommandService;
 }) => {
-	const openSettings = () => {
+	const openSettings = (e: React.MouseEvent<HTMLAnchorElement>) => {
+		// Prevent the anchor from navigating, which would reload the
+		// Electron renderer and hang the window.
+		e.preventDefault();
 		commandService.executeCommand(
 			'workbench.action.openSettings',
 			'notebook.output scroll'

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -23,9 +23,7 @@ type LongOutputOptions = Pick<NotebookDisplayOptions, 'outputLineLimit' | 'outpu
 
 type TruncationResult =
 	{ content: string } & (
-		{
-			mode: 'normal' | 'scroll';
-		} |
+		{ mode: 'normal' } |
 		{
 			mode: 'truncate';
 			contentAfter: string;
@@ -34,32 +32,13 @@ type TruncationResult =
 	);
 
 
-function useLongOutputBehavior(content: string): {
-	containerRef: React.RefObject<HTMLDivElement>; truncation: TruncationResult;
-} {
-	const containerRef = React.useRef<HTMLDivElement>(null!);
+function useLongOutputBehavior(content: string): TruncationResult {
 	const notebookOptions = useNotebookOptions();
 	const layoutOptions = notebookOptions.getLayoutConfiguration();
-
-	const [truncation, setTruncation] = React.useState<TruncationResult>(() => truncateToNumberOfLines(content, layoutOptions));
-
-	React.useEffect(() => {
-		setTruncation(truncateToNumberOfLines(content, layoutOptions));
-	}, [content, layoutOptions]);
-
-	React.useEffect(() => {
-		if (!containerRef.current) { return; }
-
-		// Check if the content is scrolling
-		const { scrollHeight, clientHeight } = containerRef.current;
-
-		// If we're not scrolling, remove the class
-		if (truncation.mode === 'scroll' && scrollHeight <= clientHeight) {
-			containerRef.current.classList.remove(`long-output-scroll`);
-		}
-	}, [truncation.mode]);
-
-	return { containerRef, truncation };
+	return React.useMemo(
+		() => truncateToNumberOfLines(content, layoutOptions),
+		[content, layoutOptions]
+	);
 }
 
 
@@ -68,14 +47,10 @@ function truncateToNumberOfLines(content: string, { outputScrolling, outputLineL
 	const splitByLine = content.trimEnd().split('\n');
 	const numLines = splitByLine.length;
 
-	const isLong = numLines > maxLines;
-
-	if (!isLong) {
+	// When scrolling is enabled or content is short, return as-is.
+	// The parent container handles scroll constraints via CSS.
+	if (outputScrolling || numLines <= maxLines) {
 		return { content, mode: 'normal' };
-	}
-
-	if (outputScrolling) {
-		return { content, mode: 'scroll' };
 	}
 
 	return {
@@ -90,34 +65,27 @@ function truncateToNumberOfLines(content: string, { outputScrolling, outputLineL
 export function CellTextOutput({ content, type }: ParsedTextOutput) {
 
 	const services = usePositronReactServicesContext();
-	const { containerRef, truncation } = useLongOutputBehavior(content);
+	const truncation = useLongOutputBehavior(content);
 
 	return <>
-		<div ref={containerRef} className={`notebook-${type} positron-notebook-text-output long-output-${truncation.mode}`}>
+		<div className={`notebook-${type} positron-notebook-text-output`}>
 			<OutputLines outputLines={ANSIOutput.processOutput(truncation.content)} />
-			{
-				truncation.mode === 'truncate'
-					? <>
-						<TruncationMessage commandService={services.commandService} truncationResult={truncation} />
-						<OutputLines outputLines={ANSIOutput.processOutput(truncation.contentAfter)} />
-					</>
-					: null
-			}
+			{truncation.mode === 'truncate' && <>
+				<TruncationMessage
+					commandService={services.commandService}
+					numLinesTruncated={truncation.numLinesTruncated}
+				/>
+				<OutputLines outputLines={ANSIOutput.processOutput(truncation.contentAfter)} />
+			</>}
 		</div>
-		{
-			truncation.mode === 'scroll'
-				? <TruncationMessage commandService={services.commandService} truncationResult={truncation} />
-				: null
-		}
-		{
-			type === 'error'
-				? <NotebookCellQuickFix errorContent={content} />
-				: null
-		}
+		{type === 'error' && <NotebookCellQuickFix errorContent={content} />}
 	</>;
 }
 
-const TruncationMessage = ({ truncationResult, commandService }: { truncationResult: TruncationResult; commandService: ICommandService }) => {
+const TruncationMessage = ({ numLinesTruncated, commandService }: {
+	numLinesTruncated: number;
+	commandService: ICommandService;
+}) => {
 	const openSettings = () => {
 		commandService.executeCommand(
 			'workbench.action.openSettings',
@@ -125,18 +93,12 @@ const TruncationMessage = ({ truncationResult, commandService }: { truncationRes
 		);
 	};
 
-	const msg = truncationResult.mode === 'truncate'
-		? `... ${truncationResult.numLinesTruncated.toLocaleString()} lines truncated.`
-		: 'Scrolling long outputs...';
-
 	return <i className='notebook-output-truncation-message'>
-		{msg + ' '}
+		{`... ${numLinesTruncated.toLocaleString()} lines truncated. `}
 		<a
 			aria-label='notebook output settings'
 			href=''
 			onClick={openSettings}
 		>Change behavior.</a>
 	</i>;
-
 };
-

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -6,9 +6,6 @@
 // CSS.
 import './CellTextOutput.css';
 
-// React.
-import React from 'react';
-
 // Other dependencies.
 import { ANSIOutput } from '../../../../../base/common/ansiOutput.js';
 import { OutputLines } from '../../../../browser/positronAnsiRenderer/outputLines.js';
@@ -35,10 +32,7 @@ type TruncationResult =
 function useLongOutputBehavior(content: string): TruncationResult {
 	const notebookOptions = useNotebookOptions();
 	const layoutOptions = notebookOptions.getLayoutConfiguration();
-	return React.useMemo(
-		() => truncateToNumberOfLines(content, layoutOptions),
-		[content, layoutOptions]
-	);
+	return truncateToNumberOfLines(content, layoutOptions);
 }
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -43,6 +43,11 @@
 		padding-inline: 0.5rem;
 		padding-block: 0.5rem;
 
+		&.output-scrolling {
+			max-height: var(--vscode-positronNotebook-output-max-height);
+			overflow-y: auto;
+		}
+
 		/* Avoid overlap with border which is overlaid from another element so
 		the layout doesn't automatically avoid it*/
 		margin-inline: 1px;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -21,7 +21,6 @@
 
 		&.single-data-explorer .positron-notebook-code-cell-outputs-inner:has(.inline-data-explorer-container) {
 			padding: 8px 0 0 0;
-			margin-inline: 0;
 			overflow: hidden; /* Data explorer handles its own scrolling */
 		}
 
@@ -47,10 +46,6 @@
 			max-height: var(--vscode-positronNotebook-output-max-height);
 			overflow-y: auto;
 		}
-
-		/* Avoid overlap with border which is overlaid from another element so
-		the layout doesn't automatically avoid it*/
-		margin-inline: 1px;
 		overflow-x: auto;
 
 		& .notebook-error,

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -22,6 +22,7 @@ import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNoteb
 import { PreloadMessageOutput } from './PreloadMessageOutput.js';
 import { CellLeftActionMenu } from './CellLeftActionMenu.js';
 import { CellOutputLeftActionMenu } from './CellOutputLeftActionMenu.js';
+import { useNotebookOptions } from '../NotebookInstanceProvider.js';
 import { CodeCellStatusFooter } from './CodeCellStatusFooter.js';
 import { renderHtml } from '../../../../../base/browser/positron/renderHtml.js';
 import { Markdown } from './Markdown.js';
@@ -38,6 +39,8 @@ interface CellOutputsSectionProps {
 
 const CellOutputsSection = React.memo(function CellOutputsSection({ cell, outputs }: CellOutputsSectionProps) {
 	const isCollapsed = useObservedValue(cell.outputIsCollapsed);
+	const notebookOptions = useNotebookOptions();
+	const layout = notebookOptions.getLayoutConfiguration();
 	const { showContextMenu } = useCellContextMenu({
 		cell,
 		menuId: MenuId.PositronNotebookCellOutputActionLeft,
@@ -79,7 +82,10 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 				data-testid='cell-output'
 				onContextMenu={handleContextMenu}
 			>
-				<div className='positron-notebook-code-cell-outputs-inner'>
+				<div className={positronClassNames(
+					'positron-notebook-code-cell-outputs-inner',
+					{ 'output-scrolling': layout.outputScrolling }
+				)}>
 					{isCollapsed
 						? <Button
 							ariaLabel={localize('positron.notebook.showHiddenOutput', 'Show hidden output')}

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.test.tsx
@@ -1,0 +1,207 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable local/code-no-dangerous-type-assertions */
+
+import assert from 'assert';
+import { flushSync } from 'react-dom';
+import { Emitter, Event } from '../../../../../../base/common/event.js';
+import { CommandsRegistry } from '../../../../../../platform/commands/common/commands.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { setupReactRenderer } from '../../../../../../base/test/browser/react.js';
+import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { TestCommandService } from '../../../../../../editor/test/browser/editorTestServices.js';
+import { NotebookOptions, NotebookOptionsChangeEvent } from '../../../../notebook/browser/notebookOptions.js';
+import { IPositronNotebookInstance } from '../../../browser/IPositronNotebookInstance.js';
+import { NotebookInstanceProvider } from '../../../browser/NotebookInstanceProvider.js';
+import { PositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
+import { PositronReactServices } from '../../../../../../base/browser/positronReactServices.js';
+import { CellTextOutput, LongOutputOptions } from '../../../browser/notebookCells/CellTextOutput.js';
+import { ParsedTextOutput } from '../../../browser/PositronNotebookCells/IPositronNotebookCell.js';
+
+class CellTextOutputFixture {
+	constructor(private readonly container: HTMLElement) { }
+
+	get outputContainer() {
+		const el = this.container.querySelector<HTMLDivElement>('.positron-notebook-text-output');
+		assert.ok(el, 'Expected output container to exist');
+		return el;
+	}
+
+	get outputLines() {
+		return this.outputContainer.querySelectorAll<HTMLDivElement>(':scope > div');
+	}
+
+	get truncationMessage() {
+		return this.container.querySelector<HTMLElement>('.notebook-output-truncation-message');
+	}
+
+	get settingsLink() {
+		return this.container.querySelector<HTMLAnchorElement>('.notebook-output-truncation-message a');
+	}
+
+	get quickFixContainer() {
+		return this.container.querySelector<HTMLElement>('.notebook-cell-quick-fix');
+	}
+
+	get outputRuns() {
+		return this.outputContainer.querySelectorAll<HTMLSpanElement>('span.output-run');
+	}
+
+	hasClass(cls: string) {
+		return this.outputContainer.classList.contains(cls);
+	}
+}
+
+/** Generate multiline content with the given number of lines. */
+function makeLines(n: number): string {
+	return Array.from({ length: n }, (_, i) => `line ${i + 1}`).join('\n');
+}
+
+suite('CellTextOutput', () => {
+	const { render } = setupReactRenderer();
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let optionsEmitter: Emitter<NotebookOptionsChangeEvent>;
+	let layoutConfig: LongOutputOptions;
+	let commandService: TestCommandService;
+	let configurationService: TestConfigurationService;
+	let contextKeyService: MockContextKeyService;
+
+	setup(() => {
+		optionsEmitter = disposables.add(new Emitter<NotebookOptionsChangeEvent>());
+		layoutConfig = { outputLineLimit: 30, outputScrolling: false };
+
+		const instantiationService = disposables.add(new TestInstantiationService());
+		commandService = new TestCommandService(instantiationService);
+
+		configurationService = new TestConfigurationService();
+		contextKeyService = disposables.add(new MockContextKeyService());
+	});
+
+	function renderCellTextOutput(
+		props: ParsedTextOutput,
+		options?: Partial<LongOutputOptions>,
+	) {
+		if (options !== undefined) {
+			layoutConfig = { ...layoutConfig, ...options };
+		}
+		const notebookOptions = {
+			onDidChangeOptions: optionsEmitter.event,
+			getLayoutConfiguration: () => layoutConfig,
+		} as unknown as NotebookOptions;
+		const instance = { notebookOptions } as unknown as IPositronNotebookInstance;
+		const services = {
+			commandService,
+			configurationService,
+			contextKeyService,
+		} as unknown as PositronReactServices;
+
+		const container = render(
+			<PositronReactServicesContext.Provider value={services}>
+				<NotebookInstanceProvider instance={instance}>
+					<CellTextOutput {...props} />
+				</NotebookInstanceProvider>
+			</PositronReactServicesContext.Provider>
+		);
+		return new CellTextOutputFixture(container);
+	}
+
+	test('renders short output', () => {
+		const fixture = renderCellTextOutput({ content: 'hello world', type: 'stdout' });
+
+		assert.ok(fixture.outputContainer.textContent?.includes('hello world'), 'Expected content');
+		assert.strictEqual(fixture.truncationMessage, null, 'Expected no truncation message');
+		assert.strictEqual(fixture.quickFixContainer, null, 'Expected no quick-fix');
+	});
+
+	test('renders error output with quick-fix', () => {
+		configurationService.setUserConfiguration('positron.assistant.enable', true);
+		configurationService.setUserConfiguration('positron.notebook.enabled', true);
+		contextKeyService.createKey('positron-assistant.hasChatModels', true);
+
+		const fixture = renderCellTextOutput({ content: 'NameError: name "x" is not defined', type: 'error' });
+
+		assert.ok(fixture.hasClass('notebook-error'), 'Expected error class');
+		assert.ok(fixture.quickFixContainer, 'Expected quick-fix container for error output');
+	});
+
+	test('does not render quick-fix for errors when assistant is disabled', () => {
+		const fixture = renderCellTextOutput({ content: 'NameError: name "x" is not defined', type: 'error' });
+
+		assert.ok(fixture.hasClass('notebook-error'), 'Expected error class');
+		assert.strictEqual(fixture.quickFixContainer, null, 'Expected no quick-fix when assistant is disabled');
+	});
+
+	test('renders multiline content within limit', () => {
+		const fixture = renderCellTextOutput({ content: '1\n2\n3', type: 'stdout' });
+
+		assert.strictEqual(fixture.outputLines.length, 3, 'Expected 3 output lines');
+		assert.strictEqual(fixture.truncationMessage, null, 'Expected no truncation message');
+	});
+
+	test('renders ANSI-colored text', () => {
+		const fixture = renderCellTextOutput({ content: '\x1b[31mred\x1b[0m plain', type: 'stdout' });
+
+		const runs = fixture.outputRuns;
+		assert.strictEqual(runs.length, 2, 'Expected two output runs');
+		assert.strictEqual(runs[0].textContent, 'red');
+		assert.strictEqual(runs[1].textContent, ' plain');
+	});
+
+	test('truncates long output when scrolling is disabled', async () => {
+		disposables.add(CommandsRegistry.registerCommand('workbench.action.openSettings', () => { }));
+
+		const content = makeLines(35);
+		const fixture = renderCellTextOutput(
+			{ content, type: 'stdout' },
+			{ outputLineLimit: 30, outputScrolling: false },
+		);
+
+		const message = fixture.truncationMessage;
+		assert.ok(message, 'Expected truncation message');
+		assert.ok(message.textContent?.includes('5 lines truncated'), 'Expected truncation count');
+
+		const link = fixture.settingsLink;
+		assert.ok(link, 'Expected "Change behavior" link');
+
+		const commandPromise = Event.toPromise(commandService.onWillExecuteCommand);
+		link.click();
+		const event = await commandPromise;
+		assert.strictEqual(event.commandId, 'workbench.action.openSettings');
+	});
+
+	test('does not truncate when scrolling is enabled', () => {
+		const content = makeLines(35);
+		const fixture = renderCellTextOutput(
+			{ content, type: 'stdout' },
+			{ outputLineLimit: 30, outputScrolling: true },
+		);
+
+		assert.ok(fixture.outputContainer.textContent?.includes('line 35'), 'Expected all lines rendered');
+		assert.strictEqual(fixture.truncationMessage, null, 'Expected no truncation message');
+	});
+
+	// TODO: useNotebookOptions has a bug where setNotebookOptions(instance.notebookOptions)
+	// passes the same object reference, so React skips the re-render. Once that hook is
+	// fixed to produce a new reference on change, unskip this test.
+	test.skip('switches from truncated to normal when line limit increases', () => {
+		const content = makeLines(35);
+		const fixture = renderCellTextOutput(
+			{ content, type: 'stdout' },
+			{ outputLineLimit: 30, outputScrolling: false },
+		);
+		assert.ok(fixture.truncationMessage, 'Expected truncation message initially');
+
+		layoutConfig = { ...layoutConfig, outputLineLimit: 50 };
+		flushSync(() => optionsEmitter.fire({ outputLineLimit: true } as NotebookOptionsChangeEvent));
+
+		assert.strictEqual(fixture.truncationMessage, null, 'Expected no truncation message after limit increase');
+		assert.ok(fixture.outputContainer.textContent?.includes('line 35'), 'Expected all lines rendered');
+	});
+});


### PR DESCRIPTION
Addresses #12366.

The behavior should be unchanged when `notebook.output.scrolling` is disabled. When enabled, the scroll bar is now in the cell output area instead of a nested container, and there is no longer a double-border (see screenshots). I 
encountered this issue while working on text wrapping (https://github.com/posit-dev/positron/issues/11720).

### Screenshots

#### Text output

##### Before - in a nested scroll container with a double border

<img width="699" height="553" alt="image" src="https://github.com/user-attachments/assets/cc4cc176-4a78-4cbb-a5e3-3373dc1c2851" />

##### After - single scrollable cell output area

<img width="708" height="666" alt="image" src="https://github.com/user-attachments/assets/20cb9a45-d5a5-45c7-b9bb-e79817747f57" />

#### Non text output

##### Before - does not scroll

<img width="696" height="865" alt="image" src="https://github.com/user-attachments/assets/8ab9f0de-f013-43b9-967a-22c9fb73df01" />

##### After - single scrollable cell output area:

<img width="706" height="683" alt="image" src="https://github.com/user-attachments/assets/7f489f8f-8703-4003-90be-8ffa7ae0c747" />

### Important notes

1. I changed the scroll enablement logic to only rely on `max-height` instead of checking the number of output lines. The benefit is it's much simpler and also handles non-text outputs (see screenshots). The downside is there is that outputs with exactly the number of lines as the line limit still show a scrollbar even though they barely overflow. I thought that was a worthwhile tradeoff.
2. The scroll container `max-height` is calculated from the output font family's line height and line limit setting instead of being hardcoded. This changes the height slightly, so we might want to tweak it.
3. I removed the floating `Scrolling long outputs... [Change behavior]` message. We're going to solve this via the output action bar instead (#12370), so I didn't want to spend time getting it to work in the new layout.
4. Used `outputFontSize` from notebook layout config instead of editor font size for output text. I didn't notice any issues but we should keep an eye out for regressions.

### Also fixes

- Removed `margin-inline: 1px` on the output container that created a visible gap between the scrollbar and the cell border. I tested across a bunch of different outputs to check that this _really_ isn't needed and won't cause a regression.
- Fixed anchor click handler in truncation message to call `preventDefault`, preventing core test hangs.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed scrollable notebook cell outputs appearing in a nested bordered container instead of scrolling within the existing output area (#12366)

### QA Notes

@:web @:positron-notebooks

Here's [a notebook with example outputs](https://github.com/posit-dev/qa-example-content/pull/110) for testing (h/t to @jmcphers for showing this approach with inline outputs).

1. Open the test notebook in the Positron Notebook Editor
2. Browse around with `notebook.output.scrolling` enabled and disabled
3. The notebook has markdown cells describing the expected behavior (we may eventually write e2e tests and remove the markdown cells)