### PR TITLE
E2E test: r-debug test fix where scrolling hides breakpoints

### DIFF
--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -304,6 +304,7 @@ test.describe('R Breakpoints', {
 		await page.keyboard.type('# test comment');
 
 		await hotKeys.minimizeBottomPanel();
+		await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Home' : 'Control+Home');
 
 		// Breakpoint should become unverified after edit
 		await debug.expectBreakpointUnverified(0);

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -303,6 +303,8 @@ test.describe('R Breakpoints', {
 		await page.keyboard.press('Enter');
 		await page.keyboard.type('# test comment');
 
+		await hotKeys.minimizeBottomPanel();
+
 		// Breakpoint should become unverified after edit
 		await debug.expectBreakpointUnverified(0);
 
@@ -310,6 +312,8 @@ test.describe('R Breakpoints', {
 		await hotKeys.selectAll();
 		await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter');
 		await debug.expectBreakpointVerified(0, 30000);
+
+		await hotKeys.restoreBottomPanel();
 
 		// Verify breakpoint still works
 		await console.pasteCodeToConsole('multiply_values(5, 3)', true);


### PR DESCRIPTION
Breakpoints are scrolled out of view when validating them.

### QA Notes

@:web @:win @:debug
