### PR TITLE
fix: use local action e2e-test-insights dash slack notifications

### DIFF
--- a/.github/actions/notify-e2e-insights/action.yml
+++ b/.github/actions/notify-e2e-insights/action.yml
@@ -24,7 +24,7 @@ inputs:
   hide_skipped:
     description: 'Hide skipped/cancelled jobs from the Slack message'
     required: false
-    default: 'true'
+    default: 'false'
   source_repo:
     description: 'GitHub owner/repo where this workflow runs (auto-detected, only override if needed)'
     required: false

--- a/.github/actions/notify-e2e-insights/action.yml
+++ b/.github/actions/notify-e2e-insights/action.yml
@@ -1,0 +1,92 @@
+name: 'Notify E2E Test Insights'
+description: 'Send workflow completion signal to the E2E Test Insights dashboard for Slack notifications'
+
+inputs:
+  api_url:
+    description: 'E2E Test Insights API URL'
+    required: false
+    default: 'https://connect.posit.it/e2e-test-insights-api'
+  webhook_secret:
+    description: 'Webhook authentication secret'
+    required: true
+  connect_api_key:
+    description: 'Posit Connect API key for authentication'
+    required: true
+  repo_id:
+    description: 'Repository identifier in the dashboard (e.g., "positron")'
+    required: true
+  title:
+    description: 'Custom title for the Slack message (e.g., "E2E Desktop Tests — Release 2026.05.0")'
+    required: false
+  filter_jobs:
+    description: 'Regex to filter which GitHub Actions jobs appear in the Slack message (e.g., "desktop /")'
+    required: false
+  hide_skipped:
+    description: 'Hide skipped/cancelled jobs from the Slack message'
+    required: false
+    default: 'true'
+  source_repo:
+    description: 'GitHub owner/repo where this workflow runs (auto-detected, only override if needed)'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Send webhook
+      shell: bash
+      env:
+        API_URL: ${{ inputs.api_url }}
+        WEBHOOK_SECRET: ${{ inputs.webhook_secret }}
+        CONNECT_API_KEY: ${{ inputs.connect_api_key }}
+        REPO_ID: ${{ inputs.repo_id }}
+        TITLE: ${{ inputs.title }}
+        FILTER_JOBS: ${{ inputs.filter_jobs }}
+        HIDE_SKIPPED: ${{ inputs.hide_skipped }}
+        SOURCE_REPO: ${{ inputs.source_repo || github.repository }}
+        RUN_ID: ${{ github.run_id }}
+        BRANCH: ${{ github.ref_name }}
+        ACTOR: ${{ github.actor }}
+        COMMIT_MSG: ${{ github.event.head_commit.message || '' }}
+      run: |
+        # Get first line of commit message (use printf to avoid broken pipe with multi-line messages)
+        COMMIT_FIRST_LINE="${COMMIT_MSG%%$'\n'*}"
+
+        # Build JSON payload with only non-empty fields
+        payload=$(jq -n \
+          --argjson run_id "$RUN_ID" \
+          --arg repo_id "$REPO_ID" \
+          --arg branch "$BRANCH" \
+          --arg actor "$ACTOR" \
+          --arg title "$TITLE" \
+          --arg filter_jobs "$FILTER_JOBS" \
+          --argjson hide_skipped "${HIDE_SKIPPED:-false}" \
+          --arg owner_repo "$SOURCE_REPO" \
+          --arg commit_message "$COMMIT_FIRST_LINE" \
+          '{
+            workflow_run_id: $run_id,
+            repo_id: $repo_id,
+            branch: $branch
+          }
+          + if $actor != "" then {actor: $actor} else {} end
+          + if $title != "" then {title: $title} else {} end
+          + if $filter_jobs != "" then {filter_jobs: $filter_jobs} else {} end
+          + if $hide_skipped then {hide_skipped: true} else {} end
+          + if $owner_repo != "" then {owner_repo: $owner_repo} else {} end
+          + if $commit_message != "" then {commit_message: $commit_message} else {} end
+          ')
+
+        response=$(curl -s -w "\n%{http_code}" -X POST \
+          "${API_URL}/webhooks/workflow-complete" \
+          -H "Authorization: Key ${CONNECT_API_KEY}" \
+          -H "X-Webhook-Secret: ${WEBHOOK_SECRET}" \
+          -H "Content-Type: application/json" \
+          -d "$payload")
+
+        http_code=$(echo "$response" | tail -1)
+        body=$(echo "$response" | sed '$d')
+
+        if [ "$http_code" = "200" ]; then
+          echo "E2E Test Insights notification queued successfully"
+        else
+          echo "::warning::E2E Test Insights webhook failed (HTTP $http_code): $body"
+        fi

