### PR TITLE
Positron nb put complex html into webview

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -156,17 +156,19 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 				if (parsedOutput.preloadMessageResult === undefined) {
 					return;
 				}
-			} else if (preferredOutputItem.mime === 'text/html' &&
-				isComplexHtml(preferredOutputItem.data.toString())) {
-				// Complex HTML (scripts, iframes, full documents) can't render
-				// inline due to Trusted Types / CSP restrictions. Route through
-				// an overlay webview where scripts execute in an isolated process.
-				parsedOutput.preloadMessageResult = this._webviewPreloadService.addNotebookOutput({
-					instance: this.instance,
-					outputId: output.outputId,
-					outputs: outputItems,
-					rawHtml: preferredOutputItem.data.toString(),
-				});
+			} else if (preferredOutputItem.mime === 'text/html') {
+				const rawHtml = preferredOutputItem.data.toString();
+				if (isComplexHtml(rawHtml)) {
+					// Complex HTML (scripts, iframes, full documents) can't render
+					// inline due to Trusted Types / CSP restrictions. Route through
+					// an overlay webview where scripts execute in an isolated process.
+					parsedOutput.preloadMessageResult = this._webviewPreloadService.addNotebookOutput({
+						instance: this.instance,
+						outputId: output.outputId,
+						outputs: outputItems,
+						rawHtml,
+					});
+				}
 			}
 
 			parsedOutputs.push(parsedOutput);

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -144,6 +144,7 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 			};
 
 			const preloadMessageType = getWebviewMessageType(outputItems);
+			const rawOutput = preferredOutputItem.data.toString();
 
 			if (preloadMessageType) {
 				parsedOutput.preloadMessageResult = this._webviewPreloadService.addNotebookOutput({
@@ -156,19 +157,16 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 				if (parsedOutput.preloadMessageResult === undefined) {
 					return;
 				}
-			} else if (preferredOutputItem.mime === 'text/html') {
-				const rawHtml = preferredOutputItem.data.toString();
-				if (isComplexHtml(rawHtml)) {
-					// Complex HTML (scripts, iframes, full documents) can't render
-					// inline due to Trusted Types / CSP restrictions. Route through
-					// an overlay webview where scripts execute in an isolated process.
-					parsedOutput.preloadMessageResult = this._webviewPreloadService.addNotebookOutput({
-						instance: this.instance,
-						outputId: output.outputId,
-						outputs: outputItems,
-						rawHtml,
-					});
-				}
+			} else if (preferredOutputItem.mime === 'text/html' && isComplexHtml(rawOutput)) {
+				// Complex HTML (scripts, iframes, full documents) can't render
+				// inline due to Trusted Types / CSP restrictions. Route through
+				// an overlay webview where scripts execute in an isolated process.
+				parsedOutput.preloadMessageResult = this._webviewPreloadService.addNotebookOutput({
+					instance: this.instance,
+					outputId: output.outputId,
+					outputs: outputItems,
+					rawHtml: rawOutput,
+				});
 			}
 
 			parsedOutputs.push(parsedOutput);

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -14,7 +14,7 @@ import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
 import { IPositronNotebookCodeCell, NotebookCellOutputs } from './IPositronNotebookCell.js';
 import { IPositronWebviewPreloadService } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
 import { pickPreferredOutputItem } from './notebookOutputUtils.js';
-import { getWebviewMessageType } from '../../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
+import { getWebviewMessageType, isComplexHtml } from '../../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
 import { INotebookExecutionStateService } from '../../../notebook/common/notebookExecutionStateService.js';
 import { IPositronCellOutputViewModel } from '../IPositronNotebookEditor.js';
 
@@ -156,6 +156,17 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 				if (parsedOutput.preloadMessageResult === undefined) {
 					return;
 				}
+			} else if (preferredOutputItem.mime === 'text/html' &&
+				isComplexHtml(preferredOutputItem.data.toString())) {
+				// Complex HTML (scripts, iframes, full documents) can't render
+				// inline due to Trusted Types / CSP restrictions. Route through
+				// an overlay webview where scripts execute in an isolated process.
+				parsedOutput.preloadMessageResult = this._webviewPreloadService.addNotebookOutput({
+					instance: this.instance,
+					outputId: output.outputId,
+					outputs: outputItems,
+					rawHtml: preferredOutputItem.data.toString(),
+				});
 			}
 
 			parsedOutputs.push(parsedOutput);

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.test.ts
@@ -228,26 +228,5 @@ suite('Positron Notebook Cell Outputs', () => {
 			assert.strictEqual(outputs[0].preloadMessageResult, undefined, 'simple HTML should not have preloadMessageResult');
 			assert.strictEqual(outputs[0].parsed.type, 'html');
 		});
-
-		test('javascript: URL in HTML is routed through webview', () => {
-			const cellWithJsUrl: TestCellInput = {
-				source: 'display(html)',
-				language: 'python',
-				mime: undefined,
-				cellKind: CellKind.Code,
-				outputs: [{
-					outputId: 'output-1',
-					outputs: [{ mime: 'text/html', data: VSBuffer.fromString('<a href="javascript:alert(1)">click</a>') }],
-				}],
-			};
-			const notebook = createTestPositronNotebookInstance([cellWithJsUrl], disposables);
-			const cell = notebook.cells.get()[0];
-
-			assert.ok(cell.isCodeCell());
-			const outputs = cell.outputs.get();
-			assert.strictEqual(outputs.length, 1);
-			assert.ok(outputs[0].preloadMessageResult, 'javascript: URL HTML should have preloadMessageResult');
-			assert.strictEqual(outputs[0].preloadMessageResult!.preloadMessageType, 'display');
-		});
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.test.ts
@@ -205,7 +205,7 @@ suite('Positron Notebook Cell Outputs', () => {
 			const outputs = cell.outputs.get();
 			assert.strictEqual(outputs.length, 1);
 			assert.ok(outputs[0].preloadMessageResult, 'should have a preloadMessageResult');
-			assert.strictEqual(outputs[0].preloadMessageResult?.preloadMessageType, 'display');
+			assert.strictEqual(outputs[0].preloadMessageResult.preloadMessageType, 'display');
 		});
 
 		test('simple HTML output renders inline without preloadMessageResult', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.test.ts
@@ -177,4 +177,77 @@ suite('Positron Notebook Cell Outputs', () => {
 			);
 		});
 	});
