### PR TITLE
Add authentication extension with Anthropic API key provider

### DIFF
--- a/build/gulpfile.extensions.ts
+++ b/build/gulpfile.extensions.ts
@@ -33,6 +33,7 @@ const commit = getVersion(root);
 // });
 const compilations = [
 	// --- Start Positron ---
+	'extensions/authentication/tsconfig.json',
 	'extensions/open-remote-ssh/tsconfig.json',
 	'extensions/positron-assistant/tsconfig.json',
 	'extensions/positron-catalog-explorer/tsconfig.json',

--- a/extensions/authentication/package.json
+++ b/extensions/authentication/package.json
@@ -12,8 +12,7 @@
 		"onStartupFinished",
 		"onAuthenticationRequest:anthropic-api",
 		"onCommand:authentication.configureProviders",
-		"onCommand:authentication.storeApiKey",
-		"onCommand:authentication.removeApiKey"
+		"onCommand:authentication.migrateApiKey"
 	],
 	"main": "./out/extension.js",
 	"contributes": {

--- a/extensions/authentication/package.json
+++ b/extensions/authentication/package.json
@@ -9,7 +9,8 @@
 		"vscode": "^1.108.0"
 	},
 	"activationEvents": [
-		"onAuthenticationRequest:anthropic-api"
+		"onAuthenticationRequest:anthropic-api",
+		"onCommand:authentication.configureProviders"
 	],
 	"main": "./out/extension.js",
 	"contributes": {

--- a/extensions/authentication/package.json
+++ b/extensions/authentication/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "authentication",
+	"displayName": "Authentication",
+	"description": "Centralized credential management",
+	"version": "0.0.1",
+	"publisher": "positron",
+	"private": true,
+	"engines": {
+		"vscode": "^1.108.0"
+	},
+	"activationEvents": [
+		"onAuthenticationRequest:anthropic-api"
+	],
+	"main": "./out/extension.js",
+	"contributes": {
+		"authentication": [
+			{
+				"id": "anthropic-api",
+				"label": "Anthropic"
+			}
+		]
+	}
+}

--- a/extensions/authentication/package.json
+++ b/extensions/authentication/package.json
@@ -9,8 +9,11 @@
 		"vscode": "^1.108.0"
 	},
 	"activationEvents": [
+		"onStartupFinished",
 		"onAuthenticationRequest:anthropic-api",
-		"onCommand:authentication.configureProviders"
+		"onCommand:authentication.configureProviders",
+		"onCommand:authentication.storeApiKey",
+		"onCommand:authentication.removeApiKey"
 	],
 	"main": "./out/extension.js",
 	"contributes": {

--- a/extensions/authentication/src/apiKeyProvider.ts
+++ b/extensions/authentication/src/apiKeyProvider.ts
@@ -71,7 +71,7 @@ export class ApiKeyAuthenticationProvider implements vscode.AuthenticationProvid
 				});
 			}
 		}
-		log.debug(`[${this.providerId}] getSessions: returned ${sessions.length} session(s)`);
+		log.debug(`[${this.displayName}] getSessions: returned ${sessions.length} session(s)`);
 		return sessions;
 	}
 
@@ -91,7 +91,7 @@ export class ApiKeyAuthenticationProvider implements vscode.AuthenticationProvid
 		if (!key) {
 			throw new Error(vscode.l10n.t('API key is required'));
 		}
-		log.info(`[${this.providerId}] Creating session via Accounts menu`);
+		log.info(`[${this.displayName}] Creating session via Accounts menu`);
 		return this.storeKey(randomUUID(), this.displayName, key);
 	}
 
@@ -124,7 +124,7 @@ export class ApiKeyAuthenticationProvider implements vscode.AuthenticationProvid
 		this._onDidChangeSessions.fire({
 			added: [session], removed: [], changed: [],
 		});
-		log.info(`[${this.providerId}] Stored key for account "${label}" (${accountId})`);
+		log.info(`[${this.displayName}] Stored key for account "${label}"`);
 		return session;
 	}
 
@@ -132,7 +132,7 @@ export class ApiKeyAuthenticationProvider implements vscode.AuthenticationProvid
 		const accounts = this.getStoredAccounts();
 		const account = accounts.find(a => a.id === sessionId);
 		if (!account) {
-			log.warn(`[${this.providerId}] removeSession: no account found for ${sessionId}`);
+			log.warn(`[${this.displayName}] removeSession: no account found for ${sessionId}`);
 			return;
 		}
 
@@ -149,6 +149,6 @@ export class ApiKeyAuthenticationProvider implements vscode.AuthenticationProvid
 			}],
 			changed: [],
 		});
-		log.info(`[${this.providerId}] Removed session for account "${account.label}" (${sessionId})`);
+		log.info(`[${this.displayName}] Removed session for account "${account.label}" (${sessionId})`);
 	}
 }

--- a/extensions/authentication/src/apiKeyProvider.ts
+++ b/extensions/authentication/src/apiKeyProvider.ts
@@ -1,0 +1,154 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { randomUUID } from 'crypto';
+import { log } from './log';
+
+interface StoredAccount {
+	readonly id: string;
+	readonly label: string;
+}
+
+/**
+ * Generic AuthenticationProvider for API-key-based services.
+ * Each provider instance manages keys for a single LLM provider (e.g. Anthropic, OpenAI).
+ * Keys are stored in `context.secrets` with pattern `apiKey-{providerId}-{accountId}`.
+ * The account registry lives in `context.globalState`.
+ */
+export class ApiKeyAuthenticationProvider implements vscode.AuthenticationProvider, vscode.Disposable {
+
+	private readonly _onDidChangeSessions =
+		new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
+	readonly onDidChangeSessions = this._onDidChangeSessions.event;
+
+	constructor(
+		private readonly providerId: string,
+		private readonly displayName: string,
+		private readonly context: vscode.ExtensionContext,
+	) { }
+
+	dispose(): void {
+		this._onDidChangeSessions.dispose();
+	}
+
+	private get accountsKey(): string {
+		return `auth.accounts.${this.providerId}`;
+	}
+
+	private getStoredAccounts(): StoredAccount[] {
+		return this.context.globalState.get<StoredAccount[]>(this.accountsKey) ?? [];
+	}
+
+	private async setStoredAccounts(accounts: StoredAccount[]): Promise<void> {
+		await this.context.globalState.update(this.accountsKey, accounts);
+	}
+
+	private secretKey(accountId: string): string {
+		return `apiKey-${this.providerId}-${accountId}`;
+	}
+
+	async getSessions(
+		_scopes?: readonly string[],
+		options?: vscode.AuthenticationProviderSessionOptions
+	): Promise<vscode.AuthenticationSession[]> {
+		const accounts = this.getStoredAccounts();
+		const filtered = options?.account
+			? accounts.filter(a => a.id === options.account!.id)
+			: accounts;
+
+		const sessions: vscode.AuthenticationSession[] = [];
+		for (const account of filtered) {
+			const key = await this.context.secrets.get(this.secretKey(account.id));
+			if (key) {
+				sessions.push({
+					id: account.id,
+					accessToken: key,
+					account: { id: account.id, label: account.label },
+					scopes: [],
+				});
+			}
+		}
+		log.debug(`[${this.providerId}] getSessions: returned ${sessions.length} session(s)`);
+		return sessions;
+	}
+
+	/**
+	 * Accounts menu entry point: prompts user for an API key via input box.
+	 */
+	async createSession(
+		_scopes: readonly string[],
+		_options?: vscode.AuthenticationProviderSessionOptions
+	): Promise<vscode.AuthenticationSession> {
+		const raw = await vscode.window.showInputBox({
+			prompt: vscode.l10n.t('Enter your {0} API key', this.displayName),
+			password: true,
+			ignoreFocusOut: true,
+		});
+		const key = raw?.trim();
+		if (!key) {
+			throw new Error(vscode.l10n.t('API key is required'));
+		}
+		log.info(`[${this.providerId}] Creating session via Accounts menu`);
+		return this.storeKey(randomUUID(), this.displayName, key);
+	}
+
+	/**
+	 * Store an API key and fire a session-added event.
+	 * Called internally by the config dialog onAction('save') handler.
+	 */
+	async storeKey(
+		accountId: string,
+		label: string,
+		key: string
+	): Promise<vscode.AuthenticationSession> {
+		await this.context.secrets.store(this.secretKey(accountId), key);
+
+		const accounts = this.getStoredAccounts();
+		const existing = accounts.findIndex(a => a.id === accountId);
+		if (existing >= 0) {
+			accounts[existing] = { id: accountId, label };
+		} else {
+			accounts.push({ id: accountId, label });
+		}
+		await this.setStoredAccounts(accounts);
+
+		const session: vscode.AuthenticationSession = {
+			id: accountId,
+			accessToken: key,
+			account: { id: accountId, label },
+			scopes: [],
+		};
+		this._onDidChangeSessions.fire({
+			added: [session], removed: [], changed: [],
+		});
+		log.info(`[${this.providerId}] Stored key for account "${label}" (${accountId})`);
+		return session;
+	}
+
+	async removeSession(sessionId: string): Promise<void> {
+		const accounts = this.getStoredAccounts();
+		const account = accounts.find(a => a.id === sessionId);
+		if (!account) {
+			log.warn(`[${this.providerId}] removeSession: no account found for ${sessionId}`);
+			return;
+		}
+
+		await this.context.secrets.delete(this.secretKey(sessionId));
+		await this.setStoredAccounts(accounts.filter(a => a.id !== sessionId));
+
+		this._onDidChangeSessions.fire({
+			added: [],
+			removed: [{
+				id: sessionId,
+				accessToken: '',
+				account: { id: account.id, label: account.label },
+				scopes: [],
+			}],
+			changed: [],
+		});
+		log.info(`[${this.providerId}] Removed session for account "${account.label}" (${sessionId})`);
+	}
+}

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -49,8 +49,9 @@ async function enrichWithCredentialState(
 			}
 		} catch (err) {
 			log.error(`Failed to check credential state for ${source.provider.id}: ${err instanceof Error ? err.message : String(err)}`);
+			return source;
 		}
