### PR TITLE
Bump Shiny-VSCode to 1.4.0

### DIFF
--- a/product.json
+++ b/product.json
@@ -254,8 +254,8 @@
 		},
 		{
 			"name": "posit.shiny",
-			"version": "1.3.4",
-			"sha256sum": "d11fd56b8c8ad10492c3ecf6329323b83e31678b16fc883e4602c621fd02ea8e",
+			"version": "1.4.0",
+			"sha256sum": "7a71a88360559de5de2da20fd9e508d64c305cb0c2477f8503b8dde77c4f1e05",
 			"repo": "https://github.com/posit-dev/shiny-vscode",
 			"metadata": {
 				"id": "7ffa9a66-85ab-44de-ab80-2eecce45b0fe",


### PR DESCRIPTION
For https://github.com/posit-dev/shiny-vscode/pull/108
Based on https://github.com/posit-dev/positron/pull/12545
Addresses https://github.com/posit-dev/positron/issues/12556


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Shiny applications are now run in console sessions instead of the terminal (https://github.com/posit-dev/positron/issues/12556). This makes it possible to debug them with Positron's new R debugger support.

#### Bug Fixes

- N/A

### QA Notes

- R Shiny apps run in console sessions, not terminals
- Other apps (Streamlit etc.) still use terminals
- Stop button in viewer works for console apps (interrupt) and disappears when idle (including when debugging the app, which is admitedly weird)
- No breakpoints: fast startup. With breakpoints: slower but breakpoints hit
- Re-running reuses the same "Shiny" console and restarts it
- Re-running also reuses sessions after extension host restart or window reload
- Re-running while debugging: debugger exits, session restarts
- When re-running, declining the interrupt prompt cancels the restart
- Dirty document auto-saved before execution
- Timeout error if URL not detected in ~25s
- Rapid "Run App" clicks: "already starting" message, no duplicates
- Restarting the extension host does not cause a restart of the application to open in a different session.
- Reloading the window does not cause a restart of the application to open in a different session. Note that the application is no longer available in the viewer, this is a known issue (and not a regression compared to the old app-in-terminal approach).

https://github.com/user-attachments/assets/004a6f65-21f5-45d9-9edc-2d922b1e1999

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:apps