### PR TITLE
e2e: fix plots flake

### DIFF
--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -21,8 +21,11 @@ test.use({
 test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 	test.describe('Python Plots', () => {
 
-		test.beforeEach(async function ({ hotKeys, sessions }) {
+		test.beforeAll(async function ({ sessions }) {
 			await sessions.start('python');
+		});
+
+		test.beforeEach(async function ({ hotKeys, sessions }) {
 			await hotKeys.stackedLayout();
 		});
 
@@ -374,9 +377,12 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 		tag: [tags.ARK]
 	}, () => {
 
+		test.beforeAll(async function ({ sessions }) {
+			await sessions.start('r');
+		});
+
 		test.beforeEach(async function ({ sessions, hotKeys }) {
 			await hotKeys.stackedLayout();
-			await sessions.start('r');
 		});
 
 		test.afterEach(async function ({ app, hotKeys }) {

--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -22,7 +22,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 	test.describe('Python Plots', () => {
 
 		test.beforeEach(async function ({ hotKeys, sessions }) {
-			await sessions.start('python')
+			await sessions.start('python');
 			await hotKeys.stackedLayout();
 		});
 

--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -21,12 +21,13 @@ test.use({
 test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 	test.describe('Python Plots', () => {
 
-		test.beforeEach(async function ({ sessions, hotKeys }) {
-			await sessions.start('python');
+		test.beforeEach(async function ({ hotKeys, sessions }) {
+			await sessions.start('python')
 			await hotKeys.stackedLayout();
 		});
 
 		test.afterEach(async function ({ app, hotKeys }) {
+			await hotKeys.closeAllEditors();
 			await hotKeys.fullSizeSecondarySidebar();
 			await expect(async () => {
 				await hotKeys.clearPlots();
@@ -180,7 +181,6 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 				// confirming the action was "editor tab" not "new window"
 				const editorGroups = page.locator('.editor-group-container');
 				await expect(editorGroups).toHaveCount(1);
-				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
 			});
 		});
 
@@ -209,7 +209,6 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await test.step('Save plot from editor', async () => {
 				await app.workbench.plots.savePlotFromEditor({ name: 'Python-scatter-editor', format: 'JPEG' });
 				await app.workbench.explorer.verifyExplorerFilesExist(['Python-scatter-editor.jpeg']);
-				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
 			});
 
 		});
@@ -381,6 +380,8 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 		});
 
 		test.afterEach(async function ({ app, hotKeys }) {
+			await hotKeys.closeAllEditors();
+			await hotKeys.fullSizeSecondarySidebar();
 			await expect(async () => {
 				await hotKeys.clearPlots();
 				await app.workbench.plots.waitForNoPlots({ timeout: 3000 });
@@ -423,13 +424,7 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await test.step('Verify plot can be opened in editor', async () => {
 				await app.workbench.plots.openPlotIn('editor');
 				await app.workbench.plots.waitForPlotInEditor();
-				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
 			});
-
-			await expect(async () => {
-				await hotKeys.clearPlots();
-				await app.workbench.plots.waitForNoPlots({ timeout: 3000 });
-			}).toPass({ timeout: 15000 });
 		});
 
 		test('R - Verify opening plot in new window', { tag: [tags.WEB, tags.WIN, tags.PLOTS, tags.CRITICAL] }, async function ({ app }) {
@@ -460,7 +455,6 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await test.step('Save plot from editor as JPEG', async () => {
 				await app.workbench.plots.savePlotFromEditor({ name: 'R-cars', format: 'JPEG' });
 				await app.workbench.explorer.verifyExplorerFilesExist(['R-cars.jpeg']);
-				await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
 			});
 		});
 


### PR DESCRIPTION
## Summary
- Moves editor cleanup (`closeAllEditors`) and plot cleanup to `afterEach` hooks instead of inline within test steps, ensuring consistent state between tests
- Removes redundant inline `closeAllEditors` and `clearPlots` calls that were duplicating cleanup logic
- Fixes flakes caused by leftover editors/plots leaking state between tests

## QA Notes
[Flake history
](https://connect.posit.it/e2e-test-insights/?tab=test_health&branch=main&date=1&preset=currently_flaky&test=Python+-+Verify+opening+plot+in+new+window%7C%7C%7Ctest%2Fe2e%2Ftests%2Fplots%2Fplots.test.ts)
@:plots @:web

🤖 Generated with [Claude Code](https://claude.com/claude-code)