### PR TITLE
Add Quarto cell status line

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/media/quartoOutputViewZone.css
+++ b/src/vs/workbench/contrib/positronQuarto/browser/media/quartoOutputViewZone.css
@@ -432,8 +432,14 @@
 	position: relative;
 }
 
+/* Hide the upstream ::after separator by default (from CodeCellStatusFooter.css) */
+.quarto-output-status-bar .code-cell-footer-duration::after {
+	display: none;
+}
+
 /* Vertical separator between duration and timestamp (only when has-separator class is set) */
 .quarto-output-status-bar .code-cell-footer-duration.has-separator::after {
+	display: block;
 	content: '';
 	position: absolute;
 	right: -7px;
@@ -446,11 +452,10 @@
 /* CPU percentage label next to sparkline */
 .quarto-output-status-bar .quarto-output-cpu-label {
 	flex-shrink: 0;
-	width: 7ch;
+	min-width: 5em;
 	margin-left: 4px;
 	margin-right: 20px;
-	font-family: var(--monaco-monospace-font);
-	font-size: 10px;
+	font-variant-numeric: tabular-nums;
 	text-align: right;
 	white-space: nowrap;
 }

--- a/src/vs/workbench/contrib/positronQuarto/browser/media/quartoOutputViewZone.css
+++ b/src/vs/workbench/contrib/positronQuarto/browser/media/quartoOutputViewZone.css
@@ -155,10 +155,6 @@
 
 /* Error output container (when widget contains non-error outputs too) */
 .quarto-output-error {
-	padding: 8px;
-	background: var(--vscode-inputValidation-errorBackground);
-	border: 1px solid var(--vscode-inputValidation-errorBorder);
-	border-radius: 2px;
 	color: var(--vscode-errorForeground);
 }
 
@@ -395,6 +391,29 @@
 	100% {
 		transform: rotate(360deg);
 	}
+}
+
+/* CPU sparkline graph in status bar during execution */
+.quarto-output-status-bar .quarto-output-sparkline {
+	display: flex;
+	align-items: center;
+	flex-shrink: 0;
+	height: 16px;
+}
+
+.quarto-output-status-bar .quarto-output-sparkline .resource-usage-graph {
+	display: block;
+}
+
+.quarto-output-status-bar .quarto-output-sparkline .resource-usage-line {
+	fill: none;
+	stroke: var(--vscode-charts-lines, var(--vscode-foreground));
+	stroke-width: 1.5;
+}
+
+.quarto-output-status-bar .quarto-output-sparkline .resource-usage-fill {
+	fill: var(--vscode-charts-lines, var(--vscode-foreground));
+	opacity: 0.2;
 }
 
 /* Status text container with duration and timestamp */

--- a/src/vs/workbench/contrib/positronQuarto/browser/media/quartoOutputViewZone.css
+++ b/src/vs/workbench/contrib/positronQuarto/browser/media/quartoOutputViewZone.css
@@ -172,20 +172,6 @@
 	-webkit-user-select: text;
 }
 
-/* Widget-level error styling (when only output is an error) */
-.quarto-inline-output.quarto-output-error-only {
-	background: var(--vscode-inputValidation-errorBackground);
-	border-color: var(--vscode-inputValidation-errorBorder);
-}
-
-/* Remove individual error styling when widget has error style */
-.quarto-inline-output.quarto-output-error-only .quarto-output-error {
-	padding: 0;
-	background: transparent;
-	border: none;
-	border-radius: 0;
-}
-
 /* Image output container */
 .quarto-output-image-container {
 	display: flex;
@@ -362,16 +348,81 @@
 	mask-image: linear-gradient(to bottom, transparent 0%, rgba(0, 0, 0, 0.3) 30%, rgba(0, 0, 0, 0.7) 60%, black 100%);
 }
 
-/* Widget-level error styling (when only output is an error) */
-.quarto-inline-output.quarto-output-error-only {
-	background: var(--vscode-inputValidation-errorBackground);
-	border-color: var(--vscode-inputValidation-errorBorder);
+/* Status bar for execution info (duration, timestamp, success/fail) */
+.quarto-output-status-bar {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	height: 24px;
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+	cursor: default;
+	user-select: none;
+	-webkit-user-select: none;
 }
 
-/* Remove individual error styling when widget has error style */
-.quarto-inline-output.quarto-output-error-only .quarto-output-error {
-	padding: 0;
+/* Reuse notebook footer icon classes scoped to quarto status bar */
+.quarto-output-status-bar .code-cell-footer-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	width: 16px;
+	height: 16px;
+	font-size: 16px;
+}
+
+.quarto-output-status-bar .codicon.code-cell-footer-icon.success {
+	color: var(--vscode-notebookStatusSuccessIcon-foreground);
+}
+
+.quarto-output-status-bar .codicon.code-cell-footer-icon.error {
+	color: var(--vscode-notebookStatusErrorIcon-foreground);
+}
+
+.quarto-output-status-bar .codicon.code-cell-footer-icon.pending {
+	color: var(--vscode-notebookStatusRunningIcon-foreground);
+}
+
+.quarto-output-status-bar .codicon.code-cell-footer-icon.running {
+	color: var(--vscode-notebookStatusRunningIcon-foreground);
+	animation: quarto-status-spin 1.5s linear infinite;
+}
+
+@keyframes quarto-status-spin {
+	100% {
+		transform: rotate(360deg);
+	}
+}
+
+/* Status text container with duration and timestamp */
+.quarto-output-status-bar .code-cell-footer-text {
+	display: flex;
+	align-items: center;
+	gap: 13px;
+	white-space: nowrap;
+}
+
+/* Duration text with separator */
+.quarto-output-status-bar .code-cell-footer-duration {
+	position: relative;
+}
+
+/* Vertical separator between duration and timestamp */
+.quarto-output-status-bar .code-cell-footer-duration::after {
+	content: '';
+	position: absolute;
+	right: -7px;
+	top: 1px;
+	bottom: 1px;
+	width: 1px;
+	background-color: var(--vscode-widget-border);
+}
+
+/* Status-only view zone: no output border/background, just the status bar */
+.quarto-inline-output.quarto-output-status-only {
 	background: transparent;
 	border: none;
-	border-radius: 0;
+	padding: 0;
+	margin: 4px 0;
 }

--- a/src/vs/workbench/contrib/positronQuarto/browser/media/quartoOutputViewZone.css
+++ b/src/vs/workbench/contrib/positronQuarto/browser/media/quartoOutputViewZone.css
@@ -402,6 +402,12 @@
 	flex-shrink: 0;
 	margin-left: auto;
 	height: 16px;
+	opacity: 0;
+	transition: opacity 400ms ease;
+}
+
+.quarto-output-status-bar .quarto-output-sparkline.sparkline-visible {
+	opacity: 1;
 }
 
 .quarto-output-status-bar .quarto-output-sparkline .resource-usage-graph {
@@ -458,6 +464,12 @@
 	font-variant-numeric: tabular-nums;
 	text-align: right;
 	white-space: nowrap;
+	opacity: 0;
+	transition: opacity 400ms ease;
+}
+
+.quarto-output-status-bar .quarto-output-cpu-label.sparkline-visible {
+	opacity: 1;
 }
 
 /* Status-only view zone: hide the output container entirely, just show the status bar */

--- a/src/vs/workbench/contrib/positronQuarto/browser/media/quartoOutputViewZone.css
+++ b/src/vs/workbench/contrib/positronQuarto/browser/media/quartoOutputViewZone.css
@@ -351,6 +351,8 @@
 	align-items: center;
 	gap: 8px;
 	height: 20px;
+	margin-top: 4px;
+	margin-bottom: 4px;
 	padding-left: 12px;
 	font-size: 11px;
 	color: var(--vscode-descriptionForeground);
@@ -430,8 +432,8 @@
 	position: relative;
 }
 
