### PR TITLE
e2e: update notebook eval tests to reflect renamed tool calls

### DIFF
--- a/test/e2e/tests/assistant-eval/README.md
+++ b/test/e2e/tests/assistant-eval/README.md
@@ -1,6 +1,6 @@
 # Positron: LLM Eval Test Catalog
 
-> 9 test cases · Auto-generated on 2026-03-04T17:56:14.438Z
+> 9 test cases · Auto-generated on 2026-04-13T11:49:32.378Z
 
 ## Hallucination
 
@@ -73,11 +73,11 @@ Load the forested package and make some plots of the forested data
 ## Notebooks
 
 <details>
-<summary><strong>py-notebook-get-cells</strong> · Edit · Ensure getNotebookCells is called for large not...</summary>
+<summary><strong>py-notebook-get-cells</strong> · Edit · Ensure getNotebookInfo is called for large note...</summary>
 
 ### Intent
 
-Ensure getNotebookCells is called for large notebooks
+Ensure getNotebookInfo is called for large notebooks
 
 ### User prompt
 
@@ -89,7 +89,7 @@ What is the value calculated in cell 21 (index 20) of my notebook?
 
 #### Required
 
-- The `getNotebookCells` tool must appear in the "Tools Called:" section (required because large notebooks use sliding window)
+- The `getNotebookInfo` tool must appear in the "Tools Called:" section (required because large notebooks use sliding window)
 - Reports the correct value from cell 21 (index 20), which is 200, since it calculates x * 10 where x = 20)
 
 #### Nice to have
@@ -119,7 +119,7 @@ What is the total revenue shown in my notebook? Just tell me the answer, don't a
 
 - Correctly identifies the total revenue as 145,500 (sum of 45000 + 52000 + 48500)
 - Response demonstrates the assistant can READ notebook contents by mentioning at least 2 of: specific revenue values (45000, 52000, 48500), months (January, February, March), or cell reference (cell 0)
-- The `editNotebookCells` tool must NOT appear in "Tools Called:" (we asked NOT to edit)
+- The `editNotebook` tool must NOT appear in "Tools Called:" (we asked NOT to edit)
 
 #### Nice to have
 
@@ -157,11 +157,11 @@ Create a new R notebook for me.
 </details>
 
 <details>
-<summary><strong>r-notebook-edit-cells</strong> · Edit · Ensure editNotebookCells is used when editing n...</summary>
+<summary><strong>r-notebook-edit-cells</strong> · Edit · Ensure editNotebook is used when editing notebo...</summary>
 
 ### Intent
 
-Ensure editNotebookCells is used when editing notebook cells
+Ensure editNotebook is used when editing notebook cells
 
 ### User prompt
 
@@ -173,7 +173,7 @@ Fix the error in cell 2 of my notebook.
 
 #### Required
 
-- The `editNotebookCells` tool must appear in the "Tools Called:" section
+- The `editNotebook` tool must appear in the "Tools Called:" section
 - The `editFile` or `positron_editFile_internal` tool must NOT appear (wrong tool for notebooks)
 
 #### Nice to have
@@ -185,16 +185,16 @@ Fix the error in cell 2 of my notebook.
 
 #### Fail if
 
-- Uses editFile instead of editNotebookCells (indicates the assistant did not correctly identify the notebook context)
+- Uses editFile instead of editNotebook (indicates the assistant did not correctly identify the notebook context)
 
 </details>
 
 <details>
-<summary><strong>r-notebook-run-cells</strong> · Agent · Ensure runNotebookCells is used to execute note...</summary>
+<summary><strong>r-notebook-run-cells</strong> · Agent · Ensure executeNotebook is used to execute noteb...</summary>
 
 ### Intent
 
-Ensure runNotebookCells is used to execute notebook cells
+Ensure executeNotebook is used to execute notebook cells
 
 ### User prompt
 
@@ -206,14 +206,14 @@ Run cell 2 of my notebook and tell me what the output is.
 
 #### Required
 
-- The `runNotebookCells` tool must appear in the "Tools Called:" section
+- The `executeNotebook` tool must appear in the "Tools Called:" section
 - Reports the correct output value (15, since x=10 and the code is result <- x + 5)
 
 #### Nice to have
 
 - Explains what the code does (adds x + 5 where x is 10)
 - Confirms the cell was executed successfully
