### PR TITLE
Allow viewer apps to run in Console sessions

### DIFF
--- a/extensions/positron-python/src/client/positron-run-app.d.ts
+++ b/extensions/positron-python/src/client/positron-run-app.d.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -23,14 +23,44 @@ export interface RunAppTerminalOptions {
 }
 
 /**
- * Represents options for the ${@link PositronRunApp.runApplication} function.
+ * Options returned from ${@link RunConsoleAppOptions.getConsoleCode}.
  */
-export interface RunAppOptions {
+export interface RunAppConsoleOptions {
     /**
-     * The human-readable label for the application e.g. `'Streamlit'`, also used as the ${@link vscode.Terminal.name}.
+     * The code to execute in the console session.
+     */
+    code: string;
+}
+
+/**
+ * Shared options for running an application.
+ */
+interface RunAppOptionsBase {
+    /**
+     * The human-readable label for the application e.g. `'Streamlit'`.
      */
     name: string;
 
+    /**
+     * The optional URL path at which to preview the application.
+     */
+    urlPath?: string;
+
+    /**
+     * The optional app ready message to wait for before previewing the application.
+     */
+    appReadyMessage?: string;
+
+    /**
+     * An optional array of app URI formats to parse the URI from the output.
+     */
+    appUrlStrings?: string[];
+}
+
+/**
+ * Options for the ${@link PositronRunApp.runApplication} function.
+ */
+export interface RunAppOptions extends RunAppOptionsBase {
     /**
      * A function that will be called to get the terminal options for running the application.
      *
@@ -44,21 +74,25 @@ export interface RunAppOptions {
         document: vscode.TextDocument,
         urlPrefix?: string,
     ) => RunAppTerminalOptions | undefined | Promise<RunAppTerminalOptions | undefined>;
+}
 
+/**
+ * Options for the ${@link PositronRunApp.runApplicationInConsole} function.
+ */
+export interface RunConsoleAppOptions extends RunAppOptionsBase {
     /**
-     * The optional URL path at which to preview the application.
+     * A function called to get the code to execute in the console session.
+     *
+     * @param runtime The language runtime metadata for the document's language.
+     * @param document The document to run.
+     * @param urlPrefix The URL prefix to use, if known.
+     * @returns The console code for running the application. Return `undefined` to abort the run.
      */
-    urlPath?: string;
-
-    /**
-     * The optional app ready message to wait for in the terminal before previewing the application.
-     */
-    appReadyMessage?: string;
-
-    /**
-     * An optional array of app URI formats to parse the URI from the terminal output.
-     */
-    appUrlStrings?: string[];
+    getConsoleCode: (
+        runtime: positron.LanguageRuntimeMetadata,
+        document: vscode.TextDocument,
+        urlPrefix?: string,
+    ) => RunAppConsoleOptions | undefined | Promise<RunAppConsoleOptions | undefined>;
 }
 
 /**
@@ -112,6 +146,15 @@ export interface PositronRunApp {
      *  started, otherwise resolves when the command has been sent to the terminal.
      */
     runApplication(options: RunAppOptions): Promise<void>;
+
+    /**
+     * Run an application in a new console session.
+     *
+     * @param options Options for running the application.
+     * @returns Resolves when the application server has started, or when the
+     *  code has been sent to the console if URL detection times out.
+     */
+    runApplicationInConsole(options: RunConsoleAppOptions): Promise<void>;
 
     /**
      * Debug an application.

--- a/extensions/positron-python/src/client/positron-run-app.d.ts
+++ b/extensions/positron-python/src/client/positron-run-app.d.ts
@@ -8,7 +8,7 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 
 /**
- * Represents options returned from ${@link RunAppOptions.getTerminalOptions}.
+ * Options returned from ${@link RunAppOptions.getTerminalOptions}.
  */
 export interface RunAppTerminalOptions {
     /**
@@ -23,9 +23,9 @@ export interface RunAppTerminalOptions {
 }
 
 /**
- * Options returned from ${@link RunConsoleAppOptions.getConsoleCode}.
+ * Code returned from ${@link RunConsoleAppOptions.getConsoleCode}.
  */
-export interface RunAppConsoleOptions {
+export interface RunAppConsoleCode {
     /**
      * The code to execute in the console session.
      */
@@ -89,7 +89,7 @@ export interface RunAppOptions extends RunAppOptionsBase {
  */
 export interface RunConsoleAppOptions extends RunAppOptionsBase {
     /**
-     * A function called to get the code to execute in the console session.
+     * A function that will be called to get the code to execute in the console session.
      *
      * @param runtime The language runtime metadata for the document's language.
      * @param document The document to run.
@@ -100,11 +100,11 @@ export interface RunConsoleAppOptions extends RunAppOptionsBase {
         runtime: positron.LanguageRuntimeMetadata,
         document: vscode.TextDocument,
         urlPrefix?: string,
-    ) => RunAppConsoleOptions | undefined | Promise<RunAppConsoleOptions | undefined>;
+    ) => RunAppConsoleCode | undefined | Promise<RunAppConsoleCode | undefined>;
 }
 
 /**
- * Represents options for the ${@link PositronRunApp.debugApplication} function.
+ * Options for the ${@link PositronRunApp.debugApplication} function.
  */
 export interface DebugAppOptions {
     /**

--- a/extensions/positron-python/src/client/positron-run-app.d.ts
+++ b/extensions/positron-python/src/client/positron-run-app.d.ts
@@ -55,6 +55,14 @@ interface RunAppOptionsBase {
      * An optional array of app URI formats to parse the URI from the output.
      */
     appUrlStrings?: string[];
+
+    /**
+     * The debug adapter type (e.g. `'ark'`) used by the runtime. When set
+     * and breakpoints are present, the runner waits for that adapter's
+     * `configurationDone` before executing app code. Leave unset for
+     * runtimes without DAP support to avoid a waiting overhead on every run.
+     */
+    debugAdapterType?: string;
 }
 
 /**

--- a/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppCommands.unit.test.ts
@@ -43,6 +43,7 @@ suite('Web app commands', () => {
                 assert.ok(!runAppOptions, 'runApplication called more than once');
                 runAppOptions = _options;
             },
+            async runApplicationInConsole() {},
             async debugApplication(_options) {
                 assert.ok(!debugAppOptions, 'debugApplication called more than once');
                 debugAppOptions = _options;

--- a/extensions/positron-run-app/justfile
+++ b/extensions/positron-run-app/justfile
@@ -1,0 +1,3 @@
+d-ts:
+  cp src/positron-run-app.d.ts ../positron-python/src/client/positron-run-app.d.ts
+  npx prettier --config ../positron-python/.prettierrc.js --write ../positron-python/src/client/positron-run-app.d.ts

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -17,12 +17,13 @@ import { shouldUsePositronProxy, showShellIntegrationNotSupportedMessage, showEn
 
 
 export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable {
+	private static readonly CONSOLE_SESSIONS_KEY = 'consoleSessionsByName';
+
 	private readonly _debugApplicationSequencerByName = new SequencerByKey<string>();
 	private readonly _debugApplicationDisposableByName = new Map<string, vscode.Disposable>();
 	private readonly _runApplicationSequencerByName = new SequencerByKey<string>();
 	private readonly _runApplicationDisposableByName = new Map<string, vscode.Disposable>();
 	private readonly _appServers = new Map<string, { terminalPid: number | undefined; proxyUri: vscode.Uri }>();
-	private readonly _consoleSessionByName = new Map<string, { session: positron.LanguageRuntimeSession; listener: vscode.Disposable }>();
 
 	constructor(
 		private readonly _globalState: vscode.Memento,
@@ -32,7 +33,6 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	public dispose() {
 		this._debugApplicationDisposableByName.forEach(disposable => disposable.dispose());
 		this._runApplicationDisposableByName.forEach(disposable => disposable.dispose());
-		this._consoleSessionByName.forEach(entry => entry.listener.dispose());
 	}
 
 	private isShellIntegrationSupported(): boolean {
@@ -302,41 +302,38 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 				});
 			}
 
-			// Restart existing console session for this app if one is still alive.
-			// This cleanly exits any active debugger state and reuses the same
-			// console tab.
-			let session = this._consoleSessionByName.get(options.name)?.session;
+			// Look up a previously used console session for this app and
+			// check if it's still alive. If so, restart it; otherwise
+			// create a fresh one.
+			let sessionId = await this.findConsoleSession(options.name);
 
-			if (session) {
+			if (sessionId) {
 				progress.report({ message: vscode.l10n.t('Restarting application...') });
 
 				try {
-					const didRestart = await positron.runtime.restartSession(session.metadata.sessionId);
+					const didRestart = await positron.runtime.restartSession(sessionId);
 					if (!didRestart) {
 						log.debug('Session restart was cancelled');
 						return;
 					}
-
-					// The `Exited` state during restart removes the map entry
-					// via the cleanup listener. Re-add it now that restart succeeded.
-					this.trackConsoleSession(options.name, session);
 				} catch (error) {
 					log.debug(`Could not restart session for ${options.name}, creating a new one: ${error}`);
-					session = undefined;
-					this._consoleSessionByName.delete(options.name);
+					sessionId = undefined;
 				}
 			}
 
-			if (!session) {
+			if (!sessionId) {
 				progress.report({ message: vscode.l10n.t('Starting console session...') });
 
-				session = await positron.runtime.startLanguageRuntime(
+				const session = await positron.runtime.startLanguageRuntime(
 					runtime.runtimeId,
 					options.name,
 				);
 
-				this.trackConsoleSession(options.name, session);
+				sessionId = session.metadata.sessionId;
 			}
+
+			this.saveConsoleSession(options.name, sessionId);
 
 			if (configurationDone) {
 				progress.report({ message: vscode.l10n.t('Waiting for debugger initialization...') });
@@ -346,7 +343,6 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 					() => log.warn('Timed out waiting for DAP configurationDone; proceeding without breakpoints'),
 				);
 			}
-			const sessionId = session.metadata.sessionId;
 
 			positron.runtime.focusSession(sessionId);
 			progress.report({ message: vscode.l10n.t('Starting application...') });
@@ -559,16 +555,35 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		return runtime;
 	}
 
-	private trackConsoleSession(name: string, session: positron.LanguageRuntimeSession): void {
-		this._consoleSessionByName.get(name)?.listener.dispose();
+	// This persists known sessions so we restart apps in the right console
+	// session after an extension host restart or a window reload
+	private saveConsoleSession(name: string, sessionId: string): Thenable<void> {
+		const persisted = this._globalState.get<Record<string, string>>(
+			PositronRunAppApiImpl.CONSOLE_SESSIONS_KEY, {}
+		);
+		persisted[name] = sessionId;
+		return this._globalState.update(PositronRunAppApiImpl.CONSOLE_SESSIONS_KEY, persisted);
+	}
 
-		const listener = session.onDidChangeRuntimeState(state => {
-			if (state === positron.RuntimeState.Exited) {
-				this._consoleSessionByName.get(name)?.listener.dispose();
-				this._consoleSessionByName.delete(name);
+	private async findConsoleSession(name: string): Promise<string | undefined> {
+		const persisted = this._globalState.get<Record<string, string>>(
+			PositronRunAppApiImpl.CONSOLE_SESSIONS_KEY, {}
+		);
+
+		// Prune all stale sessions so the persisted map doesn't grow over time
+		let pruned = false;
+		for (const [key, id] of Object.entries(persisted)) {
+			const session = await positron.runtime.getSession(id);
+			if (!session) {
+				delete persisted[key];
+				pruned = true;
 			}
-		});
-		this._consoleSessionByName.set(name, { session, listener });
+		}
+		if (pruned) {
+			await this._globalState.update(PositronRunAppApiImpl.CONSOLE_SESSIONS_KEY, persisted);
+		}
+
+		return persisted[name];
 	}
 
 	private showRunError(appName: string, error: unknown): void {

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -267,21 +267,34 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		const cleanup: vscode.Disposable[] = [];
 		try {
 
-			// When breakpoints are set, listen for DAP `configurationDone`
-			// before starting or restarting the runtime so we don't miss the
-			// event. This ensures breakpoints are installed in the backend
-			// before we execute the app code (Ark needs to know about
-			// breakpoints to inject them while sourcing app files, e.g. in
-			// Shiny). Both start and restart trigger a DAP reconnection.
-			// I noticed that Ark seems to be ready before the configuration listener
-			// fires, so we probably could optimise startup time when breakpoints are
-			// set, but likely not in a trivial way.
-			const hasBreakpoints = vscode.debug.breakpoints.length > 0;
+			// When breakpoints are set and app runner requests debugger
+			// synchronization, listen for DAP `configurationDone` before starting or
+			// restarting the runtime so we don't miss the event. This ensures
+			// breakpoints are installed in the backend before we execute the app code
+			// (Ark needs to know about breakpoints to inject them while sourcing app
+			// files, e.g. in Shiny). Both start and restart trigger a DAP
+			// reconnection.
+			//
+			// Known issues:
+			// - I noticed that Ark seems to be ready before the configuration listener
+			//   fires, so we probably could optimise startup time when breakpoints are
+			//   set, but likely not in a trivial way.
+			// - The synchronization structure is not great. We're waiting for any
+			//   debug adapter whose session type matches the one we're tracking.
+			//   There could be races when user switches session after starting a
+			//   Shiny app. We'd ideally be more targeted regarding which DAP we're
+			//   waiting on.
+			const shouldSyncDebugger =
+				options.debugAdapterType &&
+				vscode.debug.breakpoints.length > 0;
 			let configurationDone: Promise<void> | undefined;
 
-			if (hasBreakpoints) {
+			if (shouldSyncDebugger) {
 				configurationDone = new Promise<void>(resolve => {
-					const listener = this._debugAdapterTrackerFactory.onDidCompleteConfiguration(() => {
+					const listener = this._debugAdapterTrackerFactory.onDidCompleteConfiguration((session) => {
+						if (session.type !== options.debugAdapterType) {
+							return;
+						}
 						listener.dispose();
 						resolve();
 					});

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -8,7 +8,7 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 import { DebugAdapterTrackerFactory } from './debugAdapterTrackerFactory';
 import { log } from './extension';
-import { DebugAppOptions, PositronRunApp, RunAppOptions } from './positron-run-app';
+import { DebugAppOptions, PositronRunApp, RunAppOptions, RunConsoleAppOptions } from './positron-run-app';
 import { raceTimeout, removeAnsiEscapeCodes, SequencerByKey } from './utils';
 import { DID_PREVIEW_URL_TIMEOUT, IS_POSITRON_WEB, IS_RUNNING_ON_PWB, SHELL_INTEGRATION_TIMEOUT, TERMINAL_OUTPUT_TIMEOUT } from './constants.js';
 import { AppPreviewOptions, Config, PositronProxyInfo } from './types.js';
@@ -41,18 +41,33 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	}
 
 	public async runApplication(options: RunAppOptions): Promise<void> {
-		// If there's no active text editor, do nothing.
-		const document = vscode.window.activeTextEditor?.document;
+		const document = this.getDocumentForRun(options.name);
 		if (!document) {
 			return;
 		}
+		return this.queueRunApplication(document, options);
+	}
 
-		if (this._runApplicationSequencerByName.has(options.name)) {
-			vscode.window.showErrorMessage(vscode.l10n.t('{0} application is already starting.', options.name));
+	public async runApplicationInConsole(options: RunConsoleAppOptions): Promise<void> {
+		const document = this.getDocumentForRun(options.name);
+		if (!document) {
 			return;
 		}
+		return this.queueRunApplicationInConsole(document, options);
+	}
 
-		return this.queueRunApplication(document, options);
+	private getDocumentForRun(appName: string): vscode.TextDocument | undefined {
+		const document = vscode.window.activeTextEditor?.document;
+		if (!document) {
+			return undefined;
+		}
+
+		if (this._runApplicationSequencerByName.has(appName)) {
+			vscode.window.showErrorMessage(vscode.l10n.t('{0} application is already starting.', appName));
+			return undefined;
+		}
+
+		return document;
 	}
 
 	public getProxyServerUri(appUrl: string): vscode.Uri | undefined {
@@ -86,32 +101,13 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	}
 
 	private async doRunApplication(document: vscode.TextDocument, options: RunAppOptions, progress: vscode.Progress<{ message?: string }>): Promise<void> {
-		// Dispose existing disposables for the application, if any.
-		this._runApplicationDisposableByName.get(options.name)?.dispose();
-		this._runApplicationDisposableByName.delete(options.name);
-
 		progress.report({ message: vscode.l10n.t('Preparing the terminal...') });
 
-		// Save the active document if it's dirty.
-		if (document.isDirty) {
-			await document.save();
-		}
-
-		// Get the preferred runtime for the document's language.
-		const runtime = await this.getPreferredRuntime(document.languageId);
-		if (!runtime) {
+		const prepared = await this.prepareRunApplication(document, options);
+		if (!prepared) {
 			return;
 		}
-
-		// Set up the proxy server for the application if applicable.
-		let urlPrefix = undefined;
-		let proxyInfo: PositronProxyInfo | undefined;
-		if (shouldUsePositronProxy(options.name)) {
-			// Start the proxy server
-			proxyInfo = await vscode.commands.executeCommand<PositronProxyInfo>('positronProxy.startPendingProxyServer');
-			log.debug(`Proxy started for app at proxy path ${proxyInfo.proxyPath} with uri ${proxyInfo.externalUri.toString()}`);
-			urlPrefix = proxyInfo.proxyPath;
-		}
+		const { runtime, urlPrefix, proxyInfo } = prepared;
 
 		// Get the terminal options for the application.
 		const terminalOptions = await options.getTerminalOptions(runtime, document, urlPrefix);
@@ -243,6 +239,129 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		}
 	}
 
+	private queueRunApplicationInConsole(document: vscode.TextDocument, options: RunConsoleAppOptions): Promise<void> {
+		return this._runApplicationSequencerByName.queue(
+			options.name,
+			() => Promise.resolve(vscode.window.withProgress({
+				location: vscode.ProgressLocation.Notification,
+				title: vscode.l10n.t('Running {0} application', options.name),
+			},
+				(progress) => this.doRunApplicationInConsole(document, options, progress),
+			)),
+		);
+	}
+
+	private async doRunApplicationInConsole(
+		document: vscode.TextDocument,
+		options: RunConsoleAppOptions,
+		progress: vscode.Progress<{ message?: string }>,
+	): Promise<void> {
+		progress.report({ message: vscode.l10n.t('Preparing the console...') });
+		const prepared = await this.prepareRunApplication(document, options);
+		if (!prepared) {
+			return;
+		}
+		const { runtime, urlPrefix, proxyInfo } = prepared;
+
+		// Get the console code for the application.
+		const consoleCode = await options.getConsoleCode(runtime, document, urlPrefix);
+		if (!consoleCode) {
+			return;
+		}
+
+		// Start a new console session for the application.
+		progress.report({ message: vscode.l10n.t('Starting console session...') });
+		const session = await positron.runtime.startLanguageRuntime(
+			runtime.runtimeId,
+			options.name,
+		);
+		const sessionId = session.metadata.sessionId;
+
+		// Focus the new session.
+		positron.runtime.focusSession(sessionId);
+
+		progress.report({ message: vscode.l10n.t('Starting application...') });
+
+		// Set up URL detection via ExecutionObserver.
+		const appReadyMessage = options.appReadyMessage?.trim();
+		let appReady = !appReadyMessage;
+		let appUrl: URL | undefined;
+		let urlResolve: (url: URL) => void;
+
+		const urlPromise = new Promise<URL>((resolve) => {
+			urlResolve = resolve;
+		});
+
+		const processOutput = (data: string) => {
+			const dataCleaned = removeAnsiEscapeCodes(data);
+
+			if (!appReady && appReadyMessage) {
+				appReady = dataCleaned.includes(appReadyMessage);
+				if (appReady) {
+					log.debug(`App is ready - found appReadyMessage: '${appReadyMessage}'`);
+					if (appUrl) {
+						urlResolve(appUrl);
+						return;
+					}
+				}
+			}
+
+			if (!appUrl) {
+				const match = extractAppUrlFromString(dataCleaned, options.appUrlStrings);
+				if (match) {
+					appUrl = new URL(match);
+					log.debug(`Found app URL in console output: ${appUrl.toString()}`);
+					if (appReady) {
+						urlResolve(appUrl);
+						return;
+					}
+				}
+			}
+		};
+
+		const observer: positron.runtime.ExecutionObserver = {
+			onOutput: processOutput,
+			onError: processOutput,
+		};
+
+		// Execute the code in the console session.
+		// Don't await: the Thenable resolves only when the app stops.
+		positron.runtime.executeCode(
+			document.languageId,
+			consoleCode.code,
+			true,
+			false,
+			positron.RuntimeCodeExecutionMode.Interactive,
+			positron.RuntimeErrorBehavior.Continue,
+			observer,
+			sessionId,
+		).then(undefined, (error: Error) => {
+			log.error(`Console execution error: ${error.message}`);
+		});
+
+		// Wait for the URL to be detected, or timeout.
+		const url = await raceTimeout(
+			urlPromise,
+			TERMINAL_OUTPUT_TIMEOUT,
+			() => log.error('Timed out waiting for app URL in console output'),
+		);
+
+		if (!url) {
+			log.error('Cannot preview URL. App URL not found in console output.');
+			return;
+		}
+
+		// Preview the application.
+		await this.previewApp(url, {
+			proxyInfo,
+			urlPath: options.urlPath,
+			previewSource: {
+				type: positron.PreviewSourceType.Runtime,
+				id: sessionId,
+			},
+		});
+	}
+
 	public async debugApplication(options: DebugAppOptions): Promise<void> {
 		// If there's no active text editor, do nothing.
 		const document = vscode.window.activeTextEditor?.document;
@@ -367,6 +486,37 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		}
 	}
 
+	private async prepareRunApplication(
+		document: vscode.TextDocument,
+		options: { name: string },
+	): Promise<{
+		runtime: positron.LanguageRuntimeMetadata;
+		urlPrefix: string | undefined;
+		proxyInfo: PositronProxyInfo | undefined;
+	} | undefined> {
+		this._runApplicationDisposableByName.get(options.name)?.dispose();
+		this._runApplicationDisposableByName.delete(options.name);
+
+		if (document.isDirty) {
+			await document.save();
+		}
+
+		const runtime = await this.getPreferredRuntime(document.languageId);
+		if (!runtime) {
+			return undefined;
+		}
+
+		let urlPrefix = undefined;
+		let proxyInfo: PositronProxyInfo | undefined;
+		if (shouldUsePositronProxy(options.name)) {
+			proxyInfo = await vscode.commands.executeCommand<PositronProxyInfo>('positronProxy.startPendingProxyServer');
+			log.debug(`Proxy started for app at proxy path ${proxyInfo.proxyPath} with uri ${proxyInfo.externalUri.toString()}`);
+			urlPrefix = proxyInfo.proxyPath;
+		}
+
+		return { runtime, urlPrefix, proxyInfo };
+	}
+
 	/** Get the preferred runtime for a language; forwarding errors to the UI. */
 	private async getPreferredRuntime(languageId: string): Promise<positron.LanguageRuntimeMetadata | undefined> {
 		try {
@@ -467,6 +617,22 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			return false;
 		}
 
+		return this.previewApp(url, {
+			proxyInfo: options.proxyInfo,
+			urlPath: options.urlPath,
+			terminalPid: options.terminalPid,
+			previewSource: options.terminalPid !== undefined
+				? { type: positron.PreviewSourceType.Terminal, id: String(options.terminalPid) }
+				: undefined,
+		});
+	}
+
+	private async previewApp(url: URL, options: {
+		proxyInfo?: PositronProxyInfo;
+		urlPath?: string;
+		terminalPid?: number;
+		previewSource?: positron.PreviewSource;
+	}): Promise<boolean> {
 		// Example: http://localhost:8500
 		const localBaseUri = vscode.Uri.parse(url.toString());
 
@@ -502,12 +668,10 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			options.terminalPid,
 			previewUri,
 		);
+
 		// Preview the app in the Viewer.
-		if (options.terminalPid !== undefined) {
-			positron.window.previewUrl(previewUri, {
-				type: positron.PreviewSourceType.Terminal,
-				id: String(options.terminalPid)
-			});
+		if (options.previewSource) {
+			positron.window.previewUrl(previewUri, options.previewSource);
 		} else {
 			positron.window.previewUrl(previewUri);
 		}

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -9,10 +9,11 @@ import * as vscode from 'vscode';
 import { DebugAdapterTrackerFactory } from './debugAdapterTrackerFactory';
 import { log } from './extension';
 import { DebugAppOptions, PositronRunApp, RunAppOptions, RunConsoleAppOptions } from './positron-run-app';
-import { raceTimeout, removeAnsiEscapeCodes, SequencerByKey } from './utils';
+import { AppUrlDetector } from './appUrlDetector';
+import { raceTimeout, SequencerByKey } from './utils';
 import { DID_PREVIEW_URL_TIMEOUT, IS_POSITRON_WEB, IS_RUNNING_ON_PWB, SHELL_INTEGRATION_TIMEOUT, TERMINAL_OUTPUT_TIMEOUT } from './constants.js';
 import { AppPreviewOptions, Config, PositronProxyInfo } from './types.js';
-import { shouldUsePositronProxy, showShellIntegrationNotSupportedMessage, showEnableShellIntegrationMessage, extractAppUrlFromString } from './api-utils.js';
+import { shouldUsePositronProxy, showShellIntegrationNotSupportedMessage, showEnableShellIntegrationMessage } from './api-utils.js';
 
 
 export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable {
@@ -284,45 +285,11 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		progress.report({ message: vscode.l10n.t('Starting application...') });
 
 		// Set up URL detection via ExecutionObserver.
-		const appReadyMessage = options.appReadyMessage?.trim();
-		let appReady = !appReadyMessage;
-		let appUrl: URL | undefined;
-		let urlResolve: (url: URL) => void;
-
-		const urlPromise = new Promise<URL>((resolve) => {
-			urlResolve = resolve;
-		});
-
-		const processOutput = (data: string) => {
-			const dataCleaned = removeAnsiEscapeCodes(data);
-
-			if (!appReady && appReadyMessage) {
-				appReady = dataCleaned.includes(appReadyMessage);
-				if (appReady) {
-					log.debug(`App is ready - found appReadyMessage: '${appReadyMessage}'`);
-					if (appUrl) {
-						urlResolve(appUrl);
-						return;
-					}
-				}
-			}
-
-			if (!appUrl) {
-				const match = extractAppUrlFromString(dataCleaned, options.appUrlStrings);
-				if (match) {
-					appUrl = new URL(match);
-					log.debug(`Found app URL in console output: ${appUrl.toString()}`);
-					if (appReady) {
-						urlResolve(appUrl);
-						return;
-					}
-				}
-			}
-		};
+		const detector = new AppUrlDetector(options.appUrlStrings, options.appReadyMessage);
 
 		const observer: positron.runtime.ExecutionObserver = {
-			onOutput: processOutput,
-			onError: processOutput,
+			onOutput: (data) => detector.processOutput(data),
+			onError: (data) => detector.processOutput(data),
 		};
 
 		// Execute the code in the console session.
@@ -342,7 +309,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 
 		// Wait for the URL to be detected, or timeout.
 		const url = await raceTimeout(
-			urlPromise,
+			detector.found,
 			TERMINAL_OUTPUT_TIMEOUT,
 			() => log.error('Timed out waiting for app URL in console output'),
 		);
@@ -557,55 +524,21 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	private async previewUrlInExecutionOutput(execution: vscode.TerminalShellExecution, options: AppPreviewOptions) {
 		// Wait for the server URL to appear in the terminal output, or a timeout.
 		const stream = execution.read();
-		const appReadyMessage = options.appReadyMessage?.trim();
+		const detector = new AppUrlDetector(options.appUrlStrings, options.appReadyMessage);
+
+		// Feed the stream into the detector. The loop breaks once the URL is
+		// found, or ends when the terminal process exits.
+		(async () => {
+			for await (const data of stream) {
+				log.trace('Execution:', execution.commandLine.value, data);
+				if (detector.processOutput(data)) {
+					break;
+				}
+			}
+		})();
+
 		const url = await raceTimeout(
-			(async () => {
-				// If an appReadyMessage is not provided, we'll consider the app ready as soon as the URL is found.
-				let appReady = !appReadyMessage;
-				let appUrl = undefined;
-				for await (const data of stream) {
-					log.trace('Execution:', execution.commandLine.value, data);
-
-					// Ansi escape codes seem to mess up the regex match on Windows, so remove them first.
-					const dataCleaned = removeAnsiEscapeCodes(data);
-
-					// Check if the app is ready, if it's not already ready and an appReadyMessage is provided.
-					if (!appReady && appReadyMessage) {
-						appReady = dataCleaned.includes(appReadyMessage);
-						if (appReady) {
-							log.debug(`App is ready - found appReadyMessage: '${appReadyMessage}'`);
-							// If the app URL was already found, we're done!
-							if (appUrl) {
-								return appUrl;
-							}
-						}
-					}
-					// Check if the app url is found in the terminal output.
-					if (!appUrl) {
-						const match = extractAppUrlFromString(dataCleaned, options.appUrlStrings);
-						if (match) {
-							appUrl = new URL(match);
-							log.debug(`Found app URL in terminal output: ${appUrl.toString()}`);
-							// If the app is ready, we're done!
-							if (appReady) {
-								return appUrl;
-							}
-						}
-					}
-				}
-
-				// If we're here, we've reached the end of the stream without finding the app URL and/or
-				// the appReadyMessage.
-				if (!appReady) {
-					// It's possible that the app is ready, but the appReadyMessage was not found, for
-					// example, if the message has changed or was missed somehow. Log a warning.
-					log.warn(`Expected app ready message '${appReadyMessage}' not found in terminal`);
-				}
-				if (!appUrl) {
-					log.error('App URL not found in terminal output');
-				}
-				return appUrl;
-			})(),
+			detector.found,
 			TERMINAL_OUTPUT_TIMEOUT,
 			() => log.error('Timed out waiting for server output in terminal'),
 		);

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -26,7 +26,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	private readonly _appServers = new Map<string, { terminalPid: number | undefined; proxyUri: vscode.Uri }>();
 
 	constructor(
-		private readonly _globalState: vscode.Memento,
+		private readonly _state: vscode.Memento,
 		private readonly _debugAdapterTrackerFactory: DebugAdapterTrackerFactory,
 	) { }
 
@@ -36,11 +36,11 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	}
 
 	private isShellIntegrationSupported(): boolean {
-		return this._globalState.get('shellIntegrationSupported', true);
+		return this._state.get('shellIntegrationSupported', true);
 	}
 
 	public setShellIntegrationSupported(supported: boolean): Thenable<void> {
-		return this._globalState.update('shellIntegrationSupported', supported);
+		return this._state.update('shellIntegrationSupported', supported);
 	}
 
 	public async runApplication(options: RunAppOptions): Promise<void> {
@@ -558,15 +558,15 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	// This persists known sessions so we restart apps in the right console
 	// session after an extension host restart or a window reload
 	private saveConsoleSession(name: string, sessionId: string): Thenable<void> {
-		const persisted = this._globalState.get<Record<string, string>>(
+		const persisted = this._state.get<Record<string, string>>(
 			PositronRunAppApiImpl.CONSOLE_SESSIONS_KEY, {}
 		);
 		persisted[name] = sessionId;
-		return this._globalState.update(PositronRunAppApiImpl.CONSOLE_SESSIONS_KEY, persisted);
+		return this._state.update(PositronRunAppApiImpl.CONSOLE_SESSIONS_KEY, persisted);
 	}
 
 	private async findConsoleSession(name: string): Promise<string | undefined> {
-		const persisted = this._globalState.get<Record<string, string>>(
+		const persisted = this._state.get<Record<string, string>>(
 			PositronRunAppApiImpl.CONSOLE_SESSIONS_KEY, {}
 		);
 
@@ -580,7 +580,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			}
 		}
 		if (pruned) {
-			await this._globalState.update(PositronRunAppApiImpl.CONSOLE_SESSIONS_KEY, persisted);
+			await this._state.update(PositronRunAppApiImpl.CONSOLE_SESSIONS_KEY, persisted);
 		}
 
 		return persisted[name];

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -22,7 +22,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	private readonly _runApplicationSequencerByName = new SequencerByKey<string>();
 	private readonly _runApplicationDisposableByName = new Map<string, vscode.Disposable>();
 	private readonly _appServers = new Map<string, { terminalPid: number | undefined; proxyUri: vscode.Uri }>();
-	private readonly _consoleSessionByName = new Map<string, positron.LanguageRuntimeSession>();
+	private readonly _consoleSessionByName = new Map<string, { session: positron.LanguageRuntimeSession; listener: vscode.Disposable }>();
 
 	constructor(
 		private readonly _globalState: vscode.Memento,
@@ -32,6 +32,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	public dispose() {
 		this._debugApplicationDisposableByName.forEach(disposable => disposable.dispose());
 		this._runApplicationDisposableByName.forEach(disposable => disposable.dispose());
+		this._consoleSessionByName.forEach(entry => entry.listener.dispose());
 	}
 
 	private isShellIntegrationSupported(): boolean {
@@ -283,7 +284,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		// Restart existing console session for this app if one is still alive.
 		// This cleanly exits any active debugger state and reuses the same
 		// console tab.
-		let session = this._consoleSessionByName.get(options.name);
+		let session = this._consoleSessionByName.get(options.name)?.session;
 
 		if (session) {
 			progress.report({ message: vscode.l10n.t('Restarting application...') });
@@ -297,7 +298,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 
 				// The `Exited` state during restart removes the map entry
 				// via the cleanup listener. Re-add it now that restart succeeded.
-				this._consoleSessionByName.set(options.name, session);
+				this.trackConsoleSession(options.name, session);
 			} catch (error) {
 				log.debug(`Could not restart session for ${options.name}, creating a new one: ${error}`);
 				session = undefined;
@@ -313,12 +314,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 				options.name,
 			);
 
-			this._consoleSessionByName.set(options.name, session);
-			session.onDidChangeRuntimeState(state => {
-				if (state === positron.RuntimeState.Exited) {
-					this._consoleSessionByName.delete(options.name);
-				}
-			});
+			this.trackConsoleSession(options.name, session);
 		}
 
 		const sessionId = session.metadata.sessionId;
@@ -537,6 +533,18 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			throw new Error(vscode.l10n.t("No '{0}' interpreter found.", languageId));
 		}
 		return runtime;
+	}
+
+	private trackConsoleSession(name: string, session: positron.LanguageRuntimeSession): void {
+		this._consoleSessionByName.get(name)?.listener.dispose();
+
+		const listener = session.onDidChangeRuntimeState(state => {
+			if (state === positron.RuntimeState.Exited) {
+				this._consoleSessionByName.get(name)?.listener.dispose();
+				this._consoleSessionByName.delete(name);
+			}
+		});
+		this._consoleSessionByName.set(name, { session, listener });
 	}
 
 	private showRunError(appName: string, error: unknown): void {

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -22,7 +22,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	private readonly _runApplicationSequencerByName = new SequencerByKey<string>();
 	private readonly _runApplicationDisposableByName = new Map<string, vscode.Disposable>();
 	private readonly _appServers = new Map<string, { terminalPid: number | undefined; proxyUri: vscode.Uri }>();
-	private readonly _consoleSessionByName = new Map<string, string>();
+	private readonly _consoleSessionByName = new Map<string, positron.LanguageRuntimeSession>();
 
 	constructor(
 		private readonly _globalState: vscode.Memento,
@@ -263,61 +263,89 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			return;
 		}
 
-		// Reuse existing console session if one is still alive for this app.
-		let sessionId = this._consoleSessionByName.get(options.name);
+		// When breakpoints are set, listen for DAP `configurationDone`
+		// before starting or restarting the runtime so we don't miss the
+		// event. This ensures breakpoints are installed in the backend
+		// before we execute the app code (Ark needs to know about
+		// breakpoints to inject them while sourcing app files, e.g. in
+		// Shiny). Both start and restart trigger a DAP reconnection.
+		const hasBreakpoints = vscode.debug.breakpoints.length > 0;
+		let configurationDone: Promise<void> | undefined;
+		if (hasBreakpoints) {
+			configurationDone = new Promise<void>(resolve => {
+				const disposable = this._debugAdapterTrackerFactory.onDidCompleteConfiguration(() => {
+					disposable.dispose();
+					resolve();
+				});
+			});
+		}
 
-		if (sessionId) {
+		// Restart existing console session for this app if one is still alive.
+		// This cleanly exits any active debugger state and reuses the same
+		// console tab.
+		let session = this._consoleSessionByName.get(options.name);
+
+		if (session) {
 			progress.report({ message: vscode.l10n.t('Restarting application...') });
+
 			try {
-				await positron.runtime.interruptSession(sessionId);
+				// Track whether `Ready` is reached to detect cancellation.
+				// If the user declines to restart, no state changes occur and
+				// `restartSession` resolves silently.
+				let didRestart = false;
+				const stateDisposable = session.onDidChangeRuntimeState(state => {
+					if (state === positron.RuntimeState.Ready) {
+						didRestart = true;
+						stateDisposable.dispose();
+					}
+				});
+
+				await positron.runtime.restartSession(session.metadata.sessionId);
+
+				if (!didRestart) {
+					log.debug('Session restart was cancelled');
+					stateDisposable.dispose();
+					return;
+				}
+
+				// The `Exited` state during restart removes the map entry
+				// via the cleanup listener. Re-add it now that restart succeeded.
+				this._consoleSessionByName.set(options.name, session);
 			} catch (error) {
-				log.debug(`Could not interrupt session for ${options.name}, creating a new one: ${error}`);
-				sessionId = undefined;
+				log.debug(`Could not restart session for ${options.name}, creating a new one: ${error}`);
+				session = undefined;
 				this._consoleSessionByName.delete(options.name);
 			}
 		}
 
-		if (!sessionId) {
+		if (!session) {
 			progress.report({ message: vscode.l10n.t('Starting console session...') });
 
-			// When breakpoints are set, listen for DAP `configurationDone`
-			// before starting the runtime so we don't miss the event. This
-			// ensures breakpoints are installed in the backend before we
-			// execute the app code (Ark needs to know about breakpoints to
-			// inject them while sourcing app files, e.g. in Shiny).
-			const hasBreakpoints = vscode.debug.breakpoints.length > 0;
-			let configurationDone: Promise<void> | undefined;
-			if (hasBreakpoints) {
-				configurationDone = new Promise<void>(resolve => {
-					const disposable = this._debugAdapterTrackerFactory.onDidCompleteConfiguration(() => {
-						disposable.dispose();
-						resolve();
-					});
-				});
-			}
-
-			const session = await positron.runtime.startLanguageRuntime(
+			session = await positron.runtime.startLanguageRuntime(
 				runtime.runtimeId,
 				options.name,
 			);
-			sessionId = session.metadata.sessionId;
 
-			this._consoleSessionByName.set(options.name, sessionId);
-			session.onDidEndSession(() => {
-				this._consoleSessionByName.delete(options.name);
+			this._consoleSessionByName.set(options.name, session);
+			session.onDidChangeRuntimeState(state => {
+				if (state === positron.RuntimeState.Exited) {
+					this._consoleSessionByName.delete(options.name);
+				}
 			});
+		}
 
-			if (configurationDone) {
-				await raceTimeout(
-					configurationDone,
-					DAP_CONFIGURATION_TIMEOUT,
-					() => log.warn('Timed out waiting for DAP configurationDone; proceeding without breakpoints'),
-				);
-			}
+		const sessionId = session.metadata.sessionId;
+
+		if (configurationDone) {
+			progress.report({ message: vscode.l10n.t('Waiting for debugger initialization...') });
+			await raceTimeout(
+				configurationDone,
+				DAP_CONFIGURATION_TIMEOUT,
+				() => log.warn('Timed out waiting for DAP configurationDone; proceeding without breakpoints'),
+			);
 		}
 
 		positron.runtime.focusSession(sessionId);
-
 		progress.report({ message: vscode.l10n.t('Starting application...') });
 
 		// Set up URL detection via an observer for the output of our execute request

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -264,84 +264,91 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			return;
 		}
 
-		// When breakpoints are set, listen for DAP `configurationDone`
-		// before starting or restarting the runtime so we don't miss the
-		// event. This ensures breakpoints are installed in the backend
-		// before we execute the app code (Ark needs to know about
-		// breakpoints to inject them while sourcing app files, e.g. in
-		// Shiny). Both start and restart trigger a DAP reconnection.
-		const hasBreakpoints = vscode.debug.breakpoints.length > 0;
-		let configurationDone: Promise<void> | undefined;
-		if (hasBreakpoints) {
-			configurationDone = new Promise<void>(resolve => {
-				const disposable = this._debugAdapterTrackerFactory.onDidCompleteConfiguration(() => {
-					disposable.dispose();
-					resolve();
-				});
-			});
-		}
-
-		// Restart existing console session for this app if one is still alive.
-		// This cleanly exits any active debugger state and reuses the same
-		// console tab.
-		let session = this._consoleSessionByName.get(options.name)?.session;
-
-		if (session) {
-			progress.report({ message: vscode.l10n.t('Restarting application...') });
-
-			try {
-				const didRestart = await positron.runtime.restartSession(session.metadata.sessionId);
-				if (!didRestart) {
-					log.debug('Session restart was cancelled');
-					return;
-				}
-
-				// The `Exited` state during restart removes the map entry
-				// via the cleanup listener. Re-add it now that restart succeeded.
-				this.trackConsoleSession(options.name, session);
-			} catch (error) {
-				log.debug(`Could not restart session for ${options.name}, creating a new one: ${error}`);
-				session = undefined;
-				this._consoleSessionByName.delete(options.name);
-			}
-		}
-
-		if (!session) {
-			progress.report({ message: vscode.l10n.t('Starting console session...') });
-
-			session = await positron.runtime.startLanguageRuntime(
-				runtime.runtimeId,
-				options.name,
-			);
-
-			this.trackConsoleSession(options.name, session);
-		}
-
-		const sessionId = session.metadata.sessionId;
-
-		if (configurationDone) {
-			progress.report({ message: vscode.l10n.t('Waiting for debugger initialization...') });
-			await raceTimeout(
-				configurationDone,
-				DAP_CONFIGURATION_TIMEOUT,
-				() => log.warn('Timed out waiting for DAP configurationDone; proceeding without breakpoints'),
-			);
-		}
-
-		positron.runtime.focusSession(sessionId);
-		progress.report({ message: vscode.l10n.t('Starting application...') });
-
-		// Set up URL detection via an observer for the output of our execute request
-		const detector = new AppUrlDetector(options.appUrlStrings, options.appReadyMessage);
-		const cancellation = new vscode.CancellationTokenSource();
-
-		const observer: positron.runtime.ExecutionObserver = {
-			token: cancellation.token,
-			onOutput: (data) => detector.processOutput(data),
-			onError: (data) => detector.processOutput(data),
-		};
-
+		const cleanup: vscode.Disposable[] = [];
 		try {
+
+			// When breakpoints are set, listen for DAP `configurationDone`
+			// before starting or restarting the runtime so we don't miss the
+			// event. This ensures breakpoints are installed in the backend
+			// before we execute the app code (Ark needs to know about
+			// breakpoints to inject them while sourcing app files, e.g. in
+			// Shiny). Both start and restart trigger a DAP reconnection.
+			// I noticed that Ark seems to be ready before the configuration listener
+			// fires, so we probably could optimise startup time when breakpoints are
+			// set, but likely not in a trivial way.
+			const hasBreakpoints = vscode.debug.breakpoints.length > 0;
+			let configurationDone: Promise<void> | undefined;
+
+			if (hasBreakpoints) {
+				configurationDone = new Promise<void>(resolve => {
+					const listener = this._debugAdapterTrackerFactory.onDidCompleteConfiguration(() => {
+						listener.dispose();
+						resolve();
+					});
+					cleanup.push(listener);
+				});
+			}
+
+			// Restart existing console session for this app if one is still alive.
+			// This cleanly exits any active debugger state and reuses the same
+			// console tab.
+			let session = this._consoleSessionByName.get(options.name)?.session;
+
+			if (session) {
+				progress.report({ message: vscode.l10n.t('Restarting application...') });
+
+				try {
+					const didRestart = await positron.runtime.restartSession(session.metadata.sessionId);
+					if (!didRestart) {
+						log.debug('Session restart was cancelled');
+						return;
+					}
+
+					// The `Exited` state during restart removes the map entry
+					// via the cleanup listener. Re-add it now that restart succeeded.
+					this.trackConsoleSession(options.name, session);
+				} catch (error) {
+					log.debug(`Could not restart session for ${options.name}, creating a new one: ${error}`);
+					session = undefined;
+					this._consoleSessionByName.delete(options.name);
+				}
+			}
+
+			if (!session) {
+				progress.report({ message: vscode.l10n.t('Starting console session...') });
+
+				session = await positron.runtime.startLanguageRuntime(
+					runtime.runtimeId,
+					options.name,
+				);
+
+				this.trackConsoleSession(options.name, session);
+			}
+
+			if (configurationDone) {
+				progress.report({ message: vscode.l10n.t('Waiting for debugger initialization...') });
+				await raceTimeout(
+					configurationDone,
+					DAP_CONFIGURATION_TIMEOUT,
+					() => log.warn('Timed out waiting for DAP configurationDone; proceeding without breakpoints'),
+				);
+			}
+			const sessionId = session.metadata.sessionId;
+
+			positron.runtime.focusSession(sessionId);
+			progress.report({ message: vscode.l10n.t('Starting application...') });
+
+			// Set up URL detection via an observer for the output of our execute request
+			const detector = new AppUrlDetector(options.appUrlStrings, options.appReadyMessage);
+			const cancellation = new vscode.CancellationTokenSource();
+			cleanup.push(cancellation);
+
+			const observer: positron.runtime.ExecutionObserver = {
+				token: cancellation.token,
+				onOutput: (data) => detector.processOutput(data),
+				onError: (data) => detector.processOutput(data),
+			};
+
 			// Execute the code in the console session.
 			// Don't await: the Thenable resolves only when the app stops.
 			positron.runtime.executeCode(
@@ -375,7 +382,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 				},
 			});
 		} finally {
-			cancellation.dispose();
+			cleanup.forEach(d => d.dispose());
 		}
 	}
 

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -341,38 +341,42 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			onError: (data) => detector.processOutput(data),
 		};
 
-		// Execute the code in the console session.
-		// Don't await: the Thenable resolves only when the app stops.
-		positron.runtime.executeCode(
-			document.languageId,
-			consoleCode.code,
-			true,
-			false,
-			positron.RuntimeCodeExecutionMode.Interactive,
-			positron.RuntimeErrorBehavior.Continue,
-			observer,
-			sessionId,
-		).then(undefined, (error: Error) => {
-			log.error(`Console execution error: ${error.message}`);
-		});
+		try {
+			// Execute the code in the console session.
+			// Don't await: the Thenable resolves only when the app stops.
+			positron.runtime.executeCode(
+				document.languageId,
+				consoleCode.code,
+				true,
+				false,
+				positron.RuntimeCodeExecutionMode.Interactive,
+				positron.RuntimeErrorBehavior.Continue,
+				observer,
+				sessionId,
+			).then(undefined, (error: Error) => {
+				log.error(`Console execution error: ${error.message}`);
+			});
 
-		const url = await raceTimeout(
-			detector.found,
-			TERMINAL_OUTPUT_TIMEOUT,
-			() => {
-				cancellation.cancel();
-				throw new Error(vscode.l10n.t('Timed out waiting for {0} app URL in console output.', options.name));
-			},
-		);
+			const url = await raceTimeout(
+				detector.found,
+				TERMINAL_OUTPUT_TIMEOUT,
+				() => {
+					cancellation.cancel();
+					throw new Error(vscode.l10n.t('Timed out waiting for {0} app URL in console output.', options.name));
+				},
+			);
 
-		await this.previewApp(url!, {
-			proxyInfo,
-			urlPath: options.urlPath,
-			previewSource: {
-				type: positron.PreviewSourceType.Runtime,
-				id: sessionId,
-			},
-		});
+			await this.previewApp(url!, {
+				proxyInfo,
+				urlPath: options.urlPath,
+				previewSource: {
+					type: positron.PreviewSourceType.Runtime,
+					id: sessionId,
+				},
+			});
+		} finally {
+			cancellation.dispose();
+		}
 	}
 
 	public async debugApplication(options: DebugAppOptions): Promise<void> {

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -289,22 +289,9 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			progress.report({ message: vscode.l10n.t('Restarting application...') });
 
 			try {
-				// Track whether `Ready` is reached to detect cancellation.
-				// If the user declines to restart, no state changes occur and
-				// `restartSession` resolves silently.
-				let didRestart = false;
-				const stateDisposable = session.onDidChangeRuntimeState(state => {
-					if (state === positron.RuntimeState.Ready) {
-						didRestart = true;
-						stateDisposable.dispose();
-					}
-				});
-
-				await positron.runtime.restartSession(session.metadata.sessionId);
-
+				const didRestart = await positron.runtime.restartSession(session.metadata.sessionId);
 				if (!didRestart) {
 					log.debug('Session restart was cancelled');
-					stateDisposable.dispose();
 					return;
 				}
 

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -41,19 +41,27 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	}
 
 	public async runApplication(options: RunAppOptions): Promise<void> {
-		const document = this.getDocumentForRun(options.name);
-		if (!document) {
-			return;
+		try {
+			const document = this.getDocumentForRun(options.name);
+			if (!document) {
+				return;
+			}
+			await this.queueRunApplication(document, options);
+		} catch (error) {
+			this.showRunError(options.name, error);
 		}
-		return this.queueRunApplication(document, options);
 	}
 
 	public async runApplicationInConsole(options: RunConsoleAppOptions): Promise<void> {
-		const document = this.getDocumentForRun(options.name);
-		if (!document) {
-			return;
+		try {
+			const document = this.getDocumentForRun(options.name);
+			if (!document) {
+				return;
+			}
+			await this.queueRunApplicationInConsole(document, options);
+		} catch (error) {
+			this.showRunError(options.name, error);
 		}
-		return this.queueRunApplicationInConsole(document, options);
 	}
 
 	private getDocumentForRun(appName: string): vscode.TextDocument | undefined {
@@ -103,11 +111,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	private async doRunApplication(document: vscode.TextDocument, options: RunAppOptions, progress: vscode.Progress<{ message?: string }>): Promise<void> {
 		progress.report({ message: vscode.l10n.t('Preparing the terminal...') });
 
-		const prepared = await this.prepareRunApplication(document, options);
-		if (!prepared) {
-			return;
-		}
-		const { runtime, urlPrefix, proxyInfo } = prepared;
+		const { runtime, urlPrefix, proxyInfo } = await this.prepareRunApplication(document, options);
 
 		// Get the terminal options for the application.
 		const terminalOptions = await options.getTerminalOptions(runtime, document, urlPrefix);
@@ -257,11 +261,8 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		progress: vscode.Progress<{ message?: string }>,
 	): Promise<void> {
 		progress.report({ message: vscode.l10n.t('Preparing the console...') });
-		const prepared = await this.prepareRunApplication(document, options);
-		if (!prepared) {
-			return;
-		}
-		const { runtime, urlPrefix, proxyInfo } = prepared;
+
+		const { runtime, urlPrefix, proxyInfo } = await this.prepareRunApplication(document, options);
 
 		// Get the console code for the application.
 		const consoleCode = await options.getConsoleCode(runtime, document, urlPrefix);
@@ -363,18 +364,22 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	}
 
 	public async debugApplication(options: DebugAppOptions): Promise<void> {
-		// If there's no active text editor, do nothing.
-		const document = vscode.window.activeTextEditor?.document;
-		if (!document) {
-			return;
-		}
+		try {
+			// If there's no active text editor, do nothing.
+			const document = vscode.window.activeTextEditor?.document;
+			if (!document) {
+				return;
+			}
 
-		if (this._debugApplicationSequencerByName.has(options.name)) {
-			vscode.window.showErrorMessage(vscode.l10n.t('{0} application is already starting.', options.name));
-			return;
-		}
+			if (this._debugApplicationSequencerByName.has(options.name)) {
+				vscode.window.showErrorMessage(vscode.l10n.t('{0} application is already starting.', options.name));
+				return;
+			}
 
-		return this.queueDebugApplication(document, options);
+			await this.queueDebugApplication(document, options);
+		} catch (error) {
+			this.showRunError(options.name, error);
+		}
 	}
 
 	private queueDebugApplication(document: vscode.TextDocument, options: DebugAppOptions): Promise<void> {
@@ -402,15 +407,11 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		// Get the preferred runtime for the document's language.
 		progress.report({ message: vscode.l10n.t('Getting interpreter information...') });
 		const runtime = await this.getPreferredRuntime(document.languageId);
-		if (!runtime) {
-			return;
-		}
 
 		// Set up the proxy server for the application if applicable.
-		let urlPrefix = undefined;
+		let urlPrefix: string | undefined;
 		let proxyInfo: PositronProxyInfo | undefined;
 		if (shouldUsePositronProxy(options.name)) {
-			// Start the proxy server
 			proxyInfo = await vscode.commands.executeCommand<PositronProxyInfo>('positronProxy.startPendingProxyServer');
 			log.debug(`Proxy started for app at proxy path ${proxyInfo.proxyPath} with uri ${proxyInfo.externalUri.toString()}`);
 			urlPrefix = proxyInfo.proxyPath;
@@ -493,7 +494,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		runtime: positron.LanguageRuntimeMetadata;
 		urlPrefix: string | undefined;
 		proxyInfo: PositronProxyInfo | undefined;
-	} | undefined> {
+	}> {
 		this._runApplicationDisposableByName.get(options.name)?.dispose();
 		this._runApplicationDisposableByName.delete(options.name);
 
@@ -502,9 +503,6 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		}
 
 		const runtime = await this.getPreferredRuntime(document.languageId);
-		if (!runtime) {
-			return undefined;
-		}
 
 		let urlPrefix = undefined;
 		let proxyInfo: PositronProxyInfo | undefined;
@@ -517,20 +515,20 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		return { runtime, urlPrefix, proxyInfo };
 	}
 
-	/** Get the preferred runtime for a language; forwarding errors to the UI. */
-	private async getPreferredRuntime(languageId: string): Promise<positron.LanguageRuntimeMetadata | undefined> {
-		try {
-			return await positron.runtime.getPreferredRuntime(languageId);
-		} catch (error) {
-			vscode.window.showErrorMessage(
-				vscode.l10n.t(
-					"Failed to get '{0}' interpreter information. Error: {1}",
-					languageId,
-					JSON.stringify(error)
-				),
-			);
+	private async getPreferredRuntime(languageId: string): Promise<positron.LanguageRuntimeMetadata> {
+		const runtime = await positron.runtime.getPreferredRuntime(languageId);
+		if (!runtime) {
+			throw new Error(vscode.l10n.t("No '{0}' interpreter found.", languageId));
 		}
-		return undefined;
+		return runtime;
+	}
+
+	private showRunError(appName: string, error: unknown): void {
+		if (error instanceof Error) {
+			vscode.window.showErrorMessage(error.message);
+		} else {
+			vscode.window.showErrorMessage(vscode.l10n.t('Failed to start {0} application: {1}', appName, String(error)));
+		}
 	}
 
 	private showShellIntegrationMessages(rerunApplicationCallback: () => any): boolean {

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -262,23 +262,23 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			return;
 		}
 
-		// Start a new console session for the application.
 		progress.report({ message: vscode.l10n.t('Starting console session...') });
+
 		const session = await positron.runtime.startLanguageRuntime(
 			runtime.runtimeId,
 			options.name,
 		);
 		const sessionId = session.metadata.sessionId;
-
-		// Focus the new session.
 		positron.runtime.focusSession(sessionId);
 
 		progress.report({ message: vscode.l10n.t('Starting application...') });
 
-		// Set up URL detection via ExecutionObserver.
+		// Set up URL detection via an observer for the output of our execute request
 		const detector = new AppUrlDetector(options.appUrlStrings, options.appReadyMessage);
+		const cancellation = new vscode.CancellationTokenSource();
 
 		const observer: positron.runtime.ExecutionObserver = {
+			token: cancellation.token,
 			onOutput: (data) => detector.processOutput(data),
 			onError: (data) => detector.processOutput(data),
 		};
@@ -298,20 +298,16 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			log.error(`Console execution error: ${error.message}`);
 		});
 
-		// Wait for the URL to be detected, or timeout.
 		const url = await raceTimeout(
 			detector.found,
 			TERMINAL_OUTPUT_TIMEOUT,
-			() => log.error('Timed out waiting for app URL in console output'),
+			() => {
+				cancellation.cancel();
+				throw new Error(vscode.l10n.t('Timed out waiting for {0} app URL in console output.', options.name));
+			},
 		);
 
-		if (!url) {
-			log.error('Cannot preview URL. App URL not found in console output.');
-			return;
-		}
-
-		// Preview the application.
-		await this.previewApp(url, {
+		await this.previewApp(url!, {
 			proxyInfo,
 			urlPath: options.urlPath,
 			previewSource: {

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -22,6 +22,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 	private readonly _runApplicationSequencerByName = new SequencerByKey<string>();
 	private readonly _runApplicationDisposableByName = new Map<string, vscode.Disposable>();
 	private readonly _appServers = new Map<string, { terminalPid: number | undefined; proxyUri: vscode.Uri }>();
+	private readonly _consoleSessionByName = new Map<string, string>();
 
 	constructor(
 		private readonly _globalState: vscode.Memento,
@@ -262,40 +263,60 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			return;
 		}
 
-		progress.report({ message: vscode.l10n.t('Starting console session...') });
+		// Reuse existing console session if one is still alive for this app.
+		let sessionId = this._consoleSessionByName.get(options.name);
 
-		// When breakpoints are set, listen for DAP `configurationDone` before
-		// starting the runtime so we don't miss the event. This ensures
-		// breakpoints are installed in the backend before we execute the app
-		// code (Ark needs to know about breakpoints to inject them while
-		// sourcing app files, e.g. in Shiny). Only do this if user has set
-		// breakpoints because this synchronisation does slow down the app startup
-		// time quite a bit.
-		const hasBreakpoints = vscode.debug.breakpoints.length > 0;
-		let configurationDone: Promise<void> | undefined;
-		if (hasBreakpoints) {
-			configurationDone = new Promise<void>(resolve => {
-				const disposable = this._debugAdapterTrackerFactory.onDidCompleteConfiguration(() => {
-					disposable.dispose();
-					resolve();
+		if (sessionId) {
+			progress.report({ message: vscode.l10n.t('Restarting application...') });
+			try {
+				await positron.runtime.interruptSession(sessionId);
+			} catch (error) {
+				log.debug(`Could not interrupt session for ${options.name}, creating a new one: ${error}`);
+				sessionId = undefined;
+				this._consoleSessionByName.delete(options.name);
+			}
+		}
+
+		if (!sessionId) {
+			progress.report({ message: vscode.l10n.t('Starting console session...') });
+
+			// When breakpoints are set, listen for DAP `configurationDone`
+			// before starting the runtime so we don't miss the event. This
+			// ensures breakpoints are installed in the backend before we
+			// execute the app code (Ark needs to know about breakpoints to
+			// inject them while sourcing app files, e.g. in Shiny).
+			const hasBreakpoints = vscode.debug.breakpoints.length > 0;
+			let configurationDone: Promise<void> | undefined;
+			if (hasBreakpoints) {
+				configurationDone = new Promise<void>(resolve => {
+					const disposable = this._debugAdapterTrackerFactory.onDidCompleteConfiguration(() => {
+						disposable.dispose();
+						resolve();
+					});
 				});
-			});
-		}
+			}
 
-		const session = await positron.runtime.startLanguageRuntime(
-			runtime.runtimeId,
-			options.name,
-		);
-		const sessionId = session.metadata.sessionId;
-		positron.runtime.focusSession(sessionId);
-
-		if (configurationDone) {
-			await raceTimeout(
-				configurationDone,
-				DAP_CONFIGURATION_TIMEOUT,
-				() => log.warn('Timed out waiting for DAP configurationDone; proceeding without breakpoints'),
+			const session = await positron.runtime.startLanguageRuntime(
+				runtime.runtimeId,
+				options.name,
 			);
+			sessionId = session.metadata.sessionId;
+
+			this._consoleSessionByName.set(options.name, sessionId);
+			session.onDidEndSession(() => {
+				this._consoleSessionByName.delete(options.name);
+			});
+
+			if (configurationDone) {
+				await raceTimeout(
+					configurationDone,
+					DAP_CONFIGURATION_TIMEOUT,
+					() => log.warn('Timed out waiting for DAP configurationDone; proceeding without breakpoints'),
+				);
+			}
 		}
+
+		positron.runtime.focusSession(sessionId);
 
 		progress.report({ message: vscode.l10n.t('Starting application...') });
 

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -47,7 +47,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			if (!document) {
 				return;
 			}
-			await this.queueRunApplication(document, options);
+			await this.queueRunApplication(options.name, (progress) => this.doRunApplication(document, options, progress));
 		} catch (error) {
 			this.showRunError(options.name, error);
 		}
@@ -59,7 +59,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 			if (!document) {
 				return;
 			}
-			await this.queueRunApplicationInConsole(document, options);
+			await this.queueRunApplication(options.name, (progress) => this.doRunApplicationInConsole(document, options, progress));
 		} catch (error) {
 			this.showRunError(options.name, error);
 		}
@@ -97,15 +97,16 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		return undefined;
 	}
 
-	private queueRunApplication(document: vscode.TextDocument, options: RunAppOptions): Promise<void> {
+	private queueRunApplication(
+		name: string,
+		task: (progress: vscode.Progress<{ message?: string }>) => Promise<void>,
+	): Promise<void> {
 		return this._runApplicationSequencerByName.queue(
-			options.name,
-			() => Promise.resolve(vscode.window.withProgress({
+			name,
+			async () => vscode.window.withProgress({
 				location: vscode.ProgressLocation.Notification,
-				title: vscode.l10n.t('Running {0} application', options.name),
-			},
-				(progress) => this.doRunApplication(document, options, progress),
-			)),
+				title: vscode.l10n.t('Running {0} application', name),
+			}, task),
 		);
 	}
 
@@ -124,7 +125,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		// - enabled in the workspace, and
 		// - supported in the terminal.
 		const isShellIntegrationEnabledAndSupported = this.showShellIntegrationMessages(
-			() => this.queueRunApplication(document, options)
+			() => this.queueRunApplication(options.name, (progress) => this.doRunApplication(document, options, progress))
 		);
 
 		// Get existing terminals with the application's name.
@@ -244,17 +245,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 		}
 	}
 
-	private queueRunApplicationInConsole(document: vscode.TextDocument, options: RunConsoleAppOptions): Promise<void> {
-		return this._runApplicationSequencerByName.queue(
-			options.name,
-			() => Promise.resolve(vscode.window.withProgress({
-				location: vscode.ProgressLocation.Notification,
-				title: vscode.l10n.t('Running {0} application', options.name),
-			},
-				(progress) => this.doRunApplicationInConsole(document, options, progress),
-			)),
-		);
-	}
+
 
 	private async doRunApplicationInConsole(
 		document: vscode.TextDocument,

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -11,7 +11,7 @@ import { log } from './extension';
 import { DebugAppOptions, PositronRunApp, RunAppOptions, RunConsoleAppOptions } from './positron-run-app';
 import { AppUrlDetector } from './appUrlDetector';
 import { raceTimeout, SequencerByKey } from './utils';
-import { DID_PREVIEW_URL_TIMEOUT, IS_POSITRON_WEB, IS_RUNNING_ON_PWB, SHELL_INTEGRATION_TIMEOUT, TERMINAL_OUTPUT_TIMEOUT } from './constants.js';
+import { DAP_CONFIGURATION_TIMEOUT, DID_PREVIEW_URL_TIMEOUT, IS_POSITRON_WEB, IS_RUNNING_ON_PWB, SHELL_INTEGRATION_TIMEOUT, TERMINAL_OUTPUT_TIMEOUT } from './constants.js';
 import { AppPreviewOptions, Config, PositronProxyInfo } from './types.js';
 import { shouldUsePositronProxy, showShellIntegrationNotSupportedMessage, showEnableShellIntegrationMessage } from './api-utils.js';
 
@@ -264,12 +264,38 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 
 		progress.report({ message: vscode.l10n.t('Starting console session...') });
 
+		// When breakpoints are set, listen for DAP `configurationDone` before
+		// starting the runtime so we don't miss the event. This ensures
+		// breakpoints are installed in the backend before we execute the app
+		// code (Ark needs to know about breakpoints to inject them while
+		// sourcing app files, e.g. in Shiny). Only do this if user has set
+		// breakpoints because this synchronisation does slow down the app startup
+		// time quite a bit.
+		const hasBreakpoints = vscode.debug.breakpoints.length > 0;
+		let configurationDone: Promise<void> | undefined;
+		if (hasBreakpoints) {
+			configurationDone = new Promise<void>(resolve => {
+				const disposable = this._debugAdapterTrackerFactory.onDidCompleteConfiguration(() => {
+					disposable.dispose();
+					resolve();
+				});
+			});
+		}
+
 		const session = await positron.runtime.startLanguageRuntime(
 			runtime.runtimeId,
 			options.name,
 		);
 		const sessionId = session.metadata.sessionId;
 		positron.runtime.focusSession(sessionId);
+
+		if (configurationDone) {
+			await raceTimeout(
+				configurationDone,
+				DAP_CONFIGURATION_TIMEOUT,
+				() => log.warn('Timed out waiting for DAP configurationDone; proceeding without breakpoints'),
+			);
+		}
 
 		progress.report({ message: vscode.l10n.t('Starting application...') });
 

--- a/extensions/positron-run-app/src/appUrlDetector.ts
+++ b/extensions/positron-run-app/src/appUrlDetector.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { log } from './extension';
+import { removeAnsiEscapeCodes } from './utils';
+import { extractAppUrlFromString } from './api-utils';
+
+/**
+ * Detects an application URL (and optional ready message) from output chunks.
+ * Used by both the terminal and console execution paths.
+ */
+export class AppUrlDetector {
+	private _appReady: boolean;
+	private _appUrl: URL | undefined;
+	private readonly _appReadyMessage: string | undefined;
+	private readonly _resolve: (url: URL) => void;
+
+	readonly found: Promise<URL>;
+
+	constructor(
+		private readonly _appUrlStrings: string[] | undefined,
+		appReadyMessage: string | undefined,
+	) {
+		this._appReadyMessage = appReadyMessage?.trim();
+		this._appReady = !this._appReadyMessage;
+
+		let resolve!: (url: URL) => void;
+		this.found = new Promise<URL>((r) => { resolve = r; });
+		this._resolve = resolve;
+	}
+
+	/** @returns `true` when the URL has been found and the app is ready. */
+	processOutput(data: string): boolean {
+		const dataCleaned = removeAnsiEscapeCodes(data);
+
+		if (!this._appReady && this._appReadyMessage) {
+			this._appReady = dataCleaned.includes(this._appReadyMessage);
+			if (this._appReady) {
+				log.debug(`App is ready - found appReadyMessage: '${this._appReadyMessage}'`);
+				if (this._appUrl) {
+					this._resolve(this._appUrl);
+					return true;
+				}
+			}
+		}
+
+		if (!this._appUrl) {
+			const match = extractAppUrlFromString(dataCleaned, this._appUrlStrings);
+			if (match) {
+				this._appUrl = new URL(match);
+				log.debug(`Found app URL in output: ${this._appUrl.toString()}`);
+				if (this._appReady) {
+					this._resolve(this._appUrl);
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+}

--- a/extensions/positron-run-app/src/constants.ts
+++ b/extensions/positron-run-app/src/constants.ts
@@ -19,6 +19,8 @@ export const IS_RUNNING_ON_PWB = !!process.env.RS_SERVER_URL && IS_POSITRON_WEB;
 
 // Timeouts.
 export const TERMINAL_OUTPUT_TIMEOUT = 25_000;
+/** Time to wait for the debug adapter to finish its initial configuration (breakpoints etc.). */
+export const DAP_CONFIGURATION_TIMEOUT = 10_000;
 export const DID_PREVIEW_URL_TIMEOUT = TERMINAL_OUTPUT_TIMEOUT + 5_000;
 /** Time between creating a terminal and receiving its onDidChangeTerminalShellIntegration event. */
 export const SHELL_INTEGRATION_TIMEOUT = 5_000;

--- a/extensions/positron-run-app/src/constants.ts
+++ b/extensions/positron-run-app/src/constants.ts
@@ -21,6 +21,7 @@ export const IS_RUNNING_ON_PWB = !!process.env.RS_SERVER_URL && IS_POSITRON_WEB;
 export const TERMINAL_OUTPUT_TIMEOUT = 25_000;
 /** Time to wait for the debug adapter to finish its initial configuration (breakpoints etc.). */
 export const DAP_CONFIGURATION_TIMEOUT = 10_000;
+
 export const DID_PREVIEW_URL_TIMEOUT = TERMINAL_OUTPUT_TIMEOUT + 5_000;
 /** Time between creating a terminal and receiving its onDidChangeTerminalShellIntegration event. */
 export const SHELL_INTEGRATION_TIMEOUT = 5_000;

--- a/extensions/positron-run-app/src/debugAdapterTrackerFactory.ts
+++ b/extensions/positron-run-app/src/debugAdapterTrackerFactory.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -26,13 +26,18 @@ export class DebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFac
 	private readonly _disposables = new Array<vscode.Disposable>();
 
 	private readonly _onDidRequestRunInTerminal = new vscode.EventEmitter<RequestRunInTerminalEvent>();
+	private readonly _onDidCompleteConfiguration = new vscode.EventEmitter<vscode.DebugSession>();
 
 	/** Event fired when a debug session requests to run a command in the integrated terminal. */
 	public readonly onDidRequestRunInTerminal = this._onDidRequestRunInTerminal.event;
 
+	/** Event fired when a debug adapter has processed `configurationDone` (breakpoints are set). */
+	public readonly onDidCompleteConfiguration = this._onDidCompleteConfiguration.event;
+
 	dispose() {
 		this._disposables.forEach(disposable => disposable.dispose());
 		this._onDidRequestRunInTerminal.dispose();
+		this._onDidCompleteConfiguration.dispose();
 	}
 
 	public createDebugAdapterTracker(session: vscode.DebugSession): vscode.ProviderResult<vscode.DebugAdapterTracker> {
@@ -42,6 +47,9 @@ export class DebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFac
 			tracker,
 			tracker.onDidRequestRunInTerminal(processId => {
 				this._onDidRequestRunInTerminal.fire({ debugSession: session, processId });
+			}),
+			tracker.onDidCompleteConfiguration(() => {
+				this._onDidCompleteConfiguration.fire(session);
 			}),
 		);
 
@@ -53,21 +61,39 @@ class DebugAdapterTracker implements vscode.DebugAdapterTracker, vscode.Disposab
 	private _runInTerminalRequestSeq?: number;
 
 	private readonly _onDidRequestRunInTerminal = new vscode.EventEmitter<number>();
+	private readonly _onDidCompleteConfiguration = new vscode.EventEmitter<void>();
 
 	/** Event fired when a debug session requests to run a command in the integrated terminal. */
 	public readonly onDidRequestRunInTerminal = this._onDidRequestRunInTerminal.event;
 
+	/** Event fired when the adapter responds to `configurationDone`. */
+	public readonly onDidCompleteConfiguration = this._onDidCompleteConfiguration.event;
+
 	dispose() {
 		this._onDidRequestRunInTerminal.dispose();
+		this._onDidCompleteConfiguration.dispose();
 	}
 
 	public onDidSendMessage(msg: any): void {
 		// Listen for the debug adapter requesting to run a command in the integrated terminal.
-		if (msg.type === 'request' &&
+		if (
+			msg.type === 'request' &&
 			msg.command === 'runInTerminal' &&
 			msg.arguments &&
-			msg.arguments.kind === 'integrated') {
+			msg.arguments.kind === 'integrated'
+		) {
 			this._runInTerminalRequestSeq = msg.seq;
+		}
+
+		// The adapter responded to `configurationDone`, meaning all
+		// `setBreakpoints` requests have been processed (they are awaited
+		// before `configurationDone` is sent by VS Code).
+		if (
+			msg.type === 'response' &&
+			msg.command === 'configurationDone' &&
+			msg.success
+		) {
+			this._onDidCompleteConfiguration.fire();
 		}
 	}
 

--- a/extensions/positron-run-app/src/extension.ts
+++ b/extensions/positron-run-app/src/extension.ts
@@ -15,7 +15,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Positr
 	context.subscriptions.push(log);
 
 	const debugSessionTerminalWatcher = registerDebugAdapterTrackerFactory(context.subscriptions);
-	const positronRunApp = new PositronRunAppApiImpl(context.globalState, debugSessionTerminalWatcher);
+	const positronRunApp = new PositronRunAppApiImpl(context.workspaceState, debugSessionTerminalWatcher);
 
 	context.subscriptions.push(
 		vscode.window.registerTerminalLinkProvider(new AppLauncherTerminalLinkProvider(positronRunApp))

--- a/extensions/positron-run-app/src/positron-run-app.d.ts
+++ b/extensions/positron-run-app/src/positron-run-app.d.ts
@@ -55,6 +55,14 @@ interface RunAppOptionsBase {
 	 * An optional array of app URI formats to parse the URI from the output.
 	 */
 	appUrlStrings?: string[];
+
+	/**
+	 * The debug adapter type (e.g. `'ark'`) used by the runtime. When set
+	 * and breakpoints are present, the runner waits for that adapter's
+	 * `configurationDone` before executing app code. Leave unset for
+	 * runtimes without DAP support to avoid a waiting overhead on every run.
+	 */
+	debugAdapterType?: string;
 }
 
 /**

--- a/extensions/positron-run-app/src/positron-run-app.d.ts
+++ b/extensions/positron-run-app/src/positron-run-app.d.ts
@@ -23,14 +23,44 @@ export interface RunAppTerminalOptions {
 }
 
 /**
- * Represents options for the ${@link PositronRunApp.runApplication} function.
+ * Represents the code returned from ${@link RunConsoleAppOptions.getConsoleCode}.
  */
-export interface RunAppOptions {
+export interface RunAppConsoleCode {
 	/**
-	 * The human-readable label for the application e.g. `'Streamlit'`, also used as the ${@link vscode.Terminal.name}.
+	 * The code to execute in the console session.
+	 */
+	code: string;
+}
+
+/**
+ * Shared options for running an application.
+ */
+interface RunAppOptionsBase {
+	/**
+	 * The human-readable label for the application e.g. `'Streamlit'`.
 	 */
 	name: string;
 
+	/**
+	 * The optional URL path at which to preview the application.
+	 */
+	urlPath?: string;
+
+	/**
+	 * The optional app ready message to wait for before previewing the application.
+	 */
+	appReadyMessage?: string;
+
+	/**
+	 * An optional array of app URI formats to parse the URI from the output.
+	 */
+	appUrlStrings?: string[];
+}
+
+/**
+ * Represents options for the ${@link PositronRunApp.runApplication} function.
+ */
+export interface RunAppOptions extends RunAppOptionsBase {
 	/**
 	 * A function that will be called to get the terminal options for running the application.
 	 *
@@ -44,21 +74,25 @@ export interface RunAppOptions {
 		document: vscode.TextDocument,
 		urlPrefix?: string,
 	) => RunAppTerminalOptions | undefined | Promise<RunAppTerminalOptions | undefined>;
+}
 
+/**
+ * Represents options for the ${@link PositronRunApp.runApplicationInConsole} function.
+ */
+export interface RunConsoleAppOptions extends RunAppOptionsBase {
 	/**
-	 * The optional URL path at which to preview the application.
+	 * A function that will be called to get the code to execute in the console session.
+	 *
+	 * @param runtime The language runtime metadata for the document's language.
+	 * @param document The document to run.
+	 * @param urlPrefix The URL prefix to use, if known.
+	 * @returns The console code for running the application. Return `undefined` to abort the run.
 	 */
-	urlPath?: string;
-
-	/**
-	 * The optional app ready message to wait for in the terminal before previewing the application.
-	 */
-	appReadyMessage?: string;
-
-	/**
-	 * An optional array of app URI formats to parse the URI from the terminal output.
-	 */
-	appUrlStrings?: string[];
+	getConsoleCode: (
+		runtime: positron.LanguageRuntimeMetadata,
+		document: vscode.TextDocument,
+		urlPrefix?: string,
+	) => RunAppConsoleCode | undefined | Promise<RunAppConsoleCode | undefined>;
 }
 
 /**
@@ -112,6 +146,15 @@ export interface PositronRunApp {
 	 *  started, otherwise resolves when the command has been sent to the terminal.
 	 */
 	runApplication(options: RunAppOptions): Promise<void>;
+
+	/**
+	 * Run an application in a new console session.
+	 *
+	 * @param options Options for running the application.
+	 * @returns Resolves when the application server has started, or when the
+	 *  code has been sent to the console if URL detection times out.
+	 */
+	runApplicationInConsole(options: RunConsoleAppOptions): Promise<void>;
 
 	/**
 	 * Debug an application.

--- a/extensions/positron-run-app/src/positron-run-app.d.ts
+++ b/extensions/positron-run-app/src/positron-run-app.d.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -8,7 +8,7 @@ import * as positron from 'positron';
 import * as vscode from 'vscode';
 
 /**
- * Represents options returned from ${@link RunAppOptions.getTerminalOptions}.
+ * Options returned from ${@link RunAppOptions.getTerminalOptions}.
  */
 export interface RunAppTerminalOptions {
 	/**
@@ -23,7 +23,7 @@ export interface RunAppTerminalOptions {
 }
 
 /**
- * Represents the code returned from ${@link RunConsoleAppOptions.getConsoleCode}.
+ * Code returned from ${@link RunConsoleAppOptions.getConsoleCode}.
  */
 export interface RunAppConsoleCode {
 	/**
@@ -66,7 +66,7 @@ interface RunAppOptionsBase {
 }
 
 /**
- * Represents options for the ${@link PositronRunApp.runApplication} function.
+ * Options for the ${@link PositronRunApp.runApplication} function.
  */
 export interface RunAppOptions extends RunAppOptionsBase {
 	/**
@@ -85,7 +85,7 @@ export interface RunAppOptions extends RunAppOptionsBase {
 }
 
 /**
- * Represents options for the ${@link PositronRunApp.runApplicationInConsole} function.
+ * Options for the ${@link PositronRunApp.runApplicationInConsole} function.
  */
 export interface RunConsoleAppOptions extends RunAppOptionsBase {
 	/**
@@ -104,7 +104,7 @@ export interface RunConsoleAppOptions extends RunAppOptionsBase {
 }
 
 /**
- * Represents options for the ${@link PositronRunApp.debugApplication} function.
+ * Options for the ${@link PositronRunApp.debugApplication} function.
  */
 export interface DebugAppOptions {
 	/**

--- a/extensions/positron-run-app/src/utils.ts
+++ b/extensions/positron-run-app/src/utils.ts
@@ -34,7 +34,8 @@ export class SequencerByKey<TKey> {
 	queue<T>(key: TKey, promiseTask: ITask<Promise<T>>): Promise<T> {
 		const runningPromise = this.promiseMap.get(key) ?? Promise.resolve();
 		const newPromise = runningPromise
-			.catch(() => { })
+			// Swallow unhandled errors from the previous task so the current one still runs.
+			.catch((error) => { console.warn(`[positron-run-app] Previous queued task for key '${key}' failed:`, error); })
 			.then(promiseTask)
 			.finally(() => {
 				if (this.promiseMap.get(key) === newPromise) {

--- a/extensions/positron-run-app/src/utils.ts
+++ b/extensions/positron-run-app/src/utils.ts
@@ -7,15 +7,23 @@
 
 export function raceTimeout<T>(promise: Promise<T>, timeout: number, onTimeout?: () => void): Promise<T | undefined> {
 	let promiseResolve: ((value: T | undefined) => void) | undefined = undefined;
+	let promiseReject: ((reason?: unknown) => void) | undefined = undefined;
 
 	const timer = setTimeout(() => {
-		promiseResolve?.(undefined);
-		onTimeout?.();
+		try {
+			onTimeout?.();
+			promiseResolve?.(undefined);
+		} catch (error) {
+			promiseReject?.(error);
+		}
 	}, timeout);
 
 	return Promise.race([
 		promise.finally(() => clearTimeout(timer)),
-		new Promise<T | undefined>(resolve => promiseResolve = resolve)
+		new Promise<T | undefined>((resolve, reject) => {
+			promiseResolve = resolve;
+			promiseReject = reject;
+		})
 	]);
 }
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2223,9 +2223,15 @@ declare module 'positron' {
 		/**
 		 * Restart a running session.
 		 *
+		 * If the session is busy, the user is prompted whether to interrupt it
+		 * before restarting.
+		 *
 		 * @param sessionId The ID of the session to restart.
+		 * @returns `true` if the session was restarted, `false` if the
+		 *  restart was declined by the user or already in progress.
+		 *  Rejects if the session is not found or not in a restartable state.
 		 */
-		export function restartSession(sessionId: string): Thenable<void>;
+		export function restartSession(sessionId: string): Thenable<boolean>;
 
 		/**
 		 * Focus a running session.

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -2227,9 +2227,9 @@ declare module 'positron' {
 		 * before restarting.
 		 *
 		 * @param sessionId The ID of the session to restart.
-		 * @returns `true` if the session was restarted, `false` if the
-		 *  restart was declined by the user or already in progress.
-		 *  Rejects if the session is not found or not in a restartable state.
+		 * @returns `true` if the session was restarted (or a restart already in
+		 *   progress completed), `false` if the restart was declined by the user.
+		 *   Rejects if the session is not found or not in a restartable state.
 		 */
 		export function restartSession(sessionId: string): Thenable<boolean>;
 

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1753,7 +1753,7 @@ export class MainThreadLanguageRuntime
 	}
 
 	// Called by the extension host to restart a running language runtime
-	$restartSession(sessionId: string): Promise<void> {
+	$restartSession(sessionId: string): Promise<boolean> {
 		return this._runtimeSessionService.restartSession(
 			sessionId,
 			'Extension-requested runtime restart via Positron API');

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -148,7 +148,7 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 			interruptSession(sessionId: string): Thenable<void> {
 				return extHostLanguageRuntime.interruptSession(sessionId);
 			},
-			restartSession(sessionId: string): Thenable<void> {
+			restartSession(sessionId: string): Thenable<boolean> {
 				return extHostLanguageRuntime.restartSession(sessionId);
 			},
 			focusSession(sessionId: string): void {

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -56,7 +56,7 @@ export interface MainThreadLanguageRuntimeShape extends IDisposable {
 	$getSession(sessionId: string): Promise<ActiveRuntimeSessionMetadata | undefined>;
 	$getForegroundSession(): Promise<ActiveRuntimeSessionMetadata | undefined>;
 	$getNotebookSession(notebookUri: URI): Promise<ActiveRuntimeSessionMetadata | undefined>;
-	$restartSession(sessionId: string): Promise<void>;
+	$restartSession(sessionId: string): Promise<boolean>;
 	$interruptSession(sessionId: string): Promise<void>;
 	$focusSession(sessionId: string): void;
 	$deleteSession(sessionId: string): Promise<boolean>;

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -1495,7 +1495,7 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 	 *
 	 * @param sessionId The session ID to restart.
 	 */
-	public restartSession(sessionId: string): Promise<void> {
+	public restartSession(sessionId: string): Promise<boolean> {
 		return this._proxy.$restartSession(sessionId);
 	}
 

--- a/src/vs/workbench/contrib/positronPreview/browser/components/urlActionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/urlActionBars.tsx
@@ -23,6 +23,7 @@ import { kPaddingLeft, kPaddingRight } from './actionBars.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { ITerminalInstance } from '../../../terminal/browser/terminal.js';
+import { RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 
 // Constants.
 const kUrlBarInputName = 'url-bar';
@@ -63,16 +64,23 @@ export const UrlActionBars = (props: PropsWithChildren<UrlActionBarsProps>) => {
 	// State hooks for interrupt button
 	const [interruptible, setInterruptible] = useState(false);
 	const [interrupting, setInterrupting] = useState(false);
-	// Track which terminal is running the app displayed in the viewer
-	const [sourceTerminal, setSourceTerminal] = useState<ITerminalInstance | undefined>(undefined);
+
+	// The app source is either a terminal or a runtime session, never both.
+	type AppSource =
+		| { readonly type: 'terminal'; readonly terminal: ITerminalInstance }
+		| { readonly type: 'runtime'; readonly sessionId: string };
+	const [appSource, setAppSource] = useState<AppSource | undefined>(undefined);
+	const sourceTerminal = appSource?.type === 'terminal' ? appSource.terminal : undefined;
+	const sourceSessionId = appSource?.type === 'runtime' ? appSource.sessionId : undefined;
 
 	// Handler for the interrupt button.
 	const interruptHandler = async () => {
 		// Immediately hide the button to provide instant feedback
 		setInterruptible(false);
 
-		// Send Ctrl+C to the source terminal
-		if (sourceTerminal && sourceTerminal.hasChildProcesses) {
+		if (sourceSessionId) {
+			await services.runtimeSessionService.interruptSession(sourceSessionId);
+		} else if (sourceTerminal && sourceTerminal.hasChildProcesses) {
 			// Send Ctrl+C (SIGINT) to the terminal
 			sourceTerminal.sendText('\x03', false);
 
@@ -195,11 +203,17 @@ export const UrlActionBars = (props: PropsWithChildren<UrlActionBarsProps>) => {
 		return () => disposables.dispose();
 	}, [props.preview]);
 
-	// useEffect hook to capture the source terminal when preview content changes.
+	// useEffect hook to capture the source when preview content changes.
 	useEffect(() => {
-		// Check if the preview has source information indicating it came from a terminal
 		const source = props.preview.source;
-		if (source && source.type === 'terminal') {
+		if (!source) {
+			setAppSource(undefined);
+			setInterruptible(false);
+			setInterrupting(false);
+			return;
+		}
+
+		if (source.type === 'terminal') {
 			// Find the terminal with the matching process ID
 			const terminalId = parseInt(source.id, 10);
 
@@ -209,19 +223,25 @@ export const UrlActionBars = (props: PropsWithChildren<UrlActionBarsProps>) => {
 			);
 
 			if (terminal) {
-				setSourceTerminal(terminal);
+				setAppSource({ type: 'terminal', terminal });
 				if (terminal.hasChildProcesses) {
 					setInterruptible(true);
 					setInterrupting(false);
 				}
 			}
+		} else if (source.type === 'runtime') {
+			const session = services.runtimeSessionService.getSession(source.id);
+			if (session) {
+				setAppSource({ type: 'runtime', sessionId: source.id });
+				setInterruptible(session.getRuntimeState() === RuntimeState.Busy);
+				setInterrupting(false);
+			}
 		}
-	}, [props.preview, services.terminalService]);
+	}, [props.preview, services.terminalService, services.runtimeSessionService]);
 
 	// useEffect hook to track the source terminal's child process state.
 	useEffect(() => {
 		if (!sourceTerminal) {
-			setInterruptible(false);
 			return;
 		}
 
@@ -241,7 +261,7 @@ export const UrlActionBars = (props: PropsWithChildren<UrlActionBarsProps>) => {
 					// Clear the viewer when the process stops
 					services.positronPreviewService.clearAllPreviews();
 					// Clear the source terminal when processes stop
-					setSourceTerminal(undefined);
+					setAppSource(undefined);
 				}
 			})
 		);
@@ -251,12 +271,41 @@ export const UrlActionBars = (props: PropsWithChildren<UrlActionBarsProps>) => {
 			sourceTerminal.onDisposed(() => {
 				setInterruptible(false);
 				setInterrupting(false);
-				setSourceTerminal(undefined);
+				setAppSource(undefined);
 			})
 		);
 
 		return () => disposables.dispose();
 	}, [sourceTerminal, services.positronPreviewService]);
+
+	// Track the source runtime session's state for the stop button
+	useEffect(() => {
+		if (!sourceSessionId) {
+			return;
+		}
+
+		const disposables = new DisposableStore();
+
+		disposables.add(
+			services.runtimeSessionService.onDidChangeRuntimeState(e => {
+				if (e.session_id !== sourceSessionId) {
+					return;
+				}
+
+				const busy = e.new_state === RuntimeState.Busy;
+				setInterruptible(busy);
+				if (!busy) {
+					setInterrupting(false);
+				}
+
+				if (e.new_state === RuntimeState.Exited) {
+					setAppSource(undefined);
+				}
+			})
+		);
+
+		return () => disposables.dispose();
+	}, [sourceSessionId, services.runtimeSessionService]);
 
 	// Render.
 	return (

--- a/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
+++ b/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
@@ -199,7 +199,7 @@ class TestRuntimeSessionService implements IRuntimeSessionService {
 		throw new Error('Method not implemented.');
 	}
 
-	restartSession(_sessionId: string, _source: string): Promise<void> {
+	restartSession(_sessionId: string, _source: string): Promise<boolean> {
 		throw new Error('Method not implemented.');
 	}
 

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -972,10 +972,12 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 * @param source The source of the request to restart the runtime.
 	 */
 	async restartSession(sessionId: string, source: string, interrupt: boolean = true): Promise<boolean> {
-		const session = this.getSession(sessionId);
-		if (!session) {
+		const activeSession = this._activeSessionsBySessionId.get(sessionId);
+		if (!activeSession) {
 			throw new Error(`No session with ID '${sessionId}' was found.`);
 		}
+
+		const session = activeSession.session;
 		this._logService.info(
 			`Restarting session '` +
 			`${formatLanguageRuntimeSession(session)}' (Source: ${source})`);
@@ -1014,12 +1016,15 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				true
 			);
 			return true;
-		} else if (state === RuntimeState.Starting ||
-			state === RuntimeState.Restarting) {
-			// The runtime is already starting or restarting. We could show an
-			// error, but this is probably just the result of a user mashing the
-			// restart when we already have one in flight.
-			return false;
+		} else if (
+			state === RuntimeState.Starting ||
+			state === RuntimeState.Restarting
+		) {
+			// Already in progress. Wait for the existing start/restart to
+			// finish so callers can rely on the session being ready when
+			// this resolves.
+			await awaitStateChange(activeSession, [RuntimeState.Ready], 10);
+			return true;
 		} else {
 			// The runtime is not in a state where it can be restarted.
 			throw new Error(`The ${session.runtimeMetadata.languageName} session is '${state}' ` +

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -971,7 +971,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 	 * @param sessionId The session ID of the runtime to restart.
 	 * @param source The source of the request to restart the runtime.
 	 */
-	async restartSession(sessionId: string, source: string, interrupt: boolean = true): Promise<void> {
+	async restartSession(sessionId: string, source: string, interrupt: boolean = true): Promise<boolean> {
 		const session = this.getSession(sessionId);
 		if (!session) {
 			throw new Error(`No session with ID '${sessionId}' was found.`);
@@ -989,7 +989,7 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 
 			// The session was not interrupted, so we can't restart it.
 			if (!interrupted) {
-				return;
+				return false;
 			}
 		}
 
@@ -999,7 +999,8 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			state === RuntimeState.Exited) {
 			// The runtime looks like it could handle a restart request, so send
 			// one over.
-			return this.doRestartRuntime(session);
+			await this.doRestartRuntime(session);
+			return true;
 		} else if (state === RuntimeState.Uninitialized) {
 			// The runtime has never been started, or is no longer running. Just
 			// tell it to start.
@@ -1012,13 +1013,13 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 				RuntimeStartMode.Starting,
 				true
 			);
-			return;
+			return true;
 		} else if (state === RuntimeState.Starting ||
 			state === RuntimeState.Restarting) {
 			// The runtime is already starting or restarting. We could show an
 			// error, but this is probably just the result of a user mashing the
 			// restart when we already have one in flight.
-			return;
+			return false;
 		} else {
 			// The runtime is not in a state where it can be restarted.
 			throw new Error(`The ${session.runtimeMetadata.languageName} session is '${state}' ` +

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -589,10 +589,16 @@ export interface IRuntimeSessionService {
 	/**
 	 * Restart a runtime session.
 	 *
+	 * If the session is busy, the user is prompted whether to interrupt it
+	 * before restarting.
+	 *
 	 * @param sessionId The identifier of the session to restart.
 	 * @param source The source of the request to restart the session, for debugging purposes.
+	 * @returns Whether the session was restarted. `false` if the user
+	 *  declined or the session was already restarting.
+	 *  Rejects if the session is not found or not in a restartable state.
 	 */
-	restartSession(sessionId: string, source: string, interrupt?: boolean): Promise<void>;
+	restartSession(sessionId: string, source: string, interrupt?: boolean): Promise<boolean>;
 
 	/**
 	 * Interrupt a runtime session.

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -594,9 +594,10 @@ export interface IRuntimeSessionService {
 	 *
 	 * @param sessionId The identifier of the session to restart.
 	 * @param source The source of the request to restart the session, for debugging purposes.
-	 * @returns Whether the session was restarted. `false` if the user
-	 *  declined or the session was already restarting.
-	 *  Rejects if the session is not found or not in a restartable state.
+	 * @returns `true` if the session was restarted (or a restart already
+	 *  in progress completed), `false` if the restart was declined by
+	 *  the user. Rejects if the session is not found or not in a
+	 *  restartable state.
 	 */
 	restartSession(sessionId: string, source: string, interrupt?: boolean): Promise<boolean>;
 

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -936,7 +936,7 @@ suite('Positron - RuntimeSessionService', () => {
 
 			assertActiveSessions([session]);
 			assertCurrentSession(runtime, notebookUri, session);
-			assert.strictEqual(session.getRuntimeState(), RuntimeState.Starting);
+			assert.strictEqual(session.getRuntimeState(), RuntimeState.Ready);
 		});
 
 		test(`restart ${mode} in 'restarting' state`, async () => {
@@ -952,7 +952,7 @@ suite('Positron - RuntimeSessionService', () => {
 
 			assertActiveSessions([session]);
 			assertCurrentSession(runtime, notebookUri, session);
-			assert.strictEqual(session.getRuntimeState(), RuntimeState.Restarting);
+			assert.strictEqual(session.getRuntimeState(), RuntimeState.Ready);
 
 			sinon.assert.notCalled(target);
 		});


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/positron/issues/12556

Refactored positron-run-app extension to add a new `runApplicationInConsole()` entry point. The internals are shared between the terminal and console paths (in particular I extracted `AppUrlDetector` for URL detection in app output), and now handle errors a bit more consistently.

- Sessions are reused and restarted when app is started again. To make the implementation easier, `positron.runtime.restartSession()` now returns a boolean indicating whether the session restart was cancelled by the user. When cancelled, the app restart is cancelled too. When the session is already restarting, we wait for the restart to finish (new behaviour) and return true. These changes make the behaviour of `await restartSession()` clearer for callers: `true` result means the session is ready, `false` means the restart was cancelled, error means the restart couldn't be completed.

- If there are breakpoints and app runner specified a debugger type, we wait for the configuration of that debugger to be done before starting the app. The `configurationDone` event only fires after initial `setBreakpoints` requests ( one per file) are successful, and this is exactly what we need to ensure that Ark's DAP has fully started up and knows about breakpoints before sourcing the Shiny app files.

- The viewer's stop button gains support for console sessions. It sends console interrupts via the console service.

Once https://github.com/posit-dev/shiny-vscode/pull/108 is merged and released, we can bump the bundled version and merge this PR.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- NA

#### Bug Fixes

- N/A


### Draft Changelog

When we bump to a version of the Shiny vscode extension that supports console sessions:

- Shiny applications are now run in console sessions instead of the terminal (https://github.com/posit-dev/positron/issues/12556). This makes it possible to debug them with Positron's new R debugger support.

### QA Notes

- R Shiny apps run in console sessions, not terminals
- Other apps (Streamlit etc.) still use terminals
- Stop button in viewer works for console apps (interrupt) and disappears when idle (including when debugging the app, which is admitedly weird)
- No breakpoints: fast startup. With breakpoints: slower but breakpoints hit
- Re-running reuses the same "Shiny" console and restarts it
- Re-running also reuses sessions after extension host restart or window reload
- Re-running while debugging: debugger exits, session restarts
- When re-running, declining the interrupt prompt cancels the restart
- Closed/exited session: fresh one created on next run
- Dirty document auto-saved before execution
- Timeout error if URL not detected in ~25s
- Rapid "Run App" clicks: "already starting" message, no duplicates

https://github.com/user-attachments/assets/004a6f65-21f5-45d9-9edc-2d922b1e1999

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:apps