### PR TITLE
Fix autocompletion in non-inline output Quarto docs

### DIFF
--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -137,6 +137,11 @@ export class PythonLsp implements vscode.Disposable {
                   // Assistant code confirmation widget: https://github.com/posit-dev/positron/issues/7750
                   { language: 'python', scheme: 'assistant-code-confirmation-widget' },
                   { language: 'python', pattern: '**/*.py' },
+                  // Match Quarto virtual documents (vdocs) so the
+                  // console LSP can provide completions in Quarto
+                  // code blocks when inline output is disabled and
+                  // no notebook LSP exists.
+                  VDOC_SELECTOR,
               ];
 
         // This is needed in addition to the document selector, otherwise every client seems to
@@ -162,11 +167,19 @@ export class PythonLsp implements vscode.Disposable {
         // the notebook LSP skips regular console inputs.
         const shouldSkipDocument = (document: vscode.TextDocument): boolean => {
             if (!notebookUri) {
-                // Console LSP: skip vdoc files (notebook LSP handles them)
+                // Console LSP: skip vdoc files when inline output
+                // is enabled, because a notebook LSP handles them.
+                // When inline output is disabled, no notebook LSP
+                // exists, so the console LSP must handle vdocs.
                 if (document.uri.scheme === 'file') {
                     const baseName = path.basename(document.uri.fsPath);
                     if (VDOC_PATTERN.test(baseName)) {
-                        return true;
+                        const inlineOutputEnabled = vscode.workspace
+                            .getConfiguration('positron.quarto.inlineOutput')
+                            .get<boolean>('enabled', false);
+                        if (inlineOutputEnabled) {
+                            return true;
+                        }
                     }
                 }
                 // Console LSP: skip notebook console inputs

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -184,11 +184,19 @@ export class ArkLsp implements vscode.Disposable {
 				// inputs.
 				provideCompletionItem(document, position, context, token, next) {
 					if (!notebookUri) {
-						// Console LSP: skip vdoc files (notebook LSP handles them)
+						// Console LSP: skip vdoc files when inline output
+						// is enabled, because a notebook LSP handles them.
+						// When inline output is disabled, no notebook LSP
+						// exists, so the console LSP must handle vdocs.
 						if (document.uri.scheme === 'file') {
 							const baseName = path.basename(document.uri.fsPath);
 							if (VDOC_PATTERN.test(baseName)) {
-								return undefined;
+								const inlineOutputEnabled = vscode.workspace
+									.getConfiguration('positron.quarto.inlineOutput')
+									.get<boolean>('enabled', false);
+								if (inlineOutputEnabled) {
+									return undefined;
+								}
 							}
 						}
 						// Console LSP: skip notebook console inputs

--- a/test/e2e/tests/autocomplete/autocomplete-notebook-console.test.ts
+++ b/test/e2e/tests/autocomplete/autocomplete-notebook-console.test.ts
@@ -435,8 +435,8 @@ test.describe('Autocomplete with Notebook Console', {
 
 	test('R - Autocomplete works in Quarto without inline output', {
 		tag: [tags.ARK, tags.QUARTO]
-	}, async function ({ app, runCommand, openFile, sessions, hotKeys, settings }) {
-		const { editors } = app.workbench;
+	}, async function ({ app, openFile, sessions, hotKeys, settings }) {
+		const { editors, inlineQuarto } = app.workbench;
 		const page = app.code.driver.page;
 		const keyboard = page.keyboard;
 		const suggestionList = page.locator('.suggest-widget .monaco-list-row');
@@ -463,9 +463,7 @@ test.describe('Autocomplete with Notebook Console', {
 			// code block, then type data.f to trigger completions.
 			// The console LSP should handle the vdoc and provide
 			// completions for base R functions like data.frame.
-			await runCommand('workbench.action.gotoLine', { keepOpen: true });
-			await keyboard.type('11');
-			await keyboard.press('Enter');
+			await inlineQuarto.gotoLine(11);
 			await keyboard.press('End');
 			await keyboard.press('Enter');
 			await keyboard.type('data.f', { delay: 250 });

--- a/test/e2e/tests/autocomplete/autocomplete-notebook-console.test.ts
+++ b/test/e2e/tests/autocomplete/autocomplete-notebook-console.test.ts
@@ -432,4 +432,61 @@ test.describe('Autocomplete with Notebook Console', {
 			// correctly providing them.
 		});
 	});
+
+	test('R - Autocomplete works in Quarto without inline output', {
+		tag: [tags.ARK, tags.QUARTO]
+	}, async function ({ app, runCommand, openFile, sessions, hotKeys, settings }) {
+		const { editors } = app.workbench;
+		const page = app.code.driver.page;
+		const keyboard = page.keyboard;
+		const suggestionList = page.locator('.suggest-widget .monaco-list-row');
+
+		await test.step('Disable inline output', async () => {
+			await settings.set({
+				'positron.quarto.inlineOutput.enabled': false,
+				'workbench.editor.enablePreview': false,
+			}, { reload: true, waitMs: 1000 });
+		});
+
+		// Start an R console session (no notebook session will be created)
+		await sessions.start(['r']);
+		await hotKeys.closeSecondarySidebar();
+		await sessions.expectAllSessionsToBeReady();
+
+		await test.step('Open Quarto file and verify autocomplete works', async () => {
+			// Open the simple R rmd file
+			await openFile(join('workspaces', 'quarto_inline_output', 'simple_r.rmd'));
+			await editors.waitForActiveTab('simple_r.rmd');
+
+			// Go to line 11 (df <- data.frame(x, y)), press End to go
+			// to end of line, Enter to create a new line inside the
+			// code block, then type data.f to trigger completions.
+			// The console LSP should handle the vdoc and provide
+			// completions for base R functions like data.frame.
+			await runCommand('workbench.action.gotoLine', { keepOpen: true });
+			await keyboard.type('11');
+			await keyboard.press('Enter');
+			await keyboard.press('End');
+			await keyboard.press('Enter');
+			await keyboard.type('data.f', { delay: 250 });
+
+			// Explicitly trigger completions and verify we get results.
+			// Before the fix, the console LSP skipped vdoc files and
+			// no completions appeared. With the fix, the console LSP
+			// handles vdocs and provides R completions like data.frame.
+			await expect(async () => {
+				await keyboard.press('Control+Space');
+				await expect(suggestionList.first()).toBeVisible({ timeout: 5000 });
+			}).toPass({ timeout: 30000 });
+
+			// Verify we see data.frame from the R LSP (match the
+			// first exact entry, not substrings like as.data.frame)
+			const suggestWidget = page.locator('.suggest-widget');
+			await expect(suggestWidget.getByRole('option', {
+				name: 'data.frame, {base}, Function',
+				exact: true
+			})).toBeVisible();
+		});
+	});
+
 });


### PR DESCRIPTION
This change fixes an autocompletion regression introduced by #12509. Ironically, even though that PR added extensive E2E tests, it didn't include a test for Quarto documents _without_ inline output turned on.

<img width="638" height="342" alt="image" src="https://github.com/user-attachments/assets/c12960e1-10f0-435e-8421-5c5072b94f2e" />

The problem is related to the virtual docs ("vdocs") Quarto uses to feed the LSPs. #12509 prevented the console LSPs from handling these vdocs, as doing so pollutes Quarto sessions with completions from the wrong session. However, when we don't have Quarto sessions (i.e. inline output is off), we're left with _no_ completions. 

The fix is to push the filtering down a bit; now console sessions register themselves as completers for vdocs, but they avoid returning results if Quarto inline output is enabled.

Addresses https://github.com/posit-dev/positron/issues/12885. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix autocompletion in Quarto docs when inline output is disabled (#12885) 


### QA Notes

A new E2E test is added to validate that this scenario doesn't regress. Autocompletion in this area has good test coverage; #12509 added a lot of tests, but (as this regression proves) it isn't perfect. Worth spot-checking completion behavior across notebooks, Quarto sessions, and the console.

Test tags: `@:quarto` `@:notebooks` `@:positron-notebooks` `@:console`
