### PR TITLE
Fix inline assistant failing to edit empty notebook cells

### DIFF
--- a/extensions/positron-assistant/src/replaceStringProcessor.ts
+++ b/extensions/positron-assistant/src/replaceStringProcessor.ts
@@ -122,6 +122,15 @@ export class ReplaceStringProcessor {
 	}
 
 	private onOldClose() {
+		// Handle empty <old> text as "insert at current position".
+		// This occurs when the model wants to insert new code (e.g. into an empty document)
+		// without replacing existing text. We skip the find/duplicate-check because
+		// indexOf with an empty search string always "matches" at every position.
+		if (this._oldTextBuffer.length === 0 && !this._insertPosition) {
+			this._insertPosition = new vscode.Position(0, 0);
+			return;
+		}
+
 		// Find the text to replace in the document.
 		const documentText = this._document.getText();
 


### PR DESCRIPTION
Addresses #12738

## Summary

- Fixes inline assistant failing to insert code into empty notebook cells due to an empty-string `indexOf` edge case in `ReplaceStringProcessor`
- When `<old></old>` is empty (for inserting into an empty cell), `String.prototype.indexOf("", n)` never returns `-1`, causing a false-positive "multiple occurrences" error
- Adds an early return for empty `_oldTextBuffer` that sets the insert position to `(0, 0)` and skips the find/duplicate-check logic

## QA Notes

@:notebook @:assistant

1. Open a notebook with an empty code cell
2. Start inline chat (Cmd+I) in the empty cell
3. Ask to generate code (e.g. "create a test dataframe")
4. Verify code is inserted correctly without errors
5. Also verify that editing non-empty cells still works as before