### PR TITLE
Fix display of queued ranges when using Quarto commands

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -434,9 +434,11 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 			return;
 		}
 
-		// Add all ranges to queued state with decorations
+		// Add all ranges to queued state with decorations.
+		// Use effectiveCodeRange (excluding option lines like #| label: ...) so
+		// the queued range matches what _withExecutionTracking will remove later.
 		for (const execution of filteredExecutions) {
-			this._addToQueuedRanges(execution.cell.id, execution.codeRange);
+			this._addToQueuedRanges(execution.cell.id, execution.effectiveCodeRange);
 			this._addToQueue(documentUri, execution.cell.id);
 			// Only set state to Queued if cell is not already running
 			// (if it's running, the queued range decoration will still show)
@@ -466,7 +468,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 				if (token?.isCancellationRequested) {
 					// Mark remaining queued ranges as idle
 					for (const e of filteredExecutions) {
-						this._removeFromQueuedRanges(e.cell.id, e.codeRange);
+						this._removeFromQueuedRanges(e.cell.id, e.effectiveCodeRange);
 					}
 					break;
 				}
@@ -479,7 +481,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 					this._logService.debug(
 						`[QuartoExecutionManager] Inline cell ${execution.cell.id} was cancelled while queued (state: ${currentState}), skipping`
 					);
-					this._removeFromQueuedRanges(execution.cell.id, execution.codeRange);
+					this._removeFromQueuedRanges(execution.cell.id, execution.effectiveCodeRange);
 					continue;
 				}
 
@@ -503,7 +505,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 						const currentIndex = filteredExecutions.indexOf(execution);
 						for (let i = currentIndex + 1; i < filteredExecutions.length; i++) {
 							const e = filteredExecutions[i];
-							this._removeFromQueuedRanges(e.cell.id, e.codeRange);
+							this._removeFromQueuedRanges(e.cell.id, e.effectiveCodeRange);
 							this._setCellState(e.cell.id, CellExecutionState.Idle, documentUri);
 						}
 						break;
@@ -521,7 +523,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 						const currentIndex = filteredExecutions.indexOf(execution);
 						for (let i = currentIndex + 1; i < filteredExecutions.length; i++) {
 							const e = filteredExecutions[i];
-							this._removeFromQueuedRanges(e.cell.id, e.codeRange);
+							this._removeFromQueuedRanges(e.cell.id, e.effectiveCodeRange);
 							this._setCellState(e.cell.id, CellExecutionState.Idle, documentUri);
 						}
 						break;

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.test.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.test.ts
@@ -10,7 +10,8 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/tes
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { TestLanguageRuntimeSession } from '../../../../services/runtimeSession/test/common/testLanguageRuntimeSession.js';
 import { TestPositronConsoleService } from '../../../../services/positronConsole/test/browser/testPositronConsoleService.js';
-import { ExecutionOutputEvent, ICellOutput } from '../../common/quartoExecutionTypes.js';
+import { CellExecutionState, ExecutionOutputEvent, ICellOutput } from '../../common/quartoExecutionTypes.js';
+import { Range } from '../../../../../editor/common/core/range.js';
 import { RuntimeOnlineState, RuntimeOutputKind, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionMode, ILanguageRuntimeMetadata, RuntimeErrorBehavior, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { QuartoExecutionManager } from '../../browser/quartoExecutionManager.js';
@@ -532,6 +533,94 @@ suite('QuartoExecutionManager', () => {
 				capturedRange!.endLineNumber,
 				9,
 				'Should use CURRENT cell end line (9), not stale one (6)'
+			);
+		});
+	});
+
+	suite('Queued Range Cleanup', () => {
+		test('clears queued ranges after executeInlineCells with option lines (#12662)', async () => {
+			// When executeInlineCells receives a range that includes Jupyter
+			// code options (e.g. #| label: test), the range is added to the
+			// queue including the option lines. But during execution, the
+			// effective range (excluding options) was used for removal,
+			// causing a mismatch and leaving stale queued decorations.
+
+			const documentUri = URI.file('/test-options-queued.qmd');
+			const cell: QuartoCodeCell = {
+				id: 'test-options',
+				index: 0,
+				language: 'python',
+				startLine: 1,
+				endLine: 5,
+				codeStartLine: 2,
+				codeEndLine: 4,
+				label: undefined,
+				options: '',
+				contentHash: 'options123',
+			};
+
+			const documentLines = [
+				'```{python}',      // Line 1 - fence
+				'#| label: test',   // Line 2 - option line (codeStartLine)
+				'x = 1',            // Line 3 - actual code
+				'print(x)',         // Line 4 - actual code (codeEndLine)
+				'```',              // Line 5 - fence
+			];
+
+			const mockModel = new MockQuartoDocumentModel([cell], documentLines);
+			const localMockDocumentModelService = new MockDocumentModelService();
+			localMockDocumentModelService.setMockModel(mockModel);
+
+			const localMockEditorService = new MockEditorService();
+			localMockEditorService.getValueInRangeCallback = (range: unknown) => {
+				const r = range as { startLineNumber: number; endLineNumber: number };
+				return documentLines.slice(r.startLineNumber - 1, r.endLineNumber).join('\n');
+			};
+
+			const localExecutionManager = new QuartoExecutionManager(
+				mockKernelManager as unknown as IQuartoKernelManager,
+				localMockDocumentModelService as unknown as IQuartoDocumentModelService,
+				localMockEditorService as unknown as IEditorService,
+				new MockEphemeralStateService() as unknown as IEphemeralStateService,
+				new MockWorkspaceContextService() as unknown as IWorkspaceContextService,
+				logService,
+				new TestPositronConsoleService() as unknown as IPositronConsoleService,
+				new MockRuntimeSessionService() as unknown as IRuntimeSessionService,
+				new MockTerminalService() as unknown as ITerminalService,
+			);
+			disposables.add(localExecutionManager);
+
+			// Execute via executeInlineCells with range that includes option lines
+			const codeRange = new Range(2, 1, 4, 100);
+
+			const executionPromise = localExecutionManager.executeInlineCells(
+				documentUri, [codeRange]
+			);
+
+			// Wait for execution to start (the cell transitions
+			// from Queued to Running as the async setup completes)
+			const executionId = await mockKernelManager.waitForExecution();
+
+			// Complete execution
+			mockSession.receiveStateMessage({
+				parent_id: executionId,
+				state: RuntimeOnlineState.Idle,
+			});
+
+			await executionPromise;
+
+			// Queued ranges should be empty after execution completes
+			const queuedRanges = localExecutionManager.getQueuedRanges('test-options');
+			assert.strictEqual(
+				queuedRanges.length, 0,
+				'Queued ranges should be empty after execution completes'
+			);
+
+			// State should not be Queued
+			assert.notStrictEqual(
+				localExecutionManager.getExecutionState('test-options'),
+				CellExecutionState.Queued,
+				'Cell should not be in Queued state after execution'
 			);
 		});
 	});


### PR DESCRIPTION
Fixes a minor display bug around queue indicators for cells in Quarto inline output. Also adds a test for this scenario.

Addresses https://github.com/posit-dev/positron/issues/12662.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix stray execution indicators in editor gutter when executing cells in a Quarto document using Quarto commands (#12662)

