### PR TITLE
Consolidate e2e failure analyzer scripts for fewer approvals

### DIFF
--- a/.claude/skills/e2e-failure-analyzer/SKILL.md
+++ b/.claude/skills/e2e-failure-analyzer/SKILL.md
@@ -21,7 +21,14 @@ Analyzes Playwright e2e test failures from a GitHub Actions run using JSON repor
 
 ## Helper Scripts
 
-Scripts live alongside this skill in `scripts/`. Use the base directory path shown above when the skill loads (the "Base directory for this skill: ..." line) as `$SKILL_DIR`. Scripts require Node.js and are cross-platform (Windows via Git Bash, macOS, Linux). The `e2e-inspect-blobs.js` script requires `unzip` to be available in PATH (included in Git Bash on Windows).
+Scripts live alongside this skill in `scripts/`. Use the base directory path shown above when the skill loads (the "Base directory for this skill: ..." line) as `$SKILL_DIR`. Scripts require Node.js and are cross-platform (Windows via Git Bash, macOS, Linux). Scripts that extract from zip files require `unzip` to be available in PATH (included in Git Bash on Windows).
+
+### Consolidated scripts (preferred -- fewer tool calls)
+
+- **`e2e-gather-run-info.js`** - Gathers all run metadata, failed jobs, artifacts, non-e2e job log excerpts, and commit info in one call. Replaces multiple `gh api` invocations.
+- **`e2e-process-project.js`** - Processes a merged blob report project end-to-end: extracts failures, scans blobs, extracts/parses traces, extracts screenshots and error-context. Replaces multiple script + unzip invocations.
+
+### Standalone scripts (used by consolidated scripts internally, or for ad-hoc debugging)
 
 - **`e2e-extract-failures.js`** - Extracts failures from a merged Playwright JSON report
 - **`e2e-parse-trace.js`** - Parses a `trace.trace` file into an action timeline with errors and last screenshot hash
@@ -34,116 +41,72 @@ Run ID or URL from either repo:
 - `https://github.com/posit-dev/positron/actions/runs/23610137774`
 - `https://github.com/posit-dev/positron-builds/actions/runs/23938334846`
 
-## Step 1: Parse Input, Enumerate Failed Jobs, and Determine Repo
+## Step 1: Gather Run Info (single script call)
 
-Extract the run ID and repo from the URL. The two repos have different data access patterns:
+The consolidated `e2e-gather-run-info.js` script handles everything: run metadata, failed jobs, blob report artifacts, non-e2e job log excerpts, and commit info.
 
+```bash
+node "$SKILL_DIR/scripts/e2e-gather-run-info.js" <RUN_URL>
+```
+
+Output JSON contains:
+- `repo`, `runId` - parsed from URL
+- `run` - metadata (name, conclusion, html_url, head_sha, branch)
+- `failedJobs` - array of `{id, name, isE2e}` for all failed jobs
+- `nonE2eJobLogs` - map of job ID to failure log excerpts (for non-e2e jobs)
+- `artifacts` - sorted list of blob report artifact names
+- `projects` - unique project names extracted from artifacts (e.g., `e2e-chromium`, `e2e-windows`)
+- `commit` - `{message, author, files}` for the head commit
+
+Use `projects` to determine what to process:
+- If projects list is non-empty -> use **Path A** (positron repo flow) for each project
+- If empty -> use **Path B** (positron-builds flow)
+
+The two repos have different data access patterns:
 - **`posit-dev/positron`**: Uses sharded blob reports uploaded as GitHub artifacts. Requires downloading and merging.
 - **`posit-dev/positron-builds`**: Non-sharded single-job runs. HTML reports uploaded to S3 at CloudFront. No blob report artifacts.
-
-```bash
-# Get run metadata (including branch for history queries)
-gh api repos/<REPO>/actions/runs/<RUN_ID> --jq '{name: .name, conclusion: .conclusion, html_url: .html_url, head_sha: .head_sha, branch: .head_branch}'
-```
-
-### Step 1a: List ALL failed jobs
-
-Before diving into e2e reports, get the full picture of what failed:
-
-```bash
-gh api repos/<REPO>/actions/runs/<RUN_ID>/jobs --paginate \
-  --jq '.jobs[] | select(.conclusion == "failure") | {id: .id, name: .name}'
-```
-
-Categorize each failed job:
-- **e2e jobs** (name contains `e2e`): Analyze with Path A or B below
-- **Non-e2e jobs** (e.g., `test / unit`, `test / integration`, `setup / build`): Report in the summary with a link to the job logs. Extract the failure reason from the job logs:
-  ```bash
-  gh api repos/<REPO>/actions/jobs/<JOB_ID>/logs 2>&1 | grep -E "(FAIL|Error|error:|##\[error\])" | tail -20
-  ```
-
-### Step 1b: Find blob report artifacts for all e2e projects
-
-```bash
-gh api repos/<REPO>/actions/runs/<RUN_ID>/artifacts --jq '.artifacts[] | select(.name | test("^blob-report-")) | .name' | sort
-```
-
-Group by project: extract unique project names from artifact names (e.g., `blob-report-e2e-chromium-1` -> `e2e-chromium`, `blob-report-e2e-windows-1` -> `e2e-windows`). Process **all** projects that have blob reports, not just one.
-
-- If blob reports found -> use **Path A** (positron repo flow) for each project
-- If no blob reports found -> use **Path B** (positron-builds flow)
 
 ---
 
 ## Path A: posit-dev/positron (Sharded Blob Reports)
 
