### PR TITLE
e2e test - basic `ipywidgets` slider test

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -73,6 +73,15 @@ export class PositronNotebooks extends Notebooks {
 	outputTruncationMessage = (index: number) => this.cellOutput(index).getByText(/\.\.\. Show [\d,.\s\u00A0]+ more lines/);
 	outputCollapseToggle = (index: number) => this.cell.nth(index).locator('.cell-output-collapse-button-container').getByRole('button');
 
+	// Cell outputs - ipywidgets (rendered inside the notebook webview iframe)
+	widgetSlider = this.frameLocator.locator('[role="slider"]');
+	widgetReadout = this.frameLocator.locator('div.widget-readout');
+
+	async focusWidgetSlider(): Promise<void> {
+		await this.widgetSlider.hover();
+		await this.widgetSlider.focus();
+	}
+
 	// Assistant buttons (shown on error cells when assistant is enabled)
 	private askAssistantButton = this.editorActionBar.getByRole('button', { name: 'Ask Assistant', exact: true });
 	private fixErrorButton = this.code.driver.page.getByRole('button', { name: /Ask assistant to fix/i });

--- a/test/e2e/tests/notebooks-positron/notebook-ipywidgets-slider.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-ipywidgets-slider.test.ts
@@ -34,7 +34,7 @@ display(s)
 		await notebooksPositron.widgetSlider.press('ArrowLeft');
 		await expect(notebooksPositron.widgetReadout).toContainText('49');
 
-		// Moving from 49 to 51 proves that widget does NOT get stuck after first interactivity
+		// Moving from 49 to 51 proves that widget does NOT get stuck after first interactivity event.
 		await notebooksPositron.widgetSlider.press('ArrowRight');
 		await notebooksPositron.widgetSlider.press('ArrowRight');
 		await expect(notebooksPositron.widgetReadout).toContainText('51');

--- a/test/e2e/tests/notebooks-positron/notebook-ipywidgets-slider.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-ipywidgets-slider.test.ts
@@ -30,7 +30,7 @@ display(s)
 		await expect(notebooksPositron.widgetSlider).toBeVisible({ timeout: 5000 });
 		await notebooksPositron.focusWidgetSlider();
 
-		// Moving from 50 to 49 proves widgget interactivity
+		// Moving from 50 to 49 proves widget interactivity
 		await notebooksPositron.widgetSlider.press('ArrowLeft');
 		await expect(notebooksPositron.widgetReadout).toContainText('49');
 

--- a/test/e2e/tests/notebooks-positron/notebook-ipywidgets-slider.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-ipywidgets-slider.test.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+
+test.use({ suiteId: __filename });
+
+test.describe('Positron Notebooks: ipywidgets', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+}, () => {
+
+	test.beforeEach(async ({ app }) => {
+		const { notebooks, notebooksPositron } = app.workbench;
+		await notebooks.createNewNotebook();
+		await notebooksPositron.expectCellCountToBe(1);
+		await notebooksPositron.kernel.select('Python');
+	});
+
+	test('IntSlider arrow keys change value', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		await notebooksPositron.addCodeToCell(0, `
+import ipywidgets as ipw
+s = ipw.IntSlider(value=50, min=0, max=100)
+display(s)
+`, { run: true });
+
+		await expect(notebooksPositron.widgetSlider).toBeVisible({ timeout: 5000 });
+		await notebooksPositron.focusWidgetSlider();
+
+		// Moving from 50 to 49 proves widgget interactivity
+		await notebooksPositron.widgetSlider.press('ArrowLeft');
+		await expect(notebooksPositron.widgetReadout).toContainText('49');
+
+		// Moving from 49 to 51 proves that widget does NOT get stuck after first interactivity
+		await notebooksPositron.widgetSlider.press('ArrowRight');
+		await notebooksPositron.widgetSlider.press('ArrowRight');
+		await expect(notebooksPositron.widgetReadout).toContainText('51');
+	});
+
+});


### PR DESCRIPTION
This pull request adds new end-to-end test coverage for ipywidgets slider interactivity in Positron Notebooks. It introduces a dedicated test to verify that the `IntSlider` widget responds correctly to keyboard input, and enhances the page object to support widget interaction within notebook webviews.

**ipywidgets slider support and testing:**

* Added a new test file, `notebook-ipywidgets-slider.test.ts`, which verifies that the `IntSlider` ipywidget responds to arrow key presses and updates its value accordingly. This test ensures that widget interactivity is functioning as expected in Positron Notebooks.
* Enhanced the `PositronNotebooks` page object in `notebooksPositron.ts` by adding locators for the widget slider and its readout, and a helper method `focusWidgetSlider()` to programmatically focus the slider for interaction within the notebook webview iframe.

### Observations

- This test verifies that BOTH the widget **appears** and also that it is interactive. A common problem with testing `ipywidgets` is verifying that they appear but not actually testing their interactivity. This could raise breakages unexpectedly. 
- This test ONLY verifies that the slider widget works by using arrow keys to move it. It is _possible_ but _highly unlikely_ that dragging only could stop working. If that ever happens, we can then add a more complex test for that.
- This test does not verify other `ipywidgets` like dropdown boxes, text input boxes, etc. The assumption we make herein is that, if the interactive slider works, there is a high likelihood that the other (or most) widgets work as well. If this stops being the case and we find `ipywidgets`-widget specific bugs, we can then add additional test cases for such. 

### QA Notes

@:win @:web @:positron-notebooks