### PR TITLE
feat: add E2E Test Insights webhook to all test workflows

### DIFF
--- a/.github/workflows/test-cross-browser.yml
+++ b/.github/workflows/test-cross-browser.yml
@@ -108,3 +108,13 @@ jobs:
           filter_jobs: "(e2e / ([^0-9]*))$"
           include_job_durations: false
           custom_title: "E2E Cross Browser Tests — `main` (commit <https://github.com/posit-dev/positron/commit/${{ github.sha }}|${{ env.SHORT_SHA }}>)"
+
+      - name: Notify E2E Test Insights
+        if: always()
+        uses: posit-dev/e2e-test-insights/.github/actions/notify@main
+        with:
+          webhook_secret: ${{ secrets.E2E_INSIGHTS_WEBHOOK_SECRET }}
+          connect_api_key: ${{ secrets.CONNECT_API_KEY }}
+          repo_id: "positron"
+          title: "E2E Cross Browser Tests"
+          filter_jobs: "(e2e / ([^0-9]*))$"

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -364,3 +364,13 @@ jobs:
           filter_jobs: "(e2e / ([^0-9]*)|unit|integration)$"
           include_job_durations: false
           notify_on: ${{ env.notify_on }}
+
+      - name: Notify E2E Test Insights
+        if: always()
+        uses: posit-dev/e2e-test-insights/.github/actions/notify@main
+        with:
+          webhook_secret: ${{ secrets.E2E_INSIGHTS_WEBHOOK_SECRET }}
+          connect_api_key: ${{ secrets.CONNECT_API_KEY }}
+          repo_id: "positron"
+          title: "E2E Full Suite Tests"
+          filter_jobs: "(e2e / ([^0-9]*)|unit|integration)$"

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -103,13 +103,12 @@ jobs:
 
       - name: Notify E2E Test Insights
         if: always()
-        run: |
-          curl -s -X POST \
-            "${{ secrets.E2E_INSIGHTS_API_URL }}/webhooks/workflow-complete" \
-            -H "Authorization: Key ${{ secrets.CONNECT_API_KEY }}" \
-            -H "X-Webhook-Secret: ${{ secrets.E2E_INSIGHTS_WEBHOOK_SECRET }}" \
-            -H "Content-Type: application/json" \
-            -d "{\"workflow_run_id\": ${{ github.run_id }}, \"repo_id\": \"positron\", \"branch\": \"${{ github.ref_name }}\", \"actor\": \"${{ github.actor }}\", \"filter_jobs\": \"(e2e / ([^0-9]*)|unit|integration)$\", \"hide_skipped\": true}"
+        uses: posit-dev/e2e-test-insights/.github/actions/notify@main
+        with:
+          webhook_secret: ${{ secrets.E2E_INSIGHTS_WEBHOOK_SECRET }}
+          connect_api_key: ${{ secrets.CONNECT_API_KEY }}
+          repo_id: "positron"
+          filter_jobs: "(e2e / ([^0-9]*)|unit|integration)$"
 
   slack-notify-win-extensions:
     if: ${{ needs.e2e-windows-electron.outputs.extensions_failed == 'true' }}


### PR DESCRIPTION
## Summary

Adds the E2E Test Insights notify action to all 5 workflows that use `slack-workflow-status`:

Also migrates `test-merge.yml` from raw curl to the composite action.

## The action

```yaml
- uses: posit-dev/e2e-test-insights/.github/actions/notify@main
  with:
    webhook_secret: ${{ secrets.E2E_INSIGHTS_WEBHOOK_SECRET }}
    connect_api_key: ${{ secrets.CONNECT_API_KEY }}
    repo_id: "positron"
```

Auto-derives: workflow_run_id, branch, actor, commit_message, hide_skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)