### PR TITLE
Design improvements to the filter input on the Packages pane

### DIFF
--- a/src/vs/platform/positronActionBar/browser/components/actionBarFilter.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFilter.css
@@ -1,11 +1,15 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 @keyframes positronActionBarFilter-fadeIn {
-	from { opacity: 0; }
-	to { opacity: 1; }
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
 }
 
 .action-bar-filter-container {
@@ -20,8 +24,13 @@
 	margin-right: 2px;
 	align-items: center;
 	font-size: 12px;
+	box-sizing: border-box;
 	background: var(--vscode-positronActionBar-textInputBackground);
 	border: 1px solid var(--vscode-positronActionBar-textInputBorder);
+}
+
+.action-bar-filter-input.action-bar-filter-input-md {
+	height: 26px;
 }
 
 .action-bar-filter-input.focused {
@@ -49,18 +58,22 @@
 }
 
 .action-bar-filter-input .clear-button {
-	padding: 0;
-	width: 16px;
-	height: 16px;
+	padding: 3px;
 	border: none;
 	display: flex;
 	cursor: pointer;
-	margin: 0 4px 0 0;
+	margin: 0 2px 0 0;
+	border-radius: 5px;
+	align-items: center;
+	justify-content: center;
 	background: transparent;
 	animation: positronActionBarFilter-fadeIn 150ms ease-out;
 }
 
+.action-bar-filter-input .clear-button:hover:not(:disabled) {
+	background: var(--vscode-toolbar-hoverBackground);
+}
+
 .action-bar-filter-input .clear-button:focus-visible {
-	border-radius: 3px;
 	outline: 1px solid var(--vscode-focusBorder);
 }

--- a/src/vs/platform/positronActionBar/browser/components/actionBarFilter.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFilter.css
@@ -30,7 +30,7 @@
 }
 
 .action-bar-filter-input.action-bar-filter-input-md {
-	height: 26px;
+	height: 28px;
 }
 
 .action-bar-filter-input.focused {
@@ -68,6 +68,11 @@
 	justify-content: center;
 	background: transparent;
 	animation: positronActionBarFilter-fadeIn 150ms ease-out;
+}
+
+.action-bar-filter-input .clear-button:disabled {
+	cursor: default;
+	opacity: 0.5;
 }
 
 .action-bar-filter-input .clear-button:hover:not(:disabled) {

--- a/src/vs/platform/positronActionBar/browser/components/actionBarFilter.css
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFilter.css
@@ -30,7 +30,7 @@
 }
 
 .action-bar-filter-input.action-bar-filter-input-md {
-	height: 28px;
+	height: 26px;
 }
 
 .action-bar-filter-input.focused {

--- a/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
@@ -12,6 +12,9 @@ import React, { ChangeEvent, forwardRef, useImperativeHandle, useRef, useState }
 // Other dependencies.
 import { localize } from '../../../../nls.js';
 import { positronClassNames } from '../../../../base/common/positronUtilities.js';
+import { Icon as IconType } from '../../../action/common/action.js';
+import { Icon } from './icon.js';
+import { Codicon } from '../../../../base/common/codicons.js';
 
 /**
  * ActionBarFilterProps interface.
@@ -21,6 +24,7 @@ interface ActionBarFilterProps {
 	disabled?: boolean;
 	initialFilterText?: string;
 	placeholder?: string;
+	clearButtonIcon?: IconType;
 	onFilterTextChanged: (filterText: string) => void;
 }
 
@@ -105,7 +109,7 @@ export const ActionBarFilter = forwardRef<ActionBarFilterHandle, ActionBarFilter
 						onClick={buttonClearClickHandler}
 						onKeyDown={buttonClearKeyDownHandler}
 					>
-						<div className={'codicon codicon-positron-search-cancel'} />
+						<Icon icon={props.clearButtonIcon ?? Codicon.positronSearchCancel} />
 					</button>
 				)}
 			</div>

--- a/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
@@ -97,7 +97,7 @@ export const ActionBarFilter = forwardRef<ActionBarFilterHandle, ActionBarFilter
 	// Render.
 	return (
 		<div className='action-bar-filter-container' style={{ width: props.width }}>
-			<div className={positronClassNames('action-bar-filter-input', sizeClassName, 'action-bar-filter-input-sm', { 'focused': focused })}>
+			<div className={positronClassNames('action-bar-filter-input', sizeClassName, { 'focused': focused })}>
 				<input
 					ref={inputRef}
 					className='text-input'

--- a/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
@@ -30,6 +30,7 @@ interface ActionBarFilterProps {
 	initialFilterText?: string;
 	placeholder?: string;
 	clearButtonIcon?: IconType;
+	showClearAlways?: boolean;
 	size?: ActionBarFilterSize;
 	onFilterTextChanged: (filterText: string) => void;
 }
@@ -109,11 +110,11 @@ export const ActionBarFilter = forwardRef<ActionBarFilterHandle, ActionBarFilter
 					onFocus={() => setFocused(true)}
 					onKeyDown={inputKeyDownHandler}
 				/>
-				{filterText !== '' && (
+				{(filterText !== '' || props.showClearAlways) && (
 					<button
 						aria-label={localize('positronClearFilter', "Clear filter")}
 						className='clear-button'
-						disabled={props.disabled}
+						disabled={props.disabled || filterText === ''}
 						onClick={buttonClearClickHandler}
 						onKeyDown={buttonClearKeyDownHandler}
 					>

--- a/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
+++ b/src/vs/platform/positronActionBar/browser/components/actionBarFilter.tsx
@@ -17,6 +17,11 @@ import { Icon } from './icon.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 
 /**
+ * ActionBarFilterSize type.
+ */
+type ActionBarFilterSize = 'sm' | 'md';
+
+/**
  * ActionBarFilterProps interface.
  */
 interface ActionBarFilterProps {
@@ -25,6 +30,7 @@ interface ActionBarFilterProps {
 	initialFilterText?: string;
 	placeholder?: string;
 	clearButtonIcon?: IconType;
+	size?: ActionBarFilterSize;
 	onFilterTextChanged: (filterText: string) => void;
 }
 
@@ -85,10 +91,12 @@ export const ActionBarFilter = forwardRef<ActionBarFilterHandle, ActionBarFilter
 		}
 	}));
 
