### PR TITLE
Add release channel support for remote server downloads

### DIFF
--- a/build/gulpfile.reh.ts
+++ b/build/gulpfile.reh.ts
@@ -35,7 +35,7 @@ import { fetchUrls, fetchGithub } from './lib/fetch.ts';
 import jsonEditor from 'gulp-json-editor';
 
 // --- Start Positron ---
-import { positronBuildNumber } from './utils.ts';
+import { positronBuildNumber, releaseChannel } from './utils.ts';
 // eslint-disable-next-line no-duplicate-imports
 import { compileBuildWithoutManglingTask } from './gulpfile.compile.ts';
 import { getQuartoBinaries } from './lib/quarto.ts';
@@ -420,7 +420,7 @@ function packageTask(type: string, platform: string, arch: string, sourceFolderN
 		let productJsonContents = '';
 		const productJsonStream = gulp.src(['product.json'], { base: '.' })
 			// --- Start Positron ---
-			.pipe(jsonEditor({ commit, date: readISODate('out-build'), version, positronVersion, positronBuildNumber }))
+			.pipe(jsonEditor({ commit, date: readISODate('out-build'), version, positronVersion, positronBuildNumber, quality: releaseChannel }))
 			// --- End Positron ---
 			.pipe(es.through(function (file) {
 				productJsonContents = file.contents.toString();

--- a/build/gulpfile.vscode.ts
+++ b/build/gulpfile.vscode.ts
@@ -37,7 +37,7 @@ import rceditCallback from 'rcedit';
 // --- Start Positron ---
 import fancyLog from 'fancy-log';
 import { getQuartoBinaries } from './lib/quarto.ts';
-import { positronBuildNumber } from './utils.ts';
+import { positronBuildNumber, releaseChannel } from './utils.ts';
 // eslint-disable-next-line no-duplicate-imports
 import { copyExtensionBinariesTask } from './gulpfile.extensions.ts';
 // --- End Positron ---
@@ -303,7 +303,7 @@ function packageTask(platform: string, arch: string, sourceFolderName: string, d
 		let productJsonContents: string;
 		const productJsonStream = gulp.src(['product.json'], { base: '.' })
 			// --- Start Positron ---
-			.pipe(jsonEditor({ commit, date: readISODate('out-build'), checksums, version, positronVersion, positronBuildNumber }))
+			.pipe(jsonEditor({ commit, date: readISODate('out-build'), checksums, version, positronVersion, positronBuildNumber, quality: releaseChannel }))
 			// --- End Positron ---
 			.pipe(es.through(function (file) {
 				productJsonContents = file.contents.toString();

--- a/build/gulpfile.vscode.web.ts
+++ b/build/gulpfile.vscode.web.ts
@@ -23,7 +23,7 @@ import jsonEditor from 'gulp-json-editor';
 import buildfile from './buildfile.ts';
 
 // --- Start Positron ---
-import { positronBuildNumber } from './utils.ts';
+import { positronBuildNumber, releaseChannel } from './utils.ts';
 // --- End Positron ---
 
 const REPO_ROOT = path.dirname(import.meta.dirname);
@@ -109,6 +109,7 @@ export const createVSCodeWebFileContentMapper = (extensionsRoot: string, product
 					// --- Start Positron ---
 					positronVersion,
 					positronBuildNumber,
+					quality: releaseChannel,
 					// --- End Positron ---
 					version,
 					commit,

--- a/build/utils.ts
+++ b/build/utils.ts
@@ -18,3 +18,14 @@ const REPO_ROOT = path.dirname(__dirname);
 export const positronBuildNumber =
 	process.env.POSITRON_BUILD_NUMBER ??
 	child_process.execSync(`node ${REPO_ROOT}/versions/show-version.cjs --build`).toString().trim();
+
+/**
+ * Get the release channel for Positron.
+ * This controls which CDN path is used for remote server downloads.
+ * - 'dailies': Daily builds from main branch (default, retained 60 days)
+ * - 'releases': Monthly releases from release branches (retained permanently)
+ *
+ * Note: This is written to product.json as 'quality' to leverage existing
+ * VS Code URL substitution infrastructure (${quality} in URL templates).
+ */
+export const releaseChannel = process.env.VSCODE_QUALITY ?? 'dailies';

--- a/build/utils.ts
+++ b/build/utils.ts
@@ -28,4 +28,4 @@ export const positronBuildNumber =
  * Note: This is written to product.json as 'quality' to leverage existing
  * VS Code URL substitution infrastructure (${quality} in URL templates).
  */
-export const releaseChannel = process.env.VSCODE_QUALITY ?? 'dailies';
+export const releaseChannel = process.env.POSITRON_RELEASE_CHANNEL ?? 'dailies';

--- a/extensions/open-remote-ssh/package.json
+++ b/extensions/open-remote-ssh/package.json
@@ -72,7 +72,7 @@
 					"type": "string",
 					"description": "The URL from where the Positron server will be downloaded. You can use the following variables and they will be replaced dynamically:\n- ${quality}: Positron server quality, e.g. stable or insiders\n- ${version}: Positron server version, e.g. 2024.10.0-123\n- ${commit}: Positron server release commit\n- ${arch}: Positron server arch, e.g. x64, armhf, arm64\n- ${arch-long}: Positron server arch in long format, e.g. x86_64, arm64",
 					"scope": "application",
-					"default": "https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz"
+					"default": "https://cdn.posit.co/positron/${quality}/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz"
 				},
 				"remoteSSH.remotePlatform": {
 					"type": "object",

--- a/extensions/open-remote-wsl/package.json
+++ b/extensions/open-remote-wsl/package.json
@@ -43,7 +43,7 @@
           "type": "string",
           "description": "%configuration.remote.WSL.serverDownloadUrlTemplate.description%",
           "scope": "application",
-          "default": "https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz"
+          "default": "https://cdn.posit.co/positron/${quality}/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz"
         }
       }
     },

--- a/extensions/positron-dev-containers/package.json
+++ b/extensions/positron-dev-containers/package.json
@@ -125,7 +125,7 @@
         "dev.containers.serverDownloadUrlTemplate": {
           "scope": "application",
           "type": "string",
-          "default": "https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz",
+          "default": "https://cdn.posit.co/positron/${quality}/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz",
           "markdownDescription": "The URL from where the Positron server will be downloaded. You can use the following variables and they will be replaced dynamically:\n- `${quality}`: Positron server quality, e.g. stable or insiders\n- `${version}`: Positron server version, e.g. 2024.10.0-123\n- `${commit}`: Positron server release commit\n- `${os}`: Positron server OS, e.g. linux, darwin, win32\n- `${arch}`: Positron server arch, e.g. x64, arm64\n- `${arch-long}`: Positron server arch in long format, e.g. x86_64, arm64"
         }
       }

--- a/extensions/positron-dev-containers/src/server/serverConfig.ts
+++ b/extensions/positron-dev-containers/src/server/serverConfig.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/extensions/positron-dev-containers/src/server/serverConfig.ts
+++ b/extensions/positron-dev-containers/src/server/serverConfig.ts
@@ -66,7 +66,7 @@ export interface ServerConfig {
 }
 
 // Default download URL template - matches the format used by open-remote-ssh
-const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz';
+const DEFAULT_DOWNLOAD_URL_TEMPLATE = 'https://cdn.posit.co/positron/${quality}/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz';
 
 /**
  * Server configuration provider
@@ -185,15 +185,9 @@ export class ServerConfigProvider {
 	}
 
 	/**
-	 * Get the quality (stable, insider) from the environment
+	 * Get the quality (dailies, releases) from product.json
 	 */
 	private getQuality(): string {
-		// Check if this is an insider build
-		const appName = vscode.env.appName.toLowerCase();
-		if (appName.includes('insider') || appName.includes('insiders')) {
-			return 'insider';
-		}
-
 		// Check product.json for quality
 		try {
 			const appRoot = vscode.env.appRoot;
@@ -208,8 +202,8 @@ export class ServerConfigProvider {
 			this.logger.error(`Failed to read quality from product.json: ${error}`);
 		}
 
-		// Default to stable
-		return 'stable';
+		// Default to dailies for backwards compatibility
+		return 'dailies';
 	}
 
 	/**

--- a/product.json
+++ b/product.json
@@ -16,7 +16,7 @@
 	"serverLicensePrompt": "",
 	"serverApplicationName": "positron-server",
 	"serverDataFolderName": ".vscode-server",
-	"serverDownloadUrlTemplate": "https://cdn.posit.co/positron/dailies/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz",
+	"serverDownloadUrlTemplate": "https://cdn.posit.co/positron/${quality}/reh/${arch-long}/positron-reh-${os}-${arch}-${version}.tar.gz",
 	"tunnelApplicationName": "positron-tunnel",
 	"win32DirName": "Positron",
 	"win32NameVersion": "Positron",


### PR DESCRIPTION
Addresses #11382

When Positron connects to WSL, SSH, or dev container remote hosts, it downloads a server build from the CDN. Right now, we always download from the `dailies/` CDN path, which only retains builds for 60 days. After 60 days, users on a particular monthly release can no longer connect to remote hosts.

This PR adds a `quality` field to `product.json` that we can then use to control the CDN path for remote server downloads:
- `dailies` (default): For daily builds from `main` branch
- `releases`: For monthly releases from `release/*` branches

The value is set at build time via the `VSCODE_QUALITY` environment variable (at least right now; see my comment below about how we can make this whatever we want). A follow-up PR in `positron-builds` will set this environment variable based on the source branch.

#### What happens after this PR is merged but before we make changes to our builds?

- All builds (daily AND release) will have `quality: "dailies"` since our env var is not yet set in the build workflows
- Remote server downloads will continue using the `dailies/` CDN path
- This is identical to current behavior; nothing breaks, but the 60-day issue is not yet fixed

#### What happens after `positron-builds` changes?

- Daily builds: `quality: "dailies"` → downloads from `dailies/` (60-day retention)
- Release builds: `quality: "releases"` → downloads from `releases/` (permanent retention)
- The 60-day issue will be fixed for monthly release users


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix remote host connections failing after 60 days for monthly release users (#11382)

### QA Notes

@:remote-ssh

To verify the implementation locally:

1. Build Positron without setting the env var:
   ```bash
   cat <build-path>/resources/app/product.json | grep '"quality"'
   # Expected: "quality": "dailies"
   ```

2. Build with the env var set:
   ```bash
   VSCODE_QUALITY=potato <your-build-command>
   cat <build-path>/resources/app/product.json | grep '"quality"'
   # Expected: "quality": "potato"
   ```

Obviously, this will not be what we use, but it shows you how we are setting this up. 🥔 

3. Verify the URL template includes `${quality}`:
   ```bash
   cat <build-path>/resources/app/product.json | grep 'serverDownloadUrlTemplate'
   # Expected: "https://cdn.posit.co/positron/${quality}/reh/..."
   ```
