### PR TITLE
Fix user timeout for Shiny app launches

### DIFF
--- a/extensions/positron-run-app/package.json
+++ b/extensions/positron-run-app/package.json
@@ -44,6 +44,12 @@
           ],
           "description": "%configuration.runApp.previewMode%"
         },
+        "positron.runApp.urlDetectionTimeout": {
+          "type": "integer",
+          "default": 25,
+          "minimum": 1,
+          "description": "%configuration.runApp.urlDetectionTimeout%"
+        },
         "positron.appLauncher.terminalAppUrlOpenLocation": {
           "type": "string",
           "default": "ask",

--- a/extensions/positron-run-app/package.nls.json
+++ b/extensions/positron-run-app/package.nls.json
@@ -4,6 +4,7 @@
 	"configuration.appLauncher.showEnableShellIntegrationMessage": "Show a prompt when shell integration is disabled.",
 	"configuration.appLauncher.showShellIntegrationNotSupportedMessage": "Show a warning when shell integration is not supported by the active terminal.",
 	"configuration.runApp.previewMode": "Where to preview applications by default.",
+	"configuration.runApp.urlDetectionTimeout": "Maximum time in seconds to wait for an application URL to appear in the output.",
 	"configuration.runApp.previewMode.viewer": "Open in the Positron Viewer pane.",
 	"configuration.runApp.previewMode.editor": "Open in an editor tab.",
 	"configuration.runApp.previewMode.external": "Open in an external browser.",

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -11,7 +11,7 @@ import { log } from './extension';
 import { DebugAppOptions, PositronRunApp, PreviewMode, RunAppOptions, RunConsoleAppOptions } from './positron-run-app';
 import { AppUrlDetector } from './appUrlDetector';
 import { raceTimeout, SequencerByKey } from './utils';
-import { DAP_CONFIGURATION_TIMEOUT, DID_PREVIEW_URL_TIMEOUT, IS_POSITRON_WEB, IS_RUNNING_ON_PWB, SHELL_INTEGRATION_TIMEOUT, TERMINAL_OUTPUT_TIMEOUT } from './constants.js';
+import { DAP_CONFIGURATION_TIMEOUT, IS_POSITRON_WEB, IS_RUNNING_ON_PWB, SHELL_INTEGRATION_TIMEOUT, URL_DETECTION_TIMEOUT } from './constants.js';
 import { AppPreviewOptions, Config, PositronProxyInfo } from './types.js';
 import { shouldUsePositronProxy, showShellIntegrationNotSupportedMessage, showEnableShellIntegrationMessage } from './api-utils.js';
 
@@ -265,6 +265,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 					urlPath: options.urlPath,
 					appReadyMessage: options.appReadyMessage,
 					appUrlStrings: options.appUrlStrings,
+					urlDetectionTimeout: options.urlDetectionTimeout,
 				};
 
 				const previewUri = await this.previewUrlInExecutionOutput(execution, previewOptions);
