### PR TITLE
Add support for `Module` in r-versions configuration file

### DIFF
--- a/extensions/positron-environment-modules/src/api.ts
+++ b/extensions/positron-environment-modules/src/api.ts
@@ -56,6 +56,22 @@ export interface EnvironmentModulesApi {
 	): Promise<ModuleResolvedInterpreter | undefined>;
 
 	/**
+	 * Resolve an interpreter by directly specifying modules to load.
+	 *
+	 * Unlike resolveInterpreter(), this does not look up environment configuration
+	 * from settings. Use this when the module names come from an external source
+	 * (e.g., r-versions file) rather than from user settings.
+	 *
+	 * @param modules Array of module names to load
+	 * @param options Options specifying how to find and parse the interpreter
+	 * @returns Resolved interpreter info, or undefined if resolution failed
+	 */
+	resolveInterpreterFromModules(
+		modules: string[],
+		options: Omit<ResolveInterpreterOptions, 'environmentName'> & { environmentName?: string }
+	): Promise<ModuleResolvedInterpreter | undefined>;
+
+	/**
 	 * Build the startup command string for loading modules.
 	 *
 	 * @param modules Array of module names to load

--- a/extensions/positron-environment-modules/src/extension.ts
+++ b/extensions/positron-environment-modules/src/extension.ts
@@ -130,6 +130,36 @@ class EnvironmentModulesApiImpl implements EnvironmentModulesApi {
 	}
 
 	/**
+	 * Resolve an interpreter by directly specifying modules to load.
+	 *
+	 * Unlike resolveInterpreter(), this does not look up environment configuration
+	 * from settings. Use this when the module names come from an external source
+	 * (e.g., r-versions file) rather than from user settings.
+	 */
+	async resolveInterpreterFromModules(
+		modules: string[],
+		options: Omit<ResolveInterpreterOptions, 'environmentName'> & { environmentName?: string }
+	): Promise<ModuleResolvedInterpreter | undefined> {
+		// Build a synthetic config from the modules array
+		const syntheticConfig: ModuleEnvironmentConfig = {
+			languages: [options.language],
+			modules: modules
+		};
+
+		// Get init script path
+		const systemInfo = await this.getModuleSystemInfo();
+		const initScript = systemInfo.initPath;
+
+		// Resolve the interpreter
+		const fullOptions: ResolveInterpreterOptions = {
+			...options,
+			environmentName: options.environmentName || modules.join(',')
+		};
+
+		return resolveModuleInterpreter(syntheticConfig, fullOptions, initScript);
+	}
+
+	/**
 	 * Build the startup command string for loading modules.
 	 * @param modules Array of module names to load
 	 * @returns Shell command string
@@ -199,6 +229,9 @@ export async function activate(
 				return new Map();
 			},
 			async resolveInterpreter(): Promise<ModuleResolvedInterpreter | undefined> {
+				return undefined;
+			},
+			async resolveInterpreterFromModules(): Promise<ModuleResolvedInterpreter | undefined> {
 				return undefined;
 			},
 			buildStartupCommand() {

--- a/extensions/positron-r/src/kernel-spec.ts
+++ b/extensions/positron-r/src/kernel-spec.ts
@@ -380,9 +380,17 @@ export async function createJupyterKernelSpec(
 		}
 	}
 
-	// If this R is from an r-versions entry with a script, source it before launching R
+	// If this R is from an r-versions entry, handle module loading and/or script sourcing
 	if (packagerMetadata && isRVersionsMetadata(packagerMetadata)) {
-		if (packagerMetadata.script) {
+		// Handle module startup command and/or script
+		// If both are specified, module loads first, then script is sourced
+		if (packagerMetadata.moduleStartupCommand && packagerMetadata.script) {
+			startup_command = `${packagerMetadata.moduleStartupCommand} && . ${packagerMetadata.script}`;
+			LOGGER.info(`Using r-versions module and script: ${startup_command}`);
+		} else if (packagerMetadata.moduleStartupCommand) {
+			startup_command = packagerMetadata.moduleStartupCommand;
+			LOGGER.info(`Using r-versions module startup command: ${startup_command}`);
+		} else if (packagerMetadata.script) {
 			// Use POSIX-compatible source syntax (.) for portability
 			startup_command = `. ${packagerMetadata.script}`;
 			LOGGER.info(`Using r-versions startup script: ${packagerMetadata.script}`);

--- a/extensions/positron-r/src/provider-module.ts
+++ b/extensions/positron-r/src/provider-module.ts
@@ -38,6 +38,11 @@ export interface EnvironmentModulesApi {
 	isAvailable(): Promise<boolean>;
 	getEnvironmentsForLanguage(language: string): Promise<Map<string, ModuleEnvironmentConfig>>;
 	resolveInterpreter(options: ResolveInterpreterOptions): Promise<ModuleResolvedInterpreter | undefined>;
+	resolveInterpreterFromModules(
+		modules: string[],
+		options: Omit<ResolveInterpreterOptions, 'environmentName'> & { environmentName?: string }
+	): Promise<ModuleResolvedInterpreter | undefined>;
+	buildStartupCommand(modules: string[]): string;
 	registerDiscoveredRuntime(
 		environmentName: string,
 		language: string,
@@ -68,7 +73,7 @@ export async function getEnvironmentModulesApi(): Promise<EnvironmentModulesApi 
  * Parse R version from `R --version` output.
  * Example output: "R version 4.3.0 (2023-04-21) -- "Already Tomorrow""
  */
