### PR TITLE
E2E test: stop installing playwright deps

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -14,10 +14,6 @@ inputs:
     description: "Whether to install Playwright browsers (default: true)"
     required: false
     default: 'true'
-  playwright-with-deps:
-    description: "Whether to use --with-deps when installing Playwright (default: true, set to false for RHEL & SUSE)"
-    required: false
-    default: 'true'
   github-token:
     description: "GitHub token for private package access"
     required: true
@@ -128,13 +124,9 @@ runs:
       shell: bash
       run: |
         echo "::group::🎭 Install Playwright browsers"
-        if [[ "${{ inputs.playwright-with-deps }}" == "true" ]]; then
-          npx playwright install --with-deps
-        else
-          # RHEL/SUSE: Don't use --with-deps (uses apt-get which doesn't exist on RHEL/SUSE)
-          # System dependencies should be pre-installed in the Docker container
-          npx playwright install
-        fi
+        # Don't use --with-deps (uses apt-get which doesn't exist on RHEL/SUSE)
+        # System dependencies should be pre-installed in the Docker container
+        npx playwright install
         echo "::endgroup::"
 
     - name: Prelaunch

--- a/.github/workflows/test-e2e-debian.yml
+++ b/.github/workflows/test-e2e-debian.yml
@@ -165,7 +165,6 @@ jobs:
           distro: debian
           skip-cache: ${{ inputs.skip_cache }}
           install-playwright: 'true'
-          playwright-with-deps: 'false'
           github-token: ${{ github.token }}
 
       - name: Move Positron License

--- a/.github/workflows/test-e2e-rhel.yml
+++ b/.github/workflows/test-e2e-rhel.yml
@@ -165,7 +165,6 @@ jobs:
           distro: rhel
           skip-cache: ${{ inputs.skip_cache }}
           install-playwright: 'true'
-          playwright-with-deps: 'false'
           github-token: ${{ github.token }}
 
       - name: Move Positron License

--- a/.github/workflows/test-e2e-sles.yml
+++ b/.github/workflows/test-e2e-sles.yml
@@ -165,7 +165,6 @@ jobs:
           distro: suse
           skip-cache: ${{ inputs.skip_cache }}
           install-playwright: 'true'
-          playwright-with-deps: 'false'
           github-token: ${{ github.token }}
 
       - name: Move Positron License

--- a/.github/workflows/test-e2e-suse.yml
+++ b/.github/workflows/test-e2e-suse.yml
@@ -165,7 +165,6 @@ jobs:
           distro: suse
           skip-cache: ${{ inputs.skip_cache }}
           install-playwright: 'true'
-          playwright-with-deps: 'false'
           github-token: ${{ github.token }}
 
       - name: Move Positron License

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -258,7 +258,7 @@ jobs:
       - name: Install Playwright browsers
         env:
           PLAYWRIGHT_BROWSERS_PATH: .playwright-browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install
 
       - name: Install Microsoft Edge for e2e-edge project
         if: ${{ inputs.project == 'e2e-edge' }}

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Install Playwright browsers
         env:
           PLAYWRIGHT_BROWSERS_PATH: .playwright-browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install
 
       # Downloads Builtin Extensions (needed for integration & e2e testing)
       - name: Prelaunch


### PR DESCRIPTION
--with-deps is not needed when docker is used because dependencies are pre-installed

### QA Notes

@:web @:win @:rhel-web @:suse-web @:sles-web @:debian-web