### PR TITLE
e2e: verify S3 download completed successfully

### DIFF
--- a/test/e2e/pages/utils/aws.ts
+++ b/test/e2e/pages/utils/aws.ts
@@ -5,7 +5,7 @@
 
 // eslint-disable-next-line local/code-import-patterns
 import { S3Client, GetObjectCommand, GetObjectCommandOutput } from '@aws-sdk/client-s3';
-import { createWriteStream } from 'fs';
+import { createWriteStream, existsSync, statSync } from 'fs';
 import { pipeline } from 'stream';
 import { promisify } from 'util';
 
@@ -47,6 +47,15 @@ export const downloadFileFromS3 = async (options: S3FileDownloadOptions): Promis
 			const fileStream = createWriteStream(options.localFilePath);
 			const streamPipeline = promisify(pipeline);
 			await streamPipeline(response.Body, fileStream);
+
+			// Verify the file was written successfully
+			if (!existsSync(options.localFilePath)) {
+				throw new Error(`File not found after download: ${options.localFilePath}`);
+			}
+			const stats = statSync(options.localFilePath);
+			if (stats.size === 0) {
+				throw new Error(`Downloaded file is empty: ${options.localFilePath}`);
+			}
 			return;
 		} catch (error) {
 			console.error(`Attempt ${attempt + 1} failed:`, (error as any).message);


### PR DESCRIPTION
## Problem

The `very-large-data-frame` E2E test was failing/flaking with a timeout waiting for the `df2` variable when the S3 download silently failed. The R script couldn't load the parquet file, so no variable was created, leading to a confusing timeout error.

<img width="835" height="77" alt="Screenshot 2026-03-12 at 6 57 18 PM" src="https://github.com/user-attachments/assets/50824bcf-3ee2-4ce6-bcc9-89fde5f780ee" />

## Solution

Verify the downloaded file exists and isn't empty before returning from `downloadFileFromS3`. If verification fails, the error is thrown and triggers a retry (up to 3 attempts), giving a clear error message on ultimate failure.

## QA Notes
@:data-explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)