### PR TITLE
add skill to determine copilot chat extension tag

### DIFF
--- a/.claude/skills/pick-copilot-tag/SKILL.md
+++ b/.claude/skills/pick-copilot-tag/SKILL.md
@@ -56,28 +56,25 @@ Use `-v` / `--verbose` to show the full proposals list instead of just the count
 ## Example Output
 
 ```
-Positron proposals: 23 versioned (from src/vs/.../extensionsApiProposals.ts)
+Positron proposals: 9 versioned (from src/vs/.../extensionsApiProposals.ts)
 
 Code OSS version: 1.109.0
 Checking recent tag series for engine compatibility:
   v0.36 -> ^1.108.0 (compatible)
   v0.37 -> ^1.109.0 (compatible)
-  v0.38 -> ^1.110.0 (needs Code OSS > 1.109.0)
+  v0.38 -> ^1.110.0 (needs Code OSS >= 1.110.0)
 
 --- v0.37 ---
+Releases (10 tags):
 BAD v0.37.9
    chatHooks@6 (not in Positron)
    chatParticipantPrivate@13 (Positron has chatParticipantPrivate@12)
 BAD v0.37.6
    chatHooks@6 (not in Positron)
-   chatParticipantPrivate@13 (Positron has chatParticipantPrivate@12)
 OK  v0.37.5
-OK  v0.37.4
-OK  v0.37.0
+Pre-releases (41 tags):
+OK  v0.37.2026020406
 
---- v0.36 ---
-OK  v0.36.4
-OK  v0.36.0
-
-Latest compatible: v0.37.5
+Latest compatible release: v0.37.5
+Latest compatible pre-release: v0.37.2026020406
 ```

--- a/.claude/skills/pick-copilot-tag/SKILL.md
+++ b/.claude/skills/pick-copilot-tag/SKILL.md
@@ -38,10 +38,19 @@ For checking against a built Positron app instead of the source tree:
 .claude/skills/pick-copilot-tag/scripts/check-proposals.sh /Applications/Positron.app
 ```
 
+To check against a specific Positron release (fetches both proposals and the
+Code OSS version from the release tag on GitHub):
+
+```bash
+.claude/skills/pick-copilot-tag/scripts/check-proposals.sh --positron-version 2026.03.0
+```
+
 To check a specific tag series (skips auto-discovery):
 
 ```bash
 .claude/skills/pick-copilot-tag/scripts/check-proposals.sh <proposals-source> <tag-prefix>
+# or with --positron-version:
+.claude/skills/pick-copilot-tag/scripts/check-proposals.sh --positron-version 2026.03.0 v0.37
 ```
 
 ### Step 2: Report Results

--- a/.claude/skills/pick-copilot-tag/SKILL.md
+++ b/.claude/skills/pick-copilot-tag/SKILL.md
@@ -18,7 +18,7 @@ Use this skill when:
 ## Prerequisites
 
 - GitHub CLI (`gh`) installed and authenticated
-- `python3` available
+- `jq` and `python3` available
 
 ## Workflow
 
@@ -61,6 +61,7 @@ The script outputs each tag as OK or BAD with specific mismatches. Report:
 - A recommendation
 
 Use `-v` / `--verbose` to show the full proposals list instead of just the count.
+Use `--pre-releases` to also check date-based pre-release tags (skipped by default).
 
 ## Example Output
 
@@ -81,9 +82,7 @@ BAD v0.37.9
 BAD v0.37.6
    chatHooks@6 (not in Positron)
 OK  v0.37.5
-Pre-releases (41 tags):
-OK  v0.37.2026020406
+Pre-releases (41 tags, skipped -- use --pre-releases to check)
 
 Latest compatible release: v0.37.5
-Latest compatible pre-release: v0.37.2026020406
 ```

--- a/.claude/skills/pick-copilot-tag/SKILL.md
+++ b/.claude/skills/pick-copilot-tag/SKILL.md
@@ -35,7 +35,7 @@ from the source tree, discover compatible tag series, and check them all:
 For checking against a built Positron app instead of the source tree:
 
 ```bash
-.claude/skills/pick-copilot-tag/scripts/check-proposals.sh /Applications/Positron.app
+.claude/skills/pick-copilot-tag/scripts/check-proposals.sh --app /Applications/Positron.app
 ```
 
 To check against a specific Positron release (fetches both proposals and the
@@ -48,10 +48,10 @@ Code OSS version from the release tag on GitHub):
 To check a specific tag series (skips auto-discovery):
 
 ```bash
-.claude/skills/pick-copilot-tag/scripts/check-proposals.sh <proposals-source> <tag-prefix>
-# or with --positron-version:
-.claude/skills/pick-copilot-tag/scripts/check-proposals.sh --positron-version 2026.03.0 v0.37
+.claude/skills/pick-copilot-tag/scripts/check-proposals.sh --tag-series v0.37
 ```
+
+Flags can be combined, e.g. `--positron-version 2026.03.0 --tag-series v0.37`.
 
 ### Step 2: Report Results
 

--- a/.claude/skills/pick-copilot-tag/SKILL.md
+++ b/.claude/skills/pick-copilot-tag/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: pick-copilot-tag
+description: Determine which vscode-copilot-chat release tag to use for a Positron build
+---
+
+# Pick Copilot Tag
+
+Determine which `microsoft/vscode-copilot-chat` release tag is compatible with
+a given Positron build by checking API proposal version compatibility.
+
+## When to Use
+
+Use this skill when:
+- Deciding which copilot-chat tag to merge after an upstream Code OSS update
+- A release build rejects copilot-chat with "API proposals not compatible"
+- Upgrading copilot-chat and need to find the latest compatible tag
+
+## Prerequisites
+
+- GitHub CLI (`gh`) installed and authenticated
+- `python3` available
+
+## Workflow
+
+### Step 1: Run the Check
+
+From the Positron repo root, run the script with no arguments. It will
+automatically read `package.json` for the Code OSS version, extract proposals
+from the source tree, discover compatible tag series, and check them all:
+
+```bash
+.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
+```
+
+For checking against a built Positron app instead of the source tree:
+
+```bash
+.claude/skills/pick-copilot-tag/scripts/check-proposals.sh /Applications/Positron.app
+```
+
+To check a specific tag series (skips auto-discovery):
+
+```bash
+.claude/skills/pick-copilot-tag/scripts/check-proposals.sh <proposals-source> <tag-prefix>
+```
+
+### Step 2: Report Results
+
+The script outputs each tag as OK or BAD with specific mismatches. Report:
+- The **latest compatible tag** (first OK in descending version order)
+- What breaks in newer tags (which proposals changed)
+- A recommendation
+
+Use `-v` / `--verbose` to show the full proposals list instead of just the count.
+
+## Example Output
+
+```
+Positron proposals: 23 versioned (from src/vs/.../extensionsApiProposals.ts)
+
+Code OSS version: 1.109.0
+Checking recent tag series for engine compatibility:
+  v0.36 -> ^1.108.0 (compatible)
+  v0.37 -> ^1.109.0 (compatible)
+  v0.38 -> ^1.110.0 (needs Code OSS > 1.109.0)
+
+--- v0.37 ---
+BAD v0.37.9
+   chatHooks@6 (not in Positron)
+   chatParticipantPrivate@13 (Positron has chatParticipantPrivate@12)
+BAD v0.37.6
+   chatHooks@6 (not in Positron)
+   chatParticipantPrivate@13 (Positron has chatParticipantPrivate@12)
+OK  v0.37.5
+OK  v0.37.4
+OK  v0.37.0
+
+--- v0.36 ---
+OK  v0.36.4
+OK  v0.36.0
+
+Latest compatible: v0.37.5
+```

