### PR TITLE
Deduplicate packages by name in Packages pane

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -11,6 +11,7 @@ import React, {
 	CSSProperties,
 	useCallback,
 	useEffect,
+	useMemo,
 	useRef,
 	useState,
 } from 'react';
@@ -168,6 +169,20 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 		};
 	}, [loading]);
 
+	// Deduplicate packages by name, keeping only the first occurrence.
+	// The same package can exist in multiple library paths (e.g., user and system libraries).
+	// We show only the first one, matching R's library search order.
+	const deduplicatedPackages = useMemo(() => {
+		const seen = new Set<string>();
+		return packages.filter((pkg) => {
+			if (seen.has(pkg.name)) {
+				return false;
+			}
+			seen.add(pkg.name);
+			return true;
+		});
+	}, [packages]);
+
 	// UI State
 	const [focused, setFocused] = useState(false);
 
@@ -207,7 +222,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 
 	// Item renderer
 	const ItemEntry = (props: { index: number; style: CSSProperties }) => {
-		const itemProps = packages[props.index];
+		const itemProps = deduplicatedPackages[props.index];
 		const { id, name, displayName, version } = itemProps;
 
 		return (
@@ -236,7 +251,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 									tooltip: localize('positronPackages.copyAllPackages', 'Copy All'),
 									class: undefined,
 									enabled: true,
-									run: () => services.clipboardService.writeText(packages.map((pkg) => `${pkg.name} (${pkg.version})`).join('\n'))
+									run: () => services.clipboardService.writeText(deduplicatedPackages.map((pkg) => `${pkg.name} (${pkg.version})`).join('\n'))
 								},
 								new Separator(),
 								{
@@ -273,8 +288,8 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 
 	// Map selected item to package name
 	const getSelectedItemPackageName = useCallback((item: string | undefined) => {
-		return packages.find((pkg) => pkg.id === item)?.name;
-	}, [packages]);
+		return deduplicatedPackages.find((pkg) => pkg.id === item)?.name;
+	}, [deduplicatedPackages]);
 
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
@@ -312,8 +327,8 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 				<List
 					height={height - ACTION_BAR_HEIGHT}
 					innerRef={innerRef}
-					itemCount={packages.length}
-					itemKey={(index) => packages[index].id}
+					itemCount={deduplicatedPackages.length}
+					itemKey={(index) => deduplicatedPackages[index].id}
 					itemSize={26}
 					width={'calc(100% - 2px)'}
 				>


### PR DESCRIPTION
The same R package can exist in multiple library paths (user library, system library, etc.). When rendering, these duplicates would overlap at the same position causing text to appear double-drawn or bolder.

Deduplicate by package name in the UI, keeping only the first occurrence to match R's library search order.

See #12548

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Deduplicate R packages in the Packages pane to avoid multiple renderings in the UI.

### QA Notes

I don't know how to reproduce this in the wild, but you can artificially set it up. Update listPackages.tsx. Notice that we basically perform the dedupe, but just intentionally duplicate items:

```diff
+       // Deduplicate packages by name, keeping only the first occurrence.
+       // The same package can exist in multiple library paths (e.g., user and system libraries).
+       // We show only the first one, matching R's library search order.
+       const deduplicatedPackages = useMemo(() => {
+               const seen = new Set<string>();
+               const x = packages.filter((pkg) => {
+                       if (seen.has(pkg.name)) {
+                               return false;
+                       }
+                       seen.add(pkg.name);
+                       return true;
+               });
+               // Now duplicate away
+               if (x[1]) {
+                       x[0] = x[1];
+                       x[2] = x[1];
+                       x[3] = x[1];
+                       x[4] = x[1];
+
+                       x[30] = x[1];
+                       x[31] = x[1];
+                       x[32] = x[1];
+                       x[33] = x[1];
+               }
+               return x;
+       }, [packages]);
```