### PR TITLE
ci: remove notebook-focus-selection from firefox

### DIFF
--- a/.github/workflows/test-cross-browser.yml
+++ b/.github/workflows/test-cross-browser.yml
@@ -57,7 +57,7 @@ jobs:
       shards: 1
       matrix: '{"shard":[1]}'
       grep: ${{ inputs.grep }}
-      grep_invert: "great-tables"
+      grep_invert: "great-tables|notebook-focus-and-selection"
 
   e2e-webkit:
     name: e2e


### PR DESCRIPTION
### Summary
Just removing a test to avoid flakes in cross-browser workflow.

### QA Notes
n/a