### PR TITLE
Cell output action bar

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -102,6 +102,7 @@ export class MenuId {
 	static readonly PositronNotebookCellActionBarSubmenu = new MenuId('PositronNotebookCellActionBarSubmenu');
 	static readonly PositronNotebookCellActionLeft = new MenuId('PositronNotebookCellActionLeft');
 	static readonly PositronNotebookCellContext = new MenuId('PositronNotebookCellContext');
+	static readonly PositronNotebookCellOutputActionBar = new MenuId('PositronNotebookCellOutputActionBar');
 	static readonly PositronNotebookCellOutputActionLeft = new MenuId('PositronNotebookCellOutputActionLeft');
 	static readonly EditorActionsLeft = new MenuId('EditorActionsLeft');
 	static readonly EditorActionsRight = new MenuId('EditorActionsRight');

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -51,6 +51,13 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 			return this.parseCellOutputs();
 		});
 
+		// Reset collapse state when outputs are cleared so new outputs aren't born collapsed
+		this._register(this.model.onDidChangeOutputs(() => {
+			if (this.model.outputs.length === 0) {
+				this._outputIsCollapsed.set(false, undefined);
+			}
+		}));
+
 		// Execution timing observables
 		this.lastExecutionDuration = this._internalMetadata.map(({ runStartTime, runEndTime }) => {
 			/** @description lastExecutionDuration */

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
@@ -40,6 +40,8 @@
 	);
 	--_positron-notebook-cell-gap: 4px;
 	--_positron-notebook-add-cell-buttons-height: 26px; /* Icon 18px + padding 8px */
+	/* Gap between buttons in cell and output action bars */
+	--_positron-notebook-cell-action-bar-button-gap: 0.25rem;
 
 	/* Misc variables */
 	--vscode-positronNotebook-border: 1px solid

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputActionBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputActionBar.css
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Floating action bar in the top-right corner of the cell output area */
+.cell-output-action-bar {
+	position: absolute;
+	top: 0.25rem;
+	right: calc(0.25rem + 8px); /* 8px to clear the scrollbar */
+	z-index: 10;
+
+	display: flex;
+	gap: var(--_positron-notebook-cell-action-bar-button-gap);
+	border-radius: var(--vscode-positronNotebook-cell-radius);
+	background-color: var(--vscode-positronNotebook-action-bar-background);
+	border: 1px solid var(--vscode-widget-border);
+
+	/* Hidden by default, shown on output hover or keyboard focus */
+	visibility: hidden;
+}
+
+/* Show on hover of the output area or when a button inside has focus */
+.positron-notebook-outputs-section:hover > .cell-output-action-bar:not(:empty),
+.cell-output-action-bar:focus-within {
+	visibility: visible;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputActionBar.tsx
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './CellOutputActionBar.css';
+
+// React.
+import React from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../nls.js';
+import { MenuId } from '../../../../../platform/actions/common/actions.js';
+import { CellActionButton } from './actionBar/CellActionButton.js';
+import { useMenu } from '../useMenu.js';
+import { useMenuActions } from '../useMenuActions.js';
+import { useWheelForwarding } from './useWheelForwarding.js';
+import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.js';
+import { useNotebookInstance } from '../NotebookInstanceProvider.js';
+import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
+
+interface CellOutputActionBarProps {
+	cell: PositronNotebookCodeCell;
+	scrollTargetRef: React.RefObject<HTMLElement | null>;
+}
+
+export function CellOutputActionBar({ cell, scrollTargetRef }: CellOutputActionBarProps) {
+	const instance = useNotebookInstance();
+	const contextKeyService = useCellScopedContextKeyService();
+	const menu = useMenu(MenuId.PositronNotebookCellOutputActionBar, contextKeyService);
+	const actionGroups = useMenuActions(menu);
+
+	// Forward wheel events to the scrollable output container so scrolling
+	// works even when the cursor is over the action bar.
+	const barRef = React.useRef<HTMLDivElement>(null);
+	useWheelForwarding(barRef, scrollTargetRef);
+
+	return (
+		<div
+			ref={barRef}
+			aria-label={localize('positron.notebook.cellOutputActions', 'Cell output actions')}
+			className='cell-output-action-bar'
+			role='toolbar'
+		>
+			{actionGroups.map(([_group, groupActions], groupIndex) =>
+				groupActions.map((action, actionIndex) => (
+					<CellActionButton
+						key={action.id}
+						action={action}
+						cell={cell}
+						hoverManager={instance.hoverManager}
+						showSeparator={
+							// Show a separator before the last group
+							groupIndex === actionGroups.length - 2 &&
+							actionIndex === groupActions.length - 1
+						}
+					/>
+				))
+			)}
+		</div>
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputLeftActionMenu.tsx
@@ -15,7 +15,7 @@ import { ActionButton } from '../utilityComponents/ActionButton.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
 import { useObservedValue } from '../useObservedValue.js';
-import { Icon } from '../../../../../platform/positronActionBar/browser/components/icon.js';
+import { ThemeIcon } from '../../../../../platform/positronActionBar/browser/components/icon.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { useCellContextMenu } from './useCellContextMenu.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
@@ -87,7 +87,7 @@ export function CellOutputLeftActionMenu({ cell }: CellOutputLeftActionMenuProps
 				tooltip={cellOutputActions}
 				onPressed={handleShowContextMenu}
 			>
-				<Icon className='button-icon' icon={Codicon.ellipsis} />
+				<ThemeIcon icon={Codicon.ellipsis} />
 			</ActionButton>
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
@@ -3,11 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-/* Define common properties for the cell action bar */
-.positron-notebooks-cell-action-bar  {
-	--_positron-notebooks-cell-action-bar-button-gap: 0.25rem;
-}
-
 .positron-notebooks-cell-action-bar {
 	position: absolute;
 	top: calc(var(--vscode-positronNotebook-action-bar-inset) * -1);
@@ -19,7 +14,7 @@
 	border-radius: var(--vscode-positronNotebook-cell-radius);
 	background-color: var(--vscode-positronNotebook-action-bar-background);
 	display: flex;
-	gap: var(--_positron-notebooks-cell-action-bar-button-gap);
+	gap: var(--_positron-notebook-cell-action-bar-button-gap);
 
 	/* Base state: action bar hidden by default */
 	visibility: hidden;
@@ -27,53 +22,6 @@
 	/* Always show action bar when cell is active (selected) */
 	&.visible {
 		visibility: visible;
-	}
-
-	.action-button {
-		aspect-ratio: 1;
-		display: grid;
-		place-content: center;
-		padding: 3px;
-		/* The added outline here is distracting */
-		outline: revert;
-
-		/* Update the border radius so it fits cleanly with the inset on the containing box. The 1px
-		comes from the border of that box */
-		border-radius: calc(var(--vscode-positronNotebook-cell-radius) - 1px);
-
-		.button-icon {
-			align-items: center;
-			justify-content: center;
-			display: flex;
-			width: 16px;
-			aspect-ratio: 1;
-		}
-
-		/* The debug codicon (the icon itself) is misaligned with run above / run below icons by 1 pixel */
-		&.codicon-debug-alt-small {
-			position: relative;
-			top: -1px;
-		}
-
-		&.disabled {
-			color: var(--vscode-positronActionBar-disabledForeground);
-		}
-	}
-
-	/* Ensure relative positioning for the separator pseudo-element we are adding below */
-	.action-button.primary-action {
-		position: relative;
-	}
-
-	/* Add separator pseudo-element after primary action buttons (run/stop, edit) */
-	.action-button.primary-action::after {
-		content: '';
-		position: absolute;
-		right: calc((var(--_positron-notebooks-cell-action-bar-button-gap) * -1) / 2); /* Separator should be centered in between the gap */
-		top: 4px;
-		bottom: 4px;
-		width: 1px;
-		background-color: var(--vscode-positronNotebook-action-bar-border-color);
 	}
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -14,6 +14,13 @@
 	.positron-notebook-outputs-section {
 		position: relative;
 
+		/* Show scrollbar when hovering anywhere in the output section (including the
+		 * action bar), not just the scrollable container itself. */
+		&:hover .positron-notebook-scrollable-fade {
+			--_positron-notebook-scrollbar-thumb-bg: var(--vscode-scrollbarSlider-background);
+			transition: --_positron-notebook-scrollbar-thumb-bg 100ms linear;
+		}
+
 		&.no-outputs {
 			/* Dont show empty outputs at all */
 			display: none;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -36,6 +36,7 @@ import { usePositronReactServicesContext } from '../../../../../base/browser/pos
 import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from '../ContextKeysManager.js';
 import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.js';
 import { useScrollingIndicator } from './useScrollingIndicator.js';
+import { CellOutputActionBar } from './CellOutputActionBar.js';
 
 
 interface CellOutputsSectionProps {
@@ -111,6 +112,7 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 			{ 'single-data-explorer': isSingleDataExplorer && !isCollapsed }
 		)}>
 			<CellOutputLeftActionMenu cell={cell} />
+			<CellOutputActionBar cell={cell} scrollTargetRef={outputsInnerRef} />
 			<section
 				aria-label={localize('positron.notebook.cellOutput', 'Cell output')}
 				className='positron-notebook-code-cell-outputs positron-notebook-cell-outputs'
@@ -131,18 +133,16 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 						>
 							{localize('positron.notebook.showHiddenOutput', 'Show hidden output')}
 						</Button>
-						: <>
-							{outputs?.map((output) => (
-								<NotebookErrorBoundary
-									key={output.outputId}
-									componentName={`CellOutput[${output.parsed.type}]`}
-									level='output'
-									logService={services.logService}
-								>
-									<CellOutput {...output} />
-								</NotebookErrorBoundary>
-							))}
-						</>
+						: outputs?.map((output) => (
+							<NotebookErrorBoundary
+								key={output.outputId}
+								componentName={`CellOutput[${output.parsed.type}]`}
+								level='output'
+								logService={services.logService}
+							>
+								<CellOutput {...output} />
+							</NotebookErrorBoundary>
+						))
 					}
 				</div>
 			</section>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.css
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+ .cell-action-button.action-button {
+	aspect-ratio: 1;
+	display: grid;
+	place-content: center;
+	padding: 3px;
+	/* The added outline here is distracting */
+	outline: revert;
+
+	/* Update the border radius so it fits cleanly with the inset on the containing box. The 1px
+	comes from the border of that box */
+	border-radius: calc(var(--vscode-positronNotebook-cell-radius) - 1px);
+
+	/* The debug codicon (the icon itself) is misaligned with run above / run below icons by 1 pixel */
+	&.codicon-debug-alt-small {
+		position: relative;
+		top: -1px;
+	}
+
+	&.disabled {
+		color: var(--vscode-positronActionBar-disabledForeground);
+	}
+
+	/* Ensure relative positioning for the separator pseudo-element we are adding below */
+	&.separator-after {
+		position: relative;
+	}
+
+	/* Add separator pseudo-element after this button */
+	&.separator-after::after {
+		content: '';
+		position: absolute;
+		right: calc((var(--_positron-notebook-cell-action-bar-button-gap) * -1) / 2); /* Separator should be centered in between the gap */
+		top: 4px;
+		bottom: 4px;
+		width: 1px;
+		background-color: var(--vscode-positronNotebook-action-bar-border-color);
+	}
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
@@ -3,6 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import './CellActionButton.css';
+
 import { CellSelectionType } from '../../selectionMachine.js';
 import { useNotebookInstance } from '../../NotebookInstanceProvider.js';
 import { ActionButton } from '../../utilityComponents/ActionButton.js';
@@ -10,6 +12,8 @@ import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNote
 import { MenuItemAction, SubmenuItemAction } from '../../../../../../platform/actions/common/actions.js';
 import { DevErrorIcon, Icon } from '../../../../../../platform/positronActionBar/browser/components/icon.js';
 import { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
+import { positronClassNames } from '../../../../../../base/common/positronUtilities.js';
+
 
 interface CellActionButtonProps {
 	action: MenuItemAction | SubmenuItemAction;
@@ -45,7 +49,9 @@ export function CellActionButton({ action, cell, hoverManager, showSeparator }: 
 		<ActionButton
 			key={action.id}
 			ariaLabel={action.label}
-			className={showSeparator ? 'primary-action' : ''}
+			className={positronClassNames('cell-action-button', {
+				'separator-after': showSeparator,
+			})}
 			hoverManager={hoverManager}
 			// Match VSCode behavior: prefer tooltip but default to label
 			tooltip={action.tooltip && action.tooltip.length > 0 ? action.tooltip : action.label}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/NotebookCellMoreActionsMenu.tsx
@@ -3,6 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// CSS.
+import './CellActionButton.css';
+
 // React.
 import { useRef } from 'react';
 
@@ -11,7 +14,7 @@ import { showCustomContextMenu } from '../../../../../../workbench/browser/posit
 import { buildMoreActionsMenuItems } from './actionBarMenuItems.js';
 import { ActionButton } from '../../utilityComponents/ActionButton.js';
 import { MenuItemAction, SubmenuItemAction } from '../../../../../../platform/actions/common/actions.js';
-import { Icon } from '../../../../../../platform/positronActionBar/browser/components/icon.js';
+import { ThemeIcon } from '../../../../../../platform/positronActionBar/browser/components/icon.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
 import { IPositronNotebookCell } from '../../PositronNotebookCells/IPositronNotebookCell.js';
@@ -76,11 +79,13 @@ export function NotebookCellMoreActionsMenu({
 			aria-expanded={isMenuOpen}
 			aria-haspopup='menu'
 			ariaLabel={ariaLabel}
+			// Match the cell action button's styles
+			className='cell-action-button'
 			hoverManager={hoverManager}
 			tooltip={ariaLabel}
 			onPressed={showMoreActionsMenu}
 		>
-			<Icon className='button-icon' icon={Codicon.ellipsis} />
+			<ThemeIcon icon={Codicon.ellipsis} />
 		</ActionButton>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useWheelForwarding.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useWheelForwarding.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { useEffect, type RefObject } from 'react';
+
+/**
+ * Forwards wheel events from `sourceRef` to `targetRef` so that scrolling
+ * works even when the cursor is over an overlay like an action bar.
+ * Only prevents default if the scroll position actually changed, so that
+ * parent scrolling kicks in at boundaries.
+ */
+export function useWheelForwarding(
+	sourceRef: RefObject<HTMLElement | null>,
+	targetRef: RefObject<HTMLElement | null>,
+) {
+	useEffect(() => {
+		const source = sourceRef.current;
+		if (!source) {
+			return;
+		}
+		const handleWheel = (e: WheelEvent) => {
+			const scrollable = targetRef.current;
+			if (scrollable) {
+				const prevTop = scrollable.scrollTop;
+				const prevLeft = scrollable.scrollLeft;
+				scrollable.scrollTop += e.deltaY;
+				scrollable.scrollLeft += e.deltaX;
+				if (scrollable.scrollTop !== prevTop || scrollable.scrollLeft !== prevLeft) {
+					e.preventDefault();
+				}
+			}
+		};
+		source.addEventListener('wheel', handleWheel, { passive: false });
+		return () => source.removeEventListener('wheel', handleWheel);
+	}, [sourceRef, targetRef]);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -65,6 +65,7 @@ import { ActiveNotebookHasRunningRuntime } from '../../runtimeNotebookKernel/com
 import { NotebookAction2 } from './NotebookAction2.js';
 import './AskAssistantAction.js'; // Register AskAssistantAction
 import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED } from '../../../../editor/contrib/find/browser/findModel.js';
+import { Codicon } from '../../../../base/common/codicons.js';
 
 export const POSITRON_NOTEBOOK_COMMAND_MODE = ContextKeyExpr.and(
 	POSITRON_NOTEBOOK_EDITOR_FOCUSED,
@@ -1517,15 +1518,24 @@ registerAction2(class extends NotebookAction2 {
 		super({
 			id: 'positronNotebook.cell.collapseOutput',
 			title: localize2('positronNotebook.cell.collapseOutput', "Collapse Output"),
-			menu: {
-				id: MenuId.PositronNotebookCellOutputActionLeft,
-				group: PositronNotebookCellOutputActionGroup.Visibility,
-				order: 1,
-				when: ContextKeyExpr.and(
-					POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
-					POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated()
-				)
-			}
+			icon: Codicon.chevronDown,
+			menu: [
+				{
+					id: MenuId.PositronNotebookCellOutputActionBar,
+					group: PositronNotebookCellOutputActionGroup.Visibility,
+					order: 1,
+					when: POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated()
+				},
+				{
+					id: MenuId.PositronNotebookCellOutputActionLeft,
+					group: PositronNotebookCellOutputActionGroup.Visibility,
+					order: 1,
+					when: ContextKeyExpr.and(
+						POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
+						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated()
+					)
+				},
+			]
 		});
 	}
 
@@ -1544,15 +1554,24 @@ registerAction2(class extends NotebookAction2 {
 		super({
 			id: 'positronNotebook.cell.expandOutput',
 			title: localize2('positronNotebook.cell.expandOutput', "Expand Output"),
-			menu: {
-				id: MenuId.PositronNotebookCellOutputActionLeft,
-				group: PositronNotebookCellOutputActionGroup.Visibility,
-				order: 2,
-				when: ContextKeyExpr.and(
-					POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
-					POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED
-				)
-			}
+			icon: Codicon.chevronRight,
+			menu: [
+				{
+					id: MenuId.PositronNotebookCellOutputActionBar,
+					group: PositronNotebookCellOutputActionGroup.Visibility,
+					order: 2,
+					when: POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED
+				},
+				{
+					id: MenuId.PositronNotebookCellOutputActionLeft,
+					group: PositronNotebookCellOutputActionGroup.Visibility,
+					order: 2,
+					when: ContextKeyExpr.and(
+						POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
+						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED
+					)
+				},
+			]
 		});
 	}
 
@@ -1571,12 +1590,20 @@ registerAction2(class extends NotebookAction2 {
 		super({
 			id: 'positronNotebook.cell.clearOutput',
 			title: localize2('positronNotebook.cell.clearOutput', "Clear Output"),
-			menu: {
-				id: MenuId.PositronNotebookCellOutputActionLeft,
-				group: PositronNotebookCellOutputActionGroup.Visibility,
-				order: 3,
-				when: POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS
-			}
+			icon: Codicon.clearAll,
+			menu: [
+				{
+					id: MenuId.PositronNotebookCellOutputActionBar,
+					group: PositronNotebookCellOutputActionGroup.Destructive,
+					order: 1,
+				},
+				{
+					id: MenuId.PositronNotebookCellOutputActionLeft,
+					group: PositronNotebookCellOutputActionGroup.Destructive,
+					order: 1,
+					when: POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS
+				},
+			]
 		});
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
@@ -31,4 +31,5 @@ export enum PositronNotebookCellActionBarLeftGroup {
 export enum PositronNotebookCellOutputActionGroup {
 	Copy = '0_copy',
 	Visibility = '1_visibility',
+	Destructive = '2_destructive',
 }

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellActionButton.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellActionButton.test.tsx
@@ -1,0 +1,147 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable local/code-no-dangerous-type-assertions */
+
+import assert from 'assert';
+import sinon from 'sinon';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { setupReactRenderer } from '../../../../../../base/test/browser/react.js';
+import { IPositronNotebookInstance } from '../../../browser/IPositronNotebookInstance.js';
+import { NotebookInstanceProvider } from '../../../browser/NotebookInstanceProvider.js';
+import { CellActionButton } from '../../../browser/notebookCells/actionBar/CellActionButton.js';
+import { IPositronNotebookCell } from '../../../browser/PositronNotebookCells/IPositronNotebookCell.js';
+import { MenuItemAction, SubmenuItemAction } from '../../../../../../platform/actions/common/actions.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
+import { CellSelectionType } from '../../../browser/selectionMachine.js';
+
+function mockAction(overrides?: Partial<{
+	id: string;
+	label: string;
+	tooltip: string;
+	iconId: string;
+	run: () => Promise<void>;
+}>): MenuItemAction {
+	const id = overrides?.id ?? 'test-action';
+	const label = overrides?.label ?? 'Test';
+	return {
+		id,
+		label,
+		tooltip: overrides?.tooltip ?? '',
+		enabled: true,
+		item: {
+			id,
+			title: label,
+			icon: overrides?.iconId ? ThemeIcon.fromId(overrides.iconId) : undefined,
+		},
+		run: overrides?.run ?? (() => Promise.resolve()),
+		dispose: () => { },
+	} as unknown as MenuItemAction;
+}
+
+suite('CellActionButton', () => {
+	const { render } = setupReactRenderer();
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	let selectCellStub: sinon.SinonStub;
+
+	function renderButton(
+		action: MenuItemAction | SubmenuItemAction,
+		options?: { showSeparator?: boolean },
+	) {
+		selectCellStub = sinon.stub();
+		const instance = {
+			hoverManager: undefined,
+			selectionStateMachine: { selectCell: selectCellStub },
+		} as unknown as IPositronNotebookInstance;
+
+		const cell = { id: 'cell-1' } as unknown as IPositronNotebookCell;
+
+		const container = render(
+			<NotebookInstanceProvider instance={instance}>
+				<CellActionButton
+					action={action}
+					cell={cell}
+					showSeparator={options?.showSeparator}
+				/>
+			</NotebookInstanceProvider>
+		);
+		return container.querySelector<HTMLButtonElement>('button.action-button')!;
+	}
+
+	teardown(() => {
+		sinon.restore();
+	});
+
+	test('renders with aria-label from action', () => {
+		const button = renderButton(mockAction({ label: 'Collapse Output' }));
+
+		assert.ok(button);
+		assert.strictEqual(button.getAttribute('aria-label'), 'Collapse Output');
+	});
+
+	test('applies cell-action-button class', () => {
+		const button = renderButton(mockAction());
+
+		assert.ok(button.classList.contains('cell-action-button'));
+	});
+
+	test('applies separator-after class when showSeparator is true', () => {
+		const button = renderButton(mockAction(), { showSeparator: true });
+
+		assert.ok(button.classList.contains('separator-after'));
+	});
+
+	test('does not apply separator-after class when showSeparator is false', () => {
+		const button = renderButton(mockAction(), { showSeparator: false });
+
+		assert.ok(!button.classList.contains('separator-after'));
+	});
+
+	test('selects cell before running action', () => {
+		const button = renderButton(mockAction());
+
+		button.click();
+
+		assert.ok(selectCellStub.calledOnce, 'Expected selectCell to be called');
+		assert.strictEqual(selectCellStub.firstCall.args[1], CellSelectionType.Normal);
+	});
+
+	test('runs the action when clicked', async () => {
+		const runStub = sinon.stub().resolves();
+		const button = renderButton(mockAction({ run: runStub }));
+
+		button.click();
+
+		await new Promise(resolve => setTimeout(resolve, 0));
+		assert.ok(runStub.calledOnce, 'Expected action.run to be called');
+	});
+
+	test('does not throw when action.run rejects', async () => {
+		const logStub = sinon.stub(console, 'log');
+		const button = renderButton(mockAction({
+			run: () => Promise.reject(new Error('action failed')),
+		}));
+
+		button.click();
+		await new Promise(resolve => setTimeout(resolve, 0));
+		logStub.restore();
+	});
+
+	test('renders icon when action has one', () => {
+		const button = renderButton(mockAction({ iconId: 'chevron-down' }));
+
+		const icon = button.querySelector<HTMLElement>('.codicon');
+		assert.ok(icon, 'Expected icon element');
+	});
+
+	test('renders DevErrorIcon when action has no icon', () => {
+		const button = renderButton(mockAction({ iconId: undefined }));
+
+		const errorIcon = button.querySelector<HTMLElement>('.codicon-blank');
+		assert.ok(errorIcon, 'Expected DevErrorIcon (codicon-blank) for missing action icon');
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellOutputActionBar.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellOutputActionBar.test.tsx
@@ -1,0 +1,218 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable local/code-no-dangerous-type-assertions */
+
+import assert from 'assert';
+import React from 'react';
+import { mainWindow } from '../../../../../../base/browser/window.js';
+import { Event } from '../../../../../../base/common/event.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { setupReactRenderer } from '../../../../../../base/test/browser/react.js';
+import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
+import { TestCommandService } from '../../../../../../editor/test/browser/editorTestServices.js';
+import { IPositronNotebookInstance } from '../../../browser/IPositronNotebookInstance.js';
+import { NotebookInstanceProvider } from '../../../browser/NotebookInstanceProvider.js';
+import { PositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
+import { PositronReactServices } from '../../../../../../base/browser/positronReactServices.js';
+import { CellOutputActionBar } from '../../../browser/notebookCells/CellOutputActionBar.js';
+import { CellScopedContextKeyServiceProvider } from '../../../browser/notebookCells/CellContextKeyServiceProvider.js';
+import { PositronNotebookCodeCell } from '../../../browser/PositronNotebookCells/PositronNotebookCodeCell.js';
+import { IMenu, IMenuService, MenuItemAction, SubmenuItemAction } from '../../../../../../platform/actions/common/actions.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
+
+/* Creates a mock MenuItemAction with the minimum fields needed for rendering. */
+function mockAction(id: string, label: string, iconId?: string): MenuItemAction {
+	return {
+		id,
+		label,
+		tooltip: '',
+		enabled: true,
+		item: {
+			id,
+			title: label,
+			icon: iconId ? ThemeIcon.fromId(iconId) : undefined,
+		},
+		run: () => Promise.resolve(),
+		dispose: () => { },
+	} as unknown as MenuItemAction;
+}
+
+/* DOM queries for asserting on rendered CellOutputActionBar structure. */
+class CellOutputActionBarFixture {
+	constructor(private readonly container: HTMLElement) { }
+
+	get toolbar() {
+		return this.container.querySelector<HTMLDivElement>('[role="toolbar"]');
+	}
+
+	get buttons() {
+		return this.container.querySelectorAll<HTMLElement>('.action-button');
+	}
+
+	get separatorButtons() {
+		return this.container.querySelectorAll<HTMLElement>('.action-button.separator-after');
+	}
+}
+
+suite('CellOutputActionBar', () => {
+	const { render } = setupReactRenderer();
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let contextKeyService: MockContextKeyService;
+	let menuActions: [string, (MenuItemAction | SubmenuItemAction)[]][];
+
+	setup(() => {
+		contextKeyService = disposables.add(new MockContextKeyService());
+		menuActions = [];
+	});
+
+	/* Render the component with mock services and return a fixture for querying. */
+	function renderActionBar(scrollTargetRef = React.createRef<HTMLElement | null>()) {
+		const instantiationService = disposables.add(new TestInstantiationService());
+		const commandService = new TestCommandService(instantiationService);
+
+		const menu: IMenu = {
+			onDidChange: Event.None,
+			dispose: () => { },
+			getActions: () => menuActions,
+		};
+
+		const menuService: IMenuService = {
+			_serviceBrand: undefined,
+			createMenu: () => menu,
+			getMenuActions: () => [],
+			getMenuContexts: () => new Set(),
+			resetHiddenStates: () => { },
+		};
+
+		const services = {
+			commandService,
+			contextKeyService,
+			get: (id: any) => {
+				if (id === IMenuService) { return menuService; }
+				throw new Error(`Unexpected service: ${id}`);
+			},
+		} as unknown as PositronReactServices;
+
+		const instance = {
+			hoverManager: undefined,
+		} as unknown as IPositronNotebookInstance;
+
+		const cell = {} as PositronNotebookCodeCell;
+
+		const element = (
+			<PositronReactServicesContext.Provider value={services}>
+				<NotebookInstanceProvider instance={instance}>
+					<CellScopedContextKeyServiceProvider service={contextKeyService}>
+						<CellOutputActionBar cell={cell} scrollTargetRef={scrollTargetRef} />
+					</CellScopedContextKeyServiceProvider>
+				</NotebookInstanceProvider>
+			</PositronReactServicesContext.Provider>
+		);
+
+		// TODO: Render three times to settle chained useEffect state updates
+		// in useMenu and useMenuActions. Each hook sets state in an effect,
+		// requiring a separate render cycle to propagate.
+		// https://github.com/posit-dev/positron/issues/12464
+		const container = render(element);
+		render(element);
+		render(element);
+		return new CellOutputActionBarFixture(container);
+	}
+
+	test('renders empty toolbar when there are no actions', () => {
+		menuActions = [];
+		const fixture = renderActionBar();
+
+		assert.ok(fixture.toolbar);
+		assert.strictEqual(fixture.buttons.length, 0);
+	});
+
+	test('toolbar has an accessible label', () => {
+		menuActions = [
+			['0_visibility', [mockAction('collapse', 'Collapse', 'chevron-down')]],
+		];
+		const fixture = renderActionBar();
+
+		assert.ok(fixture.toolbar);
+		assert.strictEqual(fixture.toolbar.getAttribute('aria-label'), 'Cell output actions');
+	});
+
+	test('renders buttons for a single group', () => {
+		menuActions = [
+			['0_visibility', [
+				mockAction('collapse', 'Collapse', 'chevron-down'),
+				mockAction('expand', 'Expand', 'chevron-right'),
+			]],
+		];
+		const fixture = renderActionBar();
+
+		assert.strictEqual(fixture.buttons.length, 2);
+		assert.strictEqual(fixture.separatorButtons.length, 0, 'No separators for a single group');
+	});
+
+	test('renders separator before the last group', () => {
+		menuActions = [
+			['0_visibility', [
+				mockAction('collapse', 'Collapse', 'chevron-down'),
+				mockAction('expand', 'Expand', 'chevron-right'),
+			]],
+			['1_destructive', [
+				mockAction('clear', 'Clear', 'close'),
+			]],
+		];
+		const fixture = renderActionBar();
+
+		assert.strictEqual(fixture.buttons.length, 3);
+		assert.strictEqual(fixture.separatorButtons.length, 1, 'One separator before the last group');
+	});
+
+	test('only shows separator before the last group with three groups', () => {
+		menuActions = [
+			['0_visibility', [mockAction('collapse', 'Collapse', 'chevron-down')]],
+			['1_middle', [mockAction('middle', 'Middle', 'info')]],
+			['2_destructive', [mockAction('clear', 'Clear', 'close')]],
+		];
+		const fixture = renderActionBar();
+
+		assert.strictEqual(fixture.buttons.length, 3);
+		assert.strictEqual(fixture.separatorButtons.length, 1, 'Only one separator before the last group');
+	});
+
+	/* Verify the action bar wires up wheel forwarding (detailed behavior tested in useWheelForwarding.test). */
+	test('forwards wheel events to scroll target', () => {
+		menuActions = [
+			['0_visibility', [mockAction('collapse', 'Collapse', 'chevron-down')]],
+		];
+		const scrollTarget = mainWindow.document.createElement('div');
+		scrollTarget.style.overflow = 'auto';
+		scrollTarget.style.width = '100px';
+		scrollTarget.style.height = '50px';
+		const inner = mainWindow.document.createElement('div');
+		inner.style.width = '300px';
+		inner.style.height = '300px';
+		scrollTarget.appendChild(inner);
+		mainWindow.document.body.appendChild(scrollTarget);
+
+		try {
+			const scrollTargetRef = React.createRef<HTMLElement | null>();
+			scrollTargetRef.current = scrollTarget;
+
+			const fixture = renderActionBar(scrollTargetRef);
+			assert.ok(fixture.toolbar);
+
+			const event = new WheelEvent('wheel', { deltaY: 50, cancelable: true });
+			fixture.toolbar.dispatchEvent(event);
+
+			assert.strictEqual(scrollTarget.scrollTop, 50);
+			assert.strictEqual(event.defaultPrevented, true);
+		} finally {
+			scrollTarget.remove();
+		}
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/useWheelForwarding.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/useWheelForwarding.test.tsx
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import React from 'react';
+import { mainWindow } from '../../../../../../base/browser/window.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { setupReactRenderer } from '../../../../../../base/test/browser/react.js';
+import { useWheelForwarding } from '../../../browser/notebookCells/useWheelForwarding.js';
+
+/* Minimal wrapper that wires up the hook between a source div and a target ref. */
+function TestComponent({ targetRef }: {
+	targetRef: React.RefObject<HTMLElement | null>;
+}) {
+	const sourceRef = React.useRef<HTMLDivElement>(null);
+	useWheelForwarding(sourceRef, targetRef);
+	return <div ref={sourceRef} />;
+}
+
+suite('useWheelForwarding', () => {
+	const { render } = setupReactRenderer();
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	let scrollTarget: HTMLDivElement;
+	let scrollTargetRef: React.RefObject<HTMLElement | null>;
+
+	/* Create a scrollable container (100x50) with oversized content (300x300). */
+	setup(() => {
+		scrollTarget = mainWindow.document.createElement('div');
+		scrollTarget.style.overflow = 'auto';
+		scrollTarget.style.width = '100px';
+		scrollTarget.style.height = '50px';
+		const inner = mainWindow.document.createElement('div');
+		inner.style.width = '300px';
+		inner.style.height = '300px';
+		scrollTarget.appendChild(inner);
+		mainWindow.document.body.appendChild(scrollTarget);
+
+		scrollTargetRef = React.createRef<HTMLElement | null>();
+		scrollTargetRef.current = scrollTarget;
+	});
+
+	teardown(() => {
+		scrollTarget.remove();
+	});
+
+	/* Render the hook and return the source element that receives wheel events. */
+	function renderHook() {
+		const container = render(<TestComponent targetRef={scrollTargetRef} />);
+		const source = container.firstElementChild as HTMLDivElement;
+		assert.ok(source);
+		return source;
+	}
+
+	test('forwards wheel deltaY to scroll target scrollTop', () => {
+		const source = renderHook();
+		assert.strictEqual(scrollTarget.scrollTop, 0);
+
+		source.dispatchEvent(new WheelEvent('wheel', { deltaY: 50, cancelable: true }));
+
+		assert.strictEqual(scrollTarget.scrollTop, 50);
+	});
+
+	test('forwards wheel deltaX to scroll target scrollLeft', () => {
+		const source = renderHook();
+		assert.strictEqual(scrollTarget.scrollLeft, 0);
+
+		source.dispatchEvent(new WheelEvent('wheel', { deltaX: 30, cancelable: true }));
+
+		assert.strictEqual(scrollTarget.scrollLeft, 30);
+	});
+
+	test('does not preventDefault at scroll boundary', () => {
+		/* Pin to the bottom so further deltaY has no effect. */
+		scrollTarget.scrollTop = scrollTarget.scrollHeight;
+		const prevTop = scrollTarget.scrollTop;
+		const source = renderHook();
+
+		const event = new WheelEvent('wheel', { deltaY: 50, cancelable: true });
+		source.dispatchEvent(event);
+
+		assert.strictEqual(scrollTarget.scrollTop, prevTop);
+		assert.strictEqual(event.defaultPrevented, false);
+	});
+
+	test('does not throw when scroll target ref is null', () => {
+		scrollTargetRef.current = null;
+		const source = renderHook();
+
+		const event = new WheelEvent('wheel', { deltaY: 10, cancelable: true });
+		source.dispatchEvent(event);
+
+		assert.strictEqual(event.defaultPrevented, false);
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.test.ts
@@ -113,6 +113,34 @@ suite('Positron Notebook Cell Outputs', () => {
 			assert.strictEqual(outputs[0].parsed.type, 'image');
 		});
 
+		test('clearing outputs resets collapse state', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]],
+				disposables
+			);
+			const cell = notebook.cells.get()[0];
+			assert.ok(cell.isCodeCell());
+
+			// Add output
+			notebook.textModel!.applyEdits([{
+				editType: CellEditType.Output,
+				index: 0,
+				outputs: [{ outputId: 'output-1', outputs: [textOutputItem('hello')] }],
+				append: false,
+			}], true, undefined, () => undefined, undefined, false);
+			assert.strictEqual(cell.outputs.get().length, 1);
+
+			// Collapse the output
+			cell.collapseOutput();
+			assert.strictEqual(cell.outputIsCollapsed.get(), true);
+
+			// Clear outputs
+			notebook.clearCellOutput(cell);
+
+			assert.strictEqual(cell.outputs.get().length, 0);
+			assert.strictEqual(cell.outputIsCollapsed.get(), false, 'collapse state should reset when outputs are cleared');
+		});
+
 		test('outputImageTargeted context key defaults to false and can be set', () => {
 			const notebook = createTestPositronNotebookInstance(
 				[['print("hello")', 'python', CellKind.Code]],

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -18,6 +18,7 @@ const MARKDOWN_ARIA_LABEL = 'Markdown cell - Press Enter to edit';
 
 type MoreActionsMenuItems = 'Copy cell' | 'Cut cell' | 'Paste Cell Above' | 'Paste cell below' | 'Move cell down' | 'Move cell up' | 'Insert code cell above' | 'Insert code cell below';
 type EditorActionBarButtons = 'Markdown' | 'Code' | 'Clear Outputs' | 'Run All';
+type OutputActionBarButtons = 'Collapse Output' | 'Expand Output' | 'Clear Output';
 
 /**
  * Notebooks functionality exclusive to Positron notebooks.
@@ -43,7 +44,7 @@ export class PositronNotebooks extends Notebooks {
 	private addMarkdownButton = this.editorActionBar.getByRole('button', { name: 'Markdown' });
 	private addCodeButton = this.editorActionBar.getByRole('button', { name: 'Code' });
 
-	// Cell action buttons, menus, tooltips, output, etc
+	// Cell action buttons, menus, tooltips, etc
 	moreActionsButtonAtIndex = (index: number) => this.cell.nth(index).getByRole('button', { name: /More Cell Actions/i });
 	// Drag handle is a sibling of the cell inside .sortable-cell parent
 	sortableCellAtIndex = (index: number) => this.code.driver.page.locator('.sortable-cell').nth(index);
@@ -51,9 +52,7 @@ export class PositronNotebooks extends Notebooks {
 	dragZoneAtIndex = (index: number) => this.sortableCellAtIndex(index).locator('.cell-drag-zone');
 	moreActionsOption = (option: string) => this.code.driver.page.locator('button.custom-context-menu-item', { hasText: option });
 	runCellButtonAtIndex = (index: number) => this.cell.nth(index).getByRole('button', { name: 'Run Cell', exact: true });
-	private cellOutput = (index: number) => this.cell.nth(index).getByTestId('cell-output');
 	private executionOrderBadgeAtIndex = (index: number) => this.cell.nth(index).locator('.execution-order-badge');
-	private executionStatusBadgeWrapperAtIndex = (index: number) => this.cell.nth(index).locator('.execution-status-badge-wrapper');
 	private cellMarkdown = (index: number) => this.cell.nth(index).locator('.positron-notebook-markdown-rendered');
 	private cellFooterAtIndex = (index: number) => this.cell.nth(index).locator('.positron-notebook-code-cell-footer');
 	private spinnerAtIndex = (index: number) => this.cell.nth(index).getByLabel(/Cell is executing/i);
@@ -61,6 +60,11 @@ export class PositronNotebooks extends Notebooks {
 	private deleteCellButton = this.cell.getByRole('button', { name: /Delete Cell/i });
 	viewMarkdown = this.code.driver.page.getByRole('button', { name: 'View markdown' });
 	expandMarkdownEditor = this.code.driver.page.getByRole('button', { name: 'Open markdown editor' });
+
+	// Cell outputs
+	cellOutput = (index: number) => this.cell.nth(index).getByTestId('cell-output');
+	private outputActionBar = (index: number) => this.cell.nth(index).locator('.cell-output-action-bar');
+	showHiddenOutputButton = (index: number) => this.cellOutput(index).getByRole('button', { name: 'Show hidden output' });
 
 	// Assistant buttons (shown on error cells when assistant is enabled)
 	private askAssistantButton = this.editorActionBar.getByRole('button', { name: 'Ask Assistant', exact: true });
@@ -545,6 +549,18 @@ export class PositronNotebooks extends Notebooks {
 	}
 
 	/**
+	 * Action: Select an output action from the Output Action Bar for a cell.
+	 * @param cellIndex - The index of the cell to act on
+	 * @param button - The button to click on the Output Action Bar
+	 */
+	async triggerCellOutputAction(cellIndex: number, button: OutputActionBarButtons): Promise<void> {
+		await test.step(`Click "${button}" for cell ${cellIndex}`, async () => {
+			await this.cellOutput(cellIndex).hover();
+			await this.outputActionBar(cellIndex).getByRole('button', { name: button }).click();
+		});
+	}
+
+	/**
 	 * Action: Create a new code cell at the END of the notebook.
 	 */
 	private async addCodeCellToEnd(): Promise<void> {
@@ -579,14 +595,6 @@ export class PositronNotebooks extends Notebooks {
 			});
 			await expect(spinner).toHaveCount(0, { timeout: DEFAULT_TIMEOUT });
 		});
-	}
-
-	/**
-	 * Action: Hover over the execution status badge for a cell to trigger the execution info tooltip.
-	 * @param cellIndex - The index of the cell whose execution badge to hover.
-	 */
-	async hoverExecutionBadge(cellIndex: number): Promise<void> {
-		await this.executionStatusBadgeWrapperAtIndex(cellIndex).hover();
 	}
 
 	/**

--- a/test/e2e/tests/notebooks-positron/notebook-cell-output-action-bar.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-output-action-bar.test.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Positron Notebooks: Cell Output Action Bar', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+}, () => {
+
+	test('Output action bar: collapse, expand, and clear output', async function ({ app }) {
+		const { notebooks, notebooksPositron } = app.workbench;
+
+		await test.step('Setup: Open a notebook and run the first cell', async () => {
+			// Setup the notebook
+			await notebooks.createNewNotebook();
+			await notebooksPositron.expectCellCountToBe(1);
+			await notebooksPositron.kernel.select('Python');
+
+			// Run cell to generate output
+			await notebooksPositron.addCodeToCell(0, 'print("hello world")', { run: true });
+			await notebooksPositron.expectOutputAtIndex(0, ['hello world']);
+		});
+
+		await test.step('Collapse output hides the output content', async () => {
+			await notebooksPositron.triggerCellOutputAction(0, 'Collapse Output');
+			await expect(notebooksPositron.showHiddenOutputButton(0)).toBeVisible();
+			await expect(notebooksPositron.cellOutput(0).getByText('hello world')).toBeHidden();
+		});
+
+		await test.step('Expand output shows the output content again', async () => {
+			await notebooksPositron.triggerCellOutputAction(0, 'Expand Output');
+			await expect(notebooksPositron.showHiddenOutputButton(0)).toBeHidden();
+			await notebooksPositron.expectOutputAtIndex(0, ['hello world']);
+		});
+
+		await test.step('Clear output removes the output', async () => {
+			await notebooksPositron.triggerCellOutputAction(0, 'Clear Output');
+			await expect(notebooksPositron.cellOutput(0)).toBeEmpty();
+		});
+	});
+});


### PR DESCRIPTION
This PR adds a cell output action bar to easily perform actions on outputs like collapse, expand, and clear.

Addresses #12370.

The output action bar only shows on hover of the outputs section, so that the entire output can still be viewed if it happens to be really wide and occluded by the action bar.

It currently provides the same actions as the output actions menu on the left.

https://github.com/user-attachments/assets/52f60864-7366-4ae7-bfba-b2d309c6de85

### Release Notes

#### New Features

- Added a cell output action bar to easily expand, collapse, and clear outputs (#12370)

#### Bug Fixes

- N/A

### QA Notes

@:web @:positron-notebooks

This PR includes an e2e test that follows these steps:

1. Open a notebook
2. Run a cell that produces output
3. Verify that the output action bar is hidden
4. Click the Collapse Output button
5. Verify that the output collapses
6. Click the Expand Output button
7. Verify that the output shows again
8. Click the Clear Output button
9. Verify that the output is cleared