### PR TITLE
E2E test: try again to fix unit and integration tests

### DIFF
--- a/.github/actions/install-r/action.yml
+++ b/.github/actions/install-r/action.yml
@@ -2,9 +2,9 @@ name: "Setup Rig, R, and R Packages"
 description: "Install a specified R version using Rig, with an option to install additional R packages."
 inputs:
   version:
-    description: "The R version to install (e.g., 4.4.0)"
+    description: "The R version to install (e.g., 4.5.2)"
     required: false
-    default: "4.4.0"
+    default: "4.5.2"
   alternate_version:
     description: "The alternate R version to install (e.g., 4.4.2)"
     required: false

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -154,6 +154,7 @@ jobs:
         uses: ./.github/actions/install-r
         with:
           version: "4.5.2"
+          install_undetectable_interpreters: true
 
       - name: Compile Integration Tests
         run: npm run --prefix test/integration/browser compile

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -183,6 +183,7 @@ jobs:
         uses: ./.github/actions/install-r
         with:
           version: "4.5.2"
+          install_undetectable_interpreters: true
 
       - name: Save R installation and packages cache
         if: ${{ steps.cache-r.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
Somehow 4.4.0 was still being used. Maybe it was picking up the default or maybe not passing all required params was an issue?

### QA Notes


