### PR TITLE
feat: add per-cell truncate/show full output for notebook outputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,8 @@ Positron forks VSCode. Minimize merge conflicts by isolating Positron code.
 - Ensure build daemons are running before testing
 - Core tests (`src/**/*.ts`):
 	- `./scripts/test.sh`: run all tests
-	- `./scripts/test.sh --run <file>.test.ts`: run a specific file
-	- `./scripts/test.sh --run <file>.test.ts --grep '<pattern>'`: run specific tests in a file
+	- `./scripts/test.sh --run src/path/to/<file>.test.ts`: run a specific file
+	- `./scripts/test.sh --run src/path/to/<file>.test.ts --grep '<pattern>'`: run specific tests in a file
 	- `./scripts/test.sh --runGlob <glob>.test.js`: run files matching a glob (use `.js` extension with `--runGlob`)
 - Extension tests (`extensions/<extension-name>/*.test.ts`, preferred for extension development except positron-python): `npm run test-extension -- -l <extension-name> --grep <pattern>`
 	- For positron-python, see that extension's CLAUDE.md

--- a/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
@@ -55,6 +55,8 @@ export const POSITRON_NOTEBOOK_CELL_CAN_MOVE_DOWN = new RawContextKey<boolean>('
 export const POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS = new RawContextKey<boolean>('positronNotebookCellHasOutputs', false);
 export const POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT = new RawContextKey<number>('positronNotebookCellImageOutputCount', 0);
 export const POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED = new RawContextKey<boolean>('positronNotebookCellOutputIsCollapsed', false);
+export const POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS = new RawContextKey<boolean>('positronNotebookCellOutputOverflows', false);
+export const POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING = new RawContextKey<boolean>('positronNotebookCellOutputScrolling', false);
 
 /**
  * Interaction-driven context key set to true when the user right-clicks on an
@@ -82,6 +84,8 @@ export const POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS = {
 	hasOutputs: POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
 	imageOutputCount: POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT,
 	outputIsCollapsed: POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED,
+	outputOverflows: POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
+	outputScrolling: POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING,
 } as const;
 
 // Interface for the cell context keys
@@ -111,6 +115,8 @@ export function bindCellContextKeys(service: IScopedContextKeyService): IPositro
 		hasOutputs: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.hasOutputs.bindTo(service),
 		imageOutputCount: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.imageOutputCount.bindTo(service),
 		outputIsCollapsed: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputIsCollapsed.bindTo(service),
+		outputOverflows: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputOverflows.bindTo(service),
+		outputScrolling: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputScrolling.bindTo(service),
 	} satisfies IPositronNotebookCellContextKeys;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -261,7 +261,14 @@ export interface IPositronNotebookCodeCell extends IPositronNotebookCell {
 	/**
 	 * Whether the cell outputs are collapsed
 	 */
-	readonly outputIsCollapsed: ISettableObservable<boolean>;
+	readonly outputIsCollapsed: IObservable<boolean>;
+
+	/**
+	 * Per-cell output truncation override.
+	 * When undefined, the global notebook.outputScrolling setting is used.
+	 * When true, output is truncated. When false, full output is shown.
+	 */
+	readonly outputIsTruncated: IObservable<boolean | undefined>;
 
 	/**
 	 * Duration of the last execution in milliseconds
@@ -297,6 +304,21 @@ export interface IPositronNotebookCodeCell extends IPositronNotebookCell {
 	 * Toggle the collapse state of cell outputs
 	 */
 	toggleOutputCollapse(): void;
+
+	/**
+	 * Truncate the cell output.
+	 */
+	truncateOutput(): void;
+
+	/**
+	 * Show full cell output.
+	 */
+	showFullOutput(): void;
+
+	/**
+	 * Reset per-cell output truncation to follow the global setting.
+	 */
+	resetOutputTruncation(): void;
 }
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -25,6 +25,9 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 	// Output collapse state
 	private readonly _outputIsCollapsed: ISettableObservable<boolean>;
 
