### PR TITLE
feat: make truncation message clickable with 50/50 head/tail split

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.css
@@ -11,24 +11,19 @@
 	font-size: var(--vscode-positronNotebook-text-output-font-size);
 	/* Don't wrap text by default */
 	white-space: pre;
-}
 
-.positron-notebook-text-output.word-wrap {
-	/* Wrap text when word-wrap is enabled */
-	white-space: pre-wrap;
-}
+	&.word-wrap {
+		white-space: pre-wrap;
+	}
 
-.notebook-output-truncation-message {
-	display: block;
-	font-size: 0.95em;
-	opacity: 0.8;
-}
+	& .notebook-output-truncation-message {
+		display: block;
+		font-style: italic;
+		color: var(--vscode-descriptionForeground);
+		padding: 4px 0;
 
-/* Use theme link colors */
-.notebook-output-truncation-message a {
-	color: var(--vscode-textLink-foreground);
-}
-.notebook-output-truncation-message a:hover,
-.notebook-output-truncation-message a:active {
-	color: var(--vscode-textLink-activeForeground);
+		&:hover {
+			color: var(--vscode-textLink-foreground);
+		}
+	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTextOutput.tsx
@@ -6,18 +6,24 @@
 // CSS.
 import './CellTextOutput.css';
 
-// React.
-import React from 'react';
-
 // Other dependencies.
 import { ANSIOutput } from '../../../../../base/common/ansiOutput.js';
 import { OutputLines } from '../../../../browser/positronAnsiRenderer/outputLines.js';
 import { ParsedTextOutput } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { useNotebookOptions } from '../NotebookInstanceProvider.js';
-import { ICommandService } from '../../../../../platform/commands/common/commands.js';
-import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+import { localize } from '../../../../../nls.js';
 import { NotebookCellQuickFix } from './NotebookCellQuickFix.js';
+import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
+import { useNotebookInstance } from '../NotebookInstanceProvider.js';
+
+function linesTruncatedMessage(numLinesTruncated: number): string {
+	return localize(
+		'positron.notebook.linesTruncated',
+		"... {0} lines truncated",
+		numLinesTruncated.toLocaleString()
+	);
+}
 
 type TruncationResult =
 	{ content: string } & (
@@ -41,11 +47,15 @@ function truncateToNumberOfLines(content: string, effectiveScrolling: boolean, m
 		return { content, mode: 'normal' };
 	}
 
+	// Split the visible lines 50/50 between top and bottom
+	const topLines = Math.ceil(maxLines / 2);
+	const bottomLines = maxLines - topLines;
+
 	return {
 		mode: 'truncate',
-		content: splitByLine.slice(0, maxLines - 1).join('\n'),
-		contentAfter: splitByLine[splitByLine.length - 1],
-		numLinesTruncated: Math.max(numLines - maxLines, 0),
+		content: splitByLine.slice(0, topLines).join('\n'),
+		contentAfter: splitByLine.slice(numLines - bottomLines).join('\n'),
+		numLinesTruncated: numLines - maxLines,
 	};
 }
 
@@ -62,7 +72,6 @@ export function CellTextOutput({
 	onShowFullOutput
 }: CellTextOutputProps) {
 
-	const services = usePositronReactServicesContext();
 	const layoutConfig = useNotebookOptions().getLayoutConfiguration();
 	const truncation = truncateToNumberOfLines(content, effectiveScrolling, layoutConfig.outputLineLimit);
 	const outputWordWrap = layoutConfig.outputWordWrap;
@@ -72,8 +81,8 @@ export function CellTextOutput({
 			<OutputLines outputLines={ANSIOutput.processOutput(truncation.content)} />
 			{truncation.mode === 'truncate' && <>
 				<TruncationMessage
-					commandService={services.commandService}
 					numLinesTruncated={truncation.numLinesTruncated}
+					onShowFullOutput={onShowFullOutput}
 				/>
 				<OutputLines outputLines={ANSIOutput.processOutput(truncation.contentAfter)} />
 			</>}
@@ -82,26 +91,19 @@ export function CellTextOutput({
 	</>;
 }
 
-const TruncationMessage = ({ numLinesTruncated, commandService }: {
+const TruncationMessage = ({ numLinesTruncated, onShowFullOutput }: {
 	numLinesTruncated: number;
-	commandService: ICommandService;
+	onShowFullOutput: () => void;
 }) => {
-	const openSettings = (e: React.MouseEvent<HTMLAnchorElement>) => {
-		// Prevent the anchor from navigating, which would reload the
-		// Electron renderer and hang the window.
-		e.preventDefault();
-		commandService.executeCommand(
-			'workbench.action.openSettings',
-			'notebook.output scroll'
-		);
-	};
-
-	return <i className='notebook-output-truncation-message'>
-		{`... ${numLinesTruncated.toLocaleString()} lines truncated. `}
-		<a
-			aria-label='notebook output settings'
-			href=''
-			onClick={openSettings}
-		>Change behavior.</a>
-	</i>;
+	const instance = useNotebookInstance();
+	const showFullOutputLabel = localize('positron.notebook.showFullOutput', "Show Full Output");
+	return <Button
+		ariaLabel={showFullOutputLabel}
+		className='notebook-output-truncation-message'
+		hoverManager={instance.hoverManager}
+		tooltip={showFullOutputLabel}
+		onPressed={onShowFullOutput}
+	>
+		{linesTruncatedMessage(numLinesTruncated)}
+	</Button>;
 };

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.test.tsx
@@ -7,15 +7,13 @@
 /* eslint-disable local/code-no-dangerous-type-assertions */
 
 import assert from 'assert';
+import sinon from 'sinon';
 import { flushSync } from 'react-dom';
-import { Emitter, Event } from '../../../../../../base/common/event.js';
-import { CommandsRegistry } from '../../../../../../platform/commands/common/commands.js';
+import { Emitter } from '../../../../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
 import { setupReactRenderer } from '../../../../../../base/test/browser/react.js';
 import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
-import { TestInstantiationService } from '../../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
-import { TestCommandService } from '../../../../../../editor/test/browser/editorTestServices.js';
 import { NotebookDisplayOptions, NotebookLayoutConfiguration, NotebookOptions, NotebookOptionsChangeEvent } from '../../../../notebook/browser/notebookOptions.js';
 import { IPositronNotebookInstance } from '../../../browser/IPositronNotebookInstance.js';
 import { NotebookInstanceProvider } from '../../../browser/NotebookInstanceProvider.js';
@@ -39,10 +37,6 @@ class CellTextOutputFixture {
 
 	get truncationMessage() {
 		return this.container.querySelector<HTMLElement>('.notebook-output-truncation-message');
-	}
-
-	get settingsLink() {
-		return this.container.querySelector<HTMLAnchorElement>('.notebook-output-truncation-message a');
 	}
 
 	get quickFixContainer() {
@@ -69,16 +63,12 @@ suite('CellTextOutput', () => {
 
 	let optionsEmitter: Emitter<NotebookOptionsChangeEvent>;
 	let layoutConfig: Partial<NotebookLayoutConfiguration & NotebookDisplayOptions>;
-	let commandService: TestCommandService;
 	let configurationService: TestConfigurationService;
 	let contextKeyService: MockContextKeyService;
 
 	setup(() => {
 		optionsEmitter = disposables.add(new Emitter<NotebookOptionsChangeEvent>());
 		layoutConfig = { outputLineLimit: 30, outputScrolling: false, outputWordWrap: false };
-
-		const instantiationService = disposables.add(new TestInstantiationService());
-		commandService = new TestCommandService(instantiationService);
 
 		configurationService = new TestConfigurationService();
 		contextKeyService = disposables.add(new MockContextKeyService());
@@ -96,9 +86,11 @@ suite('CellTextOutput', () => {
 			onDidChangeOptions: optionsEmitter.event,
 			getLayoutConfiguration: () => layoutConfig,
 		} as unknown as NotebookOptions;
-		const instance = { notebookOptions } as unknown as IPositronNotebookInstance;
+		const instance = {
+			notebookOptions,
+			hoverManager: { showHover: () => { }, hideHover: () => { } },
+		} as unknown as IPositronNotebookInstance;
 		const services = {
-			commandService,
 			configurationService,
 			contextKeyService,
 		} as unknown as PositronReactServices;
@@ -159,9 +151,7 @@ suite('CellTextOutput', () => {
 		assert.strictEqual(runs[1].textContent, ' plain');
 	});
 
-	test('truncates long output when scrolling is disabled', async () => {
-		disposables.add(CommandsRegistry.registerCommand('workbench.action.openSettings', () => { }));
-
+	test('truncates long output when scrolling is disabled', () => {
 		const content = makeLines(35);
 		const fixture = renderCellTextOutput(
 			{ content, type: 'stdout' },
@@ -171,14 +161,6 @@ suite('CellTextOutput', () => {
 		const message = fixture.truncationMessage;
 		assert.ok(message, 'Expected truncation message');
 		assert.ok(message.textContent?.includes('5 lines truncated'), 'Expected truncation count');
-
-		const link = fixture.settingsLink;
-		assert.ok(link, 'Expected "Change behavior" link');
-
-		const commandPromise = Event.toPromise(commandService.onWillExecuteCommand);
-		link.click();
-		const event = await commandPromise;
-		assert.strictEqual(event.commandId, 'workbench.action.openSettings');
 	});
 
 	test('does not truncate when scrolling is enabled', () => {
@@ -205,6 +187,21 @@ suite('CellTextOutput', () => {
 		);
 
 		assert.ok(fixture.hasClass('word-wrap'), 'Expected word-wrap class');
+	});
+
+	test('clicking truncation message calls onShowFullOutput', () => {
+		const onShowFullOutput = sinon.stub();
+		const content = makeLines(35);
+		const fixture = renderCellTextOutput(
+			{ content, type: 'stdout' },
+			{ outputLineLimit: 30, outputScrolling: false },
+			onShowFullOutput,
+		);
+
+		const message = fixture.truncationMessage;
+		assert.ok(message, 'Expected truncation message');
+		message.click();
+		assert.strictEqual(onShowFullOutput.callCount, 1, 'Expected onShowFullOutput to be called once');
 	});
 
 	// TODO: useNotebookOptions has a bug where setNotebookOptions(instance.notebookOptions)

--- a/test/e2e/tests/notebooks-positron/notebook-cell-output.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-output.test.ts
@@ -97,6 +97,12 @@ test.describe('Positron Notebooks: Cell Output', {
 			await expect(notebooksPositron.outputTruncationMessage(0)).toBeVisible();
 		});
 
+		await test.step('Clicking the truncation message shows full output', async () => {
+			await notebooksPositron.outputTruncationMessage(0).click();
+			await expect(notebooksPositron.outputTruncationMessage(0)).toBeHidden();
+			await notebooksPositron.expectOutputAtIndex(0, ['line 25']);
+		});
+
 		await test.step('Re-running the cell resets truncation state', async () => {
 			// Currently showing full output (no truncation message).
 			// Re-run the cell - this should reset the per-cell override


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #12632
* __->__ #12631
* #12630
* #12629
* #12628

