### PR TITLE
Remove IIFE localize calls in TSX files

### DIFF
--- a/build/lib/nls.ts
+++ b/build/lib/nls.ts
@@ -78,7 +78,10 @@ export function nls(options: { preserveEnglish: boolean }): NodeJS.ReadWriteStre
 			}
 
 			base = f.base;
-			this.emit('data', _nls.patchFile(f, typescript, options));
+			// --- Start Positron ---
+			// Pass the source filename so the NLS pipeline can detect .tsx files.
+			this.emit('data', _nls.patchFile(f, typescript, options, source));
+			// --- End Positron ---
 		}, function () {
 			for (const file of [
 				new File({
@@ -222,7 +225,10 @@ const _nls = (() => {
 		functionName: 'localize' | 'localize2',
 		options: ts.CompilerOptions = {}
 	): ILocalizeAnalysisResult {
-		const filename = 'file.ts';
+		// --- Start Positron ---
+		// Use .tsx virtual filename when JSX is enabled so TypeScript parses JSX syntax.
+		const filename = options.jsx ? 'file.tsx' : 'file.ts';
+		// --- End Positron ---
 		const serviceHost = new SingleFileServiceHost(ts, Object.assign(clone(options), { noResolve: true }), filename, contents);
 		const service = ts.createLanguageService(serviceHost);
 		const sourceFile = ts.createSourceFile(filename, contents, ts.ScriptTarget.ES5, true);
@@ -439,9 +445,15 @@ const _nls = (() => {
 		return eval(`(${sourceExpression})`);
 	}
 
-	function patch(ts: typeof import('typescript'), typescript: string, javascript: string, sourcemap: sm.RawSourceMap, options: { preserveEnglish: boolean }): INlsPatchResult {
-		const { localizeCalls } = analyze(ts, typescript, 'localize');
-		const { localizeCalls: localize2Calls } = analyze(ts, typescript, 'localize2');
+	// --- Start Positron ---
+	// Pass sourceFilename so we can enable JSX parsing for .tsx files,
+	// allowing the NLS pipeline to find localize() calls inside JSX.
+	function patch(ts: typeof import('typescript'), typescript: string, javascript: string, sourcemap: sm.RawSourceMap, options: { preserveEnglish: boolean }, sourceFilename?: string): INlsPatchResult {
+		const isTsx = sourceFilename ? /\.tsx$/i.test(sourceFilename) : false;
+		const compilerOptions: ts.CompilerOptions = isTsx ? { jsx: ts.JsxEmit.ReactJSX } : {};
+		const { localizeCalls } = analyze(ts, typescript, 'localize', compilerOptions);
+		const { localizeCalls: localize2Calls } = analyze(ts, typescript, 'localize2', compilerOptions);
+	// --- End Positron ---
 
 		if (localizeCalls.length === 0 && localize2Calls.length === 0) {
 			return { javascript, sourcemap };
@@ -498,19 +510,24 @@ const _nls = (() => {
 		return { javascript, sourcemap, nlsKeys, nlsMessages };
 	}
 
-	function patchFile(javascriptFile: File, typescript: string, options: { preserveEnglish: boolean }): File {
+	// --- Start Positron ---
+	function patchFile(javascriptFile: File, typescript: string, options: { preserveEnglish: boolean }, sourceFilename?: string): File {
+	// --- End Positron ---
 		// hack?
 		const moduleId = javascriptFile.relative
 			.replace(/\.js$/, '')
 			.replace(/\\/g, '/');
 
+		// --- Start Positron ---
 		const { javascript, sourcemap, nlsKeys, nlsMessages } = patch(
 			ts,
 			typescript,
 			javascriptFile.contents!.toString(),
 			javascriptFile.sourceMap,
-			options
+			options,
+			sourceFilename
 		);
+		// --- End Positron ---
 
 		const result = fileFrom(javascriptFile, javascript);
 		result.sourceMap = sourcemap;

--- a/build/lib/tsb/builder.ts
+++ b/build/lib/tsb/builder.ts
@@ -165,7 +165,11 @@ export function createTypeScriptBuilder(config: IConfiguration, projectFile: str
 								const extname = path.extname(vinyl.relative);
 								const basename = path.basename(vinyl.relative, extname);
 								const dirname = path.dirname(vinyl.relative);
-								const tsname = (dirname === '.' ? '' : dirname + '/') + basename + '.ts';
+								// --- Start Positron ---
+								// Preserve the original extension (.ts or .tsx) so that the
+								// NLS pipeline can detect .tsx files and parse JSX correctly.
+								const tsname = (dirname === '.' ? '' : dirname + '/') + basename + path.extname(fileName);
+								// --- End Positron ---
 
 								let sourceMap = JSON.parse(sourcemapFile.text) as RawSourceMap;
 								sourceMap.sources[0] = tsname.replace(/\\/g, '/');

--- a/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -89,7 +89,7 @@ export const ActionBarFilter = forwardRef<ActionBarFilterHandle, ActionBarFilter
 					ref={inputRef}
 					className='text-input'
 					disabled={props.disabled}
-					placeholder={props.placeholder ?? (() => localize('positronFilterPlaceholder', "Filter"))()}
+					placeholder={props.placeholder ?? localize('positronFilterPlaceholder', "Filter")}
 					type='text'
 					value={filterText}
 					onBlur={() => setFocused(false)}
@@ -99,7 +99,7 @@ export const ActionBarFilter = forwardRef<ActionBarFilterHandle, ActionBarFilter
 				/>
 				{filterText !== '' && (
 					<button
-						aria-label={(() => localize('positronClearFilter', "Clear filter"))()}
+						aria-label={localize('positronClearFilter', "Clear filter")}
 						className='clear-button'
 						disabled={props.disabled}
 						onClick={buttonClearClickHandler}

--- a/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/customFolderModalPopup/customFolderMenuItems.tsx
@@ -152,11 +152,11 @@ export const CustomFolderMenuItems = (props: CustomFolderMenuItemsProps) => {
 			<CustomFolderMenuSeparator />
 			<CommandActionCustomFolderMenuItem
 				id={OpenFolderAction.ID}
-				label={(() => localize('positronOpenFolder', "Open Folder..."))()} />
+				label={localize('positronOpenFolder', "Open Folder...")} />
 			<CommandActionCustomFolderMenuItem id={PositronOpenFolderInNewWindowAction.ID} />
 			<CommandActionCustomFolderMenuItem
 				id={kCloseFolder}
-				label={(() => localize('positronCloseFolder', "Close Folder"))()}
+				label={localize('positronCloseFolder', "Close Folder")}
 				separator={true}
 				when={ContextKeyExpr.and(
 					WorkbenchStateContext.isEqualTo('folder'),

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -126,7 +126,7 @@ const isTwoParams = (filterType: RowFilterDescrType | undefined) => {
 		return false;
 	}
 	return filterNumParams(filterType) === 2;
-}
+};
 
 /**
  * AddEditRowFilterModalPopupProps interface.

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/addEditRowFilterModalPopup.tsx
@@ -831,10 +831,10 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					ref={dropDownColumnSelectorRef}
 					dataExplorerClientInstance={props.dataExplorerClientInstance}
 					selectedColumnSchema={selectedColumnSchema}
-					title={(() => localize(
+					title={localize(
 						'positron.addEditRowFilter.selectColumn',
 						"Select Column"
-					))()}
+					)}
 					onSelectedColumnSchemaChanged={columnSchema => {
 						// Set the selected column schema.
 						setSelectedColumnSchema(columnSchema);
@@ -851,10 +851,10 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					disabled={selectedColumnSchema === undefined}
 					entries={conditionEntries()}
 					selectedIdentifier={selectedFilterType}
-					title={(() => localize(
+					title={localize(
 						'positron.addEditRowFilter.selectCondition',
 						"Select Condition"
-					))()}
+					)}
 					onSelectionChanged={handleSelectionChanged}
 				/>
 
@@ -867,10 +867,10 @@ export const AddEditRowFilterModalPopup = (props: AddEditRowFilterModalPopupProp
 					className='solid button-apply-row-filter'
 					onPressed={applyRowFilter}
 				>
-					{(() => localize(
+					{localize(
 						'positron.addEditRowFilter.applyFilter',
 						"Apply Filter"
-					))()}
+					)}
 				</Button>
 			</div>
 		</PositronModalPopup>

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSearch.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/addEditRowFilterModalPopup/components/columnSearch.tsx
@@ -67,7 +67,7 @@ export const ColumnSearch = (props: ColumnSearchProps) => {
 				<input
 					ref={inputRef}
 					className='text-input'
-					placeholder={(() => localize('positron.searchPlacehold', "search"))()}
+					placeholder={localize('positron.searchPlacehold', "search")}
 					type='text'
 					value={searchText}
 					onBlur={() => setFocused(false)}

--- a/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
+++ b/src/vs/workbench/browser/positronDataExplorer/components/dataExplorerPanel/components/rowFilterBar/rowFilterBar.tsx
@@ -100,12 +100,12 @@ export const RowFilterBar = () => {
 				<OKModalDialog
 					height={150}
 					renderer={renderer}
-					title={(() => localize('positron.dataExplorer.filtering.addFilter', "Add Filter"))()}
+					title={localize('positron.dataExplorer.filtering.addFilter', "Add Filter")}
 					width={350}
 					onAccept={() => renderer.dispose()}
 					onCancel={() => renderer.dispose()}
 				>
-					<div>{(() => localize('positron.dataExplorer.filtering.filterLimit', "The maximum number of filters has been reached."))()}</div>
+					<div>{localize('positron.dataExplorer.filtering.filterLimit', "The maximum number of filters has been reached.")}</div>
 				</OKModalDialog>
 			);
 		} else {
@@ -265,7 +265,7 @@ export const RowFilterBar = () => {
 		<div ref={ref} className='row-filter-bar'>
 			<Button
 				ref={rowFilterButtonRef}
-				ariaLabel={(() => localize('positron.dataExplorer.manageFilters', "Manage Filters"))()}
+				ariaLabel={localize('positron.dataExplorer.manageFilters', "Manage Filters")}
 				className='row-filter-button'
 				disabled={!canFilter}
 				hoverManager={context.instance.tableDataDataGridInstance.hoverManager}
@@ -299,7 +299,7 @@ export const RowFilterBar = () => {
 				)}
 				<Button
 					ref={addFilterButtonRef}
-					ariaLabel={(() => localize('positron.dataExplorer.addFilter', "Add Filter"))()}
+					ariaLabel={localize('positron.dataExplorer.addFilter', "Add Filter")}
 					className='add-row-filter-button'
 					disabled={!canFilter}
 					hoverManager={context.instance.tableDataDataGridInstance.hoverManager}

--- a/src/vs/workbench/browser/positronModalDialogs/convertToCodeModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/convertToCodeModalDialog.tsx
@@ -205,10 +205,10 @@ export const ConvertToCodeModalDialog = (props: ConvertToCodeDialogProps) => {
 		<PositronModalDialog
 			height={400}
 			renderer={props.renderer}
-			title={(() => localize(
+			title={localize(
 				'positronConvertToCodeModalDialogTitle',
 				"Convert to Code"
-			))()}
+			)}
 			width={400}
 		>
 			<ContentArea>

--- a/src/vs/workbench/browser/positronModalDialogs/convertToCodeModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/convertToCodeModalDialog.tsx
@@ -36,7 +36,7 @@ export const showConvertToCodeModalDialog = async (
 	dataExplorerClientInstance: IPositronDataExplorerInstance,
 ): Promise<void> => {
 	// Create the renderer.
-	const renderer = new PositronModalReactRenderer()
+	const renderer = new PositronModalReactRenderer();
 
 	// Show the copy as code dialog.
 	renderer.render(
@@ -51,7 +51,7 @@ export const showConvertToCodeModalDialog = async (
  * ConvertToCodeDialogProps interface.
  */
 interface ConvertToCodeDialogProps {
-	dataExplorerClientInstance: IPositronDataExplorerInstance
+	dataExplorerClientInstance: IPositronDataExplorerInstance;
 	renderer: PositronModalReactRenderer;
 }
 
@@ -160,7 +160,7 @@ export const ConvertToCodeModalDialog = (props: ConvertToCodeDialogProps) => {
 			return (selectedSyntax as CodeSyntaxName).code_syntax_name;
 		}
 		return localize('positron.dataExplorer.selectCodeSyntax', 'Select Code Syntax');
-	}
+	};
 
 	const onSelectionChanged = async (item: DropDownListBoxItem<string, CodeSyntaxName>) => {
 		const typedItem = item as DropDownListBoxItem<string, CodeSyntaxName>;

--- a/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
+++ b/src/vs/workbench/browser/positronModalDialogs/newFolderFromGitModalDialog.tsx
@@ -104,10 +104,10 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 			catchErrors
 			height={300}
 			renderer={props.renderer}
-			title={(() => localize(
+			title={localize(
 				'positronNewFolderFromGitModalDialogTitle',
 				"New Folder from Git"
-			))()}
+			)}
 			width={400}
 			onAccept={async () => {
 				if (isInputEmpty(result.repo)) {
@@ -123,18 +123,18 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 				<LabeledTextInput
 					ref={folderNameRef}
 					autoFocus
-					label={(() => localize(
+					label={localize(
 						'positron.GitRepositoryURL',
 						"Git repository URL"
-					))()}
+					)}
 					value={result.repo}
 					onChange={e => setResult({ ...result, repo: e.target.value })}
 				/>
 				<LabeledFolderInput
-					label={(() => localize(
+					label={localize(
 						'positron.createFolderAsSubfolderOf',
 						"Create folder as subfolder of"
-					))()}
+					)}
 					value={parentFolderLabel}
 					onBrowse={browseHandler}
 					onChange={e => onChangeParentFolder(e.target.value)}
@@ -142,10 +142,10 @@ export const NewFolderFromGitModalDialog = (props: NewFolderFromGitModalDialogPr
 			</VerticalStack>
 			<VerticalSpacer>
 				<Checkbox
-					label={(() => localize(
+					label={localize(
 						'positron.openInNewWindow',
 						"Open in a new window"
-					))()}
+					)}
 					onChanged={checked => setResult({ ...result, newWindow: checked })} />
 			</VerticalSpacer>
 		</OKCancelModalDialog>

--- a/src/vs/workbench/browser/positronNewFolderFlow/components/steps/folderNameLocationStep.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/components/steps/folderNameLocationStep.tsx
@@ -198,10 +198,10 @@ export const FolderNameLocationStep = (props: PropsWithChildren<NewFolderFlowSte
 			nextButtonConfig: {
 				onClick: nextStep,
 				disable: okNextButtonDisabled,
-				title: (() => localize(
+				title: localize(
 					'positronNewFolderFlow.nextButtonTitle',
 					"Next"
-				))()
+				)
 			}
 		};
 	} else {
@@ -212,10 +212,10 @@ export const FolderNameLocationStep = (props: PropsWithChildren<NewFolderFlowSte
 					props.accept();
 				},
 				disable: okNextButtonDisabled,
-				title: (() => localize(
+				title: localize(
 					'positronNewFolderFlow.createButtonTitle',
 					"Create"
-				))()
+				)
 			}
 		};
 	}
@@ -226,11 +226,10 @@ export const FolderNameLocationStep = (props: PropsWithChildren<NewFolderFlowSte
 			backButtonConfig={{ onClick: props.back }}
 			cancelButtonConfig={{ onClick: props.cancel }}
 			{...okNextButtonConfig}
-			title={(() =>
-				localize(
-					'folderNameLocationStep.title',
-					"Folder Name and Location"
-				))()}
+			title={localize(
+				'folderNameLocationStep.title',
+				"Folder Name and Location"
+			)}
 		>
 			<PositronFlowSubStep
 				feedback={
@@ -244,11 +243,10 @@ export const FolderNameLocationStep = (props: PropsWithChildren<NewFolderFlowSte
 						</FlowFormattedText>
 						: undefined
 				}
-				title={(() =>
-					localize(
-						'folderNameLocationSubStep.folderName.label',
-						"Folder Name"
-					))()}
+				title={localize(
+					'folderNameLocationSubStep.folderName.label',
+					"Folder Name"
+				)}
 			>
 				<LabeledTextInput
 					autoFocus
@@ -257,12 +255,11 @@ export const FolderNameLocationStep = (props: PropsWithChildren<NewFolderFlowSte
 							folderNameFeedback.type === FlowFormattedTextType.Error) ||
 						Boolean(nameValidationErrorMsg)
 					}
-					label={(() =>
-						localize(
-							'folderNameLocationSubStep.folderName.description',
-							"Enter the name of your new {0} folder",
-							context.folderTemplate
-						))()}
+					label={localize(
+						'folderNameLocationSubStep.folderName.description',
+						"Enter the name of your new {0} folder",
+						context.folderTemplate
+					)}
 					// Don't let the user create a folder with a location that is too long.
 					maxLength={maxFolderPathLength}
 					type='text'
@@ -277,11 +274,10 @@ export const FolderNameLocationStep = (props: PropsWithChildren<NewFolderFlowSte
 							{parentPathErrorMsg}
 						</FlowFormattedText> :
 						<FlowFormattedText type={FlowFormattedTextType.Info}>
-							{(() =>
-								localize(
-									'folderNameLocationSubStep.parentFolder.feedback',
-									"New folder will be created at "
-								))()}
+							{localize(
+								'folderNameLocationSubStep.parentFolder.feedback',
+								"New folder will be created at "
+							)}
 							<PathDisplay
 								pathComponents={[
 									parentFolder,
@@ -291,21 +287,19 @@ export const FolderNameLocationStep = (props: PropsWithChildren<NewFolderFlowSte
 							/>
 						</FlowFormattedText>
 				}
-				title={(() =>
-					localize(
-						'folderNameLocationSubStep.parentFolder.label',
-						"Location"
-					))()}
+				title={localize(
+					'folderNameLocationSubStep.parentFolder.label',
+					"Location"
+				)}
 			>
 				<LabeledFolderInput
 					skipValidation
 					error={Boolean(parentPathErrorMsg)}
-					label={(() =>
-						localize(
-							'folderNameLocationSubStep.parentFolder.description',
-							"Select the location of your new {0} folder",
-							context.folderTemplate
-						))()}
+					label={localize(
+						'folderNameLocationSubStep.parentFolder.description',
+						"Select the location of your new {0} folder",
+						context.folderTemplate
+					)}
 					value={parentFolder}
 					onBrowse={browseHandler}
 					onChange={(e) => onChangeParentFolder(e.target.value)}
@@ -317,21 +311,19 @@ export const FolderNameLocationStep = (props: PropsWithChildren<NewFolderFlowSte
 				{/* TODO: display a warning/message if the user doesn't have git set up */}
 				<Checkbox
 					initialChecked={context.initGitRepo}
-					label={(() =>
-						localize(
-							'folderNameLocationSubStep.initGitRepo.label',
-							"Initialize Git repository"
-						))()}
+					label={localize(
+						'folderNameLocationSubStep.initGitRepo.label',
+						"Initialize Git repository"
+					)}
 					onChanged={(checked) => context.initGitRepo = checked}
 				/>
 				{context.folderTemplate === FolderTemplate.PythonProject && (
 					<Checkbox
 						initialChecked={context.createPyprojectToml}
-						label={(() =>
-							localize(
-								'folderNameLocationSubStep.createPyprojectToml.label',
-								"Create pyproject.toml file"
-							))()}
+						label={localize(
+							'folderNameLocationSubStep.createPyprojectToml.label',
+							"Create pyproject.toml file"
+						)}
 						onChanged={(checked) => context.createPyprojectToml = checked}
 					/>
 				)}

--- a/src/vs/workbench/browser/positronNewFolderFlow/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/components/steps/pythonEnvironmentStep.tsx
@@ -515,7 +515,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 						'pythonInterpreterSubStep.description',
 						"Select {0}",
 						whatToSelect
-					)
+					);
 				})()}
 				feedback={interpreterStepFeedback()}
 				title={(() => {
@@ -524,7 +524,7 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 						'pythonInterpreterSubStep.title',
 						"Python {0}",
 						interpreterOrVersion
-					)
+					);
 				})()}
 				titleId='pythonEnvironment-interpreterOrVersion'
 			>

--- a/src/vs/workbench/browser/positronNewFolderFlow/components/steps/pythonEnvironmentStep.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/components/steps/pythonEnvironmentStep.tsx
@@ -181,11 +181,10 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 					<FlowFormattedText
 						type={FlowFormattedTextType.Info}
 					>
-						{(() =>
-							localize(
-								'pythonEnvironmentSubStep.feedback',
-								"The environment will be created at "
-							))()}
+						{localize(
+							'pythonEnvironmentSubStep.feedback',
+							"The environment will be created at "
+						)}
 						<PathDisplay
 							maxLength={65}
 							pathComponents={
@@ -209,11 +208,10 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 					<FlowFormattedText
 						type={FlowFormattedTextType.Warning}
 					>
-						{(() =>
-							localize(
-								'pythonEnvironmentSubStep.feedback.noEnvProviders',
-								"No environment providers found. Please use an existing Python installation."
-							))()}
+						{localize(
+							'pythonEnvironmentSubStep.feedback.noEnvProviders',
+							"No environment providers found. Please use an existing Python installation."
+						)}
 					</FlowFormattedText>
 				);
 			}
@@ -288,11 +286,10 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 					<FlowFormattedText
 						type={FlowFormattedTextType.Warning}
 					>
-						{(() =>
-							localize(
-								'pythonInterpreterSubStep.feedback.uvNotInstalled',
-								"uv is not installed. Please install uv to create a uv environment."
-							))()}
+						{localize(
+							'pythonInterpreterSubStep.feedback.uvNotInstalled',
+							"uv is not installed. Please install uv to create a uv environment."
+						)}
 					</FlowFormattedText>
 				);
 			}
@@ -304,11 +301,10 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 					<FlowFormattedText
 						type={FlowFormattedTextType.Warning}
 					>
-						{(() =>
-							localize(
-								'pythonInterpreterSubStep.feedback.noInterpretersAvailable',
-								"No interpreters available since no environment providers were found."
-							))()}
+						{localize(
+							'pythonInterpreterSubStep.feedback.noInterpretersAvailable',
+							"No interpreters available since no environment providers were found."
+						)}
 					</FlowFormattedText>
 				);
 			}
@@ -318,11 +314,10 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 					<FlowFormattedText
 						type={FlowFormattedTextType.Warning}
 					>
-						{(() =>
-							localize(
-								'pythonInterpreterSubStep.feedback.condaNotInstalled',
-								"Conda is not installed. Please install Conda to create a Conda environment."
-							))()}
+						{localize(
+							'pythonInterpreterSubStep.feedback.condaNotInstalled',
+							"Conda is not installed. Please install Conda to create a Conda environment."
+						)}
 					</FlowFormattedText>
 				);
 			}
@@ -332,12 +327,11 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 				<FlowFormattedText
 					type={FlowFormattedTextType.Warning}
 				>
-					{(() =>
-						localize(
-							'pythonInterpreterSubStep.feedback.noSuitableInterpreters',
-							"No suitable interpreters found. Please install a Python interpreter with version {0} or later.",
-							minimumPythonVersion
-						))()}
+					{localize(
+						'pythonInterpreterSubStep.feedback.noSuitableInterpreters',
+						"No suitable interpreters found. Please install a Python interpreter with version {0} or later.",
+						minimumPythonVersion
+					)}
 				</FlowFormattedText>
 			);
 		}
@@ -347,11 +341,10 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 			return (
 				<FlowFormattedText type={FlowFormattedTextType.Info}>
 					<code>ipykernel</code>
-					{(() =>
-						localize(
-							'pythonInterpreterSubStep.feedback',
-							" will be installed for Python language support."
-						))()}
+					{localize(
+						'pythonInterpreterSubStep.feedback',
+						" will be installed for Python language support."
+					)}
 				</FlowFormattedText>
 			);
 		}
@@ -443,23 +436,23 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 			cancelButtonConfig={{ onClick: props.cancel }}
 			okButtonConfig={{
 				onClick: props.accept,
-				title: (() => localize(
+				title: localize(
 					'positronNewFolderFlow.createButtonTitle',
 					"Create"
-				))(),
+				),
 				disable: disableCreateButton()
 			}}
-			title={(() => localize(
+			title={localize(
 				'pythonEnvironmentStep.title',
 				"Python Environment"
-			))()}
+			)}
 		>
 			{/* New or existing Python environment selection */}
 			<PositronFlowSubStep
-				title={(() => localize(
+				title={localize(
 					'pythonEnvironmentSubStep.howToSetUpEnv',
 					"How would you like to set up your Python environment?"
-				))()}
+				)}
 				titleId='pythonEnvironment-howToSetUpEnv'
 			>
 				<RadioGroup
@@ -477,17 +470,17 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 				<PositronFlowSubStep
 					description={
 						<FlowFormattedText type={FlowFormattedTextType.Info}>
-							{(() => localize(
+							{localize(
 								'pythonEnvironmentSubStep.description',
 								"Select a way to create a new virtual environment"
-							))()}
+							)}
 						</FlowFormattedText>
 					}
 					feedback={envProviderStepFeedback()}
-					title={(() => localize(
+					title={localize(
 						'pythonEnvironmentSubStep.label',
 						"Environment Creation"
-					))()}
+					)}
 				>
 					<DropDownListBox
 						createItem={(item) => (
@@ -505,10 +498,10 @@ export const PythonEnvironmentStep = (props: PropsWithChildren<NewFolderFlowStep
 						}
 					/>
 					<LabeledTextInput
-						label={(() => localize(
+						label={localize(
 							'pythonEnvironmentNameSubStep.label',
 							"Environment name"
-						))()}
+						)}
 						value={envName ?? ''}
 						onChange={(e) => onEnvNameChanged(e.target.value)}
 					/>

--- a/src/vs/workbench/browser/positronNewFolderFlow/components/steps/rConfigurationStep.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/components/steps/rConfigurationStep.tsx
@@ -110,42 +110,39 @@ export const RConfigurationStep = (props: PropsWithChildren<NewFolderFlowStepPro
 			cancelButtonConfig={{ onClick: props.cancel }}
 			okButtonConfig={{
 				onClick: props.accept,
-				title: (() => localize(
+				title: localize(
 					'positronNewFolderFlow.createButtonTitle',
 					"Create"
-				))(),
+				),
 				disable: !selectedInterpreter
 			}}
-			title={(() => localize(
+			title={localize(
 				'rConfigurationStep.title',
 				"Project Configuration"
-			))()}
+			)}
 		>
 			<PositronFlowSubStep
-				description={(() =>
-					localize(
-						'rConfigurationStep.versionSubStep.description',
-						'Select a version of R to launch your project with'
-					))()}
+				description={localize(
+					'rConfigurationStep.versionSubStep.description',
+					'Select a version of R to launch your project with'
+				)}
 				feedback={
 					!interpretersLoading() && !interpretersAvailable() ? (
 						<FlowFormattedText
 							type={FlowFormattedTextType.Warning}
 						>
-							{(() =>
-								localize(
-									'rConfigurationStep.versionSubStep.feedback.noSuitableInterpreters',
-									'No suitable interpreters found. Please install R version {0} or later.',
-									minimumRVersion
-								))()}
+							{localize(
+								'rConfigurationStep.versionSubStep.feedback.noSuitableInterpreters',
+								'No suitable interpreters found. Please install R version {0} or later.',
+								minimumRVersion
+							)}
 						</FlowFormattedText>
 					) : undefined
 				}
-				title={(() =>
-					localize(
-						'rConfigurationStep.versionSubStep.title',
-						'R Version'
-					))()}
+				title={localize(
+					'rConfigurationStep.versionSubStep.title',
+					'R Version'
+				)}
 			>
 				<DropDownListBox
 					createItem={(item) => (
@@ -170,20 +167,18 @@ export const RConfigurationStep = (props: PropsWithChildren<NewFolderFlowStepPro
 				/>
 			</PositronFlowSubStep>
 			<PositronFlowSubStep
-				title={(() =>
-					localize(
-						'rConfigurationStep.advancedConfigSubStep.title',
-						"Advanced Configuration"
-					))()}
+				title={localize(
+					'rConfigurationStep.advancedConfigSubStep.title',
+					"Advanced Configuration"
+				)}
 			>
 				<div className='renv-configuration'>
 					<Checkbox
 						initialChecked={context.useRenv}
-						label={(() =>
-							localize(
-								'rConfigurationStep.additionalConfigSubStep.useRenv.label',
-								"Use `renv` to create a reproducible environment"
-							))()}
+						label={localize(
+							'rConfigurationStep.additionalConfigSubStep.useRenv.label',
+							"Use `renv` to create a reproducible environment"
+						)}
 						onChanged={(checked) => (context.useRenv = checked)}
 					/>
 					<ExternalLink

--- a/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowModalDialog.tsx
@@ -151,7 +151,7 @@ const NewFolderFlowModalDialog = (props: NewFolderFlowModalDialogProps) => {
 	return (
 		<PositronModalDialog
 			height={580}
-			renderer={props.renderer} title={(() => localize('positron.newFolderFromTemplate', "New Folder From Template"))()}
+			renderer={props.renderer} title={localize('positron.newFolderFromTemplate', "New Folder From Template")}
 			width={700}
 			onCancel={cancelHandler}
 		>

--- a/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowModalDialog.tsx
+++ b/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowModalDialog.tsx
@@ -20,7 +20,7 @@ import { PositronModalReactRenderer } from '../../../base/browser/positronModalR
  */
 export const showNewFolderFlowModalDialog = async (): Promise<void> => {
 	// Create the renderer.
-	const renderer = new PositronModalReactRenderer()
+	const renderer = new PositronModalReactRenderer();
 
 	// Show the new folder flow modal dialog.
 	renderer.render(

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -431,16 +431,16 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 
 	return <OKModalDialog
 		height={500}
-		okButtonTitle={(() => localize('positron.languageModelModalDialog.close', "Close"))()}
+		okButtonTitle={localize('positron.languageModelModalDialog.close', "Close")}
 		renderer={props.renderer}
-		title={(() => localize('positron.languageModelModalDialog.title', "Configure Language Model Providers"))()}
+		title={localize('positron.languageModelModalDialog.title', "Configure Language Model Providers")}
 		width={600}
 		onAccept={onClose}
 		onCancel={onClose}
 	>
 		<VerticalStack>
 			<label className='language-model-section'>
-				{(() => localize('positron.languageModelProviderModalDialog.provider', "Provider"))()}
+				{localize('positron.languageModelProviderModalDialog.provider', "Provider")}
 			</label>
 			<div className='language-model button-container'>
 				{
@@ -458,7 +458,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 				}
 			</div>
 			<label className='language-model-section'>
-				{(() => localize('positron.languageModelProviderModalDialog.authentication', "Authentication"))()}
+				{localize('positron.languageModelProviderModalDialog.authentication', "Authentication")}
 			</label>
 			{renderAuthMethodSelection()}
 			<LanguageModelConfigComponent

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog.tsx
@@ -81,7 +81,7 @@ const NewConnectionModalDialog = (props: PropsWithChildren<NewConnectionModalDia
 	return <PositronModalDialog
 		height={NEW_CONNECTION_MODAL_DIALOG_HEIGHT}
 		renderer={props.renderer}
-		title={(() => localize('positron.newConnectionModalDialog.title', "Create New Connection"))()}
+		title={localize('positron.newConnectionModalDialog.title', "Create New Connection")}
 		width={NEW_CONNECTION_MODAL_DIALOG_WIDTH}
 		onCancel={cancelHandler}
 	>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx
@@ -134,7 +134,7 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 		<Form inputs={inputs} onInputsChange={setInputs}></Form>
 
 		<div className='create-connection-code-title'>
-			{(() => localize('positron.newConnectionModalDialog.createConnection.code', "Connection Code"))()}
+			{localize('positron.newConnectionModalDialog.createConnection.code', "Connection Code")}
 		</div>
 
 		<div className={positronClassNames('create-connection-code-editor', { 'has-error': !!codeState?.errorMessage })}>
@@ -156,13 +156,13 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 				className='button action-bar-button'
 				onPressed={onCopy}
 			>
-				{(() => localize('positron.newConnectionModalDialog.createConnection.copy', 'Copy'))()}
+				{localize('positron.newConnectionModalDialog.createConnection.copy', 'Copy')}
 			</Button>
 			<Button
 				className='button action-bar-button'
 				onPressed={onCancel}
 			>
-				{(() => localize('positron.newConnectionModalDialog.createConnection.cancel', 'Cancel'))()}
+				{localize('positron.newConnectionModalDialog.createConnection.cancel', 'Cancel')}
 			</Button>
 		</div>
 
@@ -171,14 +171,14 @@ export const CreateConnection = (props: PropsWithChildren<CreateConnectionProps>
 				className='button action-bar-button'
 				onPressed={onBack}
 			>
-				{(() => localize('positron.newConnectionModalDialog.createConnection.back', 'Back'))()}
+				{localize('positron.newConnectionModalDialog.createConnection.back', 'Back')}
 			</Button>
 			<Button
 				className={`button action-bar-button`}
 				disabled={!codeState || !!codeState.errorMessage}
 				onPressed={onConnectHandler}
 			>
-				{(() => localize('positron.newConnectionModalDialog.createConnection.connect', 'Connect'))()}
+				{localize('positron.newConnectionModalDialog.createConnection.connect', 'Connect')}
 			</Button>
 		</div>
 	</div>;
@@ -250,7 +250,7 @@ const FormElement = (props: PropsWithChildren<FormElementProps>) => {
 				return <div className='labeled-input'><label className='label'>
 					<span className='label-text'>{label}</span>
 					<p>
-						{(() => localize('positron.newConnectionModalDialog.createConnection.input.noOption', 'No options provided'))()}
+						{localize('positron.newConnectionModalDialog.createConnection.input.noOption', 'No options provided')}
 					</p>
 				</label></div>;
 			}

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversDetailsState.tsx
@@ -104,13 +104,13 @@ export const ListDriversDetails = (props: PropsWithChildren<ListDriversDetailsPr
 				className='button action-bar-button'
 				onPressed={props.onBack}
 			>
-				{(() => localize('positron.resumeConnectionModalDialog.back', "Back"))()}
+				{localize('positron.resumeConnectionModalDialog.back', "Back")}
 			</Button>
 			<Button
 				className='button action-bar-button right'
 				onPressed={props.onCancel}
 			>
-				{(() => localize('positron.resumeConnectionModalDialog.cancel', "Cancel"))()}
+				{localize('positron.resumeConnectionModalDialog.cancel', "Cancel")}
 			</Button>
 		</div>
 	</div>;

--- a/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/listDriversState.tsx
@@ -93,7 +93,7 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 	return <div className='connections-new-connection-list-drivers'>
 		<div className='title'>
 			<h1>
-				{(() => localize('positron.newConnectionModalDialog.listDrivers.title', "Choose a Database Driver"))()}
+				{localize('positron.newConnectionModalDialog.listDrivers.title', "Choose a Database Driver")}
 			</h1>
 		</div>
 		<div className='select-language'>
@@ -115,7 +115,7 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 					});
 				})}
 				selectedIdentifier={languageId}
-				title={(() => localize('positron.newConnectionModalDialog.listDrivers.selectLanguage', "Select a language"))()}
+				title={localize('positron.newConnectionModalDialog.listDrivers.selectLanguage', "Select a language")}
 				onSelectionChanged={(item) => onLanguageChangeHandler(item.options.identifier)}
 			>
 			</DropDownListBox>
@@ -132,7 +132,7 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 						/>
 					)) :
 					<div className='no-drivers'>
-						{(() => localize('positron.newConnectionModalDialog.listDrivers.noDrivers', "No drivers available"))()}
+						{localize('positron.newConnectionModalDialog.listDrivers.noDrivers', "No drivers available")}
 					</div>
 			}
 		</div>
@@ -141,7 +141,7 @@ export const ListDrivers = (props: PropsWithChildren<ListDriversProps>) => {
 				className='button action-bar-button'
 				onPressed={props.onCancel}
 			>
-				{(() => localize('positron.resumeConnectionModalDialog.cancel', "Cancel"))()}
+				{localize('positron.resumeConnectionModalDialog.cancel', "Cancel")}
 			</Button>
 		</div>
 	</div>;

--- a/src/vs/workbench/contrib/positronConnections/browser/components/resumeConnectionModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/resumeConnectionModalDialog.tsx
@@ -124,7 +124,7 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 			<PositronModalDialog
 				height={RESUME_CONNECTION_MODAL_DIALOG_HEIGHT}
 				renderer={props.renderer}
-				title={(() => localize('positron.resumeConnectionModalDialog.title', "Resume Connection"))()}
+				title={localize('positron.resumeConnectionModalDialog.title', "Resume Connection")}
 				width={RESUME_CONNECTION_MODAL_DIALOG_WIDTH}
 				onCancel={cancelHandler}
 			>
@@ -150,7 +150,7 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 									disabled={!code}
 									onPressed={editHandler}
 								>
-									{(() => localize('positron.resumeConnectionModalDialog.edit', "Edit"))()}
+									{localize('positron.resumeConnectionModalDialog.edit', "Edit")}
 								</PositronButton>
 							</div>
 							<div className='bottom'>
@@ -159,13 +159,13 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 									disabled={!code}
 									onPressed={copyHandler}
 								>
-									{(() => localize('positron.resumeConnectionModalDialog.copy', "Copy"))()}
+									{localize('positron.resumeConnectionModalDialog.copy', "Copy")}
 								</PositronButton>
 								<PositronButton
 									className='button action-bar-button'
 									onPressed={cancelHandler}
 								>
-									{(() => localize('positron.resumeConnectionModalDialog.cancel', "Cancel"))()}
+									{localize('positron.resumeConnectionModalDialog.cancel', "Cancel")}
 								</PositronButton>
 							</div>
 						</div>
@@ -175,7 +175,7 @@ const ResumeConnectionModalDialog = (props: PropsWithChildren<ResumeConnectionMo
 								disabled={!activeInstance.connect}
 								onPressed={resumeHandler}
 							>
-								{(() => localize('positron.resumeConnectionModalDialog.resume', "Resume Connection"))()}
+								{localize('positron.resumeConnectionModalDialog.resume', "Resume Connection")}
 							</PositronButton>
 						</div>
 					</div>

--- a/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigationActionBar.tsx
+++ b/src/vs/workbench/contrib/positronConnections/browser/components/schemaNavigationActionBar.tsx
@@ -43,21 +43,21 @@ export const ActionBar = (props: React.PropsWithChildren<ConnectionActionBarProp
 						<ActionBarButton
 							align='left'
 							icon={ThemeIcon.fromId('arrow-left')}
-							tooltip={(() => localize('positron.schemaNavigationActionBar.back', 'Back'))()}
+							tooltip={localize('positron.schemaNavigationActionBar.back', 'Back')}
 							onPressed={() => props.onBack()}
 						/>
 						<ActionBarSeparator />
 						<ActionBarButton
 							align='left'
 							icon={ThemeIcon.fromId('positron-disconnect-connection')}
-							label={(() => localize('positron.schemaNavigationActionBar.disconnect', 'Disconnect'))()}
+							label={localize('positron.schemaNavigationActionBar.disconnect', 'Disconnect')}
 							onPressed={() => props.onDisconnect()}
 						/>
 						<ActionBarSeparator />
 						<ActionBarButton
 							align='left'
 							icon={ThemeIcon.fromId('refresh')}
-							label={(() => localize('positron.schemaNavigationActionBar.refresh', 'Refresh'))()}
+							label={localize('positron.schemaNavigationActionBar.refresh', 'Refresh')}
 							onPressed={() => props.onRefresh()}
 						/>
 					</ActionBarRegion>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -18,7 +18,7 @@ import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { PositronButton } from '../../../../../base/browser/ui/positronComponents/button/positronButton.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
-import { PositronModalPopup } from '../../../../browser/positronComponents/positronModalPopup/positronModalPopup.js'
+import { PositronModalPopup } from '../../../../browser/positronComponents/positronModalPopup/positronModalPopup.js';
 import { PositronModalReactRenderer } from '../../../../../base/browser/positronModalReactRenderer.js';
 import { ILanguageRuntimeSession, LanguageRuntimeSessionChannel } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 
@@ -59,7 +59,7 @@ export const ConsoleInstanceInfoButton = () => {
 		}
 
 		// Get the channels from the session.
-		let channels: LanguageRuntimeSessionChannel[] = []
+		let channels: LanguageRuntimeSessionChannel[] = [];
 		try {
 			channels = intersectionOutputChannels(await session.listOutputChannels());
 		} catch (err) {
@@ -81,7 +81,7 @@ export const ConsoleInstanceInfoButton = () => {
 				session={session}
 			/>
 		);
-	}
+	};
 
 	// Render.
 	return (
@@ -94,7 +94,7 @@ export const ConsoleInstanceInfoButton = () => {
 			tooltip={positronConsoleInfo}
 			onPressed={handlePressed}
 		/>
-	)
+	);
 };
 
 interface ConsoleInstanceInfoModalPopupProps {
@@ -121,7 +121,7 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 	const showKernelOutputChannelClickHandler = (channel: LanguageRuntimeSessionChannel) => {
 		props.session.showOutput(channel);
 		props.renderer.dispose();
-	}
+	};
 
 	// Render.
 	return (
@@ -174,5 +174,5 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 				</div>
 			</div>
 		</PositronModalPopup>
-	)
+	);
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceInfoButton.tsx
@@ -140,24 +140,24 @@ const ConsoleInstanceInfoModalPopup = (props: ConsoleInstanceInfoModalPopupProps
 					<p className='line' data-testid='session-name'>{props.session.dynState.sessionName}</p>
 					<div className='top-separator'>
 						<p className='line' data-testid='session-id'>
-							{(() => localize(
+							{localize(
 								'positron.console.info.sessionId', 'Session ID: {0}',
 								props.session.sessionId
-							))()}
+							)}
 						</p>
-						<p className='line' data-testid='session-state'>{(() => localize(
+						<p className='line' data-testid='session-state'>{localize(
 							'positron.console.info.state', 'State: {0}',
-							sessionState))()}
+							sessionState)}
 						</p>
 					</div>
 					<div className='top-separator'>
-						<p className='line' data-testid='session-path'>{(() => localize(
+						<p className='line' data-testid='session-path'>{localize(
 							'positron.console.info.runtimePath', 'Path: {0}',
-							props.session.runtimeMetadata.runtimePath))()}
+							props.session.runtimeMetadata.runtimePath)}
 						</p>
-						<p className='line' data-testid='session-source'>{(() => localize(
+						<p className='line' data-testid='session-source'>{localize(
 							'positron.console.info.runtimeSource', 'Source: {0}',
-							props.session.runtimeMetadata.runtimeSource))()}
+							props.session.runtimeMetadata.runtimeSource)}
 						</p>
 					</div>
 				</div>

--- a/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronHelp/browser/components/actionBars.tsx
@@ -176,7 +176,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 					{/* <ActionBarSeparator /> */}
 					{/* <ActionBarButton
 						iconId='positron-open-in-new-window'
-						tooltip={(() => localize('positronShowInNewWindow', "Show in new window"))()}
+						tooltip={localize('positronShowInNewWindow', "Show in new window")}
 					/> */}
 
 				</PositronActionBar>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeferredImage.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DeferredImage.tsx
@@ -188,7 +188,7 @@ export function DeferredImage({ src = 'no-source', ...props }: React.ComponentPr
 	switch (results.status) {
 		case 'pending':
 			return <div
-				aria-label={(() => localize('deferredImageLoading', 'Loading image...'))()}
+				aria-label={localize('deferredImageLoading', 'Loading image...')}
 				className='positron-notebooks-deferred-img-placeholder'
 				role='img'
 				{...props}

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/savePlotModalDialog.tsx
@@ -261,7 +261,7 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 		<PositronModalDialog
 			height={SAVE_PLOT_MODAL_DIALOG_HEIGHT}
 			renderer={props.renderer}
-			title={(() => localize('positron.savePlotModalDialog.title', "Save Plot"))()}
+			title={localize('positron.savePlotModalDialog.title', "Save Plot")}
 			width={SAVE_PLOT_MODAL_DIALOG_WIDTH}
 			onCancel={cancelHandler}>
 			<ContentArea>
@@ -271,10 +271,10 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 							<LabeledFolderInput
 								error={!directory.valid}
 								inputRef={inputRef}
-								label={(() => localize(
+								label={localize(
 									'positron.savePlotModalDialog.directory',
 									"Directory"
-								))()}
+								)}
 								readOnlyInput={false}
 								value={pathUriToLabel(directory.value, props.renderer.services.labelService)}
 								onBrowse={browseHandler}
@@ -289,15 +289,15 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 						<div className='file'>
 							<LabeledTextInput
 								error={!name.valid}
-								label={(() => localize(
+								label={localize(
 									'positron.savePlotModalDialog.name',
 									"Name"
-								))()}
+								)}
 								value={name.value}
 								onChange={e => setName({ value: e.target.value, valid: !!e.target.value })}
 							/>
 							<div>
-								<label>{(() => localize('positron.savePlotModalDialog.format', "Format"))()}
+								<label>{localize('positron.savePlotModalDialog.format', "Format")}
 									<DropDownListBox
 										entries={[
 											new DropDownListBoxItem<PlotRenderFormat, PlotRenderFormat>({ identifier: PlotRenderFormat.Png, title: PlotRenderFormat.Png.toUpperCase(), value: PlotRenderFormat.Png }),
@@ -307,10 +307,10 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 											new DropDownListBoxItem<PlotRenderFormat, PlotRenderFormat>({ identifier: PlotRenderFormat.Tiff, title: PlotRenderFormat.Tiff.toUpperCase(), value: PlotRenderFormat.Tiff }),
 										]}
 										selectedIdentifier={format}
-										title={(() => localize(
+										title={localize(
 											'positron.savePlotModalDialog.format',
 											"Format"
-										))()}
+										)}
 										onSelectionChanged={(ext) => { setFormat(ext.options.identifier); }} />
 								</label>
 							</div>
@@ -319,29 +319,29 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 							{enableIntrinsicSize ? <>
 								<LabeledTextInput
 									disabled={true}
-									label={(() => localize(
+									label={localize(
 										'positron.savePlotModalDialog.width',
 										"Width"
-									))()}
+									)}
 									type={'text'}
 									value={intrinsicWidth}
 								/>
 								<LabeledTextInput
 									disabled={true}
-									label={(() => localize(
+									label={localize(
 										'positron.savePlotModalDialog.height',
 										"Height"
-									))()}
+									)}
 									type={'text'}
 									value={intrinsicHeight}
 								/>
 							</> : <>
 								<LabeledTextInput
 									error={!width.valid}
-									label={(() => localize(
+									label={localize(
 										'positron.savePlotModalDialog.width',
 										"Width"
-									))()}
+									)}
 									min={1}
 									type={'number'}
 									value={width.value}
@@ -349,10 +349,10 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 								/>
 								<LabeledTextInput
 									error={!height.valid}
-									label={(() => localize(
+									label={localize(
 										'positron.savePlotModalDialog.height',
 										"Height"
-									))()}
+									)}
 									min={1}
 									type={'number'}
 									value={height.value}
@@ -361,10 +361,10 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 							</>}
 							{enableDPI && <LabeledTextInput
 								error={!dpi.valid}
-								label={(() => localize(
+								label={localize(
 									'positron.savePlotModalDialog.dpi',
 									"DPI"
-								))()}
+								)}
 								max={300}
 								min={1}
 								type={'number'}
@@ -373,38 +373,38 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 							/>}
 							<div className='error'>
 								<div>
-									{!directory.valid && (() => localize(
+									{!directory.valid && localize(
 										'positron.savePlotModalDialog.invalidPathError',
 										"Invalid path: {0}", directory.errorMessage
-									))()}
+									)}
 								</div>
 								<div>
-									{(!width.valid || !height.valid) && (() => localize(
+									{(!width.valid || !height.valid) && localize(
 										'positron.savePlotModalDialog.dimensionError',
 										"Width and height must be greater than 0."
-									))()}
+									)}
 								</div>
 								<div>
-									{!dpi.valid && (() => localize(
+									{!dpi.valid && localize(
 										'positron.savePlotModalDialog.dpiMinMaxError',
 										"DPI must be between 1 and 300."
-									))()}
+									)}
 								</div>
 								<div>
-									{!name.valid && (() => localize(
+									{!name.valid && localize(
 										'positron.savePlotModalDialog.invalidNameError',
 										"Plot name cannot be empty."
-									))()}
+									)}
 								</div>
 							</div>
 						</div>
 						<div className='use-intrinsic-size'>
 							{props.plotIntrinsicSize ? <Checkbox
 								initialChecked={enableIntrinsicSize}
-								label={(() => localize(
+								label={localize(
 									'positron.savePlotModalDialog.useIntrinsicSize',
 									"Use intrinsic size"
-								))()}
+								)}
 								onChanged={checked => setEnableIntrinsicSize(checked)} /> : null}
 						</div>
 						<div className='preview-progress'>
@@ -422,7 +422,7 @@ const SavePlotModalDialog = (props: SavePlotModalDialogProps) => {
 			<div className='plot-save-dialog-action-bar top-separator'>
 				<div className='left'>
 					<PositronButton className='action-bar-button' onPressed={updatePreview}>
-						{(() => localize('positron.savePlotModalDialog.updatePreview', "Preview"))()}
+						{localize('positron.savePlotModalDialog.updatePreview', "Preview")}
 					</PositronButton>
 				</div>
 				<div className='right'>

--- a/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/setPlotSizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/modalDialogs/setPlotSizeModalDialog.tsx
@@ -96,7 +96,7 @@ const SetPlotSizeModalDialog = (props: SetPlotSizeModalDialogProps) => {
 			tabIndex={0}
 			onPressed={acceptHandler}
 		>
-			{(() => localize('positronOK', "OK"))()}
+			{localize('positronOK', "OK")}
 		</Button>
 	);
 	const cancelButton = (
@@ -105,7 +105,7 @@ const SetPlotSizeModalDialog = (props: SetPlotSizeModalDialogProps) => {
 			tabIndex={0}
 			onPressed={cancelHandler}
 		>
-			{(() => localize('positronCancel', "Cancel"))()}
+			{localize('positronCancel', "Cancel")}
 		</Button>
 	);
 
@@ -114,7 +114,7 @@ const SetPlotSizeModalDialog = (props: SetPlotSizeModalDialogProps) => {
 		<PositronModalDialog
 			height={200}
 			renderer={props.renderer}
-			title={(() => localize('positronSetPlotSizeModalDialogTitle', "Custom Plot Size"))()}
+			title={localize('positronSetPlotSizeModalDialogTitle', "Custom Plot Size")}
 			width={350}
 			onCancel={cancelHandler}>
 			<ContentArea>
@@ -123,17 +123,17 @@ const SetPlotSizeModalDialog = (props: SetPlotSizeModalDialogProps) => {
 						<tr>
 							<td>
 								<LabeledTextInput autoFocus={true}
-									label={(() => localize(
+									label={localize(
 										'positronPlotWidth',
 										"Width"
-									))()} min={100} type='number'
+									)} min={100} type='number'
 									value={width} onChange={(el) => setWidth(el.target.valueAsNumber)} />
 							</td>
 							<td>
-								<LabeledTextInput label={(() => localize(
+								<LabeledTextInput label={localize(
 									'positronPlotHeight',
 									"Height"
-								))()}
+								)}
 									min={100} type='number'
 									value={height} onChange={(el) => setHeight(el.target.valueAsNumber)} />
 							</td>
@@ -149,7 +149,7 @@ const SetPlotSizeModalDialog = (props: SetPlotSizeModalDialogProps) => {
 						tabIndex={0}
 						onPressed={deleteHandler}
 					>
-						{(() => localize('positronDeletePlotSize', "Delete"))()}
+						{localize('positronDeletePlotSize', "Delete")}
 					</Button>
 				</div>
 				<div className='right'>

--- a/src/vs/workbench/contrib/positronVariables/browser/modalDialogs/deleteAllVariablesModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/modalDialogs/deleteAllVariablesModalDialog.tsx
@@ -54,20 +54,20 @@ export const DeleteAllVariablesModalDialog = (props: DeleteAllVariablesModalDial
 		<ConfirmDeleteModalDialog
 			height={175}
 			renderer={props.renderer}
-			title={(() => localize(
+			title={localize(
 				'positron.deleteAllVariablesModalDialogTitle',
 				"Delete All Variables"
-			))()}
+			)}
 			width={375}
 			onCancel={cancelHandler}
 			onDeleteAction={acceptHandler}
 		>
 			<VerticalStack>
 				<div>
-					{(() => localize(
+					{localize(
 						'positron.deleteAllVariablesModalDialogText',
 						"Are you sure you want to delete all variables? This operation cannot be undone."
-					))()}
+					)}
 				</div>
 			</VerticalStack>
 		</ConfirmDeleteModalDialog>

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageStart.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageStart.tsx
@@ -25,22 +25,22 @@ const WelcomePageWorkspace = () => {
 				actions={[
 					{
 						renderIcon: () => <LogoPythonProject />,
-						label: (() => localize('positron.welcome.newPythonNotebook', "Python Notebook"))(),
+						label: localize('positron.welcome.newPythonNotebook', "Python Notebook"),
 						run: () => services.commandService.executeCommand('ipynb.newUntitledIpynb', 'python'),
 						id: 'welcome.newPythonNotebook',
 						tooltip: localize('positron.welcome.newPythonNotebookDescription', "Create a new Python notebook"),
 					},
 					{
 						renderIcon: () => <LogoRProject />,
-						label: (() => localize('positron.welcome.newRNotebook', "R Notebook"))(),
+						label: localize('positron.welcome.newRNotebook', "R Notebook"),
 						run: () => services.commandService.executeCommand('ipynb.newUntitledIpynb', 'r'),
 						id: 'welcome.newRNotebook',
 						tooltip: localize('positron.welcome.newRNotebookDescription', "Create a new R notebook"),
 					},
 				]}
-				ariaLabel={(() => localize('positron.welcome.newNotebookDescription', "Create a Python or R Notebook"))()}
+				ariaLabel={localize('positron.welcome.newNotebookDescription', "Create a Python or R Notebook")}
 				codicon='positron-new-notebook'
-				label={(() => localize('positron.welcome.newNotebook', "New Notebook"))()}
+				label={localize('positron.welcome.newNotebook', "New Notebook")}
 			/>
 			<WelcomeButton
 				ariaLabel={localize('positron.welcome.newFile', "New File")}

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageStart.tsx
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/positronWelcomePageStart.tsx
@@ -88,5 +88,5 @@ export const PositronWelcomePageStart = () => {
 				? (<WelcomePageWorkspace />)
 				: (<WelcomePageNoWorkspace />)}
 		</div>
-	)
+	);
 };


### PR DESCRIPTION
## Summary

Fixes NLS (localization) extraction for `localize()` and `localize2()` calls in `.tsx` files, and removes the IIFE workaround that was previously needed to work around this bug.

## Background

Positron's React components use `.tsx` files that call `localize()` for internationalization. The VS Code NLS build pipeline extracts these calls during production builds and replaces them with numeric indices into a global message table. However, the pipeline silently failed to find `localize()` calls inside _some_ JSX expressions because:

1. **`builder.ts`** hardcoded `.ts` as the sourcemap source extension, so `.tsx` origins were lost before reaching the NLS pipeline
2. **`nls.ts`** parsed all source files as plain TypeScript using a `file.ts` virtual filename with no JSX compiler options, so the TypeScript language service couldn't parse some JSX syntax

As a workaround, `localize()` calls in JSX were wrapped in IIFEs: `(() => localize(...))()`. This happened to work because the IIFE moved the call to a position the broken parser could still find despite JSX parse errors.

## Deeper Background

## Why `ts.JsxEmit.ReactJSX` fixes NLS patching for `.tsx` files

### Without the fix

When `analyze()` creates a TypeScript language service with `file.ts` and no `jsx` option, the parser encounters JSX syntax like `<div className={localize(...)}>` and doesn't know what to make of it. It sees `<div` as the start of a type assertion, gets confused, and produces a broken AST. Some `localize()` calls are found (those the parser recovers past), others are lost in the garbled parse tree.

### With the fix

With `jsx: ts.JsxEmit.ReactJSX` and the `file.tsx` virtual filename, the parser recognizes JSX as JSX. It builds a correct AST where `localize()` calls inside JSX attributes and expressions are properly represented as call expression nodes. The existing tree-walking logic in `analyze()` then finds them all.

### How the two changes work together

- **`builder.ts`** preserves the `.tsx` extension in sourcemaps so `patch()` knows it's dealing with a `.tsx` file
- **`nls.ts`** uses that information to pass `{ jsx: ReactJSX }` to `analyze()`, which triggers `file.tsx` as the virtual filename, giving the TypeScript parser what it needs to correctly parse the source

## Changes

### Build system (2 files)

**`build/lib/tsb/builder.ts`** -- Use the original source file extension (`.ts` or `.tsx`) in sourcemap `sources` instead of hardcoding `.ts`.

**`build/lib/nls.ts`** -- Three changes:
- `patchFile()` accepts and forwards the source filename to `patch()`
- `patch()` detects `.tsx` sources and passes `{ jsx: ReactJSX }` compiler options to `analyze()`
- `analyze()` uses a `file.tsx` virtual filename when the `jsx` compiler option is set, so the TypeScript language service correctly parses JSX

### Component files (25 files)

Removed IIFE wrappers from `localize()` calls across all `.tsx` files. For example:

```tsx
// Before
placeholder={(() => localize('positronFilterPlaceholder', "Filter"))()}

// After
placeholder={localize('positronFilterPlaceholder', "Filter")}
```

## Verification

Confirmed end-to-end in a production build (`gulp vscode`):
- `out-build/` `.js` files show patched `localize(2274, null)` numeric indices
- `nls.messages.json` contains the correct extracted strings at those indices
- The patched code appears correctly in the final app bundle (`workbench.desktop.main.js`)

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

- N/A