### PR TITLE
Bump Ark to 0.1.245

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -1094,7 +1094,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.244"
+      "ark": "0.1.245"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"


### PR DESCRIPTION
- https://github.com/posit-dev/ark/pull/1099
  Progress towards posit-dev/ark#689

- https://github.com/posit-dev/ark/pull/1119

- https://github.com/posit-dev/ark/pull/1120
  Addresses posit-dev/positron#11660


### Release Notes

#### New Features

- Plots in notebooks and Quarto documents are now drawn at the user's preferred size and scaling appropriate for their display.

- Added `renv` support when fetching packages, so that only packages within a given libPath are included.

#### Bug Fixes

- Fixed a busy/idle race condition in the UI comm.


### QA Notes

See linked PRs.

@:ark