### PR TITLE
e2e: Switch rig install to winget

### DIFF
--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -298,8 +298,9 @@ jobs:
 
       # Install rig (R Installation Manager)
       - name: Install rig
+        shell: pwsh
         run: |
-          choco install rig
+          winget install --id Posit.rig --accept-source-agreements --accept-package-agreements
 
       # Install R 4.4.0 using rig
       - name: Install R 4.4.0


### PR DESCRIPTION
Using Chocolately to install rig has been flakey lately, so switching to winget in hopes it will be more reliable.

### QA Notes
@:win
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