+	const sizeClassName = props.size === 'md' ? 'action-bar-filter-input-md' : 'action-bar-filter-input-sm';
+
 	// Render.
 	return (
 		<div className='action-bar-filter-container' style={{ width: props.width }}>
-			<div className={positronClassNames('action-bar-filter-input', { 'focused': focused })}>
+			<div className={positronClassNames('action-bar-filter-input', sizeClassName, 'action-bar-filter-input-sm', { 'focused': focused })}>
 				<input
 					ref={inputRef}
 					className='text-input'

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -9,7 +9,6 @@
 
 .packages-filter-container {
 	padding: 4px 8px;
-	border-bottom: 1px solid var(--vscode-positronPackages-border);
 }
 
 .packages-list-container {
@@ -75,4 +74,9 @@
 .positron-packages-list.focused .packages-list-item.selected {
 	color: var(--vscode-list-activeSelectionForeground);
 	background: var(--vscode-list-activeSelectionBackground);
+}
+
+.packages-empty-message {
+	padding: 5px 9px 5px 20px;
+	cursor: default;
 }

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -30,6 +30,7 @@ import { ILanguageRuntimePackage } from '../../../../services/runtimeSession/com
 import { ProgressBar } from '../../../../../base/browser/ui/progressbar/progressbar.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { Separator } from '../../../../../base/common/actions.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
 
 const positronUninstallPackage = localize(
 	'positronUninstallPackage',
@@ -310,6 +311,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 
 			<div className='packages-filter-container'>
 				<ActionBarFilter
+					clearButtonIcon={Codicon.clearAll}
 					placeholder={localize('positronPackages.filterPlaceholder', "Filter packages")}
 					onFilterTextChanged={setFilterText}
 				/>

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -317,6 +317,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 
 			<div className='packages-filter-container'>
 				<ActionBarFilter
+					showClearAlways
 					clearButtonIcon={Codicon.clearAll}
 					placeholder={localize('positronPackages.filterPlaceholder', "Filter packages")}
 					size='md'
@@ -325,7 +326,8 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 			</div>
 			<div className='packages-list-container'>
 				{filteredPackages.length === 0 && debouncedFilterText ? (
-					<div className='packages-empty-message'>
+					<div className='packages-empty-message'
+						style={{ height: height - FILTER_HEIGHT }}>
 						{localize('positronPackages.noPackagesFound', "No packages found.")}
 					</div>
 				) : (

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -150,6 +150,12 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	const [filterText, setFilterText] = useState('');
 	const [debouncedFilterText, setDebouncedFilterText] = useState('');
 
+	// Clear selection when filter text changes
+	const handleFilterTextChanged = (text: string) => {
+		setFilterText(text);
+		setSelectedItem(undefined);
+	};
+
 	// Debounce filter text changes (300ms)
 	useEffect(() => {
 		const timeout = setTimeout(() => {
@@ -313,20 +319,27 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 				<ActionBarFilter
 					clearButtonIcon={Codicon.clearAll}
 					placeholder={localize('positronPackages.filterPlaceholder', "Filter packages")}
-					onFilterTextChanged={setFilterText}
+					size='md'
+					onFilterTextChanged={handleFilterTextChanged}
 				/>
 			</div>
 			<div className='packages-list-container'>
-				<List
-					height={height - FILTER_HEIGHT}
-					innerRef={innerRef}
-					itemCount={filteredPackages.length}
-					itemKey={(index) => filteredPackages[index].id}
-					itemSize={26}
-					width={'calc(100% - 2px)'}
-				>
-					{ItemEntry}
-				</List>
+				{filteredPackages.length === 0 && debouncedFilterText ? (
+					<div className='packages-empty-message'>
+						{localize('positronPackages.noPackagesFound', "No packages found.")}
+					</div>
+				) : (
+					<List
+						height={height - FILTER_HEIGHT}
+						innerRef={innerRef}
+						itemCount={filteredPackages.length}
+						itemKey={(index) => filteredPackages[index].id}
+						itemSize={26}
+						width={'calc(100% - 2px)'}
+					>
+						{ItemEntry}
+					</List>
+				)}
 			</div>
 		</div >
 	);


### PR DESCRIPTION
See #12091 

This PR adds some better visual design and UX to the search bar in the packages pane:

Changes to the ActionBarFilter:
* The ActionBarFilter now has 2 sizes: `sm` (default) or `md`. The packages pane uses the new `md` size that is 26px. This matches the Search primary sidebar input size, but not the Extensions (which is larger at 28px).
* The clear icon is now customizable with any codicon.
* The clear icon has a new prop to have it always be shown
* The clear icon now has a hover and a disabled state

Changes to the packages list related to the filter bar:
* There is an empty state for the packages when filtering
* When changing the search filter, the selected package is now automatically unselected.

Initial state:
<img width="340" height="152" alt="Screenshot 2026-04-15 at 2 07 29 PM" src="https://github.com/user-attachments/assets/bc48c52d-e670-4e57-a319-b9c8a457a331" />

With an input filter
<img width="340" height="139" alt="Screenshot 2026-04-15 at 2 07 44 PM" src="https://github.com/user-attachments/assets/8311ac17-94f3-4659-8471-05ee4a11e6b3" />

No packages found
<img width="341" height="144" alt="Screenshot 2026-04-15 at 2 07 51 PM" src="https://github.com/user-attachments/assets/3d52b27f-1298-46d0-bfdf-2d53975bfa13" />

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

For the empty state: It should not appear initially. It should only appear when a user is actively filtering the list.
I tested workflows like: performing a filter, seeing no packages installed, installing the package, refreshing, and then verifying that the package now appears.

@:packages-pane