### PR TITLE
use SF_PARTNER everywhere for Snowflake

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -1420,6 +1420,7 @@
     "yaml": "^2.8.1"
   },
   "extensionDependencies": [
-    "positron.positron-supervisor"
+    "positron.positron-supervisor",
+    "positron.positron-environment"
   ]
 }

--- a/extensions/positron-assistant/src/providers/snowflake/snowflakeProvider.ts
+++ b/extensions/positron-assistant/src/providers/snowflake/snowflakeProvider.ts
@@ -14,7 +14,6 @@ import {
 } from './snowflakeAuth';
 import { autoconfigureWithManagedCredentials, SNOWFLAKE_MANAGED_CREDENTIALS } from '../../pwb';
 import { OpenAICompatibleModelProvider } from '../openai/openaiCompatibleProvider.js';
-import { IS_RUNNING_ON_PWB } from '../../constants.js';
 import { PROVIDER_METADATA } from '../../providerMetadata.js';
 
 /**
@@ -40,7 +39,10 @@ export class SnowflakeModelProvider extends OpenAICompatibleModelProvider {
 	};
 
 	protected override get customHeaders() {
-		return { 'User-Agent': IS_RUNNING_ON_PWB ? 'posit_workbench_positron' : 'posit_positron' };
+		const envConfig = vscode.workspace.getConfiguration('environmentVariables');
+		const envVars = envConfig.get<Record<string, string>>('set') ?? {};
+		const partnerTag = envVars['SF_PARTNER'] || 'posit_positron';
+		return { 'User-Agent': partnerTag };
 	}
 
 	/**

--- a/extensions/positron-catalog-explorer/package.json
+++ b/extensions/positron-catalog-explorer/package.json
@@ -16,6 +16,9 @@
     "onStartupFinished"
   ],
   "main": "./out/extension.js",
+  "extensionDependencies": [
+    "positron.positron-environment"
+  ],
   "contributes": {
     "configuration": {
       "title": "Catalog Explorer",

--- a/extensions/positron-catalog-explorer/src/catalogs/snowflake.ts
+++ b/extensions/positron-catalog-explorer/src/catalogs/snowflake.ts
@@ -133,10 +133,16 @@ export async function registerSnowflakeCatalog(
 		connOptions = connections[connName];
 	}
 
+	// Read partner tag from positron-environment configuration
+	const envConfig = vscode.workspace.getConfiguration('environmentVariables');
+	const envVars = envConfig.get<Record<string, string>>('set') ?? {};
+	const partnerTag = envVars['SF_PARTNER'] || 'posit_positron';
+
 	// Start with base connection options
 	const connectionOptions: snowflake.ConnectionOptions = {
 		account: connOptions.account,
 		authenticator: connOptions?.authenticator || 'externalbrowser',
+		application: partnerTag,
 	};
 
 	// Apply any additional options from connection profile


### PR DESCRIPTION
This PR implements reading from the positron environments extension rather than other sources.

In the Python connector, if `SF_PARTNER` is set, it will be [consumed automatically](https://github.com/snowflakedb/snowflake-connector-python/blob/14624ed01011e05d891705a73629203587f8d635/src/snowflake/connector/connection.py#L2608). [Same with R](https://github.com/r-dbi/odbc/blob/df791ec3495c0c98f0134881cbce85b7e1815581/R/driver-snowflake.R#L220).

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- https://github.com/posit-dev/positron/issues/12266 Unify `SF_PARTNER` identifier across Snowflake-related features.


### QA Notes

I'm really not sure how to check this directly, but here are some adjacent places

- Ensure `environmentVariables.set` setting has `SF_PARTNER`.
- Check `SF_PARTNER` available in Console via `os.environ['SF_PARTNER']` in Python and `Sys.getenv("SF_PARTNER")` in R