### PR TITLE
Remove hardcoded connection timeouts for kernel sessions

### DIFF
--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -1170,7 +1170,35 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		await kernel.connected.wait();
 
 		// Connect to the session's websocket
-		await withTimeout(this.connect(), 2000, `Start failed: timed out connecting to adopted session ${this.metadata.sessionId}`);
+		const config = vscode.workspace.getConfiguration('kernelSupervisor');
+		const connectTimeout = config.get<number>('startupTimeout', 10) * 1000;
+		let retry = true;
+		const connectStartTime = Date.now();
+		do {
+			try {
+				await withTimeout(
+					this.connect(),
+					connectTimeout,
+					`Start failed: timed out connecting to adopted session ${this.metadata.sessionId} ` +
+					`after ${connectTimeout}ms`);
+			} catch (err) {
+				if (retry) {
+					this.log(
+						`Failed to connect to adopted kernel; retrying: ${summarizeError(err)}`,
+						vscode.LogLevel.Warning);
+					retry = false;
+					continue;
+				} else {
+					this.log(
+						`Failed to connect to adopted kernel: ${summarizeError(err)}`,
+						vscode.LogLevel.Error);
+					throw err;
+				}
+			} finally {
+				retry = false;
+			}
+		} while (retry);
+		this.log(`Connected to adopted kernel after ${Date.now() - connectStartTime}ms`, vscode.LogLevel.Info);
 
 		// Mark the session as ready
 		this.markReady('kernel adoption complete');
@@ -1254,7 +1282,15 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		// Wait for the session to be established before connecting. This
 		// ensures either that we've created the session (if it's new) or that
 		// we've restored it (if it's not new).
-		await withTimeout(this._established.wait(), 2000, `Start failed: timed out waiting for session ${this.metadata.sessionId} to be established`);
+		const config = vscode.workspace.getConfiguration('kernelSupervisor');
+		const establishTimeout = config.get<number>('startupTimeout', 10) * 1000;
+		const establishStartTime = Date.now();
+		await withTimeout(
+			this._established.wait(),
+			establishTimeout,
+			`Start failed: timed out waiting for session ${this.metadata.sessionId} to be established ` +
+			`after ${establishTimeout}ms`);
+		this.log(`Session ${this.metadata.sessionId} established after ${Date.now() - establishStartTime}ms`, vscode.LogLevel.Info);
 
 		let runtimeInfo: positron.LanguageRuntimeInfo | undefined = this._runtimeInfo;
 
@@ -1295,7 +1331,6 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 
 		// Before connecting, check if we should attach to the session on
 		// startup
