### PR TITLE
Fix: restore notebook scroll position after tabbing or reloading the window

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -8,6 +8,7 @@ import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { IObservable, IObservableSignal, ISettableObservable } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
 import { INotebookEditorOptions } from '../../../notebook/browser/notebookBrowser.js';
 import { NotebookPreloadOutputResults } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
 import { CellSelectionType } from '../selectionMachine.js';
@@ -83,10 +84,10 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	readonly editor: IObservable<ICodeEditor | undefined>;
 
 	/**
-	 * Observable for the cell's code editor widget.
-	 * Use this when you need to track changes to the editor (e.g., when the editor is attached/detached).
+	 * The cell editor's text model as an observable.
+	 * Null when no editor is attached or when the editor hasn't had its model set yet.
 	 */
-	readonly editorObservable: IObservable<ICodeEditor | undefined>;
+	readonly editorModel: IObservable<ITextModel | null>;
 
 	/**
 	 * Current cell outputs as an observable.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -66,8 +66,17 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	private _container: HTMLElement | undefined;
 	private readonly _execution = observableValue<INotebookCellExecution | undefined, void>('cellExecution', undefined);
 	protected readonly _editor = observableValue<ICodeEditor | undefined>('cellEditor', undefined);
-	public readonly editorObservable: IObservable<ICodeEditor | undefined> = this._editor;
 	public readonly editor: IObservable<ICodeEditor | undefined> = this._editor;
+
+	private readonly _editorModel = derived(this, reader => {
+		const editor = this._editor.read(reader);
+		if (!editor) {
+			return null;
+		}
+		const model = observableFromEvent(editor.onDidChangeModel, () => editor.getModel()).read(reader);
+		return model;
+	});
+	public readonly editorModel: IObservable<ITextModel | null> = this._editorModel;
 	protected readonly _internalMetadata;
 	private readonly _editorFocusRequested = observableSignal<void>('editorFocusRequested');
 	private _modelRef: IReference<IResolvedTextEditorModel> | undefined;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -269,8 +269,10 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		// without having to pass the options to the resolve method.
 		input.editorOptions = options;
 
-		// NOTE: Placeholder if we need to use editor view state:
-		// const viewState = options?.viewState ?? this.loadEditorViewState(input, context);
+		// Load saved view state (e.g. scroll position) from either:
+		// - options.viewState: passed explicitly when the editor is moved between groups
+		// - loadEditorViewState: loaded from persisted storage (e.g. after reload)
+		const viewState = options?.viewState ?? this.loadEditorViewState(input, context);
 		const { notebookInstance } = input;
 
 		// Update the editor control given the notebook instance.
@@ -319,6 +321,9 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 			this._editorContainer!
 		);
 
+		// Restore the editor view state (e.g. scroll position).
+		notebookInstance.restoreEditorViewState(viewState);
+
 		// Now render the React component tree.
 		this._renderReact();
 	}
@@ -338,20 +343,23 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 	override clearInput(): void {
 		this._logService.debug(this._identifier, 'clearInput');
 
-		if (this.notebookInstance) {
-			this.notebookInstance.detachView();
-		}
+		// Capture the notebook instance before super.clearInput() clears this._input.
+		const notebookInstance = this._input?.notebookInstance;
 
-		// Clear the input.
-		this._input = undefined;
+		// Call super first so that AbstractEditorWithViewState can save the
+		// editor view state (e.g. scroll position) while the input and the
+		// DOM are still alive. The base class reads view state via
+		// computeEditorViewState() which needs the notebook instance and
+		// its cells container to still be accessible.
+		super.clearInput();
+
+		// Detach the notebook instance.
+		notebookInstance?.detachView();
 
 		// Clear the editor control.
 		this._control.clear();
 
 		this._disposeReactRenderer();
-
-		// Call the base class's method.
-		super.clearInput();
 	}
 
 	override async setOptions(options: INotebookEditorOptions | undefined): Promise<void> {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorControl.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorControl.ts
@@ -39,10 +39,10 @@ export class PositronNotebookEditorControl extends Disposable implements ICompos
 			const selectionStateMachine = this._notebookInstance.selectionStateMachine;
 			const state = selectionStateMachine.state.read(reader);
 			const activeCell = getActiveCell(state);
-			// Read from the editorObservable to track changes to the editor itself.
+			// Read from the editor observable to track changes to the editor itself.
 			// This ensures we update when the editor is attached/detached (e.g., markdown cells
 			// entering edit mode) - not just when the selection state changes.
-			this._activeCodeEditor = activeCell?.editorObservable.read(reader);
+			this._activeCodeEditor = activeCell?.editor.read(reader);
 		}));
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -36,7 +36,7 @@ import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../servic
 import { ILanguageRuntimeService, RuntimeStartupPhase, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { IPositronWebviewPreloadService } from '../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
-import { autorunDelta, observableFromEvent, observableValue, runOnChange } from '../../../../base/common/observable.js';
+import { autorun, autorunDelta, observableFromEvent, observableValue, runOnChange } from '../../../../base/common/observable.js';
 import { ResourceMap } from '../../../../base/common/map.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { cellToCellDto2 } from './cellClipboardUtils.js';
@@ -188,6 +188,12 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * The DOM element that contains the cells for the notebook.
 	 */
 	private _cellsContainer: HTMLElement | undefined = undefined;
