### PR TITLE
e2e: wait for console readiness before creating new folder after uninstalling renv

### DIFF
--- a/test/e2e/tests/new-folder-flow/new-folder-flow-r.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-r.test.ts
@@ -58,6 +58,7 @@ test.describe('New Folder Flow: R Project', { tag: [tags.MODAL, tags.NEW_FOLDER_
 		const folderName = addRandomNumSuffix('r-cancelRenvInstall');
 
 		await packages.manage('renv', 'uninstall');
+		await app.workbench.console.waitForReady('>', 30000);
 		await createNewFolder(app, {
 			folderTemplate,
 			folderName,


### PR DESCRIPTION
Fixes a intermittent flake where a race condition can happen deleting the renv 


- Adds an explicit waitForReady call after packages.manage('renv', 'uninstall') in the "R - Cancel Renv install" e2e  test to ensure the R session is idle before opening the New Folder dialog
 - Mitigates a race condition where executeCode could return before R finishes processing remove.packages("renv"), causing r.getMinimumRVersion (called during dialog init) to hang on a busy R session


### QA Notes
@:new-folder-flow @:win @:web
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
