### PR TITLE
Fix workflow issues with dev Ark dependency

### DIFF
--- a/.github/actions/download-binaries/action.yml
+++ b/.github/actions/download-binaries/action.yml
@@ -23,6 +23,10 @@ runs:
         #   NOT included in cache paths, so they must be downloaded fresh on each platform
         echo "Downloading Ark binary..."
         cd positron-r && npm rebuild --foreground-scripts
+        if [ ! -f resources/ark/ark ] && [ ! -f resources/ark/ark.exe ]; then
+          echo "Error: Ark binary not found after npm rebuild"
+          exit 1
+        fi
         echo "Downloading Kallichore binary..."
         cd ../positron-supervisor && npm rebuild --foreground-scripts
         echo "Binaries downloaded successfully"

--- a/extensions/positron-r/scripts/install-kernel.ts
+++ b/extensions/positron-r/scripts/install-kernel.ts
@@ -430,8 +430,10 @@ async function main() {
 	console.log(`package.json version: ${packageJsonVersion} `);
 	console.log(`Downloaded ark version: ${localArkVersion ? localArkVersion : 'Not found'} `);
 
-	// Skip installation if versions match
-	if (packageJsonVersion === localArkVersion) {
+	// Skip installation if versions match. Repo references (org/repo@branch)
+	// always re-download because the branch tip may have new commits even though
+	// the ref string is unchanged.
+	if (packageJsonVersion === localArkVersion && !isGitHubRepoReference(packageJsonVersion)) {
 		console.log('Versions match. No action required.');
 		return;
 	}

--- a/extensions/positron-r/scripts/install-kernel.ts
+++ b/extensions/positron-r/scripts/install-kernel.ts
@@ -338,6 +338,9 @@ async function downloadFromGitHubRepository(
 			throw new Error(`Invalid Ark repository: Cargo.toml not found at the repository root`);
 		}
 
+		console.log('Updating Rust toolchain...');
+		await executeCommand('rustup update stable');
+
 		console.log('Building Ark from source...');
 
 		const buildOutput = await executeCommand('cargo build --release', undefined, tempDir);


### PR DESCRIPTION
To run frontend tests for https://github.com/posit-dev/ark/pull/1099#pullrequestreview-3956106306

Edit: That was green. I removed the dev dependency but kept the workflow fixes needed to actually run the tests on the correct version.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:ark