### PR TITLE
e2e: fix autocomplete focus and pixel ratio precision flakes

### DIFF
--- a/test/e2e/tests/autocomplete/autocomplete.test.ts
+++ b/test/e2e/tests/autocomplete/autocomplete.test.ts
@@ -184,11 +184,13 @@ async function triggerAutocompleteInEditor({ app, session, retrigger = false }: 
 	const keyboard = app.code.driver.page.keyboard;
 
 	await sessions.select(session.id);
-	await hotKeys.firstTab();
 
 	// Wait for the editor to actually have focus before typing
-	const editorInput = app.code.driver.page.locator('.editor-instance .monaco-editor .native-edit-context');
-	await expect(editorInput).toBeFocused();
+	await expect(async () => {
+		await hotKeys.firstTab();
+		const editorInput = app.code.driver.page.locator('.editor-instance .monaco-editor .native-edit-context');
+		await expect(editorInput).toBeFocused({ timeout: 2000 });
+	}).toPass({ timeout: 10000 });
 
 	if (retrigger) {
 		const triggerText = session.name.includes('Python') ? 'pd.DataF' : 'read_p';

--- a/test/e2e/tests/notebook/notebook-execution-metadata.test.ts
+++ b/test/e2e/tests/notebook/notebook-execution-metadata.test.ts
@@ -41,10 +41,11 @@ test.describe('Notebooks: Execution Metadata', {
 		expect(typeof metadata['output_width_px']).toBe('number');
 		expect(metadata['output_width_px']).toBeGreaterThan(100);
 
-		// output_pixel_ratio should be present and have a reasonable value (1.0 - 3.0)
+		// output_pixel_ratio should be present and have a reasonable value (~1.0 - 3.0)
+		// Use 0.99 lower bound to allow for floating-point precision drift
 		expect(metadata['output_pixel_ratio']).toBeDefined();
 		expect(typeof metadata['output_pixel_ratio']).toBe('number');
-		expect(metadata['output_pixel_ratio']).toBeGreaterThanOrEqual(1.0);
+		expect(metadata['output_pixel_ratio']).toBeGreaterThanOrEqual(0.99);
 		expect(metadata['output_pixel_ratio']).toBeLessThanOrEqual(3.0);
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-execution-metadata.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-execution-metadata.test.ts
@@ -37,10 +37,11 @@ test.describe('Positron Notebooks: Execution Metadata', {
 		expect(typeof metadata['output_width_px']).toBe('number');
 		expect(metadata['output_width_px']).toBeGreaterThan(100);
 
-		// output_pixel_ratio should be present and have a reasonable value (1.0 - 3.0)
+		// output_pixel_ratio should be present and have a reasonable value (~1.0 - 3.0)
+		// Use 0.99 lower bound to allow for floating-point precision drift
 		expect(metadata['output_pixel_ratio']).toBeDefined();
 		expect(typeof metadata['output_pixel_ratio']).toBe('number');
-		expect(metadata['output_pixel_ratio']).toBeGreaterThanOrEqual(1.0);
+		expect(metadata['output_pixel_ratio']).toBeGreaterThanOrEqual(0.99);
 		expect(metadata['output_pixel_ratio']).toBeLessThanOrEqual(3.0);
 	});
 });

--- a/test/e2e/tests/quarto/quarto-inline-output-cell-metadata.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-cell-metadata.test.ts
@@ -67,10 +67,11 @@ test.describe('Quarto - Inline Output: Cell Metadata', {
 		expect(typeof metadata['output_width_px']).toBe('number');
 		expect(metadata['output_width_px']).toBeGreaterThan(100);
 
-		// output_pixel_ratio should be present and have a reasonable value (1.0 - 3.0)
+		// output_pixel_ratio should be present and have a reasonable value (~1.0 - 3.0)
+		// Use 0.99 lower bound to allow for floating-point precision drift
 		expect(metadata['output_pixel_ratio']).toBeDefined();
 		expect(typeof metadata['output_pixel_ratio']).toBe('number');
-		expect(metadata['output_pixel_ratio']).toBeGreaterThanOrEqual(1.0);
+		expect(metadata['output_pixel_ratio']).toBeGreaterThanOrEqual(0.99);
 		expect(metadata['output_pixel_ratio']).toBeLessThanOrEqual(3.0);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes two flaky e2e test issues:

1. **Autocomplete editor focus** - Wrap `firstTab()` + focus check in `expect().toPass()` retry pattern to handle intermittent timing issues where the editor doesn't have focus after switching sessions

2. **Floating-point pixel ratio precision** - The `output_pixel_ratio` can be slightly less than 1.0 due to floating-point arithmetic (e.g., `0.9999999767169356`). Use `0.99` as the lower bound to account for this precision drift

## QA Notes

@:autocomplete @:notebooks

---
🤖 Generated with [Claude Code](https://claude.ai/code)