### PR TITLE
fix: scope notebook action bar to its own editor group

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarControl.tsx
@@ -9,6 +9,7 @@ import './editorActionBarControl.css';
 // Other dependencies.
 import { IEditorGroupView } from './editor.js';
 import { EditorActionBar } from './editorActionBar.js';
+import { EditorGroupContext } from './editorGroupContext.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { EditorInput } from '../../../common/editor/editorInput.js';
 import { EditorActionBarFactory } from './editorActionBarFactory.js';
@@ -83,7 +84,9 @@ export class EditorActionBarControl extends Disposable {
 		// Render the editor action bar component in the editor action bar container.
 		this._positronReactRenderer = this._register(new PositronReactRenderer(this._container));
 		this._positronReactRenderer.render(
-			<EditorActionBar editorActionBarFactory={editorActionBarFactory} />
+			<EditorGroupContext.Provider value={this._editorGroup}>
+				<EditorActionBar editorActionBarFactory={editorActionBarFactory} />
+			</EditorGroupContext.Provider>
 		);
 	}
 

--- a/src/vs/workbench/browser/parts/editor/editorGroupContext.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorGroupContext.tsx
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createContext, useContext } from 'react';
+import type { IEditorGroup } from '../../../services/editor/common/editorGroupsService.js';
+
+/**
+ * React context that provides the editor group to action bar widgets.
+ * This allows widgets to resolve their state from the correct editor group
+ * rather than the globally active (focused) editor.
+ */
+export const EditorGroupContext = createContext<IEditorGroup | undefined>(undefined);
+
+/**
+ * Hook to access the editor group from the action bar context.
+ * Returns undefined if used outside of an EditorGroupContext provider.
+ */
+export function useEditorGroup(): IEditorGroup | undefined {
+	return useContext(EditorGroupContext);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/NotebookAction2.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/NotebookAction2.ts
@@ -1,26 +1,53 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { URI } from '../../../../base/common/uri.js';
+import { isEqual } from '../../../../base/common/resources.js';
 import { Action2 } from '../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
-import { getNotebookInstanceFromActiveEditorPane } from './notebookUtils.js';
+import { getNotebookInstanceFromActiveEditorPane, getNotebookInstanceFromEditorPane } from './notebookUtils.js';
 
 /**
  * Base class for notebook-level actions that operate on IPositronNotebookInstance.
  * Automatically gets the active notebook instance and passes it to the runNotebookAction method.
+ *
+ * When invoked from the editor action bar, the resource URI of the editor group's active editor
+ * is passed as the first argument, allowing the action to target the correct notebook even when
+ * multiple notebooks are open side-by-side.
  */
 export abstract class NotebookAction2 extends Action2 {
 	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
 		const editorService = accessor.get(IEditorService);
-		const activeNotebook = getNotebookInstanceFromActiveEditorPane(editorService);
-		if (!activeNotebook) {
+
+		let notebook: IPositronNotebookInstance | undefined;
+
+		// If a resource URI was passed (e.g. from the editor action bar),
+		// find the notebook instance for that specific resource.
+		const resourceUri = args[0] instanceof URI ? args[0] : undefined;
+		if (resourceUri) {
+			for (const pane of editorService.visibleEditorPanes) {
+				const candidate = getNotebookInstanceFromEditorPane(pane);
+				if (candidate && isEqual(candidate.uri, resourceUri)) {
+					notebook = candidate;
+					break;
+				}
+			}
+		}
+
+		// Fall back to the active editor pane (e.g. when invoked from command palette)
+		if (!notebook) {
+			notebook = getNotebookInstanceFromActiveEditorPane(editorService);
+		}
+
+		if (!notebook) {
 			return;
 		}
-		const result = this.runNotebookAction(activeNotebook, accessor, ...args);
+
+		const result = this.runNotebookAction(notebook, accessor, ...args);
 		// Handle both sync (void) and async (Promise) returns
 		if (result instanceof Promise) {
 			await result;
@@ -29,4 +56,3 @@ export abstract class NotebookAction2 extends Action2 {
 
 	protected abstract runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor, ...args: unknown[]): Promise<void> | void;
 }
-

--- a/src/vs/workbench/contrib/positronNotebook/browser/NotebookAction2.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/NotebookAction2.ts
@@ -27,7 +27,7 @@ export abstract class NotebookAction2 extends Action2 {
 
 		// If a resource URI was passed (e.g. from the editor action bar),
 		// find the notebook instance for that specific resource.
-		const resourceUri = args[0] instanceof URI ? args[0] : undefined;
+		const resourceUri = URI.isUri(args[0]) ? args[0] : undefined;
 		if (resourceUri) {
 			for (const pane of editorService.visibleEditorPanes) {
 				const candidate = getNotebookInstanceFromEditorPane(pane);

--- a/src/vs/workbench/contrib/positronNotebook/browser/registerNotebookWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/registerNotebookWidget.tsx
@@ -11,7 +11,8 @@ import { PositronActionBarWidgetRegistry } from '../../../../platform/positronAc
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
 import { NotebookInstanceProvider } from './NotebookInstanceProvider.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { getNotebookInstanceFromActiveEditorPane } from './notebookUtils.js';
+import { getNotebookInstanceFromActiveEditorPane, getNotebookInstanceFromEditorPane } from './notebookUtils.js';
+import { useEditorGroup } from '../../../browser/parts/editor/editorGroupContext.js';
 
 /**
  * Options for registering a notebook widget (React component without command).
@@ -120,9 +121,19 @@ export function registerNotebookWidget(options: INotebookWidgetOptions): IDispos
 		componentFactory: (accessor) => {
 			// Return a wrapper component that provides notebook context
 			return () => {
-				// Get the active notebook using the VS Code pattern
-				const editorService = accessor.get(IEditorService);
-				const notebook = getNotebookInstanceFromActiveEditorPane(editorService);
+				// Use the editor group context to resolve the notebook instance
+				// from this specific editor group rather than the global active editor.
+				const editorGroup = useEditorGroup();
+				let notebook = editorGroup
+					? getNotebookInstanceFromEditorPane(editorGroup.activeEditorPane)
+					: undefined;
+
+				// Fall back to the global active editor (e.g. command palette context)
+				if (!notebook) {
+					const editorService = accessor.get(IEditorService);
+					notebook = getNotebookInstanceFromActiveEditorPane(editorService);
+				}
+
 				if (!notebook) {
 					return null;
 				}

--- a/test/e2e/tests/notebooks-positron/notebook-side-by-side.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-side-by-side.test.ts
@@ -1,0 +1,143 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Notebook Side-by-Side Isolation Tests
+ *
+ * Verifies that when two notebooks are open side-by-side:
+ * 1. Kernel selection and status are independent per notebook
+ * 2. The "Run All" button executes cells in its own notebook, not the focused one
+ *
+ * BUG: These tests are expected to FAIL, demonstrating that kernel status is
+ * shared across notebooks and Run All targets the focused editor.
+ */
+
+import { expect, tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+import { IDLE_STATUS_ICON } from '../../pages/sessions.js';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Notebook Side-by-Side Isolation', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+}, () => {
+
+	test('Kernel status is independent per notebook when side-by-side',
+		{
+			annotation: [{ type: 'bug', description: 'Kernel selection and status is shared across side-by-side notebooks' }]
+		},
+		async function ({ app, page }) {
+			const { notebooksPositron } = app.workbench;
+			const pythonVersion = process.env.POSITRON_PY_VER_SEL!;
+
+			// Create first notebook and select Python kernel while it is the only visible notebook.
+			// POM locators are page-scoped, so they work correctly with a single notebook.
+			await test.step('Create notebook 1 and select Python kernel', async () => {
+				await notebooksPositron.newNotebook();
+				await notebooksPositron.kernel.select('Python');
+			});
+
+			// Create second notebook (opens as a new tab, hiding notebook 1).
+			// Do NOT select a kernel for this notebook.
+			await test.step('Create notebook 2 (no kernel)', async () => {
+				await notebooksPositron.newNotebook();
+			});
+
+			// Move notebook 2 to a side editor group so both are visible.
+			// After this, notebook 2 (right) is focused, notebook 1 (left) is unfocused.
+			await test.step('Split notebooks side-by-side', async () => {
+				await app.workbench.quickaccess.runCommand('workbench.action.moveEditorToNextGroup');
+			});
+
+			// Use scoped locators to verify each editor group independently.
+			// Page-level POM locators would match elements in both groups, so we scope
+			// to each .editor-group-container to test per-notebook behavior.
+			const editorGroups = page.locator('.part.editor .editor-group-container');
+			await expect(editorGroups).toHaveCount(2, { timeout: 5000 });
+
+			// Left group = notebook 1 (Python kernel selected)
+			// Right group = notebook 2 (no kernel selected)
+			const leftGroup = editorGroups.nth(0);
+			const rightGroup = editorGroups.nth(1);
+
+			await test.step('Verify left notebook (nb1) shows Python kernel', async () => {
+				const leftKernelBadge = leftGroup.getByRole('button', { name: 'Kernel Actions' });
+				await expect(leftKernelBadge).toContainText(pythonVersion, { timeout: 15000 });
+				await expect(leftGroup.locator('.editor-action-bar-container').locator(IDLE_STATUS_ICON)).toBeVisible({ timeout: 15000 });
+			});
+
+			// BUG: Kernel status is shared across notebooks. The right notebook
+			// (which has no kernel selected) incorrectly shows the Python kernel
+			// from the left notebook.
+			await test.step('Verify right notebook (nb2) does NOT show Python kernel', async () => {
+				const rightKernelBadge = rightGroup.getByRole('button', { name: 'Kernel Actions' });
+				await expect(rightKernelBadge).not.toContainText(pythonVersion, { timeout: 5000 });
+			});
+		});
+
+	test('Run All button executes cells in its own notebook, not the focused one',
+		{
+			annotation: [{ type: 'bug', description: 'Run All button is scoped to the focused editor, not the editor it is rendered in' }]
+		},
+		async function ({ app, page }) {
+			const { notebooksPositron } = app.workbench;
+
+			// Set up notebook 1 with Python code while it is the only visible notebook.
+			await test.step('Create notebook 1 with Python code', async () => {
+				await notebooksPositron.newNotebook();
+				await notebooksPositron.kernel.select('Python');
+				await notebooksPositron.addCodeToCell(0, 'print("from_nb1")');
+			});
+
+			// Set up notebook 2 with different Python code (opens as tab, nb1 hidden).
+			await test.step('Create notebook 2 with Python code', async () => {
+				await notebooksPositron.newNotebook();
+				await notebooksPositron.kernel.select('Python');
+				await notebooksPositron.addCodeToCell(0, 'print("from_nb2")');
+			});
+
+			// Move notebook 2 to a side editor group.
+			// After: nb1 (left, unfocused), nb2 (right, focused).
+			await test.step('Split notebooks side-by-side', async () => {
+				await app.workbench.quickaccess.runCommand('workbench.action.moveEditorToNextGroup');
+			});
+
+			const editorGroups = page.locator('.part.editor .editor-group-container');
+			await expect(editorGroups).toHaveCount(2, { timeout: 5000 });
+			const leftGroup = editorGroups.nth(0);
+			const rightGroup = editorGroups.nth(1);
+
+			// Focus the LEFT notebook (nb1) by clicking on its cell.
+			// This makes nb1 the "active" editor while nb2 is visible but unfocused.
+			await test.step('Focus left notebook (nb1)', async () => {
+				await leftGroup.locator('[data-testid="notebook-cell"]').first().click();
+			});
+
+			// Click "Run All" in the RIGHT notebook's (nb2) editor action bar.
+			// BUG: This executes cells in the focused (left) notebook instead of
+			// the right notebook where the button lives.
+			await test.step('Click Run All in right notebook action bar', async () => {
+				const rightRunAll = rightGroup.locator('.editor-action-bar-container')
+					.getByRole('button', { name: 'Run All' });
+				await rightRunAll.click();
+			});
+
+			// Verify RIGHT notebook (nb2) cells have the expected output.
+			// If Run All targeted the correct notebook, nb2's cell should show "from_nb2".
+			await test.step('Verify right notebook (nb2) has output from its own code', async () => {
+				const rightCellOutput = rightGroup.locator('[data-testid="cell-output"]');
+				await expect(rightCellOutput).toContainText('from_nb2', { timeout: 30000 });
+			});
+
+			// Verify LEFT notebook (nb1) was NOT executed.
+			// If Run All incorrectly targeted the focused editor, nb1 would have output.
+			await test.step('Verify left notebook (nb1) was NOT executed', async () => {
+				const leftCellOutput = leftGroup.locator('[data-testid="cell-output"]');
+				await expect(leftCellOutput).not.toBeVisible({ timeout: 5000 });
+			});
+		});
+});

--- a/test/e2e/tests/notebooks-positron/notebook-side-by-side.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-side-by-side.test.ts
@@ -9,9 +9,6 @@
  * Verifies that when two notebooks are open side-by-side:
  * 1. Kernel selection and status are independent per notebook
  * 2. The "Run All" button executes cells in its own notebook, not the focused one
- *
- * BUG: These tests are expected to FAIL, demonstrating that kernel status is
- * shared across notebooks and Run All targets the focused editor.
  */
 
 import { expect, tags } from '../_test.setup';
@@ -27,9 +24,6 @@ test.describe('Notebook Side-by-Side Isolation', {
 }, () => {
 
 	test('Kernel status is independent per notebook when side-by-side',
-		{
-			annotation: [{ type: 'bug', description: 'Kernel selection and status is shared across side-by-side notebooks' }]
-		},
 		async function ({ app, page }) {
 			const { notebooksPositron } = app.workbench;
 			const pythonVersion = process.env.POSITRON_PY_VER_SEL!;
@@ -70,9 +64,6 @@ test.describe('Notebook Side-by-Side Isolation', {
 				await expect(leftGroup.locator('.editor-action-bar-container').locator(IDLE_STATUS_ICON)).toBeVisible({ timeout: 15000 });
 			});
 
-			// BUG: Kernel status is shared across notebooks. The right notebook
-			// (which has no kernel selected) incorrectly shows the Python kernel
-			// from the left notebook.
 			await test.step('Verify right notebook (nb2) does NOT show Python kernel', async () => {
 				const rightKernelBadge = rightGroup.getByRole('button', { name: 'Kernel Actions' });
 				await expect(rightKernelBadge).not.toContainText(pythonVersion, { timeout: 5000 });
@@ -80,9 +71,6 @@ test.describe('Notebook Side-by-Side Isolation', {
 		});
 
 	test('Run All button executes cells in its own notebook, not the focused one',
-		{
-			annotation: [{ type: 'bug', description: 'Run All button is scoped to the focused editor, not the editor it is rendered in' }]
-		},
 		async function ({ app, page }) {
 			const { notebooksPositron } = app.workbench;
 
@@ -118,8 +106,6 @@ test.describe('Notebook Side-by-Side Isolation', {
 			});
 
 			// Click "Run All" in the RIGHT notebook's (nb2) editor action bar.
-			// BUG: This executes cells in the focused (left) notebook instead of
-			// the right notebook where the button lives.
 			await test.step('Click Run All in right notebook action bar', async () => {
 				const rightRunAll = rightGroup.locator('.editor-action-bar-container')
 					.getByRole('button', { name: 'Run All' });


### PR DESCRIPTION
Addresses #12455 and #12454.

When two notebooks are open side-by-side, the editor action bar (kernel status badge, Run All, Clear Output, etc.) and notebook actions incorrectly resolved the globally active (focused) editor instead of the editor group they belong to. This caused actions in one notebook's toolbar to affect the other notebook.

The fix has two parts:
- **Action bar widgets**: Add an `EditorGroupContext` React context that provides each action bar with its editor group. `registerNotebookWidget` now resolves the notebook instance from this context instead of `editorService.activeEditorPane`.
- **Notebook commands**: Update `NotebookAction2` to accept a resource URI argument (passed by the editor action bar) and match it against visible editor panes, falling back to the active editor for command palette invocations.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed notebook action bar buttons (Run All, kernel status, etc.) targeting the wrong notebook when two notebooks are open side-by-side (#12455)
- Fixed kernel status badge showing the wrong kernel when notebooks are open side-by-side (#12454)

### QA Notes

@:positron-notebooks

1. Open two `.ipynb` files side-by-side
2. Select a Python kernel in the left notebook only
3. Verify the right notebook does NOT show the Python kernel badge
4. Add `print("left")` to the left notebook and `print("right")` to the right notebook (with a Python kernel selected)
5. Focus the left notebook, then click "Run All" in the right notebook's action bar
6. Verify only the right notebook executes