### PR TITLE
e2e: extend side-by-side notebook isolation tests

### DIFF
--- a/test/e2e/pages/editors.ts
+++ b/test/e2e/pages/editors.ts
@@ -13,8 +13,29 @@ export class Editors {
 	get editorIcon(): Locator { return this.code.driver.page.locator('.monaco-icon-label.file-icon'); }
 	get editorPart(): Locator { return this.code.driver.page.locator('.split-view-view .part.editor'); }
 	get suggestionList(): Locator { return this.code.driver.page.locator('.suggest-widget .monaco-list-row'); }
+	get editorGroups(): Locator { return this.code.driver.page.locator('.part.editor .editor-group-container'); }
 
 	constructor(private code: Code) { }
+
+	/**
+	 * Get a specific editor group by index.
+	 * Useful for side-by-side notebook testing where you need to scope actions to a specific editor.
+	 * @param index - 0-based index (0 = leftmost/first group)
+	 */
+	editorGroup(index: number): Locator {
+		return this.editorGroups.nth(index);
+	}
+
+	/**
+	 * Verify: the expected number of editor groups are visible.
+	 * @param count - Expected number of editor groups
+	 * @param timeout - Timeout for the expectation (default: 5000ms)
+	 */
+	async expectEditorGroupCount(count: number, timeout = 5000): Promise<void> {
+		await test.step(`Expect ${count} editor group(s)`, async () => {
+			await expect(this.editorGroups).toHaveCount(count, { timeout });
+		});
+	}
 
 	async clickTab(tabName: string): Promise<void> {
 		await test.step(`Click tab: ${tabName}`, async () => {

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -94,6 +94,15 @@ export class PositronNotebooks extends Notebooks {
 		this.kernel = new Kernel(this.code, this, this.contextMenu, hotKeys, quickinput);
 	}
 
+	/**
+	 * Returns a scoped version of the notebook for use with side-by-side notebooks.
+	 * All locators and actions will be scoped to the provided container.
+	 * @param container - A locator for the editor group container (e.g., `editors.editorGroup(0)`)
+	 */
+	scopedTo(container: Locator): ScopedNotebook {
+		return new ScopedNotebook(container, this.contextMenu);
+	}
+
 	// #region GETTERS
 
 	/**
@@ -1412,26 +1421,32 @@ export class PositronNotebooks extends Notebooks {
 }
 
 // -----------------
-//     Kernel
+//    KernelBase
 // -----------------
-export class Kernel {
+
+/**
+ * Base class for kernel functionality shared between Kernel and ScopedKernel.
+ * Contains common locators and methods for kernel actions.
+ */
+class KernelBase {
 	statusBadge: Locator;
-	private activeStatus: Locator;
-	private idleStatus: Locator;
-	private disconnectedStatus: Locator;
+	protected activeStatus: Locator;
+	protected idleStatus: Locator;
+	protected disconnectedStatus: Locator;
 
-	constructor(private code: Code, private notebooks: PositronNotebooks, private contextMenu: ContextMenu, private hotKeys: HotKeys, private quickinput: QuickInput) {
-		this.statusBadge = this.code.driver.page.getByRole('button', { name: 'Kernel Actions' });
-		this.activeStatus = this.notebooks.editorActionBar.locator(ACTIVE_STATUS_ICON);
-		this.idleStatus = this.notebooks.editorActionBar.locator(IDLE_STATUS_ICON);
-		this.disconnectedStatus = this.notebooks.editorActionBar.locator(DISCONNECTED_STATUS_ICON);
+	constructor(
+		statusBadge: Locator,
+		editorActionBar: Locator,
+		protected contextMenu: ContextMenu
+	) {
+		this.statusBadge = statusBadge;
+		this.activeStatus = editorActionBar.locator(ACTIVE_STATUS_ICON);
+		this.idleStatus = editorActionBar.locator(IDLE_STATUS_ICON);
+		this.disconnectedStatus = editorActionBar.locator(DISCONNECTED_STATUS_ICON);
 	}
-
-	// #region ACTIONS
 
 	/**
 	 * Action: Restart the notebook kernel and optionally wait for it to be ready.
-	 * @param param0 - { waitForRestart?: boolean } - Whether to wait for the kernel to be idle after restart (default: true).
 	 */
 	async restart({ waitForRestart = true }: { waitForRestart?: boolean } = {}): Promise<void> {
 		await test.step('Restart kernel', async () => {
@@ -1458,6 +1473,60 @@ export class Kernel {
 			await this.expectStatusToBe('disconnected', 15000);
 		});
 	}
+
+	/**
+	 * Verify: Kernel status is as expected.
+	 */
+	async expectStatusToBe(expectedStatus: SessionState, timeout = DEFAULT_TIMEOUT): Promise<void> {
+		await test.step(`Expect kernel status to be: ${expectedStatus}`, async () => {
+			const statusMap: Record<Exclude<SessionState, 'exited'>, Locator> = {
+				active: this.activeStatus,
+				idle: this.idleStatus,
+				disconnected: this.disconnectedStatus
+			};
+
+			const locator = statusMap[expectedStatus];
+			if (!locator) {
+				throw new Error(`Unknown expected status: ${expectedStatus}`);
+			}
+			await expect(locator).toBeVisible({ timeout });
+		});
+	}
+
+	/**
+	 * Verify: Kernel badge contains expected text.
+	 */
+	async expectBadgeToContain(text: string, timeout = DEFAULT_TIMEOUT): Promise<void> {
+		await test.step(`Expect kernel badge to contain: ${text}`, async () => {
+			await expect(this.statusBadge).toContainText(text, { timeout });
+		});
+	}
+}
+
+// -----------------
+//     Kernel
+// -----------------
+
+/**
+ * Full kernel functionality for single-notebook scenarios.
+ * Extends KernelBase with additional page-level methods like select().
+ */
+export class Kernel extends KernelBase {
+	constructor(
+		private code: Code,
+		private notebooks: PositronNotebooks,
+		contextMenu: ContextMenu,
+		private hotKeys: HotKeys,
+		private quickinput: QuickInput
+	) {
+		super(
+			code.driver.page.getByRole('button', { name: 'Kernel Actions' }),
+			notebooks.editorActionBar,
+			contextMenu
+		);
+	}
+
+	// #region ACTIONS
 
 	/**
 	 * Action: Open the notebook session scratchpad in console.
@@ -1568,28 +1637,92 @@ export class Kernel {
 		});
 	}
 
-	/**
-	 * Verify: Kernel status is as expected.
-	 * @param expectedStatus - the kernel status (idle | active | disconnected)
-	 * @param timeout - the timeout for the expectation
-	 */
-	async expectStatusToBe(expectedStatus: SessionState, timeout = DEFAULT_TIMEOUT): Promise<void> {
-		await test.step(`Expect kernel status to be: ${expectedStatus}`, async () => {
-			const statusMap: Record<Exclude<SessionState, 'exited'>, Locator> = {
-				active: this.activeStatus,
-				idle: this.idleStatus,
-				disconnected: this.disconnectedStatus
-			};
-
-			// Use the mapped locator for the expected status
-			const locator = statusMap[expectedStatus];
-			if (!locator) {
-				throw new Error(`Unknown expected status: ${expectedStatus}`);
-			}
-			await expect(locator).toBeVisible({ timeout });
-		});
-	}
-
 	// #endregion
 
+	/**
+	 * Returns a scoped version of the Kernel for use with side-by-side notebooks.
+	 * All locators and actions will be scoped to the provided container.
+	 * @param container - A locator for the editor group container (e.g., `.editor-group-container`)
+	 */
+	scopedTo(container: Locator): ScopedKernel {
+		const editorActionBar = container.locator('.editor-action-bar-container');
+		const statusBadge = container.getByRole('button', { name: 'Kernel Actions' });
+		return new ScopedKernel(statusBadge, editorActionBar, this.contextMenu);
+	}
+}
+
+// -----------------
+//   ScopedKernel
+// -----------------
+
+/**
+ * A scoped version of Kernel for testing side-by-side notebooks.
+ * Extends KernelBase - shares restart(), shutdown(), expectStatusToBe(), expectBadgeToContain().
+ *
+ * NOTE: For kernel selection, use the page-level `notebooksPositron.kernel.select()` while
+ * only one notebook is visible (before splitting side-by-side).
+ */
+export class ScopedKernel extends KernelBase {
+	constructor(
+		statusBadge: Locator,
+		editorActionBar: Locator,
+		contextMenu: ContextMenu
+	) {
+		super(statusBadge, editorActionBar, contextMenu);
+	}
+}
+
+// -----------------
+//  ScopedNotebook
+// -----------------
+
+/**
+ * A scoped version of PositronNotebooks for testing side-by-side notebooks.
+ * Exposes locators scoped to the provided container (editor group).
+ */
+export class ScopedNotebook {
+	/** All cells in this notebook */
+	cells: Locator;
+	/** The editor action bar for this notebook */
+	editorActionBar: Locator;
+	/** Scoped kernel helper for this notebook */
+	kernel: ScopedKernel;
+
+	// Editor action bar buttons
+	runAllButton: Locator;
+	addCodeButton: Locator;
+	addMarkdownButton: Locator;
+	clearOutputsButton: Locator;
+
+	constructor(
+		container: Locator,
+		contextMenu: ContextMenu
+	) {
+		this.cells = container.locator('[data-testid="notebook-cell"]');
+		this.editorActionBar = container.locator('.editor-action-bar-container');
+
+		const statusBadge = container.getByRole('button', { name: 'Kernel Actions' });
+		this.kernel = new ScopedKernel(statusBadge, this.editorActionBar, contextMenu);
+
+		// Action bar buttons
+		this.runAllButton = this.editorActionBar.getByRole('button', { name: 'Run All' });
+		this.addCodeButton = this.editorActionBar.getByRole('button', { name: 'Code' });
+		this.addMarkdownButton = this.editorActionBar.getByRole('button', { name: 'Markdown' });
+		this.clearOutputsButton = this.editorActionBar.getByRole('button', { name: 'Clear Outputs' });
+	}
+
+	/** Get a specific cell by index */
+	cell(index: number): Locator {
+		return this.cells.nth(index);
+	}
+
+	/** Get cell output for a specific cell */
+	cellOutput(index: number): Locator {
+		return this.cell(index).getByTestId('cell-output');
+	}
+
+	/** Get the "Run Cell" button for a specific cell */
+	runCellButton(index: number): Locator {
+		return this.cell(index).getByRole('button', { name: 'Run Cell', exact: true });
+	}
 }

--- a/test/e2e/tests/notebooks-positron/notebook-side-by-side.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-side-by-side.test.ts
@@ -8,12 +8,11 @@
  *
  * Verifies that when two notebooks are open side-by-side:
  * 1. Kernel selection and status are independent per notebook
- * 2. The "Run All" button executes cells in its own notebook, not the focused one
+ * 2. Action buttons (Run Cell, Run All, Add Code) target their own notebook, not the focused one
  */
 
 import { expect, tags } from '../_test.setup';
 import { test } from './_test.setup.js';
-import { IDLE_STATUS_ICON } from '../../pages/sessions.js';
 
 test.use({
 	suiteId: __filename
@@ -23,107 +22,121 @@ test.describe('Notebook Side-by-Side Isolation', {
 	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
 }, () => {
 
-	test('Kernel status is independent per notebook when side-by-side',
-		async function ({ app, page }) {
-			const { notebooksPositron } = app.workbench;
+	test.beforeAll(async function ({ hotKeys }) {
+		await hotKeys.closePrimarySidebar();
+		await hotKeys.closeSecondarySidebar();
+		await hotKeys.minimizeBottomPanel();
+	});
+
+	test('Kernel selection and actions are independent per notebook',
+		async function ({ app, runCommand }) {
+			const { notebooksPositron, editors } = app.workbench;
 			const pythonVersion = process.env.POSITRON_PY_VER_SEL!;
 
-			// Create first notebook and select Python kernel while it is the only visible notebook.
-			// POM locators are page-scoped, so they work correctly with a single notebook.
-			await test.step('Create notebook 1 and select Python kernel', async () => {
-				await notebooksPositron.newNotebook();
-				await notebooksPositron.kernel.select('Python');
-			});
+			// Create first notebook and select Python kernel (only nb1 visible)
+			await notebooksPositron.newNotebook();
+			await notebooksPositron.kernel.select('Python');
 
-			// Create second notebook (opens as a new tab, hiding notebook 1).
-			// Do NOT select a kernel for this notebook.
-			await test.step('Create notebook 2 (no kernel)', async () => {
-				await notebooksPositron.newNotebook();
-			});
+			// Create second notebook (opens as tab, only nb2 visible now)
+			await notebooksPositron.newNotebook();
 
-			// Move notebook 2 to a side editor group so both are visible.
-			// After this, notebook 2 (right) is focused, notebook 1 (left) is unfocused.
-			await test.step('Split notebooks side-by-side', async () => {
-				await app.workbench.quickaccess.runCommand('workbench.action.moveEditorToNextGroup');
-			});
+			// Verify nb2 has no kernel - proves kernel state doesn't inherit from nb1
+			await notebooksPositron.kernel.expectBadgeToContain('No Kernel Selected');
+			await notebooksPositron.kernel.expectStatusToBe('disconnected');
 
-			// Use scoped locators to verify each editor group independently.
-			// Page-level POM locators would match elements in both groups, so we scope
-			// to each .editor-group-container to test per-notebook behavior.
-			const editorGroups = page.locator('.part.editor .editor-group-container');
-			await expect(editorGroups).toHaveCount(2, { timeout: 5000 });
+			// Select Python kernel for nb2 (while only nb2 visible)
+			await notebooksPositron.kernel.select('Python');
 
-			// Left group = notebook 1 (Python kernel selected)
-			// Right group = notebook 2 (no kernel selected)
-			const leftGroup = editorGroups.nth(0);
-			const rightGroup = editorGroups.nth(1);
+			// Split notebooks side-by-side
+			await runCommand('workbench.action.moveEditorToNextGroup');
+			await editors.expectEditorGroupCount(2);
 
-			await test.step('Verify left notebook (nb1) shows Python kernel', async () => {
-				const leftKernelBadge = leftGroup.getByRole('button', { name: 'Kernel Actions' });
-				await expect(leftKernelBadge).toContainText(pythonVersion, { timeout: 15000 });
-				await expect(leftGroup.locator('.editor-action-bar-container').locator(IDLE_STATUS_ICON)).toBeVisible({ timeout: 15000 });
-			});
+			// Get scoped notebook helpers for each editor group
+			const leftNotebook = notebooksPositron.scopedTo(editors.editorGroup(0));
+			const rightNotebook = notebooksPositron.scopedTo(editors.editorGroup(1));
 
-			await test.step('Verify right notebook (nb2) does NOT show Python kernel', async () => {
-				const rightKernelBadge = rightGroup.getByRole('button', { name: 'Kernel Actions' });
-				await expect(rightKernelBadge).not.toContainText(pythonVersion, { timeout: 5000 });
-			});
+			// Verify both notebooks have Python kernel and are idle
+			await leftNotebook.kernel.expectBadgeToContain(pythonVersion);
+			await leftNotebook.kernel.expectStatusToBe('idle');
+			await rightNotebook.kernel.expectBadgeToContain(pythonVersion);
+			await rightNotebook.kernel.expectStatusToBe('idle');
+
+			// --- Test: Kernel actions are independent ---
+
+			// Shut down left notebook kernel and verify it does not affect right notebook
+			await leftNotebook.kernel.shutdown();
+			await leftNotebook.kernel.expectStatusToBe('disconnected');
+			await rightNotebook.kernel.expectStatusToBe('idle');
+
+			// Restart right notebook kernel and verify it does not affect left notebook
+			await rightNotebook.kernel.restart();
+			await leftNotebook.kernel.expectStatusToBe('disconnected');
+			await rightNotebook.kernel.expectStatusToBe('idle');
 		});
 
-	test('Run All button executes cells in its own notebook, not the focused one',
-		async function ({ app, page }) {
-			const { notebooksPositron } = app.workbench;
+	test('Notebook action buttons target their own notebook, not the focused one',
+		async function ({ app, runCommand }) {
+			const { notebooksPositron, editors } = app.workbench;
 
-			// Set up notebook 1 with Python code while it is the only visible notebook.
-			await test.step('Create notebook 1 with Python code', async () => {
-				await notebooksPositron.newNotebook();
-				await notebooksPositron.kernel.select('Python');
-				await notebooksPositron.addCodeToCell(0, 'print("from_nb1")');
-			});
+			// Set up notebook 1 with Python code
+			await notebooksPositron.newNotebook();
+			await notebooksPositron.kernel.select('Python');
+			await notebooksPositron.addCodeToCell(0, 'print("left_nb")');
 
-			// Set up notebook 2 with different Python code (opens as tab, nb1 hidden).
-			await test.step('Create notebook 2 with Python code', async () => {
-				await notebooksPositron.newNotebook();
-				await notebooksPositron.kernel.select('Python');
-				await notebooksPositron.addCodeToCell(0, 'print("from_nb2")');
-			});
+			// Set up notebook 2 with different Python code
+			await notebooksPositron.newNotebook();
+			await notebooksPositron.kernel.select('Python');
+			await notebooksPositron.addCodeToCell(0, 'print("right_nb")');
 
-			// Move notebook 2 to a side editor group.
-			// After: nb1 (left, unfocused), nb2 (right, focused).
-			await test.step('Split notebooks side-by-side', async () => {
-				await app.workbench.quickaccess.runCommand('workbench.action.moveEditorToNextGroup');
-			});
+			// Split side-by-side
+			await runCommand('workbench.action.moveEditorToNextGroup');
+			await editors.expectEditorGroupCount(2);
 
-			const editorGroups = page.locator('.part.editor .editor-group-container');
-			await expect(editorGroups).toHaveCount(2, { timeout: 5000 });
-			const leftGroup = editorGroups.nth(0);
-			const rightGroup = editorGroups.nth(1);
+			// Get scoped notebook helpers for each editor group
+			const leftNotebook = notebooksPositron.scopedTo(editors.editorGroup(0));
+			const rightNotebook = notebooksPositron.scopedTo(editors.editorGroup(1));
 
-			// Focus the LEFT notebook (nb1) by clicking on its cell.
-			// This makes nb1 the "active" editor while nb2 is visible but unfocused.
-			await test.step('Focus left notebook (nb1)', async () => {
-				await leftGroup.locator('[data-testid="notebook-cell"]').first().click();
-			});
+			// --- Test 1: Run Cell button (cell action bar) ---
 
-			// Click "Run All" in the RIGHT notebook's (nb2) editor action bar.
-			await test.step('Click Run All in right notebook action bar', async () => {
-				const rightRunAll = rightGroup.locator('.editor-action-bar-container')
-					.getByRole('button', { name: 'Run All' });
-				await rightRunAll.click();
-			});
+			// Focus the RIGHT notebook by clicking its cell
+			await rightNotebook.cell(0).click();
 
-			// Verify RIGHT notebook (nb2) cells have the expected output.
-			// If Run All targeted the correct notebook, nb2's cell should show "from_nb2".
-			await test.step('Verify right notebook (nb2) has output from its own code', async () => {
-				const rightCellOutput = rightGroup.locator('[data-testid="cell-output"]');
-				await expect(rightCellOutput).toContainText('from_nb2', { timeout: 30000 });
-			});
+			// Verify clicking "Run Cell" in the LEFT notebook runs the cell in the LEFT notebook, not the focused RIGHT notebook
+			await leftNotebook.runCellButton(0).click();
+			await expect(leftNotebook.cellOutput(0)).toContainText('left_nb', { timeout: 30000 });
+			await expect(rightNotebook.cellOutput(0)).not.toBeVisible({ timeout: 5000 });
 
-			// Verify LEFT notebook (nb1) was NOT executed.
-			// If Run All incorrectly targeted the focused editor, nb1 would have output.
-			await test.step('Verify left notebook (nb1) was NOT executed', async () => {
-				const leftCellOutput = leftGroup.locator('[data-testid="cell-output"]');
-				await expect(leftCellOutput).not.toBeVisible({ timeout: 5000 });
-			});
+			// --- Test 2: Run All button (editor action bar) ---
+
+			// Clear left notebook output from Test 1
+			await leftNotebook.clearOutputsButton.click();
+			await expect(leftNotebook.cellOutput(0)).not.toBeVisible({ timeout: 5000 });
+
+			// Focus the LEFT notebook
+			await leftNotebook.cell(0).click();
+
+			// Verify clicking "Run All" in the RIGHT notebook runs the cell in the RIGHT notebook, not the focused LEFT notebook
+			await rightNotebook.runAllButton.click();
+			await expect(rightNotebook.cellOutput(0)).toContainText('right_nb', { timeout: 30000 });
+			await expect(leftNotebook.cellOutput(0)).not.toBeVisible({ timeout: 5000 });
+
+			// --- Test 3: Add Code button (editor action bar) ---
+
+			// Get current cell counts
+			const leftCountBefore = await leftNotebook.cells.count();
+			const rightCountBefore = await rightNotebook.cells.count();
+
+			// Focus the LEFT notebook
+			await leftNotebook.cell(0).click();
+
+			// Click "+Code" button in the RIGHT notebook's action bar
+			await rightNotebook.addCodeButton.click();
+
+			// Verify RIGHT notebook got a new cell
+			await expect(rightNotebook.cells).toHaveCount(rightCountBefore + 1, { timeout: 5000 });
+
+			// Verify LEFT notebook cell count unchanged
+			await expect(leftNotebook.cells).toHaveCount(leftCountBefore, { timeout: 5000 });
 		});
+
 });


### PR DESCRIPTION
## Summary

- Extended e2e tests verifying side-by-side notebook isolation:
  - Kernel selection and status are independent per notebook
  - Action buttons (Run Cell, Run All, Add Code) target their own notebook, not the focused one
- Adds `ScopedNotebook` and `ScopedKernel` POM classes for scoping actions to specific editor groups
- Adds `editorGroup()` and `expectEditorGroupCount()` helpers to `Editors` page object

## QA Notes

@:positron-notebooks @:web @:win

These tests cover GitHub issues:
- #12454: Kernel selection and actions should be independent per notebook
- #12455: Notebook action bar buttons (Run All, +Code) target wrong notebook
- #12592: Cell action bar buttons (Run Cell) target wrong notebook

🤖 Generated with [Claude Code](https://claude.com/claude-code)