### PR TITLE
Fix stale auth session causing assistant e2e test flake

### DIFF
--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -39,6 +39,17 @@ export function activate(context: vscode.ExtensionContext) {
 				}
 				await provider.storeKey(accountId, label, key);
 			}
+		),
+		vscode.commands.registerCommand(
+			'authentication.removeSession',
+			async (providerId: string, accountId: string) => {
+				const provider = apiKeyProviders.get(providerId);
+				if (!provider) {
+					log.warn(`removeSession: no auth provider for "${providerId}"`);
+					return;
+				}
+				await provider.removeSession(accountId);
+			}
 		)
 	);
 }

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -286,7 +286,17 @@ async function saveModel(
 			vscode.l10n.t(`Language Model {0} has been added successfully.`, name)
 		);
 	} catch (error) {
-		if (!options?.skipSecretStorage) {
+		if (options?.skipSecretStorage && isAuthExtProvider(newConfig.provider)) {
+			// Clean up the auth extension session that was eagerly stored
+			// during the config dialog's handleSave callback
+			try {
+				await vscode.commands.executeCommand(
+					'authentication.removeSession', newConfig.provider, id
+				);
+			} catch {
+				// Ignore cleanup errors
+			}
+		} else if (!options?.skipSecretStorage) {
 			await context.secrets.delete(`apiKey-${id}`);
 		}
 		await context.globalState.update(


### PR DESCRIPTION

  - Fix a bug where a failed model registration leaves a stale auth session in the authentication extension, causing the "Verify Successful API Key Sign in and Sign Out" e2e test to
  almost always fail on the first try
  - Add authentication.removeSession command to the auth extension for session cleanup
  - Clean up eagerly-stored auth sessions in saveModel when model registration fails

  Details

  PR #12450 introduced an authentication extension that stores API key credentials eagerly during the config dialog (in handleSave), before model registration validates the key. When
  registration subsequently fails (e.g., bad API key), the saveModel error handler cleaned up context.secrets but not the auth extension session.

  This left a stale session that caused enrichWithCredentialState to report the provider as signed in on the next dialog open. The "Verify Bad API Key" test created this stale
  session, which then broke the next test's sign-in/sign-out flow. On retry, the first failed attempt's sign-out click had already cleared the stale session, so the retry passed.

### QA Notes
@:assistant @:win @:web
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
