### PR TITLE
Skip API credential validation for Snowflake Cortex

### DIFF
--- a/extensions/authentication/src/validation/snowflake.ts
+++ b/extensions/authentication/src/validation/snowflake.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
-import { KEY_VALIDATION_TIMEOUT_MS } from '../constants';
 
 class SnowflakeValidationError extends Error {
 	constructor(message: string) {
@@ -15,9 +14,11 @@ class SnowflakeValidationError extends Error {
 }
 
 /**
- * Validate Snowflake Cortex credentials by hitting the models endpoint.
- * The server authenticates before returning data, so 401/403 means bad
- * credentials while a successful response means the token is valid.
+ * Validate Snowflake Cortex credentials.
+ *
+ * Snowflake's Cortex REST API does not expose a documented lightweight
+ * endpoint suitable for credential validation. Credential errors are
+ * surfaced at request time instead.
  */
 export async function validateSnowflakeApiKey(
 	apiKey: string,
@@ -36,64 +37,5 @@ export async function validateSnowflakeApiKey(
 				'Please set your Snowflake account identifier in the base URL'
 			)
 		);
-	}
-
-	const endpoint = `${baseUrl}/chat/completions`;
-
-	const controller = new AbortController();
-	const timeout = setTimeout(
-		() => controller.abort(), KEY_VALIDATION_TIMEOUT_MS
-	);
-	try {
-		const response = await fetch(endpoint, {
-			method: 'POST',
-			headers: {
-				'Authorization': `Bearer ${apiKey}`,
-				'Content-Type': 'application/json',
-			},
-			body: JSON.stringify({ model: '', messages: [] }),
-			signal: controller.signal,
-		});
-
-		// A 400/422 means the server authenticated us but rejected
-		// the empty request body -- credentials are valid.
-		if (response.ok || response.status === 400
-			|| response.status === 422) {
-			return;
-		}
-
-		if (response.status === 401 || response.status === 403) {
-			throw new SnowflakeValidationError(
-				vscode.l10n.t('Invalid Snowflake credentials')
-			);
-		}
-
-		if (response.status === 404) {
-			throw new SnowflakeValidationError(
-				vscode.l10n.t(
-					'Snowflake endpoint not found. Check your base URL.'
-				)
-			);
-		}
-
-		throw new SnowflakeValidationError(vscode.l10n.t(
-			'Unable to validate Snowflake credentials (HTTP {0})',
-			String(response.status)
-		));
-	} catch (err) {
-		if (err instanceof Error && err.name === 'AbortError') {
-			throw new SnowflakeValidationError(vscode.l10n.t(
-				'Could not validate Snowflake credentials within {0} seconds',
-				String(KEY_VALIDATION_TIMEOUT_MS / 1000)
-			));
-		}
-		if (err instanceof SnowflakeValidationError) {
-			throw err;
-		}
-		throw new SnowflakeValidationError(vscode.l10n.t(
-			'Could not validate Snowflake credentials. Check your network connection and try again.'
-		));
-	} finally {
-		clearTimeout(timeout);
 	}
 }


### PR DESCRIPTION
Cherry pick https://github.com/posit-dev/positron/pull/12929 to main to address #12920


### Release Notes

#### New Features

- N/A

#### Bug Fixes

  - Fixed Snowflake Cortex model provider rejecting valid credentials (#12920)


### QA Notes

  @:assistant

  1. Configure a Snowflake Cortex model provider with valid credentials
  2. Click Sign In and verify it succeeds without "Invalid Snowflake credentials"
  3. Close the Configure Language Model Provider modal and verify the provider works
  4. Try with an invalid API key, close the modal, and verify an error notification appears in the bottom right corner