### PR TITLE
Fix execution delays when a console session is busy

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -7,7 +7,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import enum
 import json
 import logging
@@ -17,6 +16,7 @@ import sys
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Container, cast
+from urllib.parse import unquote, urlparse
 
 import psutil
 import traitlets
@@ -496,28 +496,39 @@ class PositronShell(ZMQInteractiveShell):
 
     def _add_editor_dir_to_sys_path(self) -> str | None:
         """
-        Add the directory of the last active editor to sys.path.
+        Add the directory of the executed file to sys.path.
 
-        Only adds the path if it differs from the working directory and code is being
-        executed from a file. This only adds the path when is_execution_source is True,
-        which indicates that code is being executed from a script file (not typed in
-        the console).
+        Uses `code_location` from the execute request's positron metadata to
+        determine the source file. Only adds the path if it differs from the
+        working directory and isn't already in sys.path.
 
         Returns the path that was added, or None if no path was added.
         """
         try:
-            ui_service = self.kernel.ui_service
-
-            # Only add to sys.path when executing code from a file
-            if not ui_service.is_execution_source:
+            parent: dict[str, Any] = self.kernel.get_parent("shell")
+            content = parent.get("content", {})
+            metadata = content.get("positron", {})
+            code_location = metadata.get("code_location")
+            if not code_location:
                 return None
 
-            editor_path = ui_service.get_editor_file_path()
-            if editor_path is None:
+            editor_uri = urlparse(code_location.get("uri", ""))
+            if editor_uri.scheme != "file":
                 return None
 
-            editor_dir = str(editor_path.parent)
-            working_dir = str(ui_service.working_directory or Path.cwd())
+            editor_path = unquote(editor_uri.path)
+
+            # On Windows, file URIs like file:///C:/path result in /C:/path after parsing
+            if (
+                len(editor_path) >= 3
+                and editor_path[0] == "/"
+                and editor_path[1].isalpha()
+                and editor_path[2] == ":"
+            ):
+                editor_path = editor_path[1:]
+
+            editor_dir = str(Path(editor_path).parent)
+            working_dir = str(self.kernel.ui_service.working_directory or Path.cwd())
 
             # If editor directory differs from working directory, add to sys.path
             if editor_dir != working_dir and editor_dir not in sys.path:
@@ -539,10 +550,6 @@ class PositronShell(ZMQInteractiveShell):
                 pass  # Already removed
             finally:
                 self._editor_path_added = None
-
-        # Clear the execution source flag
-        with contextlib.suppress(Exception):
-            self.kernel.ui_service.clear_execution_source()
 
     async def _stop(self):
         # Initiate the kernel shutdown sequence.

