### PR TITLE
Fix/notebook error boundary placement

### DIFF
--- a/src/vs/base/browser/positronReactRenderer.tsx
+++ b/src/vs/base/browser/positronReactRenderer.tsx
@@ -118,6 +118,9 @@ export class PositronReactRenderer extends Disposable {
 		super();
 
 		// Create the root.
+		// TODO: Consider passing onUncaughtError/onCaughtError callbacks to
+		// createRoot for better diagnostics when errors escape all error
+		// boundaries. This won't prevent unmounting but would log context.
 		this._root = createRoot(container);
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -422,26 +422,26 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		const reactRenderer = this._positronReactRenderer;
 
 		reactRenderer.render(
-			<NotebookVisibilityProvider isVisible={this._isVisible}>
-				<NotebookInstanceProvider instance={this.notebookInstance}>
-					<EnvironentProvider environmentBundle={{
-						size: this._size,
-						scopedContextKeyProviderCallback: container => scopedContextKeyService.createScoped(container),
-					}}>
-						<NotebookErrorBoundary
-							componentName='PositronNotebookComponent'
-							level='editor'
-							logService={this._logService}
-							onReload={() => {
-								this._disposeReactRenderer();
-								this._renderReact();
-							}}
-						>
+			<NotebookErrorBoundary
+				componentName='PositronNotebookComponent'
+				level='editor'
+				logService={this._logService}
+				onReload={() => {
+					this._disposeReactRenderer();
+					this._renderReact();
+				}}
+			>
+				<NotebookVisibilityProvider isVisible={this._isVisible}>
+					<NotebookInstanceProvider instance={this.notebookInstance}>
+						<EnvironentProvider environmentBundle={{
+							size: this._size,
+							scopedContextKeyProviderCallback: container => scopedContextKeyService.createScoped(container),
+						}}>
 							<PositronNotebookComponent />
-						</NotebookErrorBoundary>
-					</EnvironentProvider>
-				</NotebookInstanceProvider>
-			</NotebookVisibilityProvider>
+						</EnvironentProvider>
+					</NotebookInstanceProvider>
+				</NotebookVisibilityProvider>
+			</NotebookErrorBoundary>
 		);
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookErrorBoundary.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookErrorBoundary.test.tsx
@@ -6,6 +6,7 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable local/code-no-dangerous-type-assertions */
 
+import React from 'react';
 import assert from 'assert';
 import sinon from 'sinon';
 import { flushSync } from 'react-dom';
@@ -24,6 +25,10 @@ function ThrowingNonErrorComponent({ value }: { value: unknown }): never {
 
 function GoodComponent() {
 	return <div className='good-component'>Hello</div>;
+}
+
+function ThrowingProvider({ children: _children }: { children: React.ReactNode }): never {
+	throw new Error('provider error');
 }
 
 function createMockLogService() {
@@ -279,5 +284,36 @@ suite('NotebookErrorBoundary', () => {
 
 			sinon.assert.calledOnce(onReload);
 		});
+	});
+
+	suite('boundary wrapping providers', () => {
+		let originalConsoleError: typeof console.error;
+		setup(() => {
+			originalConsoleError = console.error;
+			console.error = () => { };
+		});
+		teardown(() => {
+			console.error = originalConsoleError;
+		});
+
+		test('catches errors from provider components when boundary wraps them', () => {
+			const { logService, errorSpy } = createMockLogService();
+			const container = render(
+				<NotebookErrorBoundary componentName='Test' level='editor' logService={logService} onReload={() => { }}>
+					<ThrowingProvider>
+						<GoodComponent />
+					</ThrowingProvider>
+				</NotebookErrorBoundary>
+			);
+
+			assert.ok(
+				container.querySelector<HTMLElement>('[role="alert"]'),
+				'Error boundary should catch provider errors'
+			);
+			sinon.assert.calledOnce(errorSpy);
+			const logMessage = errorSpy.firstCall.args[0] as string;
+			assert.ok(logMessage.includes('provider error'), 'Log should include the provider error message');
+		});
+
 	});
 });


### PR DESCRIPTION
Partially addresses #11802.

The editor-level `NotebookErrorBoundary` was nested within three context providers (`NotebookVisibilityProvider`, `NotebookInstanceProvider`, `EnvironentProvider`). If any provider threw during render, the error escaped the boundary entirely. 
With React 19's `createRoot`, an uncaught can producing the blank notebook screen because it unmounts the whole tree.

This PR moves the error boundary above the providers so it can catch errors from anywhere in the notebook component tree, showing the fallback error UI with a "Reload" button instead of a blank screen.


### Example
Here's an example of running a known failing output type on a windows machine (Leaflet/Folio). The output doesnt show but at least the notebook itself doesnt crash.

<img width="830" height="439" alt="image" src="https://github.com/user-attachments/assets/f5f5f444-61bf-4a31-a733-aeb821cda2ca" />


### Note
This _partially_ addresses the linked issue because the rendering still won't work, but at least the notebook wont go totally blank (in theory.)

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed a case where notebook rendering errors could produce a blank screen instead of showing the error recovery UI (#11802)

### QA Notes

@:positron-notebooks

1. Open a notebook with several cells (code + markdown)
2. Verify cells render normally -- no regression
3. Verify the error boundary fallback UI still appears for render errors (the "Something went wrong" message with Retry/Reload buttons)
