### PR TITLE
python: dont deepcopy geopandas series

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -1130,18 +1130,28 @@ class GeoDataFrameInspector(PandasDataFrameInspector):
         return self.value.shape[0] * num_cols
 
     def deepcopy(self):
-        """Copy only non-geometry columns for change detection."""
-        return self._get_non_geometry_df().copy(deep=True)
+        """Copy non-geometry columns deeply, geometry columns shallowly.
+
+        Returns a GeoDataFrame to preserve the inspector type for change detection.
+        Geometry columns are shallow-copied since we don't compare them.
+        """
+        # Shallow copy preserves GeoDataFrame type
+        result = self.value.copy(deep=False)
+
+        # Deep copy only non-geometry columns
+        geom_cols = set(self._get_geometry_column_names())
+        for col in self.value.columns:
+            if col not in geom_cols:
+                result[col] = self.value[col].copy(deep=True)
+
+        return result
 
     def equals(self, value) -> bool:
         """Compare only non-geometry columns."""
         try:
-            # Get non-geometry data from this GeoDataFrame
             self_non_geom = self._get_non_geometry_df()
-
-            # Handle comparison value - it's already a regular DataFrame from our deepcopy
-            # (geometry columns were dropped during deepcopy)
-            return self_non_geom.equals(value)
+            other_non_geom = GeoDataFrameInspector(value)._get_non_geometry_df()  # noqa: SLF001
+            return self_non_geom.equals(other_non_geom)
         except Exception:
             return False
 

--- a/extensions/positron-python/python_files/posit/positron/inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/inspectors.py
@@ -4,6 +4,7 @@
 #
 from __future__ import annotations
 
+import contextlib
 import copy
 import datetime
 import inspect
@@ -49,8 +50,6 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    import contextlib
-
     import numpy as np
     import pandas as pd
     import polars as pl
@@ -927,10 +926,7 @@ class BaseColumnInspector(_BaseMapInspector[Column], ABC):
 
 class PandasSeriesInspector(BaseColumnInspector["pd.Series"]):
     # Simplified names
-    CLASS_QNAME = (
-        "pandas.Series",
-        "geopandas.GeoSeries",
-    )
+    CLASS_QNAME = ("pandas.Series",)
 
     def get_display_name(self, key: int) -> str:
         return str(self.value.index[key])
@@ -960,6 +956,16 @@ class PandasSeriesInspector(BaseColumnInspector["pd.Series"]):
 
     def has_viewer(self) -> bool:
         return True
+
+
+class GeoSeriesInspector(PandasSeriesInspector):
+    """Inspector for geopandas.GeoSeries - excludes from change detection."""
+
+    CLASS_QNAME = ("geopandas.GeoSeries",)
+
+    def deepcopy(self):
+        """GeoSeries cannot be efficiently copied for change detection."""
+        raise copy.Error("GeoSeries contains expensive geometry objects")
 
 
 class PandasIndexInspector(BaseColumnInspector["pd.Index"]):
@@ -1063,10 +1069,7 @@ class BaseTableInspector(_BaseMapInspector[Table], Generic[Table, Column], ABC):
 
 class PandasDataFrameInspector(BaseTableInspector["pd.DataFrame", "pd.Series"]):
     # Simplified names
-    CLASS_QNAME = (
-        "pandas.DataFrame",
-        "geopandas.GeoDataFrame",
-    )
+    CLASS_QNAME = ("pandas.DataFrame",)
 
     def get_display_name(self, key: int) -> str:
         return str(self.value.columns[key])
@@ -1090,6 +1093,57 @@ class PandasDataFrameInspector(BaseTableInspector["pd.DataFrame", "pd.Series"]):
 
     def to_plaintext(self) -> str:
         return self.value.to_csv(path_or_buf=None, sep="\t")
+
+
+class GeoDataFrameInspector(PandasDataFrameInspector):
+    """Inspector for geopandas.GeoDataFrame with optimized change detection."""
+
+    CLASS_QNAME = ("geopandas.GeoDataFrame",)
+
+    def _get_geometry_column_names(self) -> list[str]:
+        """Get the names of all geometry columns."""
+        geom_cols = []
+        with contextlib.suppress(AttributeError, KeyError):
+            # First try to get the active geometry column
+            geom_cols.append(self.value.geometry.name)
+
+        # Also check for columns with geometry dtype (handles unset active geometry)
+        for col in self.value.columns:
+            if str(self.value[col].dtype) == "geometry" and col not in geom_cols:
+                geom_cols.append(col)
+
+        return geom_cols
+
+    def _get_non_geometry_df(self):
+        """Get DataFrame with geometry columns dropped."""
+        geom_cols = self._get_geometry_column_names()
+        cols_to_drop = [col for col in geom_cols if col in self.value.columns]
+        if cols_to_drop:
+            return self.value.drop(columns=cols_to_drop)
+        return self.value
+
+    def get_comparison_cost(self) -> int:
+        """Return cost based on non-geometry columns only."""
+        geom_cols = self._get_geometry_column_names()
+        num_geom_cols = sum(1 for col in geom_cols if col in self.value.columns)
+        num_cols = self.value.shape[1] - num_geom_cols
+        return self.value.shape[0] * num_cols
+
+    def deepcopy(self):
+        """Copy only non-geometry columns for change detection."""
+        return self._get_non_geometry_df().copy(deep=True)
+
+    def equals(self, value) -> bool:
+        """Compare only non-geometry columns."""
+        try:
+            # Get non-geometry data from this GeoDataFrame
+            self_non_geom = self._get_non_geometry_df()
+
+            # Handle comparison value - it's already a regular DataFrame from our deepcopy
+            # (geometry columns were dropped during deepcopy)
+            return self_non_geom.equals(value)
+        except Exception:
+            return False
 
 
 class PolarsDataFrameInspector(BaseTableInspector["pl.DataFrame", "pl.Series"]):
