### PR TITLE
Positron nb sticky cell action bar

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
@@ -39,6 +39,7 @@
 		var(--vscode-positronNotebook-action-bar-h) / 2
 	);
 	--_positron-notebook-cell-gap: 4px;
+	--_positron-notebook-cells-padding-block: 1.5rem;
 	--_positron-notebook-add-cell-buttons-height: 26px; /* Icon 18px + padding 8px */
 	/* Gap between buttons in cell and output action bars */
 	--_positron-notebook-cell-action-bar-button-gap: 0.25rem;
@@ -85,7 +86,7 @@
 }
 
 .positron-notebook-cells-container {
-	padding-block: 1.5rem;
+	padding-block: var(--_positron-notebook-cells-padding-block);
 	padding-inline: 1rem;
 	display: flex;
 	flex-direction: column;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
@@ -3,6 +3,21 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/* Sticky wrapper keeps the action bar visible when scrolling long cells.
+ * Height 0 keeps it out of the flow; the action bar overflows visually.
+ * The wrapper is needed because making the action bar directly sticky with
+ * negative margins causes margin-collapsing with the parent cell (shifting
+ * the cell up) and a height mismatch from the action bar's 2px border. */
+.positron-notebooks-cell-action-bar-container {
+	position: sticky;
+	/* Compensate for the cells container's padding (which offsets sticky
+	 * positioning from the scroll viewport) then add back the action bar
+	 * inset so the bar (positioned at -inset) lands at the viewport edge. */
+	top: calc(var(--_positron-notebook-cells-padding-block) * -1 + var(--vscode-positronNotebook-action-bar-inset));
+	height: 0;
+	z-index: 10;
+}
+
 .positron-notebooks-cell-action-bar {
 	position: absolute;
 	top: calc(var(--vscode-positronNotebook-action-bar-inset) * -1);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
@@ -28,6 +28,7 @@
 	border-style: solid;
 	border-radius: var(--vscode-positronNotebook-cell-radius);
 	background-color: var(--vscode-positronNotebook-action-bar-background);
+	transition: border-radius 0.15s ease-out;
 	display: flex;
 	gap: var(--_positron-notebook-cell-action-bar-button-gap);
 
@@ -37,6 +38,14 @@
 	/* Always show action bar when cell is active (selected) */
 	&.visible {
 		visibility: visible;
+	}
+
+	/* Toggled by useToggleOnSticky while the bar is stuck to the scrollport.
+	 * Square off the top corners so the bar meets the scroll viewport flush. */
+	&.positron-notebooks-cell-action-bar--stuck {
+		border-top-left-radius: 0;
+		border-top-right-radius: 0;
+		border-top-width: 0.5px;
 	}
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -7,7 +7,7 @@
 import './NotebookCellActionBar.css';
 
 // React.
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
@@ -21,8 +21,12 @@ import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.
 import { useMenuActions } from '../useMenuActions.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { PositronNotebookCellActionBarLeftGroup } from '../../common/positronNotebookCommon.js';
+import { useToggleOnSticky } from './useToggleOnSticky.js';
 
 const moreCellActions = localize('moreCellActions', 'More Cell Actions');
+
+/** Class toggled while the sticky action bar is pinned to the notebook scrollport. */
+const ACTION_BAR_STUCK_CLASS = 'positron-notebooks-cell-action-bar--stuck';
 
 interface NotebookCellActionBarProps {
 	cell: IPositronNotebookCell;
@@ -58,7 +62,11 @@ export function NotebookCellActionBar({ cell }: NotebookCellActionBarProps) {
 	// the separator between primary actions and all other actions
 	const lastPrimaryIndex = actionsWithMetadata.findLastIndex(item => item.isPrimary);
 
+	const actionBarRef = useRef<HTMLDivElement>(null);
+	useToggleOnSticky(actionBarRef, ACTION_BAR_STUCK_CLASS);
+
 	return <div
+		ref={actionBarRef}
 		aria-hidden={!isActiveCell}
 		aria-label={localize('cellActions', 'Cell actions')}
 		className={`positron-notebooks-cell-action-bar ${isActiveCell || isMenuOpen ? 'visible' : ''}`}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -194,7 +194,9 @@ export function NotebookCellWrapper({ cell, children }: {
 		}}
 	>
 		<CellScopedContextKeyServiceProvider service={scopedContextKeyService}>
-			<NotebookCellActionBar cell={cell} />
+			<div className='positron-notebooks-cell-action-bar-container'>
+				<NotebookCellActionBar cell={cell} />
+			</div>
 			<NotebookErrorBoundary
 				componentName={`Cell[${cell.isCodeCell() ? 'code' : cell.isMarkdownCell() ? 'markdown' : 'raw'}]`}
 				level='cell'

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useToggleOnSticky.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useToggleOnSticky.tsx
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { useLayoutEffect, type RefObject } from 'react';
+import { getWindow } from '../../../../../base/browser/dom.js';
+
+/**
+ * Toggles a CSS class on an element when its parent (`position: sticky`)
+ * container is pinned to the scrollport.
+ *
+ * A zero-height sentinel is inserted in normal flow right before the sticky
+ * container. An `IntersectionObserver` (with `root: null`) watches the
+ * sentinel. The observer clips the sentinel's bounds against every ancestor
+ * `overflow` container before checking the viewport, so it correctly detects
+ * when the sentinel scrolls past the edge of a nested scroll container --
+ * not just the outer viewport.
+ *
+ * While the sticky container is in its natural position both it and the
+ * sentinel sit at the same place and the sentinel is "intersecting."
+ * When the user scrolls far enough for the container to stick, the sentinel
+ * continues scrolling, gets clipped by the `overflow: auto` ancestor, and
+ * the observer fires with `isIntersecting: false` -- meaning "stuck."
+ *
+ * @param elementRef - Ref to the element that should receive the class
+ * @param classNameForWhenSticky - Class added while stuck, removed otherwise
+ */
+export function useToggleOnSticky(
+	elementRef: RefObject<HTMLElement | null>,
+	classNameForWhenSticky: string,
+): void {
+	useLayoutEffect(() => {
+		const el = elementRef.current;
+		if (!el || classNameForWhenSticky.length === 0) {
+			return;
+		}
+
+		// The sticky container is the direct parent of the target element.
+		const stickyContainer = el.parentElement;
+		if (!stickyContainer?.parentElement) {
+			return;
+		}
+
+		const win = getWindow(el);
+
+		// Sentinel: sits in normal flow right before the sticky container
+		// so it tracks the container's would-be static position.
+		const sentinel = win.document.createElement('div');
+		sentinel.style.height = '0';
+		sentinel.style.visibility = 'hidden';
+		sentinel.style.pointerEvents = 'none';
+		stickyContainer.parentElement.insertBefore(sentinel, stickyContainer);
+
+		// The observer clips against all ancestor overflow containers.
+		// When the sentinel is still within the scroll container's bounds
+		// it is "intersecting" -- the sticky container is not stuck.
+		// Once scrolled past the clip edge of the overflow ancestor the
+		// sentinel area drops to zero, isIntersecting becomes false,
+		// and we know the sticky container is stuck.
+		const observer = new win.IntersectionObserver(
+			([entry]) => {
+				el.classList.toggle(classNameForWhenSticky, !entry.isIntersecting);
+			},
+			{ threshold: [0] },
+		);
+		observer.observe(sentinel);
+
+		return () => {
+			observer.disconnect();
+			sentinel.remove();
+			el.classList.remove(classNameForWhenSticky);
+		};
+	}, [elementRef, classNameForWhenSticky]);
+}


### PR DESCRIPTION
Addresses #10117 

This PR adds sticky behavior to the cell action bar. This allows it to stay always visible when working with very tall cells. 

The PR should be viewed as it was committed. 

## First commit: Sticky behavior

The first commit adds the plain sticky behavior. This is minimal and safe. 

https://github.com/user-attachments/assets/5c032994-05b6-42ae-972c-7d99945e56ce

We just needed to add a wrapper div and use position sticky relative to the cell container. 

 ## Second commit: QOL improvement

The second commit improves the user experience by detecting when the bar is "stuck" and modifying the styles to look less out-of-place. This is obviously more code and potentially risky but I think the micro-interaction is worth the increased complexity. Opinions are eagerly sought though! 
 

https://github.com/user-attachments/assets/2167d97b-9d54-47aa-b663-375e921c8afe

The implementation here involves a new (reusable) hook for detecting sticky status and applying a class. Then a small class for the stuck styles. 

The hook works by placing a "sentinel" element right next to the sticky element. Then as we scroll if the sentinel is no longer right next to the sticky element on the screen then the element must be "stuck".  We use an intersection observer here to make sure we only fire when the status changes. 

@:positron-notebooks 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Positron notebook cell action bars are now sticky and wont scroll out of view for tall cells.

#### Bug Fixes

- N/A


### QA Notes

- Make a super long cell of code
- Activate the cell action bar (make cell active is easiest to test)
- Ensure that if you scroll down the action bar is always visible. 