### PR TITLE
ci: Bump Ruff extension to 2026.38.0

### DIFF
--- a/product.json
+++ b/product.json
@@ -106,7 +106,7 @@
 	"bootstrapExtensions": [
 		{
 			"name": "charliermarsh.ruff",
-			"version": "2026.36.0",
+			"version": "2026.38.0",
 			"repo": "https://github.com/astral-sh/ruff-vscode",
 			"metadata": {
 				"publisherId": {


### PR DESCRIPTION
## Summary
- Bumps the Ruff extension from 2026.36.0 to 2026.38.0

## QA Notes
n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)