@@ -1310,6 +1364,9 @@ class IbisExprInspector(PositronInspector["ibis.Expr"]):
 
 
 INSPECTOR_CLASSES: dict[str, type[PositronInspector]] = {
+    # Geopandas inspectors (before pandas to take precedence)
+    **dict.fromkeys(GeoDataFrameInspector.CLASS_QNAME, GeoDataFrameInspector),
+    **dict.fromkeys(GeoSeriesInspector.CLASS_QNAME, GeoSeriesInspector),
     **dict.fromkeys(PandasDataFrameInspector.CLASS_QNAME, PandasDataFrameInspector),
     **dict.fromkeys(PandasSeriesInspector.CLASS_QNAME, PandasSeriesInspector),
     **dict.fromkeys(PandasIndexInspector.CLASS_QNAME, PandasIndexInspector),

--- a/extensions/positron-python/python_files/posit/positron/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_inspectors.py
@@ -92,6 +92,16 @@ def verify_inspector(
                 # Check that the value is the same.
                 assert inspector.equals(copied)
 
+                # Verify the reverse direction works (snapshot inspector vs live value).
+                # This matches runtime change detection: inspector_for_snapshot.equals(live_value)
+                copied_inspector = get_inspector(copied)
+                assert type(copied_inspector) is type(inspector), (
+                    f"deepcopy changed inspector type from {type(inspector)} to {type(copied_inspector)}"
+                )
+                assert copied_inspector.equals(value), (
+                    "equals must work in both directions for change detection"
+                )
+
                 # Mutate the copied object, and check that the original object was not mutated.
                 assert mutate is not None, (
                     "mutate function must be provided to test mutable objects"

--- a/extensions/positron-python/python_files/posit/positron/tests/test_inspectors.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_inspectors.py
@@ -652,9 +652,12 @@ def test_inspect_geopandas_dataframe() -> None:
     value = geopandas.GeoDataFrame({"g": geopandas.GeoSeries([p1, p2, p3]), "data": [0, 1, 2]})
 
     rows, cols = value.shape
+    # Comparison cost should exclude geometry column (1 non-geom column * 3 rows = 3)
+    non_geom_cols = cols - 1
 
     def mutate(x):
-        x["data2"] = [4, 5, 6]
+        # Mutate non-geometry data (deepcopy only copies non-geometry columns)
+        x["data"] = [9, 9, 9]
 
     verify_inspector(
         value=value,
@@ -668,6 +671,7 @@ def test_inspect_geopandas_dataframe() -> None:
         length=cols,
         mutable=True,
         mutate=mutate,
+        comparison_cost=rows * non_geom_cols,
     )
 
 
@@ -738,9 +742,6 @@ def test_inspect_geopandas_series() -> None:
     )
     (rows,) = value.shape
 
-    def mutate(x):
-        x.iloc[0] = x.iloc[1]
-
     verify_inspector(
         value=value,
         display_value=f"geopandas.GeoSeries {value.to_list()!r}",
@@ -752,7 +753,8 @@ def test_inspect_geopandas_series() -> None:
         is_truncated=False,
         length=rows,
         mutable=True,
-        mutate=mutate,
+        # GeoSeries excludes itself from change detection (deepcopy raises copy.Error)
+        supports_deepcopy=False,
     )
 
 


### PR DESCRIPTION
`geopandas` columns can be waaayyy larger than other columns. Deepcopying them drastically slows down the console, so we probably don't want to evaluate them every time. 

We put GeoPandas Series in the `mutable_vars_excluded` part of the variables snapshot by raising a copy error. Users will still see these columns in the data explorer/variables pane, but we are NOT comparing each cell.


<img width="1679" height="640" alt="Screenshot 2026-03-31 at 3 17 00 PM" src="https://github.com/user-attachments/assets/86bf19f6-7ad4-4ab4-983f-bab6d82044f4" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- https://github.com/posit-dev/positron/issues/11918


### QA Notes

from linked issue

```python
import geopandas
import pandas as pd
from geodatasets import get_path

path_to_data = get_path("nybb")
gdf = geopandas.read_file(path_to_data)

# create large geopandas object (gdf has 5 rows)
gdfl = pd.concat([gdf.copy() for i in range(10000)])

# output is still fast
1 + 1
```