### PR TITLE
Make truncation message clickable with 50/50 head/tail split

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
@@ -18,17 +18,19 @@
 	white-space: pre-wrap;
 }
 
-.notebook-output-truncation-message {
-	display: block;
-	font-size: 0.95em;
-	opacity: 0.8;
+/* Clickable "Show N more lines" message shown when output is truncated. */
+.positron-notebook-text-output .notebook-output-truncation-message {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	/* Override the parent's monospace font and Button's unset !important. */
+	font-family: system-ui, sans-serif !important;
+	font-size: 11px;
+	line-height: 11px;
+	color: var(--vscode-editorCodeLens-foreground);
+	padding: 4px 0;
+	user-select: none;
 }
-
-/* Use theme link colors */
-.notebook-output-truncation-message a {
+.positron-notebook-text-output .notebook-output-truncation-message:hover {
 	color: var(--vscode-textLink-foreground);
-}
-.notebook-output-truncation-message a:hover,
-.notebook-output-truncation-message a:active {
-	color: var(--vscode-textLink-activeForeground);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -6,17 +6,21 @@
 // CSS.
 import './CellTextOutput.css';
 
-// React.
-import React from 'react';
-
 // Other dependencies.
 import { ANSIOutput } from '../../../../../base/common/ansiOutput.js';
 import { OutputLines } from '../../../../browser/positronAnsiRenderer/outputLines.js';
 import { ParsedTextOutput } from '../PositronNotebookCells/IPositronNotebookCell.js';
-import { useNotebookOptions } from '../NotebookInstanceProvider.js';
+import { useNotebookInstance, useNotebookOptions } from '../NotebookInstanceProvider.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+import { localize } from '../../../../../nls.js';
 import { NotebookCellQuickFix } from './NotebookCellQuickFix.js';
+import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 
+const showMoreLinesLabel = (n: number) => localize(
+	'positron.notebook.showMoreLines',
+	"... Show {0} more lines",
+	n.toLocaleString()
+);
 type TruncationResult =
 	{ content: string } & (
 		{ mode: 'normal' } |
@@ -38,11 +42,15 @@ function truncateToNumberOfLines(content: string, outputScrolling: boolean, maxL
 		return { content, mode: 'normal' };
 	}
 
+	// Split point: 50/50 between top and bottom
+	const topLines = Math.ceil(maxLines / 2);
+	const bottomLines = maxLines - topLines;
+
 	return {
 		mode: 'truncate',
-		content: splitByLine.slice(0, maxLines - 1).join('\n'),
-		contentAfter: splitByLine[splitByLine.length - 1],
-		numLinesTruncated: Math.max(numLines - maxLines, 0),
+		content: splitByLine.slice(0, topLines).join('\n'),
+		contentAfter: splitByLine.slice(numLines - bottomLines).join('\n'),
+		numLinesTruncated: numLines - maxLines,
 	};
 }
 
@@ -86,19 +94,15 @@ const TruncationMessage = ({ numLinesTruncated, onShowFullOutput }: {
 	numLinesTruncated: number;
 	onShowFullOutput: () => void;
 }) => {
-	const openSettings = (e: React.MouseEvent<HTMLAnchorElement>) => {
-		// Prevent the anchor from navigating, which would reload the
-		// Electron renderer and hang the window.
-		e.preventDefault();
-		onShowFullOutput();
-	};
-
-	return <i className='notebook-output-truncation-message'>
-		{`... ${numLinesTruncated.toLocaleString()} lines truncated. `}
-		<a
-			aria-label='notebook output settings'
-			href=''
-			onClick={openSettings}
-		>Change behavior.</a>
-	</i>;
+	const instance = useNotebookInstance();
+	const label = showMoreLinesLabel(numLinesTruncated);
+	return <Button
+		ariaLabel={label}
+		className='notebook-output-truncation-message'
+		hoverManager={instance.hoverManager}
+		onPressed={onShowFullOutput}
+	>
+		{label}
+	</Button>;
 };
+

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.test.tsx
@@ -14,8 +14,6 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/
 import { setupReactRenderer } from '../../../../../../base/test/browser/react.js';
 import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
-import { TestCommandService } from '../../../../../../editor/test/browser/editorTestServices.js';
 import { NotebookDisplayOptions, NotebookLayoutConfiguration, NotebookOptions, NotebookOptionsChangeEvent } from '../../../../notebook/browser/notebookOptions.js';
 import { IPositronNotebookInstance } from '../../../browser/IPositronNotebookInstance.js';
 import { NotebookInstanceProvider } from '../../../browser/NotebookInstanceProvider.js';
@@ -39,10 +37,6 @@ class CellTextOutputFixture {
 
 	get truncationMessage() {
 		return this.container.querySelector<HTMLElement>('.notebook-output-truncation-message');
-	}
-
-	get settingsLink() {
-		return this.container.querySelector<HTMLAnchorElement>('.notebook-output-truncation-message a');
 	}
 
 	get quickFixContainer() {
@@ -69,16 +63,12 @@ suite('CellTextOutput', () => {
 
 	let optionsEmitter: Emitter<NotebookOptionsChangeEvent>;
 	let layoutConfig: Partial<NotebookLayoutConfiguration & NotebookDisplayOptions>;
-	let commandService: TestCommandService;
 	let configurationService: TestConfigurationService;
 	let contextKeyService: MockContextKeyService;
 
 	setup(() => {
 		optionsEmitter = disposables.add(new Emitter<NotebookOptionsChangeEvent>());
 		layoutConfig = { outputLineLimit: 30, outputScrolling: false, outputWordWrap: false };
-
-		const instantiationService = disposables.add(new TestInstantiationService());
-		commandService = new TestCommandService(instantiationService);
 
 		configurationService = new TestConfigurationService();
 		contextKeyService = disposables.add(new MockContextKeyService());
@@ -96,9 +86,11 @@ suite('CellTextOutput', () => {
 			onDidChangeOptions: optionsEmitter.event,
 			getLayoutConfiguration: () => layoutConfig,
 		} as unknown as NotebookOptions;
-		const instance = { notebookOptions } as unknown as IPositronNotebookInstance;
+		const instance = {
+			notebookOptions,
+			hoverManager: { showHover: () => { }, hideHover: () => { } },
+		} as unknown as IPositronNotebookInstance;
 		const services = {
-			commandService,
 			configurationService,
 			contextKeyService,
 		} as unknown as PositronReactServices;
@@ -170,20 +162,18 @@ suite('CellTextOutput', () => {
 
 		const message = fixture.truncationMessage;
 		assert.ok(message, 'Expected truncation message');
-		assert.ok(message.textContent?.includes('5 lines truncated'), 'Expected truncation count');
+		assert.ok(message.textContent?.includes('5 more lines'), 'Expected truncation count');
 
-		// Verify visible line ranges: top 29 lines + last line, middle lines hidden
+		// 50/50 split: top 15 lines (1-15), bottom 15 lines (21-35), lines 16-20 hidden
 		const text = fixture.outputContainer.textContent ?? '';
 		assert.ok(text.includes('line 1'), 'Expected first line to be visible');
-		assert.ok(text.includes('line 29'), 'Expected line 29 (last top line) to be visible');
-		assert.ok(!text.includes('line 30'), 'Expected line 30 to be truncated');
-		assert.ok(!text.includes('line 34'), 'Expected line 34 to be truncated');
+		assert.ok(text.includes('line 15'), 'Expected line 15 (last top line) to be visible');
+		assert.ok(!text.includes('line 16\n'), 'Expected line 16 to be truncated');
+		assert.ok(!text.includes('line 20\n'), 'Expected line 20 to be truncated');
+		assert.ok(text.includes('line 21'), 'Expected line 21 (first bottom line) to be visible');
 		assert.ok(text.includes('line 35'), 'Expected last line to be visible');
 
-		const link = fixture.settingsLink;
-		assert.ok(link, 'Expected "Change behavior" link');
-
-		link.click();
+		message.click();
 		assert.ok(onShowFullOutput.calledOnce, 'Expected onShowFullOutput to be called');
 	});
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -70,7 +70,7 @@ export class PositronNotebooks extends Notebooks {
 	cellOutput = (index: number) => this.cell.nth(index).getByTestId('cell-output');
 	private outputActionBar = (index: number) => this.cell.nth(index).locator('.cell-output-action-bar');
 	outputCollapsedLabel = (index: number) => this.cellOutput(index).getByText('Output collapsed');
-	outputTruncationMessage = (index: number) => this.cellOutput(index).getByText(/\.\.\. [\d,.\s\u00A0]+ lines truncated/);
+	outputTruncationMessage = (index: number) => this.cellOutput(index).getByText(/\.\.\. Show [\d,.\s\u00A0]+ more lines/);
 	outputCollapseToggle = (index: number) => this.cell.nth(index).locator('.cell-output-collapse-button-container').getByRole('button');
 
 	// Assistant buttons (shown on error cells when assistant is enabled)

--- a/test/e2e/tests/notebooks-positron/notebook-cell-output.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-output.test.ts
@@ -91,20 +91,26 @@ test.describe('Positron Notebooks: Cell Output', {
 		const outputTruncationMessage = notebooksPositron.outputTruncationMessage(0);
 
 		await test.step('Long output is truncated with a truncation message', async () => {
-			await expect(outputTruncationMessage).toContainText('lines truncated');
+			await expect(outputTruncationMessage).toContainText('more lines');
 		});
 
 		await test.step('Show Full Output via action bar removes truncation', async () => {
 			await notebooksPositron.triggerCellOutputAction(0, 'Show Full Output');
 			await expect(outputTruncationMessage).toBeHidden();
 			// A line hidden during truncation should now be visible.
-			// With 50 lines and a 30-line limit, lines 29-48 are truncated.
+			// With 50 lines and a 30-line limit, lines 16-34 are truncated (50/50 split).
 			await notebooksPositron.expectOutputAtIndex(0, ['line 35']);
 		});
 
 		await test.step('Truncate Output via action bar restores truncation', async () => {
 			await notebooksPositron.triggerCellOutputAction(0, 'Truncate Output');
 			await expect(outputTruncationMessage).toBeVisible();
+		});
+
+		await test.step('Clicking the truncation message shows full output', async () => {
+			await notebooksPositron.outputTruncationMessage(0).click();
+			await expect(notebooksPositron.outputTruncationMessage(0)).toBeHidden();
+			await notebooksPositron.expectOutputAtIndex(0, ['line 25']);
 		});
 
 		await test.step('Re-running the cell resets truncation state', async () => {


### PR DESCRIPTION
Addresses #12581.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:web @:positron-notebooks