### PR TITLE
Bump bundled Quarto to 1.9.37

### DIFF
--- a/build/lib/quarto.js
+++ b/build/lib/quarto.js
@@ -129,7 +129,7 @@ function getQuartoLinux(version) {
  */
 function getQuartoStream() {
     // quarto version
-    const version = '1.9.36';
+    const version = '1.9.37';
     (0, fancy_log_1.default)(`Synchronizing quarto ${version}...`);
     // Get the download/unpack stream for the current platform
     return process.platform === 'win32' ?

--- a/build/lib/quarto.ts
+++ b/build/lib/quarto.ts
@@ -93,7 +93,7 @@ function getQuartoLinux(version: string): Stream {
  */
 export function getQuartoStream(): Stream {
 	// quarto version
-	const version = '1.9.36';
+	const version = '1.9.37';
 
 	fancyLog(`Synchronizing quarto ${version}...`);
 


### PR DESCRIPTION
This PR cherrypicks 7f70a0649f4286b2b7e181bd4c59a97f8a4b3e6a here to `main` so we also have the Quarto patch release moving forward.