### PR TITLE
[exploratory] Upgrade TypeScript to 6.0.1-rc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -179,7 +179,7 @@
         "ts-node": "^10.9.1",
         "tsec": "0.2.7",
         "tslib": "^2.6.3",
-        "typescript": "^6.0.0-dev.20250922",
+        "typescript": "6.0.1-rc",
         "typescript-eslint": "^8.45.0",
         "undici-types": "^6.20.0",
         "util": "^0.12.4",
@@ -20375,9 +20375,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "6.0.0-dev.20250922",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.0-dev.20250922.tgz",
-      "integrity": "sha512-4jTznRR2W8ak4kgHlxhNEauwCS/O2O2AfS3yC+Y4VxkRDFIruwdcW4+UQflBJrLCFa42lhdAAMGl1td/99KTKg==",
+      "version": "6.0.1-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.1-rc.tgz",
+      "integrity": "sha512-7XlzYb+p/7YxX6qSOzwB4mxVFRdAgWWkj1PgAZ+jzldeuFV6Z77vwFbNxHsUXAL/bhlWY2jCT8shLwDJR8337g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
     "ts-node": "^10.9.1",
     "tsec": "0.2.7",
     "tslib": "^2.6.3",
-    "typescript": "^6.0.0-dev.20250922",
+    "typescript": "6.0.1-rc",
     "typescript-eslint": "^8.45.0",
     "undici-types": "^6.20.0",
     "util": "^0.12.4",


### PR DESCRIPTION
## Summary

Upgrades TypeScript from `6.0.0-dev.20250922` (September 2025 dev build) to `6.0.1-rc` for improved stability and reliability.

## Changes

- Updates TypeScript dependency from `^6.0.0-dev.20250922` to `6.0.1-rc` in package.json
- Updates package-lock.json with new TypeScript version

## Rationale

- The current dev build is ~6 months old
- Release candidate versions are more stable than nightly dev builds
- RC versions have better community testing and bug fixes
- Reduces risk of unexpected behavior from dev builds

## Test Plan

- [ ] Verify Positron builds successfully with new TypeScript version
- [ ] Run extension tests: `npm run test-extension`
- [ ] Run E2E tests: `npm run e2e-pr`
- [ ] Verify no new TypeScript compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)