### PR TITLE
Sort package versions newest-first in version picker

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
@@ -7,6 +7,7 @@ import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IInputBox, IQuickInput, IQuickInputButton, IQuickInputService, IQuickPickItem, QuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
+import * as semver from '../../../../base/common/semver/semver.js';
 
 interface VersionSearchResult {
 	name: string;
@@ -18,6 +19,24 @@ interface PackageSearchResult {
 	description?: string;
 	// detail appears on the second line
 	detail?: string;
+}
+
+/**
+ * Sort version strings in descending order (newest first).
+ * Uses semver comparison when possible, falls back to string comparison.
+ */
+function sortVersionsDescending(versions: string[]): string[] {
+	return [...versions].sort((a, b) => {
+		const aSemver = semver.valid(a, true) ? a : semver.coerce(a);
+		const bSemver = semver.valid(b, true) ? b : semver.coerce(b);
+
+		if (aSemver && bSemver) {
+			return semver.rcompare(aSemver, bSemver, true);
+		}
+
+		// Fall back to simple string comparison
+		return a < b ? 1 : a > b ? -1 : 0;
+	});
 }
 
 export const updatePackage = async (
@@ -89,7 +108,8 @@ export const updatePackage = async (
 
 	async function pickVersion(input: MultiStepInput, state: State) {
 		const versions = await performLookup(state.selectedPackage ?? '');
-		state.versions = versions.map((v) => ({ name: v }));
+		const sortedVersions = sortVersionsDescending(versions);
+		state.versions = sortedVersions.map((v) => ({ name: v }));
 
 		const selection = await input.showQuickPick({
 			title,
@@ -195,7 +215,8 @@ export const installPackage = async (
 
 	async function pickVersion(input: MultiStepInput, state: State) {
 		const versions = await performLookup(state.selectedPackage ?? '');
-		state.versions = versions.map((v) => ({ name: v }));
+		const sortedVersions = sortVersionsDescending(versions);
+		state.versions = sortedVersions.map((v) => ({ name: v }));
 
 		const selection = await input.showQuickPick({
 			title,


### PR DESCRIPTION
See #12435

When installing or updating packages via the Packages Pane, the version picker now displays versions in descending order (newest first) instead of the order returned by package repositories.

Uses semver comparison when possible, with a fallback to locale-aware string comparison for non-semver version formats.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Sort versions with most recent first, using semver, when picking a version in the packages pane


### QA Notes

Try installing `cowsay` in python... notice that it'll now show the most recent first:

<img width="627" height="230" alt="Screenshot 2026-03-17 at 2 08 30 PM" src="https://github.com/user-attachments/assets/1c5b038c-a988-44b8-b8f1-53b259bda407" />
