### PR TITLE
Remove editor context notification

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -343,23 +343,3 @@ webbrowser.open("file://file.html")
     params = ui_comm.messages[1]["data"]["params"]
     assert params["path"] == "file.html" if sys.platform == "win32" else "file://file.html"
     assert params["destination"] != "plot"
-
-
-class TestEditorContext:
-    """Tests for editor context change handling."""
-
-    def test_editor_context_changed_acknowledged(
-        self,
-        ui_service: UiService,  # noqa: ARG002
-        ui_comm: DummyComm,
-    ) -> None:
-        """Test that editor_context_changed RPC is acknowledged."""
-        msg = json_rpc_request(
-            "editor_context_changed",
-            {"document_uri": "file:///path/to/file.py", "is_execution_source": False},
-            comm_id="dummy_comm_id",
-        )
-        ui_comm.handle_msg(msg)
-
-        # Check that a null response was sent to acknowledge the RPC
-        assert ui_comm.messages == [json_rpc_response(None)]

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -22,7 +22,6 @@ from .positron_comm import CommMessage, JsonRpcErrorCode, PositronComm
 from .ui_comm import (
     CallMethodParams,
     CallMethodRequest,
-    EditorContextChangedRequest,
     EvaluateCodeRequest,
     OpenEditorParams,
     ShowHtmlFileDestination,
@@ -247,12 +246,6 @@ class UiService:
         if isinstance(request, CallMethodRequest):
             # Unwrap nested JSON-RPC
             self._call_method(request.params)
-
-        elif isinstance(request, EditorContextChangedRequest):
-            # Acknowledge the notification (state no longer tracked here,
-            # sys.path handling uses code_location from execute request metadata)
-            if self._comm is not None:
-                self._comm.send_result(data=None)
 
         elif isinstance(request, EvaluateCodeRequest):
             self._evaluate_code(request.params.code)

--- a/extensions/positron-python/python_files/posit/positron/ui_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/ui_comm.py
@@ -212,9 +212,6 @@ class UiBackendRequest(str, enum.Enum):
     # Evaluate a statement in the interpreter
     EvaluateCode = "evaluate_code"
 
-    # Active editor context changed
-    EditorContextChanged = "editor_context_changed"
-
 
 class DidChangePlotsRenderSettingsParams(BaseModel):
     """
@@ -315,52 +312,12 @@ class EvaluateCodeRequest(BaseModel):
     )
 
 
-class EditorContextChangedParams(BaseModel):
-    """
-    This notification is sent from the frontend to the backend when the
-    active text editor changes or when code is about to be executed from a
-    file. It provides the document URI and indicates whether this is the
-    source file for code execution.
-    """
-
-    document_uri: StrictStr = Field(
-        description="The URI of the active document, or empty string if no editor is active",
-    )
-
-    is_execution_source: StrictBool = Field(
-        description="Whether this editor is the source of code being executed. When true, the backend may temporarily add the file's directory to sys.path.",
-    )
-
-
-class EditorContextChangedRequest(BaseModel):
-    """
-    This notification is sent from the frontend to the backend when the
-    active text editor changes or when code is about to be executed from a
-    file. It provides the document URI and indicates whether this is the
-    source file for code execution.
-    """
-
-    params: EditorContextChangedParams = Field(
-        description="Parameters to the EditorContextChanged method",
-    )
-
-    method: Literal[UiBackendRequest.EditorContextChanged] = Field(
-        description="The JSON-RPC method name (editor_context_changed)",
-    )
-
-    jsonrpc: str = Field(
-        default="2.0",
-        description="The JSON-RPC version specifier",
-    )
-
-
 class UiBackendMessageContent(BaseModel):
     comm_id: str
     data: Union[
         DidChangePlotsRenderSettingsRequest,
         CallMethodRequest,
         EvaluateCodeRequest,
-        EditorContextChangedRequest,
     ] = Field(..., discriminator="method")
 
 
@@ -720,10 +677,6 @@ CallMethodRequest.update_forward_refs()
 EvaluateCodeParams.update_forward_refs()
 
 EvaluateCodeRequest.update_forward_refs()
-
-EditorContextChangedParams.update_forward_refs()
-
-EditorContextChangedRequest.update_forward_refs()
 
 BusyParams.update_forward_refs()
 

--- a/positron/comms/ui-backend-openrpc.json
+++ b/positron/comms/ui-backend-openrpc.json
@@ -95,34 +95,6 @@
 					]
 				}
 			}
-		},
-		{
-			"name": "editor_context_changed",
-			"summary": "Active editor context changed",
-			"description": "This notification is sent from the frontend to the backend when the active text editor changes or when code is about to be executed from a file. It provides the document URI and indicates whether this is the source file for code execution.",
-			"params": [
-				{
-					"name": "document_uri",
-					"description": "The URI of the active document, or empty string if no editor is active",
-					"schema": {
-						"type": "string"
-					}
-				},
-				{
-					"name": "is_execution_source",
-					"description": "Whether this editor is the source of code being executed. When true, the backend may temporarily add the file's directory to sys.path.",
-					"schema": {
-						"type": "boolean"
-					}
-				}
-			],
-			"result": {
-				"schema": {
-					"name": "editor_context_changed_result",
-					"description": "Unused response to notification",
-					"type": "null"
-				}
-			}
 		}
 	]
 }

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -306,14 +306,4 @@ export class UiClientInstance extends Disposable {
 	public async didChangePlotsRenderSettings(settings: PlotRenderSettings): Promise<void> {
 		await this._comm.didChangePlotsRenderSettings(settings);
 	}
-
-	/**
-	 * Notification that the active editor context has changed.
-	 *
-	 * @param documentUri The URI of the active document, or empty string if no editor is active
-	 * @param isExecutionSource Whether this editor is the source of code being executed
-	 */
-	public async editorContextChanged(documentUri: string, isExecutionSource: boolean): Promise<void> {
-		await this._comm.editorContextChanged(documentUri, isExecutionSource);
-	}
 }

--- a/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
@@ -79,22 +79,6 @@ export interface EvaluateCodeParams {
 }
 
 /**
- * Parameters for the EditorContextChanged method.
- */
-export interface EditorContextChangedParams {
-	/**
-	 * The URI of the active document, or empty string if no editor is active
-	 */
-	document_uri: string;
-
-	/**
-	 * Whether this editor is the source of code being executed. When true,
-	 * the backend may temporarily add the file's directory to sys.path.
-	 */
-	is_execution_source: boolean;
-}
-
-/**
  * Editor metadata
  */
 export interface EditorContext {
@@ -1006,8 +990,7 @@ export enum UiFrontendRequest {
 export enum UiBackendRequest {
 	DidChangePlotsRenderSettings = 'did_change_plots_render_settings',
 	CallMethod = 'call_method',
-	EvaluateCode = 'evaluate_code',
-	EditorContextChanged = 'editor_context_changed'
+	EvaluateCode = 'evaluate_code'
 }
 
 export class PositronUiComm extends PositronBaseComm {
@@ -1073,26 +1056,6 @@ export class PositronUiComm extends PositronBaseComm {
 	 */
 	evaluateCode(code: string): Promise<EvalResult> {
 		return super.performRpc('evaluate_code', ['code'], [code]);
-	}
-
-	/**
-	 * Active editor context changed
-	 *
-	 * This notification is sent from the frontend to the backend when the
-	 * active text editor changes or when code is about to be executed from a
-	 * file. It provides the document URI and indicates whether this is the
-	 * source file for code execution.
-	 *
-	 * @param documentUri The URI of the active document, or empty string if
-	 * no editor is active
-	 * @param isExecutionSource Whether this editor is the source of code
-	 * being executed. When true, the backend may temporarily add the file's
-	 * directory to sys.path.
-	 *
-	 * @returns Unused response to notification
-	 */
-	editorContextChanged(documentUri: string, isExecutionSource: boolean): Promise<null> {
-		return super.performRpc('editor_context_changed', ['document_uri', 'is_execution_source'], [documentUri, isExecutionSource]);
 	}
 
 

--- a/src/vs/workbench/services/runtimeSession/common/activeRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/activeRuntimeSession.ts
@@ -11,7 +11,6 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
 import { IWorkbenchEnvironmentService } from '../../environment/common/environmentService.js';
-import { IEditorService } from '../../editor/common/editorService.js';
 import { RuntimeClientState } from '../../languageRuntime/common/languageRuntimeClientInstance.js';
 import { RuntimeState } from '../../languageRuntime/common/languageRuntimeService.js';
 import { IUiClientMessageInput, IUiClientMessageOutput, UiClientInstance } from '../../languageRuntime/common/languageRuntimeUiClient.js';
@@ -58,8 +57,7 @@ export class ActiveRuntimeSession extends Disposable {
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IWorkbenchEnvironmentService private readonly _environmentService: IWorkbenchEnvironmentService,
-		@IPositronConsoleService private readonly _consoleService: IPositronConsoleService,
-		@IEditorService private readonly _editorService: IEditorService
+		@IPositronConsoleService private readonly _consoleService: IPositronConsoleService
 	) {
 		super();
 
@@ -275,29 +273,6 @@ export class ActiveRuntimeSession extends Disposable {
 				}
 			});
 		}));
-
-		// Send the current active editor URI to the backend when the UI client starts,
-		// and subscribe to active editor changes to keep the backend informed.
-		// The isExecutionSource flag is false here since this is just tracking editor focus,
-		// not code execution from a file.
-		// Many tests run without an editor service, so only set up the listener if we have one.
-		if (this._editorService) {
-			const sendEditorContext = (isExecutionSource: boolean = false) => {
-				const activeEditor = this._editorService.activeEditor;
-				const documentUri = activeEditor?.resource?.toString() ?? '';
-				uiClient.editorContextChanged(documentUri, isExecutionSource).catch(err => {
-					this._logService.warn(`Failed to send editor context changed: ${err}`);
-				});
-			};
-
-			// Send the initial editor context
-			sendEditorContext();
-
-			// Listen for active editor changes and forward to the backend
-			uiClient.register(this._editorService.onDidActiveEditorChange(() => {
-				sendEditorContext();
-			}));
-		}
 
 		// Forward UI client to interested services
 		this._onUiClientStartedEmitter.fire(uiClient);


### PR DESCRIPTION
Follow up to #12576 and #11393

The notification is no longer used, so we might as well remove it for now. It causes RPC timeout warnings in the console due whenever a session is busy since we currently don't support fire and forget notifications (#7448).

For instance in integration test logs I see:

```
Failed to send editor context changed: [object Object]
Failed to send editor context changed: [object Object]
...
```

Worth noting that historically we've used a pull pattern rather than a push one, with reverse requests from Ark to Positron to query editor state.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