-- Does not use editNotebookCells when only asked to run (should use runNotebookCells)
+- Does not use editNotebook when only asked to run (should use executeNotebook)
 
 </details>
 

--- a/test/e2e/tests/assistant-eval/notebooks/py-notebook-get-cells.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/py-notebook-get-cells.ts
@@ -7,22 +7,22 @@ import { TestTags } from '../../../infra';
 import { EvalTestCase, RunResult } from '../types';
 
 /**
- * Test: getNotebookCells tool (large notebook)
+ * Test: getNotebookInfo tool (large notebook)
  *
- * TOOL: getNotebookCells
+ * TOOL: getNotebookInfo
  * SCENARIO: Large notebooks (>= 20 cells) use a sliding window for automatic context.
- *           Cells outside the window require an explicit getNotebookCells tool call.
+ *           Cells outside the window require an explicit getNotebookInfo tool call.
  *
  * This test creates a 21-cell notebook where each cell calculates `x * 10`.
  * Cell index 0 is selected, so cell index 20 is outside the automatic context window.
- * When asked about cell 21 (index 20), the assistant MUST call getNotebookCells to fetch it.
+ * When asked about cell 21 (index 20), the assistant MUST call getNotebookInfo to fetch it.
  */
 const prompt = 'What is the value calculated in cell 21 (index 20) of my notebook?';
 const mode = 'Edit';
 
 export const pyNotebookGetCells: EvalTestCase = {
 	id: 'py-notebook-get-cells',
-	description: 'Ensure getNotebookCells is called for large notebooks',
+	description: 'Ensure getNotebookInfo is called for large notebooks',
 	prompt,
 	mode,
 	language: 'Python',
@@ -63,7 +63,7 @@ export const pyNotebookGetCells: EvalTestCase = {
 
 	evaluationCriteria: {
 		required: [
-			'The `getNotebookCells` tool must appear in the "Tools Called:" section (required because large notebooks use sliding window)',
+			'The `getNotebookInfo` tool must appear in the "Tools Called:" section (required because large notebooks use sliding window)',
 			'Reports the correct value from cell 21 (index 20), which is 200, since it calculates x * 10 where x = 20)',
 		],
 		optional: [

--- a/test/e2e/tests/assistant-eval/notebooks/r-notebook-automatic-context.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/r-notebook-automatic-context.ts
@@ -15,7 +15,7 @@ import { EvalTestCase, RunResult } from '../types';
  *
  * This test creates a 1-cell notebook with revenue data and asks the assistant
  * to calculate the total. The assistant should answer correctly using the
- * automatically-provided context, without calling getNotebookCells.
+ * automatically-provided context, without calling getNotebookInfo.
  */
 const prompt = 'What is the total revenue shown in my notebook? Just tell me the answer, don\'t add or modify any cells.';
 const mode = 'Edit';
@@ -60,7 +60,7 @@ export const rNotebookAutomaticContext: EvalTestCase = {
 		required: [
 			'Correctly identifies the total revenue as 145,500 (sum of 45000 + 52000 + 48500)',
 			'Response demonstrates the assistant can READ notebook contents by mentioning at least 2 of: specific revenue values (45000, 52000, 48500), months (January, February, March), or cell reference (cell 0)',
-			'The `editNotebookCells` tool must NOT appear in "Tools Called:" (we asked NOT to edit)',
+			'The `editNotebook` tool must NOT appear in "Tools Called:" (we asked NOT to edit)',
 		],
 		optional: [
 			'Provides a clear, accurate calculation or explanation showing how the total was derived',

--- a/test/e2e/tests/assistant-eval/notebooks/r-notebook-edit-cells.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/r-notebook-edit-cells.ts
@@ -7,22 +7,22 @@ import { TestTags } from '../../../infra';
 import { EvalTestCase, RunResult } from '../types';
 
 /**
- * Test: editNotebookCells tool
+ * Test: editNotebook tool
  *
- * TOOL: editNotebookCells
- * SCENARIO: When editing notebook cells, the assistant should use editNotebookCells
+ * TOOL: editNotebook
+ * SCENARIO: When editing notebook cells, the assistant should use editNotebook
  *           (not editFile) to modify the cell content.
  *
  * This test creates a 2-cell notebook with an intentional R error in cell 2
  * (references undefined_variable). When asked to fix the error, the assistant
- * MUST call editNotebookCells to modify the cell, NOT editFile.
+ * MUST call editNotebook to modify the cell, NOT editFile.
  */
 const prompt = 'Fix the error in cell 2 of my notebook.';
 const mode = 'Edit';
 
 export const rNotebookEditCells: EvalTestCase = {
 	id: 'r-notebook-edit-cells',
-	description: 'Ensure editNotebookCells is used when editing notebook cells',
+	description: 'Ensure editNotebook is used when editing notebook cells',
 	prompt,
 	mode,
 	tags: [TestTags.POSITRON_NOTEBOOKS],
@@ -63,7 +63,7 @@ export const rNotebookEditCells: EvalTestCase = {
 
 	evaluationCriteria: {
 		required: [
-			'The `editNotebookCells` tool must appear in the "Tools Called:" section',
+			'The `editNotebook` tool must appear in the "Tools Called:" section',
 			'The `editFile` or `positron_editFile_internal` tool must NOT appear (wrong tool for notebooks)',
 		],
 		optional: [
@@ -73,7 +73,7 @@ export const rNotebookEditCells: EvalTestCase = {
 			'Explanation of what was wrong and how it was fixed',
 		],
 		failIf: [
-			'Uses editFile instead of editNotebookCells (indicates the assistant did not correctly identify the notebook context)',
+			'Uses editFile instead of editNotebook (indicates the assistant did not correctly identify the notebook context)',
 		],
 	},
 };

--- a/test/e2e/tests/assistant-eval/notebooks/r-notebook-run-cells.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/r-notebook-run-cells.ts
@@ -7,14 +7,14 @@ import { TestTags } from '../../../infra';
 import { EvalTestCase, RunResult } from '../types';
 
 /**
- * Test: runNotebookCells tool
+ * Test: executeNotebook tool
  *
- * TOOL: runNotebookCells
+ * TOOL: executeNotebook
  * SCENARIO: When asked to execute notebook cells, the assistant should use
- *           runNotebookCells to run the code. Requires Agent mode.
+ *           executeNotebook to run the code. Requires Agent mode.
  *
  * This test creates a 2-cell notebook with R code (x <- 10 and x + 5).
- * When asked to run cell 2, the assistant MUST call runNotebookCells
+ * When asked to run cell 2, the assistant MUST call executeNotebook
  * and report the output (15).
  */
 const prompt = 'Run cell 2 of my notebook and tell me what the output is.';
@@ -22,7 +22,7 @@ const mode = 'Agent';
 
 export const rNotebookRunCells: EvalTestCase = {
 	id: 'r-notebook-run-cells',
-	description: 'Ensure runNotebookCells is used to execute notebook cells',
+	description: 'Ensure executeNotebook is used to execute notebook cells',
 	prompt,
 	mode,
 	tags: [TestTags.POSITRON_NOTEBOOKS],
@@ -62,13 +62,13 @@ export const rNotebookRunCells: EvalTestCase = {
 
 	evaluationCriteria: {
 		required: [
-			'The `runNotebookCells` tool must appear in the "Tools Called:" section',
+			'The `executeNotebook` tool must appear in the "Tools Called:" section',
 			'Reports the correct output value (15, since x=10 and the code is result <- x + 5)',
 		],
 		optional: [
 			'Explains what the code does (adds x + 5 where x is 10)',
 			'Confirms the cell was executed successfully',
-			'Does not use editNotebookCells when only asked to run (should use runNotebookCells)',
+			'Does not use editNotebook when only asked to run (should use executeNotebook)',
 		],
 	},
 };


### PR DESCRIPTION
PR #12093 renamed three notebook assistant tool calls but the eval tests were not updated, causing failures (e.g., `py-notebook-get-cells` expects `getNotebookCells` but the model now calls `getNotebookInfo`).

This PR updates all eval test criteria and comments to match the new names:

- `getNotebookCells` -> `getNotebookInfo`
- `runNotebookCells` -> `executeNotebook`
- `editNotebookCells` -> `editNotebook`

### QA Notes

@:assistant-eval
