### PR TITLE
Fix truncation e2e test failing in CI

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-cell-output.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-cell-output.test.ts
@@ -67,8 +67,16 @@ test.describe('Positron Notebooks: Cell Output', {
 		});
 	});
 
-	test('Toggle long output truncation', async function ({ app }) {
+	test('Toggle long output truncation', async function ({ app, settings }) {
 		const { notebooks, notebooksPositron } = app.workbench;
+
+		// Disable output scrolling so truncation is active.
+		// In non-stable builds (e.g. CI), scrolling defaults to true
+		// (see notebook.contribution.ts NotebookSetting.outputScrolling)
+		// which disables truncation entirely.
+		await settings.set(
+			{ 'notebook.output.scrolling': false },
+		);
 
 		await test.step('Setup: Open a notebook and generate long output', async () => {
 			await notebooks.createNewNotebook();


### PR DESCRIPTION
The "Toggle long output truncation" e2e test was failing across all platforms in CI.

### Root Cause

The `notebook.output.scrolling` setting defaults to `true` in non-stable builds:

```typescript
default: typeof product.quality === 'string' && product.quality !== 'stable'
```

In CI release builds (`product.quality` is set), scrolling is enabled by default, which disables truncation entirely. The truncation message never appears, causing the test to time out. Locally, `product.quality` is `undefined`, so scrolling defaults to `false` and the test passes.

### Fix

Explicitly set `notebook.output.scrolling: false` in the test setup so truncation is active regardless of build quality.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks

This is a test-only change. The "Toggle long output truncation" test in `notebook-cell-output.test.ts` should now pass in CI.