### PR TITLE
Assistant: Fix Copilot tools failing with relative paths in Positron Assistant

### DIFF
--- a/extensions/positron-assistant/src/participants.ts
+++ b/extensions/positron-assistant/src/participants.ts
@@ -23,6 +23,7 @@ import { getEnabledTools, getPositronContextPrompts } from './api.js';
 import { isFileExcludedFromAI } from './fileExclusion.js';
 import { PromptRenderer } from './promptRender.js';
 import { getAttachedNotebookContext, serializeNotebookContextAsUserMessage } from './tools/notebookUtils.js';
+import { resolveToolInputPaths } from './pathUtils.js';
 
 export enum ParticipantID {
 	/** The participant used in the chat pane in Ask mode. */
@@ -695,6 +696,14 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 
 				log.debug(`[tool] Invoking tool ${req.name} with input: ${JSON.stringify(req.input, null, 2)}`);
 
+				// --- Start Positron ---
+				// Resolve relative paths in Copilot tool inputs to absolute paths
+				// Copilot tools expect absolute paths because they're designed to receive
+				// resolved input from Copilot's internal resolveInput() mechanism.
+				// When invoked from Positron Assistant, we need to handle this resolution ourselves.
+				const resolvedInput = resolveToolInputPaths(req.name, req.input);
+				// --- End Positron ---
+
 				// VS Code Core tools always throw errors, while many extension
 				// tools just return error messages as normal tool results.
 				// Capture errors and pass along to the model to react to
@@ -702,7 +711,7 @@ abstract class PositronAssistantParticipant implements IPositronAssistantPartici
 				let result: vscode.LanguageModelToolResult;
 				try {
 					result = await vscode.lm.invokeTool(req.name, {
-						input: req.input,
+						input: resolvedInput,
 						toolInvocationToken: request.toolInvocationToken,
 						model: request.model,
 						chatRequestId: request.id,

--- a/extensions/positron-assistant/src/pathUtils.ts
+++ b/extensions/positron-assistant/src/pathUtils.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+/**
+ * Determines if a path string is relative (not absolute).
+ * A path is considered absolute if it:
+ * - Starts with '/' (POSIX)
+ * - Starts with a drive letter like 'C:\' (Windows)
+ * - Is a URI scheme like 'file://' or 'vscode://'
+ */
+export function isRelativePath(pathString: string): boolean {
+	// Handle empty or whitespace-only paths
+	if (!pathString || pathString.trim() === '') {
+		return false;
+	}
+
+	// Check for URI schemes (file://, vscode://, etc.)
+	if (/^[a-z][a-z0-9+.-]*:/i.test(pathString)) {
+		return false;
+	}
+
+	// Check for absolute POSIX paths
+	if (pathString.startsWith('/')) {
+		return false;
+	}
+
+	// Check for Windows absolute paths (C:\, D:\, etc.)
+	if (/^[a-zA-Z]:[\\\/]/.test(pathString)) {
+		return false;
+	}
+
+	// If none of the above, it's relative
+	return true;
+}
+
+/**
+ * Resolves a relative path against the workspace root folder.
+ * Returns the absolute path if already absolute, or undefined if no workspace is open.
+ */
+export function resolvePathAgainstWorkspace(pathString: string): string | undefined {
+	// If already absolute or a URI, return as-is
+	if (!isRelativePath(pathString)) {
+		return pathString;
+	}
+
+	// Get workspace folders
+	const workspaceFolders = vscode.workspace.workspaceFolders;
+	if (!workspaceFolders || workspaceFolders.length === 0) {
+		// No workspace open - return undefined to let tool handle gracefully
+		return undefined;
+	}
+
+	// Use the first workspace folder for resolution
+	// In multi-root workspaces, this is a reasonable default
+	const workspaceRoot = workspaceFolders[0].uri.fsPath;
+
+	// Normalize path separators and resolve relative components (., ..)
+	const resolvedPath = path.resolve(workspaceRoot, pathString);
+
+	return resolvedPath;
+}
+
+// Prefixes used in the copilot_applyPatch input string to denote file operations.
+// These must match the constants in positron-copilot-chat's parseApplyPatch.ts.
+const APPLY_PATCH_PATH_PREFIXES = [
+	'*** Add File: ',
+	'*** Delete File: ',
+	'*** Update File: ',
+	'*** Move to: ',
+];
+
+/**
+ * Resolves relative paths embedded in a copilot_applyPatch input string.
+ * Paths appear on lines like "*** Add File: test.R" and must be absolute for
+ * the patch tool to locate them via IPromptPathRepresentationService.
+ */
+export function resolveApplyPatchPaths(patchInput: string): string {
+	return patchInput.split('\n').map(line => {
+		for (const prefix of APPLY_PATCH_PATH_PREFIXES) {
+			if (line.startsWith(prefix)) {
+				const filePath = line.slice(prefix.length);
+				const resolved = resolvePathAgainstWorkspace(filePath);
+				return resolved ? prefix + resolved : line;
+			}
+		}
+		return line;
+	}).join('\n');
+}
+
+/**
+ * Resolves paths in Copilot tool input objects.
+ * Only processes copilot_* tools to avoid interfering with non-Copilot tools.
+ *
+ * Handles:
+ * - copilot_createFile: { filePath: string, content?: string }
+ * - copilot_readFile: { filePath: string, offset?: number, limit?: number }
+ * - copilot_applyPatch: { input: string, explanation: string }
+ *   (paths are embedded in the input string and resolved line-by-line)
+ */
+export function resolveToolInputPaths(toolName: string, input: any): any {
+	// Only process Copilot tools
+	if (!toolName.startsWith('copilot_')) {
+		return input;
+	}
+
+	// Handle copilot_createFile and copilot_readFile
+	if ((toolName === 'copilot_createFile' || toolName === 'copilot_readFile') && input?.filePath) {
+		const resolvedPath = resolvePathAgainstWorkspace(input.filePath);
+		if (resolvedPath) {
+			return { ...input, filePath: resolvedPath };
+		}
+		// If resolution failed (no workspace), return original input
+		// The tool will fail with a more specific error message
+		return input;
+	}
+
+	// copilot_applyPatch embeds paths inside the patch string itself.
+	// Resolve any relative paths found on file operation lines.
+	if (toolName === 'copilot_applyPatch' && typeof input?.input === 'string') {
+		return { ...input, input: resolveApplyPatchPaths(input.input) };
+	}
+
+	// For any other copilot_* tools, return input unchanged
+	return input;
+}

--- a/extensions/positron-assistant/src/test/participants.test.ts
+++ b/extensions/positron-assistant/src/test/participants.test.ts
@@ -503,3 +503,158 @@ suite('PositronAssistantPromptRenderer', () => {
 		assert.ok(content.includes(`When writing R code you generally follow tidyverse coding style and principles.`));
 	});
 });
+
+suite('Tool Invocation Path Resolution', () => {
+	let sandbox: sinon.SinonSandbox;
+	let invokeToolStub: sinon.SinonStub;
+
+	setup(() => {
+		sandbox = sinon.createSandbox();
+		// Stub vscode.lm.invokeTool to capture the input passed to it
+		invokeToolStub = sandbox.stub(vscode.lm, 'invokeTool');
+		invokeToolStub.resolves(new vscode.LanguageModelToolResult([
+			new vscode.LanguageModelTextPart('Tool result')
+		]));
+
+		// PromptRenderer is a singleton that must be initialized before requestHandler runs
+		const extensionContext = mock<vscode.ExtensionContext>({});
+		new PromptRenderer(extensionContext);
+
+		// Stub getPositronChatContext (required by requestHandler)
+		sandbox.stub(positron.ai, 'getPositronChatContext').resolves({});
+	});
+
+	teardown(() => {
+		sandbox.restore();
+	});
+
+	test('resolves relative paths in copilot_createFile tool calls', async () => {
+		const workspaceUri = vscode.Uri.file('/workspace/root');
+		sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+			{ uri: workspaceUri, name: 'test', index: 0 }
+		]);
+
+		const chatParticipant = new PositronAssistantChatParticipant(
+			mock<vscode.ExtensionContext>({}),
+			new ParticipantService()
+		);
+
+		const model = new TestLanguageModelChat();
+		const emptyResponse = {
+			stream: { [Symbol.asyncIterator]: async function* () { } },
+			text: { [Symbol.asyncIterator]: async function* () { } },
+		} as vscode.LanguageModelChatResponse;
+		// First call returns a tool call; subsequent calls return empty (prevents infinite loop)
+		const sendRequestStub = sandbox.stub(model, 'sendRequest');
+		sendRequestStub.onFirstCall().resolves({
+			stream: {
+				[Symbol.asyncIterator]: async function* () {
+					yield new vscode.LanguageModelToolCallPart('call-1', 'copilot_createFile', {
+						filePath: 'test.R',
+						content: 'print("hello")'
+					});
+				}
+			},
+			text: { [Symbol.asyncIterator]: async function* () { } },
+		} as vscode.LanguageModelChatResponse);
+		sendRequestStub.resolves(emptyResponse);
+
+		const request = makeChatRequest({ model, references: [] });
+		const response = new TestChatResponseStream();
+		const token = new vscode.CancellationTokenSource().token;
+
+		await chatParticipant.requestHandler(request, { history: [] }, response, token);
+
+		// Verify invokeTool was called with resolved path
+		assert.ok(invokeToolStub.calledOnce, 'invokeTool should be called once');
+		const [toolName, options] = invokeToolStub.firstCall.args;
+		assert.strictEqual(toolName, 'copilot_createFile');
+		assert.ok(options.input.filePath.endsWith('test.R'), `Expected resolved path, got: ${options.input.filePath}`);
+		assert.ok(!options.input.filePath.startsWith('test.R'), 'Path should be absolute, not relative');
+	});
+
+	test('does not modify absolute paths in copilot tool calls', async () => {
+		const workspaceUri = vscode.Uri.file('/workspace/root');
+		sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+			{ uri: workspaceUri, name: 'test', index: 0 }
+		]);
+
+		const chatParticipant = new PositronAssistantChatParticipant(
+			mock<vscode.ExtensionContext>({}),
+			new ParticipantService()
+		);
+
+		const model = new TestLanguageModelChat();
+		const absolutePath = '/absolute/path/test.R';
+		const emptyResponse = {
+			stream: { [Symbol.asyncIterator]: async function* () { } },
+			text: { [Symbol.asyncIterator]: async function* () { } },
+		} as vscode.LanguageModelChatResponse;
+		const sendRequestStub = sandbox.stub(model, 'sendRequest');
+		sendRequestStub.onFirstCall().resolves({
+			stream: {
+				[Symbol.asyncIterator]: async function* () {
+					yield new vscode.LanguageModelToolCallPart('call-1', 'copilot_readFile', {
+						filePath: absolutePath
+					});
+				}
+			},
+			text: { [Symbol.asyncIterator]: async function* () { } },
+		} as vscode.LanguageModelChatResponse);
+		sendRequestStub.resolves(emptyResponse);
+
+		const request = makeChatRequest({ model, references: [] });
+		const response = new TestChatResponseStream();
+		const token = new vscode.CancellationTokenSource().token;
+
+		await chatParticipant.requestHandler(request, { history: [] }, response, token);
+
+		// Verify invokeTool was called with unchanged absolute path
+		assert.ok(invokeToolStub.calledOnce, 'invokeTool should be called once');
+		const [toolName, options] = invokeToolStub.firstCall.args;
+		assert.strictEqual(toolName, 'copilot_readFile');
+		assert.strictEqual(options.input.filePath, absolutePath);
+	});
+
+	test('does not modify non-Copilot tool calls', async () => {
+		const workspaceUri = vscode.Uri.file('/workspace/root');
+		sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+			{ uri: workspaceUri, name: 'test', index: 0 }
+		]);
+
+		const chatParticipant = new PositronAssistantChatParticipant(
+			mock<vscode.ExtensionContext>({}),
+			new ParticipantService()
+		);
+
+		const model = new TestLanguageModelChat();
+		const emptyResponse = {
+			stream: { [Symbol.asyncIterator]: async function* () { } },
+			text: { [Symbol.asyncIterator]: async function* () { } },
+		} as vscode.LanguageModelChatResponse;
+		const sendRequestStub = sandbox.stub(model, 'sendRequest');
+		sendRequestStub.onFirstCall().resolves({
+			stream: {
+				[Symbol.asyncIterator]: async function* () {
+					yield new vscode.LanguageModelToolCallPart('call-1', 'some_other_tool', {
+						filePath: 'test.R'
+					});
+				}
+			},
+			text: { [Symbol.asyncIterator]: async function* () { } },
+		} as vscode.LanguageModelChatResponse);
+		sendRequestStub.resolves(emptyResponse);
+
+		const request = makeChatRequest({ model, references: [] });
+		const response = new TestChatResponseStream();
+		const token = new vscode.CancellationTokenSource().token;
+
+		await chatParticipant.requestHandler(request, { history: [] }, response, token);
+
+		// Verify invokeTool was called with unchanged input
+		assert.ok(invokeToolStub.calledOnce, 'invokeTool should be called once');
+		const [toolName, options] = invokeToolStub.firstCall.args;
+		assert.strictEqual(toolName, 'some_other_tool');
+		assert.strictEqual(options.input.filePath, 'test.R');
+	});
+});

