### PR TITLE
Auto-close notebook consoles

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
@@ -19,7 +19,7 @@ import {
 	RuntimeStartMode,
 } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
-import { LanguageRuntimeSessionMode, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
+import { LanguageRuntimeSessionMode, RuntimeExitReason, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IQuartoDocumentModelService } from './quartoDocumentModelService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { ITextModel } from '../../../../editor/common/model.js';
@@ -576,12 +576,17 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 		// Update state
 		this._setKernelState(documentUri, QuartoKernelState.ShuttingDown);
 
-		if (info.session) {
-			try {
-				await info.session.shutdown();
-			} catch (error) {
-				this._logService.warn(`[QuartoKernelManager] Error shutting down kernel: ${error}`);
-			}
+		try {
+			// Use the runtime session service to shut down and delete the
+			// notebook session so the associated console instance (if any)
+			// is also cleaned up.
+			await this._runtimeSessionService.shutdownNotebookSession(
+				documentUri,
+				RuntimeExitReason.Shutdown,
+				'Quarto document closed',
+			);
+		} catch (error) {
+			this._logService.warn(`[QuartoKernelManager] Error shutting down kernel: ${error}`);
 		}
 
 		// Clean up

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSession.ts
@@ -1188,8 +1188,18 @@ export class RuntimeSessionService extends Disposable implements IRuntimeSession
 		// Actually shutdown the session.
 		try {
 			await this.shutdownRuntimeSession(session, exitReason);
-			shutdownPromise.complete();
 			this._logService.debug(`Notebook ${notebookUri.toString()} has been shut down`);
+
+			// Delete the session after shutdown so that the associated console
+			// instance (if any) is also cleaned up. The notebook is closed, so
+			// the session is no longer useful.
+			try {
+				await this.deleteSession(session.sessionId);
+			} catch (deleteErr) {
+				this._logService.debug(`Could not delete notebook session ${session.sessionId}: ${deleteErr}`);
+			}
+
+			shutdownPromise.complete();
 		} catch (error) {
 			this._logService.error(`Failed to shutdown notebook ${notebookUri.toString()}. Reason: ${error}`);
 			shutdownPromise.error(error);

--- a/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/runtimeSession.test.ts
@@ -1043,7 +1043,7 @@ suite('Positron - RuntimeSessionService', () => {
 
 		await shutdownNotebook();
 
-		assertActiveSessions([session]);
+		assertActiveSessions([]);
 		assertNotebookSessionForNotebookUri(notebookUri, undefined);
 		assert.strictEqual(session.getRuntimeState(), RuntimeState.Exited);
 	});
@@ -1057,7 +1057,7 @@ suite('Positron - RuntimeSessionService', () => {
 			selectRuntime(runtime, notebookUri),
 		]);
 
-		assertActiveSessions([session, newSession]);
+		assertActiveSessions([newSession]);
 		assertNotebookSessionForNotebookUri(notebookUri, newSession);
 		assert.strictEqual(session.getRuntimeState(), RuntimeState.Exited);
 		assert.strictEqual(newSession.getRuntimeState(), RuntimeState.Starting);
@@ -1069,7 +1069,7 @@ suite('Positron - RuntimeSessionService', () => {
 			shutdownNotebook(),
 		]);
 
-		assertActiveSessions([session]);
+		assertActiveSessions([]);
 		assertNotebookSessionForNotebookUri(notebookUri, undefined);
 		assert.strictEqual(session.getRuntimeState(), RuntimeState.Exited);
 	});


### PR DESCRIPTION
Automatically closes the notebook console when the notebook closes, by deleting the session and letting the event infrastructure clean up the console.

Addresses https://github.com/posit-dev/positron/issues/12610. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Clean up orphaned notebook consoles when notebook is closed (#12610)


### QA Notes

This change also applies to Quarto sessions (with the Quarto inline output feature turned on).

test tags: `@:notebooks` `@:quarto` `@:positron-notebooks`