### PR TITLE
fix: disambiguation to unit test skill descriptions

### DIFF
--- a/.claude/skills/author-unit-tests/SKILL.md
+++ b/.claude/skills/author-unit-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: author-unit-tests
-description: Use when writing, generating, or adding unit tests for Positron source code in src/vs/. Load this skill when analyzing a branch or PR for test coverage gaps, or when the user asks to write tests using the createTestContainer() builder pattern.
+description: Use when writing, generating, or adding unit tests for Positron source code in src/vs/. Load this skill when analyzing a branch or PR for test coverage gaps, or when the user asks to write tests using the createTestContainer() builder pattern. Not for e2e or Playwright tests -- use author-e2e-tests for those.
 ---
 
 # Positron Unit Test Authoring

--- a/.claude/skills/review-unit-tests/SKILL.md
+++ b/.claude/skills/review-unit-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-unit-tests
-description: Use when reviewing unit test files for quality, maintainability, and adherence to Positron's testing patterns. Load this skill when test files need a quality check against the builder pattern and project conventions.
+description: Use when reviewing unit test files for quality, maintainability, and adherence to Positron's testing patterns. Load this skill when test files need a quality check against the builder pattern and project conventions. Not for e2e or Playwright tests.
 ---
 
 # Positron Unit Test Review


### PR DESCRIPTION
## Summary

Oops, I thought I pushed this up with the PR I just merged, but it turns out I didn't.
- Add "Not for e2e or Playwright tests" to `author-unit-tests` and `review-unit-tests` skill descriptions
- Helps Claude pick the right skill when multiple test skills are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)