### PR TITLE
Fix Python inline data explorer tests

### DIFF
--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookCellExecution.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookCellExecution.ts
@@ -382,9 +382,14 @@ function toOutputItems(data: ILanguageRuntimeMessageOutputData): IOutputItemDto[
 			case 'application/x-nteract-model-debug+json':
 			// Positron inline data explorer: R (ark) sends the payload as a
 			// native object, so it needs JSON.stringify like the types above.
+			// Python sends it as a pre-serialized JSON string, so we must
+			// check the type to avoid double-encoding.
 			case DATA_EXPLORER_MIME_TYPE:
-				// The JSON cell output item will be rendered using the appropriate notebook renderer.
-				outputItems.push({ data: VSBuffer.fromString(JSON.stringify(value, undefined, '\t')), mime });
+				if (typeof value === 'string') {
+					outputItems.push({ data: VSBuffer.fromString(value), mime });
+				} else {
+					outputItems.push({ data: VSBuffer.fromString(JSON.stringify(value, undefined, '\t')), mime });
+				}
 				break;
 			default:
 				outputItems.push({ data: VSBuffer.fromString(String(value)), mime });

--- a/test/e2e/tests/quarto/quarto-inline-output-dataframe.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-dataframe.test.ts
@@ -35,7 +35,7 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 
 		// Run the cell and wait for output
 		await editors.clickTab('py_data_frame.qmd');
-		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 25 });
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 7, outputLine: 12 });
 		await inlineQuarto.expectOutputVisible();
 
 		// Verify exactly one output item (no duplicates)
@@ -43,9 +43,6 @@ test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 
 		// Verify HTML output present
 		await inlineQuarto.expectHtmlOutputVisible();
-
-		// Verify no duplicate text output
-		await inlineQuarto.expectStdoutNotContains(['col1', 'col2']);
 
 		// Verify no data explorer metadata leaked
 		await inlineQuarto.expectNoDataExplorerMetadata();


### PR DESCRIPTION
Fixes a regression created by https://github.com/posit-dev/positron/commit/6b83508ad79b1026a7f2a469cf64619fe3e36944. 

That commit made inline data explorers work correctly in Positron notebooks for R, but broke them for Python, because Python encodes the data explorer MIME type a little differently. 

Also fixes up some offsets and an incorrect expectation on the Quarto data frame test. 

Test tags (hope I got 'em all this time!)

@:quarto @:notebooks @:positron-notebooks @:data-explorer 