### PR TITLE
Fix doubled path segments when loading `.RData` and `.rds` files on Windows

### DIFF
--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -522,10 +522,11 @@ export async function getFilePathForLoad(resource?: vscode.Uri): Promise<string 
 	try {
 		await vscode.workspace.fs.stat(vscode.Uri.file(filePath));
 
-		// Format path relative to R's working directory, falling back to home-relative
+		// Format path relative to R's working directory, falling back to absolute.
+		// Do not use home-relative paths: on Windows, os.homedir() differs from
+		// R's path.expand("~"), which would produce doubled path segments.
 		return await positron.paths.formatPathForCode(filePath, {
-			relativeTo: ['session', 'home'],
-			homeUri: vscode.Uri.file(os.homedir())
+			relativeTo: ['session'],
 		});
 	} catch {
 		return undefined;

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -522,11 +522,13 @@ export async function getFilePathForLoad(resource?: vscode.Uri): Promise<string 
 	try {
 		await vscode.workspace.fs.stat(vscode.Uri.file(filePath));
 
-		// Format path relative to R's working directory, falling back to absolute.
-		// Do not use home-relative paths: on Windows, os.homedir() differs from
-		// R's path.expand("~"), which would produce doubled path segments.
+		// On Windows, os.homedir() returns C:\Users\name but R's ~ expands to
+		// C:\Users\name\Documents, so home-relative paths produce doubled path
+		// segments. Omit homeUri on Windows so the 'home' base is skipped and
+		// paths outside the working directory fall back to absolute.
 		return await positron.paths.formatPathForCode(filePath, {
-			relativeTo: ['session'],
+			relativeTo: ['session', 'home'],
+			homeUri: process.platform !== 'win32' ? vscode.Uri.file(os.homedir()) : undefined,
 		});
 	} catch {
 		return undefined;


### PR DESCRIPTION
Addresses #12367

On Windows, Node.js `os.homedir()` returns `C:\Users\username`, but R's `~` expands to `C:\Users\username\Documents`. The previous code passed `os.homedir()` as the home URI for path formatting, so any file under `C:\Users\username` that wasn't in R's working directory got a `~/`-relative path. R then resolved `~` incorrectly, producing doubled path segments like `C:\Users\username\Documents\Documents\...`.

In practice this meant loading `.RData` and `.rds` files from the Explorer was broken on Windows because `isEqualOrParent` always fails, the session base never matches, and everything falls back.

The fix I am proposing here is on Windows, to omit `homeUri` so the `'home'` base is skipped and paths outside the working directory fall back to absolute:

<img width="1217" height="858" alt="Screenshot 2026-04-16 at 7 34 32 PM" src="https://github.com/user-attachments/assets/9577d47d-c35e-4d00-8b00-809e1671d300" />


On macOS and Linux, behavior is unchanged; session-relative and `~/`-relative paths still work as before.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix loading `.RData`/`.rds` files from the Explorer on Windows (#12367)

### QA Notes

@:win

1. On Windows, open a workspace that contains `.RData` or `.rds` files
2. Click a file in the Explorer to open the confirmation UI, then click **Load**
3. Verify objects load successfully; no "cannot open compressed file" error

Also verify on macOS: a file inside the working directory should still produce a relative path in the console.
