### PR TITLE
python CI: skip a test

### DIFF
--- a/extensions/positron-python/python_files/tests/unittestadapter/test_execution.py
+++ b/extensions/positron-python/python_files/tests/unittestadapter/test_execution.py
@@ -176,7 +176,9 @@ def test_subtest_run(mock_send_run_data) -> None:  # noqa: ARG001
             os.fspath(TEST_DATA_PATH),
             "success",
         ),
-        (
+        # --- Start Positron ---
+        # TODO: unskip this test when upstream fixes it
+        pytest.param(
             [
                 "test_scene.TestMathOperations.test_operations(add)",
                 "test_scene.TestMathOperations.test_operations(subtract)",
@@ -185,7 +187,11 @@ def test_subtest_run(mock_send_run_data) -> None:  # noqa: ARG001
             "*",
             os.fspath(TEST_DATA_PATH / "test_scenarios" / "tests"),
             "success",
+            marks=pytest.mark.skip(
+                reason="testscenarios 0.6 dropped testtools from its dependencies",
+            ),
         ),
+        # --- End Positron ---
     ],
 )
 def test_multiple_ids_run(mock_send_run_data, test_ids, pattern, cwd, expected_outcome) -> None:  # noqa: ARG001


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/13055. Skips a test failing in nightlies on python >= 3.10 due to a dependency upgrade.

Upstream should fix this eventually because it's failing in their CI too, so we'll just watch for that and unskip this test when it's fixed.


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
CI-only change.