### PR TITLE
Fix top action bar memory leak

### DIFF
--- a/src/vs/base/common/lifecycle.ts
+++ b/src/vs/base/common/lifecycle.ts
@@ -356,7 +356,7 @@ export function dispose<T extends IDisposable>(arg: T | Iterable<T> | undefined)
 	}
 }
 
-export function disposeIfDisposable<T extends IDisposable | object>(disposables: Array<T>): Array<T> {
+export function disposeIfDisposable<T extends IDisposable | object>(disposables: ReadonlyArray<T>): Array<T> {
 	for (const d of disposables) {
 		if (isDisposable(d)) {
 			d.dispose();

--- a/src/vs/base/common/lifecycle.ts
+++ b/src/vs/base/common/lifecycle.ts
@@ -356,6 +356,7 @@ export function dispose<T extends IDisposable>(arg: T | Iterable<T> | undefined)
 	}
 }
 
+// --- Start Positron ---
 export function disposeIfDisposable<T extends IDisposable | object>(disposables: ReadonlyArray<T>): Array<T> {
 	for (const d of disposables) {
 		if (isDisposable(d)) {
@@ -364,6 +365,7 @@ export function disposeIfDisposable<T extends IDisposable | object>(disposables:
 	}
 	return [];
 }
+// --- End Positron ---
 
 /**
  * Combine multiple disposable values into a single {@link IDisposable}.

--- a/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
@@ -10,7 +10,7 @@ import './actionBarMenuButton.css';
 import { PropsWithChildren, useEffect, useRef } from 'react';
 
 // Other dependencies.
-import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { disposeIfDisposable } from '../../../../base/common/lifecycle.js';
 import { ActionBarButton } from './actionBarButton.js';
 import { Icon } from '../../../action/common/action.js';
 import { IAction } from '../../../../base/common/actions.js';
@@ -21,23 +21,6 @@ import { MouseTrigger } from '../../../../base/browser/ui/positronComponents/but
 import { AnchorAlignment, AnchorAxisAlignment } from '../../../../base/browser/ui/contextview/contextview.js';
 import { usePositronReactServicesContext } from '../../../../base/browser/positronReactRendererContext.js';
 
-/**
- * Disposes all disposable actions in an array of actions.
- */
-const disposeDisposableActions = (actions: readonly IAction[]) => {
-	/**
-	 * Type guard to check if an action is disposable.
-	 */
-	const isDisposable = (action: IAction): action is IAction & IDisposable =>
-		'dispose' in action && typeof action.dispose === 'function';
-
-	// Dispose all actions that are disposable.
-	for (const action of actions) {
-		if (isDisposable(action)) {
-			action.dispose();
-		}
-	}
-};
 
 /**
  * ActionBarMenuButtonProps interface.
@@ -131,7 +114,7 @@ export const ActionBarMenuButton = (props: PropsWithChildren<ActionBarMenuButton
 				positronActionBarContext.setMenuShowing(false);
 
 				// Dispose all disposable actions.
-				disposeDisposableActions(actions);
+				disposeIfDisposable(actions);
 			},
 			anchorAlignment: props.align && props.align === 'right' ? AnchorAlignment.RIGHT : AnchorAlignment.LEFT,
 			anchorAxisAlignment: AnchorAxisAlignment.VERTICAL,
@@ -157,7 +140,7 @@ export const ActionBarMenuButton = (props: PropsWithChildren<ActionBarMenuButton
 					await defaultAction?.run();
 
 					// Dispose all disposable actions.
-					disposeDisposableActions(actions);
+					disposeIfDisposable(actions);
 				}
 			}}
 		/>

--- a/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarMenuButton.tsx
@@ -7,9 +7,10 @@
 import './actionBarMenuButton.css';
 
 // React.
-import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
+import { PropsWithChildren, useEffect, useRef } from 'react';
 
 // Other dependencies.
+import { IDisposable } from '../../../../base/common/lifecycle.js';
 import { ActionBarButton } from './actionBarButton.js';
 import { Icon } from '../../../action/common/action.js';
 import { IAction } from '../../../../base/common/actions.js';
@@ -19,6 +20,24 @@ import { usePositronActionBarContext } from '../positronActionBarContext.js';
 import { MouseTrigger } from '../../../../base/browser/ui/positronComponents/button/button.js';
 import { AnchorAlignment, AnchorAxisAlignment } from '../../../../base/browser/ui/contextview/contextview.js';
 import { usePositronReactServicesContext } from '../../../../base/browser/positronReactRendererContext.js';
+
+/**
+ * Disposes all disposable actions in an array of actions.
+ */
+const disposeDisposableActions = (actions: readonly IAction[]) => {
+	/**
+	 * Type guard to check if an action is disposable.
+	 */
+	const isDisposable = (action: IAction): action is IAction & IDisposable =>
+		'dispose' in action && typeof action.dispose === 'function';
+
+	// Dispose all actions that are disposable.
+	for (const action of actions) {
+		if (isDisposable(action)) {
+			action.dispose();
+		}
+	}
+};
 
 /**
  * ActionBarMenuButtonProps interface.
@@ -56,8 +75,6 @@ export const ActionBarMenuButton = (props: PropsWithChildren<ActionBarMenuButton
 	// Reference hooks.
 	const buttonRef = useRef<HTMLButtonElement>(undefined!);
 
-	// State hooks.
-	const [defaultActionId, setDefaultActionId] = useState<string | undefined>(undefined);
 
 	// Manage the aria-haspopup and aria-expanded attributes.
 	useEffect(() => {
@@ -74,18 +91,6 @@ export const ActionBarMenuButton = (props: PropsWithChildren<ActionBarMenuButton
 	}, [positronActionBarContext.menuShowing]);
 
 	const { actions: getActions } = props;
-	const getMenuActions = React.useCallback(async () => {
-		const actions = await getActions();
-		const defaultAction = actions.find(action => action.checked);
-
-		setDefaultActionId(defaultAction?.id);
-
-		return actions;
-	}, [getActions]);
-
-	useEffect(() => {
-		getMenuActions();
-	}, [getMenuActions]);
 
 	// Participate in roving tabindex.
 	useRegisterWithActionBar([buttonRef]);
@@ -95,8 +100,8 @@ export const ActionBarMenuButton = (props: PropsWithChildren<ActionBarMenuButton
 	 * @returns A Promise<void> that resolves when the menu is shown.
 	 */
 	const showMenu = async () => {
-		const actions = await getActions();
 		// Get the actions. If there are no actions, return.
+		const actions = await getActions();
 		if (!actions.length) {
 			return;
 		}
@@ -121,7 +126,13 @@ export const ActionBarMenuButton = (props: PropsWithChildren<ActionBarMenuButton
 					return undefined;
 				}
 			},
-			onHide: () => positronActionBarContext.setMenuShowing(false),
+			onHide: () => {
+				// Update the menu showing state.
+				positronActionBarContext.setMenuShowing(false);
+
+				// Dispose all disposable actions.
+				disposeDisposableActions(actions);
+			},
 			anchorAlignment: props.align && props.align === 'right' ? AnchorAlignment.RIGHT : AnchorAlignment.LEFT,
 			anchorAxisAlignment: AnchorAxisAlignment.VERTICAL,
 			contextKeyService: services.contextKeyService
@@ -140,10 +151,13 @@ export const ActionBarMenuButton = (props: PropsWithChildren<ActionBarMenuButton
 				if (props.dropdownIndicator !== 'enabled-split') {
 					await showMenu();
 				} else {
-					// Run the preferred action.
+					// Run the preferred action (checked action, or first action if none checked).
 					const actions = await getActions();
-					const defaultAction = actions.find(action => action.id === defaultActionId);
-					defaultAction ? defaultAction.run() : actions[0].run();
+					const defaultAction = actions.find(action => action.checked) || actions[0];
+					await defaultAction?.run();
+
+					// Dispose all disposable actions.
+					disposeDisposableActions(actions);
 				}
 			}}
 		/>


### PR DESCRIPTION
# Fix Memory Leak in Action Bar Menu Buttons

## Issue
`Action` objects created for menu buttons were not being disposed, causing memory leaks.

## Fix
Added disposal of actions in `actionBarMenuButton.tsx`:
- Dispose actions when menu closes (`onHide` callback)
- Dispose actions after split button executes
- Removed unnecessary `useEffect` that created/disposed actions on mount

## Result
All action creation paths now properly clean up, eliminating the memory leak.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #12287 Fixed memory leak.

### QA Notes

Tests:
@:top-action-bar

- N/A