### PR TITLE
Prioritize first (affiliated) runtime at startup

### DIFF
--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -1177,12 +1177,12 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		});
 
 		// No affiliated runtimes; move on to the next phase.
-		if (!languageIds) {
+		if (languageIds.length === 0) {
 			return;
 		}
 
-		// Start the affiliated runtimes.
-		languageIds.map(languageId => {
+		// Build the sorted, filtered list of affiliations to start.
+		const affiliations = languageIds.map(languageId => {
 			// Get the affiliated runtime metadata.
 			return this.getAffiliatedRuntime(languageId);
 		}).filter(affiliation => {
@@ -1224,23 +1224,33 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			// Sort the affiliations by last used time, so that the most recently
 			// used runtime is started first
 			return b.lastUsed - a.lastUsed;
-		}).map(async (affiliation, idx) => {
-			if (idx === 0) {
-				// Let the UI know we're about to try starting this session
-				this._onWillAutoStartRuntime.fire({
-					runtime: affiliation.metadata,
-					newSession: true,
-					activate: idx === 0
-				});
-			}
-
-			// Activate the associated extension
-			await this.activateExtensionsForLanguages([affiliation.metadata.languageId]);
-
-			// Start each runtime. Activate the first one as soon as it's
-			// ready; let the others start in the background.
-			this.startAffiliatedRuntime(affiliation, idx === 0);
 		});
+
+		if (affiliations.length === 0) {
+			return;
+		}
+
+		// Start the primary (first) affiliated runtime synchronously: activate
+		// only its extension, then start it, before returning. This ensures
+		// that the caller sees a starting/running console and avoids falling
+		// through to slower paths that activate all extensions.
+		const primary = affiliations[0];
+		this._onWillAutoStartRuntime.fire({
+			runtime: primary.metadata,
+			newSession: true,
+			activate: true
+		});
+		await this.activateExtensionsForLanguages([primary.metadata.languageId]);
+		this.startAffiliatedRuntime(primary, true);
+
+		// Start the remaining affiliated runtimes in the background; they
+		// do not need to block the startup sequence.
+		for (let i = 1; i < affiliations.length; i++) {
+			const affiliation = affiliations[i];
+			this.activateExtensionsForLanguages([affiliation.metadata.languageId]).then(() => {
+				this.startAffiliatedRuntime(affiliation, false);
+			});
+		}
 	}
 
 	/**

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -1291,6 +1291,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		const key = extensionId.value;
 		const firstActivation = !this._activatedExtensions.has(key);
 		if (firstActivation) {
+			perf.mark(`code/positron/runtimeStartup/extensionPreActivate/${key}`);
 			this._logService.debug(`[Runtime startup] Activating extension ${key} for language ID ${languageId}`);
 		}
 		try {
@@ -1302,7 +1303,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 				});
 			if (firstActivation) {
 				this._activatedExtensions.add(key);
-				perf.mark(`code/positron/runtimeStartup/extensionActivated/${key}`);
+				perf.mark(`code/positron/runtimeStartup/extensionPostActivate/${key}`);
 			}
 		} catch (e) {
 			this._logService.debug(

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -1241,7 +1241,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			activate: true
 		});
 		await this.activateExtensionsForLanguages([primary.metadata.languageId]);
-		this.startAffiliatedRuntime(primary, true);
+		await this.startAffiliatedRuntime(primary, true);
 
 		// Start the remaining affiliated runtimes in the background; they
 		// do not need to block the startup sequence.
@@ -1289,8 +1289,11 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 	 */
 	private async activateExtension(extensionId: ExtensionIdentifier, languageId: string): Promise<void> {
 		const key = extensionId.value;
+		// Add to the set immediately (before the await) to prevent
+		// concurrent calls from emitting duplicate perf marks.
 		const firstActivation = !this._activatedExtensions.has(key);
 		if (firstActivation) {
+			this._activatedExtensions.add(key);
 			perf.mark(`code/positron/runtimeStartup/extensionPreActivate/${key}`);
 			this._logService.debug(`[Runtime startup] Activating extension ${key} for language ID ${languageId}`);
 		}
@@ -1302,10 +1305,12 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 					startup: false
 				});
 			if (firstActivation) {
-				this._activatedExtensions.add(key);
 				perf.mark(`code/positron/runtimeStartup/extensionPostActivate/${key}`);
 			}
 		} catch (e) {
+			if (firstActivation) {
+				this._activatedExtensions.delete(key);
+			}
 			this._logService.debug(
 				`[Runtime startup] Error activating extension ${key}: ${e}`);
 		}
@@ -1333,10 +1338,10 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 	 * @param affiliatedRuntimeMetadata The metadata for the affiliated runtime.
 	 * @param activate Whether to activate/focus the new session
 	 */
