### PR TITLE
e2e: skip windows editor action bar test

### DIFF
--- a/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -28,7 +28,7 @@ test.use({
 });
 
 test.describe('Editor Action Bar: Document Files', {
-	tag: [tags.WEB, tags.WIN, tags.EDITOR_ACTION_BAR, tags.EDITOR]
+	tag: [tags.WEB, tags.EDITOR_ACTION_BAR, tags.EDITOR]
 }, () => {
 
 	test.beforeAll(async function ({ app }) {


### PR DESCRIPTION
Skipping on windows for now while we investigate a CI failure


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
