### PR TITLE
feat(r-grammar): assign `support.class.r` scope to namespace prefixes before `::` and `:::`

### DIFF
--- a/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
@@ -161,6 +161,9 @@
 					"include": "#keywords"
 				},
 				{
+					"include": "#namespace-call"
+				},
+				{
 					"include": "#function-call"
 				},
 				{
@@ -360,6 +363,13 @@
 					"match": "(?:(?:\\d+(?:\\.\\d*)?)|(?:\\.\\d+))(?:[eE][+-]?\\d*)?[iL]?"
 				}
 			]
+		},
+		"namespace-call": {
+			"match": "([\\p{L}\\p{Nl}.][\\p{L}\\p{Nl}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}.]*)(:::?)",
+			"captures": {
+				"1": { "name": "support.class.r" },
+				"2": { "name": "keyword.operator" }
+			}
 		},
 		"operators": {
 			"name": "keyword.operator",

--- a/extensions/positron-r/syntaxes/r.tmGrammar.src.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.src.json
@@ -161,6 +161,9 @@
 					"include": "#keywords"
 				},
 				{
+					"include": "#namespace-call"
+				},
+				{
 					"include": "#function-call"
 				},
 				{
@@ -360,6 +363,13 @@
 					"match": "(?:(?:\\d+(?:\\.\\d*)?)|(?:\\.\\d+))(?:[eE][+-]?\\d*)?[iL]?"
 				}
 			]
+		},
+		"namespace-call": {
+			"match": "([\\p{L}\\p{Nl}.][\\p{L}\\p{Nl}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}.]*)(:::?)",
+			"captures": {
+				"1": { "name": "support.class.r" },
+				"2": { "name": "{{ operator }}" }
+			}
 		},
 		"operators": {
 			"name": "{{ operator }}",


### PR DESCRIPTION
Previously, any identifier preceding `::` or `:::` (e.g. `janitor` in `janitor::clean_names()`) 
received the generic `variable.object` scope, making it indistinguishable from regular variables 
and impossible to style distinctly via `editor.tokenColorCustomizations`.

This PR adds a `namespace-call` rule to the R TextMate grammar that assigns the `support.class.r` 
scope to identifiers immediately followed by `:::?`.

Users can now target package names in their theme settings:
```jsonc
"editor.tokenColorCustomizations": {
  "textMateRules": [
    {
      "scope": "support.class.r",
      "settings": { "foreground": "#ffaa00", "fontStyle": "bold" }
    }
  ]
}
```

Both `r.tmGrammar.src.json` (hand-edited) and `r.tmGrammar.gen.json` (regenerated via 
`compile-syntax`) are updated.

### Release Notes

#### New Features

- Package names preceding `::` and `:::` in R code are now assigned the `support.class.r` 
  TextMate scope, allowing them to be styled independently from regular variables.

### QA Notes

Open any R file or Quarto document containing `package::function()` calls. Run 
**Developer: Inspect Editor Tokens and Scopes** and click a package name, it should now 
show `support.class.r` instead of `variable.object`.