### PR TITLE
builds: plutil replace instead of insert for macos

### DIFF
--- a/build/darwin/sign.ts
+++ b/build/darwin/sign.ts
@@ -97,7 +97,10 @@ async function main(buildDir?: string): Promise<void> {
 	// universal will get its copy from the x64 build.
 	if (arch !== 'universal') {
 		await spawn('plutil', [
+			// --- Start Positron ---
+			// update ID after re-signing to avoid notarization error
 			'-replace',
+			// --- End Positron ---
 			'NSAppleEventsUsageDescription',
 			'-string',
 			'An application in Visual Studio Code wants to use AppleScript.',

--- a/build/darwin/sign.ts
+++ b/build/darwin/sign.ts
@@ -97,7 +97,7 @@ async function main(buildDir?: string): Promise<void> {
 	// universal will get its copy from the x64 build.
 	if (arch !== 'universal') {
 		await spawn('plutil', [
-			'-insert',
+			'-replace',
 			'NSAppleEventsUsageDescription',
 			'-string',
 			'An application in Visual Studio Code wants to use AppleScript.',


### PR DESCRIPTION
Speculative fix for failing daily build.

We think this should differ from upstream since we retry code signing as a step on failure, where upstream retries the build as a whole. It looks like this line used to be `replace`ing instead of `insert`ing 
https://github.com/microsoft/vscode/commit/5f09c5444913134282bad19fb9926fbf88e2bb92


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

See successful build: https://github.com/posit-dev/positron-builds/actions/runs/23249614413/job/67594124838