### PR TITLE
Support a limited set of important keyboard shortcuts for PDF viewer

### DIFF
--- a/extensions/positron-pdf-server/keyboard-forwarder.js
+++ b/extensions/positron-pdf-server/keyboard-forwarder.js
@@ -1,0 +1,142 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * This script is injected into the PDF.js viewer to forward specific keyboard
+ * shortcuts to VS Code. Without this, keyboard events are captured by PDF.js
+ * and don't reach VS Code's keybinding service.
+ *
+ * We use an allowlist approach to only forward shortcuts that should be handled
+ * by VS Code, while letting PDF.js handle its own shortcuts (like Cmd+F for find).
+ */
+
+(function () {
+	'use strict';
+
+	/**
+	 * Check if the keyboard event matches a shortcut that should be forwarded to VS Code.
+	 * @param {KeyboardEvent} e
+	 * @returns {boolean}
+	 */
+	function shouldForwardToVSCode(e) {
+		const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+		const cmdOrCtrl = isMac ? e.metaKey : e.ctrlKey;
+
+		// Command Palette: Cmd/Ctrl+Shift+P
+		if (cmdOrCtrl && e.shiftKey && e.code === 'KeyP') {
+			return true;
+		}
+
+		// Settings: Cmd/Ctrl+,
+		if (cmdOrCtrl && e.code === 'Comma') {
+			return true;
+		}
+
+		// Toggle Sidebar: Cmd/Ctrl+B
+		if (cmdOrCtrl && e.code === 'KeyB') {
+			return true;
+		}
+
+		// Explorer: Cmd/Ctrl+Shift+E
+		if (cmdOrCtrl && e.shiftKey && e.code === 'KeyE') {
+			return true;
+		}
+
+		// Search: Cmd/Ctrl+Shift+F
+		if (cmdOrCtrl && e.shiftKey && e.code === 'KeyF') {
+			return true;
+		}
+
+		// Note: We intentionally do NOT forward Cmd/Ctrl+P (without shift) because
+		// in a PDF context, users expect this to print the PDF, not open Quick Open.
+
+		// Close Editor: Cmd/Ctrl+W
+		if (cmdOrCtrl && e.code === 'KeyW') {
+			return true;
+		}
+
+		// New Window: Cmd/Ctrl+Shift+N
+		if (cmdOrCtrl && e.shiftKey && e.code === 'KeyN') {
+			return true;
+		}
+
+		// Escape key - useful for closing dialogs, panels
+		if (e.code === 'Escape') {
+			return true;
+		}
+
+		// F1 - Help
+		if (e.code === 'F1') {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Forward a keyboard event to the parent frames.
+	 * @param {KeyboardEvent} e
+	 * @param {string} type
+	 */
+	function forwardKeyEvent(e, type) {
+		const eventData = {
+			type: type,
+			key: e.key,
+			keyCode: e.keyCode,
+			code: e.code,
+			shiftKey: e.shiftKey,
+			altKey: e.altKey,
+			ctrlKey: e.ctrlKey,
+			metaKey: e.metaKey,
+			repeat: e.repeat
+		};
+
+		// Post message to parent frame (the VS Code webview).
+		// We use '*' for the target origin because:
+		// 1. The parent webview has a dynamic vscode-webview:// origin that we can't
+		//    easily know from this context
+		// 2. This follows the same pattern as VS Code's webview-events.js
+		// 3. Security is enforced on the receiving side, which validates that
+		//    messages come from the expected localhost origin
+		try {
+			window.parent.postMessage({
+				channel: 'pdf-keyboard-event',
+				data: eventData
+			}, '*');
+		} catch (err) {
+			// Ignore cross-origin errors
+		}
+	}
+
+	/**
+	 * Handle keydown events.
+	 * @param {KeyboardEvent} e
+	 */
+	function handleKeyDown(e) {
+		if (shouldForwardToVSCode(e)) {
+			// Prevent PDF.js from handling this shortcut
+			e.preventDefault();
+			e.stopPropagation();
+			e.stopImmediatePropagation();
+			forwardKeyEvent(e, 'keydown');
+		}
+	}
+
+	/**
+	 * Handle keyup events.
+	 * @param {KeyboardEvent} e
+	 */
+	function handleKeyUp(e) {
+		if (shouldForwardToVSCode(e)) {
+			e.preventDefault();
+			e.stopPropagation();
+			forwardKeyEvent(e, 'keyup');
+		}
+	}
+
+	// Add event listeners with capture phase to intercept before PDF.js
+	window.addEventListener('keydown', handleKeyDown, true);
+	window.addEventListener('keyup', handleKeyUp, true);
+})();

--- a/extensions/positron-pdf-server/src/pdfHttpServer.ts
+++ b/extensions/positron-pdf-server/src/pdfHttpServer.ts
@@ -77,10 +77,35 @@ export class PdfHttpServer {
 			throw new Error('Server not initialized. Call initialize() with extension path first.');
 		}
 
-		// Serve PDF.js distribution files statically (includes web/viewer.html, build/, etc.).
+		// Serve PDF.js viewer.html with keyboard forwarder script injected.
+		this.app.get('/pdfjs/web/viewer.html', async (req: express.Request, res: express.Response) => {
+			try {
+				const viewerPath = path.join(this.extensionPath!, 'pdfjs-dist', 'web', 'viewer.html');
+				let html = await fs.promises.readFile(viewerPath, 'utf-8');
+
+				// Inject our keyboard forwarder script in the <head> BEFORE PDF.js scripts.
+				// This ensures our capture-phase event listeners are registered first.
+				const scriptTag = '<script src="/keyboard-forwarder.js"></script>';
+				html = html.replace('<title>PDF.js viewer</title>', `<title>PDF.js viewer</title>\n${scriptTag}`);
+
+				res.type('text/html');
+				return res.send(html);
+			} catch (err) {
+				console.error('Error serving modified viewer.html:', err);
+				return res.status(500).send('Error loading PDF viewer');
+			}
+		});
+
+		// Serve PDF.js distribution files statically (includes web/*, build/*, etc.).
 		this.app.use('/pdfjs', express.static(
 			path.join(this.extensionPath, 'pdfjs-dist')
 		));
+
+		// Serve keyboard forwarder script for injection into PDF.js viewer.
+		this.app.get('/keyboard-forwarder.js', (_req: express.Request, res: express.Response) => {
+			res.type('application/javascript');
+			res.sendFile(path.join(this.extensionPath!, 'keyboard-forwarder.js'));
+		});
 
 		// Serve custom viewer wrapper.
 		this.app.get('/viewer', (_req: express.Request, res: express.Response) => {

--- a/extensions/positron-pdf-server/src/pdfServerProvider.ts
+++ b/extensions/positron-pdf-server/src/pdfServerProvider.ts
@@ -26,6 +26,71 @@ export class PdfServerProvider implements vscode.CustomReadonlyEditorProvider {
 	}
 
 	/**
+	 * Map a keyboard shortcut to a VS Code command.
+	 * Returns undefined if the shortcut doesn't map to a known command.
+	 */
+	private getCommandForShortcut(shortcut: {
+		code: string;
+		metaKey: boolean;
+		ctrlKey: boolean;
+		shiftKey: boolean;
+		altKey: boolean;
+	}): string | undefined {
+		const isMac = process.platform === 'darwin';
+		const cmdOrCtrl = isMac ? shortcut.metaKey : shortcut.ctrlKey;
+
+		// Command Palette: Cmd/Ctrl+Shift+P
+		if (cmdOrCtrl && shortcut.shiftKey && shortcut.code === 'KeyP') {
+			return 'workbench.action.showCommands';
+		}
+
+		// Note: We intentionally do NOT handle Cmd/Ctrl+P (without shift) because
+		// in a PDF context, users expect this to print the PDF, not open Quick Open.
+
+		// Settings: Cmd/Ctrl+,
+		if (cmdOrCtrl && shortcut.code === 'Comma') {
+			return 'workbench.action.openSettings';
+		}
+
+		// Toggle Sidebar: Cmd/Ctrl+B
+		if (cmdOrCtrl && shortcut.code === 'KeyB') {
+			return 'workbench.action.toggleSidebarVisibility';
+		}
+
+		// Explorer: Cmd/Ctrl+Shift+E
+		if (cmdOrCtrl && shortcut.shiftKey && shortcut.code === 'KeyE') {
+			return 'workbench.view.explorer';
+		}
+
+		// Search: Cmd/Ctrl+Shift+F
+		if (cmdOrCtrl && shortcut.shiftKey && shortcut.code === 'KeyF') {
+			return 'workbench.action.findInFiles';
+		}
+
+		// Close Editor: Cmd/Ctrl+W
+		if (cmdOrCtrl && shortcut.code === 'KeyW') {
+			return 'workbench.action.closeActiveEditor';
+		}
+
+		// New Window: Cmd/Ctrl+Shift+N
+		if (cmdOrCtrl && shortcut.shiftKey && shortcut.code === 'KeyN') {
+			return 'workbench.action.newWindow';
+		}
+
+		// Escape - close panels/dialogs
+		if (shortcut.code === 'Escape') {
+			return 'workbench.action.closeQuickOpen';
+		}
+
+		// F1 - Help/Command Palette
+		if (shortcut.code === 'F1') {
+			return 'workbench.action.showCommands';
+		}
+
+		return undefined;
+	}
+
+	/**
 	 * Resolve custom editor.
 	 */
 	public async resolveCustomEditor(
@@ -58,10 +123,23 @@ export class PdfServerProvider implements vscode.CustomReadonlyEditorProvider {
 			);
 		});
 
+		// Listen for keyboard shortcut messages from the webview and execute
+		// the appropriate VS Code commands. This allows shortcuts like
+		// Cmd+Shift+P to work when the PDF viewer has focus.
+		const messageListener = webviewPanel.webview.onDidReceiveMessage(async (message) => {
+			if (message.type === 'keyboard-shortcut') {
+				const command = this.getCommandForShortcut(message);
+				if (command) {
+					await vscode.commands.executeCommand(command);
+				}
+			}
+		});
+
 		// Cleanup on disposal.
 		webviewPanel.onDidDispose(() => {
-			// Dispose theme listener.
+			// Dispose listeners.
 			themeChangeListener.dispose();
+			messageListener.dispose();
 
 			// Unregister PDF from server.
 			this.httpServer.unregisterPdf(pdfId);

--- a/extensions/positron-pdf-server/src/pdfViewerWebview.ts
+++ b/extensions/positron-pdf-server/src/pdfViewerWebview.ts
@@ -74,6 +74,7 @@ export async function createWebviewHtml(
 	const viewerUrl = `${serverUrl}/viewer?file=${encodeURIComponent(pdfUrl)}&theme=${theme}`;
 
 	// Return the complete HTML for the webview, including the CSP and the iframe pointing to the viewer URL.
+	// Also includes a script to forward keyboard events from the PDF viewer to VS Code's keybinding service.
 	return `<!DOCTYPE html>
 <html>
 <head>
@@ -97,6 +98,41 @@ export async function createWebviewHtml(
 </head>
 <body>
 	<iframe id="pdf-frame" src="${viewerUrl}"></iframe>
+	<script nonce="${nonce}">
+		// Get VS Code API for messaging - this is provided by VS Code's webview infrastructure
+		const vscode = acquireVsCodeApi();
+
+		// Expected origin for messages from the PDF viewer iframe.
+		// We validate this to prevent other frames from spoofing keyboard events.
+		const expectedOrigin = new URL('${serverUrl}').origin;
+
+		// Listen for keyboard events forwarded from the PDF.js viewer.
+		// The keyboard-forwarder.js script in the PDF viewer posts messages
+		// when specific shortcuts are pressed that should be handled by VS Code.
+		window.addEventListener('message', function(event) {
+			// Validate the message origin - only accept messages from our PDF server
+			if (event.origin !== expectedOrigin) {
+				return;
+			}
+
+			if (event.data && event.data.channel === 'pdf-keyboard-event') {
+				const data = event.data.data;
+
+				// Send the keyboard event to the extension, which will execute
+				// the appropriate VS Code command
+				vscode.postMessage({
+					type: 'keyboard-shortcut',
+					key: data.key,
+					code: data.code,
+					keyCode: data.keyCode,
+					shiftKey: data.shiftKey,
+					altKey: data.altKey,
+					ctrlKey: data.ctrlKey,
+					metaKey: data.metaKey
+				});
+			}
+		});
+	</script>
 </body>
 </html>`;
 }


### PR DESCRIPTION
Addresses #12220

When the PDF viewer is focused, keyboard shortcuts like <kbd>Cmd+Shift+P</kbd> don't reach VS Code because PDF.js captures all keyboard events within its iframe. This PR implements keyboard forwarding from the PDF viewer to VS Code using an allowlist approach.

Unlike the Help pane (which forwards all keyboard events), the PDF viewer uses PDF.js which has its own rich keyboard shortcuts (<kbd>Cmd+F</kbd> for find, <kbd>Cmd+P</kbd> for print, arrow keys for navigation, etc.). Forwarding all events would break this PDF.js functionality. The allowlist approach preserves PDF.js shortcuts users expect when viewing PDFs and only forwards a specific set of VS Code navigation shortcuts (Command Palette, Settings, etc).

This does use `'*'` for postMessage target origin (same pattern as VS Code's `webview-events.js`) since the parent webview origin is dynamic, but I set up origin validation on the receiving side so only messages from the trusted localhost PDF server are processed.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed keyboard shortcuts (<kbd>Ctrl/Cmd+Shift+P</kbd>, <kbd>Cmd+B</kbd>, etc) not working when PDF viewer has focus (#12220)

### QA Notes

@:viewer @:editor

**Forwarded shortcuts to test (with PDF viewer focused):**
1. Open any PDF file in Positron
2. Click inside the PDF viewer to give it focus
3. Test each shortcut (macOS, or switch out for Windows equivalents):
   - <kbd>Cmd+Shift+P</kbd> should open Command Palette
   - <kbd>Cmd+,</kbd> should open Settings
   - <kbd>Cmd+B</kbd> should toggle sidebar
   - <kbd>Cmd+Shift+E</kbd> should open Explorer
   - <kbd>Cmd+Shift+F</kbd> should open Search
   - <kbd>Cmd+W</kbd> should close the PDF editor
   - <kbd>Cmd+Shift+N</kbd> should open new window
   - <kbd>Escape</kbd> should close any open dialogs
   - <kbd>F1</kbd> should open Command Palette

**PDF.js shortcuts that should still work:**
- <kbd>Cmd+F</kbd> for PDF find dialog (NOT VS Code's find)
- <kbd>Cmd+P</kbd> for print dialog although see https://github.com/posit-dev/positron/issues/12492
- Arrow keys for PDF navigation
- `+`/`-` to zoom in/out
