### PR TITLE
ci: include builtInExtensions.ts in cache key to fix stale extension cache

### DIFF
--- a/.github/actions/restore-build-caches/action.yml
+++ b/.github/actions/restore-build-caches/action.yml
@@ -204,7 +204,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ steps.cache-paths.outputs.builtins-paths }}
-        key: builtins-${{ runner.os }}-${{ hashFiles('product.json') }}
+        key: builtins-${{ runner.os }}-${{ hashFiles('product.json', 'build/lib/builtInExtensions.ts') }}
         restore-keys: |
           builtins-${{ runner.os }}-
 

--- a/.github/actions/restore-build-caches/action.yml
+++ b/.github/actions/restore-build-caches/action.yml
@@ -205,8 +205,6 @@ runs:
       with:
         path: ${{ steps.cache-paths.outputs.builtins-paths }}
         key: builtins-${{ runner.os }}-${{ hashFiles('product.json', 'build/lib/builtInExtensions.ts') }}
-        restore-keys: |
-          builtins-${{ runner.os }}-
 
     - name: Get Playwright version
       if: ${{ inputs.restore-playwright == 'true' }}

--- a/.github/actions/restore-build-caches/action.yml
+++ b/.github/actions/restore-build-caches/action.yml
@@ -204,7 +204,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ steps.cache-paths.outputs.builtins-paths }}
-        key: builtins-${{ runner.os }}-${{ hashFiles('product.json', 'build/lib/builtInExtensions.ts') }}
+        key: builtins-v2-${{ runner.os }}-${{ hashFiles('product.json', 'build/lib/builtInExtensions.ts') }}
 
     - name: Get Playwright version
       if: ${{ inputs.restore-playwright == 'true' }}

--- a/.github/actions/save-build-caches/action.yml
+++ b/.github/actions/save-build-caches/action.yml
@@ -137,7 +137,7 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: ${{ steps.cache-paths.outputs.builtins-paths }}
-        key: builtins-${{ runner.os }}-${{ hashFiles('product.json', 'build/lib/builtInExtensions.ts') }}
+        key: builtins-v2-${{ runner.os }}-${{ hashFiles('product.json', 'build/lib/builtInExtensions.ts') }}
 
     - name: Save Playwright browsers cache
       if: ${{ inputs.cache-playwright-hit == 'false' }}

--- a/.github/actions/save-build-caches/action.yml
+++ b/.github/actions/save-build-caches/action.yml
@@ -137,7 +137,7 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: ${{ steps.cache-paths.outputs.builtins-paths }}
-        key: builtins-${{ runner.os }}-${{ hashFiles('product.json') }}
+        key: builtins-${{ runner.os }}-${{ hashFiles('product.json', 'build/lib/builtInExtensions.ts') }}
 
     - name: Save Playwright browsers cache
       if: ${{ inputs.cache-playwright-hit == 'false' }}


### PR DESCRIPTION
### Summary

- Adds `build/lib/builtInExtensions.ts` to the builtins cache key hash
- Fixes stale cache causing `rstudio-workbench` extension to persist in CI after filtering logic changed

### Background

After commit 7fbc23b, the `rstudio-workbench` extension type changed from `reh-web` to `reh-web-pwb` in `product.json`, but the filter in `builtInExtensions.ts` wasn't updated until 063aa29929. Since the cache key only included `product.json`, the stale cache (containing the workbench extension) continued to be restored, causing E2E tests to fail with:

```
The terminal process "pwb-session-agent" failed to launch (exit code: 1)
```

### QA Notes

@:layouts