### PR TITLE
Enable _Show Notebook Console_ for Quarto documents with inline output

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/getNotebookUriFromActiveEditor.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/getNotebookUriFromActiveEditor.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../base/common/uri.js';
+import { ITextModel } from '../../../../editor/common/model.js';
+import { IEditor } from '../../../../editor/common/editorCommon.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { getContextFromActiveEditor } from '../../notebook/browser/controller/coreActions.js';
+import { usingQuartoInlineOutput, isQuartoDocument } from '../../positronQuarto/common/positronQuartoConfig.js';
+
+/**
+ * Gets the notebook URI from the active editor. This handles both regular
+ * notebook editors and Quarto documents with inline output enabled.
+ *
+ * @param editorService The editor service
+ * @param configurationService The configuration service
+ * @returns The notebook URI, or undefined if the active editor is not a notebook
+ *   or Quarto document with inline output
+ */
+export function getNotebookUriFromActiveEditor(
+	editorService: IEditorService,
+	configurationService: IConfigurationService
+): URI | undefined {
+	// First, try to get the URI from a notebook editor
+	const context = getContextFromActiveEditor(editorService);
+	if (context) {
+		return context.notebookEditor.textModel.uri;
+	}
+
+	// Fall back to checking if the active editor is a Quarto document with
+	// inline output enabled
+	if (usingQuartoInlineOutput(configurationService)) {
+		const editor = editorService.activeTextEditorControl as IEditor | undefined;
+		const model = editor?.getModel() as ITextModel | undefined;
+		if (model && isQuartoDocument(model.uri.path, model.getLanguageId())) {
+			return model.uri;
+		}
+	}
+
+	return undefined;
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/getNotebookUriFromActiveEditor.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/getNotebookUriFromActiveEditor.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../../../base/common/uri.js';
-import { ITextModel } from '../../../../editor/common/model.js';
-import { IEditor } from '../../../../editor/common/editorCommon.js';
+import { isCodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { getContextFromActiveEditor } from '../../notebook/browser/controller/coreActions.js';
@@ -33,10 +32,12 @@ export function getNotebookUriFromActiveEditor(
 	// Fall back to checking if the active editor is a Quarto document with
 	// inline output enabled
 	if (usingQuartoInlineOutput(configurationService)) {
-		const editor = editorService.activeTextEditorControl as IEditor | undefined;
-		const model = editor?.getModel() as ITextModel | undefined;
-		if (model && isQuartoDocument(model.uri.path, model.getLanguageId())) {
-			return model.uri;
+		const editor = editorService.activeTextEditorControl;
+		if (isCodeEditor(editor)) {
+			const model = editor.getModel();
+			if (model && isQuartoDocument(model.uri.path, model.getLanguageId())) {
+				return model.uri;
+			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -41,9 +41,9 @@ import { CodeAttributionSource, IConsoleCodeAttribution } from '../../../service
 import { createCodeLocation, ICodeLocation } from '../../../services/positronConsole/common/codeLocation.js';
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
 import { POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED } from '../../positronNotebook/browser/ContextKeysManager.js';
-import { getContextFromActiveEditor } from '../../notebook/browser/controller/coreActions.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { usingQuartoInlineOutput, isQuartoDocument } from '../../positronQuarto/common/positronQuartoConfig.js';
+import { usingQuartoInlineOutput, isQuartoDocument, QUARTO_INLINE_OUTPUT_ENABLED, IS_QUARTO_DOCUMENT } from '../../positronQuarto/common/positronQuartoConfig.js';
+import { getNotebookUriFromActiveEditor } from './getNotebookUriFromActiveEditor.js';
 import { IQuartoExecutionManager } from '../../positronQuarto/common/quartoExecutionTypes.js';
 
 /**
@@ -1375,7 +1375,13 @@ export function registerPositronConsoleActions() {
 				},
 				f1: true,
 				category,
-				precondition: ContextKeyExpr.equals('config.console.showNotebookConsoleActions', true),
+				precondition: ContextKeyExpr.or(
+					ContextKeyExpr.equals('config.console.showNotebookConsoleActions', true),
+					ContextKeyExpr.and(
+						QUARTO_INLINE_OUTPUT_ENABLED,
+						IS_QUARTO_DOCUMENT,
+					),
+				),
 				menu: [
 					{
 						// Add an entry to the notebook toolbar to show the
@@ -1402,12 +1408,14 @@ export function registerPositronConsoleActions() {
 			const positronConsoleService = accessor.get(IPositronConsoleService);
 			const editorService = accessor.get(IEditorService);
 			const notificationService = accessor.get(INotificationService);
+			const configurationService = accessor.get(IConfigurationService);
 
-			// Figure out the URI of the active notebook and tell the console
-			// service to start a console attached to the appropriate session
-			const context = getContextFromActiveEditor(editorService);
-			if (context) {
-				positronConsoleService.showNotebookConsole(context.notebookEditor.textModel.uri, true);
+			// Figure out the URI of the active notebook (or Quarto document
+			// with inline output) and tell the console service to start a
+			// console attached to the appropriate session
+			const notebookUri = getNotebookUriFromActiveEditor(editorService, configurationService);
+			if (notebookUri) {
+				positronConsoleService.showNotebookConsole(notebookUri, true);
 			} else {
 				notificationService.info(localize('positron.noActiveNotebook', "No active notebook; run this command with a notebook open in an editor to see its console."));
 			}


### PR DESCRIPTION
Quick change to make the _Show Notebook Console_ command work as a shortcut to open up the notebook console for the Quarto doc, if one exists.

Addresses https://github.com/posit-dev/positron/issues/12789


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Quarto inline output: fix 'Show Notebook Console' to work with Quarto documents (#12789)


Test tags: `@:quarto` `@:notebooks` `@:positron-notebooks`