### PR TITLE
e2e: fix notebook editorAtIndex locator for cross-browser support

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -28,7 +28,7 @@ export class PositronNotebooks extends Notebooks {
 	private cellsContainer = this.positronNotebook.locator('.positron-notebook-cells-container').first();
 	private newCellButton = this.code.driver.page.getByLabel(/new code cell/i);
 	private spinner = this.code.driver.page.getByLabel(/cell is executing/i);
-	editorAtIndex = (index: number) => this.cell.nth(index).locator('.view-line');
+	editorAtIndex = (index: number) => this.cell.nth(index).locator('.monaco-editor :is(.native-edit-context, .inputarea)');
 	cell = this.code.driver.page.locator('[data-testid="notebook-cell"]');
 	codeCell = this.code.driver.page.locator('[data-testid="notebook-cell"][aria-label="Code cell"]');
 	markdownCell = this.code.driver.page.locator(`[data-testid="notebook-cell"][aria-label="${MARKDOWN_ARIA_LABEL}"]`);


### PR DESCRIPTION
## Summary

Fixed positron notebooks `editorAtIndex` locator to work for all browser/os types.

## QA Notes

@:positron-notebooks @:web

🤖 Generated with [Claude Code](https://claude.com/claude-code)