### PR TITLE
Fix extra spacing in numpy array display values

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -718,6 +718,7 @@ class NumpyNdarrayInspector(_BaseArrayInspector["np.ndarray"]):
                 threshold=ARRAY_THRESHOLD,
                 edgeitems=ARRAY_EDGEITEMS,
                 separator=",",
+                formatter={"all": lambda x: str(x)},
             ),
             True,
         )

--- a/extensions/positron-python/python_files/posit/positron/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_inspectors.py
@@ -581,7 +581,7 @@ def test_inspect_numpy_array(value: np.ndarray) -> None:
     display_shape = f"({shape[0]})" if len(shape) == 1 else str(tuple(shape))
     verify_inspector(
         value=value,
-        display_value=np.array2string(value, separator=","),
+        display_value=np.array2string(value, separator=",", formatter={"all": lambda x: str(x)}),
         kind=VariableKind.Collection,
         display_type=f"numpy.int64 {display_shape}",
         type_info="numpy.ndarray",
@@ -602,7 +602,7 @@ def test_inspect_numpy_array(value: np.ndarray) -> None:
 def test_inspect_numpy_array_0d(value: np.ndarray) -> None:
     verify_inspector(
         value=value,
-        display_value=np.array2string(value, separator=","),
+        display_value=np.array2string(value, separator=",", formatter={"all": lambda x: str(x)}),
         kind=VariableKind.Number,
         display_type="numpy.int64",
         type_info="numpy.ndarray",


### PR DESCRIPTION
## Summary
Fixes extra spacing that appears before values in numpy arrays displayed in the Variables pane. Arrays like `[3, 10]` were showing as `[ 3,10]` with an unwanted space after the opening bracket.

## Changes
- Added `formatter={"all": lambda x: str(x)}` parameter to `numpy.array2string()` in `NumpyNdarrayInspector.get_display_value()` to prevent NumPy's default number alignment
- Updated test expectations in `test_inspectors.py` to match the new formatting

## Test plan
- [x] Verified fix with manual Python test
- [x] Updated unit tests to match new behavior
- [ ] Manual testing in Positron IDE:
  1. Create Python file with `import numpy as np; arr = np.array([3, 10])`
  2. Run the code
  3. Verify Variables pane shows `[3,10]` not `[ 3,10]`

Fixes #12414

🤖 Generated with [Claude Code](https://claude.com/claude-code)