### PR TITLE
Fix focus stealing when exiting edit mode in side-by-side notebooks

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -354,7 +354,7 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 				// (e.g. clicking a cell in a side-by-side notebook). This mirrors
 				// the guard in the onDidBlurEditorWidget handler above.
 				const activeEl = cell.container?.ownerDocument.activeElement;
-				if (activeEl && !instance.currentContainer?.contains(activeEl)) {
+				if (!activeEl || !instance.currentContainer?.contains(activeEl)) {
 					return;
 				}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -374,7 +374,7 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 			}
 		});
 		return () => disposable.dispose();
-	}, [cell, instance.selectionStateMachine]);
+	}, [cell, instance.currentContainer, instance.selectionStateMachine]);
 
 	return { editorPartRef, focusTargetRef };
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -21,7 +21,7 @@ import { FloatingEditorClickMenu } from '../../../../browser/codeeditor.js';
 import { CellEditorOptions } from '../../../notebook/browser/view/cellParts/cellEditorOptions.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { useEnvironment } from '../EnvironmentProvider.js';
-import { addDisposableListener } from '../../../../../base/browser/dom.js';
+import { addDisposableListener, getWindow } from '../../../../../base/browser/dom.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { PositronNotebookCellGeneral } from '../PositronNotebookCells/PositronNotebookCell.js';
 import { useObservedValue } from '../useObservedValue.js';
@@ -354,23 +354,39 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 				// (e.g. clicking a cell in a side-by-side notebook). This mirrors
 				// the guard in the onDidBlurEditorWidget handler above.
 				const activeEl = cell.container?.ownerDocument.activeElement;
