### PR TITLE
Assign `entity.name.namespace` scope to namespace prefixes before `::` and `:::`

### DIFF
--- a/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
@@ -161,6 +161,9 @@
 					"include": "#keywords"
 				},
 				{
+					"include": "#namespace-call"
+				},
+				{
 					"include": "#function-call"
 				},
 				{
@@ -360,6 +363,13 @@
 					"match": "(?:(?:\\d+(?:\\.\\d*)?)|(?:\\.\\d+))(?:[eE][+-]?\\d*)?[iL]?"
 				}
 			]
+		},
+		"namespace-call": {
+			"match": "([\\p{L}\\p{Nl}.][\\p{L}\\p{Nl}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}.]*)(:::?)",
+			"captures": {
+				"1": { "name": "support.class.r" },
+				"2": { "name": "keyword.operator" }
+			}
 		},
 		"operators": {
 			"name": "keyword.operator",

--- a/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
@@ -365,9 +365,9 @@
 			]
 		},
 		"namespace-call": {
-			"match": "(?<![A-Za-z0-9._-])([A-Za-z](?:[A-Za-z0-9.]*[A-Za-z0-9])?)(:::?)",
+			"match": "(?<![A-Za-z0-9._])([A-Za-z._][A-Za-z0-9._]*)(:::?)",
 			"captures": {
-				"1": { "name": "support.class.r" },
+				"1": { "name": "entity.name.namespace.r" },
 				"2": { "name": "keyword.operator" }
 			}
 		},

--- a/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.gen.json
@@ -365,7 +365,7 @@
 			]
 		},
 		"namespace-call": {
-			"match": "([\\p{L}\\p{Nl}.][\\p{L}\\p{Nl}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}.]*)(:::?)",
+			"match": "(?<![A-Za-z0-9._-])([A-Za-z](?:[A-Za-z0-9.]*[A-Za-z0-9])?)(:::?)",
 			"captures": {
 				"1": { "name": "support.class.r" },
 				"2": { "name": "keyword.operator" }

--- a/extensions/positron-r/syntaxes/r.tmGrammar.src.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.src.json
@@ -161,6 +161,9 @@
 					"include": "#keywords"
 				},
 				{
+					"include": "#namespace-call"
+				},
+				{
 					"include": "#function-call"
 				},
 				{
@@ -360,6 +363,13 @@
 					"match": "(?:(?:\\d+(?:\\.\\d*)?)|(?:\\.\\d+))(?:[eE][+-]?\\d*)?[iL]?"
 				}
 			]
+		},
+		"namespace-call": {
+			"match": "([\\p{L}\\p{Nl}.][\\p{L}\\p{Nl}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}.]*)(:::?)",
+			"captures": {
+				"1": { "name": "support.class.r" },
+				"2": { "name": "{{ operator }}" }
+			}
 		},
 		"operators": {
 			"name": "{{ operator }}",

--- a/extensions/positron-r/syntaxes/r.tmGrammar.src.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.src.json
@@ -365,7 +365,7 @@
 			]
 		},
 		"namespace-call": {
-			"match": "([\\p{L}\\p{Nl}.][\\p{L}\\p{Nl}\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}.]*)(:::?)",
+			"match": "(?<![A-Za-z0-9._-])([A-Za-z](?:[A-Za-z0-9.]*[A-Za-z0-9])?)(:::?)",
 			"captures": {
 				"1": { "name": "support.class.r" },
 				"2": { "name": "{{ operator }}" }

--- a/extensions/positron-r/syntaxes/r.tmGrammar.src.json
+++ b/extensions/positron-r/syntaxes/r.tmGrammar.src.json
@@ -365,9 +365,9 @@
 			]
 		},
 		"namespace-call": {
-			"match": "(?<![A-Za-z0-9._-])([A-Za-z](?:[A-Za-z0-9.]*[A-Za-z0-9])?)(:::?)",
+			"match": "(?<![A-Za-z0-9._])([A-Za-z._][A-Za-z0-9._]*)(:::?)",
 			"captures": {
-				"1": { "name": "support.class.r" },
+				"1": { "name": "entity.name.namespace.r" },
 				"2": { "name": "{{ operator }}" }
 			}
 		},


### PR DESCRIPTION
- Applies posit-dev/positron#12653 by @vrognas as an internal, non-fork PR because of the problems outlined in https://github.com/posit-dev/positron/issues/6628
- Closes https://github.com/posit-dev/positron/pull/12653
- Addresses https://github.com/posit-dev/positron/issues/12624

Previously, identifiers preceding `::` or `:::` (e.g. `ggplot2` in `ggplot2::aes()`) received the generic `variable.object` scope, making them indistinguishable from regular variables and impossible to style distinctly via `editor.tokenColorCustomizations`.

This PR adds a `namespace-call` rule to the R TextMate grammar that assigns the `support.class.r` scope to identifiers immediately followed by `:::?`. The regex is tightened relative to the original contribution to match only valid CRAN package names: must start with a letter, end with a letter or digit, and contain only ASCII letters, digits, and dots. This excludes identifiers starting with `.` or digits, or containing underscores or hyphens, which cannot be valid R package names.

Users can now target package names in their theme settings:

```json
"editor.tokenColorCustomizations": {
  "textMateRules": [
    {
      "scope": "support.class.r",
      "settings": { "foreground": "#ffaa00", "fontStyle": "bold" }
    }
  ]
}
```

I verified the grammar behavior manually using the `vscode-colorize-tests` infrastructure against valid package names (`ggplot2`, `foo.bar`, `A1.2`) and invalid ones (`.foo`, `foo.`, `1foo`, `foo_bar`). I didn't check in the tests because we don't even really run them, but it was helpful to verify the regex!

### Release Notes

#### New Features
- R: package names preceding `::` and `:::` are now assigned the `support.class.r` TextMate scope, allowing them to be styled independently from regular variables.

#### Bug Fixes
- N/A

### QA Notes

@:editor

Open any R file containing `package::function()` calls. Run _Developer: Inspect Editor Tokens and Scopes_ and click a package name. It should now show `support.class.r` instead of `variable.object`.
