### PR TITLE
Fixes issue launching Positron when built

### DIFF
--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -1122,7 +1122,7 @@ export class CodeWindow extends BaseWindow implements ICodeWindow {
 		}
 		// --- Start Positron ---
 		// Icon
-		if (!e || e.affectsConfiguration('development.iconColor')) {
+		if (e && e.affectsConfiguration('development.iconColor')) {
 			const customColor = !this.environmentMainService.isBuilt ? this.configurationService.getValue<string>('development.iconColor') : undefined;
 			const iconPath = isLinux ? join(this.environmentMainService.appRoot, 'resources/linux/positron.png') :
 				isWindows ? join(this.environmentMainService.appRoot, 'resources/win32/positron_150x150.png') :


### PR DESCRIPTION
#12486 introduced an issue launching Positron when built & when `development.iconColor` was not set. 

Addresses #12565

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixes Positron launching when 


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

- Ensure `development.iconColor` is **not** set. Inspect workspace/user JSON files.
- Launch built version of Positron (not development version). `npm run gulp ...`