### PR TITLE
Positron Notebooks | Add ability to copy output text with right-click menu

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -10,7 +10,7 @@ import './NotebookCodeCell.css';
 import React, { useMemo } from 'react';
 
 // Other dependencies.
-import { NotebookCellOutputs } from '../PositronNotebookCells/IPositronNotebookCell.js';
+import { NotebookCellOutputs, ParsedTextOutput } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { isParsedTextOutput } from '../getOutputContents.js';
 import { useObservedValue } from '../useObservedValue.js';
 import { CellEditorMonacoWidget } from './CellEditorMonacoWidget.js';
@@ -24,7 +24,8 @@ import { CellLeftActionMenu } from './CellLeftActionMenu.js';
 import { CellOutputCollapseButton } from './CellOutputCollapseButton.js';
 import { useNotebookInstance, useNotebookOptions } from '../NotebookInstanceProvider.js';
 import { CodeCellStatusFooter } from './CodeCellStatusFooter.js';
-import { isHTMLElement } from '../../../../../base/browser/dom.js';
+import { getActiveWindow, isHTMLElement } from '../../../../../base/browser/dom.js';
+import { IAction, Separator } from '../../../../../base/common/actions.js';
 import { renderHtml } from '../../../../../base/browser/positron/renderHtml.js';
 import { Markdown } from './Markdown.js';
 import { useCellContextMenu } from './useCellContextMenu.js';
@@ -38,6 +39,7 @@ import { useScrollingIndicator } from './useScrollingIndicator.js';
 import { CellOutputActionBar } from './CellOutputActionBar.js';
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 
+const copyOutputTextLabel = localize('positron.notebook.copyOutputText', "Copy Output Text");
 const expandOutputTooltip = localize('positron.notebook.expandOutput', "Click to Expand Output");
 const outputCollapsedLabel = localize('positron.notebook.outputCollapsed', 'Output collapsed');
 
@@ -103,6 +105,9 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 			return;
 		}
 
+		const x = event.clientX;
+		const y = event.clientY;
+
 		// Check if the click target is an <img> with a data: URL
 		const src = isHTMLElement(event.target) && event.target.tagName === 'IMG'
 			? (event.target as HTMLImageElement).src
@@ -114,16 +119,48 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 
 		const onHide = () => outputImageTargeted?.set(false);
 
-		if (imageDataUrl) {
-			showContextMenu(
-				{ x: event.clientX, y: event.clientY },
-				undefined,
-				onHide,
-				{ arg: { imageDataUrl }, shouldForwardArgs: true },
-			);
-		} else {
-			showContextMenu({ x: event.clientX, y: event.clientY }, undefined, onHide);
-		}
+		// Delay to next tick so the browser selection is up to date
+		// (right-click may highlight a word after the contextmenu event fires)
+		setTimeout(() => {
+			const selection = getActiveWindow().document.getSelection();
+			const hasTextOutputs = outputs.some(o => isParsedTextOutput(o.parsed));
+
+			const getClipboardActions = (): IAction[] => {
+				if (!hasTextOutputs) {
+					return [];
+				}
+
+				return [
+					{
+						id: 'positron.notebook.copyOutputText',
+						label: copyOutputTextLabel,
+						tooltip: '',
+						class: undefined,
+						enabled: true,
+						run: () => {
+							if (selection?.type === 'Range') {
+								// Copy the user's text selection
+								getActiveWindow().document.execCommand('copy');
+							} else {
+								// Fall back to copying all text output from the cell
+								const textContent = outputs
+									.filter(o => isParsedTextOutput(o.parsed))
+									.map(o => (o.parsed as ParsedTextOutput).content)
+									.join('\n');
+								services.clipboardService.writeText(textContent);
+							}
+						}
+					},
+					new Separator(),
+				];
+			};
+
+			const menuActionOptions = imageDataUrl
+				? { arg: { imageDataUrl }, shouldForwardArgs: true }
+				: undefined;
+
+			showContextMenu({ x, y }, getClipboardActions, onHide, menuActionOptions);
+		}, 0);
 	};
 
 	return (


### PR DESCRIPTION
Addresses #11852.

Adds a "Copy Output Text" item to the right-click context menu on notebook cell outputs. When text is selected, it copies the selection. When nothing is selected, it copies all text/error output from the cell (skipping images, data explorers, etc.).

This is based on the existing pattern from `NotebookMarkdownCell.tsx`.

<img width="651" height="485" alt="image" src="https://github.com/user-attachments/assets/1d088ee9-cf69-4395-a521-5c669a1bb7ea" />

<img width="641" height="503" alt="image" src="https://github.com/user-attachments/assets/4c9c023f-d458-4997-9c4d-f5fafeb93741" />

<img width="733" height="727" alt="image" src="https://github.com/user-attachments/assets/26b0a390-a992-4e21-98ec-58e75592f35a" />


### Release Notes

#### New Features
- Added "Copy Output Text" to the notebook cell output right-click menu, enabling copy of selected text or all text output (#11852)

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks

1. Open a notebook and run a cell that produces text output (e.g., `print("hello world")`)
2. Right-click on the output -- "Copy Output Text" should appear in the context menu
3. Click it -- all text output should be copied to clipboard
4. Now highlight a portion of the text output, right-click, and choose "Copy Output Text" -- only the selected text should be copied
5. Run a cell that produces an error -- verify the same behavior works on error output
6. Run a cell that produces only an image (e.g., a matplotlib plot) -- "Copy Output Text" should NOT appear
7. Run a cell with interleaved text and image outputs -- "Copy Output Text" should appear and copy only the text portions
