### PR TITLE
Auto-start kernel for Quarto docs

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
@@ -185,6 +185,13 @@ class QuartoInlineOutputContribution extends Disposable implements IWorkbenchCon
 	 * execute code.
 	 */
 	private _autoStartKernelIfNeeded(): void {
+		// Don't auto-start during startup/reconnection to avoid racing with
+		// session restoration. Open documents will be handled by
+		// _autoStartKernelsForOpenDocuments() once startup completes.
+		if (this._languageRuntimeService.startupPhase !== RuntimeStartupPhase.Complete) {
+			return;
+		}
+
 		const uri = this._editorService.activeEditor?.resource;
 		if (!uri || !this._isQuartoFile()) {
 			return;
@@ -195,8 +202,7 @@ class QuartoInlineOutputContribution extends Disposable implements IWorkbenchCon
 			return;
 		}
 
-		const inlineOutputEnabled = this._configurationService.getValue<boolean>(POSITRON_QUARTO_INLINE_OUTPUT_KEY) ?? false;
-		if (!inlineOutputEnabled) {
+		if (!this._inlineOutputEnabledKey.get()) {
 			return;
 		}
 
@@ -215,8 +221,7 @@ class QuartoInlineOutputContribution extends Disposable implements IWorkbenchCon
 	 * that we don't race with session reconnection/restoration.
 	 */
 	private _autoStartKernelsForOpenDocuments(): void {
-		const inlineOutputEnabled = this._configurationService.getValue<boolean>(POSITRON_QUARTO_INLINE_OUTPUT_KEY) ?? false;
-		if (!inlineOutputEnabled) {
+		if (!this._inlineOutputEnabledKey.get()) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
@@ -27,9 +27,11 @@ import {
 	QUARTO_INLINE_OUTPUT_ENABLED,
 	QUARTO_KERNEL_RUNNING,
 	isQuartoDocument,
+	isQuartoOrRmdFile,
 } from '../common/positronQuartoConfig.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { QuartoKernelState } from './quartoKernelManager.js';
+import { ILanguageRuntimeService, RuntimeStartupPhase } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { MenuId } from '../../../../platform/actions/common/actions.js';
 import { PositronActionBarWidgetRegistry } from '../../../../platform/positronActionBar/browser/positronActionBarWidgetRegistry.js';
 import { QuartoKernelStatusBadge } from './QuartoKernelStatusBadge.js';
@@ -78,12 +80,16 @@ class QuartoInlineOutputContribution extends Disposable implements IWorkbenchCon
 	private readonly _inlineOutputEnabledKey = QUARTO_INLINE_OUTPUT_ENABLED.bindTo(this._contextKeyService);
 	private readonly _kernelRunningKey = QUARTO_KERNEL_RUNNING.bindTo(this._contextKeyService);
 
+	/** Tracks documents that have already had auto-start attempted, so we only auto-start on first open. */
+	private readonly _autoStartedDocuments = new Set<string>();
+
 	constructor(
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@IQuartoKernelManager private readonly _quartoKernelManager: IQuartoKernelManager,
 		@IExtensionService private readonly _extensionService: IExtensionService,
+		@ILanguageRuntimeService private readonly _languageRuntimeService: ILanguageRuntimeService,
 	) {
 		super();
 
@@ -103,6 +109,7 @@ class QuartoInlineOutputContribution extends Disposable implements IWorkbenchCon
 		this._register(this._editorService.onDidActiveEditorChange(() => {
 			this._updateIsQuartoDocument();
 			this._updateKernelRunning();
+			this._autoStartKernelIfNeeded();
 		}));
 
 		// Listen for kernel state changes
@@ -114,6 +121,28 @@ class QuartoInlineOutputContribution extends Disposable implements IWorkbenchCon
 		this._register(this._extensionService.onDidChangeExtensions(() => {
 			this._updateInlineOutputEnabled();
 		}));
+
+		// Clear auto-start tracking when a Quarto document is closed,
+		// so reopening it will trigger auto-start again.
+		this._register(this._editorService.onDidCloseEditor(e => {
+			const uri = e.editor.resource;
+			if (uri) {
+				this._autoStartedDocuments.delete(uri.toString());
+			}
+		}));
+
+		// After the runtime startup phase completes (reconnection finished),
+		// auto-start kernels for any already-open Quarto documents that
+		// didn't get a session restored.
+		if (this._languageRuntimeService.startupPhase === RuntimeStartupPhase.Complete) {
+			this._autoStartKernelsForOpenDocuments();
+		} else {
+			this._register(this._languageRuntimeService.onDidChangeRuntimeStartupPhase(phase => {
+				if (phase === RuntimeStartupPhase.Complete) {
+					this._autoStartKernelsForOpenDocuments();
+				}
+			}));
+		}
 	}
 
 	private _updateInlineOutputEnabled(): void {
@@ -146,6 +175,73 @@ class QuartoInlineOutputContribution extends Disposable implements IWorkbenchCon
 			this._kernelRunningKey.set(isRunning);
 		} else {
 			this._kernelRunningKey.set(false);
+		}
+	}
+
+	/**
+	 * Auto-start the kernel for the active Quarto document if inline output
+	 * is enabled and no kernel is already running. This provides a seamless
+	 * experience where the kernel is ready by the time the user wants to
+	 * execute code.
+	 */
+	private _autoStartKernelIfNeeded(): void {
+		const uri = this._editorService.activeEditor?.resource;
+		if (!uri || !this._isQuartoFile()) {
+			return;
+		}
+
+		const key = uri.toString();
+		if (this._autoStartedDocuments.has(key)) {
+			return;
+		}
+
+		const inlineOutputEnabled = this._configurationService.getValue<boolean>(POSITRON_QUARTO_INLINE_OUTPUT_KEY) ?? false;
+		if (!inlineOutputEnabled) {
+			return;
+		}
+
+		// Mark as attempted so we don't auto-start again on tab switches
+		this._autoStartedDocuments.add(key);
+
+		// Fire and forget - kernel startup is handled asynchronously
+		this._quartoKernelManager.ensureKernelForDocument(uri).catch(() => {
+			// Errors are handled internally by the kernel manager
+		});
+	}
+
+	/**
+	 * Auto-start kernels for all open Quarto documents that don't already
+	 * have a session. Called after the runtime startup phase completes, so
+	 * that we don't race with session reconnection/restoration.
+	 */
+	private _autoStartKernelsForOpenDocuments(): void {
+		const inlineOutputEnabled = this._configurationService.getValue<boolean>(POSITRON_QUARTO_INLINE_OUTPUT_KEY) ?? false;
+		if (!inlineOutputEnabled) {
+			return;
+		}
+
+		for (const editorInput of this._editorService.editors) {
+			const uri = editorInput.resource;
+			if (!uri || !isQuartoOrRmdFile(uri.path)) {
+				continue;
+			}
+
+			const key = uri.toString();
+			if (this._autoStartedDocuments.has(key)) {
+				continue;
+			}
+
+			const state = this._quartoKernelManager.getKernelState(uri);
+			if (state !== QuartoKernelState.None) {
+				// Already has a session (e.g., restored during reconnection)
+				this._autoStartedDocuments.add(key);
+				continue;
+			}
+
+			this._autoStartedDocuments.add(key);
+			this._quartoKernelManager.ensureKernelForDocument(uri).catch(() => {
+				// Errors are handled internally by the kernel manager
+			});
 		}
 	}
 

--- a/test/e2e/tests/quarto/quarto-inline-output-autostart.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-autostart.test.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Quarto - Inline Output: Kernel Auto-Start on Open', {
+	tag: [tags.QUARTO]
+}, () => {
+
+	test.beforeAll(async function ({ settings }) {
+		await settings.set({
+			'positron.quarto.inlineOutput.enabled': true
+		}, { reload: 'web' });
+	});
+
+	test.afterEach(async function ({ hotKeys }) {
+		await hotKeys.closeAllEditors();
+	});
+
+	test('Python - Kernel starts automatically when opening a Quarto document', async function ({ python, app, openFile }) {
+		const { editors, inlineQuarto } = app.workbench;
+
+		// Open a Quarto file - the kernel should start automatically
+		// without needing to run any code
+		await openFile(join('workspaces', 'quarto_inline_output', 'simple_plot.qmd'));
+		await editors.waitForActiveTab('simple_plot.qmd');
+
+		// Verify the kernel becomes idle without running any code
+		await inlineQuarto.expectKernelIdle(60000);
+	});
+});


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/12616.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Quarto inline output: automatically start a kernel when a Quarto document is opened, instead of waiting until code is run (#12616)

#### Bug Fixes

- N/A


### QA Notes

Kernels should auto start:

- when a document is first opened or re-opened
- when code is run in the document (if there is not a kernel at the time)

Test tags: `@:quarto` `@:positron-notebooks`
