### PR TITLE
Hide irrelevant upstream notebook commands in Positron notebooks

### DIFF
--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -129,6 +129,10 @@
           "when": "notebookCellHasOutputs"
         },
         {
+          "command": "notebook.cellOutput.addToChat",
+          "when": "activeEditor != 'workbench.editor.positronNotebook'"
+        },
+        {
           "command": "notebook.cellOutput.openInTextEditor",
           "when": "false"
         }

--- a/src/vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard.ts
@@ -8,6 +8,10 @@ import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { WorkbenchPhase, registerWorkbenchContribution2 } from '../../../../../common/contributions.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 import { NOTEBOOK_CELL_EDITABLE, NOTEBOOK_EDITOR_EDITABLE, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_OUTPUT_FOCUSED } from '../../../common/notebookContextKeys.js';
+// -- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR } from '../../../common/notebookContextKeys.js';
+// -- End Positron ---
 import { cellRangeToViewCells, expandCellRangesWithHiddenCells, getNotebookEditorFromEditorPane, ICellViewModel, INotebookEditor } from '../../notebookBrowser.js';
 import { CopyAction, CutAction, PasteAction } from '../../../../../../editor/contrib/clipboard/browser/clipboard.js';
 import { IClipboardService } from '../../../../../../platform/clipboard/common/clipboardService.js';
@@ -575,6 +579,9 @@ registerAction2(class extends Action2 {
 			id: 'workbench.action.toggleNotebookClipboardLog',
 			title: localize2('toggleNotebookClipboardLog', 'Toggle Notebook Clipboard Troubleshooting'),
 			category: Categories.Developer,
+			// --- Start Positron ---
+			precondition: POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR,
+			// --- End Positron ---
 			f1: true
 		});
 	}

--- a/src/vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout.ts
@@ -15,6 +15,9 @@ import { CellStatusbarAlignment, INotebookCellStatusBarItem } from '../../../com
 import { INotebookService } from '../../../common/notebookService.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 import { n } from '../../../../../../base/browser/dom.js';
+// --- Start Positron ---
+import { POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR } from '../../../common/notebookContextKeys.js';
+// --- End Positron ---
 
 export class TroubleshootController extends Disposable implements INotebookEditorContribution {
 	static id: string = 'workbench.notebook.troubleshoot';
@@ -346,6 +349,9 @@ registerAction2(class extends Action2 {
 			id: 'notebook.toggleLayoutTroubleshoot',
 			title: localize2('workbench.notebook.toggleLayoutTroubleshoot', "Toggle Notebook Layout Troubleshoot"),
 			category: Categories.Developer,
+			// --- Start Positron ---
+			precondition: POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR,
+			// --- End Positron ---
 			f1: true
 		});
 	}
@@ -369,6 +375,9 @@ registerAction2(class extends Action2 {
 			id: 'notebook.inspectLayout',
 			title: localize2('workbench.notebook.inspectLayout', "Inspect Notebook Layout"),
 			category: Categories.Developer,
+			// --- Start Positron ---
+			precondition: POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR,
+			// --- End Positron ---
 			f1: true
 		});
 	}
@@ -394,6 +403,9 @@ registerAction2(class extends Action2 {
 			id: 'notebook.clearNotebookEdtitorTypeCache',
 			title: localize2('workbench.notebook.clearNotebookEdtitorTypeCache', "Clear Notebook Editor Type Cache"),
 			category: Categories.Developer,
+			// --- Start Positron ---
+			precondition: POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR,
+			// --- End Positron ---
 			f1: true
 		});
 	}

--- a/src/vs/workbench/contrib/notebook/browser/controller/layoutActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/layoutActions.ts
@@ -19,6 +19,10 @@ import { getNotebookEditorFromEditorPane } from '../notebookBrowser.js';
 import { INotebookEditorService } from '../services/notebookEditorService.js';
 import { NotebookSetting } from '../../common/notebookCommon.js';
 import { NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_IS_ACTIVE_EDITOR } from '../../common/notebookContextKeys.js';
+// -- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR } from '../../common/notebookContextKeys.js';
+// -- End Positron ---
 import { INotebookService } from '../../common/notebookService.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { IPreferencesService } from '../../../../services/preferences/common/preferences.js';
