### PR TITLE
E2E test: fix unit and integration tests

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -145,15 +145,15 @@ jobs:
             ~/.cache/R
             /usr/local/lib/R/site-library
             /opt/R
-          key: ${{ runner.os }}-r-4.4.0-${{ steps.download-r-desc.outputs.description-hash }}
+          key: ${{ runner.os }}-r-4.5.2-${{ steps.download-r-desc.outputs.description-hash }}
           restore-keys: |
-            ${{ runner.os }}-r-4.4.0-
+            ${{ runner.os }}-r-4.5.2-
 
       - name: Setup R
         if: ${{ steps.cache-r.outputs.cache-hit != 'true' }}
         uses: ./.github/actions/install-r
         with:
-          version: "4.4.0"
+          version: "4.5.2"
 
       - name: Compile Integration Tests
         run: npm run --prefix test/integration/browser compile

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -174,15 +174,15 @@ jobs:
             ~/.cache/R
             /usr/local/lib/R/site-library
             /opt/R
-          key: ${{ runner.os }}-r-4.4.0-${{ steps.download-r-desc.outputs.description-hash }}
+          key: ${{ runner.os }}-r-4.5.2-${{ steps.download-r-desc.outputs.description-hash }}
           restore-keys: |
-            ${{ runner.os }}-r-4.4.0-
+            ${{ runner.os }}-r-4.5.2-
 
       - name: Setup R
         if: ${{ steps.cache-r.outputs.cache-hit != 'true' }}
         uses: ./.github/actions/install-r
         with:
-          version: "4.4.0"
+          version: "4.5.2"
 
       - name: Save R installation and packages cache
         if: ${{ steps.cache-r.outputs.cache-hit != 'true' }}
@@ -194,7 +194,7 @@ jobs:
             ~/.cache/R
             /usr/local/lib/R/site-library
             /opt/R
-          key: ${{ runner.os }}-r-4.4.0-${{ steps.download-r-desc.outputs.description-hash }}
+          key: ${{ runner.os }}-r-4.5.2-${{ steps.download-r-desc.outputs.description-hash }}
 
       - name: 🧪 Run Unit Tests (Electron)
         id: electron-unit-tests


### PR DESCRIPTION
Need to bump to at least R 4.5.0 for R dependencies

### QA Notes