--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -474,14 +474,14 @@ class PositronShell(ZMQInteractiveShell):
         After execution, sends an update message to the client to summarize
         the changes observed to variables in the user's environment.
         """
+        # Clean up the temporarily added editor directory from sys.path
+        self._remove_editor_dir_from_sys_path()
+
         # If an empty cell was executed, do nothing.
         info = cast("ExecutionInfo", result.info)
         raw_cell = cast("str", info.raw_cell)
         if not raw_cell or raw_cell.isspace():
             return
-
-        # Remove the temporarily added editor directory from sys.path
-        self._remove_editor_dir_from_sys_path()
 
         # TODO: Split these to separate callbacks?
         # Check for changes to the working directory

--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -16,7 +16,8 @@ import sys
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Container, cast
-from urllib.parse import unquote, urlparse
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 import psutil
 import traitlets
@@ -516,16 +517,10 @@ class PositronShell(ZMQInteractiveShell):
             if editor_uri.scheme != "file":
                 return None
 
-            editor_path = unquote(editor_uri.path)
-
-            # On Windows, file URIs like file:///C:/path result in /C:/path after parsing
-            if (
-                len(editor_path) >= 3
-                and editor_path[0] == "/"
-                and editor_path[1].isalpha()
-                and editor_path[2] == ":"
-            ):
-                editor_path = editor_path[1:]
+            url_path = (
+                f"//{editor_uri.netloc}{editor_uri.path}" if editor_uri.netloc else editor_uri.path
+            )
+            editor_path = url2pathname(url_path)
 
             editor_dir = str(Path(editor_path).parent)
             working_dir = str(self.kernel.ui_service.working_directory or Path.cwd())

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_ipkernel.py
@@ -8,7 +8,7 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, Tuple, cast
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import IPython
 import pytest
@@ -455,10 +455,9 @@ class TestEditorSysPath:
         test_file = editor_dir / "test_module.py"
         test_file.write_text("x = 42")
 
-        # Set the editor context to the test file with is_execution_source=True
+        # Set up the parent message with code_location pointing to the test file
         editor_uri = test_file.as_uri()
-        shell.kernel.ui_service._last_active_editor_uri = editor_uri  # noqa: SLF001
-        shell.kernel.ui_service._is_execution_source = True  # noqa: SLF001
+        parent = {"content": {"positron": {"code_location": {"uri": editor_uri}}}}
 
         # Ensure we're in a different directory
         original_cwd = Path.cwd()
@@ -469,7 +468,8 @@ class TestEditorSysPath:
             sys.path.remove(str(editor_dir))
 
         # Add the path (simulates pre_run_cell)
-        added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
+        with patch.object(shell.kernel, "get_parent", return_value=parent):
+            added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
 
         # Check that editor_dir was added to sys.path
         assert added_path == str(editor_dir)
@@ -492,17 +492,17 @@ class TestEditorSysPath:
         cwd = Path.cwd()
         test_file = cwd / "test_file_in_cwd.py"
 
-        # Set the editor context to a file in cwd with is_execution_source=True
+        # Set up the parent message with code_location pointing to a file in cwd
         editor_uri = test_file.as_uri()
-        shell.kernel.ui_service._last_active_editor_uri = editor_uri  # noqa: SLF001
-        shell.kernel.ui_service._is_execution_source = True  # noqa: SLF001
+        parent = {"content": {"positron": {"code_location": {"uri": editor_uri}}}}
 
         # Count how many times cwd appears in sys.path before
         cwd_str = str(cwd)
         count_before = sys.path.count(cwd_str)
 
         # Try to add the path
-        added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
+        with patch.object(shell.kernel, "get_parent", return_value=parent):
+            added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
 
         # Should not have added anything since it's the cwd
         assert added_path is None
@@ -511,17 +511,18 @@ class TestEditorSysPath:
         count_after = sys.path.count(cwd_str)
         assert count_after == count_before
 
-    def test_no_editor_context(self, shell: PositronShell) -> None:
-        """Test that nothing happens when no editor context is set."""
+    def test_no_code_location(self, shell: PositronShell) -> None:
+        """Test that nothing happens when no code_location is in the execute request."""
         import sys
 
-        # Ensure no editor context
-        shell.kernel.ui_service._last_active_editor_uri = ""  # noqa: SLF001
+        # Parent message without positron metadata (e.g. console input)
+        parent = {"content": {}}
 
         sys_path_before = sys.path.copy()
 
         # Try to add the path
-        added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
+        with patch.object(shell.kernel, "get_parent", return_value=parent):
+            added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
 
         # Should not have added anything
         assert added_path is None
@@ -533,14 +534,14 @@ class TestEditorSysPath:
         """Test that non-file URIs are ignored."""
         import sys
 
-        # Set a non-file URI with is_execution_source=True
-        shell.kernel.ui_service._last_active_editor_uri = "untitled:Untitled-1"  # noqa: SLF001
-        shell.kernel.ui_service._is_execution_source = True  # noqa: SLF001
+        # code_location with a non-file URI
+        parent = {"content": {"positron": {"code_location": {"uri": "untitled:Untitled-1"}}}}
 
         sys_path_before = sys.path.copy()
 
         # Try to add the path
-        added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
+        with patch.object(shell.kernel, "get_parent", return_value=parent):
+            added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
 
         # Should not have added anything
         assert added_path is None
@@ -575,10 +576,9 @@ class TestEditorSysPath:
         test_module = editor_dir / "my_test_module.py"
         test_module.write_text("TEST_VALUE = 'hello from module'")
 
-        # Set the editor context to the test module with is_execution_source=True
+        # Set up the parent message with code_location pointing to the test module
         editor_uri = test_module.as_uri()
-        shell.kernel.ui_service._last_active_editor_uri = editor_uri  # noqa: SLF001
-        shell.kernel.ui_service._is_execution_source = True  # noqa: SLF001
+        parent = {"content": {"positron": {"code_location": {"uri": editor_uri}}}}
 
         # Remove editor_dir from sys.path if present
         while str(editor_dir) in sys.path:
@@ -588,8 +588,9 @@ class TestEditorSysPath:
         assert str(editor_dir) not in sys.path
 
         # Run a cell that imports the module - this should work because
-        # _handle_pre_run_cell adds the editor directory
-        result = shell.run_cell("import my_test_module; value = my_test_module.TEST_VALUE")
+        # _handle_pre_run_cell adds the editor directory via code_location
+        with patch.object(shell.kernel, "get_parent", return_value=parent):
+            result = shell.run_cell("import my_test_module; value = my_test_module.TEST_VALUE")
         result.raise_error()
 
         # Check that the import worked
@@ -605,10 +606,10 @@ class TestEditorSysPath:
         if "my_test_module" in sys.modules:
             del sys.modules["my_test_module"]
 
-    def test_does_not_add_path_when_not_execution_source(
+    def test_does_not_add_path_without_code_location(
         self, shell: PositronShell, tmp_path: Path
     ) -> None:
-        """Test that sys.path is NOT modified when is_execution_source is False."""
+        """Test that sys.path is NOT modified when there is no code_location."""
         import sys
 
         # Create a test file in a different directory
@@ -617,11 +618,8 @@ class TestEditorSysPath:
         test_file = editor_dir / "test_module.py"
         test_file.write_text("x = 42")
 
-        # Set the editor context with is_execution_source=False
-        # (simulates just switching editor focus, not executing from file)
-        editor_uri = test_file.as_uri()
-        shell.kernel.ui_service._last_active_editor_uri = editor_uri  # noqa: SLF001
-        shell.kernel.ui_service._is_execution_source = False  # noqa: SLF001
+        # Parent message without code_location (e.g. code typed in console)
+        parent = {"content": {}}
 
         # Ensure we're in a different directory
         original_cwd = Path.cwd()
@@ -634,9 +632,10 @@ class TestEditorSysPath:
         sys_path_before = sys.path.copy()
 
         # Try to add the path
-        added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
+        with patch.object(shell.kernel, "get_parent", return_value=parent):
+            added_path = shell._add_editor_dir_to_sys_path()  # noqa: SLF001
 
-        # Should not have added anything since is_execution_source is False
+        # Should not have added anything since there is no code_location
         assert added_path is None
 
         # sys.path should be unchanged

--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -349,7 +349,9 @@ class TestEditorContext:
     """Tests for editor context change handling."""
 
     def test_editor_context_changed_acknowledged(
-        self, ui_service: UiService, ui_comm: DummyComm
+        self,
+        ui_service: UiService,  # noqa: ARG002
+        ui_comm: DummyComm,
     ) -> None:
         """Test that editor_context_changed RPC is acknowledged."""
         msg = json_rpc_request(

--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -348,136 +348,16 @@ webbrowser.open("file://file.html")
 class TestEditorContext:
     """Tests for editor context change handling."""
 
-    def test_editor_context_changed(self, ui_service: UiService, ui_comm: DummyComm) -> None:
-        """Test that editor_context_changed updates the last active editor URI."""
-        document_uri = "file:///path/to/file.py"
+    def test_editor_context_changed_acknowledged(
+        self, ui_service: UiService, ui_comm: DummyComm
+    ) -> None:
+        """Test that editor_context_changed RPC is acknowledged."""
         msg = json_rpc_request(
             "editor_context_changed",
-            {"document_uri": document_uri, "is_execution_source": False},
+            {"document_uri": "file:///path/to/file.py", "is_execution_source": False},
             comm_id="dummy_comm_id",
         )
         ui_comm.handle_msg(msg)
 
-        # Check that the URI was cached
-        assert ui_service.last_active_editor_uri == document_uri
-        assert ui_service.is_execution_source is False
-
-        # Check that a null response was sent
+        # Check that a null response was sent to acknowledge the RPC
         assert ui_comm.messages == [json_rpc_response(None)]
-
-    def test_editor_context_changed_execution_source(
-        self, ui_service: UiService, ui_comm: DummyComm
-    ) -> None:
-        """Test that editor_context_changed sets is_execution_source flag."""
-        document_uri = "file:///path/to/file.py"
-        msg = json_rpc_request(
-            "editor_context_changed",
-            {"document_uri": document_uri, "is_execution_source": True},
-            comm_id="dummy_comm_id",
-        )
-        ui_comm.handle_msg(msg)
-
-        # Check that the URI was cached and execution source flag is set
-        assert ui_service.last_active_editor_uri == document_uri
-        assert ui_service.is_execution_source is True
-
-        # Check that a null response was sent
-        assert ui_comm.messages == [json_rpc_response(None)]
-
-    def test_editor_context_changed_empty_uri(
-        self, ui_service: UiService, ui_comm: DummyComm
-    ) -> None:
-        """Test that editor_context_changed handles empty URI (no active editor)."""
-        msg = json_rpc_request(
-            "editor_context_changed",
-            {"document_uri": "", "is_execution_source": False},
-            comm_id="dummy_comm_id",
-        )
-        ui_comm.handle_msg(msg)
-
-        assert ui_service.last_active_editor_uri == ""
-        assert ui_comm.messages == [json_rpc_response(None)]
-
-    def test_get_editor_file_path(self, ui_service: UiService, ui_comm: DummyComm) -> None:
-        """Test that get_editor_file_path correctly parses file URIs."""
-        # Set a file URI
-        document_uri = "file:///path/to/file.py"
-        msg = json_rpc_request(
-            "editor_context_changed",
-            {"document_uri": document_uri, "is_execution_source": False},
-            comm_id="dummy_comm_id",
-        )
-        ui_comm.handle_msg(msg)
-        ui_comm.messages.clear()
-
-        # Check that the path is correctly parsed
-        editor_path = ui_service.get_editor_file_path()
-        assert editor_path is not None
-        # Compare using Path for platform independence
-        assert editor_path == Path("/path/to/file.py")
-
-    def test_get_editor_file_path_with_spaces(
-        self, ui_service: UiService, ui_comm: DummyComm
-    ) -> None:
-        """Test that get_editor_file_path correctly handles URI-encoded paths."""
-        # Set a file URI with spaces (URI-encoded)
-        document_uri = "file:///path/to/my%20file.py"
-        msg = json_rpc_request(
-            "editor_context_changed",
-            {"document_uri": document_uri, "is_execution_source": False},
-            comm_id="dummy_comm_id",
-        )
-        ui_comm.handle_msg(msg)
-        ui_comm.messages.clear()
-
-        editor_path = ui_service.get_editor_file_path()
-        assert editor_path is not None
-        # Compare using Path for platform independence
-        assert editor_path == Path("/path/to/my file.py")
-
-    def test_get_editor_file_path_windows_uri(
-        self, ui_service: UiService, ui_comm: DummyComm
-    ) -> None:
-        """Test that get_editor_file_path correctly handles Windows file URIs."""
-        # Set a Windows-style file URI
-        document_uri = "file:///C:/Users/test/file.py"
-        msg = json_rpc_request(
-            "editor_context_changed",
-            {"document_uri": document_uri, "is_execution_source": False},
-            comm_id="dummy_comm_id",
-        )
-        ui_comm.handle_msg(msg)
-        ui_comm.messages.clear()
-
-        editor_path = ui_service.get_editor_file_path()
-        assert editor_path is not None
-        # The path should not have a leading slash on Windows
-        path_str = str(editor_path)
-        assert not path_str.startswith("/"), f"Path should not start with /: {path_str}"
-        assert not path_str.startswith("\\"), f"Path should not start with \\: {path_str}"
-        # On all platforms, the drive letter should be at the start
-        assert path_str[0] == "C" or path_str[0] == "c", f"Path should start with C: {path_str}"
-
-    def test_get_editor_file_path_non_file_uri(
-        self, ui_service: UiService, ui_comm: DummyComm
-    ) -> None:
-        """Test that get_editor_file_path returns None for non-file URIs."""
-        # Set a non-file URI (e.g., untitled)
-        document_uri = "untitled:Untitled-1"
-        msg = json_rpc_request(
-            "editor_context_changed",
-            {"document_uri": document_uri, "is_execution_source": False},
-            comm_id="dummy_comm_id",
-        )
-        ui_comm.handle_msg(msg)
-        ui_comm.messages.clear()
-
-        editor_path = ui_service.get_editor_file_path()
-        assert editor_path is None
-
-    def test_get_editor_file_path_no_editor(self, ui_service: UiService) -> None:
-        """Test that get_editor_file_path returns None when no editor URI is set."""
-        # Reset the editor context
-        ui_service._last_active_editor_uri = ""  # noqa: SLF001
-        assert ui_service.last_active_editor_uri == ""
-        assert ui_service.get_editor_file_path() is None

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -12,7 +12,7 @@ import sys
 import webbrowser
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
-from urllib.parse import unquote, urlparse
+from urllib.parse import urlparse
 
 from comm.base_comm import BaseComm
 from packaging.utils import canonicalize_name
@@ -194,60 +194,6 @@ class UiService:
 
         self.working_directory: Optional[Path] = None
 
-        # The URI of the last active editor, updated by the frontend
-        self._last_active_editor_uri: str = ""
-
-        # Whether the current editor context is the source of code being executed
-        # This is set to True when code is about to be executed from a file,
-        # and should be reset to False after execution completes.
-        self._is_execution_source: bool = False
-
-    @property
-    def last_active_editor_uri(self) -> str:
-        """
-        The URI of the last active text editor.
-
-        Returns an empty string if no editor is active.
-        """
-        return self._last_active_editor_uri
-
-    @property
-    def is_execution_source(self) -> bool:
-        """
-        Whether the current editor context is the source of code being executed.
-
-        When True, the backend should temporarily add the editor's directory to sys.path.
-        """
-        return self._is_execution_source
-
-    def clear_execution_source(self) -> None:
-        """Clear the execution source flag after code execution completes."""
-        self._is_execution_source = False
-
-    def get_editor_file_path(self) -> Optional[Path]:
-        """
-        Parse the last active editor URI and return the file path.
-
-        Returns None if no editor is active or the URI is not a file URI.
-        """
-        if not self._last_active_editor_uri:
-            return None
-
-        parsed = urlparse(self._last_active_editor_uri)
-
-        if parsed.scheme not in ["file", "vscode-remote"]:  # for remote and local files
-            return None
-
-        path = unquote(parsed.path)
-
-        # On Windows, file URIs like file:///C:/path result in /C:/path after parsing.
-        # We need to strip the leading slash to get a valid Windows path.
-        # Check for drive letter pattern: /X:/ where X is a letter
-        if len(path) >= 3 and path[0] == "/" and path[1].isalpha() and path[2] == ":":
-            path = path[1:]
-
-        return Path(path)
-
     def on_comm_open(self, comm: BaseComm, _msg: JsonRecord) -> None:
         self._comm = PositronComm(comm)
         self._comm.on_msg(self.handle_msg, UiBackendMessageContent)
@@ -303,10 +249,8 @@ class UiService:
             self._call_method(request.params)
 
         elif isinstance(request, EditorContextChangedRequest):
-            # Update the cached last active editor URI and execution source flag
-            self._last_active_editor_uri = request.params.document_uri
-            self._is_execution_source = request.params.is_execution_source
-            # Send null result to acknowledge the notification
+            # Acknowledge the notification (state no longer tracked here,
+            # sys.path handling uses code_location from execute request metadata)
             if self._comm is not None:
                 self._comm.send_result(data=None)
 

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -1867,29 +1867,6 @@ export class MainThreadLanguageRuntime
 		// Revive the URI from the serialized form, if provided.
 		const revivedUri = documentUri ? URI.revive(documentUri) : undefined;
 
-		// If a document URI is provided, notify the backend that code is being executed from a file.
-		// This allows the backend to temporarily add the file's directory to sys.path.
-		if (revivedUri) {
-			// Determine which session(s) to notify:
-			// - If a specific sessionId is provided, only notify that session
-			// - Otherwise, only notify sessions matching the languageId
-			const activeSessions = this._runtimeSessionService.getActiveSessions();
-			for (const activeSession of activeSessions) {
-				const shouldNotify = sessionId
-					? activeSession.session.sessionId === sessionId
-					: activeSession.session.runtimeMetadata.languageId === languageId;
-
-				if (shouldNotify && activeSession.uiClient) {
-					try {
-						await activeSession.uiClient.editorContextChanged(revivedUri.toString(), true);
-					} catch (err) {
-						// Log but don't fail the execution if notification fails
-						console.warn(`Failed to send editor context changed: ${err}`);
-					}
-				}
-			}
-		}
-
 		// Attribute this code to the extension that requested it. If a document
 		// URI is provided, use Script attribution so that the code location is
 		// forwarded to the kernel (e.g. for plot file attribution).

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -32,7 +32,6 @@ import { ILanguageFeaturesService } from '../../../../editor/common/services/lan
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { NOTEBOOK_EDITOR_FOCUSED } from '../../notebook/common/notebookContextKeys.js';
 import { RuntimeCodeExecutionMode, RuntimeErrorBehavior } from '../../../services/languageRuntime/common/languageRuntimeService.js';
-import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IPositronModalDialogsService } from '../../../services/positronModalDialogs/common/positronModalDialogs.js';
 import { IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { IDebugService } from '../../debug/common/debug.js';
@@ -95,7 +94,6 @@ async function executeCodeInConsole(
 		languageService: ILanguageService;
 		notificationService: INotificationService;
 		positronConsoleService: IPositronConsoleService;
-		runtimeSessionService: IRuntimeSessionService;
 		debugService: IDebugService;
 		textFileService: ITextFileService;
 	},
@@ -106,7 +104,7 @@ async function executeCodeInConsole(
 		errorBehavior?: RuntimeErrorBehavior;
 	} = {}
 ): Promise<boolean> {
-	const { editorService, languageService, notificationService, positronConsoleService, runtimeSessionService, debugService, textFileService } = services;
+	const { editorService, languageService, notificationService, positronConsoleService, debugService, textFileService } = services;
 
 	// Ensure we have a target language.
 	const languageId = opts.languageId ? opts.languageId : editorService.activeTextEditorLanguageId;
@@ -137,21 +135,6 @@ async function executeCodeInConsole(
 	const documentUri = cursorLocation.uri;
 	if (documentUri.scheme === Schemas.file && textFileService.isDirty(documentUri)) {
 		await debugService.sendBreakpoints(documentUri, true);
-	}
-
-	// Notify the backend that code is about to be executed from a file.
-	// This allows the backend to temporarily add the file's directory to sys.path.
-	// Only notify sessions matching the languageId since code will run in one of those.
-	const activeSessions = runtimeSessionService.getActiveSessions();
-	for (const activeSession of activeSessions) {
-		if (activeSession.session.runtimeMetadata.languageId === languageId && activeSession.uiClient) {
-			try {
-				await activeSession.uiClient.editorContextChanged(documentUri.toString(), true);
-			} catch (err) {
-				// Log but don't fail the execution if notification fails
-				console.warn(`Failed to send editor context changed: ${err}`);
-			}
-		}
 	}
 
 	// Ask the Positron console service to execute the code. Do not focus the console as
@@ -426,7 +409,6 @@ export function registerPositronConsoleActions() {
 
 			const notificationService = accessor.get(INotificationService);
 			const positronConsoleService = accessor.get(IPositronConsoleService);
-			const runtimeSessionService = accessor.get(IRuntimeSessionService);
 			const debugService = accessor.get(IDebugService);
 			const textFileService = accessor.get(ITextFileService);
 			const configurationService = accessor.get(IConfigurationService);
@@ -665,7 +647,6 @@ export function registerPositronConsoleActions() {
 					languageService,
 					notificationService,
 					positronConsoleService,
-					runtimeSessionService,
 					debugService,
 					textFileService
 				},
@@ -1039,7 +1020,6 @@ export function registerPositronConsoleActions() {
 		const languageService = accessor.get(ILanguageService);
 		const notificationService = accessor.get(INotificationService);
 		const positronConsoleService = accessor.get(IPositronConsoleService);
-		const runtimeSessionService = accessor.get(IRuntimeSessionService);
 		const debugService = accessor.get(IDebugService);
 		const textFileService = accessor.get(ITextFileService);
 
@@ -1109,7 +1089,6 @@ export function registerPositronConsoleActions() {
 				languageService,
 				notificationService,
 				positronConsoleService,
-				runtimeSessionService,
 				debugService,
 				textFileService,
 			},


### PR DESCRIPTION
Follow up to https://github.com/posit-dev/positron/pull/11393
Addresses https://github.com/posit-dev/positron/issues/12251

See analysis in https://github.com/posit-dev/positron/issues/12251#issuecomment-4080942717

This removes the editor context notifications sent prior to code evaluation that were causing the delays when a session was busy, and instead uses the `code_location` field sent with the execute request.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed performance regression that caused slow evaluations from editor when a console is busy (https://github.com/posit-dev/positron/issues/12251).


### QA Notes

Executing code from a script when a session is busy should not incur any delay. New e2e tests for this would be great.

The behaviour implemented in https://github.com/posit-dev/positron/pull/11393 should still work.

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:console