### PR TITLE
Actions to control per-cell output truncation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,8 @@ Positron forks VSCode. Minimize merge conflicts by isolating Positron code.
 - Ensure build daemons are running before testing
 - Core tests (`src/**/*.ts`):
 	- `./scripts/test.sh`: run all tests
-	- `./scripts/test.sh --run <file>.test.ts`: run a specific file
-	- `./scripts/test.sh --run <file>.test.ts --grep '<pattern>'`: run specific tests in a file
+	- `./scripts/test.sh --run src/path/to/<file>.test.ts`: run a specific file
+	- `./scripts/test.sh --run src/path/to/<file>.test.ts --grep '<pattern>'`: run specific tests in a file
 	- `./scripts/test.sh --runGlob <glob>.test.js`: run files matching a glob (use `.js` extension with `--runGlob`)
 - Extension tests (`extensions/<extension-name>/*.test.ts`, preferred for extension development except positron-python): `npm run test-extension -- -l <extension-name> --grep <pattern>`
 	- For positron-python, see that extension's CLAUDE.md

--- a/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
@@ -55,6 +55,8 @@ export const POSITRON_NOTEBOOK_CELL_CAN_MOVE_DOWN = new RawContextKey<boolean>('
 export const POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS = new RawContextKey<boolean>('positronNotebookCellHasOutputs', false);
 export const POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT = new RawContextKey<number>('positronNotebookCellImageOutputCount', 0);
 export const POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED = new RawContextKey<boolean>('positronNotebookCellOutputIsCollapsed', false);
+export const POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS = new RawContextKey<boolean>('positronNotebookCellOutputOverflows', false, localize('positronNotebookCellOutputOverflows', "Whether the cell's text output exceeds the line limit"));
+export const POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING = new RawContextKey<boolean>('positronNotebookCellOutputScrolling', false, localize('positronNotebookCellOutputScrolling', "Whether the cell's output is in scrolling mode"));
 
 /**
  * Interaction-driven context key set to true when the user right-clicks on an
@@ -82,6 +84,8 @@ export const POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS = {
 	hasOutputs: POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
 	imageOutputCount: POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT,
 	outputIsCollapsed: POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED,
+	outputOverflows: POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
+	outputScrolling: POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING,
 } as const;
 
 // Interface for the cell context keys
@@ -111,6 +115,8 @@ export function bindCellContextKeys(service: IScopedContextKeyService): IPositro
 		hasOutputs: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.hasOutputs.bindTo(service),
 		imageOutputCount: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.imageOutputCount.bindTo(service),
 		outputIsCollapsed: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputIsCollapsed.bindTo(service),
+		outputOverflows: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputOverflows.bindTo(service),
+		outputScrolling: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputScrolling.bindTo(service),
 	} satisfies IPositronNotebookCellContextKeys;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -261,7 +261,14 @@ export interface IPositronNotebookCodeCell extends IPositronNotebookCell {
 	/**
 	 * Whether the cell outputs are collapsed
 	 */
-	readonly outputIsCollapsed: ISettableObservable<boolean>;
+	readonly outputIsCollapsed: IObservable<boolean>;
+
+	/**
+	 * Per-cell output scrolling override.
+	 * When undefined, the global notebook.outputScrolling setting is used.
+	 * When true, output is scrollable (full). When false, output is truncated.
+	 */
+	readonly outputScrolling: IObservable<boolean | undefined>;
 
 	/**
 	 * Duration of the last execution in milliseconds
@@ -297,6 +304,21 @@ export interface IPositronNotebookCodeCell extends IPositronNotebookCell {
 	 * Toggle the collapse state of cell outputs
 	 */
 	toggleOutputCollapse(): void;
+
+	/**
+	 * Truncate the cell output.
+	 */
+	truncateOutput(): void;
+
+	/**
+	 * Show full cell output.
+	 */
+	showFullOutput(): void;
+
+	/**
+	 * Reset per-cell output truncation to follow the global setting.
+	 */
+	resetOutputScrolling(): void;
 }
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -25,6 +25,9 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 	// Output collapse state
 	private readonly _outputIsCollapsed: ISettableObservable<boolean>;
 
+	// Per-cell output scrolling override (undefined = use global setting)
+	private readonly _outputScrolling: ISettableObservable<boolean | undefined>;
+
 	// Execution timing observables
 	lastExecutionDuration;
 	lastExecutionOrder;