--- a/.claude/skills/pick-copilot-tag/references/proposal-compatibility.md
+++ b/.claude/skills/pick-copilot-tag/references/proposal-compatibility.md
@@ -30,7 +30,7 @@ that are not compatible with the current version of VS Code.
 
 - **In the extension**: `package.json` -> `enabledApiProposals` array
 - **In Positron**: compiled into `sharedProcessMain.js` (extracted at build time
-  from `src/vs/workbench/services/extensions/common/extensionsApiProposals.ts`)
+  from `src/vs/platform/extensions/common/extensionsApiProposals.ts`)
 - **In product.json**: `extensionsEnabledWithApiProposalVersion` controls which
   extensions get the strict check
 

--- a/.claude/skills/pick-copilot-tag/references/proposal-compatibility.md
+++ b/.claude/skills/pick-copilot-tag/references/proposal-compatibility.md
@@ -1,0 +1,53 @@
+# API Proposal Version Compatibility
+
+## How the check works
+
+VS Code extensions can use "proposed APIs" -- unstable APIs not yet finalized.
+Each proposal can optionally carry a version number (e.g., `chatProvider@4`).
+
+Positron's `product.json` contains an `extensionsEnabledWithApiProposalVersion`
+list. Extensions on this list get **strict version enforcement**: every versioned
+proposal in the extension's `package.json` must exactly match the version
+compiled into the Positron build.
+
+- Dev builds (`quality: null`) skip this check entirely
+- Release builds enforce it -- mismatches block extension activation
+
+## What causes failures
+
+1. **New proposal added upstream** -- e.g., `chatHooks@6` added in v0.37.6,
+   but Positron doesn't have `chatHooks` at all
+2. **Version bumped upstream** -- e.g., `chatParticipantPrivate@12` -> `@13`,
+   but Positron still has `@12`
+
+Both produce the same error:
+```
+ERR: This extension is using the API proposals 'X' and 'Y'
+that are not compatible with the current version of VS Code.
+```
+
+## Where proposals live
+
+- **In the extension**: `package.json` -> `enabledApiProposals` array
+- **In Positron**: compiled into `sharedProcessMain.js` (extracted at build time
+  from `src/vs/workbench/services/extensions/common/extensionsApiProposals.ts`)
+- **In product.json**: `extensionsEnabledWithApiProposalVersion` controls which
+  extensions get the strict check
+
+## Why engine version isn't enough
+
+Engine version match is necessary but not sufficient. There are two ways it
+can mislead:
+
+1. **Within a series**: All tags in a minor series (e.g., v0.37.0 through
+   v0.37.9) target the same `engines.vscode` range (e.g., `^1.109.0`). But
+   Microsoft cherry-picks features into release branches between patches, and
+   those features can introduce new proposals or bump existing ones.
+
+2. **Across series**: Multiple minor series can target the same engine range.
+   For example, both v0.37.x and v0.38.x targeted `^1.109.0`, but v0.38 used
+   proposals (`chatHooks`, bumped `chatParticipantPrivate`) from a pre-release
+   VS Code that didn't exist in the stable 1.109 base. See
+   posit-dev/positron-copilot-chat#15 for the full story.
+
+The only reliable check is comparing the `enabledApiProposals` arrays.

--- a/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
+++ b/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
@@ -78,7 +78,7 @@ resolve_positron_version() {
 	[[ -n "$pkg_content" ]] || die "Empty package.json content from $POSITRON_REPO at tag $tag"
 
 	_POSITRON_TAG="$tag"
-	_POSITRON_CODE_VERSION=$(echo "$pkg_content" | base64 -d | python3 -c "import json,sys; print(json.load(sys.stdin)['version'])")
+	_POSITRON_CODE_VERSION=$(echo "$pkg_content" | base64 -d | jq -r '.version')
 	echo "Code OSS version: $_POSITRON_CODE_VERSION"
 }
 