-/* Vertical separator between duration and timestamp */
-.quarto-output-status-bar .code-cell-footer-duration::after {
+/* Vertical separator between duration and timestamp (only when has-separator class is set) */
+.quarto-output-status-bar .code-cell-footer-duration.has-separator::after {
 	content: '';
 	position: absolute;
 	right: -7px;
@@ -444,8 +446,12 @@
 /* CPU percentage label next to sparkline */
 .quarto-output-status-bar .quarto-output-cpu-label {
 	flex-shrink: 0;
+	width: 7ch;
 	margin-left: 4px;
-	margin-right: 8px;
+	margin-right: 20px;
+	font-family: var(--monaco-monospace-font);
+	font-size: 10px;
+	text-align: right;
 	white-space: nowrap;
 }
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/media/quartoOutputViewZone.css
+++ b/src/vs/workbench/contrib/positronQuarto/browser/media/quartoOutputViewZone.css
@@ -350,7 +350,7 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	height: 24px;
+	height: 20px;
 	padding-left: 12px;
 	font-size: 11px;
 	color: var(--vscode-descriptionForeground);
@@ -398,6 +398,7 @@
 	display: flex;
 	align-items: center;
 	flex-shrink: 0;
+	margin-left: auto;
 	height: 16px;
 }
 
@@ -438,6 +439,14 @@
 	bottom: 1px;
 	width: 1px;
 	background-color: var(--vscode-widget-border);
+}
+
+/* CPU percentage label next to sparkline */
+.quarto-output-status-bar .quarto-output-cpu-label {
+	flex-shrink: 0;
+	margin-left: 4px;
+	margin-right: 8px;
+	white-space: nowrap;
 }
 
 /* Status-only view zone: hide the output container entirely, just show the status bar */

--- a/src/vs/workbench/contrib/positronQuarto/browser/media/quartoOutputViewZone.css
+++ b/src/vs/workbench/contrib/positronQuarto/browser/media/quartoOutputViewZone.css
@@ -348,12 +348,14 @@
 	mask-image: linear-gradient(to bottom, transparent 0%, rgba(0, 0, 0, 0.3) 30%, rgba(0, 0, 0, 0.7) 60%, black 100%);
 }
 
-/* Status bar for execution info (duration, timestamp, success/fail) */
+/* Status bar for execution info (duration, timestamp, success/fail).
+   Lives outside the styled output container but inside the view zone wrapper. */
 .quarto-output-status-bar {
 	display: flex;
 	align-items: center;
 	gap: 8px;
 	height: 24px;
+	padding-left: 12px;
 	font-size: 11px;
 	color: var(--vscode-descriptionForeground);
 	cursor: default;
@@ -419,10 +421,7 @@
 	background-color: var(--vscode-widget-border);
 }
 
-/* Status-only view zone: no output border/background, just the status bar */
+/* Status-only view zone: hide the output container entirely, just show the status bar */
 .quarto-inline-output.quarto-output-status-only {
-	background: transparent;
-	border: none;
-	padding: 0;
-	margin: 4px 0;
+	display: none;
 }

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -1972,8 +1972,14 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 			documentUri,
 		};
 
+		// Set endTime when execution finishes (Completed or Error)
+		const isFinished = state === CellExecutionState.Completed || state === CellExecutionState.Error;
 		this._onDidChangeExecutionState.fire({
-			execution: { ...execution, state },
+			execution: {
+				...execution,
+				state,
+				...(isFinished && !execution.endTime ? { endTime: Date.now() } : {}),
+			},
 			previousState,
 		});
 	}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -131,6 +131,11 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 	private readonly _onDidChangeOutputs = this._register(new Emitter<OutputChangeEvent>());
 	readonly onDidChangeOutputs = this._onDidChangeOutputs.event;
 
+	// Shared tick emitter for refreshing relative timestamps across all view zones.
+	// A single 30-second interval drives all cells instead of one timer per cell.
+	private readonly _timestampTickEmitter = this._register(new Emitter<void>());
+	private _timestampTickInterval: ReturnType<typeof setInterval> | undefined;
+
 	constructor(
 		private readonly _editor: ICodeEditor,
 		@IQuartoExecutionManager private readonly _executionManager: IQuartoExecutionManager,
@@ -151,6 +156,11 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		@IResourceUsageHistoryService private readonly _resourceUsageHistoryService: IResourceUsageHistoryService,
 	) {
 		super();
+
+		// Start a shared 30-second timer for refreshing relative timestamps
+		this._timestampTickInterval = setInterval(() => {
+			this._timestampTickEmitter.fire();
+		}, 30_000);
 
 		// Get document URI from editor model
 		const model = this._editor.getModel();
@@ -555,6 +565,10 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 	}
 
 	override dispose(): void {
+		if (this._timestampTickInterval) {
+			clearInterval(this._timestampTickInterval);
+			this._timestampTickInterval = undefined;
+		}
 		this._disposeAllViewZones();
 		super.dispose();
 	}
@@ -910,6 +924,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			this._configurationService,
 			this._documentUri,
 			this._resourceUsageHistoryService,
