### PR TITLE
Bump Ark to 0.1.242

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -1094,7 +1094,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.240"
+      "ark": "0.1.242"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
For https://github.com/posit-dev/ark/pull/1105

Should fix:

```
  ❌ r.tibble - Record data load, basic filtering and sorting [5,051,640 rows]
[tests/data-explorer/data-explorer-performance.test.ts / tests/data-explorer/data-explorer-performance.test.ts] 
(tests/data-explorer/data-explorer-performance.test.ts)  tags: :web, :win, :data-explorer, :performance
```

https://github.com/posit-dev/positron/actions/runs/22932437514/job/66561255858

@:data-explorer