### PR TITLE
Fix Quarto kernel selector leaking into other editor panes

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/positronQuarto.contribution.ts
@@ -26,6 +26,7 @@ import {
 	POSITRON_QUARTO_INLINE_OUTPUT_KEY,
 	QUARTO_INLINE_OUTPUT_ENABLED,
 	QUARTO_KERNEL_RUNNING,
+	QUARTO_LANGUAGE_IDS,
 	isQuartoDocument,
 	isQuartoOrRmdFile,
 } from '../common/positronQuartoConfig.js';
@@ -35,6 +36,7 @@ import { ILanguageRuntimeService, RuntimeStartupPhase } from '../../../services/
 import { MenuId } from '../../../../platform/actions/common/actions.js';
 import { PositronActionBarWidgetRegistry } from '../../../../platform/positronActionBar/browser/positronActionBarWidgetRegistry.js';
 import { QuartoKernelStatusBadge } from './QuartoKernelStatusBadge.js';
+import { ResourceContextKey } from '../../../common/contextkeys.js';
 
 // Import the configuration to ensure it's registered
 import '../common/positronQuartoConfig.js';
@@ -283,7 +285,17 @@ PositronActionBarWidgetRegistry.registerWidget({
 	order: 100, // Rightmost position (same as notebook kernel status)
 	when: ContextKeyExpr.and(
 		QUARTO_INLINE_OUTPUT_ENABLED,
-		IS_QUARTO_DOCUMENT
+		// Important: use the per-editor-group resourceLangId here, NOT the
+		// global IS_QUARTO_DOCUMENT context key. Widget `when` clauses are
+		// evaluated per editor pane, so global context keys leak visibility
+		// into unrelated panes (e.g. a notebook open beside a Quarto doc
+		// would show two kernel selectors). resourceLangId is set on each
+		// editor group's scoped context key service, so it correctly scopes
+		// the widget to only panes showing a Quarto file. Compare with the
+		// notebook kernel widget, which uses `activeEditor` -- also per-group.
+		ContextKeyExpr.or(
+			...QUARTO_LANGUAGE_IDS.map(id => ContextKeyExpr.equals(ResourceContextKey.LangId.key, id))
+		)
 	),
 	selfContained: true,
 	componentFactory: (accessor) => {


### PR DESCRIPTION
Addresses ##12614

Fixes the Quarto kernel status badge appearing on unrelated editor panes (e.g. a notebook open beside a Quarto document would show two kernel selectors).

### Summary

The Quarto kernel selector widget's `when` clause used `IS_QUARTO_DOCUMENT` which is a global context key set based on whichever editor is globally active. Since widget `when` clauses are evaluated per editor pane, this caused the widget to appear on all panes when a Quarto doc had focus, and disappear from the Quarto pane when another editor had focus.

Replace `IS_QUARTO_DOCUMENT` with `resourceLangId` checks in the widget's `when` clause. `resourceLangId` is set per editor group (in `editorGroupView.ts`), so the widget correctly appears only in panes showing a Quarto file regardless of which pane has focus. 

### Before
<img width="868" height="403" alt="image" src="https://github.com/user-attachments/assets/ade518a3-7158-497f-b388-1a87785ac1ee" />

### After
<img width="848" height="397" alt="Screenshot 2026-04-09 at 8 53 54 AM" src="https://github.com/user-attachments/assets/e56389dd-df1c-4e61-91af-b590d9071e50" />

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed Quarto kernel selector appearing on non-Quarto editor panes when a Quarto document is open alongside other editors

### QA Notes

@:quarto @:positron-notebooks

1. Enable Quarto inline output (`positron.quarto.inlineOutput.enabled`)
2. Open a `.qmd` file and another file side-by-side. (Use a positron notebook for extra excitement.)
3. Verify the Quarto kernel selector only appears on the Quarto document's action bar, not the notebook's
4. Click between the two panes and confirm the Quarto selector stays on the Quarto pane and doesn't appear/disappear based on focus