### PR TITLE
ci: fix failures being silently swallowed & partial core restores

### DIFF
--- a/.github/actions/restore-build-caches/action.yml
+++ b/.github/actions/restore-build-caches/action.yml
@@ -176,8 +176,6 @@ runs:
       with:
         path: ${{ steps.cache-paths.outputs.npm-core-paths }}
         key: npm-core-v7-node${{ steps.node-version.outputs.version }}-${{ runner.os }}-${{ steps.distro.outputs.distro }}-${{ steps.package-locks-hash.outputs.hash }}
-        restore-keys: |
-          npm-core-v7-node${{ steps.node-version.outputs.version }}-${{ runner.os }}-${{ steps.distro.outputs.distro }}-
 
     - name: Restore npm volatile extensions cache
       if: ${{ inputs.restore-npm-extensions == 'true' }}

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -91,6 +91,7 @@ runs:
         retry_on: error
         shell: bash
         command: |
+          set -e
           echo "::group::📦 Install node dependencies"
           if [ -n "$POSITRON_EXTENSIONS_FILTER" ]; then
             echo "📦 Installing with filter: $POSITRON_EXTENSIONS_FILTER"


### PR DESCRIPTION
## Summary
- Add `set -e` to the retry action's command block in `setup-build-env` so npm install failures properly propagate (previously `echo "::endgroup::"` overwrote the exit code to 0)
- Remove `restore-keys` from npm-core cache to prevent stale partial restores that could cause native module compilation failures (e.g. stale `.node-gyp-cache` artifacts)

Investigated from [this CI failure](https://github.com/posit-dev/positron/actions/runs/23857698563/job/69555436497) where `@vscode/native-watchdog` failed to compile, but the error was swallowed and surfaced as a confusing "Cannot find module gulp" error downstream.

Only ~3% of CI runs change the lockfile, so removing `restore-keys` has minimal impact (~1-2 min extra on those runs for a clean npm download).

## QA Notes

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)