### PR TITLE
feat: add e2e-test-insights webhook for slack notifications

### DIFF
--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -101,6 +101,16 @@ jobs:
           include_job_durations: false
           notify_on: "failure"
 
+      - name: Notify E2E Test Insights
+        if: always()
+        run: |
+          curl -s -X POST \
+            "${{ secrets.E2E_INSIGHTS_API_URL }}/webhooks/workflow-complete" \
+            -H "Authorization: Key ${{ secrets.CONNECT_API_KEY }}" \
+            -H "X-Webhook-Secret: ${{ secrets.E2E_INSIGHTS_WEBHOOK_SECRET }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"workflow_run_id\": ${{ github.run_id }}, \"repo_id\": \"positron\", \"branch\": \"${{ github.ref_name }}\", \"actor\": \"${{ github.actor }}\", \"filter_jobs\": \"(e2e / ([^0-9]*)|unit|integration)$\", \"hide_skipped\": true}"
+
   slack-notify-win-extensions:
     if: ${{ needs.e2e-windows-electron.outputs.extensions_failed == 'true' }}
     needs:


### PR DESCRIPTION
## Summary

- Adds a webhook step to the `slack-notify` job in `test-merge.yml`
- Sends workflow completion signal to the E2E Test Insights dashboard
- Runs **alongside** the existing `slack-workflow-status` notification (no replacement yet, would like to monitor for a bit)
- Dashboard provides richer Slack thread details: classified test failures (new vs known), attribution SHAs, and links to the Test Health dashboard

## What this does

After each merge-to-main test run, a `curl` step calls the dashboard's webhook endpoint with the workflow run ID. The dashboard's scheduler then:
1. Looks up the run data in its cache
2. Fetches per-job status from the GitHub API
3. Posts a Slack notification with colored sidebars and classified test details in a thread

## Test plan

- [ ] Merge a PR to main and verify both Slack notifications arrive
- [ ] Compare the new notification's thread details vs the existing one
- [ ] Monitor for a few days in parallel before considering replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)