### PR TITLE
Don't initiate startup sequence after trust

### DIFF
--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -472,23 +472,6 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		// extensions won't activate until the workspace is trusted).
 		if (!this._workspaceTrustManagementService.isWorkspaceTrusted()) {
 			this.setStartupPhase(RuntimeStartupPhase.AwaitingTrust);
-			this._register(this._workspaceTrustManagementService.onDidChangeTrust((trusted) => {
-				if (!trusted) {
-					return;
-				}
-				// When the workspace becomes trusted while we are still
-				// awaiting trust, the extension host will restart and the
-				// ext point handler will fire with language packs, which
-				// drives the startup sequence forward. However, if no
-				// language packs arrive (e.g. no extensions contribute
-				// runtimes), we need a fallback to avoid hanging forever
-				// in the AwaitingTrust phase. Route through the full
-				// startup sequence so session restore, new-folder tasks,
-				// and affiliated/recommended startup are not skipped.
-				if (this._startupPhase === RuntimeStartupPhase.AwaitingTrust) {
-					this.startupSequence();
-				}
-			}));
 		}
 
 		// Find all the sessions that need to be restored.
@@ -611,11 +594,10 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 	 */
 	private async startupSequence() {
 
-		// Guard against double entry. Both the ext-point handler and the
-		// onDidChangeTrust handler can call startupSequence() when the
-		// workspace transitions from untrusted to trusted. Setting the
-		// phase synchronously before the first await ensures only the
-		// first caller proceeds.
+		// Guard against double entry. Multiple code paths can call
+		// startupSequence() (e.g. the ext-point handler and
+		// startupAfterTrust). Setting the phase synchronously before
+		// the first await ensures only the first caller proceeds.
 		if (this._startupPhase !== RuntimeStartupPhase.AwaitingTrust &&
 			this._startupPhase !== RuntimeStartupPhase.Initializing) {
 			return;


### PR DESCRIPTION
This change fixes a regression from https://github.com/posit-dev/positron/pull/12412.

It appears that it's _normal_ for a workspace to be initially untrusted, then immediately become trusted (even when not opening it for the first time). This sequence may have changed upstream in the same set of changes that broke our trust workflow in the last few months. 

When this happens, it invokes some code that is intended to defensively ensure that the startup sequence gets invoked, but in reality just starts the startup sequence too soon. We don't actually need to worry about the case wherein no extensions contribute runtimes, as we ship several as built-ins and don't make any representations about what happens if you disable all of them. 

Despite breaking things for almost all users, this change passed all critical CI checks and even a full E2E suite. The reason for this appears to be that trust features are entirely disabled in CI. E.g.:

https://github.com/posit-dev/positron/blob/b3fb8b7c8c1243f8641147b533398d4828f45e7f/test/e2e/infra/electron.ts#L35

When the trust features are _enabled_, then trusted workspaces go through an untrusted->trusted transition instantaneously when opened, and it is this transition that causes the bug. When trust features are disabled, these events never fire, so startup proceeds normally. 

Addresses https://github.com/posit-dev/positron/issues/12427.


### QA Notes

It may be worth considering adding some basic startup tests that run in a test environment that doesn't have trust disabled. This would require some nontrivial infrastructure work since Electron itself would need to be launched in a different way than we do for every other test.