+
+	suite('complex HTML routing', () => {
+		function complexHtmlOutputItem() {
+			return { mime: 'text/html', data: VSBuffer.fromString('<html><body><iframe src="map.html"></iframe></body></html>') };
+		}
+
+		function simpleHtmlOutputItem() {
+			return { mime: 'text/html', data: VSBuffer.fromString('<p>Hello world</p>') };
+		}
+
+		test('complex HTML output produces a preloadMessageResult with display type', () => {
+			const cellWithComplexHtml: TestCellInput = {
+				source: 'display_map()',
+				language: 'python',
+				mime: undefined,
+				cellKind: CellKind.Code,
+				outputs: [{
+					outputId: 'output-1',
+					outputs: [complexHtmlOutputItem()],
+				}],
+			};
+			const notebook = createTestPositronNotebookInstance([cellWithComplexHtml], disposables);
+			const cell = notebook.cells.get()[0];
+
+			assert.ok(cell.isCodeCell(), 'cell should be a code cell');
+			const outputs = cell.outputs.get();
+			assert.strictEqual(outputs.length, 1);
+			assert.ok(outputs[0].preloadMessageResult, 'should have a preloadMessageResult');
+			assert.strictEqual(outputs[0].preloadMessageResult!.preloadMessageType, 'display');
+		});
+
+		test('simple HTML output renders inline without preloadMessageResult', () => {
+			const cellWithSimpleHtml: TestCellInput = {
+				source: 'display_html()',
+				language: 'python',
+				mime: undefined,
+				cellKind: CellKind.Code,
+				outputs: [{
+					outputId: 'output-1',
+					outputs: [simpleHtmlOutputItem()],
+				}],
+			};
+			const notebook = createTestPositronNotebookInstance([cellWithSimpleHtml], disposables);
+			const cell = notebook.cells.get()[0];
+
+			assert.ok(cell.isCodeCell());
+			const outputs = cell.outputs.get();
+			assert.strictEqual(outputs.length, 1);
+			assert.strictEqual(outputs[0].preloadMessageResult, undefined, 'simple HTML should not have preloadMessageResult');
+			assert.strictEqual(outputs[0].parsed.type, 'html');
+		});
+
+		test('javascript: URL in HTML is routed through webview', () => {
+			const cellWithJsUrl: TestCellInput = {
+				source: 'display(html)',
+				language: 'python',
+				mime: undefined,
+				cellKind: CellKind.Code,
+				outputs: [{
+					outputId: 'output-1',
+					outputs: [{ mime: 'text/html', data: VSBuffer.fromString('<a href="javascript:alert(1)">click</a>') }],
+				}],
+			};
+			const notebook = createTestPositronNotebookInstance([cellWithJsUrl], disposables);
+			const cell = notebook.cells.get()[0];
+
+			assert.ok(cell.isCodeCell());
+			const outputs = cell.outputs.get();
+			assert.strictEqual(outputs.length, 1);
+			assert.ok(outputs[0].preloadMessageResult, 'javascript: URL HTML should have preloadMessageResult');
+			assert.strictEqual(outputs[0].preloadMessageResult!.preloadMessageType, 'display');
+		});
+	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.test.ts
@@ -205,7 +205,7 @@ suite('Positron Notebook Cell Outputs', () => {
 			const outputs = cell.outputs.get();
 			assert.strictEqual(outputs.length, 1);
 			assert.ok(outputs[0].preloadMessageResult, 'should have a preloadMessageResult');
-			assert.strictEqual(outputs[0].preloadMessageResult!.preloadMessageType, 'display');
+			assert.strictEqual(outputs[0].preloadMessageResult?.preloadMessageType, 'display');
 		});
 
 		test('simple HTML output renders inline without preloadMessageResult', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/testPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/testPositronNotebookInstance.ts
@@ -29,6 +29,8 @@ import { IContextKeyService } from '../../../../../platform/contextkey/common/co
 import { IModelService } from '../../../../../editor/common/services/model.js';
 import { ILanguageService } from '../../../../../editor/common/languages/language.js';
 import { PLAINTEXT_LANGUAGE_ID } from '../../../../../editor/common/languages/modesRegistry.js';
+import { Event } from '../../../../../base/common/event.js';
+import { IPositronWebviewPreloadService } from '../../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
 
 /**
  * Test subclass of PositronNotebookInstance that exposes disposable registration.
@@ -58,6 +60,29 @@ export function positronNotebookInstantiationService(
 	instantiationService.stub(ILanguageFeatureDebounceService, instantiationService.createInstance(LanguageFeatureDebounceService));
 	instantiationService.stub(ILanguageFeaturesService, new LanguageFeaturesService());
 	instantiationService.stub(ITreeSitterLibraryService, new TestTreeSitterLibraryService());
+
+	// Override the real webview preload service with a lightweight mock to avoid
+	// creating real webviews (which create undisposed disposables in unit tests).
+	// The mock returns a display-type result for rawHtml outputs and undefined otherwise.
+	// eslint-disable-next-line local/code-no-dangerous-type-assertions
+	instantiationService.stub(IPositronWebviewPreloadService, {
+		initialize: () => { },
+		attachNotebookInstance: () => { },
+		addNotebookOutput: (opts: { outputId: string; rawHtml?: string }) => {
+			if (opts.rawHtml) {
+				return {
+					preloadMessageType: 'display' as const,
+					webview: Promise.resolve({
+						id: opts.outputId,
+						sessionId: opts.outputId,
+						dispose() { },
+						onDidRender: Event.None,
+					}),
+				};
+			}
+			return undefined;
+		},
+	} as Partial<IPositronWebviewPreloadService> as IPositronWebviewPreloadService);
 
 	return instantiationService;
 }

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/testUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/testUtils.ts
@@ -139,7 +139,22 @@ export async function createPositronNotebookTestServices(disposables: Disposable
 
 	const mockWebviewPreloadService: Partial<IPositronWebviewPreloadService> = {
 		initialize: () => { },
-		attachNotebookInstance: () => { }
+		attachNotebookInstance: () => { },
+		addNotebookOutput: (opts) => {
+			if (opts.rawHtml) {
+				const onDidRender = Event.None;
+				return {
+					preloadMessageType: 'display' as const,
+					webview: Promise.resolve({
+						id: opts.outputId,
+						sessionId: opts.outputId,
+						dispose() { },
+						onDidRender,
+					}),
+				};
+			}
+			return undefined;
+		},
 	};
 	instantiationService.stub(IPositronWebviewPreloadService, mockWebviewPreloadService);
 

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -9,6 +9,7 @@ import { ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageWebOutput } from 
 import { ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { Event } from '../../../../base/common/event.js';
 import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
 
 export const POSITRON_NOTEBOOK_OUTPUT_WEBVIEW_SERVICE_ID = 'positronNotebookOutputWebview';
 
@@ -87,9 +88,9 @@ export interface IPositronNotebookOutputWebviewService {
 	 *
 	 * @param id A unique ID for this webview; typically the output ID.
 	 * @param html The raw HTML content to render.
+	 * @param baseUri Optional base directory used to resolve relative asset URLs in the HTML.
 	 * @returns A promise that resolves to the new webview.
 	 */
-	createRawHtmlOutputWebview(id: string, html: string): Promise<INotebookOutputWebview>;
+	createRawHtmlOutputWebview(id: string, html: string, baseUri?: URI): Promise<INotebookOutputWebview>;
 
 }
-

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewService.ts
@@ -77,5 +77,19 @@ export interface IPositronNotebookOutputWebviewService {
 			viewType?: string;
 		}): Promise<INotebookOutputWebview | undefined>;
 
+	/**
+	 * Create a new notebook output webview that renders raw HTML content directly.
+	 *
+	 * Used for complex HTML outputs (e.g. folium maps, HTML with scripts/iframes)
+	 * that cannot be safely rendered inline due to Trusted Types / CSP restrictions.
+	 * The webview runs in an isolated Electron process with its own CSP, so embedded
+	 * scripts and iframes execute normally.
+	 *
+	 * @param id A unique ID for this webview; typically the output ID.
+	 * @param html The raw HTML content to render.
+	 * @returns A promise that resolves to the new webview.
+	 */
+	createRawHtmlOutputWebview(id: string, html: string): Promise<INotebookOutputWebview>;
+
 }
 

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.test.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Event } from '../../../../base/common/event.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { URI } from '../../../../base/common/uri.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { asWebviewUri } from '../../webview/common/webview.js';
+import { WebviewInitInfo } from '../../webview/browser/webview.js';
+import { PositronNotebookOutputWebviewService } from './notebookOutputWebviewServiceImpl.js';
+
+suite('PositronNotebookOutputWebviewService', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('raw HTML webviews use the notebook base URI for relative assets', async () => {
+		let capturedInitInfo: WebviewInitInfo | undefined;
+		let capturedHtml: string | undefined;
+
+		const webviewService = {
+			createWebviewOverlay(initInfo: WebviewInitInfo) {
+				capturedInitInfo = initInfo;
+				return {
+					setHtml(html: string) {
+						capturedHtml = html;
+					},
+				} as any;
+			},
+		};
+
+		const instantiationService = {
+			createInstance(_ctor: unknown, options: { id: string; sessionId: string; webview: unknown }) {
+				return {
+					id: options.id,
+					sessionId: options.sessionId,
+					webview: options.webview,
+					onDidRender: Event.None,
+					dispose() { },
+				};
+			},
+		} as Partial<IInstantiationService> as IInstantiationService;
+
+		const service = new PositronNotebookOutputWebviewService(
+			webviewService as any,
+			{} as any,
+			{} as any,
+			{} as any,
+			{} as any,
+			instantiationService,
+		);
+
+		const baseUri = URI.file('/workspace/maps');
+		await service.createRawHtmlOutputWebview('output-1', '<iframe src="map.html"></iframe>', baseUri);
+
+		assert.deepStrictEqual(
+			capturedInitInfo?.contentOptions.localResourceRoots?.map(root => root.toString()),
+			[baseUri.toString()],
+		);
+		assert.ok(capturedHtml?.includes(`<base href="${asWebviewUri(baseUri).toString(true)}/">`));
+	});
+});

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -381,8 +381,12 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 	}
 
 	private _buildRawHtmlDocument(html: string, baseUri?: URI): string {
+		// Only inject a <base> tag if the HTML doesn't already define one.
+		// In HTML only the first <base> is honored, so overriding an existing
+		// one would break outputs that set their own base URL.
+		const needsBase = baseUri && !/<base[\s>]/i.test(html);
 		const headContent = [
-			baseUri ? `<base href="${asWebviewUri(baseUri).toString(true)}/">` : '',
+			needsBase ? `<base href="${asWebviewUri(baseUri).toString(true)}/">` : '',
 			PositronNotebookOutputWebviewService.CssAddons,
 			`<script>${webviewMessageCodeString}</script>`,
 		].filter(Boolean).join('\n');

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -380,6 +380,35 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 		return notebookOutputWebview;
 	}
 
