### PR TITLE
e2e: fix cell count to account for default code cell

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -262,7 +262,9 @@ export class PositronNotebooks extends Notebooks {
 
 		let totalCellsAdded = 0;
 
-		if (codeCells > 0) {
+		if (codeCells === 0) {
+			await this.deleteCellWithActionBar(0);
+		} else if (codeCells > 0) {
 			for (let i = 0; i < codeCells; i++) {
 				await this.addCodeToCell(i, `# Cell ${i}`);
 				await this.expectCellCountToBe(totalCellsAdded + 1);

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -256,14 +256,14 @@ export class PositronNotebooks extends Notebooks {
 		await this.expectToBeVisible();
 		await this.expectCellCountToBe(1); // New notebook starts with 1 cell by default
 
-		if (codeCells === 1 && markdownCells === 0) {
+		if (codeCells <= 1 && markdownCells === 0) {
 			return;
 		}
 
-		let totalCellsAdded = 1;
+		let totalCellsAdded = 0;
 
-		if (codeCells > 1) {
-			for (let i = 1; i < codeCells; i++) {
+		if (codeCells > 0) {
+			for (let i = 0; i < codeCells; i++) {
 				await this.addCodeToCell(i, `# Cell ${i}`);
 				await this.expectCellCountToBe(totalCellsAdded + 1);
 				await this.expectCellContentAtIndexToBe(i, `# Cell ${i}`);

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -251,18 +251,19 @@ export class PositronNotebooks extends Notebooks {
 	 * @param codeCells - Number of code cells to create
 	 * @param markdownCells - Number of markdown cells to create
 	 */
-	async newNotebook({ codeCells = 0, markdownCells = 0 }: { codeCells?: number; markdownCells?: number } = {}): Promise<void> {
+	async newNotebook({ codeCells = 1, markdownCells = 0 }: { codeCells?: number; markdownCells?: number } = {}): Promise<void> {
 		await this.createNewNotebook();
 		await this.expectToBeVisible();
+		await this.expectCellCountToBe(1); // New notebook starts with 1 cell by default
 
-		if (codeCells === 0 && markdownCells === 0) {
+		if (codeCells === 1 && markdownCells === 0) {
 			return;
 		}
 
-		let totalCellsAdded = 0;
+		let totalCellsAdded = 1;
 
-		if (codeCells > 0) {
-			for (let i = 0; i < codeCells; i++) {
+		if (codeCells > 1) {
+			for (let i = 1; i < codeCells; i++) {
 				await this.addCodeToCell(i, `# Cell ${i}`);
 				await this.expectCellCountToBe(totalCellsAdded + 1);
 				await this.expectCellContentAtIndexToBe(i, `# Cell ${i}`);

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -256,15 +256,17 @@ export class PositronNotebooks extends Notebooks {
 		await this.expectToBeVisible();
 		await this.expectCellCountToBe(1); // New notebook starts with 1 cell by default
 
+		if (codeCells === 0) {
+			await this.deleteCellWithActionBar(0);
+		}
+
 		if (codeCells <= 1 && markdownCells === 0) {
 			return;
 		}
 
 		let totalCellsAdded = 0;
 
-		if (codeCells === 0) {
-			await this.deleteCellWithActionBar(0);
-		} else if (codeCells > 0) {
+		if (codeCells > 0) {
 			for (let i = 0; i < codeCells; i++) {
 				await this.addCodeToCell(i, `# Cell ${i}`);
 				await this.expectCellCountToBe(totalCellsAdded + 1);


### PR DESCRIPTION
## Summary
- Positron notebooks always create 1 code cell by default when opened from scratch
- Updated `newNotebook()` to account for this: defaults `codeCells` to 1, verifies the initial cell exists, and only adds cells beyond the default
- Prevents off-by-one cell count issues on Chromium/web where the default cell is reliably present

## Test tags
@:positron-notebooks @:web @:rhel-web

## QA Notes
Existing notebook e2e tests should pass with the updated cell counting logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)