### PR TITLE
Restore notebook scroll position on tab switch and reload

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -17,6 +17,7 @@ import { IPositronNotebookEditor } from './IPositronNotebookEditor.js';
 import { IHoverManager } from '../../../../platform/hover/browser/hoverManager.js';
 import { IPositronNotebookContribution } from './positronNotebookExtensions.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IPositronNotebookViewState } from './positronNotebookEditorTypes.js';
 
 /**
  * Metadata about the editor layout that may be relevant for execution, such as
@@ -464,6 +465,18 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	 * Returns undefined if the cells container or cell element is not mounted.
 	 */
 	getCellOffsetTop(cell: IPositronNotebookCell): number | undefined;
+
+	/**
+	 * The resolved scroll position to restore, if any.
+	 * Set by `restoreEditorViewState` and consumed by the React component.
+	 */
+	readonly scrollPosition: { cell: IPositronNotebookCell; offsetFromCell: number } | undefined;
+
+	/**
+	 * Resolves a persisted view state into a live cell reference and stores
+	 * the result for the React component to consume during mount.
+	 */
+	restoreEditorViewState(viewState: IPositronNotebookViewState | undefined): void;
 
 	/**
 	 * Fire the scroll event for the cells container.

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -482,8 +482,7 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	readonly restoredScrollPosition: IPositronNotebookResolvedScrollPosition | undefined;
 
 	/**
-	 * Resolves a persisted view state into a live cell reference and stores
-	 * the result for the React component to consume during mount.
+	 * Restore editor view state such as scroll position.
 	 */
 	restoreEditorViewState(viewState: IPositronNotebookViewState | undefined): void;
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -476,10 +476,11 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	getCellTop(cell: IPositronNotebookCell): number | undefined;
 
 	/**
-	 * The scroll position resolved by the last call to `restoreEditorViewState`.
-	 * Read by the React component on mount to restore the scroll position.
+	 * Returns the scroll position resolved by the last call to
+	 * `restoreEditorViewState` and clears it so subsequent mounts (e.g. error
+	 * boundary reloads) don't restore a stale position.
 	 */
-	readonly restoredScrollPosition: IPositronNotebookResolvedScrollPosition | undefined;
+	consumeRestoredScrollPosition(): IPositronNotebookResolvedScrollPosition | undefined;
 
 	/**
 	 * Restore editor view state such as scroll position.

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -459,6 +459,13 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	getOutputLayoutInfo(): EditorLayoutMetadata | undefined;
 
 	/**
+	 * Returns the top offset of a cell relative to the cells container.
+	 * Walks up the offsetParent chain to account for positioned wrappers.
+	 * Returns undefined if the cells container or cell element is not mounted.
+	 */
+	getCellOffsetTop(cell: IPositronNotebookCell): number | undefined;
+
+	/**
 	 * Fire the scroll event for the cells container.
 	 * Called by React when scroll or DOM mutations occur.
 	 */

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -469,17 +469,17 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	getOutputLayoutInfo(): EditorLayoutMetadata | undefined;
 
 	/**
-	 * Returns the top offset of a cell relative to the cells container.
+	 * Returns the top of a cell relative to the cells container.
 	 * Walks up the offsetParent chain to account for positioned wrappers.
 	 * Returns undefined if the cells container or cell element is not mounted.
 	 */
-	getCellOffsetTop(cell: IPositronNotebookCell): number | undefined;
+	getCellTop(cell: IPositronNotebookCell): number | undefined;
 
 	/**
-	 * The resolved scroll position to restore, if any.
-	 * Set by `restoreEditorViewState` and consumed by the React component.
+	 * The scroll position resolved by the last call to `restoreEditorViewState`.
+	 * Read by the React component on mount to restore the scroll position.
 	 */
-	readonly scrollPosition: IPositronNotebookResolvedScrollPosition | undefined;
+	readonly restoredScrollPosition: IPositronNotebookResolvedScrollPosition | undefined;
 
 	/**
 	 * Resolves a persisted view state into a live cell reference and stores

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -20,6 +20,15 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { IPositronNotebookViewState } from './positronNotebookEditorTypes.js';
 
 /**
+ * A resolved scroll position pointing to a live cell and an offset from that cell.
+ * Produced by resolving a persisted view state against the current cell list.
+ */
+export interface IPositronNotebookResolvedScrollPosition {
+	cell: IPositronNotebookCell;
+	offsetFromCell: number;
+}
+
+/**
  * Metadata about the editor layout that may be relevant for execution, such as
  * output sizing.
  */
@@ -470,7 +479,7 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	 * The resolved scroll position to restore, if any.
 	 * Set by `restoreEditorViewState` and consumed by the React component.
 	 */
-	readonly scrollPosition: { cell: IPositronNotebookCell; offsetFromCell: number } | undefined;
+	readonly scrollPosition: IPositronNotebookResolvedScrollPosition | undefined;
 
 	/**
 	 * Resolves a persisted view state into a live cell reference and stores

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -83,12 +83,6 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	readonly editor: IObservable<ICodeEditor | undefined>;
 
 	/**
-	 * Observable for the cell's code editor widget.
-	 * Use this when you need to track changes to the editor (e.g., when the editor is attached/detached).
-	 */
-	readonly editorObservable: IObservable<ICodeEditor | undefined>;
-
-	/**
 	 * Current cell outputs as an observable.
 	 * Returns undefined for markdown cells (which have no outputs).
 	 * Code cells override this to return their outputs observable.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -66,7 +66,6 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	private _container: HTMLElement | undefined;
 	private readonly _execution = observableValue<INotebookCellExecution | undefined, void>('cellExecution', undefined);
 	protected readonly _editor = observableValue<ICodeEditor | undefined>('cellEditor', undefined);
-	public readonly editorObservable: IObservable<ICodeEditor | undefined> = this._editor;
 	public readonly editor: IObservable<ICodeEditor | undefined> = this._editor;
 	protected readonly _internalMetadata;
 	private readonly _editorFocusRequested = observableSignal<void>('editorFocusRequested');

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -68,11 +68,8 @@ export function PositronNotebookComponent() {
 		notebookInstance.setCellsContainer(node);
 	}, [notebookInstance]);
 
-	// Capture the scroll position once on mount. Using a ref ensures that
-	// subsequent re-renders (e.g. from cells observable updates during async
-	// React 18 rendering) don't re-read a potentially stale instance value.
-	const scrollPositionRef = React.useRef(notebookInstance.scrollPosition);
-	const scrollPosition = scrollPositionRef.current;
+	// Restore the scroll position, if available
+	const scrollPosition = notebookInstance.scrollPosition;
 	const getScrollTop = React.useCallback(
 		() => {
 			if (!scrollPosition) { return undefined; }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -68,18 +68,23 @@ export function PositronNotebookComponent() {
 		notebookInstance.setCellsContainer(node);
 	}, [notebookInstance]);
 
-	// Restore the scroll position, if available
-	const scrollPosition = notebookInstance.scrollPosition;
+	// Capture the restored scroll position; we only restore it once.
+	const scrollPositionRef = React.useRef(notebookInstance.restoredScrollPosition);
+
+	// Callback to calculate the target scroll top from the anchor cell.
 	const getScrollTop = React.useCallback(
 		() => {
+			const scrollPosition = scrollPositionRef.current;
 			if (!scrollPosition) { return undefined; }
-			const cellTop = notebookInstance.getCellOffsetTop(scrollPosition.cell);
+			const cellTop = notebookInstance.getCellTop(scrollPosition.cell);
 			if (cellTop === undefined) { return undefined; }
 			return cellTop + scrollPosition.offsetFromCell;
 		},
-		[scrollPosition, notebookInstance]
+		[notebookInstance]
 	);
-	useScrollRestoration(containerRef, scrollPosition ? getScrollTop : undefined, services.logService);
+
+	// Effect to restore the scroll position.
+	useScrollRestoration(containerRef, scrollPositionRef.current ? getScrollTop : undefined, services.logService);
 
 	// Track cell count changes and announce to screen readers
 	React.useEffect(() => {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -68,8 +68,9 @@ export function PositronNotebookComponent() {
 		notebookInstance.setCellsContainer(node);
 	}, [notebookInstance]);
 
-	// Capture the restored scroll position; we only restore it once.
-	const scrollPositionRef = React.useRef(notebookInstance.restoredScrollPosition);
+	// Consume the restored scroll position; cleared on read so error boundary
+	// reloads don't restore a stale position.
+	const scrollPositionRef = React.useRef(notebookInstance.consumeRestoredScrollPosition());
 
 	// Callback to calculate the target scroll top from the anchor cell.
 	const getScrollTop = React.useCallback(

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -36,9 +36,19 @@ import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebook
 import { IDeletionSentinel } from './IPositronNotebookInstance.js';
 import { NotebookErrorBoundary } from './NotebookErrorBoundary.js';
 import { getSelectedCells } from './selectionMachine.js';
+import { useScrollRestoration } from './useScrollRestoration.js';
 
+interface PositronNotebookComponentProps {
+	/** Scroll position to restore when the notebook is mounted. */
+	scrollPosition?: {
+		/** Anchor cell at the top of the viewport. */
+		cell: IPositronNotebookCell;
+		/** Pixels from the top of the anchor cell to the viewport top. */
+		offsetFromCell: number;
+	};
+}
 
