### PR TITLE
Fix build daemon scripts for Windows

### DIFF
--- a/scripts/build-ps.mts
+++ b/scripts/build-ps.mts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { spawn } from 'node:child_process';
+
+const DAEMONS = ['watch-client', 'watch-extensions', 'watch-e2e'];
+const DEEMON_MISSING = /\[deemon\] No daemon running/;
+
+/**
+ * Checks if a deemon daemon is running by attaching to it briefly.
+ * If the daemon is not running, deemon prints "No daemon running" and exits
+ * quickly. If the daemon IS running, deemon attaches and starts streaming
+ * replayed output — so if we haven't seen "No daemon running" after a short
+ * wait, the daemon is running.
+ */
+function checkDaemon(name: string): Promise<'running' | 'stopped'> {
+	return new Promise((resolve) => {
+		const child = spawn('npx', ['deemon', '--attach', '--', 'npm', 'run', name], {
+			stdio: ['ignore', 'pipe', 'pipe'],
+			shell: true,
+		});
+
+		let resolved = false;
+		const done = (status: 'running' | 'stopped') => {
+			if (resolved) {
+				return;
+			}
+			resolved = true;
+			clearTimeout(runningTimeout);
+			child.kill();
+			resolve(status);
+		};
+
+		let output = '';
+		const onData = (data: { toString(): string }) => {
+			output += data.toString();
+			if (DEEMON_MISSING.test(output)) {
+				done('stopped');
+			}
+		};
+		child.stdout.on('data', onData);
+		child.stderr.on('data', onData);
+
+		// If the process exits quickly without "No daemon running", it's an
+		// unexpected state — treat as stopped.
+		child.on('close', () => done('stopped'));
+
+		// If we haven't seen "No daemon running" after 3 seconds, the daemon
+		// must be running (deemon is replaying its output).
+		const runningTimeout = setTimeout(() => done('running'), 3_000);
+	});
+}
+
+const results = await Promise.all(
+	DAEMONS.map(async (name) => ({ name, status: await checkDaemon(name) }))
+);
+
+console.log(`${'DAEMON'.padEnd(20)} STATUS`);
+for (const { name, status } of results) {
+	console.log(`${name.padEnd(20)} ${status}`);
+}

--- a/scripts/build-ps.sh
+++ b/scripts/build-ps.sh
@@ -1,18 +1,4 @@
 #!/bin/bash
 # Shows the status of Positron build daemons (watch-clientd, watch-extensionsd, watch-e2ed)
 set -euo pipefail
-
-DAEMONS=("watch-client" "watch-extensions" "watch-e2e")
-PS_OUTPUT=$(ps aux)
-
-printf "%-20s %-10s %-10s %s\n" "DAEMON" "STATUS" "PID" "STARTED"
-for daemon in "${DAEMONS[@]}"; do
-	line=$(echo "$PS_OUTPUT" | grep -F "$PWD/node_modules/.bin/deemon --daemon npm run ${daemon}" | head -1 || true)
-	if [ -n "$line" ]; then
-		pid=$(echo "$line" | awk '{print $2}')
-		started=$(echo "$line" | awk '{print $9}')
-		printf "%-20s %-10s %-10s %s\n" "$daemon" "running" "$pid" "$started"
-	else
-		printf "%-20s %-10s %-10s %s\n" "$daemon" "stopped" "-" "-"
-	fi
-done
+exec node scripts/build-ps.mts

--- a/scripts/deemon-status.mts
+++ b/scripts/deemon-status.mts
@@ -74,6 +74,7 @@ const opts = parseArgs(process.argv.slice(2));
 
 const child = spawn('npx', ['deemon', '--attach', '--', ...opts.command], {
 	stdio: ['ignore', 'pipe', 'pipe'],
+	shell: true,
 });
 
 // These variables are mutated inside callbacks (processLine/processData), but


### PR DESCRIPTION
## Summary
- Add `shell: true` to `spawn()` in `deemon-status.mts` so `npx` resolves correctly on Windows (fixes `ENOENT` error)
- Replace `ps aux` + grep approach in `build-ps.sh` with a new cross-platform `build-ps.mts` that uses deemon's own `--attach` mechanism to detect running daemons

## Test plan
- [x] Verified `npm run build-start` works on Windows
- [x] Verified `npm run build-check` works on Windows (was failing with `spawn npx ENOENT`)
- [x] Verified `npm run build-ps` correctly shows `running` when daemons are up and `stopped` when down
- [x] Verified `npm run build-stop` works on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)