### PR TITLE
Add plumbing for extension-specified execution metadata

### DIFF
--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -197,6 +197,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         mode: positron.RuntimeCodeExecutionMode,
         errorBehavior: positron.RuntimeErrorBehavior,
         codeLocation?: positron.Utf8Location,
+        executionMetadata?: Record<string, any>
     ): void {
         if (this._kernel) {
             if (this._isUninstallBundledPackageCommand(code, id)) {
@@ -204,7 +205,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
                 return;
             }
 
-            this._kernel.execute(code, id, mode, errorBehavior, codeLocation);
+            this._kernel.execute(code, id, mode, errorBehavior, codeLocation, executionMetadata);
         } else {
             throw new Error(`Cannot execute '${code}'; kernel not started`);
         }

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -197,7 +197,7 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
         mode: positron.RuntimeCodeExecutionMode,
         errorBehavior: positron.RuntimeErrorBehavior,
         codeLocation?: positron.Utf8Location,
-        executionMetadata?: Record<string, any>
+        executionMetadata?: Record<string, any>,
     ): void {
         if (this._kernel) {
             if (this._isUninstallBundledPackageCommand(code, id)) {

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -247,9 +247,10 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		mode: positron.RuntimeCodeExecutionMode,
 		errorBehavior: positron.RuntimeErrorBehavior,
 		codeLocation?: positron.Utf8Location,
+		executionMetadata?: Record<string, any>
 	): void {
 		if (this._kernel) {
-			this._kernel.execute(code, id, mode, errorBehavior, codeLocation);
+			this._kernel.execute(code, id, mode, errorBehavior, codeLocation, executionMetadata);
 		} else {
 			throw new Error(`Cannot execute '${code}'; kernel not started`);
 		}

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -792,6 +792,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		mode: positron.RuntimeCodeExecutionMode,
 		errorBehavior: positron.RuntimeErrorBehavior,
 		codeLocation?: positron.Utf8Location,
+		executionMetadata?: Record<string, unknown>
 	): void {
 
 		// Translate the parameters into a Jupyter execute request
@@ -810,6 +811,13 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 					uri: codeLocation.uri.toString(),
 					range: codeLocation.range,
 				}
+			};
+		}
+
+		if (executionMetadata) {
+			request.positron = {
+				...request.positron,
+				executionMetadata
 			};
 		}
 

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -817,7 +817,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		if (executionMetadata) {
 			request.positron = {
 				...request.positron,
-				executionMetadata
+				...executionMetadata
 			};
 		}
 

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -805,18 +805,15 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			stop_on_error: errorBehavior === positron.RuntimeErrorBehavior.Stop,
 		};
 
