### PR TITLE
Restore Panel hiding behavior lost in upstream merge

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -408,18 +408,42 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		// Wait to register these listeners after the editor group service
 		// is ready to avoid conflicts on startup
 		this.editorGroupService.whenRestored.then(() => {
+			// --- Start Positron ---
+			// On startup, if no editors are open and the panel is visible,
+			// hide the editor to maximize the panel.
+			if (this.isVisible(Parts.PANEL_PART) &&
+				this.getPanelPosition() === Position.BOTTOM &&
+				this.getPanelAlignment() === 'center' &&
+				!this.editorService.activeEditor &&
+				!this.stateModel.getRuntimeValue(LayoutStateKeys.EDITOR_HIDDEN)) {
+				this.setEditorHidden(true);
+			}
+			// --- End Positron ---
 
 			// Handle visible editors changing for parts visibility
 			// --- Start Positron ---
 			// Positron-specific editor/panel visibility handling:
-			// When no editors are visible, automatically show the panel (if hidden)
-			// When editors become visible, hide the panel (if shown by us)
+			// When the panel is visible and no editors remain, hide the editor
+			// to maximize the panel. When editors become visible again, restore
+			// the editor. Crucially, if the user has explicitly hidden the
+			// panel (e.g. via Cmd+J), we do NOT force it back open.
 			const onDidVisibleEditorsChangeHandler = () => {
 				const handled = maybeMaximizeAuxiliaryBar();
 				if (!handled) {
 					if (this.mainPartEditorService.visibleEditors.length === 0) {
-						if (!this.isVisible(Parts.PANEL_PART)) {
-							this.setPanelHidden(false);
+						// Only maximize the panel (by hiding the editor) when the
+						// panel is already visible. This prevents force-showing a
+						// panel the user has explicitly hidden.
+						if (this.isVisible(Parts.PANEL_PART) &&
+							this.getPanelPosition() === Position.BOTTOM &&
+							this.getPanelAlignment() === 'center' &&
+							!this.stateModel.getRuntimeValue(LayoutStateKeys.EDITOR_HIDDEN)) {
+							const size = this.workbenchGrid.getViewSize(this.panelPartView);
+							this.stateModel.setRuntimeValue(
+								LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT,
+								size.height
+							);
+							this.setEditorHidden(true);
 						}
 					} else {
 						showEditorIfHidden();


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/12523
Restores behavior of https://github.com/posit-dev/positron/pull/4908
Lost in https://github.com/posit-dev/positron/pull/11933

---

When looking at https://github.com/posit-dev/positron/pull/11933 and the `layout.ts` file, it looks like this behavior was just totally dropped. I even see a newly added comment block of

```
// Positron-specific editor/panel visibility handling:
// When no editors are visible, automatically show the panel (if hidden)
// When editors become visible, hide the panel (if shown by us)
```

where `When no editors are visible, automatically show the panel (if hidden)` is not right. We _don't_ want to show the panel if the user had hidden it when we drop to 0 editors.

It seems like an attempt was made to simplify the behavior, but it is really complex enough to require all of these checks, but the people making the change probably didn't know that, and we didn't have a test in place.

We definitely need a regression test this time around, I'll ask QA

Update: @midleman is going to help me with that next week

---

Same kind of video as https://github.com/posit-dev/positron/pull/4908

When Panel is "visible"
- Panel maximizes when last tab is closed

When Panel is hidden with `Cmd + J`
- Panel stays hidden after last tab is closed
- Panel stays hidden after a reload (simulating opening Positron to ensure we don't maximize immediately when Panel was hidden by the user in the previous Positron session)

https://github.com/user-attachments/assets/4212c5b8-f351-407d-8776-784687b1fe52
