### PR TITLE
Fix Ctrl+C copy on Windows in Quarto inline outputs

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
@@ -105,7 +105,11 @@ registerAction2(class CancelExecutionAction extends Action2 {
 			keybinding: {
 				when: QUARTO_PRECONDITION,
 				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyCode.KeyC,
+				// On Mac, Ctrl+C is the traditional interrupt signal and does
+				// not conflict with copy (Cmd+C). On Windows/Linux, Ctrl+C is
+				// the copy shortcut, so we must not bind it there. Users can
+				// still cancel execution via toolbar.
+				primary: 0,
 				mac: {
 					primary: KeyMod.WinCtrl | KeyCode.KeyC,
 				},

--- a/test/e2e/tests/quarto/quarto-inline-output-copy-select.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-copy-select.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags, } from '../_test.setup';
+import { test, tags, expect } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -59,6 +59,32 @@ test.describe('Quarto - Inline Output: Copy and Select', {
 
 		// Wait for success state to revert
 		await inlineQuarto.expectCopySuccessReverted();
+	});
+
+	test('Python - Verify Ctrl+C copies editor text when inline output is enabled', async function ({ python, app, openFile, hotKeys }) {
+		const { editors, inlineQuarto, clipboard } = app.workbench;
+
+		// Open a Quarto file and wait for the kernel to be ready
+		await openFile(join('workspaces', 'quarto_inline_output', 'text_output.qmd'));
+		await editors.waitForActiveTab('text_output.qmd');
+		await inlineQuarto.expectKernelStatusVisible();
+
+		// Go to line 2 (the title line: title: "Text Output Test")
+		await inlineQuarto.gotoLine(2);
+
+		// Select the line content using Home then Shift+End
+		const page = app.code.driver.page;
+		await page.keyboard.press('Home');
+		await page.keyboard.press('Shift+End');
+
+		// Copy with the standard copy shortcut (Ctrl+C / Cmd+C)
+		await clipboard.copy();
+
+		// Verify the clipboard contains the title line text
+		await expect(async () => {
+			const clipboardText = await clipboard.getClipboardText();
+			expect(clipboardText).toContain('Text Output Test');
+		}).toPass({ timeout: 5000 });
 	});
 
 	test('Python - Verify copy output command copies text from cell output', async function ({ python, app, openFile }) {


### PR DESCRIPTION
This change fixes an issue in which -- on Windows -- <kbd>Ctrl</kbd> <kbd>C</kbd> broke copying in Quarto documents that had inline output turned on.

The problem was that we added a keybinding that makes it possible to interrupt inline execution as you would at a terminal. It's a nifty feature and great for Mac, but there's no reasonable binding for this on Windows or Linux as I see it, so the command won't have one on those operating systems after this change. There are still multiple UI affordances for interrupting execution.

Also adds an E2E test for this.

Addresses https://github.com/posit-dev/positron/issues/12381

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

Should also repro on Linux since it also uses Ctrl+C for copy.

Test tags: `@:win` `@:quarto`