### PR TITLE
Migrate Posit AI auth from Assistant to Authentication

### DIFF
--- a/extensions/authentication/package.json
+++ b/extensions/authentication/package.json
@@ -11,6 +11,7 @@
 	"activationEvents": [
 		"onStartupFinished",
 		"onAuthenticationRequest:anthropic-api",
+		"onAuthenticationRequest:posit-ai",
 		"onAuthenticationRequest:ms-foundry",
 		"onAuthenticationRequest:amazon-bedrock",
 		"onCommand:authentication.configureProviders",
@@ -26,6 +27,10 @@
 			{
 				"id": "anthropic-api",
 				"label": "Anthropic"
+			},
+			{
+				"id": "posit-ai",
+				"label": "Posit AI"
 			},
 			{
 				"id": "ms-foundry",

--- a/extensions/authentication/src/authProvider.ts
+++ b/extensions/authentication/src/authProvider.ts
@@ -55,10 +55,17 @@ export class AuthProvider
 	constructor(
 		private readonly providerId: string,
 		private readonly displayName: string,
-		private readonly context: vscode.ExtensionContext,
+		protected readonly context: vscode.ExtensionContext,
 		private readonly workbench?: WorkbenchCredentialConfig,
 		private readonly credentialChain?: CredentialChainConfig,
 	) { }
+
+	/** Expose session-change events to subclasses. */
+	protected fireSessionsChanged(
+		event: vscode.AuthenticationProviderAuthenticationSessionsChangeEvent
+	): void {
+		this._onDidChangeSessions.fire(event);
+	}
 
 	dispose(): void {
 		this._disposed = true;

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -26,7 +26,7 @@ export interface RegisterAuthProviderOptions {
 	onSave?: OnSaveCallback;
 }
 
-export const authProviders = new Map<string, vscode.AuthenticationProvider>();
+export const authProviders = new Map<string, AuthProvider>();
 const apiKeyValidators = new Map<string, ApiKeyValidator>();
 const onSaveCallbacks = new Map<string, OnSaveCallback>();
 
@@ -36,7 +36,7 @@ const onSaveCallbacks = new Map<string, OnSaveCallback>();
  */
 export function registerAuthProvider(
 	providerId: string,
-	provider: vscode.AuthenticationProvider,
+	provider: AuthProvider,
 	options?: RegisterAuthProviderOptions
 ): void {
 	authProviders.set(providerId, provider);
@@ -59,8 +59,7 @@ export function registerAuthProvider(
 export function getAuthProvider(
 	providerId: string
 ): AuthProvider | undefined {
-	const provider = authProviders.get(providerId);
-	return provider instanceof AuthProvider ? provider : undefined;
+	return authProviders.get(providerId);
 }
 
 /**
@@ -75,7 +74,7 @@ async function enrichWithCredentialState(
 			return source;
 		}
 		try {
-			const sessions = await provider.getSessions([], {});
+			const sessions = await provider.getSessions();
 			const signedIn = sessions.length > 0;
 			if (signedIn && source.provider.id === 'ms-foundry' && hasManagedCredentials(FOUNDRY_MANAGED_CREDENTIALS)) {
 				return {
@@ -133,37 +132,34 @@ export async function showConfigurationDialog(
 		enrichedSources,
 		async (config, action) => {
 			log.info(`Config dialog action: "${action}" for provider "${config.provider}"`);
+			const hasAuthProvider = authProviders.has(config.provider);
 			// applyConfig is a fallback while we transition providers to the Auth extension.
 			// It should eventually be removed so that the Auth extension is the single source of truth
 			// for all provider config actions.
 			const applyConfig = async () => {
 				await vscode.commands.executeCommand('positron-assistant.applyConfigAction', config, action, enrichedSources);
 			};
-			const provider = authProviders.get(config.provider);
 			switch (action) {
 				case 'save': {
-					if (provider instanceof AuthProvider) {
-						const accountId = await handleSave(config, provider);
+					if (hasAuthProvider) {
+						const accountId = await handleSave(config);
 						addResult({ action, config, accountId });
-					} else if (provider) {
-						addResult({ action, config });
 					} else {
 						await applyConfig();
 					}
 					break;
 				}
 				case 'delete':
-					if (provider instanceof AuthProvider) {
-						await handleDelete(config, provider);
-						addResult({ action, config });
-					} else if (provider) {
+					if (hasAuthProvider) {
+						await handleDelete(config);
 						addResult({ action, config });
 					} else {
 						await applyConfig();
 					}
 					break;
 				case 'oauth-signin': {
-					if (provider) {
+					if (hasAuthProvider) {
+						const provider = authProviders.get(config.provider)!;
 						await provider.createSession([], {});
 						addResult({ action: 'save', config, accountId: config.provider });
 					} else {
@@ -172,7 +168,8 @@ export async function showConfigurationDialog(
 					break;
 				}
 				case 'oauth-signout': {
-					if (provider) {
+					if (hasAuthProvider) {
+						const provider = authProviders.get(config.provider)!;
 						await provider.removeSession('');
 						addResult({ action: 'delete', config });
 					} else {
@@ -181,6 +178,7 @@ export async function showConfigurationDialog(
 					break;
 				}
 				case 'cancel': {
+					const provider = authProviders.get(config.provider);
 					if (provider instanceof PositOAuthProvider) {
 						provider.cancelSignIn();
 					}
@@ -204,9 +202,15 @@ export async function showConfigurationDialog(
  * config, validates and stores it. Otherwise resolves via createSession.
  */
 async function handleSave(
-	config: positron.ai.LanguageModelConfig,
-	provider: AuthProvider
+	config: positron.ai.LanguageModelConfig
 ): Promise<string> {
+	const provider = authProviders.get(config.provider);
+	if (!provider) {
+		throw new Error(
+			vscode.l10n.t('No auth provider registered for {0}', config.provider)
+		);
+	}
+
 	if (config.apiKey?.trim()) {
 		return handleApiKeySave(config, provider);
 	}
@@ -246,9 +250,13 @@ async function handleApiKeySave(
 }
 
 async function handleDelete(
-	config: positron.ai.LanguageModelConfig,
-	provider: AuthProvider
+	config: positron.ai.LanguageModelConfig
 ): Promise<void> {
+	const provider = authProviders.get(config.provider);
+	if (!provider) {
+		log.warn(`handleDelete: no auth provider for "${config.provider}"`);
+		return;
+	}
 	const sessions = await provider.getSessions();
 	log.info(`Deleting ${sessions.length} session(s) for provider "${config.provider}"`);
 	for (const session of sessions) {

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { randomUUID } from 'crypto';
 import { AuthProvider } from './authProvider';
+import { PositOAuthProvider } from './positOAuthProvider';
 import { log } from './log';
 import { FOUNDRY_MANAGED_CREDENTIALS, hasManagedCredentials } from './managedCredentials';
 
@@ -25,7 +26,7 @@ export interface RegisterAuthProviderOptions {
 	onSave?: OnSaveCallback;
 }
 
-export const authProviders = new Map<string, AuthProvider>();
+export const authProviders = new Map<string, vscode.AuthenticationProvider>();
 const apiKeyValidators = new Map<string, ApiKeyValidator>();
 const onSaveCallbacks = new Map<string, OnSaveCallback>();
 
@@ -35,7 +36,7 @@ const onSaveCallbacks = new Map<string, OnSaveCallback>();
  */
 export function registerAuthProvider(
 	providerId: string,
-	provider: AuthProvider,
+	provider: vscode.AuthenticationProvider,
 	options?: RegisterAuthProviderOptions
 ): void {
 	authProviders.set(providerId, provider);
@@ -52,13 +53,14 @@ export function registerAuthProvider(
 }
 
 /**
- * Get the auth provider for a given provider ID.
- * Used by the migrateApiKey command.
+ * Get the auth provider for a given provider ID, if it is an AuthProvider
+ * (API-key-based). Used by the migrateApiKey command.
  */
 export function getAuthProvider(
 	providerId: string
 ): AuthProvider | undefined {
-	return authProviders.get(providerId);
+	const provider = authProviders.get(providerId);
+	return provider instanceof AuthProvider ? provider : undefined;
 }
 
 /**
@@ -73,7 +75,7 @@ async function enrichWithCredentialState(
 			return source;
 		}
 		try {
-			const sessions = await provider.getSessions();
+			const sessions = await provider.getSessions([], {});
 			const signedIn = sessions.length > 0;
 			if (signedIn && source.provider.id === 'ms-foundry' && hasManagedCredentials(FOUNDRY_MANAGED_CREDENTIALS)) {
 				return {
@@ -131,48 +133,60 @@ export async function showConfigurationDialog(
 		enrichedSources,
 		async (config, action) => {
 			log.info(`Config dialog action: "${action}" for provider "${config.provider}"`);
-			const hasAuthProvider = authProviders.has(config.provider);
 			// applyConfig is a fallback while we transition providers to the Auth extension.
 			// It should eventually be removed so that the Auth extension is the single source of truth
 			// for all provider config actions.
 			const applyConfig = async () => {
 				await vscode.commands.executeCommand('positron-assistant.applyConfigAction', config, action, enrichedSources);
 			};
+			const provider = authProviders.get(config.provider);
 			switch (action) {
 				case 'save': {
-					if (hasAuthProvider) {
-						const accountId = await handleSave(config);
+					if (provider instanceof AuthProvider) {
+						const accountId = await handleSave(config, provider);
 						addResult({ action, config, accountId });
+					} else if (provider) {
+						addResult({ action, config });
 					} else {
 						await applyConfig();
 					}
 					break;
 				}
 				case 'delete':
-					if (hasAuthProvider) {
-						await handleDelete(config);
+					if (provider instanceof AuthProvider) {
+						await handleDelete(config, provider);
+						addResult({ action, config });
+					} else if (provider) {
 						addResult({ action, config });
 					} else {
 						await applyConfig();
 					}
 					break;
-				case 'oauth-signin':
-					if (hasAuthProvider) {
-						addResult({ action, config });
+				case 'oauth-signin': {
+					if (provider) {
+						await provider.createSession([], {});
+						addResult({ action: 'save', config, accountId: config.provider });
 					} else {
 						await applyConfig();
 					}
 					break;
-				case 'oauth-signout':
-					if (hasAuthProvider) {
-						addResult({ action, config });
+				}
+				case 'oauth-signout': {
+					if (provider) {
+						await provider.removeSession('');
+						addResult({ action: 'delete', config });
 					} else {
 						await applyConfig();
 					}
 					break;
-				case 'cancel':
+				}
+				case 'cancel': {
+					if (provider instanceof PositOAuthProvider) {
+						provider.cancelSignIn();
+					}
 					await applyConfig();
 					break;
+				}
 				default:
 					throw new Error(
 						vscode.l10n.t('Invalid action: {0}', action)
@@ -190,15 +204,9 @@ export async function showConfigurationDialog(
  * config, validates and stores it. Otherwise resolves via createSession.
  */
 async function handleSave(
-	config: positron.ai.LanguageModelConfig
+	config: positron.ai.LanguageModelConfig,
+	provider: AuthProvider
 ): Promise<string> {
-	const provider = authProviders.get(config.provider);
-	if (!provider) {
-		throw new Error(
-			vscode.l10n.t('No auth provider registered for {0}', config.provider)
-		);
-	}
-
 	if (config.apiKey?.trim()) {
 		return handleApiKeySave(config, provider);
 	}
@@ -238,13 +246,9 @@ async function handleApiKeySave(
 }
 
 async function handleDelete(
-	config: positron.ai.LanguageModelConfig
+	config: positron.ai.LanguageModelConfig,
+	provider: AuthProvider
 ): Promise<void> {
-	const provider = authProviders.get(config.provider);
-	if (!provider) {
-		log.warn(`handleDelete: no auth provider for "${config.provider}"`);
-		return;
-	}
 	const sessions = await provider.getSessions();
 	log.info(`Deleting ${sessions.length} session(s) for provider "${config.provider}"`);
 	for (const session of sessions) {

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -159,9 +159,8 @@ export async function showConfigurationDialog(
 					break;
 				case 'oauth-signin': {
 					if (hasAuthProvider) {
-						const provider = authProviders.get(config.provider)!;
-						await provider.createSession([], {});
-						addResult({ action: 'save', config, accountId: config.provider });
+						const accountId = await handleSave(config);
+						addResult({ action: 'save', config, accountId });
 					} else {
 						await applyConfig();
 					}
@@ -169,8 +168,7 @@ export async function showConfigurationDialog(
 				}
 				case 'oauth-signout': {
 					if (hasAuthProvider) {
-						const provider = authProviders.get(config.provider)!;
-						await provider.removeSession('');
+						await handleDelete(config);
 						addResult({ action: 'delete', config });
 					} else {
 						await applyConfig();

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -53,8 +53,8 @@ export function registerAuthProvider(
 }
 
 /**
- * Get the auth provider for a given provider ID, if it is an AuthProvider
- * (API-key-based). Used by the migrateApiKey command.
+ * Get the auth provider for a given provider ID.
+ * Used by the migrateApiKey command.
  */
 export function getAuthProvider(
 	providerId: string

--- a/extensions/authentication/src/configDialog.ts
+++ b/extensions/authentication/src/configDialog.ts
@@ -8,6 +8,7 @@ import * as positron from 'positron';
 import { randomUUID } from 'crypto';
 import { AuthProvider } from './authProvider';
 import { PositOAuthProvider } from './positOAuthProvider';
+import { FOUNDRY_AUTH_PROVIDER_ID } from './constants';
 import { log } from './log';
 import { FOUNDRY_MANAGED_CREDENTIALS, hasManagedCredentials } from './managedCredentials';
 
@@ -76,7 +77,7 @@ async function enrichWithCredentialState(
 		try {
 			const sessions = await provider.getSessions();
 			const signedIn = sessions.length > 0;
-			if (signedIn && source.provider.id === 'ms-foundry' && hasManagedCredentials(FOUNDRY_MANAGED_CREDENTIALS)) {
+			if (signedIn && source.provider.id === FOUNDRY_AUTH_PROVIDER_ID && hasManagedCredentials(FOUNDRY_MANAGED_CREDENTIALS)) {
 				return {
 					...source,
 					signedIn,

--- a/extensions/authentication/src/constants.ts
+++ b/extensions/authentication/src/constants.ts
@@ -12,3 +12,5 @@ export const ANTHROPIC_MODELS_ENDPOINT = 'https://api.anthropic.com/v1/models';
 export const ANTHROPIC_API_VERSION = '2023-06-01';
 export const KEY_VALIDATION_TIMEOUT_MS = 5000;
 export const CREDENTIAL_REFRESH_INTERVAL_MS = 10 * 60 * 1000;
+
+export const POSIT_AUTH_PROVIDER_ID = 'posit-ai';

--- a/extensions/authentication/src/constants.ts
+++ b/extensions/authentication/src/constants.ts
@@ -13,4 +13,7 @@ export const ANTHROPIC_API_VERSION = '2023-06-01';
 export const KEY_VALIDATION_TIMEOUT_MS = 5000;
 export const CREDENTIAL_REFRESH_INTERVAL_MS = 10 * 60 * 1000;
 
+export const ANTHROPIC_AUTH_PROVIDER_ID = 'anthropic-api';
 export const POSIT_AUTH_PROVIDER_ID = 'posit-ai';
+export const AWS_AUTH_PROVIDER_ID = 'amazon-bedrock';
+export const FOUNDRY_AUTH_PROVIDER_ID = 'ms-foundry';

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -6,11 +6,12 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import { POSIT_AUTH_PROVIDER_ID, CREDENTIAL_REFRESH_INTERVAL_MS } from './constants';
 import { AuthProvider } from './authProvider';
 import { registerAuthProvider, showConfigurationDialog } from './configDialog';
 import { normalizeToV1Url, validateAnthropicApiKey, validateFoundryApiKey } from './validation';
 import { FOUNDRY_MANAGED_CREDENTIALS, hasManagedCredentials } from './managedCredentials';
-import { CREDENTIAL_REFRESH_INTERVAL_MS } from './constants';
+import { PositOAuthProvider } from './positOAuthProvider';
 import { log } from './log';
 import { migrateAwsSettings } from './migration/aws';
 import { registerMigrateApiKeyCommand } from './migration/apiKey';
@@ -19,6 +20,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(log);
 
 	registerAnthropicProvider(context);
+	registerPositAIProvider(context);
 	registerFoundryProvider(context);
 
 	// Migrate settings before registering the AWS provider so it
@@ -58,6 +60,18 @@ function registerAnthropicProvider(context: vscode.ExtensionContext): void {
 		validateApiKey: validateAnthropicApiKey,
 	});
 	log.info('Registered auth provider: anthropic-api');
+}
+
+function registerPositAIProvider(context: vscode.ExtensionContext): void {
+	const provider = new PositOAuthProvider(context);
+	context.subscriptions.push(
+		vscode.authentication.registerAuthenticationProvider(
+			POSIT_AUTH_PROVIDER_ID, 'Posit AI', provider
+		),
+		provider
+	);
+	registerAuthProvider(POSIT_AUTH_PROVIDER_ID, provider);
+	log.info(`Registered auth provider: ${POSIT_AUTH_PROVIDER_ID}`);
 }
 
 function registerAwsProvider(

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
-import { POSIT_AUTH_PROVIDER_ID, CREDENTIAL_REFRESH_INTERVAL_MS } from './constants';
+import { ANTHROPIC_AUTH_PROVIDER_ID, AWS_AUTH_PROVIDER_ID, CREDENTIAL_REFRESH_INTERVAL_MS, FOUNDRY_AUTH_PROVIDER_ID, POSIT_AUTH_PROVIDER_ID } from './constants';
 import { AuthProvider } from './authProvider';
 import { registerAuthProvider, showConfigurationDialog } from './configDialog';
 import { normalizeToV1Url, validateAnthropicApiKey, validateFoundryApiKey } from './validation';
@@ -47,19 +47,19 @@ export async function activate(context: vscode.ExtensionContext) {
 
 function registerAnthropicProvider(context: vscode.ExtensionContext): void {
 	const provider = new AuthProvider(
-		'anthropic-api', 'Anthropic', context
+		ANTHROPIC_AUTH_PROVIDER_ID, 'Anthropic', context
 	);
 	context.subscriptions.push(
 		vscode.authentication.registerAuthenticationProvider(
-			'anthropic-api', 'Anthropic', provider,
+			ANTHROPIC_AUTH_PROVIDER_ID, 'Anthropic', provider,
 			{ supportsMultipleAccounts: true }
 		),
 		provider
 	);
-	registerAuthProvider('anthropic-api', provider, {
+	registerAuthProvider(ANTHROPIC_AUTH_PROVIDER_ID, provider, {
 		validateApiKey: validateAnthropicApiKey,
 	});
-	log.info('Registered auth provider: anthropic-api');
+	log.info(`Registered auth provider: ${ANTHROPIC_AUTH_PROVIDER_ID}`);
 }
 
 function registerPositAIProvider(context: vscode.ExtensionContext): void {
@@ -98,7 +98,7 @@ function registerAwsProvider(
 	);
 
 	const provider = new AuthProvider(
-		'amazon-bedrock', 'AWS', context,
+		AWS_AUTH_PROVIDER_ID, 'AWS', context,
 		undefined,
 		{
 			resolve: async () => {
@@ -114,21 +114,21 @@ function registerAwsProvider(
 	);
 	context.subscriptions.push(
 		vscode.authentication.registerAuthenticationProvider(
-			'amazon-bedrock', 'AWS', provider,
+			AWS_AUTH_PROVIDER_ID, 'AWS', provider,
 			{ supportsMultipleAccounts: false }
 		),
 		provider
 	);
-	registerAuthProvider('amazon-bedrock', provider);
+	registerAuthProvider(AWS_AUTH_PROVIDER_ID, provider);
 	provider.resolveChainCredentials().catch(err =>
 		log.debug(`[AWS] Initial credential resolution failed: ${err}`)
 	);
-	log.info('Registered auth provider: amazon-bedrock');
+	log.info(`Registered auth provider: ${AWS_AUTH_PROVIDER_ID}`);
 }
 
 function registerFoundryProvider(context: vscode.ExtensionContext): void {
 	const provider = new AuthProvider(
-		'ms-foundry', 'Microsoft Foundry', context,
+		FOUNDRY_AUTH_PROVIDER_ID, 'Microsoft Foundry', context,
 		{
 			authProviderId: FOUNDRY_MANAGED_CREDENTIALS.authProvider.id,
 			scopes: FOUNDRY_MANAGED_CREDENTIALS.authProvider.scopes,
@@ -137,12 +137,12 @@ function registerFoundryProvider(context: vscode.ExtensionContext): void {
 	);
 	context.subscriptions.push(
 		vscode.authentication.registerAuthenticationProvider(
-			'ms-foundry', 'Microsoft Foundry', provider,
+			FOUNDRY_AUTH_PROVIDER_ID, 'Microsoft Foundry', provider,
 			{ supportsMultipleAccounts: false }
 		),
 		provider
 	);
-	registerAuthProvider('ms-foundry', provider, {
+	registerAuthProvider(FOUNDRY_AUTH_PROVIDER_ID, provider, {
 		validateApiKey: validateFoundryApiKey,
 		onSave: async (config) => {
 			if (config.baseUrl) {
@@ -153,7 +153,7 @@ function registerFoundryProvider(context: vscode.ExtensionContext): void {
 			}
 		},
 	});
-	log.info('Registered auth provider: ms-foundry');
+	log.info(`Registered auth provider: ${FOUNDRY_AUTH_PROVIDER_ID}`);
 
 	// Sync Workbench endpoint to auth extension setting
 	if (hasManagedCredentials(FOUNDRY_MANAGED_CREDENTIALS)) {

--- a/extensions/authentication/src/positOAuthProvider.ts
+++ b/extensions/authentication/src/positOAuthProvider.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { POSIT_AUTH_PROVIDER_ID, CREDENTIAL_REFRESH_INTERVAL_MS } from './constants';
+import { AuthProvider } from './authProvider';
 import { log } from './log';
 
 
@@ -13,18 +14,19 @@ import { log } from './log';
  * Posit AI authentication provider using OAuth 2.0 Device Authorization
  * Grant (RFC 8628).
  *
+ * Extends AuthProvider so the config dialog can treat it uniformly
+ * alongside API-key and credential-chain providers.
+ *
  * Sign-in and sign-out are routed through `createSession`/`removeSession`
  * so the config dialog can use the standard AuthenticationProvider API.
  */
-export class PositOAuthProvider implements vscode.AuthenticationProvider, vscode.Disposable {
-	private readonly _onDidChangeSessions = new vscode.EventEmitter<
-		vscode.AuthenticationProviderAuthenticationSessionsChangeEvent
-	>();
-	readonly onDidChangeSessions = this._onDidChangeSessions.event;
+export class PositOAuthProvider extends AuthProvider {
 
 	private _cancellationToken: vscode.CancellationTokenSource | null = null;
 
-	constructor(private readonly _context: vscode.ExtensionContext) { }
+	constructor(context: vscode.ExtensionContext) {
+		super(POSIT_AUTH_PROVIDER_ID, 'Posit AI', context);
+	}
 
 	private async signIn(): Promise<void> {
 		log.info('[Posit AI] Signing in.');
@@ -96,9 +98,9 @@ export class PositOAuthProvider implements vscode.AuthenticationProvider, vscode
 					const { access_token, refresh_token, expires_in } = tokenData;
 					const expiryTime = Date.now() + expires_in * 1000;
 
-					await this._context.secrets.store('posit-ai.access_token', access_token);
-					await this._context.secrets.store('posit-ai.refresh_token', refresh_token);
-					await this._context.secrets.store('posit-ai.token_expiry', expiryTime.toString());
+					await this.context.secrets.store('posit-ai.access_token', access_token);
+					await this.context.secrets.store('posit-ai.refresh_token', refresh_token);
+					await this.context.secrets.store('posit-ai.token_expiry', expiryTime.toString());
 
 					log.info('[Posit AI] Sign-in successful.');
 					return;
@@ -133,9 +135,9 @@ export class PositOAuthProvider implements vscode.AuthenticationProvider, vscode
 
 	private async signOut(): Promise<void> {
 		log.info('[Posit AI] Signing out.');
-		await this._context.secrets.delete('posit-ai.access_token');
-		await this._context.secrets.delete('posit-ai.refresh_token');
-		await this._context.secrets.delete('posit-ai.token_expiry');
+		await this.context.secrets.delete('posit-ai.access_token');
+		await this.context.secrets.delete('posit-ai.refresh_token');
+		await this.context.secrets.delete('posit-ai.token_expiry');
 	}
 
 	cancelSignIn(): void {
@@ -144,9 +146,12 @@ export class PositOAuthProvider implements vscode.AuthenticationProvider, vscode
 		this._cancellationToken = null;
 	}
 
-	// --- vscode.AuthenticationProvider ---
+	// --- AuthProvider overrides ---
 
-	async getSessions(_scopes?: readonly string[], _options?: vscode.AuthenticationProviderSessionOptions): Promise<vscode.AuthenticationSession[]> {
+	override async getSessions(
+		_scopes?: readonly string[],
+		_options?: vscode.AuthenticationProviderSessionOptions
+	): Promise<vscode.AuthenticationSession[]> {
 		try {
 			const accessToken = await this.getAccessToken();
 			return [{
@@ -160,7 +165,10 @@ export class PositOAuthProvider implements vscode.AuthenticationProvider, vscode
 		}
 	}
 
-	async createSession(_scopes: readonly string[], _options: vscode.AuthenticationProviderSessionOptions): Promise<vscode.AuthenticationSession> {
+	override async createSession(
+		_scopes: readonly string[],
+		_options?: vscode.AuthenticationProviderSessionOptions
+	): Promise<vscode.AuthenticationSession> {
 		await this.signIn();
 
 		const accessToken = await this.getAccessToken();
@@ -172,20 +180,25 @@ export class PositOAuthProvider implements vscode.AuthenticationProvider, vscode
 			scopes: [],
 		};
 
-		this._onDidChangeSessions.fire({
+		this.fireSessionsChanged({
 			added: [session], removed: [], changed: [],
 		});
 
 		return session;
 	}
 
-	async removeSession(_sessionId: string): Promise<void> {
+	override async removeSession(_sessionId: string): Promise<void> {
 		const sessions = await this.getSessions();
 		await this.signOut();
 
-		this._onDidChangeSessions.fire({
+		this.fireSessionsChanged({
 			added: [], removed: sessions, changed: [],
 		});
+	}
+
+	override dispose(): void {
+		this.cancelSignIn();
+		super.dispose();
 	}
 
 	// --- Token management ---
@@ -194,8 +207,8 @@ export class PositOAuthProvider implements vscode.AuthenticationProvider, vscode
 	 * Get the current access token, refreshing if needed.
 	 */
 	async getAccessToken(): Promise<string> {
-		let accessToken = await this._context.secrets.get('posit-ai.access_token');
-		const tokenExpiry = await this._context.secrets.get('posit-ai.token_expiry');
+		let accessToken = await this.context.secrets.get('posit-ai.access_token');
+		const tokenExpiry = await this.context.secrets.get('posit-ai.token_expiry');
 
 		if (!accessToken || !tokenExpiry) {
 			throw new Error('No Posit AI access token found. Please sign in.');
@@ -217,7 +230,7 @@ export class PositOAuthProvider implements vscode.AuthenticationProvider, vscode
 		log.info('[Posit AI] Refreshing access token.');
 		const params = this.getOAuthParameters();
 
-		const refreshToken = await this._context.secrets.get('posit-ai.refresh_token');
+		const refreshToken = await this.context.secrets.get('posit-ai.refresh_token');
 		if (!refreshToken) {
 			log.error('[Posit AI] No refresh token found.');
 			return { success: false };
@@ -253,9 +266,9 @@ export class PositOAuthProvider implements vscode.AuthenticationProvider, vscode
 		const { access_token, refresh_token, expires_in } = tokenData;
 		const expiryTime = Date.now() + expires_in * 1000;
 
-		await this._context.secrets.store('posit-ai.access_token', access_token);
-		await this._context.secrets.store('posit-ai.refresh_token', refresh_token);
-		await this._context.secrets.store('posit-ai.token_expiry', expiryTime.toString());
+		await this.context.secrets.store('posit-ai.access_token', access_token);
+		await this.context.secrets.store('posit-ai.refresh_token', refresh_token);
+		await this.context.secrets.store('posit-ai.token_expiry', expiryTime.toString());
 
 		log.info('[Posit AI] Access token refreshed successfully.');
 		return { success: true, accessToken: access_token };
@@ -271,10 +284,5 @@ export class PositOAuthProvider implements vscode.AuthenticationProvider, vscode
 			?? 'positron';
 
 		return { authHost, scope, clientId };
-	}
-
-	dispose(): void {
-		this.cancelSignIn();
-		this._onDidChangeSessions.dispose();
 	}
 }

--- a/extensions/authentication/src/positOAuthProvider.ts
+++ b/extensions/authentication/src/positOAuthProvider.ts
@@ -1,0 +1,281 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+import { POSIT_AUTH_PROVIDER_ID } from './constants';
+import { log } from './log';
+
+
+/**
+ * Posit AI authentication provider using OAuth 2.0 Device Authorization
+ * Grant (RFC 8628).
+ *
+ * Sign-in and sign-out are routed through `createSession`/`removeSession`
+ * so the config dialog can use the standard AuthenticationProvider API.
+ */
+export class PositOAuthProvider implements vscode.AuthenticationProvider, vscode.Disposable {
+	private readonly _onDidChangeSessions = new vscode.EventEmitter<
+		vscode.AuthenticationProviderAuthenticationSessionsChangeEvent
+	>();
+	readonly onDidChangeSessions = this._onDidChangeSessions.event;
+
+	private _cancellationToken: vscode.CancellationTokenSource | null = null;
+
+	constructor(private readonly _context: vscode.ExtensionContext) { }
+
+	private async signIn(): Promise<void> {
+		log.info('[Posit AI] Signing in.');
+
+		const params = this.getOAuthParameters();
+		const response = await fetch(
+			`${params.authHost}/oauth/device/authorize?scope=${params.scope}&client_id=${params.clientId}`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+			}
+		);
+
+		if (!response.ok) {
+			throw new Error(`Failed to start device authorization: ${response.statusText}`);
+		}
+
+		const data = await response.json() as {
+			verification_uri_complete: string;
+			interval: number;
+			user_code: string;
+			device_code: string;
+		};
+		const { verification_uri_complete, interval, user_code, device_code } = data;
+
+		await vscode.env.clipboard.writeText(user_code);
+		await positron.methods.showDialog(
+			'Posit AI Sign In',
+			`You will need this code to sign in: <code>${user_code}</code>. It has been copied to your clipboard.`,
+		);
+		await vscode.env.openExternal(vscode.Uri.parse(verification_uri_complete));
+
+		const cancellationToken = new vscode.CancellationTokenSource();
+		this._cancellationToken = cancellationToken;
+
+		cancellationToken.token.onCancellationRequested(() => {
+			vscode.window.showInformationMessage(vscode.l10n.t('Posit AI sign-in cancelled.'));
+		});
+
+		try {
+			let currentInterval = Math.max(interval ?? 5, 5);
+			while (true) {
+				if (cancellationToken.token.isCancellationRequested) {
+					throw new vscode.CancellationError();
+				}
+
+				await new Promise(resolve => setTimeout(resolve, currentInterval * 1000));
+
+				const tokenResponse = await fetch(
+					`${params.authHost}/oauth/token`,
+					{
+						method: 'POST',
+						headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+						body: new URLSearchParams({
+							scope: params.scope,
+							client_id: params.clientId,
+							grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+							device_code: device_code
+						}).toString()
+					}
+				);
+
+				if (tokenResponse.status === 200) {
+					const tokenData = await tokenResponse.json() as {
+						access_token: string;
+						refresh_token: string;
+						expires_in: number;
+					};
+					const { access_token, refresh_token, expires_in } = tokenData;
+					const expiryTime = Date.now() + expires_in * 1000;
+
+					await this._context.secrets.store('posit-ai.access_token', access_token);
+					await this._context.secrets.store('posit-ai.refresh_token', refresh_token);
+					await this._context.secrets.store('posit-ai.token_expiry', expiryTime.toString());
+
+					log.info('[Posit AI] Sign-in successful.');
+					return;
+				}
+
+				if (tokenResponse.status === 400) {
+					const errorData = await tokenResponse.json() as { error: string };
+					switch (errorData.error) {
+						case 'authorization_pending':
+							continue;
+						case 'slow_down':
+							currentInterval += 5;
+							continue;
+						case 'expired_token':
+							vscode.window.showErrorMessage(vscode.l10n.t('Your verification code has expired. Please try signing in again.'));
+							throw new Error('Verification code expired.');
+						case 'access_denied':
+							vscode.window.showErrorMessage(vscode.l10n.t('Authorization request was denied.'));
+							throw new Error('Authorization denied.');
+						default:
+							throw new Error(`Unexpected error during token exchange: ${errorData.error}`);
+					}
+				} else {
+					throw new Error(`Unexpected response from token endpoint: ${tokenResponse.statusText}`);
+				}
+			}
+		} finally {
+			cancellationToken.dispose();
+			this._cancellationToken = null;
+		}
+	}
+
+	private async signOut(): Promise<void> {
+		log.info('[Posit AI] Signing out.');
+		await this._context.secrets.delete('posit-ai.access_token');
+		await this._context.secrets.delete('posit-ai.refresh_token');
+		await this._context.secrets.delete('posit-ai.token_expiry');
+	}
+
+	cancelSignIn(): void {
+		this._cancellationToken?.cancel();
+		this._cancellationToken?.dispose();
+		this._cancellationToken = null;
+	}
+
+	// --- vscode.AuthenticationProvider ---
+
+	async getSessions(_scopes?: readonly string[], _options?: vscode.AuthenticationProviderSessionOptions): Promise<vscode.AuthenticationSession[]> {
+		try {
+			const accessToken = await this.getAccessToken();
+			return [{
+				id: POSIT_AUTH_PROVIDER_ID,
+				accessToken,
+				account: { label: 'Posit AI', id: POSIT_AUTH_PROVIDER_ID },
+				scopes: [],
+			}];
+		} catch {
+			return [];
+		}
+	}
+
+	async createSession(_scopes: readonly string[], _options: vscode.AuthenticationProviderSessionOptions): Promise<vscode.AuthenticationSession> {
+		await this.signIn();
+
+		const accessToken = await this.getAccessToken();
+
+		const session: vscode.AuthenticationSession = {
+			id: POSIT_AUTH_PROVIDER_ID,
+			accessToken,
+			account: { label: 'Posit AI', id: POSIT_AUTH_PROVIDER_ID },
+			scopes: [],
+		};
+
+		this._onDidChangeSessions.fire({
+			added: [session], removed: [], changed: [],
+		});
+
+		return session;
+	}
+
+	async removeSession(_sessionId: string): Promise<void> {
+		const sessions = await this.getSessions();
+		await this.signOut();
+
+		this._onDidChangeSessions.fire({
+			added: [], removed: sessions, changed: [],
+		});
+	}
+
+	// --- Token management ---
+
+	/**
+	 * Get the current access token, refreshing if needed.
+	 */
+	async getAccessToken(): Promise<string> {
+		let accessToken = await this._context.secrets.get('posit-ai.access_token');
+		const tokenExpiry = await this._context.secrets.get('posit-ai.token_expiry');
+
+		if (!accessToken || !tokenExpiry) {
+			throw new Error('No Posit AI access token found. Please sign in.');
+		}
+
+		const tenMin = 10 * 60 * 1000;
+		const expiry = parseInt(tokenExpiry) - tenMin;
+		if (Date.now() >= expiry) {
+			const result = await this.refreshAccessToken();
+			if (!result.success) {
+				throw new Error('Failed to refresh Posit AI access token. Please sign in again.');
+			}
+			accessToken = result.accessToken;
+		}
+
+		return accessToken;
+	}
+
+	private async refreshAccessToken(): Promise<{ success: false } | { success: true; accessToken: string }> {
+		log.info('[Posit AI] Refreshing access token.');
+		const params = this.getOAuthParameters();
+
+		const refreshToken = await this._context.secrets.get('posit-ai.refresh_token');
+		if (!refreshToken) {
+			log.error('[Posit AI] No refresh token found.');
+			return { success: false };
+		}
+
+		const response = await fetch(
+			`${params.authHost}/oauth/token`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+				body: new URLSearchParams({
+					scope: params.scope,
+					client_id: params.clientId,
+					grant_type: 'refresh_token',
+					refresh_token: refreshToken
+				}).toString()
+			}
+		);
+
+		if (!response.ok) {
+			const errorData = await response.json().catch(() => ({})) as { error_description?: string };
+			const errorMsg = errorData.error_description || response.statusText;
+			log.error(`[Posit AI] Failed to refresh token: ${errorMsg}`);
+			vscode.window.showErrorMessage(vscode.l10n.t('Failed to refresh Posit AI access token: {0}', errorMsg));
+			return { success: false };
+		}
+
+		const tokenData = await response.json() as {
+			access_token: string;
+			refresh_token: string;
+			expires_in: number;
+		};
+		const { access_token, refresh_token, expires_in } = tokenData;
+		const expiryTime = Date.now() + expires_in * 1000;
+
+		await this._context.secrets.store('posit-ai.access_token', access_token);
+		await this._context.secrets.store('posit-ai.refresh_token', refresh_token);
+		await this._context.secrets.store('posit-ai.token_expiry', expiryTime.toString());
+
+		log.info('[Posit AI] Access token refreshed successfully.');
+		return { success: true, accessToken: access_token };
+	}
+
+	private getOAuthParameters(): { authHost: string; scope: string; clientId: string } {
+		const config = vscode.workspace.getConfiguration('authentication.positai');
+		const authHost = config.inspect<string>('authHost')?.globalValue
+			?? 'https://login.posit.cloud';
+		const scope = config.inspect<string>('scope')?.globalValue
+			?? 'prism';
+		const clientId = config.inspect<string>('clientId')?.globalValue
+			?? 'positron';
+
+		return { authHost, scope, clientId };
+	}
+
+	dispose(): void {
+		this.cancelSignIn();
+		this._onDidChangeSessions.dispose();
+	}
+}

--- a/extensions/authentication/src/positOAuthProvider.ts
+++ b/extensions/authentication/src/positOAuthProvider.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { POSIT_AUTH_PROVIDER_ID } from './constants';
+import { POSIT_AUTH_PROVIDER_ID, CREDENTIAL_REFRESH_INTERVAL_MS } from './constants';
 import { log } from './log';
 
 
@@ -201,8 +201,7 @@ export class PositOAuthProvider implements vscode.AuthenticationProvider, vscode
 			throw new Error('No Posit AI access token found. Please sign in.');
 		}
 
-		const tenMin = 10 * 60 * 1000;
-		const expiry = parseInt(tokenExpiry) - tenMin;
+		const expiry = parseInt(tokenExpiry) - CREDENTIAL_REFRESH_INTERVAL_MS;
 		if (Date.now() >= expiry) {
 			const result = await this.refreshAccessToken();
 			if (!result.success) {

--- a/extensions/authentication/src/test/positOAuthProvider.test.ts
+++ b/extensions/authentication/src/test/positOAuthProvider.test.ts
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { POSIT_AUTH_PROVIDER_ID } from '../constants';
+import { PositOAuthProvider } from '../positOAuthProvider';
+
+function storeValidTokens(secrets: Map<string, string>, overrides?: {
+	accessToken?: string;
+	refreshToken?: string;
+	expiresAt?: number;
+}): void {
+	secrets.set('posit-ai.access_token', overrides?.accessToken ?? 'test-access-token');
+	secrets.set('posit-ai.refresh_token', overrides?.refreshToken ?? 'test-refresh-token');
+	secrets.set('posit-ai.token_expiry', String(overrides?.expiresAt ?? Date.now() + 3600 * 1000));
+}
+
+function makeMockContext(): { context: vscode.ExtensionContext; secrets: Map<string, string> } {
+	const secrets = new Map<string, string>();
+	const globalState = new Map<string, unknown>();
+	const context = {
+		secrets: {
+			get: (key: string) => Promise.resolve(secrets.get(key)),
+			store: (key: string, value: string) => {
+				secrets.set(key, value);
+				return Promise.resolve();
+			},
+			delete: (key: string) => {
+				secrets.delete(key);
+				return Promise.resolve();
+			},
+		},
+		globalState: {
+			get: <T>(key: string) => globalState.get(key) as T | undefined,
+			update: (key: string, value: unknown) => {
+				globalState.set(key, value);
+				return Promise.resolve();
+			},
+		},
+	} as unknown as vscode.ExtensionContext;
+	return { context, secrets };
+}
+
+suite('PositOAuthProvider', () => {
+	let provider: PositOAuthProvider;
+	let secrets: Map<string, string>;
+	let originalFetch: typeof globalThis.fetch;
+
+	setup(() => {
+		originalFetch = globalThis.fetch;
+		const mock = makeMockContext();
+		secrets = mock.secrets;
+		provider = new PositOAuthProvider(mock.context);
+	});
+
+	teardown(() => {
+		provider.dispose();
+		globalThis.fetch = originalFetch;
+	});
+
+	// --- getSessions ---
+
+	suite('getSessions', () => {
+		test('returns session when tokens exist', async () => {
+			storeValidTokens(secrets);
+			const sessions = await provider.getSessions();
+			assert.strictEqual(sessions.length, 1);
+			assert.strictEqual(sessions[0].id, POSIT_AUTH_PROVIDER_ID);
+			assert.strictEqual(sessions[0].accessToken, 'test-access-token');
+			assert.strictEqual(sessions[0].account.id, POSIT_AUTH_PROVIDER_ID);
+		});
+
+		test('returns empty when access token missing', async () => {
+			secrets.set('posit-ai.token_expiry', String(Date.now() + 3600 * 1000));
+			const sessions = await provider.getSessions();
+			assert.strictEqual(sessions.length, 0);
+		});
+
+	});
+
+	// --- removeSession ---
+
+	suite('removeSession', () => {
+		test('clears stored tokens', async () => {
+			storeValidTokens(secrets);
+			await provider.removeSession('');
+			assert.strictEqual(secrets.has('posit-ai.access_token'), false);
+			assert.strictEqual(secrets.has('posit-ai.refresh_token'), false);
+			assert.strictEqual(secrets.has('posit-ai.token_expiry'), false);
+		});
+
+		test('fires onDidChangeSessions with removed session', async () => {
+			storeValidTokens(secrets);
+
+			const eventPromise = new Promise<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>(
+				resolve => {
+					const disposable = provider.onDidChangeSessions(e => {
+						disposable.dispose();
+						resolve(e);
+					});
+				}
+			);
+
+			await provider.removeSession('');
+			const event = await eventPromise;
+
+			assert.strictEqual(event.removed!.length, 1);
+			assert.strictEqual(event.removed![0].id, POSIT_AUTH_PROVIDER_ID);
+			assert.strictEqual(event.added!.length, 0);
+		});
+
+	});
+
+	// --- getAccessToken ---
+
+	suite('getAccessToken', () => {
+		test('returns token when not expired', async () => {
+			storeValidTokens(secrets, {
+				accessToken: 'fresh-token',
+				expiresAt: Date.now() + 30 * 60 * 1000,
+			});
+
+			const token = await provider.getAccessToken();
+			assert.strictEqual(token, 'fresh-token');
+		});
+
+		test('throws when no tokens stored', async () => {
+			await assert.rejects(
+				() => provider.getAccessToken(),
+				(err: Error) => err.message.includes('No Posit AI access token found')
+			);
+		});
+
+		test('refreshes when token is near expiry', async () => {
+			storeValidTokens(secrets, {
+				expiresAt: Date.now() + 5 * 60 * 1000, // 5 min (within 10 min buffer)
+			});
+
+			globalThis.fetch = async () => {
+				return new Response(JSON.stringify({
+					access_token: 'new-token',
+					refresh_token: 'new-refresh',
+					expires_in: 3600,
+				}), { status: 200 });
+			};
+
+			const token = await provider.getAccessToken();
+			assert.strictEqual(token, 'new-token');
+
+			// Verify new tokens were stored
+			assert.strictEqual(secrets.get('posit-ai.access_token'), 'new-token');
+			assert.strictEqual(secrets.get('posit-ai.refresh_token'), 'new-refresh');
+		});
+
+		test('returns failure when refresh fails', async () => {
+			storeValidTokens(secrets, { expiresAt: Date.now() - 1000 });
+
+			globalThis.fetch = async () => {
+				return new Response(
+					JSON.stringify({ error_description: 'bad token' }),
+					{ status: 401 }
+				);
+			};
+
+			await assert.rejects(
+				() => provider.getAccessToken(),
+				(err: Error) => err.message.includes('Failed to refresh')
+			);
+		});
+	});
+
+});

--- a/extensions/authentication/src/test/positOAuthProvider.test.ts
+++ b/extensions/authentication/src/test/positOAuthProvider.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { POSIT_AUTH_PROVIDER_ID } from '../constants';
 import { PositOAuthProvider } from '../positOAuthProvider';
 
 function storeValidTokens(secrets: Map<string, string>, overrides?: {
@@ -60,61 +59,6 @@ suite('PositOAuthProvider', () => {
 		provider.dispose();
 		globalThis.fetch = originalFetch;
 	});
-
-	// --- getSessions ---
-
-	suite('getSessions', () => {
-		test('returns session when tokens exist', async () => {
-			storeValidTokens(secrets);
-			const sessions = await provider.getSessions();
-			assert.strictEqual(sessions.length, 1);
-			assert.strictEqual(sessions[0].id, POSIT_AUTH_PROVIDER_ID);
-			assert.strictEqual(sessions[0].accessToken, 'test-access-token');
-			assert.strictEqual(sessions[0].account.id, POSIT_AUTH_PROVIDER_ID);
-		});
-
-		test('returns empty when access token missing', async () => {
-			secrets.set('posit-ai.token_expiry', String(Date.now() + 3600 * 1000));
-			const sessions = await provider.getSessions();
-			assert.strictEqual(sessions.length, 0);
-		});
-
-	});
-
-	// --- removeSession ---
-
-	suite('removeSession', () => {
-		test('clears stored tokens', async () => {
-			storeValidTokens(secrets);
-			await provider.removeSession('');
-			assert.strictEqual(secrets.has('posit-ai.access_token'), false);
-			assert.strictEqual(secrets.has('posit-ai.refresh_token'), false);
-			assert.strictEqual(secrets.has('posit-ai.token_expiry'), false);
-		});
-
-		test('fires onDidChangeSessions with removed session', async () => {
-			storeValidTokens(secrets);
-
-			const eventPromise = new Promise<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>(
-				resolve => {
-					const disposable = provider.onDidChangeSessions(e => {
-						disposable.dispose();
-						resolve(e);
-					});
-				}
-			);
-
-			await provider.removeSession('');
-			const event = await eventPromise;
-
-			assert.strictEqual(event.removed!.length, 1);
-			assert.strictEqual(event.removed![0].id, POSIT_AUTH_PROVIDER_ID);
-			assert.strictEqual(event.added!.length, 0);
-		});
-
-	});
-
-	// --- getAccessToken ---
 
 	suite('getAccessToken', () => {
 		test('returns token when not expired', async () => {

--- a/extensions/positron-assistant/src/authExtRouting.ts
+++ b/extensions/positron-assistant/src/authExtRouting.ts
@@ -22,6 +22,7 @@ export interface ConfigDialogResult {
 /** Providers whose credentials are managed by the authentication extension. */
 const AUTH_EXT_PROVIDERS = new Set<string>([
 	'anthropic-api',
+	'posit-ai',
 	'amazon-bedrock',
 	'ms-foundry',
 ]);

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -13,7 +13,6 @@ import { clearTokenUsage } from './tokens.js';
 import { disposeModels, getAutoconfiguredModels, registerModel, removeAutoconfiguredModel } from './modelRegistration.js';
 import { CopilotService } from './copilot.js';
 import { PositronAssistantApi } from './api.js';
-import { PositModelProvider } from './providers/posit/positProvider.js';
 import { PROVIDER_ENABLE_SETTINGS_SEARCH } from './constants.js';
 import { StoredModelConfig, ModelConfig } from './configTypes.js';
 import { isAuthExtProvider, resolveApiKey, delegateConfigDialog } from './authExtRouting.js';
@@ -200,15 +199,9 @@ export async function applyConfigAction(
 		case 'delete':
 			await deleteConfigurationByProvider(context, config.provider);
 			break;
-		case 'oauth-signin':
-			await oauthSignin(config, sources, context);
-			break;
-		case 'oauth-signout':
-			await oauthSignout(config, sources, context);
-			break;
 		case 'cancel':
-			// User cancelled the dialog, clean up any pending operations.
-			PositModelProvider.cancelCurrentSignIn();
+			// No-op for auth-extension-managed providers.
+			// Cancellation handled by the auth extension.
 			break;
 		default:
 			throw new Error(vscode.l10n.t('Invalid Language Model action: {0}', action));
@@ -322,63 +315,6 @@ export async function deleteConfigurationByProvider(context: vscode.ExtensionCon
 	for (const config of targetConfigs) {
 		await deleteConfiguration(context, config.id);
 	}
-}
-
-async function oauthSignin(userConfig: positron.ai.LanguageModelConfig, sources: positron.ai.LanguageModelSource[], context: vscode.ExtensionContext) {
-	try {
-		switch (userConfig.provider) {
-			case 'copilot-auth':
-				await CopilotService.instance().signIn();
-				break;
-			case 'posit-ai':
-				await PositModelProvider.signIn(context);
-				break;
-			default:
-				throw new Error(vscode.l10n.t('OAuth sign-in is not supported for provider {0}', userConfig.provider));
-		}
-
-		// Special case: Copilot handles saving its own configuration internally
-		if (userConfig.provider !== 'copilot-auth') {
-			await saveModel(userConfig, sources, context);
-		}
-
-		PositronAssistantApi.get().notifySignIn(userConfig.provider);
-
-	} catch (error) {
-		if (error instanceof vscode.CancellationError) {
-			return;
-		}
-
-		const err = error instanceof Error ? error : new Error(JSON.stringify(error));
-		throw new Error(vscode.l10n.t(`Failed to sign in to provider {0}: {1}`, userConfig.provider, err.message));
-	}
-}
-
-async function oauthSignout(userConfig: positron.ai.LanguageModelConfig, sources: positron.ai.LanguageModelSource[], context: vscode.ExtensionContext) {
-	let oauthCompleted = false;
-	try {
-		switch (userConfig.provider) {
-			case 'copilot-auth':
-				oauthCompleted = await CopilotService.instance().signOut();
-				break;
-			case 'posit-ai':
-				oauthCompleted = await PositModelProvider.signOut(context);
-				break;
-			default:
-				throw new Error(vscode.l10n.t('OAuth sign-out is not supported for provider {0}', userConfig.provider));
-		}
-
-		if (oauthCompleted) {
-			await deleteConfigurationByProvider(context, userConfig.provider);
-		} else {
-			throw new Error(vscode.l10n.t('OAuth sign-out was not completed successfully.'));
-		}
-
-	} catch (error) {
-		const err = error instanceof Error ? error : new Error(JSON.stringify(error));
-		throw new Error(vscode.l10n.t(`Failed to sign out of provider {0}: {1}`, userConfig.provider, err.message));
-	}
-
 }
 
 /**

--- a/extensions/positron-assistant/src/config.ts
+++ b/extensions/positron-assistant/src/config.ts
@@ -199,12 +199,75 @@ export async function applyConfigAction(
 		case 'delete':
 			await deleteConfigurationByProvider(context, config.provider);
 			break;
+		case 'oauth-signin':
+			await oauthSignin(config, sources, context);
+			break;
+		case 'oauth-signout':
+			await oauthSignout(config, sources, context);
+			break;
 		case 'cancel':
 			// No-op for auth-extension-managed providers.
 			// Cancellation handled by the auth extension.
 			break;
 		default:
 			throw new Error(vscode.l10n.t('Invalid Language Model action: {0}', action));
+	}
+}
+
+async function oauthSignin(
+	userConfig: positron.ai.LanguageModelConfig,
+	sources: positron.ai.LanguageModelSource[],
+	context: vscode.ExtensionContext
+) {
+	try {
+		switch (userConfig.provider) {
+			case 'copilot-auth':
+				await CopilotService.instance().signIn();
+				break;
+			default:
+				throw new Error(vscode.l10n.t('OAuth sign-in is not supported for provider {0}', userConfig.provider));
+		}
+
+		if (userConfig.provider !== 'copilot-auth') {
+			await saveModel(userConfig, sources, context);
+		}
+
+		PositronAssistantApi.get().notifySignIn(userConfig.provider);
+
+	} catch (error) {
+		if (error instanceof vscode.CancellationError) {
+			return;
+		}
+
+		const err = error instanceof Error ? error : new Error(JSON.stringify(error));
+		throw new Error(vscode.l10n.t('Failed to sign in to provider {0}: {1}', userConfig.provider, err.message));
+	}
+}
+
+async function oauthSignout(
+	userConfig: positron.ai.LanguageModelConfig,
+	sources: positron.ai.LanguageModelSource[],
+	context: vscode.ExtensionContext
+) {
+	let oauthCompleted = false;
+	try {
+		switch (userConfig.provider) {
+			case 'copilot-auth':
+				oauthCompleted = await CopilotService.instance().signOut();
+				break;
+			default:
+				throw new Error(vscode.l10n.t('OAuth sign-out is not supported for provider {0}', userConfig.provider));
+		}
+
+		if (oauthCompleted) {
+			await deleteConfigurationByProvider(context, userConfig.provider);
+		} else {
+			throw new Error(vscode.l10n.t('OAuth sign-out was not completed successfully.'));
+		}
+
+	} catch (error) {
+		const err = error instanceof Error ? error : new Error(JSON.stringify(error));
+		throw new Error(vscode.l10n.t('Failed to sign out of provider {0}: {1}', userConfig.provider, err.message));
 	}
 }
 

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -27,8 +27,8 @@ import { collectDiagnostics } from './diagnostics.js';
 import { log } from './log.js';
 import { resetAssistantState } from './reset.js';
 import { performSettingsMigrations } from './providerMigration.js';
-import { disposeModels, registerModels, registerModelsForProvider } from './modelRegistration';
-import { registerPositAuthProvider } from './providers/posit/positProvider.js';
+import { addAutoconfiguredModel, disposeModels, getAutoconfiguredModels, registerModelWithAPI, registerModels, registerModelsForProvider } from './modelRegistration';
+import { getModelProviders } from './providers/index.js';
 import { PROVIDER_METADATA } from './providerMetadata.js';
 import { ModelConfig } from './configTypes.js';
 import { isAuthExtProvider } from './authExtRouting.js';
@@ -219,7 +219,7 @@ async function toggleInlineCompletions() {
 	let keyToToggle: string;
 	let currentValue: boolean;
 
-	if (currentLanguageId && (currentLanguageId in currentSettings)) {
+	if (currentLanguageId && Object.prototype.hasOwnProperty.call(currentSettings, currentLanguageId)) {
 		// If current file type has an explicit setting, toggle it
 		keyToToggle = currentLanguageId;
 		currentValue = currentSettings[currentLanguageId];
@@ -276,9 +276,6 @@ async function reconcileAuthProviderModels(
 }
 
 function registerAssistant(context: vscode.ExtensionContext) {
-	// Register Posit AI authentication provider
-	registerPositAuthProvider(context);
-
 	// Register Copilot service
 	registerCopilotService(context);
 

--- a/extensions/positron-assistant/src/providers/posit/positProvider.ts
+++ b/extensions/positron-assistant/src/providers/posit/positProvider.ts
@@ -113,11 +113,6 @@ export class PositModelProvider extends VercelModelProvider {
 	 * Only attaches the token for URLs matching the configured baseUrl.
 	 */
 	private async authFetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
-		const url = typeof input === 'string' ? input : input.url;
-		const baseUrl = this.baseUrl;
-		if (!url.startsWith(baseUrl)) {
-			return fetch(input, init);
-		}
 		const token = await this.getAccessToken();
 		const headers = new Headers(init?.headers);
 		headers.set('Authorization', `Bearer ${token}`);

--- a/extensions/positron-assistant/src/providers/posit/positProvider.ts
+++ b/extensions/positron-assistant/src/providers/posit/positProvider.ts
@@ -23,8 +23,6 @@ import { PROVIDER_METADATA } from '../../providerMetadata.js';
 export const DEFAULT_POSITAI_MODEL_NAME = 'Claude Sonnet 4.5';
 export const DEFAULT_POSITAI_MODEL_MATCH = 'claude-sonnet-4-5';
 
-const POSIT_AUTH_PROVIDER_ID = 'posit-ai';
-
 interface PositModelsResponse {
 	chat: {
 		display_name: string;
@@ -50,9 +48,6 @@ interface PositModelsResponse {
  * - Managed through workspace settings for authHost, scope, clientId, and baseUrl
  */
 export class PositModelProvider extends VercelModelProvider {
-	/** The cancellation token for the current operation. */
-	private static _cancellationToken: vscode.CancellationTokenSource | null = null;
-
 	private _anthropicClient!: Anthropic;
 	private _useNativeSdk!: boolean;
 	public readonly maxOutputTokens = DEFAULT_MAX_TOKEN_OUTPUT;
@@ -69,215 +64,6 @@ export class PositModelProvider extends VercelModelProvider {
 		},
 	};
 
-	private static getOAuthParameters() {
-		const config = vscode.workspace.getConfiguration('positron.assistant.positai');
-		const authHost = config.inspect<string>('authHost')?.globalValue ?? 'https://login.posit.cloud';
-		const scope = config.inspect<string>('scope')?.globalValue ?? 'prism';
-		const clientId = config.inspect<string>('clientId')?.globalValue ?? 'positron';
-		const baseUrl = config.inspect<string>('baseUrl')?.globalValue ?? 'https://gateway.posit.ai';
-
-		if (!authHost || !scope || !clientId || !baseUrl) {
-			throw new Error('OAuth parameters are not configured.');
-		}
-
-		return { authHost, scope, clientId, baseUrl };
-	}
-
-	public static async signIn(context: vscode.ExtensionContext): Promise<void> {
-		log.info('[Posit AI] Signing in.');
-
-		const params = PositModelProvider.getOAuthParameters();
-		const response = await fetch(
-			`${params.authHost}/oauth/device/authorize?scope=${params.scope}&client_id=${params.clientId}`,
-			{
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/x-www-form-urlencoded'
-				}
-			}
-		);
-
-		if (!response.ok) {
-			throw new Error(`Failed to start device authorization: ${response.statusText}`);
-		}
-
-		const data = await response.json();
-		const { verification_uri_complete, interval, user_code, device_code } = data;
-		await vscode.env.clipboard.writeText(user_code);
-		await positron.methods.showDialog(
-			'Posit AI Sign In',
-			`You will need this code to sign in: <code>${user_code}</code>. It has been copied to your clipboard.`,
-		);
-		await vscode.env.openExternal(vscode.Uri.parse(verification_uri_complete));
-
-		const cancellationToken = new vscode.CancellationTokenSource();
-		PositModelProvider._cancellationToken = cancellationToken;
-
-		cancellationToken.token.onCancellationRequested(() => {
-			vscode.window.showInformationMessage(vscode.l10n.t('Posit AI sign-in cancelled.'));
-		});
-
-		try {
-			let currentInterval = interval;
-			while (true) {
-				if (cancellationToken.token.isCancellationRequested) {
-					throw new Error('Posit AI sign-in cancelled.');
-				}
-
-				const tokenResponse = await fetch(
-					`${params.authHost}/oauth/token`,
-					{
-						method: 'POST',
-						headers: {
-							'Content-Type': 'application/x-www-form-urlencoded'
-						},
-						body: new URLSearchParams({
-							scope: params.scope,
-							client_id: params.clientId,
-							grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
-							device_code: device_code
-						}).toString()
-					}
-				);
-
-				if (tokenResponse.status === 200) {
-					const tokenData = await tokenResponse.json();
-					const { access_token, refresh_token, expires_in } = tokenData;
-					log.info('[Posit AI] Sign-in successful.');
-
-					const expiryTime = Date.now() + expires_in * 1000;
-					context.secrets.store('positron.assistant.positai.access_token', access_token);
-					context.secrets.store('positron.assistant.positai.refresh_token', refresh_token);
-					context.secrets.store('positron.assistant.positai.token_expiry', expiryTime.toString());
-					break;
-				}
-
-				if (tokenResponse.status === 400) {
-					const errorData = await tokenResponse.json();
-					switch (errorData.error) {
-						case 'authorization_pending':
-							await new Promise(resolve => setTimeout(resolve, currentInterval * 1000));
-							continue;
-						case 'slow_down':
-							currentInterval += 5;
-							await new Promise(resolve => setTimeout(resolve, currentInterval * 1000));
-							continue;
-						case 'expired_token':
-							vscode.window.showErrorMessage(vscode.l10n.t('Your verification code has expired. Please try signing in again.'));
-							throw new Error('Verification code expired.');
-						case 'access_denied':
-							vscode.window.showErrorMessage(vscode.l10n.t('Authorization request was denied.'));
-							throw new Error('Authorization denied.');
-						default:
-							throw new Error(`Unexpected error during token exchange: ${errorData.error}`);
-					}
-				} else {
-					throw new Error(`Unexpected response from token endpoint: ${tokenResponse.statusText}`);
-				}
-			}
-		} finally {
-			cancellationToken.dispose();
-		}
-
-		return;
-	}
-
-	public static async signOut(context: vscode.ExtensionContext): Promise<boolean> {
-		log.info('[Posit AI] Signing out.');
-
-		try {
-			// Sign-out is considered successful when the model is deleted in the config service
-			context.secrets.delete('positron.assistant.positai.access_token');
-			context.secrets.delete('positron.assistant.positai.refresh_token');
-			context.secrets.delete('positron.assistant.positai.token_expiry');
-			return true;
-		} catch (error) {
-			if (error instanceof Error) {
-				vscode.window.showErrorMessage(vscode.l10n.t('Failed to sign out of Posit AI: {0}', error.message));
-			} else {
-				vscode.window.showErrorMessage(vscode.l10n.t('Failed to sign out of Posit AI.'));
-			}
-			return false;
-		}
-	}
-
-	public static cancelCurrentSignIn(): void {
-		PositModelProvider._cancellationToken?.cancel();
-		PositModelProvider._cancellationToken?.dispose();
-		PositModelProvider._cancellationToken = null;
-	}
-
-	public static async refreshAccessToken(context: vscode.ExtensionContext): Promise<{ success: false } | { success: true; accessToken: string }> {
-		log.info('[Posit AI] Refreshing access token.');
-		const params = PositModelProvider.getOAuthParameters();
-
-		const refreshToken = await context.secrets.get('positron.assistant.positai.refresh_token');
-		if (!refreshToken) {
-			log.error('[Posit AI] No refresh token found.');
-			return { success: false };
-		}
-
-		const response = await fetch(
-			`${params.authHost}/oauth/token`,
-			{
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/x-www-form-urlencoded'
-				},
-				body: new URLSearchParams({
-					scope: params.scope,
-					client_id: params.clientId,
-					grant_type: 'refresh_token',
-					refresh_token: refreshToken
-				}).toString()
-			}
-		);
-
-		if (!response.ok) {
-			const errorData = await response.json();
-			const errorMsg = errorData.error_description || response.statusText;
-			log.error(`[Posit AI] Failed to refresh token: ${errorMsg}`);
-			vscode.window.showErrorMessage(vscode.l10n.t('Failed to refresh Posit AI access token: {0}', errorMsg));
-			return { success: false };
-		}
-
-		const tokenData = await response.json();
-		const { access_token, refresh_token, expires_in } = tokenData;
-		const expiryTime = Date.now() + expires_in * 1000;
-
-		await context.secrets.store('positron.assistant.positai.access_token', access_token);
-		await context.secrets.store('positron.assistant.positai.refresh_token', refresh_token);
-		await context.secrets.store('positron.assistant.positai.token_expiry', expiryTime.toString());
-
-		log.info('[Posit AI] Access token refreshed successfully.');
-		return { success: true, accessToken: access_token };
-	}
-
-	public static async getAccessToken(context: vscode.ExtensionContext): Promise<string> {
-		let accessToken = await context.secrets.get('positron.assistant.positai.access_token');
-		const tokenExpiry = await context.secrets.get('positron.assistant.positai.token_expiry');
-		const now = Date.now();
-
-		log.debug(`[Posit AI] Token expiry at ${tokenExpiry}. Current time is ${now}.`);
-
-		if (!accessToken || !tokenExpiry) {
-			throw new Error('No Posit AI access token found. Please sign in.');
-		}
-
-		const tenMin = 10 * 60 * 1000;
-		const expiry = parseInt(tokenExpiry) - tenMin;
-		if (tokenExpiry && now >= expiry) {
-			log.info('Access token has expired.');
-			const result = await PositModelProvider.refreshAccessToken(context);
-			if (!result.success) {
-				throw new Error('Failed to refresh Posit AI access token. Please sign in again.');
-			}
-			accessToken = result.accessToken;
-		}
-
-		return accessToken;
-	}
-
 	constructor(
 		_config: ModelConfig,
 		_context?: vscode.ExtensionContext,
@@ -285,12 +71,19 @@ export class PositModelProvider extends VercelModelProvider {
 		super(_config, _context);
 	}
 
+	private get baseUrl(): string {
+		return vscode.workspace
+			.getConfiguration('authentication.positai')
+			.inspect<string>('baseUrl')?.globalValue
+			?? 'https://gateway.posit.ai';
+	}
+
 	/**
 	 * Initializes the Posit AI provider with OAuth-authenticated Anthropic client.
 	 * Uses either native Anthropic SDK or Vercel AI SDK based on the useAnthropicSdk preference.
 	 */
 	protected override initializeProvider() {
-		const params = PositModelProvider.getOAuthParameters();
+		const baseUrl = this.baseUrl;
 
 		// Check preference: true (default) = native SDK, false = Vercel SDK
 		this._useNativeSdk = vscode.workspace.getConfiguration('positron.assistant')
@@ -302,14 +95,14 @@ export class PositModelProvider extends VercelModelProvider {
 				authToken: '_', // Actual token is set in authFetch
 				apiKey: '_',   // API key is not used
 				fetch: this.authFetch.bind(this),
-				baseURL: `${params.baseUrl}/anthropic`,
+				baseURL: `${baseUrl}/anthropic`,
 			});
 		} else {
 			// Initialize Vercel AI SDK provider with OAuth fetch
 			// Note: Vercel SDK expects baseURL to include /v1 (default is https://api.anthropic.com/v1)
 			this.aiProvider = createAnthropic({
 				apiKey: '_',   // API key is not used
-				baseURL: `${params.baseUrl}/anthropic/v1`,
+				baseURL: `${baseUrl}/anthropic/v1`,
 				fetch: this.authFetch.bind(this),
 			});
 		}
@@ -317,8 +110,14 @@ export class PositModelProvider extends VercelModelProvider {
 
 	/**
 	 * Custom fetch implementation that adds OAuth Bearer token to requests.
+	 * Only attaches the token for URLs matching the configured baseUrl.
 	 */
 	private async authFetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
+		const url = typeof input === 'string' ? input : input.url;
+		const baseUrl = this.baseUrl;
+		if (!url.startsWith(baseUrl)) {
+			return fetch(input, init);
+		}
 		const token = await this.getAccessToken();
 		const headers = new Headers(init?.headers);
 		headers.set('Authorization', `Bearer ${token}`);
@@ -326,13 +125,19 @@ export class PositModelProvider extends VercelModelProvider {
 	}
 
 	/**
-	 * Gets the current access token, refreshing if necessary.
+	 * Gets a fresh access token via the authentication extension.
 	 */
 	async getAccessToken(): Promise<string> {
 		try {
-			return await PositModelProvider.getAccessToken(this._context!);
+			const session = await vscode.authentication.getSession(
+				'posit-ai', [], { silent: true }
+			);
+			if (!session?.accessToken) {
+				throw new Error('No Posit AI access token found. Please sign in.');
+			}
+			return session.accessToken;
 		} catch (error) {
-			// On refresh failure, also clean up the model configuration
+			// On auth failure, clean up the model configuration
 			deleteConfiguration(this._context, this.providerId);
 			throw error;
 		}
@@ -554,13 +359,13 @@ export class PositModelProvider extends VercelModelProvider {
 
 	protected override async retrieveModelsFromApi(): Promise<vscode.LanguageModelChatInformation[] | undefined> {
 		try {
-			const params = PositModelProvider.getOAuthParameters();
+			const baseUrl = this.baseUrl;
 			const modelListing: vscode.LanguageModelChatInformation[] = [];
 			const knownPositModels = getAllModelDefinitions(this.providerId);
 
 			log.trace(`[${this.providerName}] Fetching models from Posit API...`);
 
-			const response = await this.authFetch(`${params.baseUrl}/models`);
+			const response = await this.authFetch(`${baseUrl}/models`);
 
 			if (!response.ok) {
 				throw new Error(`API returned ${response.status}`);
@@ -611,81 +416,3 @@ function isPositModelsResponse(data: unknown): data is PositModelsResponse {
 	);
 }
 
-/**
- * VS Code Authentication Provider for Posit AI.
- *
- * Allows other extensions to obtain Posit AI credentials via
- * `vscode.authentication.getSession()` without managing their own OAuth flow.
- * Delegates all authentication operations to PositModelProvider.
- */
-export class PositAuthProvider implements vscode.AuthenticationProvider {
-	private _didChangeSessions =
-		new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
-	onDidChangeSessions = this._didChangeSessions.event;
-
-	private readonly _disposable: vscode.Disposable;
-
-	constructor(private readonly _context: vscode.ExtensionContext) {
-		this._disposable = vscode.authentication.registerAuthenticationProvider(
-			POSIT_AUTH_PROVIDER_ID,
-			'Posit AI',
-			this
-		);
-	}
-
-	async getSessions(scopes?: string[]): Promise<vscode.AuthenticationSession[]> {
-		try {
-			const accessToken = await PositModelProvider.getAccessToken(this._context);
-			return [{
-				id: POSIT_AUTH_PROVIDER_ID,
-				accessToken,
-				account: { label: 'Posit AI', id: POSIT_AUTH_PROVIDER_ID },
-				scopes: scopes ?? [],
-			}];
-		} catch {
-			log.trace('[PositAuthProvider] No valid session found.');
-			return [];
-		}
-	}
-
-	async createSession(scopes: string[]): Promise<vscode.AuthenticationSession> {
-		await PositModelProvider.signIn(this._context);
-
-		const accessToken = await PositModelProvider.getAccessToken(this._context);
-		const newSession: vscode.AuthenticationSession = {
-			id: POSIT_AUTH_PROVIDER_ID,
-			accessToken,
-			account: { label: 'Posit AI', id: POSIT_AUTH_PROVIDER_ID },
-			scopes,
-		};
-
-		this._didChangeSessions.fire({
-			added: [newSession],
-			removed: [],
-			changed: [],
-		});
-
-		return newSession;
-	}
-
-	async removeSession(): Promise<void> {
-		const sessions = await this.getSessions();
-		await PositModelProvider.signOut(this._context);
-
-		this._didChangeSessions.fire({
-			added: [],
-			removed: sessions,
-			changed: [],
-		});
-	}
-
-	dispose() {
-		this._didChangeSessions.dispose();
-		this._disposable.dispose();
-	}
-}
-
-// Register Posit AI authentication provider
-export function registerPositAuthProvider(context: vscode.ExtensionContext) {
-	context.subscriptions.push(new PositAuthProvider(context));
-}

--- a/extensions/positron-assistant/src/test/positProvider.test.ts
+++ b/extensions/positron-assistant/src/test/positProvider.test.ts
@@ -43,7 +43,7 @@ suite('PositModelProvider', () => {
 		};
 
 		sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
-			if (section === 'positron.assistant.positai' || section === 'positron.assistant') {
+			if (section === 'authentication.positai' || section === 'positron.assistant') {
 				return mockConfig as any;
 			}
 			return { get: () => undefined } as any;

--- a/product.json
+++ b/product.json
@@ -659,6 +659,10 @@
 			"positron.authentication",
 			"positron.positron-assistant"
 		],
+		"posit-ai": [
+			"positron.authentication",
+			"positron.positron-assistant"
+		],
 		"ms-foundry": [
 			"positron.authentication",
 			"positron.positron-assistant"


### PR DESCRIPTION
Next piece of #12374 


Migrates Posit AI oauth from Positron Assistant to the Authentication extension. The settings changed from `positron.assistant.positai` to `authentication.positai`, but since they have not been formally declared they cannot be migrated. 

### QA Notes
Sign in/Sign out for Posit AI should continue to work without interruption, but model resolution will now happen after the Configure Language Model Provider modal is closed and auth information will be logged to Authentication.

@:assistant

