### PR TITLE
Cherry pick (2026.04 patch): Update Posit Assistant and Pyrefly

### DIFF
--- a/product.json
+++ b/product.json
@@ -200,8 +200,8 @@
 		},
 		{
 			"name": "meta.pyrefly",
-			"version": "0.58.0",
-			"sha256sum": "bfedf0ad51699d4227b3628b1007283f0ca8517f0ac46543240ac4fae89980c7",
+			"version": "0.60.0",
+			"sha256sum": "84de58c36e57d1caea48ad466bfd643113dd5599d04952cfc9cf03cf69d4117f",
 			"repo": "https://github.com/facebook/pyrefly",
 			"metadata": {
 				"publisherId": {
@@ -296,8 +296,8 @@
 		},
 		{
 			"name": "posit.assistant",
-			"version": "0.1.1",
-			"sha256": "87534c4229bac3ef6b12786226d560c9eaea6c617e2a8bd20a1fd85ee7cebf27",
+			"version": "0.2.1",
+			"sha256": "dd7a821377d62e258079c2e84962b0b7ac1be906c4cf6e5c1fd53f825da17850",
 			"metadata": {
 				"publisherId": "090804ff-7eb2-4fbd-bb61-583e34f2b070",
 				"displayName": "Posit Assistant"


### PR DESCRIPTION
Updates extensions:

- Posit Assistant 0.1.1 -> 0.2.1
- Pyrefly 0.58.0 -> 0.60.0

Addresses #12960  

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Updates Posit Assistant & Pyrefly to latest versions for bootstrapping


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
