### PR TITLE
e2e: add bottom panel tests

### DIFF
--- a/test/e2e/pages/layouts.ts
+++ b/test/e2e/pages/layouts.ts
@@ -3,10 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Locator } from '@playwright/test';
+import test, { expect, Locator } from '@playwright/test';
 import { Code } from '../infra/code';
 import { Workbench } from '../infra/workbench';
-import { expect, test } from '../tests/_test.setup.js';
 
 const FULL_APP = 'body';
 const AUX_BAR = '.part.auxiliarybar';

--- a/test/e2e/pages/layouts.ts
+++ b/test/e2e/pages/layouts.ts
@@ -6,6 +6,7 @@
 import { Locator } from '@playwright/test';
 import { Code } from '../infra/code';
 import { Workbench } from '../infra/workbench';
+import { expect, test } from '../tests/_test.setup.js';
 
 const FULL_APP = 'body';
 const AUX_BAR = '.part.auxiliarybar';
@@ -120,6 +121,20 @@ export class Layouts {
 	async boundingBoxProperty(locator: Locator, property: 'x' | 'y' | 'width' | 'height') {
 		const boundingBox = await this.boundingBox(locator);
 		return boundingBox[property];
+	}
+
+	/**
+	 * Assert that the bottom panel is visible or not visible.
+	 * @param visible Whether the panel should be visible.
+	 */
+	async expectBottomPanelToBeVisible(visible = true): Promise<void> {
+		await test.step(`Expect panel to be ${visible ? 'visible' : 'not visible'}`, async () => {
+			if (visible) {
+				await expect(this.panelContent).toBeVisible();
+			} else {
+				await expect(this.panelContent).not.toBeVisible();
+			}
+		});
 	}
 }
 

--- a/test/e2e/tests/layouts/panel-visibility.test.ts
+++ b/test/e2e/tests/layouts/panel-visibility.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect, tags } from '../_test.setup';
+import { test, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -12,23 +12,6 @@ test.use({
 test.describe('Bottom Panel Visibility', {
 	tag: [tags.WEB, tags.LAYOUTS, tags.WIN]
 }, () => {
-
-	test('Visible panel maximizes on closing last editor', async function ({ app, hotKeys, openFile }) {
-		const layouts = app.workbench.layouts;
-
-		// Open a file in editor - panel should be visible
-		await openFile('README.md');
-		await layouts.expectBottomPanelToBeVisible(true);
-
-		// Get initial panel height
-		const initialPanelHeight = await layouts.boundingBoxProperty(layouts.panel, 'height');
-
-		// Close all editors - panel should maximize
-		await hotKeys.closeAllEditors();
-		await layouts.expectBottomPanelToBeVisible(true);
-		const expandedPanelHeight = await layouts.boundingBoxProperty(layouts.panel, 'height');
-		expect(expandedPanelHeight).toBeGreaterThan(initialPanelHeight);
-	});
 
 	test('Hidden panel stays hidden on closing last editor', async function ({ app, hotKeys, openFile }) {
 		const layouts = app.workbench.layouts;

--- a/test/e2e/tests/layouts/panel-visibility.test.ts
+++ b/test/e2e/tests/layouts/panel-visibility.test.ts
@@ -13,7 +13,11 @@ test.describe('Bottom Panel Visibility', {
 	tag: [tags.WEB, tags.LAYOUTS, tags.WIN]
 }, () => {
 
-	test('Hidden panel stays hidden on closing last editor', async function ({ app, hotKeys, openFile }) {
+	test('Hidden panel stays hidden on closing last editor', {
+		annotation: [
+			{ type: 'issue', description: 'https://github.com/posit-dev/positron/pull/12644' },
+		],
+	}, async function ({ app, hotKeys, openFile }) {
 		const layouts = app.workbench.layouts;
 
 		// Open a file in editor - panel should be visible

--- a/test/e2e/tests/layouts/panel-visibility.test.ts
+++ b/test/e2e/tests/layouts/panel-visibility.test.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, expect, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Bottom Panel Visibility', {
+	tag: [tags.WEB, tags.LAYOUTS, tags.WIN]
+}, () => {
+
+	test('Visible panel maximizes on closing last editor', async function ({ app, hotKeys, openFile }) {
+		const layouts = app.workbench.layouts;
+
+		// Open a file in editor - panel should be visible
+		await openFile('README.md');
+		await layouts.expectBottomPanelToBeVisible(true);
+
+		// Get initial panel height
+		const initialPanelHeight = await layouts.boundingBoxProperty(layouts.panel, 'height');
+
+		// Close all editors - panel should maximize
+		await hotKeys.closeAllEditors();
+		await layouts.expectBottomPanelToBeVisible(true);
+		const expandedPanelHeight = await layouts.boundingBoxProperty(layouts.panel, 'height');
+		expect(expandedPanelHeight).toBeGreaterThan(initialPanelHeight);
+	});
+
+	test('Hidden panel stays hidden on closing last editor', async function ({ app, hotKeys, openFile }) {
+		const layouts = app.workbench.layouts;
+
+		// Open a file in editor - panel should be visible
+		await openFile('README.md');
+		await layouts.expectBottomPanelToBeVisible(true);
+
+		// Hide the panel explicitly
+		await hotKeys.toggleBottomPanel();
+		await layouts.expectBottomPanelToBeVisible(false);
+
+		// Close all editors - panel should remain hidden
+		await hotKeys.closeAllEditors();
+		await layouts.expectBottomPanelToBeVisible(false);
+
+		// Reload the window - panel should still be hidden after reload
+		await hotKeys.reloadWindow(true);
+		await layouts.expectBottomPanelToBeVisible(false);
+	});
+});


### PR DESCRIPTION
### Summary

Adds e2e tests for bottom panel visibility behavior when closing the last editor.
* Visible panel maximizes on closing last editor
* Hidden panel stays hidden on closing last editor (including after window reload)

### QA Notes

@:layouts @:web @:win
Related to: https://github.com/orgs/posit-dev/projects/2/views/22?sliceBy%5Bvalue%5D=midleman&pane=issue&itemId=165906557&issue=posit-dev%7Cpositron%7C12523