-Repeat the steps below for **each** e2e project that has blob report artifacts (e.g., `e2e-windows`, `e2e-electron`, `e2e-chromium`). Download all projects in parallel, then merge and analyze each.
+### A1+A2: Download, Merge, and Process (single script call)
 
-### A1: Download and Merge Reports
+The `e2e-process-project.js` script handles everything in one call: downloads blob report artifacts, copies shards into a merged directory, runs `npx playwright merge-reports`, then extracts failures, scans blobs, extracts/parses traces, and extracts screenshots. Use `--cleanup` to remove intermediate download/merge artifacts automatically.
 
-```bash
-gh run download <RUN_ID> --repo posit-dev/positron \
-  -p "blob-report-<PROJECT>-*" -D /tmp/blob-reports-<PROJECT>
-
-mkdir -p /tmp/blob-merged-<PROJECT>
-cp /tmp/blob-reports-<PROJECT>/blob-report-<PROJECT>-*/* /tmp/blob-merged-<PROJECT>/
-
-PLAYWRIGHT_JSON_OUTPUT_NAME=/tmp/report-<PROJECT>.json \
-  npx playwright merge-reports --reporter=json /tmp/blob-merged-<PROJECT>
-```
-
-Run downloads in parallel for multiple projects. Merge sequentially (npx changes cwd).
-
-### A2: Extract Failure Details from JSON Report
+For **each** project from Step 1, run:
 
 ```bash
-node "$SKILL_DIR/scripts/e2e-extract-failures.js" /tmp/report-<PROJECT>.json
+node "$SKILL_DIR/scripts/e2e-process-project.js" \
+  --download --run-id <RUN_ID> --repo <REPO> --project <PROJECT> \
+  --output-dir /tmp/e2e-analysis-<PROJECT> --cleanup
 ```
 
-Outputs a JSON array with each failure's title, file, tags, suite, project, and error details.
+If there are multiple projects, run them sequentially (each call uses npx internally).
 
-### A3: Extract Traces, Screenshots, and Logs from Blob Reports
+**Fallback**: If blob reports were already downloaded and merged (e.g., for debugging), you can skip `--download` and pass the directories directly:
 
-Each blob zip contains `report.jsonl` and `resources/*.zip`.
-
-**Find failed tests across all blobs:**
 ```bash
-node "$SKILL_DIR/scripts/e2e-inspect-blobs.js" /tmp/blob-merged-<PROJECT>
+node "$SKILL_DIR/scripts/e2e-process-project.js" \
+  /tmp/blob-merged-<PROJECT> /tmp/report-<PROJECT>.json \
+  --output-dir /tmp/e2e-analysis-<PROJECT>
 ```
 
-This outputs JSON with `failedTests` (testId, title, file, status, blob).
+Output JSON contains:
+- `outputDir` - path where screenshots and error-context files were saved
+- `failures` - array of final failures (tests that failed all retries) with title, file, tags, suite, project, errors
+- `failedTests` - array of all failed test attempts (including those that passed on retry) with testId, title, file, status, blob
+- `testDetails` - array of per-test objects, each containing:
+  - `testId`, `title`, `file`, `status`, `blob`, `attemptCount`
+  - `attempts` - array of per-attempt objects with:
+    - `trace` - parsed trace data: `timeline` (human-readable string), `errors` (array), `lastScreenshotSha1`
+    - `screenshotPath` - path to extracted last screenshot JPEG (view with Read tool)
+    - `errorContextPath` - path to extracted page snapshot markdown (view with Read tool if needed)
+  - `logHashes` - array of `{resourceHash, blob}` for logs (extract manually if needed)
 
-**Find trace/log resource hashes for specific failed test IDs:**
-```bash
-node "$SKILL_DIR/scripts/e2e-inspect-blobs.js" /tmp/blob-merged-<PROJECT> --test-ids <TEST_ID_1>,<TEST_ID_2>
-```
+**IMPORTANT: View screenshots** using the `screenshotPath` fields with the Read tool. You MUST Read **all** screenshots in a **single message** with multiple parallel Read tool calls -- this results in only one approval prompt instead of one per screenshot. View all attempts; comparing across retries reveals whether a failure is consistent or intermittent. Screenshots are the most revealing evidence for diagnosing failures.
 
-This outputs JSON with `attachments` (testId, name, contentType, resourceHash, blob).
-
-**Extract and read trace:**
-```bash
-unzip -o /tmp/blob-merged-<PROJECT>/<BLOB>.zip "resources/<TRACE_HASH>.zip" -d /tmp/trace-extract
-mkdir -p /tmp/trace-contents && cd /tmp/trace-contents
-unzip -o /tmp/trace-extract/resources/<TRACE_HASH>.zip trace.trace
-```
-
-Parse the trace action timeline:
-```bash
-node "$SKILL_DIR/scripts/e2e-parse-trace.js" /tmp/trace-contents/trace.trace
-```
-
-Outputs the last 30 actions with selectors/errors, last screenshot sha1, and error summary. Use `--last N` to adjust.
-
-Extract and view the last screenshot with the Read tool:
-```bash
-unzip -o /tmp/trace-extract/resources/<TRACE_HASH>.zip "resources/<LAST_SCREENSHOT>.jpeg" -d /tmp/trace-contents
-```
-
-**Extract logs:**
-```bash
-unzip -o /tmp/blob-merged-<PROJECT>/<BLOB>.zip "resources/<LOGS_HASH>.zip" -d /tmp/logs-extract
-mkdir -p /tmp/logs-contents && cd /tmp/logs-contents && unzip -o /tmp/logs-extract/resources/<LOGS_HASH>.zip
-```
+**View error context** with the Read tool using `errorContextPath` paths if the screenshot and trace timeline are insufficient for diagnosis.
 
 ---
 
