### PR TITLE
Update @vscode/spdlog to 0.15.8 to fix node-gyp compilation problem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@vscode/policy-watcher": "^1.3.2",
         "@vscode/proxy-agent": "^0.37.0",
         "@vscode/ripgrep": "^1.15.13",
-        "@vscode/spdlog": "^0.15.7",
+        "@vscode/spdlog": "^0.15.8",
         "@vscode/sqlite3": "5.1.12-vscode",
         "@vscode/sudo-prompt": "9.3.2",
         "@vscode/tree-sitter-wasm": "^0.3.0",
@@ -5601,9 +5601,9 @@
       }
     },
     "node_modules/@vscode/spdlog": {
-      "version": "0.15.7",
-      "resolved": "https://registry.npmjs.org/@vscode/spdlog/-/spdlog-0.15.7.tgz",
-      "integrity": "sha512-xpHAtw0IESD6wmjqLr6LbpYAmr8ZYm8AT7hGE7oM7AojNeOBngXLOqmzpXbTNTAvXBq1KHy8PwbMmY24uYR/oQ==",
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/@vscode/spdlog/-/spdlog-0.15.8.tgz",
+      "integrity": "sha512-Jh8M6b2vJfBmQua9aAiYa9sdd/htw+/71b7GZlI3v2DGbsAXIYo7gIokrfx1/0XtQPTPoJ8RKtQ9hNSPlnfXUQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@vscode/policy-watcher": "^1.3.2",
     "@vscode/proxy-agent": "^0.37.0",
     "@vscode/ripgrep": "^1.15.13",
-    "@vscode/spdlog": "^0.15.7",
+    "@vscode/spdlog": "^0.15.8",
     "@vscode/sqlite3": "5.1.12-vscode",
     "@vscode/sudo-prompt": "9.3.2",
     "@vscode/tree-sitter-wasm": "^0.3.0",

--- a/remote/package-lock.json
+++ b/remote/package-lock.json
@@ -17,7 +17,7 @@
         "@vscode/native-watchdog": "^1.4.6",
         "@vscode/proxy-agent": "^0.37.0",
         "@vscode/ripgrep": "^1.15.13",
-        "@vscode/spdlog": "^0.15.7",
+        "@vscode/spdlog": "^0.15.8",
         "@vscode/tree-sitter-wasm": "^0.3.0",
         "@vscode/vscode-languagedetection": "1.0.21",
         "@vscode/windows-process-tree": "^0.6.0",
@@ -451,9 +451,9 @@
       }
     },
     "node_modules/@vscode/spdlog": {
-      "version": "0.15.7",
-      "resolved": "https://registry.npmjs.org/@vscode/spdlog/-/spdlog-0.15.7.tgz",
-      "integrity": "sha512-xpHAtw0IESD6wmjqLr6LbpYAmr8ZYm8AT7hGE7oM7AojNeOBngXLOqmzpXbTNTAvXBq1KHy8PwbMmY24uYR/oQ==",
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/@vscode/spdlog/-/spdlog-0.15.8.tgz",
+      "integrity": "sha512-Jh8M6b2vJfBmQua9aAiYa9sdd/htw+/71b7GZlI3v2DGbsAXIYo7gIokrfx1/0XtQPTPoJ8RKtQ9hNSPlnfXUQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/remote/package.json
+++ b/remote/package.json
@@ -12,7 +12,7 @@
     "@vscode/native-watchdog": "^1.4.6",
     "@vscode/proxy-agent": "^0.37.0",
     "@vscode/ripgrep": "^1.15.13",
-    "@vscode/spdlog": "^0.15.7",
+    "@vscode/spdlog": "^0.15.8",
     "@vscode/tree-sitter-wasm": "^0.3.0",
     "@vscode/vscode-languagedetection": "1.0.21",
     "@vscode/windows-process-tree": "^0.6.0",

--- a/remote/reh-web/package-lock.json
+++ b/remote/reh-web/package-lock.json
@@ -18,7 +18,7 @@
 				"@vscode/native-watchdog": "^1.4.6",
 				"@vscode/proxy-agent": "^0.37.0",
 				"@vscode/ripgrep": "^1.15.13",
-				"@vscode/spdlog": "^0.15.7",
+				"@vscode/spdlog": "^0.15.8",
 				"@vscode/tree-sitter-wasm": "^0.3.0",
 				"@vscode/vscode-languagedetection": "1.0.21",
 				"@vscode/windows-process-tree": "^0.6.0",
@@ -500,9 +500,9 @@
 			}
 		},
 		"node_modules/@vscode/spdlog": {
-			"version": "0.15.7",
-			"resolved": "https://registry.npmjs.org/@vscode/spdlog/-/spdlog-0.15.7.tgz",
-			"integrity": "sha512-xpHAtw0IESD6wmjqLr6LbpYAmr8ZYm8AT7hGE7oM7AojNeOBngXLOqmzpXbTNTAvXBq1KHy8PwbMmY24uYR/oQ==",
+			"version": "0.15.8",
+			"resolved": "https://registry.npmjs.org/@vscode/spdlog/-/spdlog-0.15.8.tgz",
+			"integrity": "sha512-Jh8M6b2vJfBmQua9aAiYa9sdd/htw+/71b7GZlI3v2DGbsAXIYo7gIokrfx1/0XtQPTPoJ8RKtQ9hNSPlnfXUQ==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/remote/reh-web/package.json
+++ b/remote/reh-web/package.json
@@ -13,7 +13,7 @@
 		"@vscode/native-watchdog": "^1.4.6",
 		"@vscode/proxy-agent": "^0.37.0",
 		"@vscode/ripgrep": "^1.15.13",
-		"@vscode/spdlog": "^0.15.7",
+		"@vscode/spdlog": "^0.15.8",
 		"@vscode/tree-sitter-wasm": "^0.3.0",
 		"@vscode/vscode-languagedetection": "1.0.21",
 		"@vscode/windows-process-tree": "^0.6.0",


### PR DESCRIPTION
## Summary

This PR addresses a `node-gyp` compilation error that happens after updating to macOS 26.4 and Xcode 26.4.

See: https://github.com/microsoft/node-spdlog/commit/69a60dd37851493bd73e34b8e92cedf73414c867 for details about the fix.

The compilation error was:

```
[m4posit] [~/Work/positron-a] git:(main) npm install
npm warn deprecated rimraf@2.6.3: Rimraf versions prior to v4 are no longer supported
npm warn deprecated asar@3.0.3: Please use @electron/asar moving forward.  There is no API change, just a package name change
npm warn deprecated sinon@12.0.1: 16.1.1
npm warn deprecated @azure/core-http@2.3.2: This package is no longer supported. Please migrate to use @azure/core-rest-pipeline
npm error code 1
npm error path /Users/brian/Work/positron-a/node_modules/@vscode/spdlog
npm error command failed
npm error command sh -c node-gyp rebuild
npm error TOUCH Release/obj.target/../../node-addon-api/node_addon_api_except.stamp
npm error   CXX(target) Release/obj.target/spdlog/src/main.o
npm error gyp info it worked if it ends with ok
npm error gyp info using node-gyp@11.2.0
npm error gyp info using node@22.22.1 | darwin | arm64
npm error gyp info find Python using Python version 3.11.11 found at "/Users/brian/.pyenv/versions/3.11.11/bin/python3"
npm error gyp info spawn /Users/brian/.pyenv/versions/3.11.11/bin/python3
npm error gyp info spawn args [
npm error gyp info spawn args '/Users/brian/.nvm/versions/node/v22.22.1/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
npm error gyp info spawn args 'binding.gyp',
npm error gyp info spawn args '-f',
npm error gyp info spawn args 'make',
npm error gyp info spawn args '-I',
npm error gyp info spawn args '/Users/brian/Work/positron-a/node_modules/@vscode/spdlog/build/config.gypi',
npm error gyp info spawn args '-I',
npm error gyp info spawn args '/Users/brian/.nvm/versions/node/v22.22.1/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
npm error gyp info spawn args '-I',
npm error gyp info spawn args '/Users/brian/Library/Caches/node-gyp/39.3.0/include/node/common.gypi',
npm error gyp info spawn args '-Dlibrary=shared_library',
npm error gyp info spawn args '-Dvisibility=default',
npm error gyp info spawn args '-Dnode_root_dir=/Users/brian/Library/Caches/node-gyp/39.3.0',
npm error gyp info spawn args '-Dnode_gyp_dir=/Users/brian/.nvm/versions/node/v22.22.1/lib/node_modules/npm/node_modules/node-gyp',
npm error gyp info spawn args '-Dnode_lib_file=/Users/brian/Library/Caches/node-gyp/39.3.0/<(target_arch)/node.lib',
npm error gyp info spawn args '-Dmodule_root_dir=/Users/brian/Work/positron-a/node_modules/@vscode/spdlog',
npm error gyp info spawn args '-Dnode_engine=v8',
npm error gyp info spawn args '--depth=.',
npm error gyp info spawn args '--no-parallel',
npm error gyp info spawn args '--generator-output',
npm error gyp info spawn args 'build',
npm error gyp info spawn args '-Goutput_dir=.'
npm error gyp info spawn args ]
npm error gyp info spawn make
npm error gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
npm error In file included from ../src/main.cc:8:
npm error In file included from ../src/logger.h:12:
npm error In file included from ../deps/spdlog/include/spdlog/spdlog.h:12:
npm error In file included from ../deps/spdlog/include/spdlog/common.h:50:
npm error In file included from ../deps/spdlog/include/spdlog/fmt/fmt.h:27:
npm error In file included from ../deps/spdlog/include/spdlog/fmt/bundled/core.h:3321:
npm error ../deps/spdlog/include/spdlog/fmt/bundled/format.h:4168:27: warning: identifier '_a' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
npm error  4168 | constexpr auto operator"" _a(const char* s, size_t) -> detail::udl_arg<char> {
npm error       |                ~~~~~~~~~~~^~
npm error       |                operator""_a
npm error In file included from ../src/main.cc:8:
npm error In file included from ../src/logger.h:12:
npm error In file included from ../deps/spdlog/include/spdlog/spdlog.h:13:
npm error In file included from ../deps/spdlog/include/spdlog/details/registry.h:122:
npm error In file included from ../deps/spdlog/include/spdlog/details/registry-inl.h:12:
npm error In file included from ../deps/spdlog/include/spdlog/logger.h:426:
npm error In file included from ../deps/spdlog/include/spdlog/logger-inl.h:12:
npm error In file included from ../deps/spdlog/include/spdlog/pattern_formatter.h:127:
npm error In file included from ../deps/spdlog/include/spdlog/pattern_formatter-inl.h:10:
npm error ../deps/spdlog/include/spdlog/details/fmt_helper.h:105:54: error: call to consteval function 'fmt::basic_format_string<char, int &>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression
npm error   105 |         fmt_lib::format_to(std::back_inserter(dest), SPDLOG_FMT_STRING("{:02}"), n);
npm error       |                                                      ^
npm error ../deps/spdlog/include/spdlog/common.h:54:46: note: expanded from macro 'SPDLOG_FMT_STRING'
npm error    54 | #    define SPDLOG_FMT_STRING(format_string) FMT_STRING(format_string)
npm error       |                                              ^
npm error ../deps/spdlog/include/spdlog/fmt/bundled/format.h:1772:23: note: expanded from macro 'FMT_STRING'
npm error  1772 | #define FMT_STRING(s) FMT_STRING_IMPL(s, fmt::detail::compile_string, )
npm error       |                       ^
npm error ../deps/spdlog/include/spdlog/fmt/bundled/format.h:1749:3: note: expanded from macro 'FMT_STRING_IMPL'
npm error  1749 |   [] {                                                                        \
npm error       |   ^
npm error ../deps/spdlog/include/spdlog/fmt/bundled/core.h:2982:51: note: subexpression not valid in a constant expression
npm error  2982 |     context_.advance_to(context_.begin() + (begin - &*context_.begin()));
npm error       |                                             ~~~~~~^~~~~~~~~~~~~~~~~~~~
npm error ../deps/spdlog/include/spdlog/fmt/bundled/core.h:2663:15: note: in call to 'handler.on_format_specs(0, &"{:02}"[2], &"{:02}"[5])'
npm error  2663 |       begin = handler.on_format_specs(adapter.arg_id, begin + 1, end);
npm error       |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error ../deps/spdlog/include/spdlog/fmt/bundled/core.h:2688:21: note: in call to 'parse_replacement_field<char, fmt::detail::format_string_checker<char, fmt::detail::error_handler, int> &>(&"{:02}"[1], &"{:02}"[5], checker(s, {}))'
npm error  2688 |         begin = p = parse_replacement_field(p - 1, end, handler);
npm error       |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error ../deps/spdlog/include/spdlog/fmt/bundled/core.h:3159:7: note: in call to 'parse_format_string<true, char, fmt::detail::format_string_checker<char, fmt::detail::error_handler, int>>({&"{:02}"[0], 5}, checker(s, {}))'
npm error  3159 |       detail::parse_format_string<true>(str_, checker(s, {}));
npm error       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error ../deps/spdlog/include/spdlog/details/fmt_helper.h:105:54: note: in call to 'basic_format_string<FMT_COMPILE_STRING, 0>([] {
npm error     struct FMT_COMPILE_STRING : fmt::detail::compile_string {
npm error         using char_type [[maybe_unused]] = fmt::remove_cvref_t<decltype("{:02}"[0])>;
npm error         [[maybe_unused]] constexpr operator fmt::basic_string_view<char_type>() const {
npm error             return fmt::detail_exported::compile_string_to_view<char_type>("{:02}");
npm error         }
npm error     };
npm error     return FMT_COMPILE_STRING();
npm error }())'
npm error   105 |         fmt_lib::format_to(std::back_inserter(dest), SPDLOG_FMT_STRING("{:02}"), n);
npm error       |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~
npm error ../deps/spdlog/include/spdlog/common.h:54:46: note: expanded from macro 'SPDLOG_FMT_STRING'
npm error    54 | #    define SPDLOG_FMT_STRING(format_string) FMT_STRING(format_string)
npm error       |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~
npm error ../deps/spdlog/include/spdlog/fmt/bundled/format.h:1772:23: note: expanded from macro 'FMT_STRING'
npm error  1772 | #define FMT_STRING(s) FMT_STRING_IMPL(s, fmt::detail::compile_string, )
npm error       |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error ../deps/spdlog/include/spdlog/fmt/bundled/format.h:1749:3: note: expanded from macro 'FMT_STRING_IMPL'
npm error  1749 |   [] {                                                                        \
npm error       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error  1750 |     /* Use the hidden visibility as a workaround for a GCC bug (#1973). */    \
npm error       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error  1751 |     /* Use a macro-like name to avoid shadowing warnings. */                  \
npm error       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error  1752 |     struct FMT_GCC_VISIBILITY_HIDDEN FMT_COMPILE_STRING : base {              \
npm error       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error  1753 |       using char_type FMT_MAYBE_UNUSED = fmt::remove_cvref_t<decltype(s[0])>; \
npm error       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error  1754 |       FMT_MAYBE_UNUSED FMT_CONSTEXPR explicit                                 \
npm error       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error  1755 |       operator fmt::basic_string_view<char_type>() const {                    \
npm error       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error  1756 |         return fmt::detail_exported::compile_string_to_view<char_type>(s);    \
npm error       |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error  1757 |       }                                                                       \
npm error       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error  1758 |     };                                                                        \
npm error       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error  1759 |     return FMT_COMPILE_STRING();                                              \
npm error       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
npm error  1760 |   }()
npm error       |   ~~~
npm error 1 warning and 1 error generated.
npm error make: *** [Release/obj.target/spdlog/src/main.o] Error 1
npm error gyp ERR! build error 
npm error gyp ERR! stack Error: `make` failed with exit code: 2
npm error gyp ERR! stack at ChildProcess.<anonymous> (/Users/brian/.nvm/versions/node/v22.22.1/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:219:23)
npm error gyp ERR! System Darwin 25.4.0
npm error gyp ERR! command "/Users/brian/.nvm/versions/node/v22.22.1/bin/node" "/Users/brian/.nvm/versions/node/v22.22.1/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
npm error gyp ERR! cwd /Users/brian/Work/positron-a/node_modules/@vscode/spdlog
npm error gyp ERR! node -v v22.22.1
npm error gyp ERR! node-gyp -v v11.2.0
npm error gyp ERR! not ok
npm error A complete log of this run can be found in: /Users/brian/.npm/_logs/2026-03-31T19_50_43_930Z-debug-0.log
```

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

- N/A