### PR TITLE
dev: filter out posit workbench in positron dev builds

### DIFF
--- a/build/lib/builtInExtensions.ts
+++ b/build/lib/builtInExtensions.ts
@@ -192,7 +192,7 @@ export function getBuiltInExtensions(): Promise<void> {
 		// formal part of the extension definition but a custom field we use to
 		// filter out web-only extensions (i.e. Posit Workbench)
 		// @ts-ignore
-		if (extension.type === 'reh-web') {
+		if (extension.type === 'reh-web' || extension.type === 'reh-web-pwb') {
 			continue;
 		}
 		// --- End Positron ---


### PR DESCRIPTION
This slipped in #12505 since we don't have this `reh-web` check in `vscode-server` 😅 apologies yall!

NOTE: you may have to clear out your `positron/.build/builtInExtensions` directory to see the changes

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Positron dev build should not show posit workbench. 