--- a/.github/workflows/test-cross-browser.yml
+++ b/.github/workflows/test-cross-browser.yml
@@ -124,4 +124,3 @@ jobs:
           repo_id: "positron"
           title: "E2E Cross Browser Tests"
           filter_jobs: "(e2e / ([^0-9]*))$"
-          hide_skipped: 'false'

--- a/.github/workflows/test-cross-browser.yml
+++ b/.github/workflows/test-cross-browser.yml
@@ -109,9 +109,15 @@ jobs:
           include_job_durations: false
           custom_title: "E2E Cross Browser Tests — `main` (commit <https://github.com/posit-dev/positron/commit/${{ github.sha }}|${{ env.SHORT_SHA }}>)"
 
+      - name: Checkout
+        if: always()
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions/notify-e2e-insights
+
       - name: Notify E2E Test Insights
         if: always()
-        uses: posit-dev/e2e-test-insights/.github/actions/notify@main
+        uses: ./.github/actions/notify-e2e-insights
         with:
           webhook_secret: ${{ secrets.E2E_INSIGHTS_WEBHOOK_SECRET }}
           connect_api_key: ${{ secrets.CONNECT_API_KEY }}

--- a/.github/workflows/test-cross-browser.yml
+++ b/.github/workflows/test-cross-browser.yml
@@ -124,3 +124,4 @@ jobs:
           repo_id: "positron"
           title: "E2E Cross Browser Tests"
           filter_jobs: "(e2e / ([^0-9]*))$"
+          hide_skipped: 'false'

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -365,9 +365,15 @@ jobs:
           include_job_durations: false
           notify_on: ${{ env.notify_on }}
 
+      - name: Checkout
+        if: always()
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions/notify-e2e-insights
+
       - name: Notify E2E Test Insights
         if: always()
-        uses: posit-dev/e2e-test-insights/.github/actions/notify@main
+        uses: ./.github/actions/notify-e2e-insights
         with:
           webhook_secret: ${{ secrets.E2E_INSIGHTS_WEBHOOK_SECRET }}
           connect_api_key: ${{ secrets.CONNECT_API_KEY }}

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -380,3 +380,4 @@ jobs:
           repo_id: "positron"
           title: "E2E Full Suite Tests"
           filter_jobs: "(e2e / ([^0-9]*)|unit|integration)$"
+          hide_skipped: 'false'

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -380,4 +380,3 @@ jobs:
           repo_id: "positron"
           title: "E2E Full Suite Tests"
           filter_jobs: "(e2e / ([^0-9]*)|unit|integration)$"
-          hide_skipped: 'false'

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -115,6 +115,7 @@ jobs:
           connect_api_key: ${{ secrets.CONNECT_API_KEY }}
           repo_id: "positron"
           filter_jobs: "(e2e / ([^0-9]*)|unit|integration)$"
+          hide_skipped: 'false'
 
   slack-notify-win-extensions:
     if: ${{ needs.e2e-windows-electron.outputs.extensions_failed == 'true' }}

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -101,9 +101,15 @@ jobs:
           include_job_durations: false
           notify_on: "failure"
 
+      - name: Checkout
+        if: always()
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions/notify-e2e-insights
+
       - name: Notify E2E Test Insights
         if: always()
-        uses: posit-dev/e2e-test-insights/.github/actions/notify@main
+        uses: ./.github/actions/notify-e2e-insights
         with:
           webhook_secret: ${{ secrets.E2E_INSIGHTS_WEBHOOK_SECRET }}
           connect_api_key: ${{ secrets.CONNECT_API_KEY }}

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -115,7 +115,6 @@ jobs:
           connect_api_key: ${{ secrets.CONNECT_API_KEY }}
           repo_id: "positron"
           filter_jobs: "(e2e / ([^0-9]*)|unit|integration)$"
-          hide_skipped: 'false'
 
   slack-notify-win-extensions:
     if: ${{ needs.e2e-windows-electron.outputs.extensions_failed == 'true' }}


### PR DESCRIPTION
## Summary
- **Root cause**: The `e2e-test-insights` repo is internal, but `positron` is public. Public repos cannot use GitHub Actions from internal repos, causing `Unable to resolve action` errors on every workflow run with Slack notifications.
- Adds `.github/actions/notify-e2e-insights/` — a local copy of the composite action (single curl webhook call)
- Updates `test-merge.yml`, `test-cross-browser.yml`, and `test-full-suite.yml` to use the local action with sparse checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)