### PR TITLE
e2e: add console readiness test after notebook cell execution

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -219,7 +219,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await sessions.start(['python']);
 		await notebooksPositron.newNotebook();
 		await notebooksPositron.kernel.select('Python');
-		await notebooksPositron.addCodeToCell(0, 'import time; time.sleep(1); print("done")', { run: false });
+		await notebooksPositron.addCodeToCell(0, 'import time; time.sleep(3); print("done")', { run: false });
 		await notebooksPositron.runCellButtonAtIndex(0).click();
 
 		// verify the console accepts typed input

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -230,7 +230,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await console.typeToConsole('print(x)', true);
 		await console.waitForConsoleContents('42');
 
-		// the notebook cell should still be running; if "done" appeared the
+		// the notebook cell should still be running; if "done" appeared the test FAILS
 		// idea here is to guarantee that user will always get console ready INSTANTLY, not eventually...
 		await expect(notebooksPositron.cellOutput(0)).not.toContainText('done');
 	});

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -219,7 +219,8 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await sessions.start(['python']);
 		await notebooksPositron.newNotebook();
 		await notebooksPositron.kernel.select('Python');
-		await notebooksPositron.addCodeToCell(0, 'print("hello")', { run: true });
+		await notebooksPositron.addCodeToCell(0, 'import time; time.sleep(0.1); print("done")', { run: false });
+		await notebooksPositron.runCellButtonAtIndex(0).click();
 
 		// verify the console accepts typed input
 		await console.focus();
@@ -228,6 +229,10 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await console.waitForReady('>>>');
 		await console.typeToConsole('print(x)', true);
 		await console.waitForConsoleContents('42');
+
+		// the notebook cell should still be running; if "done" appeared the
+		// idea here is to guarantee that user will always get console ready INSTANTLY, not eventually...
+		await expect(notebooksPositron.cellOutput(0)).not.toContainText('done');
 	});
 
 });

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -210,6 +210,60 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		// Disable the notebook console actions setting after this test
 		await settings.remove(['console.showNotebookConsoleActions']);
 	});
