### PR TITLE
Update extension versions and fix noise in extensions check

### DIFF
--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -29,6 +29,8 @@ jobs:
       POSITRON_BUILD_NUMBER: 0 # CI skips building releases
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env

--- a/product.json
+++ b/product.json
@@ -296,8 +296,8 @@
 		},
 		{
 			"name": "posit.assistant",
-			"version": "0.3.0",
-			"sha256": "e44d6a548dbb138aff936879779a358c33732d4fa8000a4fe5452ee23be1e503",
+			"version": "0.3.1",
+			"sha256": "a2226c4670c2e173da4b918819a06994f7475f44cbcba428fadc878a719d7071",
 			"metadata": {
 				"publisherId": "090804ff-7eb2-4fbd-bb61-583e34f2b070",
 				"displayName": "Posit Assistant"

--- a/product.json
+++ b/product.json
@@ -200,8 +200,8 @@
 		},
 		{
 			"name": "meta.pyrefly",
-			"version": "0.60.0",
-			"sha256sum": "84de58c36e57d1caea48ad466bfd643113dd5599d04952cfc9cf03cf69d4117f",
+			"version": "0.61.0",
+			"sha256sum": "ff5d2ce2fbf5e7bf59be94467f5c1bdbd354b5204f4ee4a8f9087951a18cc3b6",
 			"repo": "https://github.com/facebook/pyrefly",
 			"metadata": {
 				"publisherId": {
@@ -243,8 +243,8 @@
 		},
 		{
 			"name": "quarto.quarto",
-			"version": "1.130.0",
-			"sha256sum": "8494b30a7895b2f6f52ef500bb71f64d897f6f6d3ec028ad0082ce11ed239b1e",
+			"version": "1.131.0",
+			"sha256sum": "1fcae21883e96367a6e65a76d84cf8900138c4536774f9a5387f711538389a0c",
 			"repo": "https://github.com/quarto-dev/quarto/tree/main/apps/vscode",
 			"metadata": {
 				"id": "a1be81fc-0f3a-4f2e-92ee-3fdc7ab96c73",


### PR DESCRIPTION
Update quarto, pyrefly and posit assistant extension versions.

Update extensions check job so that we stop getting "invalid revision range" in runs.

### QA Notes