@@ -432,7 +433,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 				case 'manual': {
 					const url = await raceTimeout(
 						detector.found,
-						TERMINAL_OUTPUT_TIMEOUT,
+						options.urlDetectionTimeout ?? URL_DETECTION_TIMEOUT,
 						() => {
 							cancellation.cancel();
 							throw new Error(vscode.l10n.t('Timed out waiting for {0} app URL in console output.', options.name));
@@ -539,6 +540,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 
 		// Create a promise that resolves when the server URL has been previewed,
 		// or an error has occurred, or it times out.
+		const debugPreviewTimeout = (options.urlDetectionTimeout ?? URL_DETECTION_TIMEOUT) + 5_000;
 		const didPreviewUrl = raceTimeout(
 			new Promise<boolean>((resolve) => {
 				let executionDisposable: vscode.Disposable | undefined;
@@ -559,6 +561,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 									urlPath: options.urlPath,
 									appReadyMessage: options.appReadyMessage,
 									appUrlStrings: options.appUrlStrings,
+									urlDetectionTimeout: options.urlDetectionTimeout,
 								};
 								if (await this.previewUrlInExecutionOutput(e.execution, previewOptions)) {
 									resolve(true);
@@ -569,7 +572,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 				});
 				this._debugApplicationDisposableByName.set(options.name, disposable);
 			}),
-			DID_PREVIEW_URL_TIMEOUT,
+			debugPreviewTimeout,
 			async () => {
 				await this.setShellIntegrationSupported(false);
 			});
@@ -700,7 +703,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 
 		const url = await raceTimeout(
 			detector.found,
-			TERMINAL_OUTPUT_TIMEOUT,
+			options.urlDetectionTimeout ?? URL_DETECTION_TIMEOUT,
 			() => log.error('Timed out waiting for server output in terminal'),
 		);
 

--- a/extensions/positron-run-app/src/api.ts
+++ b/extensions/positron-run-app/src/api.ts
@@ -11,7 +11,7 @@ import { log } from './extension';
 import { DebugAppOptions, PositronRunApp, PreviewMode, RunAppOptions, RunConsoleAppOptions } from './positron-run-app';
 import { AppUrlDetector } from './appUrlDetector';
 import { raceTimeout, SequencerByKey } from './utils';
-import { DAP_CONFIGURATION_TIMEOUT, IS_POSITRON_WEB, IS_RUNNING_ON_PWB, SHELL_INTEGRATION_TIMEOUT, URL_DETECTION_TIMEOUT } from './constants.js';
+import { DAP_CONFIGURATION_TIMEOUT, IS_POSITRON_WEB, IS_RUNNING_ON_PWB, SHELL_INTEGRATION_TIMEOUT } from './constants.js';
 import { AppPreviewOptions, Config, PositronProxyInfo } from './types.js';
 import { shouldUsePositronProxy, showShellIntegrationNotSupportedMessage, showEnableShellIntegrationMessage } from './api-utils.js';
 
@@ -26,6 +26,10 @@ function readDefaultPreviewMode(): PreviewMode {
 		default:
 			return 'viewer';
 	}
+}
+
+function readUrlDetectionTimeout(): number {
+	return vscode.workspace.getConfiguration().get<number>(Config.UrlDetectionTimeout, 25) * 1000;
 }
 
 function parsePreviewMode(value: string | undefined): PreviewMode {
@@ -433,7 +437,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 				case 'manual': {
 					const url = await raceTimeout(
 						detector.found,
-						options.urlDetectionTimeout ?? URL_DETECTION_TIMEOUT,
+						options.urlDetectionTimeout ?? readUrlDetectionTimeout(),
 						() => {
 							cancellation.cancel();
 							throw new Error(vscode.l10n.t('Timed out waiting for {0} app URL in console output.', options.name));
@@ -540,7 +544,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 
 		// Create a promise that resolves when the server URL has been previewed,
 		// or an error has occurred, or it times out.
-		const debugPreviewTimeout = (options.urlDetectionTimeout ?? URL_DETECTION_TIMEOUT) + 5_000;
+		const debugPreviewTimeout = (options.urlDetectionTimeout ?? readUrlDetectionTimeout()) + 5_000;
 		const didPreviewUrl = raceTimeout(
 			new Promise<boolean>((resolve) => {
 				let executionDisposable: vscode.Disposable | undefined;
@@ -703,7 +707,7 @@ export class PositronRunAppApiImpl implements PositronRunApp, vscode.Disposable 
 
 		const url = await raceTimeout(
 			detector.found,
-			options.urlDetectionTimeout ?? URL_DETECTION_TIMEOUT,
+			options.urlDetectionTimeout ?? readUrlDetectionTimeout(),
 			() => log.error('Timed out waiting for server output in terminal'),
 		);
 

--- a/extensions/positron-run-app/src/constants.ts
+++ b/extensions/positron-run-app/src/constants.ts
@@ -18,10 +18,9 @@ export const IS_POSITRON_WEB = vscode.env.uiKind === vscode.UIKind.Web;
 export const IS_RUNNING_ON_PWB = !!process.env.RS_SERVER_URL && IS_POSITRON_WEB;
 
 // Timeouts.
-export const TERMINAL_OUTPUT_TIMEOUT = 25_000;
+export const URL_DETECTION_TIMEOUT = 25_000;
 /** Time to wait for the debug adapter to finish its initial configuration (breakpoints etc.). */
 export const DAP_CONFIGURATION_TIMEOUT = 10_000;
 
-export const DID_PREVIEW_URL_TIMEOUT = TERMINAL_OUTPUT_TIMEOUT + 5_000;
 /** Time between creating a terminal and receiving its onDidChangeTerminalShellIntegration event. */
 export const SHELL_INTEGRATION_TIMEOUT = 5_000;

--- a/extensions/positron-run-app/src/constants.ts
+++ b/extensions/positron-run-app/src/constants.ts
@@ -18,7 +18,6 @@ export const IS_POSITRON_WEB = vscode.env.uiKind === vscode.UIKind.Web;
 export const IS_RUNNING_ON_PWB = !!process.env.RS_SERVER_URL && IS_POSITRON_WEB;
 
 // Timeouts.
-export const URL_DETECTION_TIMEOUT = 25_000;
 /** Time to wait for the debug adapter to finish its initial configuration (breakpoints etc.). */
 export const DAP_CONFIGURATION_TIMEOUT = 10_000;
 

--- a/extensions/positron-run-app/src/positron-run-app.d.ts
+++ b/extensions/positron-run-app/src/positron-run-app.d.ts
@@ -83,6 +83,12 @@ interface RunAppOptionsBase {
 	 * runtimes without DAP support to avoid a waiting overhead on every run.
 	 */
 	debugAdapterType?: string;
+
+	/**
+	 * Optional timeout in milliseconds for URL detection in application output.
+	 * If not specified, a default timeout is used.
+	 */
+	urlDetectionTimeout?: number;
 }
 
 /**
@@ -160,6 +166,12 @@ export interface DebugAppOptions {
 	 * An optional array of app URI formats to parse the URI from the terminal output.
 	 */
 	appUrlStrings?: string[];
+
+	/**
+	 * Optional timeout in milliseconds for URL detection in application output.
+	 * If not specified, a default timeout is used.
+	 */
+	urlDetectionTimeout?: number;
 }
 
 /**

--- a/extensions/positron-run-app/src/types.ts
+++ b/extensions/positron-run-app/src/types.ts
@@ -11,6 +11,7 @@ export enum Config {
 	ShowEnableShellIntegrationMessage = 'positron.appLauncher.showEnableShellIntegrationMessage',
 	ShowShellIntegrationNotSupportedMessage = 'positron.appLauncher.showShellIntegrationNotSupportedMessage',
 	PreviewMode = 'positron.runApp.previewMode',
+	UrlDetectionTimeout = 'positron.runApp.urlDetectionTimeout',
 }
 
 export type PositronProxyInfo = {

--- a/extensions/positron-run-app/src/types.ts
+++ b/extensions/positron-run-app/src/types.ts
@@ -26,6 +26,7 @@ export type AppPreviewOptions = {
 	urlPath?: string;
 	appReadyMessage?: string;
 	appUrlStrings?: string[];
+	urlDetectionTimeout?: number;
 };
 
 export type AppLauncherTerminalLink = vscode.TerminalLink & {


### PR DESCRIPTION
With a recent pull from https://github.com/posit-dev/shiny-vscode/pull/109, we now respect the Shiny timeout setting.

I've also added a positron-run-app setting to control the default timeout of other applications.
I'll update the changelog in the PR that bumps the Shiny extension min version.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
