### PR TITLE
e2e: add positron notebook window reload test

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -207,9 +207,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await settings.remove(['console.showNotebookConsoleActions']);
 	});
 
-	test('ensure notebook session reattaches after window reload', {
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/9695' }]
-	}, async function ({ app, hotKeys }) {
+	test('ensure notebook session reattaches after window reload', async function ({ app, hotKeys }) {
 		const { notebooksPositron } = app.workbench;
 
 		// create new notebook and select kernel

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -206,6 +206,27 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		// Disable the notebook console actions setting after this test
 		await settings.remove(['console.showNotebookConsoleActions']);
 	});
+
+	test('ensure notebook session reattaches after window reload', async function ({ app, hotKeys }) {
+		const { notebooksPositron } = app.workbench;
+
+		// create new notebook and select kernel
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.kernel.select('Python');
+		await notebooksPositron.kernel.expectKernelToBe({
+			kernelGroup: 'Python',
+			status: 'idle'
+		});
+
+		// reload window
+		await hotKeys.reloadWindow(true);
+
+		// verify kernel session reattaches and returns to idle
+		await notebooksPositron.kernel.expectKernelToBe({
+			kernelGroup: 'Python',
+			status: 'idle'
+		});
+	});
 });
 
 const rDataFrame = `data.frame(

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -207,25 +207,33 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await settings.remove(['console.showNotebookConsoleActions']);
 	});
 
-	test('ensure notebook session reattaches after window reload', async function ({ app, hotKeys }) {
+	test('ensure notebook session reattaches after window reload', {
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/9695' }]
+	}, async function ({ app, hotKeys }) {
 		const { notebooksPositron } = app.workbench;
 
 		// create new notebook and select kernel
 		await notebooksPositron.newNotebook();
 		await notebooksPositron.kernel.select('Python');
-		await notebooksPositron.kernel.expectKernelToBe({
-			kernelGroup: 'Python',
-			status: 'idle'
-		});
+
+		// cell 0: create variable x and run it
+		await notebooksPositron.addCodeToCell(0, 'x = 2', { run: true });
+
+		// cell 1: add code that depends on x, but don't run yet
+		await notebooksPositron.addCodeToCell(1, 'x + 2', { run: false });
 
 		// reload window
 		await hotKeys.reloadWindow(true);
 
-		// verify kernel session reattaches and returns to idle
+		// verify kernel session reattaches
 		await notebooksPositron.kernel.expectKernelToBe({
 			kernelGroup: 'Python',
 			status: 'idle'
 		});
+
+		// run cell 1 and verify output proves session is functionally reattached
+		await notebooksPositron.runCodeAtIndex(1);
+		await notebooksPositron.expectOutputAtIndex(1, ['4']);
 	});
 });
 


### PR DESCRIPTION
## Summary
- Tests that kernel status returns to idle after reload (verifies session reattachment works)

## QA Notes
@:positron-notebooks @:web @:win

Closes #9720 