### PR TITLE
Show notebook sessions in select session quickpick

### DIFF
--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -45,7 +45,6 @@ import { IPositronWebviewPreloadService } from '../../../services/positronWebvie
 import { IPositronConnectionsService } from '../../../services/positronConnections/common/interfaces/positronConnectionsService.js';
 import { IRuntimeNotebookKernelService } from '../../../contrib/runtimeNotebookKernel/common/interfaces/runtimeNotebookKernelService.js';
 import { LanguageRuntimeSessionChannel } from '../../common/positron/extHostTypes.positron.js';
-import { basename } from '../../../../base/common/resources.js';
 import { RuntimeOnlineState } from '../../common/extHostTypes.js';
 import { Range, IRange } from '../../../../editor/common/core/range.js';
 import { VSBuffer } from '../../../../base/common/buffer.js';
@@ -1138,13 +1137,6 @@ class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILangua
 		}
 	}
 
-	getLabel(): string {
-		// If we're a notebook session, use the notebook name, otherwise use the session name
-		if (this.dynState.currentNotebookUri) {
-			return basename(this.dynState.currentNotebookUri);
-		}
-		return this.dynState.sessionName;
-	}
 	static clientCounter = 0;
 
 	override dispose(): void {

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.tsx
@@ -34,7 +34,7 @@ const getLabel = (info: IRuntimeSessionDisplayInfo | undefined, modelService: IM
 	if (!info) {
 		return startSession;
 	}
-	return getSessionDisplayName(info, modelService);
+	return getSessionDisplayName(info, modelService, true);
 };
 
 /**

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.tsx
@@ -30,11 +30,11 @@ const startSession = localize('positron.console.startSession', "Start Session");
  * Gets the label text from session display info, or the default start session
  * label if no session is active.
  */
-const getLabel = (info: IRuntimeSessionDisplayInfo | undefined, modelService: IModelService): string => {
+const getLabel = (info: IRuntimeSessionDisplayInfo | undefined): string => {
 	if (!info) {
 		return startSession;
 	}
-	return getSessionDisplayName(info, modelService, true);
+	return getSessionDisplayName(info.notebookUri, info.sessionName);
 };
 
 /**
@@ -68,7 +68,7 @@ export const TopActionBarSessionManager = () => {
 	const services = usePositronReactServicesContext();
 
 	const [labelText, setLabelText] = useState<string>(
-		getLabel(services.runtimeSessionService.foregroundSessionDisplayInfo, services.modelService));
+		getLabel(services.runtimeSessionService.foregroundSessionDisplayInfo));
 	const [sessionIcon, setSessionIcon] = useState(
 		getIcon(services.runtimeSessionService.foregroundSessionDisplayInfo, services.modelService));
 	const info = services.runtimeSessionService.foregroundSessionDisplayInfo;
@@ -96,7 +96,7 @@ export const TopActionBarSessionManager = () => {
 		// notebook session is attempted to be set as the foreground session.
 		disposableStore.add(
 			services.runtimeSessionService.onDidChangeForegroundSessionDisplayInfo(info => {
-				setLabelText(getLabel(info, services.modelService));
+				setLabelText(getLabel(info));
 				setSessionIcon(getIcon(info, services.modelService));
 				setIconStyle(info ? getSessionIconStyle(info, services.modelService) : undefined);
 				setRuntimeStatus(getRuntimeStatus(info));

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.tsx
@@ -34,7 +34,7 @@ const getLabel = (info: IRuntimeSessionDisplayInfo | undefined): string => {
 	if (!info) {
 		return startSession;
 	}
-	return getSessionDisplayName(info.notebookUri, info.sessionName);
+	return getSessionDisplayName({ notebookUri: info.notebookUri, sessionName: info.sessionName });
 };
 
 /**

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatRuntimeSessionContext.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatRuntimeSessionContext.ts
@@ -24,6 +24,7 @@ import { localize } from '../../../../../../../nls.js';
 import { Codicon } from '../../../../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../../../../base/common/themables.js';
 import { IQuickPickSeparator } from '../../../../../../../platform/quickinput/common/quickInput.js';
+import { getSessionDisplayName } from '../../../../../positronConsole/common/sessionDisplayUtils.js';
 
 /**
  * A single summarized entry in the execution history provided to the chat model.
@@ -109,7 +110,7 @@ class RuntimeSessionContextValuePick implements IChatContextPickerItem {
 
 	toPickItem(session: ILanguageRuntimeSession): IChatContextPickerPickItem {
 		return {
-			label: session.getLabel(),
+			label: getSessionDisplayName(session.dynState.currentNotebookUri, session.dynState.sessionName),
 			iconClass: session.metadata.sessionMode === LanguageRuntimeSessionMode.Console ?
 				ThemeIcon.asClassName(Codicon.positronNewConsole) :
 				ThemeIcon.asClassName(Codicon.notebook),
@@ -306,7 +307,7 @@ export class ChatRuntimeSessionContext extends Disposable {
 
 	get name(): string {
 		if (this.value) {
-			return this.value.getLabel();
+			return getSessionDisplayName(this.value.dynState.currentNotebookUri, this.value.dynState.sessionName);
 		} else {
 			return 'runtimeSession';
 		}

--- a/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatRuntimeSessionContext.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/editor/chatRuntimeSessionContext.ts
@@ -110,7 +110,10 @@ class RuntimeSessionContextValuePick implements IChatContextPickerItem {
 
 	toPickItem(session: ILanguageRuntimeSession): IChatContextPickerPickItem {
 		return {
-			label: getSessionDisplayName(session.dynState.currentNotebookUri, session.dynState.sessionName),
+			label: getSessionDisplayName({
+				notebookUri: session.dynState.currentNotebookUri,
+				sessionName: session.dynState.sessionName,
+			}),
 			iconClass: session.metadata.sessionMode === LanguageRuntimeSessionMode.Console ?
 				ThemeIcon.asClassName(Codicon.positronNewConsole) :
 				ThemeIcon.asClassName(Codicon.notebook),
@@ -307,7 +310,10 @@ export class ChatRuntimeSessionContext extends Disposable {
 
 	get name(): string {
 		if (this.value) {
-			return getSessionDisplayName(this.value.dynState.currentNotebookUri, this.value.dynState.sessionName);
+			return getSessionDisplayName({
+				notebookUri: this.value.dynState.currentNotebookUri,
+				sessionName: this.value.dynState.sessionName,
+			});
 		} else {
 			return 'runtimeSession';
 		}

--- a/src/vs/workbench/contrib/chat/test/browser/chatRuntimeSessionContext.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/chatRuntimeSessionContext.test.ts
@@ -85,7 +85,6 @@ class MockRuntimeSession implements ILanguageRuntimeSession {
 	clientInstances: any[] = [];
 	lastUsed = Date.now();
 
-	getLabel() { return 'Test Python Session'; }
 	getRuntimeState() { return RuntimeState.Ready; }
 	restart() { return Promise.resolve(); }
 	forceQuit() { return Promise.resolve(); }

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -19,7 +19,8 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../editor/common/services/model.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
-import { getSessionIcon } from '../../positronConsole/common/sessionDisplayUtils.js';
+import { getSessionDisplayName, getSessionIcon, isQuartoSession } from '../../positronConsole/common/sessionDisplayUtils.js';
+import { RuntimeSessionDisplayInfo } from '../../../services/runtimeSession/common/runtimeSessionDisplayInfo.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
 import { dispose } from '../../../../base/common/lifecycle.js';
@@ -121,6 +122,9 @@ async function selectLanguage(accessor: ServicesAccessor) {
  * @param options The options for the quick pick.
  * @param options.allowStartSession Whether to allow the user to start a new session.
  * @param options.title The title of the quick pick.
+ * @param options.includeNotebookSessions Whether to display notebook and quarto
+ *   sessions (disabled) alongside console sessions. Defaults to true; set to
+ *   false for actions that only operate on console sessions.
  * @returns The runtime session the user selected, or undefined, if the user canceled the operation.
  */
 const selectLanguageRuntimeSession = async (
@@ -128,6 +132,7 @@ const selectLanguageRuntimeSession = async (
 	options?: {
 		allowStartSession?: boolean;
 		title?: string;
+		includeNotebookSessions?: boolean;
 	}): Promise<ILanguageRuntimeSession | undefined> => {
 
 	// Constants
@@ -138,6 +143,8 @@ const selectLanguageRuntimeSession = async (
 	const runtimeSessionService = accessor.get(IRuntimeSessionService);
 	const commandService = accessor.get(ICommandService);
 	const modelService = accessor.get(IModelService);
+
+	const includeNotebookSessions = options?.includeNotebookSessions ?? true;
 
 	// Filter active sessions by runtime state (exclude exited/uninitialized sessions).
 	const isActiveState = (session: ILanguageRuntimeSession) => {
@@ -175,19 +182,44 @@ const selectLanguageRuntimeSession = async (
 			picked: session.sessionId === foregroundSessionId,
 		}));
 
-	// Show quick pick to select an active runtime or show all runtimes.
 	const quickPickItems: QuickPickItem[] = [
 		{
 			label: localize('positron.languageRuntime.activeConsoleSessions', 'Console Sessions'),
 			type: 'separator',
 		},
 		...consoleItems,
-		{
-			type: 'separator'
-		}
 	];
 
+	if (includeNotebookSessions) {
+		// Active notebook sessions (includes quarto), sorted by creation time.
+		const activeNotebookSessions = runtimeSessionService.activeSessions
+			.filter(session => session.metadata.sessionMode === LanguageRuntimeSessionMode.Notebook)
+			.filter(isActiveState)
+			.sort((a, b) => a.metadata.createdTimestamp - b.metadata.createdTimestamp);
+
+		const notebookItems: IQuickPickItem[] = activeNotebookSessions
+			.filter(session => !isQuartoSession(session.metadata.notebookUri, modelService))
+			.map(session => ({
+				id: session.sessionId,
+				label: getSessionDisplayName(new RuntimeSessionDisplayInfo(session), modelService),
+				detail: session.runtimeMetadata.runtimePath,
+				description: session.sessionId === foregroundSessionId
+					? localize('positron.languageRuntime.currentlySelected', 'Currently Selected')
+					: undefined,
+				iconClass: ThemeIcon.asClassName(getSessionIcon(session.metadata, modelService)),
+			}));
+
+		if (notebookItems.length > 0) {
+			quickPickItems.push({
+				label: localize('positron.languageRuntime.notebookSessions', 'Notebook Sessions'),
+				type: 'separator',
+			});
+			quickPickItems.push(...notebookItems);
+		}
+	}
+
 	if (options?.allowStartSession) {
+		quickPickItems.push({ type: 'separator' });
 		quickPickItems.push({
 			label: localize('positron.languageRuntime.newConsoleSession', 'New Console Session...'),
 			id: startNewRuntimeId,
@@ -743,7 +775,10 @@ export function registerLanguageRuntimeActions() {
 
 			// Prompt the user to select a session they want to rename.
 			const session = await selectLanguageRuntimeSession(
-				accessor, { title: localize('positron.languageRuntime.selectSessionToRename', 'Select Session To Rename') });
+				accessor, {
+				includeNotebookSessions: false,
+				title: localize('positron.languageRuntime.selectSessionToRename', 'Select Session To Rename'),
+			});
 			if (!session) {
 				return;
 			}

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -197,6 +197,7 @@ const selectLanguageRuntimeSession = async (
 	};
 
 	const foregroundSessionId = runtimeSessionService.foregroundSession?.sessionId;
+	const sessionItems: IQuickPickItem[] = [];
 
 	// Create quick pick items for active console sessions sorted by creation time, oldest to newest.
 	const consoleItems: IQuickPickItem[] = runtimeSessionService.activeSessions
@@ -221,6 +222,7 @@ const selectLanguageRuntimeSession = async (
 		},
 		...consoleItems,
 	];
+	sessionItems.push(...consoleItems);
 
 	if (includeNotebookSessions) {
 		// Active notebook sessions (includes quarto), sorted by creation time.
@@ -239,6 +241,7 @@ const selectLanguageRuntimeSession = async (
 					? localize('positron.languageRuntime.currentlySelected', 'Currently Selected')
 					: undefined,
 				iconClass: ThemeIcon.asClassName(getSessionIcon(session.metadata, modelService)),
+				picked: session.sessionId === foregroundSessionId,
 			}));
 
 		if (notebookItems.length > 0) {
@@ -247,6 +250,7 @@ const selectLanguageRuntimeSession = async (
 				type: 'separator',
 			});
 			quickPickItems.push(...notebookItems);
+			sessionItems.push(...notebookItems);
 		}
 
 		const quartoItems: IQuickPickItem[] = activeNotebookSessions
@@ -259,6 +263,7 @@ const selectLanguageRuntimeSession = async (
 					? localize('positron.languageRuntime.currentlySelected', 'Currently Selected')
 					: undefined,
 				iconClass: `${ThemeIcon.asClassName(getSessionIcon(session.metadata, modelService))} ${QUARTO_QUICKPICK_ICON_CLASS}`,
+				picked: session.sessionId === foregroundSessionId,
 			}));
 
 		if (quartoItems.length > 0) {
@@ -267,6 +272,7 @@ const selectLanguageRuntimeSession = async (
 				type: 'separator',
 			});
 			quickPickItems.push(...quartoItems);
+			sessionItems.push(...quartoItems);
 		}
 	}
 
