### PR TITLE
Fix duplicated Quarto cell toolbars

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCellToolbarController.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCellToolbarController.ts
@@ -473,10 +473,12 @@ export class QuartoCellToolbarController extends Disposable implements IEditorCo
 			return;
 		}
 
-		// Hide previous cell's toolbar (unless mouse is over it)
+		// Hide previous cell's toolbar. We always reset _isCursorInCell even
+		// when the mouse is over the toolbar; _updateVisualVisibility will
+		// keep it visible while hovered but hide it once the mouse leaves.
 		if (this._currentCellId && this._currentCellId !== this._mouseCellId) {
 			const previousToolbar = this._toolbars.get(this._currentCellId);
-			if (previousToolbar && !previousToolbar.isMouseOverToolbar) {
+			if (previousToolbar) {
 				previousToolbar.setCursorInCell(false);
 			}
 		}
@@ -492,13 +494,17 @@ export class QuartoCellToolbarController extends Disposable implements IEditorCo
 	/**
 	 * Show the toolbar for the specified cell and hide all others.
 	 * This ensures only one toolbar is visible at a time.
+	 *
+	 * Note: We always call setCursorInCell(false) on non-target toolbars,
+	 * even when the mouse is over them. The toolbar's _updateVisualVisibility
+	 * will keep it visible while the mouse hovers, but once the mouse leaves,
+	 * it will properly hide since _isCursorInCell is false.
 	 */
 	private _showToolbarExclusively(cellId: string): void {
 		for (const [id, toolbar] of this._toolbars) {
 			if (id === cellId) {
 				toolbar.setCursorInCell(true);
-			} else if (!toolbar.isMouseOverToolbar) {
-				// Hide all other toolbars (unless the mouse is directly over them)
+			} else {
 				toolbar.setCursorInCell(false);
 			}
 		}

--- a/test/e2e/pages/inlineQuarto.ts
+++ b/test/e2e/pages/inlineQuarto.ts
@@ -46,6 +46,7 @@ export class InlineQuarto {
 	readonly outputContent: Locator;
 	readonly outputItem: Locator;
 	readonly cellToolbar: Locator;
+	readonly visibleCellToolbar: Locator;
 	readonly toolbarRunButton: Locator;
 	readonly toolbarCancelButton: Locator;
 	readonly closeButton: Locator;
@@ -75,6 +76,7 @@ export class InlineQuarto {
 		this.outputContent = page.locator(`${INLINE_OUTPUT} ${OUTPUT_CONTENT}`);
 		this.outputItem = page.locator(`${INLINE_OUTPUT} ${OUTPUT_ITEM}`);
 		this.cellToolbar = page.locator(CELL_TOOLBAR);
+		this.visibleCellToolbar = page.locator(`${CELL_TOOLBAR}.visible`);
 		this.toolbarRunButton = page.locator(`${CELL_TOOLBAR} ${TOOLBAR_RUN}`);
 		this.toolbarCancelButton = page.getByRole('button', { name: 'Cancel pending execution' });
 		this.closeButton = page.locator(`${INLINE_OUTPUT} ${OUTPUT_CLOSE}`);
@@ -372,6 +374,12 @@ export class InlineQuarto {
 			await expect(kernelLabel).not.toHaveText(/No Kernel|Starting\.\.\./, { timeout });
 		});
 		return kernelText!;
+	}
+
+	async expectSingleVisibleToolbar(timeout = 15000): Promise<void> {
+		await test.step('Expect exactly one visible cell toolbar', async () => {
+			await expect(this.visibleCellToolbar).toHaveCount(1, { timeout });
+		});
 	}
 
 	async expectPendingExecution({ timeout }: { timeout?: number } = { timeout: 5000 }): Promise<void> {

--- a/test/e2e/tests/quarto/quarto-inline-output-toolbar.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-toolbar.test.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { test, tags, expect } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Quarto - Inline Output: Cell Toolbar', {
+	tag: [tags.QUARTO]
+}, () => {
+
+	test.beforeAll(async function ({ settings }) {
+		await settings.set({
+			'positron.quarto.inlineOutput.enabled': true
+		}, { reload: 'web' });
+	});
+
+	test.afterEach(async function ({ hotKeys }) {
+		await hotKeys.closeAllEditors();
+	});
+
+	test('Python - Only one cell toolbar is visible after mouse leaves previous toolbar', async function ({ python, app, page, openFile }) {
+		const { editors, inlineQuarto } = app.workbench;
+
+		// Open a Quarto file with multiple cells
+		await openFile(join('workspaces', 'quarto_inline_output', 'copy_output_test.qmd'));
+		await editors.waitForActiveTab('copy_output_test.qmd');
+		await inlineQuarto.expectKernelStatusVisible();
+
+		// Navigate to first cell (line 11 is inside the first python cell)
+		await inlineQuarto.gotoLine(11);
+
+		await test.step('Wait for first cell toolbar', async () => {
+			await expect(inlineQuarto.visibleCellToolbar).toHaveCount(1, { timeout: 10000 });
+		});
+
+		await test.step('Simulate mouse hovering over first toolbar', async () => {
+			// Dispatch mouseenter on the first toolbar to simulate the
+			// mouse hovering over it. This sets _isMouseOverToolbar = true.
+			await page.locator('.quarto-cell-toolbar').first().dispatchEvent('mouseenter');
+			await page.waitForTimeout(200);
+		});
+
+		await test.step('Navigate to second cell', async () => {
+			await inlineQuarto.gotoLine(21);
+			await page.waitForTimeout(300);
+		});
+
+		await test.step('Simulate mouse leaving first toolbar', async () => {
+			// Dispatch mouseleave on the first toolbar. With the bug,
+			// the toolbar stays visible because _isCursorInCell was
+			// never reset to false when _showToolbarExclusively skipped
+			// the toolbar due to isMouseOverToolbar being true.
+			await page.locator('.quarto-cell-toolbar').first().dispatchEvent('mouseleave');
+			await page.waitForTimeout(500);
+		});
+
+		// There should be exactly one visible toolbar (the second cell's).
+		await inlineQuarto.expectSingleVisibleToolbar();
+	});
+});


### PR DESCRIPTION
This change fixes an issue that could cause duplicate Quarto cell toolbars to appears. The problem was that `isMouseOverToolbar` guards were preventing state from being updated, with the result that the toolbar didn't track the cursor correctly.

Addresses https://github.com/posit-dev/positron/issues/12543.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

New automated test included.

Test tags: `@:quarto`