-export function PositronNotebookComponent() {
+export function PositronNotebookComponent({ scrollPosition }: PositronNotebookComponentProps) {
 	const notebookInstance = useNotebookInstance();
 	const notebookCells = useObservedValue(notebookInstance.cells);
 
@@ -61,13 +71,24 @@ export function PositronNotebookComponent() {
 		CONTEXT_FIND_WIDGET_VISIBLE
 	);
 
-	React.useEffect(() => {
-		notebookInstance.setCellsContainer(containerRef.current);
-		// Initial scroll check
-		if (containerRef.current) {
-			setIsScrolled(containerRef.current.scrollTop > 0);
-		}
+	// Attach the container in the callback ref so it's available
+	// synchronously during the commit phase, for useScrollRestoration.
+	const containerCallbackRef = React.useCallback((node: HTMLDivElement | null) => {
+		containerRef.current = node;
+		notebookInstance.setCellsContainer(node);
 	}, [notebookInstance]);
+
+	// Restore scroll position, if provided
+	const getScrollTop = React.useCallback(
+		() => {
+			if (!scrollPosition) { return undefined; }
+			const cellTop = notebookInstance.getCellOffsetTop(scrollPosition.cell);
+			if (cellTop === undefined) { return undefined; }
+			return cellTop + scrollPosition.offsetFromCell;
+		},
+		[scrollPosition, notebookInstance]
+	);
+	useScrollRestoration(containerRef, scrollPosition ? getScrollTop : undefined, services.logService);
 
 	// Track cell count changes and announce to screen readers
 	React.useEffect(() => {
@@ -117,7 +138,7 @@ export function PositronNotebookComponent() {
 					role='presentation'
 				/>
 			)}
-			<div ref={containerRef} className='positron-notebook-cells-container positron-notebook-scrollable'>
+			<div ref={containerCallbackRef} className='positron-notebook-cells-container positron-notebook-scrollable'>
 				<SortableCellList
 					cells={notebookCells}
 					getSelectedCells={getSelectedCellsCallback}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -68,8 +68,7 @@ export function PositronNotebookComponent() {
 		notebookInstance.setCellsContainer(node);
 	}, [notebookInstance]);
 
-	// Consume the restored scroll position; cleared on read so error boundary
-	// reloads don't restore a stale position.
+	// Consume the restored scroll position; cleared on read reloads don't restore a stale position.
 	const scrollPositionRef = React.useRef(notebookInstance.consumeRestoredScrollPosition());
 
 	// Callback to calculate the target scroll top from the anchor cell.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -68,8 +68,11 @@ export function PositronNotebookComponent() {
 		notebookInstance.setCellsContainer(node);
 	}, [notebookInstance]);
 
-	// Restore scroll position from the instance, if any
-	const scrollPosition = notebookInstance.scrollPosition;
+	// Capture the scroll position once on mount. Using a ref ensures that
+	// subsequent re-renders (e.g. from cells observable updates during async
+	// React 18 rendering) don't re-read a potentially stale instance value.
+	const scrollPositionRef = React.useRef(notebookInstance.scrollPosition);
+	const scrollPosition = scrollPositionRef.current;
 	const getScrollTop = React.useCallback(
 		() => {
 			if (!scrollPosition) { return undefined; }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -38,17 +38,7 @@ import { NotebookErrorBoundary } from './NotebookErrorBoundary.js';
 import { getSelectedCells } from './selectionMachine.js';
 import { useScrollRestoration } from './useScrollRestoration.js';
 
-interface PositronNotebookComponentProps {
-	/** Scroll position to restore when the notebook is mounted. */
-	scrollPosition?: {
-		/** Anchor cell at the top of the viewport. */
-		cell: IPositronNotebookCell;
-		/** Pixels from the top of the anchor cell to the viewport top. */
-		offsetFromCell: number;
-	};
-}
-
-export function PositronNotebookComponent({ scrollPosition }: PositronNotebookComponentProps) {
+export function PositronNotebookComponent() {
 	const notebookInstance = useNotebookInstance();
 	const notebookCells = useObservedValue(notebookInstance.cells);
 
@@ -78,7 +68,8 @@ export function PositronNotebookComponent({ scrollPosition }: PositronNotebookCo
 		notebookInstance.setCellsContainer(node);
 	}, [notebookInstance]);
 
-	// Restore scroll position, if provided
+	// Restore scroll position from the instance, if any
+	const scrollPosition = notebookInstance.scrollPosition;
 	const getScrollTop = React.useCallback(
 		() => {
 			if (!scrollPosition) { return undefined; }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -68,7 +68,7 @@ export function PositronNotebookComponent() {
 		notebookInstance.setCellsContainer(node);
 	}, [notebookInstance]);
 
-	// Consume the restored scroll position; cleared on read reloads don't restore a stale position.
+	// Consume the restored scroll position. Cleared on read so re-renders don't restore a stale position.
 	const scrollPositionRef = React.useRef(notebookInstance.consumeRestoredScrollPosition());
 
 	// Callback to calculate the target scroll top from the anchor cell.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -434,7 +434,16 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<IPositro
 				level='editor'
 				logService={this._logService}
 				onReload={() => {
+					// Snapshot the editor view state before the DOM is unmounted.
+					const viewState = this.notebookInstance?.getEditorViewState();
+
+					// Unmount.
 					this._disposeReactRenderer();
+
+					// Restore the snapshotted editor view state.
+					this.notebookInstance?.restoreEditorViewState(viewState);
+
+					// Rerender.
 					this._renderReact();
 				}}
 			>

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -320,8 +320,11 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<IPositro
 			this._editorContainer!
 		);
 
+		// Resolve the scroll position before rendering so the component can read it from the instance.
+		notebookInstance.restoreEditorViewState(viewState);
+
 		// Now render the React component tree.
-		this._renderReact(viewState);
+		this._renderReact();
 	}
 
 	/**
@@ -392,7 +395,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<IPositro
 		}
 	}
 
-	private _renderReact(viewState?: IPositronNotebookViewState): void {
+	private _renderReact(): void {
 		this._logService.debug(this._identifier, 'renderReact');
 
 		if (!this.notebookInstance) {
@@ -415,15 +418,6 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<IPositro
 		if (!scopedContextKeyService) {
 			throw new Error('Scoped context key service is not set.');
 		}
-
-		// Resolve the scroll position cell now. This resolved cell is stable
-		// for React -- it won't shift if cells are added/removed during
-		// the restoration window.
-		const cells = this.notebookInstance.cells.get();
-		const anchor = viewState?.scrollPosition;
-		const scrollPosition = anchor && anchor.cellIndex < cells.length
-			? { cell: cells[anchor.cellIndex], offsetFromCell: anchor.offsetFromCell }
-			: undefined;
 
 		// Set the editor container for focus tracking.
 		this.notebookInstance.setEditorContainer(this._editorContainer);
@@ -450,9 +444,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<IPositro
 							size: this._size,
 							scopedContextKeyProviderCallback: container => scopedContextKeyService.createScoped(container),
 						}}>
-							<PositronNotebookComponent
-								scrollPosition={scrollPosition}
-							/>
+							<PositronNotebookComponent />
 						</EnvironentProvider>
 					</NotebookInstanceProvider>
 				</NotebookVisibilityProvider>

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -434,16 +434,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<IPositro
 				level='editor'
 				logService={this._logService}
 				onReload={() => {
-					// Snapshot the editor view state before the DOM is unmounted.
-					const viewState = this.notebookInstance?.getEditorViewState();
-
-					// Unmount.
 					this._disposeReactRenderer();
-
-					// Restore the snapshotted editor view state.
-					this.notebookInstance?.restoreEditorViewState(viewState);
-
-					// Rerender.
 					this._renderReact();
 				}}
 			>

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -20,10 +20,8 @@ import {
 	IEditorOpenContext,
 	IEditorPaneSelectionChangeEvent
 } from '../../../common/editor.js';
-import {
-	INotebookEditorOptions,
-	INotebookEditorViewState
-} from '../../notebook/browser/notebookBrowser.js';
+import { INotebookEditorOptions } from '../../notebook/browser/notebookBrowser.js';
+import { IPositronNotebookEditorOptions, IPositronNotebookViewState } from './positronNotebookEditorTypes.js';
 import { NotebookInstanceProvider } from './NotebookInstanceProvider.js';
 import { PositronNotebookComponent } from './PositronNotebookComponent.js';
 import { EnvironentProvider } from './EnvironmentProvider.js';
@@ -51,7 +49,7 @@ const POSITRON_NOTEBOOK_EDITOR_VIEW_STATE_PREFERENCE_KEY =
 
 
 
-export class PositronNotebookEditor extends AbstractEditorWithViewState<INotebookEditorViewState> {
+export class PositronNotebookEditor extends AbstractEditorWithViewState<IPositronNotebookViewState> {
 	/**
 	 * Value to keep track of what instance of the editor this is.
 	 * Used for keeping track of the editor in the logs.
@@ -139,7 +137,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 	 * by comparing with the underlying model (this was a fix for
 	 * https://github.com/microsoft/vscode/issues/40114).
 	 */
-	protected override computeEditorViewState(resource: URI): INotebookEditorViewState | undefined {
+	protected override computeEditorViewState(resource: URI): IPositronNotebookViewState | undefined {
 		if (this.notebookInstance &&
 			this.notebookInstance.textModel &&
 			isEqual(this.notebookInstance.textModel.uri, resource)) {
@@ -247,7 +245,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 
 	override async setInput(
 		input: PositronNotebookEditorInput,
-		options: INotebookEditorOptions | undefined,
+		options: IPositronNotebookEditorOptions | undefined,
 		context: IEditorOpenContext,
 		token: CancellationToken,
 		noRetry?: boolean
@@ -269,8 +267,11 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		// without having to pass the options to the resolve method.
 		input.editorOptions = options;
 
-		// NOTE: Placeholder if we need to use editor view state:
-		// const viewState = options?.viewState ?? this.loadEditorViewState(input, context);
+		// Load saved view state (e.g. scroll position) from either:
+		// - options.viewState: passed explicitly when the editor is moved between groups
+		// - loadEditorViewState: loaded from persisted storage (e.g. after reload)
+		const viewState = options?.viewState
+			?? this.loadEditorViewState(input, context);
 		const { notebookInstance } = input;
 
 		// Update the editor control given the notebook instance.
@@ -320,7 +321,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		);
 
 		// Now render the React component tree.
-		this._renderReact();
+		this._renderReact(viewState);
 	}
 
 	/**
@@ -338,20 +339,23 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 	override clearInput(): void {
 		this._logService.debug(this._identifier, 'clearInput');
 
-		if (this.notebookInstance) {
-			this.notebookInstance.detachView();
-		}
+		// Capture the notebook instance before super.clearInput() clears this._input.
+		const notebookInstance = this._input?.notebookInstance;
 
-		// Clear the input.
-		this._input = undefined;
+		// Call super first so that AbstractEditorWithViewState can save the
+		// editor view state (e.g. scroll position) while the input and the
+		// DOM are still alive. The base class reads view state via
+		// computeEditorViewState() which needs the notebook instance and
+		// its cells container to still be accessible.
+		super.clearInput();
+
+		// Detach the notebook instance.
+		notebookInstance?.detachView();
 
 		// Clear the editor control.
 		this._control.clear();
 
 		this._disposeReactRenderer();
-
-		// Call the base class's method.
-		super.clearInput();
 	}
 
 	override async setOptions(options: INotebookEditorOptions | undefined): Promise<void> {
@@ -388,7 +392,7 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		}
 	}
 
-	private _renderReact(): void {
+	private _renderReact(viewState?: IPositronNotebookViewState): void {
 		this._logService.debug(this._identifier, 'renderReact');
 
 		if (!this.notebookInstance) {
@@ -411,6 +415,15 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 		if (!scopedContextKeyService) {
 			throw new Error('Scoped context key service is not set.');
 		}
+
+		// Resolve the scroll position cell now. This resolved cell is stable
+		// for React -- it won't shift if cells are added/removed during
+		// the restoration window.
+		const cells = this.notebookInstance.cells.get();
+		const anchor = viewState?.scrollPosition;
+		const scrollPosition = anchor && anchor.cellIndex < cells.length
+			? { cell: cells[anchor.cellIndex], offsetFromCell: anchor.offsetFromCell }
+			: undefined;
 
 		// Set the editor container for focus tracking.
 		this.notebookInstance.setEditorContainer(this._editorContainer);
@@ -437,7 +450,9 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<INoteboo
 							size: this._size,
 							scopedContextKeyProviderCallback: container => scopedContextKeyService.createScoped(container),
 						}}>
-							<PositronNotebookComponent />
+							<PositronNotebookComponent
+								scrollPosition={scrollPosition}
+							/>
 						</EnvironentProvider>
 					</NotebookInstanceProvider>
 				</NotebookVisibilityProvider>

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorControl.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorControl.ts
@@ -39,10 +39,10 @@ export class PositronNotebookEditorControl extends Disposable implements ICompos
 			const selectionStateMachine = this._notebookInstance.selectionStateMachine;
 			const state = selectionStateMachine.state.read(reader);
 			const activeCell = getActiveCell(state);
-			// Read from the editorObservable to track changes to the editor itself.
+			// Read from the editor observable to track changes to the editor itself.
 			// This ensures we update when the editor is attached/detached (e.g., markdown cells
 			// entering edit mode) - not just when the selection state changes.
-			this._activeCodeEditor = activeCell?.editorObservable.read(reader);
+			this._activeCodeEditor = activeCell?.editor.read(reader);
 		}));
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -186,10 +186,10 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	private readonly _editorContainerListeners = this._register(new DisposableStore());
 
 	/**
-	 * Resolved scroll position to restore when the notebook is next rendered.
-	 * Set by `restoreEditorViewState` and consumed by the React component.
+	 * The scroll position resolved by the last call to `restoreEditorViewState`.
+	 * Read by the React component on mount to restore the scroll position.
 	 */
-	private _scrollPosition: IPositronNotebookResolvedScrollPosition | undefined;
+	private _restoredScrollPosition: IPositronNotebookResolvedScrollPosition | undefined;
 
 	/**
 	 * The DOM element that contains the cells for the notebook.
@@ -348,11 +348,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	}
 
 	/**
-	 * Returns the top offset of a cell relative to the cells container.
+	 * Returns the top of a cell relative to the cells container.
 	 * Walks up the offsetParent chain to account for positioned wrappers
 	 * (e.g. sortable-cell with position: relative).
 	 */
-	getCellOffsetTop(cell: IPositronNotebookCell): number | undefined {
+	getCellTop(cell: IPositronNotebookCell): number | undefined {
 		const container = this._cellsContainer;
 		if (!container || !cell.container) {
 			return undefined;
@@ -1988,11 +1988,11 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	}
 
 	/**
-	 * The resolved scroll position to restore, if any.
-	 * Read by the React component during mount.
+	 * The scroll position resolved by the last call to `restoreEditorViewState`.
+	 * Read by the React component on mount to restore the scroll position.
 	 */
-	get scrollPosition(): IPositronNotebookResolvedScrollPosition | undefined {
-		return this._scrollPosition;
+	get restoredScrollPosition(): IPositronNotebookResolvedScrollPosition | undefined {
+		return this._restoredScrollPosition;
 	}
 
 	/**
@@ -2002,7 +2002,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	restoreEditorViewState(viewState: IPositronNotebookViewState | undefined): void {
 		const cells = this.cells.get();
 		const anchor = viewState?.scrollPosition;
-		this._scrollPosition = anchor && anchor.cellIndex < cells.length
+		this._restoredScrollPosition = anchor && anchor.cellIndex < cells.length
 			? { cell: cells[anchor.cellIndex], offsetFromCell: anchor.offsetFromCell }
 			: undefined;
 	}
@@ -2038,7 +2038,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			if (!cell.container) {
 				continue;
 			}
-			const cellTop = this.getCellOffsetTop(cell);
+			const cellTop = this.getCellTop(cell);
 			if (cellTop !== undefined && cellTop + cell.container.offsetHeight > scrollTop) {
 				return {
 					cellIndex: i,
@@ -2054,7 +2054,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			if (!cell.container) {
 				continue;
 			}
-			const cellTop = this.getCellOffsetTop(cell);
+			const cellTop = this.getCellTop(cell);
 			if (cellTop !== undefined) {
 				return {
 					cellIndex: i,

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -58,7 +58,7 @@ import { IEditorOptions } from '../../../../editor/common/config/editorOptions.j
 import { FontInfo } from '../../../../editor/common/config/fontInfo.js';
 import { createBareFontInfoFromRawSettings } from '../../../../editor/common/config/fontInfoFromSettings.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
-import { IPositronNotebookViewState, IPositronNotebookScrollAnchor } from './positronNotebookEditorTypes.js';
+import { IPositronNotebookViewState, IPositronNotebookScrollPosition } from './positronNotebookEditorTypes.js';
 
 interface IPositronNotebookInstanceRequiredTextModel extends IPositronNotebookInstance {
 	textModel: NotebookTextModel;
@@ -184,6 +184,12 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Disposables for the editor container event listeners
 	 */
 	private readonly _editorContainerListeners = this._register(new DisposableStore());
+
+	/**
+	 * Resolved scroll position to restore when the notebook is next rendered.
+	 * Set by `restoreEditorViewState` and consumed by the React component.
+	 */
+	private _scrollPosition: { cell: IPositronNotebookCell; offsetFromCell: number } | undefined;
 
 	/**
 	 * The DOM element that contains the cells for the notebook.
@@ -1982,6 +1988,26 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	}
 
 	/**
+	 * The resolved scroll position to restore, if any.
+	 * Read by the React component during mount.
+	 */
+	get scrollPosition(): { cell: IPositronNotebookCell; offsetFromCell: number } | undefined {
+		return this._scrollPosition;
+	}
+
+	/**
+	 * Resolves a persisted view state (cell index) into a live cell reference
+	 * and stores the result for the React component to consume.
+	 */
+	restoreEditorViewState(viewState: IPositronNotebookViewState | undefined): void {
+		const cells = this.cells.get();
+		const anchor = viewState?.scrollPosition;
+		this._scrollPosition = anchor && anchor.cellIndex < cells.length
+			? { cell: cells[anchor.cellIndex], offsetFromCell: anchor.offsetFromCell }
+			: undefined;
+	}
+
+	/**
 	 * Gets the current state of the editor. This should
 	 * fully determine the view we see.
 	 */
@@ -1999,7 +2025,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Finds the first cell at least partially visible in the viewport and
 	 * returns its index plus the pixel offset from its top to scrollTop.
 	 */
-	private _getScrollPosition(): IPositronNotebookScrollAnchor | undefined {
+	private _getScrollPosition(): IPositronNotebookScrollPosition | undefined {
 		const container = this._cellsContainer;
 		if (!container) {
 			return undefined;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -25,7 +25,7 @@ import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebook
 import { CellSelectionType, getActiveCell, getEditingCell, getSelectedCells, SelectionState, SelectionStateMachine, toCellRanges } from '../../../contrib/positronNotebook/browser/selectionMachine.js';
 import { PositronNotebookContextKeyManager } from './ContextKeysManager.js';
 import { IPositronNotebookService } from './positronNotebookService.js';
-import { EditorLayoutMetadata, IDeletionSentinel, IPositronNotebookInstance, KernelStatus, NotebookOperationType } from './IPositronNotebookInstance.js';
+import { EditorLayoutMetadata, IDeletionSentinel, IPositronNotebookInstance, IPositronNotebookResolvedScrollPosition, KernelStatus, NotebookOperationType } from './IPositronNotebookInstance.js';
 import { POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY } from '../common/positronNotebookConfig.js';
 import { getAssistantSettings } from '../common/notebookAssistantMetadata.js';
 import { NotebookCellTextModel } from '../../notebook/common/model/notebookCellTextModel.js';
@@ -189,7 +189,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Resolved scroll position to restore when the notebook is next rendered.
 	 * Set by `restoreEditorViewState` and consumed by the React component.
 	 */
-	private _scrollPosition: { cell: IPositronNotebookCell; offsetFromCell: number } | undefined;
+	private _scrollPosition: IPositronNotebookResolvedScrollPosition | undefined;
 
 	/**
 	 * The DOM element that contains the cells for the notebook.
@@ -1991,7 +1991,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * The resolved scroll position to restore, if any.
 	 * Read by the React component during mount.
 	 */
-	get scrollPosition(): { cell: IPositronNotebookCell; offsetFromCell: number } | undefined {
+	get scrollPosition(): IPositronNotebookResolvedScrollPosition | undefined {
 		return this._scrollPosition;
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -2360,13 +2360,13 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 				const cell = state.type === SelectionState.SingleSelection
 					? state.active
 					: state.selected[0];
-				cell.container?.focus();
+				cell.container?.focus({ preventScroll: true });
 				break;
 			}
 
 			case SelectionState.NoCells:
 				// Fall back to notebook container
-				this.currentContainer?.focus();
+				this.currentContainer?.focus({ preventScroll: true });
 				break;
 		}
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1996,8 +1996,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	}
 
 	/**
-	 * Resolves a persisted view state (cell index) into a live cell reference
-	 * and stores the result for the React component to consume.
+	 * Restore editor view state such as scroll position.
 	 */
 	restoreEditorViewState(viewState: IPositronNotebookViewState | undefined): void {
 		const cells = this.cells.get();

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -11,7 +11,7 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IContextKeyService, IScopedContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { IActiveNotebookEditorDelegate, IBaseCellEditorOptions, ICellViewModel, INotebookCellOverlayChangeAccessor, INotebookDeltaDecoration, INotebookEditorCreationOptions, INotebookEditorOptions, INotebookEditorViewState, INotebookViewZoneChangeAccessor } from '../../notebook/browser/notebookBrowser.js';
+import { IActiveNotebookEditorDelegate, IBaseCellEditorOptions, ICellViewModel, INotebookCellOverlayChangeAccessor, INotebookDeltaDecoration, INotebookEditorCreationOptions, INotebookEditorOptions, INotebookViewZoneChangeAccessor } from '../../notebook/browser/notebookBrowser.js';
 import { NotebookLayoutInfo } from '../../notebook/browser/notebookViewEvents.js';
 import { NotebookOptions } from '../../notebook/browser/notebookOptions.js';
 import { NotebookTextModel } from '../../notebook/common/model/notebookTextModel.js';
@@ -58,6 +58,7 @@ import { IEditorOptions } from '../../../../editor/common/config/editorOptions.j
 import { FontInfo } from '../../../../editor/common/config/fontInfo.js';
 import { createBareFontInfoFromRawSettings } from '../../../../editor/common/config/fontInfoFromSettings.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
+import { IPositronNotebookViewState, IPositronNotebookScrollAnchor } from './positronNotebookEditorTypes.js';
 
 interface IPositronNotebookInstanceRequiredTextModel extends IPositronNotebookInstance {
 	textModel: NotebookTextModel;
@@ -193,11 +194,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * The DOM element for contributions (like find widget) to render into.
 	 */
 	private _overlayContainer: HTMLElement | undefined = undefined;
-
-	/**
-	 * Disposables for the current cells container event listeners
-	 */
-	private readonly _cellsContainerListeners = this._register(new DisposableStore());
 
 	/**
 	 * Key-value map of language to base cell editor options for cells of that language.
@@ -337,15 +333,31 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * @param container The container element to set, or null to clear
 	 */
 	setCellsContainer(container: HTMLElement | null): void {
-		// Clean up any existing listeners
-		this._cellsContainerListeners.clear();
-
 		if (!container) {
 			this._cellsContainer = undefined;
 			return;
 		}
 
 		this._cellsContainer = container;
+	}
+
+	/**
+	 * Returns the top offset of a cell relative to the cells container.
+	 * Walks up the offsetParent chain to account for positioned wrappers
+	 * (e.g. sortable-cell with position: relative).
+	 */
+	getCellOffsetTop(cell: IPositronNotebookCell): number | undefined {
+		const container = this._cellsContainer;
+		if (!container || !cell.container) {
+			return undefined;
+		}
+		let top = 0;
+		let current: HTMLElement | null | undefined = cell.container;
+		while (current && current !== container) {
+			top += current.offsetTop;
+			current = DOM.isHTMLElement(current.offsetParent) ? current.offsetParent : null;
+		}
+		return top;
 	}
 
 	/**
@@ -1973,15 +1985,59 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Gets the current state of the editor. This should
 	 * fully determine the view we see.
 	 */
-	getEditorViewState(): INotebookEditorViewState {
-		// NOTE: Placeholder if we need to use editor view state
+	getEditorViewState(): IPositronNotebookViewState | undefined {
+		if (!this._cellsContainer || !this._cellsContainer.isConnected) {
+			return undefined;
+		}
+
 		return {
-			editingCells: {},
-			cellLineNumberStates: {},
-			editorViewStates: {},
-			collapsedInputCells: {},
-			collapsedOutputCells: {},
+			scrollPosition: this._getScrollPosition(),
 		};
+	}
+
+	/**
+	 * Finds the first cell at least partially visible in the viewport and
+	 * returns its index plus the pixel offset from its top to scrollTop.
+	 */
+	private _getScrollPosition(): IPositronNotebookScrollAnchor | undefined {
+		const container = this._cellsContainer;
+		if (!container) {
+			return undefined;
+		}
+		const scrollTop = container.scrollTop;
+		const cells = this.cells.get();
+
+		for (let i = 0; i < cells.length; i++) {
+			const cell = cells[i];
+			if (!cell.container) {
+				continue;
+			}
+			const cellTop = this.getCellOffsetTop(cell);
+			if (cellTop !== undefined && cellTop + cell.container.offsetHeight > scrollTop) {
+				return {
+					cellIndex: i,
+					offsetFromCell: scrollTop - cellTop,
+				};
+			}
+		}
+
+		// Scrolled past all cells (e.g. into trailing add-cell controls).
+		// Anchor to the last cell so the position is still persisted.
+		for (let i = cells.length - 1; i >= 0; i--) {
+			const cell = cells[i];
+			if (!cell.container) {
+				continue;
+			}
+			const cellTop = this.getCellOffsetTop(cell);
+			if (cellTop !== undefined) {
+				return {
+					cellIndex: i,
+					offsetFromCell: scrollTop - cellTop,
+				};
+			}
+		}
+
+		return undefined;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1988,11 +1988,14 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	}
 
 	/**
-	 * The scroll position resolved by the last call to `restoreEditorViewState`.
-	 * Read by the React component on mount to restore the scroll position.
+	 * Returns the scroll position resolved by the last call to
+	 * `restoreEditorViewState` and clears it so subsequent mounts (e.g. error
+	 * boundary reloads) don't restore a stale position.
 	 */
-	get restoredScrollPosition(): IPositronNotebookResolvedScrollPosition | undefined {
-		return this._restoredScrollPosition;
+	consumeRestoredScrollPosition(): IPositronNotebookResolvedScrollPosition | undefined {
+		const pos = this._restoredScrollPosition;
+		this._restoredScrollPosition = undefined;
+		return pos;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -84,7 +84,7 @@ export function NotebookCellWrapper({ cell, children }: {
 			!wasEditingCodeCell &&
 			// 3. The find widget is focused (to keep focus in the find input)
 			!findWidgetFocused) {
-			cellElement.focus({ preventScroll: true });
+			cellElement.focus();
 		}
 	}, [isActiveCell, selectionStatus, cellElement, cell, notebookInstance]);
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -24,6 +24,7 @@ import { ScreenReaderOnly } from '../../../../../base/browser/ui/positronCompone
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { NotebookErrorBoundary } from '../NotebookErrorBoundary.js';
 import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED } from '../../../../../editor/contrib/find/browser/findModel.js';
+import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 
 export function NotebookCellWrapper({ cell, children }: {
 	cell: IPositronNotebookCell;
@@ -38,7 +39,16 @@ export function NotebookCellWrapper({ cell, children }: {
 	 * that are bound in useCellContextKeys which required a valid cell ref.
 	 */
 	const [cellElement, setCellElement] = React.useState<HTMLDivElement | null>(null);
-	const cellRef = React.useCallback((node: HTMLDivElement | null) => { setCellElement(node); }, []);
+
+	// Attach the container in the callback ref so cell.container is available
+	// synchronously during the commit phase, for useScrollRestoration.
+	const cellRef = React.useCallback((node: HTMLDivElement | null) => {
+		setCellElement(node);
+		if (node) {
+			// Attach the container so the cell instance can properly control focus.
+			cell.attachContainer(node);
+		}
+	}, [cell]);
 
 	const services = usePositronReactServicesContext();
 	const notebookInstance = useNotebookInstance();
@@ -48,13 +58,6 @@ export function NotebookCellWrapper({ cell, children }: {
 	const isActiveCell = useObservedValue(cell.isActive);
 	// Track previous selection status to detect edit mode exit
 	const prevSelectionStatusRef = React.useRef<CellSelectionStatus | undefined>(undefined);
-
-	React.useEffect(() => {
-		if (cellElement) {
-			// Attach the container so the cell instance can properly control focus.
-			cell.attachContainer(cellElement);
-		}
-	}, [cell, cellElement]);
 
 	// Focus management: focus when this cell becomes the active cell
 	React.useLayoutEffect(() => {
@@ -89,6 +92,7 @@ export function NotebookCellWrapper({ cell, children }: {
 	const scopedContextKeyService = useCellContextKeys(cell, cellElement, environment, notebookInstance);
 
 	const cellType = cell.isRawCell() ? 'Raw' : cell.isCodeCell() ? 'Code' : 'Markdown';
+	const cellTypeLower = cellType.toLowerCase();
 	const isSelected = selectionStatus === CellSelectionStatus.Selected || selectionStatus === CellSelectionStatus.Editing;
 
 	/**
@@ -139,7 +143,11 @@ export function NotebookCellWrapper({ cell, children }: {
 			? localize('notebookCell', '{0} cell', cellType)
 			: localize('notebookCellEditable', '{0} cell - Press Enter to edit', cellType)}
 		aria-selected={isSelected}
-		className={`positron-notebook-cell positron-notebook-${cell.isRawCell() ? 'raw' : cell.isCodeCell() ? 'code' : 'markdown'}-cell ${selectionStatus}`}
+		className={positronClassNames(
+			'positron-notebook-cell',
+			`positron-notebook-${cellTypeLower}-cell`,
+			selectionStatus,
+		)}
 		data-testid='notebook-cell'
 		role='article'
 		tabIndex={0}
@@ -198,7 +206,7 @@ export function NotebookCellWrapper({ cell, children }: {
 				<NotebookCellActionBar cell={cell} />
 			</div>
 			<NotebookErrorBoundary
-				componentName={`Cell[${cell.isCodeCell() ? 'code' : cell.isMarkdownCell() ? 'markdown' : 'raw'}]`}
+				componentName={`Cell[${cellTypeLower}]`}
 				level='cell'
 				logService={services.logService}
 			>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -84,7 +84,7 @@ export function NotebookCellWrapper({ cell, children }: {
 			!wasEditingCodeCell &&
 			// 3. The find widget is focused (to keep focus in the find input)
 			!findWidgetFocused) {
-			cellElement.focus();
+			cellElement.focus({ preventScroll: true });
 		}
 	}, [isActiveCell, selectionStatus, cellElement, cell, notebookInstance]);
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -43,7 +43,8 @@ import { extname, isEqual } from '../../../../base/common/resources.js';
 import { CellKind, CellUri, NotebookWorkingCopyTypeIdentifier } from '../../notebook/common/notebookCommon.js';
 import { registerNotebookWidget } from './registerNotebookWidget.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
-import { INotebookEditorOptions, IPYNB_VIEW_TYPE } from '../../notebook/browser/notebookBrowser.js';
+import { IPYNB_VIEW_TYPE } from '../../notebook/browser/notebookBrowser.js';
+import { IPositronNotebookEditorOptions } from './positronNotebookEditorTypes.js';
 import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID, PositronNotebookActionId, PositronNotebookCellActionBarLeftGroup, PositronNotebookCellOutputActionGroup, usingPositronNotebooks } from '../common/positronNotebookCommon.js';
 import { QMD_VIEW_TYPE } from '../../positronQuartoNotebook/common/quartoNotebookConstants.js';
 import { getActiveCell, getSelectedCells, SelectionState } from './selectionMachine.js';
@@ -282,7 +283,7 @@ class PositronNotebookContribution extends Disposable {
 						info.viewType,
 					);
 					// Create notebook editor options from base text editor options
-					const notebookEditorOptions: INotebookEditorOptions = {
+					const notebookEditorOptions: IPositronNotebookEditorOptions = {
 						...editorInput.options,
 						cellOptions: editorInput,
 						// Override text editor view state - it's not valid for notebook editors

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookEditorTypes.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookEditorTypes.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { INotebookEditorOptions } from '../../notebook/browser/notebookBrowser.js';
+
+/**
+ * Identifies a cell at the top of the viewport for scroll restoration.
+ * Using a cell anchor rather than absolute pixel positions handles async
+ * content rendering that changes heights above the viewport.
+ */
+export interface IPositronNotebookScrollAnchor {
+	/** Index of the cell at the top of the viewport. */
+	cellIndex: number;
+	/** Pixels from the top of that cell's DOM element to the viewport top.
+	 *  Positive means the cell is partially scrolled out of view above. */
+	offsetFromCell: number;
+}
+
+/**
+ * Notebook editor view state persisted when the editor is backgrounded,
+ * or when Positron is reloaded.
+ */
+export interface IPositronNotebookViewState {
+	scrollPosition?: IPositronNotebookScrollAnchor;
+}
+
+/**
+ * Editor options for the Positron notebook editor.
+ */
+export interface IPositronNotebookEditorOptions extends Omit<INotebookEditorOptions, 'viewState'> {
+	readonly viewState?: IPositronNotebookViewState;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookEditorTypes.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookEditorTypes.ts
@@ -10,7 +10,7 @@ import { INotebookEditorOptions } from '../../notebook/browser/notebookBrowser.j
  * Using a cell anchor rather than absolute pixel positions handles async
  * content rendering that changes heights above the viewport.
  */
-export interface IPositronNotebookScrollAnchor {
+export interface IPositronNotebookScrollPosition {
 	/** Index of the cell at the top of the viewport. */
 	cellIndex: number;
 	/** Pixels from the top of that cell's DOM element to the viewport top.
@@ -23,7 +23,7 @@ export interface IPositronNotebookScrollAnchor {
  * or when Positron is reloaded.
  */
 export interface IPositronNotebookViewState {
-	scrollPosition?: IPositronNotebookScrollAnchor;
+	scrollPosition?: IPositronNotebookScrollPosition;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronNotebook/browser/useScrollRestoration.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/useScrollRestoration.tsx
@@ -1,0 +1,135 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { RefObject, useLayoutEffect } from 'react';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { disposableTimeout } from '../../../../base/common/async.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { addDisposableListener, getWindow } from '../../../../base/browser/dom.js';
+
+/** Number of consecutive stable frames required to consider the scroll position stable. */
+const STABLE_THRESHOLD = 5;
+
+/** Maximum time (ms) to keep the restoration loop running before giving up. */
+const TIMEOUT_MS = 1500;
+
+/**
+ * Restores scroll position by continuously scrolling the container to the
+ * target returned by {@link getScrollTop}. A requestAnimationFrame loop
+ * runs for up to 1.5 s to accommodate async layout shifts (e.g. from markdown
+ * previews and editor model loading). The loop stops early once the position
+ * has been stable for several consecutive frames, or if the user scrolls
+ * (detected via wheel/pointer/keyboard events, since programmatic scrollTop
+ * assignments also fire scroll events).
+ *
+ * @param containerRef Ref to the scrollable container element.
+ * @param getScrollTop Callback returning the target scrollTop, or undefined
+ *   if the target cannot be resolved. Called each frame. Pass undefined to skip.
+ * @param logService Logger for debug output.
+ */
+export function useScrollRestoration(
+	containerRef: RefObject<HTMLElement | null>,
+	getScrollTop: (() => number | undefined) | undefined,
+	logService: ILogService
+) {
+	// Use a layout effect so that if the first scroll position update is correct
+	// it'll apply before the paint, avoiding a flash of incorrect scroll position.
+	return useLayoutEffect(() => {
+		// Nothing to restore.
+		if (!getScrollTop) {
+			return;
+		}
+
+		const container = containerRef.current;
+
+		// Container not yet in the DOM, nothing we can do.
+		if (!container) {
+			return;
+		}
+
+		const startTimestamp = performance.now();
+		const targetWindow = getWindow(container);
+		const disposables = new DisposableStore();
+		let running = true;
+		let pendingFrame: number | undefined;
+
+		/** Number of consecutive frames where the scroll position did not change. */
+		let stableFrames = 0;
+
+		/** Stop the restoration loop and log the final state. */
+		const stop = (reason: string) => {
+			if (!running) {
+				return;
+			}
+			running = false;
+
+			if (pendingFrame !== undefined) {
+				targetWindow.cancelAnimationFrame(pendingFrame);
+				pendingFrame = undefined;
+			}
+			disposables.dispose();
+
+			const target = getScrollTop();
+			const drift = target !== undefined
+				? container.scrollTop - target
+				: NaN;
+			logService.debug(
+				`[scroll-restore] ${reason} +${(performance.now() - startTimestamp).toFixed(0)}ms:` +
+				` final scrollTop=${container.scrollTop}, drift=${drift.toFixed(1)}px`
+			);
+		};
+
+		/** Schedule a scroll position correction for the next frame. */
+		const scheduleUpdate = () => {
+			if (!running) {
+				return;
+			}
+
+			pendingFrame = targetWindow.requestAnimationFrame(() => {
+				pendingFrame = undefined;
+
+				const target = getScrollTop();
+
+				if (target === undefined) {
+					stop('no-target');
+					return;
+				}
+
+				if (Math.abs(container.scrollTop - target) < 1) {
+					// Close enough. Once stable for enough consecutive frames,
+					// the layout has settled and we can stop.
+					if (++stableFrames >= STABLE_THRESHOLD) {
+						stop('stable');
+						return;
+					}
+				} else {
+					// Still drifting (e.g. async content is shifting layout).
+					// Reset the stable counter and correct the scroll position.
+					stableFrames = 0;
+					container.scrollTop = target;
+				}
+
+				scheduleUpdate();
+			});
+		};
+
+		// Kick off the loop.
+		scheduleUpdate();
+
+		// Cancel restoration on user-initiated scroll input. We listen for
+		// specific input events rather than the generic 'scroll' event because
+		// our own programmatic scrollTop assignments also fire 'scroll'.
+		disposables.add(addDisposableListener(container, 'wheel', () => stop('wheel')));
+		disposables.add(addDisposableListener(container, 'pointerdown', () => stop('pointerdown')));
+		disposables.add(addDisposableListener(container, 'keydown', () => stop('keydown')));
+
+		// Hard cutoff in case layout never stabilizes.
+		disposables.add(disposableTimeout(() => stop('timeout'), TIMEOUT_MS));
+
+		return () => {
+			stop('unmount');
+		};
+	}, [getScrollTop, logService, containerRef]);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/useScrollRestoration.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/useScrollRestoration.tsx
@@ -5,12 +5,14 @@
 
 import { RefObject, useLayoutEffect } from 'react';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
-import { disposableTimeout } from '../../../../base/common/async.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { addDisposableListener, getWindow } from '../../../../base/browser/dom.js';
 
-/** Number of consecutive stable frames required to consider the scroll position stable. */
-const STABLE_THRESHOLD = 5;
+/**
+ * Wall-clock time (ms) the scroll position must remain stable (no corrections
+ * needed) before we consider the layout settled and stop the loop.
+ */
+const STABLE_DURATION_MS = 200;
 
 /** Maximum time (ms) to keep the restoration loop running before giving up. */
 const TIMEOUT_MS = 1500;
@@ -20,7 +22,7 @@ const TIMEOUT_MS = 1500;
  * target returned by {@link getScrollTop}. A requestAnimationFrame loop
  * runs for up to 1.5 s to accommodate async layout shifts (e.g. from markdown
  * previews and editor model loading). The loop stops early once the position
- * has been stable for several consecutive frames, or if the user scrolls
+ * has been stable for 200 ms of wall-clock time, or if the user scrolls
  * (detected via wheel/pointer/keyboard events, since programmatic scrollTop
  * assignments also fire scroll events).
  *
@@ -64,8 +66,10 @@ export function useScrollRestoration(
 		let pendingFrame: number | undefined;
 		let frameCount = 0;
 
-		/** Number of consecutive frames where the scroll position did not change. */
-		let stableFrames = 0;
+		/** Wall-clock time of the last correction. Used for time-based stability
+		 *  detection. We declare stable once no correction has been needed for
+		 *  STABLE_DURATION_MS of real elapsed time. */
+		let lastCorrectionTime = startTimestamp;
 
 		/** Stop the restoration loop and log the final state. */
 		const stop = (reason: string) => {
@@ -84,9 +88,10 @@ export function useScrollRestoration(
 			const drift = target !== undefined
 				? container.scrollTop - target
 				: NaN;
+			const stableSince = performance.now() - lastCorrectionTime;
 			logService.debug(
 				`[scroll-restore] ${reason} +${(performance.now() - startTimestamp).toFixed(0)}ms` +
-				` (${frameCount} frames):` +
+				` (${frameCount} frames, stable ${stableSince.toFixed(0)}ms):` +
 				` final scrollTop=${container.scrollTop}, target=${target}, drift=${drift.toFixed(1)}px`
 			);
 		};
@@ -110,21 +115,29 @@ export function useScrollRestoration(
 				}
 
 				if (Math.abs(container.scrollTop - target) < 1) {
-					// Close enough. Once stable for enough consecutive frames,
-					// the layout has settled and we can stop.
-					if (++stableFrames >= STABLE_THRESHOLD) {
+					// Close enough. If no correction has been needed for
+					// STABLE_DURATION_MS of wall-clock time, the layout has
+					// settled and we can stop.
+					if (performance.now() - lastCorrectionTime >= STABLE_DURATION_MS) {
 						stop('stable');
 						return;
 					}
 				} else {
 					// Still drifting (e.g. async content is shifting layout).
-					// Reset the stable counter and correct the scroll position.
+					// Record the correction time and fix the scroll position.
 					logService.debug(
 						`[scroll-restore] correcting frame ${frameCount}:` +
 						` scrollTop=${container.scrollTop} -> target=${target}, delta=${(container.scrollTop - target).toFixed(1)}`
 					);
-					stableFrames = 0;
+					lastCorrectionTime = performance.now();
 					container.scrollTop = target;
+				}
+
+				// Check the timeout inside the rAF callback so the last
+				// frame always gets a correction attempt before we stop.
+				if (performance.now() - startTimestamp > TIMEOUT_MS) {
+					stop('timeout');
+					return;
 				}
 
 				scheduleUpdate();
@@ -140,9 +153,6 @@ export function useScrollRestoration(
 		disposables.add(addDisposableListener(container, 'wheel', () => stop('wheel')));
 		disposables.add(addDisposableListener(container, 'pointerdown', () => stop('pointerdown')));
 		disposables.add(addDisposableListener(container, 'keydown', () => stop('keydown')));
-
-		// Hard cutoff in case layout never stabilizes.
-		disposables.add(disposableTimeout(() => stop('timeout'), TIMEOUT_MS));
 
 		return () => {
 			stop('unmount');

--- a/src/vs/workbench/contrib/positronNotebook/browser/useScrollRestoration.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/useScrollRestoration.tsx
@@ -39,6 +39,7 @@ export function useScrollRestoration(
 	return useLayoutEffect(() => {
 		// Nothing to restore.
 		if (!getScrollTop) {
+			logService.debug('[scroll-restore] skipped: no getScrollTop callback');
 			return;
 		}
 
@@ -46,14 +47,22 @@ export function useScrollRestoration(
 
 		// Container not yet in the DOM, nothing we can do.
 		if (!container) {
+			logService.debug('[scroll-restore] skipped: container not in DOM');
 			return;
 		}
+
+		const initialScrollTop = container.scrollTop;
+		const initialTarget = getScrollTop();
+		logService.debug(
+			`[scroll-restore] starting: initialScrollTop=${initialScrollTop}, target=${initialTarget}`
+		);
 
 		const startTimestamp = performance.now();
 		const targetWindow = getWindow(container);
 		const disposables = new DisposableStore();
 		let running = true;
 		let pendingFrame: number | undefined;
+		let frameCount = 0;
 
 		/** Number of consecutive frames where the scroll position did not change. */
 		let stableFrames = 0;
@@ -76,8 +85,9 @@ export function useScrollRestoration(
 				? container.scrollTop - target
 				: NaN;
 			logService.debug(
-				`[scroll-restore] ${reason} +${(performance.now() - startTimestamp).toFixed(0)}ms:` +
-				` final scrollTop=${container.scrollTop}, drift=${drift.toFixed(1)}px`
+				`[scroll-restore] ${reason} +${(performance.now() - startTimestamp).toFixed(0)}ms` +
+				` (${frameCount} frames):` +
+				` final scrollTop=${container.scrollTop}, target=${target}, drift=${drift.toFixed(1)}px`
 			);
 		};
 
@@ -89,10 +99,12 @@ export function useScrollRestoration(
 
 			pendingFrame = targetWindow.requestAnimationFrame(() => {
 				pendingFrame = undefined;
+				frameCount++;
 
 				const target = getScrollTop();
 
 				if (target === undefined) {
+					logService.debug(`[scroll-restore] target became undefined on frame ${frameCount}`);
 					stop('no-target');
 					return;
 				}
@@ -107,6 +119,10 @@ export function useScrollRestoration(
 				} else {
 					// Still drifting (e.g. async content is shifting layout).
 					// Reset the stable counter and correct the scroll position.
+					logService.debug(
+						`[scroll-restore] correcting frame ${frameCount}:` +
+						` scrollTop=${container.scrollTop} -> target=${target}, delta=${(container.scrollTop - target).toFixed(1)}`
+					);
 					stableFrames = 0;
 					container.scrollTop = target;
 				}

--- a/src/vs/workbench/contrib/positronNotebook/browser/useScrollRestoration.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/useScrollRestoration.tsx
@@ -85,14 +85,13 @@ export function useScrollRestoration(
 			disposables.dispose();
 
 			const target = getScrollTop();
-			const drift = target !== undefined
-				? container.scrollTop - target
-				: NaN;
+			const drift = target && container.scrollTop - target;
+			const driftString = drift ? `${drift.toFixed(1)}px` : 'N/A (getScrollTop returned undefined)';
 			const stableSince = performance.now() - lastCorrectionTime;
 			logService.debug(
 				`[scroll-restore] stopped with reason: ${reason} +${(performance.now() - startTimestamp).toFixed(0)}ms` +
 				` (${frameCount} frames, stable ${stableSince.toFixed(0)}ms):` +
-				` final scrollTop=${container.scrollTop}, target=${target}, drift=${drift.toFixed(1)}px`
+				` final scrollTop=${container.scrollTop}, target=${target}, drift=${driftString}`
 			);
 		};
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/useScrollRestoration.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/useScrollRestoration.tsx
@@ -15,14 +15,14 @@ import { addDisposableListener, getWindow } from '../../../../base/browser/dom.j
 const STABLE_DURATION_MS = 500;
 
 /** Maximum time (ms) to keep the restoration loop running before giving up. */
-const TIMEOUT_MS = 1000;
+const TIMEOUT_MS = 1500;
 
 /**
  * Restores scroll position by continuously scrolling the container to the
  * target returned by {@link getScrollTop}. A requestAnimationFrame loop
  * runs for up to 1.5 s to accommodate async layout shifts (e.g. from markdown
  * previews and editor model loading). The loop stops early once the position
- * has been stable for 200 ms of wall-clock time, or if the user scrolls
+ * has been stable for 500 ms of wall-clock time, or if the user scrolls
  * (detected via wheel/pointer/keyboard events, since programmatic scrollTop
  * assignments also fire scroll events).
  *

--- a/src/vs/workbench/contrib/positronNotebook/browser/useScrollRestoration.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/useScrollRestoration.tsx
@@ -12,10 +12,10 @@ import { addDisposableListener, getWindow } from '../../../../base/browser/dom.j
  * Wall-clock time (ms) the scroll position must remain stable (no corrections
  * needed) before we consider the layout settled and stop the loop.
  */
-const STABLE_DURATION_MS = 200;
+const STABLE_DURATION_MS = 500;
 
 /** Maximum time (ms) to keep the restoration loop running before giving up. */
-const TIMEOUT_MS = 1500;
+const TIMEOUT_MS = 1000;
 
 /**
  * Restores scroll position by continuously scrolling the container to the
@@ -90,7 +90,7 @@ export function useScrollRestoration(
 				: NaN;
 			const stableSince = performance.now() - lastCorrectionTime;
 			logService.debug(
-				`[scroll-restore] ${reason} +${(performance.now() - startTimestamp).toFixed(0)}ms` +
+				`[scroll-restore] stopped with reason: ${reason} +${(performance.now() - startTimestamp).toFixed(0)}ms` +
 				` (${frameCount} frames, stable ${stableSince.toFixed(0)}ms):` +
 				` final scrollTop=${container.scrollTop}, target=${target}, drift=${drift.toFixed(1)}px`
 			);

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -32,7 +32,7 @@ type OutputActionBarButtons = 'Collapse Output' | 'Expand Output' | 'Clear Outpu
 export class PositronNotebooks extends Notebooks {
 	// Containers, generic locators
 	private positronNotebook = this.code.driver.page.locator('.positron-notebook').first();
-	private cellsContainer = this.positronNotebook.locator('.positron-notebook-cells-container').first();
+	cellsContainer = this.positronNotebook.locator('.positron-notebook-cells-container').first();
 	private newCellButton = this.code.driver.page.getByLabel(/new code cell/i);
 	private spinner = this.code.driver.page.getByLabel(/cell is executing/i);
 	editorAtIndex = (index: number) => this.cell.nth(index).locator('.monaco-editor :is(.native-edit-context, .inputarea)');

--- a/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import path from 'path';
+import { tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+import { expect } from '@playwright/test';
+
+// Use the pokemon notebook because it has mixed markdown and code cells,
+// which have different rendering times that could affect scroll restoration.
+const NOTEBOOK_FILE = 'pokemon.ipynb';
+const NOTEBOOK_PATH = path.join('workspaces', 'pokemon', NOTEBOOK_FILE);
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Positron Notebooks: Scroll Position', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+}, () => {
+
+	test('Scroll position is restored when switching tabs', async function ({ app }) {
+		const { notebooksPositron, editors } = app.workbench;
+
+		// Open the notebook
+		await notebooksPositron.openNotebook(NOTEBOOK_PATH);
+
+		// Scroll to a middle cell in the notebook
+		const middleCellIndex = Math.floor(await notebooksPositron.cell.count() / 2);
+		await notebooksPositron.cell.nth(middleCellIndex).scrollIntoViewIfNeeded();
+
+		// Capture the scroll position
+		const scrollTopBefore = await notebooksPositron.getScrollTop();
+		expect(scrollTopBefore).toBeGreaterThan(0);
+
+		// Open a new untitled file to background the notebook
+		await editors.newUntitledFile();
+
+		// Switch back to the notebook tab by clicking it directly.
+		// We can't use editors.selectTab() here because it expects a Monaco
+		// editor to receive focus, but the notebook is a custom editor.
+		await app.code.driver.page.getByRole('tab', { name: NOTEBOOK_FILE }).click();
+		await notebooksPositron.expectToBeVisible();
+
+		// Verify the scroll position is restored.
+		// The anchor-based restore refines for up to 1.5s as cells render,
+		// so poll until stable.
+		await expect.poll(async () => {
+			const scrollTop = await notebooksPositron.getScrollTop();
+			return Math.abs(scrollTop - scrollTopBefore);
+		}, { timeout: 5000 }).toBeLessThanOrEqual(1);
+	});
+
+	test('Scroll position is restored after window reload', async function ({ app, hotKeys }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Open the notebook
+		await notebooksPositron.openNotebook(NOTEBOOK_PATH);
+
+		// Scroll to a middle cell in the notebook
+		const middleCellIndex = Math.floor(await notebooksPositron.cell.count() / 2);
+		await notebooksPositron.cell.nth(middleCellIndex).scrollIntoViewIfNeeded();
+
+		// Capture the scroll position
+		const scrollTopBefore = await notebooksPositron.getScrollTop();
+		expect(scrollTopBefore).toBeGreaterThan(0);
+
+		// Reload the window
+		await hotKeys.reloadWindow(true);
+
+		// Wait for the notebook to be visible again after reload
+		await notebooksPositron.expectToBeVisible();
+
+		// Verify the scroll position is restored.
+		// The anchor-based restore refines for up to 1.5s as cells render,
+		// so poll until stable.
+		await expect.poll(async () => {
+			const scrollTop = await notebooksPositron.getScrollTop();
+			return Math.abs(scrollTop - scrollTopBefore);
+		}, { timeout: 5000 }).toBeLessThanOrEqual(1);
+	});
+});

--- a/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
@@ -75,6 +75,9 @@ test.describe('Positron Notebooks: Scroll Position', {
 		await expect.poll(async () => {
 			const scrollTop = await notebooksPositron.getScrollTop();
 			return Math.abs(scrollTop - scrollTopBefore);
-		}, { timeout: 5000 }).toBeLessThanOrEqual(1);
+			// Allow a small delta here. For unknown reasons, we can't yet match it
+			// excactly after a window reload. Should not significantly affect the
+			// user experience.
+		}, { timeout: 5000 }).toBeLessThanOrEqual(50);
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
@@ -7,56 +7,11 @@ import path from 'path';
 import { tags } from '../_test.setup';
 import { test } from './_test.setup.js';
 import { expect } from '@playwright/test';
-import { PositronNotebooks } from '../../pages/notebooksPositron';
 
 // Use the pokemon notebook because it has mixed markdown and code cells,
 // which have different rendering times that could affect scroll restoration.
 const NOTEBOOK_FILE = 'pokemon.ipynb';
 const NOTEBOOK_PATH = path.join('workspaces', 'pokemon', NOTEBOOK_FILE);
-
-/**
- * The scroll restoration code anchors to the topmost partially-visible cell
- * and preserves its offset from the viewport top. This helper captures that
- * anchor position so the test can verify it's restored.
- */
-async function getAnchorCellPosition(notebooksPositron: PositronNotebooks) {
-	const containerBox = await notebooksPositron.cellsContainer.boundingBox();
-	expect(containerBox).not.toBeNull();
-	const viewportTop = containerBox!.y;
-
-	const cellCount = await notebooksPositron.cell.count();
-	for (let i = 0; i < cellCount; i++) {
-		const cellBox = await notebooksPositron.cell.nth(i).boundingBox();
-		if (!cellBox) { continue; }
-		// First cell whose bottom edge is below the viewport top
-		if (cellBox.y + cellBox.height > viewportTop) {
-			return { cellIndex: i, offsetFromViewportTop: cellBox.y - viewportTop };
-		}
-	}
-	throw new Error('No anchor cell found in viewport');
-}
-
-/**
- * Asserts that the anchor cell's offset from the viewport top is restored
- * within tolerance. We check the cell's viewport-relative position rather
- * than absolute scrollTop because the anchor-based restoration preserves
- * the anchor cell's viewport position, and cumulative cell heights may
- * differ across platforms (e.g. different font metrics on Linux CI vs
- * macOS) or after a full reload.
- */
-async function expectAnchorPositionRestored(
-	notebooksPositron: PositronNotebooks,
-	expectedIndex: number,
-	expectedOffset: number,
-) {
-	await expect.poll(async () => {
-		const containerBox = await notebooksPositron.cellsContainer.boundingBox();
-		const cellBox = await notebooksPositron.cell.nth(expectedIndex).boundingBox();
-		if (!containerBox || !cellBox) { return Infinity; }
-		const currentOffset = cellBox.y - containerBox.y;
-		return Math.abs(currentOffset - expectedOffset);
-	}, { timeout: 5000 }).toBeLessThanOrEqual(1);
-}
 
 test.use({
 	suiteId: __filename
@@ -76,8 +31,9 @@ test.describe('Positron Notebooks: Scroll Position', {
 		const middleCellIndex = Math.floor(await notebooksPositron.cell.count() / 2);
 		await notebooksPositron.cell.nth(middleCellIndex).scrollIntoViewIfNeeded();
 
-		// Capture the anchor cell's position relative to the viewport
-		const { cellIndex, offsetFromViewportTop } = await getAnchorCellPosition(notebooksPositron);
+		// Capture the scroll position
+		const scrollTopBefore = await notebooksPositron.getScrollTop();
+		expect(scrollTopBefore).toBeGreaterThan(0);
 
 		// Open a new untitled file to background the notebook
 		await editors.newUntitledFile();
@@ -88,9 +44,11 @@ test.describe('Positron Notebooks: Scroll Position', {
 		await app.code.driver.page.getByRole('tab', { name: NOTEBOOK_FILE }).click();
 		await notebooksPositron.expectToBeVisible();
 
-		// Verify the anchor cell is at the same offset from the viewport top.
-		// The restore refines for up to 1.5s as cells render, so poll until stable.
-		await expectAnchorPositionRestored(notebooksPositron, cellIndex, offsetFromViewportTop);
+		// Verify the scroll position is restored.
+		await expect.poll(async () => {
+			const scrollTop = await notebooksPositron.getScrollTop();
+			return Math.abs(scrollTop - scrollTopBefore);
+		}, { timeout: 5000 }).toBeLessThanOrEqual(1);
 	});
 
 	test('Scroll position is restored after window reload', async function ({ app, hotKeys }) {
@@ -103,8 +61,9 @@ test.describe('Positron Notebooks: Scroll Position', {
 		const middleCellIndex = Math.floor(await notebooksPositron.cell.count() / 2);
 		await notebooksPositron.cell.nth(middleCellIndex).scrollIntoViewIfNeeded();
 
-		// Capture the anchor cell's position relative to the viewport
-		const { cellIndex, offsetFromViewportTop } = await getAnchorCellPosition(notebooksPositron);
+		// Capture the scroll position
+		const scrollTopBefore = await notebooksPositron.getScrollTop();
+		expect(scrollTopBefore).toBeGreaterThan(0);
 
 		// Reload the window
 		await hotKeys.reloadWindow(true);
@@ -112,8 +71,10 @@ test.describe('Positron Notebooks: Scroll Position', {
 		// Wait for the notebook to be visible again after reload
 		await notebooksPositron.expectToBeVisible();
 
-		// Verify the anchor cell is at the same offset from the viewport top.
-		// The restore refines for up to 1.5s as cells render, so poll until stable.
-		await expectAnchorPositionRestored(notebooksPositron, cellIndex, offsetFromViewportTop);
+		// Verify the scroll position is restored.
+		await expect.poll(async () => {
+			const scrollTop = await notebooksPositron.getScrollTop();
+			return Math.abs(scrollTop - scrollTopBefore);
+		}, { timeout: 5000 }).toBeLessThanOrEqual(1);
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
@@ -7,11 +7,56 @@ import path from 'path';
 import { tags } from '../_test.setup';
 import { test } from './_test.setup.js';
 import { expect } from '@playwright/test';
+import { PositronNotebooks } from '../../pages/notebooksPositron';
 
 // Use the pokemon notebook because it has mixed markdown and code cells,
 // which have different rendering times that could affect scroll restoration.
 const NOTEBOOK_FILE = 'pokemon.ipynb';
 const NOTEBOOK_PATH = path.join('workspaces', 'pokemon', NOTEBOOK_FILE);
+
+/**
+ * The scroll restoration code anchors to the topmost partially-visible cell
+ * and preserves its offset from the viewport top. This helper captures that
+ * anchor position so the test can verify it's restored.
+ */
+async function getAnchorCellPosition(notebooksPositron: PositronNotebooks) {
+	const containerBox = await notebooksPositron.cellsContainer.boundingBox();
+	expect(containerBox).not.toBeNull();
+	const viewportTop = containerBox!.y;
+
+	const cellCount = await notebooksPositron.cell.count();
+	for (let i = 0; i < cellCount; i++) {
+		const cellBox = await notebooksPositron.cell.nth(i).boundingBox();
+		if (!cellBox) { continue; }
+		// First cell whose bottom edge is below the viewport top
+		if (cellBox.y + cellBox.height > viewportTop) {
+			return { cellIndex: i, offsetFromViewportTop: cellBox.y - viewportTop };
+		}
+	}
+	throw new Error('No anchor cell found in viewport');
+}
+
+/**
+ * Asserts that the anchor cell's offset from the viewport top is restored
+ * within tolerance. We check the cell's viewport-relative position rather
+ * than absolute scrollTop because the anchor-based restoration preserves
+ * the anchor cell's viewport position, and cumulative cell heights may
+ * differ across platforms (e.g. different font metrics on Linux CI vs
+ * macOS) or after a full reload.
+ */
+async function expectAnchorPositionRestored(
+	notebooksPositron: PositronNotebooks,
+	expectedIndex: number,
+	expectedOffset: number,
+) {
+	await expect.poll(async () => {
+		const containerBox = await notebooksPositron.cellsContainer.boundingBox();
+		const cellBox = await notebooksPositron.cell.nth(expectedIndex).boundingBox();
+		if (!containerBox || !cellBox) { return Infinity; }
+		const currentOffset = cellBox.y - containerBox.y;
+		return Math.abs(currentOffset - expectedOffset);
+	}, { timeout: 5000 }).toBeLessThanOrEqual(1);
+}
 
 test.use({
 	suiteId: __filename
@@ -31,9 +76,8 @@ test.describe('Positron Notebooks: Scroll Position', {
 		const middleCellIndex = Math.floor(await notebooksPositron.cell.count() / 2);
 		await notebooksPositron.cell.nth(middleCellIndex).scrollIntoViewIfNeeded();
 
-		// Capture the scroll position
-		const scrollTopBefore = await notebooksPositron.getScrollTop();
-		expect(scrollTopBefore).toBeGreaterThan(0);
+		// Capture the anchor cell's position relative to the viewport
+		const { cellIndex, offsetFromViewportTop } = await getAnchorCellPosition(notebooksPositron);
 
 		// Open a new untitled file to background the notebook
 		await editors.newUntitledFile();
@@ -44,13 +88,9 @@ test.describe('Positron Notebooks: Scroll Position', {
 		await app.code.driver.page.getByRole('tab', { name: NOTEBOOK_FILE }).click();
 		await notebooksPositron.expectToBeVisible();
 
-		// Verify the scroll position is restored.
-		// The anchor-based restore refines for up to 1.5s as cells render,
-		// so poll until stable.
-		await expect.poll(async () => {
-			const scrollTop = await notebooksPositron.getScrollTop();
-			return Math.abs(scrollTop - scrollTopBefore);
-		}, { timeout: 5000 }).toBeLessThanOrEqual(1);
+		// Verify the anchor cell is at the same offset from the viewport top.
+		// The restore refines for up to 1.5s as cells render, so poll until stable.
+		await expectAnchorPositionRestored(notebooksPositron, cellIndex, offsetFromViewportTop);
 	});
 
 	test('Scroll position is restored after window reload', async function ({ app, hotKeys }) {
@@ -63,9 +103,8 @@ test.describe('Positron Notebooks: Scroll Position', {
 		const middleCellIndex = Math.floor(await notebooksPositron.cell.count() / 2);
 		await notebooksPositron.cell.nth(middleCellIndex).scrollIntoViewIfNeeded();
 
-		// Capture the scroll position
-		const scrollTopBefore = await notebooksPositron.getScrollTop();
-		expect(scrollTopBefore).toBeGreaterThan(0);
+		// Capture the anchor cell's position relative to the viewport
+		const { cellIndex, offsetFromViewportTop } = await getAnchorCellPosition(notebooksPositron);
 
 		// Reload the window
 		await hotKeys.reloadWindow(true);
@@ -73,12 +112,8 @@ test.describe('Positron Notebooks: Scroll Position', {
 		// Wait for the notebook to be visible again after reload
 		await notebooksPositron.expectToBeVisible();
 
-		// Verify the scroll position is restored.
-		// The anchor-based restore refines for up to 1.5s as cells render,
-		// so poll until stable.
-		await expect.poll(async () => {
-			const scrollTop = await notebooksPositron.getScrollTop();
-			return Math.abs(scrollTop - scrollTopBefore);
-		}, { timeout: 5000 }).toBeLessThanOrEqual(1);
+		// Verify the anchor cell is at the same offset from the viewport top.
+		// The restore refines for up to 1.5s as cells render, so poll until stable.
+		await expectAnchorPositionRestored(notebooksPositron, cellIndex, offsetFromViewportTop);
 	});
 });


### PR DESCRIPTION
Addresses #11777.

Restores notebook scroll position when switching tabs or reloading the window. The approach anchors to the first visible cell (by index) plus an offset in pixels, which handles async content re-rendering that shifts cell heights (e.g. markdown previews, editor model loading). A `useScrollRestoration` hook runs a rAF loop for up to 1.5s, re-applying the target scrollTop each frame until the layout stabilizes or the user scrolls.

Key changes:
- `PositronNotebookInstance.getEditorViewState()` now captures the scroll anchor (cell index + offset) instead of returning a placeholder
- `clearInput()` reordered so `super.clearInput()` runs first, allowing the base class to persist view state while the DOM is still alive
- Removed duplicate `editorObservable` field from `IPositronNotebookCell` (was identical to `editor`)
- Cell container attachment moved to a callback ref for synchronous availability during the commit phase

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed notebook scroll position not being restored when switching tabs or reloading the window (#11777)

### QA Notes

@:positron-notebooks @:win @:web

1. Open a notebook with enough cells to scroll (e.g. `qa-example-content/workspaces/pokemon/pokemon.ipynb`)
2. Scroll down to the middle of the notebook
3. Open a new file tab, then switch back to the notebook
4. Verify scroll position is restored
5. Scroll to a different position, then reload the window (Cmd+Shift+P > "Developer: Reload Window")
6. Verify scroll position is restored