### PR TITLE
Feature/custom context menu hover

### DIFF
--- a/src/vs/base/browser/positronModalReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalReactRenderer.tsx
@@ -53,6 +53,60 @@ interface PositronModalReactRendererOptions {
 }
 
 /**
+ * Stack class.
+ */
+class Stack<T> {
+	// The items in the stack.
+	private items: T[] = [];
+
+	/**
+	 * Pushes an item onto the stack.
+	 * @param item The item to push onto the stack.
+	 */
+	push(item: T): void {
+		this.items.push(item);
+	}
+
+	/**
+	 * Pops an item from the stack.
+	 * @returns The popped item or undefined if the stack is empty.
+	 */
+	pop(): T | undefined {
+		return this.items.pop();
+	}
+
+	/**
+	 * Peeks at the top item of the stack without removing it.
+	 * @returns The top item of the stack or undefined if the stack is empty.
+	 */
+	peek(): T | undefined {
+		return this.items[this.items.length - 1];
+	}
+
+	/**
+	 * Determines whether the stack is empty.
+	 * @returns true if the stack is empty; otherwise, false.
+	 */
+	isEmpty(): boolean { return this.items.length === 0; }
+
+	/**
+	 * Gets the size of the stack.
+	 * @returns The size of the stack.
+	 */
+	size(): number {
+		return this.items.length;
+	}
+
+	/**
+	 * Iterates over each item in the stack from bottom to top.
+	 * @param callback The callback function to call for each item.
+	 */
+	forEach(callback: (item: T) => void): void {
+		this.items.forEach(callback);
+	}
+}
+
+/**
  * PositronModalReactRenderer class.
  * Manages rendering a React element as a modal popup.
  */
