### PR TITLE
Auto align memory usage popup

### DIFF
--- a/src/vs/workbench/contrib/positronVariables/browser/components/memoryUsageDropdown.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/memoryUsageDropdown.tsx
@@ -225,7 +225,7 @@ export const MemoryUsageDropdown = (props: MemoryUsageDropdownProps) => {
 			fixedHeight={true}
 			height='auto'
 			keyboardNavigationStyle='dialog'
-			popupAlignment='right'
+			popupAlignment='auto'
 			popupPosition='bottom'
 			renderer={props.renderer}
 			width={400}


### PR DESCRIPTION
Automatically align the memory usage popup, so that it shows up on the right rather than the left as necessary.

<img width="683" height="463" alt="image" src="https://github.com/user-attachments/assets/a0dc1b8e-a3bf-4243-beb7-b330cd8bf482" />

Addresses https://github.com/posit-dev/positron/issues/12460.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
