### PR TITLE
Positron Notebooks | Add keyboard shortcut for executing cell and adding new one beneath

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -60,6 +60,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { UpdateNotebookWorkingDirectoryAction } from './UpdateNotebookWorkingDirectoryAction.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
+import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
 import { PositronNotebookPromptContribution } from './positronNotebookPrompt.js';
 import { ActiveNotebookHasRunningRuntime } from '../../runtimeNotebookKernel/common/activeRuntimeNotebookContextManager.js';
 import { NotebookAction2 } from './NotebookAction2.js';
@@ -1093,6 +1094,38 @@ registerAction2(class extends NotebookAction2 {
 });
 
 
+/**
+ * Resolves the active cell, executes it, and exits edit/markdown-preview mode.
+ * Shared by the Shift+Enter and Alt+Enter notebook actions.
+ * Returns the cell so callers can decide what to do next, or `null` if there
+ * is no active cell.
+ */
+function executeActiveCell(notebook: IPositronNotebookInstance): IPositronNotebookCell | null {
+	const state = notebook.selectionStateMachine.state.get();
+	const cell = getActiveCell(state);
+	if (!cell) {
+		return null;
+	}
+
+	// Exit edit mode if we're in it
+	if (state.type === SelectionState.EditingSelection) {
+		notebook.selectionStateMachine.exitEditor();
+	}
+
+	// Execute the cell only if it's a code cell. Otherwise the user would
+	// have to double call for markdown cells to open and then close the editor.
+	if (cell.isCodeCell()) {
+		cell.run();
+	}
+
+	// If the cell is a markdown cell and the editor is open, close it.
+	if (cell.isMarkdownCell() && cell.editorShown.get()) {
+		cell.toggleEditor();
+	}
+
+	return cell;
+}
+
 // Execute cell and select below
 registerAction2(class extends NotebookAction2 {
 	constructor() {
@@ -1122,27 +1155,9 @@ registerAction2(class extends NotebookAction2 {
 			return;
 		}
 
-		// Get the active cell
-		const cell = getActiveCell(state);
+		const cell = executeActiveCell(notebook);
 		if (!cell) {
 			return;
-		}
-
-		// Check if we're in edit mode and exit if so
-		if (state.type === SelectionState.EditingSelection) {
-			notebook.selectionStateMachine.exitEditor();
-		}
-
-		// Execute the cell only if it's a code cell. Otherwise the user would
-		// have to double call for markdown cells to open and then close the
-		// editor.
-		if (cell.isCodeCell()) {
-			cell.run();
-		}
-
-		// If the cell is a markdown cell and the editor is open, close it. Otherwise just pass over.
-		if (cell.isMarkdownCell() && cell.editorShown.get()) {
-			cell.toggleEditor();
 		}
 
 		// If this is the last cell, insert a new cell below of the same type
@@ -1154,6 +1169,31 @@ registerAction2(class extends NotebookAction2 {
 			// Only move down if we didn't add a cell
 			notebook.selectionStateMachine.moveSelectionDown(false);
 		}
+	}
+});
+
+// Execute cell, insert a new cell below, and focus it (Alt+Enter, Jupyter-style)
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.executeAndInsertBelow',
+			title: localize2('positronNotebook.cell.executeAndInsertBelow', "Execute Cell and Insert Below"),
+			keybinding: {
+				when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyMod.Alt | KeyCode.Enter
+			}
+		});
+	}
+
+	override async runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		const cell = executeActiveCell(notebook);
+		if (!cell) {
+			return;
+		}
+
+		// Always insert a new cell below of the same type and focus it
+		notebook.addCell(cell.kind, cell.index + 1, true);
 	}
 });
 


### PR DESCRIPTION
Addresses #11773

This PR adds a new command (alt + enter) for positron notebooks that runs the active cell and then inserts a new cell beneath it. This is the same behavior as shift + enter at the final cell in a notebook but enables new cells to be added when messing with non-terminal parts of the notebook.

https://github.com/user-attachments/assets/478b04dc-90fd-45eb-ba13-75378794808f






A few architectural decisions:

Here are the architectural notes for your PR body:

---


- **Extracted `executeActiveCell()` helper.** The shared logic between Shift+Enter and Alt+Enter (resolve active cell, exit edit mode, run code cell, close markdown editor) was duplicated inline. I pulled it into a helper that returns the cell so each caller only contains its post-execution logic. This _could_ have been added to the notebook instance but felt minor enough to keep in the contribution file inline.

- **No multi-selection handling.** Upstream VS Code's Alt+Enter operates on the single active cell even when multiple cells are selected. We match that behavior here. 


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Added Shift + Enter keyboard shortcut to the Positron Notebook Editor to run active cell and insert a new cell immediately beneath.

#### Bug Fixes

- N/A


### QA Notes



1. Open a `.ipynb` file in the Positron notebook editor
2. Place cursor in a code cell that is not the last cell
3. Press Alt+Enter (Option+Enter on Mac)
4. Verify the cell runs and a new empty code cell is inserted below with focus
5. Repeat from the last cell -- should behave the same (not just move down)
6. Verify Shift+Enter still works as before (runs cell and moves to next, no insert)
