### PR TITLE
Add support for comm notifications from frontend to backend

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_comm.py
@@ -145,6 +145,16 @@ class PositronComm:
             The Pydantic model to parse the message with.
         """
 
+        def _is_rpc(raw_msg: JsonRecord) -> bool:
+            """JSON-RPC requests have an `id` field; notifications don't."""
+            content = raw_msg.get("content")
+            if not isinstance(content, dict):
+                return False
+            data = content.get("data")
+            if not isinstance(data, dict):
+                return False
+            return "id" in data
+
         def _handle_msg(
             raw_msg: JsonRecord,
         ) -> None:
@@ -162,10 +172,13 @@ class PositronComm:
                         and error["ctx"]["discriminator_key"] == "method"
                     ):
                         method = error["ctx"]["discriminator_value"]
-                        self.send_error(
-                            JsonRpcErrorCode.METHOD_NOT_FOUND,
-                            f"Unknown method '{method}'",
-                        )
+                        if _is_rpc(raw_msg):
+                            self.send_error(
+                                JsonRpcErrorCode.METHOD_NOT_FOUND,
+                                f"Unknown method '{method}'",
+                            )
+                        else:
+                            logger.warning(f"Unknown notification method '{method}'")
                         return
 
                     elif (
@@ -174,16 +187,22 @@ class PositronComm:
                         and error["type"] == "value_error.const"
                     ):
                         method = error["ctx"]["given"]
-                        self.send_error(
-                            JsonRpcErrorCode.METHOD_NOT_FOUND,
-                            f"Unknown method '{method}'",
-                        )
+                        if _is_rpc(raw_msg):
+                            self.send_error(
+                                JsonRpcErrorCode.METHOD_NOT_FOUND,
+                                f"Unknown method '{method}'",
+                            )
+                        else:
+                            logger.warning(f"Unknown notification method '{method}'")
                         return
 
-                self.send_error(
-                    JsonRpcErrorCode.INVALID_REQUEST,
-                    f"Invalid request: {exception}",
-                )
+                if _is_rpc(raw_msg):
+                    self.send_error(
+                        JsonRpcErrorCode.INVALID_REQUEST,
+                        f"Invalid request: {exception}",
+                    )
+                else:
+                    logger.warning(f"Invalid notification: {exception}")
                 return
 
             callback(comm_msg, raw_msg)
@@ -193,10 +212,13 @@ class PositronComm:
                 with self.send_lock:
                     _handle_msg(raw_msg)
             except Exception as exception:
-                self.send_error(
-                    JsonRpcErrorCode.INTERNAL_ERROR,
-                    f"Internal error: {exception}",
-                )
+                if _is_rpc(raw_msg):
+                    self.send_error(
+                        JsonRpcErrorCode.INTERNAL_ERROR,
+                        f"Internal error: {exception}",
+                    )
+                else:
+                    logger.warning(f"Unhandled error in notification handler: {exception}")
 
         self.comm.on_msg(handle_msg)
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -14,6 +14,7 @@ import pandas as pd
 import polars as pl
 import pytest
 
+from positron.plot_comm import PlotRenderFormat
 from positron.positron_ipkernel import PositronIPyKernel, PositronShell
 from positron.ui import UiService
 from positron.ui_comm import ShowHtmlFileDestination, UiFrontendEvent
@@ -147,6 +148,22 @@ def test_is_module_loaded(ui_comm: DummyComm) -> None:
 
     # Check that the response is sent, with a result of False.
     assert ui_comm.messages == [json_rpc_response(result=False)]
+
+
+def test_did_change_plots_render_settings(kernel: PositronIPyKernel, ui_comm: DummyComm) -> None:
+    msg = json_rpc_request(
+        "did_change_plots_render_settings",
+        {"settings": {"size": {"width": 800, "height": 600}, "pixel_ratio": 2.0, "format": "png"}},
+        comm_id="dummy_comm_id",
+    )
+    ui_comm.handle_msg(msg)
+
+    settings = kernel.plots_service.get_render_settings()
+    assert settings is not None
+    assert settings.size.width == 800
+    assert settings.size.height == 600
+    assert settings.pixel_ratio == 2.0
+    assert settings.format == PlotRenderFormat.Png
 
 
 def test_clear_console(ui_service: UiService, ui_comm: DummyComm) -> None:

