### PR TITLE
Respect the `positron.viewer.openLocalhostUrls` setting in the `show_url` handler

### DIFF
--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -30,6 +30,7 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 import { Schemas } from '../../../../base/common/network.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { localize } from '../../../../nls.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 
 /**
  * Positron preview service; keeps track of the set of active previews and
@@ -61,7 +62,8 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IPositronNotebookOutputWebviewService private readonly _notebookOutputWebviewService: IPositronNotebookOutputWebviewService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
-		@IEditorService private readonly _editorService: IEditorService
+		@IEditorService private readonly _editorService: IEditorService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
 		this.onDidCreatePreviewWebview = this._onDidCreatePreviewWebviewEmitter.event;
@@ -492,6 +494,15 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		// Check to see whether we can handle this URL in the viewer; if we
 		// can't, hand it over to the opener service.
 		if (!this.canOpenInViewer(uri)) {
+			this._openerService.open(uri, {
+				openExternal: true,
+			});
+			return;
+		}
+
+		// If the user prefers to open localhost URLs in the browser, hand
+		// it over to the opener service.
+		if (!this._configurationService.getValue<boolean>('positron.viewer.openLocalhostUrls')) {
 			this._openerService.open(uri, {
 				openExternal: true,
 			});


### PR DESCRIPTION
Progress towards https://github.com/posit-dev/positron/issues/8450

@jmcphers let me know that the reason all URLs are routed by `getOption("browser")` to the frontend in Positron (unlike RStudio which opens http URLs with the OS browser) is to properly support the remote use cases (remote desktop and remote web).

So a simple approach is to let users configure what to do with localhost URLs on the frontend side entirely. This covers all  all remote scenarios. Luckily we already have a setting for this:

<img width="377" height="85" alt="Screenshot 2026-04-03 at 18 15 04" src="https://github.com/user-attachments/assets/e60ed61c-8029-4d42-a221-0370f276d1c1" />

That's used for URLs opened by extensions, see https://github.com/posit-dev/positron/blob/c4d6bab60dd914427a2d47a4b64e75e025d94059/extensions/positron-viewer/src/extension.ts#L34

I think it makes sense for the setting to also apply for localhost URL opened from a backend kernel:

https://github.com/user-attachments/assets/a8aa989b-199d-4882-8e96-389528ea10fa

I haven't changed the default as that seems a larger change. Since Shiny users are already reaching for an R option for this behaviour, it seems a Positron setting is even more ergonomic.