### PR TITLE
Use plus icon for notebook add cell buttons

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.tsx
@@ -41,7 +41,7 @@ export function AddCodeCellButton({ notebookInstance, index, bordered }: { noteb
 		bordered={bordered}
 		fullLabel={fullLabel}
 		hoverManager={notebookInstance.hoverManager}
-		icon={Codicon.code}
+		icon={Codicon.plus}
 		label={label}
 		onClick={() => notebookInstance.addCell(CellKind.Code, index, true)}
 	/>;
@@ -57,7 +57,7 @@ export function AddMarkdownCellButton({ notebookInstance, index, bordered }: { n
 		bordered={bordered}
 		fullLabel={fullLabel}
 		hoverManager={notebookInstance.hoverManager}
-		icon={Codicon.markdown}
+		icon={Codicon.plus}
 		label={label}
 		onClick={() => notebookInstance.addCell(CellKind.Markup, index, true)}
 	/>;

--- a/src/vs/workbench/contrib/positronNotebook/browser/utilityComponents/IconedButton.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/utilityComponents/IconedButton.css
@@ -6,19 +6,23 @@
 .positron-iconed-button {
 	cursor: pointer;
 	display: flex;
-	gap: 6px;
+	align-items: center;
+	gap: 4px;
 	font-size: 12px;
 	color: var(--vscode-positronNotebook-deemphasized-foreground);
-
-	.button-icon {
-		color: inherit;
-		font-size: 18px;
-		transform: translateY(0px);
-	}
 
 	.action-label {
 		cursor: pointer;
 	}
+}
+
+.positron-iconed-button div.button-icon {
+	color: inherit;
+	font-size: 14px;
+}
+.positron-iconed-button div.button-icon.codicon-plus {
+	/* The plus icon is not centered vertically within its canvas */
+	transform: translate(1px, 1px);
 }
 
 .positron-iconed-button.bordered {


### PR DESCRIPTION
Partially addresses #11775 

## Summary
- Replace code/markdown icons with plus icons on the between-cell add cell buttons

<img width="603" height="259" alt="image" src="https://github.com/user-attachments/assets/4b37b407-bca9-48d2-8344-8363ed2cad57" />


### Old
<img width="603" height="259" alt="image" src="https://github.com/user-attachments/assets/6975e444-299a-42af-afba-8bcf7b0a5839" />


## QA Notes

Open a notebook with multiple cells. Hover between cells and verify the add cell buttons show a "+" icon instead of the old code/markdown icons.