### PR TITLE
feat: add drag handle to vertically resize scrollable cell output

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -46,6 +46,21 @@
 
 	.positron-notebook-cell-outputs {
 		overflow: hidden;
+		position: relative;
+	}
+
+	/* Resize handle at the bottom of scrollable output */
+	.cell-output-resize-handle {
+		height: 4px;
+		cursor: ns-resize;
+		position: relative;
+		background: transparent;
+		transition: background-color 150ms;
+	}
+
+	.cell-output-resize-handle:hover,
+	.cell-output-resize-handle:active {
+		background-color: var(--vscode-sash-hoverBorder);
 	}
 
 	.positron-notebook-code-cell-outputs-inner {
@@ -55,6 +70,11 @@
 
 		&.output-scrolling {
 			max-height: var(--vscode-positronNotebook-output-max-height);
+			overflow-y: auto;
+		}
+
+		/* When user has manually resized, the inline style controls height */
+		&.height-override {
 			overflow-y: auto;
 		}
 		overflow-x: auto;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -37,6 +37,7 @@ import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.
 import { useScrollingIndicator } from './useScrollingIndicator.js';
 import { CellOutputActionBar } from './CellOutputActionBar.js';
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
+import { useOutputResize } from './useOutputResize.js';
 
 const expandOutputTooltip = localize('positron.notebook.expandOutput', "Click to Expand Output");
 const outputCollapsedLabel = localize('positron.notebook.outputCollapsed', 'Output collapsed');
@@ -54,6 +55,7 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 	const layout = notebookOptions.getLayoutConfiguration();
 	const outputsInnerRef = React.useRef<HTMLDivElement>(null);
 	useScrollingIndicator(outputsInnerRef);
+	const { handleRef: resizeHandleRef, heightOverride, clearHeightOverride } = useOutputResize(outputsInnerRef);
 	const contextKeyService = useCellScopedContextKeyService();
 	const outputImageTargeted = useMemo(
 		() => contextKeyService ? POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED.bindTo(contextKeyService) : undefined,
@@ -65,6 +67,15 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 	const effectiveScrolling = perCellTruncated !== undefined
 		? !perCellTruncated
 		: layout.outputScrolling;
+
+	// Reset height override when outputs change (new execution) or scrolling mode toggles
+	const prevOutputsRef = React.useRef(outputs);
+	const prevScrollingRef = React.useRef(effectiveScrolling);
+	if (prevOutputsRef.current !== outputs || prevScrollingRef.current !== effectiveScrolling) {
+		prevOutputsRef.current = outputs;
+		prevScrollingRef.current = effectiveScrolling;
+		clearHeightOverride();
+	}
 
 	// Detect when output content would overflow the max-height constraint.
 	// We compare against the CSS variable rather than scrollHeight > clientHeight
@@ -169,8 +180,11 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 					'positron-notebook-code-cell-outputs-inner',
 					'positron-notebook-scrollable',
 					'positron-notebook-scrollable-fade',
-					{ 'output-scrolling': effectiveScrolling }
-				)}>
+					{ 'output-scrolling': effectiveScrolling },
+					{ 'height-override': heightOverride !== undefined }
+				)}
+				style={heightOverride !== undefined ? { maxHeight: heightOverride, height: heightOverride } : undefined}
+				>
 					{isCollapsed
 						? <CollapsedOutputLabel onExpand={handleShowHiddenOutput} />
 						: outputs?.map((output) => (
@@ -185,6 +199,13 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 						))
 					}
 				</div>
+				{effectiveScrolling && !isCollapsed && outputs.length > 0 &&
+					<div
+						ref={resizeHandleRef}
+						className='cell-output-resize-handle'
+						onDoubleClick={clearHeightOverride}
+					/>
+				}
 			</section>
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useOutputResize.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useOutputResize.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { useCallback, useRef, useState, type RefObject } from 'react';
+
+/** Minimum height the output container can be resized to (in pixels). */
+const MIN_HEIGHT = 50;
+
+/**
+ * Hook that enables vertical resizing of a scrollable output container via a
+ * drag handle. Returns:
+ * - `handleRef`: callback ref to attach to the drag handle element
+ * - `heightOverride`: the current user-set height (undefined = use default)
+ * - `clearHeightOverride`: resets to default sizing
+ */
+export function useOutputResize(
+	scrollContainerRef: RefObject<HTMLElement | null>,
+): {
+	handleRef: (el: HTMLElement | null) => (() => void) | void;
+	heightOverride: number | undefined;
+	clearHeightOverride: () => void;
+} {
+	const [heightOverride, setHeightOverride] = useState<number | undefined>(undefined);
+	const dragging = useRef(false);
+	const startY = useRef(0);
+	const startHeight = useRef(0);
+
+	const clearHeightOverride = useCallback(() => setHeightOverride(undefined), []);
+
+	const handleRef = useCallback((handle: HTMLElement | null) => {
+		if (!handle) {
+			return;
+		}
+
+		const onMouseDown = (e: MouseEvent) => {
+			e.preventDefault();
+			const container = scrollContainerRef.current;
+			if (!container) {
+				return;
+			}
+
+			dragging.current = true;
+			startY.current = e.clientY;
+			startHeight.current = container.offsetHeight;
+
+			document.body.style.cursor = 'ns-resize';
+			// Prevent text selection while dragging
+			document.body.style.userSelect = 'none';
+
+			const onMouseMove = (moveEvent: MouseEvent) => {
+				if (!dragging.current) {
+					return;
+				}
+				const delta = moveEvent.clientY - startY.current;
+				const newHeight = Math.max(MIN_HEIGHT, startHeight.current + delta);
+				setHeightOverride(newHeight);
+			};
+
+			const onMouseUp = () => {
+				dragging.current = false;
+				document.body.style.cursor = '';
+				document.body.style.userSelect = '';
+				document.removeEventListener('mousemove', onMouseMove);
+				document.removeEventListener('mouseup', onMouseUp);
+			};
+
+			document.addEventListener('mousemove', onMouseMove);
+			document.addEventListener('mouseup', onMouseUp);
+		};
+
+		handle.addEventListener('mousedown', onMouseDown);
+		return () => handle.removeEventListener('mousedown', onMouseDown);
+	}, [scrollContainerRef]);
+
+	return { handleRef, heightOverride, clearHeightOverride };
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #12632
* #12631
* #12630
* #12629
* #12628

Adds a resize handle at the bottom of scrollable notebook cell output
containers. The handle appears as a thin bar that highlights on hover
using the sash color. Double-click resets to default height. The height
override is automatically cleared when cell outputs change or scrolling
mode toggles.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>