+	async createRawHtmlOutputWebview(id: string, html: string): Promise<INotebookOutputWebview> {
+		const webview = this._webviewService.createWebviewOverlay({
+			origin: DOM.getActiveWindow().origin,
+			contentOptions: {
+				allowScripts: true,
+				localResourceRoots: [],
+			},
+			extension: undefined,
+			options: {
+				retainContextWhenHidden: true,
+			},
+			title: '',
+		});
+
+		// Wrap the HTML with the sizing script so useWebviewMount receives
+		// webviewMetrics messages and can set the container height.
+		webview.setHtml(`<head>
+${PositronNotebookOutputWebviewService.CssAddons}
+<script>${webviewMessageCodeString}</script>
+</head>
+<body>${html}</body>`);
+
+		return this._instantiationService.createInstance(NotebookOutputWebview, {
+			id,
+			sessionId: id,
+			webview,
+		});
+	}
+
 	/**
 	 * A set of CSS addons to inject into the HTML of the webview. Used to do things like
 	 * hide elements that are not functional in the context of positron such as links to

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -380,12 +380,44 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 		return notebookOutputWebview;
 	}
 
-	async createRawHtmlOutputWebview(id: string, html: string): Promise<INotebookOutputWebview> {
+	private _buildRawHtmlDocument(html: string, baseUri?: URI): string {
+		const headContent = [
+			baseUri ? `<base href="${asWebviewUri(baseUri).toString(true)}/">` : '',
+			PositronNotebookOutputWebviewService.CssAddons,
+			`<script>${webviewMessageCodeString}</script>`,
+		].filter(Boolean).join('\n');
+
+		if (/<head[\s>]/i.test(html)) {
+			return html.replace(/<head(\s[^>]*)?>/i, match => `${match}\n${headContent}`);
+		}
+
+		if (/<html[\s>]/i.test(html)) {
+			return html.replace(/<html(\s[^>]*)?>/i, match => `${match}\n<head>\n${headContent}\n</head>`);
+		}
+
+		if (/<body[\s>]/i.test(html)) {
+			return `<html>
+<head>
+${headContent}
+</head>
+${html}
+</html>`;
+		}
+
+		return `<html>
+<head>
+${headContent}
+</head>
+<body>${html}</body>
+</html>`;
+	}
+
+	async createRawHtmlOutputWebview(id: string, html: string, baseUri?: URI): Promise<INotebookOutputWebview> {
 		const webview = this._webviewService.createWebviewOverlay({
 			origin: DOM.getActiveWindow().origin,
 			contentOptions: {
 				allowScripts: true,
-				localResourceRoots: [],
+				localResourceRoots: baseUri ? [baseUri] : [],
 			},
 			extension: undefined,
 			options: {
@@ -394,13 +426,9 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 			title: '',
 		});
 
-		// Wrap the HTML with the sizing script so useWebviewMount receives
-		// webviewMetrics messages and can set the container height.
-		webview.setHtml(`<head>
-${PositronNotebookOutputWebviewService.CssAddons}
-<script>${webviewMessageCodeString}</script>
-</head>
-<body>${html}</body>`);
+		// Inject a base URL and sizing script so relative assets resolve and
+		// useWebviewMount receives webviewMetrics messages for layout.
+		webview.setHtml(this._buildRawHtmlDocument(html, baseUri));
 
 		return this._instantiationService.createInstance(NotebookOutputWebview, {
 			id,

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadService.test.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadService.test.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Emitter, Event } from '../../../../base/common/event.js';
+import { VSBuffer } from '../../../../base/common/buffer.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { IPositronWebviewPreloadService } from '../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
+import { PositronWebviewPreloadService } from './positronWebviewPreloadsService.js';
+import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
+import { IPositronNotebookOutputWebviewService, INotebookOutputWebview } from '../../positronOutputWebview/browser/notebookOutputWebviewService.js';
+import { IPositronIPyWidgetsService } from '../../../services/positronIPyWidgets/common/positronIPyWidgetsService.js';
+import { IPositronNotebookInstance } from '../../positronNotebook/browser/IPositronNotebookInstance.js';
+import { IOverlayWebview } from '../../webview/browser/webview.js';
+
+/** Minimal stub for IPositronNotebookInstance */
+function stubNotebookInstance(id: string): IPositronNotebookInstance {
+	return { getId: () => id } as any;
+}
+
+/** Counts raw HTML webview creations */
+function stubOutputWebviewService(): IPositronNotebookOutputWebviewService & { rawHtmlCreationCount: number } {
+	let count = 0;
+	return {
+		_serviceBrand: undefined,
+		get rawHtmlCreationCount() { return count; },
+		createRawHtmlOutputWebview(id: string, _html: string): Promise<INotebookOutputWebview> {
+			count++;
+			const onDidRender = new Emitter<void>();
+			return Promise.resolve({
+				id,
+				sessionId: id,
+				webview: {} as IOverlayWebview,
+				onDidRender: onDidRender.event,
+				dispose() { onDidRender.dispose(); },
+			});
+		},
+		createNotebookOutputWebview: () => Promise.resolve(undefined),
+		createMultiMessageWebview: () => Promise.resolve(undefined),
+	} as any;
+}
+
+suite('PositronWebviewPreloadService - addNotebookOutput rawHtml', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let service: IPositronWebviewPreloadService;
+	let outputWebviewService: ReturnType<typeof stubOutputWebviewService>;
+	const notebookInstance = stubNotebookInstance('nb-1');
+
+	setup(() => {
+		outputWebviewService = stubOutputWebviewService();
+
+		const runtimeSessionService = {
+			activeSessions: [],
+			onWillStartSession: Event.None,
+		} as unknown as IRuntimeSessionService;
+
+		const ipyWidgetsService = {} as IPositronIPyWidgetsService;
+
+		service = disposables.add(new PositronWebviewPreloadService(
+			runtimeSessionService,
+			outputWebviewService,
+			ipyWidgetsService,
+		));
+
+		service.attachNotebookInstance(notebookInstance);
+	});
+
+	test('rawHtml parameter creates a raw HTML webview and returns display result', async () => {
+		const result = service.addNotebookOutput({
+			instance: notebookInstance,
+			outputId: 'out-1',
+			outputs: [{ mime: 'text/html', data: VSBuffer.fromString('<iframe>') }],
+			rawHtml: '<iframe src="map.html"></iframe>',
+		});
+
+		assert.ok(result, 'should return a result');
+		assert.strictEqual(result!.preloadMessageType, 'display');
+		assert.ok('webview' in result!, 'display result should have a webview');
+		assert.strictEqual(outputWebviewService.rawHtmlCreationCount, 1);
+
+		// Resolve the webview promise to check the ID
+		const webview = await (result as any).webview;
+		assert.strictEqual(webview.id, 'out-1');
+		webview.dispose();
+	});
+
+	test('without rawHtml, text/html output returns undefined (not a webview type)', () => {
+		const result = service.addNotebookOutput({
+			instance: notebookInstance,
+			outputId: 'out-2',
+			outputs: [{ mime: 'text/html', data: VSBuffer.fromString('<p>simple</p>') }],
+		});
+
+		assert.strictEqual(result, undefined, 'plain HTML should not create a webview');
+		assert.strictEqual(outputWebviewService.rawHtmlCreationCount, 0);
+	});
+});

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadService.test.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadService.test.ts
@@ -14,20 +14,24 @@ import { IPositronNotebookOutputWebviewService, INotebookOutputWebview } from '.
 import { IPositronIPyWidgetsService } from '../../../services/positronIPyWidgets/common/positronIPyWidgetsService.js';
 import { IPositronNotebookInstance } from '../../positronNotebook/browser/IPositronNotebookInstance.js';
 import { IOverlayWebview } from '../../webview/browser/webview.js';
