### PR TITLE
Add `allow-modals` globally to all webviews

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,8 +5,10 @@
 	<meta charset="UTF-8">
 
 	<!-- Start PWB: serve same origin -->
+	<!-- Start Positron -->
 	<meta http-equiv="Content-Security-Policy"
 		content="default-src 'none'; script-src 'sha256-j1uPS0qZRnSUxfKTtL2l2BetdVzsO+993hE6uOqT1qk=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+    <!-- End Positron -->
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -6,7 +6,7 @@
 
 	<!-- Start PWB: serve same origin -->
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-X1zQvQpFh8bFSLkKoLUOK283Zj1CdgZo5Yx6GBb29Ec=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-j1uPS0qZRnSUxfKTtL2l2BetdVzsO+993hE6uOqT1qk=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -1069,6 +1069,10 @@
 					sandboxRules.add('allow-forms');
 				}
 				newFrame.setAttribute('sandbox', Array.from(sandboxRules).join(' '));
+				// --- Start Positron ---
+				// Required for PDF viewer print functionality (window.print() in sandboxed iframes).
+				newFrame.sandbox.add('allow-modals');
+				// --- End Positron ---
 
 				const allowRules = ['cross-origin-isolated;', 'autoplay;', 'local-network-access;'];
 				if (!isFirefox && options.allowScripts) {

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -458,6 +458,10 @@ export class WebviewElement extends Disposable implements IWebviewElement, Webvi
 		element.name = this.id;
 		element.className = `webview ${options.customClasses || ''}`;
 		element.sandbox.add('allow-scripts', 'allow-same-origin', 'allow-forms', 'allow-pointer-lock', 'allow-downloads');
+		// --- Start Positron ---
+		// Required for PDF viewer print functionality (window.print() in sandboxed iframes).
+		element.sandbox.add('allow-modals');
+		// --- End Positron ---
 
 		const allowRules = ['cross-origin-isolated', 'autoplay', 'local-network-access'];
 		if (!isFirefox) {


### PR DESCRIPTION
Addresses #12492

When the PDF viewer is focused, pressing the print button or <kbd>Cmd/Ctrl+P</kbd> showed a "preparing document for printing..." dialog but nothing happened afterward. The root cause is a three-level sandboxed iframe chain: VS Code's outer webview frame (Level 2), the `pre/index.html` content frame (Level 3), and the PDF.js viewer frame (Level 4). `window.print()` is blocked in any sandboxed context that lacks `allow-modals`, and the flag must be present at every level of the chain for the innermost frame to inherit it.

This fix adds `allow-modals` globally to both Level 2 (in `webviewElement.ts`) and Level 3 (in `pre/index.html`). I tried out a more targeted approach (threading an `allowModals` option through the full API stack and enabling it only for the PDF provider) but actually the custom editor lifecycle creates the webview iframe before `resolveCustomEditor` runs, so there is no reliable moment to set the sandbox flag before the frame navigates! 

The global approach does deviate from upstream VS Code's deliberate choice to exclude `allow-modals` (which would otherwise allow extension webviews to call `window.alert()`, `window.confirm()`, and `window.prompt()`), but the risk is low for Positron's extension ecosystem, and any extension already using `enableScripts: true` has a far larger attack surface than these modal dialogs.

The `pre/index.html` change also required updating the file's inline-script CSP hash, since the hash is computed over the exact script bytes and any modification invalidates it. I'm going to see if we need to get that same change over to `vscode-server`.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed PDF viewer print button and <kbd>Cmd/Ctrl+P</kbd> not opening a print dialog (#12492)

### QA Notes

@:pdf @:viewer

1. Open any PDF file in Positron
2. Click the print button in the PDF toolbar, or press <kbd>Cmd+P</kbd> (macOS) / <kbd>Ctrl+P</kbd> (Windows/Linux) with the PDF viewer focused
3. Verify that a print dialog opens (previously a "preparing..." spinner appeared and nothing else happened)
4. Verify that the PDF viewer still renders correctly (regression check)
