### PR TITLE
E2E test: make triggerAndClick default to not exact text match

### DIFF
--- a/test/e2e/pages/dialog-contextMenu.ts
+++ b/test/e2e/pages/dialog-contextMenu.ts
@@ -17,8 +17,8 @@ export class ContextMenu {
 	private get page(): Page { return this.code.driver.page; }
 	private isNativeMenu: boolean;
 	private get contextMenu(): Locator { return this.page.locator('.monaco-menu'); }
-	private getContextMenuItem(label: string | RegExp): Locator { return this.contextMenu.getByRole('menuitem', { name: label, exact: true }); }
-	private getContextMenuCheckboxItem(label: string | RegExp): Locator { return this.contextMenu.getByRole('menuitemcheckbox', { name: label, exact: true }); }
+	private getContextMenuItem(label: string | RegExp, exact = false): Locator { return this.contextMenu.getByRole('menuitem', { name: label, exact }); }
+	private getContextMenuCheckboxItem(label: string | RegExp, exact = false): Locator { return this.contextMenu.getByRole('menuitemcheckbox', { name: label, exact }); }
 
 	constructor(private code: Code) {
 		// Check if we're on macOS AND we have an Electron app instance
@@ -68,12 +68,13 @@ export class ContextMenu {
 	 * @param menuItemLabel The label of the menu item to click
 	 * @param menuItemType The type of the menu item, either 'menuitemcheckbox' or 'menuitem'
 	 * @param menuTriggerButton The mouse button to use when clicking the menu trigger (default: 'left')
+	 * @param exact Whether to use exact match for the menu item label (default: false)
 	 */
-	async triggerAndClick({ menuTrigger, menuItemLabel, menuItemType = 'menuitem', menuTriggerButton = 'left' }: ContextMenuClick): Promise<void> {
+	async triggerAndClick({ menuTrigger, menuItemLabel, menuItemType = 'menuitem', menuTriggerButton = 'left', exact = false }: ContextMenuClick): Promise<void> {
 		await test.step(`Trigger context menu and click '${menuItemLabel}'`, async () => {
 			if (this.isNativeMenu) {
 				this.code.logger.log(`Using native menu to select: ${menuItemLabel}`);
-				await this.nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel, menuTriggerButton });
+				await this.nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel, menuTriggerButton, exact });
 			} else {
 				this.code.logger.log(`Using web menu to select: ${menuItemLabel}`);
 
@@ -89,8 +90,8 @@ export class ContextMenu {
 					await expect(this.contextMenu).toBeVisible({ timeout: 2000 });
 
 					const menuItem = menuItemType === 'menuitemcheckbox'
-						? this.getContextMenuCheckboxItem(menuItemLabel)
-						: this.getContextMenuItem(menuItemLabel);
+						? this.getContextMenuCheckboxItem(menuItemLabel, exact)
+						: this.getContextMenuItem(menuItemLabel, exact);
 
 					await menuItem.hover({ timeout: 2000 });
 					await this.page.waitForTimeout(200);
@@ -199,8 +200,9 @@ export class ContextMenu {
 	 *
 	 * @param menuTrigger The locator that will trigger the context menu when clicked
 	 * @param menuItemLabel The label of the menu item to click
+	 * @param exact Whether to use exact match (native menus always use exact match for strings)
 	 */
-	private async nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel, menuTriggerButton = 'left' }: Omit<ContextMenuClick, 'menuItemType'> & { clickButton?: ClickButton }): Promise<void> {
+	private async nativeMenuTriggerAndClick({ menuTrigger, menuItemLabel, menuTriggerButton = 'left', exact = false }: Omit<ContextMenuClick, 'menuItemType'> & { clickButton?: ClickButton }): Promise<void> {
 		const menuItems = await this.triggerMenu(menuTrigger, menuTriggerButton);
 
 		if (!menuItems) {
@@ -305,4 +307,5 @@ interface ContextMenuClick {
 	menuItemLabel: string | RegExp;
 	menuItemType?: 'menuitemcheckbox' | 'menuitem';
 	menuTriggerButton?: ClickButton;
+	exact?: boolean;
 }

--- a/test/e2e/pages/packages.ts
+++ b/test/e2e/pages/packages.ts
@@ -135,7 +135,8 @@ export class Packages {
 		// Open the package actions menu and click "Install Package"
 		await this.contextMenu.triggerAndClick({
 			menuTrigger: this.packageActionsButton,
-			menuItemLabel: 'Install Package'
+			menuItemLabel: 'Install Package',
+			exact: true
 		});
 
 		// Wait for the quick input to appear


### PR DESCRIPTION
Cleaning up an error I accidentally introduced by requiring exact text match with triggerAncClick

### QA Notes

