### PR TITLE
Fix webview-based output rendering broken after VS Code 1.109 merge

### DIFF
--- a/extensions/positron-ipywidgets/renderer/esbuild.js
+++ b/extensions/positron-ipywidgets/renderer/esbuild.js
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 // @ts-check
-const fs = require('fs');
 const path = require('path');
 
 const srcDir = path.join(__dirname, 'src');
@@ -26,17 +25,11 @@ require('../../esbuild-webview-common.mjs').run({
 			'.eot': 'dataurl',
 		},
 		define: {
-			// RequireJS is loaded by the renderer at activation time. Some of our dependencies
+			// RequireJS is loaded as a notebook static preload. Some of our dependencies
 			// (e.g. backbone) try to use RequireJS's `define` if it's present, but esbuild expects
 			// these modules to behave like CommonJS modules. Override the global `define` to
 			// undefined to disable this behavior during bundling.
 			'define': 'undefined',
 		},
 	},
-}, process.argv, (/** @type {string} */ outDir) => {
-	// Copy RequireJS to the output directory so the renderer can load it at activation time.
-	fs.copyFileSync(
-		path.join(__dirname, 'node_modules', 'requirejs', 'require.js'),
-		path.join(outDir, 'require.js'),
-	);
-});
+}, process.argv);

--- a/extensions/positron-ipywidgets/renderer/package-lock.json
+++ b/extensions/positron-ipywidgets/renderer/package-lock.json
@@ -18,8 +18,7 @@
         "@jupyterlab/rendermime-interfaces": "^3.10.4",
         "@jupyterlab/services": "^7.2.3",
         "@lumino/coreutils": "^2.1.2",