+
+	/**
+	 * Scroll position to restore when the cells container is ready.
+	 * See the comments in setCellsContainer() for details on how this is applied.
+	 */
+	private _pendingScrollPosition: INotebookEditorViewState['scrollPosition'] = undefined;
 
 	/**
 	 * The DOM element for contributions (like find widget) to render into.
@@ -346,6 +352,49 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		}
 
 		this._cellsContainer = container;
+
+		// Restore pending scroll position if one was queued by restoreEditorViewState().
+		//
+		// Scroll restoration requires careful timing. When the editor is re-activated
+		// (e.g. switching tabs or reloading the window), the lifecycle is:
+		//
+		//   1. PositronNotebookEditor.setInput() loads saved view state and calls
+		//      restoreEditorViewState(), which stores the pending scroll position.
+		//   2. PositronNotebookEditor._renderReact() renders the React component tree.
+		//   3. React's useEffect fires (after the browser has painted), calling
+		//      setCellsContainer() with the container ref. However, cell editor
+		//      widgets (Monaco editors) mount asynchronously after this, so the
+		//      cells may not yet have their final heights.
+		//   4. Here, we set up an autorun that watches each cell's
+		//      editorModel observable. Once all cells have their editor
+		//      models set (meaning their content heights are computed), we
+		//      apply the saved scroll position.
+		if (this._pendingScrollPosition !== undefined &&
+			(this._pendingScrollPosition.top > 0 || this._pendingScrollPosition.left > 0)) {
+			// Pop the pending scroll position.
+			const targetScroll = this._pendingScrollPosition;
+			this._pendingScrollPosition = undefined;
+
+			const scrollDisposable = this._cellsContainerListeners.add(autorun(reader => {
+				// Read each cell's editorModel observable. The autorun
+				// re-subscribes on each run, so if .every() short-circuits
+				// on a null cell, we'll re-run when that cell becomes ready
+				// and progressively subscribe to the remaining cells.
+				const cells = this.cells.read(reader);
+				const allReady = cells.every(c => c.editorModel.read(reader) !== null);
+				if (!allReady) {
+					return;
+				}
+
+				// All cell editors have their models set and content heights
+				// computed. Apply the saved scroll position.
+				container.scrollTop = targetScroll.top;
+				container.scrollLeft = targetScroll.left;
+
+				// Stop listening.
+				scrollDisposable.dispose();
+			}));
+		}
 	}
 
 	/**
@@ -1974,14 +2023,25 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * fully determine the view we see.
 	 */
 	getEditorViewState(): INotebookEditorViewState {
-		// NOTE: Placeholder if we need to use editor view state
 		return {
 			editingCells: {},
 			cellLineNumberStates: {},
 			editorViewStates: {},
 			collapsedInputCells: {},
 			collapsedOutputCells: {},
+			scrollPosition: this._cellsContainer ? {
+				left: this._cellsContainer.scrollLeft,
+				top: this._cellsContainer.scrollTop,
+			} : undefined,
 		};
+	}
+
+	/**
+	 * Queues view state to be restored when the cells container is next mounted.
+	 * See the comments in setCellsContainer for the full timing and explanation.
+	 */
+	restoreEditorViewState(viewState: INotebookEditorViewState | undefined): void {
+		this._pendingScrollPosition = viewState?.scrollPosition;
 	}
 
 	/**
@@ -2278,13 +2338,14 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 				const cell = state.type === SelectionState.SingleSelection
 					? state.active
 					: state.selected[0];
-				cell.container?.focus();
+				cell.container?.focus({ preventScroll: true });
+
 				break;
 			}
 
 			case SelectionState.NoCells:
 				// Fall back to notebook container
-				this.currentContainer?.focus();
+				this.currentContainer?.focus({ preventScroll: true });
 				break;
 		}
 	}

--- a/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import path from 'path';
+import { tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+import { expect } from '@playwright/test';
+
+const NOTEBOOK_PATH = path.join('workspaces', 'bitmap-notebook', 'bitmap-notebook.ipynb');
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Positron Notebooks: Scroll Position', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+}, () => {
+
+	test('Scroll position is restored when switching tabs', async function ({ app }) {
+		const { notebooksPositron, editors } = app.workbench;
+
+		// Open the notebook and wait for it to render
+		await notebooksPositron.openNotebook(NOTEBOOK_PATH);
+		await notebooksPositron.expectToBeVisible();
+
+		// Scroll to a middle cell in the notebook
+		await notebooksPositron.cell.nth(10).scrollIntoViewIfNeeded();
+
+		// Capture the scroll position
+		const scrollTopBefore = await notebooksPositron.getScrollTop();
+		expect(scrollTopBefore).toBeGreaterThan(0);
+
+		// Open a new untitled file to background the notebook
+		await editors.newUntitledFile();
+
+		// Switch back to the notebook tab by clicking it directly.
+		// We can't use editors.selectTab() here because it expects a Monaco
+		// editor to receive focus, but the notebook is a custom editor.
+		await app.code.driver.page.getByRole('tab', { name: 'bitmap-notebook.ipynb' }).click();
+		await notebooksPositron.expectToBeVisible();
+
+		// Verify the scroll position is restored
+		const scrollTopAfter = await notebooksPositron.getScrollTop();
+		expect(Math.abs(scrollTopAfter - scrollTopBefore)).toBeLessThanOrEqual(1);
+	});
+
+	test('Scroll position is restored after window reload', async function ({ app, hotKeys }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Open the notebook and wait for it to render
+		await notebooksPositron.openNotebook(NOTEBOOK_PATH);
+		await notebooksPositron.expectToBeVisible();
+
+		// Scroll to a middle cell in the notebook
+		await notebooksPositron.cell.nth(10).scrollIntoViewIfNeeded();
+
+		// Capture the scroll position
+		const scrollTopBefore = await notebooksPositron.getScrollTop();
+		expect(scrollTopBefore).toBeGreaterThan(0);
+
+		// Reload the window
+		await hotKeys.reloadWindow(true);
+
+		// Wait for the notebook to be visible again after reload
+		await notebooksPositron.expectToBeVisible();
+
+		// Verify the scroll position is restored
+		const scrollTopAfter = await notebooksPositron.getScrollTop();
+		expect(Math.abs(scrollTopAfter - scrollTopBefore)).toBeLessThanOrEqual(1);
+	});
+});


### PR DESCRIPTION
Addresses #11777.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Notebooks' scroll positions are now restored after tabbing or reloading the window (#11777)

### QA Notes

@:web @:positron-notebooks

See the e2e test and issue for repro steps.