### PR TITLE
Change default for `chat.viewSessions.enabled`

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -461,7 +461,10 @@ configurationRegistry.registerConfiguration({
 		},
 		[ChatConfiguration.ChatViewSessionsEnabled]: {
 			type: 'boolean',
-			default: true,
+			// --- Start Positron ---
+			// default: true,
+			default: false,
+			// --- End Positron ---
 			description: nls.localize('chat.viewSessions.enabled', "Show chat agent sessions when chat is empty or to the side when chat view is wide enough."),
 		},
 		[ChatConfiguration.ChatViewSessionsOrientation]: {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/12666, at least for now

<img width="1523" height="1057" alt="Screenshot 2026-04-01 at 3 05 46 PM" src="https://github.com/user-attachments/assets/0c50c006-c9e4-452d-992e-4f982fa8962e" />

This PR changes the default for `chat.viewSessions.enabled` from `true` to `false` to prevent the chat sessions panel from cutting off the Positron Assistant panel at certain window sizes. This is a temporary fix while a proper layout solution is pursued or we just decide this is not worth spending time on, ahead of migrating to Posit Assistant here.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix Positron Assistant panel being cut off by the chat sessions panel (#12666)

### QA Notes

@:assistant

Open the Assistant panel and verify it is not cut off at various window sizes, including narrow widths. Confirm that `chat.viewSessions.enabled` can still be set to `true` manually to restore sessions panel behavior.


