### PR TITLE
Fix Anthropic sign in/out state sync and model registration

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -64,6 +64,11 @@ const extensions = [
 	},
 	// --- Start Positron ---
 	{
+		label: 'authentication',
+		workspaceFolder: path.join(os.tmpdir(), `authentication-${Math.floor(Math.random() * 100000)}`),
+		mocha: { timeout: 60_000 }
+	},
+	{
 		label: 'positron-assistant',
 		workspaceFolder: 'extensions/positron-assistant/test-workspace',
 		mocha: { timeout: 60_000 }

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -15,12 +15,14 @@ export interface ConfigDialogResult {
 	accountId?: string;
 }
 
-export const apiKeyProviders = new Map<string, ApiKeyAuthenticationProvider>();
+export type ApiKeyValidator = (apiKey: string, config: positron.ai.LanguageModelConfig) => Promise<void>;
 
-const ANTHROPIC_PROVIDER_ID = 'anthropic-api';
-const ANTHROPIC_MODELS_ENDPOINT = 'https://api.anthropic.com/v1/models';
-const ANTHROPIC_API_VERSION = '2023-06-01';
-const KEY_VALIDATION_TIMEOUT_MS = 5000;
+export interface RegisterApiKeyProviderOptions {
+	validateApiKey?: ApiKeyValidator;
+}
+
+export const apiKeyProviders = new Map<string, ApiKeyAuthenticationProvider>();
+const apiKeyValidators = new Map<string, ApiKeyValidator>();
 
 /**
  * Register an API key provider so the config dialog can store/remove
@@ -28,9 +30,15 @@ const KEY_VALIDATION_TIMEOUT_MS = 5000;
  */
 export function registerApiKeyProvider(
 	providerId: string,
-	provider: ApiKeyAuthenticationProvider
+	provider: ApiKeyAuthenticationProvider,
+	options?: RegisterApiKeyProviderOptions
 ): void {
 	apiKeyProviders.set(providerId, provider);
+	if (options?.validateApiKey) {
+		apiKeyValidators.set(providerId, options.validateApiKey);
+	} else {
+		apiKeyValidators.delete(providerId);
+	}
 }
 
 /**
@@ -158,51 +166,14 @@ async function handleSave(
 	if (!apiKey) {
 		throw new Error(vscode.l10n.t('API key is required'));
 	}
-	if (config.provider === ANTHROPIC_PROVIDER_ID) {
-		await validateAnthropicApiKey(apiKey);
+	const validateApiKey = apiKeyValidators.get(config.provider);
+	if (validateApiKey) {
+		await validateApiKey(apiKey, config);
 	}
 	const accountId = randomUUID();
 	log.info(`Saving credential for provider "${config.provider}", name "${config.name}" (${accountId})`);
 	await provider.storeKey(accountId, config.name, apiKey);
 	return accountId;
-}
-
-async function validateAnthropicApiKey(apiKey: string): Promise<void> {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), KEY_VALIDATION_TIMEOUT_MS);
-	try {
-		const response = await fetch(ANTHROPIC_MODELS_ENDPOINT, {
-			method: 'GET',
-			headers: {
-				'x-api-key': apiKey,
-				'anthropic-version': ANTHROPIC_API_VERSION,
-			},
-			signal: controller.signal,
-		});
-
-		if (response.ok) {
-			return;
-		}
-
-		if (response.status === 401 || response.status === 403) {
-			throw new Error(vscode.l10n.t('Invalid Anthropic API key'));
-		}
-
-		throw new Error(vscode.l10n.t(
-			'Unable to validate Anthropic API key (HTTP {0})',
-			String(response.status)
-		));
-	} catch (err) {
-		if (err instanceof Error && err.name === 'AbortError') {
-			throw new Error(vscode.l10n.t('Could not validate Anthropic API key within {0} seconds', String(KEY_VALIDATION_TIMEOUT_MS / 1000)));
-		}
-		if (err instanceof Error && err.message.includes('Invalid Anthropic API key')) {
-			throw err;
-		}
-		throw new Error(vscode.l10n.t('Could not validate Anthropic API key. Check your network connection and try again.'));
-	} finally {
-		clearTimeout(timeout);
-	}
 }
 
 async function handleDelete(

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -17,6 +17,11 @@ export interface ConfigDialogResult {
 
 export const apiKeyProviders = new Map<string, ApiKeyAuthenticationProvider>();
 
+const ANTHROPIC_PROVIDER_ID = 'anthropic-api';
+const ANTHROPIC_MODELS_ENDPOINT = 'https://api.anthropic.com/v1/models';
+const ANTHROPIC_API_VERSION = '2023-06-01';
+const KEY_VALIDATION_TIMEOUT_MS = 5000;
+
 /**
  * Register an API key provider so the config dialog can store/remove
  * credentials through it.
@@ -153,10 +158,51 @@ async function handleSave(
 	if (!apiKey) {
 		throw new Error(vscode.l10n.t('API key is required'));
 	}
+	if (config.provider === ANTHROPIC_PROVIDER_ID) {
+		await validateAnthropicApiKey(apiKey);
+	}
 	const accountId = randomUUID();
 	log.info(`Saving credential for provider "${config.provider}", name "${config.name}" (${accountId})`);
 	await provider.storeKey(accountId, config.name, apiKey);
 	return accountId;
+}
+
+async function validateAnthropicApiKey(apiKey: string): Promise<void> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), KEY_VALIDATION_TIMEOUT_MS);
+	try {
+		const response = await fetch(ANTHROPIC_MODELS_ENDPOINT, {
+			method: 'GET',
+			headers: {
+				'x-api-key': apiKey,
+				'anthropic-version': ANTHROPIC_API_VERSION,
+			},
+			signal: controller.signal,
+		});
+
+		if (response.ok) {
+			return;
+		}
+
+		if (response.status === 401 || response.status === 403) {
+			throw new Error(vscode.l10n.t('Invalid Anthropic API key'));
+		}
+
+		throw new Error(vscode.l10n.t(
+			'Unable to validate Anthropic API key (HTTP {0})',
+			String(response.status)
+		));
+	} catch (err) {
+		if (err instanceof Error && err.name === 'AbortError') {
+			throw new Error(vscode.l10n.t('Could not validate Anthropic API key within {0} seconds', String(KEY_VALIDATION_TIMEOUT_MS / 1000)));
+		}
+		if (err instanceof Error && err.message.includes('Invalid Anthropic API key')) {
+			throw err;
+		}
+		throw new Error(vscode.l10n.t('Could not validate Anthropic API key. Check your network connection and try again.'));
+	} finally {
+		clearTimeout(timeout);
+	}
 }
 
 async function handleDelete(

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -102,13 +102,19 @@ export async function showConfigurationDialog(
 		async (config, action) => {
 			log.info(`Config dialog action: "${action}" for provider "${config.provider}"`);
 			const hasAuthProvider = apiKeyProviders.has(config.provider);
+			// applyConfig is a fallback while we transition providers to the Auth extension.
+			// It should eventually be removed so that the Auth extension is the single source of truth
+			// for all provider config actions.
+			const applyConfig = async () => {
+				await vscode.commands.executeCommand('positron-assistant.applyConfigAction', config, action, enrichedSources);
+			};
 			switch (action) {
 				case 'save': {
 					if (hasAuthProvider) {
 						const accountId = await handleSave(config);
 						addResult({ action, config, accountId });
 					} else {
-						await vscode.commands.executeCommand('positron-assistant.applyConfigAction', config, action, enrichedSources);
+						await applyConfig();
 					}
 					break;
 				}
@@ -117,25 +123,25 @@ export async function showConfigurationDialog(
 						await handleDelete(config);
 						addResult({ action, config });
 					} else {
-						await vscode.commands.executeCommand('positron-assistant.applyConfigAction', config, action, enrichedSources);
+						await applyConfig();
 					}
 					break;
 				case 'oauth-signin':
 					if (hasAuthProvider) {
 						addResult({ action, config });
 					} else {
-						await vscode.commands.executeCommand('positron-assistant.applyConfigAction', config, action, enrichedSources);
+						await applyConfig();
 					}
 					break;
 				case 'oauth-signout':
 					if (hasAuthProvider) {
 						addResult({ action, config });
 					} else {
-						await vscode.commands.executeCommand('positron-assistant.applyConfigAction', config, action, enrichedSources);
+						await applyConfig();
 					}
 					break;
 				case 'cancel':
-					await vscode.commands.executeCommand('positron-assistant.applyConfigAction', config, action, enrichedSources);
+					await applyConfig();
 					break;
 				default:
 					throw new Error(

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -88,32 +88,41 @@ export async function showConfigurationDialog(
 		enrichedSources,
 		async (config, action) => {
 			log.info(`Config dialog action: "${action}" for provider "${config.provider}"`);
+			const hasAuthProvider = apiKeyProviders.has(config.provider);
 			switch (action) {
 				case 'save': {
-					if (apiKeyProviders.has(config.provider)) {
+					if (hasAuthProvider) {
 						const accountId = await handleSave(config);
 						addResult({ action, config, accountId });
 					} else {
-						addResult({ action, config });
+						await vscode.commands.executeCommand('positron-assistant.applyConfigAction', config, action, enrichedSources);
 					}
 					break;
 				}
 				case 'delete':
-					if (apiKeyProviders.has(config.provider)) {
+					if (hasAuthProvider) {
 						await handleDelete(config);
+						addResult({ action, config });
+					} else {
+						await vscode.commands.executeCommand('positron-assistant.applyConfigAction', config, action, enrichedSources);
 					}
-					addResult({ action, config });
 					break;
 				case 'oauth-signin':
-					// Phase 5: handle OAuth sign-in
-					addResult({ action, config });
+					if (hasAuthProvider) {
+						addResult({ action, config });
+					} else {
+						await vscode.commands.executeCommand('positron-assistant.applyConfigAction', config, action, enrichedSources);
+					}
 					break;
 				case 'oauth-signout':
-					// Phase 5: handle OAuth sign-out
-					addResult({ action, config });
+					if (hasAuthProvider) {
+						addResult({ action, config });
+					} else {
+						await vscode.commands.executeCommand('positron-assistant.applyConfigAction', config, action, enrichedSources);
+					}
 					break;
 				case 'cancel':
-					// Phase 5: cancel pending OAuth operations
+					await vscode.commands.executeCommand('positron-assistant.applyConfigAction', config, action, enrichedSources);
 					break;
 				default:
 					throw new Error(

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -37,14 +37,13 @@ async function enrichWithCredentialState(
 	sources: positron.ai.LanguageModelSource[]
 ): Promise<positron.ai.LanguageModelSource[]> {
 	return Promise.all(sources.map(async (source) => {
-		if (!apiKeyProviders.has(source.provider.id)) {
+		const provider = apiKeyProviders.get(source.provider.id);
+		if (!provider) {
 			return source;
 		}
 		try {
-			const session = await vscode.authentication.getSession(
-				source.provider.id, [], { silent: true }
-			);
-			if (session) {
+			const sessions = await provider.getSessions();
+			if (sessions.length > 0) {
 				return { ...source, signedIn: true };
 			}
 		} catch (err) {
@@ -76,6 +75,15 @@ export async function showConfigurationDialog(
 
 	const results: ConfigDialogResult[] = [];
 
+	const addResult = (result: ConfigDialogResult) => {
+		const idx = results.findIndex(r => r.config.provider === result.config.provider);
+		if (idx !== -1) {
+			results[idx] = result;
+		} else {
+			results.push(result);
+		}
+	};
+
 	await positron.ai.showLanguageModelConfig(
 		enrichedSources,
 		async (config, action) => {
@@ -84,9 +92,9 @@ export async function showConfigurationDialog(
 				case 'save': {
 					if (apiKeyProviders.has(config.provider)) {
 						const accountId = await handleSave(config);
-						results.push({ action, config, accountId });
+						addResult({ action, config, accountId });
 					} else {
-						results.push({ action, config });
+						addResult({ action, config });
 					}
 					break;
 				}
@@ -94,15 +102,15 @@ export async function showConfigurationDialog(
 					if (apiKeyProviders.has(config.provider)) {
 						await handleDelete(config);
 					}
-					results.push({ action, config });
+					addResult({ action, config });
 					break;
 				case 'oauth-signin':
 					// Phase 5: handle OAuth sign-in
-					results.push({ action, config });
+					addResult({ action, config });
 					break;
 				case 'oauth-signout':
 					// Phase 5: handle OAuth sign-out
-					results.push({ action, config });
+					addResult({ action, config });
 					break;
 				case 'cancel':
 					// Phase 5: cancel pending OAuth operations

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { ApiKeyAuthenticationProvider } from './apiKeyProvider';
 import { apiKeyProviders, registerApiKeyProvider, showConfigurationDialog } from './configDialog';
+import { validateAnthropicApiKey } from './validation';
 import { log } from './log';
 
 export function activate(context: vscode.ExtensionContext) {
@@ -54,6 +55,8 @@ function registerAnthropicProvider(context: vscode.ExtensionContext): void {
 		),
 		provider
 	);
-	registerApiKeyProvider('anthropic-api', provider);
+	registerApiKeyProvider('anthropic-api', provider, {
+		validateApiKey: validateAnthropicApiKey,
+	});
 	log.info('Registered auth provider: anthropic-api');
 }

--- a/extensions/authentication/src/test/apiKeyProvider.test.ts
+++ b/extensions/authentication/src/test/apiKeyProvider.test.ts
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { ApiKeyAuthenticationProvider } from '../apiKeyProvider';
+
+suite('ApiKeyAuthenticationProvider', () => {
+	let provider: ApiKeyAuthenticationProvider;
+	let secrets: Map<string, string>;
+	let globalState: Map<string, unknown>;
+
+	setup(() => {
+		secrets = new Map();
+		globalState = new Map();
+
+		const mockContext = {
+			secrets: {
+				get: (key: string) => Promise.resolve(secrets.get(key)),
+				store: (key: string, value: string) => {
+					secrets.set(key, value);
+					return Promise.resolve();
+				},
+				delete: (key: string) => {
+					secrets.delete(key);
+					return Promise.resolve();
+				},
+			},
+			globalState: {
+				get: <T>(key: string) => globalState.get(key) as T | undefined,
+				update: (key: string, value: unknown) => {
+					globalState.set(key, value);
+					return Promise.resolve();
+				},
+			},
+		} as unknown as vscode.ExtensionContext;
+
+		provider = new ApiKeyAuthenticationProvider(
+			'test-provider',
+			'Test Provider',
+			mockContext,
+		);
+	});
+
+	teardown(() => {
+		provider.dispose();
+	});
+
+	test('storeKey fires onDidChangeSessions with added session', async () => {
+		const eventPromise = new Promise<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>(
+			resolve => {
+				const disposable = provider.onDidChangeSessions(e => {
+					disposable.dispose();
+					resolve(e);
+				});
+			}
+		);
+
+		await provider.storeKey('acc-1', 'Test Account', 'sk-test-key');
+		const event = await eventPromise;
+
+		assert.strictEqual(event.added!.length, 1);
+		assert.strictEqual(event.added![0].id, 'acc-1');
+		assert.strictEqual(event.added![0].accessToken, 'sk-test-key');
+		assert.strictEqual(event.removed!.length, 0);
+	});
+
+	test('removeSession fires onDidChangeSessions with removed session', async () => {
+		// First store a session
+		await provider.storeKey('acc-1', 'Test Account', 'sk-test-key');
+
+		const eventPromise = new Promise<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>(
+			resolve => {
+				const disposable = provider.onDidChangeSessions(e => {
+					disposable.dispose();
+					resolve(e);
+				});
+			}
+		);
+
+		await provider.removeSession('acc-1');
+		const event = await eventPromise;
+
+		assert.strictEqual(event.removed!.length, 1);
+		assert.strictEqual(event.removed![0].id, 'acc-1');
+		assert.strictEqual(event.added!.length, 0);
+	});
+
+	test('removeSession for nonexistent id does not fire event', async () => {
+		let eventFired = false;
+		const disposable = provider.onDidChangeSessions(() => {
+			eventFired = true;
+		});
+
+		await provider.removeSession('nonexistent-id');
+
+		// Give any async events a chance to fire
+		await new Promise(resolve => setTimeout(resolve, 50));
+
+		assert.strictEqual(eventFired, false);
+		disposable.dispose();
+	});
+
+	test('getSessions returns stored sessions', async () => {
+		await provider.storeKey('acc-1', 'Account 1', 'key-1');
+		await provider.storeKey('acc-2', 'Account 2', 'key-2');
+
+		const sessions = await provider.getSessions();
+
+		assert.strictEqual(sessions.length, 2);
+		const ids = sessions.map(s => s.id).sort();
+		assert.deepStrictEqual(ids, ['acc-1', 'acc-2']);
+		assert.strictEqual(
+			sessions.find(s => s.id === 'acc-1')!.accessToken,
+			'key-1'
+		);
+	});
+});

--- a/extensions/authentication/src/test/configDialog.test.ts
+++ b/extensions/authentication/src/test/configDialog.test.ts
@@ -1,0 +1,124 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+import { apiKeyProviders, registerApiKeyProvider, showConfigurationDialog } from '../configDialog';
+import { ApiKeyAuthenticationProvider } from '../apiKeyProvider';
+
+suite('configDialog', () => {
+	let originalShowLanguageModelConfig: typeof positron.ai.showLanguageModelConfig;
+	let originalFetch: typeof globalThis.fetch;
+	let provider: ApiKeyAuthenticationProvider;
+
+	setup(() => {
+		apiKeyProviders.clear();
+		originalShowLanguageModelConfig = positron.ai.showLanguageModelConfig;
+		originalFetch = globalThis.fetch;
+		const secrets = new Map<string, string>();
+		const globalState = new Map<string, unknown>();
+		const mockContext = {
+			secrets: {
+				get: (key: string) => Promise.resolve(secrets.get(key)),
+				store: (key: string, value: string) => {
+					secrets.set(key, value);
+					return Promise.resolve();
+				},
+				delete: (key: string) => {
+					secrets.delete(key);
+					return Promise.resolve();
+				},
+			},
+			globalState: {
+				get: <T>(key: string) => globalState.get(key) as T | undefined,
+				update: (key: string, value: unknown) => {
+					globalState.set(key, value);
+					return Promise.resolve();
+				},
+			},
+		} as unknown as vscode.ExtensionContext;
+		provider = new ApiKeyAuthenticationProvider('anthropic-api', 'Anthropic', mockContext);
+		registerApiKeyProvider('anthropic-api', provider);
+	});
+
+	teardown(() => {
+		provider.dispose();
+		apiKeyProviders.clear();
+		positron.ai.showLanguageModelConfig = originalShowLanguageModelConfig;
+		globalThis.fetch = originalFetch;
+	});
+
+	test('validates Anthropic key before storing', async () => {
+		let validated = false;
+		let stored = false;
+		globalThis.fetch = async () => {
+			validated = true;
+			return { ok: true, status: 200 } as Response;
+		};
+
+		provider.storeKey = async (accountId: string, label: string, key: string) => {
+			stored = true;
+			return {
+				id: accountId,
+				accessToken: key,
+				account: { id: accountId, label },
+				scopes: [],
+			};
+		};
+
+		const source = {
+			type: positron.PositronLanguageModelType.Chat,
+			provider: { id: 'anthropic-api', displayName: 'Anthropic', settingName: 'anthropic-api' },
+			signedIn: false,
+			defaults: { name: 'Anthropic', model: 'claude-sonnet-4-0' },
+			supportedOptions: [],
+		} as unknown as positron.ai.LanguageModelSource;
+
+		positron.ai.showLanguageModelConfig = async (_sources, onAction) => {
+			await onAction({ provider: 'anthropic-api', type: positron.PositronLanguageModelType.Chat, name: 'Anthropic', model: 'claude-sonnet-4-0', apiKey: 'sk-ant-valid' }, 'save');
+		};
+
+		await showConfigurationDialog([source]);
+
+		assert.strictEqual(validated, true);
+		assert.strictEqual(stored, true);
+	});
+
+	test('rejects invalid Anthropic key and does not store', async () => {
+		let stored = false;
+		globalThis.fetch = async () => {
+			return { ok: false, status: 401 } as Response;
+		};
+
+		provider.storeKey = async (accountId: string, label: string, key: string) => {
+			stored = true;
+			return {
+				id: accountId,
+				accessToken: key,
+				account: { id: accountId, label },
+				scopes: [],
+			};
+		};
+
+		const source = {
+			type: positron.PositronLanguageModelType.Chat,
+			provider: { id: 'anthropic-api', displayName: 'Anthropic', settingName: 'anthropic-api' },
+			signedIn: false,
+			defaults: { name: 'Anthropic', model: 'claude-sonnet-4-0' },
+			supportedOptions: [],
+		} as unknown as positron.ai.LanguageModelSource;
+
+		positron.ai.showLanguageModelConfig = async (_sources, onAction) => {
+			await onAction({ provider: 'anthropic-api', type: positron.PositronLanguageModelType.Chat, name: 'Anthropic', model: 'claude-sonnet-4-0', apiKey: 'sk-ant-invalid' }, 'save');
+		};
+
+		await assert.rejects(
+			showConfigurationDialog([source]),
+			(error: Error) => error.message.includes('Invalid Anthropic API key')
+		);
+		assert.strictEqual(stored, false);
+	});
+});

--- a/extensions/authentication/src/test/configDialog.test.ts
+++ b/extensions/authentication/src/test/configDialog.test.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { apiKeyProviders, registerApiKeyProvider, showConfigurationDialog } from '../configDialog';
 import { ApiKeyAuthenticationProvider } from '../apiKeyProvider';
+import { validateAnthropicApiKey } from '../validation';
 
 suite('configDialog', () => {
 	let originalShowLanguageModelConfig: typeof positron.ai.showLanguageModelConfig;
@@ -41,7 +42,9 @@ suite('configDialog', () => {
 			},
 		} as unknown as vscode.ExtensionContext;
 		provider = new ApiKeyAuthenticationProvider('anthropic-api', 'Anthropic', mockContext);
-		registerApiKeyProvider('anthropic-api', provider);
+		registerApiKeyProvider('anthropic-api', provider, {
+			validateApiKey: async (apiKey) => validateAnthropicApiKey(apiKey),
+		});
 	});
 
 	teardown(() => {

--- a/extensions/authentication/src/validation/anthropic.ts
+++ b/extensions/authentication/src/validation/anthropic.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+const ANTHROPIC_MODELS_ENDPOINT = 'https://api.anthropic.com/v1/models';
+const ANTHROPIC_API_VERSION = '2023-06-01';
+const KEY_VALIDATION_TIMEOUT_MS = 5000;
+
+export async function validateAnthropicApiKey(apiKey: string): Promise<void> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), KEY_VALIDATION_TIMEOUT_MS);
+	try {
+		const response = await fetch(ANTHROPIC_MODELS_ENDPOINT, {
+			method: 'GET',
+			headers: {
+				'x-api-key': apiKey,
+				'anthropic-version': ANTHROPIC_API_VERSION,
+			},
+			signal: controller.signal,
+		});
+
+		if (response.ok) {
+			return;
+		}
+
+		if (response.status === 401 || response.status === 403) {
+			throw new Error(vscode.l10n.t('Invalid Anthropic API key'));
+		}
+
+		throw new Error(vscode.l10n.t(
+			'Unable to validate Anthropic API key (HTTP {0})',
+			String(response.status)
+		));
+	} catch (err) {
+		if (err instanceof Error && err.name === 'AbortError') {
+			throw new Error(vscode.l10n.t('Could not validate Anthropic API key within {0} seconds', String(KEY_VALIDATION_TIMEOUT_MS / 1000)));
+		}
+		if (err instanceof Error && err.message.includes('Invalid Anthropic API key')) {
+			throw err;
+		}
+		throw new Error(vscode.l10n.t('Could not validate Anthropic API key. Check your network connection and try again.'));
+	} finally {
+		clearTimeout(timeout);
+	}
+}

--- a/extensions/authentication/src/validation/anthropic.ts
+++ b/extensions/authentication/src/validation/anthropic.ts
@@ -9,6 +9,13 @@ const ANTHROPIC_MODELS_ENDPOINT = 'https://api.anthropic.com/v1/models';
 const ANTHROPIC_API_VERSION = '2023-06-01';
 const KEY_VALIDATION_TIMEOUT_MS = 5000;
 
+class ApiKeyValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'ApiKeyValidationError';
+	}
+}
+
 export async function validateAnthropicApiKey(apiKey: string): Promise<void> {
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), KEY_VALIDATION_TIMEOUT_MS);
@@ -27,21 +34,21 @@ export async function validateAnthropicApiKey(apiKey: string): Promise<void> {
 		}
 
 		if (response.status === 401 || response.status === 403) {
-			throw new Error(vscode.l10n.t('Invalid Anthropic API key'));
+			throw new ApiKeyValidationError(vscode.l10n.t('Invalid Anthropic API key'));
 		}
 
-		throw new Error(vscode.l10n.t(
+		throw new ApiKeyValidationError(vscode.l10n.t(
 			'Unable to validate Anthropic API key (HTTP {0})',
 			String(response.status)
 		));
 	} catch (err) {
 		if (err instanceof Error && err.name === 'AbortError') {
-			throw new Error(vscode.l10n.t('Could not validate Anthropic API key within {0} seconds', String(KEY_VALIDATION_TIMEOUT_MS / 1000)));
+			throw new ApiKeyValidationError(vscode.l10n.t('Could not validate Anthropic API key within {0} seconds', String(KEY_VALIDATION_TIMEOUT_MS / 1000)));
 		}
-		if (err instanceof Error && err.message.includes('Anthropic API key')) {
+		if (err instanceof ApiKeyValidationError) {
 			throw err;
 		}
-		throw new Error(vscode.l10n.t('Could not validate Anthropic API key. Check your network connection and try again.'));
+		throw new ApiKeyValidationError(vscode.l10n.t('Could not validate Anthropic API key. Check your network connection and try again.'));
 	} finally {
 		clearTimeout(timeout);
 	}

--- a/extensions/authentication/src/validation/anthropic.ts
+++ b/extensions/authentication/src/validation/anthropic.ts
@@ -38,7 +38,7 @@ export async function validateAnthropicApiKey(apiKey: string): Promise<void> {
 		if (err instanceof Error && err.name === 'AbortError') {
 			throw new Error(vscode.l10n.t('Could not validate Anthropic API key within {0} seconds', String(KEY_VALIDATION_TIMEOUT_MS / 1000)));
 		}
-		if (err instanceof Error && err.message.includes('Invalid Anthropic API key')) {
+		if (err instanceof Error && err.message.includes('Anthropic API key')) {
 			throw err;
 		}
 		throw new Error(vscode.l10n.t('Could not validate Anthropic API key. Check your network connection and try again.'));

--- a/extensions/authentication/src/validation/index.ts
+++ b/extensions/authentication/src/validation/index.ts
@@ -1,0 +1,6 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export { validateAnthropicApiKey } from './anthropic';

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -1421,6 +1421,7 @@
   },
   "extensionDependencies": [
     "positron.positron-supervisor",
-    "positron.positron-environment"
+    "positron.positron-environment",
+    "positron.authentication"
   ]
 }

--- a/extensions/positron-assistant/src/authExtRouting.ts
+++ b/extensions/positron-assistant/src/authExtRouting.ts
@@ -48,6 +48,15 @@ export async function getApiKey(
 			providerLogger.logAuthentication('success', 'via Authentication extension');
 			return session.accessToken;
 		}
+
+		// Fallback for account mapping mismatches: use any available provider session.
+		const fallbackSession = await vscode.authentication.getSession(
+			providerId, [], { silent: true }
+		);
+		if (fallbackSession?.accessToken) {
+			providerLogger.logAuthentication('success', 'via Authentication extension fallback session');
+			return fallbackSession.accessToken;
+		}
 	} catch (err) {
 		providerLogger.warn(`Failed to read auth session for ${accountId}`, err);
 	}

--- a/extensions/positron-assistant/src/authExtRouting.ts
+++ b/extensions/positron-assistant/src/authExtRouting.ts
@@ -49,10 +49,13 @@ export async function getApiKey(
 			return session.accessToken;
 		}
 
-		// Fallback for account mapping mismatches: only use fallback when there
-		// is exactly one account for the provider to avoid cross-account token use.
+		// If requested account no longer exists, do not attempt fallback to
+		// another account's session token.
 		const accounts = await vscode.authentication.getAccounts(providerId);
-		if (accounts.length === 1) {
+		const hasRequestedAccount = accounts.some(account => account.id === accountId);
+		if (!hasRequestedAccount) {
+			providerLogger.warn(`Requested auth account no longer exists: ${accountId}`);
+		} else if (accounts.length === 1) {
 			const fallbackSession = await vscode.authentication.getSession(
 				providerId,
 				[],

--- a/extensions/positron-assistant/src/authExtRouting.ts
+++ b/extensions/positron-assistant/src/authExtRouting.ts
@@ -49,13 +49,19 @@ export async function getApiKey(
 			return session.accessToken;
 		}
 
-		// Fallback for account mapping mismatches: use any available provider session.
-		const fallbackSession = await vscode.authentication.getSession(
-			providerId, [], { silent: true }
-		);
-		if (fallbackSession?.accessToken) {
-			providerLogger.logAuthentication('success', 'via Authentication extension fallback session');
-			return fallbackSession.accessToken;
+		// Fallback for account mapping mismatches: only use fallback when there
+		// is exactly one account for the provider to avoid cross-account token use.
+		const accounts = await vscode.authentication.getAccounts(providerId);
+		if (accounts.length === 1) {
+			const fallbackSession = await vscode.authentication.getSession(
+				providerId,
+				[],
+				{ silent: true, account: { id: accounts[0].id, label: '' } }
+			);
+			if (fallbackSession?.accessToken) {
+				providerLogger.logAuthentication('success', 'via Authentication extension single-account fallback session');
+				return fallbackSession.accessToken;
+			}
 		}
 	} catch (err) {
 		providerLogger.warn(`Failed to read auth session for ${accountId}`, err);

--- a/extensions/positron-assistant/src/authExtRouting.ts
+++ b/extensions/positron-assistant/src/authExtRouting.ts
@@ -49,22 +49,20 @@ export async function getApiKey(
 			return session.accessToken;
 		}
 
-		// If requested account no longer exists, do not attempt fallback to
-		// another account's session token.
-		const accounts = await vscode.authentication.getAccounts(providerId);
-		const hasRequestedAccount = accounts.some(account => account.id === accountId);
-		if (!hasRequestedAccount) {
-			providerLogger.warn(`Requested auth account no longer exists: ${accountId}`);
-		} else if (accounts.length === 1) {
+		const fallbackAccounts = await vscode.authentication.getAccounts(providerId);
+		for (const fallbackAccount of fallbackAccounts) {
 			const fallbackSession = await vscode.authentication.getSession(
 				providerId,
 				[],
-				{ silent: true, account: { id: accounts[0].id, label: '' } }
+				{ silent: true, account: { id: fallbackAccount.id, label: '' } }
 			);
 			if (fallbackSession?.accessToken) {
-				providerLogger.logAuthentication('success', 'via Authentication extension single-account fallback session');
+				providerLogger.logAuthentication('success', 'via Authentication extension fallback account session');
 				return fallbackSession.accessToken;
 			}
+		}
+		if (fallbackAccounts.length === 0) {
+			providerLogger.warn(`Requested auth account no longer exists: ${accountId}`);
 		}
 	} catch (err) {
 		providerLogger.warn(`Failed to read auth session for ${accountId}`, err);

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -298,16 +298,19 @@ async function saveModel(
 	}
 }
 
-async function deleteConfigurationByProvider(context: vscode.ExtensionContext, providerId: string) {
+export async function deleteConfigurationByProvider(context: vscode.ExtensionContext, providerId: string) {
 	const existingConfigs: Array<StoredModelConfig> = context.globalState.get('positron.assistant.models') || [];
-	const targetConfig = existingConfigs.find(config => config.provider === providerId);
-	if (targetConfig === undefined) {
+	const targetConfigs = existingConfigs.filter(config => config.provider === providerId);
+	if (targetConfigs.length === 0) {
 		// Provider may be autoconfigured and not in persistent state
 		// Remove from autoconfigured models list if present
 		removeAutoconfiguredModel(providerId);
 		return;
 	}
-	await deleteConfiguration(context, targetConfig.id);
+
+	for (const config of targetConfigs) {
+		await deleteConfiguration(context, config.id);
+	}
 }
 
 async function oauthSignin(userConfig: positron.ai.LanguageModelConfig, sources: positron.ai.LanguageModelSource[], context: vscode.ExtensionContext) {

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -175,32 +175,43 @@ export async function showConfigurationDialog(
 	// action results so we can handle model lifecycle here.
 	const results = await delegateConfigDialog(sources, { preselectedProviderId });
 	for (const result of results) {
-		switch (result.action) {
-			case 'save':
-				if (isAuthExtProvider(result.config.provider) && result.accountId) {
-					await saveModel(result.config, sources, context, {
-						id: result.accountId, skipSecretStorage: true
-					});
-				} else {
-					await saveModel(result.config, sources, context);
-				}
-				break;
-			case 'delete':
-				await deleteConfigurationByProvider(context, result.config.provider);
-				break;
-			case 'oauth-signin':
-				await oauthSignin(result.config, sources, context);
-				break;
-			case 'oauth-signout':
-				await oauthSignout(result.config, sources, context);
-				break;
-			case 'cancel':
-				// User cancelled the dialog, clean up any pending operations
-				PositModelProvider.cancelCurrentSignIn();
-				break;
-			default:
-				throw new Error(vscode.l10n.t('Invalid Language Model action: {0}', result.action));
-		}
+		await applyConfigAction(context, sources, result.config, result.action, result.accountId);
+	}
+}
+
+export async function applyConfigAction(
+	context: vscode.ExtensionContext,
+	sources: positron.ai.LanguageModelSource[],
+	config: positron.ai.LanguageModelConfig,
+	action: string,
+	accountId?: string,
+) {
+	switch (action) {
+		case 'save':
+			if (isAuthExtProvider(config.provider) && accountId) {
+				await saveModel(config, sources, context, {
+					id: accountId,
+					skipSecretStorage: true,
+				});
+			} else {
+				await saveModel(config, sources, context);
+			}
+			break;
+		case 'delete':
+			await deleteConfigurationByProvider(context, config.provider);
+			break;
+		case 'oauth-signin':
+			await oauthSignin(config, sources, context);
+			break;
+		case 'oauth-signout':
+			await oauthSignout(config, sources, context);
+			break;
+		case 'cancel':
+			// User cancelled the dialog, clean up any pending operations.
+			PositModelProvider.cancelCurrentSignIn();
+			break;
+		default:
+			throw new Error(vscode.l10n.t('Invalid Language Model action: {0}', action));
 	}
 }
 

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { deleteConfigurationByProvider, expandConfigToSource, getStoredModels, logStoredModels, showConfigurationDialog } from './config';
+import { applyConfigAction, deleteConfigurationByProvider, expandConfigToSource, getStoredModels, logStoredModels, showConfigurationDialog } from './config';
 import { registerSupportedProviders, validateProvidersEnabled } from './providerConfiguration.js';
 import { registerMappedEditsProvider } from './edits';
 import { ParticipantService, registerParticipants } from './participants';
@@ -42,6 +42,14 @@ function registerConfigureProvidersCommand(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('positron-assistant.configureProviders', async (providerId?: string) => {
 			await showConfigurationDialog(context, providerId);
+		}),
+		vscode.commands.registerCommand('positron-assistant.applyConfigAction', async (
+			config: positron.ai.LanguageModelConfig,
+			action: string,
+			sources: positron.ai.LanguageModelSource[],
+			accountId?: string,
+		) => {
+			await applyConfigAction(context, sources, config, action, accountId);
 		}),
 		vscode.commands.registerCommand('positron-assistant.logStoredModels', async () => {
 			logStoredModels(context);

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { applyConfigAction, deleteConfigurationByProvider, expandConfigToSource, getStoredModels, logStoredModels, showConfigurationDialog } from './config';
+import { applyConfigAction, deleteConfiguration, deleteConfigurationByProvider, expandConfigToSource, getStoredModels, logStoredModels, showConfigurationDialog } from './config';
 import { registerSupportedProviders, validateProvidersEnabled } from './providerConfiguration.js';
 import { registerMappedEditsProvider } from './edits';
 import { ParticipantService, registerParticipants } from './participants';
@@ -387,15 +387,25 @@ function registerAssistant(context: vscode.ExtensionContext) {
 
 		try {
 			const accounts = await vscode.authentication.getAccounts(providerId);
-			if (accounts.length === 0) {
-				await deleteConfigurationByProvider(context, providerId);
-			} else {
-				// Only re-register if Assistant already has stored configs for this provider.
-				// This keeps Accounts-menu sign-in from creating new model configs implicitly.
-				const hasStoredConfig = getStoredModels(context).some(model => model.provider === providerId);
-				if (hasStoredConfig) {
-					await registerModelsForProvider(context, providerId);
+			const accountIds = new Set(accounts.map(account => account.id));
+			const providerModels = getStoredModels(context).filter(model => model.provider === providerId);
+
+			for (const model of providerModels) {
+				if (!accountIds.has(model.id)) {
+					await deleteConfiguration(context, model.id);
 				}
+			}
+
+			if (accountIds.size === 0) {
+				await deleteConfigurationByProvider(context, providerId);
+				return;
+			}
+
+			// Only re-register if Assistant still has stored configs for this provider.
+			// This keeps Accounts-menu sign-in from creating new model configs implicitly.
+			const hasStoredConfig = getStoredModels(context).some(model => model.provider === providerId);
+			if (hasStoredConfig) {
+				await registerModelsForProvider(context, providerId);
 			}
 		} catch (error) {
 			log.warn(`[Auth Session Sync] Failed to sync provider ${providerId}: ${error instanceof Error ? error.message : String(error)}`);

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { expandConfigToSource, getStoredModels, logStoredModels, showConfigurationDialog } from './config';
+import { deleteConfigurationByProvider, expandConfigToSource, getStoredModels, logStoredModels, showConfigurationDialog } from './config';
 import { registerSupportedProviders, validateProvidersEnabled } from './providerConfiguration.js';
 import { registerMappedEditsProvider } from './edits';
 import { ParticipantService, registerParticipants } from './participants';
@@ -32,6 +32,7 @@ import { getModelProviders } from './providers/index.js';
 import { registerPositAuthProvider } from './providers/posit/positProvider.js';
 import { PROVIDER_METADATA } from './providerMetadata.js';
 import { ModelConfig } from './configTypes.js';
+import { isAuthExtProvider } from './authExtRouting.js';
 
 // (Authentication provider is registered via registerCopilotAuthProvider)
 
@@ -368,6 +369,30 @@ function registerAssistant(context: vscode.ExtensionContext) {
 		.catch((e) => {
 			log.error(`[Foundry] Provider initialization chain failed: ${e instanceof Error ? e.message : String(e)}`);
 		});
+
+	// Keep Positron Assistant model state in sync when users sign out via Accounts menu.
+	context.subscriptions.push(vscode.authentication.onDidChangeSessions(async (e) => {
+		const providerId = e.provider.id;
+		if (!isAuthExtProvider(providerId)) {
+			return;
+		}
+
+		try {
+			const accounts = await vscode.authentication.getAccounts(providerId);
+			if (accounts.length === 0) {
+				await deleteConfigurationByProvider(context, providerId);
+			} else {
+				// Only re-register if Assistant already has stored configs for this provider.
+				// This keeps Accounts-menu sign-in from creating new model configs implicitly.
+				const hasStoredConfig = getStoredModels(context).some(model => model.provider === providerId);
+				if (hasStoredConfig) {
+					await registerModelsForProvider(context, providerId);
+				}
+			}
+		} catch (error) {
+			log.warn(`[Auth Session Sync] Failed to sync provider ${providerId}: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}));
 
 	// Track opened files for completion context
 	registerHistoryTracking(context);

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -352,6 +352,28 @@ function registerDeferredFoundryAutoconfigure(context: vscode.ExtensionContext) 
 	log.debug('[Foundry] Listening for Workbench auth sessions for deferred autoconfigure');
 }
 
+async function reconcileAuthProviderModels(
+	context: vscode.ExtensionContext,
+	providerId: string,
+): Promise<boolean> {
+	const accounts = await vscode.authentication.getAccounts(providerId);
+	const accountIds = new Set(accounts.map(account => account.id));
+	const providerModels = getStoredModels(context).filter(model => model.provider === providerId);
+
+	for (const model of providerModels) {
+		if (!accountIds.has(model.id)) {
+			await deleteConfiguration(context, model.id);
+		}
+	}
+
+	if (accountIds.size === 0) {
+		await deleteConfigurationByProvider(context, providerId);
+		return false;
+	}
+
+	return getStoredModels(context).some(model => model.provider === providerId);
+}
+
 function registerAssistant(context: vscode.ExtensionContext) {
 	// Register Posit AI authentication provider
 	registerPositAuthProvider(context);
@@ -364,6 +386,23 @@ function registerAssistant(context: vscode.ExtensionContext) {
 
 	// Initialize provider configuration system (registration, migration, validation)
 	initializeProviderConfiguration(context)
+		.then(async () => {
+			// Reconcile stale auth-backed configs before model registration so
+			// startup doesn't attempt to register with missing session IDs.
+			const authProviderIds = new Set(
+				getStoredModels(context)
+					.map(model => model.provider)
+					.filter(providerId => isAuthExtProvider(providerId))
+			);
+
+			for (const providerId of authProviderIds) {
+				try {
+					await reconcileAuthProviderModels(context, providerId);
+				} catch (error) {
+					log.warn(`[Auth Startup Reconcile] Failed for provider ${providerId}: ${error instanceof Error ? error.message : String(error)}`);
+				}
+			}
+		})
 		.then(() => {
 			// After initialization, register models
 			return registerModels(context);
@@ -386,24 +425,9 @@ function registerAssistant(context: vscode.ExtensionContext) {
 		}
 
 		try {
-			const accounts = await vscode.authentication.getAccounts(providerId);
-			const accountIds = new Set(accounts.map(account => account.id));
-			const providerModels = getStoredModels(context).filter(model => model.provider === providerId);
-
-			for (const model of providerModels) {
-				if (!accountIds.has(model.id)) {
-					await deleteConfiguration(context, model.id);
-				}
-			}
-
-			if (accountIds.size === 0) {
-				await deleteConfigurationByProvider(context, providerId);
-				return;
-			}
-
+			const hasStoredConfig = await reconcileAuthProviderModels(context, providerId);
 			// Only re-register if Assistant still has stored configs for this provider.
 			// This keeps Accounts-menu sign-in from creating new model configs implicitly.
-			const hasStoredConfig = getStoredModels(context).some(model => model.provider === providerId);
 			if (hasStoredConfig) {
 				await registerModelsForProvider(context, providerId);
 			}

--- a/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadAiFeatures.ts
@@ -63,9 +63,11 @@ export class MainThreadAiFeatures extends Disposable implements MainThreadAiFeat
 				sources,
 				async (config, action) => {
 					await this._proxy.$responseLanguageModelConfig(id, config, action);
+				},
+				() => {
+					this._proxy.$onCompleteLanguageModelConfig(id);
 					resolve();
 				},
-				() => this._proxy.$onCompleteLanguageModelConfig(id),
 				options,
 			);
 		});

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -17,7 +17,7 @@ interface LanguageModelConfigComponentProps {
 	config: IPositronLanguageModelConfig,
 	source: IPositronLanguageModelSource,
 	onChange: (config: IPositronLanguageModelConfig) => void,
-	onSignIn: () => void,
+	onSignIn: (apiKeyFromInput?: string) => void,
 	onCancel: () => void,
 	closeDialog: () => void,
 }
@@ -137,6 +137,7 @@ function interpolate(text: string, value: (key: string) => React.ReactNode | und
 export const LanguageModelConfigComponent = (props: LanguageModelConfigComponentProps) => {
 	const { authMethod, authStatus, config, source } = props;
 	const { apiKey } = config;
+	const apiKeyInputRef = React.useRef<HTMLInputElement | null>(null);
 
 	const hasAutoconfigure = !!source.defaults.autoconfigure && source.defaults.autoconfigure.signedIn;
 	const showApiKeyInput = authMethod === AuthMethod.API_KEY && authStatus !== AuthStatus.SIGNED_IN && !hasAutoconfigure;
@@ -151,8 +152,8 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 
 	return <>
 		{!hasAutoconfigure && <div className='language-model-container input'>
-			{showApiKeyInput && <ApiKey apiKey={apiKey} onChange={onChange} />}
-			<SignInButton authMethod={authMethod} authStatus={authStatus} onSignIn={props.onSignIn} />
+			{showApiKeyInput && <ApiKey apiKey={apiKey} inputRef={apiKeyInputRef} onChange={onChange} />}
+			<SignInButton authMethod={authMethod} authStatus={authStatus} onSignIn={() => props.onSignIn(apiKeyInputRef.current?.value)} />
 			{showCancelButton &&
 				<Button className='language-model button cancel' onPressed={() => props.onCancel()}>
 					{localize('positron.languageModelConfig.cancel', "Cancel")}
@@ -212,10 +213,11 @@ const BaseUrl = (props: { baseUrl?: string; signedIn?: boolean; onChange: (newBa
 	</>);
 };
 
-const ApiKey = (props: { apiKey?: string, onChange: (newApiKey: string) => void }) => {
+const ApiKey = (props: { apiKey?: string, inputRef: React.RefObject<HTMLInputElement | null>, onChange: (newApiKey: string) => void }) => {
 	return (<>
 		<div className='language-model-authentication-container' id='api-key-input'>
 			<LabeledTextInput
+				ref={props.inputRef}
 				label={apiKeyInputLabel}
 				type='password'
 				value={props.apiKey ?? ''}

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -24,6 +24,8 @@ import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { AuthMethod, AuthStatus } from './types.js';
 import { PositronModalReactRenderer } from '../../../../base/browser/positronModalReactRenderer.js';
 import { ErrorMessageWithLinks } from './components/errorMessageWithLinks.js';
+import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
+import { syncAuthSessions } from './languageModelSessionSync.js';
 
 export const showLanguageModelModalDialog = (
 	sources: IPositronLanguageModelSource[],
@@ -104,6 +106,9 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 
 	// Config for the provider, which is what is sent to the extension when signing in or out of a provider.
 	const [providerConfig, setProviderConfig] = useState<IPositronLanguageModelConfig>(() => providerSourceToConfig(defaultProvider));
+	// Use a ref so submit handlers always read the latest config value.
+	const providerConfigRef = useRef(providerConfig);
+	providerConfigRef.current = providerConfig;
 
 	// UI State
 	const [showProgress, setShowProgress] = useState(false);
@@ -122,6 +127,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	// Each provider source contains the info needed to populate the modal UI with provider details, such as
 	// the provider ID, auth methods and whether the user is signed in or not with the provider.
 	const [providerSources, setProviderSources] = useState<IPositronLanguageModelSource[]>(providers);
+	const trackedProviderIdsRef = useRef<string[]>(providers.map(source => source.provider.id));
 
 	// Update the provider sources when the service emits a change to the language model config.
 	// This occurs when a user signs in or out of a provider.
@@ -147,6 +153,31 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 		}));
 		return () => { disposables.forEach(d => d.dispose()); };
 	}, [props.renderer.services.positronAssistantService]);
+
+	// Listen for auth session changes from the Authentication extension so API key providers
+	// update immediately after save/delete while the modal is open.
+	useEffect(() => {
+		const authService = props.renderer.services.get(IAuthenticationService);
+		const disposable = syncAuthSessions(
+			authService,
+			trackedProviderIdsRef.current,
+			(providerId, signedIn) => {
+				setProviderSources(prevSources => {
+					const index = prevSources.findIndex(source => source.provider.id === providerId);
+					if (index === -1) {
+						return prevSources;
+					}
+					const updatedSources = [...prevSources];
+					updatedSources[index] = {
+						...prevSources[index],
+						signedIn,
+					};
+					return updatedSources;
+				});
+			}
+		);
+		return () => disposable.dispose();
+	}, [props.renderer.services]);
 
 	// Keep selectedProvider in sync with providerSources
 	useEffect(() => {
@@ -268,28 +299,44 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	};
 
 	/** When the user clicks the Sign In button */
-	const onSignIn = async () => {
+	const onSignIn = async (apiKeyFromInput?: string) => {
 		if (!selectedProvider) {
 			return;
 		}
 		setShowProgress(true);
 		setErrorMessage(undefined);
+		let currentConfig = providerConfigRef.current;
+
+		if (getAuthMethod() === AuthMethod.API_KEY) {
+			const liveApiKey = apiKeyFromInput;
+			if (typeof liveApiKey === 'string' && liveApiKey.length > 0 && liveApiKey !== currentConfig.apiKey) {
+				currentConfig = { ...currentConfig, apiKey: liveApiKey };
+				providerConfigRef.current = currentConfig;
+				setProviderConfig(currentConfig);
+			}
+		}
 
 		try {
-			if (!providerConfig) {
+			if (!currentConfig) {
 				setErrorMessage(localize('positron.languageModelProviderModalDialog.incompleteConfig', 'The configuration is incomplete.'));
 				return;
 			}
+
+			let action: string;
 
 			// Handle the main chat/completion model configuration
 			switch (getAuthMethod()) {
 				case AuthMethod.NONE:
 				// Use the same actions as API_KEY
 				case AuthMethod.API_KEY:
-					await props.onAction(providerConfig, isSignedIn() ? 'delete' : 'save');
+					// When currently signed in, this button acts as sign out.
+					// Otherwise, treat it as sign in/save.
+					action = isSignedIn() ? 'delete' : 'save';
+					await props.onAction(currentConfig, action);
 					break;
 				case AuthMethod.OAUTH:
-					await props.onAction(providerConfig, isSignedIn() ? 'oauth-signout' : 'oauth-signin');
+					action = isSignedIn() ? 'oauth-signout' : 'oauth-signin';
+					await props.onAction(currentConfig, action);
 					break;
 				default:
 					setErrorMessage(localize('positron.languageModelProviderModalDialog.unsupportedAuthMethod', 'Unsupported authentication method.'));
@@ -297,19 +344,19 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 			}
 
 			// Handle completion model if needed
-			if (providerConfig.completions) {
+			if (currentConfig.completions) {
 				// Assume a completion source exists with the same provider ID and compatible auth details
-				const completionSource = allProviders.find((source) => source.provider.id === providerConfig.provider && source.type === 'completion')!;
+				const completionSource = allProviders.find((source) => source.provider.id === currentConfig.provider && source.type === 'completion')!;
 				const completionConfig = {
-					provider: providerConfig.provider,
+					provider: currentConfig.provider,
 					type: PositronLanguageModelType.Completion,
 					...completionSource.defaults,
-					apiKey: providerConfig.apiKey,
-					oauth: providerConfig.oauth,
+					apiKey: currentConfig.apiKey,
+					oauth: currentConfig.oauth,
 				};
 				await props.onAction(
 					completionConfig,
-					selectedProvider.signedIn ? 'delete' : 'save');
+					action === 'delete' ? 'delete' : 'save');
 			}
 		} catch (e) {
 			setErrorMessage(e instanceof Error ? e.message : String(e));
@@ -322,7 +369,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	const onCancel = async () => {
 		// NOTE: this action is currently only applicable to Copilot OAuth.
 		// See positron.ai.showLanguageModelConfig in extensions/positron-assistant/src/config.ts
-		await props.onAction(providerConfig, 'cancel')
+		await props.onAction(providerConfigRef.current, 'cancel')
 			.catch((e) => {
 				setErrorMessage(e.message);
 			}).finally(() => {
@@ -415,6 +462,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 				source={selectedProvider}
 				onCancel={onCancel}
 				onChange={(config) => {
+					providerConfigRef.current = config;
 					setProviderConfig(config);
 				}}
 				onSignIn={onSignIn}

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -127,7 +127,6 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	// Each provider source contains the info needed to populate the modal UI with provider details, such as
 	// the provider ID, auth methods and whether the user is signed in or not with the provider.
 	const [providerSources, setProviderSources] = useState<IPositronLanguageModelSource[]>(providers);
-	const trackedProviderIdsRef = useRef<string[]>(providers.map(source => source.provider.id));
 
 	// Update the provider sources when the service emits a change to the language model config.
 	// This occurs when a user signs in or out of a provider.
@@ -160,7 +159,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 		const authService = props.renderer.services.get(IAuthenticationService);
 		const disposable = syncAuthSessions(
 			authService,
-			trackedProviderIdsRef.current,
+			providers.map(source => source.provider.id),
 			(providerId, signedIn) => {
 				setProviderSources(prevSources => {
 					const index = prevSources.findIndex(source => source.provider.id === providerId);
@@ -177,7 +176,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 			}
 		);
 		return () => disposable.dispose();
-	}, [props.renderer.services]);
+	}, [props.renderer.services, providers]);
 
 	// Keep selectedProvider in sync with providerSources
 	useEffect(() => {

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -358,6 +358,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 					completionConfig,
 					action === 'delete' ? 'delete' : 'save');
 			}
+
 		} catch (e) {
 			setErrorMessage(e instanceof Error ? e.message : String(e));
 		} finally {

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -309,7 +309,8 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 
 		if (getAuthMethod() === AuthMethod.API_KEY) {
 			const liveApiKey = apiKeyFromInput;
-			if (typeof liveApiKey === 'string' && liveApiKey.length > 0 && liveApiKey !== currentConfig.apiKey) {
+			const currentApiKey = currentConfig.apiKey ?? '';
+			if (typeof liveApiKey === 'string' && liveApiKey !== currentApiKey) {
 				currentConfig = { ...currentConfig, apiKey: liveApiKey };
 				providerConfigRef.current = currentConfig;
 				setProviderConfig(currentConfig);

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelSessionSync.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelSessionSync.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
+
+/**
+ * Callback invoked when an auth session change affects a tracked provider.
+ * @param providerId The provider whose session state changed.
+ * @param signedIn Whether any sessions remain for the provider.
+ */
+export type SessionSyncCallback = (providerId: string, signedIn: boolean) => void;
+
+/**
+ * Subscribe to authentication session changes for a set of provider IDs.
+ * When a session is added or removed for a matching provider, queries the
+ * actual session count and invokes the callback with the result.
+ *
+ * @param authService The authentication service to listen to.
+ * @param providerIds The provider IDs to track.
+ * @param callback Called with (providerId, signedIn) on relevant changes.
+ * @returns A disposable that removes the listener.
+ */
+export function syncAuthSessions(
+	authService: IAuthenticationService,
+	providerIds: string[],
+	callback: SessionSyncCallback,
+): IDisposable {
+	return authService.onDidChangeSessions(async (e) => {
+		if (!providerIds.includes(e.providerId)) {
+			return;
+		}
+		try {
+			const sessions = await authService.getSessions(e.providerId);
+			callback(e.providerId, sessions.length > 0);
+		} catch {
+			// Provider may not be registered yet
+		}
+	});
+}

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/languageModelSessionSync.test.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/languageModelSessionSync.test.ts
@@ -1,0 +1,121 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Emitter } from '../../../../../base/common/event.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { AuthenticationSession, AuthenticationSessionsChangeEvent, IAuthenticationService } from '../../../../services/authentication/common/authentication.js';
+import { syncAuthSessions } from '../../browser/languageModelSessionSync.js';
+
+suite('syncAuthSessions', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let emitter: Emitter<{ providerId: string; label: string; event: AuthenticationSessionsChangeEvent }>;
+	let sessionsMap: Map<string, AuthenticationSession[]>;
+	let authService: IAuthenticationService;
+
+	setup(() => {
+		emitter = disposables.add(
+			new Emitter<{ providerId: string; label: string; event: AuthenticationSessionsChangeEvent }>()
+		);
+		sessionsMap = new Map();
+		authService = {
+			onDidChangeSessions: emitter.event,
+			getSessions: async (providerId: string) => {
+				return sessionsMap.get(providerId) ?? [];
+			},
+		} as unknown as IAuthenticationService;
+	});
+
+	test('updates signedIn to true when session added for matching provider', async () => {
+		const results: { providerId: string; signedIn: boolean }[] = [];
+		disposables.add(
+			syncAuthSessions(authService, ['anthropic-api'], (providerId, signedIn) => {
+				results.push({ providerId, signedIn });
+			})
+		);
+
+		sessionsMap.set('anthropic-api', [
+			{ id: '1', accessToken: 'key', account: { id: '1', label: 'test' }, scopes: [] },
+		]);
+		emitter.fire({
+			providerId: 'anthropic-api',
+			label: 'Anthropic',
+			event: { added: [{ id: '1', accessToken: 'key', account: { id: '1', label: 'test' }, scopes: [] }], removed: undefined, changed: undefined },
+		});
+
+		// Allow the async handler to complete
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		assert.strictEqual(results.length, 1);
+		assert.strictEqual(results[0].providerId, 'anthropic-api');
+		assert.strictEqual(results[0].signedIn, true);
+	});
+
+	test('updates signedIn to false when all sessions removed', async () => {
+		const results: { providerId: string; signedIn: boolean }[] = [];
+		disposables.add(
+			syncAuthSessions(authService, ['anthropic-api'], (providerId, signedIn) => {
+				results.push({ providerId, signedIn });
+			})
+		);
+
+		// No sessions for this provider
+		sessionsMap.set('anthropic-api', []);
+		emitter.fire({
+			providerId: 'anthropic-api',
+			label: 'Anthropic',
+			event: { added: undefined, removed: [{ id: '1', accessToken: '', account: { id: '1', label: 'test' }, scopes: [] }], changed: undefined },
+		});
+
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		assert.strictEqual(results.length, 1);
+		assert.strictEqual(results[0].providerId, 'anthropic-api');
+		assert.strictEqual(results[0].signedIn, false);
+	});
+
+	test('ignores session changes for non-matching providers', async () => {
+		const results: { providerId: string; signedIn: boolean }[] = [];
+		disposables.add(
+			syncAuthSessions(authService, ['anthropic-api'], (providerId, signedIn) => {
+				results.push({ providerId, signedIn });
+			})
+		);
+
+		emitter.fire({
+			providerId: 'github',
+			label: 'GitHub',
+			event: { added: [{ id: '1', accessToken: 'tok', account: { id: '1', label: 'user' }, scopes: [] }], removed: undefined, changed: undefined },
+		});
+
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		assert.strictEqual(results.length, 0);
+	});
+
+	test('disposes listener on cleanup', () => {
+		const results: { providerId: string; signedIn: boolean }[] = [];
+		const disposable = syncAuthSessions(
+			authService,
+			['anthropic-api'],
+			(providerId, signedIn) => {
+				results.push({ providerId, signedIn });
+			}
+		);
+		disposable.dispose();
+
+		sessionsMap.set('anthropic-api', [
+			{ id: '1', accessToken: 'key', account: { id: '1', label: 'test' }, scopes: [] },
+		]);
+		emitter.fire({
+			providerId: 'anthropic-api',
+			label: 'Anthropic',
+			event: { added: [{ id: '1', accessToken: 'key', account: { id: '1', label: 'test' }, scopes: [] }], removed: undefined, changed: undefined },
+		});
+
+		assert.strictEqual(results.length, 0);
+	});
+});

--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -280,10 +280,13 @@ test.describe('Positron Assistant Model Picker Default Indicator - Multiple Prov
 
 		// Sign in to Anthropic (method handles auto-sign-in detection)
 		await assistant.loginModelProvider('anthropic-api');
-		await assistant.pickModel();
 
 		// Verify Anthropic default - Claude Haiku 4.5 should have "(default)"
-		await assistant.expectModelInPicker('Claude Haiku 4.5 (default)');
+		await expect(async () => {
+			await assistant.closeModelPickerDropdown();
+			await assistant.pickModel();
+			await assistant.expectModelInPicker('Claude Haiku 4.5 (default)');
+		}).toPass({ timeout: 30000 });
 
 		// Verify other Anthropic models do NOT have "(default)"
 		await assistant.expectModelInPicker(/^Claude Sonnet 4$/);


### PR DESCRIPTION
Next PR for #12374 
Fixes Anthropic sign-in/sign-out regressions after #12450 and reduces account-mismatch risk in auth token resolution.

- Signing in/out of a provider that uses the Authentication extension will not resolve models until the Configure Language Model Provider modal is closed. If errors occur at that point, they will pop up in the corner and be logged to Positron Assistant logs.
- Added live auth-session sync in the language model modal so state updates immediately while the dialog is open.
- Fixed API key submit staleness by passing current input value at click time and syncing cleared values into submit state.
- Added startup + event-driven reconciliation of stored auth-backed model configs against current auth accounts to remove stale model IDs.
- Hardened auth token resolution to avoid rebinding a stale model config to a different remaining account.
- Added Anthropic key validation separate from model resolution
- Added/updated tests for auth session events, config dialog validation behavior, and modal session-sync logic.

### QA Notes

This changes fixes several state related bugs that could happen,particuarly when testing sign in/out and repeating these actions within one modal. It should also fix the test failures we've seen with Anthropic.

@:assistant
