### PR TITLE
Fix unit tests by stubbing IPositronConsoleService in runtime session tests

### DIFF
--- a/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testRuntimeSessionService.ts
@@ -22,6 +22,8 @@ import { IWorkspaceTrustManagementService } from '../../../../../platform/worksp
 import { IExtensionService } from '../../../extensions/common/extensions.js';
 import { LanguageRuntimeService } from '../../../languageRuntime/common/languageRuntime.js';
 import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionLocation, LanguageRuntimeSessionMode, LanguageRuntimeStartupBehavior } from '../../../languageRuntime/common/languageRuntimeService.js';
+import { IPositronConsoleService } from '../../../positronConsole/browser/interfaces/positronConsoleService.js';
+import { TestPositronConsoleService } from '../../../positronConsole/test/browser/testPositronConsoleService.js';
 import { IPositronModalDialogsService } from '../../../positronModalDialogs/common/positronModalDialogs.js';
 import { RuntimeSessionService } from '../../common/runtimeSession.js';
 import { IRuntimeSessionService, RuntimeStartMode } from '../../common/runtimeSessionService.js';
@@ -51,6 +53,7 @@ export function createRuntimeServices(
 	instantiationService.stub(IFileService, disposables.add(new TestDirectoryFileService()));
 	instantiationService.stub(IPathService, new TestPathService());
 	instantiationService.stub(ILanguageRuntimeService, disposables.add(instantiationService.createInstance(LanguageRuntimeService)));
+	instantiationService.stub(IPositronConsoleService, new TestPositronConsoleService());
 	instantiationService.stub(IPositronModalDialogsService, new TestPositronModalDialogService());
 	instantiationService.stub(ICommandService, new TestCommandService(instantiationService));
 	instantiationService.stub(IKeybindingService, new MockKeybindingService());

--- a/src/vs/workbench/test/browser/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/positronWorkbenchTestServices.ts
@@ -33,7 +33,7 @@ import { IConfigurationService } from '../../../platform/configuration/common/co
 import { IRuntimeSessionService } from '../../services/runtimeSession/common/runtimeSessionService.js';
 import { TestConfigurationService } from '../../../platform/configuration/test/common/testConfigurationService.js';
 import { IPositronConsoleService } from '../../services/positronConsole/browser/interfaces/positronConsoleService.js';
-import { PositronConsoleService } from '../../services/positronConsole/browser/positronConsoleService.js';
+import { TestPositronConsoleService } from '../../services/positronConsole/test/browser/testPositronConsoleService.js';
 import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
 import { INotebookExecutionService } from '../../contrib/notebook/common/notebookExecutionService.js';
 import { TestNotebookExecutionService } from '../common/positronWorkbenchTestServices.js';
@@ -97,7 +97,7 @@ export function positronWorkbenchInstantiationService(
 	instantiationService.stub(IPositronWebviewPreloadService, disposables.add(instantiationService.createInstance(PositronWebviewPreloadService)));
 	instantiationService.stub(IPositronIPyWidgetsService, disposables.add(instantiationService.createInstance(PositronIPyWidgetsService)));
 	instantiationService.stub(IPositronPlotsService, disposables.add(instantiationService.createInstance(PositronPlotsService)));
-	instantiationService.stub(IPositronConsoleService, disposables.add(instantiationService.createInstance(PositronConsoleService)));
+	instantiationService.stub(IPositronConsoleService, new TestPositronConsoleService());
 	instantiationService.stub(IQuartoExecutionManager, disposables.add(instantiationService.createInstance(QuartoExecutionManager)));
 	instantiationService.stub(IPositronVariablesService, disposables.add(instantiationService.createInstance(PositronVariablesService)));
 


### PR DESCRIPTION
Addresses #12810

The getConsoleWidth() call added in #12312 requires a console service. Which revealed that a few existing tests weren't taking full advantage of the existing test console service. So I leaned into that in a few more places.