### PR TITLE
fix bug that prevented the auth extension from being bundled in release

### DIFF
--- a/extensions/authentication/extension.webpack.config.js
+++ b/extensions/authentication/extension.webpack.config.js
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+//@ts-check
+
+'use strict';
+
+const withDefaults = require('../shared.webpack.config.mjs').default;
+
+module.exports.default = withDefaults({
+	context: __dirname,
+	entry: {
+		extension: './src/extension.ts',
+	},
+	node: {
+		__dirname: false
+	}
+});


### PR DESCRIPTION
This adds the Auth extension to daily builds. I used Positron Assistant as a reference and manually built the release locally to confirm the fix.