-function parseRVersion(output: string): string | undefined {
+export function parseRVersion(output: string): string | undefined {
 	const match = output.match(/R version (\d+\.\d+\.\d+)/);
 	return match ? match[1] : undefined;
 }

--- a/extensions/positron-r/src/provider-rversions.ts
+++ b/extensions/positron-r/src/provider-rversions.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { RBinary } from './provider.js';
 import { ReasonDiscovered, RVersionsMetadata } from './r-installation.js';
 import { LOGGER } from './extension.js';
+import { getEnvironmentModulesApi, parseRVersion } from './provider-module.js';
 
 /**
  * Represents a single entry parsed from an r-versions file.
@@ -192,13 +193,95 @@ export async function discoverRVersionsBinaries(): Promise<RBinary[]> {
 
 	const binaries: RBinary[] = [];
 
+	// Get environment modules API for entries with Module field
+	const modulesApi = await getEnvironmentModulesApi();
+	const modulesAvailable = modulesApi ? await modulesApi.isAvailable() : false;
+
 	for (const entry of entries) {
-		// For now, only handle entries with Path field
-		// TODO: module field support will be added in a later PR
-		if (!entry.path) {
-			if (entry.module) {
-				LOGGER.info(`Skipping r-versions entry with Module field (not yet supported): ${entry.module}`);
+		// Handle entries with Module field
+		if (entry.module) {
+			if (!modulesAvailable) {
+				// Module system not available
+				if (entry.path) {
+					// Scenario A fallback: use Path without module loading
+					LOGGER.warn(`Module system not available; using Path without module for: ${entry.module}`);
+				} else {
+					// Scenario B: cannot proceed without module system
+					LOGGER.warn(`Skipping r-versions entry with Module field (module system not available): ${entry.module}`);
+					continue;
+				}
 			}
+
+			let binPath: string | undefined;
+			let moduleStartupCommand: string | undefined;
+
+			if (entry.path) {
+				// Scenario A: Module + Path - use Path for binary, build startup command for module
+				if (!fs.existsSync(entry.path)) {
+					LOGGER.warn(`R_HOME path from r-versions does not exist: ${entry.path}`);
+					continue;
+				}
+				binPath = getRBinaryFromHome(entry.path);
+				if (!binPath) {
+					continue;
+				}
+				if (modulesAvailable && modulesApi) {
+					moduleStartupCommand = modulesApi.buildStartupCommand([entry.module]);
+					LOGGER.info(`Built module startup command for ${entry.module}: ${moduleStartupCommand}`);
+				}
+			} else {
+				// Scenario B: Module only - resolve binary path via module system
+				if (!modulesAvailable || !modulesApi) {
+					// Already logged warning above
+					continue;
+				}
+
+				LOGGER.info(`Resolving R binary from module: ${entry.module}`);
+				const resolved = await modulesApi.resolveInterpreterFromModules(
+					[entry.module],
+					{
+						environmentName: entry.label || entry.module,
+						language: 'r',
+						interpreterBinaryNames: ['R'],
+						versionArgs: ['--version'],
+						parseVersion: parseRVersion
+					}
+				);
+
+				if (!resolved) {
+					LOGGER.warn(`Failed to resolve R binary from module: ${entry.module}`);
+					continue;
+				}
+
+				binPath = resolved.interpreterPath;
+				moduleStartupCommand = resolved.startupCommand;
+				LOGGER.info(`Resolved R at ${binPath} from module ${entry.module}`);
+			}
+
+			// Build metadata from r-versions entry fields
+			const metadata: RVersionsMetadata = {
+				type: 'rversions',
+				label: entry.label,
+				script: entry.script,
+				repo: entry.repo,
+				library: entry.library,
+				module: entry.module,
+				moduleStartupCommand: moduleStartupCommand,
+			};
+
+			binaries.push({
+				path: binPath,
+				reasons: [ReasonDiscovered.RVERSIONS],
+				packagerMetadata: metadata,
+			});
+
+			LOGGER.info(`Found R at ${binPath} from r-versions file (with module: ${entry.module})`);
+			continue;
+		}
+
+		// Handle entries with Path only (no Module)
+		if (!entry.path) {
+			LOGGER.warn('Skipping r-versions entry without Path or Module field');
 			continue;
 		}
 

--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -129,6 +129,10 @@ export interface RVersionsMetadata {
 	readonly repo?: string;
 	/** Colon-separated list of R library directories */
 	readonly library?: string;
+	/** Environment module to load */
+	readonly module?: string;
+	/** Pre-computed startup command for module loading */
+	readonly moduleStartupCommand?: string;
 }
 
 /**


### PR DESCRIPTION
Addresses #11426.

This PR adds support for the `Module` field in r-versions configuration files, enabling environment module loading for R installations discovered via r-versions. This is the sixth and final PR in the r-versions implementation series! 6️⃣ 

Two scenarios are supported:
- **Module + Path**: Uses the Path field for the R binary location, loads the module at startup for environment setup (e.g., compiler toolchains, MPI, optimized libraries)
- **Module only**: Resolves the R binary path dynamically via the module system

When both `Module` and `Script` fields are specified, the module loads first, then the script is sourced.

I did my local development and testing testing on macOS by temporarily patching darwin checks in the environment-modules extension, setting up Homebrew modules (`brew install modules`), creating modulefiles, and configuring MODULEPATH. This required patches to `module-system.ts`, `extension.ts`, `provider-module.ts`, and `kernel-spec.ts` to allow macOS, plus adding MODULEPATH to launch.json. I took this all out, but probably we should review with a real Linux environment modules situation.

### Release Notes

#### New Features
- Workbench: added support for reading Posit Workbench's `r-versions` configuration file to discover R installations with extended metadata. This enables administrators to configure R installations with custom labels, startup scripts, repository settings, library paths, and environment module integration for users on Linux servers. (#11426)

#### Bug Fixes
- N/A

### QA Notes

@:interpreter

Testing this out requires a Linux system with environment modules installed (e.g., Lmod or Environment Modules). Module systems are not really supported on Windows or macOS.

1. Install environment modules (if not present):
   ```bash
   # Ubuntu/Debian
   sudo apt install environment-modules
   # Or for Lmod
   sudo apt install lmod
   ```

2. Create a test modulefile at `/usr/share/modules/modulefiles/R/4.4`:
   ```tcl
   #%Module1.0
   proc ModulesHelp { } {
       puts stderr "R 4.4"
   }
   module-whatis "R 4.4"
   prepend-path PATH /opt/R/4.4.0/bin
   setenv R_HOME /opt/R/4.4.0/lib/R
   ```

3. Create an r-versions file at `/etc/rstudio/r-versions`:
   ```
   # Test Module + Path scenario
   Path: /opt/R/4.4.0/lib/R
   Module: R/4.4
   Label: R 4.4 (Module + Path test)
   
   # Test Module-only scenario
   Module: R/4.3
   Label: R 4.3 (Module-only test)
   ```

4. Launch Positron and verify:
   - Both R versions appear in the interpreter picker with their custom labels
   - Starting a session shows module loading in the logs: `Using r-versions module startup command: ...`
   - In R console, verify module loaded: `Sys.getenv("LOADEDMODULES")` should include the module name

5. Test Module + Script combination by adding a test script:
   ```
   Path: /opt/R/4.4.0/lib/R
   Module: R/4.4
   Script: /tmp/test-script.sh
   Label: R 4.4 (Module + Script test)
   ```
   Where `/tmp/test-script.sh` contains:
   ```bash
   #!/bin/bash
   export TEST_VAR="module_script_test"
   ```
   Verify in R: `Sys.getenv("TEST_VAR")` returns `"module_script_test"`
