### PR TITLE
e2e: Add SOFT_FAIL tag and issue annotation to Memory Usage tests

### DIFF
--- a/test/e2e/tests/variables/variables-memory-usage.test.ts
+++ b/test/e2e/tests/variables/variables-memory-usage.test.ts
@@ -11,7 +11,7 @@ test.use({
 
 test.describe('Variables: Memory Usage', {
 	tag: [tags.WIN, tags.VARIABLES, tags.SESSIONS, tags.SOFT_FAIL],
-	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/actions/runs/23053059849' }]
+	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/12476' }]
 }, () => {
 
 	test.beforeEach(async function ({ hotKeys }) {

--- a/test/e2e/tests/variables/variables-memory-usage.test.ts
+++ b/test/e2e/tests/variables/variables-memory-usage.test.ts
@@ -10,7 +10,8 @@ test.use({
 });
 
 test.describe('Variables: Memory Usage', {
-	tag: [tags.WIN, tags.VARIABLES, tags.SESSIONS]
+	tag: [tags.WIN, tags.VARIABLES, tags.SESSIONS, tags.SOFT_FAIL],
+	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/actions/runs/23053059849' }]
 }, () => {
 
 	test.beforeEach(async function ({ hotKeys }) {


### PR DESCRIPTION
These tests are new and have a flake due to https://github.com/posit-dev/positron/issues/12476, so moving to soft-fail for now.  Soft-fail can be removed whent the issue is fixed.

### QA Notes
@:variables
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