@@ -306,11 +269,7 @@ When analyzing, consider:
 
 ### Check the triggering commit
 
-For tests that **failed all retries** (not just flaky), inspect the head commit (from the `head_sha` in Step 1) to assess whether it could have caused the failure:
-
-```bash
-gh api repos/<REPO>/commits/<HEAD_SHA> --jq '{message: .commit.message, author: .commit.author.name, files: [.files[].filename]}'
-```
+For tests that **failed all retries** (not just flaky), inspect the head commit using the `commit` field from Step 1's `e2e-gather-run-info.js` output (already includes message, author, and changed files).
 
 Compare the changed files against:
 - **The failing test file itself** and its page objects/helpers -- changes here could introduce a test logic bug
@@ -355,6 +314,13 @@ Offer to:
 
 ## Cleanup
 
+**Path A**: If you used `--cleanup` with `e2e-process-project.js`, the download/merge artifacts are already removed. Only the `--output-dir` remains (screenshots and error-context). Remove it with exact paths (no globs):
+
 ```bash
-rm -rf /tmp/blob-reports-* /tmp/blob-merged-* /tmp/blob-jsonl-* /tmp/report-*.json /tmp/trace-extract /tmp/trace-contents /tmp/logs-extract /tmp/logs-contents /tmp/blob-inspect* /tmp/pw-screenshot-* /tmp/pw-trace* /tmp/pw-logs* /tmp/pw-report*
+rm -rf /tmp/e2e-analysis-<PROJECT>
+```
+
+**Path B**: Remove artifacts with exact paths:
+```bash
+rm -rf /tmp/pw-screenshots /tmp/pw-traces /tmp/pw-logs
 ```

--- a/.claude/skills/e2e-failure-analyzer/SKILL.md
+++ b/.claude/skills/e2e-failure-analyzer/SKILL.md
@@ -303,7 +303,7 @@ For each failure, include the **platform** (OS and project/browser) where it occ
 
 When multiple projects/platforms are analyzed in a single run, note which platforms each failure occurred on and whether the same test passed on other platforms.
 
-Present the analysis in a summary table that includes columns for: test name, platform, root cause category, and severity. Then provide detailed analysis for each failure below the table.
+Present the analysis in a summary table that includes columns for: test name, platform, root cause category, and severity. In the severity column, clearly distinguish tests that **failed all retries** (hard failures) from tests that **passed on retry** (flaky). This distinction comes from comparing `failures` (final failures after all retries) vs `failedTests` (all attempts including those that recovered). Then provide detailed analysis for each failure below the table.
 
 Include **non-e2e job failures** (unit tests, integration tests, build failures) in the summary table as well, with the job name as the test name and a brief description of the failure extracted from the job logs.
 

