### PR TITLE
e2e: add hotkey for configuring language model providers

### DIFF
--- a/test/e2e/fixtures/keybindings.json
+++ b/test/e2e/fixtures/keybindings.json
@@ -129,6 +129,10 @@
         "key": "cmd+l r",
         "command": "quarto.runCurrent" // Quarto: Run Current Code
     },
+    {
+        "key": "cmd+l b",
+        "command": "positron-assistant.configureProviders" // Configure Language Model Providers
+    },
     // Custom keybinding for command palette to avoid browser shortcut conflicts.
     // The default Ctrl+Shift+P opens private browsing in Firefox, so we use a
     // multi-key sequence that browsers won't intercept.

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -280,6 +280,14 @@ export class HotKeys {
 	}
 
 	// -----------------------
+	// ---  Assistant Actions ---
+	// -----------------------
+
+	public configureProviders() {
+		return this.pressHotKeys('Cmd+L B', 'Configure Language Model Providers');
+	}
+
+	// -----------------------
 	// ---  Debug Actions  ---
 	// -----------------------
 

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -9,6 +9,7 @@ import { Code } from '../infra/code';
 import { QuickAccess } from './quickaccess';
 import { Toasts } from './dialog-toasts';
 import { Modals } from './dialog-modals.js';
+import { HotKeys } from './hotKeys.js';
 
 /**
  * Fills an input element's value using evaluate() instead of Playwright's
@@ -234,7 +235,11 @@ function isProviderAutoSignedIn(provider: ModelProvider): boolean {
  */
 export class Assistant {
 
-	constructor(private code: Code, private quickaccess: QuickAccess, private toasts: Toasts, private modals: Modals) { }
+	private hotKeys: HotKeys;
+
+	constructor(private code: Code, private quickaccess: QuickAccess, private toasts: Toasts, private modals: Modals) {
+		this.hotKeys = new HotKeys(code);
+	}
 
 	async verifyChatButtonVisible() {
 		await expect(this.code.driver.page.locator(CHAT_BUTTON)).toBeVisible();
@@ -265,7 +270,7 @@ export class Assistant {
 	}
 
 	async runConfigureProviders() {
-		await this.quickaccess.runCommand('positron-assistant.configureProviders');
+		await this.hotKeys.configureProviders();
 	}
 
 	async clickConfigureProvidersLink() {
@@ -377,8 +382,8 @@ export class Assistant {
 		}
 
 		await test.step(`Sign in to ${provider} model provider`, async () => {
-			// Open the model configuration dialog via command (more reliable than clicking UI)
-			await this.quickaccess.runCommand('positron-assistant.configureProviders');
+			// Open the model configuration dialog via hotkey (more reliable than command palette UI)
+			await this.hotKeys.configureProviders();
 
 			// Select the provider
 			await this.selectModelProvider(provider);

--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -169,11 +169,12 @@ test.describe('Positron Assistant Chat Editing', { tag: [tags.WIN, tags.ASSISTAN
 		await app.workbench.variables.expectVariableToBe('foo', '200');
 	});
 
-	test('Verify Manage Models is available', { tag: [tags.SOFT_FAIL] }, async function ({ app }) {
+	test('Verify Manage Models is available', { tag: [tags.SOFT_FAIL] }, async function ({ app, page }) {
 		// sometimes the menu closes due to language model loading (?), so retry
 		await expect(async () => {
 			await app.workbench.assistant.pickModel();
 			await app.workbench.assistant.expectManageModelsVisible();
+			await page.keyboard.press('Escape');
 		}).toPass({ timeout: 30000 });
 	});
 });


### PR DESCRIPTION
Use hotkey for configureProviders command in assistant e2e tests to avoid some flakes with quickInput.


  - Added cmd+l b keybinding for positron-assistant.configureProviders in test/e2e/fixtures/keybindings.json
  - Added configureProviders() hotkey method to HotKeys class
  - Updated Assistant page object to use the hotkey in runConfigureProviders() and loginModelProvider()
  - Added Escape keypress in "Verify Manage Models is available" test retry loop

### QA Notes
@:assistant

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