-		if (codeLocation) {
+		// If a code location or execution metadata is provided, include it in the request
+		if (codeLocation || executionMetadata) {
 			request.positron = {
-				code_location: {
-					uri: codeLocation.uri.toString(),
-					range: codeLocation.range,
-				}
-			};
-		}
-
-		if (executionMetadata) {
-			request.positron = {
-				...request.positron,
+				...(codeLocation ? {
+					code_location: {
+						uri: codeLocation.uri.toString(),
+						range: codeLocation.range
+					}
+				} : {}),
 				...executionMetadata
 			};
 		}

--- a/extensions/positron-supervisor/src/jupyter/ExecuteRequest.ts
+++ b/extensions/positron-supervisor/src/jupyter/ExecuteRequest.ts
@@ -50,6 +50,9 @@ export interface JupyterExecuteRequest {
 export interface JupyterPositronExecuteRequest {
 	/** Location of `code`. Character offsets are in UTF-8 bytes (not UTF-16 or code points). */
 	code_location?: JupyterPositronLocation;
+
+	/** Additional metadata to associate with this execution. */
+	executionMetadata?: Record<string, unknown>;
 }
 
 /**

--- a/extensions/positron-zed/src/positronZedLanguageRuntime.ts
+++ b/extensions/positron-zed/src/positronZedLanguageRuntime.ts
@@ -1832,7 +1832,19 @@ export class PositronZedRuntimeSession implements positron.LanguageRuntimeSessio
 
 		// Perform the execution
 		try {
-			const result = await positron.runtime.executeCode(languageId, codeToExecute, focus, true, mode, errorBehavior);
+			const result = await positron.runtime.executeCode(
+				languageId,
+				codeToExecute,
+				focus,
+				true,
+				mode,
+				errorBehavior,
+				undefined, // execution observer
+				undefined, // session id
+				undefined, // document uri,
+				{
+					"arose-from": "zed-simulation"
+				});
 			if (result) {
 				this.simulateOutputMessage(parentId, JSON.stringify(result, undefined, 2));
 			} else {

--- a/extensions/vscode-api-tests/src/singlefolder-tests/positron/runtime.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/positron/runtime.test.ts
@@ -20,6 +20,7 @@ class TestLanguageRuntimeSession implements positron.LanguageRuntimeSession {
 	private _currentExecutionId = '';
 	private _variables: Map<string, any> = new Map();
 	private _runtimeInfo: positron.LanguageRuntimeInfo | undefined;
+	public lastExecutionMetadata: Record<string, any> | undefined;
 
 	onDidReceiveRuntimeMessage: vscode.Event<positron.LanguageRuntimeMessage> = this._onDidReceiveRuntimeMessage.event;
 	onDidChangeRuntimeState: vscode.Event<positron.RuntimeState> = this._onDidChangeRuntimeState.event;
@@ -50,9 +51,10 @@ class TestLanguageRuntimeSession implements positron.LanguageRuntimeSession {
 		return `msg-${TestLanguageRuntimeSession.messageId++}`;
 	}
 
-	execute(code: string, id: string, _mode: positron.RuntimeCodeExecutionMode): void {
+	execute(code: string, id: string, _mode: positron.RuntimeCodeExecutionMode, _errorBehavior: positron.RuntimeErrorBehavior, _codeLocation?: positron.Utf8Location, executionMetadata?: Record<string, any>): void {
 		this._currentExecutionId = id;
 		this._executingCode = code;
+		this.lastExecutionMetadata = executionMetadata;
 
 		// Emit the busy message
 		this._onDidReceiveRuntimeMessage.fire({
@@ -426,6 +428,8 @@ class TestLanguageRuntimeManager implements positron.LanguageRuntimeManager {
 
 	onDidDiscoverRuntime = this.onDidDiscoverRuntimeEmitter.event;
 
+	public createdSessions: TestLanguageRuntimeSession[] = [];
+
 	async* discoverAllRuntimes(): AsyncGenerator<positron.LanguageRuntimeMetadata> {
 		yield testLanguageRuntimeMetadata();
 	}
@@ -438,7 +442,9 @@ class TestLanguageRuntimeManager implements positron.LanguageRuntimeManager {
 		runtimeMetadata: positron.LanguageRuntimeMetadata,
 		sessionMetadata: positron.RuntimeSessionMetadata
 	): Promise<positron.LanguageRuntimeSession> {
-		return new TestLanguageRuntimeSession(runtimeMetadata, sessionMetadata);
+		const session = new TestLanguageRuntimeSession(runtimeMetadata, sessionMetadata);
+		this.createdSessions.push(session);
+		return session;
 	}
 }
 
@@ -855,6 +861,67 @@ suite('positron API - executeCode', () => {
 			// Expected behavior - getSessionVariables should throw when the variable doesn't exist
 			assert.ok(error.message.includes('z'), 'Error should mention the missing variable name');
 		}
+	});
+
+	test('executeCode passes executionMetadata to the runtime session', async () => {
+		// Use a unique language ID so that a fresh session is created via our
+		// manager (existing 'test' sessions from earlier tests would be reused).
+		const languageId = 'test-metadata';
+		const metadata = testLanguageRuntimeMetadata();
+		metadata.languageId = languageId;
+		metadata.languageName = 'TestMetadata';
+		metadata.runtimeId = '00000000-0000-0000-0000-300000000000';
+
+		// Create a manager that yields this unique runtime
+		const manager: TestLanguageRuntimeManager & { _metadata: positron.LanguageRuntimeMetadata } = Object.assign(
+			new TestLanguageRuntimeManager(), { _metadata: metadata }
+		);
+		// Override discoverAllRuntimes to yield our custom metadata
+		manager.discoverAllRuntimes = async function* () { yield metadata; };
+
+		const managerDisposable = positron.runtime.registerLanguageRuntimeManager(languageId, manager);
+		disposables.push(managerDisposable);
+
+		// Wait for the runtime to be registered
+		await poll(
+			async () => (await positron.runtime.getRegisteredRuntimes())
+				.filter(runtime => runtime.languageId === languageId),
+			runtimes => runtimes.length > 0,
+			'test-metadata runtime should be registered'
+		);
+
+		const testMetadata = { source: 'test-extension', requestId: '12345' };
+
+		// Execute code with executionMetadata (the 10th parameter)
+		await Promise.race([
+			positron.runtime.executeCode(
+				languageId,       // languageId
+				'print("meta")', // code
+				false,            // focus
+				false,            // allowIncomplete
+				positron.RuntimeCodeExecutionMode.Interactive,
+				positron.RuntimeErrorBehavior.Stop,
+				undefined,        // observer
+				undefined,        // sessionId
+				undefined,        // documentUri
+				testMetadata      // executionMetadata
+			),
+			new Promise<any>((_, reject) => {
+				setTimeout(() => {
+					reject(new Error('Execution timed out after 2 seconds'));
+				}, 2000);
+			})
+		]);
+
+		// Find the test session created by our manager and verify
+		// executionMetadata was received by the runtime's execute method.
+		const session = manager.createdSessions[manager.createdSessions.length - 1];
+		assert.ok(session, 'A session should have been created');
+		assert.deepStrictEqual(
+			session.lastExecutionMetadata,
+			testMetadata,
+			'executionMetadata should be passed through to the runtime session'
+		);
 	});
 });
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1254,6 +1254,7 @@ declare module 'positron' {
 		 * @param mode The code execution mode
 		 * @param errorBehavior The code execution error behavior
 		 * @param codeLocation Optionally, the location of `code` in the source editor.
+		 * @param executionMetadata Optionally, a record of additional metadata to associate with this execution.
 		 * Note: The errorBehavior parameter is currently ignored by kernels
 		 */
 		execute(
@@ -1262,6 +1263,7 @@ declare module 'positron' {
 			mode: RuntimeCodeExecutionMode,
 			errorBehavior: RuntimeErrorBehavior,
 			codeLocation?: Utf8Location,
+			executionMetadata?: Record<string, any>,
 		): void;
 
 		/**
@@ -2090,6 +2092,11 @@ declare module 'positron' {
 		 *  not provided, an appropriate session will be chosen, and if no
 		 *  session for the desired language is running at all, a new session
 		 *  will be started.
+		 * @param documentUri An optional URI of the document in which the code to execute is located.
+		 * @param executionMetadata An optional object containing additional
+		 *  metadata to pass to the language runtime. Will be included in the
+		 *  `positron` field of the `metadata` argument passed to the runtime's
+		 *  `execute` method.
 		 * @returns A Thenable that resolves with the result of the code execution,
 		 *  as a map of MIME types to values.
 		 */
@@ -2101,7 +2108,8 @@ declare module 'positron' {
 			errorBehavior?: RuntimeErrorBehavior,
 			observer?: ExecutionObserver,
 			sessionId?: string,
-			documentUri?: vscode.Uri): Thenable<Record<string, any>>;
+			documentUri?: vscode.Uri,
+			executionMetadata?: Record<string, any>): Thenable<Record<string, any>>;
 
 		/**
 		 * Evaluates code silently in a language runtime, without displaying
@@ -2129,9 +2137,13 @@ declare module 'positron' {
 		 *
 		 * @param documentUri The URI of the document
 		 * @param range The ranges of the cells to execute
+		 * @param executionMetadata An optional array of metadata objects to
+		 *  pass to the language runtime, one for each cell being executed.
 		 */
 		export function executeInlineCell(documentUri: vscode.Uri,
-			cellRanges: vscode.Range[]): Thenable<void>;
+			cellRanges: vscode.Range[],
+			executionMetadata?: Record<string, any>[]
+		): Thenable<void>;
 
 		/**
 		 * Register a language runtime manager with Positron.

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -549,6 +549,7 @@ class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILangua
 		mode: RuntimeCodeExecutionMode,
 		errorBehavior: RuntimeErrorBehavior,
 		attribution?: IConsoleCodeAttribution,
+		executionMetadata?: Record<string, unknown>,
 	): void {
 		this._lastUsed = Date.now();
 
@@ -560,7 +561,7 @@ class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILangua
 			codeLocation = attribution.metadata?.codeLocation;
 		}
 
-		this._proxy.$executeCode(this.handle, code, id, mode, errorBehavior, codeLocation);
+		this._proxy.$executeCode(this.handle, code, id, mode, errorBehavior, codeLocation, undefined, executionMetadata);
 	}
 
 	isCodeFragmentComplete(code: string): Thenable<RuntimeCodeFragmentStatus> {
@@ -1860,7 +1861,8 @@ export class MainThreadLanguageRuntime
 		mode?: RuntimeCodeExecutionMode,
 		errorBehavior?: RuntimeErrorBehavior,
 		executionId?: string,
-		documentUri?: URI): Promise<string> {
+		documentUri?: URI,
+		executionMetadata?: Record<string, unknown>): Promise<string> {
 
 		// Revive the URI from the serialized form, if provided.
 		const revivedUri = documentUri ? URI.revive(documentUri) : undefined;
@@ -1917,22 +1919,22 @@ export class MainThreadLanguageRuntime
 		}
 
 		return this._positronConsoleService.executeCode(
-			languageId, sessionId, code, attribution, focus, allowIncomplete, mode, errorBehavior, executionId);
+			languageId, sessionId, code, attribution, focus, allowIncomplete, mode, errorBehavior, executionId, undefined, executionMetadata);
 	}
 
-	$executeInlineCells(_extensionId: string, documentUri: URI, ranges: IRange[]): Promise<void> {
+	$executeInlineCells(_extensionId: string, documentUri: URI, ranges: IRange[], executionMetadata?: Record<string, unknown>[]): Promise<void> {
 		const revivedUri = URI.revive(documentUri);
 		// Convert IRange objects (with startLineNumber, etc.) to editor Range objects
 		const cellRanges = ranges.map(r => Range.lift(r));
-		return this._quartoExecutionManager.executeInlineCells(revivedUri, cellRanges);
+		return this._quartoExecutionManager.executeInlineCells(revivedUri, cellRanges, undefined, executionMetadata);
 	}
 
-	$executeInSession(sessionId: string, code: string, id: string, mode: RuntimeCodeExecutionMode, errorBehavior: RuntimeErrorBehavior): Promise<void> {
+	$executeInSession(sessionId: string, code: string, id: string, mode: RuntimeCodeExecutionMode, errorBehavior: RuntimeErrorBehavior, executionMetadata?: Record<string, unknown>): Promise<void> {
 		const session = this._runtimeSessionService.getSession(sessionId);
 		if (!session) {
 			return Promise.reject(new Error(`No such session: ${id}`));
 		}
-		return Promise.resolve(session.execute(code, id, mode, errorBehavior));
+		return Promise.resolve(session.execute(code, id, mode, errorBehavior, undefined, executionMetadata));
 	}
 
 	$shutdownSession(sessionId: string, exitReason: RuntimeExitReason): Promise<void> {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -93,16 +93,16 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 
 		// --- Start Positron ---
 		const runtime: typeof positron.runtime = {
-			executeCode(languageId, code, focus, allowIncomplete?, mode?, errorBehavior?, observer?, sessionId?, documentUri?): Thenable<Record<string, unknown>> {
+			executeCode(languageId, code, focus, allowIncomplete?, mode?, errorBehavior?, observer?, sessionId?, documentUri?, executionMetadata?): Thenable<Record<string, unknown>> {
 				const extensionId = extension.identifier.value;
-				return extHostLanguageRuntime.executeCode(languageId, code, extensionId, focus, allowIncomplete, mode, errorBehavior, observer, sessionId, documentUri);
+				return extHostLanguageRuntime.executeCode(languageId, code, extensionId, focus, allowIncomplete, mode, errorBehavior, observer, sessionId, documentUri, executionMetadata);
 			},
 			evaluateCode(languageId: string, code: string, cancellationToken?: vscode.CancellationToken, sessionId?: string): Thenable<positron.EvalResult> {
 				return extHostLanguageRuntime.evaluateCode(languageId, code, cancellationToken, sessionId);
 			},
-			executeInlineCell(documentUri, ranges): Thenable<void> {
+			executeInlineCell(documentUri, ranges, executionMetadata?): Thenable<void> {
 				const extensionId = extension.identifier.value;
-				return extHostLanguageRuntime.executeInlineCells(extensionId, documentUri, ranges);
+				return extHostLanguageRuntime.executeInlineCells(extensionId, documentUri, ranges, executionMetadata);
 			},
 			registerLanguageRuntimeManager(
 				languageId: string,

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -48,8 +48,8 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$startLanguageRuntime(runtimeId: string, sessionName: string, sessionMode: LanguageRuntimeSessionMode, notebookUri: URI | undefined): Promise<string>;
 	$completeLanguageRuntimeDiscovery(): void;
 	$unregisterLanguageRuntime(runtimeId: string): void;
-	$executeCode(languageId: string, extensionId: string, sessionId: string | undefined, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode, errorBehavior?: RuntimeErrorBehavior, executionId?: string, documentUri?: URI): Promise<string>;
-	$executeInlineCells(extensionId: string, documentUri: URI, cellRanges: IRange[]): Promise<void>;
+	$executeCode(languageId: string, extensionId: string, sessionId: string | undefined, code: string, focus: boolean, allowIncomplete?: boolean, mode?: RuntimeCodeExecutionMode, errorBehavior?: RuntimeErrorBehavior, executionId?: string, documentUri?: URI, executionMetadata?: Record<string, unknown>): Promise<string>;
+	$executeInlineCells(extensionId: string, documentUri: URI, cellRanges: IRange[], executionMetadata?: Record<string, unknown>[]): Promise<void>;
 	$getPreferredRuntime(languageId: string): Promise<ILanguageRuntimeMetadata | undefined>;
 	$getRegisteredRuntimes(): Promise<ILanguageRuntimeMetadata[]>;
 	$getActiveSessions(): Promise<ActiveRuntimeSessionMetadata[]>;
@@ -61,7 +61,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$focusSession(sessionId: string): void;
 	$deleteSession(sessionId: string): Promise<boolean>;
 	$shutdownSession(sessionId: string, exitReason: RuntimeExitReason): Promise<void>;
-	$executeInSession(sessionId: string, code: string, id: string, mode: RuntimeCodeExecutionMode, errorBehavior: RuntimeErrorBehavior): Promise<void>;
+	$executeInSession(sessionId: string, code: string, id: string, mode: RuntimeCodeExecutionMode, errorBehavior: RuntimeErrorBehavior, executionMetadata?: Record<string, unknown>): Promise<void>;
 	$getSessionDynState(sessionId: string): Promise<LanguageRuntimeDynState>;
 	$getSessionWorkingDirectory(sessionId?: string): Promise<string | undefined>;
 	$getSessionVariables(sessionId: string, accessKeys?: Array<Array<string>>): Promise<Array<Array<Variable>>>;
@@ -86,7 +86,7 @@ export interface ExtHostLanguageRuntimeShape {
 	$disposeLanguageRuntime(handle: number): Promise<void>;
 	$startLanguageRuntime(handle: number): Promise<ILanguageRuntimeInfo>;
 	$openResource(handle: number, resource: URI | string): Promise<boolean>;
-	$executeCode(handle: number, code: string, id: string, mode: RuntimeCodeExecutionMode, errorBehavior: RuntimeErrorBehavior, codeLocation?: ICodeLocation, executionId?: string): void;
+	$executeCode(handle: number, code: string, id: string, mode: RuntimeCodeExecutionMode, errorBehavior: RuntimeErrorBehavior, codeLocation?: ICodeLocation, executionId?: string, executionMetadata?: Record<string, unknown>): void;
 	$isCodeFragmentComplete(handle: number, code: string): Promise<RuntimeCodeFragmentStatus>;
 	$createClient(handle: number, id: string, type: RuntimeClientType, params: unknown, metadata?: unknown): Promise<void>;
 	$listClients(handle: number, type?: RuntimeClientType): Promise<Record<string, string>>;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -241,8 +241,10 @@ export class ExtHostRuntimeSessionProxy
 	execute(code: string,
 		id: string,
 		mode: RuntimeCodeExecutionMode,
-		errorBehavior: RuntimeErrorBehavior) {
-		return this._proxy.$executeInSession(this.sessionId, code, id, mode, errorBehavior);
+		errorBehavior: RuntimeErrorBehavior,
+		_codeLocation?: positron.Utf8Location,
+		executionMetadata?: Record<string, unknown>) {
+		return this._proxy.$executeInSession(this.sessionId, code, id, mode, errorBehavior, executionMetadata);
 	}
 
 	/**
@@ -849,7 +851,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		return Promise.resolve(this._runtimeSessions[handle].openResource!(resource));
 	}
 
-	$executeCode(handle: number, code: string, id: string, mode: RuntimeCodeExecutionMode, errorBehavior: RuntimeErrorBehavior, codeLocation?: ICodeLocation): void {
+	$executeCode(handle: number, code: string, id: string, mode: RuntimeCodeExecutionMode, errorBehavior: RuntimeErrorBehavior, codeLocation?: ICodeLocation, _executionId?: string, executionMetadata?: Record<string, unknown>): void {
 		if (handle >= this._runtimeSessions.length) {
 			throw new Error(`Cannot execute code: session handle '${handle}' not found or no longer valid.`);
 		}
@@ -863,7 +865,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 			};
 		}
 
-		this._runtimeSessions[handle].execute(code, id, mode, errorBehavior, codeLocationRevived);
+		this._runtimeSessions[handle].execute(code, id, mode, errorBehavior, codeLocationRevived, executionMetadata);
 	}
 
 	$isCodeFragmentComplete(handle: number, code: string): Promise<RuntimeCodeFragmentStatus> {
@@ -1336,7 +1338,8 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		errorBehavior?: RuntimeErrorBehavior,
 		observer?: IExecutionObserver,
 		sessionId?: string,
-		documentUri?: URI): Promise<Record<string, unknown>> {
+		documentUri?: URI,
+		executionMetadata?: Record<string, unknown>): Promise<Record<string, unknown>> {
 
 		// Create a UUID and an observer for this execution request
 		const executionId = generateUuid();
@@ -1350,7 +1353,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		// more or less fixed since it's part of the public API, but the
 		// internal parameter order can be more logical.
 		this._proxy.$executeCode(
-			languageId, extensionId, sessionId, code, focus, allowIncomplete, mode, errorBehavior, executionId, documentUri).then(
+			languageId, extensionId, sessionId, code, focus, allowIncomplete, mode, errorBehavior, executionId, documentUri, executionMetadata).then(
 				(sessionId) => {
 					// Bind the session ID to the observer so we can use it later
 					executionObserver.sessionId = sessionId;
@@ -1438,13 +1441,13 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 	 *
 	 * @returns A promise that resolves when the request has been sent
 	 */
-	public executeInlineCells(extensionId: string, documentUri: URI, cellRanges: any[]): Promise<void> {
+	public executeInlineCells(extensionId: string, documentUri: URI, cellRanges: any[], executionMetadata?: Record<string, unknown>[]): Promise<void> {
 		// Convert vscode.Range objects to serializable IRange format
 		// Filter out undefined/null ranges in case any are invalid
 		const convertedRanges = cellRanges
 			.filter(r => r != null)
 			.map(r => typeConvert.Range.from(r)!);
-		return this._proxy.$executeInlineCells(extensionId, documentUri, convertedRanges);
+		return this._proxy.$executeInlineCells(extensionId, documentUri, convertedRanges, executionMetadata);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -309,7 +309,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 	 * - `error: true` (default) - Stop execution queue on error.
 	 * - `error: false` - Continue execution queue even on error.
 	 */
-	async executeInlineCells(documentUri: URI, codeRanges: Range[], token?: CancellationToken): Promise<void> {
+	async executeInlineCells(documentUri: URI, codeRanges: Range[], token?: CancellationToken, executionMetadata?: Record<string, unknown>[]): Promise<void> {
 		if (codeRanges.length === 0) {
 			return;
 		}
@@ -333,10 +333,12 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 			codeRange: Range;
 			effectiveCodeRange: Range;
 			options: QuartoCellExecutionOptions;
+			executionMetadata?: Record<string, unknown>;
 		}
 		const executions: InlineExecution[] = [];
 
-		for (const range of codeRanges) {
+		for (let rangeIdx = 0; rangeIdx < codeRanges.length; rangeIdx++) {
+			const range = codeRanges[rangeIdx];
 			// Find the cell containing this range
 			let containingCell: QuartoCodeCell | undefined;
 			for (const quartoCell of quartoCells) {
@@ -389,6 +391,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 				codeRange: clampedRange,
 				effectiveCodeRange,
 				options,
+				executionMetadata: executionMetadata?.[rangeIdx],
 			});
 		}
 
@@ -471,7 +474,8 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 						execution.cell,
 						execution.effectiveCodeRange,
 						execution.options,
-						token
+						token,
+						execution.executionMetadata
 					);
 
 					// If error occurred and error option is true (stop on error),
@@ -536,7 +540,8 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		cell: QuartoCodeCell,
 		codeRange: Range,
 		options: QuartoCellExecutionOptions = DEFAULT_CELL_EXECUTION_OPTIONS,
-		token?: CancellationToken
+		token?: CancellationToken,
+		executionMetadata?: Record<string, unknown>
 	): Promise<boolean> {
 		const cellLanguage = cell.language.toLowerCase();
 
@@ -598,7 +603,9 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 					code,
 					executionId,
 					RuntimeCodeExecutionMode.Interactive,
-					errorBehavior
+					errorBehavior,
+					undefined,
+					executionMetadata
 				);
 
 				// Fire the event signaling code execution.

--- a/src/vs/workbench/contrib/positronQuarto/common/quartoExecutionTypes.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/quartoExecutionTypes.ts
@@ -185,7 +185,7 @@ export interface IQuartoExecutionManager {
 	 * @param codeRanges Ranges of code to execute (can be partial cells)
 	 * @param token Optional cancellation token
 	 */
-	executeInlineCells(documentUri: URI, codeRanges: Range[], token?: CancellationToken): Promise<void>;
+	executeInlineCells(documentUri: URI, codeRanges: Range[], token?: CancellationToken, executionMetadata?: Record<string, unknown>[]): Promise<void>;
 
 	/**
 	 * Cancel execution for a document.

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -141,7 +141,8 @@ export interface IPositronConsoleService {
 		mode?: RuntimeCodeExecutionMode,
 		errorBehavior?: RuntimeErrorBehavior,
 		executionId?: string,
-		documentUri?: URI): Promise<string>;
+		documentUri?: URI,
+		executionMetadata?: Record<string, unknown>): Promise<string>;
 
 	/**
 	 * Fires when code is executed in any Positron console instance.
@@ -480,7 +481,8 @@ export interface IPositronConsoleInstance {
 		attribution: IConsoleCodeAttribution,
 		mode?: RuntimeCodeExecutionMode,
 		errorBehavior?: RuntimeErrorBehavior,
-		executionId?: string): void;
+		executionId?: string,
+		executionMetadata?: Record<string, unknown>): void;
 
 	/**
 	 * Replies to the active prompt.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1839,6 +1839,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	 * @param mode Possible code execution modes for a language runtime.
 	 * @param errorBehavior Possible error behavior for a language runtime.
 	 * @param executionId An optional ID that can be used to identify the execution.
+	 * @param executionMetadata Optional metadata to associate with the execution.
 	 */
 	executeCode(code: string,
 		attribution: IConsoleCodeAttribution,

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -649,7 +649,9 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 		allowIncomplete?: boolean,
 		mode?: RuntimeCodeExecutionMode,
 		errorBehavior?: RuntimeErrorBehavior,
-		executionId?: string): Promise<string> {
+		executionId?: string,
+		_documentUri?: URI,
+		executionMetadata?: Record<string, unknown>): Promise<string> {
 		// When code is executed in the console service, open the console view. This opens
 		// the relevant pane composite if needed.
 		await this._viewsService.openView(POSITRON_CONSOLE_VIEW_ID, false);
@@ -758,7 +760,7 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 		}
 
 		// Enqueue the code in the Positron console instance.
-		await positronConsoleInstance.enqueueCode(code, attribution, allowIncomplete, mode, errorBehavior, executionId);
+		await positronConsoleInstance.enqueueCode(code, attribution, allowIncomplete, mode, errorBehavior, executionId, executionMetadata);
 		return Promise.resolve(positronConsoleInstance.sessionId);
 	}
 
@@ -1006,6 +1008,7 @@ interface IPendingCodeFragment {
 	executionId: string | undefined;
 	mode: RuntimeCodeExecutionMode;
 	errorBehavior: RuntimeErrorBehavior;
+	executionMetadata?: Record<string, unknown>;
 }
 
 /**
@@ -1669,7 +1672,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		allowIncomplete?: boolean,
 		mode?: RuntimeCodeExecutionMode,
 		errorBehavior?: RuntimeErrorBehavior,
-		executionId?: string) {
+		executionId?: string,
+		executionMetadata?: Record<string, unknown>) {
 		// If a manually assigned execution ID is provided, add it to the set of
 		// external execution IDs.
 		if (executionId) {
@@ -1685,7 +1689,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				attribution,
 				executionId,
 				mode ?? RuntimeCodeExecutionMode.Interactive,
-				errorBehavior ?? RuntimeErrorBehavior.Continue
+				errorBehavior ?? RuntimeErrorBehavior.Continue,
+				executionMetadata
 			);
 			return;
 		}
@@ -1700,7 +1705,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				attribution,
 				executionId,
 				mode ?? RuntimeCodeExecutionMode.Interactive,
-				errorBehavior ?? RuntimeErrorBehavior.Continue
+				errorBehavior ?? RuntimeErrorBehavior.Continue,
+				executionMetadata
 			);
 			return;
 		}
@@ -1741,7 +1747,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				pendingCode += '\n' + code;
 				if (await shouldExecuteCode(pendingCode)) {
 					this.setPendingCode();
-					this.doExecuteCode(pendingCode, attribution, mode, errorBehavior, executionId);
+					this.doExecuteCode(pendingCode, attribution, mode, errorBehavior, executionId, executionMetadata);
 				} else {
 					// Update the pending code. More will be revealed.
 					this.setPendingCode(pendingCode, executionId);
@@ -1754,7 +1760,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 		// Execute the code if it is complete, or set it as pending if it is not.
 		if (await shouldExecuteCode(code)) {
-			this.doExecuteCode(code, attribution, mode, errorBehavior, executionId);
+			this.doExecuteCode(code, attribution, mode, errorBehavior, executionId, executionMetadata);
 		} else {
 			this.setPendingCode(code, executionId);
 		}
@@ -1838,9 +1844,10 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		attribution: IConsoleCodeAttribution,
 		mode?: RuntimeCodeExecutionMode,
 		errorBehavior?: RuntimeErrorBehavior,
-		executionId?: string) {
+		executionId?: string,
+		executionMetadata?: Record<string, unknown>) {
 		this.setPendingCode();
-		this.doExecuteCode(code, attribution, mode, errorBehavior, executionId);
+		this.doExecuteCode(code, attribution, mode, errorBehavior, executionId, executionMetadata);
 	}
 
 	/**
@@ -2712,14 +2719,16 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		attribution: IConsoleCodeAttribution,
 		executionId: string | undefined,
 		mode: RuntimeCodeExecutionMode,
-		errorBehavior: RuntimeErrorBehavior) {
+		errorBehavior: RuntimeErrorBehavior,
+		executionMetadata?: Record<string, unknown>) {
 		// Add to the pending code queue.
 		this._pendingCodeQueue.push({
 			code,
 			attribution,
 			executionId,
 			mode,
-			errorBehavior
+			errorBehavior,
+			executionMetadata
 		});
 
 		// Only create/update visual pending input for interactive mode.
@@ -3022,6 +3031,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			pendingItem.mode,
 			pendingItem.errorBehavior,
 			pendingItem.attribution,
+			pendingItem.executionMetadata,
 		);
 
 		// Create and fire the onDidExecuteCode event.
@@ -3067,7 +3077,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		attribution: IConsoleCodeAttribution,
 		mode: RuntimeCodeExecutionMode = RuntimeCodeExecutionMode.Interactive,
 		errorBehavior: RuntimeErrorBehavior = RuntimeErrorBehavior.Continue,
-		executionId?: string
+		executionId?: string,
+		executionMetadata?: Record<string, unknown>
 	) {
 		// Use the supplied execution ID if known; otherwise, generate one
 		const id = executionId || this.generateExecutionId(code);
@@ -3125,6 +3136,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			mode,
 			errorBehavior,
 			attribution,
+			executionMetadata,
 		);
 
 		// Create and fire the onDidExecuteCode event.

--- a/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
@@ -171,7 +171,9 @@ export class TestPositronConsoleService implements IPositronConsoleService {
 		allowIncomplete?: boolean,
 		mode?: RuntimeCodeExecutionMode,
 		errorBehavior?: RuntimeErrorBehavior,
-		executionId?: string
+		executionId?: string,
+		_documentUri?: URI,
+		_executionMetadata?: Record<string, unknown>
 	): Promise<string> {
 		// Create a code executed event
 		const event = this.createTestCodeExecutedEvent(languageId, code, attribution);
@@ -504,7 +506,8 @@ export class TestPositronConsoleInstance implements IPositronConsoleInstance {
 		attribution: IConsoleCodeAttribution,
 		mode?: RuntimeCodeExecutionMode,
 		errorBehavior?: RuntimeErrorBehavior,
-		executionId = 'test-execution-id'
+		executionId = 'test-execution-id',
+		_executionMetadata?: Record<string, unknown>
 	): void {
 		const event: ILanguageRuntimeCodeExecutedEvent = {
 			executionId,

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -189,6 +189,7 @@ export interface ILanguageRuntimeSession extends IDisposable {
 		mode: RuntimeCodeExecutionMode,
 		errorBehavior: RuntimeErrorBehavior,
 		attribution?: IConsoleCodeAttribution,
+		executionMetadata?: Record<string, unknown>,
 	): void;
 
 	/** Test a code fragment for completeness */


### PR DESCRIPTION
This change makes it possible for an extension to add arbitrary metadata (key/value pairs) to code execution requests. The metadata is passed through to the kernel in the `positron` field of the Jupyter `execute_request` message, alongside any metadata added by Positron itself (such as the source location).

This is a stepping stone towards https://github.com/posit-dev/positron/issues/12150 (and some related issues); the planned end state is that the Quarto extension will read chunk options like figure height/width when the code is executed, and supply them in this new parameter along with the code to be run. The kernels can then read the values from the execution request when rendering.