### PR TITLE
Bump bundled Quarto to 1.9.36

### DIFF
--- a/build/lib/quarto.js
+++ b/build/lib/quarto.js
@@ -129,7 +129,7 @@ function getQuartoLinux(version) {
  */
 function getQuartoStream() {
     // quarto version
-    const version = '1.8.27';
+    const version = '1.9.36';
     (0, fancy_log_1.default)(`Synchronizing quarto ${version}...`);
     // Get the download/unpack stream for the current platform
     return process.platform === 'win32' ?

--- a/build/lib/quarto.ts
+++ b/build/lib/quarto.ts
@@ -93,7 +93,7 @@ function getQuartoLinux(version: string): Stream {
  */
 export function getQuartoStream(): Stream {
 	// quarto version
-	const version = '1.8.27';
+	const version = '1.9.36';
 
 	fancyLog(`Synchronizing quarto ${version}...`);
 


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/12319

None of our e2e tests run with the bundled Quarto so there is no reason to run any extra tests on this branch.

I notice that the Windows e2e tests nicely use the `quarto-dev/quarto-actions/setup` GH action, which is great; those will automatically get the update to the new release.

Our Ubuntu e2e tests may need work to get the update, since they use a pre-built Docker container.