--- a/extensions/positron-assistant/src/test/pathUtils.test.ts
+++ b/extensions/positron-assistant/src/test/pathUtils.test.ts
@@ -1,0 +1,316 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { isRelativePath, resolvePathAgainstWorkspace, resolveApplyPatchPaths, resolveToolInputPaths } from '../pathUtils';
+
+suite('Path Utils', () => {
+	let sandbox: sinon.SinonSandbox;
+
+	setup(() => {
+		sandbox = sinon.createSandbox();
+	});
+
+	teardown(() => {
+		sandbox.restore();
+	});
+
+	suite('isRelativePath', () => {
+		test('identifies relative paths', () => {
+			assert.strictEqual(isRelativePath('test.R'), true);
+			assert.strictEqual(isRelativePath('src/file.py'), true);
+			assert.strictEqual(isRelativePath('./file.js'), true);
+			assert.strictEqual(isRelativePath('../data/file.csv'), true);
+			assert.strictEqual(isRelativePath('folder/subfolder/file.txt'), true);
+		});
+
+		test('identifies absolute POSIX paths', () => {
+			assert.strictEqual(isRelativePath('/Users/foo/test.R'), false);
+			assert.strictEqual(isRelativePath('/home/user/file.py'), false);
+			assert.strictEqual(isRelativePath('/absolute/path'), false);
+		});
+
+		test('identifies absolute Windows paths', () => {
+			assert.strictEqual(isRelativePath('C:\\Users\\foo\\test.R'), false);
+			assert.strictEqual(isRelativePath('D:\\data\\file.csv'), false);
+			assert.strictEqual(isRelativePath('c:/Users/foo/test.R'), false); // Mixed separators
+		});
+
+		test('identifies URI schemes', () => {
+			assert.strictEqual(isRelativePath('file:///path/to/file'), false);
+			assert.strictEqual(isRelativePath('vscode://file/path'), false);
+			assert.strictEqual(isRelativePath('http://example.com'), false);
+			assert.strictEqual(isRelativePath('https://example.com/file'), false);
+		});
+
+		test('handles edge cases', () => {
+			assert.strictEqual(isRelativePath(''), false);
+			assert.strictEqual(isRelativePath('   '), false);
+		});
+	});
+
+	suite('resolvePathAgainstWorkspace', () => {
+		test('returns absolute paths unchanged', () => {
+			const absolutePath = '/Users/foo/test.R';
+			assert.strictEqual(resolvePathAgainstWorkspace(absolutePath), absolutePath);
+		});
+
+		test('returns Windows absolute paths unchanged', () => {
+			const windowsPath = 'C:\\Users\\foo\\test.R';
+			assert.strictEqual(resolvePathAgainstWorkspace(windowsPath), windowsPath);
+		});
+
+		test('returns URIs unchanged', () => {
+			const uri = 'file:///Users/foo/test.R';
+			assert.strictEqual(resolvePathAgainstWorkspace(uri), uri);
+		});
+
+		test('resolves relative path against workspace root', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const result = resolvePathAgainstWorkspace('test.R');
+			const expected = path.join('/workspace/root', 'test.R');
+			assert.strictEqual(result, expected);
+		});
+
+		test('resolves nested relative paths', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const result = resolvePathAgainstWorkspace('src/utils/helper.ts');
+			const expected = path.join('/workspace/root', 'src/utils/helper.ts');
+			assert.strictEqual(result, expected);
+		});
+
+		test('resolves paths with ./ prefix', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const result = resolvePathAgainstWorkspace('./test.R');
+			const expected = path.join('/workspace/root', 'test.R');
+			assert.strictEqual(result, expected);
+		});
+
+		test('resolves paths with ../ prefix', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const result = resolvePathAgainstWorkspace('../test.R');
+			const expected = path.resolve('/workspace/root', '../test.R');
+			assert.strictEqual(result, expected);
+		});
+
+		test('returns undefined when no workspace is open', () => {
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value(undefined);
+			assert.strictEqual(resolvePathAgainstWorkspace('test.R'), undefined);
+		});
+
+		test('returns undefined when workspace folders array is empty', () => {
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([]);
+			assert.strictEqual(resolvePathAgainstWorkspace('test.R'), undefined);
+		});
+
+		test('uses first workspace folder in multi-root workspace', () => {
+			const workspaceUri1 = vscode.Uri.file('/workspace/root1');
+			const workspaceUri2 = vscode.Uri.file('/workspace/root2');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri1, name: 'test1', index: 0 },
+				{ uri: workspaceUri2, name: 'test2', index: 1 }
+			]);
+
+			const result = resolvePathAgainstWorkspace('test.R');
+			const expected = path.join('/workspace/root1', 'test.R');
+			assert.strictEqual(result, expected);
+		});
+	});
+
+	suite('resolveApplyPatchPaths', () => {
+		test('resolves relative paths on Add File lines', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const patch = '*** Begin Patch\n*** Add File: test.R\n+content\n*** End Patch';
+			const result = resolveApplyPatchPaths(patch);
+
+			const expected = path.join('/workspace/root', 'test.R');
+			assert.ok(result.includes(`*** Add File: ${expected}`), `Got: ${result}`);
+		});
+
+		test('resolves relative paths on Update File lines', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const patch = '*** Begin Patch\n*** Update File: src/app.ts\n@@ fn\n-old\n+new\n*** End Patch';
+			const result = resolveApplyPatchPaths(patch);
+
+			const expected = path.join('/workspace/root', 'src/app.ts');
+			assert.ok(result.includes(`*** Update File: ${expected}`), `Got: ${result}`);
+		});
+
+		test('resolves relative paths on Delete File and Move to lines', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const patch = '*** Begin Patch\n*** Delete File: old.R\n*** Move to: new.R\n*** End Patch';
+			const result = resolveApplyPatchPaths(patch);
+
+			const expectedDelete = path.join('/workspace/root', 'old.R');
+			const expectedMove = path.join('/workspace/root', 'new.R');
+			assert.ok(result.includes(`*** Delete File: ${expectedDelete}`), `Got: ${result}`);
+			assert.ok(result.includes(`*** Move to: ${expectedMove}`), `Got: ${result}`);
+		});
+
+		test('preserves absolute paths unchanged', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const patch = '*** Begin Patch\n*** Add File: /absolute/path/test.R\n+content\n*** End Patch';
+			const result = resolveApplyPatchPaths(patch);
+
+			assert.ok(result.includes('*** Add File: /absolute/path/test.R'), `Got: ${result}`);
+		});
+
+		test('leaves non-path lines unchanged', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const patch = '*** Begin Patch\n*** Add File: test.R\n+content line\n-removed line\n*** End Patch';
+			const result = resolveApplyPatchPaths(patch);
+
+			assert.ok(result.includes('+content line'), `Got: ${result}`);
+			assert.ok(result.includes('-removed line'), `Got: ${result}`);
+		});
+	});
+
+	suite('resolveToolInputPaths', () => {
+		test('does not modify non-Copilot tools', () => {
+			const input = { filePath: 'test.R' };
+			const result = resolveToolInputPaths('some_other_tool', input);
+			assert.strictEqual(result, input);
+			assert.strictEqual(result.filePath, 'test.R');
+		});
+
+		test('resolves copilot_createFile paths', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const input = { filePath: 'test.R', content: 'print("hello")' };
+			const result = resolveToolInputPaths('copilot_createFile', input);
+
+			const expected = path.join('/workspace/root', 'test.R');
+			assert.strictEqual(result.filePath, expected);
+			assert.strictEqual(result.content, 'print("hello")');
+		});
+
+		test('resolves copilot_readFile paths', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const input = { filePath: 'src/utils.ts', offset: 10, limit: 100 };
+			const result = resolveToolInputPaths('copilot_readFile', input);
+
+			const expected = path.join('/workspace/root', 'src/utils.ts');
+			assert.strictEqual(result.filePath, expected);
+			assert.strictEqual(result.offset, 10);
+			assert.strictEqual(result.limit, 100);
+		});
+
+		test('preserves absolute paths in copilot_createFile', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const input = { filePath: '/absolute/path/test.R', content: 'test' };
+			const result = resolveToolInputPaths('copilot_createFile', input);
+
+			assert.strictEqual(result.filePath, '/absolute/path/test.R');
+		});
+
+		test('returns original input when no workspace is open', () => {
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value(undefined);
+
+			const input = { filePath: 'test.R', content: 'test' };
+			const result = resolveToolInputPaths('copilot_createFile', input);
+
+			// Should return original input unchanged
+			assert.strictEqual(result.filePath, 'test.R');
+		});
+
+		test('resolves relative paths in copilot_applyPatch input string', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const patchInput = '*** Begin Patch\n*** Add File: test.R\n+print("hello")\n*** End Patch';
+			const input = { input: patchInput, explanation: 'Adding test file' };
+			const result = resolveToolInputPaths('copilot_applyPatch', input);
+
+			const expectedPath = path.join('/workspace/root', 'test.R');
+			assert.ok(result.input.includes(`*** Add File: ${expectedPath}`), `Expected resolved path in patch, got: ${result.input}`);
+			assert.strictEqual(result.explanation, 'Adding test file');
+		});
+
+		test('preserves absolute paths in copilot_applyPatch input string', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const patchInput = '*** Begin Patch\n*** Update File: /absolute/path/test.R\n@@ fn\n-old\n+new\n*** End Patch';
+			const input = { input: patchInput, explanation: 'Updating test file' };
+			const result = resolveToolInputPaths('copilot_applyPatch', input);
+
+			assert.ok(result.input.includes('*** Update File: /absolute/path/test.R'), `Absolute path should be preserved, got: ${result.input}`);
+		});
+
+		test('handles missing filePath gracefully', () => {
+			const workspaceUri = vscode.Uri.file('/workspace/root');
+			sandbox.stub(vscode.workspace, 'workspaceFolders').value([
+				{ uri: workspaceUri, name: 'test', index: 0 }
+			]);
+
+			const input = { content: 'test' }; // Missing filePath
+			const result = resolveToolInputPaths('copilot_createFile', input);
+
+			assert.strictEqual(result, input);
+		});
+
+		test('handles null/undefined input gracefully', () => {
+			const result1 = resolveToolInputPaths('copilot_createFile', null);
+			const result2 = resolveToolInputPaths('copilot_createFile', undefined);
+
+			assert.strictEqual(result1, null);
+			assert.strictEqual(result2, undefined);
+		});
+	});
+});