-		return source;
+		return { ...source, signedIn: false };
 	}));
 }
 

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -5,6 +5,22 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
+import { randomUUID } from 'crypto';
+import { ApiKeyAuthenticationProvider } from './apiKeyProvider';
+import { log } from './log';
+
+const apiKeyProviders = new Map<string, ApiKeyAuthenticationProvider>();
+
+/**
+ * Register an API key provider so the config dialog can store/remove
+ * credentials through it.
+ */
+export function registerApiKeyProvider(
+	providerId: string,
+	provider: ApiKeyAuthenticationProvider
+): void {
+	apiKeyProviders.set(providerId, provider);
+}
 
 /**
  * Enrich sources with credential state from registered authentication providers.
@@ -43,16 +59,18 @@ export async function showConfigurationDialog(
 	options?: positron.ai.ShowLanguageModelConfigOptions
 ): Promise<void> {
 	const enrichedSources = await enrichWithCredentialState(sources);
+	log.info(`Opening config dialog with ${enrichedSources.length} source(s)`);
 
 	return positron.ai.showLanguageModelConfig(
 		enrichedSources,
-		async (_config, action) => {
+		async (config, action) => {
+			log.info(`Config dialog action: "${action}" for provider "${config.provider}"`);
 			switch (action) {
 				case 'save':
-					// Phase 3: store API key via ApiKeyAuthenticationProvider
+					await handleSave(config);
 					break;
 				case 'delete':
-					// Phase 3: remove auth session
+					await handleDelete(config);
 					break;
 				case 'oauth-signin':
 					// Phase 5: handle OAuth sign-in
@@ -71,4 +89,32 @@ export async function showConfigurationDialog(
 		},
 		options
 	);
+}
+
+async function handleSave(config: positron.ai.LanguageModelConfig): Promise<void> {
+	const provider = apiKeyProviders.get(config.provider);
+	if (!provider) {
+		throw new Error(
+			vscode.l10n.t('No auth provider registered for {0}', config.provider)
+		);
+	}
+	const apiKey = config.apiKey?.trim();
+	if (!apiKey) {
+		throw new Error(vscode.l10n.t('API key is required'));
+	}
+	log.info(`Saving credential for provider "${config.provider}", name "${config.name}"`);
+	await provider.storeKey(randomUUID(), config.name, apiKey);
+}
+
+async function handleDelete(config: positron.ai.LanguageModelConfig): Promise<void> {
+	const provider = apiKeyProviders.get(config.provider);
+	if (!provider) {
+		log.warn(`handleDelete: no auth provider for "${config.provider}"`);
+		return;
+	}
+	const sessions = await provider.getSessions();
+	log.info(`Deleting ${sessions.length} session(s) for provider "${config.provider}"`);
+	for (const session of sessions) {
+		await provider.removeSession(session.id);
+	}
 }

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+
+/**
+ * Enrich sources with credential state from registered authentication providers.
+ * For each source whose provider.id matches a registered auth provider, check
+ * whether a session exists and set signedIn accordingly.
+ */
+async function enrichWithCredentialState(
+	sources: positron.ai.LanguageModelSource[]
+): Promise<positron.ai.LanguageModelSource[]> {
+	return Promise.all(sources.map(async (source) => {
+		try {
+			const session = await vscode.authentication.getSession(
+				source.provider.id, [], { silent: true }
+			);
+			if (session) {
+				return { ...source, signedIn: true };
+			}
+		} catch (err) {
+			if (!(err instanceof Error) || !err.message.includes('is currently registered')) {
+				throw err;
+			}
+		}
+		return source;
+	}));
+}
+
+/**
+ * Show the language model configuration dialog. Enriches the caller-provided
+ * sources with credential state from this extension's auth providers, then
+ * delegates to the Positron core modal.
+ *
+ * Called via `vscode.commands.executeCommand('authentication.configureProviders', sources, options)`.
+ */
+export async function showConfigurationDialog(
+	sources: positron.ai.LanguageModelSource[],
+	options?: positron.ai.ShowLanguageModelConfigOptions
+): Promise<void> {
+	const enrichedSources = await enrichWithCredentialState(sources);
+
+	return positron.ai.showLanguageModelConfig(
+		enrichedSources,
+		async (_config, action) => {
+			switch (action) {
+				case 'save':
+					// Phase 3: store API key via ApiKeyAuthenticationProvider
+					break;
+				case 'delete':
+					// Phase 3: remove auth session
+					break;
+				case 'oauth-signin':
+					// Phase 5: handle OAuth sign-in
+					break;
+				case 'oauth-signout':
+					// Phase 5: handle OAuth sign-out
+					break;
+				case 'cancel':
+					// Phase 5: cancel pending OAuth operations
+					break;
+				default:
+					throw new Error(
+						vscode.l10n.t('Invalid action: {0}', action)
+					);
+			}
+		},
+		options
+	);
+}

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -9,7 +9,7 @@ import { randomUUID } from 'crypto';
 import { ApiKeyAuthenticationProvider } from './apiKeyProvider';
 import { log } from './log';
 
