### PR TITLE
Fix console hang on first startup after upgrade

### DIFF
--- a/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
@@ -354,13 +354,13 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 
 		if (lastKnownVersion === currentVersion) {
 			this._logService.info(
-				'[bootstrap] Extension versions match, skipping bootstrap wait'
+				'Subsequent launch, skipping bootstrap wait'
 			);
 			return;
 		}
 
 		this._logService.info(
-			'[bootstrap] Version mismatch detected ' +
+			'Bootstrap version mismatch detected ' +
 			`(installed: "${lastKnownVersion}", current: "${currentVersion}"). ` +
 			'Waiting for shared process bootstrap to complete before scanning extensions...'
 		);
@@ -369,7 +369,7 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 		await channel.call('getInstalled', [null]);
 
 		this._logService.info(
-			'[bootstrap] Shared process bootstrap complete, proceeding with extension scan'
+			'Shared process bootstrap complete, proceeding with extension scan'
 		);
 	}
 	// --- End Positron ---

--- a/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
@@ -343,13 +343,16 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 		const currentVersion = `${this._productService.positronVersion}-${this._productService.positronBuildNumber}`;
 
 		let lastKnownVersion = '';
-		try {
-			if (await this._fileService.exists(versionFileUri)) {
+		const fileExists = await this._fileService.exists(versionFileUri);
+		if (fileExists) {
+			try {
 				const content = await this._fileService.readFile(versionFileUri);
 				lastKnownVersion = content.value.toString().trim();
+			} catch (err) {
+				this._logService.warn(
+					`Failed to read bootstrap version file: ${err}`
+				);
 			}
-		} catch {
-			// If we can't read the file, assume mismatch
 		}
 
 		if (lastKnownVersion === currentVersion) {
@@ -376,7 +379,13 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 
 	private async _doResolveExtensions(emitter: AsyncIterableEmitter<ResolvedExtensions>): Promise<void> {
 		// --- Start Positron ---
-		await this._waitForBootstrapExtensionsIfNeeded();
+		try {
+			await this._waitForBootstrapExtensionsIfNeeded();
+		} catch (err) {
+			this._logService.error(
+				`Bootstrap extension wait failed, proceeding with scan: ${err}`
+			);
+		}
 		// --- End Positron ---
 		this._extensionScanner.startScanningExtensions();
 

--- a/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/nativeExtensionService.ts
@@ -58,6 +58,10 @@ import { ILifecycleService, LifecyclePhase } from '../../lifecycle/common/lifecy
 import { IRemoteAgentService } from '../../remote/common/remoteAgentService.js';
 import { IRemoteExplorerService } from '../../remote/common/remoteExplorerService.js';
 import { AsyncIterableEmitter, AsyncIterableProducer } from '../../../../base/common/async.js';
+// --- Start Positron ---
+import { INativeEnvironmentService } from '../../../../platform/environment/common/environment.js'; // eslint-disable-line no-duplicate-imports
+import { ISharedProcessService } from '../../../../platform/ipc/electron-browser/services.js';
+// --- End Positron ---
 
 export class NativeExtensionService extends AbstractExtensionService implements IExtensionService {
 
@@ -87,6 +91,11 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 		@IExtensionGalleryService private readonly _extensionGalleryService: IExtensionGalleryService,
 		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
 		@IDialogService dialogService: IDialogService,
+		// --- Start Positron ---
+		@INativeEnvironmentService private readonly _nativeEnvironmentService: INativeEnvironmentService,
+		@ISharedProcessService private readonly _sharedProcessService: ISharedProcessService,
+		// --- End Positron ---
+
 	) {
 		const extensionsProposedApi = instantiationService.createInstance(ExtensionsProposedApi);
 		const extensionScanner = instantiationService.createInstance(CachedExtensionScanner);
@@ -321,7 +330,54 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 		return new AsyncIterableProducer(emitter => this._doResolveExtensions(emitter));
 	}
 
+	// --- Start Positron ---
+	/**
+	 * Wait for bootstrap extension installation to complete if a version
+	 * mismatch is detected. This prevents the workbench from scanning
+	 * the pre-bootstrap extension profile and then receiving disruptive
+	 * delta-update events when bootstrap finishes.
+	 */
+	private async _waitForBootstrapExtensionsIfNeeded(): Promise<void> {
+		const extensionsPath = this._nativeEnvironmentService.extensionsPath;
+		const versionFileUri = URI.file(`${extensionsPath}/.version`);
+		const currentVersion = `${this._productService.positronVersion}-${this._productService.positronBuildNumber}`;
+
+		let lastKnownVersion = '';
+		try {
+			if (await this._fileService.exists(versionFileUri)) {
+				const content = await this._fileService.readFile(versionFileUri);
+				lastKnownVersion = content.value.toString().trim();
+			}
+		} catch {
+			// If we can't read the file, assume mismatch
+		}
+
+		if (lastKnownVersion === currentVersion) {
+			this._logService.info(
+				'[bootstrap] Extension versions match, skipping bootstrap wait'
+			);
+			return;
+		}
+
+		this._logService.info(
+			'[bootstrap] Version mismatch detected ' +
+			`(installed: "${lastKnownVersion}", current: "${currentVersion}"). ` +
+			'Waiting for shared process bootstrap to complete before scanning extensions...'
+		);
+
+		const channel = this._sharedProcessService.getChannel('extensions');
+		await channel.call('getInstalled', [null]);
+
+		this._logService.info(
+			'[bootstrap] Shared process bootstrap complete, proceeding with extension scan'
+		);
+	}
+	// --- End Positron ---
+
 	private async _doResolveExtensions(emitter: AsyncIterableEmitter<ResolvedExtensions>): Promise<void> {
+		// --- Start Positron ---
+		await this._waitForBootstrapExtensionsIfNeeded();
+		// --- End Positron ---
 		this._extensionScanner.startScanningExtensions();
 
 		const remoteAuthority = this._environmentService.remoteAuthority;


### PR DESCRIPTION
Addresses #11230.

After upgrading Positron, the first startup can cause the console to hang  indefinitely. This is caused by a race condition between bootstrap extension installation and extension scanning. I was only able to reproduce the hang when I had existing bootstrapped extensions in my directory that needed to be upgraded.

With the fix, the extension service waits for bootstrapped extensions to be installed before starting scanning. Instead of the console hanging, users will see a brief pause on the first launch after upgrade while bootstrap extensions install.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix console hanging on first startup after upgrading Positron (#11230)

### QA Notes

@:console @:critical @:extensions

After upgrading Positron, the console should not hang on first launch.