### PR TITLE
e2e: Add ghost cell keyboard shortcut tests (`Cmd+Shift+G`)

### DIFF
--- a/test/e2e/fixtures/keybindings.json
+++ b/test/e2e/fixtures/keybindings.json
@@ -99,6 +99,10 @@
         "command": "positronNotebook.selectKernel" // Select Notebook Kernel
     },
     {
+        "key": "cmd+shift+g",
+        "command": "positronNotebook.triggerGhostCell" // Trigger Ghost Cell Suggestion
+    },
+    {
         "key": "cmd+j s",
         "command": "workbench.debug.viewlet.action.removeAllBreakpoints" // Debugger: Clear All Breakpoints
     },    {

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -73,6 +73,10 @@ export class HotKeys {
 		await this.pressHotKeys('Cmd+F', 'Search in notebook');
 	}
 
+	public async triggerGhostCell() {
+		await this.pressHotKeys('Cmd+Shift+G', 'Trigger ghost cell suggestion');
+	}
+
 	// --------------------
 	// --- File Actions ---
 	// --------------------

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -21,7 +21,7 @@ export class HotKeys {
 	}
 
 	// ----------------------
-	// --- Editing Actions ---
+	// --- Editing Actions --
 	// ----------------------
 
 	public async copy() {

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -74,10 +74,6 @@ export class PositronNotebooks extends Notebooks {
 	private searchDecoration = this.code.driver.page.locator('.findMatchInline');
 
 	// Ghost Cell
-	private static readonly GHOST_CELL_GENERATION_TIMEOUT = 5000;
-	private static readonly GHOST_CELL_RENDER_TIMEOUT = 30000;
-	private static readonly GHOST_CELL_REQUEST_TIMEOUT = 10000;
-
 	private ghostCellHeader = this.code.driver.page.locator('.ghost-cell-header');
 	private ghostCellGenerating = this.code.driver.page.locator('text=Generating suggestion...');
 	private ghostCellExplanationText = this.code.driver.page.locator('.ghost-cell-explanation-text');
@@ -1173,7 +1169,7 @@ export class PositronNotebooks extends Notebooks {
 	 */
 	async expectGhostCellGenerationVisible(): Promise<void> {
 		await test.step('Verify "Generating suggestion..." is visible', async () => {
-			await expect(this.ghostCellGenerating).toBeVisible({ timeout: PositronNotebooks.GHOST_CELL_GENERATION_TIMEOUT });
+			await expect(this.ghostCellGenerating).toBeVisible({ timeout: 5000 });
 		});
 	}
 
@@ -1183,7 +1179,7 @@ export class PositronNotebooks extends Notebooks {
 	async expectGhostCellVisible(): Promise<void> {
 		await test.step('Verify ghost cell is visible with all components', async () => {
 			// Wait for header first (indicates ghost cell is rendering)
-			await expect(this.ghostCellHeader).toBeVisible({ timeout: PositronNotebooks.GHOST_CELL_RENDER_TIMEOUT });
+			await expect(this.ghostCellHeader).toBeVisible();
 
 			// Then check all other components in parallel
 			await Promise.all([
@@ -1224,7 +1220,7 @@ export class PositronNotebooks extends Notebooks {
 	async expectGhostCellAwaitingRequest(): Promise<void> {
 		await test.step('Verify "AI suggestion available on request" is visible', async () => {
 			// Wait for the container first
-			await expect(this.ghostCellAwaitingRequest).toBeVisible({ timeout: PositronNotebooks.GHOST_CELL_REQUEST_TIMEOUT });
+			await expect(this.ghostCellAwaitingRequest).toBeVisible();
 
 			// Then check all other elements in parallel
 			await Promise.all([

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -73,6 +73,30 @@ export class PositronNotebooks extends Notebooks {
 	private searchCloseButton = this.searchWidget.getByRole('button', { name: 'Close', exact: true });
 	private searchDecoration = this.code.driver.page.locator('.findMatchInline');
 
+	// Ghost Cell
+	private static readonly GHOST_CELL_GENERATION_TIMEOUT = 5000;
+	private static readonly GHOST_CELL_RENDER_TIMEOUT = 30000;
+	private static readonly GHOST_CELL_REQUEST_TIMEOUT = 10000;
+
+	private ghostCellHeader = this.code.driver.page.locator('.ghost-cell-header');
+	private ghostCellGenerating = this.code.driver.page.locator('text=Generating suggestion...');
+	private ghostCellExplanationText = this.code.driver.page.locator('.ghost-cell-explanation-text');
+	private ghostCellModeToggle = this.code.driver.page.locator('.ghost-cell-mode-toggle');
+	private ghostCellAccept = this.code.driver.page.locator('.ghost-cell-accept');
+	private ghostCellDismiss = this.code.driver.page.locator('.ghost-cell-dismiss');
+	private ghostCellRegenerate = this.code.driver.page.locator('.ghost-cell-regenerate');
+	private ghostCellCodePreview = this.code.driver.page.locator('.ghost-cell-code-preview');
+	private ghostCellCodeText = this.code.driver.page.locator('.ghost-cell-code-text');
+	private ghostCellFooter = this.code.driver.page.locator('.ghost-cell-footer');
+	private ghostCellInfoButton = this.code.driver.page.locator('.ghost-cell-info-button');
+	private ghostCellModelInfo = this.code.driver.page.locator('.ghost-cell-model-info');
+	private ghostCellAwaitingRequest = this.code.driver.page.locator('.ghost-cell-awaiting-request');
+	private ghostCellAwaitingText = this.code.driver.page.locator('.ghost-cell-awaiting-text');
+	private ghostCellGetSuggestion = this.code.driver.page.locator('.ghost-cell-get-suggestion');
+	private ghostCellDismissButton = this.code.driver.page.locator('.ghost-cell-dismiss-button');
+	private ghostCellModeToggleContainer = this.code.driver.page.locator('.ghost-cell-mode-toggle .toggle-container');
+	private ghostCellAutomaticButton = this.code.driver.page.locator('.ghost-cell-mode-toggle .toggle-button.left');
+	private ghostCellOnDemandButton = this.code.driver.page.locator('.ghost-cell-mode-toggle .toggle-button.right');
 
 	constructor(code: Code, quickinput: QuickInput, quickaccess: QuickAccess, hotKeys: HotKeys, private contextMenu: ContextMenu) {
 		super(code, quickinput, quickaccess, hotKeys);
@@ -1141,6 +1165,129 @@ export class PositronNotebooks extends Notebooks {
 			}).toPass({ timeout: DEFAULT_TIMEOUT });
 		});
 	}
+
+	// #region Ghost Cell Verifications
+
+	/**
+	 * Verify: "Generating suggestion..." message is visible.
+	 */
+	async expectGhostCellGenerationVisible(): Promise<void> {
+		await test.step('Verify "Generating suggestion..." is visible', async () => {
+			await expect(this.ghostCellGenerating).toBeVisible({ timeout: PositronNotebooks.GHOST_CELL_GENERATION_TIMEOUT });
+		});
+	}
+
+	/**
+	 * Verify: Ghost cell is visible with all expected components.
+	 */
+	async expectGhostCellVisible(): Promise<void> {
+		await test.step('Verify ghost cell is visible with all components', async () => {
+			// Wait for header first (indicates ghost cell is rendering)
+			await expect(this.ghostCellHeader).toBeVisible({ timeout: PositronNotebooks.GHOST_CELL_RENDER_TIMEOUT });
+
+			// Then check all other components in parallel
+			await Promise.all([
+				// Header components
+				expect(this.ghostCellExplanationText).toBeVisible(),
+				expect(this.ghostCellModeToggle).toBeVisible(),
+				expect(this.ghostCellAccept).toBeVisible(),
+				expect(this.ghostCellDismiss).toBeVisible(),
+				expect(this.ghostCellRegenerate).toBeVisible(),
+
+				// Code preview
+				expect(this.ghostCellCodePreview).toBeVisible(),
+				expect(this.ghostCellCodeText).toBeVisible(),
+
+				// Footer
+				expect(this.ghostCellFooter).toBeVisible(),
+				expect(this.ghostCellInfoButton).toBeVisible(),
+				expect(this.ghostCellModelInfo).toBeVisible()
+			]);
+		});
+	}
+
+	/**
+	 * Verify: Ghost cell mode is set to the expected value.
+	 * @param automatic - True for Automatic mode, false for On-demand mode
+	 */
+	async expectGhostCellMode(automatic: boolean): Promise<void> {
+		await test.step(`Verify ghost cell mode is ${automatic ? 'Automatic' : 'On-demand'}`, async () => {
+			const button = automatic ? this.ghostCellAutomaticButton : this.ghostCellOnDemandButton;
+			// Check button has the highlighted class (indicates it's selected)
+			await expect(button).toHaveClass(/highlighted/);
+		});
+	}
+
+	/**
+	 * Verify: "AI suggestion available on request" UI is visible.
+	 */
+	async expectGhostCellAwaitingRequest(): Promise<void> {
+		await test.step('Verify "AI suggestion available on request" is visible', async () => {
+			// Wait for the container first
+			await expect(this.ghostCellAwaitingRequest).toBeVisible({ timeout: PositronNotebooks.GHOST_CELL_REQUEST_TIMEOUT });
+
+			// Then check all other elements in parallel
+			await Promise.all([
+				expect(this.ghostCellAwaitingText).toHaveText('AI suggestion available on request'),
+				expect(this.ghostCellGetSuggestion).toBeVisible(),
+				expect(this.ghostCellGetSuggestion).toHaveText('Get Suggestion'),
+				expect(this.ghostCellDismissButton).toBeVisible()
+			]);
+		});
+	}
+
+	/**
+	 * Verify: Ghost cell contains expected text.
+	 * @param expectedText - The text expected to be in the ghost cell
+	 */
+	async expectGhostCellToContainText(expectedText: string): Promise<void> {
+		await test.step(`Verify ghost cell contains text: "${expectedText}"`, async () => {
+			await expect(this.ghostCellCodeText).toContainText(expectedText);
+		});
+	}
+
+	// #endregion
+
+	// #region Ghost Cell Actions
+
+	/**
+	 * Action: Select ghost cell mode.
+	 * @param automatic - True for Automatic mode, false for On-demand mode
+	 */
+	async selectGhostCellMode(automatic: boolean): Promise<void> {
+		await test.step(`Select ghost cell mode: ${automatic ? 'Automatic' : 'On-demand'}`, async () => {
+			// Add retry logic for potentially flaky toggle
+			await expect(async () => {
+				// Click the appropriate button directly
+				const button = automatic ? this.ghostCellAutomaticButton : this.ghostCellOnDemandButton;
+				await button.click();
+
+				// Verify the mode was selected
+				await this.expectGhostCellMode(automatic);
+			}).toPass({ timeout: 5000 });
+		});
+	}
+
+	/**
+	 * Action: Accept ghost cell suggestion (clicks Accept and Run).
+	 */
+	async acceptGhostCellSuggestion(): Promise<void> {
+		await test.step('Accept ghost cell suggestion', async () => {
+			const acceptButton = this.code.driver.page.locator('.ghost-cell-accept .split-button-main');
+			await acceptButton.click();
+		});
+	}
+
+	/**
+	 * Action: Request a suggestion by clicking "Get Suggestion" button.
+	 */
+	async getSuggestion(): Promise<void> {
+		await test.step('Request suggestion', async () => {
+			await this.ghostCellGetSuggestion.click();
+		});
+	}
+
+	// #endregion
 
 	/**
 	 * Get the current scroll position of the notebook cells container.

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -142,7 +142,7 @@ export class PositronNotebooks extends Notebooks {
 
 
 	/**
-	 * Get the index of the currently focused cell.
+	 * Get the index of currently focused cell.
 	 */
 	async getFocusedCellIndex(): Promise<number | null> {
 		return await test.step(`Get focused cell index`, async () => {

--- a/test/e2e/tests/notebooks-positron/notebook-ghost-cell-keyboard-shortcut.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-ghost-cell-keyboard-shortcut.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Notebook: Ghost Cell Keyboard Shortcut', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+}, () => {
+	test.beforeAll(async function ({ app, settings }) {
+		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
+	});
+
+	test.afterEach(async function ({ hotKeys }) {
+		await hotKeys.closeAllEditors();
+	});
+
+	test('Ghost cell workflow: Automatic mode to On-demand mode with Accept and Run', async function ({ app, hotKeys }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Setup notebook with sample code
+		await notebooksPositron.newNotebook({ codeCells: 2 });
+		await notebooksPositron.addCodeToCell(0, 'import pandas as pd\ndf = pd.read_csv("data.csv")', { run: false });
+		await notebooksPositron.addCodeToCell(1, 'df_clean = df.dropna()', { run: false });
+		await notebooksPositron.selectCellAtIndex(1, { editMode: false });
+
+		// Trigger ghost cell with keyboard shortcut
+		await hotKeys.triggerGhostCell();
+
+		// Verify "Generating suggestion..." appears
+		await notebooksPositron.expectGhostCellGenerationVisible();
+
+		// Wait for ghost cell to appear and verify all components
+		await notebooksPositron.expectGhostCellVisible();
+
+		// Verify default mode is Automatic
+		await notebooksPositron.expectGhostCellMode(true);
+
+		// Switch to On-demand mode
+		await notebooksPositron.selectGhostCellMode(false);
+		// Note: selectGhostCellMode already verifies the mode was selected
+
+		// Accept and Run the suggestion
+		await notebooksPositron.acceptGhostCellSuggestion();
+
+		// Verify cell is generated and executed (cell count increases)
+		await notebooksPositron.expectCellCountToBe(3);
+
+		// Verify "AI suggestion available on request" appears for On-demand mode
+		await notebooksPositron.expectGhostCellAwaitingRequest();
+
+		// Request a suggestion to trigger generation again
+		await notebooksPositron.getSuggestion();
+
+		// Verify "Generating suggestion..." appears again
+		await notebooksPositron.expectGhostCellGenerationVisible();
+	});
+});

--- a/test/e2e/tests/notebooks-positron/notebook-ghost-cell-keyboard-shortcut.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-ghost-cell-keyboard-shortcut.test.ts
@@ -3,7 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, tags } from '../_test.setup';
+import { tags } from '../_test.setup';
+import { test } from './_test.setup.js';
 
 test.use({
 	suiteId: __filename


### PR DESCRIPTION
## Summary
Add comprehensive e2e tests for Cmd+Shift+G ghost cell keyboard shortcut:
- Test "Generating suggestion..." message appears when triggered
- Validate ghost cell header, code preview, and footer components
- Test Automatic mode (default) and On-demand mode
- Verify "AI suggestion available on request" UI
- Test Get Suggestion button triggering new generation

Addresses #12441 

@:web @:win @:positron-notebooks