+	// Per-cell output truncation override (undefined = use global setting)
+	private readonly _outputIsTruncated: ISettableObservable<boolean | undefined>;
+
 	// Execution timing observables
 	lastExecutionDuration;
 	lastExecutionOrder;
@@ -46,6 +49,12 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 			cellModel.collapseState?.outputCollapsed ?? false
 		);
 
+		// Per-cell output truncation override (undefined = use global setting)
+		this._outputIsTruncated = observableValue<boolean | undefined>(
+			'outputIsTruncated',
+			undefined
+		);
+
 		this._outputs = observableFromEvent(this, Event.any(this.model.onDidChangeOutputs, this.model.onDidChangeOutputItems), () => {
 			/** @description cellOutputs */
 			return this.parseCellOutputs();
@@ -56,6 +65,9 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 			if (this.model.outputs.length === 0) {
 				this._outputIsCollapsed.set(false, undefined);
 			}
+
+			// Reset per-cell truncation override when outputs change (clear or re-run)
+			this._outputIsTruncated.set(undefined, undefined);
 		}));
 
 		// Execution timing observables
@@ -93,6 +105,22 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 
 	toggleOutputCollapse(): void {
 		this._outputIsCollapsed.set(!this._outputIsCollapsed.get(), undefined);
+	}
+
+	get outputIsTruncated(): ISettableObservable<boolean | undefined> {
+		return this._outputIsTruncated;
+	}
+
+	truncateOutput(): void {
+		this._outputIsTruncated.set(true, undefined);
+	}
+
+	showFullOutput(): void {
+		this._outputIsTruncated.set(false, undefined);
+	}
+
+	resetOutputTruncation(): void {
+		this._outputIsTruncated.set(undefined, undefined);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -437,6 +437,18 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 		this._notebookOptions = this._instantiationService.createInstance(NotebookOptions, DOM.getActiveWindow(), this.isReadOnly, undefined);
 
+		// Reset per-cell scrolling overrides when the global output scrolling
+		// setting changes so all cells follow the new default.
+		this._register(this._notebookOptions.onDidChangeOptions(e => {
+			if (e.outputScrolling) {
+				for (const cell of this.cells.get()) {
+					if (cell.isCodeCell()) {
+						cell.resetOutputTruncation();
+					}
+				}
+			}
+		}));
+
 		return this._notebookOptions;
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -15,12 +15,9 @@ import { OutputLines } from '../../../../browser/positronAnsiRenderer/outputLine
 import { ParsedTextOutput } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { useNotebookOptions } from '../NotebookInstanceProvider.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
-import { NotebookDisplayOptions } from '../../../notebook/browser/notebookOptions.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 import { NotebookCellQuickFix } from './NotebookCellQuickFix.js';
-
-export type LongOutputOptions = Pick<NotebookDisplayOptions, 'outputLineLimit' | 'outputScrolling'>;
 
 type TruncationResult =
 	{ content: string } & (
@@ -33,14 +30,14 @@ type TruncationResult =
 	);
 
 
-function truncateToNumberOfLines(content: string, { outputScrolling, outputLineLimit: maxLines }: LongOutputOptions): TruncationResult {
+function truncateToNumberOfLines(content: string, effectiveScrolling: boolean, maxLines: number): TruncationResult {
 	// Trim newline from end of content if it exists.
 	const splitByLine = content.trimEnd().split('\n');
 	const numLines = splitByLine.length;
 
 	// When scrolling is enabled or content is short, return as-is.
 	// The parent container handles scroll constraints via CSS.
-	if (outputScrolling || numLines <= maxLines) {
+	if (effectiveScrolling || numLines <= maxLines) {
 		return { content, mode: 'normal' };
 	}
 
@@ -52,12 +49,22 @@ function truncateToNumberOfLines(content: string, { outputScrolling, outputLineL
 	};
 }
 
+export interface CellTextOutputProps extends ParsedTextOutput {
+	effectiveScrolling: boolean;
+	onShowFullOutput: () => void;
+}
 
-export function CellTextOutput({ content, type }: ParsedTextOutput) {
+
+export function CellTextOutput({
+	content,
+	type,
+	effectiveScrolling,
+	onShowFullOutput
+}: CellTextOutputProps) {
 
 	const services = usePositronReactServicesContext();
 	const layoutConfig = useNotebookOptions().getLayoutConfiguration();
-	const truncation = truncateToNumberOfLines(content, layoutConfig);
+	const truncation = truncateToNumberOfLines(content, effectiveScrolling, layoutConfig.outputLineLimit);
 	const outputWordWrap = layoutConfig.outputWordWrap;
 
 	return <>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -24,7 +24,7 @@ import { CellLeftActionMenu } from './CellLeftActionMenu.js';
 import { CellOutputCollapseButton } from './CellOutputCollapseButton.js';
 import { useNotebookInstance, useNotebookOptions } from '../NotebookInstanceProvider.js';
 import { CodeCellStatusFooter } from './CodeCellStatusFooter.js';
-import { isHTMLElement } from '../../../../../base/browser/dom.js';
+import { getWindow, isHTMLElement } from '../../../../../base/browser/dom.js';
 import { renderHtml } from '../../../../../base/browser/positron/renderHtml.js';
 import { Markdown } from './Markdown.js';
 import { useCellContextMenu } from './useCellContextMenu.js';
@@ -32,7 +32,7 @@ import { MenuId } from '../../../../../platform/actions/common/actions.js';
 import { DataExplorerCellOutput } from './DataExplorerCellOutput.js';
 import { NotebookErrorBoundary } from '../NotebookErrorBoundary.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
-import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from '../ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS } from '../ContextKeysManager.js';
 import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.js';
 import { useScrollingIndicator } from './useScrollingIndicator.js';
 import { CellOutputActionBar } from './CellOutputActionBar.js';
@@ -49,15 +49,58 @@ interface CellOutputsSectionProps {
 const CellOutputsSection = React.memo(function CellOutputsSection({ cell, outputs }: CellOutputsSectionProps) {
 	const services = usePositronReactServicesContext();
 	const isCollapsed = useObservedValue(cell.outputIsCollapsed);
+	const perCellTruncated = useObservedValue(cell.outputIsTruncated);
+	const notebookOptions = useNotebookOptions();
+	const layout = notebookOptions.getLayoutConfiguration();
+	const outputsInnerRef = React.useRef<HTMLDivElement>(null);
+	useScrollingIndicator(outputsInnerRef);
 	const contextKeyService = useCellScopedContextKeyService();
 	const outputImageTargeted = useMemo(
 		() => contextKeyService ? POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED.bindTo(contextKeyService) : undefined,
 		[contextKeyService]
 	);
-	const notebookOptions = useNotebookOptions();
-	const layout = notebookOptions.getLayoutConfiguration();
-	const outputsInnerRef = React.useRef<HTMLDivElement>(null);
-	useScrollingIndicator(outputsInnerRef);
+
+	// Effective scrolling: per-cell truncation override takes precedence over global setting.
+	// When truncated, scrolling is disabled. When not truncated, scrolling is enabled.
+	const effectiveScrolling = perCellTruncated !== undefined
+		? !perCellTruncated
+		: layout.outputScrolling;
+
+	// Detect when output content would overflow the max-height constraint.
+	// We compare against the CSS variable rather than scrollHeight > clientHeight
+	// because when scrolling is disabled there's no max-height and no overflow.
+	React.useEffect(() => {
+		const el = outputsInnerRef.current;
+		if (!el || !contextKeyService) {
+			return;
+		}
+
+		const outputOverflowsKey = POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS.bindTo(contextKeyService);
+
+		const updateOverflow = () => {
+			const maxHeightStr = getWindow(el).getComputedStyle(el).getPropertyValue('--vscode-positronNotebook-output-max-height');
+			const maxHeight = parseFloat(maxHeightStr);
+			if (maxHeight > 0) {
+				outputOverflowsKey.set(el.scrollHeight > maxHeight);
+			} else {
+				outputOverflowsKey.set(el.scrollHeight > el.clientHeight);
+			}
+		};
+
+		const observer = new ResizeObserver(updateOverflow);
+		observer.observe(el);
+		// Also observe children for content changes
+		for (const child of el.children) {
+			observer.observe(child);
+		}
+		updateOverflow();
+
+		return () => {
+			observer.disconnect();
+			outputOverflowsKey.reset();
+		};
+	}, [contextKeyService, outputs, isCollapsed, effectiveScrolling]);
+
 	const { showContextMenu } = useCellContextMenu({
 		cell,
 		menuId: MenuId.PositronNotebookCellOutputActionContext,
@@ -126,7 +169,7 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 					'positron-notebook-code-cell-outputs-inner',
 					'positron-notebook-scrollable',
 					'positron-notebook-scrollable-fade',
-					{ 'output-scrolling': layout.outputScrolling }
+					{ 'output-scrolling': effectiveScrolling }
 				)}>
 					{isCollapsed
 						? <CollapsedOutputLabel onExpand={handleShowHiddenOutput} />
@@ -137,7 +180,7 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 								level='output'
 								logService={services.logService}
 							>
-								<CellOutput {...output} />
+								<CellOutput {...output} effectiveScrolling={effectiveScrolling} onShowFullOutput={() => cell.showFullOutput()} />
 							</NotebookErrorBoundary>
 						))
 					}
@@ -176,15 +219,20 @@ export const NotebookCodeCell = React.memo(function NotebookCodeCell({ cell }: {
 	return prevProps.cell === nextProps.cell;
 });
 
-const CellOutput = React.memo(function CellOutput(output: NotebookCellOutputs) {
+interface CellOutputProps extends NotebookCellOutputs {
+	effectiveScrolling: boolean;
+	onShowFullOutput: () => void;
+}
+
+const CellOutput = React.memo(function CellOutput(output: CellOutputProps) {
 	if (output.preloadMessageResult) {
 		return <PreloadMessageOutput preloadMessageResult={output.preloadMessageResult} />;
 	}
 
-	const { parsed, outputs } = output;
+	const { parsed, outputs, effectiveScrolling, onShowFullOutput } = output;
 
 	if (isParsedTextOutput(parsed)) {
-		return <CellTextOutput {...parsed} />;
+		return <CellTextOutput {...parsed} effectiveScrolling={effectiveScrolling} onShowFullOutput={onShowFullOutput} />;
 	}
 
 	switch (parsed.type) {
@@ -208,7 +256,8 @@ const CellOutput = React.memo(function CellOutput(output: NotebookCellOutputs) {
 }, (prevProps, nextProps) => {
 	// Reference equality on parsed is correct - new execution creates new parsed objects
 	return prevProps.outputId === nextProps.outputId &&
-		prevProps.parsed === nextProps.parsed;
+		prevProps.parsed === nextProps.parsed &&
+		prevProps.effectiveScrolling === nextProps.effectiveScrolling;
 });
 
 const CollapsedOutputLabel = ({ onExpand }: { onExpand: () => void }) => {
@@ -223,4 +272,3 @@ const CollapsedOutputLabel = ({ onExpand }: { onExpand: () => void }) => {
 		{outputCollapsedLabel}
 	</Button>;
 };
-

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
@@ -52,6 +52,12 @@ export function useCellContextKeys(
 		const keys = bindCellContextKeys(scopedContextKeyService);
 
 		// Keep context keys in sync with cell state
+		const updateOutputScrollingKey = () => {
+			const perCellTruncated = cell.isCodeCell() ? cell.outputIsTruncated.get() : undefined;
+			const globalScrolling = notebookInstance.notebookOptions.getLayoutConfiguration().outputScrolling;
+			keys.outputScrolling.set(perCellTruncated !== undefined ? !perCellTruncated : globalScrolling);
+		};
+
 		disposables.add(autorun(reader => {
 			if (!keys) {
 				return;
@@ -86,6 +92,17 @@ export function useCellContextKeys(
 			keys.hasOutputs.set(outputs.length > 0);
 			keys.imageOutputCount.set(outputs.filter(o => o.parsed.type === 'image').length);
 			keys.outputIsCollapsed.set(outputIsCollapsed);
+			// Read the per-cell observable so autorun re-fires when it changes
+			if (cell.isCodeCell()) { cell.outputIsTruncated.read(reader); }
+			updateOutputScrollingKey();
+		}));
+
+		// Also update outputScrolling when the global notebook option changes,
+		// since getLayoutConfiguration() is not an observable tracked by autorun.
+		disposables.add(notebookInstance.notebookOptions.onDidChangeOptions(e => {
+			if (e.outputScrolling) {
+				updateOutputScrollingKey();
+			}
 		}));
 
 		// Set the state to let other components know that the context keys are ready

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -47,7 +47,7 @@ import { INotebookEditorOptions, IPYNB_VIEW_TYPE } from '../../notebook/browser/
 import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID, PositronNotebookActionId, PositronNotebookCellActionBarLeftGroup, PositronNotebookCellOutputActionGroup, usingPositronNotebooks } from '../common/positronNotebookCommon.js';
 import { QMD_VIEW_TYPE } from '../../positronQuartoNotebook/common/quartoNotebookConstants.js';
 import { getActiveCell, getSelectedCells, SelectionState } from './selectionMachine.js';
-import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from './ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from './ContextKeysManager.js';
 import './contrib/undoRedo/positronNotebookUndoRedo.js';
 import { registerAction2, MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { ExecuteSelectionInConsoleAction } from './ExecuteSelectionInConsoleAction.js';
@@ -1509,6 +1509,66 @@ registerAction2(class extends NotebookAction2 {
 
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
 		notebook.joinCellBelow();
+	}
+});
+
+// Truncate output
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.truncateOutput',
+			title: localize2('positronNotebook.cell.truncateOutput', "Truncate Output"),
+			icon: Codicon.fold,
+			menu: {
+				id: MenuId.PositronNotebookCellOutputActionBar,
+				group: PositronNotebookCellOutputActionGroup.Visibility,
+				order: 0,
+				when: ContextKeyExpr.and(
+					POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
+					POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated(),
+					POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
+					POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING
+				)
+			}
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor): void {
+		const state = notebook.selectionStateMachine.state.get();
+		const cell = getActiveCell(state);
+		if (cell?.isCodeCell()) {
+			cell.truncateOutput();
+		}
+	}
+});
+
+// Show full output
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.showFullOutput',
+			title: localize2('positronNotebook.cell.showFullOutput', "Show Full Output"),
+			icon: Codicon.unfold,
+			menu: {
+				id: MenuId.PositronNotebookCellOutputActionBar,
+				group: PositronNotebookCellOutputActionGroup.Visibility,
+				order: 0,
+				when: ContextKeyExpr.and(
+					POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
+					POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated(),
+					POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
+					POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING.toNegated()
+				)
+			}
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor): void {
+		const state = notebook.selectionStateMachine.state.get();
+		const cell = getActiveCell(state);
+		if (cell?.isCodeCell()) {
+			cell.showFullOutput();
+		}
 	}
 });
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.test.tsx
@@ -87,6 +87,7 @@ suite('CellTextOutput', () => {
 	function renderCellTextOutput(
 		props: ParsedTextOutput,
 		options?: Partial<NotebookLayoutConfiguration & NotebookDisplayOptions>,
+		onShowFullOutput: () => void = () => { },
 	) {
 		if (options !== undefined) {
 			layoutConfig = { ...layoutConfig, ...options };
@@ -105,7 +106,11 @@ suite('CellTextOutput', () => {
 		const container = render(
 			<PositronReactServicesContext.Provider value={services}>
 				<NotebookInstanceProvider instance={instance}>
-					<CellTextOutput {...props} />
+					<CellTextOutput
+						{...props}
+						effectiveScrolling={layoutConfig.outputScrolling ?? false}
+						onShowFullOutput={onShowFullOutput}
+					/>
 				</NotebookInstanceProvider>
 			</PositronReactServicesContext.Provider>
 		);

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.test.ts
@@ -4,12 +4,110 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { CellKind, NotebookCellsChangeType } from '../../../notebook/common/notebookCommon.js';
+import { CellEditType, CellKind, NotebookCellsChangeType } from '../../../notebook/common/notebookCommon.js';
 import { createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
 
 suite('PositronNotebookCell', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('Output truncation state', () => {
+		test('outputIsTruncated defaults to undefined', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]], disposables
+			);
+			const cell = notebook.cells.get()[0];
+			assert.ok(cell.isCodeCell());
+			assert.strictEqual(cell.outputIsTruncated.get(), undefined);
+		});
+
+		test('truncateOutput sets outputIsTruncated to true', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]], disposables
+			);
+			const cell = notebook.cells.get()[0];
+			assert.ok(cell.isCodeCell());
+			cell.truncateOutput();
+			assert.strictEqual(cell.outputIsTruncated.get(), true);
+		});
+
+		test('showFullOutput sets outputIsTruncated to false', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]], disposables
+			);
+			const cell = notebook.cells.get()[0];
+			assert.ok(cell.isCodeCell());
+			cell.showFullOutput();
+			assert.strictEqual(cell.outputIsTruncated.get(), false);
+		});
+
+		test('truncateOutput after showFullOutput toggles back to true', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]], disposables
+			);
+			const cell = notebook.cells.get()[0];
+			assert.ok(cell.isCodeCell());
+			cell.showFullOutput();
+			assert.strictEqual(cell.outputIsTruncated.get(), false);
+			cell.truncateOutput();
+			assert.strictEqual(cell.outputIsTruncated.get(), true);
+		});
+
+		test('collapse and expand does not affect truncation state', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]], disposables
+			);
+			const cell = notebook.cells.get()[0];
+			assert.ok(cell.isCodeCell());
+
+			// Verify with truncation = false (showing full output)
+			cell.showFullOutput();
+			cell.collapseOutput();
+			assert.strictEqual(cell.outputIsTruncated.get(), false, 'showing full: unchanged after collapse');
+			cell.expandOutput();
+			assert.strictEqual(cell.outputIsTruncated.get(), false, 'showing full: unchanged after expand');
+
+			// Verify with truncation = true (truncated)
+			cell.truncateOutput();
+			cell.collapseOutput();
+			assert.strictEqual(cell.outputIsTruncated.get(), true, 'truncated: unchanged after collapse');
+			cell.expandOutput();
+			assert.strictEqual(cell.outputIsTruncated.get(), true, 'truncated: unchanged after expand');
+		});
+
+		test('new output resets truncation state to undefined', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]], disposables
+			);
+			const cell = notebook.cells.get()[0];
+			assert.ok(cell.isCodeCell());
+			const textModel = notebook.textModel;
+			assert.ok(textModel);
+
+			const applyNewOutput = () => textModel.applyEdits([{
+				editType: CellEditType.Output,
+				index: 0,
+				outputs: [{
+					outputId: `output-${Math.random()}`,
+					outputs: [{ mime: 'application/vnd.code.notebook.stdout', data: VSBuffer.fromString('new output') }],
+				}],
+				append: false,
+			}], true, undefined, () => undefined, undefined, false);
+
+			// Reset from showing full output (false -> undefined)
+			cell.showFullOutput();
+			assert.strictEqual(cell.outputIsTruncated.get(), false, 'precondition: showFullOutput sets false');
+			applyNewOutput();
+			assert.strictEqual(cell.outputIsTruncated.get(), undefined, 'should reset from false');
+
+			// Reset from truncated (true -> undefined)
+			cell.truncateOutput();
+			assert.strictEqual(cell.outputIsTruncated.get(), true, 'precondition: truncateOutput sets true');
+			applyNewOutput();
+			assert.strictEqual(cell.outputIsTruncated.get(), undefined, 'should reset from true');
+		});
+	});
 
 	/** Tests to ensure that the test harness is correctly setup, useful for debugging the test harness */
 	suite('Test Harness', () => {

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -70,6 +70,7 @@ export class PositronNotebooks extends Notebooks {
 	cellOutput = (index: number) => this.cell.nth(index).getByTestId('cell-output');
 	private outputActionBar = (index: number) => this.cell.nth(index).locator('.cell-output-action-bar');
 	outputCollapsedLabel = (index: number) => this.cellOutput(index).getByText('Output collapsed');
+	outputTruncationMessage = (index: number) => this.cellOutput(index).getByText(/\.\.\. [\d,.\s\u00A0]+ lines truncated/);
 	outputCollapseToggle = (index: number) => this.cell.nth(index).locator('.cell-output-collapse-button-container').getByRole('button');
 
 	// Assistant buttons (shown on error cells when assistant is enabled)

--- a/test/e2e/tests/notebooks-positron/notebook-cell-output.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-output.test.ts
@@ -66,4 +66,44 @@ test.describe('Positron Notebooks: Cell Output', {
 			await expect(notebooksPositron.cellOutput(0)).toBeEmpty();
 		});
 	});
+
+	test('Toggle long output truncation', async function ({ app }) {
+		const { notebooks, notebooksPositron } = app.workbench;
+
+		await test.step('Setup: Open a notebook and generate long output', async () => {
+			await notebooks.createNewNotebook();
+			await notebooksPositron.expectCellCountToBe(1);
+			await notebooksPositron.kernel.select('Python');
+
+			// Generate output that exceeds the default 30-line limit
+			await notebooksPositron.addCodeToCell(0, 'for i in range(50): print(f"line {i}")', { run: true });
+			await notebooksPositron.expectOutputAtIndex(0, ['line 0']);
+		});
+
+		await test.step('Long output is truncated with a truncation message', async () => {
+			await expect(notebooksPositron.outputTruncationMessage(0)).toBeVisible();
+			await expect(notebooksPositron.outputTruncationMessage(0)).toContainText('lines truncated');
+		});
+
+		await test.step('Show Full Output via action bar removes truncation', async () => {
+			await notebooksPositron.triggerCellOutputAction(0, 'Show Full Output');
+			await expect(notebooksPositron.outputTruncationMessage(0)).toBeHidden();
+			// A middle line (hidden during truncation) should now be visible
+			await notebooksPositron.expectOutputAtIndex(0, ['line 25']);
+		});
+
+		await test.step('Truncate Output via action bar restores truncation', async () => {
+			await notebooksPositron.triggerCellOutputAction(0, 'Truncate Output');
+			await expect(notebooksPositron.outputTruncationMessage(0)).toBeVisible();
+		});
+
+		await test.step('Re-running the cell resets truncation state', async () => {
+			// Currently showing full output (no truncation message).
+			// Re-run the cell - this should reset the per-cell override
+			// back to the global default (truncated).
+			await notebooksPositron.runCodeAtIndex(0);
+
+			await expect(notebooksPositron.outputTruncationMessage(0)).toBeVisible();
+		});
+	});
 });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #12632
* #12631
* __->__ #12630
* #12629
* #12628

Add Truncate Output and Show Full Output actions to the cell output
action bar. When output overflows, users can toggle between truncated
view (with 50/50 head/tail split and a clickable truncation message)
and full scrollable output on a per-cell basis.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>