@@ -65,6 +69,9 @@ registerAction2(class NotebookConfigureLayoutAction extends Action2 {
 			id: 'workbench.notebook.layout.configure',
 			title: localize2('workbench.notebook.layout.configure.label', "Customize Notebook Layout"),
 			f1: true,
+			// --- Start Positron ---
+			precondition: POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR,
+			// --- End Positron ---
 			category: NOTEBOOK_ACTIONS_CATEGORY,
 			menu: [
 				{
@@ -268,7 +275,10 @@ registerAction2(class ToggleNotebookStickyScroll extends Action2 {
 				mnemonicTitle: localize({ key: 'mitoggleNotebookStickyScroll', comment: ['&& denotes a mnemonic'] }, "&&Sticky Scroll"),
 			},
 			menu: [
-				{ id: MenuId.CommandPalette },
+				// --- Start Positron ---
+				// Command palette entry uses `when` (not `precondition`) because this action registers explicit menu entries without `f1: true`.
+				{ id: MenuId.CommandPalette, when: POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR },
+				// --- End Positron ---
 				{ id: MenuId.NotebookStickyScrollContext, group: 'notebookView', order: 2 },
 				{ id: MenuId.NotebookToolbarContext, group: 'notebookView', order: 2 }
 			]

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookKernelHistoryServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookKernelHistoryServiceImpl.ts
@@ -7,6 +7,9 @@ import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { LinkedMap, Touch } from '../../../../../base/common/map.js';
 import { localize2 } from '../../../../../nls.js';
 import { Categories } from '../../../../../platform/action/common/actionCommonCategories.js';
+// --- Start Positron ---
+import { POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR } from '../../common/notebookContextKeys.js';
+// --- End Positron ---
 import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
@@ -140,6 +143,9 @@ registerAction2(class extends Action2 {
 			id: 'notebook.clearNotebookKernelsMRUCache',
 			title: localize2('workbench.notebook.clearNotebookKernelsMRUCache', "Clear Notebook Kernels MRU Cache"),
 			category: Categories.Developer,
+			// --- Start Positron ---
+			precondition: POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR,
+			// --- End Positron ---
 			f1: true
 		});
 	}

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookViewZones.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookViewZones.ts
@@ -11,6 +11,10 @@ import { localize2 } from '../../../../../nls.js';
 import { Categories } from '../../../../../platform/action/common/actionCommonCategories.js';
 import { Action2, registerAction2 } from '../../../../../platform/actions/common/actions.js';
 import { IsDevelopmentContext } from '../../../../../platform/contextkey/common/contextkeys.js';
+// --- Start Positron ---
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR } from '../../common/notebookContextKeys.js';
+// --- End Positron ---
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
 import { getNotebookEditorFromEditorPane, INotebookViewCellsUpdateEvent, INotebookViewZone, INotebookViewZoneChangeAccessor } from '../notebookBrowser.js';
 import { NotebookCellListView } from '../view/notebookCellListView.js';
@@ -220,7 +224,9 @@ class ToggleNotebookViewZoneDeveloperAction extends Action2 {
 			id: 'notebook.developer.addViewZones',
 			title: localize2('workbench.notebook.developer.addViewZones', "Toggle Notebook View Zones"),
 			category: Categories.Developer,
-			precondition: IsDevelopmentContext,
+			// --- Start Positron ---
+			precondition: ContextKeyExpr.and(IsDevelopmentContext, POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR),
+			// --- End Positron ---
 			f1: true
 		});
 	}

--- a/src/vs/workbench/contrib/notebook/common/notebookContextKeys.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookContextKeys.ts
@@ -5,6 +5,9 @@
 
 import { ContextKeyExpr, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { INTERACTIVE_WINDOW_EDITOR_ID, NOTEBOOK_EDITOR_ID, REPL_EDITOR_ID } from './notebookCommon.js';
+// --- Start Positron ---
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../positronNotebook/common/positronNotebookCommon.js';
+// --- End Positron ---
 
 
 
@@ -68,5 +71,8 @@ export const NOTEBOOK_INTERRUPTIBLE_KERNEL = new RawContextKey<boolean>('noteboo
 export const NOTEBOOK_MISSING_KERNEL_EXTENSION = new RawContextKey<boolean>('notebookMissingKernelExtension', false);
 export const NOTEBOOK_HAS_OUTPUTS = new RawContextKey<boolean>('notebookHasOutputs', false);
 export const KERNEL_HAS_VARIABLE_PROVIDER = new RawContextKey<boolean>('kernelHasVariableProvider', false);
+// --- Start Positron ---
+export const POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR = ContextKeyExpr.notEquals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID);
+// --- End Positron ---
 
 //#endregion

--- a/src/vs/workbench/contrib/notebook/test/browser/positronNotebookCommandPalette.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/positronNotebookCommandPalette.test.ts
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { MenuId, MenuRegistry, isIMenuItem } from '../../../../../platform/actions/common/actions.js';
+import { ContextKeyValue, IContext } from '../../../../../platform/contextkey/common/contextkey.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../positronNotebook/common/positronNotebookCommon.js';
+import { POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR } from '../../common/notebookContextKeys.js';
+
+// Side-effect imports: trigger registerAction2() calls that add commands to MenuRegistry
+import '../../browser/controller/layoutActions.js';
+import '../../browser/contrib/troubleshoot/layout.js';
+import '../../browser/contrib/clipboard/notebookClipboard.js';
+import '../../browser/services/notebookKernelHistoryServiceImpl.js';
+import '../../browser/viewParts/notebookViewZones.js';
+
+/**
+ * Upstream notebook command IDs that should be hidden from the command palette
+ * when the Positron notebook editor is active.
+ *
+ * 'notebook.cellOutput.addToChat' is excluded because it is registered via
+ * extensions/ipynb/package.json, not registerAction2(), so it is not present
+ * in MenuRegistry during core unit tests.
+ */
+const HIDDEN_COMMAND_IDS = [
+	'workbench.notebook.layout.configure',
+	'notebook.action.toggleNotebookStickyScroll',
+	'notebook.clearNotebookEdtitorTypeCache',
+	'notebook.clearNotebookKernelsMRUCache',
+	'notebook.inspectLayout',
+	'notebook.toggleLayoutTroubleshoot',
+	'workbench.action.toggleNotebookClipboardLog',
+	'notebook.developer.addViewZones',
+];
+
+function createContext(values: Record<string, ContextKeyValue>): IContext {
+	return { getValue: <T extends ContextKeyValue>(key: string) => values[key] as T | undefined };
+}
+
+suite('Positron Notebook Command Palette Visibility', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR evaluates correctly', () => {
+		assert.strictEqual(
+			POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR.evaluate(
+				createContext({ activeEditor: POSITRON_NOTEBOOK_EDITOR_ID })
+			),
+			false,
+			'should be false when Positron notebook is the active editor'
+		);
+
+		assert.strictEqual(
+			POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR.evaluate(
+				createContext({ activeEditor: 'workbench.editor.notebook' })
+			),
+			true,
+			'should be true when upstream notebook is the active editor'
+		);
+
+		assert.strictEqual(
+			POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR.evaluate(
+				createContext({})
+			),
+			true,
+			'should be true when no editor is active'
+		);
+	});
+
+	test('hidden commands have when clauses that exclude the Positron notebook editor', () => {
+		const positronContext = createContext({
+			activeEditor: POSITRON_NOTEBOOK_EDITOR_ID,
+			// isDevelopment is true so the AND with IsDevelopmentContext still
+			// evaluates; the Positron gate should make the result false.
+			isDevelopment: true,
+		});
+		const paletteItems = MenuRegistry.getMenuItems(MenuId.CommandPalette);
+		const foundCommands = new Set<string>();
+
+		for (const item of paletteItems) {
+			if (isIMenuItem(item) && HIDDEN_COMMAND_IDS.includes(item.command.id)) {
+				foundCommands.add(item.command.id);
+				assert.ok(
+					item.when,
+					`Command '${item.command.id}' should have a 'when' clause`
+				);
+				assert.strictEqual(
+					item.when.evaluate(positronContext),
+					false,
+					`Command '${item.command.id}' should be hidden when Positron notebook editor is active`
+				);
+			}
+		}
+
+		for (const id of HIDDEN_COMMAND_IDS) {
+			assert.ok(
+				foundCommands.has(id),
+				`Command '${id}' should be registered in the CommandPalette`
+			);
+		}
+	});
+
+	test('hidden commands are visible when upstream notebook editor is active', () => {
+		const upstreamContext = createContext({
+			activeEditor: 'workbench.editor.notebook',
+			// notebook.developer.addViewZones also requires IsDevelopmentContext
+			isDevelopment: true,
+		});
+		const paletteItems = MenuRegistry.getMenuItems(MenuId.CommandPalette);
+
+		for (const item of paletteItems) {
+			if (isIMenuItem(item) && HIDDEN_COMMAND_IDS.includes(item.command.id)) {
+				assert.strictEqual(
+					item.when!.evaluate(upstreamContext),
+					true,
+					`Command '${item.command.id}' should be visible when upstream notebook editor is active`
+				);
+			}
+		}
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/actions.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/actions.tsx
@@ -13,6 +13,7 @@ import { PositronModalReactRenderer } from '../../../../../../base/browser/posit
 import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 import { NotebookAction2 } from '../../NotebookAction2.js';
 import { POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
 import { GhostCellController } from './controller.js';
 import { REQUEST_GHOST_CELL_SUGGESTION_COMMAND_ID, SHOW_GHOST_CELL_INFO_COMMAND_ID } from './config.js';
 import { GhostCellInfoModalDialog } from './GhostCellInfoModalDialog.js';
@@ -59,6 +60,7 @@ registerGhostCellAction({
 	title: localize2('positronNotebook.enableGhostCellSuggestionsForNotebook', 'Enable Ghost Cell Suggestions for This Notebook'),
 	f1: true,
 	category: localize2('positronNotebook.category', 'Positron Notebook'),
+	precondition: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
 	run: (controller) => controller.enableGhostCellSuggestionsForNotebook(),
 });
 
@@ -68,7 +70,7 @@ registerGhostCellAction({
 	title: localize2('positronNotebook.showGhostCellInfo', 'About Ghost Cell Suggestions'),
 	f1: true,
 	category: localize2('positronNotebook.category', 'Positron Notebook'),
-	precondition: ContextKeyExpr.equals('activeEditor', 'workbench.editor.positronNotebook'),
+	precondition: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
 	run: (controller) => {
 		const state = controller.ghostCellState.get();
 		const modelName = state.status === 'ready' ? state.modelName : undefined;


### PR DESCRIPTION
Addresses #10481.

Hides upstream VS Code notebook commands (developer troubleshooting, layout configuration, sticky scroll, etc.) from the command palette when the Positron notebook editor is active. These commands target the upstream notebook implementation and don't apply to Positron notebooks.

Introduces a shared `POSITRON_NOTEBOOK_IS_NOT_ACTIVE_EDITOR` context key expression used as a `precondition` (for `f1: true` commands) or `when` clause (for explicit `MenuId.CommandPalette` entries) to gate visibility. Also replaces a hard-coded editor ID string in ghost cell actions with the `POSITRON_NOTEBOOK_EDITOR_ID` constant.

### Before changes (note developer commands etc.)
<img width="716" height="605" alt="image" src="https://github.com/user-attachments/assets/452b0d46-ef53-4e91-94c1-889a306c4479" />


### After changes
<img width="736" height="551" alt="image" src="https://github.com/user-attachments/assets/a09ba4c7-9379-453e-a4b8-270f8af0fbdf" />


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Hide irrelevant upstream notebook commands from the command palette when using the Positron notebook editor (#10481)

### QA Notes

@:notebooks @:positron-notebooks

1. Open a `.ipynb` file in the Positron notebook editor
2. Open the command palette (Cmd+Shift+P)
3. Search for "notebook" -- verify the following commands are **not** listed:
   - Customize Notebook Layout
   - Toggle Notebook Sticky Scroll
   - Toggle Notebook Layout Troubleshoot
   - Inspect Notebook Layout
   - Clear Notebook Editor Type Cache
   - Clear Notebook Kernels MRU Cache
   - Toggle Notebook Clipboard Troubleshooting
   - Toggle Notebook View Zones
   - Add Cell Output to Chat
4. Open a `.ipynb` in the **standard VS Code notebook editor** (disable Positron notebook) and verify those commands **do** appear