### PR TITLE
e2e: fix flake on R Markdown preview test (windows)

### DIFF
--- a/test/e2e/pages/editorActionBar.ts
+++ b/test/e2e/pages/editorActionBar.ts
@@ -142,11 +142,10 @@ export class EditorActionBar {
 	 * Verify: Check that the preview renders the specified heading
 	 * @param heading the heading to verify in the preview
 	 */
-	async verifyPreviewRendersHtml(heading: string) {
+	async verifyPreviewRendersHtml(heading: string, timeout = 5000) {
 		await test.step('Verify "preview" renders html', async () => {
-			await this.page.getByLabel('Preview', { exact: true }).nth(0).click();
 			const viewerFrame = this.viewer.getViewerFrame().frameLocator('iframe');
-			await expect(viewerFrame.getByRole('heading', { name: heading })).toBeVisible({ timeout: 60000 });
+			await expect(viewerFrame.getByRole('heading', { name: heading })).toBeVisible({ timeout });
 		});
 	}
 

--- a/test/e2e/pages/editorActionBar.ts
+++ b/test/e2e/pages/editorActionBar.ts
@@ -142,7 +142,7 @@ export class EditorActionBar {
 	 * Verify: Check that the preview renders the specified heading
 	 * @param heading the heading to verify in the preview
 	 */
-	async verifyPreviewRendersHtml(heading: string, timeout = 5000) {
+	async verifyPreviewRendersHtml(heading: string, timeout = 20000) {
 		await test.step('Verify "preview" renders html', async () => {
 			const viewerFrame = this.viewer.getViewerFrame().frameLocator('iframe');
 			await expect(viewerFrame.getByRole('heading', { name: heading })).toBeVisible({ timeout });

--- a/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
@@ -70,8 +70,10 @@ test.describe('Editor Action Bar: Document Files', {
 // Helper functions
 
 async function verifyPreviewRendersHtml(heading: string) {
-	// await editorActionBar.clickButton('Preview');
-	await editorActionBar.verifyPreviewRendersHtml(heading);
+	await expect(async () => {
+		await editorActionBar.clickButton('Preview');
+		await editorActionBar.verifyPreviewRendersHtml(heading);
+	}).toPass({ timeout: 60000 });
 }
 
 async function verifySplitEditor(tabName: string) {


### PR DESCRIPTION
## Summary

- Fix intermittent test failure in "R Markdown Document - Verify `preview`, `split editor`, `open in new window` behavior"
- Root cause: Quarto extension throws `TypeError: Cannot read properties of undefined (reading 'reduce')` during `slideIndex` calculation in `renderFormat`
- Solution: Wrap click+verify in `expect().toPass()` retry pattern so that clicking Preview again retries the render

## QA Notes

@:win @:editor-action-bar

This is a test-only change that adds retry logic to handle an intermittent Quarto extension error on Windows. No product behavior changes.

---
🤖 Generated with [Claude Code](https://claude.ai/code)