### PR TITLE
Fix R dataframe printing in the Console

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -1094,7 +1094,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.248"
+      "ark": "0.1.249"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/test/e2e/tests/console/console-r-dataframe.test.ts
+++ b/test/e2e/tests/console/console-r-dataframe.test.ts
@@ -9,7 +9,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Console Pane: R Data Frame Output #12799', {
+test.describe('Console Pane: R Data Frame Output', {
 	tag: [tags.CONSOLE, tags.ARK]
 }, () => {
 

--- a/test/e2e/tests/console/console-r-dataframe.test.ts
+++ b/test/e2e/tests/console/console-r-dataframe.test.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Console Pane: R Data Frame Output #12799', {
+	tag: [tags.CONSOLE, tags.ARK]
+}, () => {
+
+	test('R - data.frame autoprint shows correct output', async function ({ app, r }) {
+		// Create and print a simple data frame
+		await app.workbench.console.executeCode('R', 'df <- data.frame(x = 1:3, y = c("a", "b", "c"))');
+		await app.workbench.console.executeCode('R', 'df');
+
+		// The console should show the data frame contents
+		await app.workbench.console.waitForConsoleContents('x y', { timeout: 30000 });
+		await app.workbench.console.waitForConsoleContents('1 a', { timeout: 10000 });
+	});
+});


### PR DESCRIPTION
Bumps Ark to pick up https://github.com/posit-dev/ark/pull/1132 (see notes in that PR). Also adds a test to ensure this does not regress in the future. 

Addresses https://github.com/posit-dev/positron/issues/12799. 

Tags: @:quarto @:ark @:notebooks :@positron-notebooks @:console