### PR TITLE
e2e: add new setting for posit assistant

### DIFF
--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -17,5 +17,6 @@
 	"posit.workbench.showWorkbenchFlaskHint": false,
 	"editor.accessibilitySupport": "off",
 	"githubIssues.issueCompletions.enabled": false,
-	"posit.assistant.sidebarView": true
+	"posit.assistant.sidebarView": true,
+	"assistant.sidebarView": true
 }


### PR DESCRIPTION
A recent Posit Assistant update changed the enable setting

### QA Notes
@:posit-assistant
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