@@ -46,6 +49,12 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 			cellModel.collapseState?.outputCollapsed ?? false
 		);
 
+		// Per-cell output scrolling override (undefined = use global setting)
+		this._outputScrolling = observableValue<boolean | undefined>(
+			'outputScrolling',
+			undefined
+		);
+
 		this._outputs = observableFromEvent(this, Event.any(this.model.onDidChangeOutputs, this.model.onDidChangeOutputItems), () => {
 			/** @description cellOutputs */
 			return this.parseCellOutputs();
@@ -56,6 +65,9 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 			if (this.model.outputs.length === 0) {
 				this._outputIsCollapsed.set(false, undefined);
 			}
+
+			// Reset per-cell scrolling override when outputs change (clear or re-run)
+			this._outputScrolling.set(undefined, undefined);
 		}));
 
 		// Execution timing observables
@@ -93,6 +105,22 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 
 	toggleOutputCollapse(): void {
 		this._outputIsCollapsed.set(!this._outputIsCollapsed.get(), undefined);
+	}
+
+	get outputScrolling(): ISettableObservable<boolean | undefined> {
+		return this._outputScrolling;
+	}
+
+	truncateOutput(): void {
+		this._outputScrolling.set(false, undefined);
+	}
+
+	showFullOutput(): void {
+		this._outputScrolling.set(true, undefined);
+	}
+
+	resetOutputScrolling(): void {
+		this._outputScrolling.set(undefined, undefined);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -437,6 +437,20 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 		this._notebookOptions = this._instantiationService.createInstance(NotebookOptions, DOM.getActiveWindow(), this.isReadOnly, undefined);
 
+		// Reset per-cell scrolling overrides when the global output scrolling setting
+		// changes so all cells follow the new default.
+		this._register(this._notebookOptions.onDidChangeOptions(e => {
+			if (!e.outputScrolling) {
+				return;
+			}
+			for (const cell of this.cells.get()) {
+				if (!cell.isCodeCell()) {
+					continue;
+				}
+				cell.resetOutputScrolling();
+			}
+		}));
+
 		return this._notebookOptions;
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -14,13 +14,8 @@ import { ANSIOutput } from '../../../../../base/common/ansiOutput.js';
 import { OutputLines } from '../../../../browser/positronAnsiRenderer/outputLines.js';
 import { ParsedTextOutput } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { useNotebookOptions } from '../NotebookInstanceProvider.js';
-import { ICommandService } from '../../../../../platform/commands/common/commands.js';
-import { NotebookDisplayOptions } from '../../../notebook/browser/notebookOptions.js';
-import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 import { NotebookCellQuickFix } from './NotebookCellQuickFix.js';
-
-export type LongOutputOptions = Pick<NotebookDisplayOptions, 'outputLineLimit' | 'outputScrolling'>;
 
 type TruncationResult =
 	{ content: string } & (
@@ -32,8 +27,7 @@ type TruncationResult =
 		}
 	);
 
