### PR TITLE
Skip failing tests from drag and drop reordering

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-cell-reordering.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-reordering.test.ts
@@ -171,7 +171,7 @@ test.describe('Notebook Cell Reordering', {
 		await notebooksPositron.expectDragHandleVisibility(0, true);
 	});
 
-	test('Drag-and-drop: swap 1st and 2nd cell', async function ({ app }) {
+	test.skip('Drag-and-drop: swap 1st and 2nd cell', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 
 		// Setup: Create notebook with 3 cells
@@ -349,7 +349,7 @@ test.describe('Notebook Cell Reordering', {
 		await notebooksPositron.expectCellCountToBe(5);
 	});
 
-	test('Multi-drag: single cell drag ignores multi-selection when dragging unselected cell', async function ({ app }) {
+	test.skip('Multi-drag: single cell drag ignores multi-selection when dragging unselected cell', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
 

--- a/test/e2e/tests/notebooks-positron/notebook-debug.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-debug.test.ts
@@ -26,7 +26,7 @@ test.describe('Positron Notebook Debugging', {
 	tag: [tags.WEB, tags.WIN, tags.DEBUG, tags.POSITRON_NOTEBOOKS]
 }, () => {
 
-	test('Python - Core debugging workflow: breakpoints, variable inspection, step controls, and output verification', async ({ app, hotKeys }) => {
+	test.skip('Python - Core debugging workflow: breakpoints, variable inspection, step controls, and output verification', async ({ app, hotKeys }) => {
 		const { notebooksPositron, debug } = app.workbench;
 
 		await notebooksPositron.createNewNotebook();


### PR DESCRIPTION
Related to:

- https://github.com/posit-dev/positron/pull/12127
- https://github.com/posit-dev/positron/pull/12564

This PR skips the failing notebook tests for now so we can avoid breaking other runs.

@:positron-notebooks @:web @:win