-				if (!activeEl || !instance.currentContainer?.contains(activeEl)) {
+				if (activeEl && !instance.currentContainer?.contains(activeEl)) {
 					return;
 				}
 
-				// Only focus the focus trap if the cell has outputs.
-				// When there are no outputs, the focus trap has tabIndex=-1 (not in tab order),
-				// so focusing it would disrupt keyboard navigation. In that case, let
-				// NotebookCellWrapper handle focus by focusing the cell container instead.
-				// Read current outputs value - undefined for markdown cells (no outputs)
-				const currentOutputs = cell.outputs?.get() ?? [];
-				const hasOutputs = currentOutputs.length > 0;
-				if (hasOutputs) {
-					focusTargetRef.current?.focus();
-				} else {
-					// Focus the cell container for cells without outputs
-					cell.container?.focus();
+				const restoreCellFocus = () => {
+					// Only focus the focus trap if the cell has outputs.
+					// When there are no outputs, the focus trap has tabIndex=-1
+					// (not in tab order), so focusing it would disrupt keyboard
+					// navigation. In that case, focus the cell container instead.
+					const currentOutputs = cell.outputs?.get() ?? [];
+					const hasOutputs = currentOutputs.length > 0;
+					if (hasOutputs) {
+						focusTargetRef.current?.focus();
+					} else {
+						cell.container?.focus();
+					}
+				};
+
+				if (!activeEl) {
+					// activeElement is transiently null during blur/focus
+					// handoff. Defer to the next frame so the browser settles
+					// on the actual target before we decide.
+					getWindow(cell.container).requestAnimationFrame(() => {
+						const resolved = cell.container?.ownerDocument.activeElement;
+						if (resolved && !instance.currentContainer?.contains(resolved)) {
+							return;
+						}
+						restoreCellFocus();
+					});
+					return;
 				}
+
+				restoreCellFocus();
 			}
 		});
 		return () => disposable.dispose();

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -350,6 +350,14 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 				lastValue.active === cell &&
 				newValue.type === SelectionState.SingleSelection &&
 				newValue.active === cell) {
+				// Don't steal focus if the user navigated to a different editor
+				// (e.g. clicking a cell in a side-by-side notebook). This mirrors
+				// the guard in the onDidBlurEditorWidget handler above.
+				const activeEl = cell.container?.ownerDocument.activeElement;
+				if (activeEl && !instance.currentContainer?.contains(activeEl)) {
+					return;
+				}
+
 				// Only focus the focus trap if the cell has outputs.
 				// When there are no outputs, the focus trap has tabIndex=-1 (not in tab order),
 				// so focusing it would disrupt keyboard navigation. In that case, let

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -378,6 +378,9 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 					// handoff. Defer to the next frame so the browser settles
 					// on the actual target before we decide.
 					const win = getWindow(cell.container);
+					if (pendingFrame !== undefined) {
+						win.cancelAnimationFrame(pendingFrame);
+					}
 					pendingFrame = win.requestAnimationFrame(() => {
 						pendingFrame = undefined;
 						// Re-check selection state: if the user moved to

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -344,6 +344,7 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 
 	// Watch for exit-editor transitions to return focus to the focus trap
 	React.useEffect(() => {
+		let pendingFrame: number | undefined;
 		const disposable = autorunDelta(instance.selectionStateMachine.state, ({ lastValue, newValue }) => {
 			// Check if we transitioned from editing THIS cell to single selection of THIS cell
 			if (lastValue?.type === SelectionState.EditingSelection &&
@@ -376,7 +377,16 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 					// activeElement is transiently null during blur/focus
 					// handoff. Defer to the next frame so the browser settles
 					// on the actual target before we decide.
-					getWindow(cell.container).requestAnimationFrame(() => {
+					const win = getWindow(cell.container);
+					pendingFrame = win.requestAnimationFrame(() => {
+						pendingFrame = undefined;
+						// Re-check selection state: if the user moved to
+						// another cell during the deferred frame, bail out.
+						const currentState = instance.selectionStateMachine.state.get();
+						if (currentState.type !== SelectionState.SingleSelection ||
+							currentState.active !== cell) {
+							return;
+						}
 						const resolved = cell.container?.ownerDocument.activeElement;
 						if (resolved && !instance.currentContainer?.contains(resolved)) {
 							return;
@@ -389,7 +399,12 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 				restoreCellFocus();
 			}
 		});
-		return () => disposable.dispose();
+		return () => {
+			disposable.dispose();
+			if (pendingFrame !== undefined) {
+				getWindow(cell.container).cancelAnimationFrame(pendingFrame);
+			}
+		};
 	}, [cell, instance.currentContainer, instance.selectionStateMachine]);
 
 	return { editorPartRef, focusTargetRef };

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
@@ -53,6 +53,13 @@ export function CellActionButton({ action, cell, hoverManager, showSeparator }: 
 	const successTimeoutRef = useRef<Timeout | undefined>(undefined);
 
 	const handleActionClick = useCallback(async () => {
+		// Focus this notebook's container so it becomes the active editor.
+		// The Button component calls preventDefault() on mousedown which
+		// prevents the browser from transferring focus to the button.
+		// Without this, commands dispatch against the wrong notebook in
+		// side-by-side scenarios.
+		instance.currentContainer?.focus();
+
 		// Actions assume cell is selected, so ensure this is the case
 		instance.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
@@ -57,8 +57,13 @@ export function CellActionButton({ action, cell, hoverManager, showSeparator }: 
 		// The Button component calls preventDefault() on mousedown which
 		// prevents the browser from transferring focus to the button.
 		// Without this, commands dispatch against the wrong notebook in
-		// side-by-side scenarios.
-		instance.currentContainer?.focus();
+		// side-by-side scenarios. Only move focus when the active element
+		// is outside the container (mouse click); skip for keyboard
+		// activation where focus is already on the button inside it.
+		const container = instance.currentContainer;
+		if (container && !container.contains(container.ownerDocument.activeElement)) {
+			container.focus();
+		}
 
 		// Actions assume cell is selected, so ensure this is the case
 		instance.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
@@ -41,6 +41,15 @@ export function buildMoreActionsMenuItems(
 			label: action.label,
 			icon: ThemeIcon.isThemeIcon(action.item.icon) ? action.item.icon.id : undefined,
 			onWillSelect: () => {
+				// Focus this notebook's container so it becomes the active editor.
+				// The menu popup lives outside the notebook container, so the
+				// active element is never inside it at selection time. Without
+				// this, commands dispatch against the wrong notebook in
+				// side-by-side scenarios.
+				const container = instance.currentContainer;
+				if (container && !container.contains(container.ownerDocument.activeElement)) {
+					container.focus();
+				}
 				// Select cell BEFORE command runs to keep notebook selection in sync
 				instance.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
 			},

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/actionBarMenuItems.ts
@@ -42,14 +42,10 @@ export function buildMoreActionsMenuItems(
 			icon: ThemeIcon.isThemeIcon(action.item.icon) ? action.item.icon.id : undefined,
 			onWillSelect: () => {
 				// Focus this notebook's container so it becomes the active editor.
-				// The menu popup lives outside the notebook container, so the
-				// active element is never inside it at selection time. Without
-				// this, commands dispatch against the wrong notebook in
-				// side-by-side scenarios.
-				const container = instance.currentContainer;
-				if (container && !container.contains(container.ownerDocument.activeElement)) {
-					container.focus();
-				}
+				// The menu popup renders outside the notebook container, so
+				// without this, commands dispatch against the wrong notebook
+				// in side-by-side scenarios.
+				instance.currentContainer?.focus();
 				// Select cell BEFORE command runs to keep notebook selection in sync
 				instance.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
 			},

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellActionButton.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellActionButton.test.tsx
@@ -81,6 +81,7 @@ suite('CellActionButton', () => {
 		selectCellStub = sinon.stub();
 		instance = {
 			hoverManager: undefined,
+			currentContainer: undefined,
 			selectionStateMachine: { selectCell: selectCellStub },
 		} as unknown as IPositronNotebookInstance;
 		cell = { id: 'cell-1' } as unknown as IPositronNotebookCell;

--- a/test/e2e/pages/editors.ts
+++ b/test/e2e/pages/editors.ts
@@ -184,6 +184,24 @@ export class Editors {
 		});
 	}
 
+	/**
+	 * Verify: editor group at `index` has the `active` CSS class.
+	 */
+	async expectEditorGroupActive(index: number, timeout?: number): Promise<void> {
+		await test.step(`Expect editor group ${index} to be active`, async () => {
+			await expect(this.editorGroup(index)).toHaveClass(/\bactive\b/, { timeout });
+		});
+	}
+
+	/**
+	 * Verify: editor group at `index` has the `inactive` CSS class.
+	 */
+	async expectEditorGroupInactive(index: number): Promise<void> {
+		await test.step(`Expect editor group ${index} to be inactive`, async () => {
+			await expect(this.editorGroup(index)).toHaveClass(/\binactive\b/);
+		});
+	}
+
 	async expectActiveEditorIconClassToMatch(iconClass: RegExp): Promise<void> {
 		await test.step(`Expect active editor icon to match: ${iconClass}`, async () => {
 			await expect(this.activeEditor.locator(this.editorIcon)).toHaveClass(iconClass);

--- a/test/e2e/tests/notebooks-positron/notebook-focus-side-by-side.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-side-by-side.test.ts
@@ -10,7 +10,7 @@
  * side-by-side notebooks, especially when a cell in one notebook is in edit mode.
  */
 
-import { expect, tags } from '../_test.setup';
+import { tags } from '../_test.setup';
 import { test } from './_test.setup.js';
 
 test.use({
@@ -55,7 +55,7 @@ test.describe('Notebook Side-by-Side Focus', {
 
 			// Click into code cell in the LEFT notebook to enter edit mode
 			await leftNotebook.cell(0).click();
-			await expect(leftGroup).toHaveClass(/\bactive\b/, { timeout: 5000 });
+			await editors.expectEditorGroupActive(0, 5000);
 
 			// Click the rendered markdown cell in the RIGHT notebook
 			await rightNotebook.cell(1).click();
@@ -64,7 +64,7 @@ test.describe('Notebook Side-by-Side Focus', {
 			// The bug causes focus to snap back to the left notebook due to
 			// the autorunDelta in CellEditorMonacoWidget.tsx stealing focus
 			// when the left notebook's cell exits edit mode.
-			await expect(rightGroup).toHaveClass(/\bactive\b/, { timeout: 5000 });
-			await expect(leftGroup).toHaveClass(/\binactive\b/);
+			await editors.expectEditorGroupActive(1, 5000);
+			await editors.expectEditorGroupInactive(0);
 		});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-focus-side-by-side.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-side-by-side.test.ts
@@ -72,4 +72,57 @@ test.describe('Notebook Side-by-Side Focus', {
 			await editors.expectEditorGroupActive(1, 5000);
 			await editors.expectEditorGroupInactive(0);
 		});
+
+	test('Overflow menu actions target correct notebook in side-by-side layout',
+		async function ({ app, runCommand }) {
+			const { notebooksPositron, editors } = app.workbench;
+
+			// Create first notebook with two code cells
+			await notebooksPositron.newNotebook({ codeCells: 2 });
+			await notebooksPositron.kernel.select('Python');
+			await notebooksPositron.kernel.expectStatusToBe('idle');
+
+			// Create second notebook with two code cells
+			await notebooksPositron.newNotebook({ codeCells: 2 });
+			await notebooksPositron.kernel.select('Python');
+			await notebooksPositron.kernel.expectStatusToBe('idle');
+
+			// Split notebooks side-by-side
+			await runCommand('workbench.action.moveEditorToNextGroup');
+			await editors.expectEditorGroupCount(2);
+
+			const leftGroup = editors.editorGroup(0);
+			const rightGroup = editors.editorGroup(1);
+			const leftNotebook = notebooksPositron.scopedTo(leftGroup);
+			const rightNotebook = notebooksPositron.scopedTo(rightGroup);
+
+			// Click into the LEFT notebook to give it focus
+			await leftNotebook.cell(0).click();
+			await editors.expectEditorGroupActive(0, 5000);
+
+			// Hover over a cell in the RIGHT notebook to reveal the action bar,
+			// then click the "More Cell Actions" overflow button
+			const rightCell = rightNotebook.cell(0);
+			await rightCell.hover();
+			// Use a CSS selector instead of getByRole because the action bar
+			// has aria-hidden=true when the cell is not active. We
+			// intentionally skip clicking the cell first since that would
+			// transfer focus and mask the bug we are testing.
+			const moreActionsButton = rightCell.locator('button[aria-label="More Cell Actions"]');
+			await expect(moreActionsButton).toBeVisible();
+			await moreActionsButton.click();
+
+			// Select "Insert Code Cell Below" from the context menu
+			const insertOption = app.code.driver.page.locator(
+				'button.custom-context-menu-item',
+				{ hasText: 'Insert Code Cell Below' }
+			);
+			await insertOption.click();
+
+			// Verify the right editor group is now active (focus was transferred)
+			// and the insert operated on the RIGHT notebook (cell count increased)
+			await editors.expectEditorGroupActive(1, 5000);
+			await expect(rightNotebook.cells).toHaveCount(3);
+			await expect(leftNotebook.cells).toHaveCount(2);
+		});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-focus-side-by-side.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-side-by-side.test.ts
@@ -10,7 +10,7 @@
  * side-by-side notebooks, especially when a cell in one notebook is in edit mode.
  */
 
-import { tags } from '../_test.setup';
+import { expect, tags } from '../_test.setup';
 import { test } from './_test.setup.js';
 
 test.use({
@@ -56,6 +56,11 @@ test.describe('Notebook Side-by-Side Focus', {
 			// Click into code cell in the LEFT notebook to enter edit mode
 			await leftNotebook.cell(0).click();
 			await editors.expectEditorGroupActive(0, 5000);
+			// Verify the cell actually entered edit mode (Monaco editor focused).
+			// The bug only manifests on the EditingSelection -> SingleSelection
+			// transition, so edit mode is a prerequisite.
+			const leftEditorFocused = leftNotebook.cell(0).locator('.monaco-editor-background .focused');
+			await expect(leftEditorFocused).toHaveCount(1);
 
 			// Click the rendered markdown cell in the RIGHT notebook
 			await rightNotebook.cell(1).click();

--- a/test/e2e/tests/notebooks-positron/notebook-focus-side-by-side.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-side-by-side.test.ts
@@ -73,6 +73,47 @@ test.describe('Notebook Side-by-Side Focus', {
 			await editors.expectEditorGroupInactive(0);
 		});
 
+	test('Cell action button targets correct notebook in side-by-side layout',
+		async function ({ app, runCommand }) {
+			const { notebooksPositron, editors } = app.workbench;
+
+			// Create first notebook with two code cells
+			await notebooksPositron.newNotebook({ codeCells: 2 });
+			await notebooksPositron.kernel.select('Python');
+			await notebooksPositron.kernel.expectStatusToBe('idle');
+
+			// Create second notebook with two code cells
+			await notebooksPositron.newNotebook({ codeCells: 2 });
+			await notebooksPositron.kernel.select('Python');
+			await notebooksPositron.kernel.expectStatusToBe('idle');
+
+			// Split notebooks side-by-side
+			await runCommand('workbench.action.moveEditorToNextGroup');
+			await editors.expectEditorGroupCount(2);
+
+			const leftGroup = editors.editorGroup(0);
+			const rightGroup = editors.editorGroup(1);
+			const leftNotebook = notebooksPositron.scopedTo(leftGroup);
+			const rightNotebook = notebooksPositron.scopedTo(rightGroup);
+
+			// Click into the LEFT notebook to give it focus
+			await leftNotebook.cell(0).click();
+			await editors.expectEditorGroupActive(0, 5000);
+
+			// Hover over a cell in the RIGHT notebook to reveal the action bar,
+			// then click the "Run Cell" button directly (not through overflow menu)
+			const rightCell = rightNotebook.cell(0);
+			await rightCell.hover();
+			const runCellButton = rightCell.locator('button[aria-label="Run Cell"]');
+			await expect(runCellButton).toBeVisible();
+			await runCellButton.click();
+
+			// Verify the right editor group is now active (focus was transferred
+			// by the CellActionButton's focus guard)
+			await editors.expectEditorGroupActive(1, 5000);
+			await editors.expectEditorGroupInactive(0);
+		});
+
 	test('Overflow menu actions target correct notebook in side-by-side layout',
 		async function ({ app, runCommand }) {
 			const { notebooksPositron, editors } = app.workbench;

--- a/test/e2e/tests/notebooks-positron/notebook-focus-side-by-side.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-side-by-side.test.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Notebook Side-by-Side Focus Tests
+ *
+ * Verifies that focus stays in the correct notebook when switching between
+ * side-by-side notebooks, especially when a cell in one notebook is in edit mode.
+ */
+
+import { expect, tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Notebook Side-by-Side Focus', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+}, () => {
+
+	test.beforeAll(async function ({ hotKeys }) {
+		await hotKeys.closePrimarySidebar();
+		await hotKeys.closeSecondarySidebar();
+		await hotKeys.minimizeBottomPanel();
+	});
+
+	test('Focus stays in target notebook when clicking markdown cell while other notebook is in edit mode',
+		async function ({ app, runCommand }) {
+			const { notebooksPositron, editors } = app.workbench;
+
+			// Create first notebook with a code cell and select Python kernel
+			await notebooksPositron.newNotebook();
+			await notebooksPositron.kernel.select('Python');
+			await notebooksPositron.kernel.expectStatusToBe('idle');
+			await notebooksPositron.addCodeToCell(0, 'x = 1');
+
+			// Create second notebook with a code cell and a markdown cell
+			await notebooksPositron.newNotebook({ codeCells: 1, markdownCells: 1 });
+			await notebooksPositron.kernel.select('Python');
+			await notebooksPositron.kernel.expectStatusToBe('idle');
+			// Press Escape to exit markdown edit mode and render the cell
+			await app.code.driver.page.keyboard.press('Escape');
+
+			// Split notebooks side-by-side
+			await runCommand('workbench.action.moveEditorToNextGroup');
+			await editors.expectEditorGroupCount(2);
+
+			const leftGroup = editors.editorGroup(0);
+			const rightGroup = editors.editorGroup(1);
+			const leftNotebook = notebooksPositron.scopedTo(leftGroup);
+			const rightNotebook = notebooksPositron.scopedTo(rightGroup);
+
+			// Click into code cell in the LEFT notebook to enter edit mode
+			await leftNotebook.cell(0).click();
+			await expect(leftGroup).toHaveClass(/\bactive\b/, { timeout: 5000 });
+
+			// Click the rendered markdown cell in the RIGHT notebook
+			await rightNotebook.cell(1).click();
+
+			// Verify the right editor group becomes and STAYS active.
+			// The bug causes focus to snap back to the left notebook due to
+			// the autorunDelta in CellEditorMonacoWidget.tsx stealing focus
+			// when the left notebook's cell exits edit mode.
+			await expect(rightGroup).toHaveClass(/\bactive\b/, { timeout: 5000 });
+			await expect(leftGroup).toHaveClass(/\binactive\b/);
+		});
+});


### PR DESCRIPTION
Addresses #12682.

When two notebooks are open side-by-side and a cell in Notebook A is in edit mode, clicking into Notebook B causes focus to snap back to A. The root cause is the `autorunDelta` in `CellEditorMonacoWidget.tsx` that unconditionally calls `.focus()` on Notebook A's cell when the selection state transitions from `EditingSelection` to `SingleSelection`.

https://github.com/user-attachments/assets/10f0c2ee-fce3-4b2f-93fe-f06f4329c0c8


This PR adds focus guards at three points:

1. **Exit-editor focus restore** (`CellEditorMonacoWidget.tsx`): Before restoring focus to a cell's focus trap or container, check whether the active element is already inside a *different* notebook's container. If so, bail out instead of stealing focus. Also handles the transient `null` `activeElement` case (during blur/focus handoff) by deferring the check to the next animation frame.

2. **Cell action buttons** (`CellActionButton.tsx`): Focus the notebook container before dispatching commands so they target the correct notebook when clicking a button in the non-focused side.

3. **Overflow menu actions** (`actionBarMenuItems.ts`): Same container-focus guard for context menu items, which render outside the notebook container.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed side-by-side notebooks stealing focus when exiting edit mode in one notebook while clicking into another (#12682)

### QA Notes

@:positron-notebooks @:win @:web

1. Open two `.ipynb` notebooks side-by-side, both with Python kernels
2. Click into a code cell in the left notebook (enter edit mode -- cursor should be blinking)
3. Click a **markdown cell** in the right notebook
4. Verify the right notebook stays focused (interpreter picker shows its session, editor group stays active)

Also verify cell action buttons in the non-focused notebook:
5. With focus in the left notebook, hover a cell in the right notebook
6. Click "Run Cell" -- verify the command executes in the right notebook
7. Repeat with the overflow menu ("More Cell Actions" > "Insert Code Cell Below") -- verify the cell is inserted in the right notebook, not the left