### PR TITLE
Fix Packages pane showing no session on restart

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/interfaces/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/interfaces/positronPackagesService.ts
@@ -23,6 +23,8 @@ export interface IPositronPackagesService {
 
 	readonly activeSession: ILanguageRuntimeSession | undefined;
 
+	readonly activePackagesInstance: IPositronPackagesInstance | undefined;
+
 	/**
 	 * The onDidRefreshPackagesInstance event.
 	 */

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
@@ -55,6 +55,12 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		this._register(this._runtimeSessionService.onDidChangeForegroundSession(session => {
 			this.setActiveInstance(session?.sessionId);
 		}));
+
+		// Initialize with the current foreground session if one exists.
+		const foregroundSession = this._runtimeSessionService.foregroundSession;
+		if (foregroundSession) {
+			this.createOrAssignInstance(foregroundSession, true);
+		}
 	}
 
 	private createOrAssignInstance(session: ILanguageRuntimeSession, activate: boolean) {
@@ -97,6 +103,10 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 
 	get activeSession(): ILanguageRuntimeSession | undefined {
 		return this._activeInstance?.session;
+	}
+
+	get activePackagesInstance(): IPositronPackagesInstance | undefined {
+		return this._activeInstance;
 	}
 
 	async refreshPackages(token?: CancellationToken): Promise<ILanguageRuntimePackage[]> {

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesState.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesState.tsx
@@ -28,7 +28,7 @@ export const usePositronPackagesState = (
 ): PositronPackagesState => {
 	// Hooks.
 	const services = usePositronReactServicesContext();
-	const [instance, setInstance] = useState<IPositronPackagesInstance>();
+	const [instance, setInstance] = useState<IPositronPackagesInstance | undefined>(services.positronPackagesService.activePackagesInstance);
 
 	// When the active session changes
 	useEffect(() => {


### PR DESCRIPTION
See #12530

### Summary

The Packages pane would show "None" as its selected session when reopening Positron with multiple sessions. This happened because:

1. The service didn't initialize with the current foreground session on startup
2. The React state hook didn't read the initial value from the service

### Changes

- Initialize service with current foreground session in constructor
- Add `activePackagesInstance` getter to the service interface
- Read initial instance value in state hook's `useState` initializer

### Release Notes

#### Bug Fixes

- The Packages pane now correctly shows the active session when reopening Positron (#12530).

### QA Notes

To reproduce the original issue:

1. Start Positron with the packages pane closed.
2. Start sessions
3. Open the Packages pane - it should show the foreground session (not "None")

With this change, it should initialize to the current foreground session instead.