### PR TITLE
assistant: update provider setting tags and default enabled providers (#12955)

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -473,6 +473,11 @@
             "default": "",
             "markdownDescription": "%configuration.models.preference.snowflakeCortex.description%"
           },
+          "positron.assistant.models.preference.msFoundry": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "%configuration.models.preference.msFoundry.description%"
+          },
           "positron.assistant.models.preference.openAI": {
             "type": "string",
             "default": "",
@@ -486,18 +491,7 @@
           "positron.assistant.models.preference.positAI": {
             "type": "string",
             "default": "",
-            "markdownDescription": "%configuration.models.preference.positAI.description%",
-            "tags": [
-              "advanced"
-            ]
-          },
-          "positron.assistant.models.preference.msFoundry": {
-            "type": "string",
-            "default": "",
-            "markdownDescription": "%configuration.models.preference.msFoundry.description%",
-            "tags": [
-              "advanced"
-            ]
+            "markdownDescription": "%configuration.models.preference.positAI.description%"
           },
           "positron.assistant.models.preference.google": {
             "type": "string",
@@ -633,6 +627,38 @@
               ]
             ]
           },
+          "positron.assistant.models.overrides.msFoundry": {
+            "type": "array",
+            "default": [],
+            "markdownDescription": "%configuration.models.overrides.msFoundry.description%",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Display name for the model"
+                },
+                "identifier": {
+                  "type": "string",
+                  "description": "Model identifier for API calls"
+                },
+                "maxInputTokens": {
+                  "type": "number",
+                  "minimum": 512,
+                  "description": "Maximum input tokens for this model"
+                },
+                "maxOutputTokens": {
+                  "type": "number",
+                  "minimum": 512,
+                  "description": "Maximum output tokens for this model"
+                }
+              },
+              "required": [
+                "name",
+                "identifier"
+              ]
+            }
+          },
           "positron.assistant.models.overrides.openAI": {
             "type": "array",
             "default": [],
@@ -719,44 +745,6 @@
             "type": "array",
             "default": [],
             "markdownDescription": "%configuration.models.overrides.positAI.description%",
-            "tags": [
-              "advanced"
-            ],
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Display name for the model"
-                },
-                "identifier": {
-                  "type": "string",
-                  "description": "Model identifier for API calls"
-                },
-                "maxInputTokens": {
-                  "type": "number",
-                  "minimum": 512,
-                  "description": "Maximum input tokens for this model"
-                },
-                "maxOutputTokens": {
-                  "type": "number",
-                  "minimum": 512,
-                  "description": "Maximum output tokens for this model"
-                }
-              },
-              "required": [
-                "name",
-                "identifier"
-              ]
-            }
-          },
-          "positron.assistant.models.overrides.msFoundry": {
-            "type": "array",
-            "default": [],
-            "markdownDescription": "%configuration.models.overrides.msFoundry.description%",
-            "tags": [
-              "advanced"
-            ],
             "items": {
               "type": "object",
               "properties": {
@@ -843,30 +831,30 @@
           },
           "positron.assistant.provider.amazonBedrock.enable": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "markdownDescription": "%configuration.provider.amazonBedrock.enable.description%",
-            "tags": [
-              "preview"
-            ],
             "order": 3
           },
           "positron.assistant.provider.snowflakeCortex.enable": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "markdownDescription": "%configuration.provider.snowflakeCortex.enable.description%",
-            "tags": [
-              "preview"
-            ],
             "order": 4
           },
-          "positron.assistant.provider.openAI.enable": {
+          "positron.assistant.provider.msFoundry.enable": {
             "type": "boolean",
             "default": false,
-            "markdownDescription": "%configuration.provider.openAI.enable.description%",
+            "markdownDescription": "%configuration.provider.msFoundry.enable.description%",
             "tags": [
               "preview"
             ],
             "order": 5
+          },
+          "positron.assistant.provider.openAI.enable": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "%configuration.provider.openAI.enable.description%",
+            "order": 6
           },
           "positron.assistant.provider.customProvider.enable": {
             "type": "boolean",
@@ -875,25 +863,14 @@
             "tags": [
               "experimental"
             ],
-            "order": 6
+            "order": 7
           },
           "positron.assistant.provider.positAI.enable": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "markdownDescription": "%configuration.provider.positAI.enable.description%",
             "tags": [
-              "experimental",
-              "advanced"
-            ],
-            "order": 7
-          },
-          "positron.assistant.provider.msFoundry.enable": {
-            "type": "boolean",
-            "default": false,
-            "markdownDescription": "%configuration.provider.msFoundry.enable.description%",
-            "tags": [
-              "experimental",
-              "advanced"
+              "preview"
             ],
             "order": 8
           },

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -249,8 +249,62 @@ async function initializeProviderConfiguration(context: vscode.ExtensionContext)
 	// 2. Perform settings migrations (provider enablement, model preferences, custom models)
 	await performSettingsMigrations();
 