+			this._timestampTickEmitter.event,
 		);
 
 		// Set up clear callback

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -534,16 +534,13 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		if (mime === 'application/vnd.code.notebook.error') {
 			try {
 				const errorData = JSON.parse(data);
-				const parts: string[] = [];
-				if (errorData.name) {
-					parts.push(`${errorData.name}: ${errorData.message || ''}`);
-				} else if (errorData.message) {
-					parts.push(errorData.message);
+				const stack = (errorData.stack || '').trim();
+				if (stack) {
+					return stack;
 				}
-				if (errorData.stack) {
-					parts.push(errorData.stack);
-				}
-				return parts.join('\n');
+				const name = (errorData.name || '').trim();
+				const message = (errorData.message || '').trim();
+				return name ? `${name}: ${message}` : (message || '');
 			} catch {
 				return data;
 			}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -267,10 +267,15 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 				const currentState = event.execution.state;
 				const isRunning = currentState === CellExecutionState.Running;
 
-				// Update view zone button state
-				const viewZone = this._viewZones.get(cellId);
+				// Update view zone button state and execution info
+				let viewZone = this._viewZones.get(cellId);
 				if (viewZone) {
 					viewZone.setExecuting(isRunning);
+					viewZone.setExecutionInfo(
+						currentState,
+						event.execution.startTime,
+						event.execution.endTime,
+					);
 				}
 
 				// When execution starts, put existing output into recomputing state
@@ -292,12 +297,38 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 
 				// When execution finishes (Idle, Completed, or Error), if still in
 				// recomputing state (no new output arrived), clear the old outputs
-				const executionFinished = currentState === CellExecutionState.Idle ||
-					currentState === CellExecutionState.Completed ||
+				// but keep the view zone visible for the status bar
+				const executionFinished = currentState === CellExecutionState.Completed ||
 					currentState === CellExecutionState.Error;
 
 				if (executionFinished && viewZone?.isRecomputing) {
-					// No new output was produced - clear the old output and hide
+					// No new output was produced - clear old output but keep
+					// view zone for status display
+					viewZone.clearOutputs();
+					this._onDidChangeOutputs.fire({
+						cellId,
+						documentUri: this._documentUri!,
+						outputs: [],
+					});
+				}
+
+				// When execution finishes and there is no view zone yet,
+				// create one to show the status bar
+				if (executionFinished && !viewZone) {
+					viewZone = this._createViewZone(cellId);
+					if (viewZone) {
+						this._viewZones.set(cellId, viewZone);
+						viewZone.setExecutionInfo(
+							currentState,
+							event.execution.startTime,
+							event.execution.endTime,
+						);
+					}
+				}
+
+				// When state goes to Idle (e.g. after cancellation), hide
+				// status-only view zones since there's nothing meaningful to show
+				if (currentState === CellExecutionState.Idle && viewZone?.isRecomputing) {
 					viewZone.clearOutputs();
 					this._viewZones.delete(cellId);
 					this._onDidChangeOutputs.fire({

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -446,6 +446,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 	clearAllOutputs(): void {
 		this._disposeAllViewZones();
 		this._outputsByCell.clear();
+		this._executionInfoByCell.clear();
 	}
 
 	/**
@@ -914,6 +915,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		// Set up clear callback
 		viewZone.onClear = () => {
 			this._outputsByCell.delete(cellId);
+			this._executionInfoByCell.delete(cellId);
 			this._viewZones.delete(cellId);
 			this._onDidChangeOutputs.fire({
 				cellId,

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputManager.ts
@@ -29,6 +29,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IPositronNotebookOutputWebviewService } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
 import { IQuartoKernelManager } from './quartoKernelManager.js';
 import { ILanguageRuntimeMessageWebOutput, LanguageRuntimeMessageType, RuntimeOutputKind, PositronOutputLocation } from '../../../services/languageRuntime/common/languageRuntimeService.js';
+import { IResourceUsageHistoryService } from '../../../services/positronConsole/browser/resourceUsageHistoryService.js';
 
 export const IQuartoOutputManager = createDecorator<IQuartoOutputManager>('quartoOutputManager');
 
@@ -103,6 +104,8 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 	// Track content hashes for each cell ID so we can find cells that moved
 	// (cell IDs include the index, which changes when cells are inserted/deleted)
 	private readonly _contentHashByCellId = new Map<string, string>();
+	// Track last-known execution info per cell so the status bar can survive tab switches
+	private readonly _executionInfoByCell = new Map<string, { state: CellExecutionState; startTime?: number; endTime?: number }>();
 	private _documentUri: URI | undefined;
 	private _featureEnabled: boolean;
 	private _outputHandlingInitialized = false;
@@ -122,6 +125,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 	private readonly _stashedOutputsByUri = new Map<string, {
 		outputsByCell: Map<string, ICellOutput[]>;
 		contentHashByCellId: Map<string, string>;
+		executionInfoByCell: Map<string, { state: CellExecutionState; startTime?: number; endTime?: number }>;
 	}>();
 
 	private readonly _onDidChangeOutputs = this._register(new Emitter<OutputChangeEvent>());
@@ -144,6 +148,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		@IEditorService private readonly _editorService: IEditorService,
 		@IPositronPreviewService private readonly _previewService: IPositronPreviewService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IResourceUsageHistoryService private readonly _resourceUsageHistoryService: IResourceUsageHistoryService,
 	) {
 		super();
 
@@ -180,19 +185,22 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			// Capture the previous URI before updating
 			const previousUri = this._documentUri;
 
-			// Stash outputs for the previous document so they can be restored
-			// when switching back. This preserves data explorer MIME items that
-			// the disk cache intentionally strips.
-			if (previousUri && this._outputsByCell.size > 0) {
+			// Stash outputs and execution info for the previous document so they
+			// can be restored when switching back. This preserves data explorer
+			// MIME items that the disk cache intentionally strips, and also
+			// preserves the status bar state (duration, timestamp).
+			if (previousUri && (this._outputsByCell.size > 0 || this._executionInfoByCell.size > 0)) {
 				this._stashedOutputsByUri.set(previousUri.toString(), {
 					outputsByCell: new Map(this._outputsByCell),
 					contentHashByCellId: new Map(this._contentHashByCellId),
+					executionInfoByCell: new Map(this._executionInfoByCell),
 				});
 			}
 
 			this._disposeAllViewZones();
 			this._outputsByCell.clear();
 			this._contentHashByCellId.clear();
+			this._executionInfoByCell.clear();
 
 			// Clear previous output handling subscriptions to prevent duplicates
 			this._outputHandlingDisposables.clear();
@@ -269,6 +277,16 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 
 				// Update view zone button state and execution info
 				let viewZone = this._viewZones.get(cellId);
+
+				// When execution starts and there is no view zone yet,
+				// create one to show the status bar (Running...)
+				if (isRunning && !viewZone) {
+					viewZone = this._createViewZone(cellId);
+					if (viewZone) {
+						this._viewZones.set(cellId, viewZone);
+					}
+				}
+
 				if (viewZone) {
 					viewZone.setExecuting(isRunning);
 					viewZone.setExecutionInfo(
@@ -277,6 +295,13 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 						event.execution.endTime,
 					);
 				}
+
+				// Track execution info so it survives tab switches
+				this._executionInfoByCell.set(cellId, {
+					state: currentState,
+					startTime: event.execution.startTime,
+					endTime: event.execution.endTime,
+				});
 
 				// When execution starts, put existing output into recomputing state
 				// instead of clearing it immediately
@@ -331,6 +356,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 				if (currentState === CellExecutionState.Idle && viewZone?.isRecomputing) {
 					viewZone.clearOutputs();
 					this._viewZones.delete(cellId);
+					this._executionInfoByCell.delete(cellId);
 					this._onDidChangeOutputs.fire({
 						cellId,
 						documentUri: this._documentUri!,
@@ -634,7 +660,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 		// outputs preserve data explorer MIME items so the inline data explorer
 		// can reconnect to a live comm without going through the disk cache.
 		const stash = this._stashedOutputsByUri.get(this._documentUri.toString());
-		if (stash && stash.outputsByCell.size > 0) {
+		if (stash && (stash.outputsByCell.size > 0 || stash.executionInfoByCell.size > 0)) {
 			this._stashedOutputsByUri.delete(this._documentUri.toString());
 			this._cachedOutputsLoaded = true;
 			this._restoreFromStash(stash);
@@ -746,10 +772,17 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 	 * Restore outputs from a stash saved during a previous model change (tab switch).
 	 * The stash preserves data explorer MIME items that the disk cache strips.
 	 */
-	private _restoreFromStash(stash: { outputsByCell: Map<string, ICellOutput[]>; contentHashByCellId: Map<string, string> }): void {
-		// Restore content hashes
+	private _restoreFromStash(stash: {
+		outputsByCell: Map<string, ICellOutput[]>;
+		contentHashByCellId: Map<string, string>;
+		executionInfoByCell: Map<string, { state: CellExecutionState; startTime?: number; endTime?: number }>;
+	}): void {
+		// Restore content hashes and execution info
 		for (const [cellId, hash] of stash.contentHashByCellId) {
 			this._contentHashByCellId.set(cellId, hash);
+		}
+		for (const [cellId, info] of stash.executionInfoByCell) {
+			this._executionInfoByCell.set(cellId, info);
 		}
 
 		// Restore outputs and recreate view zones
@@ -770,6 +803,22 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 				}
 			}
 			restoredCount++;
+		}
+
+		// Restore execution info on view zones (including status-only cells
+		// that had no outputs but did have a status bar)
+		for (const [cellId, info] of stash.executionInfoByCell) {
+			let viewZone = this._viewZones.get(cellId);
+			if (!viewZone) {
+				// Create a view zone for status-only cells (no outputs but had status bar)
+				viewZone = this._createViewZone(cellId);
+				if (viewZone) {
+					this._viewZones.set(cellId, viewZone);
+				}
+			}
+			if (viewZone) {
+				viewZone.setExecutionInfo(info.state, info.startTime, info.endTime);
+			}
 		}
 
 		this._logService.debug('[QuartoOutputContribution] Restored outputs from stash for', restoredCount, 'cells');
@@ -862,6 +911,7 @@ export class QuartoOutputContribution extends Disposable implements IEditorContr
 			this._maxLines,
 			this._configurationService,
 			this._documentUri,
+			this._resourceUsageHistoryService,
 		);
 
 		// Set up clear callback

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -277,7 +277,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		this._statusText = document.createElement('span');
 		this._statusText.className = 'code-cell-footer-text';
 		this._statusBar.appendChild(this._statusText);
-		this._styledContainer.appendChild(this._statusBar);
+		this.domNode.insertBefore(this._statusBar, this._styledContainer);
 
 		// Create output container
 		this._outputContainer = document.createElement('div');
@@ -1912,7 +1912,9 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		}
 
 		// Measure the styled container's height (content + padding + border, but not margin)
-		const styledHeight = this._styledContainer.offsetHeight;
+		// plus the status bar height when it's displayed above the output
+		const statusBarHeight = this._statusBar.style.display !== 'none' ? this._statusBar.offsetHeight : 0;
+		const styledHeight = this._styledContainer.offsetHeight + statusBarHeight;
 
 		// Show the Copy button if there's enough room and there's copiable content
 		// Copy is prioritized (shown first) since it's the most common action

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -188,10 +188,15 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	private readonly _resourceUsageDisposables = this._register(new DisposableStore());
 	private _resourceUsageData: ILanguageRuntimeResourceUsage[] = [];
 	private _sparklineGeneration = 0;
+	private _sparklineDelayTimeout: ReturnType<typeof setTimeout> | undefined;
+	private _sparklineFadeOutTimeout: ReturnType<typeof setTimeout> | undefined;
 
 	// Live timer interval during execution
 	private _timerInterval: ReturnType<typeof setInterval> | undefined;
 	private _executionStartTime: number | undefined;
+
+	// Subscription to a shared tick event for refreshing the relative timestamp
+	private _timestampRefreshDisposable: { dispose(): void } | undefined;
 
 	// Icon element inside the close button (for switching between close and stop icons)
 	private _buttonIcon!: HTMLSpanElement;
@@ -233,6 +238,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		configurationService?: IConfigurationService,
 		documentUri?: URI,
 		private readonly _resourceUsageHistoryService?: IResourceUsageHistoryService,
+		private readonly _onTimestampTick?: VSEvent<void>,
 	) {
 		super();
 
@@ -445,7 +451,8 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		if (state === CellExecutionState.Idle && !startTime) {
 			this._statusBar.style.display = 'none';
 			this._stopTimer();
-			this._stopSparkline();
+			this._stopTimestampRefresh();
+			this._stopSparkline(true);
 			this._updateStatusOnlyState();
 			this._updateHeight();
 			return;
@@ -456,6 +463,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		this._statusText.textContent = '';
 		dom.clearNode(this._statusText);
 		this._stopTimer();
+		this._stopTimestampRefresh();
 		this._stopSparkline();
 
 		this._statusBar.style.display = '';
@@ -502,7 +510,24 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			const timestampSpan = document.createElement('span');
 			timestampSpan.textContent = getRelativeTime(endTime);
 			this._statusText.appendChild(timestampSpan);
+
+			// Subscribe to the shared timestamp tick so "just now"
+			// naturally transitions to "1 min ago", etc.
+			this._stopTimestampRefresh();
+			if (this._onTimestampTick) {
+				this._timestampRefreshDisposable = this._onTimestampTick(() => {
+					timestampSpan.textContent = getRelativeTime(endTime);
+				});
+			}
 		}
+	}
+
+	/**
+	 * Stop listening for timestamp refresh ticks.
+	 */
+	private _stopTimestampRefresh(): void {
+		this._timestampRefreshDisposable?.dispose();
+		this._timestampRefreshDisposable = undefined;
 	}
 
 	/**
@@ -561,6 +586,12 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			return;
 		}
 
+		// Clear any pending fade-out from a previous execution
+		if (this._sparklineFadeOutTimeout) {
+			clearTimeout(this._sparklineFadeOutTimeout);
+			this._sparklineFadeOutTimeout = undefined;
+		}
+
 		const maxPoints = Math.floor(QuartoOutputViewZone.SPARKLINE_WIDTH / 2) + 1;
 
 		// Seed with historical data from the resource usage history service
@@ -582,9 +613,11 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			});
 		}
 
-		// Show containers
+		// Show containers (initially invisible via CSS opacity: 0)
 		this._sparklineContainer.style.display = '';
+		this._sparklineContainer.classList.remove('sparkline-visible');
 		this._cpuLabel.style.display = '';
+		this._cpuLabel.classList.remove('sparkline-visible');
 
 		// Create React renderer for the sparkline
 		if (!this._sparklineRenderer) {
@@ -604,22 +637,63 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 				this._updateCpuLabel();
 			})
 		);
+
+		// Delay appearance by 200ms, then fade in over 400ms (via CSS transition)
+		this._sparklineDelayTimeout = setTimeout(() => {
+			this._sparklineDelayTimeout = undefined;
+			if (this._sparklineGeneration !== generation) {
+				return;
+			}
+			this._sparklineContainer.classList.add('sparkline-visible');
+			this._cpuLabel.classList.add('sparkline-visible');
+		}, 200);
 	}
 
 	/**
 	 * Stop showing the CPU sparkline and clean up.
 	 */
-	private _stopSparkline(): void {
+	private _stopSparkline(immediate?: boolean): void {
+		// Cancel any pending delay timer
+		if (this._sparklineDelayTimeout) {
+			clearTimeout(this._sparklineDelayTimeout);
+			this._sparklineDelayTimeout = undefined;
+		}
+
 		this._sparklineGeneration++;
 		this._resourceUsageDisposables.clear();
+
+		if (immediate || !this._sparklineContainer.classList.contains('sparkline-visible')) {
+			// Immediate cleanup (dispose, clear output, or never became visible)
+			this._cleanupSparkline();
+			return;
+		}
+
+		// Fade out over 400ms (via CSS transition), then clean up
+		this._sparklineContainer.classList.remove('sparkline-visible');
+		this._cpuLabel.classList.remove('sparkline-visible');
+		this._sparklineFadeOutTimeout = setTimeout(() => {
+			this._sparklineFadeOutTimeout = undefined;
+			this._cleanupSparkline();
+		}, 400);
+	}
+
+	/**
+	 * Immediately tear down sparkline DOM and state.
+	 */
+	private _cleanupSparkline(): void {
+		if (this._sparklineFadeOutTimeout) {
+			clearTimeout(this._sparklineFadeOutTimeout);
+			this._sparklineFadeOutTimeout = undefined;
+		}
 		if (this._sparklineRenderer) {
 			this._sparklineRenderer.dispose();
 			this._sparklineRenderer = undefined;
 		}
-		// Clear any residual DOM content and hide
 		dom.clearNode(this._sparklineContainer);
 		this._sparklineContainer.style.display = 'none';
+		this._sparklineContainer.classList.remove('sparkline-visible');
 		this._cpuLabel.style.display = 'none';
+		this._cpuLabel.classList.remove('sparkline-visible');
 		this._cpuLabel.textContent = '';
 		this._resourceUsageData = [];
 	}
@@ -795,7 +869,8 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		// status line should be cleared too.
 		this._statusBar.style.display = 'none';
 		this._stopTimer();
-		this._stopSparkline();
+		this._stopTimestampRefresh();
+		this._stopSparkline(true);
 
 		this._isStatusOnly = false;
 		this.hide();
@@ -909,7 +984,8 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	override dispose(): void {
 		this.hide();
 		this._stopTimer();
-		this._stopSparkline();
+		this._stopTimestampRefresh();
+		this._stopSparkline(true);
 		this._disposeResizeObserver();
 		this._disposeAllWebviews();
 		this._disposeAllReactRenderers();

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -494,7 +494,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		if (startTime && endTime) {
 			const duration = endTime - startTime;
 			const durationSpan = document.createElement('span');
-			durationSpan.className = 'code-cell-footer-duration';
+			durationSpan.className = 'code-cell-footer-duration has-separator';
 			durationSpan.textContent = formatCellDuration(duration);
 			this._statusText.appendChild(durationSpan);
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -32,6 +32,7 @@ import { QuartoInlineDataExplorer } from './quartoInlineDataExplorer.js';
 import { parseVariablePath } from '../../../services/positronDataExplorer/common/utils.js';
 import { calculateInlineDataExplorerHeight } from './quartoInlineDataExplorerLayout.js';
 import { ResourceUsageGraph } from '../../positronConsole/browser/components/resourceUsageGraph.js';
+import { IResourceUsageHistoryService } from '../../../services/positronConsole/browser/resourceUsageHistoryService.js';
 
 /**
  * Minimum height for a view zone in pixels.
@@ -182,9 +183,14 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 
 	// Resource usage sparkline shown during execution
 	private readonly _sparklineContainer: HTMLElement;
+	private readonly _cpuLabel: HTMLSpanElement;
 	private _sparklineRenderer: PositronReactRenderer | undefined;
 	private readonly _resourceUsageDisposables = this._register(new DisposableStore());
 	private _resourceUsageData: ILanguageRuntimeResourceUsage[] = [];
+
+	// Live timer interval during execution
+	private _timerInterval: ReturnType<typeof setInterval> | undefined;
+	private _executionStartTime: number | undefined;
 
 	// Icon element inside the close button (for switching between close and stop icons)
 	private _buttonIcon!: HTMLSpanElement;
@@ -225,6 +231,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		maxLines: number = 40,
 		configurationService?: IConfigurationService,
 		documentUri?: URI,
+		private readonly _resourceUsageHistoryService?: IResourceUsageHistoryService,
 	) {
 		super();
 
@@ -281,13 +288,17 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		this._statusIcon = document.createElement('span');
 		this._statusIcon.className = 'codicon code-cell-footer-icon';
 		this._statusBar.appendChild(this._statusIcon);
+		this._statusText = document.createElement('span');
+		this._statusText.className = 'code-cell-footer-text';
+		this._statusBar.appendChild(this._statusText);
 		this._sparklineContainer = document.createElement('div');
 		this._sparklineContainer.className = 'quarto-output-sparkline';
 		this._sparklineContainer.style.display = 'none';
 		this._statusBar.appendChild(this._sparklineContainer);
-		this._statusText = document.createElement('span');
-		this._statusText.className = 'code-cell-footer-text';
-		this._statusBar.appendChild(this._statusText);
+		this._cpuLabel = document.createElement('span');
+		this._cpuLabel.className = 'quarto-output-cpu-label';
+		this._cpuLabel.style.display = 'none';
+		this._statusBar.appendChild(this._cpuLabel);
 		this.domNode.insertBefore(this._statusBar, this._styledContainer);
 
 		// Create output container
@@ -432,6 +443,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		// Hide status bar when idle with no timing info
 		if (state === CellExecutionState.Idle && !startTime) {
 			this._statusBar.style.display = 'none';
+			this._stopTimer();
 			this._stopSparkline();
 			this._updateStatusOnlyState();
 			this._updateHeight();
@@ -442,6 +454,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		this._statusIcon.className = 'codicon code-cell-footer-icon';
 		this._statusText.textContent = '';
 		dom.clearNode(this._statusText);
+		this._stopTimer();
 		this._stopSparkline();
 
 		this._statusBar.style.display = '';
@@ -450,7 +463,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		switch (state) {
 			case CellExecutionState.Running:
 				this._statusIcon.classList.add(...ThemeIcon.asClassName(Codicon.sync).split(' '), 'running');
-				this._statusText.textContent = localize('quartoRunning', 'Running...');
+				this._startTimer(startTime);
 				this._startSparkline();
 				break;
 			case CellExecutionState.Queued:
@@ -492,6 +505,48 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	}
 
 	/**
+	 * Start a live timer that updates the status text every 100ms with
+	 * the elapsed execution time.
+	 */
+	private _startTimer(startTime?: number): void {
+		this._executionStartTime = startTime ?? Date.now();
+
+		// Build the duration span (same structure as completed state)
+		const durationSpan = document.createElement('span');
+		durationSpan.className = 'code-cell-footer-duration';
+		durationSpan.textContent = '0.0s';
+		dom.clearNode(this._statusText);
+		this._statusText.appendChild(durationSpan);
+
+		// Format elapsed time always in seconds (no ms) to avoid jumpy transitions
+		const formatElapsed = (ms: number): string => {
+			const minutes = Math.floor(ms / 1000 / 60);
+			const seconds = Math.floor(ms / 1000) % 60;
+			const tenths = Math.floor((ms % 1000) / 100);
+			if (minutes > 0) {
+				return `${minutes}m ${seconds}.${tenths}s`;
+			}
+			return `${seconds}.${tenths}s`;
+		};
+
+		this._timerInterval = setInterval(() => {
+			const elapsed = Date.now() - this._executionStartTime!;
+			durationSpan.textContent = formatElapsed(elapsed);
+		}, 100);
+	}
+
+	/**
+	 * Stop the live timer.
+	 */
+	private _stopTimer(): void {
+		if (this._timerInterval) {
+			clearInterval(this._timerInterval);
+			this._timerInterval = undefined;
+		}
+		this._executionStartTime = undefined;
+	}
+
+	/**
 	 * Height and width of the sparkline graph in the status bar.
 	 */
 	private static readonly SPARKLINE_HEIGHT = 16;
@@ -505,9 +560,23 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			return;
 		}
 
-		// Reset data and show container
+		const maxPoints = Math.floor(QuartoOutputViewZone.SPARKLINE_WIDTH / 2) + 1;
+
+		// Seed with historical data from the resource usage history service
 		this._resourceUsageData = [];
+		if (this._resourceUsageHistoryService) {
+			this._resourceUsageHistoryService.getHistory(this._session.sessionId).then(history => {
+				if (history.length > 0) {
+					this._resourceUsageData = history.slice(-maxPoints);
+					this._renderSparkline();
+					this._updateCpuLabel();
+				}
+			});
+		}
+
+		// Show containers
 		this._sparklineContainer.style.display = '';
+		this._cpuLabel.style.display = '';
 
 		// Create React renderer for the sparkline
 		if (!this._sparklineRenderer) {
@@ -520,12 +589,11 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		this._resourceUsageDisposables.add(
 			this._session.onDidUpdateResourceUsage((usage) => {
 				this._resourceUsageData.push(usage);
-				// Keep only the most recent points that fit the width
-				const maxPoints = Math.floor(QuartoOutputViewZone.SPARKLINE_WIDTH / 2) + 1;
 				if (this._resourceUsageData.length > maxPoints) {
 					this._resourceUsageData = this._resourceUsageData.slice(-maxPoints);
 				}
 				this._renderSparkline();
+				this._updateCpuLabel();
 			})
 		);
 	}
@@ -542,6 +610,8 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		// Clear any residual DOM content and hide
 		dom.clearNode(this._sparklineContainer);
 		this._sparklineContainer.style.display = 'none';
+		this._cpuLabel.style.display = 'none';
+		this._cpuLabel.textContent = '';
 		this._resourceUsageData = [];
 	}
 
@@ -559,6 +629,16 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 				height: QuartoOutputViewZone.SPARKLINE_HEIGHT,
 			})
 		);
