### PR TITLE
e2e: Add SOFT_FAIL tag to Restart Host Extension tests

### DIFF
--- a/test/e2e/tests/extensions/restart-host-ext.test.ts
+++ b/test/e2e/tests/extensions/restart-host-ext.test.ts
@@ -9,7 +9,10 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Restart Host Extension', { tag: [tags.EXTENSIONS, tags.WIN] }, () => {
+test.describe('Restart Host Extension', {
+	tag: [tags.EXTENSIONS, tags.WIN, tags.SOFT_FAIL],
+	annotation: { type: 'issue', description: 'https://github.com/posit-dev/positron/issues/12476' }
+}, () => {
 
 	test.afterEach(async ({ app }) => {
 		await app.workbench.sessions.deleteAll();
@@ -25,7 +28,7 @@ test.describe('Restart Host Extension', { tag: [tags.EXTENSIONS, tags.WIN] }, ()
 		await app.workbench.console.waitForConsoleContents('101');
 	});
 
-	test('Verify Restart Extension Host command works - Python', { tag: [tags.SOFT_FAIL] }, async function ({ app, python }) {
+	test('Verify Restart Extension Host command works - Python', async function ({ app, python }) {
 		await app.workbench.quickaccess.runCommand('workbench.action.restartExtensionHost');
 		await app.workbench.console.waitForConsoleContents('Extensions restarting...');
 		await app.workbench.console.waitForReady('>>>');


### PR DESCRIPTION
These tests have a flake due to #12476, so moving to soft-fail for now. Soft-fail can be removed whent the issue is fixed.

### QA Notes
@:extensions
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