-	// 3. Validate that at least one provider is enabled
+	// 3. Apply PWB-specific provider defaults
+	await applyPwbProviderDefaults(context);
+
+	// 4. Validate that at least one provider is enabled
 	await validateProvidersEnabled();
+}
+
+/**
+ * Apply PWB-specific provider defaults.
+ *
+ * On Posit Workbench, Posit AI should default to disabled, but users and admins
+ * can still configure it. Since package.json doesn't support conditional defaults,
+ * we use globalState to track whether we've applied the PWB default. This ensures:
+ * - First run on PWB: Posit AI is disabled (unless already configured)
+ * - Admin configures via policy: their choice is respected because we can't overwrite admin policies
+ * - User changes the setting: their choice is preserved
+ * - Subsequent runs: we don't overwrite existing choices
+ *
+ * See: https://github.com/posit-dev/positron/issues/12954
+ */
+async function applyPwbProviderDefaults(context: vscode.ExtensionContext): Promise<void> {
+	if (!IS_RUNNING_ON_PWB) {
+		return;
+	}
+
+	const pwbDefaultAppliedKey = 'positAI.pwbDefaultApplied';
+	const pwbDefaultApplied = context.globalState.get<boolean>(pwbDefaultAppliedKey);
+
+	if (!pwbDefaultApplied) {
+		const config = vscode.workspace.getConfiguration('positron.assistant.provider.positAI');
+		const currentValue = config.get<boolean>('enable');
+
+		// If already disabled (by admin policy, user, or any other means), nothing to do
+		if (currentValue !== false) {
+			const enableInspect = config.inspect<boolean>('enable');
+
+			// Only apply default if no one has explicitly configured this setting.
+			// Admin policy values aren't exposed via inspect(), but if an admin
+			// enforced a policy, the update will fail and we catch it below.
+			const hasExplicitValue = enableInspect?.globalValue !== undefined ||
+				enableInspect?.workspaceValue !== undefined ||
+				enableInspect?.workspaceFolderValue !== undefined;
+
+			if (!hasExplicitValue) {
+				try {
+					await config.update('enable', false, vscode.ConfigurationTarget.Global);
+				} catch (e) {
+					// Setting may be enforced by admin policy; log and continue
+					log.warn(`Posit AI enablement enforced by admin policy and cannot be updated: ${e instanceof Error ? e.message : String(e)}`);
+				}
+			}
+		}
+
+		// Always mark as applied so we don't retry
+		await context.globalState.update(pwbDefaultAppliedKey, true);
+	}
 }
 
 async function reconcileAuthProviderModels(


### PR DESCRIPTION
_Cherry-picked from https://github.com/posit-dev/positron/pull/12955_

- Addresses https://github.com/posit-dev/positron/issues/12954
- Diff is long, due to reordering of the settings to match the order on the docs site https://github.com/posit-dev/positron-website/pull/327 (msfoundry after snowflake)

### Release Notes

#### Bug Fixes

- Assistant: update provider settings tags and default enabled providers (#12954)

### QA Notes

Foundry-related settings are now visible by default, with the enablement setting tagged as Preview (matches other preview providers).

<img width="992" height="715" alt="image"
src="https://github.com/user-attachments/assets/5297e99f-592c-4277-9e60-194f1851b3c1" />

Additional changes

- Removed preview tags from Bedrock, Snowflake, OpenAI
- Kept Copilot, Foundry at preview
- Changed Posit AI from experimental to preview
- Removed advanced tags from Posit AI preference/override settings
- Enabled Bedrock, Snowflake, OpenAI by default
- Conditionally enabled Posit AI by default
    - enabled by default on desktop
- disabled by default on PWB (uses globalState to apply PWB-specific default on first run; users can still toggle the setting on either platform)