### PR TITLE
feat: replace 'Show hidden output' button with muted 'Output collapsed' label

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -49,6 +49,7 @@
 	}
 
 	.positron-notebook-code-cell-outputs-inner {
+		font-family: var(--vscode-positronNotebook-text-output-font-family, var(--monaco-monospace-font));
 		padding-inline: 0.5rem;
 		padding-block: 0.5rem;
 
@@ -81,23 +82,16 @@
 			}
 		}
 
-		/* Button to show hidden outputs styled as a link */
-		.show-hidden-output-button {
+		/* Muted label shown when output is collapsed, clickable to expand. */
+		.collapsed-output-label {
 			font-size: 12px;
-			color: var(--vscode-textLink-foreground);
-			background: none;
-			border: none;
+			font-style: italic;
+			color: var(--vscode-descriptionForeground);
 			padding: 0;
-		}
 
-		.show-hidden-output-button:hover {
-			text-decoration: underline;
-		}
-
-		/* override the global .monaco-workbench button focus outline style */
-		.show-hidden-output-button:focus,
-		.show-hidden-output-button:focus-visible {
-			outline-offset: 2px !important;
+			&:hover {
+				color: var(--vscode-textLink-foreground);
+			}
 		}
 	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -22,12 +22,11 @@ import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNoteb
 import { PreloadMessageOutput } from './PreloadMessageOutput.js';
 import { CellLeftActionMenu } from './CellLeftActionMenu.js';
 import { CellOutputCollapseButton } from './CellOutputCollapseButton.js';
-import { useNotebookOptions } from '../NotebookInstanceProvider.js';
+import { useNotebookInstance, useNotebookOptions } from '../NotebookInstanceProvider.js';
 import { CodeCellStatusFooter } from './CodeCellStatusFooter.js';
 import { isHTMLElement } from '../../../../../base/browser/dom.js';
 import { renderHtml } from '../../../../../base/browser/positron/renderHtml.js';
 import { Markdown } from './Markdown.js';
-import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 import { useCellContextMenu } from './useCellContextMenu.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
 import { DataExplorerCellOutput } from './DataExplorerCellOutput.js';
@@ -37,7 +36,10 @@ import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from '../ContextKeysManager.j
 import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.js';
 import { useScrollingIndicator } from './useScrollingIndicator.js';
 import { CellOutputActionBar } from './CellOutputActionBar.js';
+import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 
+const expandOutputTooltip = localize('positron.notebook.expandOutput', "Click to Expand Output");
+const outputCollapsedLabel = localize('positron.notebook.outputCollapsed', 'Output collapsed');
 
 interface CellOutputsSectionProps {
 	cell: PositronNotebookCodeCell;
@@ -127,13 +129,7 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 					{ 'output-scrolling': layout.outputScrolling }
 				)}>
 					{isCollapsed
-						? <Button
-							ariaLabel={localize('positron.notebook.showHiddenOutput', 'Show hidden output')}
-							className='show-hidden-output-button'
-							onPressed={handleShowHiddenOutput}
-						>
-							{localize('positron.notebook.showHiddenOutput', 'Show hidden output')}
-						</Button>
+						? <CollapsedOutputLabel onExpand={handleShowHiddenOutput} />
 						: outputs?.map((output) => (
 							<NotebookErrorBoundary
 								key={output.outputId}
@@ -214,4 +210,17 @@ const CellOutput = React.memo(function CellOutput(output: NotebookCellOutputs) {
 	return prevProps.outputId === nextProps.outputId &&
 		prevProps.parsed === nextProps.parsed;
 });
+
+const CollapsedOutputLabel = ({ onExpand }: { onExpand: () => void }) => {
+	const instance = useNotebookInstance();
+	return <Button
+		ariaLabel={expandOutputTooltip}
+		className='collapsed-output-label'
+		hoverManager={instance.hoverManager}
+		tooltip={expandOutputTooltip}
+		onPressed={onExpand}
+	>
+		{outputCollapsedLabel}
+	</Button>;
+};
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1519,15 +1519,17 @@ registerAction2(class extends NotebookAction2 {
 			id: 'positronNotebook.cell.collapseOutput',
 			title: localize2('positronNotebook.cell.collapseOutput', "Collapse Output"),
 			icon: Codicon.chevronDown,
-			menu: {
-				id: MenuId.PositronNotebookCellOutputActionContext,
-				group: PositronNotebookCellOutputActionGroup.Visibility,
-				order: 1,
-				when: ContextKeyExpr.and(
-					POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
-					POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated()
-				)
-			}
+			menu: [
+				{
+					id: MenuId.PositronNotebookCellOutputActionContext,
+					group: PositronNotebookCellOutputActionGroup.Visibility,
+					order: 1,
+					when: ContextKeyExpr.and(
+						POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
+						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated()
+					)
+				},
+			]
 		});
 	}
 
@@ -1547,15 +1549,17 @@ registerAction2(class extends NotebookAction2 {
 			id: 'positronNotebook.cell.expandOutput',
 			title: localize2('positronNotebook.cell.expandOutput', "Expand Output"),
 			icon: Codicon.chevronRight,
-			menu: {
-				id: MenuId.PositronNotebookCellOutputActionContext,
-				group: PositronNotebookCellOutputActionGroup.Visibility,
-				order: 2,
-				when: ContextKeyExpr.and(
-					POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
-					POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED
-				)
-			}
+			menu: [
+				{
+					id: MenuId.PositronNotebookCellOutputActionContext,
+					group: PositronNotebookCellOutputActionGroup.Visibility,
+					order: 2,
+					when: ContextKeyExpr.and(
+						POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
+						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED
+					)
+				},
+			]
 		});
 	}
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -69,7 +69,7 @@ export class PositronNotebooks extends Notebooks {
 	// Cell outputs
 	cellOutput = (index: number) => this.cell.nth(index).getByTestId('cell-output');
 	private outputActionBar = (index: number) => this.cell.nth(index).locator('.cell-output-action-bar');
-	showHiddenOutputButton = (index: number) => this.cellOutput(index).getByRole('button', { name: 'Show hidden output' });
+	outputCollapsedLabel = (index: number) => this.cellOutput(index).getByText('Output collapsed');
 	outputCollapseToggle = (index: number) => this.cell.nth(index).locator('.cell-output-collapse-button-container').getByRole('button');
 
 	// Assistant buttons (shown on error cells when assistant is enabled)

--- a/test/e2e/tests/notebooks-positron/notebook-cell-output.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-output.test.ts
@@ -51,13 +51,13 @@ test.describe('Positron Notebooks: Cell Output', {
 
 		await test.step('Clicking the collapse toggle hides the output', async () => {
 			await notebooksPositron.outputCollapseToggle(0).click();
-			await expect(notebooksPositron.showHiddenOutputButton(0)).toBeVisible();
+			await expect(notebooksPositron.outputCollapsedLabel(0)).toBeVisible();
 			await expect(notebooksPositron.cellOutput(0).getByText('hello world')).toBeHidden();
 		});
 
 		await test.step('Clicking the expand toggle shows the output again', async () => {
 			await notebooksPositron.outputCollapseToggle(0).click();
-			await expect(notebooksPositron.showHiddenOutputButton(0)).toBeHidden();
+			await expect(notebooksPositron.outputCollapsedLabel(0)).toBeHidden();
 			await notebooksPositron.expectOutputAtIndex(0, ['hello world']);
 		});
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #12632
* #12631
* #12630
* __->__ #12629
* #12628

Replace the prominent "Show hidden output" button with a subtle, italic
"Output collapsed" label using the Button component for VS Code-style
tooltips. Uses descriptionForeground for accessible contrast and
inherits monospace font from the outputs container.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>