### PR TITLE
Fix notebook cell output not updating during streaming execution

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Event } from '../../../../../base/common/event.js';
 import { ISettableObservable, observableFromEvent, observableValue } from '../../../../../base/common/observable.js';
 import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
 import { NotebookCellTextModel } from '../../../notebook/common/model/notebookCellTextModel.js';
@@ -45,7 +46,7 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 			cellModel.collapseState?.outputCollapsed ?? false
 		);
 
-		this._outputs = observableFromEvent(this, this.model.onDidChangeOutputs, () => {
+		this._outputs = observableFromEvent(this, Event.any(this.model.onDidChangeOutputs, this.model.onDidChangeOutputItems), () => {
 			/** @description cellOutputs */
 			return this.parseCellOutputs();
 		});


### PR DESCRIPTION
Addresses #11726, #12502, #11630.

The Positron notebook editor was not rendering incremental/streaming output
in real-time during cell execution. Only the first output message appeared;
subsequent output (e.g., print statements in loops, tqdm progress bars,
rich.progress track) was invisible until the cell was stopped, the notebook
was saved and reopened, or the tab was switched.

https://github.com/user-attachments/assets/d6ae32ac-fb33-45e1-954a-d0d7441499ae


The root cause was that the cell output observable in `PositronNotebookCodeCell`
only subscribed to `onDidChangeOutputs` (structural add/remove of outputs),
but not `onDidChangeOutputItems` (in-place data appends to existing outputs).
When the kernel streams consecutive messages to the same stream (stdout/stderr),
subsequent messages are appended to the existing output via `changeOutputItems()`,
which only fires `onDidChangeOutputItems`. The UI never saw these updates.

The fix subscribes to both events using `Event.any()`, matching the pattern
used by the upstream VSCode notebook (see `notebook.contribution.ts:603`).

**Note:** This fix resolves the core issue of streaming output not appearing
in real-time. However, libraries that use advanced terminal escape codes for
in-place updates (e.g., `rich.progress`, `tqdm`) will still render incorrectly
-- showing stacked intermediate states instead of a single updating line. That
is a separate ANSI escape code rendering issue (the stream text renderer does
not handle `ESC[K` erase-to-end-of-line and similar cursor control sequences)
and should be tracked independently.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed Positron notebook cell output not updating in real-time during streaming execution (#11726, #12502, #11630)

### QA Notes

@:positron-notebooks

1. Create a notebook with the following cell and run it:
```python
import time
for i in range(20):
    print(f"Iteration {i} completed.")
    time.sleep(0.1)
print("Done!")
```
2. Verify each iteration appears in real-time as the cell executes, not just after completion.

3. Also verify rapid output works without freezing:
```python
for i in range(200):
    print(f"Line {i}")
```