### PR TITLE
Wire up `notebook.output.wordWrap` setting to Positron notebook text outputs

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
@@ -9,10 +9,12 @@
 		var(--monaco-monospace-font)
 	);
 	font-size: var(--vscode-positronNotebook-text-output-font-size);
+	/* Don't wrap text by default */
 	white-space: pre;
 }
 
 .positron-notebook-text-output.word-wrap {
+	/* Wrap text when word-wrap is enabled */
 	white-space: pre-wrap;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
@@ -9,6 +9,10 @@
 		var(--monaco-monospace-font)
 	);
 	font-size: var(--vscode-positronNotebook-text-output-font-size);
+	white-space: pre;
+}
+
+.positron-notebook-text-output.word-wrap {
 	white-space: pre-wrap;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -63,9 +63,11 @@ export function CellTextOutput({ content, type }: ParsedTextOutput) {
 
 	const services = usePositronReactServicesContext();
 	const truncation = useLongOutputBehavior(content);
+	const notebookOptions = useNotebookOptions();
+	const outputWordWrap = notebookOptions.getLayoutConfiguration().outputWordWrap;
 
 	return <>
-		<div className={`notebook-${type} positron-notebook-text-output`}>
+		<div className={`notebook-${type} positron-notebook-text-output${outputWordWrap ? ' word-wrap' : ''}`}>
 			<OutputLines outputLines={ANSIOutput.processOutput(truncation.content)} />
 			{truncation.mode === 'truncate' && <>
 				<TruncationMessage

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -17,6 +17,7 @@ import { useNotebookOptions } from '../NotebookInstanceProvider.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { NotebookDisplayOptions } from '../../../notebook/browser/notebookOptions.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 import { NotebookCellQuickFix } from './NotebookCellQuickFix.js';
 
 export type LongOutputOptions = Pick<NotebookDisplayOptions, 'outputLineLimit' | 'outputScrolling'>;
@@ -67,7 +68,7 @@ export function CellTextOutput({ content, type }: ParsedTextOutput) {
 	const outputWordWrap = notebookOptions.getLayoutConfiguration().outputWordWrap;
 
 	return <>
-		<div className={`notebook-${type} positron-notebook-text-output${outputWordWrap ? ' word-wrap' : ''}`}>
+		<div className={positronClassNames(`notebook-${type}`, 'positron-notebook-text-output', { 'word-wrap': outputWordWrap })}>
 			<OutputLines outputLines={ANSIOutput.processOutput(truncation.content)} />
 			{truncation.mode === 'truncate' && <>
 				<TruncationMessage

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -33,13 +33,6 @@ type TruncationResult =
 	);
 
 
-function useLongOutputBehavior(content: string): TruncationResult {
-	const notebookOptions = useNotebookOptions();
-	const layoutOptions = notebookOptions.getLayoutConfiguration();
-	return truncateToNumberOfLines(content, layoutOptions);
-}
-
-
 function truncateToNumberOfLines(content: string, { outputScrolling, outputLineLimit: maxLines }: LongOutputOptions): TruncationResult {
 	// Trim newline from end of content if it exists.
 	const splitByLine = content.trimEnd().split('\n');
@@ -63,9 +56,9 @@ function truncateToNumberOfLines(content: string, { outputScrolling, outputLineL
 export function CellTextOutput({ content, type }: ParsedTextOutput) {
 
 	const services = usePositronReactServicesContext();
-	const truncation = useLongOutputBehavior(content);
-	const notebookOptions = useNotebookOptions();
-	const outputWordWrap = notebookOptions.getLayoutConfiguration().outputWordWrap;
+	const layoutConfig = useNotebookOptions().getLayoutConfiguration();
+	const truncation = truncateToNumberOfLines(content, layoutConfig);
+	const outputWordWrap = layoutConfig.outputWordWrap;
 
 	return <>
 		<div className={positronClassNames(`notebook-${type}`, 'positron-notebook-text-output', { 'word-wrap': outputWordWrap })}>

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.test.tsx
@@ -68,14 +68,14 @@ suite('CellTextOutput', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	let optionsEmitter: Emitter<NotebookOptionsChangeEvent>;
-	let layoutConfig: LongOutputOptions;
+	let layoutConfig: LongOutputOptions & { outputWordWrap: boolean };
 	let commandService: TestCommandService;
 	let configurationService: TestConfigurationService;
 	let contextKeyService: MockContextKeyService;
 
 	setup(() => {
 		optionsEmitter = disposables.add(new Emitter<NotebookOptionsChangeEvent>());
-		layoutConfig = { outputLineLimit: 30, outputScrolling: false };
+		layoutConfig = { outputLineLimit: 30, outputScrolling: false, outputWordWrap: false };
 
 		const instantiationService = disposables.add(new TestInstantiationService());
 		commandService = new TestCommandService(instantiationService);
@@ -185,6 +185,19 @@ suite('CellTextOutput', () => {
 
 		assert.ok(fixture.outputContainer.textContent?.includes('line 35'), 'Expected all lines rendered');
 		assert.strictEqual(fixture.truncationMessage, null, 'Expected no truncation message');
+	});
+
+	test('does not apply word-wrap class when outputWordWrap is false', () => {
+		const fixture = renderCellTextOutput({ content: 'hello', type: 'stdout' });
+
+		assert.ok(!fixture.hasClass('word-wrap'), 'Expected no word-wrap class');
+	});
+
+	test('applies word-wrap class when outputWordWrap is true', () => {
+		layoutConfig = { ...layoutConfig, outputWordWrap: true };
+		const fixture = renderCellTextOutput({ content: 'hello', type: 'stdout' });
+
+		assert.ok(fixture.hasClass('word-wrap'), 'Expected word-wrap class');
 	});
 
 	// TODO: useNotebookOptions has a bug where setNotebookOptions(instance.notebookOptions)

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.test.tsx
@@ -16,12 +16,12 @@ import { MockContextKeyService } from '../../../../../../platform/keybinding/tes
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { TestCommandService } from '../../../../../../editor/test/browser/editorTestServices.js';
-import { NotebookOptions, NotebookOptionsChangeEvent } from '../../../../notebook/browser/notebookOptions.js';
+import { NotebookDisplayOptions, NotebookLayoutConfiguration, NotebookOptions, NotebookOptionsChangeEvent } from '../../../../notebook/browser/notebookOptions.js';
 import { IPositronNotebookInstance } from '../../../browser/IPositronNotebookInstance.js';
 import { NotebookInstanceProvider } from '../../../browser/NotebookInstanceProvider.js';
 import { PositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
 import { PositronReactServices } from '../../../../../../base/browser/positronReactServices.js';
-import { CellTextOutput, LongOutputOptions } from '../../../browser/notebookCells/CellTextOutput.js';
+import { CellTextOutput } from '../../../browser/notebookCells/CellTextOutput.js';
 import { ParsedTextOutput } from '../../../browser/PositronNotebookCells/IPositronNotebookCell.js';
 
 class CellTextOutputFixture {
@@ -68,7 +68,7 @@ suite('CellTextOutput', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	let optionsEmitter: Emitter<NotebookOptionsChangeEvent>;
-	let layoutConfig: LongOutputOptions & { outputWordWrap: boolean };
+	let layoutConfig: Partial<NotebookLayoutConfiguration & NotebookDisplayOptions>;
 	let commandService: TestCommandService;
 	let configurationService: TestConfigurationService;
 	let contextKeyService: MockContextKeyService;
@@ -86,7 +86,7 @@ suite('CellTextOutput', () => {
 
 	function renderCellTextOutput(
 		props: ParsedTextOutput,
-		options?: Partial<LongOutputOptions>,
+		options?: Partial<NotebookLayoutConfiguration & NotebookDisplayOptions>,
 	) {
 		if (options !== undefined) {
 			layoutConfig = { ...layoutConfig, ...options };
@@ -194,8 +194,10 @@ suite('CellTextOutput', () => {
 	});
 
 	test('applies word-wrap class when outputWordWrap is true', () => {
-		layoutConfig = { ...layoutConfig, outputWordWrap: true };
-		const fixture = renderCellTextOutput({ content: 'hello', type: 'stdout' });
+		const fixture = renderCellTextOutput(
+			{ content: 'hello', type: 'stdout' },
+			{ outputWordWrap: true },
+		);
 
 		assert.ok(fixture.hasClass('word-wrap'), 'Expected word-wrap class');
 	});


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/11720.

### Known issues

Will handle these separately:

- https://github.com/posit-dev/positron/issues/12421
- https://github.com/posit-dev/positron/issues/12422

### Screenshots

#### Before - always wraps regardless of `notebook.output.wordWrap`

<img width="706" height="158" alt="image" src="https://github.com/user-attachments/assets/b79bdcff-b325-4bb9-b2b5-8ca15ee8ae49" />

#### After

##### Wraps when `notebook.output.wordWrap` is enabled

<img width="714" height="156" alt="image" src="https://github.com/user-attachments/assets/50570f6f-6e38-4dfb-b2dc-8123f9726d91" />

##### No wrap when `notebook.output.wordWrap` is disabled (default)

<img width="714" height="138" alt="image" src="https://github.com/user-attachments/assets/635ed760-84b8-4a7a-86f5-1d4ba8153503" />

### Release Notes

#### New Features

- Positron notebook text outputs now respect the `notebook.output.wordWrap` setting (#11720)

#### Bug Fixes

- N/A

### QA Notes

@:positron-notebooks @:web

1. Open a notebook with a wide text output ([example](https://github.com/posit-dev/qa-example-content/pull/111))
2. Verify output scrolls horizontally and does not wrap
3. Enable `notebook.output.wordWrap` setting
4. Verify output wraps and no longer horizontally scrolls