@@ -281,7 +287,7 @@ const selectLanguageRuntimeSession = async (
 	const result = await quickInputService.pick(quickPickItems, {
 		title: options?.title || localize('positron.languageRuntime.selectSession.quickPickTitle', 'Select Interpreter Session'),
 		canPickMany: false,
-		activeItem: consoleItems.filter(item => item.picked)[0]
+		activeItem: sessionItems.find(item => item.picked)
 	});
 
 	// Handle the user's selection.

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -20,7 +20,6 @@ import { ILanguageService } from '../../../../editor/common/languages/language.j
 import { IModelService } from '../../../../editor/common/services/model.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { getSessionDisplayName, getSessionIcon, isQuartoSession } from '../../positronConsole/common/sessionDisplayUtils.js';
-import { RuntimeSessionDisplayInfo } from '../../../services/runtimeSession/common/runtimeSessionDisplayInfo.js';
 import { registerThemingParticipant } from '../../../../platform/theme/common/themeService.js';
 import { POSITRON_QUARTO_ICON } from '../../../common/theme.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
@@ -51,6 +50,26 @@ registerThemingParticipant((theme, collector) => {
 		collector.addRule(`.quick-input-list-icon.${QUARTO_QUICKPICK_ICON_CLASS}.codicon { color: ${quartoColor}; }`);
 	}
 });
