### PR TITLE
Show error reason when Update All Packages fails

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -21,7 +21,7 @@ import { IPositronPackagesService } from './interfaces/positronPackagesService.j
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { PositronPackagesService } from './positronPackagesService.js';
 import { ILanguageRuntimePackage } from '../../../services/runtimeSession/common/runtimeSessionService.js';
-import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IProgressService, ProgressLocation } from '../../../../platform/progress/common/progress.js';
 
@@ -323,20 +323,8 @@ class UpdateAllPackagesAction extends Action2 {
 			try {
 				await service.updateAllPackages(cts.token);
 			} catch (e) {
-				notifications.notify({
-					severity: Severity.Error,
-					actions: {
-						primary: [{
-							id: 'viewLogs',
-							label: nls.localize('positronPackages.viewLogs', 'View Logs'),
-							tooltip: nls.localize('positronPackages.viewLogs', 'View Logs'),
-							enabled: true,
-							class: undefined,
-							run: () => service.activeSession?.showOutput(),
-						}]
-					},
-					message: nls.localize('positronPackages.failedToUpdateAllPackages', "Failed to update all packages"),
-				});
+				notifications.error(e);
+				throw e;
 			}
 		}, () => cts.dispose(true));
 	}


### PR DESCRIPTION
Previously, the Update All Packages action showed a generic "Failed to update all packages" message with a View Logs button. Now it shows the actual error message, matching how other package actions handle errors.

See #11996

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

I tested this by replacing PipPackageManager._ensurePip() with a stub that throws:

```diff
diff --git a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
index 1f13a13e8..bac2bb4fe 100644
--- a/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
+++ b/extensions/positron-python/src/client/positron/packages/pipPackageManager.ts
@@ -26,7 +26,7 @@ export class PipPackageManager implements IPackageManager {
         private readonly _messageEmitter: MessageEmitter,
         private readonly _serviceContainer: IServiceContainer,
         private readonly _session: PackageSession,

     async getPackages(token?: vscode.CancellationToken): Promise<positron.LanguageRuntimePackage[]> {
         return this._callMethod<positron.LanguageRuntimePackage[]>('getPackagesInstalled', token);
@@ -159,13 +159,14 @@ export class PipPackageManager implements IPackageManager {
      * Ensure pip is available, throwing an error if not.
      */
     private async _ensurePip(): Promise<void> {
-        const hasPip = await this.isPipAvailable();
-        if (!hasPip) {
-            throw new Error(
-                'pip is not available in this Python environment. ' +
-                    'Please install pip to use package management features.',
-            );
-        }
+        throw new Error("FOO: Debug!!");
     }

     /**
```

With this change, all the package management commands will fail and show "FOO: Debug!!". In a real scenario, this would be the error message of the actual error.