### PR TITLE
Allow changing the kernel for Quarto documents

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
@@ -25,6 +25,7 @@ import {
 	IS_QUARTO_DOCUMENT,
 	POSITRON_QUARTO_INLINE_OUTPUT_KEY,
 	QUARTO_INLINE_OUTPUT_ENABLED,
+	QUARTO_KERNEL_BUSY,
 	QUARTO_KERNEL_RUNNING,
 	isQuartoDocument,
 	isQuartoOrRmdFile,
@@ -79,6 +80,7 @@ class QuartoInlineOutputContribution extends Disposable implements IWorkbenchCon
 	private readonly _isQuartoDocumentKey = IS_QUARTO_DOCUMENT.bindTo(this._contextKeyService);
 	private readonly _inlineOutputEnabledKey = QUARTO_INLINE_OUTPUT_ENABLED.bindTo(this._contextKeyService);
 	private readonly _kernelRunningKey = QUARTO_KERNEL_RUNNING.bindTo(this._contextKeyService);
+	private readonly _kernelBusyKey = QUARTO_KERNEL_BUSY.bindTo(this._contextKeyService);
 
 	/** Tracks documents that have already had auto-start attempted, so we only auto-start on first open. */
 	private readonly _autoStartedDocuments = new Set<string>();
@@ -173,8 +175,10 @@ class QuartoInlineOutputContribution extends Disposable implements IWorkbenchCon
 				state === QuartoKernelState.Busy ||
 				state === QuartoKernelState.Starting;
 			this._kernelRunningKey.set(isRunning);
+			this._kernelBusyKey.set(state === QuartoKernelState.Busy);
 		} else {
 			this._kernelRunningKey.set(false);
+			this._kernelBusyKey.set(false);
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
@@ -45,7 +45,7 @@ export const enum QuartoCommandId {
 /**
  * Category for Quarto commands.
  */
-const QUARTO_CATEGORY = localize2('quarto.category', 'Quarto');
+const QUARTO_CATEGORY = localize2('quarto.category', "Quarto");
 
 /**
  * Common precondition for Quarto commands: feature enabled and in a Quarto document.
@@ -98,7 +98,7 @@ registerAction2(class CancelExecutionAction extends Action2 {
 		super({
 			id: QuartoCommandId.CancelExecution,
 			title: {
-				value: localize('quarto.cancelExecution', 'Cancel Execution'),
+				value: localize('quarto.cancelExecution', "Cancel Execution"),
 				original: 'Cancel Execution',
 			},
 			category: QUARTO_CATEGORY,
@@ -143,7 +143,7 @@ registerAction2(class ClearAllOutputsAction extends Action2 {
 		super({
 			id: QuartoCommandId.ClearAllOutputs,
 			title: {
-				value: localize('quarto.clearAllOutputs', 'Clear All Outputs'),
+				value: localize('quarto.clearAllOutputs', "Clear All Outputs"),
 				original: 'Clear All Outputs',
 			},
 			category: QUARTO_CATEGORY,
@@ -181,7 +181,7 @@ registerAction2(class RestartKernelAction extends Action2 {
 		super({
 			id: QuartoCommandId.RestartKernel,
 			title: {
-				value: localize('quarto.restartKernel', 'Restart Kernel'),
+				value: localize('quarto.restartKernel', "Restart Kernel"),
 				original: 'Restart Kernel',
 			},
 			category: QUARTO_CATEGORY,
@@ -217,10 +217,7 @@ registerAction2(class InterruptKernelAction extends Action2 {
 	constructor() {
 		super({
 			id: QuartoCommandId.InterruptKernel,
-			title: {
-				value: localize('quarto.interruptKernel', 'Interrupt Kernel'),
-				original: 'Interrupt Kernel',
-			},
+			title: localize2('quarto.interruptKernel', "Interrupt Kernel"),
 			category: QUARTO_CATEGORY,
 			f1: true,
 			precondition: QUARTO_PRECONDITION,
@@ -259,10 +256,7 @@ registerAction2(class ShutdownKernelAction extends Action2 {
 	constructor() {
 		super({
 			id: QuartoCommandId.ShutdownKernel,
-			title: {
-				value: localize('quarto.shutdownKernel', 'Shutdown Kernel'),
-				original: 'Shutdown Kernel',
-			},
+			title: localize2('quarto.shutdownKernel', "Shutdown Kernel"),
 			category: QUARTO_CATEGORY,
 			f1: true,
 			precondition: ContextKeyExpr.and(QUARTO_PRECONDITION, QUARTO_KERNEL_RUNNING),
@@ -298,10 +292,7 @@ registerAction2(class ChangeKernelAction extends Action2 {
 	constructor() {
 		super({
 			id: QuartoCommandId.ChangeKernel,
-			title: {
-				value: localize('quarto.changeKernel', 'Change Kernel...'),
-				original: 'Change Kernel...',
-			},
+			title: localize2('quarto.changeKernel', "Change Kernel..."),
 			category: QUARTO_CATEGORY,
 			f1: true,
 			precondition: ContextKeyExpr.and(
@@ -340,7 +331,7 @@ registerAction2(class ChangeKernelAction extends Action2 {
 		const currentRuntimeId = currentSession?.runtimeMetadata.runtimeId;
 
 		const quickPick = quickInputService.createQuickPick<IQuickPickItem & { runtime?: ILanguageRuntimeMetadata }>();
-		quickPick.title = localize('quarto.changeKernel.title', 'Select Quarto Kernel');
+		quickPick.title = localize('quarto.changeKernel.title', "Select Quarto Kernel");
 
 		const gatherRuntimePicks = () => {
 			const runtimes = languageRuntimeService.registeredRuntimes
@@ -349,7 +340,7 @@ registerAction2(class ChangeKernelAction extends Action2 {
 			if (runtimes.length === 0) {
 				quickPick.busy = true;
 				quickPick.items = [{
-					label: localize('quarto.changeKernel.noRuntime', 'No {0} runtimes found', language),
+					label: localize('quarto.changeKernel.noRuntime', "No {0} runtimes found", language),
 				}];
 			} else {
 				quickPick.busy = false;
@@ -405,10 +396,7 @@ registerAction2(class CopyOutputAction extends Action2 {
 	constructor() {
 		super({
 			id: QuartoCommandId.CopyOutput,
-			title: {
-				value: localize('quarto.copyOutput', 'Copy Cell Output'),
-				original: 'Copy Cell Output',
-			},
+			title: localize2('quarto.copyOutput', "Copy Cell Output"),
 			category: QUARTO_CATEGORY,
 			f1: true,
 			precondition: QUARTO_PRECONDITION,
@@ -448,10 +436,7 @@ registerAction2(class ClearOutputCacheAction extends Action2 {
 	constructor() {
 		super({
 			id: QuartoCommandId.ClearOutputCache,
-			title: {
-				value: localize('quarto.clearOutputCache', 'Clear Inline Output Cache...'),
-				original: 'Clear Inline Output Cache...',
-			},
+			title: localize2('quarto.clearOutputCache', "Clear Inline Output Cache..."),
 			category: QUARTO_CATEGORY,
 			f1: true,
 			precondition: QUARTO_INLINE_OUTPUT_ENABLED,
@@ -470,9 +455,9 @@ registerAction2(class ClearOutputCacheAction extends Action2 {
 		// If cache is empty, show a simple message
 		if (cacheInfo.fileCount === 0) {
 			await modalDialogsService.showSimpleModalDialogMessage(
-				localize('quarto.cacheEmpty.title', 'Cache Empty'),
-				localize('quarto.cacheEmpty.message', 'The Quarto inline output cache is empty.'),
-				localize('quarto.ok', 'OK')
+				localize('quarto.cacheEmpty.title', "Cache Empty"),
+				localize('quarto.cacheEmpty.message', "The Quarto inline output cache is empty."),
+				localize('quarto.ok', "OK")
 			);
 			return;
 		}
@@ -482,15 +467,15 @@ registerAction2(class ClearOutputCacheAction extends Action2 {
 
 		// Show confirmation dialog
 		const confirmed = await modalDialogsService.showSimpleModalDialogPrompt(
-			localize('quarto.clearCache.title', 'Clear Inline Output Cache'),
+			localize('quarto.clearCache.title', "Clear Inline Output Cache"),
 			localize(
 				'quarto.clearCache.message',
-				'The Quarto inline output cache is using {0} of storage ({1} files).\n\nOutputs from all documents will be removed. This action cannot be undone.',
+				"The Quarto inline output cache is using {0} of storage ({1} files).\n\nOutputs from all documents will be removed. This action cannot be undone.",
 				formattedSize,
 				cacheInfo.fileCount
 			),
-			localize('quarto.clearCache.confirm', 'Remove'),
-			localize('quarto.cancel', 'Cancel'),
+			localize('quarto.clearCache.confirm', "Remove"),
+			localize('quarto.cancel', "Cancel"),
 			250 // height
 		);
 
@@ -510,7 +495,7 @@ registerAction2(class ClearOutputCacheAction extends Action2 {
 			notificationService.info(
 				localize(
 					'quarto.clearCache.success',
-					'Quarto inline output cache removed successfully ({0} files, {1})',
+					"Quarto inline output cache removed successfully ({0} files, {1})",
 					result.filesDeleted,
 					formattedFreed
 				)
@@ -525,7 +510,7 @@ registerAction2(class ClearOutputCacheAction extends Action2 {
 				severity: Severity.Warning,
 				message: localize(
 					'quarto.clearCache.partial',
-					'Quarto inline output cache partially cleared ({0} of {1} files removed). Some errors occurred:\n{2}',
+					"Quarto inline output cache partially cleared ({0} of {1} files removed). Some errors occurred:\n{2}",
 					result.filesDeleted,
 					cacheInfo.fileCount,
 					errorSummary
@@ -543,10 +528,7 @@ registerAction2(class ShowOutputCacheAction extends Action2 {
 	constructor() {
 		super({
 			id: QuartoCommandId.ShowOutputCache,
-			title: {
-				value: localize('quarto.showOutputCache', 'Show Output Cache'),
-				original: 'Show Output Cache',
-			},
+			title: localize2('quarto.showOutputCache', "Show Output Cache"),
 			category: QUARTO_CATEGORY,
 			f1: true,
 			precondition: QUARTO_INLINE_OUTPUT_ENABLED,
@@ -563,7 +545,7 @@ registerAction2(class ShowOutputCacheAction extends Action2 {
 		const context = getQuartoContext(editorService);
 		if (!context) {
 			notificationService.info(
-				localize('quarto.showOutputCache.noQuartoFile', 'Open a Quarto file to view its output cache.')
+				localize('quarto.showOutputCache.noQuartoFile', "Open a Quarto file to view its output cache.")
 			);
 			return;
 		}
@@ -580,7 +562,7 @@ registerAction2(class ShowOutputCacheAction extends Action2 {
 			notificationService.info(
 				localize(
 					'quarto.showOutputCache.noCacheExists',
-					'No output cache exists for {0}. Run one or more cells in the document to create one.',
+					"No output cache exists for {0}. Run one or more cells in the document to create one.",
 					fileName
 				)
 			);
@@ -607,10 +589,7 @@ registerAction2(class SaveCellPlotAction extends Action2 {
 	constructor() {
 		super({
 			id: QuartoCommandId.SaveCellPlot,
-			title: {
-				value: localize('quarto.saveCellPlot', 'Save Cell Plot Output As...'),
-				original: 'Save Cell Plot Output As...',
-			},
+			title: localize2('quarto.saveCellPlot', "Save Cell Plot Output As..."),
 			category: QUARTO_CATEGORY,
 			f1: true,
 			precondition: QUARTO_PRECONDITION,
@@ -629,7 +608,7 @@ registerAction2(class SaveCellPlotAction extends Action2 {
 		const { editor } = context;
 		const position = editor.getPosition();
 		if (!position) {
-			notificationService.warn(localize('quarto.saveCellPlot.noCursor', 'No cursor position'));
+			notificationService.warn(localize('quarto.saveCellPlot.noCursor', "No cursor position"));
 			return false;
 		}
 
@@ -642,14 +621,14 @@ registerAction2(class SaveCellPlotAction extends Action2 {
 		// Check if cursor is in a cell
 		const cellId = contribution.getCellIdAtLine(position.lineNumber);
 		if (!cellId) {
-			notificationService.warn(localize('quarto.saveCellPlot.noCell', 'Cursor is not in a code cell'));
+			notificationService.warn(localize('quarto.saveCellPlot.noCell', "Cursor is not in a code cell"));
 			return false;
 		}
 
 		// Get plot info for the cell at cursor position
 		const plotInfo = contribution.getPlotInfoForCellAtLine(position.lineNumber);
 		if (!plotInfo) {
-			notificationService.warn(localize('quarto.saveCellPlot.noPlot', 'No single plot output in this cell'));
+			notificationService.warn(localize('quarto.saveCellPlot.noPlot', "No single plot output in this cell"));
 			return false;
 		}
 
@@ -693,7 +672,7 @@ registerAction2(class PopoutOutputAction extends Action2 {
 		const { editor } = context;
 		const position = editor.getPosition();
 		if (!position) {
-			notificationService.warn(localize('quarto.popoutOutput.noCursor', 'No cursor position'));
+			notificationService.warn(localize('quarto.popoutOutput.noCursor', "No cursor position"));
 			return false;
 		}
 
@@ -706,14 +685,14 @@ registerAction2(class PopoutOutputAction extends Action2 {
 		// Check if cursor is in a cell
 		const cellId = contribution.getCellIdAtLine(position.lineNumber);
 		if (!cellId) {
-			notificationService.warn(localize('quarto.popoutOutput.noCell', 'Cursor is not in a code cell'));
+			notificationService.warn(localize('quarto.popoutOutput.noCell', "Cursor is not in a code cell"));
 			return false;
 		}
 
 		// Try to popout the output for the cell at cursor position
 		const success = contribution.popoutForCellAtLine(position.lineNumber);
 		if (!success) {
-			notificationService.warn(localize('quarto.popoutOutput.noOutput', 'No output available to open for this cell'));
+			notificationService.warn(localize('quarto.popoutOutput.noOutput', "No output available to open for this cell"));
 			return false;
 		}
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
@@ -357,8 +357,15 @@ registerAction2(class ChangeKernelAction extends Action2 {
 					label: runtime.runtimeName,
 					description: runtime.runtimePath,
 					runtime,
-					picked: runtime.runtimeId === currentRuntimeId,
 				}));
+
+				// Pre-select the current runtime
+				const currentItem = quickPick.items.find(
+					item => (item as any).runtime?.runtimeId === currentRuntimeId
+				);
+				if (currentItem) {
+					quickPick.activeItems = [currentItem];
+				}
 			}
 		};
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
@@ -14,11 +14,13 @@ import { ITextModel } from '../../../../editor/common/model.js';
 import { IQuartoExecutionManager, IQuartoOutputCacheService } from '../common/quartoExecutionTypes.js';
 import { IQuartoKernelManager } from './quartoKernelManager.js';
 import { IQuartoOutputManager } from './quartoOutputManager.js';
-import { IS_QUARTO_DOCUMENT, QUARTO_INLINE_OUTPUT_ENABLED, QUARTO_KERNEL_RUNNING, isQuartoDocument } from '../common/positronQuartoConfig.js';
+import { IS_QUARTO_DOCUMENT, QUARTO_INLINE_OUTPUT_ENABLED, QUARTO_KERNEL_BUSY, QUARTO_KERNEL_RUNNING, isQuartoDocument } from '../common/positronQuartoConfig.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { QuartoOutputContribution } from './quartoOutputManager.js';
 import { IPositronModalDialogsService } from '../../../services/positronModalDialogs/common/positronModalDialogs.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ByteSize, IFileService } from '../../../../platform/files/common/files.js';
 import { basename } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -285,6 +287,103 @@ registerAction2(class ShutdownKernelAction extends Action2 {
 		const { documentUri } = context;
 
 		await kernelManager.shutdownKernelForDocument(documentUri);
+	}
+});
+
+/**
+ * Change the kernel for the current Quarto document.
+ * Shows a quick pick with available runtimes matching the document's language.
+ */
+registerAction2(class ChangeKernelAction extends Action2 {
+	constructor() {
+		super({
+			id: QuartoCommandId.ChangeKernel,
+			title: {
+				value: localize('quarto.changeKernel', 'Change Kernel...'),
+				original: 'Change Kernel...',
+			},
+			category: QUARTO_CATEGORY,
+			f1: true,
+			precondition: ContextKeyExpr.and(
+				QUARTO_PRECONDITION,
+				QUARTO_KERNEL_BUSY.negate()
+			),
+			menu: {
+				id: MenuId.PositronQuartoKernelSubmenu,
+				order: 0,
+				when: QUARTO_KERNEL_BUSY.negate(),
+			},
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const kernelManager = accessor.get(IQuartoKernelManager);
+		const quickInputService = accessor.get(IQuickInputService);
+		const languageRuntimeService = accessor.get(ILanguageRuntimeService);
+
+		const context = getQuartoContext(editorService);
+		if (!context) {
+			return;
+		}
+
+		const { documentUri } = context;
+
+		// Get the document's primary language to filter runtimes
+		const language = await kernelManager.getDocumentLanguage(documentUri);
+		if (!language) {
+			return;
+		}
+
+		// Get the current session's runtime ID to mark as selected
+		const currentSession = kernelManager.getSessionForDocument(documentUri);
+		const currentRuntimeId = currentSession?.runtimeMetadata.runtimeId;
+
+		const quickPick = quickInputService.createQuickPick<IQuickPickItem & { runtime?: ILanguageRuntimeMetadata }>();
+		quickPick.title = localize('quarto.changeKernel.title', 'Select Quarto Kernel');
+
+		const gatherRuntimePicks = () => {
+			const runtimes = languageRuntimeService.registeredRuntimes
+				.filter(r => r.languageId === language);
+
+			if (runtimes.length === 0) {
+				quickPick.busy = true;
+				quickPick.items = [{
+					label: localize('quarto.changeKernel.noRuntime', 'No {0} runtimes found', language),
+				}];
+			} else {
+				quickPick.busy = false;
+				quickPick.items = runtimes.map(runtime => ({
+					label: runtime.runtimeName,
+					description: runtime.runtimePath,
+					runtime,
+					picked: runtime.runtimeId === currentRuntimeId,
+				}));
+			}
+		};
+
+		// Watch for new runtimes being registered
+		const onDidRegisterDisposable = languageRuntimeService.onDidRegisterRuntime(gatherRuntimePicks);
+
+		gatherRuntimePicks();
+
+		return new Promise<void>(resolve => {
+			quickPick.onDidAccept(async () => {
+				const selected = quickPick.selectedItems[0];
+				if (selected?.runtime && selected.runtime.runtimeId !== currentRuntimeId) {
+					await kernelManager.changeKernelForDocument(documentUri, selected.runtime.runtimeId);
+				}
+				quickPick.hide();
+			});
+
+			quickPick.show();
+
+			quickPick.onDidHide(() => {
+				onDidRegisterDisposable.dispose();
+				quickPick.dispose();
+				resolve();
+			});
+		});
 	}
 });
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
@@ -368,10 +368,13 @@ registerAction2(class ChangeKernelAction extends Action2 {
 		gatherRuntimePicks();
 
 		return new Promise<void>(resolve => {
-			quickPick.onDidAccept(async () => {
+			quickPick.onDidAccept(() => {
 				const selected = quickPick.selectedItems[0];
 				if (selected?.runtime && selected.runtime.runtimeId !== currentRuntimeId) {
-					await kernelManager.changeKernelForDocument(documentUri, selected.runtime.runtimeId);
+					// Fire and forget; the kernel state badge will show
+					// progress as the old kernel shuts down and the new
+					// one starts up.
+					kernelManager.changeKernelForDocument(documentUri, selected.runtime.runtimeId);
 				}
 				quickPick.hide();
 			});

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
@@ -718,13 +718,9 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 	 * Persist kernel bindings to workspace storage.
 	 */
 	private _persistKernelBindings(): void {
-		const data: Record<string, string> = {};
-		for (const [key, value] of this._kernelBindings) {
-			data[key] = value;
-		}
 		this._storageService.store(
 			STORAGE_KEY_KERNEL_BINDINGS,
-			JSON.stringify(data),
+			JSON.stringify(Object.fromEntries(this._kernelBindings)),
 			StorageScope.WORKSPACE,
 			StorageTarget.MACHINE
 		);

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
@@ -797,7 +797,12 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 				const persistedRuntimeId = this._kernelBindings.get(documentUri.toString());
 				if (persistedRuntimeId) {
 					runtime = this._languageRuntimeService.registeredRuntimes
-						.find(r => r.runtimeId === persistedRuntimeId);
+						.find(r => r.runtimeId === persistedRuntimeId && r.languageId === language);
+					if (!runtime) {
+						// Persisted binding doesn't match the current language; clear it
+						this._kernelBindings.delete(documentUri.toString());
+						this._persistKernelBindings();
+					}
 				}
 			}
 			if (!runtime) {

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
@@ -593,7 +593,28 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 		return QuartoKernelState.None;
 	}
 
+	/**
+	 * Shut down the kernel for a document, logging any errors.
+	 *
+	 * @param documentUri The URI of the document whose kernel should be shut down.
+	 */
 	async shutdownKernelForDocument(documentUri: URI): Promise<void> {
+		try {
+			await this.tryShutdownKernelForDocument(documentUri);
+		} catch (error) {
+			this._logService.error(`[QuartoKernelManager] Failed to shut down kernel for ${documentUri.toString()}:`, error);
+		}
+	}
+
+	/**
+	 * Try to shut down the kernel for a document, throwing any errors to the caller.
+	 *
+	 * @param documentUri The URI of the document whose kernel should be shut down.
+	 *
+	 * @returns A promise that resolves when the kernel has been shut down, or
+	 * rejects if an error occurs during shutdown.
+	 */
+	async tryShutdownKernelForDocument(documentUri: URI): Promise<void> {
 		const info = this._documentKernels.get(documentUri);
 		if (!info) {
 			return;
@@ -617,8 +638,6 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 				RuntimeExitReason.Shutdown,
 				'Quarto kernel shutdown',
 			);
-		} catch (error) {
-			this._logService.warn(`[QuartoKernelManager] Error shutting down kernel: ${error}`);
 		} finally {
 			// For cleanup, we want to. dispose of listeners, then fire the state-change
 			// event while the _documentKernels entry is still present, then delete the entry.
@@ -673,7 +692,7 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 		// so that the user can still switch to the new kernel.
 		const oldRuntimeName = this._documentKernels.get(documentUri)?.session?.runtimeMetadata.runtimeName;
 		try {
-			await this.shutdownKernelForDocument(documentUri);
+			await this.tryShutdownKernelForDocument(documentUri);
 		} catch (error) {
 			this._logService.error(`[QuartoKernelManager] Failed to shut down existing kernel for ${documentUri.toString()}:`, error);
 			this._notificationService.warn(

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
@@ -676,10 +676,6 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 		documentUri: URI,
 		runtimeId: string
 	): Promise<ILanguageRuntimeSession | undefined> {
-		// Persist the selection
-		this._kernelBindings.set(documentUri.toString(), runtimeId);
-		this._persistKernelBindings();
-
 		// Find the runtime metadata for the requested runtime
 		const runtime = this._languageRuntimeService.registeredRuntimes
 			.find(r => r.runtimeId === runtimeId);
@@ -687,6 +683,10 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 			this._logService.warn(`[QuartoKernelManager] Runtime not found: ${runtimeId}`);
 			return undefined;
 		}
+
+		// Persist the selection now that we've validated the runtime exists
+		this._kernelBindings.set(documentUri.toString(), runtimeId);
+		this._persistKernelBindings();
 
 		// Shut down any existing session; if this fails, warn but continue
 		// so that the user can still switch to the new kernel.

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
@@ -173,8 +173,8 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 					this._kernelBindings.set(key, value);
 				}
 			}
-		} catch {
-			// ignore
+		} catch (e) {
+			this._logService.warn('[QuartoKernelManager] Failed to parse persisted kernel bindings: ', e);
 		}
 
 		// Clean up sessions when documents are closed
@@ -661,15 +661,30 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 		this._kernelBindings.set(documentUri.toString(), runtimeId);
 		this._persistKernelBindings();
 
-		// Shut down any existing session
-		await this.shutdownKernelForDocument(documentUri);
-
 		// Find the runtime metadata for the requested runtime
 		const runtime = this._languageRuntimeService.registeredRuntimes
 			.find(r => r.runtimeId === runtimeId);
 		if (!runtime) {
 			this._logService.warn(`[QuartoKernelManager] Runtime not found: ${runtimeId}`);
 			return undefined;
+		}
+
+		// Shut down any existing session; if this fails, warn but continue
+		// so that the user can still switch to the new kernel.
+		const oldRuntimeName = this._documentKernels.get(documentUri)?.session?.runtimeMetadata.runtimeName;
+		try {
+			await this.shutdownKernelForDocument(documentUri);
+		} catch (error) {
+			this._logService.error(`[QuartoKernelManager] Failed to shut down existing kernel for ${documentUri.toString()}:`, error);
+			this._notificationService.warn(
+				localize(
+					'quartoKernel.shutdownFailed',
+					"Failed to shut down {0} while switching to {1}: {2}",
+					oldRuntimeName ?? 'the previous kernel',
+					runtime.runtimeName,
+					error instanceof Error ? error.message : String(error)
+				)
+			);
 		}
 
 		// Start a new session with the specified runtime

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
@@ -12,6 +12,7 @@ import { Action } from '../../../../base/common/actions.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { localize } from '../../../../nls.js';
 import {
 	ILanguageRuntimeSession,
@@ -19,7 +20,7 @@ import {
 	RuntimeStartMode,
 } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
-import { LanguageRuntimeSessionMode, RuntimeExitReason, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionMode, RuntimeExitReason, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IQuartoDocumentModelService } from './quartoDocumentModelService.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { ITextModel } from '../../../../editor/common/model.js';
@@ -101,6 +102,18 @@ export interface IQuartoKernelManager {
 	 * Interrupt the kernel for a document.
 	 */
 	interruptKernelForDocument(documentUri: URI): void;
+
+	/**
+	 * Change the kernel for a document. Shuts down any existing session
+	 * and starts a new one with the specified runtime.
+	 * The choice is persisted so it will be used on subsequent opens.
+	 */
+	changeKernelForDocument(documentUri: URI, runtimeId: string): Promise<ILanguageRuntimeSession | undefined>;
+
+	/**
+	 * Get the primary language for a document.
+	 */
+	getDocumentLanguage(documentUri: URI): Promise<string | undefined>;
 }
 
 /**
@@ -114,6 +127,9 @@ interface DocumentKernelInfo {
 	startupCancellation: CancellationTokenSource | undefined;
 }
 
+/** Storage key for persisted kernel selections. */
+const STORAGE_KEY_KERNEL_BINDINGS = 'positronQuarto.kernelBindings';
+
 /**
  * Implementation of the Quarto kernel manager.
  * Manages kernel sessions for Quarto documents, one session per document.
@@ -122,6 +138,9 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 	declare readonly _serviceBrand: undefined;
 
 	private readonly _documentKernels = new ResourceMap<DocumentKernelInfo>();
+
+	/** Persisted runtime selections keyed by document URI string. */
+	private readonly _kernelBindings = new Map<string, string>();
 
 	/** Pending cleanup timeouts, tracked so they can be cancelled on dispose */
 	private readonly _pendingCleanupTimeouts = new Set<ReturnType<typeof setTimeout>>();
@@ -135,14 +154,28 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 	constructor(
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
 		@IRuntimeStartupService private readonly _runtimeStartupService: IRuntimeStartupService,
+		@ILanguageRuntimeService private readonly _languageRuntimeService: ILanguageRuntimeService,
 		@IQuartoDocumentModelService private readonly _quartoDocumentModelService: IQuartoDocumentModelService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@ILogService private readonly _logService: ILogService,
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IStorageService private readonly _storageService: IStorageService,
 		@IQuartoOutputCacheService private readonly _cacheService: IQuartoOutputCacheService,
 	) {
 		super();
+
+		// Restore persisted kernel bindings
+		try {
+			const data = JSON.parse(this._storageService.get(STORAGE_KEY_KERNEL_BINDINGS, StorageScope.WORKSPACE, '{}'));
+			for (const [key, value] of Object.entries(data)) {
+				if (typeof value === 'string') {
+					this._kernelBindings.set(key, value);
+				}
+			}
+		} catch {
+			// ignore
+		}
 
 		// Clean up sessions when documents are closed
 		this._register(this._editorService.onDidCloseEditor(e => {
@@ -620,12 +653,56 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 		}
 	}
 
+	async changeKernelForDocument(
+		documentUri: URI,
+		runtimeId: string
+	): Promise<ILanguageRuntimeSession | undefined> {
+		// Persist the selection
+		this._kernelBindings.set(documentUri.toString(), runtimeId);
+		this._persistKernelBindings();
+
+		// Shut down any existing session
+		await this.shutdownKernelForDocument(documentUri);
+
+		// Find the runtime metadata for the requested runtime
+		const runtime = this._languageRuntimeService.registeredRuntimes
+			.find(r => r.runtimeId === runtimeId);
+		if (!runtime) {
+			this._logService.warn(`[QuartoKernelManager] Runtime not found: ${runtimeId}`);
+			return undefined;
+		}
+
+		// Start a new session with the specified runtime
+		return this._startKernelWithRetry(documentUri, undefined, runtime);
+	}
+
+	async getDocumentLanguage(documentUri: URI): Promise<string | undefined> {
+		return this._getDocumentLanguage(documentUri);
+	}
+
+	/**
+	 * Persist kernel bindings to workspace storage.
+	 */
+	private _persistKernelBindings(): void {
+		const data: Record<string, string> = {};
+		for (const [key, value] of this._kernelBindings) {
+			data[key] = value;
+		}
+		this._storageService.store(
+			STORAGE_KEY_KERNEL_BINDINGS,
+			JSON.stringify(data),
+			StorageScope.WORKSPACE,
+			StorageTarget.MACHINE
+		);
+	}
+
 	/**
 	 * Start a kernel with retry logic and exponential backoff.
 	 */
 	private async _startKernelWithRetry(
 		documentUri: URI,
-		token?: CancellationToken
+		token?: CancellationToken,
+		runtimeOverride?: ILanguageRuntimeMetadata
 	): Promise<ILanguageRuntimeSession | undefined> {
 		let lastError: Error | undefined;
 
@@ -636,7 +713,7 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 			}
 
 			try {
-				const session = await this._startKernel(documentUri, token);
+				const session = await this._startKernel(documentUri, token, runtimeOverride);
 				if (session) {
 					return session;
 				}
@@ -665,10 +742,12 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 
 	/**
 	 * Start a kernel session for a document.
+	 * @param runtimeOverride If provided, use this runtime instead of the preferred one.
 	 */
 	private async _startKernel(
 		documentUri: URI,
-		token?: CancellationToken
+		token?: CancellationToken,
+		runtimeOverride?: ILanguageRuntimeMetadata
 	): Promise<ILanguageRuntimeSession | undefined> {
 		// Initialize or get document info
 		let info = this._documentKernels.get(documentUri);
@@ -709,8 +788,21 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 			info.language = language;
 			this._logService.debug(`[QuartoKernelManager] Starting ${language} kernel for ${documentUri.toString()}`);
 
-			// Get preferred runtime for language
-			const runtime = this._runtimeStartupService.getPreferredRuntime(language);
+			// Determine which runtime to use:
+			// 1. Explicit override (from changeKernelForDocument)
+			// 2. Persisted binding for this document
+			// 3. Preferred runtime for the language
+			let runtime: ILanguageRuntimeMetadata | undefined = runtimeOverride;
+			if (!runtime) {
+				const persistedRuntimeId = this._kernelBindings.get(documentUri.toString());
+				if (persistedRuntimeId) {
+					runtime = this._languageRuntimeService.registeredRuntimes
+						.find(r => r.runtimeId === persistedRuntimeId);
+				}
+			}
+			if (!runtime) {
+				runtime = this._runtimeStartupService.getPreferredRuntime(language);
+			}
 			if (!runtime) {
 				this._logService.warn(`[QuartoKernelManager] No runtime found for language: ${language}`);
 				this._setKernelState(documentUri, QuartoKernelState.Error);

--- a/src/vs/workbench/contrib/positronQuarto/common/positronQuartoConfig.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/positronQuartoConfig.ts
@@ -53,6 +53,16 @@ export const QUARTO_KERNEL_RUNNING = new RawContextKey<boolean>(
 	localize('quartoKernelRunning', 'Whether the active Quarto document has a running kernel')
 );
 
+/**
+ * Context key for whether the active Quarto document's kernel is busy executing code.
+ * Used to disable actions like Change Kernel while code is running.
+ */
+export const QUARTO_KERNEL_BUSY = new RawContextKey<boolean>(
+	'positron.quartoKernelBusy',
+	false,
+	localize('quartoKernelBusy', 'Whether the active Quarto document kernel is busy executing code')
+);
+
 // Register the configuration setting
 const configurationRegistry = Registry.as<IConfigurationRegistry>(
 	Extensions.Configuration

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoKernelManager.test.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoKernelManager.test.ts
@@ -1,0 +1,265 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* eslint-disable local/code-no-dangerous-type-assertions */
+
+import assert from 'assert';
+import { URI } from '../../../../../base/common/uri.js';
+import { Event } from '../../../../../base/common/event.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { TestRuntimeStartupService } from '../../../../services/runtimeStartup/test/common/testRuntimeStartupService.js';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionMode, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionLocation, RuntimeExitReason, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { IQuartoDocumentModelService } from '../../browser/quartoDocumentModelService.js';
+import { IQuartoOutputCacheService } from '../../common/quartoExecutionTypes.js';
+import { QuartoKernelManager, QuartoKernelState } from '../../browser/quartoKernelManager.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
+
+function makeRuntime(id: string, languageId: string, name: string): ILanguageRuntimeMetadata {
+	return {
+		base64EncodedIconSvg: '',
+		extensionId: { value: 'test.extension' } as ExtensionIdentifier,
+		extraRuntimeData: {},
+		languageId,
+		runtimeId: id,
+		runtimeName: name,
+		languageName: languageId,
+		languageVersion: '1.0.0',
+		runtimePath: `/path/to/${id}`,
+		runtimeShortName: name,
+		runtimeSource: 'test',
+		runtimeVersion: '1.0.0',
+		sessionLocation: LanguageRuntimeSessionLocation.Machine,
+		startupBehavior: LanguageRuntimeStartupBehavior.Explicit,
+	};
+}
+
+const pythonRuntime1 = makeRuntime('python-3.11', 'python', 'Python 3.11');
+const pythonRuntime2 = makeRuntime('python-3.12', 'python', 'Python 3.12');
+const rRuntime1 = makeRuntime('r-4.4', 'r', 'R 4.4');
+
+const docUri = URI.file('/test/doc.qmd');
+
+suite('QuartoKernelManager', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
+	let kernelManager: QuartoKernelManager;
+	let runtimeStartupService: TestRuntimeStartupService;
+	let storageService: InMemoryStorageService;
+
+	// Track calls to startNewRuntimeSession
+	let startedRuntimeIds: string[];
+	let shutdownUris: URI[];
+	let nextSessionId: number;
+
+	// Mutable state for mocks that tests can override
+	let primaryLanguage: string;
+	let registeredRuntimes: ILanguageRuntimeMetadata[];
+
+	const allRuntimes = [pythonRuntime1, pythonRuntime2, rRuntime1];
+
+	function findRuntimeById(id: string): ILanguageRuntimeMetadata {
+		return allRuntimes.find(r => r.runtimeId === id) ?? pythonRuntime1;
+	}
+
+	setup(() => {
+		runtimeStartupService = new TestRuntimeStartupService();
+		runtimeStartupService.setPreferredRuntime('python', pythonRuntime1);
+		runtimeStartupService.setPreferredRuntime('r', rRuntime1);
+
+		storageService = disposables.add(new InMemoryStorageService());
+
+		startedRuntimeIds = [];
+		shutdownUris = [];
+		nextSessionId = 0;
+		primaryLanguage = 'python';
+		registeredRuntimes = [pythonRuntime1, pythonRuntime2, rRuntime1];
+
+		const mockRuntimeSessionService: Partial<IRuntimeSessionService> = {
+			async startNewRuntimeSession(runtimeId: string, _name: string, _mode: LanguageRuntimeSessionMode, _notebookUri?: URI) {
+				startedRuntimeIds.push(runtimeId);
+				return `session-${nextSessionId++}`;
+			},
+			getSession(_id: string) {
+				// Return a minimal session that passes the _waitForSessionReady check
+				// by being already idle, and supports shutdown/state queries.
+				return {
+					sessionId: `session-${nextSessionId - 1}`,
+					runtimeMetadata: startedRuntimeIds.length > 0
+						? findRuntimeById(startedRuntimeIds[startedRuntimeIds.length - 1])
+						: pythonRuntime1,
+					getRuntimeState() { return RuntimeState.Idle; },
+					onDidChangeRuntimeState: Event.None,
+					onDidCompleteStartup: Event.None,
+					onDidEncounterStartupFailure: Event.None,
+					onDidEndSession: Event.None,
+					async shutdown(_reason: RuntimeExitReason) { /* no-op */ },
+				} as any;
+			},
+			getNotebookSessionForNotebookUri(_uri: URI) { return undefined; },
+			getActiveSessions() { return []; },
+			async shutdownNotebookSession(uri: URI) { shutdownUris.push(uri); },
+			onDidStartRuntime: Event.None,
+		};
+
+		const mockLanguageRuntimeService: Partial<ILanguageRuntimeService> = {
+			get registeredRuntimes() {
+				return registeredRuntimes;
+			},
+		};
+
+		const mockDocModelService: Partial<IQuartoDocumentModelService> = {
+			getModel(_textModel: any) {
+				return { primaryLanguage, cells: [] } as any;
+			},
+		};
+
+		const mockEditorService: Partial<IEditorService> = {
+			findEditors(_uri: any) {
+				return [{
+					editor: {
+						async resolve() {
+							return {
+								textEditorModel: { uri: docUri, getLanguageId: () => 'quarto' },
+							};
+						},
+					},
+				}] as any;
+			},
+			onDidCloseEditor: Event.None as any,
+		};
+
+		const mockCacheService: Partial<IQuartoOutputCacheService> = {};
+
+		kernelManager = disposables.add(new QuartoKernelManager(
+			mockRuntimeSessionService as IRuntimeSessionService,
+			runtimeStartupService,
+			mockLanguageRuntimeService as ILanguageRuntimeService,
+			mockDocModelService as IQuartoDocumentModelService,
+			mockEditorService as IEditorService,
+			new NullLogService(),
+			{ warn() { }, notify() { }, info() { } } as any,
+			new TestConfigurationService() as any,
+			storageService,
+			mockCacheService as IQuartoOutputCacheService,
+		));
+	});
+
+	test('ensureKernelForDocument uses preferred runtime by default', async () => {
+		await kernelManager.ensureKernelForDocument(docUri);
+		assert.deepStrictEqual(startedRuntimeIds, ['python-3.11']);
+	});
+
+	test('changeKernelForDocument shuts down old session and starts new runtime', async () => {
+		await kernelManager.ensureKernelForDocument(docUri);
+		startedRuntimeIds.length = 0;
+
+		await kernelManager.changeKernelForDocument(docUri, pythonRuntime2.runtimeId);
+
+		assert.strictEqual(shutdownUris.length, 1);
+		assert.strictEqual(shutdownUris[0].toString(), docUri.toString());
+		assert.deepStrictEqual(startedRuntimeIds, ['python-3.12']);
+	});
+
+	test('persisted binding is used on next ensureKernelForDocument', async () => {
+		// Change to runtime2, which persists the choice
+		await kernelManager.ensureKernelForDocument(docUri);
+		await kernelManager.changeKernelForDocument(docUri, pythonRuntime2.runtimeId);
+		startedRuntimeIds.length = 0;
+		shutdownUris.length = 0;
+
+		// Simulate document close + reopen: shut down then ensure again
+		await kernelManager.shutdownKernelForDocument(docUri);
+		await kernelManager.ensureKernelForDocument(docUri);
+
+		// Should start runtime2, not the preferred runtime1
+		assert.deepStrictEqual(startedRuntimeIds, ['python-3.12']);
+	});
+
+	test('persisted binding survives new manager instance (storage round-trip)', async () => {
+		await kernelManager.ensureKernelForDocument(docUri);
+		await kernelManager.changeKernelForDocument(docUri, pythonRuntime2.runtimeId);
+
+		// Create a fresh manager using the same storage
+		startedRuntimeIds.length = 0;
+
+		const mockRuntimeSessionService2: Partial<IRuntimeSessionService> = {
+			async startNewRuntimeSession(runtimeId: string) {
+				startedRuntimeIds.push(runtimeId);
+				return `session-${nextSessionId++}`;
+			},
+			getSession() {
+				return {
+					sessionId: `session-${nextSessionId - 1}`,
+					runtimeMetadata: pythonRuntime2,
+					getRuntimeState() { return RuntimeState.Idle; },
+					onDidChangeRuntimeState: Event.None,
+					onDidCompleteStartup: Event.None,
+					onDidEncounterStartupFailure: Event.None,
+					onDidEndSession: Event.None,
+					async shutdown() { },
+				} as any;
+			},
+			getNotebookSessionForNotebookUri() { return undefined; },
+			getActiveSessions() { return []; },
+			async shutdownNotebookSession() { },
+			onDidStartRuntime: Event.None,
+		};
+
+		const km2 = disposables.add(new QuartoKernelManager(
+			mockRuntimeSessionService2 as IRuntimeSessionService,
+			runtimeStartupService,
+			{ get registeredRuntimes() { return [pythonRuntime1, pythonRuntime2]; } } as ILanguageRuntimeService,
+			{ getModel() { return { primaryLanguage: 'python', cells: [] }; } } as any,
+			{ findEditors() { return [{ editor: { async resolve() { return { textEditorModel: { uri: docUri, getLanguageId: () => 'quarto' } }; } } }]; }, onDidCloseEditor: Event.None } as any,
+			new NullLogService(),
+			{ warn() { }, notify() { }, info() { } } as any,
+			new TestConfigurationService() as any,
+			storageService, // same storage
+			{} as IQuartoOutputCacheService,
+		));
+
+		await km2.ensureKernelForDocument(docUri);
+		assert.deepStrictEqual(startedRuntimeIds, ['python-3.12']);
+	});
+
+	test('persisted binding is cleared when document language changes', async () => {
+		// Start with Python and persist a binding to python-3.12
+		await kernelManager.ensureKernelForDocument(docUri);
+		await kernelManager.changeKernelForDocument(docUri, pythonRuntime2.runtimeId);
+		startedRuntimeIds.length = 0;
+		shutdownUris.length = 0;
+
+		// Simulate: document is closed, YAML changed to R, reopened
+		await kernelManager.shutdownKernelForDocument(docUri);
+		primaryLanguage = 'r';
+		await kernelManager.ensureKernelForDocument(docUri);
+
+		// Should start the R runtime, not the stale Python binding
+		assert.deepStrictEqual(startedRuntimeIds, ['r-4.4']);
+	});
+
+	test('changeKernelForDocument fires state change events', async () => {
+		await kernelManager.ensureKernelForDocument(docUri);
+
+		const states: QuartoKernelState[] = [];
+		disposables.add(kernelManager.onDidChangeKernelState(e => {
+			if (e.documentUri.toString() === docUri.toString()) {
+				states.push(e.newState);
+			}
+		}));
+
+		await kernelManager.changeKernelForDocument(docUri, pythonRuntime2.runtimeId);
+
+		// Should see shutdown states then startup states
+		assert.ok(states.includes(QuartoKernelState.None), 'should transition through None on shutdown');
+		assert.ok(states.includes(QuartoKernelState.Starting), 'should transition through Starting');
+		assert.ok(states.includes(QuartoKernelState.Ready), 'should reach Ready');
+	});
+});

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -24,7 +24,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 
 		// ensure when no kernel is selected, restart/shutdown are disabled
 		await notebooksPositron.kernel.expectMenuToContain([
-			{ label: 'Change Kernel', enabled: true },
+			{ label: 'Change Kernel...', enabled: true },
 			{ label: 'Restart Kernel', enabled: false },
 			{ label: 'Shutdown Kernel', enabled: false },
 		]);
@@ -65,7 +65,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await notebooksPositron.kernel.expectMenuToContain([
 			{ label: 'Restart Kernel', enabled: true },
 			{ label: 'Shutdown Kernel', enabled: false },
-			{ label: 'Change Kernel', enabled: true },
+			{ label: 'Change Kernel...', enabled: true },
 		]);
 
 		// re-start kernel from shutdown state and ensure state changes


### PR DESCRIPTION
This change adds a _Change Kernel_ command so that it's possible to change which kernel is used to run code in a Quarto document with inline output.

<img width="632" height="600" alt="image" src="https://github.com/user-attachments/assets/cb46fc67-be0d-4174-8f4b-d4a4c2057167" />

Positron remembers explicitly chosen kernels, so once you've selected one with this menu, it'll be the kernel we use with the document in the future. Currently there's no way to pre-configure this, nor change it except through this menu. This brings us to parity with notebooks, but it'd be worth considering whether there is a more explicit mechanism we could offer. 

Addresses https://github.com/posit-dev/positron/issues/12684.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Quarto inline output: add tool to switch the interpreter used to run code in Quarto documents (#12684)

#### Bug Fixes

- N/A

### QA Notes

The binding between the Quarto documents and the runtimes is per-workspace, so if you open the same document in different workspace, it will have an independent binding there.

Test tags: `@:quarto` `@:notebooks` `@:positron-notebooks`