### PR TITLE
Fix session selection driven from the plots pane

### DIFF
--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -970,11 +970,13 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 			throw new Error(`Cannot reveal execution: no Positron console instance found for session ID ${sessionId}.`);
 		}
 
-		// Open the console view to ensure it's visible.
 		this._viewsService.openView(POSITRON_CONSOLE_VIEW_ID, false);
 
-		// Set this console instance as active.
-		this.setActivePositronConsoleInstance(consoleInstance);
+		// Activate the console instance if it isn't already active
+		if (consoleInstance !== this._activePositronConsoleInstance) {
+			this.setActivePositronConsoleInstance(consoleInstance);
+			this._runtimeSessionService.foregroundSession = consoleInstance.session;
+		}
 
 		// Ask the console instance to reveal the execution.
 		if (!consoleInstance.revealExecution(executionId)) {

--- a/test/e2e/pages/plots.ts
+++ b/test/e2e/pages/plots.ts
@@ -21,6 +21,7 @@ const COPY_PLOT_BUTTON = '.positron-plots-container .positron-dynamic-action-bar
 const ZOOM_PLOT_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Fit"]';
 const OPEN_IN_EDITOR_DROPDOWN_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Select where to open plot"]';
 const OVERFLOW_MENU_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="overflow"]';
+const SESSION_NAME_BUTTON = '.plot-session-name';
 const ORIGIN_FILE_BUTTON = '.plot-origin-file';
 const OUTER_WEBVIEW_FRAME = '.webview';
 const INNER_WEBVIEW_FRAME = '#active-frame';
@@ -40,6 +41,7 @@ export class Plots {
 	copyPlotButton: Locator;
 	zoomPlotButton: Locator;
 	currentPlot: Locator;
+	sessionNameButton: Locator;
 	originFileButton: Locator;
 	savePlotModal: Locator;
 	overwriteModal: Locator;
@@ -55,9 +57,16 @@ export class Plots {
 		this.copyPlotButton = this.code.driver.page.locator(COPY_PLOT_BUTTON);
 		this.zoomPlotButton = this.code.driver.page.locator(ZOOM_PLOT_BUTTON);
 		this.currentPlot = this.code.driver.page.locator(CURRENT_PLOT);
+		this.sessionNameButton = this.code.driver.page.locator(SESSION_NAME_BUTTON);
 		this.originFileButton = this.code.driver.page.locator(ORIGIN_FILE_BUTTON);
 		this.savePlotModal = this.code.driver.page.locator('.positron-modal-dialog-box').filter({ hasText: 'Save Plot' });
 		this.overwriteModal = this.code.driver.page.locator('.positron-modal-dialog-box').filter({ hasText: 'The file already exists' });
+	}
+
+	async clickSessionNameButton() {
+		await test.step('Click session name button on plot', async () => {
+			await this.sessionNameButton.click();
+		});
 	}
 
 	async clickOriginFileButton() {

--- a/test/e2e/tests/plots/plot-file-attribution.test.ts
+++ b/test/e2e/tests/plots/plot-file-attribution.test.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -103,3 +103,51 @@ for (const config of languageConfigs) {
 		});
 	});
 }
+
+test.describe('Plot Session Select', { tag: [tags.PLOTS] }, () => {
+	const pyFileName = 'plot-session-select-test.py';
+	const pyFileContent = [
+		'import matplotlib.pyplot as plt',
+		'plt.plot([1, 2, 3, 4, 5])',
+		'plt.show()',
+		''
+	].join('\n');
+
+	test.afterEach(async function ({ app, hotKeys }) {
+		await hotKeys.closeAllEditors();
+		await hotKeys.clearPlots();
+		await app.workbench.plots.waitForNoPlots({ timeout: 3000 });
+	});
+
+	test.afterAll(async function ({ cleanup }) {
+		await cleanup.removeTestFiles([pyFileName]);
+	});
+
+	test('Clicking plot session button updates the interpreter picker', async function ({ app, sessions, openFile, hotKeys }) {
+		const { plots } = app.workbench;
+
+		// Start Python and generate a plot
+		const pySession = await sessions.start('python');
+		const filePath = path.join(app.workspacePathOrFolder, pyFileName);
+		fs.writeFileSync(filePath, pyFileContent);
+		await openFile(pyFileName);
+		for (let i = 0; i < countLines(pyFileContent); i++) {
+			await hotKeys.runLineOfCode();
+		}
+		await plots.waitForCurrentPlot();
+
+		// Start R, which switches the active session away from Python
+		const rSession = await sessions.start('r');
+		await sessions.expectSessionPickerToBe(rSession.name);
+
+		// Verify the plot's session name button is visible and contains
+		// the Python session name
+		await expect(plots.sessionNameButton).toBeVisible({ timeout: 15000 });
+
+		// Click the session name button on the plot to navigate to Python
+		await plots.clickSessionNameButton();
+
+		// Verify the interpreter picker updated to show the Python session
+		await sessions.expectSessionPickerToBe(pySession.name);
+	});
+});


### PR DESCRIPTION
Fixes an issue changing sessions after using the session selector in the Plots pane attribution section. The problem is pretty simple; the foreground session was getting out of sync with the active console instance. 

The active console instance should not have to match the foreground session, so more investigation is warranted, but in the interests of keeping the fix minimal, I've just make sure we also update the foreground session when doing an execution reveal. 

Also adds an E2E test to guard against regressions. 

Addresses https://github.com/posit-dev/positron/issues/12255.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix an issue switching between consoles after selecting one via the Plots pane (#12255)


### QA Notes

Tags: `@:plots`