+	}
+
+	/**
+	 * Update the CPU percentage label from the latest resource usage data point.
+	 */
+	private _updateCpuLabel(): void {
+		if (this._resourceUsageData.length > 0) {
+			const latest = this._resourceUsageData[this._resourceUsageData.length - 1];
+			this._cpuLabel.textContent = `CPU ${Math.round(latest.cpu_percent)}%`;
+		}
 	}
 
 	/**
@@ -799,6 +879,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 
 	override dispose(): void {
 		this.hide();
+		this._stopTimer();
 		this._stopSparkline();
 		this._disposeResizeObserver();
 		this._disposeAllWebviews();

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -19,7 +19,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { INotebookOutputWebview, IPositronNotebookOutputWebviewService } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
 import { isHTMLOutputWebviewMessage } from '../../positronWebviewPreloads/browser/notebookOutputUtils.js';
 import { ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
-import { RuntimeOutputKind, ILanguageRuntimeMessageWebOutput, PositronOutputLocation, LanguageRuntimeMessageType } from '../../../services/languageRuntime/common/languageRuntimeService.js';
+import { RuntimeOutputKind, ILanguageRuntimeMessageWebOutput, PositronOutputLocation, LanguageRuntimeMessageType, ILanguageRuntimeResourceUsage } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { EditorLayoutInfo, EditorOption } from '../../../../editor/common/config/editorOptions.js';
 import { applyFontInfo } from '../../../../editor/browser/config/domFontInfo.js';
 import { ANSIOutput, ANSIOutputLine, ANSIOutputRun } from '../../../../base/common/ansiOutput.js';
@@ -31,6 +31,7 @@ import { POSITRON_NOTEBOOK_INLINE_DATA_EXPLORER_ENABLED_KEY } from '../../positr
 import { QuartoInlineDataExplorer } from './quartoInlineDataExplorer.js';
 import { parseVariablePath } from '../../../services/positronDataExplorer/common/utils.js';
 import { calculateInlineDataExplorerHeight } from './quartoInlineDataExplorerLayout.js';
+import { ResourceUsageGraph } from '../../positronConsole/browser/components/resourceUsageGraph.js';
 
 /**
  * Minimum height for a view zone in pixels.
@@ -179,6 +180,12 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	private readonly _statusIcon: HTMLSpanElement;
 	private readonly _statusText: HTMLElement;
 
+	// Resource usage sparkline shown during execution
+	private readonly _sparklineContainer: HTMLElement;
+	private _sparklineRenderer: PositronReactRenderer | undefined;
+	private readonly _resourceUsageDisposables = this._register(new DisposableStore());
+	private _resourceUsageData: ILanguageRuntimeResourceUsage[] = [];
+
 	// Icon element inside the close button (for switching between close and stop icons)
 	private _buttonIcon!: HTMLSpanElement;
 
@@ -274,6 +281,10 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		this._statusIcon = document.createElement('span');
 		this._statusIcon.className = 'codicon code-cell-footer-icon';
 		this._statusBar.appendChild(this._statusIcon);
+		this._sparklineContainer = document.createElement('div');
+		this._sparklineContainer.className = 'quarto-output-sparkline';
+		this._sparklineContainer.style.display = 'none';
+		this._statusBar.appendChild(this._sparklineContainer);
 		this._statusText = document.createElement('span');
 		this._statusText.className = 'code-cell-footer-text';
 		this._statusBar.appendChild(this._statusText);
@@ -421,36 +432,39 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		// Hide status bar when idle with no timing info
 		if (state === CellExecutionState.Idle && !startTime) {
 			this._statusBar.style.display = 'none';
+			this._stopSparkline();
 			this._updateStatusOnlyState();
 			this._updateHeight();
 			return;
 		}
 
+		// Always reset everything first to avoid stale state from previous calls
+		this._statusIcon.className = 'codicon code-cell-footer-icon';
+		this._statusText.textContent = '';
+		dom.clearNode(this._statusText);
+		this._stopSparkline();
+
 		this._statusBar.style.display = '';
 
-		// Update icon
-		this._statusIcon.className = 'codicon code-cell-footer-icon';
+		// Apply new state
 		switch (state) {
 			case CellExecutionState.Running:
 				this._statusIcon.classList.add(...ThemeIcon.asClassName(Codicon.sync).split(' '), 'running');
 				this._statusText.textContent = localize('quartoRunning', 'Running...');
+				this._startSparkline();
 				break;
 			case CellExecutionState.Queued:
 				this._statusIcon.classList.add(...ThemeIcon.asClassName(Codicon.clock).split(' '), 'pending');
 				this._statusText.textContent = localize('quartoQueued', 'Queued');
 				break;
-			case CellExecutionState.Completed: {
+			case CellExecutionState.Completed:
 				this._statusIcon.classList.add(...ThemeIcon.asClassName(Codicon.check).split(' '), 'success');
-				this._statusText.innerHTML = '';
 				this._buildDurationText(startTime, endTime);
 				break;
-			}
-			case CellExecutionState.Error: {
+			case CellExecutionState.Error:
 				this._statusIcon.classList.add(...ThemeIcon.asClassName(Codicon.error).split(' '), 'error');
-				this._statusText.innerHTML = '';
 				this._buildDurationText(startTime, endTime);
 				break;
-			}
 			default:
 				this._statusBar.style.display = 'none';
 				break;
@@ -475,6 +489,76 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			timestampSpan.textContent = getRelativeTime(endTime);
 			this._statusText.appendChild(timestampSpan);
 		}
+	}
+
+	/**
+	 * Height and width of the sparkline graph in the status bar.
+	 */
+	private static readonly SPARKLINE_HEIGHT = 16;
+	private static readonly SPARKLINE_WIDTH = 80;
+
+	/**
+	 * Start showing the CPU sparkline in the status bar during execution.
+	 */
+	private _startSparkline(): void {
+		if (!this._session) {
+			return;
+		}
+
+		// Reset data and show container
+		this._resourceUsageData = [];
+		this._sparklineContainer.style.display = '';
+
+		// Create React renderer for the sparkline
+		if (!this._sparklineRenderer) {
+			this._sparklineRenderer = new PositronReactRenderer(this._sparklineContainer);
+		}
+		this._renderSparkline();
+
+		// Subscribe to resource usage updates from the session
+		this._resourceUsageDisposables.clear();
+		this._resourceUsageDisposables.add(
+			this._session.onDidUpdateResourceUsage((usage) => {
+				this._resourceUsageData.push(usage);
+				// Keep only the most recent points that fit the width
+				const maxPoints = Math.floor(QuartoOutputViewZone.SPARKLINE_WIDTH / 2) + 1;
+				if (this._resourceUsageData.length > maxPoints) {
+					this._resourceUsageData = this._resourceUsageData.slice(-maxPoints);
+				}
+				this._renderSparkline();
+			})
+		);
+	}
+
+	/**
+	 * Stop showing the CPU sparkline and clean up.
+	 */
+	private _stopSparkline(): void {
+		this._resourceUsageDisposables.clear();
+		if (this._sparklineRenderer) {
+			this._sparklineRenderer.dispose();
+			this._sparklineRenderer = undefined;
+		}
+		// Clear any residual DOM content and hide
+		dom.clearNode(this._sparklineContainer);
+		this._sparklineContainer.style.display = 'none';
+		this._resourceUsageData = [];
+	}
+
+	/**
+	 * Render the sparkline graph with current data.
+	 */
+	private _renderSparkline(): void {
+		if (!this._sparklineRenderer) {
+			return;
+		}
+		this._sparklineRenderer.render(
+			React.createElement(ResourceUsageGraph, {
+				data: this._resourceUsageData,
+				width: QuartoOutputViewZone.SPARKLINE_WIDTH,
+				height: QuartoOutputViewZone.SPARKLINE_HEIGHT,
+			})
+		);
 	}
 
 	/**
@@ -715,6 +799,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 
 	override dispose(): void {
 		this.hide();
+		this._stopSparkline();
 		this._disposeResizeObserver();
 		this._disposeAllWebviews();
 		this._disposeAllReactRenderers();

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -187,6 +187,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	private _sparklineRenderer: PositronReactRenderer | undefined;
 	private readonly _resourceUsageDisposables = this._register(new DisposableStore());
 	private _resourceUsageData: ILanguageRuntimeResourceUsage[] = [];
+	private _sparklineGeneration = 0;
 
 	// Live timer interval during execution
 	private _timerInterval: ReturnType<typeof setInterval> | undefined;
@@ -564,13 +565,20 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 
 		// Seed with historical data from the resource usage history service
 		this._resourceUsageData = [];
+		const generation = ++this._sparklineGeneration;
 		if (this._resourceUsageHistoryService) {
 			this._resourceUsageHistoryService.getHistory(this._session.sessionId).then(history => {
+				// Discard results if sparkline was stopped or restarted
+				if (this._sparklineGeneration !== generation) {
+					return;
+				}
 				if (history.length > 0) {
 					this._resourceUsageData = history.slice(-maxPoints);
 					this._renderSparkline();
 					this._updateCpuLabel();
 				}
+			}, _err => {
+				// History unavailable; leave sparkline empty
 			});
 		}
 
@@ -602,6 +610,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	 * Stop showing the CPU sparkline and clean up.
 	 */
 	private _stopSparkline(): void {
+		this._sparklineGeneration++;
 		this._resourceUsageDisposables.clear();
 		if (this._sparklineRenderer) {
 			this._sparklineRenderer.dispose();

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -790,15 +790,15 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		this._isRecomputing = false;
 		this._styledContainer.classList.remove('quarto-output-recomputing');
 
-		// Update status-only state (may still show status bar)
-		this._updateStatusOnlyState();
+		// Hide the status bar and stop any running timer/sparkline.
+		// This is an explicit user action to dismiss the output, so the
+		// status line should be cleared too.
+		this._statusBar.style.display = 'none';
+		this._stopTimer();
+		this._stopSparkline();
 
-		// Hide the view zone when outputs are cleared (unless showing status only)
-		if (!this._isStatusOnly) {
-			this.hide();
-		} else {
-			this._updateHeight();
-		}
+		this._isStatusOnly = false;
+		this.hide();
 
 		this._onClear?.();
 	}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -729,6 +729,26 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			this.setRecomputing(false);
 		}
 