-
-function truncateToNumberOfLines(content: string, { outputScrolling, outputLineLimit: maxLines }: LongOutputOptions): TruncationResult {
+function truncateToNumberOfLines(content: string, outputScrolling: boolean, maxLines: number): TruncationResult {
 	// Trim newline from end of content if it exists.
 	const splitByLine = content.trimEnd().split('\n');
 	const numLines = splitByLine.length;
@@ -52,21 +46,34 @@ function truncateToNumberOfLines(content: string, { outputScrolling, outputLineL
 	};
 }
 
+export interface CellTextOutputProps extends ParsedTextOutput {
+	outputScrolling: boolean;
+	onShowFullOutput: () => void;
+}
 
-export function CellTextOutput({ content, type }: ParsedTextOutput) {
 
-	const services = usePositronReactServicesContext();
+export function CellTextOutput({
+	content,
+	type,
+	outputScrolling,
+	onShowFullOutput,
+}: CellTextOutputProps) {
+
 	const layoutConfig = useNotebookOptions().getLayoutConfiguration();
-	const truncation = truncateToNumberOfLines(content, layoutConfig);
+	const truncation = truncateToNumberOfLines(content, outputScrolling, layoutConfig.outputLineLimit);
 	const outputWordWrap = layoutConfig.outputWordWrap;
 
 	return <>
-		<div className={positronClassNames(`notebook-${type}`, 'positron-notebook-text-output', { 'word-wrap': outputWordWrap })}>
+		<div className={positronClassNames(
+			`notebook-${type}`,
+			'positron-notebook-text-output',
+			{ 'word-wrap': outputWordWrap },
+		)}>
 			<OutputLines outputLines={ANSIOutput.processOutput(truncation.content)} />
 			{truncation.mode === 'truncate' && <>
 				<TruncationMessage
-					commandService={services.commandService}
 					numLinesTruncated={truncation.numLinesTruncated}
+					onShowFullOutput={onShowFullOutput}
 				/>
 				<OutputLines outputLines={ANSIOutput.processOutput(truncation.contentAfter)} />
 			</>}
@@ -75,18 +82,15 @@ export function CellTextOutput({ content, type }: ParsedTextOutput) {
 	</>;
 }
 
-const TruncationMessage = ({ numLinesTruncated, commandService }: {
+const TruncationMessage = ({ numLinesTruncated, onShowFullOutput }: {
 	numLinesTruncated: number;
-	commandService: ICommandService;
+	onShowFullOutput: () => void;
 }) => {
 	const openSettings = (e: React.MouseEvent<HTMLAnchorElement>) => {
 		// Prevent the anchor from navigating, which would reload the
 		// Electron renderer and hang the window.
 		e.preventDefault();
-		commandService.executeCommand(
-			'workbench.action.openSettings',
-			'notebook.output scroll'
-		);
+		onShowFullOutput();
 	};
 
 	return <i className='notebook-output-truncation-message'>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -32,7 +32,7 @@ import { MenuId } from '../../../../../platform/actions/common/actions.js';
 import { DataExplorerCellOutput } from './DataExplorerCellOutput.js';
 import { NotebookErrorBoundary } from '../NotebookErrorBoundary.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
-import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from '../ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS } from '../ContextKeysManager.js';
 import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.js';
 import { useScrollingIndicator } from './useScrollingIndicator.js';
 import { CellOutputActionBar } from './CellOutputActionBar.js';
@@ -49,7 +49,12 @@ interface CellOutputsSectionProps {
 const CellOutputsSection = React.memo(function CellOutputsSection({ cell, outputs }: CellOutputsSectionProps) {
 	const services = usePositronReactServicesContext();
 	const isCollapsed = useObservedValue(cell.outputIsCollapsed);
+	const perCellScrolling = useObservedValue(cell.outputScrolling);
 	const contextKeyService = useCellScopedContextKeyService();
+	const outputOverflowsKey = useMemo(
+		() => contextKeyService ? POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS.bindTo(contextKeyService) : undefined,
+		[contextKeyService]
+	);
 	const outputImageTargeted = useMemo(
 		() => contextKeyService ? POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED.bindTo(contextKeyService) : undefined,
 		[contextKeyService]
@@ -58,6 +63,19 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 	const layout = notebookOptions.getLayoutConfiguration();
 	const outputsInnerRef = React.useRef<HTMLDivElement>(null);
 	useScrollingIndicator(outputsInnerRef);
+
+	// Per-cell scrolling override takes precedence over global setting.
+	const outputScrolling = perCellScrolling ?? layout.outputScrolling;
+
+	// Update the output overflow context key.
+	React.useEffect(() => {
+		if (!outputOverflowsKey) { return; }
+		const hasOverflowingOutput = outputs.some(o =>
+			isParsedTextOutput(o.parsed) && o.parsed.content.trimEnd().split('\n').length > layout.outputLineLimit
+		);
+		outputOverflowsKey.set(hasOverflowingOutput);
+	}, [outputs, layout.outputLineLimit, outputOverflowsKey]);
+
 	const { showContextMenu } = useCellContextMenu({
 		cell,
 		menuId: MenuId.PositronNotebookCellOutputActionContext,
@@ -126,7 +144,7 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 					'positron-notebook-code-cell-outputs-inner',
 					'positron-notebook-scrollable',
 					'positron-notebook-scrollable-fade',
-					{ 'output-scrolling': layout.outputScrolling }
+					{ 'output-scrolling': outputScrolling }
 				)}>
 					{isCollapsed
 						? <CollapsedOutputLabel onExpand={handleShowHiddenOutput} />
@@ -137,7 +155,11 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 								level='output'
 								logService={services.logService}
 							>
-								<CellOutput {...output} />
+								<CellOutput
+									{...output}
+									outputScrolling={outputScrolling}
+									onShowFullOutput={() => cell.showFullOutput()}
+								/>
 							</NotebookErrorBoundary>
 						))
 					}
@@ -176,15 +198,24 @@ export const NotebookCodeCell = React.memo(function NotebookCodeCell({ cell }: {
 	return prevProps.cell === nextProps.cell;
 });
 
-const CellOutput = React.memo(function CellOutput(output: NotebookCellOutputs) {
+interface CellOutputProps extends NotebookCellOutputs {
+	outputScrolling: boolean;
+	onShowFullOutput: () => void;
+}
+
+const CellOutput = React.memo(function CellOutput(output: CellOutputProps) {
 	if (output.preloadMessageResult) {
 		return <PreloadMessageOutput preloadMessageResult={output.preloadMessageResult} />;
 	}
 
-	const { parsed, outputs } = output;
+	const { parsed, outputs, outputScrolling, onShowFullOutput } = output;
 
 	if (isParsedTextOutput(parsed)) {
-		return <CellTextOutput {...parsed} />;
+		return <CellTextOutput
+			{...parsed}
+			outputScrolling={outputScrolling}
+			onShowFullOutput={onShowFullOutput}
+		/>;
 	}
 
 	switch (parsed.type) {
@@ -208,7 +239,8 @@ const CellOutput = React.memo(function CellOutput(output: NotebookCellOutputs) {
 }, (prevProps, nextProps) => {
 	// Reference equality on parsed is correct - new execution creates new parsed objects
 	return prevProps.outputId === nextProps.outputId &&
-		prevProps.parsed === nextProps.parsed;
+		prevProps.parsed === nextProps.parsed &&
+		prevProps.outputScrolling === nextProps.outputScrolling;
 });
 
 const CollapsedOutputLabel = ({ onExpand }: { onExpand: () => void }) => {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
@@ -7,7 +7,8 @@
 import React from 'react';
 
 // Other dependencies.
-import { autorun } from '../../../../../base/common/observable.js';
+import { Event } from '../../../../../base/common/event.js';
+import { autorun, observableFromEvent } from '../../../../../base/common/observable.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { CellSelectionStatus, IPositronNotebookCell } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { IPositronNotebookInstance } from '../IPositronNotebookInstance.js';
@@ -51,13 +52,14 @@ export function useCellContextKeys(
 		// Bind the cell-specific context keys
 		const keys = bindCellContextKeys(scopedContextKeyService);
 
-		// Keep context keys in sync with cell state
-		disposables.add(autorun(reader => {
-			if (!keys) {
-				return;
-			}
+		/* Observable of the global outputScrolling option. */
+		const globalOutputScrollingObs = observableFromEvent(
+			Event.filter(notebookInstance.notebookOptions.onDidChangeOptions, e => Boolean(e.outputScrolling), disposables),
+			() => notebookInstance.notebookOptions.getLayoutConfiguration().outputScrolling
+		);
 
-			if (!cell || cell.index === -1) {
+		disposables.add(autorun(reader => {
+			if (cell.index === -1) {
 				resetCellContextKeys(keys);
 				return;
 			}
@@ -69,6 +71,8 @@ export function useCellContextKeys(
 			const cells = notebookInstance.cells.read(reader);
 			const outputs = cell.isCodeCell() ? cell.outputs.read(reader) : [];
 			const outputIsCollapsed = cell.isCodeCell() ? cell.outputIsCollapsed.read(reader) : false;
+			const outputScrolling = cell.isCodeCell() ? cell.outputScrolling.read(reader) : undefined;
+			const globalOutputScrolling = globalOutputScrollingObs.read(reader);
 
 			keys.isCode.set(cell.isCodeCell());
 			keys.isMarkdown.set(cell.isMarkdownCell());
@@ -86,6 +90,7 @@ export function useCellContextKeys(
 			keys.hasOutputs.set(outputs.length > 0);
 			keys.imageOutputCount.set(outputs.filter(o => o.parsed.type === 'image').length);
 			keys.outputIsCollapsed.set(outputIsCollapsed);
+			keys.outputScrolling.set(outputScrolling ?? globalOutputScrolling);
 		}));
 
 		// Set the state to let other components know that the context keys are ready

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -47,7 +47,7 @@ import { INotebookEditorOptions, IPYNB_VIEW_TYPE } from '../../notebook/browser/
 import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID, PositronNotebookActionId, PositronNotebookCellActionBarLeftGroup, PositronNotebookCellOutputActionGroup, usingPositronNotebooks } from '../common/positronNotebookCommon.js';
 import { QMD_VIEW_TYPE } from '../../positronQuartoNotebook/common/quartoNotebookConstants.js';
 import { getActiveCell, getSelectedCells, SelectionState } from './selectionMachine.js';
-import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from './ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from './ContextKeysManager.js';
 import './contrib/undoRedo/positronNotebookUndoRedo.js';
 import { registerAction2, MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { ExecuteSelectionInConsoleAction } from './ExecuteSelectionInConsoleAction.js';
@@ -1509,6 +1509,92 @@ registerAction2(class extends NotebookAction2 {
 
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
 		notebook.joinCellBelow();
+	}
+});
+
+// Truncate output
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.truncateOutput',
+			title: localize2('positronNotebook.cell.truncateOutput', "Truncate Output"),
+			icon: Codicon.fold,
+			menu: [
+				{
+					id: MenuId.PositronNotebookCellOutputActionBar,
+					group: PositronNotebookCellOutputActionGroup.Visibility,
+					order: 0,
+					when: ContextKeyExpr.and(
+						POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
+						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated(),
+						POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
+						POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING
+					)
+				},
+				{
+					id: MenuId.PositronNotebookCellOutputActionContext,
+					group: PositronNotebookCellOutputActionGroup.Visibility,
+					order: 0,
+					when: ContextKeyExpr.and(
+						POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
+						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated(),
+						POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
+						POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING
+					)
+				}
+			]
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor): void {
+		const state = notebook.selectionStateMachine.state.get();
+		const cell = getActiveCell(state);
+		if (cell?.isCodeCell()) {
+			cell.truncateOutput();
+		}
+	}
+});
+
+// Show full output
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.showFullOutput',
+			title: localize2('positronNotebook.cell.showFullOutput', "Show Full Output"),
+			icon: Codicon.unfold,
+			menu: [
+				{
+					id: MenuId.PositronNotebookCellOutputActionBar,
+					group: PositronNotebookCellOutputActionGroup.Visibility,
+					order: 0,
+					when: ContextKeyExpr.and(
+						POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
+						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated(),
+						POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
+						POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING.toNegated()
+					)
+				},
+				{
+					id: MenuId.PositronNotebookCellOutputActionContext,
+					group: PositronNotebookCellOutputActionGroup.Visibility,
+					order: 0,
+					when: ContextKeyExpr.and(
+						POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
+						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated(),
+						POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
+						POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING.toNegated()
+					)
+				}
+			]
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor): void {
+		const state = notebook.selectionStateMachine.state.get();
+		const cell = getActiveCell(state);
+		if (cell?.isCodeCell()) {
+			cell.showFullOutput();
+		}
 	}
 });
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.test.tsx
@@ -7,9 +7,9 @@
 /* eslint-disable local/code-no-dangerous-type-assertions */
 
 import assert from 'assert';
+import sinon from 'sinon';
 import { flushSync } from 'react-dom';
-import { Emitter, Event } from '../../../../../../base/common/event.js';
-import { CommandsRegistry } from '../../../../../../platform/commands/common/commands.js';
+import { Emitter } from '../../../../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { setupReactRenderer } from '../../../../../../base/test/browser/react.js';
 import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
@@ -87,6 +87,7 @@ suite('CellTextOutput', () => {
 	function renderCellTextOutput(
 		props: ParsedTextOutput,
 		options?: Partial<NotebookLayoutConfiguration & NotebookDisplayOptions>,
+		onShowFullOutput: () => void = () => { },
 	) {
 		if (options !== undefined) {
 			layoutConfig = { ...layoutConfig, ...options };
@@ -105,7 +106,11 @@ suite('CellTextOutput', () => {
 		const container = render(
 			<PositronReactServicesContext.Provider value={services}>
 				<NotebookInstanceProvider instance={instance}>
-					<CellTextOutput {...props} />
+					<CellTextOutput
+						{...props}
+						outputScrolling={layoutConfig.outputScrolling ?? false}
+						onShowFullOutput={onShowFullOutput}
+					/>
 				</NotebookInstanceProvider>
 			</PositronReactServicesContext.Provider>
 		);
@@ -154,26 +159,32 @@ suite('CellTextOutput', () => {
 		assert.strictEqual(runs[1].textContent, ' plain');
 	});
 
-	test('truncates long output when scrolling is disabled', async () => {
-		disposables.add(CommandsRegistry.registerCommand('workbench.action.openSettings', () => { }));
-
+	test('truncates long output when scrolling is disabled', () => {
+		const onShowFullOutput = sinon.stub();
 		const content = makeLines(35);
 		const fixture = renderCellTextOutput(
 			{ content, type: 'stdout' },
 			{ outputLineLimit: 30, outputScrolling: false },
+			onShowFullOutput,
 		);
 
 		const message = fixture.truncationMessage;
 		assert.ok(message, 'Expected truncation message');
 		assert.ok(message.textContent?.includes('5 lines truncated'), 'Expected truncation count');
 
+		// Verify visible line ranges: top 29 lines + last line, middle lines hidden
+		const text = fixture.outputContainer.textContent ?? '';
+		assert.ok(text.includes('line 1'), 'Expected first line to be visible');
+		assert.ok(text.includes('line 29'), 'Expected line 29 (last top line) to be visible');
+		assert.ok(!text.includes('line 30'), 'Expected line 30 to be truncated');
+		assert.ok(!text.includes('line 34'), 'Expected line 34 to be truncated');
+		assert.ok(text.includes('line 35'), 'Expected last line to be visible');
+
 		const link = fixture.settingsLink;
 		assert.ok(link, 'Expected "Change behavior" link');
 
-		const commandPromise = Event.toPromise(commandService.onWillExecuteCommand);
 		link.click();
-		const event = await commandPromise;
-		assert.strictEqual(event.commandId, 'workbench.action.openSettings');
+		assert.ok(onShowFullOutput.calledOnce, 'Expected onShowFullOutput to be called');
 	});
 
 	test('does not truncate when scrolling is enabled', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.test.ts
@@ -4,60 +4,135 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { CellKind, NotebookCellsChangeType } from '../../../notebook/common/notebookCommon.js';
-import { createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
+import { CellEditType, CellKind, NotebookCellsChangeType } from '../../../notebook/common/notebookCommon.js';
+import { createTestPositronNotebookInstance, TestPositronNotebookInstance } from './testPositronNotebookInstance.js';
+import { PositronNotebookCodeCell } from '../../browser/PositronNotebookCells/PositronNotebookCodeCell.js';
 
 suite('PositronNotebookCell', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	/** Tests to ensure that the test harness is correctly setup, useful for debugging the test harness */
-	suite('Test Harness', () => {
-		test('cells have editors auto-attached', () => {
-			const notebook = createTestPositronNotebookInstance(
-				[['print("hello")', 'python', CellKind.Code]], disposables
-			);
+	let notebook: TestPositronNotebookInstance;
+	let cell: PositronNotebookCodeCell;
 
-			const cell = notebook.cells.get()[0];
-			assert.ok(cell.currentEditor, 'Cell should have an auto-attached editor');
+	setup(() => {
+		notebook = createTestPositronNotebookInstance(
+			[['print("hello")', 'python', CellKind.Code]], disposables
+		);
+		cell = notebook.cells.get()[0] as PositronNotebookCodeCell;
+		assert.ok(cell.isCodeCell(), 'Expected cell to be a code cell');
+	});
 
-			const editorModel = cell.currentEditor.getModel();
-			assert.ok(editorModel, 'Cell editor should have a model');
-
-			assert.strictEqual(cell.getContent(), editorModel.getValue(), 'Cell content should match editor model value');
-			assert.strictEqual(cell.model.textModel, editorModel, 'Cell model should be the editor model');
+	suite('Output scrolling state', () => {
+		test('outputScrolling defaults to undefined', () => {
+			assert.strictEqual(cell.outputScrolling.get(), undefined);
 		});
 
-		test('setValue propagates through the content change event chain', () => {
-			const notebook = createTestPositronNotebookInstance(
-				[['original content', 'python', CellKind.Code]], disposables
-			);
-
-			const cell = notebook.cells.get()[0];
-			const notebookModel = notebook.textModel!;
-
-			// Link 1: NotebookCellTextModel fires onDidChangeContent when textModel changes
-			let cellContentFired = false;
-			disposables.add(cell.model.onDidChangeContent((e) => {
-				if (e === 'content' || (typeof e === 'object' && e.type === 'model')) {
-					cellContentFired = true;
-				}
-			}));
-
-			// Link 2: NotebookTextModel fires onDidChangeContent with ChangeCellContent
-			let notebookModelFired = false;
-			disposables.add(notebookModel.onDidChangeContent((e) => {
-				if (e.rawEvents.some(
-					event => event.kind === NotebookCellsChangeType.ChangeCellContent ||
-						event.kind === NotebookCellsChangeType.ModelChange)) {
-					notebookModelFired = true;
-				}
-			}));
-
-			cell.model.textModel!.setValue('new content');
-
-			assert.ok(cellContentFired, 'NotebookCellTextModel.onDidChangeContent should fire when textModel.setValue() is called');
-			assert.ok(notebookModelFired, 'NotebookTextModel.onDidChangeContent should fire when textModel.setValue() is called');
+		test('truncateOutput sets outputScrolling to false', () => {
+			cell.truncateOutput();
+			assert.strictEqual(cell.outputScrolling.get(), false);
 		});
+
+		test('showFullOutput sets outputScrolling to true', () => {
+			cell.showFullOutput();
+			assert.strictEqual(cell.outputScrolling.get(), true);
+		});
+
+		test('collapse and expand does not affect scrolling state', () => {
+			// Verify with scrolling = true (showing full output)
+			cell.showFullOutput();
+			cell.collapseOutput();
+			assert.strictEqual(cell.outputScrolling.get(), true);
+			cell.expandOutput();
+			assert.strictEqual(cell.outputScrolling.get(), true);
+
+			// Verify with scrolling = false (truncated)
+			cell.truncateOutput();
+			cell.collapseOutput();
+			assert.strictEqual(cell.outputScrolling.get(), false);
+			cell.expandOutput();
+			assert.strictEqual(cell.outputScrolling.get(), false);
+		});
+
+		test('new output resets scrolling state to undefined', () => {
+			const textModel = notebook.textModel;
+			assert.ok(textModel);
+
+			const applyNewOutput = () => textModel.applyEdits([{
+				editType: CellEditType.Output,
+				index: 0,
+				outputs: [{
+					outputId: `output-${Math.random()}`,
+					outputs: [{ mime: 'application/vnd.code.notebook.stdout', data: VSBuffer.fromString('new output') }],
+				}],
+				append: false,
+			}], true, undefined, () => undefined, undefined, false);
+
+			// Reset from showing full output (true -> undefined)
+			cell.showFullOutput();
+			assert.strictEqual(cell.outputScrolling.get(), true);
+			applyNewOutput();
+			assert.strictEqual(cell.outputScrolling.get(), undefined);
+
+			// Reset from truncated (false -> undefined)
+			cell.truncateOutput();
+			assert.strictEqual(cell.outputScrolling.get(), false);
+			applyNewOutput();
+			assert.strictEqual(cell.outputScrolling.get(), undefined);
+		});
+	});
+
+});
+
+/** Tests to ensure that the test harness is correctly setup, useful for debugging the test harness */
+suite('PositronNotebookCell Test Harness', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('cells have editors auto-attached', () => {
+		const notebook = createTestPositronNotebookInstance(
+			[['print("hello")', 'python', CellKind.Code]], disposables
+		);
+
+		const cell = notebook.cells.get()[0];
+		assert.ok(cell.currentEditor, 'Cell should have an auto-attached editor');
+
+		const editorModel = cell.currentEditor.getModel();
+		assert.ok(editorModel, 'Cell editor should have a model');
+
+		assert.strictEqual(cell.getContent(), editorModel.getValue(), 'Cell content should match editor model value');
+		assert.strictEqual(cell.model.textModel, editorModel, 'Cell model should be the editor model');
+	});
+
+	test('setValue propagates through the content change event chain', () => {
+		const notebook = createTestPositronNotebookInstance(
+			[['original content', 'python', CellKind.Code]], disposables
+		);
+
+		const cell = notebook.cells.get()[0];
+		const notebookModel = notebook.textModel!;
+
+		// Link 1: NotebookCellTextModel fires onDidChangeContent when textModel changes
+		let cellContentFired = false;
+		disposables.add(cell.model.onDidChangeContent((e) => {
+			if (e === 'content' || (typeof e === 'object' && e.type === 'model')) {
+				cellContentFired = true;
+			}
+		}));
+
+		// Link 2: NotebookTextModel fires onDidChangeContent with ChangeCellContent
+		let notebookModelFired = false;
+		disposables.add(notebookModel.onDidChangeContent((e) => {
+			if (e.rawEvents.some(
+				event => event.kind === NotebookCellsChangeType.ChangeCellContent ||
+					event.kind === NotebookCellsChangeType.ModelChange)) {
+				notebookModelFired = true;
+			}
+		}));
+
+		cell.model.textModel!.setValue('new content');
+
+		assert.ok(cellContentFired, 'NotebookCellTextModel.onDidChangeContent should fire when textModel.setValue() is called');
+		assert.ok(notebookModelFired, 'NotebookTextModel.onDidChangeContent should fire when textModel.setValue() is called');
 	});
 });

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -70,6 +70,7 @@ export class PositronNotebooks extends Notebooks {
 	cellOutput = (index: number) => this.cell.nth(index).getByTestId('cell-output');
 	private outputActionBar = (index: number) => this.cell.nth(index).locator('.cell-output-action-bar');
 	outputCollapsedLabel = (index: number) => this.cellOutput(index).getByText('Output collapsed');
+	outputTruncationMessage = (index: number) => this.cellOutput(index).getByText(/\.\.\. [\d,.\s\u00A0]+ lines truncated/);
 	outputCollapseToggle = (index: number) => this.cell.nth(index).locator('.cell-output-collapse-button-container').getByRole('button');
 
 	// Assistant buttons (shown on error cells when assistant is enabled)

--- a/test/e2e/tests/notebooks-positron/notebook-cell-output.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-output.test.ts
@@ -66,4 +66,46 @@ test.describe('Positron Notebooks: Cell Output', {
 			await expect(notebooksPositron.cellOutput(0)).toBeEmpty();
 		});
 	});
+
+	test('Toggle long output truncation', async function ({ app }) {
+		const { notebooks, notebooksPositron } = app.workbench;
+
+		await test.step('Setup: Open a notebook and generate long output', async () => {
+			await notebooks.createNewNotebook();
+			await notebooksPositron.expectCellCountToBe(1);
+			await notebooksPositron.kernel.select('Python');
+
+			// Generate output that exceeds the default 30-line limit
+			await notebooksPositron.addCodeToCell(0, 'for i in range(50): print(f"line {i}")', { run: true });
+			await notebooksPositron.expectOutputAtIndex(0, ['line 0']);
+		});
+
+		const outputTruncationMessage = notebooksPositron.outputTruncationMessage(0);
+
+		await test.step('Long output is truncated with a truncation message', async () => {
+			await expect(outputTruncationMessage).toContainText('lines truncated');
+		});
+
+		await test.step('Show Full Output via action bar removes truncation', async () => {
+			await notebooksPositron.triggerCellOutputAction(0, 'Show Full Output');
+			await expect(outputTruncationMessage).toBeHidden();
+			// A line hidden during truncation should now be visible.
+			// With 50 lines and a 30-line limit, lines 29-48 are truncated.
+			await notebooksPositron.expectOutputAtIndex(0, ['line 35']);
+		});
+
+		await test.step('Truncate Output via action bar restores truncation', async () => {
+			await notebooksPositron.triggerCellOutputAction(0, 'Truncate Output');
+			await expect(outputTruncationMessage).toBeVisible();
+		});
+
+		await test.step('Re-running the cell resets truncation state', async () => {
+			// Currently showing full output (no truncation message).
+			// Re-run the cell - this should reset the per-cell override
+			// back to the global default (truncated).
+			await notebooksPositron.runCodeAtIndex(0);
+
+			await expect(outputTruncationMessage).toBeVisible();
+		});
+	});
 });


### PR DESCRIPTION
Add Truncate Output and Show Full Output actions to the cell output action bar. When output overflows, users can toggle between truncated view and full scrollable output on a per-cell basis.

Addresses #12518.

https://github.com/user-attachments/assets/2749baf3-60cf-40a8-87fe-a7e25f47a60c

### Release Notes

#### New Features

- Long text notebook cell outputs can be individually truncated (#12518)

#### Bug Fixes

- N/A

### QA Notes

@:web @:positron-notebooks

Includes e2e and unit test.