--- a/.claude/skills/e2e-failure-analyzer/scripts/e2e-gather-run-info.js
+++ b/.claude/skills/e2e-failure-analyzer/scripts/e2e-gather-run-info.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// Gathers all run metadata, failed jobs, artifacts, and commit info in one call.
+// Replaces ~6 separate `gh api` invocations from the skill's Step 1.
+//
+// Usage: node e2e-gather-run-info.js <run-url-or-id> [--repo <owner/repo>]
+//
+// Output: JSON with:
+//   repo, runId, run (metadata), failedJobs, nonE2eJobLogs,
+//   artifacts, projects, commit
+
+import { execFileSync } from 'child_process';
+
+const args = process.argv.slice(2);
+let runInput = null;
+let repoOverride = null;
+
+for (let i = 0; i < args.length; i++) {
+	if (args[i] === '--repo' && args[i + 1]) {
+		repoOverride = args[++i];
+	} else if (!runInput) {
+		runInput = args[i];
+	}
+}
+
+if (!runInput) {
+	console.error('Usage: node e2e-gather-run-info.js <run-url-or-id> [--repo <owner/repo>]');
+	process.exit(1);
+}
+
+// Extract repo and run ID from URL
+let repo, runId;
+const urlMatch = runInput.match(/github\.com\/([^/]+\/[^/]+)\/actions\/runs\/(\d+)/);
+if (urlMatch) {
+	repo = urlMatch[1];
+	runId = urlMatch[2];
+} else if (/^\d+$/.test(runInput)) {
+	runId = runInput;
+	repo = repoOverride || 'posit-dev/positron';
+} else {
+	console.error('Invalid input. Provide a GitHub Actions run URL or numeric run ID.');
+	process.exit(1);
+}
+
+function gh(...ghArgs) {
+	try {
+		return execFileSync('gh', ghArgs, {
+			encoding: 'utf8',
+			stdio: ['pipe', 'pipe', 'pipe'],
+			timeout: 60000,
+			maxBuffer: 50 * 1024 * 1024, // 50MB - CI logs can be very large
+			shell: true, // needed on Windows where gh is a .cmd wrapper
+		}).trim();
+	} catch (err) {
+		process.stderr.write(`Warning: gh command failed: gh ${ghArgs.join(' ')}\n`);
+		process.stderr.write(`  ${(err.stderr || err.message || '').toString().trim().slice(0, 500)}\n`);
+		return '';
+	}
+}
+
+// 1. Get run metadata
+process.stderr.write('Fetching run metadata...\n');
+const runMeta = JSON.parse(
+	gh('api', `repos/${repo}/actions/runs/${runId}`,
+		'--jq', '{name: .name, conclusion: .conclusion, html_url: .html_url, head_sha: .head_sha, branch: .head_branch}')
+	|| '{}'
+);
+
+// 2. List all failed jobs (paginated)
+process.stderr.write('Listing failed jobs...\n');
+const failedJobsRaw = gh('api', `repos/${repo}/actions/runs/${runId}/jobs`, '--paginate',
+	'--jq', '.jobs[] | select(.conclusion == "failure") | {id: .id, name: .name}');
+
+const failedJobs = failedJobsRaw
+	.split('\n')
+	.filter(Boolean)
+	.map(line => { try { return JSON.parse(line); } catch { return null; } })
+	.filter(Boolean)
+	.map(job => ({
+		...job,
+		isE2e: /e2e/i.test(job.name),
+	}));
+
+// 3. Get non-e2e job failure excerpts
+const nonE2eJobs = failedJobs.filter(j => !j.isE2e);
+const nonE2eJobLogs = {};
+for (const job of nonE2eJobs) {
+	process.stderr.write(`Fetching logs for non-e2e job: ${job.name}...\n`);
+	const logs = gh('api', `repos/${repo}/actions/jobs/${job.id}/logs`);
+	const failLines = logs
+		.split('\n')
+		.filter(l => /(FAIL|Error|error:|##\[error\])/.test(l))
+		.slice(-30)
+		.map(l => l.replace(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s*/, '').trim());
+	nonE2eJobLogs[job.id] = failLines.join('\n');
+}
+
+// 4. List blob report artifacts
+process.stderr.write('Listing blob report artifacts...\n');
+const artifactsRaw = gh('api', `repos/${repo}/actions/runs/${runId}/artifacts`,
+	'--jq', '.artifacts[] | select(.name | test("^blob-report-")) | .name');
+const artifacts = artifactsRaw.split('\n').filter(Boolean).sort();
+
+// Extract unique project names from artifact names like "blob-report-e2e-chromium-1"
+const projects = [...new Set(
+	artifacts.map(name => {
+		const match = name.match(/^blob-report-(.+)-\d+$/);
+		return match ? match[1] : null;
+	}).filter(Boolean)
+)];
+
+// 5. Get commit info
+let commit = {};
+if (runMeta.head_sha) {
+	process.stderr.write('Fetching commit info...\n');
+	const commitRaw = gh('api', `repos/${repo}/commits/${runMeta.head_sha}`,
+		'--jq', '{message: .commit.message, author: .commit.author.name, files: [.files[].filename]}');
+	if (commitRaw) {
+		try { commit = JSON.parse(commitRaw); } catch { /* ignore */ }
+	}
+}
+
+const result = {
+	repo,
+	runId,
+	run: runMeta,
+	failedJobs,
+	nonE2eJobLogs,
+	artifacts,
+	projects,
+	commit,
+};
+
+console.log(JSON.stringify(result, null, 2));
+process.stderr.write(`Done. Found ${failedJobs.length} failed jobs, ${projects.length} e2e projects.\n`);

--- a/.claude/skills/e2e-failure-analyzer/scripts/e2e-gather-run-info.js
+++ b/.claude/skills/e2e-failure-analyzer/scripts/e2e-gather-run-info.js
@@ -48,7 +48,8 @@ function gh(...ghArgs) {
 			stdio: ['pipe', 'pipe', 'pipe'],
 			timeout: 60000,
 			maxBuffer: 50 * 1024 * 1024, // 50MB - CI logs can be very large
-			shell: true, // needed on Windows where gh is a .cmd wrapper
+			// Note: do NOT use shell: true here -- the --jq arguments contain
+			// pipe characters that cmd.exe would interpret as shell pipes.
 		}).trim();
 	} catch (err) {
 		process.stderr.write(`Warning: gh command failed: gh ${ghArgs.join(' ')}\n`);

--- a/.claude/skills/e2e-failure-analyzer/scripts/e2e-gather-run-info.js
+++ b/.claude/skills/e2e-failure-analyzer/scripts/e2e-gather-run-info.js
@@ -43,13 +43,14 @@ if (urlMatch) {
 
 function gh(...ghArgs) {
 	try {
+		// Do NOT use shell: true -- the --jq arguments contain pipe characters
+		// that cmd.exe would interpret as shell pipes. This works in Git Bash
+		// (Claude Code's shell on Windows) where gh resolves as a real binary.
 		return execFileSync('gh', ghArgs, {
 			encoding: 'utf8',
 			stdio: ['pipe', 'pipe', 'pipe'],
 			timeout: 60000,
 			maxBuffer: 50 * 1024 * 1024, // 50MB - CI logs can be very large
-			// Note: do NOT use shell: true here -- the --jq arguments contain
-			// pipe characters that cmd.exe would interpret as shell pipes.
 		}).trim();
 	} catch (err) {
 		process.stderr.write(`Warning: gh command failed: gh ${ghArgs.join(' ')}\n`);

--- a/.claude/skills/e2e-failure-analyzer/scripts/e2e-process-project.js
+++ b/.claude/skills/e2e-failure-analyzer/scripts/e2e-process-project.js
@@ -1,0 +1,526 @@
+#!/usr/bin/env node
+// Processes a blob report project end-to-end: optionally downloads and merges
+// sharded blob reports, then extracts failures, scans blobs for failed tests
+// and attachments, extracts/parses traces, and extracts screenshots and
+// error-context snapshots.
+//
+// Consolidates the download/merge step, e2e-extract-failures, e2e-inspect-blobs
+// (both modes), and e2e-parse-trace into a single invocation.
+//
+// Usage:
+//   # Pre-merged (blob-dir and report already exist):
+//   node e2e-process-project.js <blob-dir> <merged-report.json> [options]
+//
+//   # Download and merge automatically:
+//   node e2e-process-project.js --download --run-id <ID> --repo <owner/repo> --project <PROJECT> [options]
+//
+// Options:
+//   --output-dir <dir>   Where to save screenshots and error-context (default: /tmp/e2e-analysis-<random>)
+//   --last <N>           Number of trace actions to show (default: 30)
+//   --cleanup            Remove blob-reports, blob-merged, and report JSON after processing
+//
+// Output: JSON to stdout with failures, test details, trace timelines, and paths
+//         to extracted screenshots/error-context files in the output directory.
+
+import { readFileSync, existsSync, readdirSync, mkdirSync, writeFileSync, rmSync, cpSync } from 'fs';
+import { join, resolve } from 'path';
+import { execFileSync } from 'child_process';
+import { tmpdir } from 'os';
+import { randomBytes } from 'crypto';
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+const cliArgs = process.argv.slice(2);
+let blobDir = null;
+let reportPath = null;
+let outputDir = null;
+let lastN = 30;
+let doDownload = false;
+let runId = null;
+let repo = null;
+let project = null;
+let doCleanup = false;
+
+for (let i = 0; i < cliArgs.length; i++) {
+	switch (cliArgs[i]) {
+		case '--output-dir': outputDir = cliArgs[++i]; break;
+		case '--last': lastN = parseInt(cliArgs[++i], 10); break;
+		case '--download': doDownload = true; break;
+		case '--run-id': runId = cliArgs[++i]; break;
+		case '--repo': repo = cliArgs[++i]; break;
+		case '--project': project = cliArgs[++i]; break;
+		case '--cleanup': doCleanup = true; break;
+		default:
+			if (!blobDir) blobDir = cliArgs[i];
+			else if (!reportPath) reportPath = cliArgs[i];
+	}
+}
+
+if (doDownload) {
+	if (!runId || !project) {
+		console.error('--download requires --run-id and --project (--repo defaults to posit-dev/positron)');
+		process.exit(1);
+	}
+	repo = repo || 'posit-dev/positron';
+
+	// Derive paths from project name
+	const blobReportsDir = join(tmpdir(), `blob-reports-${project}`);
+	const blobMergedDir = join(tmpdir(), `blob-merged-${project}`);
+	const mergedReportPath = join(tmpdir(), `report-${project}.json`);
+
+	// Step 1: Download blob report artifacts
+	process.stderr.write(`Downloading blob reports for ${project}...\n`);
+	try {
+		// Clean previous downloads
+		rmSync(blobReportsDir, { recursive: true, force: true });
+		rmSync(blobMergedDir, { recursive: true, force: true });
+
+		execFileSync('gh', [
+			'run', 'download', runId, '--repo', repo,
+			'-p', `blob-report-${project}-*`, '-D', blobReportsDir,
+		], { stdio: ['pipe', 'pipe', 'pipe'], timeout: 120000, shell: true }); // shell: true for Windows .cmd wrappers
+	} catch (err) {
+		console.error(`Failed to download blob reports: ${(err.stderr || err.message || '').toString().trim().slice(0, 500)}`);
+		process.exit(1);
+	}
+
+	// Step 2: Copy all shard contents into merged directory
+	process.stderr.write('Merging blob report shards...\n');
+	mkdirSync(blobMergedDir, { recursive: true });
+	for (const shardDir of readdirSync(blobReportsDir)) {
+		const shardPath = join(blobReportsDir, shardDir);
+		try {
+			for (const file of readdirSync(shardPath)) {
+				cpSync(join(shardPath, file), join(blobMergedDir, file));
+			}
+		} catch {
+			// shardPath might be a file not a dir, skip
+		}
+	}
+
+	// Step 3: Merge reports with Playwright
+	process.stderr.write('Running playwright merge-reports...\n');
+	try {
+		execFileSync('npx', ['playwright', 'merge-reports', '--reporter=json', blobMergedDir], {
+			stdio: ['pipe', 'pipe', 'pipe'],
+			timeout: 120000,
+			shell: true, // needed on Windows where npx is a .cmd wrapper
+			env: { ...process.env, PLAYWRIGHT_JSON_OUTPUT_NAME: mergedReportPath },
+		});
+	} catch (err) {
+		console.error(`Failed to merge reports: ${(err.stderr || err.message || '').toString().trim().slice(0, 500)}`);
+		process.exit(1);
+	}
+
+	blobDir = blobMergedDir;
+	reportPath = mergedReportPath;
+}
+
+if (!blobDir || !reportPath) {
+	console.error('Usage: node e2e-process-project.js <blob-dir> <merged-report.json> [options]');
+	console.error('   or: node e2e-process-project.js --download --run-id <ID> --project <PROJECT> [options]');
+	process.exit(1);
+}
+
+const resolvedBlobDir = resolve(blobDir);
+const resolvedReportPath = resolve(reportPath);
+
+if (!existsSync(resolvedBlobDir)) {
+	console.error(`Blob directory not found: ${resolvedBlobDir}`);
+	process.exit(1);
+}
+if (!existsSync(resolvedReportPath)) {
+	console.error(`Report file not found: ${resolvedReportPath}`);
+	process.exit(1);
+}
+
+if (!outputDir) {
+	outputDir = join(tmpdir(), `e2e-analysis-${project || randomBytes(4).toString('hex')}`);
+}
+const resolvedOutputDir = resolve(outputDir);
+mkdirSync(join(resolvedOutputDir, 'screenshots'), { recursive: true });
+mkdirSync(join(resolvedOutputDir, 'error-context'), { recursive: true });
+
+// Temp dir for intermediate unzip operations (cleaned up at exit)
+const tmpWorkDir = join(tmpdir(), `e2e-process-${randomBytes(4).toString('hex')}`);
+mkdirSync(tmpWorkDir, { recursive: true });
+
+// ---------------------------------------------------------------------------
+// 1. Extract failures from merged Playwright JSON report
+//    (logic from e2e-extract-failures.js)
+// ---------------------------------------------------------------------------
+function extractFailures(path) {
+	const report = JSON.parse(readFileSync(path, 'utf8'));
+	const FAIL = new Set(['failed', 'timedOut', 'interrupted']);
+
+	function walk(suite, suitePath) {
+		const results = [];
+		for (const child of suite.suites || []) {
+			results.push(...walk(child, suitePath.concat(child.title || '')));
+		}
+		for (const spec of suite.specs || []) {
+			const failed = typeof spec.ok === 'boolean'
+				? !spec.ok
+				: spec.tests?.some(t => t.results?.some(r => FAIL.has(r?.status))) &&
+				  !spec.tests?.some(t => t.results?.some(r => r?.status === 'passed'));
+			if (!failed) continue;
+
+			const errors = [];
+			const projects = new Set();
+			for (const t of spec.tests || []) {
+				if (t.projectName) projects.add(t.projectName);
+				for (const r of t.results || []) {
+					if (FAIL.has(r?.status)) {
+						errors.push({
+							status: r.status,
+							error: (r.error?.message || '').slice(0, 2000),
+							snippet: (r.error?.snippet || '').slice(0, 1000),
+						});
+					}
+				}
+			}
+
+			results.push({
+				title: spec.title,
+				file: spec.file || spec.location?.file,
+				tags: spec.tags || [],
+				suite: suitePath.filter(Boolean).join(' > '),
+				project: [...projects].join(', ') || 'unknown',
+				errors,
+			});
+		}
+		return results;
+	}
+
+	const failures = [];
+	for (const s of report.suites || []) {
+		failures.push(...walk(s, [s.title || '']));
+	}
+	return failures;
+}
+
+// ---------------------------------------------------------------------------
+// 2. Scan blob reports for failed tests and their attachments
+//    (logic from e2e-inspect-blobs.js, both modes combined in one pass)
+// ---------------------------------------------------------------------------
+function scanBlobs(blobDirPath) {
+	const FAIL = new Set(['failed', 'timedOut', 'interrupted']);
+	const zipFiles = readdirSync(blobDirPath).filter(f => f.endsWith('.zip'));
+
+	const testMeta = new Map();     // testId -> {title, file}
+	const failedTests = [];         // all failed onTestEnd events
+	const failedTestIds = new Set();
+	// Collect ALL onAttach events keyed by testId. We filter to failed tests
+	// after the scan since onAttach can arrive before onTestEnd in the JSONL.
+	const allAttachments = new Map(); // testId -> [{name, contentType, path, resourceHash, blob}]
+
+	function collectTestMeta(suite, filePath) {
+		for (const entry of suite.entries || []) {
+			if (entry.testId) {
+				testMeta.set(entry.testId, {
+					title: entry.title,
+					file: suite.location?.file || filePath,
+				});
+			}
+			if (entry.entries) collectTestMeta(entry, filePath);
+		}
+	}
+
+	for (const zipFile of zipFiles) {
+		const zipPath = join(blobDirPath, zipFile);
+		const extractDir = join(tmpWorkDir, `blob-${zipFile.replace('.zip', '')}`);
+
+		try {
+			mkdirSync(extractDir, { recursive: true });
+			execFileSync('unzip', ['-o', zipPath, 'report.jsonl', '-d', extractDir], {
+				stdio: ['pipe', 'pipe', 'pipe'],
+			});
+		} catch {
+			continue;
+		}
+
+		const jsonlPath = join(extractDir, 'report.jsonl');
+		if (!existsSync(jsonlPath)) continue;
+
+		const lines = readFileSync(jsonlPath, 'utf8').split('\n').filter(Boolean);
+
+		for (const line of lines) {
+			let event;
+			try { event = JSON.parse(line); } catch { continue; }
+
+			if (event.method === 'onProject') {
+				for (const suite of event.params?.project?.suites || []) {
+					collectTestMeta(suite, suite.title);
+				}
+			}
+
+			if (event.method === 'onTestEnd') {
+				const status = event.params?.result?.status;
+				if (FAIL.has(status)) {
+					const id = event.params.test?.testId;
+					failedTestIds.add(id);
+					const meta = testMeta.get(id) || {};
+					failedTests.push({
+						testId: id,
+						title: meta.title || null,
+						file: meta.file || null,
+						status,
+						blob: zipFile,
+					});
+				}
+			}
+
+			if (event.method === 'onAttach') {
+				const testId = event.params?.testId;
+				if (!allAttachments.has(testId)) {
+					allAttachments.set(testId, []);
+				}
+				for (const att of event.params.attachments || []) {
+					const attPath = att.path || '';
+					const hashMatch = attPath.match(/([a-f0-9]{40})\./);
+					allAttachments.get(testId).push({
+						name: att.name,
+						contentType: att.contentType,
+						path: attPath,
+						resourceHash: hashMatch ? hashMatch[1] : null,
+						blob: zipFile,
+					});
+				}
+			}
+		}
+	}
+
+	// Filter attachments to only failed tests
+	const attachmentsByTestId = new Map();
+	for (const testId of failedTestIds) {
+		if (allAttachments.has(testId)) {
+			attachmentsByTestId.set(testId, allAttachments.get(testId));
+		}
+	}
+
+	return { failedTests, failedTestIds, attachmentsByTestId };
+}
+
+// ---------------------------------------------------------------------------
+// 3. Parse a trace.trace file
+//    (logic from e2e-parse-trace.js)
+// ---------------------------------------------------------------------------
+function parseTrace(tracePath) {
+	const content = readFileSync(tracePath, 'utf8');
+	const lines = content.split('\n').filter(Boolean);
+	const events = [];
+	for (const line of lines) {
+		try { events.push(JSON.parse(line)); } catch { /* skip */ }
+	}
+
+	const actions = events.filter(e => e.type === 'before' || e.type === 'after');
+	const recent = actions.slice(-lastN);
+
+	const timelineLines = [];
+	timelineLines.push(`=== Action Timeline (last ${Math.min(lastN, actions.length)} of ${actions.length} events) ===\n`);
+
+	for (const a of recent) {
+		if (a.type === 'before') {
+			let info = `${a.class || '?'}.${a.method || '?'}`;
+			if (a.startTime != null) info += ` (t=${Math.round(a.startTime)})`;
+			if (a.params?.selector) info += ` selector: ${a.params.selector}`;
+			if (a.params?.url) info += ` url: ${a.params.url}`;
+			timelineLines.push(`[before] ${info}`);
+		} else {
+			const err = a.error?.message?.slice(0, 300);
+			if (err) {
+				timelineLines.push(`[after]  ERROR: ${err}`);
+			} else {
+				let info = 'ok';
+				if (a.endTime != null) info += ` (t=${Math.round(a.endTime)})`;
+				timelineLines.push(`[after]  ${info}`);
+			}
+		}
+	}
+
+	const screenshots = events.filter(e => e.type === 'screencast-frame');
+	const lastScreenshot = screenshots.length > 0 ? screenshots[screenshots.length - 1] : null;
+
+	if (lastScreenshot) {
+		timelineLines.push(`\n=== Screenshots ===`);
+		timelineLines.push(`Total screencast frames: ${screenshots.length}`);
+		timelineLines.push(`Last screenshot sha1: ${lastScreenshot.sha1}`);
+		timelineLines.push(`Last screenshot timestamp: ${lastScreenshot.timestamp}`);
+	}
+
+	const errorEvents = events.filter(e => e.type === 'after' && e.error);
+	const errors = errorEvents.map(e => (e.error.message || '').slice(0, 500));
+
+	if (errors.length > 0) {
+		timelineLines.push(`\n=== Errors (${errors.length}) ===`);
+		for (const err of errors) {
+			timelineLines.push(`- ${err}`);
+		}
+	}
+
+	return {
+		timeline: timelineLines.join('\n'),
+		errors,
+		lastScreenshotSha1: lastScreenshot?.sha1 || null,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: unzip operations
+// ---------------------------------------------------------------------------
+
+/** Extract a single file from a zip to a destination directory. Returns the extracted path or null. */
+function unzipFile(zipPath, entryPath, destDir) {
+	try {
+		mkdirSync(destDir, { recursive: true });
+		execFileSync('unzip', ['-o', zipPath, entryPath, '-d', destDir], {
+			stdio: ['pipe', 'pipe', 'pipe'],
+		});
+		const extracted = join(destDir, entryPath);
+		return existsSync(extracted) ? extracted : null;
+	} catch {
+		return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Main processing
+// ---------------------------------------------------------------------------
+
+process.stderr.write('Extracting failures from merged report...\n');
+const failures = extractFailures(resolvedReportPath);
+
+process.stderr.write('Scanning blob reports for failed tests and attachments...\n');
+const { failedTests, failedTestIds, attachmentsByTestId } = scanBlobs(resolvedBlobDir);
+
+process.stderr.write(`Found ${failures.length} final failures, ${failedTestIds.size} unique failed test IDs across all attempts.\n`);
+
+// Build detailed per-test data
+const testDetails = [];
+
+for (const testId of failedTestIds) {
+	const testInfo = failedTests.find(t => t.testId === testId);
+	const attachments = attachmentsByTestId.get(testId) || [];
+
+	const traceAtts = attachments.filter(a => a.name === 'trace' && a.contentType === 'application/zip');
+	const errorCtxAtts = attachments.filter(a => a.name === 'error-context' && a.contentType === 'text/markdown');
+	const logsAtts = attachments.filter(a => a.name?.includes('logs-') && a.contentType === 'application/zip');
+
+	const shortId = testId.slice(0, 12);
+	const attempts = [];
+
+	for (let i = 0; i < traceAtts.length; i++) {
+		const traceAtt = traceAtts[i];
+		const errorCtxAtt = errorCtxAtts[i]; // may be undefined
+
+		let traceData = null;
+		let screenshotPath = null;
+
+		// Extract and parse trace
+		if (traceAtt.resourceHash) {
+			process.stderr.write(`  Processing trace for ${shortId} attempt ${i}...\n`);
+
+			// Step 1: extract the resource zip from the blob zip
+			const traceExtractDir = join(tmpWorkDir, `trace-${shortId}-${i}`);
+			const resourceZipPath = unzipFile(
+				join(resolvedBlobDir, traceAtt.blob),
+				traceAtt.path,
+				traceExtractDir
+			);
+
+			if (resourceZipPath) {
+				// Step 2: extract trace.trace from the resource zip
+				const traceDir = join(tmpWorkDir, `trace-parsed-${shortId}-${i}`);
+				const tracePath = unzipFile(resourceZipPath, 'trace.trace', traceDir);
+
+				if (tracePath) {
+					traceData = parseTrace(tracePath);
+
+					// Step 3: extract last screenshot from resource zip
+					// The sha1 field from screencast-frame events is the full filename
+					// including extension (e.g., "page@abc123-timestamp.jpeg")
+					if (traceData.lastScreenshotSha1) {
+						const ssFileName = `${shortId}-attempt${i}.jpeg`;
+						const ssDestPath = join(resolvedOutputDir, 'screenshots', ssFileName);
+						const ssEntry = `resources/${traceData.lastScreenshotSha1}`;
+						const ssTempDir = join(tmpWorkDir, `ss-${shortId}-${i}`);
+						const ssExtracted = unzipFile(resourceZipPath, ssEntry, ssTempDir);
+
+						if (ssExtracted) {
+							writeFileSync(ssDestPath, readFileSync(ssExtracted));
+							screenshotPath = ssDestPath;
+						}
+					}
+				}
+			}
+		}
+
+		// Extract error context markdown
+		let errorContextPath = null;
+		if (errorCtxAtt?.resourceHash) {
+			const mdEntry = `resources/${errorCtxAtt.resourceHash}.markdown`;
+			const mdTempDir = join(tmpWorkDir, `errctx-${shortId}-${i}`);
+			const mdExtracted = unzipFile(
+				join(resolvedBlobDir, errorCtxAtt.blob),
+				mdEntry,
+				mdTempDir
+			);
+
+			if (mdExtracted) {
+				const mdContent = readFileSync(mdExtracted, 'utf8');
+				const mdFileName = `${shortId}-attempt${i}.md`;
+				const mdDestPath = join(resolvedOutputDir, 'error-context', mdFileName);
+				writeFileSync(mdDestPath, mdContent);
+				errorContextPath = mdDestPath;
+			}
+		}
+
+		attempts.push({
+			attemptIndex: i,
+			trace: traceData,
+			screenshotPath,
+			errorContextPath,
+		});
+	}
+
+	testDetails.push({
+		testId,
+		title: testInfo?.title || null,
+		file: testInfo?.file || null,
+		status: testInfo?.status || null,
+		blob: testInfo?.blob || null,
+		attemptCount: traceAtts.length,
+		attempts,
+		logHashes: logsAtts.map(a => ({ resourceHash: a.resourceHash, blob: a.blob })),
+	});
+}
+
+// Clean up temp work directory
+try {
+	rmSync(tmpWorkDir, { recursive: true, force: true });
+} catch { /* best effort */ }
+
+// Clean up download/merge artifacts if --cleanup was specified
+if (doCleanup && project) {
+	process.stderr.write('Cleaning up download/merge artifacts...\n');
+	const blobReportsDir = join(tmpdir(), `blob-reports-${project}`);
+	const blobMergedDir = join(tmpdir(), `blob-merged-${project}`);
+	const mergedReportPath = join(tmpdir(), `report-${project}.json`);
+	for (const p of [blobReportsDir, blobMergedDir, mergedReportPath]) {
+		try { rmSync(p, { recursive: true, force: true }); } catch { /* best effort */ }
+	}
+}
+
+const result = {
+	outputDir: resolvedOutputDir,
+	failures,
+	failedTests,
+	testDetails,
+};
+
+console.log(JSON.stringify(result, null, 2));
+
+process.stderr.write(`\nDone. Screenshots: ${join(resolvedOutputDir, 'screenshots')}\n`);
+process.stderr.write(`Total: ${failures.length} final failures, ${testDetails.length} unique failed tests, ` +
+	`${testDetails.reduce((sum, t) => sum + t.attempts.length, 0)} trace attempts processed.\n`);


### PR DESCRIPTION
Cleanup of the new failure analysis skill, to minimize approvals needed.

## Summary
- Adds two consolidated scripts (`e2e-gather-run-info.js`, `e2e-process-project.js`) that batch multiple `gh api`, `unzip`, and `node` calls into single invocations, reducing approval prompts from ~26 to ~3-4 when running the `/e2e-failure-analyzer` skill
- `e2e-process-project.js` supports `--download` (handles `gh run download` + merge internally) and `--cleanup` (removes intermediate artifacts), eliminating separate bash calls for those steps
- Updates `SKILL.md` to use the new scripts, batch screenshot reads, use exact cleanup paths (no globs), and explicitly distinguish "failed all retries" vs "passed on retry" in the summary table

## Test plan
- [x] Tested `e2e-gather-run-info.js` against run 24207668586 (release branch) and 24211776879 (main)
- [x] Tested `e2e-process-project.js` with `--download --cleanup` end-to-end
- [x] Verified screenshots extracted correctly and are viewable
- [x] Verified `--cleanup` removes intermediate artifacts but preserves output dir
- [x] Verified full skill flow produces equivalent analysis output
- [x] Standalone scripts (`e2e-extract-failures.js`, `e2e-inspect-blobs.js`, `e2e-parse-trace.js`) remain unchanged and functional