### PR TITLE
Fix Foundry managed credentials auto-configuration on Workbench

### DIFF
--- a/extensions/authentication/src/authProvider.ts
+++ b/extensions/authentication/src/authProvider.ts
@@ -75,8 +75,8 @@ export class AuthProvider
 		return !!this.credentialChain?.preventSignOut;
 	}
 
-	/** Expose session-change events to subclasses. */
-	protected fireSessionsChanged(
+	/** Expose session-change events. */
+	fireSessionsChanged(
 		event: vscode.AuthenticationProviderAuthenticationSessionsChangeEvent
 	): void {
 		this._onDidChangeSessions.fire(event);

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -236,10 +236,20 @@ function registerFoundryProvider(context: vscode.ExtensionContext): void {
 	});
 	logger.info('Registered auth provider');
 
+	// Forward Workbench session changes so consumers listening for
+	// ms-foundry events are notified when the managed token arrives.
+	context.subscriptions.push(
+		vscode.authentication.onDidChangeSessions((e) => {
+			if (e.provider.id === FOUNDRY_MANAGED_CREDENTIALS.authProvider.id) {
+				provider.fireSessionsChanged({ added: [], removed: [], changed: [] });
+			}
+		})
+	);
+
 	// Sync Workbench endpoint to auth extension setting
 	if (hasManagedCredentials(FOUNDRY_MANAGED_CREDENTIALS)) {
 		const endpoint = vscode.workspace
-			.getConfiguration('positWorkbench.foundry')
+			.getConfiguration('posit.workbench.foundry')
 			.get<string>('endpoint', '');
 		if (endpoint) {
 			const normalized = normalizeToV1Url(endpoint);

--- a/extensions/authentication/src/managedCredentials.ts
+++ b/extensions/authentication/src/managedCredentials.ts
@@ -51,7 +51,7 @@ export const FOUNDRY_MANAGED_CREDENTIALS: AuthTokenCredentialConfig = {
 		scopes: ['msfoundry'],
 	},
 	validator: () => {
-		const config = vscode.workspace.getConfiguration('positWorkbench.foundry');
+		const config = vscode.workspace.getConfiguration('posit.workbench.foundry');
 		return !!config.get<string>('endpoint', '');
 	},
 };

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -394,6 +394,14 @@ function registerAssistant(context: vscode.ExtensionContext) {
 					log.warn(`[Auth Startup] Deferred session registration failed for ${providerId}: ${e instanceof Error ? e.message : String(e)}`);
 				}
 			}
+
+			// Register session-backed providers that aren't covered by
+			// queued events (e.g. Workbench-managed credentials).
+			for (const providerId of SESSION_PROVIDERS) {
+				if (!unique.includes(providerId)) {
+					await registerModelsForProvider(context, providerId, providerId);
+				}
+			}
 		})
 		.catch((e) => {
 			initialRegistrationComplete = true;

--- a/product.json
+++ b/product.json
@@ -94,10 +94,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "2026.4.19",
+			"version": "2026.5.2",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web-pwb",
-			"sha256": "2a08a4be73c55170f57fc784f1a47aab1795e9503a973dddee8ee170f2bd58c2",
+			"sha256": "dcab9474334bb9ede3639277c0034baa3d482b12057abba2308d2756e2bc69e1",
 			"metadata": {
 				"publisherDisplayName": "Posit PBC"
 			}


### PR DESCRIPTION
Addresses rstudio/rstudio-workbench-vscode-ext#460.

This is the main branch version of #12998, which was the minimal patch for release/2026.04. On main, the `positWorkbench.foundry` setting was never renamed to `posit.workbench.foundry`, so the Foundry endpoint lookup silently returned empty and managed credentials were never configured. This PR fixes the setting name and adds event forwarding so the assistant picks up Foundry tokens that arrive after initial startup.

Changes:
- Fix `positWorkbench.foundry` → `posit.workbench.foundry`
- Make `fireSessionsChanged` public and forward `posit-workbench` session changes as `ms-foundry` events
- Check SESSION_PROVIDERS at startup for credentials not covered by queued events (from #12998)

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix Foundry managed credentials not auto-configuring on Workbench

### QA Notes

@:assistant @:workbench

1. On Workbench with Foundry delegated credentials configured (without `auth-refresh-tokens=1`), launch a Positron session and open Configure Language Model Providers — Foundry should appear auto-configured
2. On desktop, verify existing Foundry API key auth still works
3. On desktop, verify no regressions for other providers (Anthropic, OpenAI, Bedrock)