### PR TITLE
Add progress and cancellation support to the packages pane

### DIFF
--- a/extensions/positron-python/src/client/common/terminal/syncTerminalService.ts
+++ b/extensions/positron-python/src/client/common/terminal/syncTerminalService.ts
@@ -133,7 +133,7 @@ export class SynchronousTerminalService implements ITerminalService, Disposable 
         try {
             const pythonExec = this.pythonInterpreter || (await this.interpreter.getActiveInterpreter(undefined));
             const sendArgs = internalScripts.shell_exec(command, lockFile.filePath, args);
-            await this.terminalService.sendCommand(pythonExec?.path || 'python', sendArgs);
+            await this.terminalService.sendCommand(pythonExec?.path || 'python', sendArgs, cancel);
             const promise = swallowExceptions ? state.completed : state.completed.catch(noop);
             await Cancellation.race(() => promise, cancel);
         } finally {

--- a/extensions/positron-python/src/client/common/terminal/syncTerminalService.ts
+++ b/extensions/positron-python/src/client/common/terminal/syncTerminalService.ts
@@ -133,7 +133,7 @@ export class SynchronousTerminalService implements ITerminalService, Disposable 
         try {
             const pythonExec = this.pythonInterpreter || (await this.interpreter.getActiveInterpreter(undefined));
             const sendArgs = internalScripts.shell_exec(command, lockFile.filePath, args);
-            await this.terminalService.sendCommand(pythonExec?.path || 'python', sendArgs, cancel);
+            await this.terminalService.sendCommand(pythonExec?.path || 'python', sendArgs);
             const promise = swallowExceptions ? state.completed : state.completed.catch(noop);
             await Cancellation.race(() => promise, cancel);
         } finally {

--- a/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
@@ -304,10 +304,8 @@ export class CondaPackageManager implements IPackageManager {
         // Wrap callMethod promise with cancellation handling
         return new Promise<T>((resolve, reject) => {
             const cancelDisp = token.onCancellationRequested(async () => {
-                // Interrupt kernel if supported
-                if (this._session.interrupt) {
-                    await this._session.interrupt();
-                }
+                // Interrupt the session via the runtime service
+                await positron.runtime.interruptSession(this._session.metadata.sessionId);
                 reject(new vscode.CancellationError());
             });
 

--- a/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
@@ -65,7 +65,7 @@ export class CondaPackageManager implements IPackageManager {
         _messageEmitter: MessageEmitter,
         private readonly _serviceContainer: IServiceContainer,
         private readonly _session: PackageSession,
-    ) {}
+    ) { }
 
     async getPackages(token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
         return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', token);
@@ -147,11 +147,6 @@ export class CondaPackageManager implements IPackageManager {
         try {
             // Use wildcard pattern for partial matching
             const result = await this._executeCondaWithOutput(['search', `*${query}*`, '--json'], token);
-
-            if (token.isCancellationRequested) {
-                throw new vscode.CancellationError();
-            }
-
             const json = parseCondaSearchResult(result);
 
             // Return unique package names with the latest version (sorted by timestamp)
@@ -183,11 +178,6 @@ export class CondaPackageManager implements IPackageManager {
 
         try {
             const result = await this._executeCondaWithOutput(['search', name, '--json'], token);
-
-            if (token.isCancellationRequested) {
-                throw new vscode.CancellationError();
-            }
-
             const json = parseCondaSearchResult(result);
 
             // Get all unique versions for this package
@@ -232,7 +222,7 @@ export class CondaPackageManager implements IPackageManager {
         if (!condaEnvInfo?.path) {
             throw new Error(
                 'Could not determine conda environment path. ' +
-                    'Ensure this Python interpreter is part of a conda environment.',
+                'Ensure this Python interpreter is part of a conda environment.',
             );
         }
 

--- a/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
@@ -146,7 +146,7 @@ export class CondaPackageManager implements IPackageManager {
 
         try {
             // Use wildcard pattern for partial matching
-            const result = await this._executeCondaWithOutput(['search', `*${query}*`, '--json']);
+            const result = await this._executeCondaWithOutput(['search', `*${query}*`, '--json'], token);
 
             if (token.isCancellationRequested) {
                 throw new vscode.CancellationError();
@@ -182,7 +182,7 @@ export class CondaPackageManager implements IPackageManager {
         await this._ensureConda();
 
         try {
-            const result = await this._executeCondaWithOutput(['search', name, '--json']);
+            const result = await this._executeCondaWithOutput(['search', name, '--json'], token);
 
             if (token.isCancellationRequested) {
                 throw new vscode.CancellationError();
@@ -286,12 +286,12 @@ export class CondaPackageManager implements IPackageManager {
     /**
      * Execute a conda command and capture stdout.
      */
-    private async _executeCondaWithOutput(args: string[]): Promise<string> {
+    private async _executeCondaWithOutput(args: string[], token: vscode.CancellationToken): Promise<string> {
         const condaFile = await this._getCondaFile();
         const processServiceFactory = this._serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
         const processService = await processServiceFactory.create();
 
-        const result = await processService.exec(condaFile, args);
+        const result = await processService.exec(condaFile, args, { token });
         return result.stdout;
     }
 

--- a/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
@@ -271,7 +271,16 @@ export class CondaPackageManager implements IPackageManager {
         // Ensure terminal is created and ready before sending command
         await terminalService.show();
 
-        await terminalService.sendCommand(condaFile, args, token);
+        const disposable = token.onCancellationRequested(async () => {
+            // Send Ctrl+C to interrupt the running command
+            await terminalService.sendText('\x03');
+        });
+
+        try {
+            await terminalService.sendCommand(condaFile, args, token);
+        } finally {
+            disposable.dispose();
+        }
     }
 
     /**

--- a/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
@@ -5,11 +5,17 @@
 
 import * as positron from 'positron';
 import * as vscode from 'vscode';
+import { CancellationTokenSource } from 'vscode';
 import { IProcessServiceFactory } from '../../common/process/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IComponentAdapter, ICondaService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
+
+/** Get a non-cancelling token to use when no token is provided */
+function getNonCancellingToken(): vscode.CancellationToken {
+    return new CancellationTokenSource().token;
+}
 
 /** Package info returned by `conda search --json` */
 interface CondaPackageInfo {
@@ -67,8 +73,9 @@ export class CondaPackageManager implements IPackageManager {
         private readonly _session: PackageSession,
     ) {}
 
-    async getPackages(token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', token);
+    async getPackages(token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+        const cancellation = token ?? getNonCancellingToken();
+        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', cancellation);
     }
 
     /**
@@ -83,12 +90,13 @@ export class CondaPackageManager implements IPackageManager {
         }
     }
 
-    async installPackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void> {
+    async installPackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
         }
 
-        if (token.isCancellationRequested) {
+        const cancellation = token ?? getNonCancellingToken();
+        if (cancellation.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -98,15 +106,16 @@ export class CondaPackageManager implements IPackageManager {
         const envPrefix = await this._getEnvironmentPrefix();
         const args = ['install', '--prefix', envPrefix, '-y', ...packageSpecs];
 
-        await this._executeCondaInTerminal(args, token);
+        await this._executeCondaInTerminal(args, cancellation);
     }
 
-    async uninstallPackages(packages: string[], token: vscode.CancellationToken): Promise<void> {
+    async uninstallPackages(packages: string[], token?: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
         }
 
-        if (token.isCancellationRequested) {
+        const cancellation = token ?? getNonCancellingToken();
+        if (cancellation.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -115,17 +124,18 @@ export class CondaPackageManager implements IPackageManager {
         const envPrefix = await this._getEnvironmentPrefix();
         const args = ['remove', '--prefix', envPrefix, '-y', ...packages];
 
-        await this._executeCondaInTerminal(args, token);
+        await this._executeCondaInTerminal(args, cancellation);
     }
 
-    async updatePackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void> {
+    async updatePackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
         // Use installPackages() because conda update doesn't support version specs.
         // conda install will update (or downgrade) to the specified version.
         return this.installPackages(packages, token);
     }
 
-    async updateAllPackages(token: vscode.CancellationToken): Promise<void> {
-        if (token.isCancellationRequested) {
+    async updateAllPackages(token?: vscode.CancellationToken): Promise<void> {
+        const cancellation = token ?? getNonCancellingToken();
+        if (cancellation.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -134,11 +144,12 @@ export class CondaPackageManager implements IPackageManager {
         const envPrefix = await this._getEnvironmentPrefix();
         const args = ['update', '--prefix', envPrefix, '--all', '-y'];
 
-        await this._executeCondaInTerminal(args, token);
+        await this._executeCondaInTerminal(args, cancellation);
     }
 
-    async searchPackages(query: string, token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        if (token.isCancellationRequested) {
+    async searchPackages(query: string, token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+        const cancellation = token ?? getNonCancellingToken();
+        if (cancellation.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -146,7 +157,7 @@ export class CondaPackageManager implements IPackageManager {
 
         try {
             // Use wildcard pattern for partial matching
-            const result = await this._executeCondaWithOutput(['search', `*${query}*`, '--json'], token);
+            const result = await this._executeCondaWithOutput(['search', `*${query}*`, '--json'], cancellation);
             const json = parseCondaSearchResult(result);
 
             // Return unique package names with the latest version (sorted by timestamp)
@@ -169,15 +180,16 @@ export class CondaPackageManager implements IPackageManager {
         }
     }
 
-    async searchPackageVersions(name: string, token: vscode.CancellationToken): Promise<string[]> {
-        if (token.isCancellationRequested) {
+    async searchPackageVersions(name: string, token?: vscode.CancellationToken): Promise<string[]> {
+        const cancellation = token ?? getNonCancellingToken();
+        if (cancellation.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
         await this._ensureConda();
 
         try {
-            const result = await this._executeCondaWithOutput(['search', name, '--json'], token);
+            const result = await this._executeCondaWithOutput(['search', name, '--json'], cancellation);
             const json = parseCondaSearchResult(result);
 
             // Get all unique versions for this package

--- a/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
@@ -65,7 +65,7 @@ export class CondaPackageManager implements IPackageManager {
         _messageEmitter: MessageEmitter,
         private readonly _serviceContainer: IServiceContainer,
         private readonly _session: PackageSession,
-    ) { }
+    ) {}
 
     async getPackages(token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
         return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', token);
@@ -222,7 +222,7 @@ export class CondaPackageManager implements IPackageManager {
         if (!condaEnvInfo?.path) {
             throw new Error(
                 'Could not determine conda environment path. ' +
-                'Ensure this Python interpreter is part of a conda environment.',
+                    'Ensure this Python interpreter is part of a conda environment.',
             );
         }
 
@@ -289,11 +289,7 @@ export class CondaPackageManager implements IPackageManager {
      * Call a kernel method with cancellation support.
      * If the token is cancelled, interrupts the kernel (if supported).
      */
-    private async _callMethod<T>(
-        method: string,
-        token: vscode.CancellationToken,
-        ...args: unknown[]
-    ): Promise<T> {
+    private async _callMethod<T>(method: string, token: vscode.CancellationToken, ...args: unknown[]): Promise<T> {
         if (token.isCancellationRequested) {
             throw new vscode.CancellationError();
         }

--- a/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
@@ -9,7 +9,7 @@ import { IProcessServiceFactory } from '../../common/process/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IComponentAdapter, ICondaService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
-import { IPackageManager, MessageEmitter, PackageKernel } from './types';
+import { IPackageManager, MessageEmitter, PackageSession } from './types';
 
 /** Package info returned by `conda search --json` */
 interface CondaPackageInfo {
@@ -64,11 +64,11 @@ export class CondaPackageManager implements IPackageManager {
         private readonly _pythonPath: string,
         _messageEmitter: MessageEmitter,
         private readonly _serviceContainer: IServiceContainer,
-        private readonly _kernel: PackageKernel,
+        private readonly _session: PackageSession,
     ) {}
 
-    async getPackages(): Promise<positron.LanguageRuntimePackage[]> {
-        return this._kernel.callMethod('getPackagesInstalled');
+    async getPackages(token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', token);
     }
 
     /**
@@ -83,9 +83,13 @@ export class CondaPackageManager implements IPackageManager {
         }
     }
 
-    async installPackages(packages: positron.PackageSpec[]): Promise<void> {
+    async installPackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
+        }
+
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
         }
 
         await this._ensureConda();
@@ -94,12 +98,16 @@ export class CondaPackageManager implements IPackageManager {
         const envPrefix = await this._getEnvironmentPrefix();
         const args = ['install', '--prefix', envPrefix, '-y', ...packageSpecs];
 
-        await this._executeCondaInTerminal(args);
+        await this._executeCondaInTerminal(args, token);
     }
 
-    async uninstallPackages(packages: string[]): Promise<void> {
+    async uninstallPackages(packages: string[], token: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
+        }
+
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
         }
 
         await this._ensureConda();
@@ -107,30 +115,43 @@ export class CondaPackageManager implements IPackageManager {
         const envPrefix = await this._getEnvironmentPrefix();
         const args = ['remove', '--prefix', envPrefix, '-y', ...packages];
 
-        await this._executeCondaInTerminal(args);
+        await this._executeCondaInTerminal(args, token);
     }
 
-    async updatePackages(packages: positron.PackageSpec[]): Promise<void> {
+    async updatePackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void> {
         // Use installPackages() because conda update doesn't support version specs.
         // conda install will update (or downgrade) to the specified version.
-        return this.installPackages(packages);
+        return this.installPackages(packages, token);
     }
 
-    async updateAllPackages(): Promise<void> {
+    async updateAllPackages(token: vscode.CancellationToken): Promise<void> {
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+
         await this._ensureConda();
 
         const envPrefix = await this._getEnvironmentPrefix();
         const args = ['update', '--prefix', envPrefix, '--all', '-y'];
 
-        await this._executeCondaInTerminal(args);
+        await this._executeCondaInTerminal(args, token);
     }
 
-    async searchPackages(query: string): Promise<positron.LanguageRuntimePackage[]> {
+    async searchPackages(query: string, token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+
         await this._ensureConda();
 
         try {
             // Use wildcard pattern for partial matching
             const result = await this._executeCondaWithOutput(['search', `*${query}*`, '--json']);
+
+            if (token.isCancellationRequested) {
+                throw new vscode.CancellationError();
+            }
+
             const json = parseCondaSearchResult(result);
 
             // Return unique package names with the latest version (sorted by timestamp)
@@ -144,17 +165,29 @@ export class CondaPackageManager implements IPackageManager {
                     version: latest.version,
                 };
             });
-        } catch {
+        } catch (e) {
+            if (e instanceof vscode.CancellationError) {
+                throw e;
+            }
             // Return empty array if search fails (e.g., no matches)
             return [];
         }
     }
 
-    async searchPackageVersions(name: string): Promise<string[]> {
+    async searchPackageVersions(name: string, token: vscode.CancellationToken): Promise<string[]> {
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+
         await this._ensureConda();
 
         try {
             const result = await this._executeCondaWithOutput(['search', name, '--json']);
+
+            if (token.isCancellationRequested) {
+                throw new vscode.CancellationError();
+            }
+
             const json = parseCondaSearchResult(result);
 
             // Get all unique versions for this package
@@ -167,7 +200,10 @@ export class CondaPackageManager implements IPackageManager {
             const sorted = [...packageInfo].sort((a, b) => b.timestamp - a.timestamp);
             const versions = [...new Set(sorted.map((p) => p.version))];
             return versions;
-        } catch {
+        } catch (e) {
+            if (e instanceof vscode.CancellationError) {
+                throw e;
+            }
             return [];
         }
     }
@@ -224,20 +260,18 @@ export class CondaPackageManager implements IPackageManager {
 
     /**
      * Execute a conda command in the terminal (visible to user).
+     * @param args The conda arguments to execute
+     * @param token Cancellation token
      */
-    private async _executeCondaInTerminal(args: string[]): Promise<void> {
+    private async _executeCondaInTerminal(args: string[], token: vscode.CancellationToken): Promise<void> {
         const condaFile = await this._getCondaFile();
         const terminalService = this._serviceContainer
             .get<ITerminalServiceFactory>(ITerminalServiceFactory)
             .getTerminalService({});
         // Ensure terminal is created and ready before sending command
         await terminalService.show();
-        const tokenSource = new vscode.CancellationTokenSource();
-        try {
-            await terminalService.sendCommand(condaFile, args, tokenSource.token);
-        } finally {
-            tokenSource.dispose();
-        }
+
+        await terminalService.sendCommand(condaFile, args, token);
     }
 
     /**
@@ -250,5 +284,42 @@ export class CondaPackageManager implements IPackageManager {
 
         const result = await processService.exec(condaFile, args);
         return result.stdout;
+    }
+
+    /**
+     * Call a kernel method with cancellation support.
+     * If the token is cancelled, interrupts the kernel (if supported).
+     */
+    private async _callMethod<T>(
+        method: string,
+        token: vscode.CancellationToken,
+        ...args: unknown[]
+    ): Promise<T> {
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+
+        const resultPromise = this._session.callMethod(method, ...args) as Promise<T>;
+
+        // Wrap callMethod promise with cancellation handling
+        return new Promise<T>((resolve, reject) => {
+            const cancelDisp = token.onCancellationRequested(async () => {
+                // Interrupt kernel if supported
+                if (this._session.interrupt) {
+                    await this._session.interrupt();
+                }
+                reject(new vscode.CancellationError());
+            });
+
+            resultPromise
+                .then((result) => {
+                    cancelDisp.dispose();
+                    resolve(result);
+                })
+                .catch((err) => {
+                    cancelDisp.dispose();
+                    reject(err);
+                });
+        });
     }
 }

--- a/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/condaPackageManager.ts
@@ -5,17 +5,11 @@
 
 import * as positron from 'positron';
 import * as vscode from 'vscode';
-import { CancellationTokenSource } from 'vscode';
 import { IProcessServiceFactory } from '../../common/process/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IComponentAdapter, ICondaService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
-
-/** Get a non-cancelling token to use when no token is provided */
-function getNonCancellingToken(): vscode.CancellationToken {
-    return new CancellationTokenSource().token;
-}
 
 /** Package info returned by `conda search --json` */
 interface CondaPackageInfo {
@@ -74,8 +68,7 @@ export class CondaPackageManager implements IPackageManager {
     ) {}
 
     async getPackages(token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        const cancellation = token ?? getNonCancellingToken();
-        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', cancellation);
+        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', token);
     }
 
     /**
@@ -95,8 +88,7 @@ export class CondaPackageManager implements IPackageManager {
             return;
         }
 
-        const cancellation = token ?? getNonCancellingToken();
-        if (cancellation.isCancellationRequested) {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -106,7 +98,7 @@ export class CondaPackageManager implements IPackageManager {
         const envPrefix = await this._getEnvironmentPrefix();
         const args = ['install', '--prefix', envPrefix, '-y', ...packageSpecs];
 
-        await this._executeCondaInTerminal(args, cancellation);
+        await this._executeCondaInTerminal(args, token);
     }
 
     async uninstallPackages(packages: string[], token?: vscode.CancellationToken): Promise<void> {
@@ -114,8 +106,7 @@ export class CondaPackageManager implements IPackageManager {
             return;
         }
 
-        const cancellation = token ?? getNonCancellingToken();
-        if (cancellation.isCancellationRequested) {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -124,7 +115,7 @@ export class CondaPackageManager implements IPackageManager {
         const envPrefix = await this._getEnvironmentPrefix();
         const args = ['remove', '--prefix', envPrefix, '-y', ...packages];
 
-        await this._executeCondaInTerminal(args, cancellation);
+        await this._executeCondaInTerminal(args, token);
     }
 
     async updatePackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
@@ -134,8 +125,7 @@ export class CondaPackageManager implements IPackageManager {
     }
 
     async updateAllPackages(token?: vscode.CancellationToken): Promise<void> {
-        const cancellation = token ?? getNonCancellingToken();
-        if (cancellation.isCancellationRequested) {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -144,12 +134,11 @@ export class CondaPackageManager implements IPackageManager {
         const envPrefix = await this._getEnvironmentPrefix();
         const args = ['update', '--prefix', envPrefix, '--all', '-y'];
 
-        await this._executeCondaInTerminal(args, cancellation);
+        await this._executeCondaInTerminal(args, token);
     }
 
     async searchPackages(query: string, token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        const cancellation = token ?? getNonCancellingToken();
-        if (cancellation.isCancellationRequested) {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -157,7 +146,7 @@ export class CondaPackageManager implements IPackageManager {
 
         try {
             // Use wildcard pattern for partial matching
-            const result = await this._executeCondaWithOutput(['search', `*${query}*`, '--json'], cancellation);
+            const result = await this._executeCondaWithOutput(['search', `*${query}*`, '--json'], token);
             const json = parseCondaSearchResult(result);
 
             // Return unique package names with the latest version (sorted by timestamp)
@@ -181,15 +170,14 @@ export class CondaPackageManager implements IPackageManager {
     }
 
     async searchPackageVersions(name: string, token?: vscode.CancellationToken): Promise<string[]> {
-        const cancellation = token ?? getNonCancellingToken();
-        if (cancellation.isCancellationRequested) {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
         await this._ensureConda();
 
         try {
-            const result = await this._executeCondaWithOutput(['search', name, '--json'], cancellation);
+            const result = await this._executeCondaWithOutput(['search', name, '--json'], token);
             const json = parseCondaSearchResult(result);
 
             // Get all unique versions for this package
@@ -263,9 +251,9 @@ export class CondaPackageManager implements IPackageManager {
     /**
      * Execute a conda command in the terminal (visible to user).
      * @param args The conda arguments to execute
-     * @param token Cancellation token
+     * @param token Optional cancellation token
      */
-    private async _executeCondaInTerminal(args: string[], token: vscode.CancellationToken): Promise<void> {
+    private async _executeCondaInTerminal(args: string[], token?: vscode.CancellationToken): Promise<void> {
         const condaFile = await this._getCondaFile();
         const terminalService = this._serviceContainer
             .get<ITerminalServiceFactory>(ITerminalServiceFactory)
@@ -273,7 +261,7 @@ export class CondaPackageManager implements IPackageManager {
         // Ensure terminal is created and ready before sending command
         await terminalService.show();
 
-        const disposable = token.onCancellationRequested(async () => {
+        const disposable = token?.onCancellationRequested(async () => {
             // Send Ctrl+C to interrupt the running command
             await terminalService.sendText('\x03');
         });
@@ -281,14 +269,14 @@ export class CondaPackageManager implements IPackageManager {
         try {
             await terminalService.sendCommand(condaFile, args, token);
         } finally {
-            disposable.dispose();
+            disposable?.dispose();
         }
     }
 
     /**
      * Execute a conda command and capture stdout.
      */
-    private async _executeCondaWithOutput(args: string[], token: vscode.CancellationToken): Promise<string> {
+    private async _executeCondaWithOutput(args: string[], token?: vscode.CancellationToken): Promise<string> {
         const condaFile = await this._getCondaFile();
         const processServiceFactory = this._serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
         const processService = await processServiceFactory.create();
@@ -301,12 +289,17 @@ export class CondaPackageManager implements IPackageManager {
      * Call a kernel method with cancellation support.
      * If the token is cancelled, interrupts the kernel (if supported).
      */
-    private async _callMethod<T>(method: string, token: vscode.CancellationToken, ...args: unknown[]): Promise<T> {
-        if (token.isCancellationRequested) {
+    private async _callMethod<T>(method: string, token?: vscode.CancellationToken, ...args: unknown[]): Promise<T> {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
         const resultPromise = this._session.callMethod(method, ...args) as Promise<T>;
+
+        // If no token provided, just return the method result
+        if (!token) {
+            return resultPromise;
+        }
 
         // Wrap callMethod promise with cancellation handling
         return new Promise<T>((resolve, reject) => {

--- a/extensions/positron-python/src/client/positron/packages/packageManagerFactory.ts
+++ b/extensions/positron-python/src/client/positron/packages/packageManagerFactory.ts
@@ -7,7 +7,7 @@ import { IServiceContainer } from '../../ioc/types';
 import { EnvironmentType } from '../../pythonEnvironments/info';
 import { CondaPackageManager } from './condaPackageManager';
 import { PipPackageManager } from './pipPackageManager';
-import { IPackageManager, MessageEmitter, PackageKernel } from './types';
+import { IPackageManager, MessageEmitter, PackageSession } from './types';
 import { UvPackageManager } from './uvPackageManager';
 
 /**
@@ -24,7 +24,7 @@ export class PackageManagerFactory {
      * @param pythonPath The path to the Python interpreter
      * @param messageEmitter The emitter for runtime messages
      * @param serviceContainer The service container for dependency injection
-     * @param kernel The kernel for RPC-based package listing
+     * @param session The session for RPC-based package operations
      * @returns The appropriate package manager for the environment
      */
     static create(
@@ -32,22 +32,22 @@ export class PackageManagerFactory {
         pythonPath: string,
         messageEmitter: MessageEmitter,
         serviceContainer: IServiceContainer,
-        kernel: PackageKernel,
+        session: PackageSession,
     ): IPackageManager {
         if (runtimeSource?.toLowerCase() === EnvironmentType.Uv.toLowerCase()) {
-            return new UvPackageManager(pythonPath, messageEmitter, serviceContainer, kernel);
+            return new UvPackageManager(pythonPath, messageEmitter, serviceContainer, session);
         }
 
         if (runtimeSource?.toLowerCase() === EnvironmentType.Conda.toLowerCase()) {
-            return new CondaPackageManager(pythonPath, messageEmitter, serviceContainer, kernel);
+            return new CondaPackageManager(pythonPath, messageEmitter, serviceContainer, session);
         }
 
         if (runtimeSource?.toLowerCase() === EnvironmentType.Venv.toLowerCase()) {
-            return new PipPackageManager(pythonPath, messageEmitter, serviceContainer, kernel);
+            return new PipPackageManager(pythonPath, messageEmitter, serviceContainer, session);
         }
 
         // Default to PipPackageManager for all other environment types
         // This includes Pyenv, Global, System, VirtualEnv, etc.
-        return new PipPackageManager(pythonPath, messageEmitter, serviceContainer, kernel);
+        return new PipPackageManager(pythonPath, messageEmitter, serviceContainer, session);
     }
 }

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -28,8 +28,15 @@ export class PipPackageManager implements IPackageManager {
         private readonly _kernel: PackageKernel,
     ) {}
 
-    async getPackages(): Promise<positron.LanguageRuntimePackage[]> {
-        return this._kernel.callMethod('getPackagesInstalled');
+    async getPackages(token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+        const result = await this._kernel.callMethod('getPackagesInstalled');
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+        return result;
     }
 
     /**
@@ -44,9 +51,13 @@ export class PipPackageManager implements IPackageManager {
         }
     }
 
-    async installPackages(packages: positron.PackageSpec[]): Promise<void> {
+    async installPackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
+        }
+
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
         }
 
         await this._ensurePip();
@@ -55,24 +66,32 @@ export class PipPackageManager implements IPackageManager {
         const flags = await this._getInstallFlags();
         const args = ['install', ...flags, ...packageSpecs];
 
-        await this._executePipInTerminal(args);
+        await this._executePipInTerminal(args, token);
     }
 
-    async uninstallPackages(packages: string[]): Promise<void> {
+    async uninstallPackages(packages: string[], token?: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
+        }
+
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
         }
 
         await this._ensurePip();
 
         const args = ['uninstall', '-y', ...packages];
 
-        await this._executePipInTerminal(args);
+        await this._executePipInTerminal(args, token);
     }
 
-    async updatePackages(packages: positron.PackageSpec[]): Promise<void> {
+    async updatePackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
+        }
+
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
         }
 
         await this._ensurePip();
@@ -81,10 +100,14 @@ export class PipPackageManager implements IPackageManager {
         const flags = await this._getInstallFlags();
         const args = ['install', '--upgrade', ...flags, ...packageSpecs];
 
-        await this._executePipInTerminal(args);
+        await this._executePipInTerminal(args, token);
     }
 
-    async updateAllPackages(): Promise<void> {
+    async updateAllPackages(token?: vscode.CancellationToken): Promise<void> {
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+
         await this._ensurePip();
 
         // First, get list of outdated packages
@@ -96,6 +119,10 @@ export class PipPackageManager implements IPackageManager {
             ['list', '--outdated', '--format=json', ...proxyFlags],
             {},
         );
+
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
 
         let outdatedPackages: Array<{ name: string }> = [];
         try {
@@ -113,15 +140,31 @@ export class PipPackageManager implements IPackageManager {
         const flags = await this._getInstallFlags();
         const args = ['install', '--upgrade', ...flags, ...packageNames];
 
-        await this._executePipInTerminal(args);
+        await this._executePipInTerminal(args, token);
     }
 
-    async searchPackages(query: string): Promise<positron.LanguageRuntimePackage[]> {
-        return searchPyPI(query);
+    async searchPackages(query: string, token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+        // TODO: Pass token to searchPyPI for fetch cancellation
+        const result = await searchPyPI(query);
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+        return result;
     }
 
-    async searchPackageVersions(name: string): Promise<string[]> {
-        return searchPyPIVersions(name);
+    async searchPackageVersions(name: string, token?: vscode.CancellationToken): Promise<string[]> {
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+        // TODO: Pass token to searchPyPIVersions for fetch cancellation
+        const result = await searchPyPIVersions(name);
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+        return result;
     }
 
     // =========================================================================
@@ -181,18 +224,24 @@ export class PipPackageManager implements IPackageManager {
 
     /**
      * Execute a pip command in the terminal (visible to user).
+     * @param args The pip arguments to execute
+     * @param token Optional cancellation token
      */
-    private async _executePipInTerminal(args: string[]): Promise<void> {
+    private async _executePipInTerminal(args: string[], token?: vscode.CancellationToken): Promise<void> {
         const terminalService = this._serviceContainer
             .get<ITerminalServiceFactory>(ITerminalServiceFactory)
             .getTerminalService({});
         // Ensure terminal is created and ready before sending command
         await terminalService.show();
-        const tokenSource = new vscode.CancellationTokenSource();
+
+        // Use external token if provided, otherwise create internal one
+        const tokenSource = token ? undefined : new vscode.CancellationTokenSource();
+        const effectiveToken = token ?? tokenSource!.token;
+
         try {
-            await terminalService.sendCommand(this._pythonPath, ['-m', 'pip', ...args], tokenSource.token);
+            await terminalService.sendCommand(this._pythonPath, ['-m', 'pip', ...args], effectiveToken);
         } finally {
-            tokenSource.dispose();
+            tokenSource?.dispose();
         }
     }
 

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -238,10 +238,8 @@ export class PipPackageManager implements IPackageManager {
         // Wrap callMethod promise with cancellation handling
         return new Promise<T>((resolve, reject) => {
             const cancelDisp = token.onCancellationRequested(async () => {
-                // Interrupt kernel if supported
-                if (this._session.interrupt) {
-                    await this._session.interrupt();
-                }
+                // Interrupt the session via the runtime service
+                await positron.runtime.interruptSession(this._session.metadata.sessionId);
                 reject(new vscode.CancellationError());
             });
 

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -6,11 +6,17 @@
 import { randomUUID } from 'crypto';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
+import { CancellationTokenSource } from 'vscode';
 import { IPythonExecutionFactory, IPythonExecutionService } from '../../common/process/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
+
+/** Get a non-cancelling token to use when no token is provided */
+function getNonCancellingToken(): vscode.CancellationToken {
+    return new CancellationTokenSource().token;
+}
 
 /**
  * Pip Package Manager
@@ -28,8 +34,9 @@ export class PipPackageManager implements IPackageManager {
         private readonly _session: PackageSession,
     ) {}
 
-    async getPackages(token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', token);
+    async getPackages(token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+        const cancellation = token ?? getNonCancellingToken();
+        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', cancellation);
     }
 
     /**
@@ -44,8 +51,9 @@ export class PipPackageManager implements IPackageManager {
         }
     }
 
-    async installPackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void> {
-        if (token.isCancellationRequested) {
+    async installPackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
+        const cancellation = token ?? getNonCancellingToken();
+        if (cancellation.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -59,15 +67,16 @@ export class PipPackageManager implements IPackageManager {
         const flags = await this._getInstallFlags();
         const args = ['install', ...flags, ...packageSpecs];
 
-        await this._executePipInTerminal(args, token);
+        await this._executePipInTerminal(args, cancellation);
     }
 
-    async uninstallPackages(packages: string[], token: vscode.CancellationToken): Promise<void> {
+    async uninstallPackages(packages: string[], token?: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
         }
 
-        if (token.isCancellationRequested) {
+        const cancellation = token ?? getNonCancellingToken();
+        if (cancellation.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -75,15 +84,16 @@ export class PipPackageManager implements IPackageManager {
 
         const args = ['uninstall', '-y', ...packages];
 
-        await this._executePipInTerminal(args, token);
+        await this._executePipInTerminal(args, cancellation);
     }
 
-    async updatePackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void> {
+    async updatePackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
         }
 
-        if (token.isCancellationRequested) {
+        const cancellation = token ?? getNonCancellingToken();
+        if (cancellation.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -93,11 +103,12 @@ export class PipPackageManager implements IPackageManager {
         const flags = await this._getInstallFlags();
         const args = ['install', '--upgrade', ...flags, ...packageSpecs];
 
-        await this._executePipInTerminal(args, token);
+        await this._executePipInTerminal(args, cancellation);
     }
 
-    async updateAllPackages(token: vscode.CancellationToken): Promise<void> {
-        if (token.isCancellationRequested) {
+    async updateAllPackages(token?: vscode.CancellationToken): Promise<void> {
+        const cancellation = token ?? getNonCancellingToken();
+        if (cancellation.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -110,10 +121,10 @@ export class PipPackageManager implements IPackageManager {
         const outdatedResult = await pythonService.execModule(
             'pip',
             ['list', '--outdated', '--format=json', ...proxyFlags],
-            { token },
+            { token: cancellation },
         );
 
-        if (token.isCancellationRequested) {
+        if (cancellation.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -133,15 +144,17 @@ export class PipPackageManager implements IPackageManager {
         const flags = await this._getInstallFlags();
         const args = ['install', '--upgrade', ...flags, ...packageNames];
 
-        await this._executePipInTerminal(args, token);
+        await this._executePipInTerminal(args, cancellation);
     }
 
-    async searchPackages(query: string, token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        return searchPyPI(query, token);
+    async searchPackages(query: string, token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+        const cancellation = token ?? getNonCancellingToken();
+        return searchPyPI(query, cancellation);
     }
 
-    async searchPackageVersions(name: string, token: vscode.CancellationToken): Promise<string[]> {
-        return searchPyPIVersions(name, token);
+    async searchPackageVersions(name: string, token?: vscode.CancellationToken): Promise<string[]> {
+        const cancellation = token ?? getNonCancellingToken();
+        return searchPyPIVersions(name, cancellation);
     }
 
     // =========================================================================

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -6,17 +6,11 @@
 import { randomUUID } from 'crypto';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
-import { CancellationTokenSource } from 'vscode';
 import { IPythonExecutionFactory, IPythonExecutionService } from '../../common/process/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
-
-/** Get a non-cancelling token to use when no token is provided */
-function getNonCancellingToken(): vscode.CancellationToken {
-    return new CancellationTokenSource().token;
-}
 
 /**
  * Pip Package Manager
@@ -35,8 +29,7 @@ export class PipPackageManager implements IPackageManager {
     ) {}
 
     async getPackages(token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        const cancellation = token ?? getNonCancellingToken();
-        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', cancellation);
+        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', token);
     }
 
     /**
@@ -52,8 +45,7 @@ export class PipPackageManager implements IPackageManager {
     }
 
     async installPackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
-        const cancellation = token ?? getNonCancellingToken();
-        if (cancellation.isCancellationRequested) {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -67,7 +59,7 @@ export class PipPackageManager implements IPackageManager {
         const flags = await this._getInstallFlags();
         const args = ['install', ...flags, ...packageSpecs];
 
-        await this._executePipInTerminal(args, cancellation);
+        await this._executePipInTerminal(args, token);
     }
 
     async uninstallPackages(packages: string[], token?: vscode.CancellationToken): Promise<void> {
@@ -75,8 +67,7 @@ export class PipPackageManager implements IPackageManager {
             return;
         }
 
-        const cancellation = token ?? getNonCancellingToken();
-        if (cancellation.isCancellationRequested) {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -84,7 +75,7 @@ export class PipPackageManager implements IPackageManager {
 
         const args = ['uninstall', '-y', ...packages];
 
-        await this._executePipInTerminal(args, cancellation);
+        await this._executePipInTerminal(args, token);
     }
 
     async updatePackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
@@ -92,8 +83,7 @@ export class PipPackageManager implements IPackageManager {
             return;
         }
 
-        const cancellation = token ?? getNonCancellingToken();
-        if (cancellation.isCancellationRequested) {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -103,12 +93,11 @@ export class PipPackageManager implements IPackageManager {
         const flags = await this._getInstallFlags();
         const args = ['install', '--upgrade', ...flags, ...packageSpecs];
 
-        await this._executePipInTerminal(args, cancellation);
+        await this._executePipInTerminal(args, token);
     }
 
     async updateAllPackages(token?: vscode.CancellationToken): Promise<void> {
-        const cancellation = token ?? getNonCancellingToken();
-        if (cancellation.isCancellationRequested) {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -121,10 +110,10 @@ export class PipPackageManager implements IPackageManager {
         const outdatedResult = await pythonService.execModule(
             'pip',
             ['list', '--outdated', '--format=json', ...proxyFlags],
-            { token: cancellation },
+            { token },
         );
 
-        if (cancellation.isCancellationRequested) {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -144,17 +133,15 @@ export class PipPackageManager implements IPackageManager {
         const flags = await this._getInstallFlags();
         const args = ['install', '--upgrade', ...flags, ...packageNames];
 
-        await this._executePipInTerminal(args, cancellation);
+        await this._executePipInTerminal(args, token);
     }
 
     async searchPackages(query: string, token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        const cancellation = token ?? getNonCancellingToken();
-        return searchPyPI(query, cancellation);
+        return searchPyPI(query, token);
     }
 
     async searchPackageVersions(name: string, token?: vscode.CancellationToken): Promise<string[]> {
-        const cancellation = token ?? getNonCancellingToken();
-        return searchPyPIVersions(name, cancellation);
+        return searchPyPIVersions(name, token);
     }
 
     // =========================================================================
@@ -215,16 +202,16 @@ export class PipPackageManager implements IPackageManager {
     /**
      * Execute a pip command in the terminal (visible to user).
      * @param args The pip arguments to execute
-     * @param token Cancellation token
+     * @param token Optional cancellation token
      */
-    private async _executePipInTerminal(args: string[], token: vscode.CancellationToken): Promise<void> {
+    private async _executePipInTerminal(args: string[], token?: vscode.CancellationToken): Promise<void> {
         const terminalService = this._serviceContainer
             .get<ITerminalServiceFactory>(ITerminalServiceFactory)
             .getTerminalService({});
         // Ensure terminal is created and ready before sending command
         await terminalService.show();
 
-        const disposable = token.onCancellationRequested(async () => {
+        const disposable = token?.onCancellationRequested(async () => {
             // Send Ctrl+C to interrupt the running command
             await terminalService.sendText('\x03');
         });
@@ -232,7 +219,7 @@ export class PipPackageManager implements IPackageManager {
         try {
             await terminalService.sendCommand(this._pythonPath, ['-m', 'pip', ...args], token);
         } finally {
-            disposable.dispose();
+            disposable?.dispose();
         }
     }
 
@@ -240,12 +227,17 @@ export class PipPackageManager implements IPackageManager {
      * Call a kernel method with cancellation support.
      * If the token is cancelled, interrupts the kernel (if supported).
      */
-    private async _callMethod<T>(method: string, token: vscode.CancellationToken, ...args: unknown[]): Promise<T> {
-        if (token.isCancellationRequested) {
+    private async _callMethod<T>(method: string, token?: vscode.CancellationToken, ...args: unknown[]): Promise<T> {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
         const resultPromise = this._session.callMethod(method, ...args) as Promise<T>;
+
+        // If no token provided, just return the method result
+        if (!token) {
+            return resultPromise;
+        }
 
         // Wrap callMethod promise with cancellation handling
         return new Promise<T>((resolve, reject) => {

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -10,7 +10,7 @@ import { IPythonExecutionFactory, IPythonExecutionService } from '../../common/p
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
-import { IPackageManager, MessageEmitter, PackageKernel } from './types';
+import { IPackageManager, MessageEmitter, PackageSession } from './types';
 
 /**
  * Pip Package Manager
@@ -25,18 +25,11 @@ export class PipPackageManager implements IPackageManager {
         private readonly _pythonPath: string,
         private readonly _messageEmitter: MessageEmitter,
         private readonly _serviceContainer: IServiceContainer,
-        private readonly _kernel: PackageKernel,
-    ) {}
+        private readonly _session: PackageSession,
+    ) { }
 
-    async getPackages(token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        if (token?.isCancellationRequested) {
-            throw new vscode.CancellationError();
-        }
-        const result = await this._kernel.callMethod('getPackagesInstalled');
-        if (token?.isCancellationRequested) {
-            throw new vscode.CancellationError();
-        }
-        return result;
+    async getPackages(token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', token);
     }
 
     /**
@@ -51,13 +44,13 @@ export class PipPackageManager implements IPackageManager {
         }
     }
 
-    async installPackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
-        if (packages.length === 0) {
-            return;
+    async installPackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void> {
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
         }
 
-        if (token?.isCancellationRequested) {
-            throw new vscode.CancellationError();
+        if (packages.length === 0) {
+            return;
         }
 
         await this._ensurePip();
@@ -69,12 +62,12 @@ export class PipPackageManager implements IPackageManager {
         await this._executePipInTerminal(args, token);
     }
 
-    async uninstallPackages(packages: string[], token?: vscode.CancellationToken): Promise<void> {
+    async uninstallPackages(packages: string[], token: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
         }
 
-        if (token?.isCancellationRequested) {
+        if (token.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -85,12 +78,12 @@ export class PipPackageManager implements IPackageManager {
         await this._executePipInTerminal(args, token);
     }
 
-    async updatePackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
+    async updatePackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
         }
 
-        if (token?.isCancellationRequested) {
+        if (token.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -103,8 +96,8 @@ export class PipPackageManager implements IPackageManager {
         await this._executePipInTerminal(args, token);
     }
 
-    async updateAllPackages(token?: vscode.CancellationToken): Promise<void> {
-        if (token?.isCancellationRequested) {
+    async updateAllPackages(token: vscode.CancellationToken): Promise<void> {
+        if (token.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -117,10 +110,10 @@ export class PipPackageManager implements IPackageManager {
         const outdatedResult = await pythonService.execModule(
             'pip',
             ['list', '--outdated', '--format=json', ...proxyFlags],
-            {},
+            { token },
         );
 
-        if (token?.isCancellationRequested) {
+        if (token.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -143,28 +136,12 @@ export class PipPackageManager implements IPackageManager {
         await this._executePipInTerminal(args, token);
     }
 
-    async searchPackages(query: string, token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        if (token?.isCancellationRequested) {
-            throw new vscode.CancellationError();
-        }
-        // TODO: Pass token to searchPyPI for fetch cancellation
-        const result = await searchPyPI(query);
-        if (token?.isCancellationRequested) {
-            throw new vscode.CancellationError();
-        }
-        return result;
+    async searchPackages(query: string, token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+        return searchPyPI(query, token);
     }
 
-    async searchPackageVersions(name: string, token?: vscode.CancellationToken): Promise<string[]> {
-        if (token?.isCancellationRequested) {
-            throw new vscode.CancellationError();
-        }
-        // TODO: Pass token to searchPyPIVersions for fetch cancellation
-        const result = await searchPyPIVersions(name);
-        if (token?.isCancellationRequested) {
-            throw new vscode.CancellationError();
-        }
-        return result;
+    async searchPackageVersions(name: string, token: vscode.CancellationToken): Promise<string[]> {
+        return searchPyPIVersions(name, token);
     }
 
     // =========================================================================
@@ -190,7 +167,7 @@ export class PipPackageManager implements IPackageManager {
         if (!hasPip) {
             throw new Error(
                 'pip is not available in this Python environment. ' +
-                    'Please install pip to use package management features.',
+                'Please install pip to use package management features.',
             );
         }
     }
@@ -225,24 +202,62 @@ export class PipPackageManager implements IPackageManager {
     /**
      * Execute a pip command in the terminal (visible to user).
      * @param args The pip arguments to execute
-     * @param token Optional cancellation token
+     * @param token Cancellation token
      */
-    private async _executePipInTerminal(args: string[], token?: vscode.CancellationToken): Promise<void> {
+    private async _executePipInTerminal(args: string[], token: vscode.CancellationToken): Promise<void> {
         const terminalService = this._serviceContainer
             .get<ITerminalServiceFactory>(ITerminalServiceFactory)
             .getTerminalService({});
         // Ensure terminal is created and ready before sending command
         await terminalService.show();
 
-        // Use external token if provided, otherwise create internal one
-        const tokenSource = token ? undefined : new vscode.CancellationTokenSource();
-        const effectiveToken = token ?? tokenSource!.token;
+        const disposable = token.onCancellationRequested(async () => {
+            // Send Ctrl+C to interrupt the running command
+            await terminalService.sendText('\x03');
+        });
 
         try {
-            await terminalService.sendCommand(this._pythonPath, ['-m', 'pip', ...args], effectiveToken);
+            await terminalService.sendCommand(this._pythonPath, ['-m', 'pip', ...args], token);
         } finally {
-            tokenSource?.dispose();
+            disposable.dispose();
         }
+    }
+
+    /**
+     * Call a kernel method with cancellation support.
+     * If the token is cancelled, interrupts the kernel (if supported).
+     */
+    private async _callMethod<T>(
+        method: string,
+        token: vscode.CancellationToken,
+        ...args: unknown[]
+    ): Promise<T> {
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+
+        const resultPromise = this._session.callMethod(method, ...args) as Promise<T>;
+
+        // Wrap callMethod promise with cancellation handling
+        return new Promise<T>((resolve, reject) => {
+            const cancelDisp = token.onCancellationRequested(async () => {
+                // Interrupt kernel if supported
+                if (this._session.interrupt) {
+                    await this._session.interrupt();
+                }
+                reject(new vscode.CancellationError());
+            });
+
+            resultPromise
+                .then((result) => {
+                    cancelDisp.dispose();
+                    resolve(result);
+                })
+                .catch((err) => {
+                    cancelDisp.dispose();
+                    reject(err);
+                });
+        });
     }
 
     /**

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -26,7 +26,7 @@ export class PipPackageManager implements IPackageManager {
         private readonly _messageEmitter: MessageEmitter,
         private readonly _serviceContainer: IServiceContainer,
         private readonly _session: PackageSession,
-    ) { }
+    ) {}
 
     async getPackages(token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
         return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', token);
@@ -167,7 +167,7 @@ export class PipPackageManager implements IPackageManager {
         if (!hasPip) {
             throw new Error(
                 'pip is not available in this Python environment. ' +
-                'Please install pip to use package management features.',
+                    'Please install pip to use package management features.',
             );
         }
     }
@@ -227,11 +227,7 @@ export class PipPackageManager implements IPackageManager {
      * Call a kernel method with cancellation support.
      * If the token is cancelled, interrupts the kernel (if supported).
      */
-    private async _callMethod<T>(
-        method: string,
-        token: vscode.CancellationToken,
-        ...args: unknown[]
-    ): Promise<T> {
+    private async _callMethod<T>(method: string, token: vscode.CancellationToken, ...args: unknown[]): Promise<T> {
         if (token.isCancellationRequested) {
             throw new vscode.CancellationError();
         }

--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -113,10 +113,6 @@ export class PipPackageManager implements IPackageManager {
             { token },
         );
 
-        if (token?.isCancellationRequested) {
-            throw new vscode.CancellationError();
-        }
-
         let outdatedPackages: Array<{ name: string }> = [];
         try {
             outdatedPackages = JSON.parse(outdatedResult.stdout);

--- a/extensions/positron-python/src/client/positron/packages/pypiSearch.ts
+++ b/extensions/positron-python/src/client/positron/packages/pypiSearch.ts
@@ -4,36 +4,68 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as positron from 'positron';
+import * as vscode from 'vscode';
+
+/**
+ * Create an AbortSignal from a CancellationToken for use with fetch.
+ */
+function createAbortSignal(token: vscode.CancellationToken): AbortSignal {
+    const controller = new AbortController();
+    token.onCancellationRequested(() => controller.abort());
+    return controller.signal;
+}
 
 /**
  * Search PyPI for packages matching a query.
  */
-export async function searchPyPI(query: string): Promise<positron.LanguageRuntimePackage[]> {
-    const response = await fetch('https://pypi.org/simple/', {
-        headers: { Accept: 'application/vnd.pypi.simple.v1+json' },
-    });
-    const json = (await response.json()) as {
-        projects: { name: string }[];
-    };
+export async function searchPyPI(
+    query: string,
+    token: vscode.CancellationToken,
+): Promise<positron.LanguageRuntimePackage[]> {
+    try {
+        const response = await fetch('https://pypi.org/simple/', {
+            headers: { Accept: 'application/vnd.pypi.simple.v1+json' },
+            signal: createAbortSignal(token),
+        });
+        const json = (await response.json()) as {
+            projects: { name: string }[];
+        };
 
-    return json.projects
-        .map((x) => x.name)
-        .filter((x) => x.includes(query))
-        .map((x) => ({
-            id: x,
-            name: x,
-            displayName: x,
-            version: '0',
-        }));
+        return json.projects
+            .map((x) => x.name)
+            .filter((x) => x.includes(query))
+            .map((x) => ({
+                id: x,
+                name: x,
+                displayName: x,
+                version: '0',
+            }));
+    } catch (e) {
+        if (e instanceof Error && e.name === 'AbortError') {
+            throw new vscode.CancellationError();
+        }
+        throw e;
+    }
 }
 
 /**
  * Search PyPI for available versions of a specific package.
  */
-export async function searchPyPIVersions(name: string): Promise<string[]> {
-    const response = await fetch(`https://pypi.org/simple/${name}/`, {
-        headers: { Accept: 'application/vnd.pypi.simple.v1+json' },
-    });
-    const json = (await response.json()) as { versions: string[] };
-    return json.versions;
+export async function searchPyPIVersions(
+    name: string,
+    token: vscode.CancellationToken,
+): Promise<string[]> {
+    try {
+        const response = await fetch(`https://pypi.org/simple/${name}/`, {
+            headers: { Accept: 'application/vnd.pypi.simple.v1+json' },
+            signal: createAbortSignal(token),
+        });
+        const json = (await response.json()) as { versions: string[] };
+        return json.versions;
+    } catch (e) {
+        if (e instanceof Error && e.name === 'AbortError') {
+            throw new vscode.CancellationError();
+        }
+        throw e;
+    }
 }

--- a/extensions/positron-python/src/client/positron/packages/pypiSearch.ts
+++ b/extensions/positron-python/src/client/positron/packages/pypiSearch.ts
@@ -51,10 +51,7 @@ export async function searchPyPI(
 /**
  * Search PyPI for available versions of a specific package.
  */
-export async function searchPyPIVersions(
-    name: string,
-    token: vscode.CancellationToken,
-): Promise<string[]> {
+export async function searchPyPIVersions(name: string, token: vscode.CancellationToken): Promise<string[]> {
     try {
         const response = await fetch(`https://pypi.org/simple/${name}/`, {
             headers: { Accept: 'application/vnd.pypi.simple.v1+json' },

--- a/extensions/positron-python/src/client/positron/packages/pypiSearch.ts
+++ b/extensions/positron-python/src/client/positron/packages/pypiSearch.ts
@@ -9,7 +9,10 @@ import * as vscode from 'vscode';
 /**
  * Create an AbortSignal from a CancellationToken for use with fetch.
  */
-function createAbortSignal(token: vscode.CancellationToken): AbortSignal {
+function createAbortSignal(token?: vscode.CancellationToken): AbortSignal | undefined {
+    if (!token) {
+        return undefined;
+    }
     const controller = new AbortController();
     token.onCancellationRequested(() => controller.abort());
     return controller.signal;
@@ -20,7 +23,7 @@ function createAbortSignal(token: vscode.CancellationToken): AbortSignal {
  */
 export async function searchPyPI(
     query: string,
-    token: vscode.CancellationToken,
+    token?: vscode.CancellationToken,
 ): Promise<positron.LanguageRuntimePackage[]> {
     try {
         const response = await fetch('https://pypi.org/simple/', {
@@ -51,7 +54,7 @@ export async function searchPyPI(
 /**
  * Search PyPI for available versions of a specific package.
  */
-export async function searchPyPIVersions(name: string, token: vscode.CancellationToken): Promise<string[]> {
+export async function searchPyPIVersions(name: string, token?: vscode.CancellationToken): Promise<string[]> {
     try {
         const response = await fetch(`https://pypi.org/simple/${name}/`, {
             headers: { Accept: 'application/vnd.pypi.simple.v1+json' },

--- a/extensions/positron-python/src/client/positron/packages/types.ts
+++ b/extensions/positron-python/src/client/positron/packages/types.ts
@@ -17,10 +17,10 @@ export interface MessageEmitter {
  * Interface for a session that supports RPC method calls.
  */
 export interface PackageSession {
+    /** Session metadata containing the session ID */
+    metadata: { sessionId: string };
     /** Call an RPC method on the session */
     callMethod(method: string, ...args: unknown[]): Thenable<unknown>;
-    /** Interrupt the session. Optional - not all sessions support this. */
-    interrupt?(): Thenable<void>;
 }
 
 /**

--- a/extensions/positron-python/src/client/positron/packages/types.ts
+++ b/extensions/positron-python/src/client/positron/packages/types.ts
@@ -31,51 +31,51 @@ export interface PackageSession {
 export interface IPackageManager {
     /**
      * Get list of installed packages.
-     * @param token Cancellation token
+     * @param token Optional cancellation token
      * @returns Array of installed packages
      */
-    getPackages(token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]>;
+    getPackages(token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]>;
 
     /**
      * Install one or more packages.
      * @param packages Array of package install requests with name and optional version
-     * @param token Cancellation token
+     * @param token Optional cancellation token
      */
-    installPackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void>;
+    installPackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void>;
 
     /**
      * Uninstall one or more packages.
      * @param packages Array of package names to uninstall
-     * @param token Cancellation token
+     * @param token Optional cancellation token
      */
-    uninstallPackages(packages: string[], token: vscode.CancellationToken): Promise<void>;
+    uninstallPackages(packages: string[], token?: vscode.CancellationToken): Promise<void>;
 
     /**
      * Update specific packages to latest versions.
      * @param packages Array of package install requests with name and optional version
-     * @param token Cancellation token
+     * @param token Optional cancellation token
      */
-    updatePackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void>;
+    updatePackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void>;
 
     /**
      * Update all installed packages to their latest versions.
-     * @param token Cancellation token
+     * @param token Optional cancellation token
      */
-    updateAllPackages(token: vscode.CancellationToken): Promise<void>;
+    updateAllPackages(token?: vscode.CancellationToken): Promise<void>;
 
     /**
      * Search for packages matching a query.
      * @param query Search query string
-     * @param token Cancellation token
+     * @param token Optional cancellation token
      * @returns Array of matching packages
      */
-    searchPackages(query: string, token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]>;
+    searchPackages(query: string, token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]>;
 
     /**
      * Search for available versions of a specific package.
      * @param name Package name
-     * @param token Cancellation token
+     * @param token Optional cancellation token
      * @returns Array of version strings
      */
-    searchPackageVersions(name: string, token: vscode.CancellationToken): Promise<string[]>;
+    searchPackageVersions(name: string, token?: vscode.CancellationToken): Promise<string[]>;
 }

--- a/extensions/positron-python/src/client/positron/packages/types.ts
+++ b/extensions/positron-python/src/client/positron/packages/types.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as positron from 'positron';
+import * as vscode from 'vscode';
 
 /**
  * Interface for emitting messages to the Positron console
@@ -13,10 +14,13 @@ export interface MessageEmitter {
 }
 
 /**
- * Interface for a kernel that can list installed packages via RPC.
+ * Interface for a session that supports RPC method calls.
  */
-export interface PackageKernel {
-    callMethod(method: 'getPackagesInstalled'): Promise<positron.LanguageRuntimePackage[]>;
+export interface PackageSession {
+    /** Call an RPC method on the session */
+    callMethod(method: string, ...args: unknown[]): Thenable<unknown>;
+    /** Interrupt the session. Optional - not all sessions support this. */
+    interrupt?(): Thenable<void>;
 }
 
 /**
@@ -27,44 +31,51 @@ export interface PackageKernel {
 export interface IPackageManager {
     /**
      * Get list of installed packages.
+     * @param token Cancellation token
      * @returns Array of installed packages
      */
-    getPackages(): Promise<positron.LanguageRuntimePackage[]>;
+    getPackages(token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]>;
 
     /**
      * Install one or more packages.
      * @param packages Array of package install requests with name and optional version
+     * @param token Cancellation token
      */
-    installPackages(packages: positron.PackageSpec[]): Promise<void>;
+    installPackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void>;
 
     /**
      * Uninstall one or more packages.
      * @param packages Array of package names to uninstall
+     * @param token Cancellation token
      */
-    uninstallPackages(packages: string[]): Promise<void>;
+    uninstallPackages(packages: string[], token: vscode.CancellationToken): Promise<void>;
 
     /**
      * Update specific packages to latest versions.
      * @param packages Array of package install requests with name and optional version
+     * @param token Cancellation token
      */
-    updatePackages(packages: positron.PackageSpec[]): Promise<void>;
+    updatePackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void>;
 
     /**
      * Update all installed packages to their latest versions.
+     * @param token Cancellation token
      */
-    updateAllPackages(): Promise<void>;
+    updateAllPackages(token: vscode.CancellationToken): Promise<void>;
 
     /**
      * Search for packages matching a query.
      * @param query Search query string
+     * @param token Cancellation token
      * @returns Array of matching packages
      */
-    searchPackages(query: string): Promise<positron.LanguageRuntimePackage[]>;
+    searchPackages(query: string, token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]>;
 
     /**
      * Search for available versions of a specific package.
      * @param name Package name
+     * @param token Cancellation token
      * @returns Array of version strings
      */
-    searchPackageVersions(name: string): Promise<string[]>;
+    searchPackageVersions(name: string, token: vscode.CancellationToken): Promise<string[]>;
 }

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -138,10 +138,6 @@ export class UvPackageManager implements IPackageManager {
             // Environment workflow: get outdated packages and upgrade them
             const outdatedPackages = await this._getOutdatedPackages(token);
 
-            if (token?.isCancellationRequested) {
-                throw new vscode.CancellationError();
-            }
-
             if (outdatedPackages.length === 0) {
                 this._emitMessage('All packages are up to date.\n');
                 return;

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -7,7 +7,6 @@ import { randomUUID } from 'crypto';
 import * as path from 'path';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
-import { CancellationTokenSource } from 'vscode';
 import { IWorkspaceService } from '../../common/application/types';
 import { IFileSystem } from '../../common/platform/types';
 import { IProcessServiceFactory } from '../../common/process/types';
@@ -16,11 +15,6 @@ import { IServiceContainer } from '../../ioc/types';
 import { isUvInstalled } from '../../pythonEnvironments/common/environmentManagers/uv';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
-
-/** Get a non-cancelling token to use when no token is provided */
-function getNonCancellingToken(): vscode.CancellationToken {
-    return new CancellationTokenSource().token;
-}
 
 /**
  * uv Package Manager
@@ -39,8 +33,7 @@ export class UvPackageManager implements IPackageManager {
     ) {}
 
     async getPackages(token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        const cancellation = token ?? getNonCancellingToken();
-        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', cancellation);
+        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', token);
     }
 
     /**
@@ -59,8 +52,7 @@ export class UvPackageManager implements IPackageManager {
             return;
         }
 
-        const cancellation = token ?? getNonCancellingToken();
-        if (cancellation.isCancellationRequested) {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -72,11 +64,11 @@ export class UvPackageManager implements IPackageManager {
         if (useProjectWorkflow) {
             // Project workflow: uv add --active --python <path> <packages>
             const args = ['add', '--active', '--python', this._pythonPath, ...packageSpecs];
-            await this._executeUvInTerminal(args, cancellation);
+            await this._executeUvInTerminal(args, token);
         } else {
             // Environment workflow: uv pip install --python <path> <packages>
             const args = ['pip', 'install', '--python', this._pythonPath, ...packageSpecs];
-            await this._executeUvInTerminal(args, cancellation);
+            await this._executeUvInTerminal(args, token);
         }
     }
 
@@ -85,8 +77,7 @@ export class UvPackageManager implements IPackageManager {
             return;
         }
 
-        const cancellation = token ?? getNonCancellingToken();
-        if (cancellation.isCancellationRequested) {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -97,11 +88,11 @@ export class UvPackageManager implements IPackageManager {
         if (useProjectWorkflow) {
             // Project workflow: uv remove --active --python <path> <packages>
             const args = ['remove', '--active', '--python', this._pythonPath, ...packages];
-            await this._executeUvInTerminal(args, cancellation);
+            await this._executeUvInTerminal(args, token);
         } else {
             // Environment workflow: uv pip uninstall --python <path> <packages>
             const args = ['pip', 'uninstall', '--python', this._pythonPath, ...packages];
-            await this._executeUvInTerminal(args, cancellation);
+            await this._executeUvInTerminal(args, token);
         }
     }
 
@@ -110,8 +101,7 @@ export class UvPackageManager implements IPackageManager {
             return;
         }
 
-        const cancellation = token ?? getNonCancellingToken();
-        if (cancellation.isCancellationRequested) {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -123,17 +113,16 @@ export class UvPackageManager implements IPackageManager {
         if (useProjectWorkflow) {
             // Project workflow: uv add --upgrade --active --python <path> <packages>
             const args = ['add', '--upgrade', '--active', '--python', this._pythonPath, ...packageSpecs];
-            await this._executeUvInTerminal(args, cancellation);
+            await this._executeUvInTerminal(args, token);
         } else {
             // Environment workflow: uv pip install --upgrade --python <path> <packages>
             const args = ['pip', 'install', '--upgrade', '--python', this._pythonPath, ...packageSpecs];
-            await this._executeUvInTerminal(args, cancellation);
+            await this._executeUvInTerminal(args, token);
         }
     }
 
     async updateAllPackages(token?: vscode.CancellationToken): Promise<void> {
-        const cancellation = token ?? getNonCancellingToken();
-        if (cancellation.isCancellationRequested) {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -144,12 +133,12 @@ export class UvPackageManager implements IPackageManager {
         if (useProjectWorkflow) {
             // Project workflow: uv sync --upgrade --active --python <path>
             const args = ['sync', '--upgrade', '--active', '--python', this._pythonPath];
-            await this._executeUvInTerminal(args, cancellation);
+            await this._executeUvInTerminal(args, token);
         } else {
             // Environment workflow: get outdated packages and upgrade them
-            const outdatedPackages = await this._getOutdatedPackages(cancellation);
+            const outdatedPackages = await this._getOutdatedPackages(token);
 
-            if (cancellation.isCancellationRequested) {
+            if (token?.isCancellationRequested) {
                 throw new vscode.CancellationError();
             }
 
@@ -160,18 +149,16 @@ export class UvPackageManager implements IPackageManager {
 
             const packageNames = outdatedPackages.map((pkg) => pkg.name);
             const args = ['pip', 'install', '--upgrade', '--python', this._pythonPath, ...packageNames];
-            await this._executeUvInTerminal(args, cancellation);
+            await this._executeUvInTerminal(args, token);
         }
     }
 
     async searchPackages(query: string, token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        const cancellation = token ?? getNonCancellingToken();
-        return searchPyPI(query, cancellation);
+        return searchPyPI(query, token);
     }
 
     async searchPackageVersions(name: string, token?: vscode.CancellationToken): Promise<string[]> {
-        const cancellation = token ?? getNonCancellingToken();
-        return searchPyPIVersions(name, cancellation);
+        return searchPyPIVersions(name, token);
     }
 
     // =========================================================================
@@ -247,7 +234,7 @@ export class UvPackageManager implements IPackageManager {
     /**
      * Get list of outdated packages using uv pip list.
      */
-    private async _getOutdatedPackages(token: vscode.CancellationToken): Promise<Array<{ name: string }>> {
+    private async _getOutdatedPackages(token?: vscode.CancellationToken): Promise<Array<{ name: string }>> {
         const processServiceFactory = this._serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
         const processService = await processServiceFactory.create();
         const proxyEnv = this._getProxyEnv();
@@ -295,9 +282,9 @@ export class UvPackageManager implements IPackageManager {
     /**
      * Execute a uv command in the terminal (visible to user).
      * @param args The uv arguments to execute
-     * @param token Cancellation token
+     * @param token Optional cancellation token
      */
-    private async _executeUvInTerminal(args: string[], token: vscode.CancellationToken): Promise<void> {
+    private async _executeUvInTerminal(args: string[], token?: vscode.CancellationToken): Promise<void> {
         const proxyEnv = this._getProxyEnv();
         const terminalService = this._serviceContainer
             .get<ITerminalServiceFactory>(ITerminalServiceFactory)
@@ -305,7 +292,7 @@ export class UvPackageManager implements IPackageManager {
         // Ensure terminal is created and ready before sending command
         await terminalService.show();
 
-        const disposable = token.onCancellationRequested(async () => {
+        const disposable = token?.onCancellationRequested(async () => {
             // Send Ctrl+C to interrupt the running command
             await terminalService.sendText('\x03');
         });
@@ -313,7 +300,7 @@ export class UvPackageManager implements IPackageManager {
         try {
             await terminalService.sendCommand('uv', args, token);
         } finally {
-            disposable.dispose();
+            disposable?.dispose();
         }
     }
 
@@ -321,12 +308,17 @@ export class UvPackageManager implements IPackageManager {
      * Call a kernel method with cancellation support.
      * If the token is cancelled, interrupts the kernel (if supported).
      */
-    private async _callMethod<T>(method: string, token: vscode.CancellationToken, ...args: unknown[]): Promise<T> {
-        if (token.isCancellationRequested) {
+    private async _callMethod<T>(method: string, token?: vscode.CancellationToken, ...args: unknown[]): Promise<T> {
+        if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
         const resultPromise = this._session.callMethod(method, ...args) as Promise<T>;
+
+        // If no token provided, just return the method result
+        if (!token) {
+            return resultPromise;
+        }
 
         // Wrap callMethod promise with cancellation handling
         return new Promise<T>((resolve, reject) => {

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -308,11 +308,7 @@ export class UvPackageManager implements IPackageManager {
      * Call a kernel method with cancellation support.
      * If the token is cancelled, interrupts the kernel (if supported).
      */
-    private async _callMethod<T>(
-        method: string,
-        token: vscode.CancellationToken,
-        ...args: unknown[]
-    ): Promise<T> {
+    private async _callMethod<T>(method: string, token: vscode.CancellationToken, ...args: unknown[]): Promise<T> {
         if (token.isCancellationRequested) {
             throw new vscode.CancellationError();
         }

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -7,6 +7,7 @@ import { randomUUID } from 'crypto';
 import * as path from 'path';
 import * as positron from 'positron';
 import * as vscode from 'vscode';
+import { CancellationTokenSource } from 'vscode';
 import { IWorkspaceService } from '../../common/application/types';
 import { IFileSystem } from '../../common/platform/types';
 import { IProcessServiceFactory } from '../../common/process/types';
@@ -15,6 +16,11 @@ import { IServiceContainer } from '../../ioc/types';
 import { isUvInstalled } from '../../pythonEnvironments/common/environmentManagers/uv';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
 import { IPackageManager, MessageEmitter, PackageSession } from './types';
+
+/** Get a non-cancelling token to use when no token is provided */
+function getNonCancellingToken(): vscode.CancellationToken {
+    return new CancellationTokenSource().token;
+}
 
 /**
  * uv Package Manager
@@ -32,8 +38,9 @@ export class UvPackageManager implements IPackageManager {
         private readonly _session: PackageSession,
     ) {}
 
-    async getPackages(token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', token);
+    async getPackages(token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+        const cancellation = token ?? getNonCancellingToken();
+        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', cancellation);
     }
 
     /**
@@ -47,12 +54,13 @@ export class UvPackageManager implements IPackageManager {
         }
     }
 
-    async installPackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void> {
+    async installPackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
         }
 
-        if (token.isCancellationRequested) {
+        const cancellation = token ?? getNonCancellingToken();
+        if (cancellation.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -64,20 +72,21 @@ export class UvPackageManager implements IPackageManager {
         if (useProjectWorkflow) {
             // Project workflow: uv add --active --python <path> <packages>
             const args = ['add', '--active', '--python', this._pythonPath, ...packageSpecs];
-            await this._executeUvInTerminal(args, token);
+            await this._executeUvInTerminal(args, cancellation);
         } else {
             // Environment workflow: uv pip install --python <path> <packages>
             const args = ['pip', 'install', '--python', this._pythonPath, ...packageSpecs];
-            await this._executeUvInTerminal(args, token);
+            await this._executeUvInTerminal(args, cancellation);
         }
     }
 
-    async uninstallPackages(packages: string[], token: vscode.CancellationToken): Promise<void> {
+    async uninstallPackages(packages: string[], token?: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
         }
 
-        if (token.isCancellationRequested) {
+        const cancellation = token ?? getNonCancellingToken();
+        if (cancellation.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -88,20 +97,21 @@ export class UvPackageManager implements IPackageManager {
         if (useProjectWorkflow) {
             // Project workflow: uv remove --active --python <path> <packages>
             const args = ['remove', '--active', '--python', this._pythonPath, ...packages];
-            await this._executeUvInTerminal(args, token);
+            await this._executeUvInTerminal(args, cancellation);
         } else {
             // Environment workflow: uv pip uninstall --python <path> <packages>
             const args = ['pip', 'uninstall', '--python', this._pythonPath, ...packages];
-            await this._executeUvInTerminal(args, token);
+            await this._executeUvInTerminal(args, cancellation);
         }
     }
 
-    async updatePackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void> {
+    async updatePackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
         }
 
-        if (token.isCancellationRequested) {
+        const cancellation = token ?? getNonCancellingToken();
+        if (cancellation.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -113,16 +123,17 @@ export class UvPackageManager implements IPackageManager {
         if (useProjectWorkflow) {
             // Project workflow: uv add --upgrade --active --python <path> <packages>
             const args = ['add', '--upgrade', '--active', '--python', this._pythonPath, ...packageSpecs];
-            await this._executeUvInTerminal(args, token);
+            await this._executeUvInTerminal(args, cancellation);
         } else {
             // Environment workflow: uv pip install --upgrade --python <path> <packages>
             const args = ['pip', 'install', '--upgrade', '--python', this._pythonPath, ...packageSpecs];
-            await this._executeUvInTerminal(args, token);
+            await this._executeUvInTerminal(args, cancellation);
         }
     }
 
-    async updateAllPackages(token: vscode.CancellationToken): Promise<void> {
-        if (token.isCancellationRequested) {
+    async updateAllPackages(token?: vscode.CancellationToken): Promise<void> {
+        const cancellation = token ?? getNonCancellingToken();
+        if (cancellation.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
 
@@ -133,12 +144,12 @@ export class UvPackageManager implements IPackageManager {
         if (useProjectWorkflow) {
             // Project workflow: uv sync --upgrade --active --python <path>
             const args = ['sync', '--upgrade', '--active', '--python', this._pythonPath];
-            await this._executeUvInTerminal(args, token);
+            await this._executeUvInTerminal(args, cancellation);
         } else {
             // Environment workflow: get outdated packages and upgrade them
-            const outdatedPackages = await this._getOutdatedPackages(token);
+            const outdatedPackages = await this._getOutdatedPackages(cancellation);
 
-            if (token.isCancellationRequested) {
+            if (cancellation.isCancellationRequested) {
                 throw new vscode.CancellationError();
             }
 
@@ -149,16 +160,18 @@ export class UvPackageManager implements IPackageManager {
 
             const packageNames = outdatedPackages.map((pkg) => pkg.name);
             const args = ['pip', 'install', '--upgrade', '--python', this._pythonPath, ...packageNames];
-            await this._executeUvInTerminal(args, token);
+            await this._executeUvInTerminal(args, cancellation);
         }
     }
 
-    async searchPackages(query: string, token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        return searchPyPI(query, token);
+    async searchPackages(query: string, token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+        const cancellation = token ?? getNonCancellingToken();
+        return searchPyPI(query, cancellation);
     }
 
-    async searchPackageVersions(name: string, token: vscode.CancellationToken): Promise<string[]> {
-        return searchPyPIVersions(name, token);
+    async searchPackageVersions(name: string, token?: vscode.CancellationToken): Promise<string[]> {
+        const cancellation = token ?? getNonCancellingToken();
+        return searchPyPIVersions(name, cancellation);
     }
 
     // =========================================================================

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -14,7 +14,7 @@ import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IServiceContainer } from '../../ioc/types';
 import { isUvInstalled } from '../../pythonEnvironments/common/environmentManagers/uv';
 import { searchPyPI, searchPyPIVersions } from './pypiSearch';
-import { IPackageManager, MessageEmitter, PackageKernel } from './types';
+import { IPackageManager, MessageEmitter, PackageSession } from './types';
 
 /**
  * uv Package Manager
@@ -29,11 +29,11 @@ export class UvPackageManager implements IPackageManager {
         private readonly _pythonPath: string,
         private readonly _messageEmitter: MessageEmitter,
         private readonly _serviceContainer: IServiceContainer,
-        private readonly _kernel: PackageKernel,
+        private readonly _session: PackageSession,
     ) {}
 
-    async getPackages(): Promise<positron.LanguageRuntimePackage[]> {
-        return this._kernel.callMethod('getPackagesInstalled');
+    async getPackages(token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+        return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', token);
     }
 
     /**
@@ -47,9 +47,13 @@ export class UvPackageManager implements IPackageManager {
         }
     }
 
-    async installPackages(packages: positron.PackageSpec[]): Promise<void> {
+    async installPackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
+        }
+
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
         }
 
         await this._ensureUv();
@@ -60,17 +64,21 @@ export class UvPackageManager implements IPackageManager {
         if (useProjectWorkflow) {
             // Project workflow: uv add --active --python <path> <packages>
             const args = ['add', '--active', '--python', this._pythonPath, ...packageSpecs];
-            await this._executeUvInTerminal(args);
+            await this._executeUvInTerminal(args, token);
         } else {
             // Environment workflow: uv pip install --python <path> <packages>
             const args = ['pip', 'install', '--python', this._pythonPath, ...packageSpecs];
-            await this._executeUvInTerminal(args);
+            await this._executeUvInTerminal(args, token);
         }
     }
 
-    async uninstallPackages(packages: string[]): Promise<void> {
+    async uninstallPackages(packages: string[], token: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
+        }
+
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
         }
 
         await this._ensureUv();
@@ -80,17 +88,21 @@ export class UvPackageManager implements IPackageManager {
         if (useProjectWorkflow) {
             // Project workflow: uv remove --active --python <path> <packages>
             const args = ['remove', '--active', '--python', this._pythonPath, ...packages];
-            await this._executeUvInTerminal(args);
+            await this._executeUvInTerminal(args, token);
         } else {
             // Environment workflow: uv pip uninstall --python <path> <packages>
             const args = ['pip', 'uninstall', '--python', this._pythonPath, ...packages];
-            await this._executeUvInTerminal(args);
+            await this._executeUvInTerminal(args, token);
         }
     }
 
-    async updatePackages(packages: positron.PackageSpec[]): Promise<void> {
+    async updatePackages(packages: positron.PackageSpec[], token: vscode.CancellationToken): Promise<void> {
         if (packages.length === 0) {
             return;
+        }
+
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
         }
 
         await this._ensureUv();
@@ -101,15 +113,19 @@ export class UvPackageManager implements IPackageManager {
         if (useProjectWorkflow) {
             // Project workflow: uv add --upgrade --active --python <path> <packages>
             const args = ['add', '--upgrade', '--active', '--python', this._pythonPath, ...packageSpecs];
-            await this._executeUvInTerminal(args);
+            await this._executeUvInTerminal(args, token);
         } else {
             // Environment workflow: uv pip install --upgrade --python <path> <packages>
             const args = ['pip', 'install', '--upgrade', '--python', this._pythonPath, ...packageSpecs];
-            await this._executeUvInTerminal(args);
+            await this._executeUvInTerminal(args, token);
         }
     }
 
-    async updateAllPackages(): Promise<void> {
+    async updateAllPackages(token: vscode.CancellationToken): Promise<void> {
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+
         await this._ensureUv();
 
         const useProjectWorkflow = await this._shouldUseProjectWorkflow();
@@ -117,10 +133,14 @@ export class UvPackageManager implements IPackageManager {
         if (useProjectWorkflow) {
             // Project workflow: uv sync --upgrade --active --python <path>
             const args = ['sync', '--upgrade', '--active', '--python', this._pythonPath];
-            await this._executeUvInTerminal(args);
+            await this._executeUvInTerminal(args, token);
         } else {
             // Environment workflow: get outdated packages and upgrade them
             const outdatedPackages = await this._getOutdatedPackages();
+
+            if (token.isCancellationRequested) {
+                throw new vscode.CancellationError();
+            }
 
             if (outdatedPackages.length === 0) {
                 this._emitMessage('All packages are up to date.\n');
@@ -129,16 +149,32 @@ export class UvPackageManager implements IPackageManager {
 
             const packageNames = outdatedPackages.map((pkg) => pkg.name);
             const args = ['pip', 'install', '--upgrade', '--python', this._pythonPath, ...packageNames];
-            await this._executeUvInTerminal(args);
+            await this._executeUvInTerminal(args, token);
         }
     }
 
-    async searchPackages(query: string): Promise<positron.LanguageRuntimePackage[]> {
-        return searchPyPI(query);
+    async searchPackages(query: string, token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+        // TODO: Pass token to searchPyPI for fetch cancellation
+        const result = await searchPyPI(query);
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+        return result;
     }
 
-    async searchPackageVersions(name: string): Promise<string[]> {
-        return searchPyPIVersions(name);
+    async searchPackageVersions(name: string, token: vscode.CancellationToken): Promise<string[]> {
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+        // TODO: Pass token to searchPyPIVersions for fetch cancellation
+        const result = await searchPyPIVersions(name);
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+        return result;
     }
 
     // =========================================================================
@@ -261,20 +297,55 @@ export class UvPackageManager implements IPackageManager {
 
     /**
      * Execute a uv command in the terminal (visible to user).
+     * @param args The uv arguments to execute
+     * @param token Cancellation token
      */
-    private async _executeUvInTerminal(args: string[]): Promise<void> {
+    private async _executeUvInTerminal(args: string[], token: vscode.CancellationToken): Promise<void> {
         const proxyEnv = this._getProxyEnv();
         const terminalService = this._serviceContainer
             .get<ITerminalServiceFactory>(ITerminalServiceFactory)
             .getTerminalService({ env: proxyEnv });
         // Ensure terminal is created and ready before sending command
         await terminalService.show();
-        const tokenSource = new vscode.CancellationTokenSource();
-        try {
-            await terminalService.sendCommand('uv', args, tokenSource.token);
-        } finally {
-            tokenSource.dispose();
+
+        await terminalService.sendCommand('uv', args, token);
+    }
+
+    /**
+     * Call a kernel method with cancellation support.
+     * If the token is cancelled, interrupts the kernel (if supported).
+     */
+    private async _callMethod<T>(
+        method: string,
+        token: vscode.CancellationToken,
+        ...args: unknown[]
+    ): Promise<T> {
+        if (token.isCancellationRequested) {
+            throw new vscode.CancellationError();
         }
+
+        const resultPromise = this._session.callMethod(method, ...args) as Promise<T>;
+
+        // Wrap callMethod promise with cancellation handling
+        return new Promise<T>((resolve, reject) => {
+            const cancelDisp = token.onCancellationRequested(async () => {
+                // Interrupt kernel if supported
+                if (this._session.interrupt) {
+                    await this._session.interrupt();
+                }
+                reject(new vscode.CancellationError());
+            });
+
+            resultPromise
+                .then((result) => {
+                    cancelDisp.dispose();
+                    resolve(result);
+                })
+                .catch((err) => {
+                    cancelDisp.dispose();
+                    reject(err);
+                });
+        });
     }
 
     /**

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -136,7 +136,7 @@ export class UvPackageManager implements IPackageManager {
             await this._executeUvInTerminal(args, token);
         } else {
             // Environment workflow: get outdated packages and upgrade them
-            const outdatedPackages = await this._getOutdatedPackages();
+            const outdatedPackages = await this._getOutdatedPackages(token);
 
             if (token.isCancellationRequested) {
                 throw new vscode.CancellationError();
@@ -234,7 +234,7 @@ export class UvPackageManager implements IPackageManager {
     /**
      * Get list of outdated packages using uv pip list.
      */
-    private async _getOutdatedPackages(): Promise<Array<{ name: string }>> {
+    private async _getOutdatedPackages(token: vscode.CancellationToken): Promise<Array<{ name: string }>> {
         const processServiceFactory = this._serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
         const processService = await processServiceFactory.create();
         const proxyEnv = this._getProxyEnv();
@@ -243,7 +243,7 @@ export class UvPackageManager implements IPackageManager {
             const result = await processService.exec(
                 'uv',
                 ['pip', 'list', '--outdated', '--format=json', '--python', this._pythonPath],
-                { extraVariables: proxyEnv },
+                { extraVariables: proxyEnv, token },
             );
 
             if (result.stdout) {

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -154,27 +154,11 @@ export class UvPackageManager implements IPackageManager {
     }
 
     async searchPackages(query: string, token: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
-        if (token.isCancellationRequested) {
-            throw new vscode.CancellationError();
-        }
-        // TODO: Pass token to searchPyPI for fetch cancellation
-        const result = await searchPyPI(query);
-        if (token.isCancellationRequested) {
-            throw new vscode.CancellationError();
-        }
-        return result;
+        return searchPyPI(query, token);
     }
 
     async searchPackageVersions(name: string, token: vscode.CancellationToken): Promise<string[]> {
-        if (token.isCancellationRequested) {
-            throw new vscode.CancellationError();
-        }
-        // TODO: Pass token to searchPyPIVersions for fetch cancellation
-        const result = await searchPyPIVersions(name);
-        if (token.isCancellationRequested) {
-            throw new vscode.CancellationError();
-        }
-        return result;
+        return searchPyPIVersions(name, token);
     }
 
     // =========================================================================
@@ -308,7 +292,16 @@ export class UvPackageManager implements IPackageManager {
         // Ensure terminal is created and ready before sending command
         await terminalService.show();
 
-        await terminalService.sendCommand('uv', args, token);
+        const disposable = token.onCancellationRequested(async () => {
+            // Send Ctrl+C to interrupt the running command
+            await terminalService.sendText('\x03');
+        });
+
+        try {
+            await terminalService.sendCommand('uv', args, token);
+        } finally {
+            disposable.dispose();
+        }
     }
 
     /**

--- a/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/uvPackageManager.ts
@@ -319,10 +319,8 @@ export class UvPackageManager implements IPackageManager {
         // Wrap callMethod promise with cancellation handling
         return new Promise<T>((resolve, reject) => {
             const cancelDisp = token.onCancellationRequested(async () => {
-                // Interrupt kernel if supported
-                if (this._session.interrupt) {
-                    await this._session.interrupt();
-                }
+                // Interrupt the session via the runtime service
+                await positron.runtime.interruptSession(this._session.metadata.sessionId);
                 reject(new vscode.CancellationError());
             });
 

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -499,12 +499,13 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             this._kernel = await this.createKernel();
 
             // Create package manager now that kernel is available
+            // Pass `this` (the session) which provides callMethod and interrupt
             this._packageManager = PackageManagerFactory.create(
                 this.runtimeMetadata.runtimeSource,
                 this._pythonPath,
                 this._messageEmitter,
                 this.serviceContainer,
-                this._kernel,
+                this,
             );
         }
 

--- a/extensions/positron-python/src/test/positron/condaPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/condaPackageManager.unit.test.ts
@@ -9,11 +9,12 @@ import { interfaces } from 'inversify';
 // eslint-disable-next-line import/no-unresolved
 import * as positron from 'positron';
 import * as sinon from 'sinon';
+import * as vscode from 'vscode';
 import { ITerminalService, ITerminalServiceFactory } from '../../client/common/terminal/types';
 import { IComponentAdapter, ICondaService } from '../../client/interpreter/contracts';
 import { IServiceContainer } from '../../client/ioc/types';
 import { CondaPackageManager } from '../../client/positron/packages/condaPackageManager';
-import { MessageEmitter, PackageKernel } from '../../client/positron/packages/types';
+import { MessageEmitter, PackageSession } from '../../client/positron/packages/types';
 import { mock } from './utils';
 
 suite('Conda Package Manager', () => {
@@ -23,14 +24,16 @@ suite('Conda Package Manager', () => {
     let componentAdapter: IComponentAdapter;
     let terminalService: ITerminalService;
     let messageEmitter: MessageEmitter;
-    let kernel: PackageKernel;
+    let session: PackageSession;
     let sendCommandStub: sinon.SinonStub;
+    let cancellationToken: vscode.CancellationToken;
 
     const pythonPath = '/path/to/conda/envs/myenv/bin/python';
     const condaEnvPath = '/path/to/conda/envs/myenv';
     const condaFile = '/path/to/conda';
 
     setup(() => {
+        cancellationToken = new vscode.CancellationTokenSource().token;
         sendCommandStub = sinon.stub().resolves();
 
         terminalService = mock<ITerminalService>({
@@ -70,11 +73,11 @@ suite('Conda Package Manager', () => {
             fire: () => {},
         });
 
-        kernel = mock<PackageKernel>({
+        session = mock<PackageSession>({
             callMethod: () => Promise.resolve([]),
         });
 
-        condaPackageManager = new CondaPackageManager(pythonPath, messageEmitter, serviceContainer, kernel);
+        condaPackageManager = new CondaPackageManager(pythonPath, messageEmitter, serviceContainer, session);
     });
 
     teardown(() => {
@@ -85,7 +88,7 @@ suite('Conda Package Manager', () => {
         test('installs single package with conda install', async () => {
             const packages: positron.PackageSpec[] = [{ name: 'numpy' }];
 
-            await condaPackageManager.installPackages(packages);
+            await condaPackageManager.installPackages(packages, cancellationToken);
 
             sinon.assert.calledOnce(sendCommandStub);
             const [executable, args] = sendCommandStub.firstCall.args;
@@ -96,7 +99,7 @@ suite('Conda Package Manager', () => {
         test('installs multiple packages', async () => {
             const packages: positron.PackageSpec[] = [{ name: 'numpy' }, { name: 'pandas' }];
 
-            await condaPackageManager.installPackages(packages);
+            await condaPackageManager.installPackages(packages, cancellationToken);
 
             sinon.assert.calledOnce(sendCommandStub);
             const [, args] = sendCommandStub.firstCall.args;
@@ -106,7 +109,7 @@ suite('Conda Package Manager', () => {
         test('installs package with specific version', async () => {
             const packages: positron.PackageSpec[] = [{ name: 'numpy', version: '1.24.0' }];
 
-            await condaPackageManager.installPackages(packages);
+            await condaPackageManager.installPackages(packages, cancellationToken);
 
             sinon.assert.calledOnce(sendCommandStub);
             const [, args] = sendCommandStub.firstCall.args;
@@ -114,7 +117,7 @@ suite('Conda Package Manager', () => {
         });
 
         test('does nothing for empty package list', async () => {
-            await condaPackageManager.installPackages([]);
+            await condaPackageManager.installPackages([], cancellationToken);
 
             sinon.assert.notCalled(sendCommandStub);
         });
@@ -122,7 +125,7 @@ suite('Conda Package Manager', () => {
 
     suite('uninstallPackages', () => {
         test('uninstalls single package with conda remove', async () => {
-            await condaPackageManager.uninstallPackages(['numpy']);
+            await condaPackageManager.uninstallPackages(['numpy'], cancellationToken);
 
             sinon.assert.calledOnce(sendCommandStub);
             const [executable, args] = sendCommandStub.firstCall.args;
@@ -131,7 +134,7 @@ suite('Conda Package Manager', () => {
         });
 
         test('uninstalls multiple packages', async () => {
-            await condaPackageManager.uninstallPackages(['numpy', 'pandas']);
+            await condaPackageManager.uninstallPackages(['numpy', 'pandas'], cancellationToken);
 
             sinon.assert.calledOnce(sendCommandStub);
             const [, args] = sendCommandStub.firstCall.args;
@@ -139,7 +142,7 @@ suite('Conda Package Manager', () => {
         });
 
         test('does nothing for empty package list', async () => {
-            await condaPackageManager.uninstallPackages([]);
+            await condaPackageManager.uninstallPackages([], cancellationToken);
 
             sinon.assert.notCalled(sendCommandStub);
         });
@@ -149,7 +152,7 @@ suite('Conda Package Manager', () => {
         test('updates single package with conda update', async () => {
             const packages: positron.PackageSpec[] = [{ name: 'numpy' }];
 
-            await condaPackageManager.updatePackages(packages);
+            await condaPackageManager.updatePackages(packages, cancellationToken);
 
             sinon.assert.calledOnce(sendCommandStub);
             const [executable, args] = sendCommandStub.firstCall.args;
@@ -160,7 +163,7 @@ suite('Conda Package Manager', () => {
         test('updates multiple packages', async () => {
             const packages: positron.PackageSpec[] = [{ name: 'numpy' }, { name: 'pandas' }];
 
-            await condaPackageManager.updatePackages(packages);
+            await condaPackageManager.updatePackages(packages, cancellationToken);
 
             sinon.assert.calledOnce(sendCommandStub);
             const [, args] = sendCommandStub.firstCall.args;
@@ -168,7 +171,7 @@ suite('Conda Package Manager', () => {
         });
 
         test('does nothing for empty package list', async () => {
-            await condaPackageManager.updatePackages([]);
+            await condaPackageManager.updatePackages([], cancellationToken);
 
             sinon.assert.notCalled(sendCommandStub);
         });
@@ -176,7 +179,7 @@ suite('Conda Package Manager', () => {
 
     suite('updateAllPackages', () => {
         test('updates all packages with conda update --all', async () => {
-            await condaPackageManager.updateAllPackages();
+            await condaPackageManager.updateAllPackages(cancellationToken);
 
             sinon.assert.calledOnce(sendCommandStub);
             const [executable, args] = sendCommandStub.firstCall.args;
@@ -209,10 +212,10 @@ suite('Conda Package Manager', () => {
                 },
             });
 
-            condaPackageManager = new CondaPackageManager(pythonPath, messageEmitter, serviceContainer, kernel);
+            condaPackageManager = new CondaPackageManager(pythonPath, messageEmitter, serviceContainer, session);
 
             await assert.rejects(
-                () => condaPackageManager.installPackages([{ name: 'numpy' }]),
+                () => condaPackageManager.installPackages([{ name: 'numpy' }], cancellationToken),
                 /conda is not available/,
             );
         });
@@ -239,10 +242,10 @@ suite('Conda Package Manager', () => {
                 },
             });
 
-            condaPackageManager = new CondaPackageManager(pythonPath, messageEmitter, serviceContainer, kernel);
+            condaPackageManager = new CondaPackageManager(pythonPath, messageEmitter, serviceContainer, session);
 
             await assert.rejects(
-                () => condaPackageManager.installPackages([{ name: 'numpy' }]),
+                () => condaPackageManager.installPackages([{ name: 'numpy' }], cancellationToken),
                 /Could not determine conda environment path/,
             );
         });

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -73,6 +73,7 @@ suite('UvPackageManager Tests', () => {
 
         // Create session mock
         session = {
+            metadata: { sessionId: 'test-session-id' },
             callMethod: sinon.stub().resolves([]),
         };
 

--- a/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/uvPackageManager.unit.test.ts
@@ -15,7 +15,7 @@ import { IWorkspaceService } from '../../client/common/application/types';
 import { IFileSystem } from '../../client/common/platform/types';
 import { IServiceContainer } from '../../client/ioc/types';
 import { UvPackageManager } from '../../client/positron/packages/uvPackageManager';
-import { PackageKernel } from '../../client/positron/packages/types';
+import { PackageSession } from '../../client/positron/packages/types';
 
 /**
  * Interface for emitting messages to the Positron console (matches the one in uvPackageManager.ts)
@@ -38,7 +38,7 @@ suite('UvPackageManager Tests', () => {
     let workspaceService: IWorkspaceService;
     let fileSystem: IFileSystem;
     let messageEmitter: MessageEmitter;
-    let kernel: PackageKernel;
+    let session: PackageSession;
 
     setup(() => {
         // Create mocks for services
@@ -71,13 +71,13 @@ suite('UvPackageManager Tests', () => {
             fire: sinon.stub(),
         };
 
-        // Create kernel mock
-        kernel = {
+        // Create session mock
+        session = {
             callMethod: sinon.stub().resolves([]),
         };
 
         // Create package manager instance
-        uvPackageManager = new UvPackageManagerTest('/path/to/python', messageEmitter, serviceContainer, kernel);
+        uvPackageManager = new UvPackageManagerTest('/path/to/python', messageEmitter, serviceContainer, session);
     });
 
     teardown(() => {

--- a/extensions/positron-r/src/packages.ts
+++ b/extensions/positron-r/src/packages.ts
@@ -309,8 +309,8 @@ export class RPackageManager {
 
 		const promise = new Promise<void>((resolve, reject) => {
 			// Register cancellation handler to interrupt R execution
-			const cancelDisp = token?.onCancellationRequested(() => {
-				this._session.interrupt();
+			const cancelDisp = token?.onCancellationRequested(async () => {
+				await positron.runtime.interruptSession(this._session.metadata.sessionId);
 				reject(new vscode.CancellationError());
 				disp.dispose();
 			});
@@ -371,7 +371,7 @@ export class RPackageManager {
 		// Wrap `callMethod` promise with cancellation handling
 		return new Promise<T>((resolve, reject) => {
 			const cancelDisp = token.onCancellationRequested(async () => {
-				await this._session.interrupt();
+				await positron.runtime.interruptSession(this._session.metadata.sessionId);
 				reject(new vscode.CancellationError());
 			});
 
@@ -401,8 +401,8 @@ export class RPackageManager {
 
 		const promise = new Promise<void>((resolve, reject) => {
 			// Register cancellation handler to interrupt R execution
-			const cancelDisp = token?.onCancellationRequested(() => {
-				this._session.interrupt();
+			const cancelDisp = token?.onCancellationRequested(async () => {
+				await positron.runtime.interruptSession(this._session.metadata.sessionId);
 				reject(new vscode.CancellationError());
 				disp.dispose();
 			});

--- a/extensions/positron-r/src/packages.ts
+++ b/extensions/positron-r/src/packages.ts
@@ -22,21 +22,33 @@ export class RPackageManager {
 
 	/**
 	 * Get list of installed packages from all libpaths.
+	 * @param token Optional cancellation token
 	 */
-	async getPackages(): Promise<positron.LanguageRuntimePackage[]> {
+	async getPackages(token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+		if (token?.isCancellationRequested) {
+			throw new vscode.CancellationError();
+		}
 		const method = await this._getPakMethod();
 		const result = await this._session.callMethod('pkg_list', method);
+		if (token?.isCancellationRequested) {
+			throw new vscode.CancellationError();
+		}
 		return result ?? [];
 	}
 
 	/**
 	 * Install one or more packages.
 	 * @param packages Array of package install requests with name and optional version
+	 * @param token Optional cancellation token
 	 */
-	async installPackages(packages: positron.PackageSpec[]): Promise<void> {
+	async installPackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
 		// Validate package names
 		for (const pkg of packages) {
 			this._validatePackageName(pkg.name);
+		}
+
+		if (token?.isCancellationRequested) {
+			throw new vscode.CancellationError();
 		}
 
 		// If we're installing pak, don't prompt to install pak
@@ -60,18 +72,23 @@ export class RPackageManager {
 			code = `install.packages(${pkgVector})`;
 		}
 
-		await this._executeAndWait(code);
+		await this._executeAndWait(code, token);
 		this._session.invalidatePackageResourceCaches();
 	}
 
 	/**
 	 * Update specific packages to latest versions.
 	 * @param packages Array of package install requests with name and optional version
+	 * @param token Optional cancellation token
 	 */
-	async updatePackages(packages: positron.PackageSpec[]): Promise<void> {
+	async updatePackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
 		// Validate package names
 		for (const pkg of packages) {
 			this._validatePackageName(pkg.name);
+		}
+
+		if (token?.isCancellationRequested) {
+			throw new vscode.CancellationError();
 		}
 
 		const method = await this._ensurePak();
@@ -88,28 +105,36 @@ export class RPackageManager {
 			code = `install.packages(${pkgVector})`;
 		}
 
-		await this._executeAndWait(code);
+		await this._executeAndWait(code, token);
 		this._session.invalidatePackageResourceCaches();
 	}
 
 	/**
 	 * Update all packages with available updates.
+	 * @param token Optional cancellation token
 	 */
-	async updateAllPackages(): Promise<void> {
+	async updateAllPackages(token?: vscode.CancellationToken): Promise<void> {
+		if (token?.isCancellationRequested) {
+			throw new vscode.CancellationError();
+		}
+
 		const method = await this._ensurePak();
 
 		if (method === 'pak') {
 			// Get outdated packages via RPC, then update with pak
 			const outdated = await this._session.callMethod('pkg_outdated') as string[] ?? [];
+			if (token?.isCancellationRequested) {
+				throw new vscode.CancellationError();
+			}
 			if (outdated.length > 0) {
 				const pkgVector = this._formatRVector(outdated);
-				await this._executeAndWait(`pak::pkg_install(${pkgVector}, ask = FALSE)`);
+				await this._executeAndWait(`pak::pkg_install(${pkgVector}, ask = FALSE)`, token);
 			} else {
 				// TODO: notify user see https://github.com/posit-dev/positron/issues/11997
 			}
 
 		} else {
-			await this._executeAndWait(`update.packages(ask = FALSE)`);
+			await this._executeAndWait(`update.packages(ask = FALSE)`, token);
 		}
 
 		this._session.invalidatePackageResourceCaches();
@@ -117,11 +142,17 @@ export class RPackageManager {
 
 	/**
 	 * Uninstall one or more packages.
+	 * @param packageNames Array of package names to uninstall
+	 * @param token Optional cancellation token
 	 */
-	async uninstallPackages(packageNames: string[]): Promise<void> {
+	async uninstallPackages(packageNames: string[], token?: vscode.CancellationToken): Promise<void> {
 		// Validate package names
 		for (const pkg of packageNames) {
 			this._validatePackageName(pkg);
+		}
+
+		if (token?.isCancellationRequested) {
+			throw new vscode.CancellationError();
 		}
 
 		const method = await this._getPakMethod();
@@ -134,7 +165,7 @@ export class RPackageManager {
 			code = `remove.packages(${pkgVector})`;
 		}
 
-		await this._executeAndWait(code);
+		await this._executeAndWait(code, token);
 
 		// Silently unload namespaces after removal (ignore errors)
 		try {
@@ -151,24 +182,41 @@ export class RPackageManager {
 
 	/**
 	 * Search repo for packages matching the query.
+	 * @param query Search query string
+	 * @param token Optional cancellation token
 	 */
-	async searchPackages(query: string): Promise<positron.LanguageRuntimePackage[]> {
+	async searchPackages(query: string, token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
+		if (token?.isCancellationRequested) {
+			throw new vscode.CancellationError();
+		}
 		const method = await this._getPakMethod();
 		const result = await this._session.callMethod('pkg_search', query, method);
+		if (token?.isCancellationRequested) {
+			throw new vscode.CancellationError();
+		}
 		return result ?? [];
 	}
 
 	/**
 	 * Get available versions of a specific package.
 	 * Returns the current version from configured repos.
+	 * @param name Package name
+	 * @param token Optional cancellation token
 	 *
 	 * TODO: Add support for historical versions from repo archive.
 	 */
-	async searchPackageVersions(name: string): Promise<string[]> {
+	async searchPackageVersions(name: string, token?: vscode.CancellationToken): Promise<string[]> {
 		this._validatePackageName(name);
+
+		if (token?.isCancellationRequested) {
+			throw new vscode.CancellationError();
+		}
 
 		try {
 			const result = await this._session.callMethod('pkg_search_versions', name);
+			if (token?.isCancellationRequested) {
+				throw new vscode.CancellationError();
+			}
 			return result ?? [];
 		} catch (e) {
 			console.log(e);
@@ -262,11 +310,20 @@ export class RPackageManager {
 	/**
 	 * Execute R code in the console and wait for completion.
 	 * Uses NonInteractive mode so output appears in the console.
+	 * @param code The R code to execute
+	 * @param token Optional cancellation token - if cancelled, interrupts the R session
 	 */
-	private async _executeAndWait(code: string): Promise<void> {
+	private async _executeAndWait(code: string, token?: vscode.CancellationToken): Promise<void> {
 		const id = randomUUID();
 
 		const promise = new Promise<void>((resolve, reject) => {
+			// Register cancellation handler to interrupt R execution
+			const cancelDisp = token?.onCancellationRequested(() => {
+				this._session.interrupt();
+				reject(new vscode.CancellationError());
+				disp.dispose();
+			});
+
 			const disp = this._session.onDidReceiveRuntimeMessage((msg) => {
 				if (msg.parent_id !== id) {
 					return;
@@ -277,6 +334,7 @@ export class RPackageManager {
 					if (stateMsg.state === positron.RuntimeOnlineState.Idle) {
 						resolve();
 						disp.dispose();
+						cancelDisp?.dispose();
 					}
 				}
 
@@ -284,6 +342,7 @@ export class RPackageManager {
 					const errorMsg = msg as positron.LanguageRuntimeError;
 					reject(new Error(errorMsg.message));
 					disp.dispose();
+					cancelDisp?.dispose();
 				}
 			});
 		});

--- a/extensions/positron-r/src/packages.ts
+++ b/extensions/positron-r/src/packages.ts
@@ -28,11 +28,11 @@ export class RPackageManager {
 		if (token?.isCancellationRequested) {
 			throw new vscode.CancellationError();
 		}
+
 		const method = await this._getPakMethod();
-		const result = await this._session.callMethod('pkg_list', method);
-		if (token?.isCancellationRequested) {
-			throw new vscode.CancellationError();
-		}
+		const result = await this._callMethod<positron.LanguageRuntimePackage[] | null>(
+			'pkg_list', token, method
+		);
 		return result ?? [];
 	}
 
@@ -42,13 +42,13 @@ export class RPackageManager {
 	 * @param token Optional cancellation token
 	 */
 	async installPackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
+		if (token?.isCancellationRequested) {
+			throw new vscode.CancellationError();
+		}
+
 		// Validate package names
 		for (const pkg of packages) {
 			this._validatePackageName(pkg.name);
-		}
-
-		if (token?.isCancellationRequested) {
-			throw new vscode.CancellationError();
 		}
 
 		// If we're installing pak, don't prompt to install pak
@@ -72,7 +72,7 @@ export class RPackageManager {
 			code = `install.packages(${pkgVector})`;
 		}
 
-		await this._executeAndWait(code, token);
+		await this._execute(code, token);
 		this._session.invalidatePackageResourceCaches();
 	}
 
@@ -82,13 +82,13 @@ export class RPackageManager {
 	 * @param token Optional cancellation token
 	 */
 	async updatePackages(packages: positron.PackageSpec[], token?: vscode.CancellationToken): Promise<void> {
+		if (token?.isCancellationRequested) {
+			throw new vscode.CancellationError();
+		}
+
 		// Validate package names
 		for (const pkg of packages) {
 			this._validatePackageName(pkg.name);
-		}
-
-		if (token?.isCancellationRequested) {
-			throw new vscode.CancellationError();
 		}
 
 		const method = await this._ensurePak();
@@ -105,7 +105,7 @@ export class RPackageManager {
 			code = `install.packages(${pkgVector})`;
 		}
 
-		await this._executeAndWait(code, token);
+		await this._execute(code, token);
 		this._session.invalidatePackageResourceCaches();
 	}
 
@@ -122,19 +122,18 @@ export class RPackageManager {
 
 		if (method === 'pak') {
 			// Get outdated packages via RPC, then update with pak
-			const outdated = await this._session.callMethod('pkg_outdated') as string[] ?? [];
-			if (token?.isCancellationRequested) {
-				throw new vscode.CancellationError();
-			}
+			const outdated = await this._callMethod<string[] | null>(
+				'pkg_outdated', token
+			) ?? [];
 			if (outdated.length > 0) {
 				const pkgVector = this._formatRVector(outdated);
-				await this._executeAndWait(`pak::pkg_install(${pkgVector}, ask = FALSE)`, token);
+				await this._execute(`pak::pkg_install(${pkgVector}, ask = FALSE)`, token);
 			} else {
 				// TODO: notify user see https://github.com/posit-dev/positron/issues/11997
 			}
 
 		} else {
-			await this._executeAndWait(`update.packages(ask = FALSE)`, token);
+			await this._execute(`update.packages(ask = FALSE)`, token);
 		}
 
 		this._session.invalidatePackageResourceCaches();
@@ -146,13 +145,13 @@ export class RPackageManager {
 	 * @param token Optional cancellation token
 	 */
 	async uninstallPackages(packageNames: string[], token?: vscode.CancellationToken): Promise<void> {
+		if (token?.isCancellationRequested) {
+			throw new vscode.CancellationError();
+		}
+
 		// Validate package names
 		for (const pkg of packageNames) {
 			this._validatePackageName(pkg);
-		}
-
-		if (token?.isCancellationRequested) {
-			throw new vscode.CancellationError();
 		}
 
 		const method = await this._getPakMethod();
@@ -165,7 +164,7 @@ export class RPackageManager {
 			code = `remove.packages(${pkgVector})`;
 		}
 
-		await this._executeAndWait(code, token);
+		await this._execute(code, token);
 
 		// Silently unload namespaces after removal (ignore errors)
 		try {
@@ -189,11 +188,11 @@ export class RPackageManager {
 		if (token?.isCancellationRequested) {
 			throw new vscode.CancellationError();
 		}
+
 		const method = await this._getPakMethod();
-		const result = await this._session.callMethod('pkg_search', query, method);
-		if (token?.isCancellationRequested) {
-			throw new vscode.CancellationError();
-		}
+		const result = await this._callMethod<positron.LanguageRuntimePackage[] | null>(
+			'pkg_search', token, query, method
+		);
 		return result ?? [];
 	}
 
@@ -206,23 +205,15 @@ export class RPackageManager {
 	 * TODO: Add support for historical versions from repo archive.
 	 */
 	async searchPackageVersions(name: string, token?: vscode.CancellationToken): Promise<string[]> {
-		this._validatePackageName(name);
-
 		if (token?.isCancellationRequested) {
 			throw new vscode.CancellationError();
 		}
 
-		try {
-			const result = await this._session.callMethod('pkg_search_versions', name);
-			if (token?.isCancellationRequested) {
-				throw new vscode.CancellationError();
-			}
-			return result ?? [];
-		} catch (e) {
-			console.log(e);
-			// Return empty if we can't get versions
-			return [];
-		}
+		this._validatePackageName(name);
+		const result = await this._callMethod<string[] | null>(
+			'pkg_search_versions', token, name
+		);
+		return result ?? [];
 	}
 
 	// =========================================================================
@@ -275,7 +266,7 @@ export class RPackageManager {
 		const install = await this._promptInstallPak();
 		if (install) {
 			// Use base R to install pak
-			await this._executeAndWait('install.packages("pak")');
+			await this._execute('install.packages("pak")');
 			const nowHasPak = await this._detectPak();
 			return nowHasPak ? 'pak' : 'base';
 		} else {
@@ -313,7 +304,7 @@ export class RPackageManager {
 	 * @param code The R code to execute
 	 * @param token Optional cancellation token - if cancelled, interrupts the R session
 	 */
-	private async _executeAndWait(code: string, token?: vscode.CancellationToken): Promise<void> {
+	private async _execute(code: string, token?: vscode.CancellationToken): Promise<void> {
 		const id = randomUUID();
 
 		const promise = new Promise<void>((resolve, reject) => {
@@ -358,12 +349,64 @@ export class RPackageManager {
 	}
 
 	/**
-	 * Execute R code silently without showing in the console.
+	 * Call an RPC method with cancellation support.
+	 * If the token is cancelled, interrupts the R session.
 	 */
-	private async _executeSilently(code: string): Promise<void> {
+	private async _callMethod<T>(
+		method: string,
+		token: vscode.CancellationToken | undefined,
+		...args: unknown[]
+	): Promise<T> {
+		if (token?.isCancellationRequested) {
+			throw new vscode.CancellationError();
+		}
+
+		const resultPromise = this._session.callMethod(method, ...args) as Promise<T>;
+
+		// If no token provided, just return the method result
+		if (!token) {
+			return resultPromise;
+		}
+
+		// Wrap `callMethod` promise with cancellation handling
+		return new Promise<T>((resolve, reject) => {
+			const cancelDisp = token.onCancellationRequested(async () => {
+				await this._session.interrupt();
+				reject(new vscode.CancellationError());
+			});
+
+			resultPromise
+				.then((result) => {
+					cancelDisp.dispose();
+					resolve(result);
+				})
+				.catch((err) => {
+					cancelDisp.dispose();
+					reject(err);
+				});
+		});
+	}
+
+	/**
+	 * Execute R code silently without showing in the console.
+	 * @param code The R code to execute
+	 * @param token Optional cancellation token - if cancelled, interrupts the R session
+	 */
+	private async _executeSilently(code: string, token?: vscode.CancellationToken): Promise<void> {
+		if (token?.isCancellationRequested) {
+			throw new vscode.CancellationError();
+		}
+
 		const id = randomUUID();
 
 		const promise = new Promise<void>((resolve, reject) => {
+			// Register cancellation handler to interrupt R execution
+			const cancelDisp = token?.onCancellationRequested(() => {
+				this._session.interrupt();
+				reject(new vscode.CancellationError());
+				disp.dispose();
+			});
+
 			const disp = this._session.onDidReceiveRuntimeMessage((msg) => {
 				if (msg.parent_id !== id) {
 					return;
@@ -374,6 +417,7 @@ export class RPackageManager {
 					if (stateMsg.state === positron.RuntimeOnlineState.Idle) {
 						resolve();
 						disp.dispose();
+						cancelDisp?.dispose();
 					}
 				}
 
@@ -381,6 +425,7 @@ export class RPackageManager {
 					const errorMsg = msg as positron.LanguageRuntimeError;
 					reject(new Error(errorMsg.message));
 					disp.dispose();
+					cancelDisp?.dispose();
 				}
 			});
 		});

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1169,43 +1169,50 @@ declare module 'positron' {
 	export interface LanguageRuntimePackageManager {
 		/**
 		 * Get list of installed packages.
+		 * @param token Cancellation token
 		 */
-		getPackages(): Thenable<LanguageRuntimePackage[]>;
+		getPackages(token: vscode.CancellationToken): Thenable<LanguageRuntimePackage[]>;
 
 		/**
 		 * Install the list of packages.
 		 * @param packages Array of package install requests with name and optional version
+		 * @param token Cancellation token
 		 */
-		installPackages(packages: PackageSpec[]): Thenable<void>;
+		installPackages(packages: PackageSpec[], token: vscode.CancellationToken): Thenable<void>;
 
 		/**
 		 * Uninstall the list of packages.
 		 * @param packageNames Array of package names to uninstall
+		 * @param token Cancellation token
 		 */
-		uninstallPackages(packageNames: string[]): Thenable<void>;
+		uninstallPackages(packageNames: string[], token: vscode.CancellationToken): Thenable<void>;
 
 		/**
 		 * Update the list of packages.
 		 * @param packages Array of package install requests with name and optional version
+		 * @param token Cancellation token
 		 */
-		updatePackages(packages: PackageSpec[]): Thenable<void>;
+		updatePackages(packages: PackageSpec[], token: vscode.CancellationToken): Thenable<void>;
 
 		/**
 		 * Update all installed packages.
+		 * @param token Cancellation token
 		 */
-		updateAllPackages(): Thenable<void>;
+		updateAllPackages(token: vscode.CancellationToken): Thenable<void>;
 
 		/**
 		 * Search a repository for packages matching the query.
 		 * @param query Search query string
+		 * @param token Cancellation token
 		 */
-		searchPackages(query: string): Thenable<LanguageRuntimePackage[]>;
+		searchPackages(query: string, token: vscode.CancellationToken): Thenable<LanguageRuntimePackage[]>;
 
 		/**
 		 * Search a repository for available versions of a package.
 		 * @param name Package name
+		 * @param token Cancellation token
 		 */
-		searchPackageVersions(name: string): Thenable<string[]>;
+		searchPackageVersions(name: string, token: vscode.CancellationToken): Thenable<string[]>;
 	}
 
 	/**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1169,50 +1169,50 @@ declare module 'positron' {
 	export interface LanguageRuntimePackageManager {
 		/**
 		 * Get list of installed packages.
-		 * @param token Cancellation token
+		 * @param token Optional cancellation token
 		 */
-		getPackages(token: vscode.CancellationToken): Thenable<LanguageRuntimePackage[]>;
+		getPackages(token?: vscode.CancellationToken): Thenable<LanguageRuntimePackage[]>;
 
 		/**
 		 * Install the list of packages.
 		 * @param packages Array of package install requests with name and optional version
-		 * @param token Cancellation token
+		 * @param token Optional cancellation token
 		 */
-		installPackages(packages: PackageSpec[], token: vscode.CancellationToken): Thenable<void>;
+		installPackages(packages: PackageSpec[], token?: vscode.CancellationToken): Thenable<void>;
 
 		/**
 		 * Uninstall the list of packages.
 		 * @param packageNames Array of package names to uninstall
-		 * @param token Cancellation token
+		 * @param token Optional cancellation token
 		 */
-		uninstallPackages(packageNames: string[], token: vscode.CancellationToken): Thenable<void>;
+		uninstallPackages(packageNames: string[], token?: vscode.CancellationToken): Thenable<void>;
 
 		/**
 		 * Update the list of packages.
 		 * @param packages Array of package install requests with name and optional version
-		 * @param token Cancellation token
+		 * @param token Optional cancellation token
 		 */
-		updatePackages(packages: PackageSpec[], token: vscode.CancellationToken): Thenable<void>;
+		updatePackages(packages: PackageSpec[], token?: vscode.CancellationToken): Thenable<void>;
 
 		/**
 		 * Update all installed packages.
-		 * @param token Cancellation token
+		 * @param token Optional cancellation token
 		 */
-		updateAllPackages(token: vscode.CancellationToken): Thenable<void>;
+		updateAllPackages(token?: vscode.CancellationToken): Thenable<void>;
 
 		/**
 		 * Search a repository for packages matching the query.
 		 * @param query Search query string
-		 * @param token Cancellation token
+		 * @param token Optional cancellation token
 		 */
-		searchPackages(query: string, token: vscode.CancellationToken): Thenable<LanguageRuntimePackage[]>;
+		searchPackages(query: string, token?: vscode.CancellationToken): Thenable<LanguageRuntimePackage[]>;
 
 		/**
 		 * Search a repository for available versions of a package.
 		 * @param name Package name
-		 * @param token Cancellation token
+		 * @param token Optional cancellation token
 		 */
-		searchPackageVersions(name: string, token: vscode.CancellationToken): Thenable<string[]>;
+		searchPackageVersions(name: string, token?: vscode.CancellationToken): Thenable<string[]>;
 	}
 
 	/**

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -24,6 +24,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IRuntimeClientInstance, IRuntimeClientOutput, RuntimeClientState, RuntimeClientStatus, RuntimeClientType } from '../../../services/languageRuntime/common/languageRuntimeClientInstance.js';
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { IPositronPlotsService } from '../../../services/positronPlots/common/positronPlots.js';
 import { IPositronIPyWidgetsService, MIME_TYPE_WIDGET_STATE, MIME_TYPE_WIDGET_VIEW } from '../../../services/positronIPyWidgets/common/positronIPyWidgetsService.js';
@@ -127,32 +128,32 @@ class ExtHostLanguageRuntimePackageManagerAdapter implements ILanguageRuntimePac
 		private readonly _handle: number,
 	) { }
 
-	getPackages(): Promise<ILanguageRuntimePackage[]> {
-		return this._proxy.$getPackages(this._handle);
+	getPackages(token?: CancellationToken): Promise<ILanguageRuntimePackage[]> {
+		return this._proxy.$getPackages(this._handle, token ?? CancellationToken.None);
 	}
 
-	installPackages(packages: IPackageSpec[]): Promise<void> {
-		return this._proxy.$installPackages(this._handle, packages);
+	installPackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void> {
+		return this._proxy.$installPackages(this._handle, packages, token ?? CancellationToken.None);
 	}
 
-	uninstallPackages(packageNames: string[]): Promise<void> {
-		return this._proxy.$uninstallPackages(this._handle, packageNames);
+	uninstallPackages(packageNames: string[], token?: CancellationToken): Promise<void> {
+		return this._proxy.$uninstallPackages(this._handle, packageNames, token ?? CancellationToken.None);
 	}
 
-	updatePackages(packages: IPackageSpec[]): Promise<void> {
-		return this._proxy.$updatePackages(this._handle, packages);
+	updatePackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void> {
+		return this._proxy.$updatePackages(this._handle, packages, token ?? CancellationToken.None);
 	}
 
-	updateAllPackages(): Promise<void> {
-		return this._proxy.$updateAllPackages(this._handle);
+	updateAllPackages(token?: CancellationToken): Promise<void> {
+		return this._proxy.$updateAllPackages(this._handle, token ?? CancellationToken.None);
 	}
 
-	searchPackages(query: string): Promise<ILanguageRuntimePackage[]> {
-		return this._proxy.$searchPackages(this._handle, query);
+	searchPackages(query: string, token?: CancellationToken): Promise<ILanguageRuntimePackage[]> {
+		return this._proxy.$searchPackages(this._handle, query, token ?? CancellationToken.None);
 	}
 
-	searchPackageVersions(name: string): Promise<string[]> {
-		return this._proxy.$searchPackageVersions(this._handle, name);
+	searchPackageVersions(name: string, token?: CancellationToken): Promise<string[]> {
+		return this._proxy.$searchPackageVersions(this._handle, name, token ?? CancellationToken.None);
 	}
 }
 

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -128,32 +128,32 @@ class ExtHostLanguageRuntimePackageManagerAdapter implements ILanguageRuntimePac
 		private readonly _handle: number,
 	) { }
 
-	getPackages(token?: CancellationToken): Promise<ILanguageRuntimePackage[]> {
-		return this._proxy.$getPackages(this._handle, token ?? CancellationToken.None);
+	getPackages(token: CancellationToken): Promise<ILanguageRuntimePackage[]> {
+		return this._proxy.$getPackages(this._handle, token);
 	}
 
-	installPackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void> {
-		return this._proxy.$installPackages(this._handle, packages, token ?? CancellationToken.None);
+	installPackages(packages: IPackageSpec[], token: CancellationToken): Promise<void> {
+		return this._proxy.$installPackages(this._handle, packages, token);
 	}
 
-	uninstallPackages(packageNames: string[], token?: CancellationToken): Promise<void> {
-		return this._proxy.$uninstallPackages(this._handle, packageNames, token ?? CancellationToken.None);
+	uninstallPackages(packageNames: string[], token: CancellationToken): Promise<void> {
+		return this._proxy.$uninstallPackages(this._handle, packageNames, token);
 	}
 
-	updatePackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void> {
-		return this._proxy.$updatePackages(this._handle, packages, token ?? CancellationToken.None);
+	updatePackages(packages: IPackageSpec[], token: CancellationToken): Promise<void> {
+		return this._proxy.$updatePackages(this._handle, packages, token);
 	}
 
-	updateAllPackages(token?: CancellationToken): Promise<void> {
-		return this._proxy.$updateAllPackages(this._handle, token ?? CancellationToken.None);
+	updateAllPackages(token: CancellationToken): Promise<void> {
+		return this._proxy.$updateAllPackages(this._handle, token);
 	}
 
-	searchPackages(query: string, token?: CancellationToken): Promise<ILanguageRuntimePackage[]> {
-		return this._proxy.$searchPackages(this._handle, query, token ?? CancellationToken.None);
+	searchPackages(query: string, token: CancellationToken): Promise<ILanguageRuntimePackage[]> {
+		return this._proxy.$searchPackages(this._handle, query, token);
 	}
 
-	searchPackageVersions(name: string, token?: CancellationToken): Promise<string[]> {
-		return this._proxy.$searchPackageVersions(this._handle, name, token ?? CancellationToken.None);
+	searchPackageVersions(name: string, token: CancellationToken): Promise<string[]> {
+		return this._proxy.$searchPackageVersions(this._handle, name, token);
 	}
 }
 

--- a/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.protocol.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { ILanguageRuntimeInfo, ILanguageRuntimeMetadata, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState, ILanguageRuntimeMessage, ILanguageRuntimeExit, RuntimeExitReason, LanguageRuntimeSessionMode, ILanguageRuntimeResourceUsage, ILanguageRuntimeLaunchInfo } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { createProxyIdentifier, IRPCProtocol, SerializableObjectWithBuffers } from '../../../services/extensions/common/proxyIdentifier.js';
@@ -108,13 +109,13 @@ export interface ExtHostLanguageRuntimeShape {
 	$recommendWorkspaceRuntimes(disabledLanguageIds: string[]): Promise<ILanguageRuntimeMetadata[]>;
 	$notifyForegroundSessionChanged(sessionId: string | undefined): void;
 	$notifyCodeExecuted(event: ILanguageRuntimeCodeExecutedEvent): void;
-	$getPackages(handle: number): Promise<LanguageRuntimePackage[]>;
-	$installPackages(handle: number, packages: PackageSpec[]): Promise<void>;
-	$uninstallPackages(handle: number, packageNames: string[]): Promise<void>;
-	$updatePackages(handle: number, packages: PackageSpec[]): Promise<void>;
-	$updateAllPackages(handle: number): Promise<void>;
-	$searchPackages(handle: number, query: string): Promise<LanguageRuntimePackage[]>;
-	$searchPackageVersions(handle: number, name: string): Promise<string[]>;
+	$getPackages(handle: number, token: CancellationToken): Promise<LanguageRuntimePackage[]>;
+	$installPackages(handle: number, packages: PackageSpec[], token: CancellationToken): Promise<void>;
+	$uninstallPackages(handle: number, packageNames: string[], token: CancellationToken): Promise<void>;
+	$updatePackages(handle: number, packages: PackageSpec[], token: CancellationToken): Promise<void>;
+	$updateAllPackages(handle: number, token: CancellationToken): Promise<void>;
+	$searchPackages(handle: number, query: string, token: CancellationToken): Promise<LanguageRuntimePackage[]>;
+	$searchPackageVersions(handle: number, name: string, token: CancellationToken): Promise<string[]>;
 }
 
 // This is the interface that the main process exposes to the extension host

--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -734,39 +734,39 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		return packageManager;
 	}
 
-	async $getPackages(handle: number): Promise<positron.LanguageRuntimePackage[]> {
+	async $getPackages(handle: number, token: CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
 		const packageManager = this.getPackageManagerOrThrow(handle, 'get packages from runtime');
-		return packageManager.getPackages();
+		return packageManager.getPackages(token);
 	}
 
-	async $installPackages(handle: number, packages: positron.PackageSpec[]): Promise<void> {
+	async $installPackages(handle: number, packages: positron.PackageSpec[], token: CancellationToken): Promise<void> {
 		const packageManager = this.getPackageManagerOrThrow(handle, 'install packages');
-		return packageManager.installPackages(packages);
+		return packageManager.installPackages(packages, token);
 	}
 
-	async $uninstallPackages(handle: number, packageNames: string[]): Promise<void> {
+	async $uninstallPackages(handle: number, packageNames: string[], token: CancellationToken): Promise<void> {
 		const packageManager = this.getPackageManagerOrThrow(handle, 'uninstall packages');
-		return packageManager.uninstallPackages(packageNames);
+		return packageManager.uninstallPackages(packageNames, token);
 	}
 
-	async $updatePackages(handle: number, packages: positron.PackageSpec[]): Promise<void> {
+	async $updatePackages(handle: number, packages: positron.PackageSpec[], token: CancellationToken): Promise<void> {
 		const packageManager = this.getPackageManagerOrThrow(handle, 'update packages');
-		return packageManager.updatePackages(packages);
+		return packageManager.updatePackages(packages, token);
 	}
 
-	async $updateAllPackages(handle: number): Promise<void> {
+	async $updateAllPackages(handle: number, token: CancellationToken): Promise<void> {
 		const packageManager = this.getPackageManagerOrThrow(handle, 'update all packages');
-		return packageManager.updateAllPackages();
+		return packageManager.updateAllPackages(token);
 	}
 
-	async $searchPackages(handle: number, query: string): Promise<positron.LanguageRuntimePackage[]> {
+	async $searchPackages(handle: number, query: string, token: CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
 		const packageManager = this.getPackageManagerOrThrow(handle, 'search packages');
-		return packageManager.searchPackages(query);
+		return packageManager.searchPackages(query, token);
 	}
 
-	async $searchPackageVersions(handle: number, name: string): Promise<string[]> {
+	async $searchPackageVersions(handle: number, name: string, token: CancellationToken): Promise<string[]> {
 		const packageManager = this.getPackageManagerOrThrow(handle, 'search package versions');
-		return packageManager.searchPackageVersions(name);
+		return packageManager.searchPackageVersions(name, token);
 	}
 
 	async $restartSession(handle: number, workingDirectory?: string): Promise<void> {

--- a/src/vs/workbench/contrib/positronPackages/browser/interfaces/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/interfaces/positronPackagesService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
 import { Event } from '../../../../../base/common/event.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILanguageRuntimePackage, ILanguageRuntimeSession, IPackageSpec } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
@@ -32,23 +33,51 @@ export interface IPositronPackagesService {
 	setActivePositronPackagesSession(session: ILanguageRuntimeSession): unknown;
 
 	/**
-	 * Gets the installed packages for the given session ID.
-	 *
-	 * @param sessionId
+	 * Gets the installed packages for the active session.
+	 * @param token Optional cancellation token
 	 */
-	refreshPackages(): Promise<ILanguageRuntimePackage[]>;
+	refreshPackages(token?: CancellationToken): Promise<ILanguageRuntimePackage[]>;
 
-	installPackages(packages: IPackageSpec[]): Promise<void>;
+	/**
+	 * Install packages in the active session.
+	 * @param packages Array of package specifications to install
+	 * @param token Optional cancellation token
+	 */
+	installPackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void>;
 
-	uninstallPackages(packageNames: string[]): Promise<void>;
+	/**
+	 * Uninstall packages from the active session.
+	 * @param packageNames Array of package names to uninstall
+	 * @param token Optional cancellation token
+	 */
+	uninstallPackages(packageNames: string[], token?: CancellationToken): Promise<void>;
 
-	updatePackages(packages: IPackageSpec[]): Promise<void>;
+	/**
+	 * Update packages in the active session.
+	 * @param packages Array of package specifications to update
+	 * @param token Optional cancellation token
+	 */
+	updatePackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void>;
 
-	updateAllPackages(): Promise<void>;
+	/**
+	 * Update all packages in the active session.
+	 * @param token Optional cancellation token
+	 */
+	updateAllPackages(token?: CancellationToken): Promise<void>;
 
-	searchPackages(query: string): Promise<ILanguageRuntimePackage[]>;
+	/**
+	 * Search for packages matching a query.
+	 * @param query Search query
+	 * @param token Optional cancellation token
+	 */
+	searchPackages(query: string, token?: CancellationToken): Promise<ILanguageRuntimePackage[]>;
 
-	searchPackageVersions(name: string): Promise<string[]>;
+	/**
+	 * Search for available versions of a package.
+	 * @param name Package name
+	 * @param token Optional cancellation token
+	 */
+	searchPackageVersions(name: string, token?: CancellationToken): Promise<string[]>;
 
 	getInstances(): IPositronPackagesInstance[];
 }

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -21,7 +21,6 @@ import { IPositronPackagesService } from './interfaces/positronPackagesService.j
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { PositronPackagesService } from './positronPackagesService.js';
 import { ILanguageRuntimePackage } from '../../../services/runtimeSession/common/runtimeSessionService.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
@@ -159,7 +158,7 @@ class InstallPackageAction extends Action2 {
 				}, () => cts.dispose(true));
 			};
 
-			await installPackage(accessor, performSearch, performSearchVersions, performInstall);
+			await installPackage(accessor, performSearch, performSearchVersions, performInstall, cts);
 		} catch (error) {
 			notifications.error(error);
 			throw error;
@@ -181,14 +180,14 @@ class UninstallPackageAction extends Action2 {
 	}
 	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
 		const service = accessor.get<IPositronPackagesService>(IPositronPackagesService);
-		const commands = accessor.get<ICommandService>(ICommandService);
 		const dialogService = accessor.get<IDialogService>(IDialogService);
 		const notifications = accessor.get<INotificationService>(INotificationService);
 		const progress = accessor.get<IProgressService>(IProgressService);
+		const cts = new CancellationTokenSource();
 
 		try {
 			const performSearch = async () => {
-				const packages = await commands.executeCommand(PACKAGES_REFRESH_COMMAND_ID) as ILanguageRuntimePackage[];
+				const packages = await service.refreshPackages(cts.token);
 				return packages
 					.map((x) => ({
 						name: x.displayName
@@ -196,8 +195,6 @@ class UninstallPackageAction extends Action2 {
 			};
 
 			const performUninstall = async (pkg: string): Promise<void> => {
-				const uninstallCts = new CancellationTokenSource();
-
 				await progress.withProgress({
 					title: nls.localize('positronPackages.uninstallingPackages', 'Uninstalling Packages...'),
 					location: ProgressLocation.Notification,
@@ -205,11 +202,11 @@ class UninstallPackageAction extends Action2 {
 					delay: 500
 				}, async () => {
 					try {
-						await service.uninstallPackages([pkg], uninstallCts.token);
+						await service.uninstallPackages([pkg], cts.token);
 					} catch (e) {
 						notifications.error(e);
 					}
-				}, () => uninstallCts.dispose(true));
+				}, () => cts.dispose(true));
 			};
 
 			const argPackage = args.at(0) as string | undefined;
@@ -221,7 +218,7 @@ class UninstallPackageAction extends Action2 {
 					await performUninstall(argPackage);
 				}
 			} else {
-				await uninstallPackage(accessor, performSearch, performUninstall);
+				await uninstallPackage(accessor, performSearch, performUninstall, cts);
 			}
 		} catch (error) {
 			notifications.error(error);
@@ -249,7 +246,6 @@ class UpdatePackageAction extends Action2 {
 	}
 	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
 		const service = accessor.get<IPositronPackagesService>(IPositronPackagesService);
-		const commands = accessor.get<ICommandService>(ICommandService);
 		const notifications = accessor.get<INotificationService>(INotificationService);
 		const progress = accessor.get<IProgressService>(IProgressService);
 
@@ -258,7 +254,7 @@ class UpdatePackageAction extends Action2 {
 
 		try {
 			const performSearch = async () => {
-				const packages = await commands.executeCommand(PACKAGES_REFRESH_COMMAND_ID) as ILanguageRuntimePackage[];
+				const packages = await service.refreshPackages(cts.token);
 				return packages
 					.map((x) => ({
 						name: x.displayName
@@ -266,7 +262,7 @@ class UpdatePackageAction extends Action2 {
 			};
 
 			const performSearchVersions = async (pkg: string) => {
-				return await service.searchPackageVersions(pkg, cts.token);
+				return service.searchPackageVersions(pkg, cts.token);
 			};
 
 			const performUpdate = async (pkg: string, version: string): Promise<void> => {
@@ -285,7 +281,7 @@ class UpdatePackageAction extends Action2 {
 			};
 
 			const arg0 = args.at(0) as string | undefined;
-			await updatePackage(accessor, performSearch, performSearchVersions, performUpdate, arg0);
+			await updatePackage(accessor, performSearch, performSearchVersions, performUpdate, arg0, cts);
 		} catch (error) {
 			notifications.error(error);
 			throw error;

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -103,8 +103,10 @@ class RefreshPackagesAction extends Action2 {
 			} catch (error) {
 				notifications.error(error);
 				throw error;
+			} finally {
+				cts.dispose(true);
 			}
-		}, () => cts.dispose(true));
+		}, () => cts.cancel());
 	}
 }
 
@@ -141,8 +143,6 @@ class InstallPackageAction extends Action2 {
 					throw new Error('No version specified.');
 				}
 
-				const installCts = new CancellationTokenSource();
-
 				await progress.withProgress({
 					title: nls.localize('positronPackages.installingPackages', 'Installing Packages...'),
 					location: ProgressLocation.Notification,
@@ -150,24 +150,13 @@ class InstallPackageAction extends Action2 {
 					delay: 500
 				}, async () => {
 					try {
-						await service.installPackages([{ name: pkg, version }], installCts.token);
+						await service.installPackages([{ name: pkg, version }], cts.token);
 					} catch (e) {
-						notifications.notify({
-							severity: Severity.Error,
-							actions: {
-								primary: [{
-									id: 'viewLogs',
-									label: nls.localize('positronPackages.viewLogs', 'View Logs'),
-									tooltip: nls.localize('positronPackages.viewLogs', 'View Logs'),
-									enabled: true,
-									class: undefined,
-									run: () => service.activeSession?.showOutput(),
-								}]
-							},
-							message: nls.localize('positronPackages.failedToInstallPackage', "Failed to install package: '{0}'", pkg),
-						});
+						notifications.error(e);
+					} finally {
+						cts.dispose(true);
 					}
-				}, () => installCts.dispose(true));
+				}, () => cts.dispose(true));
 			};
 
 			await installPackage(accessor, performSearch, performSearchVersions, performInstall);
@@ -175,7 +164,7 @@ class InstallPackageAction extends Action2 {
 			notifications.error(error);
 			throw error;
 		} finally {
-			cts.dispose();
+			cts.dispose(true);
 		}
 	}
 }
@@ -218,20 +207,7 @@ class UninstallPackageAction extends Action2 {
 					try {
 						await service.uninstallPackages([pkg], uninstallCts.token);
 					} catch (e) {
-						notifications.notify({
-							severity: Severity.Error,
-							actions: {
-								primary: [{
-									id: 'viewLogs',
-									label: nls.localize('positronPackages.viewLogs', 'View Logs'),
-									tooltip: nls.localize('positronPackages.viewLogs', 'View Logs'),
-									enabled: true,
-									class: undefined,
-									run: () => service.activeSession?.showOutput(),
-								}]
-							},
-							message: nls.localize('positronPackages.failedToUninstallPackage', "Failed to uninstall package: '{0}'", pkg),
-						});
+						notifications.error(e);
 					}
 				}, () => uninstallCts.dispose(true));
 			};
@@ -294,8 +270,6 @@ class UpdatePackageAction extends Action2 {
 			};
 
 			const performUpdate = async (pkg: string, version: string): Promise<void> => {
-				const updateCts = new CancellationTokenSource();
-
 				await progress.withProgress({
 					title: nls.localize('positronPackages.updatingPackages', 'Updating Packages...'),
 					location: ProgressLocation.Notification,
@@ -303,24 +277,11 @@ class UpdatePackageAction extends Action2 {
 					delay: 500
 				}, async () => {
 					try {
-						await service.updatePackages([{ name: pkg, version }], updateCts.token);
+						await service.updatePackages([{ name: pkg, version }], cts.token);
 					} catch (e) {
-						notifications.notify({
-							severity: Severity.Error,
-							actions: {
-								primary: [{
-									id: 'viewLogs',
-									label: nls.localize('positronPackages.viewLogs', 'View Logs'),
-									tooltip: nls.localize('positronPackages.viewLogs', 'View Logs'),
-									enabled: true,
-									class: undefined,
-									run: () => service.activeSession?.showOutput(),
-								}]
-							},
-							message: nls.localize('positronPackages.failedToUpdatePackage', "Failed to update package: '{0}'", pkg),
-						});
+						notifications.error(e);
 					}
-				}, () => updateCts.dispose(true));
+				}, () => cts.dispose(true));
 			};
 
 			const arg0 = args.at(0) as string | undefined;
@@ -329,7 +290,7 @@ class UpdatePackageAction extends Action2 {
 			notifications.error(error);
 			throw error;
 		} finally {
-			cts.dispose();
+			cts.dispose(true);
 		}
 	}
 }

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import * as nls from '../../../../nls.js';
@@ -84,15 +85,26 @@ class RefreshPackagesAction extends Action2 {
 			precondition: POSITRON_PACKAGES_ENABLED,
 		});
 	}
-	override run(accessor: ServicesAccessor, ...args: unknown[]): Promise<ILanguageRuntimePackage[]> {
+	override async run(accessor: ServicesAccessor): Promise<ILanguageRuntimePackage[]> {
 		const service = accessor.get<IPositronPackagesService>(IPositronPackagesService);
 		const notifications = accessor.get<INotificationService>(INotificationService);
-		try {
-			return service.refreshPackages();
-		} catch (error) {
-			notifications.error(error);
-			throw error;
-		}
+		const progress = accessor.get<IProgressService>(IProgressService);
+
+		const cts = new CancellationTokenSource();
+
+		return progress.withProgress({
+			title: nls.localize('positronPackages.refreshingPackages', 'Refreshing Packages...'),
+			location: ProgressLocation.Notification,
+			cancellable: true,
+			delay: 500
+		}, async () => {
+			try {
+				return await service.refreshPackages(cts.token);
+			} catch (error) {
+				notifications.error(error);
+				throw error;
+			}
+		}, () => cts.dispose(true));
 	}
 }
 
@@ -107,18 +119,21 @@ class InstallPackageAction extends Action2 {
 			precondition: POSITRON_PACKAGES_ENABLED,
 		});
 	}
-	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
+	override async run(accessor: ServicesAccessor): Promise<void> {
 		const service = accessor.get<IPositronPackagesService>(IPositronPackagesService);
 		const notifications = accessor.get<INotificationService>(INotificationService);
 		const progress = accessor.get<IProgressService>(IProgressService);
 
+		// Create a token source for the entire install flow (search + install)
+		const cts = new CancellationTokenSource();
+
 		try {
 			const performSearch = async (q: string) => {
-				return await service.searchPackages(q);
+				return await service.searchPackages(q, cts.token);
 			};
 
 			const performSearchVersions = async (pkg: string) => {
-				return await service.searchPackageVersions(pkg);
+				return await service.searchPackageVersions(pkg, cts.token);
 			};
 
 			const performInstall = async (pkg: string, version?: string): Promise<void> => {
@@ -126,13 +141,16 @@ class InstallPackageAction extends Action2 {
 					throw new Error('No version specified.');
 				}
 
+				const installCts = new CancellationTokenSource();
+
 				await progress.withProgress({
 					title: nls.localize('positronPackages.installingPackages', 'Installing Packages...'),
 					location: ProgressLocation.Notification,
+					cancellable: true,
 					delay: 500
-				}, async (_progress) => {
+				}, async () => {
 					try {
-						await service.installPackages([{ name: pkg, version }]);
+						await service.installPackages([{ name: pkg, version }], installCts.token);
 					} catch (e) {
 						notifications.notify({
 							severity: Severity.Error,
@@ -149,13 +167,15 @@ class InstallPackageAction extends Action2 {
 							message: nls.localize('positronPackages.failedToInstallPackage', "Failed to install package: '{0}'", pkg),
 						});
 					}
-				});
+				}, () => installCts.dispose(true));
 			};
 
 			await installPackage(accessor, performSearch, performSearchVersions, performInstall);
 		} catch (error) {
 			notifications.error(error);
 			throw error;
+		} finally {
+			cts.dispose();
 		}
 	}
 }
@@ -186,14 +206,17 @@ class UninstallPackageAction extends Action2 {
 					}));
 			};
 
-			const performUninstall = async (pkg: string, version?: string): Promise<void> => {
+			const performUninstall = async (pkg: string): Promise<void> => {
+				const uninstallCts = new CancellationTokenSource();
+
 				await progress.withProgress({
 					title: nls.localize('positronPackages.uninstallingPackages', 'Uninstalling Packages...'),
 					location: ProgressLocation.Notification,
+					cancellable: true,
 					delay: 500
-				}, async (_progress) => {
+				}, async () => {
 					try {
-						await service.uninstallPackages([pkg]);
+						await service.uninstallPackages([pkg], uninstallCts.token);
 					} catch (e) {
 						notifications.notify({
 							severity: Severity.Error,
@@ -210,7 +233,7 @@ class UninstallPackageAction extends Action2 {
 							message: nls.localize('positronPackages.failedToUninstallPackage', "Failed to uninstall package: '{0}'", pkg),
 						});
 					}
-				});
+				}, () => uninstallCts.dispose(true));
 			};
 
 			const argPackage = args.at(0) as string | undefined;
@@ -253,6 +276,10 @@ class UpdatePackageAction extends Action2 {
 		const commands = accessor.get<ICommandService>(ICommandService);
 		const notifications = accessor.get<INotificationService>(INotificationService);
 		const progress = accessor.get<IProgressService>(IProgressService);
+
+		// Create a token source for the entire update flow
+		const cts = new CancellationTokenSource();
+
 		try {
 			const performSearch = async () => {
 				const packages = await commands.executeCommand(PACKAGES_REFRESH_COMMAND_ID) as ILanguageRuntimePackage[];
@@ -263,18 +290,20 @@ class UpdatePackageAction extends Action2 {
 			};
 
 			const performSearchVersions = async (pkg: string) => {
-				return await service.searchPackageVersions(pkg);
+				return await service.searchPackageVersions(pkg, cts.token);
 			};
 
 			const performUpdate = async (pkg: string, version: string): Promise<void> => {
+				const updateCts = new CancellationTokenSource();
 
 				await progress.withProgress({
 					title: nls.localize('positronPackages.updatingPackages', 'Updating Packages...'),
 					location: ProgressLocation.Notification,
+					cancellable: true,
 					delay: 500
-				}, async (_progress) => {
+				}, async () => {
 					try {
-						await service.updatePackages([{ name: pkg, version }]);
+						await service.updatePackages([{ name: pkg, version }], updateCts.token);
 					} catch (e) {
 						notifications.notify({
 							severity: Severity.Error,
@@ -291,7 +320,7 @@ class UpdatePackageAction extends Action2 {
 							message: nls.localize('positronPackages.failedToUpdatePackage', "Failed to update package: '{0}'", pkg),
 						});
 					}
-				});
+				}, () => updateCts.dispose(true));
 			};
 
 			const arg0 = args.at(0) as string | undefined;
@@ -299,6 +328,8 @@ class UpdatePackageAction extends Action2 {
 		} catch (error) {
 			notifications.error(error);
 			throw error;
+		} finally {
+			cts.dispose();
 		}
 	}
 }
@@ -319,18 +350,21 @@ class UpdateAllPackagesAction extends Action2 {
 			}
 		});
 	}
-	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
+	override async run(accessor: ServicesAccessor): Promise<void> {
 		const service = accessor.get<IPositronPackagesService>(IPositronPackagesService);
 		const notifications = accessor.get<INotificationService>(INotificationService);
 		const progress = accessor.get<IProgressService>(IProgressService);
 
+		const cts = new CancellationTokenSource();
+
 		await progress.withProgress({
 			title: nls.localize('positronPackages.updatingPackages', 'Updating Packages...'),
 			location: ProgressLocation.Notification,
+			cancellable: true,
 			delay: 500
-		}, async (_progress) => {
+		}, async () => {
 			try {
-				await service.updateAllPackages();
+				await service.updateAllPackages(cts.token);
 			} catch (e) {
 				notifications.notify({
 					severity: Severity.Error,
@@ -347,7 +381,7 @@ class UpdateAllPackagesAction extends Action2 {
 					message: nls.localize('positronPackages.failedToUpdateAllPackages', "Failed to update all packages"),
 				});
 			}
-		});
+		}, () => cts.dispose(true));
 	}
 }
 

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesInstance.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesInstance.ts
@@ -114,11 +114,12 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 
 	async refreshPackages(token?: CancellationToken): Promise<ILanguageRuntimePackage[]> {
 		const packageManager = this.getPackageManagerOrThrow();
+		const effectiveToken = token ?? CancellationToken.None;
 
 		// Loading
 		this._onDidChangeRefreshState.fire(true);
 		try {
-			this._packages = await packageManager.getPackages(token);
+			this._packages = await packageManager.getPackages(effectiveToken);
 			this._onDidRefreshPackagesInstance.fire(this._packages);
 			return this._packages;
 		} finally {
@@ -128,15 +129,17 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 
 	async installPackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void> {
 		const packageManager = this.getPackageManagerOrThrow();
+		const effectiveToken = token ?? CancellationToken.None;
+		console.log(`FOO: effectiveToken = ${effectiveToken === CancellationToken.None}`);
 
 		// Loading
 		this._onDidChangeInstallState.fire(true);
 
 		try {
-			await packageManager.installPackages(packages, token);
+			await packageManager.installPackages(packages, effectiveToken);
 
 			// Fire refresh event.
-			this._packages = await packageManager.getPackages(token);
+			this._packages = await packageManager.getPackages(effectiveToken);
 			this._onDidRefreshPackagesInstance.fire(this._packages);
 		} finally {
 			// Completed
@@ -146,15 +149,16 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 
 	async uninstallPackages(packageNames: string[], token?: CancellationToken): Promise<void> {
 		const packageManager = this.getPackageManagerOrThrow();
+		const effectiveToken = token ?? CancellationToken.None;
 
 		// Loading
 		this._onDidChangeUninstallState.fire(true);
 
 		try {
-			await packageManager.uninstallPackages(packageNames, token);
+			await packageManager.uninstallPackages(packageNames, effectiveToken);
 
 			// Fire refresh event.
-			this._packages = await packageManager.getPackages(token);
+			this._packages = await packageManager.getPackages(effectiveToken);
 			this._onDidRefreshPackagesInstance.fire(this._packages);
 		} finally {
 			// Completed
@@ -164,18 +168,19 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 
 	async updatePackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void> {
 		const packageManager = this.getPackageManagerOrThrow();
+		const effectiveToken = token ?? CancellationToken.None;
 
 		// Loading
 		this._onDidChangeUpdateState.fire(true);
 
 		try {
-			await packageManager.updatePackages(packages, token);
-			if (token?.isCancellationRequested) {
+			await packageManager.updatePackages(packages, effectiveToken);
+			if (effectiveToken.isCancellationRequested) {
 				return;
 			}
 
 			// Fire refresh event.
-			this._packages = await packageManager.getPackages(token);
+			this._packages = await packageManager.getPackages(effectiveToken);
 			this._onDidRefreshPackagesInstance.fire(this._packages);
 		} finally {
 			// Completed
@@ -185,18 +190,19 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 
 	async updateAllPackages(token?: CancellationToken): Promise<void> {
 		const packageManager = this.getPackageManagerOrThrow();
+		const effectiveToken = token ?? CancellationToken.None;
 
 		// Loading
 		this._onDidChangeUpdateAllState.fire(true);
 
 		try {
-			await packageManager.updateAllPackages(token);
-			if (token?.isCancellationRequested) {
+			await packageManager.updateAllPackages(effectiveToken);
+			if (effectiveToken.isCancellationRequested) {
 				return;
 			}
 
 			// Fire refresh event.
-			this._packages = await packageManager.getPackages(token);
+			this._packages = await packageManager.getPackages(effectiveToken);
 			this._onDidRefreshPackagesInstance.fire(this._packages);
 		} finally {
 			// Completed
@@ -206,8 +212,9 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 
 	async searchPackages(name: string, token?: CancellationToken): Promise<ILanguageRuntimePackage[]> {
 		const packageManager = this.getPackageManagerOrThrow();
-		const results = await packageManager.searchPackages(name, token);
-		if (token?.isCancellationRequested) {
+		const effectiveToken = token ?? CancellationToken.None;
+		const results = await packageManager.searchPackages(name, effectiveToken);
+		if (effectiveToken.isCancellationRequested) {
 			return [];
 		}
 		return results;
@@ -215,8 +222,9 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 
 	async searchPackageVersions(name: string, token?: CancellationToken): Promise<string[]> {
 		const packageManager = this.getPackageManagerOrThrow();
-		const results = await packageManager.searchPackageVersions(name, token);
-		if (token?.isCancellationRequested) {
+		const effectiveToken = token ?? CancellationToken.None;
+		const results = await packageManager.searchPackageVersions(name, effectiveToken);
+		if (effectiveToken.isCancellationRequested) {
 			return [];
 		}
 		return results;

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesInstance.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesInstance.ts
@@ -130,7 +130,6 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 	async installPackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void> {
 		const packageManager = this.getPackageManagerOrThrow();
 		const effectiveToken = token ?? CancellationToken.None;
-		console.log(`FOO: effectiveToken = ${effectiveToken === CancellationToken.None}`);
 
 		// Loading
 		this._onDidChangeInstallState.fire(true);

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesInstance.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesInstance.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -14,13 +15,13 @@ export interface IPositronPackagesInstance {
 	session: ILanguageRuntimeSession;
 	attachRuntime(): void;
 	detachRuntime(): void;
-	refreshPackages(): Promise<ILanguageRuntimePackage[]>;
-	installPackages(packages: IPackageSpec[]): Promise<void>;
-	uninstallPackages(packageNames: string[]): Promise<void>;
-	updatePackages(packages: IPackageSpec[]): Promise<void>;
-	updateAllPackages(): Promise<void>;
-	searchPackages(name: string): Promise<ILanguageRuntimePackage[]>;
-	searchPackageVersions(name: string): Promise<string[]>;
+	refreshPackages(token?: CancellationToken): Promise<ILanguageRuntimePackage[]>;
+	installPackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void>;
+	uninstallPackages(packageNames: string[], token?: CancellationToken): Promise<void>;
+	updatePackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void>;
+	updateAllPackages(token?: CancellationToken): Promise<void>;
+	searchPackages(name: string, token?: CancellationToken): Promise<ILanguageRuntimePackage[]>;
+	searchPackageVersions(name: string, token?: CancellationToken): Promise<string[]>;
 
 	readonly onDidRefreshPackagesInstance: Event<ILanguageRuntimePackage[]>;
 
@@ -111,13 +112,13 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 		return packageManager;
 	}
 
-	async refreshPackages(): Promise<ILanguageRuntimePackage[]> {
+	async refreshPackages(token?: CancellationToken): Promise<ILanguageRuntimePackage[]> {
 		const packageManager = this.getPackageManagerOrThrow();
 
 		// Loading
 		this._onDidChangeRefreshState.fire(true);
 		try {
-			this._packages = await packageManager.getPackages();
+			this._packages = await packageManager.getPackages(token);
 			this._onDidRefreshPackagesInstance.fire(this._packages);
 			return this._packages;
 		} finally {
@@ -125,17 +126,17 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 		}
 	}
 
-	async installPackages(packages: IPackageSpec[]): Promise<void> {
+	async installPackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void> {
 		const packageManager = this.getPackageManagerOrThrow();
 
 		// Loading
 		this._onDidChangeInstallState.fire(true);
 
 		try {
-			await packageManager.installPackages(packages);
+			await packageManager.installPackages(packages, token);
 
 			// Fire refresh event.
-			this._packages = await packageManager.getPackages();
+			this._packages = await packageManager.getPackages(token);
 			this._onDidRefreshPackagesInstance.fire(this._packages);
 		} finally {
 			// Completed
@@ -143,17 +144,17 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 		}
 	}
 
-	async uninstallPackages(packageNames: string[]): Promise<void> {
+	async uninstallPackages(packageNames: string[], token?: CancellationToken): Promise<void> {
 		const packageManager = this.getPackageManagerOrThrow();
 
 		// Loading
 		this._onDidChangeUninstallState.fire(true);
 
 		try {
-			await packageManager.uninstallPackages(packageNames);
+			await packageManager.uninstallPackages(packageNames, token);
 
 			// Fire refresh event.
-			this._packages = await packageManager.getPackages();
+			this._packages = await packageManager.getPackages(token);
 			this._onDidRefreshPackagesInstance.fire(this._packages);
 		} finally {
 			// Completed
@@ -161,17 +162,20 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 		}
 	}
 
-	async updatePackages(packages: IPackageSpec[]): Promise<void> {
+	async updatePackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void> {
 		const packageManager = this.getPackageManagerOrThrow();
 
 		// Loading
 		this._onDidChangeUpdateState.fire(true);
 
 		try {
-			await packageManager.updatePackages(packages);
+			await packageManager.updatePackages(packages, token);
+			if (token?.isCancellationRequested) {
+				return;
+			}
 
 			// Fire refresh event.
-			this._packages = await packageManager.getPackages();
+			this._packages = await packageManager.getPackages(token);
 			this._onDidRefreshPackagesInstance.fire(this._packages);
 		} finally {
 			// Completed
@@ -179,17 +183,20 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 		}
 	}
 
-	async updateAllPackages(): Promise<void> {
+	async updateAllPackages(token?: CancellationToken): Promise<void> {
 		const packageManager = this.getPackageManagerOrThrow();
 
 		// Loading
 		this._onDidChangeUpdateAllState.fire(true);
 
 		try {
-			await packageManager.updateAllPackages();
+			await packageManager.updateAllPackages(token);
+			if (token?.isCancellationRequested) {
+				return;
+			}
 
 			// Fire refresh event.
-			this._packages = await packageManager.getPackages();
+			this._packages = await packageManager.getPackages(token);
 			this._onDidRefreshPackagesInstance.fire(this._packages);
 		} finally {
 			// Completed
@@ -197,14 +204,22 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 		}
 	}
 
-	async searchPackages(name: string): Promise<ILanguageRuntimePackage[]> {
+	async searchPackages(name: string, token?: CancellationToken): Promise<ILanguageRuntimePackage[]> {
 		const packageManager = this.getPackageManagerOrThrow();
-		return await packageManager.searchPackages(name);
+		const results = await packageManager.searchPackages(name, token);
+		if (token?.isCancellationRequested) {
+			return [];
+		}
+		return results;
 	}
 
-	async searchPackageVersions(name: string): Promise<string[]> {
+	async searchPackageVersions(name: string, token?: CancellationToken): Promise<string[]> {
 		const packageManager = this.getPackageManagerOrThrow();
-		return await packageManager.searchPackageVersions(name);
+		const results = await packageManager.searchPackageVersions(name, token);
+		if (token?.isCancellationRequested) {
+			return [];
+		}
+		return results;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
@@ -25,8 +26,8 @@ export const updatePackage = async (
 	performGetPackages: (q: string) => Promise<PackageSearchResult[]>,
 	performLookup: (q: string) => Promise<string[]>,
 	performUpdate: (pkg: string, version: string) => Promise<void>,
-	packageToInstall?: string
-
+	packageToInstall?: string,
+	cts?: CancellationTokenSource,
 ) => {
 	const title = localize('positronPackages.updatePackageTitle', 'Update Package');
 
@@ -49,9 +50,9 @@ export const updatePackage = async (
 
 		if (packageToInstall) {
 			state.selectedPackage = packageToInstall;
-			await MultiStepInput.run(accessor, (input) => pickVersion(input, state));
+			await MultiStepInput.run(accessor, (input) => pickVersion(input, state), cts);
 		} else {
-			await MultiStepInput.run(accessor, (input) => showLoading(input, state));
+			await MultiStepInput.run(accessor, (input) => showLoading(input, state), cts);
 		}
 
 		return state as State;
@@ -113,7 +114,8 @@ export const updatePackage = async (
 export const uninstallPackage = async (
 	accessor: ServicesAccessor,
 	performGetPackages: (q: string) => Promise<PackageSearchResult[]>,
-	performUninstall: (pkg: string, version?: string) => Promise<void>
+	performUninstall: (pkg: string, version?: string) => Promise<void>,
+	cts?: CancellationTokenSource,
 ) => {
 	const title = localize('positronPackages.uninstallPackageTitle', 'Uninstall Package');
 
@@ -127,7 +129,7 @@ export const uninstallPackage = async (
 			packages: [],
 			selectedPackage: undefined,
 		};
-		await MultiStepInput.run(accessor, (input) => showLoading(input, state));
+		await MultiStepInput.run(accessor, (input) => showLoading(input, state), cts);
 		return state as State;
 	}
 
@@ -170,6 +172,7 @@ export const installPackage = async (
 	performSearch: (q: string) => Promise<PackageSearchResult[]>,
 	performLookup: (q: string) => Promise<string[]>,
 	performInstall: (pkg: string, version?: string) => Promise<void>,
+	cts?: CancellationTokenSource,
 ) => {
 	const title = localize('positronPackages.installPackageTitle', 'Install Package');
 
@@ -189,7 +192,7 @@ export const installPackage = async (
 			selectedPackage: undefined,
 			selectedVersion: undefined,
 		};
-		await MultiStepInput.run(accessor, (input) => searchPackage(input, state));
+		await MultiStepInput.run(accessor, (input) => searchPackage(input, state), cts);
 		return state as State;
 	}
 
@@ -296,15 +299,13 @@ interface InputBoxParameters {
 
 class MultiStepInput {
 	quickPickService: IQuickInputService;
-	static async run(accessor: ServicesAccessor, start: InputStep) {
+	static async run(accessor: ServicesAccessor, start: InputStep, cts?: CancellationTokenSource) {
 		const quickPickService = accessor.get(IQuickInputService);
-		const input = new MultiStepInput(quickPickService);
+		const input = new MultiStepInput(quickPickService, cts);
 		return input.stepThrough(start);
 	}
 
-
-
-	constructor(quickPickService: IQuickInputService) {
+	constructor(quickPickService: IQuickInputService, private readonly cts?: CancellationTokenSource) {
 		this.quickPickService = quickPickService;
 	}
 
@@ -327,7 +328,8 @@ class MultiStepInput {
 					step = this.steps.pop();
 				} else if (err === InputFlowAction.resume) {
 					step = this.steps.pop();
-				} else if (err === InputFlowAction.cancel) {
+				} else if (err === InputFlowAction.cancel || err.cause === InputFlowAction.cancel || err.message === InputFlowAction.cancel || err.message === 'canceled') {
+					this.cts?.cancel();
 					step = undefined;
 				} else {
 					throw err;
@@ -376,7 +378,10 @@ class MultiStepInput {
 							}
 						}),
 						input.onDidChangeSelection((items) => resolve(items[0])),
-						input.onDidHide(() => reject(InputFlowAction.cancel)),
+						input.onDidHide(() => {
+							this.cts?.cancel();
+							reject(InputFlowAction.cancel);
+						}),
 					);
 					if (this.current) {
 						this.current.dispose();

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { timeout } from '../../../../base/common/async.js';
+import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, DisposableMap } from '../../../../base/common/lifecycle.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
@@ -98,11 +99,11 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		return this._activeInstance?.session;
 	}
 
-	async refreshPackages(): Promise<ILanguageRuntimePackage[]> {
+	async refreshPackages(token?: CancellationToken): Promise<ILanguageRuntimePackage[]> {
 		const instance = this._activeInstance;
 		if (instance) {
 			return await Promise.race([
-				instance.refreshPackages(),
+				instance.refreshPackages(token),
 				timeout(TIMEOUT_REFRESH_MS).then(() => { throw new Error('Package refresh timed out'); })
 			]);
 		}
@@ -110,55 +111,55 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		throw new Error('No active session found.');
 	}
 
-	async installPackages(packages: IPackageSpec[]): Promise<void> {
+	async installPackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void> {
 		const instance = this._activeInstance;
 		if (instance) {
-			return await instance.installPackages(packages);
+			return await instance.installPackages(packages, token);
 		}
 
 		throw new Error('No active session found.');
 	}
 
-	async uninstallPackages(packageNames: string[]): Promise<void> {
+	async uninstallPackages(packageNames: string[], token?: CancellationToken): Promise<void> {
 		const instance = this._activeInstance;
 		if (instance) {
-			return await instance.uninstallPackages(packageNames);
+			return await instance.uninstallPackages(packageNames, token);
 		}
 
 		throw new Error('No active session found.');
 	}
 
-	async updatePackages(packages: IPackageSpec[]): Promise<void> {
+	async updatePackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void> {
 		const instance = this._activeInstance;
 		if (instance) {
-			return await instance.updatePackages(packages);
+			return await instance.updatePackages(packages, token);
 		}
 
 		throw new Error('No active session found.');
 	}
 
-	async updateAllPackages(): Promise<void> {
+	async updateAllPackages(token?: CancellationToken): Promise<void> {
 		const instance = this._activeInstance;
 		if (instance) {
-			return await instance.updateAllPackages();
+			return await instance.updateAllPackages(token);
 		}
 
 		throw new Error('No active session found.');
 	}
 
-	async searchPackages(name: string): Promise<ILanguageRuntimePackage[]> {
+	async searchPackages(name: string, token?: CancellationToken): Promise<ILanguageRuntimePackage[]> {
 		const instance = this._activeInstance;
 		if (instance) {
-			return await instance.searchPackages(name);
+			return await instance.searchPackages(name, token);
 		}
 
 		throw new Error('No active session found.');
 	}
 
-	async searchPackageVersions(name: string): Promise<string[]> {
+	async searchPackageVersions(name: string, token?: CancellationToken): Promise<string[]> {
 		const instance = this._activeInstance;
 		if (instance) {
-			return await instance.searchPackageVersions(name);
+			return await instance.searchPackageVersions(name, token);
 		}
 
 		throw new Error('No active session found.');

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -296,50 +296,50 @@ export interface IPackageSpec {
 export interface ILanguageRuntimePackageManager {
 	/**
 	 * Get list of installed packages.
-	 * @param token Cancellation token
+	 * @param token Optional cancellation token
 	 */
-	getPackages(token: CancellationToken): Promise<ILanguageRuntimePackage[]>;
+	getPackages(token?: CancellationToken): Promise<ILanguageRuntimePackage[]>;
 
 	/**
 	 * Install the list of packages.
 	 * @param packages Array of package install requests with name and optional version
-	 * @param token Cancellation token
+	 * @param token Optional cancellation token
 	 */
-	installPackages(packages: IPackageSpec[], token: CancellationToken): Promise<void>;
+	installPackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void>;
 
 	/**
 	 * Uninstall the list of packages.
 	 * @param packageNames Array of package names to uninstall
-	 * @param token Cancellation token
+	 * @param token Optional cancellation token
 	 */
-	uninstallPackages(packageNames: string[], token: CancellationToken): Promise<void>;
+	uninstallPackages(packageNames: string[], token?: CancellationToken): Promise<void>;
 
 	/**
 	 * Update the list of packages.
 	 * @param packages Array of package install requests with name and optional version
-	 * @param token Cancellation token
+	 * @param token Optional cancellation token
 	 */
-	updatePackages(packages: IPackageSpec[], token: CancellationToken): Promise<void>;
+	updatePackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void>;
 
 	/**
 	 * Update all installed packages.
-	 * @param token Cancellation token
+	 * @param token Optional cancellation token
 	 */
-	updateAllPackages(token: CancellationToken): Promise<void>;
+	updateAllPackages(token?: CancellationToken): Promise<void>;
 
 	/**
 	 * Search a repository for packages matching the query.
 	 * @param query Search query string
-	 * @param token Cancellation token
+	 * @param token Optional cancellation token
 	 */
-	searchPackages(query: string, token: CancellationToken): Promise<ILanguageRuntimePackage[]>;
+	searchPackages(query: string, token?: CancellationToken): Promise<ILanguageRuntimePackage[]>;
 
 	/**
 	 * Search a repository for available versions of a package.
 	 * @param name Package name
-	 * @param token Cancellation token
+	 * @param token Optional cancellation token
 	 */
-	searchPackageVersions(name: string, token: CancellationToken): Promise<string[]>;
+	searchPackageVersions(name: string, token?: CancellationToken): Promise<string[]>;
 }
 
 /**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -296,50 +296,50 @@ export interface IPackageSpec {
 export interface ILanguageRuntimePackageManager {
 	/**
 	 * Get list of installed packages.
-	 * @param token Optional cancellation token
+	 * @param token Cancellation token
 	 */
-	getPackages(token?: CancellationToken): Promise<ILanguageRuntimePackage[]>;
+	getPackages(token: CancellationToken): Promise<ILanguageRuntimePackage[]>;
 
 	/**
 	 * Install the list of packages.
 	 * @param packages Array of package install requests with name and optional version
-	 * @param token Optional cancellation token
+	 * @param token Cancellation token
 	 */
-	installPackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void>;
+	installPackages(packages: IPackageSpec[], token: CancellationToken): Promise<void>;
 
 	/**
 	 * Uninstall the list of packages.
 	 * @param packageNames Array of package names to uninstall
-	 * @param token Optional cancellation token
+	 * @param token Cancellation token
 	 */
-	uninstallPackages(packageNames: string[], token?: CancellationToken): Promise<void>;
+	uninstallPackages(packageNames: string[], token: CancellationToken): Promise<void>;
 
 	/**
 	 * Update the list of packages.
 	 * @param packages Array of package install requests with name and optional version
-	 * @param token Optional cancellation token
+	 * @param token Cancellation token
 	 */
-	updatePackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void>;
+	updatePackages(packages: IPackageSpec[], token: CancellationToken): Promise<void>;
 
 	/**
 	 * Update all installed packages.
-	 * @param token Optional cancellation token
+	 * @param token Cancellation token
 	 */
-	updateAllPackages(token?: CancellationToken): Promise<void>;
+	updateAllPackages(token: CancellationToken): Promise<void>;
 
 	/**
 	 * Search a repository for packages matching the query.
 	 * @param query Search query string
-	 * @param token Optional cancellation token
+	 * @param token Cancellation token
 	 */
-	searchPackages(query: string, token?: CancellationToken): Promise<ILanguageRuntimePackage[]>;
+	searchPackages(query: string, token: CancellationToken): Promise<ILanguageRuntimePackage[]>;
 
 	/**
 	 * Search a repository for available versions of a package.
 	 * @param name Package name
-	 * @param token Optional cancellation token
+	 * @param token Cancellation token
 	 */
-	searchPackageVersions(name: string, token?: CancellationToken): Promise<string[]>;
+	searchPackageVersions(name: string, token: CancellationToken): Promise<string[]>;
 }
 
 /**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { Event } from '../../../../base/common/event.js';
 import { URI } from '../../../../base/common/uri.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
@@ -295,43 +296,50 @@ export interface IPackageSpec {
 export interface ILanguageRuntimePackageManager {
 	/**
 	 * Get list of installed packages.
+	 * @param token Optional cancellation token
 	 */
-	getPackages(): Promise<ILanguageRuntimePackage[]>;
+	getPackages(token?: CancellationToken): Promise<ILanguageRuntimePackage[]>;
 
 	/**
 	 * Install the list of packages.
 	 * @param packages Array of package install requests with name and optional version
+	 * @param token Optional cancellation token
 	 */
-	installPackages(packages: IPackageSpec[]): Promise<void>;
+	installPackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void>;
 
 	/**
 	 * Uninstall the list of packages.
 	 * @param packageNames Array of package names to uninstall
+	 * @param token Optional cancellation token
 	 */
-	uninstallPackages(packageNames: string[]): Promise<void>;
+	uninstallPackages(packageNames: string[], token?: CancellationToken): Promise<void>;
 
 	/**
 	 * Update the list of packages.
 	 * @param packages Array of package install requests with name and optional version
+	 * @param token Optional cancellation token
 	 */
-	updatePackages(packages: IPackageSpec[]): Promise<void>;
+	updatePackages(packages: IPackageSpec[], token?: CancellationToken): Promise<void>;
 
 	/**
 	 * Update all installed packages.
+	 * @param token Optional cancellation token
 	 */
-	updateAllPackages(): Promise<void>;
+	updateAllPackages(token?: CancellationToken): Promise<void>;
 
 	/**
 	 * Search a repository for packages matching the query.
 	 * @param query Search query string
+	 * @param token Optional cancellation token
 	 */
-	searchPackages(query: string): Promise<ILanguageRuntimePackage[]>;
+	searchPackages(query: string, token?: CancellationToken): Promise<ILanguageRuntimePackage[]>;
 
 	/**
 	 * Search a repository for available versions of a package.
 	 * @param name Package name
+	 * @param token Optional cancellation token
 	 */
-	searchPackageVersions(name: string): Promise<string[]>;
+	searchPackageVersions(name: string, token?: CancellationToken): Promise<string[]>;
 }
 
 /**


### PR DESCRIPTION
This PR adds progress and cancellation support to the package pane actions.

The two areas of attention to support were:
- Dismissing any quick pick menus
- Clicking the Cancel button in the withProgress notification

There were four distinct actions to cancel:
- session.execution
- session.callMethod
- HTTP requests
- spawning processes in the terminal

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Adds Progress/Cancellation support to packages pane actions.

### QA Notes

I testing this by adding a 4 second sleep to `.ps.rpc.pkg_list` in ark...

I also added a sleep to the commands used to perform the actual package management. Something like this: `tryCatch({Sys.sleep(4); <the actual command>}, interrupt = function(e) NULL)`

You could then use the install, update, or uninstall commands to kick off the request. For update/uninstall it is when the quick pick is first shown it'll refresh (and you can press ESC to cancel it), for install it is when actually peforming a search. I did the same for the version picker call.

When actually performing the package management functions, we use the notification service's withProgress function, and there is a cancel button that should also work. We usually end package management functions with a call to refresh, so you could, using that 4 second delay, mutate the package and cancel during the refresh stage, and see nothing is being updated to verify that the cancellation took effect. Then manually click refresh and see ~4 seconds later that it works.

With the above `tryCatch` change with a sleep you can also introduce enough time to interrupt the package management call.