### PR TITLE
Add opt-out anonymous usage reporting with random, resettable ID

### DIFF
--- a/src/vs/platform/update/common/positronUpdateUtils.ts
+++ b/src/vs/platform/update/common/positronUpdateUtils.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Builds the update check URL with optional query parameters for language and telemetry reporting.
+ * @param baseUrl The base URL for the update check
+ * @param languages Array of active languages (e.g., ['python', 'r'])
+ * @param includeLanguages Whether to include language parameters
+ * @param anonymousId The anonymous telemetry ID, or undefined to omit
+ * @returns The complete URL with query parameters
+ */
+export function buildUpdateUrl(
+	baseUrl: string,
+	languages: string[],
+	includeLanguages: boolean,
+	anonymousId: string | undefined
+): string {
+	const urlParams: string[] = [];
+	if (includeLanguages && languages.length > 0) {
+		urlParams.push(...languages.map(lang => `${lang}=1`));
+	}
+	if (anonymousId) {
+		urlParams.push(`uuid=${anonymousId}`);
+	}
+	return urlParams.length > 0 ? `${baseUrl}?${urlParams.join('&')}` : baseUrl;
+}

--- a/src/vs/platform/update/common/update.config.contribution.ts
+++ b/src/vs/platform/update/common/update.config.contribution.ts
@@ -35,7 +35,7 @@ configurationRegistry.registerConfiguration({
 				category: PolicyCategory.Update,
 				minimumVersion: '1.67',
 				localization: {
-					description: { key: 'updateMode', value: localize('updateMode', "Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service."), },
+					description: { key: 'updateModePolicy', value: localize('updateModePolicy', "Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service."), },
 					enumDescriptions: [
 						{
 							key: 'none',
@@ -69,7 +69,7 @@ configurationRegistry.registerConfiguration({
 			type: 'string',
 			default: 'default',
 			scope: ConfigurationScope.APPLICATION,
-			description: localize('updateMode', "Configure whether you receive automatic updates. Requires a restart after change to take effect."),
+			description: localize('updateChannel', "Configure whether you receive automatic updates. Requires a restart after change to take effect."),
 			deprecationMessage: localize('deprecated', "This setting is deprecated, please use '{0}' instead.", 'update.mode')
 		},
 		'update.positron.channel': {
@@ -90,6 +90,14 @@ configurationRegistry.registerConfiguration({
 			default: true,
 			scope: ConfigurationScope.APPLICATION,
 			description: localize('update.primaryLanguageReporting', "Share the primary data science languages in use, such as Python and R, to help us improve Positron."),
+			tags: ['usesOnlineServices'],
+			included: !isWeb
+		},
+		'update.anonymousUsageReporting': {
+			type: 'boolean',
+			default: true,
+			scope: ConfigurationScope.APPLICATION,
+			markdownDescription: localize('update.anonymousUsageReporting', "Share an anonymous identifier during update checks to help us understand unique usage patterns. This ID is randomly generated and not linked to any other identifiers. See our [privacy policy](https://positron.posit.co/privacy.html#positron-data-collection) for details."),
 			tags: ['usesOnlineServices'],
 			included: !isWeb
 		},

--- a/src/vs/platform/update/common/update.ts
+++ b/src/vs/platform/update/common/update.ts
@@ -118,5 +118,6 @@ export interface IUpdateService {
 	// --- Start Positron ---
 	updateActiveLanguages(languages: string[]): void;
 	getReleaseNotes(): Promise<string>;
+	resetTelemetryId(): string;
 	// --- End Positron ---
 }

--- a/src/vs/platform/update/common/update.ts
+++ b/src/vs/platform/update/common/update.ts
@@ -118,6 +118,6 @@ export interface IUpdateService {
 	// --- Start Positron ---
 	updateActiveLanguages(languages: string[]): void;
 	getReleaseNotes(): Promise<string>;
-	resetTelemetryId(): string;
+	resetTelemetryId(): void;
 	// --- End Positron ---
 }

--- a/src/vs/platform/update/common/updateIpc.ts
+++ b/src/vs/platform/update/common/updateIpc.ts
@@ -100,11 +100,8 @@ export class UpdateChannelClient implements IUpdateService {
 		return this.channel.call('getReleaseNotes');
 	}
 
-	resetTelemetryId(): string {
+	resetTelemetryId(): void {
 		this.channel.call('resetTelemetryId');
-		// The actual ID is generated on the main process side
-		// This just triggers the reset; the return value isn't used by the caller
-		return '';
 	}
 	// --- End Positron ---
 }

--- a/src/vs/platform/update/common/updateIpc.ts
+++ b/src/vs/platform/update/common/updateIpc.ts
@@ -32,6 +32,7 @@ export class UpdateChannel implements IServerChannel {
 			case 'disableProgressiveReleases': return this.service.disableProgressiveReleases();
 			case 'updateActiveLanguages': return Promise.resolve(this.service.updateActiveLanguages(arg));
 			case 'getReleaseNotes': return this.service.getReleaseNotes();
+			case 'resetTelemetryId': return Promise.resolve(this.service.resetTelemetryId());
 		}
 
 		throw new Error(`Call not found: ${command}`);
@@ -97,6 +98,13 @@ export class UpdateChannelClient implements IUpdateService {
 
 	getReleaseNotes(): Promise<string> {
 		return this.channel.call('getReleaseNotes');
+	}
+
+	resetTelemetryId(): string {
+		this.channel.call('resetTelemetryId');
+		// The actual ID is generated on the main process side
+		// This just triggers the reset; the return value isn't used by the caller
+		return '';
 	}
 	// --- End Positron ---
 }

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -15,12 +15,15 @@ import { IRequestService } from '../../request/common/request.js';
 import { AvailableForDownload, DisablementReason, IUpdateService, State, StateType, UpdateType } from '../common/update.js';
 
 //--- Start Positron ---
+import * as crypto from 'crypto';
 // eslint-disable-next-line no-duplicate-imports
 import { asJson, asText } from '../../request/common/request.js';
 // eslint-disable-next-line no-duplicate-imports
 import { IUpdate } from '../common/update.js';
 import { hasUpdate } from '../common/positronVersion.js';
 import { INativeHostMainService } from '../../native/electron-main/nativeHostMainService.js';
+import { IStateService } from '../../state/node/state.js';
+import { buildUpdateUrl } from '../common/positronUpdateUtils.js';
 
 export function createUpdateURL(platform: string, channel: string, productService: IProductService): string {
 	return `${productService.updateUrl}/${channel}/${platform}`;
@@ -43,6 +46,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	private _activeLanguages: string[];
 	// enable the service to download and apply updates automatically
 	protected enableAutoUpdate = false;
+	private static readonly TELEMETRY_ID_KEY = 'telemetry.anonymousId';
 	// --- End Positron ---
 
 	private _state: State = State.Uninitialized;
@@ -68,7 +72,8 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		@ILogService protected logService: ILogService,
 		// --- Start Positron ---
 		@IProductService protected readonly productService: IProductService,
-		@INativeHostMainService protected readonly nativeHostMainService: INativeHostMainService
+		@INativeHostMainService protected readonly nativeHostMainService: INativeHostMainService,
+		@IStateService protected readonly stateService: IStateService
 		// --- End Positron ---
 	) {
 		// --- Start Positron ---
@@ -162,7 +167,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		// settings migration from prereleases to releases
 		if (persistedUpdateChannel && persistedUpdateChannel === 'prereleases') {
 			this.configurationService.updateValue('update.positron.channel', 'releases');
-			persistedUpdateChannel = 'releases'
+			persistedUpdateChannel = 'releases';
 		}
 
 		return process.env.POSITRON_UPDATE_CHANNEL ?? persistedUpdateChannel;
@@ -192,7 +197,10 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	// --- Start Positron ---
 	async checkForUpdates(explicit: boolean): Promise<void> {
 		const includeLanguages = this.configurationService.getValue<boolean>('update.primaryLanguageReporting');
+		const includeAnonymousId = this.configurationService.getValue<boolean>('update.anonymousUsageReporting');
+
 		this.logService.debug('update#checkForUpdates, includeLanguages =', includeLanguages);
+		this.logService.debug('update#checkForUpdates, includeAnonymousUsage =', includeAnonymousId);
 		this.logService.trace('update#checkForUpdates, state = ', this.state.type);
 
 		this.logService.debug('update#checkForUpdates, languages =', this._activeLanguages.join(', '));
@@ -201,10 +209,10 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		}
 
 		this.setState(State.CheckingForUpdates(explicit));
-		let releaseMetadataUrl = this.url;
-		if (includeLanguages && this._activeLanguages.length > 0) {
-			releaseMetadataUrl = `${releaseMetadataUrl}?${this._activeLanguages.map(lang => `${lang}=1`).join('&')}`;
-		}
+
+		// Build URL with optional parameters
+		const anonymousId = includeAnonymousId ? this.getOrCreateTelemetryId() : undefined;
+		const releaseMetadataUrl = buildUpdateUrl(this.url!, this._activeLanguages, includeLanguages, anonymousId);
 
 		this.logService.debug('update#checkForUpdates, url =', releaseMetadataUrl);
 
@@ -383,6 +391,21 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	}
 	updateActiveLanguages(languages: string[]): void {
 		this._activeLanguages = languages;
+	}
+
+	private getOrCreateTelemetryId(): string {
+		let id = this.stateService.getItem<string>(AbstractUpdateService.TELEMETRY_ID_KEY);
+		if (!id) {
+			id = crypto.randomUUID();
+			this.stateService.setItem(AbstractUpdateService.TELEMETRY_ID_KEY, id);
+		}
+		return id;
+	}
+
+	resetTelemetryId(): string {
+		const newId = crypto.randomUUID();
+		this.stateService.setItem(AbstractUpdateService.TELEMETRY_ID_KEY, newId);
+		return newId;
 	}
 	// --- End Positron ---
 }

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -402,10 +402,9 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		return id;
 	}
 
-	resetTelemetryId(): string {
+	resetTelemetryId(): void {
 		const newId = crypto.randomUUID();
 		this.stateService.setItem(AbstractUpdateService.TELEMETRY_ID_KEY, newId);
-		return newId;
 	}
 	// --- End Positron ---
 }

--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -20,6 +20,7 @@ import { AbstractUpdateService, createUpdateURL, UpdateErrorClassification } fro
 
 // --- Start Positron ---
 import { INativeHostMainService } from '../../native/electron-main/nativeHostMainService.js';
+import { IStateService } from '../../state/node/state.js';
 import { arch } from 'os';
 // --- End Positron ---
 
@@ -41,9 +42,10 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 		@IRequestService requestService: IRequestService,
 		@ILogService logService: ILogService,
 		@IProductService productService: IProductService,
-		@INativeHostMainService nativeHostMainService: INativeHostMainService
+		@INativeHostMainService nativeHostMainService: INativeHostMainService,
+		@IStateService stateService: IStateService
 	) {
-		super(lifecycleMainService, configurationService, environmentMainService, requestService, logService, productService, nativeHostMainService);
+		super(lifecycleMainService, configurationService, environmentMainService, requestService, logService, productService, nativeHostMainService, stateService);
 		// --- End Positron ---
 
 		lifecycleMainService.setRelaunchHandler(this);

--- a/src/vs/platform/update/electron-main/updateService.linux.ts
+++ b/src/vs/platform/update/electron-main/updateService.linux.ts
@@ -13,6 +13,7 @@ import { IProductService } from '../../product/common/productService.js';
 import { asJson, IRequestService } from '../../request/common/request.js';
 import { AvailableForDownload, IUpdate, State, UpdateType } from '../common/update.js';
 import { AbstractUpdateService, createUpdateURL } from './abstractUpdateService.js';
+import { IStateService } from '../../state/node/state.js';
 
 export class LinuxUpdateService extends AbstractUpdateService {
 
@@ -24,9 +25,10 @@ export class LinuxUpdateService extends AbstractUpdateService {
 		@IRequestService requestService: IRequestService,
 		@ILogService logService: ILogService,
 		@INativeHostMainService nativeHostMainService: INativeHostMainService,
-		@IProductService productService: IProductService
+		@IProductService productService: IProductService,
+		@IStateService stateService: IStateService
 	) {
-		super(lifecycleMainService, configurationService, environmentMainService, requestService, logService, productService, nativeHostMainService);
+		super(lifecycleMainService, configurationService, environmentMainService, requestService, logService, productService, nativeHostMainService, stateService);
 	}
 
 	protected buildUpdateFeedUrl(channel: string): string {

--- a/src/vs/platform/update/electron-main/updateService.snap.ts
+++ b/src/vs/platform/update/electron-main/updateService.snap.ts
@@ -145,9 +145,8 @@ abstract class AbstractUpdateService implements IUpdateService {
 	getReleaseNotes(): Promise<string> {
 		return Promise.resolve('No release notes available');
 	}
-	resetTelemetryId(): string {
-		// no-op for snap so return empty string
-		return '';
+	resetTelemetryId(): void {
+		// no-op for snap
 	}
 	// --- End Positron ---
 }

--- a/src/vs/platform/update/electron-main/updateService.snap.ts
+++ b/src/vs/platform/update/electron-main/updateService.snap.ts
@@ -145,6 +145,10 @@ abstract class AbstractUpdateService implements IUpdateService {
 	getReleaseNotes(): Promise<string> {
 		return Promise.resolve('No release notes available');
 	}
+	resetTelemetryId(): string {
+		// no-op for snap so return empty string
+		return '';
+	}
 	// --- End Positron ---
 }
 

--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -31,6 +31,7 @@ import { DisablementReason, IUpdate, State, StateType, UpdateType } from '../com
 import { mkdirSync } from 'fs';
 // --- End Positron ---
 import { AbstractUpdateService, createUpdateURL, UpdateErrorClassification } from './abstractUpdateService.js';
+import { IStateService } from '../../state/node/state.js';
 
 async function pollUntil(fn: () => boolean, millis = 1000): Promise<void> {
 	while (!fn()) {
@@ -76,9 +77,10 @@ export class Win32UpdateService extends AbstractUpdateService implements IRelaun
 		@ILogService logService: ILogService,
 		@IFileService private readonly fileService: IFileService,
 		@IProductService productService: IProductService,
-		@INativeHostMainService nativeHostMainService: INativeHostMainService
+		@INativeHostMainService nativeHostMainService: INativeHostMainService,
+		@IStateService stateService: IStateService
 	) {
-		super(lifecycleMainService, configurationService, environmentMainService, requestService, logService, productService, nativeHostMainService);
+		super(lifecycleMainService, configurationService, environmentMainService, requestService, logService, productService, nativeHostMainService, stateService);
 
 		lifecycleMainService.setRelaunchHandler(this);
 	}

--- a/src/vs/platform/update/test/common/positronUpdateUtils.test.ts
+++ b/src/vs/platform/update/test/common/positronUpdateUtils.test.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { buildUpdateUrl } from '../../common/positronUpdateUtils.js';
+
+suite('buildUpdateUrl', function () {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const baseUrl = 'https://updates.example.com/releases/darwin/arm64/releases.json';
+
+	suite('with no optional parameters', function () {
+		test('returns base URL unchanged when no languages and no anonymous ID', () => {
+			const result = buildUpdateUrl(baseUrl, [], false, undefined);
+			assert.strictEqual(result, baseUrl);
+		});
+
+		test('returns base URL unchanged when languages disabled even with languages present', () => {
+			const result = buildUpdateUrl(baseUrl, ['python', 'r'], false, undefined);
+			assert.strictEqual(result, baseUrl);
+		});
+
+		test('returns base URL unchanged when languages enabled but empty', () => {
+			const result = buildUpdateUrl(baseUrl, [], true, undefined);
+			assert.strictEqual(result, baseUrl);
+		});
+	});
+
+	suite('with language parameters', function () {
+		test('includes single language parameter', () => {
+			const result = buildUpdateUrl(baseUrl, ['python'], true, undefined);
+			assert.strictEqual(result, `${baseUrl}?python=1`);
+		});
+
+		test('includes multiple language parameters', () => {
+			const result = buildUpdateUrl(baseUrl, ['python', 'r'], true, undefined);
+			assert.strictEqual(result, `${baseUrl}?python=1&r=1`);
+		});
+	});
+
+	suite('with anonymous ID parameter', function () {
+		test('includes uuid parameter when anonymous ID provided', () => {
+			const anonymousId = '12345678-1234-1234-1234-123456789012';
+			const result = buildUpdateUrl(baseUrl, [], false, anonymousId);
+			assert.strictEqual(result, `${baseUrl}?uuid=${anonymousId}`);
+		});
+
+		test('does not include uuid parameter when anonymous ID is undefined', () => {
+			const result = buildUpdateUrl(baseUrl, [], false, undefined);
+			assert.strictEqual(result, baseUrl);
+		});
+	});
+
+	suite('with both languages and anonymous ID', function () {
+		test('includes both language and uuid parameters', () => {
+			const anonymousId = '12345678-1234-1234-1234-123456789012';
+			const result = buildUpdateUrl(baseUrl, ['python', 'r'], true, anonymousId);
+			assert.strictEqual(result, `${baseUrl}?python=1&r=1&uuid=${anonymousId}`);
+		});
+
+		test('languages come before uuid in query string', () => {
+			const anonymousId = '12345678-1234-1234-1234-123456789012';
+			const result = buildUpdateUrl(baseUrl, ['python'], true, anonymousId);
+			assert.ok(result.indexOf('python=1') < result.indexOf('uuid='), 'language should come before uuid');
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronTelemetry/browser/positronTelemetry.contribution.ts
+++ b/src/vs/workbench/contrib/positronTelemetry/browser/positronTelemetry.contribution.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
+import { Action2, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { IUpdateService } from '../../../../platform/update/common/update.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'update.resetAnonymousId',
+			title: {
+				value: localize('update.resetAnonymousId', "Reset Anonymous Telemetry ID"),
+				original: 'Reset Anonymous Telemetry ID'
+			},
+			category: Categories.Preferences,
+			f1: true
+		});
+	}
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const updateService = accessor.get(IUpdateService);
+		const notificationService = accessor.get(INotificationService);
+
+		updateService.resetTelemetryId();
+		notificationService.info(localize('telemetryIdReset', "Your anonymous telemetry ID has been reset."));
+	}
+});

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -1144,6 +1144,11 @@ export class GettingStartedPage extends EditorPane {
 				id: 'positron-newsletter',
 				title: localize('positron.welcome.newsletter', "Sign Up for Positron Updates"),
 				href: 'https://posit.co/positron-updates-signup/'
+			},
+			{
+				id: 'positron-privacy',
+				title: localize('positron.welcome.privacy', "Privacy"),
+				href: this.docsService.getUrl('privacy.html')
 			}
 		];
 

--- a/src/vs/workbench/services/update/browser/updateService.ts
+++ b/src/vs/workbench/services/update/browser/updateService.ts
@@ -109,6 +109,10 @@ export class BrowserUpdateService extends Disposable implements IUpdateService {
 	getReleaseNotes(): Promise<string> {
 		return Promise.resolve('No release notes available');
 	}
+	resetTelemetryId(): string {
+		// no-op for browser - return empty string
+		return '';
+	}
 	// --- End Positron ---
 }
 

--- a/src/vs/workbench/services/update/browser/updateService.ts
+++ b/src/vs/workbench/services/update/browser/updateService.ts
@@ -109,9 +109,8 @@ export class BrowserUpdateService extends Disposable implements IUpdateService {
 	getReleaseNotes(): Promise<string> {
 		return Promise.resolve('No release notes available');
 	}
-	resetTelemetryId(): string {
-		// no-op for browser - return empty string
-		return '';
+	resetTelemetryId(): void {
+		// no-op for browser
 	}
 	// --- End Positron ---
 }

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -322,6 +322,7 @@ import './contrib/positronPlotsGalleryEditor/browser/positronPlotsGalleryEditor.
 import './contrib/positronOutputWebview/browser/notebookOutputWebview.contribution.js';
 import './contrib/positronNotebook/browser/positronNotebook.contribution.js';
 import './contrib/positronWelcome/browser/positronWelcome.contribution.js';
+import './contrib/positronTelemetry/browser/positronTelemetry.contribution.js';
 // --- End Positron ---
 
 // Terminal


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron-builds/issues/850

This PR adds opt-in-by-default anonymous usage reporting to help us understand usage patterns of Positron.

We removed and disabled the (very extensive!) telemetry infrastructure that Microsoft has built in https://github.com/posit-dev/positron/pull/2882, but we are interested in gathering some usage data of our own in a lighter weight, more privacy-friendly way. Here is the approach we're taking:

- A random UUID is generated on first use (not derived from any hardware or user identifier, not the same as the VS Code unique ID, etc)
- The ID has zero mathematical correlation to machine IDs, MAC addresses, or any other personal or device identifier
- Users can disable reporting via the `update.anonymousUsageReporting` setting
- Users can reset their ID anytime via "Preferences: Reset Anonymous Telemetry ID" command
- The ID is only sent during update checks (not continuous tracking)

### A few technical details

- The UUID is stored in the user's app data directory (user-scoped, not machine-scoped)
- Sent as a `uuid=` query parameter during existing update checks
- Follows the existing pattern of `update.primaryLanguageReporting`
- Reinstalling Positron generates a fresh ID

We want to be as transparent and clear as possible about the data we're collecting, so we are planning for a blog post ahead of the next release outlining exactly what we're doing, why, the questions we want to answer, and how users can control what they're sharing.

### Release Notes

#### New Features
- Added anonymous usage reporting during update checks to help us understand unique usage patterns. This uses a random, resettable ID that is not linked to any other identifiers. Users can opt out via the `update.anonymousUsageReporting` setting or reset their ID via the command palette.

#### Bug Fixes
- N/A

### QA Notes

@:welcome @:vscode-settings

1. Open Settings and search for "anonymousUsageReporting" to verify setting appears with privacy policy link
2. Open Welcome page (Help > Welcome) to verify "Privacy" link appears in Help section
3. Enable debug logging (Developer: Set Log Level > Debug), then run "Check for Updates" and verify logs show `uuid=` parameter in URL
4. Run "Preferences: Reset Anonymous Telemetry ID" command to verify notification appears
5. Run "Check for Updates" again and verify the logs show a new UUID
6. Disable `update.anonymousUsageReporting` setting and check for updates again to verify `uuid=` is NOT in URL
