### PR TITLE
Fix littered execution indicators in Console

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityInput.tsx
@@ -123,6 +123,13 @@ export const ActivityInput = (props: ActivityInputProps) => {
 			setState(props.activityItemInput.state);
 		}));
 
+		// Re-sync state: the item's state may have changed between
+		// the component mounting (useState initialization) and this
+		// effect running (which is deferred until after paint). Without
+		// this, state changes that occur in that window are missed
+		// because no subscriber was listening yet.
+		setState(props.activityItemInput.state);
+
 		// Return the cleanup function that will dispose of the disposables.
 		return () => disposableStore.dispose();
 	}, [props.activityItemInput]);

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
@@ -115,13 +115,20 @@ export class RuntimeItemActivity extends RuntimeItem {
 				}
 			} else if (activityItem instanceof ActivityItemInput && activityItem.state !== ActivityItemInputState.Provisional) {
 				// When a non-provisional ActivityItemInput is being added, see if there's a
-				// provisional ActivityItemInput for it in the activity items. If there is, replace
-				// the provisional ActivityItemInput with the actual ActivityItemInput.
+				// provisional or already-completed ActivityItemInput for it in the activity
+				// items. If there is, replace it with the actual ActivityItemInput.
 				for (let i = this._activityItems.length - 1; i >= 0; --i) {
 					const activityItemToCheck = this._activityItems[i];
 					if (activityItemToCheck instanceof ActivityItemInput) {
-						if (activityItemToCheck.state === ActivityItemInputState.Provisional &&
+						if ((activityItemToCheck.state === ActivityItemInputState.Provisional ||
+							activityItemToCheck.state === ActivityItemInputState.Completed) &&
 							activityItemToCheck.parentId === activityItem.parentId) {
+							// If the item was already completed (idle received
+							// before the input message), propagate that state
+							// to the replacement so it doesn't show as executing.
+							if (activityItemToCheck.state === ActivityItemInputState.Completed) {
+								activityItem.state = ActivityItemInputState.Completed;
+							}
 							this._activityItems[i] = activityItem;
 							return;
 						}

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1950,6 +1950,22 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	}
 
 	/**
+	 * Clears the executing state of all ActivityItemInputs that are still
+	 * marked as executing. This is a safeguard to ensure that executing
+	 * indicators don't get stuck due to missed or out-of-order state messages.
+	 */
+	private clearExecutingActivityInputs() {
+		for (const activity of this._runtimeItemActivities.values()) {
+			for (const item of activity.activityItems) {
+				if (item instanceof ActivityItemInput &&
+					item.state === ActivityItemInputState.Executing) {
+					item.state = ActivityItemInputState.Completed;
+				}
+			}
+		}
+	}
+
+	/**
 	 * Marks the Input activity item that matches the given parent ID as busy or
 	 * not busy.
 	 *
@@ -1972,6 +1988,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					input.state = busy ?
 						ActivityItemInputState.Executing :
 						ActivityItemInputState.Completed;
+				} else if (!busy) {
+					// The idle message arrived before the input message
+					// replaced the provisional item. Mark as completed so
+					// the replacement inherits this state in addActivityItem.
+					input.state = ActivityItemInputState.Completed;
 				}
 
 				// Found the input, so we're done.
@@ -2488,15 +2509,24 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 					}
 
 					case RuntimeOnlineState.Idle: {
-						if (languageRuntimeMessageState.parent_id.startsWith(POSITRON_CONSOLE_EXEC_PREFIX) ||
+						const isConsoleExecution =
+							languageRuntimeMessageState.parent_id.startsWith(POSITRON_CONSOLE_EXEC_PREFIX) ||
 							this._externalExecutionIds.has(languageRuntimeMessageState.parent_id) ||
-							this.state === PositronConsoleState.Offline) {
+							this.state === PositronConsoleState.Offline;
+						if (isConsoleExecution) {
 							this.setState(PositronConsoleState.Ready);
 						}
 						// Mark the associated input as idle.
 						this.markInputBusyState(languageRuntimeMessageState.parent_id, false);
 						// This external execution ID has completed, so we can remove it.
 						this._externalExecutionIds.delete(languageRuntimeMessageState.parent_id);
+						// Safeguard: when returning to Ready after a console
+						// execution, ensure all previous items that were marked
+						// as executing are marked as completed so that the
+						// executing indicator (green gutter line) is cleared.
+						if (isConsoleExecution) {
+							this.clearExecutingActivityInputs();
+						}
 						break;
 					}
 				}
@@ -2672,16 +2702,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			this._runtimeAttached = false;
 			this._onDidAttachRuntime.fire(undefined);
 
-			// Clear the executing state of all ActivityItemInputs inputs. When a runtime exits, it
-			// may not send an Idle message corresponding to the command that caused it to exit (for
-			// instance if the command causes the runtime to crash).
-			for (const activity of this._runtimeItemActivities.values()) {
-				for (const item of activity.activityItems) {
-					if (item instanceof ActivityItemInput) {
-						item.state = ActivityItemInputState.Completed;
-					}
-				}
-			}
+			// Clear the executing state of all ActivityItemInputs. When a
+			// runtime exits, it may not send an Idle message corresponding
+			// to the command that caused it to exit (for instance if the
+			// command causes the runtime to crash).
+			this.clearExecutingActivityInputs();
 
 			// Dispose of the runtime event handlers.
 			this._runtimeDisposableStore.clear();


### PR DESCRIPTION
This change addresses an issue that causes duplicate/littered execution indicators in the Console. There are a few safeguards added here to make sure this doesn't happen:

- Guard against `idle` and `input` messages arriving out of order (typically we'd expect the input message to arrive within the busy/idle window but not a guarantee)
- Sync state in `useEffect` as it can change between initialization and mounting
- Clear any stray indicators when console becomes ready again

Addresses https://github.com/posit-dev/positron/issues/12277.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix execution indicator litter in the Console (#12277)


### QA Notes

There's no clear repo for this; it's a race condition so happens "sometimes". I'm able to reproduce most consistently in R due to how it sends messages, and with commands that return quickly (e.g. simple arithmetic, `Sys.time()`, `R.version`, etc.)