-		const config = vscode.workspace.getConfiguration('kernelSupervisor');
 		const attachOnStartup = config.get('attachOnStartup', false) && this._extra?.attachOnStartup;
 		if (attachOnStartup) {
 			try {
@@ -1306,7 +1341,35 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		}
 
 		// Connect to the session's websocket
-		await withTimeout(this.connect(), 2000, `Start failed: timed out connecting to session ${this.metadata.sessionId}`);
+		const connectTimeout = config.get<number>('startupTimeout', 10) * 1000;
+		const connectStartTime = Date.now();
+		retry = true;
+		do {
+			try {
+				await withTimeout(
+					this.connect(),
+					connectTimeout,
+					`Start failed: timed out connecting to session ${this.metadata.sessionId} after ${connectTimeout}ms`);
+			} catch (err) {
+				if (retry) {
+					this.log(
+						`Failed to connect to session; retrying: ${summarizeError(err)}`,
+						vscode.LogLevel.Warning
+					);
+					retry = false;
+					continue;
+				} else {
+					this.log(
+						`Failed to connect to session: ${summarizeError(err)}`,
+						vscode.LogLevel.Error
+					);
+					throw err;
+				}
+			} finally {
+				retry = false;
+			}
+		} while (retry);
+		this.log(`Connected to session after ${Date.now() - connectStartTime}ms`, vscode.LogLevel.Info);
 
 		if (this._new) {
 			// If it's a new session and we got runtime info from starting it,

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -1172,32 +1172,29 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		// Connect to the session's websocket
 		const config = vscode.workspace.getConfiguration('kernelSupervisor');
 		const connectTimeout = config.get<number>('startupTimeout', 10) * 1000;
-		let retry = true;
 		const connectStartTime = Date.now();
-		do {
+		for (let attempt = 0; attempt < 2; attempt++) {
 			try {
 				await withTimeout(
 					this.connect(),
 					connectTimeout,
 					`Start failed: timed out connecting to adopted session ${this.metadata.sessionId} ` +
 					`after ${connectTimeout}ms`);
+				break;
 			} catch (err) {
-				if (retry) {
+				// Allow one retry for Axios (connectivity) errors on the first attempt
+				if (attempt == 0 && isAxiosError(err)) {
 					this.log(
 						`Failed to connect to adopted kernel; retrying: ${summarizeError(err)}`,
 						vscode.LogLevel.Warning);
-					retry = false;
-					continue;
 				} else {
 					this.log(
 						`Failed to connect to adopted kernel: ${summarizeError(err)}`,
 						vscode.LogLevel.Error);
 					throw err;
 				}
-			} finally {
-				retry = false;
 			}
-		} while (retry);
+		}
 		this.log(`Connected to adopted kernel after ${Date.now() - connectStartTime}ms`, vscode.LogLevel.Info);
 
 		// Mark the session as ready
@@ -1343,21 +1340,19 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		// Connect to the session's websocket
 		const connectTimeout = config.get<number>('startupTimeout', 10) * 1000;
 		const connectStartTime = Date.now();
-		retry = true;
-		do {
+		for (let attempt = 0; attempt < 2; attempt++) {
 			try {
 				await withTimeout(
 					this.connect(),
 					connectTimeout,
 					`Start failed: timed out connecting to session ${this.metadata.sessionId} after ${connectTimeout}ms`);
+				break;
 			} catch (err) {
-				if (retry) {
+				if (attempt == 0 && isAxiosError(err)) {
 					this.log(
 						`Failed to connect to session; retrying: ${summarizeError(err)}`,
 						vscode.LogLevel.Warning
 					);
-					retry = false;
-					continue;
 				} else {
 					this.log(
 						`Failed to connect to session: ${summarizeError(err)}`,
@@ -1365,10 +1360,8 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 					);
 					throw err;
 				}
-			} finally {
-				retry = false;
 			}
-		} while (retry);
+		}
 		this.log(`Connected to session after ${Date.now() - connectStartTime}ms`, vscode.LogLevel.Info);
 
 		if (this._new) {

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -1171,14 +1171,14 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 
 		// Connect to the session's websocket
 		const config = vscode.workspace.getConfiguration('kernelSupervisor');
-		const connectTimeout = config.get<number>('startupTimeout', 10) * 1000;
+		const connectTimeout = config.get<number>('startupTimeout', 15) * 1000;
 		const connectStartTime = Date.now();
 		for (let attempt = 0; attempt < 2; attempt++) {
 			try {
 				await withTimeout(
 					this.connect(),
 					connectTimeout,
-					`Start failed: timed out connecting to adopted session ${this.metadata.sessionId} ` +
+					`Timed out connecting to adopted session ${this.metadata.sessionId} ` +
 					`after ${connectTimeout}ms`);
 				break;
 			} catch (err) {
@@ -1280,13 +1280,13 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		// ensures either that we've created the session (if it's new) or that
 		// we've restored it (if it's not new).
 		const config = vscode.workspace.getConfiguration('kernelSupervisor');
-		const establishTimeout = config.get<number>('startupTimeout', 10) * 1000;
+		const timeout = config.get<number>('startupTimeout', 15) * 1000;
 		const establishStartTime = Date.now();
 		await withTimeout(
 			this._established.wait(),
-			establishTimeout,
+			timeout,
 			`Start failed: timed out waiting for session ${this.metadata.sessionId} to be established ` +
-			`after ${establishTimeout}ms`);
+			`after ${timeout}ms`);
 		this.log(`Session ${this.metadata.sessionId} established after ${Date.now() - establishStartTime}ms`, vscode.LogLevel.Info);
 
 		let runtimeInfo: positron.LanguageRuntimeInfo | undefined = this._runtimeInfo;
@@ -1338,14 +1338,13 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		}
 
 		// Connect to the session's websocket
-		const connectTimeout = config.get<number>('startupTimeout', 10) * 1000;
 		const connectStartTime = Date.now();
 		for (let attempt = 0; attempt < 2; attempt++) {
 			try {
 				await withTimeout(
 					this.connect(),
-					connectTimeout,
-					`Start failed: timed out connecting to session ${this.metadata.sessionId} after ${connectTimeout}ms`);
+					timeout,
+					`Start failed: timed out connecting to session ${this.metadata.sessionId} after ${timeout}ms`);
 				break;
 			} catch (err) {
 				if (attempt === 0 && isAxiosError(err)) {

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -1285,7 +1285,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 		await withTimeout(
 			this._established.wait(),
 			timeout,
-			`Start failed: timed out waiting for session ${this.metadata.sessionId} to be established ` +
+			`Timed out waiting for session ${this.metadata.sessionId} to be established ` +
 			`after ${timeout}ms`);
 		this.log(`Session ${this.metadata.sessionId} established after ${Date.now() - establishStartTime}ms`, vscode.LogLevel.Info);
 
@@ -1344,7 +1344,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 				await withTimeout(
 					this.connect(),
 					timeout,
-					`Start failed: timed out connecting to session ${this.metadata.sessionId} after ${timeout}ms`);
+					`Timed out connecting to session ${this.metadata.sessionId} after ${timeout}ms`);
 				break;
 			} catch (err) {
 				if (attempt === 0 && isAxiosError(err)) {

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -1183,7 +1183,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 				break;
 			} catch (err) {
 				// Allow one retry for Axios (connectivity) errors on the first attempt
-				if (attempt == 0 && isAxiosError(err)) {
+				if (attempt === 0 && isAxiosError(err)) {
 					this.log(
 						`Failed to connect to adopted kernel; retrying: ${summarizeError(err)}`,
 						vscode.LogLevel.Warning);
@@ -1348,7 +1348,7 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 					`Start failed: timed out connecting to session ${this.metadata.sessionId} after ${connectTimeout}ms`);
 				break;
 			} catch (err) {
-				if (attempt == 0 && isAxiosError(err)) {
+				if (attempt === 0 && isAxiosError(err)) {
 					this.log(
 						`Failed to connect to session; retrying: ${summarizeError(err)}`,
 						vscode.LogLevel.Warning


### PR DESCRIPTION
This change is intended to mitigate some issues we've seen in the wild around connecting to kernel sessions by removing all of the hardcoded timeouts and replacing them with the configurable Kallichore "startup timeout". This isn't a perfect semantic match, but we want to avoid having many different timeouts to configure.

This operation _should_ be incredibly fast since it's a local network connection and we only try to make it once we have successfully asked the server to provision the other end; it is 6ms on my machine. However, some user reports indicate dramatically longer waits, especially on Windows. 

Now:
- The timeout is configurable, and is also much more generous, waiting up to 15s by default instead of 2s
- We also retry one time if the error is network-related
- The time taken to connect to a session is logged in its supervisor channel

This ought to mitigate #8000, but doesn't necessarily resolve it.
