### PR TITLE
python LS: fix threading bug when starting a new LSP server

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_lsp.py
@@ -584,12 +584,13 @@ class PositronLanguageServer(LanguageServer):
         self.protocol._shutdown = False  # noqa: SLF001
 
         # Stop any existing server thread
-        if self._server_thread is not None and self._server_thread.is_alive():
+        existing_thread = self._server_thread
+        if existing_thread is not None and existing_thread.is_alive():
             logger.warning("LSP server thread already exists, shutting it down")
             if self._stop_event:
                 self._stop_event.set()
-                self._server_thread.join(timeout=5)
-                if self._server_thread.is_alive():
+                existing_thread.join(timeout=5)
+                if existing_thread.is_alive():
                     logger.warning("LSP server thread did not exit after 5s, dropping it")
 
         # Start the server in a new thread


### PR DESCRIPTION
Addresses #12694.

When starting the LSP server, we check for existing threads and shut them down. There was a race condition where
- we'd shut down the old thread (and if successful, set its reference to `None`)
- wait for 5 seconds
- check if it was still alive

But by then, the reference to the thread had been updated to `None` since it was shut down, and we'd get a false positive traceback printed to the Console.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed rare `'NoneType' object has no attribute 'is_alive'` bug in Python consoles #12694


### QA Notes

Try restarting the extension host and/or switching between sessions.