+		// When an error output arrives, remove the preceding stderr output
+		// if it's redundant. R (and some other runtimes) send the error text
+		// as both a stderr stream message and a structured error message,
+		// which would otherwise render the same content twice.
+		const hasError = output.items.some(
+			i => i.mime === 'application/vnd.code.notebook.error'
+		);
+		if (hasError && this._outputs.length > 0) {
+			const prev = this._outputs[this._outputs.length - 1];
+			const isStderr = prev.items.length === 1 &&
+				prev.items[0].mime === 'application/vnd.code.notebook.stderr';
+			if (isStderr) {
+				this._outputs.pop();
+				const lastChild = this._outputContainer.lastElementChild;
+				if (lastChild) {
+					this._outputContainer.removeChild(lastChild);
+				}
+			}
+		}
+
 		this._outputs.push(output);
 		this._renderOutput(output);
 		this._updateStatusOnlyState();
@@ -1197,16 +1217,18 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		if (mime === 'application/vnd.code.notebook.error') {
 			try {
 				const errorData = JSON.parse(data);
-				const parts: string[] = [];
-				if (errorData.name) {
-					parts.push(`${errorData.name}: ${errorData.message || ''}`);
-				} else if (errorData.message) {
-					parts.push(errorData.message);
+				const stack = (errorData.stack || '').trim();
+				const name = (errorData.name || '').trim();
+				const message = (errorData.message || '').trim();
+
+				if (stack && name && stack.startsWith(name)) {
+					return stack;
+				} else if (stack && stack !== message) {
+					const header = name ? `${name}: ${message}` : message;
+					return header ? `${header}\n${stack}` : stack;
+				} else {
+					return name ? `${name}: ${message}` : (message || stack);
 				}
-				if (errorData.stack) {
-					parts.push(errorData.stack);
-				}
-				return parts.join('\n');
 			} catch {
 				return data;
 			}
@@ -1709,20 +1731,18 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		try {
 			const errorData = JSON.parse(data);
 
-			// Format error output
-			const parts: string[] = [];
-			if (errorData.name) {
-				parts.push(`${errorData.name}: ${errorData.message || ''}`);
-			} else if (errorData.message) {
-				parts.push(errorData.message);
+			// Prefer the stack/traceback when available: it is the most
+			// complete representation and preserves ANSI formatting that
+			// runtimes (especially R) use for colors and bold text.
+			// Only fall back to name+message when no stack is provided.
+			const stack = (errorData.stack || '').trim();
+			if (stack) {
+				errorText = stack;
+			} else if (errorData.name) {
+				errorText = `${errorData.name}: ${errorData.message || ''}`;
+			} else {
+				errorText = errorData.message || '';
 			}
-			// Only add stack if it's different from the message
-			// R sometimes sends the error message in both fields
-			if (errorData.stack && errorData.stack.trim() !== (errorData.message || '').trim()) {
-				parts.push(errorData.stack);
-			}
-
-			errorText = parts.join('\n');
 		} catch {
 			// If not JSON, render as plain text
 			errorText = data;
@@ -2082,16 +2102,20 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		const statusBarHeight = this._statusBar.style.display !== 'none' ? this._statusBar.offsetHeight : 0;
 		const styledHeight = this._styledContainer.offsetHeight + statusBarHeight;
 
+		// Use the styled container's height (not including status bar) for button
+		// visibility, since the buttons are positioned inside the styled container
+		const containerHeight = this._styledContainer.offsetHeight;
+
 		// Show the Copy button if there's enough room and there's copiable content
 		// Copy is prioritized (shown first) since it's the most common action
-		this._copyButton.style.display = styledHeight > 40 && this.hasCopiableContent() ? 'block' : 'none';
+		this._copyButton.style.display = containerHeight > 40 && this.hasCopiableContent() ? 'block' : 'none';
 
 		// Show the Popout button if there's more room and there's popout content
 		// (not just errors - plot, HTML, or text content)
-		this._popoutButton.style.display = styledHeight > 80 && this.hasPopoutContent() ? 'block' : 'none';
+		this._popoutButton.style.display = containerHeight > 80 && this.hasPopoutContent() ? 'block' : 'none';
 
 		// Show the Save button if there's even more room and there's exactly one plot
-		this._saveButton.style.display = styledHeight > 100 && this.hasSinglePlot() ? 'block' : 'none';
+		this._saveButton.style.display = containerHeight > 100 && this.hasSinglePlot() ? 'block' : 'none';
 
 		// Add margin space (4px top + 4px bottom) plus 5px spacing below the widget
 		const newHeight = Math.max(MIN_VIEW_ZONE_HEIGHT, styledHeight + 13);

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoOutputViewZone.ts
@@ -10,8 +10,9 @@ import { status as ariaStatus } from '../../../../base/browser/ui/aria/aria.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ICodeEditor, IViewZone } from '../../../../editor/browser/editorBrowser.js';
 import { localize } from '../../../../nls.js';
-import { ICellOutput, ICellOutputItem, DATA_EXPLORER_MIME_TYPE } from '../common/quartoExecutionTypes.js';
+import { ICellOutput, ICellOutputItem, DATA_EXPLORER_MIME_TYPE, CellExecutionState } from '../common/quartoExecutionTypes.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { formatCellDuration, getRelativeTime } from '../../positronNotebook/browser/notebookCells/cellExecutionUtils.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Event as VSEvent, Emitter } from '../../../../base/common/event.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -167,8 +168,16 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	// Maximum number of lines to display for text output before truncating
 	private _maxLines: number;
 
+	// Whether this view zone is showing only a status bar (no output content)
+	private _isStatusOnly = false;
+
 	// Inner styled container (separate from domNode so Monaco's height doesn't stretch it)
 	private readonly _styledContainer: HTMLElement;
+
+	// Status bar element showing execution state, duration, and timestamp
+	private readonly _statusBar: HTMLElement;
+	private readonly _statusIcon: HTMLSpanElement;
+	private readonly _statusText: HTMLElement;
 
 	// Icon element inside the close button (for switching between close and stop icons)
 	private _buttonIcon!: HTMLSpanElement;
@@ -257,6 +266,18 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		this._saveButton.style.display = 'none';
 
 		this._styledContainer.appendChild(buttonContainer);
+
+		// Create status bar for execution info (hidden by default)
+		this._statusBar = document.createElement('div');
+		this._statusBar.className = 'quarto-output-status-bar';
+		this._statusBar.style.display = 'none';
+		this._statusIcon = document.createElement('span');
+		this._statusIcon.className = 'codicon code-cell-footer-icon';
+		this._statusBar.appendChild(this._statusIcon);
+		this._statusText = document.createElement('span');
+		this._statusText.className = 'code-cell-footer-text';
+		this._statusBar.appendChild(this._statusText);
+		this._styledContainer.appendChild(this._statusBar);
 
 		// Create output container
 		this._outputContainer = document.createElement('div');
@@ -393,6 +414,80 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 	}
 
 	/**
+	 * Set execution information to display in the status bar.
+	 * Hides the status bar when no meaningful info is available (e.g. cached outputs).
+	 */
+	setExecutionInfo(state: CellExecutionState, startTime?: number, endTime?: number): void {
+		// Hide status bar when idle with no timing info
+		if (state === CellExecutionState.Idle && !startTime) {
+			this._statusBar.style.display = 'none';
+			this._updateStatusOnlyState();
+			this._updateHeight();
+			return;
+		}
+
+		this._statusBar.style.display = '';
+
+		// Update icon
+		this._statusIcon.className = 'codicon code-cell-footer-icon';
+		switch (state) {
+			case CellExecutionState.Running:
+				this._statusIcon.classList.add(...ThemeIcon.asClassName(Codicon.sync).split(' '), 'running');
+				this._statusText.textContent = localize('quartoRunning', 'Running...');
+				break;
+			case CellExecutionState.Queued:
+				this._statusIcon.classList.add(...ThemeIcon.asClassName(Codicon.clock).split(' '), 'pending');
+				this._statusText.textContent = localize('quartoQueued', 'Queued');
+				break;
+			case CellExecutionState.Completed: {
+				this._statusIcon.classList.add(...ThemeIcon.asClassName(Codicon.check).split(' '), 'success');
+				this._statusText.innerHTML = '';
+				this._buildDurationText(startTime, endTime);
+				break;
+			}
+			case CellExecutionState.Error: {
+				this._statusIcon.classList.add(...ThemeIcon.asClassName(Codicon.error).split(' '), 'error');
+				this._statusText.innerHTML = '';
+				this._buildDurationText(startTime, endTime);
+				break;
+			}
+			default:
+				this._statusBar.style.display = 'none';
+				break;
+		}
+
+		this._updateStatusOnlyState();
+		this._updateHeight();
+	}
+
+	/**
+	 * Build duration and timestamp text elements inside the status text span.
+	 */
+	private _buildDurationText(startTime?: number, endTime?: number): void {
+		if (startTime && endTime) {
+			const duration = endTime - startTime;
+			const durationSpan = document.createElement('span');
+			durationSpan.className = 'code-cell-footer-duration';
+			durationSpan.textContent = formatCellDuration(duration);
+			this._statusText.appendChild(durationSpan);
+
+			const timestampSpan = document.createElement('span');
+			timestampSpan.textContent = getRelativeTime(endTime);
+			this._statusText.appendChild(timestampSpan);
+		}
+	}
+
+	/**
+	 * Update the status-only CSS class based on whether we have outputs.
+	 */
+	private _updateStatusOnlyState(): void {
+		const hasStatus = this._statusBar.style.display !== 'none';
+		const hasOutputs = this._outputs.length > 0;
+		this._isStatusOnly = hasStatus && !hasOutputs;
+		this._styledContainer.classList.toggle('quarto-output-status-only', this._isStatusOnly);
+	}
+
+	/**
 	 * Update the visual appearance for recomputing state.
 	 */
 	private _updateRecomputingState(): void {
@@ -472,8 +567,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 
 		this._outputs.push(output);
 		this._renderOutput(output);
-		// Update error-only class after adding new output
-		this._styledContainer.classList.toggle('quarto-output-error-only', this._isErrorOnly());
+		this._updateStatusOnlyState();
 		this._updateHeight();
 		this._announceOutput(output);
 	}
@@ -503,8 +597,15 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		this._isRecomputing = false;
 		this._styledContainer.classList.remove('quarto-output-recomputing');
 
-		// Hide the view zone when outputs are cleared
-		this.hide();
+		// Update status-only state (may still show status bar)
+		this._updateStatusOnlyState();
+
+		// Hide the view zone when outputs are cleared (unless showing status only)
+		if (!this._isStatusOnly) {
+			this.hide();
+		} else {
+			this._updateHeight();
+		}
 
 		this._onClear?.();
 	}
@@ -1074,7 +1175,7 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 			this._updateHeight();
 		});
 