+
+	test('Python - notebook console accepts input after cell execution', {
+		tag: [tags.CONSOLE],
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/11704' }]
+	}, async function ({ app, sessions, settings }) {
+		const { notebooksPositron, console } = app.workbench;
+
+		await settings.set({ 'console.showNotebookConsoleActions': true }, { reload: true, waitMs: 1000 });
+
+		// create notebook and select Python kernel
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.kernel.select('Python');
+
+		// execute a cell to ensure the kernel is active
+		await notebooksPositron.addCodeToCell(0, 'x = 42', { run: true });
+
+		// open the notebook console
+		await notebooksPositron.kernel.openNotebookConsole();
+		await sessions.select('Untitled-1.ipynb');
+		await console.waitForReady('>>>');
+
+		// verify the console can execute code that references the notebook variable
+		await console.pasteCodeToConsole('print(x)', true);
+		await console.waitForConsoleContents('42');
+
+		await settings.remove(['console.showNotebookConsoleActions']);
+	});
+
+	test('R - notebook console accepts input after cell execution', {
+		tag: [tags.ARK, tags.CONSOLE],
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/11704' }]
+	}, async function ({ app, sessions, settings }) {
+		const { notebooksPositron, console } = app.workbench;
+
+		await settings.set({ 'console.showNotebookConsoleActions': true }, { reload: true, waitMs: 1000 });
+
+		// create notebook and select R kernel
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.kernel.select('R');
+
+		// execute a cell to ensure the kernel is active
+		await notebooksPositron.addCodeToCell(0, 'x <- 42', { run: true });
+
+		// open the notebook console
+		await notebooksPositron.kernel.openNotebookConsole();
+		await sessions.select('Untitled-1.ipynb');
+		await console.waitForReady('>');
+
+		// verify the console can execute code that references the notebook variable
+		await console.pasteCodeToConsole('print(x)', true);
+		await console.waitForConsoleContents('[1] 42');
+
+		await settings.remove(['console.showNotebookConsoleActions']);
+	});
 });
 
 const rDataFrame = `data.frame(

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -219,7 +219,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await sessions.start(['python']);
 		await notebooksPositron.newNotebook();
 		await notebooksPositron.kernel.select('Python');
-		await notebooksPositron.addCodeToCell(0, 'import time; time.sleep(3); print("done")', { run: false });
+		await notebooksPositron.addCodeToCell(0, 'import time; time.sleep(6); print("done")', { run: false });
 		await notebooksPositron.runCellButtonAtIndex(0).click();
 
 		// verify the console accepts typed input

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -219,7 +219,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await sessions.start(['python']);
 		await notebooksPositron.newNotebook();
 		await notebooksPositron.kernel.select('Python');
-		await notebooksPositron.addCodeToCell(0, 'import time; time.sleep(0.1); print("done")', { run: false });
+		await notebooksPositron.addCodeToCell(0, 'import time; time.sleep(1); print("done")', { run: false });
 		await notebooksPositron.runCellButtonAtIndex(0).click();
 
 		// verify the console accepts typed input

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -212,7 +212,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 	});
 
 	test('Python - console accepts input after notebook cell execution', {
-		tag: [tags.CONSOLE],
+		tag: [tags.CONSOLE, tags.POSITRON_NOTEBOOKS, tags.WIN],
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/11704' }]
 	}, async function ({ app, sessions }) {
 		const { notebooksPositron, console } = app.workbench;

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -211,59 +211,25 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await settings.remove(['console.showNotebookConsoleActions']);
 	});
 
-	test('Python - notebook console accepts input after cell execution', {
+	test('Python - console accepts input after notebook cell execution', {
 		tag: [tags.CONSOLE],
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/11704' }]
-	}, async function ({ app, sessions, settings }) {
+	}, async function ({ app, sessions }) {
 		const { notebooksPositron, console } = app.workbench;
-
-		await settings.set({ 'console.showNotebookConsoleActions': true }, { reload: true, waitMs: 1000 });
-
-		// create notebook and select Python kernel
+		await sessions.start(['python']);
 		await notebooksPositron.newNotebook();
 		await notebooksPositron.kernel.select('Python');
+		await notebooksPositron.addCodeToCell(0, 'print("hello")', { run: true });
 
-		// execute a cell to ensure the kernel is active
-		await notebooksPositron.addCodeToCell(0, 'x = 42', { run: true });
-
-		// open the notebook console
-		await notebooksPositron.kernel.openNotebookConsole();
-		await sessions.select('Untitled-1.ipynb');
+		// verify the console accepts typed input
+		await console.focus();
 		await console.waitForReady('>>>');
-
-		// verify the console can execute code that references the notebook variable
-		await console.pasteCodeToConsole('print(x)', true);
+		await console.typeToConsole('x = 42', true);
+		await console.waitForReady('>>>');
+		await console.typeToConsole('print(x)', true);
 		await console.waitForConsoleContents('42');
-
-		await settings.remove(['console.showNotebookConsoleActions']);
 	});
 
-	test('R - notebook console accepts input after cell execution', {
-		tag: [tags.ARK, tags.CONSOLE],
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/11704' }]
-	}, async function ({ app, sessions, settings }) {
-		const { notebooksPositron, console } = app.workbench;
-
-		await settings.set({ 'console.showNotebookConsoleActions': true }, { reload: true, waitMs: 1000 });
-
-		// create notebook and select R kernel
-		await notebooksPositron.newNotebook();
-		await notebooksPositron.kernel.select('R');
-
-		// execute a cell to ensure the kernel is active
-		await notebooksPositron.addCodeToCell(0, 'x <- 42', { run: true });
-
-		// open the notebook console
-		await notebooksPositron.kernel.openNotebookConsole();
-		await sessions.select('Untitled-1.ipynb');
-		await console.waitForReady('>');
-
-		// verify the console can execute code that references the notebook variable
-		await console.pasteCodeToConsole('print(x)', true);
-		await console.waitForConsoleContents('[1] 42');
-
-		await settings.remove(['console.showNotebookConsoleActions']);
-	});
 });
 
 const rDataFrame = `data.frame(


### PR DESCRIPTION
For this first test, I decided to be more minimalistic and simple: just focusing on the simple act of console focus taking place INSTANTLY right after a cell execution. If issues emerge in the future, we may consider adding additional cases that are outlined in description of #11704. 

---

Adds one focused e2e test to `notebook-kernel-behavior.test.ts` that verifies the console accepts typed input after notebook cell execution. The test starts a Python console session, creates a notebook, executes a cell containing timed execution, then focuses the console and types `x = 42` followed by `print(x)` to confirm the console is ready INSTANTLY. If it takes too long for console to be ready, test FAILS.

This is a rework of draft PR #11871 which was closed because it had too much overlap with existing test suites. This PR takes a minimal approach: one test, no new files, no new helpers, no duplication.

### QA Notes

@:positron-notebooks @:console @:win