### PR DESCRIPTION
Addresses #11488.

When Positron Assistant invokes Copilot tools, the LLM often provides relative file paths (e.g. `test.R`). Copilot's tools are designed to receive already-resolved absolute paths -- Copilot normally handles this via an internal `resolveInput()` mechanism that is not called when tools are invoked through Positron Assistant. This caused failures like `Invalid input path: test.R. Be sure to use an absolute path.` and `Directory / is outside of the workspace and can't be read`.

This PR adds a path resolution step in `participants.ts` that intercepts `copilot_*` tool calls before they are passed to `vscode.lm.invokeTool()`, resolving relative paths against the first workspace folder root. The logic lives in a new `pathUtils.ts` file and handles three tools:

- **`copilot_createFile` / `copilot_readFile`**: resolves the `filePath` property directly
- **`copilot_applyPatch`**: parses the patch input string line-by-line and resolves relative paths on `*** Add File:`, `*** Update File:`, `*** Delete File:`, and `*** Move to:` lines -- the format used by the patch tool's parser

Absolute paths and non-Copilot tools are passed through unchanged.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix Positron Assistant failing to create, read, or patch files when given relative paths in Edit/Agent mode (#11488)

### QA Notes

@:assistant

1. Open a workspace folder in Positron
2. In Positron Assistant (Agent or Edit mode), ask it to create a new file with a relative path, e.g. `"Create a file called test.R that prints hello world"`
3. Verify the file is created at the workspace root rather than failing with a path error
4. Ask it to modify the file (e.g. `"Add a comment at the top of test.R"`) and verify the patch is applied without a `Directory / is outside of the workspace` error