@@ -157,11 +157,8 @@ discover_tag_series() {
 		[[ -n "$content" ]] || continue
 
 		local engine
-		engine=$(echo "$content" | base64 -d 2>/dev/null | python3 -c "
-import sys, json
-pkg = json.load(sys.stdin)
-print(pkg.get('engines', {}).get('vscode', 'unknown'))
-" 2>/dev/null) || continue
+		engine=$(echo "$content" | base64 -d 2>/dev/null \
+			| jq -r '.engines.vscode // "unknown"' 2>/dev/null) || continue
 
 		# Parse engine minor version from e.g. ^1.109.0
 		local engine_minor
@@ -236,16 +233,13 @@ check_tag_list() {
 
 		# Parse engine and proposals in one shot
 		local parsed
-		parsed=$(echo "$content" | base64 -d 2>/dev/null | python3 -c "
-import sys, json, re
-pkg = json.load(sys.stdin)
-engine = pkg.get('engines', {}).get('vscode', '')
-m = re.search(r'(\d+)\.(\d+)', engine)
-print(m.group(2) if m else '')
-print(engine)
-for p in sorted(p for p in pkg.get('enabledApiProposals', []) if '@' in p):
-    print(p)
-" 2>/dev/null) || continue
+		parsed=$(echo "$content" | base64 -d 2>/dev/null | jq -r '
+			(.engines.vscode // "") as $engine |
+			($engine | capture("(?<maj>[0-9]+)\\.(?<min>[0-9]+)") // null) as $m |
+			(if $m then $m.min else "" end),
+			$engine,
+			([(.enabledApiProposals // [])[] | select(contains("@"))] | sort | .[])
+		' 2>/dev/null) || continue
 
 		local tag_engine_minor tag_engine ext_proposals
 		tag_engine_minor=$(echo "$parsed" | sed -n '1p')
@@ -393,7 +387,7 @@ echo ""
 if [[ -n "$TAG_PREFIX" ]]; then
 	# Try to get Code OSS version for per-tag engine checking
 	if [[ -z "$_CODE_OSS_MINOR" && -f "package.json" ]]; then
-		local_version=$(python3 -c "import json; print(json.load(open('package.json'))['version'])" 2>/dev/null) || true
+		local_version=$(jq -r '.version' package.json 2>/dev/null) || true
 		_CODE_OSS_MINOR=$(echo "$local_version" | cut -d. -f2)
 	fi
 	# Explicit tag prefix -- check just that series
@@ -402,7 +396,7 @@ else
 	# Determine Code OSS version (if not already set by --positron-version)
 	if [[ -z "$_CODE_OSS_MINOR" ]]; then
 		if [[ -f "package.json" ]]; then
-			code_oss_version=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
+			code_oss_version=$(jq -r '.version' package.json)
 		else
 			die "No tag prefix given and no package.json found. Run from the Positron repo root, pass --positron-version, or pass an explicit tag prefix."
 		fi

--- a/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
+++ b/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
@@ -88,11 +88,13 @@ discover_tag_series() {
 	echo "Checking recent tag series for engine compatibility:"
 	local candidates=""
 	for series in $all_series; do
+		local content
+		content=$(gh api "repos/$REPO/contents/package.json?ref=${series}.0" \
+			--jq '.content' 2>/dev/null) || continue
+		[[ -n "$content" ]] || continue
+
 		local engine
-		engine=$(gh api "repos/$REPO/contents/package.json?ref=${series}.0" \
-			--jq '.content' 2>/dev/null \
-			| base64 -d \
-			| python3 -c "
+		engine=$(echo "$content" | base64 -d 2>/dev/null | python3 -c "
 import sys, json
 pkg = json.load(sys.stdin)
 print(pkg.get('engines', {}).get('vscode', 'unknown'))
@@ -106,41 +108,80 @@ print(pkg.get('engines', {}).get('vscode', 'unknown'))
 		if [[ "$engine_minor" -le "$code_oss_minor" ]]; then
 			echo "  $series -> $engine (compatible)"
 			candidates+="$series"$'\n'
+		elif [[ "$engine_minor" -le "$((code_oss_minor + 1))" ]]; then
+			# The .0 release needs a newer engine, but date-based pre-releases
+			# in this series may target an older engine (they predate .0).
+			echo "  $series -> $engine (pre-releases may be compatible)"
+			candidates+="$series"$'\n'
 		else
-			echo "  $series -> $engine (needs Code OSS > $code_oss_version)"
+			local min_version
+			min_version=$(echo "$engine" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+			echo "  $series -> $engine (needs Code OSS >= ${min_version:-$engine})"
 		fi
 	done
 
-	# Return candidates newest-first so _LATEST_OK picks the highest series.
+	# Return candidates newest-first so we check the highest series first.
 	_CANDIDATES=$(echo "$candidates" | grep -v '^$' | sort -rV || true)
 }
 
-# --- Check a single tag series ------------------------------------------------
+# --- Check a list of tags ----------------------------------------------------
+# Sets _FOUND_OK to the first (newest) compatible tag, or "" if none found.
 
-check_series() {
-	local tag_prefix="$1"
+check_tag_list() {
+	local tags="$1"
 	local positron_proposals="$2"
+	_FOUND_OK=""
 
-	echo ""
-	echo "--- $tag_prefix ---"
-
-	local tags
-	tags=$(gh api "repos/$REPO/git/matching-refs/tags/$tag_prefix." \
-		--jq '.[].ref | ltrimstr("refs/tags/")' \
-		| grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-		| sort -rV)
-
-	[[ -n "$tags" ]] || { echo "No tags found matching $tag_prefix.*"; return; }
+	# Track consecutive skips to print a summary instead of one line per tag.
+	local skip_count=0 skip_first="" skip_last="" skip_reason=""
+	_flush_skips() {
+		if [[ "$skip_count" -eq 0 ]]; then return; fi
+		if [[ "$skip_count" -eq 1 ]]; then
+			echo "SKIP $skip_first ($skip_reason)"
+		else
+			echo "SKIP $skip_first .. $skip_last ($skip_count tags, $skip_reason)"
+		fi
+		skip_count=0 skip_first="" skip_last="" skip_reason=""
+	}
 
 	for tag in $tags; do
-		local ext_proposals
-		ext_proposals=$(gh api "repos/$REPO/contents/package.json?ref=$tag" \
-			--jq '.content' | base64 -d | python3 -c "
-import sys, json
+		local content
+		content=$(gh api "repos/$REPO/contents/package.json?ref=$tag" \
+			--jq '.content' 2>/dev/null) || continue
+		[[ -n "$content" ]] || continue
+
+		# Parse engine and proposals in one shot
+		local parsed
+		parsed=$(echo "$content" | base64 -d 2>/dev/null | python3 -c "
+import sys, json, re
 pkg = json.load(sys.stdin)
+engine = pkg.get('engines', {}).get('vscode', '')
+m = re.search(r'(\d+)\.(\d+)', engine)
+print(m.group(2) if m else '')
+print(engine)
 for p in sorted(p for p in pkg.get('enabledApiProposals', []) if '@' in p):
     print(p)
-")
+" 2>/dev/null) || continue
+
+		local tag_engine_minor tag_engine ext_proposals
+		tag_engine_minor=$(echo "$parsed" | sed -n '1p')
+		tag_engine=$(echo "$parsed" | sed -n '2p')
+		ext_proposals=$(echo "$parsed" | tail -n +3)
+
+		# Check per-tag engine compatibility
+		if [[ -n "$_CODE_OSS_MINOR" && -n "$tag_engine_minor" \
+				&& "$tag_engine_minor" -gt "$_CODE_OSS_MINOR" ]]; then
+			local min_v
+			min_v=$(echo "$tag_engine" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+			skip_count=$((skip_count + 1))
+			[[ -z "$skip_first" ]] && skip_first="$tag"
+			skip_last="$tag"
+			skip_reason="needs Code OSS >= ${min_v:-$tag_engine}"
+			continue
+		fi
+
+		# Flush any accumulated skips before printing a non-skip result
+		_flush_skips
 
 		local issues=""
 		while IFS= read -r prop; do
@@ -159,10 +200,7 @@ for p in sorted(p for p in pkg.get('enabledApiProposals', []) if '@' in p):
 
 		if [[ -z "$issues" ]]; then
 			echo "OK  $tag"
-			# First OK is the latest compatible (tags are sorted newest-first)
-			if [[ -z "$_LATEST_OK" ]]; then
-				_LATEST_OK="$tag"
-			fi
+			_FOUND_OK="$tag"
 			return
 		else
 			echo "BAD $tag"
@@ -170,17 +208,64 @@ for p in sorted(p for p in pkg.get('enabledApiProposals', []) if '@' in p):
 		fi
 	done
 
-	echo "(no compatible tags in $tag_prefix series)"
+	_flush_skips
+}
+
+# --- Check a single tag series ------------------------------------------------
+
+check_series() {
+	local tag_prefix="$1"
+	local positron_proposals="$2"
+
+	echo ""
+	echo "--- $tag_prefix ---"
+
+	local all_tags
+	all_tags=$(gh api "repos/$REPO/git/matching-refs/tags/$tag_prefix." --paginate \
+		--jq '.[].ref | ltrimstr("refs/tags/")' \
+		| grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+		| sort -rV)
+
+	[[ -n "$all_tags" ]] || { echo "No tags found matching $tag_prefix.*"; return; }
+
+	# Separate semver releases (1-3 digit patch) from date-based pre-releases (4+ digits)
+	local release_tags prerelease_tags
+	release_tags=$(echo "$all_tags" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]{1,3}$' || true)
+	prerelease_tags=$(echo "$all_tags" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]{4,}$' || true)
+
+	if [[ -n "$release_tags" ]]; then
+		local count
+		count=$(echo "$release_tags" | wc -l | tr -d ' ')
+		echo "Releases ($count tags):"
+		check_tag_list "$release_tags" "$positron_proposals"
+		if [[ -n "$_FOUND_OK" && -z "$_LATEST_OK" ]]; then
+			_LATEST_OK="$_FOUND_OK"
+		fi
+	fi
+
+	if [[ -n "$prerelease_tags" ]]; then
+		local count
+		count=$(echo "$prerelease_tags" | wc -l | tr -d ' ')
+		echo "Pre-releases ($count tags):"
+		check_tag_list "$prerelease_tags" "$positron_proposals"
+		if [[ -n "$_FOUND_OK" && -z "$_LATEST_PRERELEASE" ]]; then
+			_LATEST_PRERELEASE="$_FOUND_OK"
+		fi
+	fi
 }
 
 # --- Main ---------------------------------------------------------------------
 # Globals set by functions:
-#   _CANDIDATES  - newline-separated tag series (set by discover_tag_series)
-#   _LATEST_OK   - highest compatible tag found (set by check_series)
+#   _CANDIDATES        - newline-separated tag series (set by discover_tag_series)
+#   _CODE_OSS_MINOR    - Code OSS minor version for per-tag engine checks
+#   _LATEST_OK         - highest compatible release tag (set by check_series)
+#   _LATEST_PRERELEASE - highest compatible pre-release tag (set by check_series)
 
 PROPOSALS_SOURCE="${1:-}"
 TAG_PREFIX="${2:-}"
+_CODE_OSS_MINOR=""
 _LATEST_OK=""
+_LATEST_PRERELEASE=""
 
 # Default proposals source to the TypeScript file in the repo
 if [[ -z "$PROPOSALS_SOURCE" ]]; then
@@ -200,18 +285,29 @@ fi
 echo ""
 
 if [[ -n "$TAG_PREFIX" ]]; then
+	# Try to get Code OSS version for per-tag engine checking
+	if [[ -f "package.json" ]]; then
+		local_version=$(python3 -c "import json; print(json.load(open('package.json'))['version'])" 2>/dev/null) || true
+		_CODE_OSS_MINOR=$(echo "$local_version" | cut -d. -f2)
+	fi
 	# Explicit tag prefix -- check just that series
 	check_series "$TAG_PREFIX" "$positron_proposals"
 else
 	# Auto-discover compatible series from package.json
 	[[ -f "package.json" ]] || die "No tag prefix given and no package.json found. Run from the Positron repo root or pass an explicit tag prefix."
 	code_oss_version=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
+	_CODE_OSS_MINOR=$(echo "$code_oss_version" | cut -d. -f2)
 
 	discover_tag_series "$code_oss_version"
 	[[ -n "$_CANDIDATES" ]] || die "No compatible tag series found for Code OSS $code_oss_version"
 
 	for series in $_CANDIDATES; do
 		check_series "$series" "$positron_proposals"
+		# Stop checking lower series once we find a compatible release.
+		# Pre-releases alone don't stop the search -- we prefer releases.
+		if [[ -n "$_LATEST_OK" ]]; then
+			break
+		fi
 	done
 fi
 
@@ -219,7 +315,12 @@ fi
 
 echo ""
 if [[ -n "$_LATEST_OK" ]]; then
-	echo "Latest compatible: $_LATEST_OK"
+	echo "Latest compatible release: $_LATEST_OK"
+	if [[ -n "$_LATEST_PRERELEASE" ]]; then
+		echo "Latest compatible pre-release: $_LATEST_PRERELEASE"
+	fi
+elif [[ -n "$_LATEST_PRERELEASE" ]]; then
+	echo "Latest compatible (pre-release only): $_LATEST_PRERELEASE"
 else
 	echo "No compatible tags found."
 fi

--- a/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
+++ b/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
@@ -19,7 +19,7 @@
 #                                    Looks up the release tag on GitHub, retrieves the
 #                                    Code OSS version and proposals from that build.
 #
-# Requires: gh, python3
+# Requires: gh, jq, python3
 
 set -euo pipefail
 

--- a/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
+++ b/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
@@ -133,10 +133,28 @@ check_tag_list() {
 	local positron_proposals="$2"
 	_FOUND_OK=""
 
+	local total checked=0
+	total=$(echo "$tags" | wc -l | tr -d ' ')
+
+	# Progress indicator (only when stderr is a terminal).
+	local show_progress=false
+	[[ -t 2 ]] && show_progress=true
+	_progress() {
+		if [[ "$show_progress" == true ]]; then
+			printf '\r\033[K  checking %d/%d: %s ...' "$@" >&2
+		fi
+	}
+	_clear_progress() {
+		if [[ "$show_progress" == true ]]; then
+			printf '\r\033[K' >&2
+		fi
+	}
+
 	# Track consecutive skips to print a summary instead of one line per tag.
 	local skip_count=0 skip_first="" skip_last="" skip_reason=""
 	_flush_skips() {
 		if [[ "$skip_count" -eq 0 ]]; then return; fi
+		_clear_progress
 		if [[ "$skip_count" -eq 1 ]]; then
 			echo "SKIP $skip_first ($skip_reason)"
 		else
@@ -146,6 +164,9 @@ check_tag_list() {
 	}
 
 	for tag in $tags; do
+		checked=$((checked + 1))
+		_progress "$checked" "$total" "$tag"
+
 		local content
 		content=$(gh api "repos/$REPO/contents/package.json?ref=$tag" \
 			--jq '.content' 2>/dev/null) || continue
@@ -183,6 +204,7 @@ for p in sorted(p for p in pkg.get('enabledApiProposals', []) if '@' in p):
 
 		# Flush any accumulated skips before printing a non-skip result
 		_flush_skips
+		_clear_progress
 
 		local issues=""
 		while IFS= read -r prop; do
@@ -202,6 +224,7 @@ for p in sorted(p for p in pkg.get('enabledApiProposals', []) if '@' in p):
 		if [[ -z "$issues" ]]; then
 			echo "OK  $tag"
 			_FOUND_OK="$tag"
+			_clear_progress
 			return
 		else
 			echo "BAD $tag"
@@ -210,6 +233,7 @@ for p in sorted(p for p in pkg.get('enabledApiProposals', []) if '@' in p):
 	done
 
 	_flush_skips
+	_clear_progress
 }
 
 # --- Check a single tag series ------------------------------------------------

--- a/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
+++ b/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
@@ -5,13 +5,18 @@
 #   ./check-proposals.sh                              # auto-detect from repo
 #   ./check-proposals.sh <proposals-source>            # auto-discover tags
 #   ./check-proposals.sh <proposals-source> <tag-prefix>  # explicit tag series
+#   ./check-proposals.sh --positron-version 2026.03.0  # check against a release
+#   ./check-proposals.sh --positron-version 2026.03.0 v0.37  # release + explicit series
 #
 # With no arguments, reads package.json for the Code OSS version, extracts
 # proposals from the source tree, and discovers compatible tag series
 # automatically.
 #
 # Options:
-#   -v, --verbose   Show full list of Positron proposals (default: count only)
+#   -v, --verbose                    Show full list of Positron proposals (default: count only)
+#   --positron-version <version>     Check against a Positron release (e.g. 2026.03.0)
+#                                    Looks up the release tag on GitHub, retrieves the
+#                                    Code OSS version and proposals from that build.
 #
 # Requires: gh, python3
 
@@ -19,22 +24,78 @@ set -euo pipefail
 
 REPO="microsoft/vscode-copilot-chat"
 PROPOSALS_TS="src/vs/platform/extensions/common/extensionsApiProposals.ts"
+POSITRON_REPO="posit-dev/positron"
 VERBOSE=false
+POSITRON_VERSION=""
 
 die() { echo "error: $*" >&2; exit 1; }
 
 # --- Parse flags ---------------------------------------------------------------
 
 args=()
-for arg in "$@"; do
-	case "$arg" in
-		-v|--verbose) VERBOSE=true ;;
-		*) args+=("$arg") ;;
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		-v|--verbose) VERBOSE=true; shift ;;
+		--positron-version)
+			[[ -n "${2:-}" ]] || die "--positron-version requires a version (e.g. 2026.03.0)"
+			POSITRON_VERSION="$2"; shift 2 ;;
+		*) args+=("$1"); shift ;;
 	esac
 done
 set -- "${args[@]+${args[@]}}"
 
+# --- Resolve Positron release tag ---------------------------------------------
+# Given a Positron version (e.g. 2026.03.0 or 2026.03.0-212), find the
+# published release tag on GitHub and extract its Code OSS version.
+# Sets: _POSITRON_TAG, _POSITRON_CODE_VERSION
+
+resolve_positron_version() {
+	local version="$1"
+
+	# If the version already includes a build number, use it directly.
+	# Otherwise, find the latest published release matching the prefix.
+	local tag
+	if [[ "$version" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]+-[0-9]+$ ]]; then
+		tag="$version"
+	elif [[ "$version" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]+$ ]]; then
+		tag=$(gh api "repos/$POSITRON_REPO/releases" --paginate \
+			--jq ".[].tag_name | select(startswith(\"$version-\"))" \
+			| sort -t- -k2 -rn | head -1)
+		[[ -n "$tag" ]] || die "No published release found for Positron $version"
+	else
+		die "--positron-version must be YYYY.MM.PATCH or YYYY.MM.PATCH-BUILD (e.g. 2026.03.0), got: $version"
+	fi
+
+	echo "Positron release: $tag"
+
+	# Fetch Code OSS version from that tag's package.json
+	local pkg_content
+	pkg_content=$(gh api "repos/$POSITRON_REPO/contents/package.json?ref=$tag" \
+		--jq '.content' 2>/dev/null) || die "Could not fetch package.json from $POSITRON_REPO at tag $tag"
+	[[ -n "$pkg_content" ]] || die "Empty package.json content from $POSITRON_REPO at tag $tag"
+
+	_POSITRON_TAG="$tag"
+	_POSITRON_CODE_VERSION=$(echo "$pkg_content" | base64 -d | python3 -c "import json,sys; print(json.load(sys.stdin)['version'])")
+	echo "Code OSS version: $_POSITRON_CODE_VERSION"
+}
+
 # --- Resolve Positron proposals ------------------------------------------------
+
+# Fetch proposals from a remote Positron tag on GitHub.
+resolve_proposals_from_tag() {
+	local tag="$1"
+	local content
+	content=$(gh api "repos/$POSITRON_REPO/contents/$PROPOSALS_TS?ref=$tag" \
+		--jq '.content' 2>/dev/null) || die "Could not fetch $PROPOSALS_TS from $POSITRON_REPO at tag $tag"
+	[[ -n "$content" ]] || die "Empty proposals file from $POSITRON_REPO at tag $tag"
+
+	echo "$content" | base64 -d | python3 -c "
+import re, sys
+content = sys.stdin.read()
+for m in re.finditer(r'(\w+)\s*:\s*\{[^}]*version\s*:\s*(\d+)', content):
+    print(f'{m.group(1)}@{m.group(2)}')
+" | sort -u
+}
 
 resolve_proposals() {
 	local source="$1"
@@ -75,8 +136,6 @@ discover_tag_series() {
 	local code_oss_version="$1"
 	local code_oss_minor
 	code_oss_minor=$(echo "$code_oss_version" | cut -d. -f2)
-
-	echo "Code OSS version: $code_oss_version"
 
 	# List all unique tag series (check last 5 minor versions)
 	local all_series
@@ -286,43 +345,63 @@ check_series() {
 #   _LATEST_OK         - highest compatible release tag (set by check_series)
 #   _LATEST_PRERELEASE - highest compatible pre-release tag (set by check_series)
 
-PROPOSALS_SOURCE="${1:-}"
-TAG_PREFIX="${2:-}"
 _CODE_OSS_MINOR=""
 _LATEST_OK=""
 _LATEST_PRERELEASE=""
 
-# Default proposals source to the TypeScript file in the repo
-if [[ -z "$PROPOSALS_SOURCE" ]]; then
-	[[ -f "$PROPOSALS_TS" ]] || die "No proposals source given and $PROPOSALS_TS not found. Run from the Positron repo root or pass an explicit path."
-	PROPOSALS_SOURCE="$PROPOSALS_TS"
+# When --positron-version is given, the only positional arg (if any) is a tag
+# prefix to select a specific series. Otherwise, positionals are
+# [proposals-source [tag-prefix]].
+if [[ -n "$POSITRON_VERSION" ]]; then
+	[[ $# -le 1 ]] || die "--positron-version accepts at most one positional argument (tag prefix), got $#"
+	PROPOSALS_SOURCE=""
+	TAG_PREFIX="${1:-}"
+	resolve_positron_version "$POSITRON_VERSION"
+	code_oss_version="$_POSITRON_CODE_VERSION"
+	_CODE_OSS_MINOR=$(echo "$code_oss_version" | cut -d. -f2)
+	positron_proposals=$(resolve_proposals_from_tag "$_POSITRON_TAG")
+	proposals_label="$POSITRON_REPO@$_POSITRON_TAG"
+else
+	PROPOSALS_SOURCE="${1:-}"
+	TAG_PREFIX="${2:-}"
+	# Default proposals source to the TypeScript file in the repo
+	if [[ -z "$PROPOSALS_SOURCE" ]]; then
+		[[ -f "$PROPOSALS_TS" ]] || die "No proposals source given and $PROPOSALS_TS not found. Run from the Positron repo root or pass an explicit path."
+		PROPOSALS_SOURCE="$PROPOSALS_TS"
+	fi
+	positron_proposals=$(resolve_proposals "$PROPOSALS_SOURCE")
+	proposals_label="$PROPOSALS_SOURCE"
 fi
 
-positron_proposals=$(resolve_proposals "$PROPOSALS_SOURCE")
 proposal_count=$(echo "$positron_proposals" | wc -l | tr -d ' ')
 
 if [[ "$VERBOSE" == true ]]; then
-	echo "Positron proposals ($proposal_count versioned, from $PROPOSALS_SOURCE):"
+	echo "Positron proposals ($proposal_count versioned, from $proposals_label):"
 	echo "$positron_proposals" | sed 's/^/  /'
 else
-	echo "Positron proposals: $proposal_count versioned (from $PROPOSALS_SOURCE)"
+	echo "Positron proposals: $proposal_count versioned (from $proposals_label)"
 fi
 echo ""
 
 if [[ -n "$TAG_PREFIX" ]]; then
 	# Try to get Code OSS version for per-tag engine checking
-	if [[ -f "package.json" ]]; then
+	if [[ -z "$_CODE_OSS_MINOR" && -f "package.json" ]]; then
 		local_version=$(python3 -c "import json; print(json.load(open('package.json'))['version'])" 2>/dev/null) || true
 		_CODE_OSS_MINOR=$(echo "$local_version" | cut -d. -f2)
 	fi
 	# Explicit tag prefix -- check just that series
 	check_series "$TAG_PREFIX" "$positron_proposals"
 else
-	# Auto-discover compatible series from package.json
-	[[ -f "package.json" ]] || die "No tag prefix given and no package.json found. Run from the Positron repo root or pass an explicit tag prefix."
-	code_oss_version=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
-	_CODE_OSS_MINOR=$(echo "$code_oss_version" | cut -d. -f2)
-
+	# Determine Code OSS version (if not already set by --positron-version)
+	if [[ -z "$_CODE_OSS_MINOR" ]]; then
+		if [[ -f "package.json" ]]; then
+			code_oss_version=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
+		else
+			die "No tag prefix given and no package.json found. Run from the Positron repo root, pass --positron-version, or pass an explicit tag prefix."
+		fi
+		_CODE_OSS_MINOR=$(echo "$code_oss_version" | cut -d. -f2)
+		echo "Code OSS version: $code_oss_version"
+	fi
 	discover_tag_series "$code_oss_version"
 	[[ -n "$_CANDIDATES" ]] || die "No compatible tag series found for Code OSS $code_oss_version"
 

--- a/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
+++ b/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
@@ -44,12 +44,13 @@ resolve_proposals() {
 		local js
 		js=$(find "$source" -name 'sharedProcessMain.js' -print -quit 2>/dev/null)
 		[[ -n "$js" ]] || die "Could not find sharedProcessMain.js inside $source"
-		# Extract name@version from the proposals map structure (minified:
-		# name:{proposal:"...",version:N} )
+		# Extract name@version from the proposals map structure. The JS may
+		# be minified (name:{proposal:"...",version:N}) or pretty-printed
+		# with newlines and indentation, so allow optional whitespace.
 		python3 -c "
 import re, sys
 content = open(sys.argv[1]).read()
-for m in re.finditer(r'(\w+):\{proposal:\"[^\"]+\",version:(\d+)\}', content):
+for m in re.finditer(r'(\w+):\s*\{\s*proposal:\s*\"[^\"]+\"\s*,\s*version:\s*(\d+)\s*\}', content):
     print(f'{m.group(1)}@{m.group(2)}')
 " "$js" | sort -u
 	elif [[ -f "$source" && "$source" == *.ts ]]; then

--- a/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
+++ b/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
@@ -14,6 +14,7 @@
 #
 # Options:
 #   -v, --verbose                    Show full list of Positron proposals (default: count only)
+#   --pre-releases                   Also check date-based pre-release tags (default: releases only)
 #   --positron-version <version>     Check against a Positron release (e.g. 2026.03.0)
 #                                    Looks up the release tag on GitHub, retrieves the
 #                                    Code OSS version and proposals from that build.
@@ -26,6 +27,7 @@ REPO="microsoft/vscode-copilot-chat"
 PROPOSALS_TS="src/vs/platform/extensions/common/extensionsApiProposals.ts"
 POSITRON_REPO="posit-dev/positron"
 VERBOSE=false
+PRE_RELEASES=false
 POSITRON_VERSION=""
 
 die() { echo "error: $*" >&2; exit 1; }
@@ -36,6 +38,7 @@ args=()
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 		-v|--verbose) VERBOSE=true; shift ;;
+		--pre-releases) PRE_RELEASES=true; shift ;;
 		--positron-version)
 			[[ -n "${2:-}" ]] || die "--positron-version requires a version (e.g. 2026.03.0)"
 			POSITRON_VERSION="$2"; shift 2 ;;
@@ -327,7 +330,7 @@ check_series() {
 		fi
 	fi
 
-	if [[ -n "$prerelease_tags" ]]; then
+	if [[ -n "$prerelease_tags" && "$PRE_RELEASES" == true ]]; then
 		local count
 		count=$(echo "$prerelease_tags" | wc -l | tr -d ' ')
 		echo "Pre-releases ($count tags):"
@@ -335,6 +338,10 @@ check_series() {
 		if [[ -n "$_FOUND_OK" && -z "$_LATEST_PRERELEASE" ]]; then
 			_LATEST_PRERELEASE="$_FOUND_OK"
 		fi
+	elif [[ -n "$prerelease_tags" ]]; then
+		local count
+		count=$(echo "$prerelease_tags" | wc -l | tr -d ' ')
+		echo "Pre-releases ($count tags, skipped -- use --pre-releases to check)"
 	fi
 }
 

--- a/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
+++ b/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Check upstream release tags for API proposal compatibility with a Positron build.
+#
+# Usage:
+#   ./check-proposals.sh                              # auto-detect from repo
+#   ./check-proposals.sh <proposals-source>            # auto-discover tags
+#   ./check-proposals.sh <proposals-source> <tag-prefix>  # explicit tag series
+#
+# With no arguments, reads package.json for the Code OSS version, extracts
+# proposals from the source tree, and discovers compatible tag series
+# automatically.
+#
+# Options:
+#   -v, --verbose   Show full list of Positron proposals (default: count only)
+#
+# Requires: gh, python3
+
+set -euo pipefail
+
+REPO="microsoft/vscode-copilot-chat"
+PROPOSALS_TS="src/vs/platform/extensions/common/extensionsApiProposals.ts"
+VERBOSE=false
+
+die() { echo "error: $*" >&2; exit 1; }
+
+# --- Parse flags ---------------------------------------------------------------
+
+args=()
+for arg in "$@"; do
+	case "$arg" in
+		-v|--verbose) VERBOSE=true ;;
+		*) args+=("$arg") ;;
+	esac
+done
+set -- "${args[@]+${args[@]}}"
+
+# --- Resolve Positron proposals ------------------------------------------------
+
+resolve_proposals() {
+	local source="$1"
+
+	if [[ -d "$source" || "$source" == *.app ]]; then
+		# It's a Positron app bundle -- extract from sharedProcessMain.js
+		local js
+		js=$(find "$source" -name 'sharedProcessMain.js' -print -quit 2>/dev/null)
+		[[ -n "$js" ]] || die "Could not find sharedProcessMain.js inside $source"
+		# Extract name@version from the proposals map structure (minified:
+		# name:{proposal:"...",version:N} )
+		python3 -c "
+import re, sys
+content = open(sys.argv[1]).read()
+for m in re.finditer(r'(\w+):\{proposal:\"[^\"]+\",version:(\d+)\}', content):
+    print(f'{m.group(1)}@{m.group(2)}')
+" "$js" | sort -u
+	elif [[ -f "$source" && "$source" == *.ts ]]; then
+		# TypeScript source file (extensionsApiProposals.ts)
+		python3 -c "
+import re, sys
+content = open(sys.argv[1]).read()
+for m in re.finditer(r'(\w+)\s*:\s*\{[^}]*version\s*:\s*(\d+)', content):
+    print(f'{m.group(1)}@{m.group(2)}')
+" "$source" | sort -u
+	elif [[ -f "$source" ]]; then
+		# Plain text file (one proposal@version per line)
+		grep -vE '^\s*(#|$)' "$source" | sort -u
+	else
+		die "Not a file or directory: $source"
+	fi
+}
+
+# --- Discover compatible tag series from Code OSS version ---------------------
+
+discover_tag_series() {
+	local code_oss_version="$1"
+	local code_oss_minor
+	code_oss_minor=$(echo "$code_oss_version" | cut -d. -f2)
+
+	echo "Code OSS version: $code_oss_version"
+
+	# List all unique tag series (check last 5 minor versions)
+	local all_series
+	all_series=$(gh api "repos/$REPO/git/matching-refs/tags/v" --paginate \
+		--jq '.[].ref | ltrimstr("refs/tags/")' \
+		| grep -oE '^v[0-9]+\.[0-9]+' | sort -uV | tail -5)
+
+	[[ -n "$all_series" ]] || die "Could not list tag series from $REPO"
+
+	echo "Checking recent tag series for engine compatibility:"
+	local candidates=""
+	for series in $all_series; do
+		local engine
+		engine=$(gh api "repos/$REPO/contents/package.json?ref=${series}.0" \
+			--jq '.content' 2>/dev/null \
+			| base64 -d \
+			| python3 -c "
+import sys, json
+pkg = json.load(sys.stdin)
+print(pkg.get('engines', {}).get('vscode', 'unknown'))
+" 2>/dev/null) || continue
+
+		# Parse engine minor version from e.g. ^1.109.0
+		local engine_minor
+		engine_minor=$(echo "$engine" | grep -oE '[0-9]+\.[0-9]+' | head -1 | cut -d. -f2)
+		[[ -n "$engine_minor" ]] || continue
+
+		if [[ "$engine_minor" -le "$code_oss_minor" ]]; then
+			echo "  $series -> $engine (compatible)"
+			candidates+="$series"$'\n'
+		else
+			echo "  $series -> $engine (needs Code OSS > $code_oss_version)"
+		fi
+	done
+
+	# Return candidates newest-first so _LATEST_OK picks the highest series.
+	_CANDIDATES=$(echo "$candidates" | grep -v '^$' | sort -rV || true)
+}
+
+# --- Check a single tag series ------------------------------------------------
+
+check_series() {
+	local tag_prefix="$1"
+	local positron_proposals="$2"
+
+	echo ""
+	echo "--- $tag_prefix ---"
+
+	local tags
+	tags=$(gh api "repos/$REPO/git/matching-refs/tags/$tag_prefix." \
+		--jq '.[].ref | ltrimstr("refs/tags/")' \
+		| grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+		| sort -rV)
+
+	[[ -n "$tags" ]] || { echo "No tags found matching $tag_prefix.*"; return; }
+
+	for tag in $tags; do
+		local ext_proposals
+		ext_proposals=$(gh api "repos/$REPO/contents/package.json?ref=$tag" \
+			--jq '.content' | base64 -d | python3 -c "
+import sys, json
+pkg = json.load(sys.stdin)
+for p in sorted(p for p in pkg.get('enabledApiProposals', []) if '@' in p):
+    print(p)
+")
+
+		local issues=""
+		while IFS= read -r prop; do
+			[[ -z "$prop" ]] && continue
+			if ! echo "$positron_proposals" | grep -qxF "$prop"; then
+				local name="${prop%%@*}"
+				local match
+				match=$(echo "$positron_proposals" | grep -E "^${name}@" || true)
+				if [[ -n "$match" ]]; then
+					issues+="   $prop (Positron has $match)"$'\n'
+				else
+					issues+="   $prop (not in Positron)"$'\n'
+				fi
+			fi
+		done <<< "$ext_proposals"
+
+		if [[ -z "$issues" ]]; then
+			echo "OK  $tag"
+			# First OK is the latest compatible (tags are sorted newest-first)
+			if [[ -z "$_LATEST_OK" ]]; then
+				_LATEST_OK="$tag"
+			fi
+			return
+		else
+			echo "BAD $tag"
+			printf '%s' "$issues"
+		fi
+	done
+
+	echo "(no compatible tags in $tag_prefix series)"
+}
+
+# --- Main ---------------------------------------------------------------------
+# Globals set by functions:
+#   _CANDIDATES  - newline-separated tag series (set by discover_tag_series)
+#   _LATEST_OK   - highest compatible tag found (set by check_series)
+
+PROPOSALS_SOURCE="${1:-}"
+TAG_PREFIX="${2:-}"
+_LATEST_OK=""
+
+# Default proposals source to the TypeScript file in the repo
+if [[ -z "$PROPOSALS_SOURCE" ]]; then
+	[[ -f "$PROPOSALS_TS" ]] || die "No proposals source given and $PROPOSALS_TS not found. Run from the Positron repo root or pass an explicit path."
+	PROPOSALS_SOURCE="$PROPOSALS_TS"
+fi
+
+positron_proposals=$(resolve_proposals "$PROPOSALS_SOURCE")
+proposal_count=$(echo "$positron_proposals" | wc -l | tr -d ' ')
+
+if [[ "$VERBOSE" == true ]]; then
+	echo "Positron proposals ($proposal_count versioned, from $PROPOSALS_SOURCE):"
+	echo "$positron_proposals" | sed 's/^/  /'
+else
+	echo "Positron proposals: $proposal_count versioned (from $PROPOSALS_SOURCE)"
+fi
+echo ""
+
+if [[ -n "$TAG_PREFIX" ]]; then
+	# Explicit tag prefix -- check just that series
+	check_series "$TAG_PREFIX" "$positron_proposals"
+else
+	# Auto-discover compatible series from package.json
+	[[ -f "package.json" ]] || die "No tag prefix given and no package.json found. Run from the Positron repo root or pass an explicit tag prefix."
+	code_oss_version=$(python3 -c "import json; print(json.load(open('package.json'))['version'])")
+
+	discover_tag_series "$code_oss_version"
+	[[ -n "$_CANDIDATES" ]] || die "No compatible tag series found for Code OSS $code_oss_version"
+
+	for series in $_CANDIDATES; do
+		check_series "$series" "$positron_proposals"
+	done
+fi
+
+# --- Summary ------------------------------------------------------------------
+
+echo ""
+if [[ -n "$_LATEST_OK" ]]; then
+	echo "Latest compatible: $_LATEST_OK"
+else
+	echo "No compatible tags found."
+fi

--- a/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
+++ b/.claude/skills/pick-copilot-tag/scripts/check-proposals.sh
@@ -2,22 +2,23 @@
 # Check upstream release tags for API proposal compatibility with a Positron build.
 #
 # Usage:
-#   ./check-proposals.sh                              # auto-detect from repo
-#   ./check-proposals.sh <proposals-source>            # auto-discover tags
-#   ./check-proposals.sh <proposals-source> <tag-prefix>  # explicit tag series
-#   ./check-proposals.sh --positron-version 2026.03.0  # check against a release
-#   ./check-proposals.sh --positron-version 2026.03.0 v0.37  # release + explicit series
+#   ./check-proposals.sh                                        # auto-detect from repo
+#   ./check-proposals.sh --app /Applications/Positron.app       # check a built app
+#   ./check-proposals.sh --positron-version 2026.03.0           # check a release
+#   ./check-proposals.sh --tag-series v0.37                     # check one tag series
 #
 # With no arguments, reads package.json for the Code OSS version, extracts
 # proposals from the source tree, and discovers compatible tag series
 # automatically.
 #
 # Options:
-#   -v, --verbose                    Show full list of Positron proposals (default: count only)
-#   --pre-releases                   Also check date-based pre-release tags (default: releases only)
+#   --app <path>                     Check against a built Positron app bundle
+#   --tag-series <prefix>            Check only this tag series (e.g. v0.37)
 #   --positron-version <version>     Check against a Positron release (e.g. 2026.03.0)
 #                                    Looks up the release tag on GitHub, retrieves the
 #                                    Code OSS version and proposals from that build.
+#   --pre-releases                   Also check date-based pre-release tags (default: releases only)
+#   -v, --verbose                    Show full list of Positron proposals (default: count only)
 #
 # Requires: gh, jq, python3
 
@@ -29,12 +30,13 @@ POSITRON_REPO="posit-dev/positron"
 VERBOSE=false
 PRE_RELEASES=false
 POSITRON_VERSION=""
+APP_PATH=""
+TAG_PREFIX=""
 
 die() { echo "error: $*" >&2; exit 1; }
 
 # --- Parse flags ---------------------------------------------------------------
 
-args=()
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 		-v|--verbose) VERBOSE=true; shift ;;
@@ -42,10 +44,16 @@ while [[ $# -gt 0 ]]; do
 		--positron-version)
 			[[ -n "${2:-}" ]] || die "--positron-version requires a version (e.g. 2026.03.0)"
 			POSITRON_VERSION="$2"; shift 2 ;;
-		*) args+=("$1"); shift ;;
+		--app)
+			[[ -n "${2:-}" ]] || die "--app requires a path to a Positron app bundle"
+			APP_PATH="$2"; shift 2 ;;
+		--tag-series)
+			[[ -n "${2:-}" ]] || die "--tag-series requires a prefix (e.g. v0.37)"
+			TAG_PREFIX="$2"; shift 2 ;;
+		-*) die "Unknown option: $1" ;;
+		*) die "Unexpected argument: $1. Use --app, --tag-series, or --positron-version." ;;
 	esac
 done
-set -- "${args[@]+${args[@]}}"
 
 # --- Resolve Positron release tag ---------------------------------------------
 # Given a Positron version (e.g. 2026.03.0 or 2026.03.0-212), find the
@@ -100,37 +108,32 @@ for m in re.finditer(r'(\w+)\s*:\s*\{[^}]*version\s*:\s*(\d+)', content):
 " | sort -u
 }
 
-resolve_proposals() {
-	local source="$1"
-
-	if [[ -d "$source" || "$source" == *.app ]]; then
-		# It's a Positron app bundle -- extract from sharedProcessMain.js
-		local js
-		js=$(find "$source" -name 'sharedProcessMain.js' -print -quit 2>/dev/null)
-		[[ -n "$js" ]] || die "Could not find sharedProcessMain.js inside $source"
-		# Extract name@version from the proposals map structure. The JS may
-		# be minified (name:{proposal:"...",version:N}) or pretty-printed
-		# with newlines and indentation, so allow optional whitespace.
-		python3 -c "
+resolve_proposals_from_app() {
+	local app_path="$1"
+	[[ -d "$app_path" || "$app_path" == *.app ]] || die "Not an app bundle or directory: $app_path"
+	local js
+	js=$(find "$app_path" -name 'sharedProcessMain.js' -print -quit 2>/dev/null)
+	[[ -n "$js" ]] || die "Could not find sharedProcessMain.js inside $app_path"
+	# Extract name@version from the proposals map structure. The JS may
+	# be minified (name:{proposal:"...",version:N}) or pretty-printed
+	# with newlines and indentation, so allow optional whitespace.
+	python3 -c "
 import re, sys
 content = open(sys.argv[1]).read()
 for m in re.finditer(r'(\w+):\s*\{\s*proposal:\s*\"[^\"]+\"\s*,\s*version:\s*(\d+)\s*\}', content):
     print(f'{m.group(1)}@{m.group(2)}')
 " "$js" | sort -u
-	elif [[ -f "$source" && "$source" == *.ts ]]; then
-		# TypeScript source file (extensionsApiProposals.ts)
-		python3 -c "
+}
+
+resolve_proposals_from_source() {
+	local ts_file="$1"
+	[[ -f "$ts_file" ]] || die "Proposals file not found: $ts_file"
+	python3 -c "
 import re, sys
 content = open(sys.argv[1]).read()
 for m in re.finditer(r'(\w+)\s*:\s*\{[^}]*version\s*:\s*(\d+)', content):
     print(f'{m.group(1)}@{m.group(2)}')
-" "$source" | sort -u
-	elif [[ -f "$source" ]]; then
-		# Plain text file (one proposal@version per line)
-		grep -vE '^\s*(#|$)' "$source" | sort -u
-	else
-		die "Not a file or directory: $source"
-	fi
+" "$ts_file" | sort -u
 }
 
 # --- Discover compatible tag series from Code OSS version ---------------------
@@ -350,28 +353,25 @@ _CODE_OSS_MINOR=""
 _LATEST_OK=""
 _LATEST_PRERELEASE=""
 
-# When --positron-version is given, the only positional arg (if any) is a tag
-# prefix to select a specific series. Otherwise, positionals are
-# [proposals-source [tag-prefix]].
+# Validate flag combinations
+if [[ -n "$POSITRON_VERSION" && -n "$APP_PATH" ]]; then
+	die "Use --positron-version to check a remote release, or --app to check a local build, but not both"
+fi
+
+# Resolve proposals from the chosen source
 if [[ -n "$POSITRON_VERSION" ]]; then
-	[[ $# -le 1 ]] || die "--positron-version accepts at most one positional argument (tag prefix), got $#"
-	PROPOSALS_SOURCE=""
-	TAG_PREFIX="${1:-}"
 	resolve_positron_version "$POSITRON_VERSION"
 	code_oss_version="$_POSITRON_CODE_VERSION"
 	_CODE_OSS_MINOR=$(echo "$code_oss_version" | cut -d. -f2)
 	positron_proposals=$(resolve_proposals_from_tag "$_POSITRON_TAG")
 	proposals_label="$POSITRON_REPO@$_POSITRON_TAG"
+elif [[ -n "$APP_PATH" ]]; then
+	positron_proposals=$(resolve_proposals_from_app "$APP_PATH")
+	proposals_label="$APP_PATH"
 else
-	PROPOSALS_SOURCE="${1:-}"
-	TAG_PREFIX="${2:-}"
-	# Default proposals source to the TypeScript file in the repo
-	if [[ -z "$PROPOSALS_SOURCE" ]]; then
-		[[ -f "$PROPOSALS_TS" ]] || die "No proposals source given and $PROPOSALS_TS not found. Run from the Positron repo root or pass an explicit path."
-		PROPOSALS_SOURCE="$PROPOSALS_TS"
-	fi
-	positron_proposals=$(resolve_proposals "$PROPOSALS_SOURCE")
-	proposals_label="$PROPOSALS_SOURCE"
+	[[ -f "$PROPOSALS_TS" ]] || die "$PROPOSALS_TS not found. Run from the Positron repo root, or use --app or --positron-version."
+	positron_proposals=$(resolve_proposals_from_source "$PROPOSALS_TS")
+	proposals_label="$PROPOSALS_TS"
 fi
 
 proposal_count=$(echo "$positron_proposals" | wc -l | tr -d ' ')
@@ -398,7 +398,7 @@ else
 		if [[ -f "package.json" ]]; then
 			code_oss_version=$(jq -r '.version' package.json)
 		else
-			die "No tag prefix given and no package.json found. Run from the Positron repo root, pass --positron-version, or pass an explicit tag prefix."
+			die "No package.json found. Run from the Positron repo root, use --positron-version, or use --tag-series."
 		fi
 		_CODE_OSS_MINOR=$(echo "$code_oss_version" | cut -d. -f2)
 		echo "Code OSS version: $code_oss_version"

--- a/.claude/skills/review-upstream-merge.md
+++ b/.claude/skills/review-upstream-merge.md
@@ -142,7 +142,11 @@ echo "Expected Node version: $NVMRC_VERSION"
 
 See commit `ffd551b3553` for an example of updating node versions across all files.
 
-### Step 6: Generate Review Report
+### Step 6: Check Copilot Extension Compatibility
+
+Upstream merges change the Code OSS version and API proposals compiled into Positron. Use the `pick-copilot-tag` skill to determine which `microsoft/vscode-copilot-chat` tag to use with the new build. Flag the latest compatible tag and any regressions vs. the currently pinned version.
+
+### Step 7: Generate Review Report
 
 Create a structured report with these sections:
 
@@ -202,6 +206,16 @@ Create a structured report with these sections:
 | Admin enforced settings | [OK/Changed] |
 | Relative path generation | [OK/Changed] |
 
+### Copilot Extension Compatibility
+
+| Tag | Status | Issues |
+|-----|--------|--------|
+| ... | OK/BAD | ... |
+
+**Latest compatible tag**: vX.Y.Z
+**Currently pinned**: vX.Y.Z
+**Action**: [None/Update needed]
+
 ### Potential Concerns
 [List any concerns with risk level]
 
@@ -209,7 +223,7 @@ Create a structured report with these sections:
 [Safe to merge / Needs attention / Do not merge]
 ```
 
-### Step 7: Additional Checks (if needed)
+### Step 8: Additional Checks (if needed)
 
 If the review identifies concerns that require investigating how Posit Workbench integrates with this code, **prompt the user for the rstudio-pro repository location**:
 
@@ -244,3 +258,4 @@ The merge is safe if:
 - [ ] File controls still functional
 - [ ] No major dependency breaking changes
 - [ ] Build environment Node versions match `.nvmrc` (or flagged for update)
+- [ ] Copilot extension compatibility checked (latest compatible tag identified)


### PR DESCRIPTION
## Summary

- Adds a Claude Code skill and shell script that checks which `microsoft/vscode-copilot-chat` release tags are compatible with a Positron build by comparing underlying Code OSS version and API proposal versions
- Helps prevent issues like #12410 where a copilot-chat bump introduces proposals that Positron doesn't support yet, silently breaking Copilot in release builds
- Separates release tags from date-based pre-release tags and checks per-tag engine compatibility, so we can identify the latest safe tag to use
- Pre-releases are skipped by default (opt in with `--pre-releases`) since we typically pin to stable releases
- Supports checking against the local source tree (default), a built Positron app (`--app`), or a specific Positron release on GitHub (`--positron-version`)
- Includes a reference doc explaining why engine version alone isn't sufficient and how proposal version enforcement works
- Updates the `review-upstream-merge` skill with a copilot compatibility check step and report section
- Shows a progress indicator when checking many tags so the script doesn't appear hung

## How to use

**As a Claude Code skill** -- ask Claude to `/pick-copilot-tag` and it will run the check and report results.

**Directly from the command line** -- from the Positron repo root:

```bash
# Auto-discover compatible tag series from package.json
.claude/skills/pick-copilot-tag/scripts/check-proposals.sh

# Check against a built Positron app instead of the source tree
.claude/skills/pick-copilot-tag/scripts/check-proposals.sh --app /Applications/Positron.app

# Check against a specific Positron release
.claude/skills/pick-copilot-tag/scripts/check-proposals.sh --positron-version 2026.03.0

# Check a specific tag series
.claude/skills/pick-copilot-tag/scripts/check-proposals.sh --tag-series v0.37
```

Requires `gh` (GitHub CLI) authenticated, `jq`, and `python3`.

## Example output

Ran the script from the positron repo:

```bash
$ .claude/skills/pick-copilot-tag/scripts/check-proposals.sh

Positron proposals: 9 versioned (from src/vs/.../extensionsApiProposals.ts)

Code OSS version: 1.109.2
Checking recent tag series for engine compatibility:
  v0.36 -> ^1.108.0 (compatible)
  v0.37 -> ^1.109.0-20260124 (compatible)
  v0.38 -> ^1.110.0-20260223 (pre-releases may be compatible)
  v0.39 -> ^1.111.0 (needs Code OSS >= 1.111.0)

--- v0.38 ---
Releases (3 tags):
SKIP v0.38.2 .. v0.38.0 (3 tags, needs Code OSS >= 1.110.0)
Pre-releases (58 tags, skipped -- use --pre-releases to check)

--- v0.37 ---
Releases (9 tags):
BAD v0.37.9
   chatHooks@6 (not in Positron)
   chatParticipantPrivate@13 (Positron has chatParticipantPrivate@12)
OK  v0.37.5
Pre-releases (41 tags, skipped -- use --pre-releases to check)

Latest compatible release: v0.37.5
```
