### PR TITLE
Fix notebook drag-and-drop e2e test flakiness

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.tsx
@@ -26,7 +26,7 @@ export function AddCellButtons({ index }: { index: number }) {
 		'positron-add-cell-buttons',
 		{ 'drop-target': showIndicator },
 	)}>
-		{showIndicator && <div className='drag-drop-indicator' />}
+		{showIndicator && <div className='drag-drop-indicator' data-testid='drop-indicator' />}
 		<AddCodeCellButton bordered index={index} notebookInstance={notebookInstance} />
 		<AddMarkdownCellButton bordered index={index} notebookInstance={notebookInstance} />
 	</div>;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/SortableCellList.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/SortableCellList.tsx
@@ -29,6 +29,9 @@ import {
 import * as DOM from '../../../../../base/browser/dom.js';
 import { IPositronNotebookCell } from '../PositronNotebookCells/IPositronNotebookCell.js';
 
+/** Minimum pointer distance (px) before a drag activates. Exported so e2e tests can reference the same value. */
+export const DRAG_ACTIVATION_DISTANCE_PX = 10;
+
 interface SortableCellListProps {
 	cells: IPositronNotebookCell[];
 	onReorder: (cells: IPositronNotebookCell[], targetIndex: number) => void;
@@ -81,11 +84,11 @@ export function SortableCellList({
 	const [isDropNoOp, setIsDropNoOp] = React.useState(false);
 	const isDropNoOpRef = React.useRef(false);
 
-	// Require 10px movement before drag starts (prevents accidental drags)
+	// Require movement before drag starts (prevents accidental drags)
 	const sensors = useSensors(
 		useSensor(PointerSensor, {
 			activationConstraint: {
-				distance: 10,
+				distance: DRAG_ACTIVATION_DISTANCE_PX,
 			},
 		}),
 		useSensor(KeyboardSensor, {

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -409,7 +409,7 @@ export class PositronNotebooks extends Notebooks {
 				// (which shifts cell positions mid-move).
 				const targetCell = this.sortableCellAtIndex(toIndex);
 				await page.evaluate(
-					(el) => el.scrollIntoView({ block: 'center' }),
+					(el) => el!.scrollIntoView({ block: 'center' }),
 					await targetCell.elementHandle()
 				);
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -369,13 +369,10 @@ export class PositronNotebooks extends Notebooks {
 	private async _activateDrag(cellIndex: number): Promise<{ startX: number; startY: number }> {
 		const dragHandle = this.dragHandleAtIndex(cellIndex);
 
-		// Hover near the left edge of the cell to trigger handle visibility
+		// Hover near the left edge of the cell to trigger handle visibility.
+		// Uses locator.hover() for auto-wait and auto-scroll guarantees
 		// (avoids coupling to the internal .cell-drag-zone CSS class).
-		const cellBox = await this.sortableCellAtIndex(cellIndex).boundingBox();
-		if (!cellBox) {
-			throw new Error('Could not get bounding box for sortable cell');
-		}
-		await this.code.driver.page.mouse.move(cellBox.x + 8, cellBox.y + cellBox.height / 2);
+		await this.sortableCellAtIndex(cellIndex).hover({ position: { x: 8, y: 20 } });
 		await expect(dragHandle).toBeVisible({ timeout: 2000 });
 
 		const handleBox = await dragHandle.boundingBox();
@@ -573,13 +570,10 @@ export class PositronNotebooks extends Notebooks {
 	 */
 	async hoverCell(cellIndex: number): Promise<void> {
 		await test.step(`Hover over cell at index ${cellIndex}`, async () => {
-			// Hover near the left edge of the cell to trigger handle visibility
+			// Hover near the left edge of the cell to trigger handle visibility.
+			// Uses locator.hover() for auto-wait and auto-scroll guarantees
 			// (avoids coupling to the internal .cell-drag-zone CSS class).
-			const cellBox = await this.sortableCellAtIndex(cellIndex).boundingBox();
-			if (!cellBox) {
-				throw new Error('Could not get bounding box for sortable cell');
-			}
-			await this.code.driver.page.mouse.move(cellBox.x + 8, cellBox.y + cellBox.height / 2);
+			await this.sortableCellAtIndex(cellIndex).hover({ position: { x: 8, y: 20 } });
 		});
 	}
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -401,33 +401,40 @@ export class PositronNotebooks extends Notebooks {
 			const { startX } = await this._activateDrag(fromIndex);
 			const page = this.code.driver.page;
 
-			// Get the target cell's position
-			const targetCell = this.sortableCellAtIndex(toIndex);
-			const targetBox = await targetCell.boundingBox();
-			if (!targetBox) {
-				throw new Error('Could not get bounding box for target cell during drag');
+			try {
+				// Scroll the target cell into view programmatically AFTER
+				// the drag activates. _activateDrag hovers the source cell
+				// which may scroll the container; we need the target visible
+				// so the mouse move doesn't trigger dnd-kit's auto-scroll
+				// (which shifts cell positions mid-move).
+				const targetCell = this.sortableCellAtIndex(toIndex);
+				await page.evaluate(
+					(el) => el.scrollIntoView({ block: 'center' }),
+					await targetCell.elementHandle()
+				);
+
+				const targetBox = await targetCell.boundingBox();
+				if (!targetBox) {
+					throw new Error('Could not get bounding box for target cell during drag');
+				}
+
+				// Target INSIDE the cell at 75% (bottom quarter) or 25% (top
+				// quarter) so the pointer is unambiguously in the correct half
+				// for dnd-kit's collision detection.
+				const targetY = toIndex > fromIndex
+					? targetBox.y + targetBox.height * 0.75
+					: targetBox.y + targetBox.height * 0.25;
+
+				await page.mouse.move(startX, targetY, { steps: 10 });
+
+				// Wait for the drop indicator to appear, confirming dnd-kit has
+				// processed the final pointer position and computed the drop target.
+				await expect(
+					page.locator('.drag-drop-indicator')
+				).toBeVisible({ timeout: 2000 });
+			} finally {
+				await page.mouse.up();
 			}
-
-			// For downward drags, target just past the bottom of the target cell.
-			// For upward drags, target just above the top.
-			// dnd-kit uses pointer position to determine which half of the
-			// cell the pointer is in, so we need to be clearly past center.
-			const targetY = toIndex > fromIndex
-				? targetBox.y + targetBox.height + 5
-				: targetBox.y - 5;
-
-			// Keep X on the same column as the drag handle start position.
-			// Moving diagonally across the page can take the cursor outside
-			// the notebook area during long drags.
-			await page.mouse.move(startX, targetY, { steps: 20 });
-
-			// Wait for the drop indicator to appear, confirming dnd-kit has
-			// processed the final pointer position and computed the drop target.
-			await expect(
-				page.locator('.drag-drop-indicator')
-			).toBeVisible({ timeout: 2000 });
-
-			await page.mouse.up();
 		});
 	}
 
@@ -498,19 +505,21 @@ export class PositronNotebooks extends Notebooks {
 				return { reachable: false };
 			};
 
-			// First check if target is already visible (no scrolling needed)
-			const initialCheck = await isTargetReachable();
-			if (initialCheck.reachable && initialCheck.targetY !== undefined) {
-				await this.code.driver.page.mouse.move(startX, initialCheck.targetY, { steps: 10 });
-				await this.code.driver.page.mouse.up();
-				return;
-			}
-
-			// Move to edge and wait for auto-scroll to bring target into view
-			// Use polling with timeout instead of fixed iteration count
-			await this.code.driver.page.mouse.move(startX, edgeY, { steps: 5 });
+			const dropIndicator = this.code.driver.page.locator('.drag-drop-indicator');
 
 			try {
+				// First check if target is already visible (no scrolling needed)
+				const initialCheck = await isTargetReachable();
+				if (initialCheck.reachable && initialCheck.targetY !== undefined) {
+					await this.code.driver.page.mouse.move(startX, initialCheck.targetY, { steps: 10 });
+					await expect(dropIndicator).toBeVisible({ timeout: 2000 });
+					return;
+				}
+
+				// Move to edge and wait for auto-scroll to bring target into view
+				// Use polling with timeout instead of fixed iteration count
+				await this.code.driver.page.mouse.move(startX, edgeY, { steps: 5 });
+
 				await expect(async () => {
 					// Keep cursor at edge to maintain auto-scroll
 					await this.code.driver.page.mouse.move(startX, edgeY, { steps: 2 });
@@ -526,20 +535,14 @@ export class PositronNotebooks extends Notebooks {
 				const finalCheck = await isTargetReachable();
 				if (finalCheck.reachable && finalCheck.targetY !== undefined) {
 					await this.code.driver.page.mouse.move(startX, finalCheck.targetY, { steps: 10 });
-					// Wait for the drop indicator to confirm dnd-kit processed the position
-					await expect(
-						this.code.driver.page.locator('.drag-drop-indicator')
-					).toBeVisible({ timeout: 2000 });
-					await this.code.driver.page.mouse.up();
+					await expect(dropIndicator).toBeVisible({ timeout: 2000 });
 					return;
 				}
-			} catch {
-				// Auto-scroll didn't bring target into view - clean up and fail
-				await this.code.driver.page.mouse.up();
-				throw new Error(`Could not reach target cell at index ${toIndex} via auto-scroll`);
-			}
 
-			await this.code.driver.page.mouse.up();
+				throw new Error(`Could not reach target cell at index ${toIndex} via auto-scroll`);
+			} finally {
+				await this.code.driver.page.mouse.up();
+			}
 		});
 	}
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -431,12 +431,11 @@ export class PositronNotebooks extends Notebooks {
 
 				await page.mouse.move(startX, targetY, { steps: 10 });
 
-				// Wait for dnd-kit to process the pointer position. The drop
-				// indicator appears for real moves; for no-op positions (cell
-				// dropped back where it started) the noop highlight appears
-				// instead. Accept either signal.
+				// Wait for the drop indicator to appear, confirming dnd-kit
+				// processed the pointer position. This method is only used for
+				// real (non-no-op) moves, so the indicator will always appear.
 				await expect(
-					page.locator('.drag-drop-indicator, .sortable-cell-noop')
+					page.locator('.drag-drop-indicator')
 				).toBeVisible({ timeout: 2000 });
 			} finally {
 				await page.mouse.up();
@@ -511,14 +510,16 @@ export class PositronNotebooks extends Notebooks {
 				return { reachable: false };
 			};
 
-			const dropSignal = this.code.driver.page.locator('.drag-drop-indicator, .sortable-cell-noop');
+			// This method is only used for real (non-no-op) moves, so
+			// the drop indicator will always appear.
+			const dropIndicator = this.code.driver.page.locator('.drag-drop-indicator');
 
 			try {
 				// First check if target is already visible (no scrolling needed)
 				const initialCheck = await isTargetReachable();
 				if (initialCheck.reachable && initialCheck.targetY !== undefined) {
 					await this.code.driver.page.mouse.move(startX, initialCheck.targetY, { steps: 10 });
-					await expect(dropSignal).toBeVisible({ timeout: 2000 });
+					await expect(dropIndicator).toBeVisible({ timeout: 2000 });
 					return;
 				}
 
@@ -541,7 +542,7 @@ export class PositronNotebooks extends Notebooks {
 				const finalCheck = await isTargetReachable();
 				if (finalCheck.reachable && finalCheck.targetY !== undefined) {
 					await this.code.driver.page.mouse.move(startX, finalCheck.targetY, { steps: 10 });
-					await expect(dropSignal).toBeVisible({ timeout: 2000 });
+					await expect(dropIndicator).toBeVisible({ timeout: 2000 });
 					return;
 				}
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -381,6 +381,13 @@ export class PositronNotebooks extends Notebooks {
 		await this.code.driver.page.mouse.down();
 		await this.code.driver.page.mouse.move(startX, startY + 15, { steps: 3 });
 
+		// Wait for drag to actually activate: the body gets a
+		// 'dragging-notebook-cell' class and the dragged cell becomes
+		// semi-transparent ('sortable-cell-hidden').
+		const page = this.code.driver.page;
+		await expect(page.locator('body.dragging-notebook-cell')).toBeAttached({ timeout: 2000 });
+		await expect(this.sortableCellAtIndex(cellIndex)).toHaveClass(/sortable-cell-hidden/, { timeout: 2000 });
+
 		return { startX, startY };
 	}
 
@@ -392,12 +399,9 @@ export class PositronNotebooks extends Notebooks {
 	async dragCellToPosition(fromIndex: number, toIndex: number): Promise<void> {
 		await test.step(`Drag cell from index ${fromIndex} to index ${toIndex}`, async () => {
 			const { startX } = await this._activateDrag(fromIndex);
+			const page = this.code.driver.page;
 
-			// Wait for the dragged cell to collapse and CSS transitions to settle.
-			// The dragged cell gets `height: 0` which shifts siblings.
-			await this.code.driver.page.waitForTimeout(200);
-
-			// Get the target cell's position after collapse settles
+			// Get the target cell's position
 			const targetCell = this.sortableCellAtIndex(toIndex);
 			const targetBox = await targetCell.boundingBox();
 			if (!targetBox) {
@@ -406,8 +410,8 @@ export class PositronNotebooks extends Notebooks {
 
 			// For downward drags, target just past the bottom of the target cell.
 			// For upward drags, target just above the top.
-			// dnd-kit uses closestCenter, so we need to be clearly past the
-			// center of the target cell.
+			// dnd-kit uses pointer position to determine which half of the
+			// cell the pointer is in, so we need to be clearly past center.
 			const targetY = toIndex > fromIndex
 				? targetBox.y + targetBox.height + 5
 				: targetBox.y - 5;
@@ -415,8 +419,15 @@ export class PositronNotebooks extends Notebooks {
 			// Keep X on the same column as the drag handle start position.
 			// Moving diagonally across the page can take the cursor outside
 			// the notebook area during long drags.
-			await this.code.driver.page.mouse.move(startX, targetY, { steps: 20 });
-			await this.code.driver.page.mouse.up();
+			await page.mouse.move(startX, targetY, { steps: 20 });
+
+			// Wait for the drop indicator to appear, confirming dnd-kit has
+			// processed the final pointer position and computed the drop target.
+			await expect(
+				page.locator('.drag-drop-indicator')
+			).toBeVisible({ timeout: 2000 });
+
+			await page.mouse.up();
 		});
 	}
 
@@ -446,9 +457,6 @@ export class PositronNotebooks extends Notebooks {
 			await expect(sourceCell).toBeVisible();
 
 			const { startX } = await this._activateDrag(fromIndex);
-
-			// Wait for the dragged cell to collapse and CSS transitions to settle
-			await this.code.driver.page.waitForTimeout(200);
 
 			// Get the notebook container for viewport bounds
 			const notebookContainer = this.positronNotebook;
@@ -518,8 +526,10 @@ export class PositronNotebooks extends Notebooks {
 				const finalCheck = await isTargetReachable();
 				if (finalCheck.reachable && finalCheck.targetY !== undefined) {
 					await this.code.driver.page.mouse.move(startX, finalCheck.targetY, { steps: 10 });
-					// Wait one frame for dnd-kit to process the final position
-					await this.code.driver.page.evaluate(() => new Promise(requestAnimationFrame));
+					// Wait for the drop indicator to confirm dnd-kit processed the position
+					await expect(
+						this.code.driver.page.locator('.drag-drop-indicator')
+					).toBeVisible({ timeout: 2000 });
 					await this.code.driver.page.mouse.up();
 					return;
 				}

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -408,9 +408,13 @@ export class PositronNotebooks extends Notebooks {
 				// so the mouse move doesn't trigger dnd-kit's auto-scroll
 				// (which shifts cell positions mid-move).
 				const targetCell = this.sortableCellAtIndex(toIndex);
+				const handle = await targetCell.elementHandle();
+				if (!handle) {
+					throw new Error('Could not get element handle for target cell');
+				}
 				await page.evaluate(
-					(el) => el!.scrollIntoView({ block: 'center' }),
-					await targetCell.elementHandle()
+					(el) => el.scrollIntoView({ block: 'center' }),
+					handle
 				);
 
 				const targetBox = await targetCell.boundingBox();
@@ -427,10 +431,12 @@ export class PositronNotebooks extends Notebooks {
 
 				await page.mouse.move(startX, targetY, { steps: 10 });
 
-				// Wait for the drop indicator to appear, confirming dnd-kit has
-				// processed the final pointer position and computed the drop target.
+				// Wait for dnd-kit to process the pointer position. The drop
+				// indicator appears for real moves; for no-op positions (cell
+				// dropped back where it started) the noop highlight appears
+				// instead. Accept either signal.
 				await expect(
-					page.locator('.drag-drop-indicator')
+					page.locator('.drag-drop-indicator, .sortable-cell-noop')
 				).toBeVisible({ timeout: 2000 });
 			} finally {
 				await page.mouse.up();
@@ -505,14 +511,14 @@ export class PositronNotebooks extends Notebooks {
 				return { reachable: false };
 			};
 
-			const dropIndicator = this.code.driver.page.locator('.drag-drop-indicator');
+			const dropSignal = this.code.driver.page.locator('.drag-drop-indicator, .sortable-cell-noop');
 
 			try {
 				// First check if target is already visible (no scrolling needed)
 				const initialCheck = await isTargetReachable();
 				if (initialCheck.reachable && initialCheck.targetY !== undefined) {
 					await this.code.driver.page.mouse.move(startX, initialCheck.targetY, { steps: 10 });
-					await expect(dropIndicator).toBeVisible({ timeout: 2000 });
+					await expect(dropSignal).toBeVisible({ timeout: 2000 });
 					return;
 				}
 
@@ -535,7 +541,7 @@ export class PositronNotebooks extends Notebooks {
 				const finalCheck = await isTargetReachable();
 				if (finalCheck.reachable && finalCheck.targetY !== undefined) {
 					await this.code.driver.page.mouse.move(startX, finalCheck.targetY, { steps: 10 });
-					await expect(dropIndicator).toBeVisible({ timeout: 2000 });
+					await expect(dropSignal).toBeVisible({ timeout: 2000 });
 					return;
 				}
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -14,6 +14,12 @@ import { ACTIVE_STATUS_ICON, DISCONNECTED_STATUS_ICON, IDLE_STATUS_ICON, Session
 import { basename, relative } from 'path';
 
 const DEFAULT_TIMEOUT = 10000;
+
+/**
+ * Minimum pointer distance (px) before a drag activates.
+ * Must match DRAG_ACTIVATION_DISTANCE_PX in SortableCellList.tsx.
+ */
+const DRAG_ACTIVATION_DISTANCE_PX = 10;
 const MARKDOWN_ARIA_LABEL = 'Markdown cell - Press Enter to edit';
 
 type MoreActionsMenuItems = 'Copy cell' | 'Cut cell' | 'Paste Cell Above' | 'Paste cell below' | 'Move cell down' | 'Move cell up' | 'Insert code cell above' | 'Insert code cell below';
@@ -48,7 +54,6 @@ export class PositronNotebooks extends Notebooks {
 	// Drag handle is a sibling of the cell inside .sortable-cell parent
 	sortableCellAtIndex = (index: number) => this.code.driver.page.locator('.sortable-cell').nth(index);
 	dragHandleAtIndex = (index: number) => this.sortableCellAtIndex(index).getByRole('button', { name: /Drag to reorder cell/i });
-	dragZoneAtIndex = (index: number) => this.sortableCellAtIndex(index).locator('.cell-drag-zone');
 	moreActionsOption = (option: string) => this.code.driver.page.locator('button.custom-context-menu-item', { hasText: option });
 	runCellButtonAtIndex = (index: number) => this.cell.nth(index).getByRole('button', { name: 'Run Cell', exact: true });
 	private cellOutput = (index: number) => this.cell.nth(index).getByTestId('cell-output');
@@ -364,8 +369,13 @@ export class PositronNotebooks extends Notebooks {
 	private async _activateDrag(cellIndex: number): Promise<{ startX: number; startY: number }> {
 		const dragHandle = this.dragHandleAtIndex(cellIndex);
 
-		// Hover the left-edge drag zone to reveal the handle via CSS :hover
-		await this.dragZoneAtIndex(cellIndex).hover();
+		// Hover near the left edge of the cell to trigger handle visibility
+		// (avoids coupling to the internal .cell-drag-zone CSS class).
+		const cellBox = await this.sortableCellAtIndex(cellIndex).boundingBox();
+		if (!cellBox) {
+			throw new Error('Could not get bounding box for sortable cell');
+		}
+		await this.code.driver.page.mouse.move(cellBox.x + 8, cellBox.y + cellBox.height / 2);
 		await expect(dragHandle).toBeVisible({ timeout: 2000 });
 
 		const handleBox = await dragHandle.boundingBox();
@@ -376,17 +386,16 @@ export class PositronNotebooks extends Notebooks {
 		const startX = handleBox.x + handleBox.width / 2;
 		const startY = handleBox.y + handleBox.height / 2;
 
-		// Start drag and move past activation threshold (10px in SortableCellList.tsx)
+		// Start drag and move past activation threshold
+		// (DRAG_ACTIVATION_DISTANCE_PX in SortableCellList.tsx)
 		await this.code.driver.page.mouse.move(startX, startY);
 		await this.code.driver.page.mouse.down();
-		await this.code.driver.page.mouse.move(startX, startY + 15, { steps: 3 });
+		await this.code.driver.page.mouse.move(startX, startY + DRAG_ACTIVATION_DISTANCE_PX + 5, { steps: 3 });
 
-		// Wait for drag to actually activate: the body gets a
-		// 'dragging-notebook-cell' class and the dragged cell becomes
-		// semi-transparent ('sortable-cell-hidden').
+		// Wait for the cursor-following drag overlay to appear, which is the
+		// user-visible signal that a drag is fully active.
 		const page = this.code.driver.page;
-		await expect(page.locator('body.dragging-notebook-cell')).toBeAttached({ timeout: 2000 });
-		await expect(this.sortableCellAtIndex(cellIndex)).toHaveClass(/sortable-cell-hidden/, { timeout: 2000 });
+		await expect(page.locator('.cursor-following-overlay')).toBeVisible({ timeout: 2000 });
 
 		return { startX, startY };
 	}
@@ -422,9 +431,10 @@ export class PositronNotebooks extends Notebooks {
 					throw new Error('Could not get bounding box for target cell during drag');
 				}
 
-				// Target INSIDE the cell at 75% (bottom quarter) or 25% (top
-				// quarter) so the pointer is unambiguously in the correct half
-				// for dnd-kit's collision detection.
+				// Target 75%/25% inside the cell because dnd-kit's collision
+				// detection uses the vertical midpoint to decide above vs. below
+				// placement. See: SortableCellList.tsx collisionDetection
+				// callback (midY calculation).
 				const targetY = toIndex > fromIndex
 					? targetBox.y + targetBox.height * 0.75
 					: targetBox.y + targetBox.height * 0.25;
@@ -435,7 +445,7 @@ export class PositronNotebooks extends Notebooks {
 				// processed the pointer position. This method is only used for
 				// real (non-no-op) moves, so the indicator will always appear.
 				await expect(
-					page.locator('.drag-drop-indicator')
+					page.getByTestId('drop-indicator')
 				).toBeVisible({ timeout: 2000 });
 			} finally {
 				await page.mouse.up();
@@ -501,6 +511,10 @@ export class PositronNotebooks extends Notebooks {
 				const containerBottom = containerBox.y + containerBox.height * 0.9;
 
 				if (targetCenter >= containerTop && targetCenter <= containerBottom) {
+					// Target 75%/25% inside the cell because dnd-kit's collision
+					// detection uses the vertical midpoint to decide above vs.
+					// below placement. See: SortableCellList.tsx collisionDetection
+					// callback (midY calculation).
 					const dropY = scrollingDown
 						? targetBox.y + targetBox.height * 0.75
 						: targetBox.y + targetBox.height * 0.25;
@@ -512,7 +526,7 @@ export class PositronNotebooks extends Notebooks {
 
 			// This method is only used for real (non-no-op) moves, so
 			// the drop indicator will always appear.
-			const dropIndicator = this.code.driver.page.locator('.drag-drop-indicator');
+			const dropIndicator = this.code.driver.page.getByTestId('drop-indicator');
 
 			try {
 				// First check if target is already visible (no scrolling needed)
@@ -559,8 +573,13 @@ export class PositronNotebooks extends Notebooks {
 	 */
 	async hoverCell(cellIndex: number): Promise<void> {
 		await test.step(`Hover over cell at index ${cellIndex}`, async () => {
-			// Hover the left-edge drag zone to trigger drag handle visibility
-			await this.dragZoneAtIndex(cellIndex).hover();
+			// Hover near the left edge of the cell to trigger handle visibility
+			// (avoids coupling to the internal .cell-drag-zone CSS class).
+			const cellBox = await this.sortableCellAtIndex(cellIndex).boundingBox();
+			if (!cellBox) {
+				throw new Error('Could not get bounding box for sortable cell');
+			}
+			await this.code.driver.page.mouse.move(cellBox.x + 8, cellBox.y + cellBox.height / 2);
 		});
 	}
 
@@ -1172,7 +1191,7 @@ export class PositronNotebooks extends Notebooks {
 			const dragHandle = this.dragHandleAtIndex(cellIndex);
 
 			// Note: Drag handle uses opacity for show/hide (see SortableCell.css)
-			// opacity: 0 when hidden, 1 on hover (via CSS :hover on .cell-drag-zone)
+			// opacity: 0 when hidden, 1 on hover (via CSS :hover on parent element)
 			await expect(async () => {
 				const opacity = await dragHandle.evaluate(el =>
 					parseFloat(window.getComputedStyle(el).opacity)

--- a/test/e2e/tests/notebooks-positron/notebook-cell-reordering.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-reordering.test.ts
@@ -171,7 +171,7 @@ test.describe('Notebook Cell Reordering', {
 		await notebooksPositron.expectDragHandleVisibility(0, true);
 	});
 
-	test.skip('Drag-and-drop: swap 1st and 2nd cell', async function ({ app }) {
+	test('Drag-and-drop: swap 1st and 2nd cell', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 
 		// Setup: Create notebook with 3 cells
@@ -349,7 +349,7 @@ test.describe('Notebook Cell Reordering', {
 		await notebooksPositron.expectCellCountToBe(5);
 	});
 
-	test.skip('Multi-drag: single cell drag ignores multi-selection when dragging unselected cell', async function ({ app }) {
+	test('Multi-drag: single cell drag ignores multi-selection when dragging unselected cell', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
 


### PR DESCRIPTION
## Summary

- Replace fixed `waitForTimeout(200)` calls and `requestAnimationFrame` waits with observable DOM signal checks in the notebook drag-and-drop e2e test helpers
- In `_activateDrag()`: wait for `body.dragging-notebook-cell` and `.sortable-cell-hidden` to confirm the drag actually activated before proceeding
- In `dragCellToPosition()` and `dragCellToPositionWithScroll()`: wait for `.drag-drop-indicator` to be visible before releasing the mouse, confirming dnd-kit has processed the pointer position

These tests were failing on CI (run [#2730](https://github.com/posit-dev/positron/actions/runs/23202589466)) across all three platforms (chromium, electron, windows):
- "Drag-and-drop: swap 1st and 2nd cell"
- "Multi-drag: single cell drag ignores multi-selection when dragging unselected cell"

The root cause was a race condition: `mouse.up()` could fire before dnd-kit's React render cycle processed the final pointer position. On fast local machines the 200ms timeout usually sufficed, but on slower CI runners it didn't.

## Test plan

- [x] All 19 notebook cell reordering e2e tests pass locally (`npx playwright test test/e2e/tests/notebooks-positron/notebook-cell-reordering.test.ts --project e2e-electron`)
- [ ] CI passes on chromium, electron, and windows

## QA Notes
@:positron-notebooks @:web @:win