### PR TITLE
e2e: disable githubIssues.issueCompletions

### DIFF
--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -15,5 +15,6 @@
 	"positron.assistant.provider.echo.enable": true,
 	"positron.assistant.provider.error.enable": true,
   "posit.workbench.showWorkbenchFlaskHint": false,
-	"editor.accessibilitySupport": "off"
+	"editor.accessibilitySupport": "off",
+	"githubIssues.issueCompletions.enabled": false
 }

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -15,6 +15,11 @@ test.describe('Notebook Focus and Selection', {
 	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.CROSS_BROWSER]
 }, () => {
 
+	test.beforeAll(async function ({ hotKeys }) {
+		await hotKeys.minimizeBottomPanel();
+		await hotKeys.closeSecondarySidebar();
+	});
+
 	test('Arrow keys move cell selection up and down', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;


### PR DESCRIPTION
## Summary
Disabling the `githubIssues.issueCompletions.enabled` extension which was causing mis-clicks on notebook cell tests.
<img width="1110" height="809" alt="Screenshot 2026-03-13 at 7 33 22 AM" src="https://github.com/user-attachments/assets/822e78a6-a638-4720-be42-d1e745dd60ee" />

## QA Notes
@:positron-notebooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)