-const apiKeyProviders = new Map<string, ApiKeyAuthenticationProvider>();
+export const apiKeyProviders = new Map<string, ApiKeyAuthenticationProvider>();
 
 /**
  * Register an API key provider so the config dialog can store/remove

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -48,7 +48,8 @@ async function enrichWithCredentialState(
 				return { ...source, signedIn: true };
 			}
 		} catch (err) {
-			log.warn(`Failed to check credential state for ${source.provider.id}: ${err}`);
+			log.error(`Failed to check credential state for ${source.provider.id}: ${err instanceof Error ? err.message : String(err)}`);
+			throw err;
 		}
 		return source;
 	}));

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -9,6 +9,12 @@ import { randomUUID } from 'crypto';
 import { ApiKeyAuthenticationProvider } from './apiKeyProvider';
 import { log } from './log';
 
+export interface ConfigDialogResult {
+	action: string;
+	config: positron.ai.LanguageModelConfig;
+	accountId?: string;
+}
+
 export const apiKeyProviders = new Map<string, ApiKeyAuthenticationProvider>();
 
 /**
@@ -50,33 +56,51 @@ async function enrichWithCredentialState(
 /**
  * Show the language model configuration dialog. Enriches the caller-provided
  * sources with credential state from this extension's auth providers, then
- * delegates to the Positron core modal.
+ * delegates to the core modal.
+ *
+ * For providers with a registered auth provider, credential storage and
+ * removal are handled directly within this callback. For all other
+ * providers the action is recorded and returned so the caller can handle
+ * model lifecycle.
  *
  * Called via `vscode.commands.executeCommand('authentication.configureProviders', sources, options)`.
  */
 export async function showConfigurationDialog(
 	sources: positron.ai.LanguageModelSource[],
 	options?: positron.ai.ShowLanguageModelConfigOptions
-): Promise<void> {
+): Promise<ConfigDialogResult[]> {
 	const enrichedSources = await enrichWithCredentialState(sources);
 	log.info(`Opening config dialog with ${enrichedSources.length} source(s)`);
 
-	return positron.ai.showLanguageModelConfig(
+	const results: ConfigDialogResult[] = [];
+
+	await positron.ai.showLanguageModelConfig(
 		enrichedSources,
 		async (config, action) => {
 			log.info(`Config dialog action: "${action}" for provider "${config.provider}"`);
 			switch (action) {
-				case 'save':
-					await handleSave(config);
+				case 'save': {
+					if (apiKeyProviders.has(config.provider)) {
+						const accountId = await handleSave(config);
+						results.push({ action, config, accountId });
+					} else {
+						results.push({ action, config });
+					}
 					break;
+				}
 				case 'delete':
-					await handleDelete(config);
+					if (apiKeyProviders.has(config.provider)) {
+						await handleDelete(config);
+					}
+					results.push({ action, config });
 					break;
 				case 'oauth-signin':
 					// Phase 5: handle OAuth sign-in
+					results.push({ action, config });
 					break;
 				case 'oauth-signout':
 					// Phase 5: handle OAuth sign-out
+					results.push({ action, config });
 					break;
 				case 'cancel':
 					// Phase 5: cancel pending OAuth operations
@@ -89,9 +113,17 @@ export async function showConfigurationDialog(
 		},
 		options
 	);
+
+	return results;
 }
 
-async function handleSave(config: positron.ai.LanguageModelConfig): Promise<void> {
+/**
+ * Store the API key credential. Returns the generated account ID so the
+ * caller can use it for model registration.
+ */
+async function handleSave(
+	config: positron.ai.LanguageModelConfig
+): Promise<string> {
 	const provider = apiKeyProviders.get(config.provider);
 	if (!provider) {
 		throw new Error(
@@ -102,11 +134,15 @@ async function handleSave(config: positron.ai.LanguageModelConfig): Promise<void
 	if (!apiKey) {
 		throw new Error(vscode.l10n.t('API key is required'));
 	}
-	log.info(`Saving credential for provider "${config.provider}", name "${config.name}"`);
-	await provider.storeKey(randomUUID(), config.name, apiKey);
+	const accountId = randomUUID();
+	log.info(`Saving credential for provider "${config.provider}", name "${config.name}" (${accountId})`);
+	await provider.storeKey(accountId, config.name, apiKey);
+	return accountId;
 }
 
-async function handleDelete(config: positron.ai.LanguageModelConfig): Promise<void> {
+async function handleDelete(
+	config: positron.ai.LanguageModelConfig
+): Promise<void> {
 	const provider = apiKeyProviders.get(config.provider);
 	if (!provider) {
 		log.warn(`handleDelete: no auth provider for "${config.provider}"`);

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -37,6 +37,9 @@ async function enrichWithCredentialState(
 	sources: positron.ai.LanguageModelSource[]
 ): Promise<positron.ai.LanguageModelSource[]> {
 	return Promise.all(sources.map(async (source) => {
+		if (!apiKeyProviders.has(source.provider.id)) {
+			return source;
+		}
 		try {
 			const session = await vscode.authentication.getSession(
 				source.provider.id, [], { silent: true }
@@ -45,9 +48,7 @@ async function enrichWithCredentialState(
 				return { ...source, signedIn: true };
 			}
 		} catch (err) {
-			if (!(err instanceof Error) || !err.message.includes('is currently registered')) {
-				throw err;
-			}
+			log.warn(`Failed to check credential state for ${source.provider.id}: ${err}`);
 		}
 		return source;
 	}));

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -49,7 +49,6 @@ async function enrichWithCredentialState(
 			}
 		} catch (err) {
 			log.error(`Failed to check credential state for ${source.provider.id}: ${err instanceof Error ? err.message : String(err)}`);
-			throw err;
 		}
 		return source;
 	}));

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -4,7 +4,19 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import * as positron from 'positron';
+import { showConfigurationDialog } from './configDialog';
 
 export function activate(context: vscode.ExtensionContext) {
-	// Authentication providers will be registered in subsequent phases.
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'authentication.configureProviders',
+			async (
+				sources?: positron.ai.LanguageModelSource[],
+				options?: positron.ai.ShowLanguageModelConfigOptions
+			) => {
+				await showConfigurationDialog(sources ?? [], options);
+			}
+		)
+	);
 }

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -30,7 +30,7 @@ export function activate(context: vscode.ExtensionContext) {
 			async (providerId: string, accountId: string, label: string, key: string) => {
 				const provider = apiKeyProviders.get(providerId);
 				if (!provider) {
-					throw new Error(`No auth provider registered for ${providerId}`);
+					throw new Error(vscode.l10n.t("No auth provider registered for {0}", providerId));
 				}
 				const existing = await provider.getSessions([], { account: { id: accountId, label: '' } });
 				if (existing.length > 0) {

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { ApiKeyAuthenticationProvider } from './apiKeyProvider';
-import { registerApiKeyProvider, showConfigurationDialog } from './configDialog';
+import { apiKeyProviders, registerApiKeyProvider, showConfigurationDialog } from './configDialog';
 import { log } from './log';
 
 export function activate(context: vscode.ExtensionContext) {
@@ -23,6 +23,36 @@ export function activate(context: vscode.ExtensionContext) {
 				options?: positron.ai.ShowLanguageModelConfigOptions
 			) => {
 				await showConfigurationDialog(sources ?? [], options);
+			}
+		),
+		vscode.commands.registerCommand(
+			'authentication.storeApiKey',
+			async (providerId: string, accountId: string, label: string, key: string) => {
+				const provider = apiKeyProviders.get(providerId);
+				if (!provider) {
+					throw new Error(`No auth provider registered for ${providerId}`);
+				}
+				await provider.storeKey(accountId, label, key);
+			}
+		),
+		vscode.commands.registerCommand(
+			'authentication.removeApiKey',
+			async (providerId: string, accountId: string) => {
+				const provider = apiKeyProviders.get(providerId);
+				if (!provider) {
+					throw new Error(`No auth provider registered for ${providerId}`);
+				}
+				await provider.removeSession(accountId);
+			}
+		),
+		// TODO: Remove before merging. Dev-only command for testing auth flow.
+		vscode.commands.registerCommand(
+			'authentication.testSignIn',
+			async () => {
+				const session = await vscode.authentication.getSession(
+					'anthropic-api', [], { createIfNone: true }
+				);
+				log.info(`Test sign-in result: ${session.account.label} (${session.account.id})`);
 			}
 		)
 	);

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -22,37 +22,22 @@ export function activate(context: vscode.ExtensionContext) {
 				sources?: positron.ai.LanguageModelSource[],
 				options?: positron.ai.ShowLanguageModelConfigOptions
 			) => {
-				await showConfigurationDialog(sources ?? [], options);
+				return showConfigurationDialog(sources ?? [], options);
 			}
 		),
 		vscode.commands.registerCommand(
-			'authentication.storeApiKey',
+			'authentication.migrateApiKey',
 			async (providerId: string, accountId: string, label: string, key: string) => {
 				const provider = apiKeyProviders.get(providerId);
 				if (!provider) {
 					throw new Error(`No auth provider registered for ${providerId}`);
 				}
-				await provider.storeKey(accountId, label, key);
-			}
-		),
-		vscode.commands.registerCommand(
-			'authentication.removeApiKey',
-			async (providerId: string, accountId: string) => {
-				const provider = apiKeyProviders.get(providerId);
-				if (!provider) {
-					throw new Error(`No auth provider registered for ${providerId}`);
+				const existing = await provider.getSessions([], { account: { id: accountId, label: '' } });
+				if (existing.length > 0) {
+					log.info(`Skipping migration for ${providerId}/${accountId}: session already exists`);
+					return;
 				}
-				await provider.removeSession(accountId);
-			}
-		),
-		// TODO: Remove before merging. Dev-only command for testing auth flow.
-		vscode.commands.registerCommand(
-			'authentication.testSignIn',
-			async () => {
-				const session = await vscode.authentication.getSession(
-					'anthropic-api', [], { createIfNone: true }
-				);
-				log.info(`Test sign-in result: ${session.account.label} (${session.account.id})`);
+				await provider.storeKey(accountId, label, key);
 			}
 		)
 	);

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -5,9 +5,16 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { showConfigurationDialog } from './configDialog';
+import { ApiKeyAuthenticationProvider } from './apiKeyProvider';
+import { registerApiKeyProvider, showConfigurationDialog } from './configDialog';
+import { log } from './log';
 
 export function activate(context: vscode.ExtensionContext) {
+	context.subscriptions.push(log);
+
+	registerAnthropicProvider(context);
+	log.info('Authentication extension activated');
+
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'authentication.configureProviders',
@@ -19,4 +26,19 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 		)
 	);
+}
+
+function registerAnthropicProvider(context: vscode.ExtensionContext): void {
+	const provider = new ApiKeyAuthenticationProvider(
+		'anthropic-api', 'Anthropic', context
+	);
+	context.subscriptions.push(
+		vscode.authentication.registerAuthenticationProvider(
+			'anthropic-api', 'Anthropic', provider,
+			{ supportsMultipleAccounts: true }
+		),
+		provider
+	);
+	registerApiKeyProvider('anthropic-api', provider);
+	log.info('Registered auth provider: anthropic-api');
 }

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+	// Authentication providers will be registered in subsequent phases.
+}

--- a/extensions/authentication/src/log.ts
+++ b/extensions/authentication/src/log.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export const log: vscode.LogOutputChannel =
+	vscode.window.createOutputChannel('Authentication', { log: true });

--- a/extensions/authentication/tsconfig.json
+++ b/extensions/authentication/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"target": "es2020",
+		"lib": ["es2020"],
+		"outDir": "out",
+		"sourceMap": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"rootDir": "src"
+	},
+	"include": [
+		"src/**/*",
+		"../../src/vscode-dts/vscode.d.ts",
+		"../../src/positron-dts/positron.d.ts"
+	],
+	"exclude": ["node_modules"]
+}

--- a/extensions/positron-assistant/src/authExtRouting.ts
+++ b/extensions/positron-assistant/src/authExtRouting.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// --- Start Positron ---
+// Temporary routing layer for per-provider credential migration to the
+// authentication extension. Providers listed here store and read API keys
+// through the auth extension's vscode.authentication API instead of
+// context.secrets directly. Remove this file when all providers are migrated
+// (Phase 7).
+// --- End Positron ---
+
+import * as vscode from 'vscode';
+
+/** Providers whose credentials are managed by the authentication extension. */
+const AUTH_EXT_PROVIDERS = new Set<string>([
+	'anthropic-api',
+]);
+
+export function isAuthExtProvider(providerId: string): boolean {
+	return AUTH_EXT_PROVIDERS.has(providerId);
+}
+
+export async function storeApiKey(
+	providerId: string,
+	accountId: string,
+	label: string,
+	key: string
+): Promise<void> {
+	await vscode.commands.executeCommand(
+		'authentication.storeApiKey', providerId, accountId, label, key
+	);
+}
+
+export async function getApiKey(
+	providerId: string,
+	accountId: string
+): Promise<string | undefined> {
+	try {
+		const session = await vscode.authentication.getSession(
+			providerId, [], { silent: true, account: { id: accountId, label: '' } }
+		);
+		return session?.accessToken;
+	} catch {
+		return undefined;
+	}
+}
+
+export async function removeApiKey(
+	providerId: string,
+	accountId: string
+): Promise<void> {
+	await vscode.commands.executeCommand(
+		'authentication.removeApiKey', providerId, accountId
+	);
+}

--- a/extensions/positron-assistant/src/authExtRouting.ts
+++ b/extensions/positron-assistant/src/authExtRouting.ts
@@ -69,8 +69,12 @@ export async function getApiKeyWithMigration(
 		return undefined;
 	}
 	log.info(`Migrating legacy API key for ${providerId}/${accountId} to auth extension`);
-	await storeApiKey(providerId, accountId, label, legacyKey);
-	await secrets.delete(`apiKey-${accountId}`);
+	try {
+		await storeApiKey(providerId, accountId, label, legacyKey);
+		await secrets.delete(`apiKey-${accountId}`);
+	} catch (err) {
+		log.warn(`Migration failed for ${providerId}/${accountId}, using legacy key: ${err}`);
+	}
 	return legacyKey;
 }
 