+import { URI } from '../../../../base/common/uri.js';
 
 /** Minimal stub for IPositronNotebookInstance */
-function stubNotebookInstance(id: string): IPositronNotebookInstance {
-	return { getId: () => id } as any;
+function stubNotebookInstance(id: string, uri = URI.file('/workspace/notebook.ipynb')): IPositronNotebookInstance {
+	return { getId: () => id, uri } as any;
 }
 
 /** Counts raw HTML webview creations */
-function stubOutputWebviewService(): IPositronNotebookOutputWebviewService & { rawHtmlCreationCount: number } {
+function stubOutputWebviewService(): IPositronNotebookOutputWebviewService & { rawHtmlCreationCount: number; rawHtmlBaseUris: (URI | undefined)[] } {
 	let count = 0;
+	const rawHtmlBaseUris: (URI | undefined)[] = [];
 	return {
 		_serviceBrand: undefined,
 		get rawHtmlCreationCount() { return count; },
-		createRawHtmlOutputWebview(id: string, _html: string): Promise<INotebookOutputWebview> {
+		rawHtmlBaseUris,
+		createRawHtmlOutputWebview(id: string, _html: string, baseUri?: URI): Promise<INotebookOutputWebview> {
 			count++;
+			rawHtmlBaseUris.push(baseUri);
 			const onDidRender = new Emitter<void>();
 			return Promise.resolve({
 				id,
@@ -80,11 +84,27 @@ suite('PositronWebviewPreloadService - addNotebookOutput rawHtml', () => {
 		assert.strictEqual(result!.preloadMessageType, 'display');
 		assert.ok('webview' in result!, 'display result should have a webview');
 		assert.strictEqual(outputWebviewService.rawHtmlCreationCount, 1);
+		assert.strictEqual(outputWebviewService.rawHtmlBaseUris[0]?.toString(), URI.file('/workspace').toString());
 
 		// Resolve the webview promise to check the ID
 		const webview = await (result as any).webview;
 		assert.strictEqual(webview.id, 'out-1');
 		webview.dispose();
+	});
+
+	test('untitled notebooks do not set a base URI for raw HTML', () => {
+		const untitledNotebook = stubNotebookInstance('nb-untitled', URI.from({ scheme: 'untitled', path: '/Untitled-1.ipynb' }));
+		service.attachNotebookInstance(untitledNotebook);
+
+		const result = service.addNotebookOutput({
+			instance: untitledNotebook,
+			outputId: 'out-untitled',
+			outputs: [{ mime: 'text/html', data: VSBuffer.fromString('<iframe>') }],
+			rawHtml: '<iframe src="map.html"></iframe>',
+		});
+
+		assert.ok(result, 'should return a result');
+		assert.strictEqual(outputWebviewService.rawHtmlBaseUris[0], undefined);
 	});
 
 	test('without rawHtml, text/html output returns undefined (not a webview type)', () => {

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -16,6 +16,8 @@ import { VSBuffer } from '../../../../base/common/buffer.js';
 import { isWebviewDisplayMessage, getWebviewMessageType } from '../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
 import { IPositronNotebookInstance } from '../../positronNotebook/browser/IPositronNotebookInstance.js';
 import { IPositronIPyWidgetsService } from '../../../services/positronIPyWidgets/common/positronIPyWidgetsService.js';
+import { dirname } from '../../../../base/common/resources.js';
+import { Schemas } from '../../../../base/common/network.js';
 
 /**
  * Format of output from a notebook cell
@@ -194,6 +196,9 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 		// Raw HTML outputs bypass MIME-based type detection and are rendered
 		// directly in an isolated overlay webview.
 		if (rawHtml) {
+			const rawHtmlBaseUri = instance.uri.scheme === Schemas.untitled
+				? undefined
+				: dirname(instance.uri);
 			// TODO: Overlay webviews (display AND raw HTML) are not disposed when
 			// outputs are cleared, cells are deleted, or output types change. A
 			// follow-up PR should add model-change reconciliation for all webview
@@ -202,7 +207,7 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 			// component mount/unmount cycles.
 			return {
 				preloadMessageType: 'display',
-				webview: this._notebookOutputWebviewService.createRawHtmlOutputWebview(outputId, rawHtml),
+				webview: this._notebookOutputWebviewService.createRawHtmlOutputWebview(outputId, rawHtml, rawHtmlBaseUri),
 			};
 		}
 

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/positronWebviewPreloadsService.ts
@@ -177,16 +177,33 @@ export class PositronWebviewPreloadService extends Disposable implements IPositr
 	public addNotebookOutput({
 		instance,
 		outputId,
-		outputs
+		outputs,
+		rawHtml
 	}: {
 		instance: IPositronNotebookInstance;
 		outputId: NotebookOutput['outputId'];
 		outputs: NotebookOutput['outputs'];
+		rawHtml?: string;
 	}): NotebookPreloadOutputResults | undefined {
 		const notebookMessages = this._messagesByNotebookId.get(instance.getId());
 
 		if (!notebookMessages) {
 			throw new Error(`PositronWebviewPreloadService: Notebook ${instance.getId()} not found in messagesByNotebookId map.`);
+		}
+
+		// Raw HTML outputs bypass MIME-based type detection and are rendered
+		// directly in an isolated overlay webview.
+		if (rawHtml) {
+			// TODO: Overlay webviews (display AND raw HTML) are not disposed when
+			// outputs are cleared, cells are deleted, or output types change. A
+			// follow-up PR should add model-change reconciliation for all webview
+			// types. This is also a virtualization prerequisite: when cells are
+			// virtualized, the service will need to hold webviews across
+			// component mount/unmount cycles.
+			return {
+				preloadMessageType: 'display',
+				webview: this._notebookOutputWebviewService.createRawHtmlOutputWebview(outputId, rawHtml),
+			};
 		}
 
 		// Check if this output contains any mime types that require webview handling

--- a/src/vs/workbench/services/positronIPyWidgets/common/webviewPreloadUtils.ts
+++ b/src/vs/workbench/services/positronIPyWidgets/common/webviewPreloadUtils.ts
@@ -136,3 +136,22 @@ export function getWebviewMessageType(outputs: { mime: string }[]): 'widget' | '
 
 	return null;
 }
+
+/**
+ * Checks whether HTML content contains elements that cannot be safely rendered
+ * inline due to Trusted Types / CSP restrictions or because they can load
+ * active external content (scripts, iframes, embeds, full documents).
+ * Such content needs to be routed through a sandboxed webview.
+ */
+export function isComplexHtml(html: string): boolean {
+	const lower = html.toLowerCase();
+	return lower.includes('<script') ||
+		lower.includes('<body') ||
+		lower.includes('<html') ||
+		lower.includes('<iframe') ||
+		lower.includes('<object') ||
+		lower.includes('<embed') ||
+		lower.includes('<!doctype') ||
+		lower.includes('javascript:') ||
+		/\son\w+\s*=/i.test(html);
+}

--- a/src/vs/workbench/services/positronIPyWidgets/common/webviewPreloadUtils.ts
+++ b/src/vs/workbench/services/positronIPyWidgets/common/webviewPreloadUtils.ts
@@ -142,6 +142,11 @@ export function getWebviewMessageType(outputs: { mime: string }[]): 'widget' | '
  * inline due to Trusted Types / CSP restrictions or because they can load
  * active external content (scripts, iframes, embeds, full documents).
  * Such content needs to be routed through a sandboxed webview.
+ *
+ * Uses substring matching rather than word-boundary regex intentionally.
+ * This may over-classify custom elements like `<script-viewer>` as complex,
+ * but a false positive just routes through a webview (safe, still renders).
+ * A false negative would be a security gap. We prefer conservative detection.
  */
 export function isComplexHtml(html: string): boolean {
 	const lower = html.toLowerCase();

--- a/src/vs/workbench/services/positronIPyWidgets/test/common/webviewPreloadUtils.test.ts
+++ b/src/vs/workbench/services/positronIPyWidgets/test/common/webviewPreloadUtils.test.ts
@@ -4,9 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { isComplexHtml } from '../../common/webviewPreloadUtils.js';
 
 suite('isComplexHtml', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
 	// Positive cases: these should all be detected as complex
 	test('detects script tags', () => {
 		assert.strictEqual(isComplexHtml('<div><script>alert(1)</script></div>'), true);

--- a/src/vs/workbench/services/positronIPyWidgets/test/common/webviewPreloadUtils.test.ts
+++ b/src/vs/workbench/services/positronIPyWidgets/test/common/webviewPreloadUtils.test.ts
@@ -10,25 +10,23 @@ import { isComplexHtml } from '../../common/webviewPreloadUtils.js';
 suite('isComplexHtml', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('detects script tags', () => {
-		assert.strictEqual(isComplexHtml('<div><script>alert(1)</script></div>'), true);
-	});
-
-	test('detects iframe tags', () => {
-		assert.strictEqual(isComplexHtml('<iframe src="https://example.com"></iframe>'), true);
-	});
-
-	test('detects full HTML documents', () => {
-		assert.strictEqual(isComplexHtml('<html><body><p>Hello</p></body></html>'), true);
-	});
-
-	test('detects javascript: URLs', () => {
-		assert.strictEqual(isComplexHtml('<a href="javascript:alert(1)">click</a>'), true);
-	});
-
-	test('detects inline event handlers', () => {
-		assert.strictEqual(isComplexHtml('<img src="x" onerror="alert(1)">'), true);
-	});
+	// Each entry exercises a distinct detection branch in isComplexHtml().
+	const complexCases: [string, string][] = [
+		['script', '<div><script>alert(1)</script></div>'],
+		['iframe', '<iframe src="https://example.com"></iframe>'],
+		['object', '<object data="file.swf"></object>'],
+		['embed', '<embed src="file.pdf">'],
+		['body', '<body><p>Hello</p></body>'],
+		['html', '<html><p>Hello</p></html>'],
+		['doctype', '<!DOCTYPE html><html></html>'],
+		['javascript: URL', '<a href="javascript:alert(1)">click</a>'],
+		['event handler', '<img src="x" onerror="alert(1)">'],
+	];
+	for (const [label, html] of complexCases) {
+		test(`detects ${label}`, () => {
+			assert.strictEqual(isComplexHtml(html), true);
+		});
+	}
 
 	test('data attributes containing "on" prefix are not complex', () => {
 		assert.strictEqual(isComplexHtml('<div data-onclick="value">test</div>'), false);

--- a/src/vs/workbench/services/positronIPyWidgets/test/common/webviewPreloadUtils.test.ts
+++ b/src/vs/workbench/services/positronIPyWidgets/test/common/webviewPreloadUtils.test.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { isComplexHtml } from '../../common/webviewPreloadUtils.js';
+
+suite('isComplexHtml', () => {
+	// Positive cases: these should all be detected as complex
+	test('detects script tags', () => {
+		assert.strictEqual(isComplexHtml('<div><script>alert(1)</script></div>'), true);
+	});
+
+	test('detects iframe tags', () => {
+		assert.strictEqual(isComplexHtml('<iframe src="https://example.com"></iframe>'), true);
+	});
+
+	test('detects object tags', () => {
+		assert.strictEqual(isComplexHtml('<object data="file.swf"></object>'), true);
+	});
+
+	test('detects embed tags', () => {
+		assert.strictEqual(isComplexHtml('<embed src="file.pdf">'), true);
+	});
+
+	test('detects full HTML documents with body', () => {
+		assert.strictEqual(isComplexHtml('<html><body><p>Hello</p></body></html>'), true);
+	});
+
+	test('detects doctype declarations', () => {
+		assert.strictEqual(isComplexHtml('<!DOCTYPE html><html></html>'), true);
+	});
+
+	test('detects javascript: URLs', () => {
+		assert.strictEqual(isComplexHtml('<a href="javascript:alert(1)">click</a>'), true);
+	});
+
+	test('detects inline event handlers', () => {
+		assert.strictEqual(isComplexHtml('<img src="x" onerror="alert(1)">'), true);
+	});
+
+	test('detects onclick handler', () => {
+		assert.strictEqual(isComplexHtml('<button onclick="doSomething()">Click</button>'), true);
+	});
+
+	test('is case-insensitive for tags', () => {
+		assert.strictEqual(isComplexHtml('<SCRIPT>alert(1)</SCRIPT>'), true);
+		assert.strictEqual(isComplexHtml('<IFrame src="x"></IFrame>'), true);
+	});
+
+	// Negative cases: these should NOT be detected as complex
+	test('simple HTML paragraph is not complex', () => {
+		assert.strictEqual(isComplexHtml('<p>Hello world</p>'), false);
+	});
+
+	test('HTML with inline styles is not complex', () => {
+		assert.strictEqual(isComplexHtml('<div style="color: red">styled</div>'), false);
+	});
+
+	test('data attributes containing "on" prefix are not complex', () => {
+		assert.strictEqual(isComplexHtml('<div data-onclick="value">test</div>'), false);
+	});
+
+	test('HTML table is not complex', () => {
+		assert.strictEqual(isComplexHtml('<table><tr><td>cell</td></tr></table>'), false);
+	});
+
+	test('empty string is not complex', () => {
+		assert.strictEqual(isComplexHtml(''), false);
+	});
+});

--- a/src/vs/workbench/services/positronIPyWidgets/test/common/webviewPreloadUtils.test.ts
+++ b/src/vs/workbench/services/positronIPyWidgets/test/common/webviewPreloadUtils.test.ts
@@ -10,7 +10,6 @@ import { isComplexHtml } from '../../common/webviewPreloadUtils.js';
 suite('isComplexHtml', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	// Positive cases: these should all be detected as complex
 	test('detects script tags', () => {
 		assert.strictEqual(isComplexHtml('<div><script>alert(1)</script></div>'), true);
 	});
@@ -19,20 +18,8 @@ suite('isComplexHtml', () => {
 		assert.strictEqual(isComplexHtml('<iframe src="https://example.com"></iframe>'), true);
 	});
 
-	test('detects object tags', () => {
-		assert.strictEqual(isComplexHtml('<object data="file.swf"></object>'), true);
-	});
-
-	test('detects embed tags', () => {
-		assert.strictEqual(isComplexHtml('<embed src="file.pdf">'), true);
-	});
-
-	test('detects full HTML documents with body', () => {
+	test('detects full HTML documents', () => {
 		assert.strictEqual(isComplexHtml('<html><body><p>Hello</p></body></html>'), true);
-	});
-
-	test('detects doctype declarations', () => {
-		assert.strictEqual(isComplexHtml('<!DOCTYPE html><html></html>'), true);
 	});
 
 	test('detects javascript: URLs', () => {
@@ -43,33 +30,11 @@ suite('isComplexHtml', () => {
 		assert.strictEqual(isComplexHtml('<img src="x" onerror="alert(1)">'), true);
 	});
 
-	test('detects onclick handler', () => {
-		assert.strictEqual(isComplexHtml('<button onclick="doSomething()">Click</button>'), true);
-	});
-
-	test('is case-insensitive for tags', () => {
-		assert.strictEqual(isComplexHtml('<SCRIPT>alert(1)</SCRIPT>'), true);
-		assert.strictEqual(isComplexHtml('<IFrame src="x"></IFrame>'), true);
-	});
-
-	// Negative cases: these should NOT be detected as complex
-	test('simple HTML paragraph is not complex', () => {
-		assert.strictEqual(isComplexHtml('<p>Hello world</p>'), false);
-	});
-
-	test('HTML with inline styles is not complex', () => {
-		assert.strictEqual(isComplexHtml('<div style="color: red">styled</div>'), false);
-	});
-
 	test('data attributes containing "on" prefix are not complex', () => {
 		assert.strictEqual(isComplexHtml('<div data-onclick="value">test</div>'), false);
 	});
 
-	test('HTML table is not complex', () => {
-		assert.strictEqual(isComplexHtml('<table><tr><td>cell</td></tr></table>'), false);
-	});
-
-	test('empty string is not complex', () => {
-		assert.strictEqual(isComplexHtml(''), false);
+	test('simple HTML is not complex', () => {
+		assert.strictEqual(isComplexHtml('<p>Hello world</p>'), false);
 	});
 });

--- a/src/vs/workbench/services/positronWebviewPreloads/browser/positronWebviewPreloadService.ts
+++ b/src/vs/workbench/services/positronWebviewPreloads/browser/positronWebviewPreloadService.ts
@@ -73,7 +73,9 @@ export interface IPositronWebviewPreloadService {
 	attachNotebookInstance(instance: IPositronNotebookInstance): void;
 
 	/**
-	 * Add output from a notebook cell and process it for webview preloads
+	 * Add output from a notebook cell and process it for webview preloads.
+	 * When rawHtml is provided, the output bypasses MIME-based type detection
+	 * and is rendered directly in an isolated overlay webview.
 	 */
 	addNotebookOutput(
 		opts:
@@ -81,6 +83,7 @@ export interface IPositronWebviewPreloadService {
 				instance: IPositronNotebookInstance;
 				outputId: string;
 				outputs: { mime: string; data: VSBuffer }[];
+				rawHtml?: string;
 			}
 	): NotebookPreloadOutputResults | undefined;
 }


### PR DESCRIPTION
Partially addresses #11802

TLDR: Move many html output types into webviews so they can actually properly run things like iframes and script tags.

---

Some outputs with the html mime type contain `<script>`, `<iframe>`, or other active content that can't render inline in Positron notebooks due to things like CSP restrictions. This hasnt been an issue for things like ipython widgets because they include a widget mime-type as well and we were using that to route to a webview output but some other libraries like leaflet or folium just sent a plain html mime type with everything needed in it. 

### Old Behavior
<img width="751" height="393" alt="image" src="https://github.com/user-attachments/assets/2281991a-cf1e-4283-8169-93e81b9207d4" />


### New Behavior
<img width="767" height="703" alt="image" src="https://github.com/user-attachments/assets/5cae2e7b-214c-4055-ae7a-0d52d9e50b19" />


## Solution

Route "complex" HTML outputs through an isolated overlay webview instead of trying to render them inline. This basically matches what the console does now, although inverted as the console checks for simple html to decide if it can render inline whereas non-webview is our default for performance reasons so we're checking for the case where we _can't_ do that.. 

The approach has three pieces:

1. **Detection** -- an `isComplexHtml()` helper that checks for scripts, iframes, embeds, full documents, `javascript:` URLs, and inline event handlers. 
2. **Webview factory** -- a `createRawHtmlOutputWebview()` method that creates a simple overlay webview with the HTML injected directly (no renderer infrastructure needed)
3. **Routing** -- when `parseCellOutputs()` encounters `text/html` that `isComplexHtml()` flags, it passes a `rawHtml` hint through the existing `addNotebookOutput()` pipeline, which triggers the webview path instead of inline rendering

## What this doesn't do (yet)

- **Webview reconciliation** -- when outputs are cleared or cells deleted, the overlay webview isn't explicitly disposed. This is a pre-existing issue for display webviews too. Dealing with this in this PR would have made it a lot bigger. Will be deferred to a followup PR that also fixes the existing webview problems. 
- **Trust gating** -- complex HTML renders through a webview regardless of workspace trust state. Can be added later if needed.

### Release Notes



#### New Features

- N/A

#### Bug Fixes

- Non-iPywidget HTML-based outputs now render in Positron Notebooks properly. 


### QA Notes

@:positron-notebooks @:html

1. Open a Python notebook and run a cell that produces complex HTML output:
   ```python
   import folium
   m = folium.Map(location=[45.5236, -122.6750])
   m
   ```
   Verify the map renders in an overlay webview (interactive, scrollable, not a blank box).

2. Run a cell that produces simple HTML:
   ```python
   from IPython.display import HTML
   HTML("<p>Hello <strong>world</strong></p>")
   ```
   Verify it still renders inline (no webview, just styled text).

3. Run a cell with a `<script>` tag in the output:
   ```python
   from IPython.display import HTML
   HTML("<div id='target'></div><script>document.getElementById('target').textContent = 'Script ran!'</script>")
   ```
   Verify "Script ran!" appears in the output (the script executes inside the webview).
   
 4.  This cell should allow you to copy and paste properly within the webview.
   ```python
  from IPython.display import HTML
  
  HTML("""
  <html>
  <body>
      <h2>Copy/Paste Test</h2>
      <p>Script not executing</p>
      <table border="1" style="border-collapse: collapse; padding: 8px;">
          <tr><th>Name</th><th>Value</th></tr>
          <tr><td>Alpha</td><td>100</td></tr>
          <tr><td>Beta</td><td>200</td></tr>
          <tr><td>Gamma</td><td>300</td></tr>
      </table>
      <input type="text" value="Can you edit and copy from this input?" style="width: 300px; margin-top: 10px;">
      <script>
          document.querySelector('h2').innerHTML = 'Horray! The script is executing';
      </script>
  </body>
  </html>
  """)
  ```