-        "@lumino/widgets": "^2.3.2",
-        "requirejs": "^2.3.6"
+        "@lumino/widgets": "^2.3.2"
       },
       "devDependencies": {
         "@types/vscode-webview": "^1.57.5",
@@ -1210,19 +1209,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/requirejs": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.8.tgz",
-      "integrity": "sha512-7/cTSLOdYkNBNJcDMWf+luFvMriVm7eYxp4BcFCsAX0wF421Vyce5SXP17c+Jd5otXKGNehIonFlyQXSowL6Mw==",
-      "license": "MIT",
-      "bin": {
-        "r_js": "bin/r.js",
-        "r.js": "bin/r.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/requires-port": {

--- a/extensions/positron-ipywidgets/renderer/package.json
+++ b/extensions/positron-ipywidgets/renderer/package.json
@@ -13,8 +13,7 @@
     "@jupyterlab/rendermime-interfaces": "^3.10.4",
     "@jupyterlab/services": "^7.2.3",
     "@lumino/coreutils": "^2.1.2",
-    "@lumino/widgets": "^2.3.2",
-    "requirejs": "^2.3.6"
+    "@lumino/widgets": "^2.3.2"
   },
   "devDependencies": {
     "@types/vscode-webview": "^1.57.5",

--- a/extensions/positron-ipywidgets/renderer/src/index.ts
+++ b/extensions/positron-ipywidgets/renderer/src/index.ts
@@ -28,21 +28,10 @@ export const activate: ActivationFunction = async (context) => {
 	// However, we still need to define them as AMD modules since if a third party module
 	// depends on them it will try to load them with requirejs.
 
-	// Load RequireJS if it's not already available. It was previously provided by the notebook
-	// webview via vs/loader.js, but upstream removed that as part of the ESM migration.
-	if (!isDefineFn((window as Window & { define?: unknown }).define)) {
-		await new Promise<void>((resolve, reject) => {
-			const script = document.createElement('script');
-			script.src = new URL('./require.js', import.meta.url).href;
-			script.onload = () => resolve();
-			script.onerror = () => reject(new Error('Failed to load RequireJS'));
-			document.head.appendChild(script);
-		});
-	}
-
+	// RequireJS is provided by the ms-toolsai.jupyter-renderers static preload (preload.js).
 	const define: unknown = (window as Window & { define?: unknown }).define;
 	if (!isDefineFn(define)) {
-		throw new Error('Requirejs is needed, please ensure it is loaded on the page.');
+		throw new Error('RequireJS is needed but was not loaded by the notebook static preload.');
 	}
 	define('@jupyter-widgets/base', () => base);
 	define('@jupyter-widgets/controls', () => controls);

--- a/product.json
+++ b/product.json
@@ -167,6 +167,22 @@
 			}
 		},
 		{
+			"name": "ms-toolsai.jupyter-renderers",
+			"version": "1.3.0",
+			"sha256sum": "d09f6c517a8090a932bb4e2c31bcb2de34ddb2a71133477f6c47f28f36eb76ae",
+			"repo": "https://github.com/Microsoft/vscode-notebook-renderers",
+			"metadata": {
+				"id": "b15c72f8-d5fe-421a-a4f7-27ed9f6addbf",
+				"publisherId": {
+					"publisherId": "ac8eb7c9-3e59-4b39-8040-f0484d8170ce",
+					"publisherName": "ms-toolsai",
+					"displayName": "Microsoft",
+					"flags": "verified"
+				},
+				"publisherDisplayName": "ms-toolsai"
+			}
+		},
+		{
 			"name": "ms-toolsai.jupyter",
 			"version": "2025.9.1",
 			"sha256sum": "110660656944c4ab0ff687db488c2e8c59c67ec121dcf09bcaa54b6edd9ce71f",

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -57,10 +57,10 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 	 * @returns An array of renderers and the mime type they are preferred for along with the
 	 * associated output message.
 	 */
-	private _findRenderersForOutputs(outputs: ILanguageRuntimeMessageWebOutput[]): MessageRenderInfo[] {
+	private _findRenderersForOutputs(outputs: ILanguageRuntimeMessageWebOutput[], viewType?: string): MessageRenderInfo[] {
 		return outputs
 			.map(output => {
-				const info = this._findRendererForOutput(output);
+				const info = this._findRendererForOutput(output, viewType);
 				if (!info) {
 					this._logService.warn(
 						'Failed to find renderer for output with mime types: ' +
@@ -113,7 +113,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 		viewType?: string;
 	}): Promise<INotebookOutputWebview | undefined> {
 
-		const displayInfo = this._findRendererForOutput(displayMessage);
+		const displayInfo = this._findRendererForOutput(displayMessage, viewType);
 		if (!displayInfo) {
 			this._logService.error(
 				'Failed to find renderer for output message with mime types: ' +
@@ -126,7 +126,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 			id: displayMessage.id,
 			runtimeId,
 			displayMessageInfo: displayInfo,
-			preReqMessagesInfo: this._findRenderersForOutputs(preReqMessages),
+			preReqMessagesInfo: this._findRenderersForOutputs(preReqMessages, viewType),
 			viewType,
 		});
 	}

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -429,10 +429,14 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 
 	/** Handles a language runtime output message. */
 	private async handleRuntimeOutputMessage(previewId: string, message: ILanguageRuntimeMessageOutput | ILanguageRuntimeMessageUpdateOutput, session: ILanguageRuntimeSession) {
+		// viewType ensures renderers registered for the jupyter-notebook type
+		// are resolved (e.g. Plotly) and that notebook static preloads (e.g.
+		// RequireJS from ms-toolsai.jupyter-renderers) are injected.
 		const webview = await this._notebookOutputWebviewService.createNotebookOutputWebview({
 			id: message.id,
 			runtime: session,
-			output: message
+			output: message,
+			viewType: 'jupyter-notebook',
 		});
 		if (webview) {
 			const preview = this.createPreviewWebview(

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -979,11 +979,15 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			resource_roots: undefined,
 		};
 
-		// Create a notebook output webview for the output
+		// Create a notebook output webview for the output.
+		// viewType ensures renderers registered for the jupyter-notebook type
+		// are resolved (e.g. Plotly) and that notebook static preloads (e.g.
+		// RequireJS from ms-toolsai.jupyter-renderers) are injected.
 		const notebookWebview = await this._webviewService.createNotebookOutputWebview({
 			id: runtimeMessage.id,
 			runtime: session,
 			output: runtimeMessage,
+			viewType: 'jupyter-notebook',
 		});
 
 		if (!notebookWebview) {

--- a/test/e2e/tests/quarto/quarto-inline-output-popout.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-popout.test.ts
@@ -122,7 +122,7 @@ test.describe('Quarto - Inline Output: Popout', {
 		await expect(inlineQuarto.popoutButton).not.toBeVisible({ timeout: 5000 });
 	});
 
-	test.skip('Python - Verify popout button opens interactive HTML in viewer panel',
+	test('Python - Verify popout button opens interactive HTML in viewer panel',
 		{
 			annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/12373' }]
 		}, async function ({ app, openFile }) {


### PR DESCRIPTION
Addresses #6507, #12373.

### Timeline

1. Before bootstrapped extensions:
    1. `mstooolsai.jupyter-renderers` was a built-in extension. Its `jupyter-notebook-renderer` handled plotly plots. Its notebook preload script shipped RequireJS, but Positron's custom output webviews never loaded it because `viewType` wasn't passed through to `getStaticPreloadsData()`. This went unnoticed because VS Code's `vs/loader.js` _also_ bundled RequireJS.
    2. Positron's `positron-ipywidgets` renderer handled ipywidgets and used RequireJS from `vs/loader.js`.

2. Bootstrapped extensions introduced (PR #6403):
    1. Other Jupyter extensions moved to bootstrap, but `jupyter-renderers` stayed as built-in because moving it caused e2e tests to fail, still unknown why (#6507).

3. VS Code 1.109 merge (PR #11933):
    1. `vs/loader.js` removed upstream. This broke ipywidgets and plotly because RequireJS was no longer provided.
    2. We accidentally dropped `jupyter-renderers` from `builtInExtensions` during merge conflict resolution. This broke plotly because we no longer had the plotly renderer.
    3. BTW `rstudio-workbench` was also downgraded from v1.6.47 to v1.6.46 here. Was that intentional?

### Changes

This PR makes the following changes:

1. Add `jupyter-renderers` that was accidentally dropped from `product.json`. For some reason e2e tests pass in CI with it as a bootstrapped extension now, I'm not sure why 🤷.
2. Fix `getStaticPreloadsData()` so it loads RequireJS via `jupyter-renderer` preload.
3. Remove RequireJS from ipywidgets. It's no longer needed given the fixes above.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed Quarto and notebook interactive plots (e.g. Plotly) regression (#12373)

### QA Notes

@:quarto @:notebooks @:plots @:viewer @:positron-notebooks