-		this._resizeObserver.observe(this._outputContainer);
+		this._resizeObserver.observe(this._styledContainer);
 	}
 
 	private _disposeResizeObserver(): void {
@@ -1105,26 +1206,9 @@ export class QuartoOutputViewZone extends Disposable implements IViewZone {
 		this._disposeAllReactRenderers();
 		dom.clearNode(this._outputContainer);
 
-		// Check if all outputs are errors only
-		const isErrorOnly = this._isErrorOnly();
-		this._styledContainer.classList.toggle('quarto-output-error-only', isErrorOnly);
-
 		for (const output of this._outputs) {
 			this._renderOutput(output);
 		}
-	}
-
-	/**
-	 * Check if all outputs contain only error items.
-	 */
-	private _isErrorOnly(): boolean {
-		if (this._outputs.length === 0) {
-			return false;
-		}
-		return this._outputs.every(output =>
-			output.items.length > 0 &&
-			output.items.every(item => item.mime === 'application/vnd.code.notebook.error')
-		);
 	}
 
 	private _renderOutput(output: ICellOutput): void {

--- a/test/e2e/pages/inlineQuarto.ts
+++ b/test/e2e/pages/inlineQuarto.ts
@@ -290,6 +290,21 @@ export class InlineQuarto {
 		});
 	}
 