--- a/extensions/positron-assistant/src/authExtRouting.ts
+++ b/extensions/positron-assistant/src/authExtRouting.ts
@@ -12,6 +12,7 @@
 // --- End Positron ---
 
 import * as vscode from 'vscode';
+import { log } from './log.js';
 
 /** Providers whose credentials are managed by the authentication extension. */
 const AUTH_EXT_PROVIDERS = new Set<string>([
@@ -42,9 +43,35 @@ export async function getApiKey(
 			providerId, [], { silent: true, account: { id: accountId, label: '' } }
 		);
 		return session?.accessToken;
-	} catch {
+	} catch (err) {
+		log.warn(`Failed to read auth session for ${providerId}/${accountId}: ${err}`);
 		return undefined;
 	}
+}
+
+/**
+ * Migrate a legacy API key from context.secrets to the auth extension.
+ * Returns the key if migration succeeded or the key was already in the
+ * auth extension; undefined if no key exists anywhere.
+ */
+export async function getApiKeyWithMigration(
+	providerId: string,
+	accountId: string,
+	label: string,
+	secrets: vscode.SecretStorage
+): Promise<string | undefined> {
+	const authKey = await getApiKey(providerId, accountId);
+	if (authKey) {
+		return authKey;
+	}
+	const legacyKey = await secrets.get(`apiKey-${accountId}`);
+	if (!legacyKey) {
+		return undefined;
+	}
+	log.info(`Migrating legacy API key for ${providerId}/${accountId} to auth extension`);
+	await storeApiKey(providerId, accountId, label, legacyKey);
+	await secrets.delete(`apiKey-${accountId}`);
+	return legacyKey;
 }
 
 export async function removeApiKey(

--- a/extensions/positron-assistant/src/authExtRouting.ts
+++ b/extensions/positron-assistant/src/authExtRouting.ts
@@ -10,7 +10,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { log } from './log.js';
+import { ModelProviderLogger } from './providers/base/modelProviderLogger.js';
 
 /** Result returned by the auth extension's config dialog command. */
 export interface ConfigDialogResult {
@@ -39,26 +39,28 @@ export async function getApiKey(
 	label: string,
 	secrets: vscode.SecretStorage
 ): Promise<string | undefined> {
+	const providerLogger = new ModelProviderLogger(label);
 	try {
 		const session = await vscode.authentication.getSession(
 			providerId, [], { silent: true, account: { id: accountId, label: '' } }
 		);
 		if (session?.accessToken) {
+			providerLogger.logAuthentication('success', 'via Authentication extension');
 			return session.accessToken;
 		}
 	} catch (err) {
-		log.warn(`Failed to read auth session for ${providerId}/${accountId}: ${err}`);
+		providerLogger.warn(`Failed to read auth session for ${accountId}`, err);
 	}
 	const legacyKey = await secrets.get(`apiKey-${accountId}`);
 	if (legacyKey) {
-		log.info(`Migrating legacy API key for ${providerId}/${accountId} to auth extension`);
+		providerLogger.info(`Migrating legacy API key for ${accountId} to auth extension`);
 		try {
 			await vscode.commands.executeCommand(
 				'authentication.migrateApiKey', providerId, accountId, label, legacyKey
 			);
 			await secrets.delete(`apiKey-${accountId}`);
 		} catch (err) {
-			log.warn(`Migration failed for ${providerId}/${accountId}, using legacy key: ${err}`);
+			providerLogger.warn(`Migration failed for ${accountId}, using legacy key`, err);
 		}
 	}
 	return legacyKey;

--- a/extensions/positron-assistant/src/authExtRouting.ts
+++ b/extensions/positron-assistant/src/authExtRouting.ts
@@ -3,16 +3,21 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// --- Start Positron ---
 // Temporary routing layer for per-provider credential migration to the
-// authentication extension. Providers listed here store and read API keys
-// through the auth extension's vscode.authentication API instead of
-// context.secrets directly. Remove this file when all providers are migrated
-// (Phase 7).
-// --- End Positron ---
+// authentication extension. Authentication for these providers are managed by
+// the auth extension's vscode.authentication API.
+// Remove this file when all providers are migrated.
 
 import * as vscode from 'vscode';
+import * as positron from 'positron';
 import { log } from './log.js';
+
+/** Result returned by the auth extension's config dialog command. */
+export interface ConfigDialogResult {
+	action: string;
+	config: positron.ai.LanguageModelConfig;
+	accountId?: string;
+}
 
 /** Providers whose credentials are managed by the authentication extension. */
 const AUTH_EXT_PROVIDERS = new Set<string>([
@@ -23,66 +28,52 @@ export function isAuthExtProvider(providerId: string): boolean {
 	return AUTH_EXT_PROVIDERS.has(providerId);
 }
 
-export async function storeApiKey(
-	providerId: string,
-	accountId: string,
-	label: string,
-	key: string
-): Promise<void> {
-	await vscode.commands.executeCommand(
-		'authentication.storeApiKey', providerId, accountId, label, key
-	);
-}
-
-export async function getApiKey(
-	providerId: string,
-	accountId: string
-): Promise<string | undefined> {
-	try {
-		const session = await vscode.authentication.getSession(
-			providerId, [], { silent: true, account: { id: accountId, label: '' } }
-		);
-		return session?.accessToken;
-	} catch (err) {
-		log.warn(`Failed to read auth session for ${providerId}/${accountId}: ${err}`);
-		return undefined;
-	}
-}
-
 /**
- * Migrate a legacy API key from context.secrets to the auth extension.
- * Returns the key if migration succeeded or the key was already in the
- * auth extension; undefined if no key exists anywhere.
+ * Read an API key from the auth extension via vscode.authentication.
+ * Falls back to context.secrets for legacy keys and migrates them to
+ * the auth extension on first read.
  */
-export async function getApiKeyWithMigration(
+export async function getApiKey(
 	providerId: string,
 	accountId: string,
 	label: string,
 	secrets: vscode.SecretStorage
 ): Promise<string | undefined> {
-	const authKey = await getApiKey(providerId, accountId);
-	if (authKey) {
-		return authKey;
+	try {
+		const session = await vscode.authentication.getSession(
+			providerId, [], { silent: true, account: { id: accountId, label: '' } }
+		);
+		if (session?.accessToken) {
+			return session.accessToken;
+		}
+	} catch (err) {
+		log.warn(`Failed to read auth session for ${providerId}/${accountId}: ${err}`);
 	}
 	const legacyKey = await secrets.get(`apiKey-${accountId}`);
-	if (!legacyKey) {
-		return undefined;
-	}
-	log.info(`Migrating legacy API key for ${providerId}/${accountId} to auth extension`);
-	try {
-		await storeApiKey(providerId, accountId, label, legacyKey);
-		await secrets.delete(`apiKey-${accountId}`);
-	} catch (err) {
-		log.warn(`Migration failed for ${providerId}/${accountId}, using legacy key: ${err}`);
+	if (legacyKey) {
+		log.info(`Migrating legacy API key for ${providerId}/${accountId} to auth extension`);
+		try {
+			await vscode.commands.executeCommand(
+				'authentication.migrateApiKey', providerId, accountId, label, legacyKey
+			);
+			await secrets.delete(`apiKey-${accountId}`);
+		} catch (err) {
+			log.warn(`Migration failed for ${providerId}/${accountId}, using legacy key: ${err}`);
+		}
 	}
 	return legacyKey;
 }
 
-export async function removeApiKey(
-	providerId: string,
-	accountId: string
-): Promise<void> {
-	await vscode.commands.executeCommand(
-		'authentication.removeApiKey', providerId, accountId
+/**
+ * Delegate the config dialog to the authentication extension.
+ * Returns the actions taken so the caller can handle model lifecycle.
+ */
+export async function delegateConfigDialog(
+	sources: positron.ai.LanguageModelSource[],
+	options?: positron.ai.ShowLanguageModelConfigOptions
+): Promise<ConfigDialogResult[]> {
+	const results = await vscode.commands.executeCommand<ConfigDialogResult[]>(
+		'authentication.configureProviders', sources, options
 	);
+	return results ?? [];
 }

--- a/extensions/positron-assistant/src/authExtRouting.ts
+++ b/extensions/positron-assistant/src/authExtRouting.ts
@@ -67,6 +67,19 @@ export async function getApiKey(
 }
 
 /**
+ * Resolve an API key for a stored model config. Routes to the auth
+ * extension for migrated providers, falls back to legacy secret storage.
+ */
+export async function resolveApiKey(
+	config: { provider: string; id: string; name: string },
+	secrets: vscode.SecretStorage
+): Promise<string | undefined> {
+	return isAuthExtProvider(config.provider)
+		? getApiKey(config.provider, config.id, config.name, secrets)
+		: secrets.get(`apiKey-${config.id}`);
+}
+
+/**
  * Delegate the config dialog to the authentication extension.
  * Returns the actions taken so the caller can handle model lifecycle.
  */

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -17,7 +17,7 @@ import { PositModelProvider } from './providers/posit/positProvider.js';
 import { PROVIDER_ENABLE_SETTINGS_SEARCH } from './constants.js';
 import { StoredModelConfig, ModelConfig } from './configTypes.js';
 // --- Start Positron ---
-import { isAuthExtProvider, storeApiKey, getApiKey, removeApiKey } from './authExtRouting.js';
+import { isAuthExtProvider, storeApiKey, getApiKeyWithMigration, removeApiKey } from './authExtRouting.js';
 // --- End Positron ---
 
 export function getStoredModels(context: vscode.ExtensionContext): StoredModelConfig[] {
@@ -34,7 +34,7 @@ export async function getModelConfiguration(id: string, context: vscode.Extensio
 
 	// --- Start Positron ---
 	const apiKey = isAuthExtProvider(config.provider)
-		? await getApiKey(config.provider, config.id)
+		? await getApiKeyWithMigration(config.provider, config.id, config.name, context.secrets)
 		: await context.secrets.get(`apiKey-${config.id}`);
 	// --- End Positron ---
 	return {
@@ -50,7 +50,7 @@ export async function getModelConfigurations(context: vscode.ExtensionContext): 
 		storedConfigs.map(async (config) => {
 			// --- Start Positron ---
 			const apiKey = isAuthExtProvider(config.provider)
-				? await getApiKey(config.provider, config.id)
+				? await getApiKeyWithMigration(config.provider, config.id, config.name, context.secrets)
 				: await context.secrets.get(`apiKey-${config.id}`);
 			// --- End Positron ---
 			return {

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -16,7 +16,7 @@ import { PositronAssistantApi } from './api.js';
 import { PositModelProvider } from './providers/posit/positProvider.js';
 import { PROVIDER_ENABLE_SETTINGS_SEARCH } from './constants.js';
 import { StoredModelConfig, ModelConfig } from './configTypes.js';
-import { isAuthExtProvider, getApiKey, delegateConfigDialog } from './authExtRouting.js';
+import { isAuthExtProvider, resolveApiKey, delegateConfigDialog } from './authExtRouting.js';
 
 export function getStoredModels(context: vscode.ExtensionContext): StoredModelConfig[] {
 	return context.globalState.get('positron.assistant.models') || [];
@@ -30,9 +30,7 @@ export async function getModelConfiguration(id: string, context: vscode.Extensio
 		return undefined;
 	}
 
-	const apiKey = isAuthExtProvider(config.provider)
-		? await getApiKey(config.provider, config.id, config.name, context.secrets)
-		: await context.secrets.get(`apiKey-${config.id}`);
+	const apiKey = await resolveApiKey(config, context.secrets);
 	return {
 		...config,
 		apiKey: apiKey || ''
@@ -44,9 +42,7 @@ export async function getModelConfigurations(context: vscode.ExtensionContext): 
 
 	const fullConfigs: ModelConfig[] = await Promise.all(
 		storedConfigs.map(async (config) => {
-			const apiKey = isAuthExtProvider(config.provider)
-				? await getApiKey(config.provider, config.id, config.name, context.secrets)
-				: await context.secrets.get(`apiKey-${config.id}`);
+			const apiKey = await resolveApiKey(config, context.secrets);
 			return {
 				...config,
 				apiKey: apiKey || ''

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -16,6 +16,9 @@ import { PositronAssistantApi } from './api.js';
 import { PositModelProvider } from './providers/posit/positProvider.js';
 import { PROVIDER_ENABLE_SETTINGS_SEARCH } from './constants.js';
 import { StoredModelConfig, ModelConfig } from './configTypes.js';
+// --- Start Positron ---
+import { isAuthExtProvider, storeApiKey, getApiKey, removeApiKey } from './authExtRouting.js';
+// --- End Positron ---
 
 export function getStoredModels(context: vscode.ExtensionContext): StoredModelConfig[] {
 	return context.globalState.get('positron.assistant.models') || [];
@@ -29,7 +32,11 @@ export async function getModelConfiguration(id: string, context: vscode.Extensio
 		return undefined;
 	}
 
-	const apiKey = await context.secrets.get(`apiKey-${config.id}`);
+	// --- Start Positron ---
+	const apiKey = isAuthExtProvider(config.provider)
+		? await getApiKey(config.provider, config.id)
+		: await context.secrets.get(`apiKey-${config.id}`);
+	// --- End Positron ---
 	return {
 		...config,
 		apiKey: apiKey || ''
@@ -41,7 +48,11 @@ export async function getModelConfigurations(context: vscode.ExtensionContext): 
 
 	const fullConfigs: ModelConfig[] = await Promise.all(
 		storedConfigs.map(async (config) => {
-			const apiKey = await context.secrets.get(`apiKey-${config.id}`);
+			// --- Start Positron ---
+			const apiKey = isAuthExtProvider(config.provider)
+				? await getApiKey(config.provider, config.id)
+				: await context.secrets.get(`apiKey-${config.id}`);
+			// --- End Positron ---
 			return {
 				...config,
 				apiKey: apiKey || ''
@@ -220,10 +231,17 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 			}
 		});
 
-	// Store API key in secret storage
+	// --- Start Positron ---
+	// Store API key: routed providers go through the auth extension,
+	// others use direct secret storage.
 	if (apiKey) {
-		await context.secrets.store(`apiKey-${id}`, apiKey);
+		if (isAuthExtProvider(userConfig.provider)) {
+			await storeApiKey(userConfig.provider, id, name, apiKey);
+		} else {
+			await context.secrets.store(`apiKey-${id}`, apiKey);
+		}
 	}
+	// --- End Positron ---
 
 	// Get existing configurations
 	const existingConfigs: Array<StoredModelConfig> = context.globalState.get('positron.assistant.models') || [];
@@ -272,7 +290,13 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 			vscode.l10n.t(`Language Model {0} has been added successfully.`, name)
 		);
 	} catch (error) {
-		await context.secrets.delete(`apiKey-${id}`);
+		// --- Start Positron ---
+		if (isAuthExtProvider(userConfig.provider)) {
+			await removeApiKey(userConfig.provider, id);
+		} else {
+			await context.secrets.delete(`apiKey-${id}`);
+		}
+		// --- End Positron ---
 		await context.globalState.update(
 			'positron.assistant.models',
 			existingConfigs
@@ -392,7 +416,13 @@ export async function deleteConfiguration(context: vscode.ExtensionContext, id: 
 		updatedConfigs
 	);
 
-	await context.secrets.delete(`apiKey-${id}`);
+	// --- Start Positron ---
+	if (isAuthExtProvider(targetConfig.provider)) {
+		await removeApiKey(targetConfig.provider, id);
+	} else {
+		await context.secrets.delete(`apiKey-${id}`);
+	}
+	// --- End Positron ---
 
 	disposeModels(id);
 

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -16,7 +16,7 @@ import { PositronAssistantApi } from './api.js';
 import { PositModelProvider } from './providers/posit/positProvider.js';
 import { PROVIDER_ENABLE_SETTINGS_SEARCH } from './constants.js';
 import { StoredModelConfig, ModelConfig } from './configTypes.js';
-import { isAuthExtProvider, getApiKey, delegateConfigDialog, ConfigDialogResult } from './authExtRouting.js';
+import { isAuthExtProvider, getApiKey, delegateConfigDialog } from './authExtRouting.js';
 
 export function getStoredModels(context: vscode.ExtensionContext): StoredModelConfig[] {
 	return context.globalState.get('positron.assistant.models') || [];
@@ -181,7 +181,9 @@ export async function showConfigurationDialog(
 		switch (result.action) {
 			case 'save':
 				if (isAuthExtProvider(result.config.provider) && result.accountId) {
-					await saveModelFromAuthResult(result, sources, context);
+					await saveModel(result.config, sources, context, {
+						id: result.accountId, skipSecretStorage: true
+					});
 				} else {
 					await saveModel(result.config, sources, context);
 				}
@@ -205,16 +207,19 @@ export async function showConfigurationDialog(
 	}
 }
 
-async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: positron.ai.LanguageModelSource[], context: vscode.ExtensionContext) {
+async function saveModel(
+	userConfig: positron.ai.LanguageModelConfig,
+	sources: positron.ai.LanguageModelSource[],
+	context: vscode.ExtensionContext,
+	options?: { id?: string; skipSecretStorage?: boolean }
+) {
 	const { name: nameRaw, model: modelRaw, baseUrl: baseUrlRaw, apiKey: apiKeyRaw, oauth: oauth, ...otherConfig } = userConfig;
 	const name = nameRaw.trim();
 	const model = modelRaw.trim();
 	const baseUrl = baseUrlRaw?.trim();
 	const apiKey = apiKeyRaw?.trim();
 
-	// Create unique ID for the configuration
-	const id = randomUUID();
-
+	const id = options?.id ?? randomUUID();
 
 	// Filter out sources that use autoconfiguration for required field validation
 	sources = sources.filter(source => source.defaults.autoconfigure === undefined);
@@ -231,8 +236,8 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 			}
 		});
 
-	// Store API key in secret storage
-	if (apiKey) {
+	// Store API key in secret storage (skipped when the auth extension owns credentials)
+	if (!options?.skipSecretStorage && apiKey) {
 		await context.secrets.store(`apiKey-${id}`, apiKey);
 	}
 
@@ -248,7 +253,6 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 		model,
 		baseUrl,
 	};
-
 
 	// Register the new model FIRST, before saving configuration
 	// Note: Autoconfigurable providers are registered upon extension activation, so don't need to be handled here.
@@ -283,71 +287,15 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 			vscode.l10n.t(`Language Model {0} has been added successfully.`, name)
 		);
 	} catch (error) {
-		await context.secrets.delete(`apiKey-${id}`);
+		if (!options?.skipSecretStorage) {
+			await context.secrets.delete(`apiKey-${id}`);
+		}
 		await context.globalState.update(
 			'positron.assistant.models',
 			existingConfigs
 		);
 		const err = error instanceof Error ? error : new Error(JSON.stringify(error));
 		throw new Error(vscode.l10n.t(`Failed to add language model {0}: {1}`, name, err.message));
-	}
-}
-
-/**
- * Register a model after the auth extension's dialog has already stored
- * the credential. Uses the accountId from the dialog result as the
- * model config ID so reads via vscode.authentication.getSession match.
- */
-async function saveModelFromAuthResult(
-	result: ConfigDialogResult,
-	sources: positron.ai.LanguageModelSource[],
-	context: vscode.ExtensionContext
-): Promise<void> {
-	const { config, accountId } = result;
-	const name = config.name.trim();
-	const model = config.model.trim();
-	const baseUrl = config.baseUrl?.trim();
-	const id = accountId!;
-
-	const existingConfigs: Array<StoredModelConfig> =
-		context.globalState.get('positron.assistant.models') || [];
-
-	const newConfig: StoredModelConfig = {
-		type: config.type,
-		provider: config.provider,
-		id,
-		name,
-		model,
-		baseUrl,
-	};
-
-	try {
-		await registerModel(newConfig, context);
-		await context.globalState.update(
-			'positron.assistant.models',
-			[...existingConfigs, newConfig]
-		);
-		positron.ai.addLanguageModelConfig(expandConfigToSource(newConfig));
-		if (baseUrl) {
-			await context.globalState.update(
-				`positron.assistant.lastBaseUrl.${newConfig.provider}`,
-				baseUrl
-			);
-		}
-		PositronAssistantApi.get().notifySignIn(name);
-		vscode.window.showInformationMessage(
-			vscode.l10n.t('Language Model {0} has been added successfully.', name)
-		);
-	} catch (error) {
-		await context.globalState.update(
-			'positron.assistant.models',
-			existingConfigs
-		);
-		const err = error instanceof Error
-			? error : new Error(JSON.stringify(error));
-		throw new Error(
-			vscode.l10n.t('Failed to add language model {0}: {1}', name, err.message)
-		);
 	}
 }
 

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -16,9 +16,7 @@ import { PositronAssistantApi } from './api.js';
 import { PositModelProvider } from './providers/posit/positProvider.js';
 import { PROVIDER_ENABLE_SETTINGS_SEARCH } from './constants.js';
 import { StoredModelConfig, ModelConfig } from './configTypes.js';
-// --- Start Positron ---
-import { isAuthExtProvider, storeApiKey, getApiKeyWithMigration, removeApiKey } from './authExtRouting.js';
-// --- End Positron ---
+import { isAuthExtProvider, getApiKey, delegateConfigDialog, ConfigDialogResult } from './authExtRouting.js';
 
 export function getStoredModels(context: vscode.ExtensionContext): StoredModelConfig[] {
 	return context.globalState.get('positron.assistant.models') || [];
@@ -32,11 +30,9 @@ export async function getModelConfiguration(id: string, context: vscode.Extensio
 		return undefined;
 	}
 
-	// --- Start Positron ---
 	const apiKey = isAuthExtProvider(config.provider)
-		? await getApiKeyWithMigration(config.provider, config.id, config.name, context.secrets)
+		? await getApiKey(config.provider, config.id, config.name, context.secrets)
 		: await context.secrets.get(`apiKey-${config.id}`);
-	// --- End Positron ---
 	return {
 		...config,
 		apiKey: apiKey || ''
@@ -48,11 +44,9 @@ export async function getModelConfigurations(context: vscode.ExtensionContext): 
 
 	const fullConfigs: ModelConfig[] = await Promise.all(
 		storedConfigs.map(async (config) => {
-			// --- Start Positron ---
 			const apiKey = isAuthExtProvider(config.provider)
-				? await getApiKeyWithMigration(config.provider, config.id, config.name, context.secrets)
+				? await getApiKey(config.provider, config.id, config.name, context.secrets)
 				: await context.secrets.get(`apiKey-${config.id}`);
-			// --- End Positron ---
 			return {
 				...config,
 				apiKey: apiKey || ''
@@ -179,30 +173,36 @@ export async function showConfigurationDialog(
 			})
 	);
 
-	// Show a modal asking user for configuration details
-	return positron.ai.showLanguageModelConfig(sources, async (userConfig, action) => {
-		switch (action) {
+	// Delegate the config dialog to the authentication extension. It
+	// handles credential storage/removal for routed providers and returns
+	// action results so we can handle model lifecycle here.
+	const results = await delegateConfigDialog(sources, { preselectedProviderId });
+	for (const result of results) {
+		switch (result.action) {
 			case 'save':
-				await saveModel(userConfig, sources, context);
+				if (isAuthExtProvider(result.config.provider) && result.accountId) {
+					await saveModelFromAuthResult(result, sources, context);
+				} else {
+					await saveModel(result.config, sources, context);
+				}
 				break;
 			case 'delete':
-				await deleteConfigurationByProvider(context, userConfig.provider);
+				await deleteConfigurationByProvider(context, result.config.provider);
 				break;
 			case 'oauth-signin':
-				await oauthSignin(userConfig, sources, context);
+				await oauthSignin(result.config, sources, context);
 				break;
 			case 'oauth-signout':
-				await oauthSignout(userConfig, sources, context);
+				await oauthSignout(result.config, sources, context);
 				break;
 			case 'cancel':
 				// User cancelled the dialog, clean up any pending operations
 				PositModelProvider.cancelCurrentSignIn();
 				break;
 			default:
-				throw new Error(vscode.l10n.t('Invalid Language Model action: {0}', action));
+				throw new Error(vscode.l10n.t('Invalid Language Model action: {0}', result.action));
 		}
-	}, { preselectedProviderId });
-
+	}
 }
 
 async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: positron.ai.LanguageModelSource[], context: vscode.ExtensionContext) {
@@ -231,17 +231,10 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 			}
 		});
 
-	// --- Start Positron ---
-	// Store API key: routed providers go through the auth extension,
-	// others use direct secret storage.
+	// Store API key in secret storage
 	if (apiKey) {
-		if (isAuthExtProvider(userConfig.provider)) {
-			await storeApiKey(userConfig.provider, id, name, apiKey);
-		} else {
-			await context.secrets.store(`apiKey-${id}`, apiKey);
-		}
+		await context.secrets.store(`apiKey-${id}`, apiKey);
 	}
-	// --- End Positron ---
 
 	// Get existing configurations
 	const existingConfigs: Array<StoredModelConfig> = context.globalState.get('positron.assistant.models') || [];
@@ -290,19 +283,71 @@ async function saveModel(userConfig: positron.ai.LanguageModelConfig, sources: p
 			vscode.l10n.t(`Language Model {0} has been added successfully.`, name)
 		);
 	} catch (error) {
-		// --- Start Positron ---
-		if (isAuthExtProvider(userConfig.provider)) {
-			await removeApiKey(userConfig.provider, id);
-		} else {
-			await context.secrets.delete(`apiKey-${id}`);
-		}
-		// --- End Positron ---
+		await context.secrets.delete(`apiKey-${id}`);
 		await context.globalState.update(
 			'positron.assistant.models',
 			existingConfigs
 		);
 		const err = error instanceof Error ? error : new Error(JSON.stringify(error));
 		throw new Error(vscode.l10n.t(`Failed to add language model {0}: {1}`, name, err.message));
+	}
+}
+
+/**
+ * Register a model after the auth extension's dialog has already stored
+ * the credential. Uses the accountId from the dialog result as the
+ * model config ID so reads via vscode.authentication.getSession match.
+ */
+async function saveModelFromAuthResult(
+	result: ConfigDialogResult,
+	sources: positron.ai.LanguageModelSource[],
+	context: vscode.ExtensionContext
+): Promise<void> {
+	const { config, accountId } = result;
+	const name = config.name.trim();
+	const model = config.model.trim();
+	const baseUrl = config.baseUrl?.trim();
+	const id = accountId!;
+
+	const existingConfigs: Array<StoredModelConfig> =
+		context.globalState.get('positron.assistant.models') || [];
+
+	const newConfig: StoredModelConfig = {
+		type: config.type,
+		provider: config.provider,
+		id,
+		name,
+		model,
+		baseUrl,
+	};
+
+	try {
+		await registerModel(newConfig, context);
+		await context.globalState.update(
+			'positron.assistant.models',
+			[...existingConfigs, newConfig]
+		);
+		positron.ai.addLanguageModelConfig(expandConfigToSource(newConfig));
+		if (baseUrl) {
+			await context.globalState.update(
+				`positron.assistant.lastBaseUrl.${newConfig.provider}`,
+				baseUrl
+			);
+		}
+		PositronAssistantApi.get().notifySignIn(name);
+		vscode.window.showInformationMessage(
+			vscode.l10n.t('Language Model {0} has been added successfully.', name)
+		);
+	} catch (error) {
+		await context.globalState.update(
+			'positron.assistant.models',
+			existingConfigs
+		);
+		const err = error instanceof Error
+			? error : new Error(JSON.stringify(error));
+		throw new Error(
+			vscode.l10n.t('Failed to add language model {0}: {1}', name, err.message)
+		);
 	}
 }
 
@@ -416,13 +461,9 @@ export async function deleteConfiguration(context: vscode.ExtensionContext, id: 
 		updatedConfigs
 	);
 
-	// --- Start Positron ---
-	if (isAuthExtProvider(targetConfig.provider)) {
-		await removeApiKey(targetConfig.provider, id);
-	} else {
+	if (!isAuthExtProvider(targetConfig.provider)) {
 		await context.secrets.delete(`apiKey-${id}`);
 	}
-	// --- End Positron ---
 
 	disposeModels(id);
 

--- a/extensions/positron-assistant/src/modelRegistration.ts
+++ b/extensions/positron-assistant/src/modelRegistration.ts
@@ -12,6 +12,9 @@ import { newCompletionProvider } from './completion';
 import { ALL_DOCUMENTS_SELECTOR } from './constants.js';
 import { AssistantError } from './errors';
 import { log } from './log.js';
+// --- Start Positron ---
+import { isAuthExtProvider, getApiKey } from './authExtRouting.js';
+// --- End Positron ---
 
 const hasChatModelsContextKey = 'positron-assistant.hasChatModels';
 
@@ -93,7 +96,11 @@ export async function registerModel(config: StoredModelConfig, context: vscode.E
 			apiKey: undefined // will be filled in below if needed
 		};
 
-		const apiKey = await context.secrets.get(`apiKey-${modelConfig.id}`);
+		// --- Start Positron ---
+		const apiKey = isAuthExtProvider(modelConfig.provider)
+			? await getApiKey(modelConfig.provider, modelConfig.id)
+			: await context.secrets.get(`apiKey-${modelConfig.id}`);
+		// --- End Positron ---
 		if (apiKey) {
 			modelConfig.apiKey = apiKey;
 		}

--- a/extensions/positron-assistant/src/modelRegistration.ts
+++ b/extensions/positron-assistant/src/modelRegistration.ts
@@ -13,7 +13,7 @@ import { ALL_DOCUMENTS_SELECTOR } from './constants.js';
 import { AssistantError } from './errors';
 import { log } from './log.js';
 // --- Start Positron ---
-import { isAuthExtProvider, getApiKey } from './authExtRouting.js';
+import { isAuthExtProvider, getApiKeyWithMigration } from './authExtRouting.js';
 // --- End Positron ---
 
 const hasChatModelsContextKey = 'positron-assistant.hasChatModels';
@@ -98,7 +98,7 @@ export async function registerModel(config: StoredModelConfig, context: vscode.E
 
 		// --- Start Positron ---
 		const apiKey = isAuthExtProvider(modelConfig.provider)
-			? await getApiKey(modelConfig.provider, modelConfig.id)
+			? await getApiKeyWithMigration(modelConfig.provider, modelConfig.id, modelConfig.name, context.secrets)
 			: await context.secrets.get(`apiKey-${modelConfig.id}`);
 		// --- End Positron ---
 		if (apiKey) {

--- a/extensions/positron-assistant/src/modelRegistration.ts
+++ b/extensions/positron-assistant/src/modelRegistration.ts
@@ -12,7 +12,7 @@ import { newCompletionProvider } from './completion';
 import { ALL_DOCUMENTS_SELECTOR } from './constants.js';
 import { AssistantError } from './errors';
 import { log } from './log.js';
-import { isAuthExtProvider, getApiKey } from './authExtRouting.js';
+import { resolveApiKey } from './authExtRouting.js';
 
 const hasChatModelsContextKey = 'positron-assistant.hasChatModels';
 
@@ -94,9 +94,7 @@ export async function registerModel(config: StoredModelConfig, context: vscode.E
 			apiKey: undefined // will be filled in below if needed
 		};
 
-		const apiKey = isAuthExtProvider(modelConfig.provider)
-			? await getApiKey(modelConfig.provider, modelConfig.id, modelConfig.name, context.secrets)
-			: await context.secrets.get(`apiKey-${modelConfig.id}`);
+		const apiKey = await resolveApiKey(modelConfig, context.secrets);
 		if (apiKey) {
 			modelConfig.apiKey = apiKey;
 		}

--- a/extensions/positron-assistant/src/modelRegistration.ts
+++ b/extensions/positron-assistant/src/modelRegistration.ts
@@ -12,9 +12,7 @@ import { newCompletionProvider } from './completion';
 import { ALL_DOCUMENTS_SELECTOR } from './constants.js';
 import { AssistantError } from './errors';
 import { log } from './log.js';
-// --- Start Positron ---
-import { isAuthExtProvider, getApiKeyWithMigration } from './authExtRouting.js';
-// --- End Positron ---
+import { isAuthExtProvider, getApiKey } from './authExtRouting.js';
 
 const hasChatModelsContextKey = 'positron-assistant.hasChatModels';
 
@@ -96,11 +94,9 @@ export async function registerModel(config: StoredModelConfig, context: vscode.E
 			apiKey: undefined // will be filled in below if needed
 		};
 
-		// --- Start Positron ---
 		const apiKey = isAuthExtProvider(modelConfig.provider)
-			? await getApiKeyWithMigration(modelConfig.provider, modelConfig.id, modelConfig.name, context.secrets)
+			? await getApiKey(modelConfig.provider, modelConfig.id, modelConfig.name, context.secrets)
 			: await context.secrets.get(`apiKey-${modelConfig.id}`);
-		// --- End Positron ---
 		if (apiKey) {
 			modelConfig.apiKey = apiKey;
 		}

--- a/extensions/positron-assistant/src/test/config.test.ts
+++ b/extensions/positron-assistant/src/test/config.test.ts
@@ -124,7 +124,10 @@ suite('Configuration Dialog Tests', () => {
 			await showConfigurationDialog(mockContext);
 
 			assert.ok(!mockShowInformationMessage.called, 'Should not show information message');
-			assert.ok(mockShowLanguageModelConfig.called, 'Should show configuration dialog');
+			const delegateCall = mockExecuteCommand.getCalls().find(
+				(c: sinon.SinonSpyCall) => c.args[0] === 'authentication.configureProviders'
+			);
+			assert.ok(delegateCall, 'Should delegate to auth extension config dialog');
 		});
 	});
 });

--- a/product.json
+++ b/product.json
@@ -654,6 +654,9 @@
 		],
 		"posit-workbench": [
 			"positron.positron-assistant"
+		],
+		"anthropic-api": [
+			"positron.positron-assistant"
 		]
 	}
 }

--- a/product.json
+++ b/product.json
@@ -656,6 +656,7 @@
 			"positron.positron-assistant"
 		],
 		"anthropic-api": [
+			"positron.authentication",
 			"positron.positron-assistant"
 		]
 	}

--- a/src/vs/workbench/contrib/authentication/browser/actions/manageTrustedExtensionsForAccountAction.ts
+++ b/src/vs/workbench/contrib/authentication/browser/actions/manageTrustedExtensionsForAccountAction.ts
@@ -154,7 +154,7 @@ class ManageTrustedExtensionsForAccountActionImpl {
 		const _toQuickPickItem = this._toQuickPickItem.bind(this);
 		return [
 			...otherExtensions.sort(sortByLastUsed).map(_toQuickPickItem),
-			{ type: 'separator', label: localize('trustedExtensions', "Trusted by Microsoft") } satisfies IQuickPickSeparator,
+			{ type: 'separator', label: localize('trustedExtensions', "Trusted by Positron") } satisfies IQuickPickSeparator,
 			...trustedExtensions.sort(sortByLastUsed).map(_toQuickPickItem)
 		];
 	}


### PR DESCRIPTION
First PR for #12374 

Adds an Authentication extension that centralizes credential management using VS Code's `AuthenticationProvider` API. Migrates Anthropic API key handling as the first provider, and adds a temporary, per-provider routing layer to Assistant for incremental migration of the remaining providers.

The Authentication extension logs to "Authentication" in the output pane: 
<img width="1064" height="255" alt="image" src="https://github.com/user-attachments/assets/930540aa-8200-4af6-a7ed-37fc52dcb149" />

Anthropic creds are now managed as an Account: 
<img width="668" height="208" alt="image" src="https://github.com/user-attachments/assets/26bb4663-b13f-488b-a8ac-bfcf97803e7d" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes
@:assistant

- The user facing changes from this PR should be subtle
- Configured Anthropic credentials should continue to work without needing to be reauthenticated, but Anthropic will now appear in the Accounts menu and the auth will be logged to "Authentication" in the output pane. The Configure Language Model Providers modal should still continue to work for all providers.
