### PR TITLE
E2E test: disallow extra output on interpreter startup

### DIFF
--- a/test/e2e/tests/console/console-python.test.ts
+++ b/test/e2e/tests/console/console-python.test.ts
@@ -26,6 +26,11 @@ test.describe('Console Pane: Alternate Python', { tag: [tags.WEB, tags.CONSOLE, 
 
 test.describe('Console Pane: Python', { tag: [tags.WEB, tags.CONSOLE, tags.WIN] }, () => {
 
+	test('Python - do not allow extra console output on start', async function ({ app, python }) {
+
+		await app.workbench.console.waitForConsoleContents(process.env.POSITRON_PY_VER_SEL!, { expectedCount: 2, timeout: 20000 });
+	});
+
 	test('Python - queue user input while interpreter is starting', async function ({ app, sessions }) {
 		await sessions.startAndSkipMetadata({ language: 'Python', waitForReady: false });
 		await app.workbench.console.executeCode('Python', 'import time; time.sleep(5); print("done");',);

--- a/test/e2e/tests/console/console-r.test.ts
+++ b/test/e2e/tests/console/console-r.test.ts
@@ -17,6 +17,11 @@ test.describe('Console Pane: R', {
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 	});
 
+	test('R - do not allow extra console output on start', async function ({ app, r }) {
+
+		await app.workbench.console.waitForConsoleContents(process.env.POSITRON_R_VER_SEL!, { expectedCount: 2, timeout: 20000 });
+	});
+
 	test('R - Verify cat from .Rprofile', async function ({ app, r }) {
 		await expect(async () => {
 			await app.workbench.console.waitForConsoleContents('cat from .Rprofile');


### PR DESCRIPTION
Don't allow extraneous output when starting an interpreter.

https://github.com/posit-dev/positron/issues/12167

### QA Notes

@:console @:web @:win
