### PR TITLE
Avoid 'dancing consoles' at startup

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/startupStatus.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/startupStatus.tsx
@@ -84,7 +84,11 @@ export const StartupStatus = () => {
 		disposableStore.add(
 			services.runtimeStartupService.onWillAutoStartRuntime(
 				evt => {
-					setRuntimeStartupEvent(evt);
+					// Ignore auto-start events that won't activate to avoid
+					// flickering between several runtimes starting up
+					if (evt.activate) {
+						setRuntimeStartupEvent(evt);
+					}
 				}));
 
 		// Return the cleanup function that will dispose of the disposables.

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -11,7 +11,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IOpener, IOpenerService, OpenExternalOptions, OpenInternalOptions } from '../../../../platform/opener/common/opener.js';
-import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionLocation, LanguageRuntimeSessionMode, LanguageRuntimeStartupBehavior, RuntimeExitReason, RuntimeState, LanguageStartupBehavior, formatLanguageRuntimeMetadata, formatLanguageRuntimeSession } from '../../languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionLocation, LanguageRuntimeSessionMode, LanguageRuntimeStartupBehavior, RuntimeExitReason, RuntimeState, LanguageStartupBehavior, formatLanguageRuntimeMetadata, formatLanguageRuntimeSession, RuntimeStartupPhase } from '../../languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeGlobalEvent, INotebookLanguageRuntimeSession, ILanguageRuntimeSession, ILanguageRuntimeSessionManager, ILanguageRuntimeSessionStateEvent, INotebookSessionUriChangedEvent, IRuntimeSessionMetadata, IRuntimeSessionService, IRuntimeSessionWillStartEvent, RuntimeStartMode, INotebookRuntimeSessionMetadata } from './runtimeSessionService.js';
 import { IWorkspaceTrustManagementService } from '../../../../platform/workspace/common/workspaceTrust.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -474,7 +474,13 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			//       returned here. Is that expected?
 			const existingSession = this.getConsoleSessionForRuntime(runtimeId, true);
 			if (existingSession) {
-				// Set it as the foreground session and return.
+				// If startup is not yet complete, don't set the session as
+				// foreground yet, as it interrupts the session selection that
+				// happens during startup
+				if (this._languageRuntimeService.startupPhase !== RuntimeStartupPhase.Complete) {
+					return;
+				}
+				// Otherwise, set it as the foreground session and return.
 				if (existingSession.runtimeMetadata.runtimeId !== this.foregroundSession?.runtimeMetadata.runtimeId) {
 					this.foregroundSession = existingSession;
 				}
@@ -1717,7 +1723,11 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 
 			// Make the newly-started runtime the foreground runtime if it's a console session.
 			if (session.metadata.sessionMode === LanguageRuntimeSessionMode.Console) {
-				this.foregroundSession = session;
+				// Make this the foreground session if there isn't one already,
+				// or if the caller requested to activate it.
+				if (!this.foregroundSession || activate) {
+					this.foregroundSession = session;
+				}
 			}
 		} catch (reason) {
 			this.clearStartingSessionMaps(

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -474,10 +474,11 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 			//       returned here. Is that expected?
 			const existingSession = this.getConsoleSessionForRuntime(runtimeId, true);
 			if (existingSession) {
-				// If startup is not yet complete, don't set the session as
-				// foreground yet, as it interrupts the session selection that
-				// happens during startup
-				if (this._languageRuntimeService.startupPhase !== RuntimeStartupPhase.Complete) {
+				// If startup is not yet complete, don't override the foreground
+				// session, as it interrupts the session selection that happens
+				// during startup
+				if (this.foregroundSession &&
+					this._languageRuntimeService.startupPhase !== RuntimeStartupPhase.Complete) {
 					return;
 				}
 				// Otherwise, set it as the foreground session and return.

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -916,6 +916,14 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			return;
 		}
 
+		// Ignore if there's already a foreground session, regardless of
+		// language; at this point either we've autostarted a different runtime
+		// or the user has manually started a runtime, and we don't want to
+		// interfere by starting another one.
+		if (this._runtimeSessionService.foregroundSession) {
+			return;
+		}
+
 		// Get the runtime metadata that is affiliated with this workspace, if any.
 		const affiliatedRuntimeMetadataStr = this._storageService.get(
 			this.storageKeyForRuntime(metadata), this.affiliationStorageScope());
@@ -953,7 +961,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 					metadata.runtimeName,
 					LanguageRuntimeSessionMode.Console,
 					undefined, // Console session
-					`Affiliated runtime for workspace`,
+					`Affiliated runtime for workspace registered`,
 					RuntimeStartMode.Starting,
 					true);
 			} catch (e) {

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -1221,7 +1221,8 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				// Let the UI know we're about to try starting this session
 				this._onWillAutoStartRuntime.fire({
 					runtime: affiliation.metadata,
-					newSession: true
+					newSession: true,
+					activate: idx === 0
 				});
 			}
 
@@ -1385,7 +1386,8 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		// Let the UI know we're about to try reconnecting to this session
 		this._onWillAutoStartRuntime.fire({
 			runtime: sessions[0].runtimeMetadata,
-			newSession: false
+			newSession: false,
+			activate: true
 		});
 
 		// Activate any extensions needed for the sessions we want to reconnect
@@ -1743,7 +1745,8 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 	) {
 		this._onWillAutoStartRuntime.fire({
 			runtime: metadata,
-			newSession: true
+			newSession: true,
+			activate
 		});
 		this._runtimeSessionService.autoStartRuntime(metadata, source, activate);
 	}

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartupService.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartupService.ts
@@ -19,6 +19,7 @@ export const IRuntimeStartupService =
 export interface IRuntimeAutoStartEvent {
 	runtime: ILanguageRuntimeMetadata;
 	newSession: boolean;
+	activate: boolean;
 }
 
 /**

--- a/src/vs/workbench/services/runtimeStartup/test/common/testRuntimeStartupService.ts
+++ b/src/vs/workbench/services/runtimeStartup/test/common/testRuntimeStartupService.ts
@@ -100,7 +100,7 @@ export class TestRuntimeStartupService implements IRuntimeStartupService {
 	 * @param newSession Whether this is a new session.
 	 */
 	public fireWillAutoStartRuntime(runtime: ILanguageRuntimeMetadata, newSession: boolean): void {
-		this._onWillAutoStartRuntimeEmitter.fire({ runtime, newSession });
+		this._onWillAutoStartRuntimeEmitter.fire({ runtime, newSession, activate: true });
 	}
 
 	/**


### PR DESCRIPTION
This PR makes Positron startup much calmer when multiple affiliated runtimes exist. The changes are pretty simple:

- When firing events that indicate that a runtime will start, note whether we plan to activate the runtime at startup, and use that in the Console to decide whether to flip to the "Preparing" state for the runtime.
- Don't make every session that starts the foreground session; only do this if the session is marked for activation.
- When `selectLanguageRuntime` is called during startup, do not allow it to override the runtime selection process that happens at startup. (The Python extension does this.)

With these changes, you will also notice fewer unwanted Pythons starting in R environments. Since these changes make it possible for the Python console to go completely unused (never focused) in a Positron session, the dormant logic that switches off unused languages can come back into play.

There is a big caveat here, however, which is that the Python extension is still aggressively starting Python in workspaces that don't want or need it. Depending on the timing, this can negate much of the benefits of the above changes; once startup is complete from Positron's perspective, it allows the Python extension to start a new Python if it wants to, and this will focus the new Python session and establish an affiliation. I didn't try to tackle this problem since it is scheduled for work soon in https://github.com/posit-dev/positron/issues/12116.

Addresses https://github.com/posit-dev/positron/issues/10929. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Reduce flickering/switching at startup between languages in the Console for projects that use R and Python (#10929)


### QA Notes

This change specifically addresses startup issues for workspaces that have _affiliated_ runtimes (that is, we know ahead of time which to start). If you observe problematic behavior, use the Runtime Startup Diagnostics report. If you see this, you should have a "calm" startup:

| Runtime                | Name                   | Mode    | State | Start Reason                            | Created     |
| ---------------------- | ---------------------- | ------- | ----- | --------------------------------------- | ----------- |
| Python 3.12.10 (Pyenv) | Python 3.12.10 (Pyenv) | console | idle  | Affiliated Python runtime for workspace | 11:23:14 AM |
| R 4.5.0                | R 4.5.0                | console | idle  | Affiliated R runtime for workspace      | 11:23:14 AM |

If you see Python starting due to "extension requested" activation, then you may still experience some dancing at startup. 

Test tags: `@:console` `@:sessions`