### PR TITLE
Bump Air extension to 0.24.0

### DIFF
--- a/product.json
+++ b/product.json
@@ -243,7 +243,7 @@
 		},
 		{
 			"name": "posit.air-vscode",
-			"version": "0.22.0",
+			"version": "0.24.0",
 			"repo": "https://github.com/posit-dev/air",
 			"metadata": {
 				"publisherId": "090804ff-7eb2-4fbd-bb61-583e34f2b070",


### PR DESCRIPTION
Nothing particularly notable for the extension, but quite a few CLI updates https://github.com/posit-dev/air/releases/tag/0.9.0