--- a/extensions/positron-python/python_files/posit/positron/tests/utils.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/utils.py
@@ -112,6 +112,7 @@ def json_rpc_request(
         "content": {
             "data": {
                 "jsonrpc": "2.0",
+                "id": "test-id",
                 "method": method,
                 **data,
             },

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -24,6 +24,7 @@ from .ui_comm import (
     CallMethodRequest,
     DidChangePlotsRenderSettingsEvent,
     EvaluateCodeRequest,
+    FrontendReadyEvent,
     OpenEditorParams,
     ShowHtmlFileDestination,
     ShowHtmlFileParams,
@@ -253,6 +254,9 @@ class UiService:
 
         elif isinstance(request, DidChangePlotsRenderSettingsEvent):
             self.kernel.plots_service.update_render_settings(request.params.settings)
+
+        elif isinstance(request, FrontendReadyEvent):
+            pass
 
         else:
             logger.warning(f"Unhandled request: {request}")

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -22,6 +22,7 @@ from .positron_comm import CommMessage, JsonRpcErrorCode, PositronComm
 from .ui_comm import (
     CallMethodParams,
     CallMethodRequest,
+    DidChangePlotsRenderSettingsEvent,
     EvaluateCodeRequest,
     OpenEditorParams,
     ShowHtmlFileDestination,
@@ -249,6 +250,9 @@ class UiService:
 
         elif isinstance(request, EvaluateCodeRequest):
             self._evaluate_code(request.params.code)
+
+        elif isinstance(request, DidChangePlotsRenderSettingsEvent):
+            self.kernel.plots_service.update_render_settings(request.params.settings)
 
         else:
             logger.warning(f"Unhandled request: {request}")

--- a/extensions/positron-python/python_files/posit/positron/ui_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/ui_comm.py
@@ -202,10 +202,6 @@ class UiBackendRequest(str, enum.Enum):
     An enumeration of all the possible requests that can be sent to the backend ui comm.
     """
 
-    # Notification that the settings to render a plot (i.e. the plot size)
-    # have changed.
-    DidChangePlotsRenderSettings = "did_change_plots_render_settings"
-
     # Notification that the frontend is ready
     FrontendReady = "frontend_ready"
 
@@ -214,6 +210,17 @@ class UiBackendRequest(str, enum.Enum):
 
     # Evaluate a statement in the interpreter
     EvaluateCode = "evaluate_code"
+
+
+@enum.unique
+class UiBackendEvent(str, enum.Enum):
+    """
+    An enumeration of all the possible events (notifications) that can be sent to the backend ui comm.
+    """
+
+    # Notification that the settings to render a plot (i.e. the plot size)
+    # have changed.
+    DidChangePlotsRenderSettings = "did_change_plots_render_settings"
 
 
 class DidChangePlotsRenderSettingsParams(BaseModel):
@@ -228,7 +235,7 @@ class DidChangePlotsRenderSettingsParams(BaseModel):
     )
 
 
-class DidChangePlotsRenderSettingsRequest(BaseModel):
+class DidChangePlotsRenderSettingsNotification(BaseModel):
     """
     Typically fired when the plot component has been resized by the user.
     This notification is useful to produce accurate pre-renderings of
@@ -239,7 +246,7 @@ class DidChangePlotsRenderSettingsRequest(BaseModel):
         description="Parameters to the DidChangePlotsRenderSettings method",
     )
 
-    method: Literal[UiBackendRequest.DidChangePlotsRenderSettings] = Field(
+    method: Literal[UiBackendEvent.DidChangePlotsRenderSettings] = Field(
         description="The JSON-RPC method name (did_change_plots_render_settings)",
     )
 
@@ -353,7 +360,7 @@ class EvaluateCodeRequest(BaseModel):
 class UiBackendMessageContent(BaseModel):
     comm_id: str
     data: Union[
-        DidChangePlotsRenderSettingsRequest,
+        DidChangePlotsRenderSettingsNotification,
         FrontendReadyRequest,
         CallMethodRequest,
         EvaluateCodeRequest,
@@ -707,7 +714,7 @@ PreviewSource.update_forward_refs()
 
 DidChangePlotsRenderSettingsParams.update_forward_refs()
 
-DidChangePlotsRenderSettingsRequest.update_forward_refs()
+DidChangePlotsRenderSettingsNotification.update_forward_refs()
 
 FrontendReadyParams.update_forward_refs()
 

--- a/extensions/positron-python/python_files/posit/positron/ui_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/ui_comm.py
@@ -235,7 +235,7 @@ class DidChangePlotsRenderSettingsParams(BaseModel):
     )
 
 
-class DidChangePlotsRenderSettingsNotification(BaseModel):
+class DidChangePlotsRenderSettingsEvent(BaseModel):
     """
     Typically fired when the plot component has been resized by the user.
     This notification is useful to produce accurate pre-renderings of
@@ -360,7 +360,7 @@ class EvaluateCodeRequest(BaseModel):
 class UiBackendMessageContent(BaseModel):
     comm_id: str
     data: Union[
-        DidChangePlotsRenderSettingsNotification,
+        DidChangePlotsRenderSettingsEvent,
         FrontendReadyRequest,
         CallMethodRequest,
         EvaluateCodeRequest,
@@ -714,7 +714,7 @@ PreviewSource.update_forward_refs()
 
 DidChangePlotsRenderSettingsParams.update_forward_refs()
 
-DidChangePlotsRenderSettingsNotification.update_forward_refs()
+DidChangePlotsRenderSettingsEvent.update_forward_refs()
 
 FrontendReadyParams.update_forward_refs()
 

--- a/extensions/positron-python/python_files/posit/positron/ui_comm.py
+++ b/extensions/positron-python/python_files/posit/positron/ui_comm.py
@@ -202,9 +202,6 @@ class UiBackendRequest(str, enum.Enum):
     An enumeration of all the possible requests that can be sent to the backend ui comm.
     """
 
-    # Notification that the frontend is ready
-    FrontendReady = "frontend_ready"
-
     # Run a method in the interpreter and return the result to the frontend
     CallMethod = "call_method"
 
@@ -221,6 +218,9 @@ class UiBackendEvent(str, enum.Enum):
     # Notification that the settings to render a plot (i.e. the plot size)
     # have changed.
     DidChangePlotsRenderSettings = "did_change_plots_render_settings"
+
+    # Notification that the frontend is ready
+    FrontendReady = "frontend_ready"
 
 
 class DidChangePlotsRenderSettingsParams(BaseModel):
@@ -269,7 +269,7 @@ class FrontendReadyParams(BaseModel):
     )
 
 
-class FrontendReadyRequest(BaseModel):
+class FrontendReadyEvent(BaseModel):
     """
     This notification is sent by the frontend after the UI comm has been
     established. The backend uses this signal to run session
@@ -281,7 +281,7 @@ class FrontendReadyRequest(BaseModel):
         description="Parameters to the FrontendReady method",
     )
 
-    method: Literal[UiBackendRequest.FrontendReady] = Field(
+    method: Literal[UiBackendEvent.FrontendReady] = Field(
         description="The JSON-RPC method name (frontend_ready)",
     )
 
@@ -361,7 +361,7 @@ class UiBackendMessageContent(BaseModel):
     comm_id: str
     data: Union[
         DidChangePlotsRenderSettingsEvent,
-        FrontendReadyRequest,
+        FrontendReadyEvent,
         CallMethodRequest,
         EvaluateCodeRequest,
     ] = Field(..., discriminator="method")
@@ -718,7 +718,7 @@ DidChangePlotsRenderSettingsEvent.update_forward_refs()
 
 FrontendReadyParams.update_forward_refs()
 
-FrontendReadyRequest.update_forward_refs()
+FrontendReadyEvent.update_forward_refs()
 
 CallMethodParams.update_forward_refs()
 

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -1094,7 +1094,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.249"
+      "ark": "0.1.250"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -685,7 +685,7 @@ use serde::Serialize;
 		yield `}\n\n`;
 	}
 
-	// Create the event enum
+	// Create the event enums
 	if (frontend) {
 		yield '/**\n';
 		yield ` * Frontend events for the ${name} comm\n`;
@@ -694,6 +694,31 @@ use serde::Serialize;
 		yield `#[serde(tag = "method", content = "params")]\n`;
 		yield `pub enum ${snakeCaseToSentenceCase(name)}FrontendEvent {\n`;
 		for (const method of frontend.methods) {
+			if (method.result !== undefined) {
+				continue;
+			}
+			if (method.description) {
+				yield formatComment('\t/// ', method.description);
+			}
+			yield `\t#[serde(rename = "${method.name}")]\n`;
+			yield `\t${snakeCaseToSentenceCase(method.name)}`;
+			if (method.params.length > 0) {
+				yield `(${snakeCaseToSentenceCase(method.name)}Params),\n\n`;
+			} else {
+				yield ',\n\n';
+			}
+		}
+		yield `}\n\n`;
+	}
+
+	if (backend && backend.methods.some((method: any) => !method.result)) {
+		yield '/**\n';
+		yield ` * Backend events (notifications) for the ${name} comm\n`;
+		yield ' */\n';
+		yield `#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]\n`;
+		yield `#[serde(tag = "method", content = "params")]\n`;
+		yield `pub enum ${snakeCaseToSentenceCase(name)}BackendEvent {\n`;
+		for (const method of backend.methods) {
 			if (method.result !== undefined) {
 				continue;
 			}
@@ -1073,6 +1098,23 @@ from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictI
 	}
 
 	if (backend) {
+		const notifications = backend.methods.filter((m: any) => !m.result);
+		if (notifications.length) {
+			yield '@enum.unique\n';
+			yield `class ${snakeCaseToSentenceCase(name)}BackendEvent(str, enum.Enum):\n`;
+			yield `    """\n`;
+			yield `    An enumeration of all the possible events (notifications) that can be sent to the backend ${name} comm.\n`;
+			yield `    """\n`;
+			yield `\n`;
+			for (const method of notifications) {
+				yield formatComment('    # ', method.summary);
+				yield `    ${snakeCaseToSentenceCase(method.name)} = "${method.name}"\n`;
+				yield '\n';
+			}
+		}
+	}
+
+	if (backend) {
 		for (const method of backend.methods) {
 			if (!method.description) {
 				throw new Error(`No description for '${method.name}'; please add a description to the schema`);
@@ -1111,7 +1153,8 @@ from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictI
 				}
 			}
 
-			const klass = `${snakeCaseToSentenceCase(method.name)}Request`;
+			const suffix = method.result ? 'Request' : 'Notification';
+			const klass = `${snakeCaseToSentenceCase(method.name)}${suffix}`;
 			models.push(klass);
 			yield `class ${klass}(BaseModel):\n`;
 			yield `    """\n`;
@@ -1124,7 +1167,10 @@ from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictI
 				yield `    )\n`;
 				yield `\n`;
 			}
-			yield `    method: Literal[${snakeCaseToSentenceCase(name)}BackendRequest.${snakeCaseToSentenceCase(method.name)}] = Field(\n`;
+			const methodEnum = method.result
+				? `${snakeCaseToSentenceCase(name)}BackendRequest`
+				: `${snakeCaseToSentenceCase(name)}BackendEvent`;
+			yield `    method: Literal[${methodEnum}.${snakeCaseToSentenceCase(method.name)}] = Field(\n`;
 			yield `        description="The JSON-RPC method name (${method.name})",\n`;
 			yield `    )\n`;
 			yield '\n';
@@ -1141,11 +1187,13 @@ from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictI
 		yield `class ${snakeCaseToSentenceCase(name)}BackendMessageContent(BaseModel):\n`;
 		yield `    comm_id: str\n`;
 		if (backend.methods.length === 1) {
-			yield `    data: ${snakeCaseToSentenceCase(backend.methods[0].name)}Request`;
+			const suffix = backend.methods[0].result ? 'Request' : 'Notification';
+			yield `    data: ${snakeCaseToSentenceCase(backend.methods[0].name)}${suffix}`;
 		} else {
 			yield `    data: Union[\n`;
 			for (const method of backend.methods) {
-				yield `        ${snakeCaseToSentenceCase(method.name)}Request,\n`;
+				const suffix = method.result ? 'Request' : 'Notification';
+				yield `        ${snakeCaseToSentenceCase(method.name)}${suffix},\n`;
 			}
 			yield `    ] = Field(..., discriminator="method")\n`;
 		}
@@ -1398,9 +1446,18 @@ import { IRuntimeClientInstance } from './languageRuntimeClientInstance.js';
 
 	if (backend) {
 		yield `export enum ${snakeCaseToSentenceCase(name)}BackendRequest {\n`;
-		const requests = backend.methods.map((method: any) => `\t${snakeCaseToSentenceCase(method.name)} = '${method.name}'`);
+		const requestMethods = backend.methods.filter((m: any) => m.result);
+		const requests = requestMethods.map((method: any) => `\t${snakeCaseToSentenceCase(method.name)} = '${method.name}'`);
 		yield requests.join(',\n');
 		yield '\n}\n\n';
+
+		const eventMethods = backend.methods.filter((m: any) => !m.result);
+		if (eventMethods.length) {
+			yield `export enum ${snakeCaseToSentenceCase(name)}BackendEvent {\n`;
+			const events = eventMethods.map((method: any) => `\t${snakeCaseToSentenceCase(method.name)} = '${method.name}'`);
+			yield events.join(',\n');
+			yield '\n}\n\n';
+		}
 	}
 
 	yield `export class Positron${snakeCaseToSentenceCase(name)}Comm extends PositronBaseComm {\n`;
@@ -1474,21 +1531,26 @@ import { IRuntimeClientInstance } from './languageRuntimeClientInstance.js';
 					yield ', ';
 				}
 			}
-			yield '): Promise<';
-			if (method.result && method.result.schema) {
-				if (method.result.schema.type === 'object') {
-					yield snakeCaseToSentenceCase(method.result.schema.name);
+			if (method.result) {
+				yield '): Promise<';
+				if (method.result.schema) {
+					if (method.result.schema.type === 'object') {
+						yield snakeCaseToSentenceCase(method.result.schema.name);
+					} else {
+						yield deriveType(contracts, TypescriptTypeMap, method.name, method.result.schema);
+					}
+					if (isOptional(method.result)) {
+						yield ' | undefined';
+					}
 				} else {
-					yield deriveType(contracts, TypescriptTypeMap, method.name, method.result.schema);
+					yield 'void';
 				}
-				if (isOptional(method.result)) {
-					yield ' | undefined';
-				}
+				yield '> {\n';
+				yield '\t\treturn super.performRpc(\'' + method.name + '\', [';
 			} else {
-				yield 'void';
+				yield '): void {\n';
+				yield '\t\tsuper.notify(\'' + method.name + '\', [';
 			}
-			yield '> {\n';
-			yield '\t\treturn super.performRpc(\'' + method.name + '\', [';
 			for (let i = 0; i < method.params.length; i++) {
 				yield `'${method.params[i].name}'`;
 				if (i < method.params.length - 1) {

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -1078,15 +1078,15 @@ from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictI
 			}
 		}
 
-		const notifications = backend.methods.filter((m: any) => !m.result);
-		if (notifications.length) {
+		const events = backend.methods.filter((m: any) => !m.result);
+		if (events.length) {
 			yield '@enum.unique\n';
 			yield `class ${snakeCaseToSentenceCase(name)}BackendEvent(str, enum.Enum):\n`;
 			yield `    """\n`;
 			yield `    An enumeration of all the possible events (notifications) that can be sent to the backend ${name} comm.\n`;
 			yield `    """\n`;
 			yield `\n`;
-			for (const method of notifications) {
+			for (const method of events) {
 				yield formatComment('    # ', method.summary);
 				yield `    ${snakeCaseToSentenceCase(method.name)} = "${method.name}"\n`;
 				yield '\n';
@@ -1131,7 +1131,7 @@ from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictI
 				}
 			}
 
-			const suffix = method.result ? 'Request' : 'Notification';
+			const suffix = method.result ? 'Request' : 'Event';
 			const klass = `${snakeCaseToSentenceCase(method.name)}${suffix}`;
 			models.push(klass);
 			yield `class ${klass}(BaseModel):\n`;
@@ -1165,12 +1165,12 @@ from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictI
 		yield `class ${snakeCaseToSentenceCase(name)}BackendMessageContent(BaseModel):\n`;
 		yield `    comm_id: str\n`;
 		if (backend.methods.length === 1) {
-			const suffix = backend.methods[0].result ? 'Request' : 'Notification';
+			const suffix = backend.methods[0].result ? 'Request' : 'Event';
 			yield `    data: ${snakeCaseToSentenceCase(backend.methods[0].name)}${suffix}`;
 		} else {
 			yield `    data: Union[\n`;
 			for (const method of backend.methods) {
-				const suffix = method.result ? 'Request' : 'Notification';
+				const suffix = method.result ? 'Request' : 'Event';
 				yield `        ${snakeCaseToSentenceCase(method.name)}${suffix},\n`;
 			}
 			yield `    ] = Field(..., discriminator="method")\n`;

--- a/positron/comms/generate-comms.ts
+++ b/positron/comms/generate-comms.ts
@@ -686,42 +686,24 @@ use serde::Serialize;
 	}
 
 	// Create the event enums
-	if (frontend) {
-		yield '/**\n';
-		yield ` * Frontend events for the ${name} comm\n`;
-		yield ' */\n';
-		yield `#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]\n`;
-		yield `#[serde(tag = "method", content = "params")]\n`;
-		yield `pub enum ${snakeCaseToSentenceCase(name)}FrontendEvent {\n`;
-		for (const method of frontend.methods) {
-			if (method.result !== undefined) {
-				continue;
-			}
-			if (method.description) {
-				yield formatComment('\t/// ', method.description);
-			}
-			yield `\t#[serde(rename = "${method.name}")]\n`;
-			yield `\t${snakeCaseToSentenceCase(method.name)}`;
-			if (method.params.length > 0) {
-				yield `(${snakeCaseToSentenceCase(method.name)}Params),\n\n`;
-			} else {
-				yield ',\n\n';
-			}
+	for (const contract of namedContracts) {
+		const source = contract.source;
+		if (!source) {
+			continue;
 		}
-		yield `}\n\n`;
-	}
 
-	if (backend && backend.methods.some((method: any) => !method.result)) {
+		const events = source.methods.filter((method: any) => !method.result);
+		if (events.length === 0) {
+			continue;
+		}
+
 		yield '/**\n';
-		yield ` * Backend events (notifications) for the ${name} comm\n`;
+		yield ` * ${contract.name} events for the ${name} comm\n`;
 		yield ' */\n';
 		yield `#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]\n`;
 		yield `#[serde(tag = "method", content = "params")]\n`;
-		yield `pub enum ${snakeCaseToSentenceCase(name)}BackendEvent {\n`;
-		for (const method of backend.methods) {
-			if (method.result !== undefined) {
-				continue;
-			}
+		yield `pub enum ${snakeCaseToSentenceCase(name)}${contract.name}Event {\n`;
+		for (const method of events) {
 			if (method.description) {
 				yield formatComment('\t/// ', method.description);
 			}
@@ -1095,9 +1077,7 @@ from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictI
 				yield '\n';
 			}
 		}
-	}
 
-	if (backend) {
 		const notifications = backend.methods.filter((m: any) => !m.result);
 		if (notifications.length) {
 			yield '@enum.unique\n';
@@ -1112,9 +1092,7 @@ from ._vendor.pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictI
 				yield '\n';
 			}
 		}
-	}
 
-	if (backend) {
 		for (const method of backend.methods) {
 			if (!method.description) {
 				throw new Error(`No description for '${method.name}'; please add a description to the schema`);

--- a/positron/comms/ui-backend-openrpc.json
+++ b/positron/comms/ui-backend-openrpc.json
@@ -31,14 +31,7 @@
 						"type": "string"
 					}
 				}
-			],
-			"result": {
-				"schema": {
-					"name": "frontend_ready_result",
-					"description": "Unused response to notification",
-					"type": "null"
-				}
-			}
+			]
 		},
 		{
 			"name": "call_method",

--- a/positron/comms/ui-backend-openrpc.json
+++ b/positron/comms/ui-backend-openrpc.json
@@ -17,14 +17,7 @@
 						"$ref": "plot-backend-openrpc.json#/components/schemas/plot_render_settings"
 					}
 				}
-			],
-			"result": {
-				"schema": {
-					"name": "did_change_plot_render_settings_result",
-					"description": "Unused response to notification",
-					"type": "null"
-				}
-			}
+			]
 		},
 		{
 			"name": "frontend_ready",

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -12,7 +12,6 @@ import { HTMLFileSystemProvider } from '../../../../platform/files/browser/htmlF
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { createSuggestedFileNameForPlot, DarkFilter, HistoryPolicy, IPositronPlotClient, IPositronPlotsService, PlotRenderFormat, PlotRenderSettings, PlotsDisplayLocation, POSITRON_PLOTS_LOCATION_CONTEXT, POSITRON_PLOTS_VIEW_ID, ZoomLevel } from '../../../services/positronPlots/common/positronPlots.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { StaticPlotClient } from '../../../services/positronPlots/common/staticPlotClient.js';
 import { IStorageService, StorageTarget, StorageScope } from '../../../../platform/storage/common/storage.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
@@ -922,15 +921,11 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		if (session.runtimeMetadata.uiSubscriptions?.includes(UiRuntimeNotifications.DidChangePlotsRenderSettings)) {
 			this._register(this._runtimeSessionService.watchUiClient(session.sessionId, (uiClient) => {
 				// Send initial settings immediately
-				uiClient.
-					didChangePlotsRenderSettings(this.getPlotsRenderSettings()).
-					catch(onUnexpectedError);
+				uiClient.didChangePlotsRenderSettings(this.getPlotsRenderSettings());
 
 				// Forward future settings updates
 				return this.onDidChangePlotsRenderSettings(settings => {
-					uiClient.
-						didChangePlotsRenderSettings(settings).
-						catch(onUnexpectedError);
+					uiClient.didChangePlotsRenderSettings(settings);
 				});
 			}));
 		}

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -274,8 +274,8 @@ export class UiClientInstance extends Disposable {
 	 * @param startType The type of session start ('new', 'restart', or
 	 * 'reconnect')
 	 */
-	public frontendReady(startType: string): Promise<null> {
-		return this._comm.frontendReady(startType);
+	public frontendReady(startType: string): void {
+		this._comm.frontendReady(startType);
 	}
 
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimeUiClient.ts
@@ -313,7 +313,7 @@ export class UiClientInstance extends Disposable {
 	 * @param settings Plot rendering settings
 	 *
 	 */
-	public async didChangePlotsRenderSettings(settings: PlotRenderSettings): Promise<void> {
-		await this._comm.didChangePlotsRenderSettings(settings);
+	public didChangePlotsRenderSettings(settings: PlotRenderSettings): void {
+		this._comm.didChangePlotsRenderSettings(settings);
 	}
 }

--- a/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
@@ -308,26 +308,28 @@ export class PositronBaseComm extends Disposable {
 	}
 
 	/**
-	 * Send a fire-and-forget JSON-RPC notification to the backend.
+	 * Send a fire-and-forget JSON-RPC notification (or event) to the backend.
 	 *
 	 * Unlike `performRpc`, this does not include an `id` field and does
 	 * not wait for a response. Per the JSON-RPC spec, the absence of
 	 * `id` signals that no response is expected.
 	 *
-	 * @param rpcName The name of the notification method.
+	 * @param rpcName The name of the event method.
 	 * @param paramNames The parameter names.
 	 * @param paramValues The parameter values.
 	 */
-	protected notify(rpcName: string,
+	protected notify(
+		rpcName: string,
 		paramNames: Array<string>,
-		paramValues: Array<any>): void {
+		paramValues: Array<unknown>
+	): void {
 
-		const params: any = {};
+		const params: Record<string, unknown> = {};
 		for (let i = 0; i < paramNames.length; i++) {
 			params[paramNames[i]] = paramValues[i];
 		}
 
-		const notification: any = {
+		const notification: Record<string, unknown> = {
 			jsonrpc: '2.0',
 			method: rpcName,
 		};

--- a/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
@@ -220,14 +220,16 @@ export class PositronBaseComm extends Disposable {
 	 * @returns A promise that resolves to the result of the RPC, or rejects
 	 *  with a PositronCommError.
 	 */
-	protected async performRpc<T>(rpcName: string,
+	protected async performRpc<T>(
+		rpcName: string,
 		paramNames: Array<string>,
-		paramValues: Array<any>): Promise<T> {
+		paramValues: Array<unknown>
+	): Promise<T> {
 
 		// Create the RPC arguments from the parameter names and values. This
 		// allows us to pass the parameters as positional parameters, but
 		// still have them be named parameters in the RPC.
-		const rpcArgs: any = {};
+		const rpcArgs: Record<string, unknown> = {};
 		for (let i = 0; i < paramNames.length; i++) {
 			rpcArgs[paramNames[i]] = paramValues[i];
 		}
@@ -240,7 +242,7 @@ export class PositronBaseComm extends Disposable {
 		// level. It only expresses that this is a request, not a notification, as
 		// required by the JSON-RPC spec. This allows comms at the other end to
 		// determine whether they should respond to the message.
-		const request: any = {
+		const request: Record<string, unknown> = {
 			jsonrpc: '2.0',
 			method: rpcName,
 			id
@@ -253,7 +255,7 @@ export class PositronBaseComm extends Disposable {
 		}
 
 		// Perform the RPC
-		let response = {} as any;
+		let response: Record<string, unknown> = {};
 		try {
 			// Check for explicitly set timeout in options, otherwise use the default.
 			const defaultTimeout = 5000; // 5 seconds
@@ -279,11 +281,11 @@ export class PositronBaseComm extends Disposable {
 
 		// If the response is an error, throw it
 		if (Object.keys(response).includes('error')) {
-			const error = response.error;
+			const error = response.error as PositronCommError;
 
 			// Populate the error object with the name of the error code
 			// for conformity with code that expects an Error object.
-			error.name = `RPC Error ${response.error.code}`;
+			error.name = `RPC Error ${error.code}`;
 
 			throw error;
 		}
@@ -304,7 +306,7 @@ export class PositronBaseComm extends Disposable {
 		}
 
 		// Otherwise, return the result
-		return response.result;
+		return response.result as T;
 	}
 
 	/**

--- a/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
@@ -158,6 +158,10 @@ export class PositronBaseComm extends Disposable {
 					`on comm ${this.clientInstance.getClientId()}: ` +
 					`${JSON.stringify(data.params)} ` +
 					`(No listeners for event '${data.method}'`);
+			} else {
+				console.warn(`Dropping unexpected message ` +
+					`on comm ${this.clientInstance.getClientId()}: ` +
+					`${JSON.stringify(data)}`);
 			}
 		}));
 
@@ -301,5 +305,37 @@ export class PositronBaseComm extends Disposable {
 
 		// Otherwise, return the result
 		return response.result;
+	}
+
+	/**
+	 * Send a fire-and-forget JSON-RPC notification to the backend.
+	 *
+	 * Unlike `performRpc`, this does not include an `id` field and does
+	 * not wait for a response. Per the JSON-RPC spec, the absence of
+	 * `id` signals that no response is expected.
+	 *
+	 * @param rpcName The name of the notification method.
+	 * @param paramNames The parameter names.
+	 * @param paramValues The parameter values.
+	 */
+	protected notify(rpcName: string,
+		paramNames: Array<string>,
+		paramValues: Array<any>): void {
+
+		const params: any = {};
+		for (let i = 0; i < paramNames.length; i++) {
+			params[paramNames[i]] = paramValues[i];
+		}
+
+		const notification: any = {
+			jsonrpc: '2.0',
+			method: rpcName,
+		};
+
+		if (paramNames.length > 0) {
+			notification.params = params;
+		}
+
+		this.clientInstance.sendMessage(notification);
 	}
 }

--- a/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronBaseComm.ts
@@ -226,13 +226,7 @@ export class PositronBaseComm extends Disposable {
 		paramValues: Array<unknown>
 	): Promise<T> {
 
-		// Create the RPC arguments from the parameter names and values. This
-		// allows us to pass the parameters as positional parameters, but
-		// still have them be named parameters in the RPC.
-		const rpcArgs: Record<string, unknown> = {};
-		for (let i = 0; i < paramNames.length; i++) {
-			rpcArgs[paramNames[i]] = paramValues[i];
-		}
+		const rpcArgs = this.zipParams(paramNames, paramValues);
 
 		// Generate a unique ID for this message.
 		const id = generateUuid();
@@ -321,19 +315,16 @@ export class PositronBaseComm extends Disposable {
 	 * @param paramValues The parameter values.
 	 */
 	protected notify(
-		rpcName: string,
+		methodName: string,
 		paramNames: Array<string>,
 		paramValues: Array<unknown>
 	): void {
 
-		const params: Record<string, unknown> = {};
-		for (let i = 0; i < paramNames.length; i++) {
-			params[paramNames[i]] = paramValues[i];
-		}
+		const params = this.zipParams(paramNames, paramValues);
 
 		const notification: Record<string, unknown> = {
 			jsonrpc: '2.0',
-			method: rpcName,
+			method: methodName,
 		};
 
 		if (paramNames.length > 0) {
@@ -341,5 +332,29 @@ export class PositronBaseComm extends Disposable {
 		}
 
 		this.clientInstance.sendMessage(notification);
+	}
+
+	/**
+	 * Zip parallel arrays of parameter names and values into a
+	 * JSON-RPC params object.
+	 *
+	 * @param paramNames The parameter names.
+	 * @param paramValues The parameter values (must be same length as paramNames).
+	 */
+	private zipParams(
+		paramNames: Array<string>,
+		paramValues: Array<unknown>
+	): Record<string, unknown> {
+		if (paramNames.length !== paramValues.length) {
+			throw new Error(
+				`paramNames length (${paramNames.length}) !== ` +
+				`paramValues length (${paramValues.length})`
+			);
+		}
+		const params: Record<string, unknown> = {};
+		for (let i = 0; i < paramNames.length; i++) {
+			params[paramNames[i]] = paramValues[i];
+		}
+		return params;
 	}
 }

--- a/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
@@ -999,10 +999,13 @@ export enum UiFrontendRequest {
 }
 
 export enum UiBackendRequest {
-	DidChangePlotsRenderSettings = 'did_change_plots_render_settings',
 	FrontendReady = 'frontend_ready',
 	CallMethod = 'call_method',
 	EvaluateCode = 'evaluate_code'
+}
+
+export enum UiBackendEvent {
+	DidChangePlotsRenderSettings = 'did_change_plots_render_settings'
 }
 
 export class PositronUiComm extends PositronBaseComm {
@@ -1035,10 +1038,9 @@ export class PositronUiComm extends PositronBaseComm {
 	 *
 	 * @param settings Plot rendering settings.
 	 *
-	 * @returns Unused response to notification
 	 */
-	didChangePlotsRenderSettings(settings: PlotRenderSettings): Promise<null> {
-		return super.performRpc('did_change_plots_render_settings', ['settings'], [settings]);
+	didChangePlotsRenderSettings(settings: PlotRenderSettings): void {
+		super.notify('did_change_plots_render_settings', ['settings'], [settings]);
 	}
 
 	/**
@@ -1169,4 +1171,3 @@ export class PositronUiComm extends PositronBaseComm {
 	 */
 	onDidClearWebviewPreloads: Event<ClearWebviewPreloadsEvent>;
 }
-

--- a/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
+++ b/src/vs/workbench/services/languageRuntime/common/positronUiComm.ts
@@ -999,13 +999,13 @@ export enum UiFrontendRequest {
 }
 
 export enum UiBackendRequest {
-	FrontendReady = 'frontend_ready',
 	CallMethod = 'call_method',
 	EvaluateCode = 'evaluate_code'
 }
 
 export enum UiBackendEvent {
-	DidChangePlotsRenderSettings = 'did_change_plots_render_settings'
+	DidChangePlotsRenderSettings = 'did_change_plots_render_settings',
+	FrontendReady = 'frontend_ready'
 }
 
 export class PositronUiComm extends PositronBaseComm {
@@ -1054,10 +1054,9 @@ export class PositronUiComm extends PositronBaseComm {
 	 * @param startType The type of session start: 'new' for new sessions,
 	 * 'restart' for restarted sessions, 'reconnect' for reconnected sessions
 	 *
-	 * @returns Unused response to notification
 	 */
-	frontendReady(startType: string): Promise<null> {
-		return super.performRpc('frontend_ready', ['start_type'], [startType]);
+	frontendReady(startType: string): void {
+		super.notify('frontend_ready', ['start_type'], [startType]);
 	}
 
 	/**
@@ -1171,3 +1170,4 @@ export class PositronUiComm extends PositronBaseComm {
 	 */
 	onDidClearWebviewPreloads: Event<ClearWebviewPreloadsEvent>;
 }
+

--- a/src/vs/workbench/services/runtimeSession/common/activeRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/common/activeRuntimeSession.ts
@@ -309,9 +309,7 @@ export class ActiveRuntimeSession extends Disposable {
 		// Notify the backend that the frontend is ready. The backend
 		// uses this signal to run session init hooks that may need to
 		// make RPCs back to the frontend (e.g. rstudioapi calls).
-		uiClient.frontendReady(startType).catch(err => {
-			this._logService.warn(`frontendReady RPC failed: ${err}`);
-		});
+		uiClient.frontendReady(startType);
 
 		return client.getClientId();
 	}


### PR DESCRIPTION
Closes https://github.com/posit-dev/positron/issues/7448
Progress towards https://github.com/posit-dev/positron/issues/7449

Companion PR: https://github.com/posit-dev/ark/pull/1140

Currently we don't support comm notifications from the frontend to the backend (https://github.com/posit-dev/positron/issues/7448). To work around this, we use RPCs instead and just ignore the response. However this has significant downsides as RPCs are expected to respond promptly within a 5 second timeout. If the runtime is unable to respond right away because it's busy, and the request is awaited instead of being sent in a fire and forget way, we get:

- Log warnings about timeouts
- Or worse, user-visible delay until timeout is reached

See https://github.com/posit-dev/positron/issues/12251 and https://github.com/posit-dev/positron/pull/12576 for a recent bad case of this. See also https://github.com/posit-dev/positron/issues/3659 and https://github.com/posit-dev/positron/pull/7286.

With the default timeout, using RPCs for fire-and-forget notifications is kind of a footgun. To prevent this sort of issues in the future, this PR implements the missing paths for notifications from frontend to backend:

- Support in comm generation
- "Plot render settings" is now a notification. Progress towards https://github.com/posit-dev/positron/issues/7449. This serves as a POC on the Python side.
- "Frontend ready" (from https://github.com/posit-dev/positron/pull/12312) is now a notification.

The companion PR implements both notifications on the Ark side.



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:plots
@:ark