### PR TITLE
Inline data explorer: preserve column sort indicators on explorer re-mount

### DIFF
--- a/src/vs/workbench/services/positronDataExplorer/browser/inlineTableDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/inlineTableDataGridInstance.tsx
@@ -260,6 +260,16 @@ export class InlineTableDataGridInstance extends DataGridInstance {
 		this._columnLayoutManager.setEntries(state.table_shape.num_columns);
 		this._rowLayoutManager.setEntries(state.table_shape.num_rows);
 
+		// Rebuild column sort keys from state so that sort indicators are
+		// preserved when the explorer re-mounts (e.g. after a tab switch).
+		this._columnSortKeys.clear();
+		state.sort_keys.forEach((key, sortIndex) => {
+			this._columnSortKeys.set(
+				key.column_index,
+				new ColumnSortKeyDescriptor(sortIndex, key.column_index, key.ascending)
+			);
+		});
+
 		// Now fetch the actual data
 		await this.fetchData(InvalidateCacheFlags.All);
 	}


### PR DESCRIPTION
Addresses #12065.

When sorting a column in the inline (notebook) data explorer, the sort indicator arrow and sort index badge display correctly. However, switching to another tab and back causes these indicators to vanish, even though the data remains sorted. The root cause is that `InlineTableDataGridInstance.initialize()` -- called on every remount -- fetched the backend state but never used its `sort_keys` to populate the grid's `_columnSortKeys` map.

This adds sort key reconstruction from the backend state during `initialize()`, using the same logic already present in the `onDidUpdateBackendState` event handler.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed inline data explorer sort indicators disappearing after switching tabs in notebooks (#12065)

### QA Notes

@:positron-notebooks

1. Open a notebook with a data frame output displayed inline (e.g. run `df` in a Python cell)
2. Right-click a column header and select "Sort Ascending"
3. Verify the ascending arrow and `#1` badge appear in the column header
4. Switch to a different editor tab, then switch back to the notebook
5. Verify the sort arrow and badge are still visible and the data remains sorted
6. Repeat with "Sort Descending" and multi-column sorts to confirm they also persist