### PR TITLE
Assistant: fix missing copilot models

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1198,12 +1198,22 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		models = this.filterAvailableModels(models);
 		// --- End Positron ---
 
+		// --- Start Positron ---
+		// Upstream checks `isDefaultForLocation` here and falls back to cached
+		// models when no default is found.  Positron's `filterAvailableModels`
+		// runs *before* this check (above), so the default model may already
+		// have been removed (e.g. user hid it, or its provider is disabled).
+		// That causes the fallback to permanently replace live models with a
+		// stale cache that never gets updated.  Only fall back when there are
+		// genuinely no live models (e.g. extension not yet activated).
+		// See: https://github.com/posit-dev/positron/discussions/12884
+		//      https://github.com/posit-dev/positron/issues/12572
+		/*
 		if (models.length === 0 || models.some(m => m.metadata.isDefaultForLocation[this.location]) === false) {
-			// --- Start Positron ---
-			// Apply the same filtering to cached models before using them as fallback
-			/*
 			models = cachedModels;
-			*/
+		*/
+		if (models.length === 0) {
+			// Apply the same filtering to cached models before using them as fallback
 			models = this.filterAvailableModels(cachedModels);
 			// --- End Positron ---
 		} else {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -1161,71 +1161,25 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		return !!model.metadata.capabilities?.toolCalling;
 	}
 
-	// --- Start Positron ---
-	/**
-	 * Helper to filter models for user-selectable, mode-supported, and provider-enabled models.
-	 */
-	private filterAvailableModels(models: ILanguageModelChatMetadataAndIdentifier[]): ILanguageModelChatMetadataAndIdentifier[] {
-		return models.filter(entry => {
-			// Must be from an enabled provider
-			if (!this.positronAssistantConfigService.isProviderEnabled(entry.metadata?.vendor)) {
-				return false;
-			}
-			// Must be user-selectable
-			if (!entry.metadata?.isUserSelectable) {
-				return false;
-			}
-			// Must be supported for the current mode/agent
-			if (!this.modelSupportedForDefaultAgent(entry)) {
-				return false;
-			}
-			// Must be supported for inline chat if we're in that context
-			if (!this.modelSupportedForInlineChat(entry)) {
-				return false;
-			}
-			return true;
-		});
-	}
-	// --- End Positron ---
-
 	private getModels(): ILanguageModelChatMetadataAndIdentifier[] {
 		const cachedModels = this.storageService.getObject<ILanguageModelChatMetadataAndIdentifier[]>(CachedLanguageModelsKey, StorageScope.APPLICATION, []);
 		let models = this.languageModelsService.getLanguageModelIds()
 			.map(modelId => ({ identifier: modelId, metadata: this.languageModelsService.lookupLanguageModel(modelId)! }));
 
-		// --- Start Positron ---
-		// Filter for user-selectable models that are supported in the current mode and enabled via config
-		models = this.filterAvailableModels(models);
-		// --- End Positron ---
-
-		// --- Start Positron ---
-		// Upstream checks `isDefaultForLocation` here and falls back to cached
-		// models when no default is found.  Positron's `filterAvailableModels`
-		// runs *before* this check (above), so the default model may already
-		// have been removed (e.g. user hid it, or its provider is disabled).
-		// That causes the fallback to permanently replace live models with a
-		// stale cache that never gets updated.  Only fall back when there are
-		// genuinely no live models (e.g. extension not yet activated).
-		// See: https://github.com/posit-dev/positron/discussions/12884
-		//      https://github.com/posit-dev/positron/issues/12572
-		/*
 		if (models.length === 0 || models.some(m => m.metadata.isDefaultForLocation[this.location]) === false) {
 			models = cachedModels;
-		*/
-		if (models.length === 0) {
-			// Apply the same filtering to cached models before using them as fallback
-			models = this.filterAvailableModels(cachedModels);
-			// --- End Positron ---
 		} else {
 			this.storageService.store(CachedLanguageModelsKey, models, StorageScope.APPLICATION, StorageTarget.MACHINE);
 		}
 		models.sort((a, b) => a.metadata.name.localeCompare(b.metadata.name));
 		// --- Start Positron ---
-		// Don't re-filter here - we already filtered above
+		// Add isProviderEnabled check so only models from enabled providers appear in the picker.
+		// See: https://github.com/posit-dev/positron/discussions/12884
+		//      https://github.com/posit-dev/positron/issues/12572
+		return models.filter(entry => this.positronAssistantConfigService.isProviderEnabled(entry.metadata?.vendor) && entry.metadata?.isUserSelectable && this.modelSupportedForDefaultAgent(entry) && this.modelSupportedForInlineChat(entry));
 		/*
 		return models.filter(entry => entry.metadata?.isUserSelectable && this.modelSupportedForDefaultAgent(entry) && this.modelSupportedForInlineChat(entry));
 		*/
-		return models;
 		// --- End Positron ---
 	}
 


### PR DESCRIPTION
## Summary

This is a speculative fix for these issues in the model picker:
- model picker not showing GPT-5 mini despite being available from the API (https://github.com/posit-dev/positron/issues/13053 / https://github.com/posit-dev/positron/discussions/12884)
- model picker becoming empty when hiding the default model (https://github.com/posit-dev/positron/issues/12572)

I haven't been able to reproduce this locally, but tracing through the code, it seems the root cause is our Positron patches in `getModels()` -- we were filtering out the default model before upstream's cache check, which caused the picker to get stuck on stale data. Hoping that rolling back to upstream's flow and keeping our filtering at the end should sort both issues out 🤞 

### Problem

Positron had restructured `getModels()` in `chatInputPart.ts` with three patch blocks that moved model filtering (via `filterAvailableModels`) to **before** the upstream cache fallback check. Upstream's cache check looks for a model with `isDefaultForLocation` set -- if none is found, it replaces the entire live model list with cached data.

Because Positron filtered first, the default model could be removed before this check (e.g., user hid it, or its provider was disabled), causing the fallback to permanently activate. Once active, the cache was never updated (the update only happens in the `else` branch), so newly available models like GPT-5 mini never appeared.

### Fix

Remove the three Positron patch blocks and the `filterAvailableModels` helper method. Restore upstream's `getModels()` flow unchanged. Add the single Positron-specific check (`isProviderEnabled`) to the existing upstream return filter.

This also removes some of our changes to upstream code which is a plus!

### Why this works

Upstream's design is: cache check on unfiltered models, display filter at the end. By restoring this order:

- The default model is always present for the `isDefaultForLocation` check, so the cache fallback only triggers on genuine cold starts (no models resolved yet)
- The cache stays fresh because the `else` branch (which updates it) executes whenever live models exist
- `isProviderEnabled` still gates what the user sees, just applied at the final filter like the other predicates

### Release Notes

#### Bug Fixes

- Assistant: fix issues with copilot models missing from model picker (#12572, #13053)


### QA Notes

- [ ] GPT-5 mini (or current default model) appears in model picker dropdown
- [ ] Hiding the default model in language models editor does not empty the picker
- [ ] Models from a disabled provider do not appear in the picker
- [ ] Fresh install with no cache: models appear after extension activates
- [ ] Multiple providers (Copilot + Posit AI): all enabled models appear