### PR TITLE
Fix `did_change_plots_render_settings` RPC timeout after restart

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -12,6 +12,7 @@ import { HTMLFileSystemProvider } from '../../../../platform/files/browser/htmlF
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { createSuggestedFileNameForPlot, DarkFilter, HistoryPolicy, IPositronPlotClient, IPositronPlotsService, PlotRenderFormat, PlotRenderSettings, PlotsDisplayLocation, POSITRON_PLOTS_LOCATION_CONTEXT, POSITRON_PLOTS_VIEW_ID, ZoomLevel } from '../../../services/positronPlots/common/positronPlots.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { StaticPlotClient } from '../../../services/positronPlots/common/staticPlotClient.js';
 import { IStorageService, StorageTarget, StorageScope } from '../../../../platform/storage/common/storage.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
@@ -920,14 +921,13 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		// https://github.com/posit-dev/positron/issues/4997.
 		if (session.runtimeMetadata.uiSubscriptions?.includes(UiRuntimeNotifications.DidChangePlotsRenderSettings)) {
 			this._register(this._runtimeSessionService.watchUiClient(session.sessionId, (uiClient) => {
-				// Forward future settings updates. Note that the lifecycle of that event
-				// handler is tied to the UI client itself, not to the lifecycle of the session.
-				uiClient.register(this.onDidChangePlotsRenderSettings(settings => {
-					uiClient.didChangePlotsRenderSettings(settings);
-				}));
-
 				// Send initial settings immediately
 				uiClient.didChangePlotsRenderSettings(this.getPlotsRenderSettings());
+
+				// Forward future settings updates
+				return this.onDidChangePlotsRenderSettings(settings => {
+					uiClient.didChangePlotsRenderSettings(settings);
+				});
 			}));
 		}
 	}

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -922,11 +922,15 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		if (session.runtimeMetadata.uiSubscriptions?.includes(UiRuntimeNotifications.DidChangePlotsRenderSettings)) {
 			this._register(this._runtimeSessionService.watchUiClient(session.sessionId, (uiClient) => {
 				// Send initial settings immediately
-				uiClient.didChangePlotsRenderSettings(this.getPlotsRenderSettings());
+				uiClient.
+					didChangePlotsRenderSettings(this.getPlotsRenderSettings()).
+					catch(onUnexpectedError);
 
 				// Forward future settings updates
 				return this.onDidChangePlotsRenderSettings(settings => {
-					uiClient.didChangePlotsRenderSettings(settings);
+					uiClient.
+						didChangePlotsRenderSettings(settings).
+						catch(onUnexpectedError);
 				});
 			}));
 		}

--- a/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
+++ b/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
@@ -268,7 +268,7 @@ class TestRuntimeSessionService implements IRuntimeSessionService {
 		return this._onWillStartSession;
 	}
 
-	watchUiClient(sessionId: string, handler: (uiClient: UiClientInstance) => void): IDisposable {
+	watchUiClient(sessionId: string, handler: (uiClient: UiClientInstance) => IDisposable | void): IDisposable {
 		throw new Error('Method not implemented.');
 	}
 }

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1894,26 +1894,44 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 * Register handler for the `onDidStartUiClient` event and run handler if already started.
 	 *
 	 * This ensures `handler` is run for both current and future instances of a session's UI client.
+	 * The `IDisposable` returned by `handler` is automatically disposed before the next
+	 * invocation, ensuring resources tied to a previous UI client are cleaned up on restart.
 	 *
 	 * @param sessionId The ID of the session to observe.
-	 * @param handler Called with started UI clients.
-	 * @returns An `IDisposable` to clean up the event handler.
+	 * @param handler Called with started UI clients. The returned `IDisposable` is
+	 *   disposed before the next invocation and on outer disposal.
+	 * @returns An `IDisposable` to clean up the event handler and the current handler disposable.
 	 */
-	watchUiClient(sessionId: string, handler: (uiClient: UiClientInstance) => void): IDisposable {
+	watchUiClient(sessionId: string, handler: (uiClient: UiClientInstance) => IDisposable | void): IDisposable {
+		const store = new DisposableStore();
+		let handlerDisposable: IDisposable | undefined;
+
+		// Enforces "one at a time" invariant. Disposes the previous handler before
+		// running new one.
+		const runHandler = (uiClient: UiClientInstance) => {
+			handlerDisposable?.dispose();
+			handlerDisposable = handler(uiClient) ?? undefined;
+		};
+
 		// Run handler with currently started client, if any
 		const currentUiClient = this.getActiveSession(sessionId)?.uiClient;
 		if (currentUiClient) {
-			handler(currentUiClient);
+			runHandler(currentUiClient);
 		}
 
 		// Run handler on future instances, e.g. after reconnect
-		const disposable = this.onDidStartUiClient((event) => {
+		store.add(this.onDidStartUiClient((event) => {
 			if (event.sessionId === sessionId) {
-				handler(event.uiClient);
+				runHandler(event.uiClient);
 			}
-		});
+		}));
 
-		return disposable;
+		store.add(toDisposable(() => {
+			handlerDisposable?.dispose();
+			handlerDisposable = undefined;
+		}));
+
+		return store;
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -675,12 +675,14 @@ export interface IRuntimeSessionService {
 	 * Register handler for the `onDidStartUiClient` event and run handler if already started.
 	 *
 	 * This ensures `handler` is run for both current and future instances of a session's UI client.
+	 * If the handler returns an `IDisposable`, it is disposed before the handler is called again
+	 * with a new client (e.g. after restart).
 	 *
 	 * @param sessionId The ID of the session to observe.
-	 * @param handler Called with started UI clients.
+	 * @param handler Called with started UI clients. May return an `IDisposable` for per-client cleanup.
 	 * @returns An `IDisposable` to clean up the event handler.
 	 */
-	watchUiClient(sessionId: string, handler: (uiClient: UiClientInstance) => void): IDisposable;
+	watchUiClient(sessionId: string, handler: (uiClient: UiClientInstance) => IDisposable | void): IDisposable;
 
 	/**
 	 * When true, suppresses implicit runtime auto-start triggered by


### PR DESCRIPTION
QA has observed RPC timeout errors related to plot settings notifications:
https://github.com/posit-dev/positron/actions/runs/22686916473/job/65781214214

After an R session restart, `did_change_plots_render_settings` RPCs (which are really notifications but we can't send those from frontend yet https://github.com/posit-dev/positron/issues/7448) time out with a 5-second delay. On the backend side, we see a concomittant "Received message for unknown comm channel", whose comm ID corresponds to the stale UI comm from before the restart. This means the frontend is sending a render settings notification to a stale UI comm. The new comm is alive and working, but the old event listener is still active, so every plot render settings change fires RPCs on both.

The bug is a race: it only triggers when a layout change happens between "new UI client created" and "old UI client disposed," which is why it appears intermittently in tests that manipulate the UI around restarts.

The timeout manifested as a user-visible toast notification, which indicates a lack of handling. These timeouts should be logged, not surfaced to users, especially since this is semantically a fire-and-forget notification.

To fix this:

- `watchUiClient` now manages per-client cleanup: when a new UI client arrives, resources returned by the previous handler invocation are disposed automatically. This tears down the stale event listener immediately, rather than relying on the old `UiClientInstance` being disposed in time.

- Fire-and-forget RPC calls that can't meaningfully handle errors now route failures through `onUnexpectedError` instead of producing unhandled rejections. The Workbench handler simply logs.

@:plots