@@ -62,7 +116,7 @@ export class PositronModalReactRenderer extends Disposable {
 	/**
 	 * The renderers stack.
 	 */
-	private static readonly _renderersStack = new Set<PositronModalReactRenderer>();
+	private static readonly _renderersStack = new Stack<PositronModalReactRenderer>();
 
 	/**
 	 * Unbind callback that unbinds the most recently bound event listeners.
@@ -136,41 +190,45 @@ export class PositronModalReactRenderer extends Disposable {
 	}
 
 	/**
-	 * Dispose method.
+	 * Dispose method. Disposes this renderer and all renderers above it on the stack.
 	 */
 	public override dispose(): void {
-		// Call the base class's dispose method.
-		super.dispose();
+		// Only dispose if we haven't already been disposed.
+		if (this._overlay === undefined && this._root === undefined) {
+			super.dispose();
+			return;
+		}
 
-		// Return focus to the last focused element.
-		// Use preventScroll to avoid unwanted scrolling when focus is restored
-		// (e.g., inline data explorer in notebooks scrolling the notebook container).
-		this._lastFocusedElement?.focus({ preventScroll: true });
-
-		// If this renderer was rendered, dispose it.
-		if (this._overlay !== undefined && this._root !== undefined) {
-			// If there is a parent, remove its aria-expanded property.
-			if (this._options.parent !== undefined) {
-				this._options.parent.removeAttribute('aria-expanded');
+		// Collect all renderers from the top of the stack down to and including this one.
+		const renderersToDispose: PositronModalReactRenderer[] = [];
+		while (!PositronModalReactRenderer._renderersStack.isEmpty()) {
+			// Pop the top renderer from the stack. If there isn't one, break.
+			const rendererToDispose = PositronModalReactRenderer._renderersStack.pop();
+			if (rendererToDispose === undefined) {
+				break;
 			}
 
-			// Unmount the root.
-			this._root.unmount();
-			this._root = undefined;
+			// Add the renderer to the list of renderers to dispose.
+			renderersToDispose.push(rendererToDispose);
 
-			// Remove the overlay from from the container.
-			this._overlay.remove();
-			this._overlay = undefined;
-
-			// Delete this renderer from the renderers stack and bind event listeners.
-			PositronModalReactRenderer._renderersStack.delete(this);
-			PositronModalReactRenderer.bindEventListeners();
+			// If the popped renderer is this renderer, break.
+			if (rendererToDispose === this) {
+				break;
+			}
 		}
 
-		// Call the onDisposed callback.
-		if (this._options.onDisposed !== undefined) {
-			this._options.onDisposed();
+		// Dispose each renderer (child modals first).
+		for (const rendererToDispose of renderersToDispose) {
+			// Clean up the renderer's DOM and React resources.
+			rendererToDispose.doDispose();
+
+			// Dispose the renderer's Disposable resources (event emitters, etc).
+			// Use Disposable.prototype to call parent's dispose without triggering recursion.
+			Disposable.prototype.dispose.call(rendererToDispose);
 		}
+
+		// Rebind event listeners for the new top renderer.
+		PositronModalReactRenderer.bindEventListeners();
 	}
 
 	//#endregion Constructor & Dispose
@@ -244,7 +302,7 @@ export class PositronModalReactRenderer extends Disposable {
 			this._overlay.focus();
 
 			// Push this renderer onto the renderers stack and bind event listeners.
-			PositronModalReactRenderer._renderersStack.add(this);
+			PositronModalReactRenderer._renderersStack.push(this);
 			PositronModalReactRenderer.bindEventListeners();
 		}
 	}
@@ -264,7 +322,7 @@ export class PositronModalReactRenderer extends Disposable {
 		}
 
 		// Get the renderer to bind event listeners for. If there isn't one, return.
-		const renderer = [...PositronModalReactRenderer._renderersStack].pop();
+		const renderer = PositronModalReactRenderer._renderersStack.peek();
 		if (renderer === undefined) {
 			return;
 		}
@@ -329,6 +387,37 @@ export class PositronModalReactRenderer extends Disposable {
 			window.removeEventListener(MOUSEDOWN, mousedownHandler, true);
 			window.removeEventListener(RESIZE, resizeHandler, false);
 		};
+	}
+
+	/**
+	 * Internal dispose method that cleans up this renderer's resources.
+	 */
+	private doDispose(): void {
+		// Return focus to the last focused element.
+		// Use preventScroll to avoid unwanted scrolling when focus is restored
+		// (e.g., inline data explorer in notebooks scrolling the notebook container).
+		this._lastFocusedElement?.focus({ preventScroll: true });
+
+		// If this renderer was rendered, dispose it.
+		if (this._overlay !== undefined && this._root !== undefined) {
+			// If there is a parent, remove its aria-expanded property.
+			if (this._options.parent !== undefined) {
+				this._options.parent.removeAttribute('aria-expanded');
+			}
+
+			// Unmount the root.
+			this._root.unmount();
+			this._root = undefined;
+
+			// Remove the overlay from the container.
+			this._overlay.remove();
+			this._overlay = undefined;
+		}
+
+		// Call the onDisposed callback.
+		if (this._options.onDisposed !== undefined) {
+			this._options.onDisposed();
+		}
 	}
 
 	//#endregion Private Methods

--- a/src/vs/base/browser/positronModalReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalReactRenderer.tsx
@@ -303,34 +303,38 @@ export class PositronModalReactRenderer extends Disposable {
 	 * @param reactElement The ReactElement to render.
 	 */
 	public render(reactElement: ReactElement) {
-		// Prevent rendering more than once.
-		if (this._overlay === undefined && this._root === undefined) {
-			// If there is a parent, set its aria-expanded property to true.
-			if (this._options.parent !== undefined) {
-				this._options.parent.setAttribute('aria-expanded', 'true');
-			}
-
-			// Create the overlay element in the container and the root element in the overlay
-			// element.
-			this._overlay = this._options.container!.appendChild(
-				DOM.$('.positron-modal-overlay', { tabIndex: 0 })
-			);
-			this._root = createRoot(this._overlay);
-
-			// Render the ReactElement that was supplied.
-			this._root.render(
-				<PositronReactServicesProvider>
-					{reactElement}
-				</PositronReactServicesProvider>
-			);
-
-			// Drive focus into the overlay element.
-			this._overlay.focus();
-
-			// Push this renderer onto the renderers stack and bind event listeners.
-			PositronModalReactRenderer._renderersStack.push(this);
-			PositronModalReactRenderer.bindEventListeners();
+		// Return if this renderer has already been rendered.
+		if (this._root !== undefined) {
+			// This should never happen, but log if it does.
+			console.error('[PositronModalReactRenderer] Attempted to render a React element when one has already been rendered');
+			return;
 		}
+
+		// If there is a parent, set its aria-expanded property to true.
+		if (this._options.parent !== undefined) {
+			this._options.parent.setAttribute('aria-expanded', 'true');
+		}
+
+		// Create the overlay element in the container and the root element in the overlay
+		// element.
+		this._overlay = this._options.container!.appendChild(
+			DOM.$('.positron-modal-overlay', { tabIndex: 0 })
+		);
+		this._root = createRoot(this._overlay);
+
+		// Render the ReactElement that was supplied.
+		this._root.render(
+			<PositronReactServicesProvider>
+				{reactElement}
+			</PositronReactServicesProvider>
+		);
+
+		// Drive focus into the overlay element.
+		this._overlay.focus();
+
+		// Push this renderer onto the renderers stack and bind event listeners.
+		PositronModalReactRenderer._renderersStack.push(this);
+		PositronModalReactRenderer.bindEventListeners();
 	}
 
 	//#endregion Public Methods
@@ -396,8 +400,8 @@ export class PositronModalReactRenderer extends Disposable {
 		 * @param e A UIEvent.
 		 */
 		const resizeHandler = (e: UIEvent) => {
-			PositronModalReactRenderer._renderersStack.forEach(renderer => {
-				renderer._onResizeEmitter.fire(e);
+			PositronModalReactRenderer._renderersStack.forEach((positronModalReactRenderer: PositronModalReactRenderer) => {
+				positronModalReactRenderer._onResizeEmitter.fire(e);
 			});
 		};
 

--- a/src/vs/base/browser/positronModalReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalReactRenderer.tsx
@@ -16,7 +16,7 @@ import { Emitter } from '../common/event.js';
 import { Disposable } from '../common/lifecycle.js';
 import { StandardKeyboardEvent } from './keyboardEvent.js';
 import { PositronReactServices } from './positronReactServices.js';
-import { PositronReactServicesContext } from './positronReactRendererContext.js';
+import { PositronReactServicesProvider } from './positronReactRendererContext.js';
 import { ResultKind } from '../../platform/keybinding/common/keybindingResolver.js';
 
 /**
@@ -235,9 +235,9 @@ export class PositronModalReactRenderer extends Disposable {
 
 			// Render the ReactElement that was supplied.
 			this._root.render(
-				<PositronReactServicesContext.Provider value={PositronReactServices.services}>
+				<PositronReactServicesProvider>
 					{reactElement}
-				</PositronReactServicesContext.Provider>
+				</PositronReactServicesProvider>
 			);
 
 			// Drive focus into the overlay element.

--- a/src/vs/base/browser/positronModalReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalReactRenderer.tsx
@@ -116,16 +116,16 @@ export class PositronModalReactRenderer extends Disposable {
 		super();
 
 		// If the container is not provided, use the active container.
-		if (!_options.container) {
+		if (_options.container === undefined) {
 			_options.container = PositronReactServices.services.workbenchLayoutService.activeContainer;
 		}
 
 		// Get the active element.
 		let activeElement: Element | null = null;
-		if (_options.parent) {
+		if (_options.parent !== undefined) {
 			activeElement = DOM.getWindow(_options.parent).document.activeElement;
 		}
-		if (!activeElement) {
+		if (activeElement === null) {
 			activeElement = DOM.getActiveWindow().document.activeElement;
 		}
 
@@ -148,9 +148,9 @@ export class PositronModalReactRenderer extends Disposable {
 		this._lastFocusedElement?.focus({ preventScroll: true });
 
 		// If this renderer was rendered, dispose it.
-		if (this._overlay && this._root) {
+		if (this._overlay !== undefined && this._root !== undefined) {
 			// If there is a parent, remove its aria-expanded property.
-			if (this._options.parent) {
+			if (this._options.parent !== undefined) {
 				this._options.parent.removeAttribute('aria-expanded');
 			}
 
@@ -168,7 +168,7 @@ export class PositronModalReactRenderer extends Disposable {
 		}
 
 		// Call the onDisposed callback.
-		if (this._options.onDisposed) {
+		if (this._options.onDisposed !== undefined) {
 			this._options.onDisposed();
 		}
 	}
@@ -220,9 +220,9 @@ export class PositronModalReactRenderer extends Disposable {
 	 */
 	public render(reactElement: ReactElement) {
 		// Prevent rendering more than once.
-		if (!this._overlay && !this._root) {
+		if (this._overlay === undefined && this._root === undefined) {
 			// If there is a parent, set its aria-expanded property to true.
-			if (this._options.parent) {
+			if (this._options.parent !== undefined) {
 				this._options.parent.setAttribute('aria-expanded', 'true');
 			}
 
@@ -258,14 +258,14 @@ export class PositronModalReactRenderer extends Disposable {
 	 */
 	private static bindEventListeners() {
 		// Unbind the most recently bound event listeners.
-		if (PositronModalReactRenderer._unbindCallback) {
+		if (PositronModalReactRenderer._unbindCallback !== undefined) {
 			PositronModalReactRenderer._unbindCallback();
 			PositronModalReactRenderer._unbindCallback = undefined;
 		}
 
 		// Get the renderer to bind event listeners for. If there isn't one, return.
 		const renderer = [...PositronModalReactRenderer._renderersStack].pop();
-		if (!renderer) {
+		if (renderer === undefined) {
 			return;
 		}
 
@@ -289,7 +289,7 @@ export class PositronModalReactRenderer extends Disposable {
 
 			// If a keybinding to a command was found, stop it from being processed if it is not one
 			// of the allowable commands.
-			if (resolutionResult.kind === ResultKind.KbFound && resolutionResult.commandId) {
+			if (resolutionResult.kind === ResultKind.KbFound && resolutionResult.commandId !== null) {
 				if (ALLOWABLE_COMMANDS.indexOf(resolutionResult.commandId) === -1) {
 					DOM.EventHelper.stop(event, true);
 				}
@@ -318,14 +318,14 @@ export class PositronModalReactRenderer extends Disposable {
 		};
 
 		// Add global keydown, mousedown, and resize event listeners.
-		window.addEventListener(KEYDOWN, keydownHandler, renderer._options.disableCaptures ? false : true);
+		window.addEventListener(KEYDOWN, keydownHandler, renderer._options.disableCaptures === true ? false : true);
 		window.addEventListener(MOUSEDOWN, mousedownHandler, true);
 		window.addEventListener(RESIZE, resizeHandler, false);
 
 		// Return the cleanup function that removes our event listeners.
 		PositronModalReactRenderer._unbindCallback = () => {
 			// Remove keydown, mousedown, and resize event listeners.
-			window.removeEventListener(KEYDOWN, keydownHandler, renderer._options.disableCaptures ? false : true);
+			window.removeEventListener(KEYDOWN, keydownHandler, renderer._options.disableCaptures === true ? false : true);
 			window.removeEventListener(MOUSEDOWN, mousedownHandler, true);
 			window.removeEventListener(RESIZE, resizeHandler, false);
 		};

--- a/src/vs/base/browser/positronModalReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalReactRenderer.tsx
@@ -193,42 +193,68 @@ export class PositronModalReactRenderer extends Disposable {
 	 * Dispose method. Disposes this renderer and all renderers above it on the stack.
 	 */
 	public override dispose(): void {
-		// Only dispose if we haven't already been disposed.
-		if (this._overlay === undefined && this._root === undefined) {
-			super.dispose();
+		// Return if this renderer was never rendered or has already been disposed.
+		if (this._root === undefined) {
 			return;
 		}
 
-		// Collect all renderers from the top of the stack down to and including this one.
-		const renderersToDispose: PositronModalReactRenderer[] = [];
+		// Dispose all renderers above this one on the stack (child modals).
 		while (!PositronModalReactRenderer._renderersStack.isEmpty()) {
-			// Pop the top renderer from the stack. If there isn't one, break.
-			const rendererToDispose = PositronModalReactRenderer._renderersStack.pop();
-			if (rendererToDispose === undefined) {
+			// Get the top renderer on the stack.
+			const topRenderer = PositronModalReactRenderer._renderersStack.peek();
+
+			// If the top of the stack is this renderer, we're done unwinding children.
+			if (topRenderer === this) {
 				break;
 			}
 
-			// Add the renderer to the list of renderers to dispose.
-			renderersToDispose.push(rendererToDispose);
-
-			// If the popped renderer is this renderer, break.
-			if (rendererToDispose === this) {
-				break;
+			// Dispose the child renderer (which will pop itself from the stack).
+			if (topRenderer !== undefined) {
+				topRenderer.dispose();
 			}
 		}
 
-		// Dispose each renderer (child modals first).
-		for (const rendererToDispose of renderersToDispose) {
-			// Clean up the renderer's DOM and React resources.
-			rendererToDispose.doDispose();
+		// Now dispose this renderer.
+		// Remove ourselves from the stack.
+		const poppedRenderer = PositronModalReactRenderer._renderersStack.pop();
+		if (poppedRenderer !== this) {
+			// This should never happen, but log if it does.
+			console.error('[PositronModalReactRenderer] Disposed renderer was not at top of stack');
+		}
 
-			// Dispose the renderer's Disposable resources (event emitters, etc).
-			// Use Disposable.prototype to call parent's dispose without triggering recursion.
-			Disposable.prototype.dispose.call(rendererToDispose);
+		// Return focus to the last focused element.
+		// Use preventScroll to avoid unwanted scrolling when focus is restored
+		// (e.g., inline data explorer in notebooks scrolling the notebook container).
+		this._lastFocusedElement?.focus({ preventScroll: true });
+
+		// If this renderer was rendered, dispose it.
+		if (this._root !== undefined) {
+			// If there is a parent, remove its aria-expanded property.
+			if (this._options.parent !== undefined) {
+				this._options.parent.removeAttribute('aria-expanded');
+			}
+
+			// Unmount the root.
+			this._root.unmount();
+			this._root = undefined;
+
+			// Remove the overlay from the container.
+			if (this._overlay !== undefined) {
+				this._overlay.remove();
+				this._overlay = undefined;
+			}
+		}
+
+		// Call the onDisposed callback.
+		if (this._options.onDisposed !== undefined) {
+			this._options.onDisposed();
 		}
 
 		// Rebind event listeners for the new top renderer.
 		PositronModalReactRenderer.bindEventListeners();
+
+		// Call the base class's dispose method.
+		super.dispose();
 	}
 
 	//#endregion Constructor & Dispose
@@ -387,37 +413,6 @@ export class PositronModalReactRenderer extends Disposable {
 			window.removeEventListener(MOUSEDOWN, mousedownHandler, true);
 			window.removeEventListener(RESIZE, resizeHandler, false);
 		};
-	}
-
-	/**
-	 * Internal dispose method that cleans up this renderer's resources.
-	 */
-	private doDispose(): void {
-		// Return focus to the last focused element.
-		// Use preventScroll to avoid unwanted scrolling when focus is restored
-		// (e.g., inline data explorer in notebooks scrolling the notebook container).
-		this._lastFocusedElement?.focus({ preventScroll: true });
-
-		// If this renderer was rendered, dispose it.
-		if (this._overlay !== undefined && this._root !== undefined) {
-			// If there is a parent, remove its aria-expanded property.
-			if (this._options.parent !== undefined) {
-				this._options.parent.removeAttribute('aria-expanded');
-			}
-
-			// Unmount the root.
-			this._root.unmount();
-			this._root = undefined;
-
-			// Remove the overlay from the container.
-			this._overlay.remove();
-			this._overlay = undefined;
-		}
-
-		// Call the onDisposed callback.
-		if (this._options.onDisposed !== undefined) {
-			this._options.onDisposed();
-		}
 	}
 
 	//#endregion Private Methods

--- a/src/vs/base/browser/positronModalReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalReactRenderer.tsx
@@ -61,6 +61,12 @@ class Stack<T> {
 	private items: T[] = [];
 
 	/**
+	 * Determines whether the stack is empty.
+	 * @returns true if the stack is empty; otherwise, false.
+	 */
+	isEmpty(): boolean { return this.items.length === 0; }
+
+	/**
 	 * Pushes an item onto the stack.
 	 * @param item The item to push onto the stack.
 	 */
@@ -77,25 +83,19 @@ class Stack<T> {
 	}
 
 	/**
-	 * Peeks at the top item of the stack without removing it.
+	 * Gets the top item of the stack without removing it.
 	 * @returns The top item of the stack or undefined if the stack is empty.
 	 */
-	peek(): T | undefined {
+	top(): T | undefined {
 		return this.items[this.items.length - 1];
 	}
 
 	/**
-	 * Determines whether the stack is empty.
-	 * @returns true if the stack is empty; otherwise, false.
+	 * Gets the bottom item of the stack without removing it.
+	 * @returns The bottom item of the stack or undefined if the stack is empty.
 	 */
-	isEmpty(): boolean { return this.items.length === 0; }
-
-	/**
-	 * Gets the size of the stack.
-	 * @returns The size of the stack.
-	 */
-	size(): number {
-		return this.items.length;
+	bottom(): T | undefined {
+		return this.items[0];
 	}
 
 	/**
@@ -142,6 +142,11 @@ export class PositronModalReactRenderer extends Disposable {
 	 * Gets or sets the root where the React element will be rendered.
 	 */
 	private _root?: Root;
+
+	/**
+	 * Provides the bounding rect of this renderer's popup element. Registered by PositronModalPopup.
+	 */
+	private _boundsProvider?: () => DOMRect;
 
 	/**
 	 * The onKeyDown event emitter.
@@ -202,7 +207,7 @@ export class PositronModalReactRenderer extends Disposable {
 		// Dispose all renderers above this one on the stack (child modals).
 		while (!PositronModalReactRenderer._renderersStack.isEmpty()) {
 			// Get the top renderer on the stack.
-			const topRenderer = PositronModalReactRenderer._renderersStack.peek();
+			const topRenderer = PositronModalReactRenderer._renderersStack.top();
 
 			// If the top of the stack is this renderer, we're done unwinding children.
 			if (topRenderer === this) {
@@ -300,6 +305,39 @@ export class PositronModalReactRenderer extends Disposable {
 	//#region Public Methods
 
 	/**
+	 * Registers a function that returns the bounding rect of this renderer's popup element.
+	 * Called by PositronModalPopup so the renderer stack can check click containment.
+	 * @param boundsProvider A function that returns the popup's DOMRect.
+	 */
+	public setBoundsProvider(boundsProvider: () => DOMRect): void {
+		this._boundsProvider = boundsProvider;
+	}
+
+	/**
+	 * Returns true if the mouse event occurred inside the popup of any renderer in the stack.
+	 * @param e The mouse event to check.
+	 */
+	public static isInsideAnyPopup(e: MouseEvent): boolean {
+		let inside = false;
+		PositronModalReactRenderer._renderersStack.forEach(renderer => {
+			if (renderer._boundsProvider !== undefined) {
+				const rect = renderer._boundsProvider();
+				if (e.clientX >= rect.left && e.clientX <= rect.right && e.clientY >= rect.top && e.clientY <= rect.bottom) {
+					inside = true;
+				}
+			}
+		});
+		return inside;
+	}
+
+	/**
+	 * Disposes all renderers in the stack by disposing the bottom renderer, which cascades upward.
+	 */
+	public static disposeAll(): void {
+		PositronModalReactRenderer._renderersStack.bottom()?.dispose();
+	}
+
+	/**
 	 * Renders the ReactElement that was supplied.
 	 * @param reactElement The ReactElement to render.
 	 */
@@ -361,7 +399,7 @@ export class PositronModalReactRenderer extends Disposable {
 		}
 
 		// Get the renderer to bind event listeners for. If there isn't one, return.
-		const renderer = PositronModalReactRenderer._renderersStack.peek();
+		const renderer = PositronModalReactRenderer._renderersStack.top();
 		if (renderer === undefined) {
 			return;
 		}

--- a/src/vs/base/browser/positronModalReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalReactRenderer.tsx
@@ -199,8 +199,9 @@ export class PositronModalReactRenderer extends Disposable {
 	 * Dispose method. Disposes this renderer and all renderers above it on the stack.
 	 */
 	public override dispose(): void {
-		// Return if this renderer was never rendered or has already been disposed.
+		// If never rendered, just clean up internal resources and return.
 		if (this._root === undefined) {
+			super.dispose();
 			return;
 		}
 

--- a/src/vs/base/browser/positronModalReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalReactRenderer.tsx
@@ -48,8 +48,9 @@ const RESIZE = 'resize';
 interface PositronModalReactRendererOptions {
 	container?: HTMLElement;
 	parent?: HTMLElement;
-	onDisposed?: () => void;
+	allowPointerPassthrough?: boolean;
 	disableCaptures?: boolean;
+	onDisposed?: () => void;
 }
 
 /**
@@ -320,6 +321,14 @@ export class PositronModalReactRenderer extends Disposable {
 		this._overlay = this._options.container!.appendChild(
 			DOM.$('.positron-modal-overlay', { tabIndex: 0 })
 		);
+
+		// When pointer passthrough is enabled, allow mouse events to pass through the overlay
+		// to elements beneath it (used for cascading context menus).
+		if (this._options.allowPointerPassthrough === true) {
+			this._overlay.style.pointerEvents = 'none';
+		}
+
+		// Create the root for this modal renderer.
 		this._root = createRoot(this._overlay);
 
 		// Render the ReactElement that was supplied.

--- a/src/vs/base/browser/positronReactRenderer.tsx
+++ b/src/vs/base/browser/positronReactRenderer.tsx
@@ -10,8 +10,7 @@ import { createRoot, Root } from 'react-dom/client';
 // Other dependencies.
 import { Event } from '../common/event.js';
 import { Disposable, IDisposable } from '../common/lifecycle.js';
-import { PositronReactServices } from './positronReactServices.js';
-import { PositronReactServicesContext } from './positronReactRendererContext.js';
+import { PositronReactServicesProvider } from './positronReactRendererContext.js';
 
 /**
  * ISize interface.
@@ -127,7 +126,7 @@ export class PositronReactRenderer extends Disposable {
 	 */
 	public override dispose(): void {
 		// Unmount and dispose of the root.
-		if (this._root) {
+		if (this._root !== undefined) {
 			this._root.unmount();
 			this._root = undefined;
 		}
@@ -145,11 +144,11 @@ export class PositronReactRenderer extends Disposable {
 	 * @param reactElement The React element.
 	 */
 	public render(reactElement: ReactElement) {
-		if (this._root) {
+		if (this._root !== undefined) {
 			this._root.render(
-				<PositronReactServicesContext.Provider value={PositronReactServices.services}>
+				<PositronReactServicesProvider>
 					{reactElement}
-				</PositronReactServicesContext.Provider>
+				</PositronReactServicesProvider>
 			);
 		}
 	}
@@ -167,7 +166,7 @@ export class PositronReactRenderer extends Disposable {
 	 * @deprecated Use Disposable instead.
 	 */
 	public destroy() {
-		if (this._root) {
+		if (this._root !== undefined) {
 			this._root.unmount();
 			this._root = undefined;
 		}

--- a/src/vs/base/browser/positronReactRendererContext.tsx
+++ b/src/vs/base/browser/positronReactRendererContext.tsx
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { createContext, useContext } from 'react';
+import React, { createContext, useContext } from 'react';
 
 // Other dependencies.
 import { PositronReactServices } from './positronReactServices.js';
@@ -12,6 +12,18 @@ import { PositronReactServices } from './positronReactServices.js';
  * PositronReactServicesContext.
  */
 export const PositronReactServicesContext = createContext<PositronReactServices>(undefined!);
+
+/**
+ * PositronReactServicesProvider component.
+ * Provides the Positron React services context to children.
+ */
+export const PositronReactServicesProvider = ({ children }: { children: React.ReactNode }) => {
+	return (
+		<PositronReactServicesContext.Provider value={PositronReactServices.services}>
+			{children}
+		</PositronReactServicesContext.Provider>
+	);
+};
 
 /**
  * usePositronReactServicesContext hook.

--- a/src/vs/base/browser/ui/positronComponents/button/button.tsx
+++ b/src/vs/base/browser/ui/positronComponents/button/button.tsx
@@ -7,7 +7,7 @@
 import './button.css';
 
 // React.
-import React, { CSSProperties, forwardRef, KeyboardEvent, MouseEvent, PropsWithChildren, useImperativeHandle, useRef, useState } from 'react';
+import React, { CSSProperties, KeyboardEvent, MouseEvent, PropsWithChildren, useImperativeHandle, useRef, useState } from 'react';
 
 // Other dependencies.
 import { positronClassNames } from '../../../../common/positronUtilities.js';
@@ -50,6 +50,7 @@ export interface ButtonProps {
 	readonly onMouseEnter?: () => void;
 	readonly onMouseLeave?: () => void;
 	readonly onPressed?: (e: KeyboardModifiers) => void;
+	ref?: React.Ref<HTMLButtonElement>;
 }
 
 /**
@@ -57,12 +58,12 @@ export interface ButtonProps {
  * @param props A PropsWithChildren<ButtonProps> that contains the component properties.
  * @returns The rendered component.
  */
-export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProps>>((props, ref) => {
+export const Button = (props: PropsWithChildren<ButtonProps>) => {
 	// Reference hooks.
 	const buttonRef = useRef<HTMLButtonElement>(undefined!);
 
 	// Customize the ref handle that is exposed.
-	useImperativeHandle(ref, () => buttonRef.current, []);
+	useImperativeHandle(props.ref, () => buttonRef.current, []);
 
 	// State hooks.
 	const [mouseInside, setMouseInside] = useState(false);
@@ -197,7 +198,7 @@ export const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProp
 			{props.children}
 		</button>
 	);
-});
+};
 
 // Set the display name.
 Button.displayName = 'Button';

--- a/src/vs/base/test/browser/positronModalReactRenderer.test.ts
+++ b/src/vs/base/test/browser/positronModalReactRenderer.test.ts
@@ -1,9 +1,10 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import assert from 'assert';
+import * as sinon from 'sinon';
 import { PositronModalReactRenderer } from '../../browser/positronModalReactRenderer.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../common/utils.js';
 
@@ -208,6 +209,10 @@ suite('PositronModalReactRenderer', () => {
 			const container = createMockContainer();
 			const renderer = disposables.add(new PositronModalReactRenderer({ container }));
 
+			// Stub console.error to prevent actual console output in tests
+			const consoleErrorStub = sinon.stub(console, 'error');
+			disposables.add({ dispose: () => consoleErrorStub.restore() });
+
 			renderer.render(createMockReactElement());
 			const firstChild = container.firstChild;
 
@@ -217,6 +222,10 @@ suite('PositronModalReactRenderer', () => {
 			// Should still be the same child
 			assert.strictEqual(container.firstChild, firstChild);
 			assert.strictEqual(container.children.length, 1);
+
+			// Should have logged an error
+			assert.strictEqual(consoleErrorStub.callCount, 1);
+			assert.ok(consoleErrorStub.calledWith('[PositronModalReactRenderer] Attempted to render a React element when one has already been rendered'));
 
 			renderer.dispose();
 		});

--- a/src/vs/base/test/browser/positronModalReactRenderer.test.ts
+++ b/src/vs/base/test/browser/positronModalReactRenderer.test.ts
@@ -1,0 +1,260 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { PositronModalReactRenderer } from '../../browser/positronModalReactRenderer.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../common/utils.js';
+
+suite('PositronModalReactRenderer', () => {
+	// Disposables.
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	/**
+	 * Creates a mock container element for testing.
+	 */
+	function createMockContainer(): HTMLElement {
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+		disposables.add({ dispose: () => container.remove() });
+		return container;
+	}
+
+	/**
+	 * Creates a mock React element for testing.
+	 */
+	function createMockReactElement(): any {
+		return { type: 'div', props: {} };
+	}
+
+	/**
+	 * Dispose test suite.
+	 */
+	suite('dispose', () => {
+		/**
+		 * Test disposing a single renderer.
+		 */
+		test('disposes a single renderer', () => {
+			const container = createMockContainer();
+			const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+
+			renderer.render(createMockReactElement());
+
+			// Verify it's in the DOM
+			assert.strictEqual(container.children.length, 1);
+
+			renderer.dispose();
+
+			// Verify it's been removed
+			assert.strictEqual(container.children.length, 0);
+		});
+
+		test('disposes the top renderer without affecting others', () => {
+			const container = createMockContainer();
+
+			// Create 10 renderers
+			const renderers: PositronModalReactRenderer[] = [];
+			for (let i = 0; i < 10; i++) {
+				const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+				renderer.render(createMockReactElement());
+				renderers.push(renderer);
+			}
+
+			// All 10 should be in the DOM
+			assert.strictEqual(container.children.length, 10);
+
+			// Dispose the top renderer (last one)
+			renderers[9].dispose();
+
+			// Only the top renderer should be removed
+			assert.strictEqual(container.children.length, 9);
+
+			// Clean up remaining renderers
+			for (let i = 8; i >= 0; i--) {
+				renderers[i].dispose();
+			}
+		});
+
+		test('disposes middle renderer and all renderers above it', () => {
+			const container = createMockContainer();
+
+			// Create 10 renderers
+			const renderers: PositronModalReactRenderer[] = [];
+			for (let i = 0; i < 10; i++) {
+				const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+				renderer.render(createMockReactElement());
+				renderers.push(renderer);
+			}
+
+			// All 10 should be in the DOM
+			assert.strictEqual(container.children.length, 10);
+
+			// Dispose the middle renderer (index 5) - should dispose renderers 5-9
+			renderers[5].dispose();
+
+			// Only renderers 0-4 should remain (5 renderers)
+			assert.strictEqual(container.children.length, 5);
+
+			// Clean up remaining renderers
+			for (let i = 4; i >= 0; i--) {
+				renderers[i].dispose();
+			}
+		});
+
+		test('disposes bottom renderer and all renderers above it', () => {
+			const container = createMockContainer();
+
+			// Create 10 renderers
+			const renderers: PositronModalReactRenderer[] = [];
+			for (let i = 0; i < 10; i++) {
+				const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+				renderer.render(createMockReactElement());
+				renderers.push(renderer);
+			}
+
+			// All 10 should be in the DOM
+			assert.strictEqual(container.children.length, 10);
+
+			// Dispose the bottom renderer (first one) - should dispose all renderers
+			renderers[0].dispose();
+
+			// All should be removed
+			assert.strictEqual(container.children.length, 0);
+		});
+
+		test('handles double dispose gracefully', () => {
+			const container = createMockContainer();
+			const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+
+			renderer.render(createMockReactElement());
+			renderer.dispose();
+
+			// Second dispose should not throw
+			assert.doesNotThrow(() => renderer.dispose());
+		});
+
+		test('calls onDisposed callback', () => {
+			const container = createMockContainer();
+			let callbackCalled = false;
+
+			const renderer = disposables.add(new PositronModalReactRenderer({
+				container,
+				onDisposed: () => { callbackCalled = true; }
+			}));
+
+			renderer.render(createMockReactElement());
+			renderer.dispose();
+
+			assert.strictEqual(callbackCalled, true);
+		});
+
+		test('calls onDisposed for all disposed renderers when disposing middle renderer', () => {
+			const container = createMockContainer();
+
+			// Create 10 renderers with callback flags
+			const callbackFlags: boolean[] = new Array(10).fill(false);
+			const renderers: PositronModalReactRenderer[] = [];
+
+			for (let i = 0; i < 10; i++) {
+				const index = i; // Capture for closure
+				const renderer = disposables.add(new PositronModalReactRenderer({
+					container,
+					onDisposed: () => { callbackFlags[index] = true; }
+				}));
+				renderer.render(createMockReactElement());
+				renderers.push(renderer);
+			}
+
+			// Dispose renderer at index 4 - should dispose renderers 4-9
+			renderers[4].dispose();
+
+			// Renderers 0-3 should not be disposed
+			for (let i = 0; i < 4; i++) {
+				assert.strictEqual(callbackFlags[i], false, `renderer ${i} should not be disposed`);
+			}
+
+			// Renderers 4-9 should be disposed
+			for (let i = 4; i < 10; i++) {
+				assert.strictEqual(callbackFlags[i], true, `renderer ${i} should be disposed`);
+			}
+
+			// Clean up remaining renderers
+			for (let i = 3; i >= 0; i--) {
+				renderers[i].dispose();
+			}
+		});
+	});
+
+	/**
+	 * Dispose test suite.
+	 */
+	suite('render', () => {
+		test('renders React element into container', () => {
+			const container = createMockContainer();
+			const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+
+			assert.strictEqual(container.children.length, 0);
+
+			renderer.render(createMockReactElement());
+
+			assert.strictEqual(container.children.length, 1);
+			assert.ok(container.querySelector('.positron-modal-overlay'));
+
+			renderer.dispose();
+		});
+
+		test('does not render twice', () => {
+			const container = createMockContainer();
+			const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+
+			renderer.render(createMockReactElement());
+			const firstChild = container.firstChild;
+
+			// Try to render again
+			renderer.render(createMockReactElement());
+
+			// Should still be the same child
+			assert.strictEqual(container.firstChild, firstChild);
+			assert.strictEqual(container.children.length, 1);
+
+			renderer.dispose();
+		});
+	});
+
+	/**
+	 * Parent element test suite.
+	 */
+	suite('parent element', () => {
+		test('sets aria-expanded on parent when rendered', () => {
+			const container = createMockContainer();
+			const parent = document.createElement('div');
+			container.appendChild(parent);
+
+			const renderer = disposables.add(new PositronModalReactRenderer({ container, parent }));
+
+			assert.strictEqual(parent.getAttribute('aria-expanded'), null);
+
+			renderer.render(createMockReactElement());
+
+			assert.strictEqual(parent.getAttribute('aria-expanded'), 'true');
+
+			renderer.dispose();
+		});
+
+		test('removes aria-expanded from parent when disposed', () => {
+			const container = createMockContainer();
+			const parent = document.createElement('div');
+			container.appendChild(parent);
+
+			const renderer = disposables.add(new PositronModalReactRenderer({ container, parent }));
+
+			renderer.render(createMockReactElement());
+			assert.strictEqual(parent.getAttribute('aria-expanded'), 'true');
+
+			renderer.dispose();
+
+			assert.strictEqual(parent.hasAttribute('aria-expanded'), false);
+		});
+	});
+});

--- a/src/vs/base/test/browser/positronModalReactRenderer.test.ts
+++ b/src/vs/base/test/browser/positronModalReactRenderer.test.ts
@@ -266,4 +266,180 @@ suite('PositronModalReactRenderer', () => {
 			assert.strictEqual(parent.hasAttribute('aria-expanded'), false);
 		});
 	});
+
+	/**
+	 * disposeAll test suite.
+	 */
+	suite('disposeAll', () => {
+		test('disposes all renderers in the stack', () => {
+			const container = createMockContainer();
+
+			const renderers: PositronModalReactRenderer[] = [];
+			for (let i = 0; i < 5; i++) {
+				const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+				renderer.render(createMockReactElement());
+				renderers.push(renderer);
+			}
+
+			assert.strictEqual(container.children.length, 5);
+
+			PositronModalReactRenderer.disposeAll();
+
+			assert.strictEqual(container.children.length, 0);
+		});
+
+		test('calls onDisposed for every renderer', () => {
+			const container = createMockContainer();
+			const callbackFlags: boolean[] = new Array(5).fill(false);
+
+			for (let i = 0; i < 5; i++) {
+				const index = i;
+				const renderer = disposables.add(new PositronModalReactRenderer({
+					container,
+					onDisposed: () => { callbackFlags[index] = true; }
+				}));
+				renderer.render(createMockReactElement());
+			}
+
+			PositronModalReactRenderer.disposeAll();
+
+			assert.ok(callbackFlags.every(f => f), 'all onDisposed callbacks should have been called');
+		});
+
+		test('is a no-op on an empty stack', () => {
+			assert.doesNotThrow(() => PositronModalReactRenderer.disposeAll());
+		});
+	});
+
+	/**
+	 * isInsideAnyPopup / setBoundsProvider test suite.
+	 */
+	suite('isInsideAnyPopup', () => {
+		/**
+		 * Creates a mouse event at the given coordinates.
+		 */
+		function createMouseEvent(clientX: number, clientY: number): MouseEvent {
+			return new MouseEvent('mousedown', { clientX, clientY });
+		}
+
+		test('returns false when stack is empty', () => {
+			const e = createMouseEvent(100, 100);
+			assert.strictEqual(PositronModalReactRenderer.isInsideAnyPopup(e), false);
+		});
+
+		test('returns true when point is inside the registered bounds', () => {
+			const container = createMockContainer();
+			const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+			renderer.render(createMockReactElement());
+
+			renderer.setBoundsProvider(() => new DOMRect(50, 50, 200, 200));
+
+			assert.strictEqual(PositronModalReactRenderer.isInsideAnyPopup(createMouseEvent(100, 100)), true);
+
+			renderer.dispose();
+		});
+
+		test('returns false when point is outside the registered bounds', () => {
+			const container = createMockContainer();
+			const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+			renderer.render(createMockReactElement());
+
+			renderer.setBoundsProvider(() => new DOMRect(50, 50, 200, 200));
+
+			assert.strictEqual(PositronModalReactRenderer.isInsideAnyPopup(createMouseEvent(10, 10)), false);
+
+			renderer.dispose();
+		});
+
+		test('returns true when point is inside any one popup in the stack', () => {
+			const container = createMockContainer();
+
+			const r1 = disposables.add(new PositronModalReactRenderer({ container }));
+			r1.render(createMockReactElement());
+			r1.setBoundsProvider(() => new DOMRect(0, 0, 100, 100));
+
+			const r2 = disposables.add(new PositronModalReactRenderer({ container }));
+			r2.render(createMockReactElement());
+			r2.setBoundsProvider(() => new DOMRect(200, 200, 100, 100));
+
+			// Inside r1 only
+			assert.strictEqual(PositronModalReactRenderer.isInsideAnyPopup(createMouseEvent(50, 50)), true);
+			// Inside r2 only
+			assert.strictEqual(PositronModalReactRenderer.isInsideAnyPopup(createMouseEvent(250, 250)), true);
+			// Outside both
+			assert.strictEqual(PositronModalReactRenderer.isInsideAnyPopup(createMouseEvent(500, 500)), false);
+
+			PositronModalReactRenderer.disposeAll();
+		});
+
+		test('returns false for renderer with no bounds provider registered', () => {
+			const container = createMockContainer();
+			const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+			renderer.render(createMockReactElement());
+
+			// No setBoundsProvider call - should not throw and should return false
+			assert.strictEqual(PositronModalReactRenderer.isInsideAnyPopup(createMouseEvent(100, 100)), false);
+
+			renderer.dispose();
+		});
+	});
+
+	/**
+	 * allowPointerPassthrough test suite.
+	 */
+	suite('allowPointerPassthrough', () => {
+		test('sets pointer-events: none on the overlay when enabled', () => {
+			const container = createMockContainer();
+			const renderer = disposables.add(new PositronModalReactRenderer({
+				container,
+				allowPointerPassthrough: true
+			}));
+			renderer.render(createMockReactElement());
+
+			const overlay = container.querySelector('.positron-modal-overlay') as HTMLElement;
+			assert.ok(overlay);
+			assert.strictEqual(overlay.style.pointerEvents, 'none');
+
+			renderer.dispose();
+		});
+
+		test('does not set pointer-events on the overlay when disabled', () => {
+			const container = createMockContainer();
+			const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+			renderer.render(createMockReactElement());
+
+			const overlay = container.querySelector('.positron-modal-overlay') as HTMLElement;
+			assert.ok(overlay);
+			assert.notStrictEqual(overlay.style.pointerEvents, 'none');
+
+			renderer.dispose();
+		});
+	});
+
+	/**
+	 * Unrendered renderer test suite.
+	 */
+	suite('unrendered renderer', () => {
+		test('dispose before render is a no-op', () => {
+			const container = createMockContainer();
+			const renderer = disposables.add(new PositronModalReactRenderer({ container }));
+
+			assert.doesNotThrow(() => renderer.dispose());
+			assert.strictEqual(container.children.length, 0);
+		});
+
+		test('onDisposed is not called when renderer was never rendered', () => {
+			const container = createMockContainer();
+			let callbackCalled = false;
+
+			const renderer = disposables.add(new PositronModalReactRenderer({
+				container,
+				onDisposed: () => { callbackCalled = true; }
+			}));
+
+			renderer.dispose();
+
+			assert.strictEqual(callbackCalled, false);
+		});
+	});
 });

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -209,11 +209,11 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 	const MenuItem = (options: CustomContextMenuItemOptions) => {
 		// Get the shortcut, if there is a command ID.
 		let shortcut = '';
-		if (options.commandId) {
+		if (!!options.commandId) {
 			const keybinding = services.keybindingService.lookupKeybinding(options.commandId);
-			if (keybinding) {
+			if (!!keybinding) {
 				let label = keybinding.getLabel();
-				if (label) {
+				if (!!label) {
 					if (isMacintosh) {
 						label = label.replace('⇧', '⇧ ');
 						label = label.replace('⌥', '⌥ ');
@@ -318,7 +318,7 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 		 */
 		const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
 			// Do nothing if the submenu item is disabled.
-			if (options.disabled) {
+			if (!!options.disabled) {
 				return;
 			}
 

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -7,7 +7,7 @@
 import './customContextMenu.css';
 
 // React.
-import React, { useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 
 // Other dependencies.
 import * as DOM from '../../../../base/browser/dom.js';
@@ -20,6 +20,9 @@ import { CustomContextMenuItem, CustomContextMenuItemOptions } from './customCon
 import { PositronModalReactRenderer } from '../../../../base/browser/positronModalReactRenderer.js';
 import { usePositronReactServicesContext } from '../../../../base/browser/positronReactRendererContext.js';
 import { AnchorMode, AnchorPoint, PopupAlignment, PopupPosition, PositronModalPopup } from '../positronModalPopup/positronModalPopup.js';
+
+// Constants.
+const SUBMENU_HOVER_DELAY = 300;
 
 /**
  * CustomContextMenuEntry type.
@@ -98,6 +101,7 @@ export interface CustomContextMenuProps {
  * @param entries The context menu entries.
  * @param onClose The callback to call when the context menu is closed/disposed.
  * @param onDismissParentMenus Callback to dismiss parent menus when an item is selected.
+ * @returns The PositronModalReactRenderer for the custom context menu that can be disposed to close the context menu (and its submenu hierarchy).
  */
 export const showCustomContextMenu = ({
 	isSubmenu,
@@ -111,7 +115,7 @@ export const showCustomContextMenu = ({
 	entries,
 	onClose,
 	onDismissParentMenus,
-}: CustomContextMenuProps) => {
+}: CustomContextMenuProps): PositronModalReactRenderer => {
 	// Create the renderer.
 	const renderer = new PositronModalReactRenderer({
 		allowPointerPassthrough: isSubmenu,
@@ -121,12 +125,12 @@ export const showCustomContextMenu = ({
 	});
 
 	// Supply the default width.
-	if (!width) {
+	if (width === undefined) {
 		width = 'auto';
 	}
 
 	// Supply the default min width.
-	if (!minWidth) {
+	if (minWidth === undefined) {
 		minWidth = 'auto';
 	}
 
@@ -145,6 +149,9 @@ export const showCustomContextMenu = ({
 			onDismissParentMenus={onDismissParentMenus}
 		/>
 	);
+
+	// Return the renderer so callers can dispose it (and its submenu hierarchy).
+	return renderer;
 };
 
 /**
@@ -169,8 +176,22 @@ interface CustomContextMenuModalPopupProps {
  * @returns The rendered component.
  */
 const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) => {
-	// Context hooks.
+	// Services.
 	const services = usePositronReactServicesContext();
+
+	// The active submenu renderer.
+	const activeSubmenuRendererRef = useRef<PositronModalReactRenderer | undefined>(undefined);
+
+	/**
+	 * Closes the active submenu.
+	 */
+	const closeActiveSubmenu = useCallback(() => {
+		// If there is an active submenu, dispose it and clear the ref.
+		if (activeSubmenuRendererRef.current !== undefined) {
+			activeSubmenuRendererRef.current.dispose();
+			activeSubmenuRendererRef.current = undefined;
+		}
+	}, []);
 
 	/**
 	 * Dismisses this modal popup.
@@ -198,7 +219,14 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 	 */
 	const MenuSeparator = () => {
 		// Render.
-		return <div className='custom-context-menu-separator' role='separator' />;
+		return (
+			<div
+				className='custom-context-menu-separator'
+				role='separator'
+				// When the mouse enters a menu separator, close the active submenu.
+				onMouseEnter={closeActiveSubmenu}
+			/>
+		);
 	};
 
 	/**
@@ -236,11 +264,13 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 					{ 'checkable': options.checked !== undefined }
 				)}
 				disabled={options.disabled}
+				// When the mouse enters a menu item, close the active submenu.
+				onMouseEnter={closeActiveSubmenu}
 				onPressed={e => {
 					// Ensure we close the menu and the parent menus when a menu item selection is made.
 					dismissAllMenus();
 					options.onWillSelect?.();
-					if (options.commandId) {
+					if (options.commandId !== undefined) {
 						services.commandService.executeCommand(options.commandId);
 					}
 					options.onSelected(e);
@@ -291,18 +321,61 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 		// Reference to the submenu item that will be used to position the actual submenu popup.
 		const buttonRef = useRef<HTMLButtonElement>(null);
 
+		// The submenu renderer ref.
+		const submenuRendererRef = useRef<PositronModalReactRenderer | undefined>(undefined);
+
+		// Timer for the hover delay before opening a submenu. This prevents submenus from
+		// flickering open and closed as the user moves the mouse through the menu vertically.
+		const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+		/**
+		 * Starts the hover timer to open the submenu after a delay.
+		 */
+		const startHoverTimer = () => {
+			// Cancel pending hover timer.
+			cancelHoverTimer();
+
+			// Do nothing if the submenu item is disabled.
+			if (options.disabled === true) {
+				return;
+			}
+
+			// Start a new hover timer to open the submenu after a delay.
+			hoverTimerRef.current = setTimeout(openSubmenu, SUBMENU_HOVER_DELAY);
+		};
+
+		/**
+		 * Cancels the hover timer.
+		 */
+		const cancelHoverTimer = () => {
+			// If there is a hover timer, cancel it and clear the ref.
+			if (hoverTimerRef.current !== undefined) {
+				clearTimeout(hoverTimerRef.current);
+				hoverTimerRef.current = undefined;
+			}
+		};
+
 		/**
 		 * Opens the submenu (another custom context menu) positioned relative to this menu item.
 		 */
 		const openSubmenu = () => {
+			// Do nothing if the submenu item is disabled or if the button ref is not set yet.
 			if (options.disabled || !buttonRef.current) {
 				return;
 			}
 
+			// If this item's submenu is already the active one, return. Don't close and reopen it (which causes a flicker).
+			if (submenuRendererRef.current !== undefined && submenuRendererRef.current === activeSubmenuRendererRef.current) {
+				return;
+			}
+
+			// Close the active submenu before opening this submenu.
+			closeActiveSubmenu();
+
 			// Show the submenu by creating a new custom context menu instance.
 			// We use 'avoid' anchor mode to position the submenu adjacent to the parent menu item,
 			// instead of below the parent menu item so the parent menu item is not covered up.
-			showCustomContextMenu({
+			const renderer = showCustomContextMenu({
 				isSubmenu: true,
 				anchorElement: buttonRef.current,
 				popupPosition: 'auto',
@@ -312,7 +385,15 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 				entries: options.entries(),
 				// Passing down a function that will allow the submenu to dismiss the parent menus.
 				onDismissParentMenus: dismissAllMenus,
+				// On close, clear the submenu renderer ref.
+				onClose: () => {
+					submenuRendererRef.current = undefined;
+				},
 			});
+
+			// Set the submenu renderer ref and the active submenu renderer ref to this submenu's renderer.
+			submenuRendererRef.current = renderer;
+			activeSubmenuRendererRef.current = renderer;
 		};
 
 		/**
@@ -322,6 +403,9 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 		 * @param e The keyboard event.
 		 */
 		const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+			// Cancel hover timer on keydown.
+			cancelHoverTimer();
+
 			// Do nothing if the submenu item is disabled.
 			if (!!options.disabled) {
 				return;
@@ -343,6 +427,8 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 				className='custom-context-menu-item'
 				disabled={options.disabled}
 				onKeyDown={handleKeyDown}
+				onMouseEnter={startHoverTimer}
+				onMouseLeave={cancelHoverTimer}
 				onPressed={openSubmenu}
 			>
 				{options.icon &&

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -7,7 +7,7 @@
 import './customContextMenu.css';
 
 // React.
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 
 // Other dependencies.
 import * as DOM from '../../../../base/browser/dom.js';
@@ -354,6 +354,9 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 				hoverTimerRef.current = undefined;
 			}
 		};
+
+		// Cancel hover timer on unmount.
+		useEffect(() => cancelHoverTimer, []);
 
 		/**
 		 * Opens the submenu (another custom context menu) positioned relative to this menu item.

--- a/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
+++ b/src/vs/workbench/browser/positronComponents/customContextMenu/customContextMenu.tsx
@@ -68,6 +68,7 @@ export class CustomContextMenuSubmenu {
  * CustomContextMenuProps interface.
  */
 export interface CustomContextMenuProps {
+	readonly isSubmenu?: boolean;
 	readonly anchorElement: HTMLElement;
 	readonly anchorPoint?: AnchorPoint;
 	readonly popupPosition: PopupPosition;
@@ -87,6 +88,7 @@ export interface CustomContextMenuProps {
 
 /**
  * Shows a custom context menu.
+ * @param isSubmenu Whether this context menu is a submenu.
  * @param anchorElement The anchor element.
  * @param anchorPoint The anchor point.
  * @param popupPosition The popup position.
@@ -98,6 +100,7 @@ export interface CustomContextMenuProps {
  * @param onDismissParentMenus Callback to dismiss parent menus when an item is selected.
  */
 export const showCustomContextMenu = ({
+	isSubmenu,
 	anchorElement,
 	anchorPoint,
 	popupPosition,
@@ -111,6 +114,7 @@ export const showCustomContextMenu = ({
 }: CustomContextMenuProps) => {
 	// Create the renderer.
 	const renderer = new PositronModalReactRenderer({
+		allowPointerPassthrough: isSubmenu,
 		container: PositronReactServices.services.workbenchLayoutService.getContainer(DOM.getWindow(anchorElement)),
 		parent: anchorElement,
 		onDisposed: onClose
@@ -299,6 +303,7 @@ const CustomContextMenuModalPopup = (props: CustomContextMenuModalPopupProps) =>
 			// We use 'avoid' anchor mode to position the submenu adjacent to the parent menu item,
 			// instead of below the parent menu item so the parent menu item is not covered up.
 			showCustomContextMenu({
+				isSubmenu: true,
 				anchorElement: buttonRef.current,
 				popupPosition: 'auto',
 				popupAlignment: 'auto',

--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.css
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.css
@@ -17,6 +17,7 @@
 	width: min-content;
 	height: min-content;
 	box-sizing: border-box;
+	pointer-events: auto;
 	color: var(--vscode-positronModalDialog-foreground);
 	border: 1px solid var(--vscode-positronModalDialog-border);
 	background-color: var(--vscode-positronModalDialog-background);

--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -152,24 +152,17 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 		let anchorY: number;
 		let anchorWidth: number;
 		let anchorHeight: number;
-		if (props.anchorPoint) {
+		if (props.anchorPoint !== undefined) {
 			anchorX = props.anchorPoint.clientX;
 			anchorY = props.anchorPoint.clientY;
 			anchorWidth = 0;
 			anchorHeight = 0;
-		} else if (props.anchorElement) {
+		} else {
 			const topLeftAnchorOffset = DOM.getTopLeftOffset(props.anchorElement);
 			anchorX = topLeftAnchorOffset.left;
 			anchorY = topLeftAnchorOffset.top;
 			anchorWidth = props.anchorElement.offsetWidth;
 			anchorHeight = props.anchorElement.offsetHeight;
-		} else {
-			// If no anchor point or element is provided, default to the center
-			// of the document.
-			anchorX = documentWidth / 2;
-			anchorY = documentHeight / 2;
-			anchorWidth = 0;
-			anchorHeight = 0;
 		}
 
 		// Create the popup layout.
@@ -427,6 +420,9 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 
 	// Event handlers.
 	useEffect(() => {
+		// Set this popup's bounds provider with the renderer so that we can check click containment.
+		props.renderer.setBoundsProvider(() => popupRef.current.getBoundingClientRect());
+
 		// Create a disposable store for the event handlers we'll add.
 		const disposableStore = new DisposableStore();
 
@@ -461,6 +457,7 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 			 */
 			const navigateFocusableElements = (direction: 'next' | 'previous', wrap: boolean) => {
 				// Get the focusable elements.
+				// eslint-disable-next-line no-restricted-syntax
 				const focusableElements = popupContainerRef.current.querySelectorAll<HTMLElement>(
 					props.focusableElementSelectors ?? focusableElementSelectors
 				);
@@ -561,10 +558,19 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 
 		// Add the onMouseDown event handler.
 		disposableStore.add(props.renderer.onMouseDown(e => {
+			// Get the bounding client rect of the popup.
 			const clientRect = popupRef.current.getBoundingClientRect();
-			if (!(e.clientX >= clientRect.left && e.clientX <= clientRect.right &&
-				e.clientY >= clientRect.top && e.clientY <= clientRect.bottom)) {
-				props.renderer.dispose();
+
+			// If the click is outside this popup's bounds, decide what to dismiss.
+			if (!(e.clientX >= clientRect.left && e.clientX <= clientRect.right && e.clientY >= clientRect.top && e.clientY <= clientRect.bottom)) {
+				// If the click is outside every popup in the stack, dismiss the root renderer so
+				// the entire popup stack is dismissed. Otherwise just close this popup (e.g. a
+				// submenu when the user clicks back into its parent menu).
+				if (!PositronModalReactRenderer.isInsideAnyPopup(e)) {
+					PositronModalReactRenderer.disposeAll();
+				} else {
+					props.renderer.dispose();
+				}
 			}
 		}));
 


### PR DESCRIPTION
## Summary

Adds hover-based show/hide for submenus in `CustomContextMenu`, backed by foundational improvements to `PositronModalReactRenderer` that make stacked modal renderers work correctly.

### `PositronModalReactRenderer` improvements

- **Stack-ordered disposal**: Replaced the unordered `Set` with a proper `Stack<T>` (with `push`, `pop`, `top`, `bottom`, `isEmpty`, `forEach`). Disposing a renderer now automatically disposes all child renderers above it first, ensuring teardown always happens in correct order.
- **`disposeAll()`**: New static method that disposes the entire stack by disposing the bottom renderer, which cascades upward.
- **`isInsideAnyPopup()`**: New static method that checks whether a mouse event falls within the bounds of any popup currently in the stack. Used by `PositronModalPopup` to decide whether an outside click should close just the top popup or the entire stack.
- **`setBoundsProvider()`**: New method allowing `PositronModalPopup` to register a bounds callback with its renderer, so the stack can perform the containment check above.
- **`allowPointerPassthrough` option**: When set, the overlay's `pointer-events` is set to `none`, allowing mouse events to reach popups beneath it. Used by submenus so the parent menu remains interactive while a submenu is open.
- **Cleaner `render`/`dispose` logic**: Guards against double-render and double-dispose; `onDisposed` callback and focus restoration now happen reliably in all cases.
- **`PositronReactServicesProvider` component**: Extracted the services context provider into a named component used by both `PositronModalReactRenderer` and `PositronReactRenderer`, replacing the inline `Context.Provider` pattern.
- **Tests**: Added `positronModalReactRenderer.test.ts` covering single/stacked disposal, mid-stack disposal cascade, double-dispose safety, `onDisposed` callbacks, double-render prevention, and `aria-expanded` lifecycle.

### `Button` component

Migrated from `forwardRef` to the React 19 `ref` prop pattern.

### `PositronModalPopup` improvements

- Registers a bounds provider with its renderer on mount so the stack can check click containment.
- Updated the outside-click handler: if the click is outside every popup in the stack, `disposeAll()` closes everything; if it's inside another popup (e.g. the user clicked back into a parent menu), only the current popup is disposed.
- Added `pointer-events: auto` to `.positron-modal-popup` so it receives mouse events even when nested inside a passthrough overlay.

### `CustomContextMenu` submenu support

- Submenu items open after a 300ms hover delay, preventing flicker as the mouse moves vertically through items.
- Moving the mouse to another item or a separator closes the active submenu.
- The hover timer is cancelled on keydown to prevent conflicts with keyboard navigation.
- ArrowRight opens a submenu; ArrowLeft closes it and returns focus to the parent menu.
- Each menu tracks the active submenu renderer; opening a new submenu disposes the previous one without flicker if the same submenu is already open.
- Selecting any item dismisses the entire menu hierarchy via a chained `onDismissParentMenus` callback.
- `showCustomContextMenu` now returns the renderer so callers can dispose the hierarchy programmatically.

Here's a screen recording of cascading submenus:

https://github.com/user-attachments/assets/fff3b312-e1a2-4136-8233-76b10a1d1a64

### Release Notes

#### New Features

- #12158 Adds hover-based show/hide for submenus.

#### Bug Fixes

- N/A

### QA Notes

TESTS:
@:plots