+
+/**
+ * Builds a display label that includes the runtime name for notebook sessions
+ * since the session name for notebooks has no information about the runtime
+ * being used.
+ */
+function getSessionDisplayNameWithRuntime(session: ILanguageRuntimeSession): string {
+	const notebookUri = session.metadata.notebookUri;
+	const base = getSessionDisplayName(notebookUri, session.dynState.sessionName);
+	// just to be safe, if this is not a notebook session or we don't have a notebook URI, return the base display name.
+	if (session.metadata.sessionMode !== LanguageRuntimeSessionMode.Notebook || !notebookUri) {
+		return base;
+	}
+	// For Quarto sessions, sessionName already equals the filename, so using
+	// it as the " - env" suffix would duplicate. Fall back to runtimeName.
+	const env = session.dynState.sessionName === base
+		? session.runtimeMetadata.runtimeName
+		: session.dynState.sessionName;
+	return `${base} - ${env}`;
+}
 
 // Quick pick item interfaces.
 interface LanguageRuntimeQuickPickItem extends IQuickPickItem { runtime: ILanguageRuntimeMetadata }
@@ -214,7 +233,7 @@ const selectLanguageRuntimeSession = async (
 			.filter(session => !isQuartoSession(session.metadata.notebookUri, modelService))
 			.map(session => ({
 				id: session.sessionId,
-				label: getSessionDisplayName(new RuntimeSessionDisplayInfo(session), modelService),
+				label: getSessionDisplayNameWithRuntime(session),
 				detail: session.runtimeMetadata.runtimePath,
 				description: session.sessionId === foregroundSessionId
 					? localize('positron.languageRuntime.currentlySelected', 'Currently Selected')
@@ -234,7 +253,7 @@ const selectLanguageRuntimeSession = async (
 			.filter(session => isQuartoSession(session.metadata.notebookUri, modelService))
 			.map(session => ({
 				id: session.sessionId,
-				label: getSessionDisplayName(new RuntimeSessionDisplayInfo(session), modelService),
+				label: getSessionDisplayNameWithRuntime(session),
 				detail: session.runtimeMetadata.runtimePath,
 				description: session.sessionId === foregroundSessionId
 					? localize('positron.languageRuntime.currentlySelected', 'Currently Selected')

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -58,7 +58,7 @@ registerThemingParticipant((theme, collector) => {
  */
 function getSessionDisplayNameWithRuntime(session: ILanguageRuntimeSession): string {
 	const notebookUri = session.metadata.notebookUri;
-	const base = getSessionDisplayName(notebookUri, session.dynState.sessionName);
+	const base = getSessionDisplayName({ notebookUri, sessionName: session.dynState.sessionName });
 	// just to be safe, if this is not a notebook session or we don't have a notebook URI, return the base display name.
 	if (session.metadata.sessionMode !== LanguageRuntimeSessionMode.Notebook || !notebookUri) {
 		return base;
@@ -230,7 +230,7 @@ const selectLanguageRuntimeSession = async (
 			.sort((a, b) => a.metadata.createdTimestamp - b.metadata.createdTimestamp);
 
 		const notebookItems: IQuickPickItem[] = activeNotebookSessions
-			.filter(session => !isQuartoSession(session.metadata.notebookUri, modelService))
+			.filter(session => !isQuartoSession({ notebookUri: session.metadata.notebookUri, modelService }))
 			.map(session => ({
 				id: session.sessionId,
 				label: getSessionDisplayNameWithRuntime(session),
@@ -250,7 +250,7 @@ const selectLanguageRuntimeSession = async (
 		}
 
 		const quartoItems: IQuickPickItem[] = activeNotebookSessions
-			.filter(session => isQuartoSession(session.metadata.notebookUri, modelService))
+			.filter(session => isQuartoSession({ notebookUri: session.metadata.notebookUri, modelService }))
 			.map(session => ({
 				id: session.sessionId,
 				label: getSessionDisplayNameWithRuntime(session),

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -585,7 +585,7 @@ export function registerLanguageRuntimeActions() {
 			const newActiveSession = await selectLanguageRuntimeSession(accessor,
 				{
 					allowStartSession: true,
-					title: localize('positron.languageRuntime.changeForegroundSession.quickPickTitle', 'Interpreter Sessions')
+					title: localize('positron.languageRuntime.changeForegroundSession.quickPickTitle', 'Running Interpreter Sessions')
 				}
 			);
 

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -645,6 +645,7 @@ export function registerLanguageRuntimeActions() {
 		async accessor => {
 			// Access services.
 			const commandService = accessor.get(ICommandService);
+			const editorService = accessor.get(IEditorService);
 			const runtimeSessionService = accessor.get(IRuntimeSessionService);
 
 			// Prompt the user to select a runtime to use.
@@ -655,11 +656,21 @@ export function registerLanguageRuntimeActions() {
 				}
 			);
 
-			// If the user selected a specific session, set it as the active session if it still exists
-			if (newActiveSession) {
-				// Drive focus into the Positron console.
-				commandService.executeCommand('workbench.panel.positronConsole.focus');
+			if (!newActiveSession) {
+				return;
+			}
+
+			const notebookUri = newActiveSession.metadata.notebookUri;
+			if (notebookUri) {
+				// For notebook sessions, we want to focus the editor
+				// associated with the session's notebook URI when changing
+				// the foreground session.
+				await editorService.openEditor({ resource: notebookUri });
 				runtimeSessionService.foregroundSession = newActiveSession;
+			} else {
+				// For console sessions, drive focus into the console pane
+				runtimeSessionService.foregroundSession = newActiveSession;
+				commandService.executeCommand('workbench.panel.positronConsole.focus');
 			}
 		}
 	);

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -21,6 +21,8 @@ import { IModelService } from '../../../../editor/common/services/model.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { getSessionDisplayName, getSessionIcon, isQuartoSession } from '../../positronConsole/common/sessionDisplayUtils.js';
 import { RuntimeSessionDisplayInfo } from '../../../services/runtimeSession/common/runtimeSessionDisplayInfo.js';
+import { registerThemingParticipant } from '../../../../platform/theme/common/themeService.js';
+import { POSITRON_QUARTO_ICON } from '../../../common/theme.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
 import { dispose } from '../../../../base/common/lifecycle.js';
@@ -38,6 +40,17 @@ import { getErrorMessage } from '../../../../base/common/errors.js';
 
 // The category for language runtime actions.
 const category: ILocalizedString = { value: LANGUAGE_RUNTIME_ACTION_CATEGORY, original: 'Interpreter' };
+
+// Class applied to the Quarto icon in the session quickpick so it picks up the
+// Quarto theme color. IQuickPickItem only accepts a CSS class name (not a React
+// style), so we register a themed rule keyed on this class.
+const QUARTO_QUICKPICK_ICON_CLASS = 'positron-quickpick-quarto-icon';
+registerThemingParticipant((theme, collector) => {
+	const quartoColor = theme.getColor(POSITRON_QUARTO_ICON);
+	if (quartoColor) {
+		collector.addRule(`.quick-input-list-icon.${QUARTO_QUICKPICK_ICON_CLASS}.codicon { color: ${quartoColor}; }`);
+	}
+});
 
 // Quick pick item interfaces.
 interface LanguageRuntimeQuickPickItem extends IQuickPickItem { runtime: ILanguageRuntimeMetadata }
@@ -215,6 +228,26 @@ const selectLanguageRuntimeSession = async (
 				type: 'separator',
 			});
 			quickPickItems.push(...notebookItems);
+		}
+
+		const quartoItems: IQuickPickItem[] = activeNotebookSessions
+			.filter(session => isQuartoSession(session.metadata.notebookUri, modelService))
+			.map(session => ({
+				id: session.sessionId,
+				label: getSessionDisplayName(new RuntimeSessionDisplayInfo(session), modelService),
+				detail: session.runtimeMetadata.runtimePath,
+				description: session.sessionId === foregroundSessionId
+					? localize('positron.languageRuntime.currentlySelected', 'Currently Selected')
+					: undefined,
+				iconClass: `${ThemeIcon.asClassName(getSessionIcon(session.metadata, modelService))} ${QUARTO_QUICKPICK_ICON_CLASS}`,
+			}));
+
+		if (quartoItems.length > 0) {
+			quickPickItems.push({
+				label: localize('positron.languageRuntime.quartoSessions', 'Quarto Sessions'),
+				type: 'separator',
+			});
+			quickPickItems.push(...quartoItems);
 		}
 	}
 

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -17,6 +17,9 @@ import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessi
 import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionService, RuntimeClientType, RuntimeStartMode } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
+import { IModelService } from '../../../../editor/common/services/model.js';
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { getSessionIcon } from '../../positronConsole/common/sessionDisplayUtils.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
 import { dispose } from '../../../../base/common/lifecycle.js';
@@ -134,45 +137,43 @@ const selectLanguageRuntimeSession = async (
 	const quickInputService = accessor.get(IQuickInputService);
 	const runtimeSessionService = accessor.get(IRuntimeSessionService);
 	const commandService = accessor.get(ICommandService);
+	const modelService = accessor.get(IModelService);
+
+	// Filter active sessions by runtime state (exclude exited/uninitialized sessions).
+	const isActiveState = (session: ILanguageRuntimeSession) => {
+		switch (session.getRuntimeState()) {
+			case RuntimeState.Initializing:
+			case RuntimeState.Starting:
+			case RuntimeState.Ready:
+			case RuntimeState.Idle:
+			case RuntimeState.Busy:
+			case RuntimeState.Restarting:
+			case RuntimeState.Exiting:
+			case RuntimeState.Offline:
+			case RuntimeState.Interrupting:
+				return true;
+			default:
+				return false;
+		}
+	};
+
+	const foregroundSessionId = runtimeSessionService.foregroundSession?.sessionId;
 
 	// Create quick pick items for active console sessions sorted by creation time, oldest to newest.
-	const sortedActiveSessions = runtimeSessionService.activeSessions
+	const consoleItems: IQuickPickItem[] = runtimeSessionService.activeSessions
 		.filter(session => session.metadata.sessionMode === LanguageRuntimeSessionMode.Console)
-		.sort((a, b) => a.metadata.createdTimestamp - b.metadata.createdTimestamp);
-
-	const activeRuntimeItems: IQuickPickItem[] = sortedActiveSessions.filter(
-		(session) => {
-			switch (session.getRuntimeState()) {
-				case RuntimeState.Initializing:
-				case RuntimeState.Starting:
-				case RuntimeState.Ready:
-				case RuntimeState.Idle:
-				case RuntimeState.Busy:
-				case RuntimeState.Restarting:
-				case RuntimeState.Exiting:
-				case RuntimeState.Offline:
-				case RuntimeState.Interrupting:
-					return true;
-				default:
-					return false;
-			}
-		}
-	).map(
-		(session) => {
-			const isForegroundSession =
-				session.sessionId === runtimeSessionService.foregroundSession?.sessionId;
-			return {
-				id: session.sessionId,
-				label: session.dynState.sessionName,
-				detail: session.runtimeMetadata.runtimePath,
-				description: isForegroundSession ? localize('positron.languageRuntime.currentlySelected', 'Currently Selected') : undefined,
-				iconPath: {
-					dark: URI.parse(`data:image/svg+xml;base64, ${session.runtimeMetadata.base64EncodedIconSvg}`),
-				},
-				picked: isForegroundSession,
-			};
-		}
-	);
+		.filter(isActiveState)
+		.sort((a, b) => a.metadata.createdTimestamp - b.metadata.createdTimestamp)
+		.map(session => ({
+			id: session.sessionId,
+			label: session.dynState.sessionName,
+			detail: session.runtimeMetadata.runtimePath,
+			description: session.sessionId === foregroundSessionId
+				? localize('positron.languageRuntime.currentlySelected', 'Currently Selected')
+				: undefined,
+			iconClass: ThemeIcon.asClassName(getSessionIcon(session.metadata, modelService)),
+			picked: session.sessionId === foregroundSessionId,
+		}));
 
 	// Show quick pick to select an active runtime or show all runtimes.
 	const quickPickItems: QuickPickItem[] = [
@@ -180,7 +181,7 @@ const selectLanguageRuntimeSession = async (
 			label: localize('positron.languageRuntime.activeConsoleSessions', 'Console Sessions'),
 			type: 'separator',
 		},
-		...activeRuntimeItems,
+		...consoleItems,
 		{
 			type: 'separator'
 		}
@@ -196,7 +197,7 @@ const selectLanguageRuntimeSession = async (
 	const result = await quickInputService.pick(quickPickItems, {
 		title: options?.title || localize('positron.languageRuntime.selectSession.quickPickTitle', 'Select Interpreter Session'),
 		canPickMany: false,
-		activeItem: activeRuntimeItems.filter(item => item.picked)[0]
+		activeItem: consoleItems.filter(item => item.picked)[0]
 	});
 
 	// Handle the user's selection.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
@@ -53,10 +53,10 @@ export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: 
 	const positronConsoleContext = usePositronConsoleContext();
 
 	// Compute the session display name.
-	const sessionDisplayName = getSessionDisplayName(
-		positronConsoleInstance.sessionMetadata.notebookUri,
-		positronConsoleInstance.sessionName,
-	);
+	const sessionDisplayName = getSessionDisplayName({
+		notebookUri: positronConsoleInstance.sessionMetadata.notebookUri,
+		sessionName: positronConsoleInstance.sessionName,
+	});
 
 	// State
 	const [deleteDisabled, setDeleteDisabled] = useState(false);
@@ -118,10 +118,10 @@ export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: 
 		disposableStore.add(
 			services.runtimeSessionService.onDidUpdateSessionName(session => {
 				if (session.sessionId === positronConsoleInstance.sessionId) {
-					setSessionName(getSessionDisplayName(
-						session.dynState.currentNotebookUri,
-						session.dynState.sessionName,
-					));
+					setSessionName(getSessionDisplayName({
+						notebookUri: session.dynState.currentNotebookUri,
+						sessionName: session.dynState.sessionName,
+					}));
 				}
 			})
 		);
@@ -143,10 +143,10 @@ export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: 
 				if (e.sessionId === positronConsoleInstance.sessionId) {
 					const session = services.runtimeSessionService.getActiveSession(positronConsoleInstance.sessionId);
 					if (session) {
-						setSessionName(getSessionDisplayName(
-							session.session.dynState.currentNotebookUri,
-							session.session.dynState.sessionName,
-						));
+						setSessionName(getSessionDisplayName({
+							notebookUri: session.session.dynState.currentNotebookUri,
+							sessionName: session.session.dynState.sessionName,
+						}));
 					}
 				}
 			})

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
@@ -118,7 +118,10 @@ export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: 
 		disposableStore.add(
 			services.runtimeSessionService.onDidUpdateSessionName(session => {
 				if (session.sessionId === positronConsoleInstance.sessionId) {
-					setSessionName(session.getLabel());
+					setSessionName(getSessionDisplayName(
+						session.dynState.currentNotebookUri,
+						session.dynState.sessionName,
+					));
 				}
 			})
 		);
@@ -140,7 +143,10 @@ export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: 
 				if (e.sessionId === positronConsoleInstance.sessionId) {
 					const session = services.runtimeSessionService.getActiveSession(positronConsoleInstance.sessionId);
 					if (session) {
-						setSessionName(session.session.getLabel());
+						setSessionName(getSessionDisplayName(
+							session.session.dynState.currentNotebookUri,
+							session.session.dynState.sessionName,
+						));
 					}
 				}
 			})

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
@@ -22,7 +22,7 @@ import { isMacintosh } from '../../../../../base/common/platform.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { ILanguageRuntimeResourceUsage, LanguageRuntimeSessionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { RuntimeIcon } from './runtimeIcon.js';
-import { getNotebookDisplayName } from '../../common/sessionDisplayUtils.js';
+import { getSessionDisplayName } from '../../common/sessionDisplayUtils.js';
 import { ResourceUsageGraph } from './resourceUsageGraph.js';
 import { ResourceUsageStats } from './resourceUsageStats.js';
 import { ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
@@ -52,23 +52,11 @@ export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: 
 	const services = usePositronReactServicesContext();
 	const positronConsoleContext = usePositronConsoleContext();
 
-	/**
-	 * Compute the session display name. For notebook sessions, we
-	 * use getNotebookDisplayName so untitled document names are
-	 * handled correctly (e.g. "Untitled.ipynb" vs "Untitled.qmd").
-	 */
-	const isNotebookSession =
-		positronConsoleInstance.sessionMetadata.sessionMode === LanguageRuntimeSessionMode.Notebook;
-	let sessionDisplayName = '';
-	if (isNotebookSession) {
-		sessionDisplayName = getNotebookDisplayName(
-			positronConsoleInstance.sessionMetadata.notebookUri!, services.modelService);
-	} else {
-		const session = services.runtimeSessionService.getActiveSession(positronConsoleInstance.sessionId);
-		sessionDisplayName = session
-			? session.session.getLabel()
-			: positronConsoleInstance.sessionName;
-	}
+	// Compute the session display name.
+	const sessionDisplayName = getSessionDisplayName(
+		positronConsoleInstance.sessionMetadata.notebookUri,
+		positronConsoleInstance.sessionName,
+	);
 
 	// State
 	const [deleteDisabled, setDeleteDisabled] = useState(false);

--- a/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
+++ b/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
@@ -4,13 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from '../../../../base/common/uri.js';
-import { basename } from '../../../../base/common/path.js';
+import { basename, extname } from '../../../../base/common/path.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { IModelService } from '../../../../editor/common/services/model.js';
 import { asCssVariable } from '../../../../platform/theme/common/colorUtils.js';
 import { LanguageRuntimeSessionMode, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
-import { IRuntimeSessionDisplayInfo } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { POSITRON_QUARTO_ICON } from '../../../common/theme.js';
 import { isQuartoDocument } from '../../positronQuarto/common/positronQuartoConfig.js';
 
@@ -29,48 +28,23 @@ export function isQuartoSession(notebookUri: URI | undefined, modelService: IMod
 }
 
 /**
- * Gets the display name for a notebook file. For untitled Quarto documents,
- * the .qmd extension is appended since the URI doesn't include it.
- */
-export function getNotebookDisplayName(notebookUri: URI, modelService: IModelService): string {
-	let name = basename(notebookUri.path);
-	if (!name.includes('.') && isQuartoSession(notebookUri, modelService)) {
-		name = `${name}.qmd`;
-	}
-	return name;
-}
-
-/**
- * Gets the display label for a session.
+ * Gets the display label for a session given a notebook URI and session name.
+ * This is the canonical way to derive a session's label in UI surfaces.
  *
- * For notebook sessions, we show the notebook file name and the runtime
- * name (e.g., "foo.ipynb - Python 3.12"). For untitled Quarto documents,
- * the .qmd extension is appended since the URI doesn't include it.
- *
- * Pass `short: true` to drop the " - runtime" suffix for notebook sessions.
- *
- * For console sessions, we always show the session name (the `short` flag is
- * ignored).
+ * For notebook sessions, returns the filename from the URI. Untitled Quarto
+ * URIs lack the .qmd extension, so we fall back to sessionName, which the
+ * Quarto kernel manager populates with the filename + extension. For sessions
+ * without a notebook URI (console), returns sessionName.
  */
 export function getSessionDisplayName(
-	info: IRuntimeSessionDisplayInfo,
-	modelService: IModelService,
-	short: boolean = false,
+	notebookUri: URI | undefined,
+	sessionName: string,
 ): string {
-	if (info.sessionMode === LanguageRuntimeSessionMode.Notebook && info.notebookUri) {
-		const notebookName = getNotebookDisplayName(info.notebookUri, modelService);
-		if (short) {
-			return notebookName;
-		}
-		// For Quarto sessions, show the underlying runtime name (e.g.
-		// "Python 3.12.11 (Pyenv)") instead of the session name (which is
-		// "Quarto: <file>.qmd" and would duplicate the file name).
-		const env = isQuartoSession(info.notebookUri, modelService)
-			? info.runtimeName
-			: info.sessionName;
-		return `${notebookName} - ${env}`;
+	if (!notebookUri) {
+		return sessionName;
 	}
-	return info.sessionName;
+	const name = basename(notebookUri.path);
+	return extname(name) ? name : sessionName;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
+++ b/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
@@ -41,15 +41,27 @@ export function getNotebookDisplayName(notebookUri: URI, modelService: IModelSer
 }
 
 /**
- * Gets the display label for a session. For notebook sessions, this includes
- * the notebook file name and the runtime name. For Quarto sessions, the
- * runtime name is used instead of the session name (which redundantly
- * contains the file name). For untitled Quarto documents, the .qmd extension
- * is appended since the URI doesn't include it.
+ * Gets the display label for a session.
+ *
+ * For notebook sessions, we show the notebook file name and the runtime
+ * name (e.g., "foo.ipynb - Python 3.12"). For untitled Quarto documents,
+ * the .qmd extension is appended since the URI doesn't include it.
+ *
+ * Pass `short: true` to drop the " - runtime" suffix for notebook sessions.
+ *
+ * For console sessions, we always show the session name (the `short` flag is
+ * ignored).
  */
-export function getSessionDisplayName(info: IRuntimeSessionDisplayInfo, modelService: IModelService): string {
+export function getSessionDisplayName(
+	info: IRuntimeSessionDisplayInfo,
+	modelService: IModelService,
+	short: boolean = false,
+): string {
 	if (info.sessionMode === LanguageRuntimeSessionMode.Notebook && info.notebookUri) {
 		const notebookName = getNotebookDisplayName(info.notebookUri, modelService);
+		if (short) {
+			return notebookName;
+		}
 		// For Quarto sessions, show the underlying runtime name (e.g.
 		// "Python 3.12.11 (Pyenv)") instead of the session name (which is
 		// "Quarto: <file>.qmd" and would duplicate the file name).

--- a/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
+++ b/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
@@ -19,7 +19,9 @@ import { isQuartoDocument } from '../../positronQuarto/common/positronQuartoConf
  * URI path has .qmd/.rmd) and untitled files (where the model's language ID is
  * set to "quarto" or "rmd" by the Quarto extension).
  */
-export function isQuartoSession(notebookUri: URI | undefined, modelService: IModelService): boolean {
+export function isQuartoSession(
+	{ notebookUri, modelService }: { notebookUri: URI | undefined; modelService: IModelService },
+): boolean {
 	if (!notebookUri) {
 		return false;
 	}
@@ -37,8 +39,7 @@ export function isQuartoSession(notebookUri: URI | undefined, modelService: IMod
  * without a notebook URI (console), returns sessionName.
  */
 export function getSessionDisplayName(
-	notebookUri: URI | undefined,
-	sessionName: string,
+	{ notebookUri, sessionName }: { notebookUri: URI | undefined; sessionName: string },
 ): string {
 	if (!notebookUri) {
 		return sessionName;
@@ -62,7 +63,7 @@ interface SessionIconInfo {
  */
 export function getSessionIcon(info: SessionIconInfo, modelService: IModelService): ThemeIcon {
 	if (info.sessionMode === LanguageRuntimeSessionMode.Notebook) {
-		if (isQuartoSession(info.notebookUri, modelService)) {
+		if (isQuartoSession({ notebookUri: info.notebookUri, modelService })) {
 			return Codicon.positronQuarto;
 		}
 		return Codicon.notebook;
@@ -76,7 +77,7 @@ export function getSessionIcon(info: SessionIconInfo, modelService: IModelServic
  */
 export function getSessionIconStyle(info: SessionIconInfo, modelService: IModelService): React.CSSProperties | undefined {
 	if (info.sessionMode === LanguageRuntimeSessionMode.Notebook &&
-		isQuartoSession(info.notebookUri, modelService)) {
+		isQuartoSession({ notebookUri: info.notebookUri, modelService })) {
 		return { color: asCssVariable(POSITRON_QUARTO_ICON) };
 	}
 	return undefined;

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoKernelManager.ts
@@ -851,13 +851,13 @@ export class QuartoKernelManager extends Disposable implements IQuartoKernelMana
 				return undefined;
 			}
 
-			// Start the session. Ensure the file name includes an extension for
-			// untitled documents (whose URIs don't include .qmd).
+			// Use the filename (with extension) as the session name. Untitled
+			// Quarto URIs don't include the .qmd extension, so append it here.
 			let fileName = documentUri.path.split('/').pop() ?? '';
 			if (!isQuartoOrRmdFile(fileName)) {
 				fileName = `${fileName}.qmd`;
 			}
-			const sessionName = `Quarto: ${fileName}`;
+			const sessionName = fileName;
 			const sessionId = await this._runtimeSessionService.startNewRuntimeSession(
 				runtime.runtimeId,
 				sessionName,

--- a/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
+++ b/src/vs/workbench/services/positronHistory/test/common/executionHistoryService.test.ts
@@ -485,10 +485,6 @@ class TestLanguageRuntimeSession extends Disposable implements ILanguageRuntimeS
 		throw new Error('Method not implemented.');
 	}
 
-	getLabel(): string {
-		return this.dynState.sessionName;
-	}
-
 	isIdle(): boolean {
 		throw new Error('Method not implemented.');
 	}

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -250,9 +250,6 @@ export interface ILanguageRuntimeSession extends IDisposable {
 	/** Show profiler log of the runtime, if supported */
 	showProfile(): Thenable<void>;
 
-	/** Get the label associated with the session. This is a more human-readable name for the session. */
-	getLabel(): string;
-
 	/** Updates the session's name */
 	updateSessionName(sessionName: string): void;
 

--- a/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
@@ -476,10 +476,6 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 			session_name: this.dynState.sessionName
 		});
 	}
-
-	getLabel(): string {
-		return this.dynState.sessionName;
-	}
 }
 
 export async function waitForRuntimeState(


### PR DESCRIPTION
Addresses #11905

Notebook and Quarto sessions now appear in the interpreter session quick pick (the "Select Session" picker) as groups alongside Console Sessions. This gives users a single place to see everything that's currently running. Clicking on a notebook/quarto session will cause the active editor (and console if applicable) to change.

Session items now show icons based off the session mode instead of the runtime (python, r). Quarto icon picks up the `positronConsole.quartoIcon` theme color via a themed CSS rule (`registerThemingParticipant`). NOTE: Based off feedback the icons will be changing in a follow-up PR very soon!

A new `includeNotebookSessions` option on `selectLanguageRuntimeSession` controls whether notebook/quarto groups are shown (default `true`). This allows us to exclude notebook sessions for the "Rename Session" command which should only work on console sessions (we don't allow renaming notebook sessions because we don't display the session name anywhere and instead construct the label based off the filename. Renaming a notebook session wouldn't be useful to a user).

The interpreter picker button now show just the filename for notebook/quarto sessions (e.g. `foo.qmd`) rather than `filename - runtime`. The quickpick retains the `filename - runtime` pattern so users can see the environment at a glance.

Quarto sessions no longer carry a `Quarto: ` prefix. The kernel manager now sets `sessionName` to just the filename (with `.qmd` appended to the session name for untitled docs whose URIs don't carry the extension). This simplifies how we derive the session "label" everywhere else. We have a `getSessionDisplayName(notebookUri, sessionName)` helper that handles all UI surfaces (top action bar button, console tab, chat picker, quickpick). The `session.getLabel()` was removed from `ILanguageRuntimeSession` since (1) the label we show for a session is a UI concern and not a session object concern (2) the session level getLabel was unable to handle all scenarios such as untitled files (3) and we now sometimes need to derive the session label from session metadata without the actual session (exited notebook/console sessions)

### Screenshots

**Interpreter picker with notebook and quarto sessions:**

https://github.com/user-attachments/assets/250fc823-716f-4f33-8e60-b8b6a877794c

**Untitled qmd and ipynb session naming** 

https://github.com/user-attachments/assets/dd3c7ca2-e9a1-428e-a25e-f3c3c6b3da4b

**Rename session command quickpick list (console only, notebook/quarto hidden):**

https://github.com/user-attachments/assets/97a1f7c9-5be1-4331-a361-f4d2775618ff



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Display notebook and Quarto sessions in the interpreter session quickpick (#11905)

#### Bug Fixes

- N/A


### QA Notes
@:interpreter
@:notebooks
@:quarto
@:sessions
