### PR TITLE
python: drastically speed up extension activation

### DIFF
--- a/extensions/positron-python/src/client/activation/activationManager.ts
+++ b/extensions/positron-python/src/client/activation/activationManager.ts
@@ -94,7 +94,14 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
 
         if (this.workspaceService.isTrusted) {
             // Do not interact with interpreters in a untrusted workspace.
-            await this.autoSelection.autoSelectInterpreter(resource);
+            // --- Start Positron ---
+            // Don't block activation on auto-selection. Positron's runtime
+            // startup uses its own interpreter heuristics and does not depend on
+            // the upstream auto-selection result.
+            //
+            // await this.autoSelection.autoSelectInterpreter(resource);
+            this.autoSelection.autoSelectInterpreter(resource).ignoreErrors();
+            // --- End Positron ---
             await this.interpreterPathService.copyOldInterpreterStorageValuesToNew(resource);
         }
         await sendActivationTelemetry(this.fileSystem, this.workspaceService, resource);

--- a/extensions/positron-python/src/client/positron/discoverer.ts
+++ b/extensions/positron-python/src/client/positron/discoverer.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -35,6 +35,13 @@ export async function* pythonRuntimeDiscoverer(
         const interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
         const interpreterSelector = serviceContainer.get<IInterpreterSelector>(IInterpreterSelector);
 
+        // Ensure PET discovery is complete before reading interpreters. If a
+        // refresh is already in progress (started during extension
+        // initialization) triggerRefresh() joins it rather than starting a new
+        // one; if no refresh is running (e.g. user-initiated re-discovery)
+        // this starts a fresh scan.
+        await interpreterService.triggerRefresh().ignoreErrors();
+
         // Get the recommended interpreter
         // NOTE: We may need to pass a resource to getSettings to support multi-root workspaces
         const workspaceUri = vscode.workspace.workspaceFolders?.[0]?.uri;
@@ -47,8 +54,6 @@ export async function* pythonRuntimeDiscoverer(
         }
         traceInfo(`pythonRuntimeDiscoverer: recommended interpreter: ${recommendedInterpreter?.path}`);
 
-        // Discover Python interpreters
-        await interpreterService.triggerRefresh().ignoreErrors();
         let interpreters = interpreterService.getInterpreters();
 
         traceInfo(`pythonRuntimeDiscoverer: discovered ${interpreters.length} Python interpreters`);

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -368,6 +368,14 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
 
     private _condaEnvDirs: string[] = [];
 
+    // --- Start Positron ---
+    // Cache of resolved symlink paths, keyed by executable filename.
+    // Maintained incrementally in addEnv()/removeEnv() so checkForExistingEnv()
+    // can do O(1) lookups instead of re-resolving all existing envs on every
+    // new env addition (which was O(N^2) total).
+    private _resolvedSymlinks = new Map<string, string>();
+    // --- End Positron ---
+
     constructor(private readonly finder: NativePythonFinder) {
         this._onProgress = new EventEmitter<ProgressNotificationEvent>();
         this._onChanged = new EventEmitter<PythonEnvCollectionChangedEvent>();
@@ -555,7 +563,11 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
             if (!old) {
                 // If the 'info' env is not already in the list, check if it is one of the additional env directories,
                 // and if so, check if we have an equivalent env already and determine if we should add the 'info' env.
-                const { reason, existingEnv } = await checkForExistingEnv(this._envs, info);
+                const { reason, existingEnv } = await checkForExistingEnv(
+                    this._envs,
+                    info,
+                    this._resolvedSymlinks,
+                );
                 switch (reason) {
                     case ExistingEnvAction.KeepExistingEnv:
                         // We found an 'old' equivalent env, but it has a shorter path than the equivalent new 'info' env.
@@ -583,9 +595,20 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
                         break;
                 }
             }
-            // --- End Positron ---
             if (old) {
-                this._envs = this._envs.filter((item) => item.executable.filename !== info.executable.filename);
+                // Remove the replaced env's symlink cache entry. In the
+                // ReplaceExistingEnv case, old's filename differs from info's,
+                // so we also need to filter _envs by old's filename to
+                // actually remove it (not just info's filename, which isn't
+                // in _envs yet).
+                const oldFilename = old.executable.filename;
+                this._resolvedSymlinks.delete(oldFilename);
+                this._envs = this._envs.filter(
+                    (item) =>
+                        item.executable.filename !== info.executable.filename &&
+                        item.executable.filename !== oldFilename,
+                );
+                // --- End Positron ---
                 this._envs.push(info);
                 if (hasChanged(old, info)) {
                     this._onChanged.fire({ type: FileChangeType.Changed, old, new: info, searchLocation });
@@ -603,10 +626,16 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
         if (typeof env === 'string') {
             const old = this._envs.find((item) => item.executable.filename === env);
             this._envs = this._envs.filter((item) => item.executable.filename !== env);
+            // --- Start Positron ---
+            this._resolvedSymlinks.delete(env);
+            // --- End Positron ---
             this._onChanged.fire({ type: FileChangeType.Deleted, old });
             return;
         }
         this._envs = this._envs.filter((item) => item.executable.filename !== env.executable.filename);
+        // --- Start Positron ---
+        this._resolvedSymlinks.delete(env.executable.filename);
+        // --- End Positron ---
         this._onChanged.fire({ type: FileChangeType.Deleted, old: env });
     }
 
@@ -917,7 +946,11 @@ class NativeWithModulesApi implements IDiscoveryAPI, Disposable {
  * @return The result of the check -- how to proceed with the new environment and if found,
  *         the equivalent existing environment.
  */
-async function checkForExistingEnv(envs: PythonEnvInfo[], newEnv: PythonEnvInfo): Promise<ExistingEnvResult> {
+async function checkForExistingEnv(
+    envs: PythonEnvInfo[],
+    newEnv: PythonEnvInfo,
+    resolvedSymlinks: Map<string, string>,
+): Promise<ExistingEnvResult> {
     const additionalEnvDirs = await getAdditionalEnvDirs();
     const isAdditionalEnv = additionalEnvDirs.find((dir) => isParentPath(newEnv.executable.filename, dir));
 
@@ -928,13 +961,18 @@ async function checkForExistingEnv(envs: PythonEnvInfo[], newEnv: PythonEnvInfo)
     }
 
     // Look for an existing environment in the same additional environment directory
-    // as the new env.
+    // as the new env. Use the cached resolved symlinks to avoid an O(N) pass of
+    // resolveSymbolicLink() calls on every invocation.
     const resolvedEnv = await resolveSymbolicLink(newEnv.executable.filename);
     let existingEnv: PythonEnvInfo | undefined;
-    const resolvedItems = await Promise.all(envs.map((item) => resolveSymbolicLink(item.executable.filename)));
-    for (let i = 0; i < envs.length; i++) {
-        if (arePathsSame(resolvedEnv, resolvedItems[i])) {
-            existingEnv = envs[i];
+    for (const item of envs) {
+        let resolvedItem = resolvedSymlinks.get(item.executable.filename);
+        if (resolvedItem === undefined) {
+            resolvedItem = await resolveSymbolicLink(item.executable.filename);
+            resolvedSymlinks.set(item.executable.filename, resolvedItem);
+        }
+        if (arePathsSame(resolvedEnv, resolvedItem)) {
+            existingEnv = item;
             break;
         }
     }

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -563,11 +563,7 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
             if (!old) {
                 // If the 'info' env is not already in the list, check if it is one of the additional env directories,
                 // and if so, check if we have an equivalent env already and determine if we should add the 'info' env.
-                const { reason, existingEnv } = await checkForExistingEnv(
-                    this._envs,
-                    info,
-                    this._resolvedSymlinks,
-                );
+                const { reason, existingEnv } = await checkForExistingEnv(this._envs, info, this._resolvedSymlinks);
                 switch (reason) {
                     case ExistingEnvAction.KeepExistingEnv:
                         // We found an 'old' equivalent env, but it has a shorter path than the equivalent new 'info' env.

--- a/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
@@ -23,6 +23,8 @@ import * as ws from '../../client/common/vscodeApis/workspaceApis';
 
 // --- Start Positron ---
 import * as uvApi from '../../client/pythonEnvironments/common/environmentManagers/uv';
+import * as externalDeps from '../../client/pythonEnvironments/common/externalDependencies';
+import * as nativeFinder from '../../client/pythonEnvironments/base/locators/common/nativePythonFinder';
 // --- End Positron ---
 
 suite('Native Python API', () => {
@@ -459,6 +461,59 @@ suite('Native Python API', () => {
         assert.isDefined(addedEnv.version.release);
         assert.equal(addedEnv.version.release?.level, 'alpha');
         assert.equal(addedEnv.version.release?.serial, 5);
+    });
+
+    test('ReplaceExistingEnv: shorter-path equivalent env replaces the longer one', async () => {
+        // Two interpreters in an additional env dir that symlink to the same target.
+        // The shorter path should replace the longer one (not be added alongside it).
+        const additionalDir = '/opt/python';
+        const longerPath = '/opt/python/3.10/bin/python3.10';
+        const shorterPath = '/opt/python/3.10/bin/python';
+        const symlinkTarget = '/opt/python/3.10/bin/python3.10';
+
+        sinon.stub(nativeFinder, 'getAdditionalEnvDirs').resolves([additionalDir]);
+        sinon.stub(externalDeps, 'resolveSymbolicLink').callsFake(async (p: string) => {
+            // Both paths resolve to the same underlying binary.
+            if (p === longerPath || p === shorterPath) {
+                return symlinkTarget;
+            }
+            return p;
+        });
+
+        const longerEnv: NativeEnvInfo = {
+            displayName: 'Python 3.10',
+            name: 'python3.10',
+            executable: longerPath,
+            kind: NativePythonEnvironmentKind.LinuxGlobal,
+            version: '3.10.0',
+            prefix: '/opt/python/3.10',
+        };
+        const shorterEnv: NativeEnvInfo = {
+            displayName: 'Python',
+            name: 'python',
+            executable: shorterPath,
+            kind: NativePythonEnvironmentKind.LinuxGlobal,
+            version: '3.10.0',
+            prefix: '/opt/python/3.10',
+        };
+
+        // Yield the longer-path env first, then the shorter-path equivalent.
+        // The shorter one should trigger ReplaceExistingEnv and evict the longer one.
+        mockFinder
+            .setup((f) => f.refresh())
+            .returns(() => {
+                async function* generator() {
+                    yield* [longerEnv, shorterEnv];
+                }
+                return generator();
+            })
+            .verifiable(typemoq.Times.once());
+
+        await api.triggerRefresh();
+
+        const envs = api.getEnvs();
+        assert.equal(envs.length, 1, 'expected exactly one env (longer path should be replaced)');
+        assert.equal(envs[0].executable.filename, shorterPath);
     });
     // --- End Positron ---
 });


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/12349.

Three fixes to unblock Python extension startup:

### 1. Don't block activation on PET finishing

This is the biggest impact (and smallest change 🙂). During extension activation, we previously awaited `autoSelection.autoSelectInterpreter()`, which in turn awaited the full PET refresh. This could take 60+ seconds on systems with many conda environments or slow filesystem access.

But that's an upstream method! Positron's runtime startup doesn't depend on it. We have our own auto-selection logic elsewhere. So this PR drops the `await` and lets upstream auto-selection run in the background for upstream consumers (e.g. status bar, `configSettings.ts` fallback).

### 2. Eliminate a redundant PET run

During discovery, we had a block of Positron code that awaited PET to complete and then called it again. This PR moves the PET `triggerRefresh()` to the top of the discoverer, before that block of code. `triggerRefresh()`'s built-in dedup joins the initial in-progress refresh (which was trigged during activation) instead of starting a new one.

### 3. Fix O(n^2) symlink resolution during environment discovery

A small fix, but maybe will have an impact for a large number of envs. `checkForExistingEnv` in `nativeAPI.ts` resolved symlinks for all existing environments on every new env addition. This PR adds a cache of resolved symlinks, so total complexity drops to O(N).

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix Python extension activation and interpreter discovery blocking startup, and speed it up (#12349)

### QA Notes

@:interpreter

I have a fast machine with not many Python interpreters, so in order to test this, what worked for me was simulating a really slow PET by adding
```ts
await new Promise(resolve => setTimeout(resolve, 30000));
```
right above the `try` in this block of code:
https://github.com/posit-dev/positron/blob/4600b0878e7cd692743fe77dff07c2d9bea7d662/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts#L417-L418

And here are a few test cases. It would probably be a good idea to clear Positron state before these when appropriate.

Startup timing (check Runtime Startup Diagnostics):

1. **Cold start, no `.venv`**: Check without a workspace, or open a workspace without a `.venv` directory. `ms-python.python` activation should complete in seconds (not 30-60+). Total discovery phase should match the time of a single PET refresh, not double.
2. **Cold start, workspace with `.venv`**: Open a workspace containing `.venv/`. Python should auto-start immediately via the local venv (recommended runtime), unchanged from current behavior.
3. **Warm start (second session)**: Subsequent launches of the same workspace should be fast (cached interpreter) — unchanged from current behavior. (Slow discovery still will happen in the background.)
4. **Re-discovery**: Run the `Python: Discover All Interpreters` command from the command palette after initial discovery completes. Verify it triggers a fresh PET scan (check the Python Language Pack log for a new `Native locator: Refresh started` / `Refresh finished` pair) and any newly-added interpreters appear in the interpreter picker.
5. **Affiliated runtime**: In a workspace where a Python runtime was previously used, verify that runtime is started again on open.