+	/**
+	 * Verify that the error output at the given index has at most the
+	 * expected number of rendered lines (div elements inside the pre).
+	 * Catches regressions where error text is duplicated.
+	 */
+	async expectErrorMaxLines(maxLines: number, { index = 0, timeout = 10000 }: { index?: number; timeout?: number } = {}): Promise<void> {
+		await test.step(`Expect error output has at most ${maxLines} lines`, async () => {
+			const errorEl = this.errorOutput.nth(index);
+			await expect(errorEl).toBeVisible({ timeout });
+			// Each ANSI output line is rendered as a <div> inside a <pre>
+			const lineCount = await errorEl.locator('pre > div').count();
+			expect(lineCount, `Expected at most ${maxLines} lines in error, but found ${lineCount}`).toBeLessThanOrEqual(maxLines);
+		});
+	}
+
 	async expectHtmlOutputVisible(): Promise<void> {
 		await test.step('Verify HTML output present', async () => {
 			const htmlCount = await this.htmlOutput.count();

--- a/test/e2e/tests/quarto/quarto-inline-output-r.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-r.test.ts
@@ -77,6 +77,10 @@ test.describe('Quarto - Inline Output: R', {
 		// Verify error message and count
 		await inlineQuarto.expectErrorCount(1);
 		await inlineQuarto.expectOutputContainsText('oh no');
+
+		// Verify error text is not duplicated (regression: name+message
+		// was rendered alongside the full stack trace, doubling the output)
+		await inlineQuarto.expectErrorMaxLines(3);
 	});
 
 	test('R - Verify long text output is truncated with open in editor link', async function ({ app, openFile, r }) {


### PR DESCRIPTION
This change aligns the Quarto inline output experience with the Positron notebook experience in several ways:

The cell's execution status is displayed while it is running, and status along with timing info is shown when complete. Some styling and resources are reused from the notebook component. In addition to visual parity, this component provides better tactile feedback when a cell runs (formerly running a cell that produced no output was a very unsatisfying experience).

<img width="671" height="322" alt="image" src="https://github.com/user-attachments/assets/f70a0396-339a-48af-9cdf-7fa965e7e279" />

Error treatment is also improved; instead of turning the whole background red, we rely on the red status indicator.

Addresses https://github.com/posit-dev/positron/issues/12155.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Quarto inline output cells receive a new status line showing execution status and time (#12155)

#### Bug Fixes

- N/A


### QA Notes

Just like Positron notebooks, this metadata (when was the cell run? how long did it take) is only available in the current Positron session; it is not saved to disk. You will not see the values (or the cell status line at all) when opening a file with saved outputs.

test tags: `@:quarto` `@:notebooks` `@:positron-notebooks` 