### PR TITLE
Fix embedded link background in assistant error messages

### DIFF
--- a/src/vs/base/browser/ui/positronComponents/embeddedLink/embeddedLink.css
+++ b/src/vs/base/browser/ui/positronComponents/embeddedLink/embeddedLink.css
@@ -5,4 +5,5 @@
 
 .embedded-link a {
 	color: var(--vscode-textLink-foreground);
+	background-color: transparent;
 }


### PR DESCRIPTION
Fixes the issue where links in error messages (e.g., Bedrock authentication errors) in the Configure Language Model Providers dialog had a white background in some themes, making them unreadable. Adds `background-color: transparent` to the `EmbeddedLink` component's anchor styling.

Light:
<img width="602" height="503" alt="Screenshot 2026-04-09 at 9 48 59 AM" src="https://github.com/user-attachments/assets/d6834acd-d9e7-4d59-8373-7d1e3a41c86f" />

Dark:
<img width="602" height="502" alt="Screenshot 2026-04-09 at 9 49 07 AM" src="https://github.com/user-attachments/assets/7a2c0783-9740-4972-88cb-f18e2a19fc9c" />

**Note:** The authentication extension changes error messages & does not include settings links, so this issue is not immediately apparent on testing. The above screenshots used a modified error message for testing. 

Addresses #12202.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed an issue where links in assistant error messages could have a white background in some themes, making them hard to read (#12202)


### QA Notes

@:assistant
Validate by opening the Configure Language Model Providers dialog, triggering a Bedrock authentication error, and verifying that the links in the error message have no background color across light, dark, and high-contrast themes.