-	private startAffiliatedRuntime(
+	private async startAffiliatedRuntime(
 		affiliatedRuntime: IAffiliatedRuntimeMetadata,
 		activate: boolean
-	): void {
+	): Promise<void> {
 
 		// No-op if no affiliated runtime metadata.
 		if (!affiliatedRuntime.metadata) {
@@ -1357,7 +1362,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 		affiliatedRuntime.lastStarted = Date.now();
 		this.saveAffiliatedRuntime(affiliatedRuntime);
 
-		this.autoStartRuntime(affiliatedRuntimeMetadata,
+		await this.autoStartRuntime(affiliatedRuntimeMetadata,
 			`Affiliated ${affiliatedRuntimeMetadata.languageName} runtime for workspace`,
 			activate);
 	}
@@ -1767,7 +1772,7 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			newSession: true,
 			activate
 		});
-		this._runtimeSessionService.autoStartRuntime(metadata, source, activate);
+		await this._runtimeSessionService.autoStartRuntime(metadata, source, activate);
 	}
 
 	// Storage key prefix for architecture mismatch dismissal


### PR DESCRIPTION
This change prioritizes startup for the first affiliated runtime above all other runtime extension activation, startup, and discovery activity. Afterwards, runtime startup looks like this for e.g. R:

| Name                                                                            | Timestamp     | Delta | Total |
| ------------------------------------------------------------------------------- | ------------- | ----- | ----- |
| code/positron/runtimeStartupBegin                                               | 1774030313958 | 0     | 0     |
| code/positron/runtimeStartupPhase/initializing                                  | 1774030313958 | 0     | 0     |
| code/positron/runtimeStartupPhase/awaitingTrust                                 | 1774030313958 | 0     | 0     |
| code/positron/runtimeStartupPhase/starting                                      | 1774030314427 | 469   | 469   |
| code/positron/runtimeStartup/extensionPreActivate/positron.positron-r           | 1774030314458 | 31    | 500   |
| code/positron/positron.positron-supervisor/initializing                         | 1774030314974 | 516   | 1016  |
| code/positron/positron.positron-supervisor/terminalOpened                       | 1774030314987 | 13    | 1029  |
| code/positron/positron.positron-supervisor/started                              | 1774030315688 | 701   | 1730  |
| code/positron/runtimeStartup/extensionPostActivate/positron.positron-r          | 1774030315702 | 14    | 1744  |
| code/positron/positron.positron-supervisor/ready                                | 1774030315713 | 11    | 1755  |
| code/positron/runtimeSessionWillStart/r-a9ac40ff                                | 1774030318016 | 2303  | 4058  |
| code/positron/runtimeSessionStart/r-a9ac40ff                                    | 1774030318536 | 520   | 4578  |
| code/positron/firstRuntimeReady                                                 | 1774030318536 | 0     | 4578  |
| code/positron/runtimeStartup/extensionPreActivate/positron.positron-javascript  | 1774030318543 | 7     | 4585  |
| code/positron/runtimeStartup/extensionPreActivate/ms-python.python              | 1774030318543 | 0     | 4585  |
| code/positron/runtimeStartup/extensionPreActivate/positron.positron-reticulate  | 1774030318543 | 0     | 4585  |
| code/positron/runtimeStartup/extensionPreActivate/positron.positron-zed         | 1774030318543 | 0     | 4585  |
| code/positron/runtimeStartup/extensionPostActivate/ms-python.python             | 1774030318550 | 7     | 4592  |
| code/positron/runtimeStartup/extensionPostActivate/positron.positron-javascript | 1774030318563 | 13    | 4605  |
| code/positron/runtimeStartup/extensionPostActivate/positron.positron-reticulate | 1774030318563 | 0     | 4605  |
| code/positron/runtimeStartup/extensionPostActivate/positron.positron-zed        | 1774030318563 | 0     | 4605  |
| code/positron/runtimeStartupPhase/discovering                                   | 1774030318564 | 1     | 4606  |
| code/positron/runtimeSessionWillStart/python-0489b933                           | 1774030321339 | 2775  | 7381  |
| code/positron/runtimeStartupPhase/complete                                      | 1774030322833 | 1494  | 8875  |

In this example, we get to a usable R console 4.6 seconds after boot. Only once R has started do we go back and activate other extensions, discover all runtimes, etc. 

The general approach here is to make things _more_ synchronous instead of trying to do everything at once. Previously, we were not awaiting startup of affiliated runtimes, which caused us to look for recommended runtimes before moving to the starting phase (which had the side effect of activating all runtime extensions before we could proceed). 

There is some minor inefficiency introduced by this change as we _could_ technically orchestrate extension activation to happen in the background _during_ startup of the first runtime. However, this won't make startup appear any faster and adds more concurrency and complexity, so I'd like to experiment with this more linear approach.

Another minor change is to mark both pre and post activation for extensions, to help understand how they are contributing to startup; as early startup diagnostics reports have rolled in, it _looks_ like slow activation is the biggest contributor to the very slow startup cases, but it's hard to tell since we only log activation end times. Now we also log activation start times, so we know how long each extension is taking.

Addresses https://github.com/posit-dev/positron/issues/12338. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Improve console startup performance in existing workspaces (#12338)

#### Bug Fixes

- N/A


### QA Notes

Historically, touching the startup logic has had a high regression rate, so I'll run a full suite on this. It is worth testing the startup workflow with/without workspace trust, too, since that is not currently covered by automation.

Test tags: `@:console` `@:sessions` `@:notebooks`
