### PR TITLE
Support clearing R console via `cat`

### DIFF
--- a/src/vs/base/common/ansiOutput.ts
+++ b/src/vs/base/common/ansiOutput.ts
@@ -472,6 +472,13 @@ export class ANSIOutput {
 				break;
 			}
 
+			// FF (form feed) is handled at the service level as a
+			// console clear. Ignore it here so it doesn't render as
+			// visible text.
+			case '\f': {
+				break;
+			}
+
 			// CR flushes the buffer and sets the output column to 0.
 			case '\r': {
 				this.flushBuffer();

--- a/src/vs/base/test/common/ansiOutput.test.ts
+++ b/src/vs/base/test/common/ansiOutput.test.ts
@@ -14,6 +14,7 @@ import { ANSIColor, ANSIFormat, ANSIOutput, ANSIStyle } from '../../common/ansiO
  */
 const BS = '\b';
 const CR = '\r';
+const FF = '\f';
 const LF = '\n';
 const CRLF = `\r\n`;
 const PANGRAM = 'The quick brown fox jumps over the lazy dog';
@@ -680,6 +681,43 @@ suite('ANSIOutput', () => {
 			assert.equal(outputLines[i].outputRuns[0].format, undefined);
 			assert.equal(outputLines[i].outputRuns[0].text, PANGRAM);
 		}
+	});
+
+	test('Test ANSIOutput FF is silently ignored', () => {
+		// Setup.
+		const ansiOutput = new ANSIOutput();
+		ansiOutput.processOutput(FF);
+		const outputLines = ansiOutput.outputLines;
+
+		// A lone form feed should produce no visible output.
+		assert.equal(outputLines.length, 1);
+		assert.equal(outputLines[0].outputRuns.length, 0);
+	});
+
+	test('Test ANSIOutput FF between text is ignored', () => {
+		// Setup.
+		const ansiOutput = new ANSIOutput();
+		ansiOutput.processOutput(`Hello${FF}World`);
+		const outputLines = ansiOutput.outputLines;
+
+		// Form feed is stripped; text on either side is concatenated.
+		assert.equal(outputLines.length, 1);
+		assert.equal(outputLines[0].outputRuns.length, 1);
+		assert.equal(outputLines[0].outputRuns[0].text, 'HelloWorld');
+	});
+
+	test('Test ANSIOutput FF with newlines', () => {
+		// Setup.
+		const ansiOutput = new ANSIOutput();
+		ansiOutput.processOutput(`Line1${LF}${FF}Line2`);
+		const outputLines = ansiOutput.outputLines;
+
+		// Form feed is ignored; the LF still creates a new line.
+		assert.equal(outputLines.length, 2);
+		assert.equal(outputLines[0].outputRuns.length, 1);
+		assert.equal(outputLines[0].outputRuns[0].text, 'Line1');
+		assert.equal(outputLines[1].outputRuns.length, 1);
+		assert.equal(outputLines[1].outputRuns[0].text, 'Line2');
 	});
 
 	test('Test ANSIOutput with 10 lines separated by LF and CRLF', () => {

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -2541,6 +2541,22 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				);
 			}
 
+			// In R, cat("\014") / cat("\f") clears the console,
+			// matching RStudio behavior. If the R runtime outputs a
+			// form feed character, clear the console and only keep
+			// text after the last form feed.
+			let text = languageRuntimeMessageStream.text;
+			if (this._session?.runtimeMetadata?.languageId === 'r') {
+				const lastFF = text.lastIndexOf('\f');
+				if (lastFF !== -1) {
+					this.clearConsole();
+					text = text.substring(lastFF + 1);
+					if (text.length === 0) {
+						return;
+					}
+				}
+			}
+
 			// Handle stdout and stderr.
 			if (languageRuntimeMessageStream.name === 'stdout') {
 				this.addOrUpdateRuntimeItemActivity(
@@ -2550,7 +2566,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 						languageRuntimeMessageStream.parent_id,
 						new Date(languageRuntimeMessageStream.when),
 						ActivityItemStreamType.OUTPUT,
-						languageRuntimeMessageStream.text
+						text
 					)
 				);
 			} else if (languageRuntimeMessageStream.name === 'stderr') {
@@ -2561,7 +2577,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 						languageRuntimeMessageStream.parent_id,
 						new Date(languageRuntimeMessageStream.when),
 						ActivityItemStreamType.ERROR,
-						languageRuntimeMessageStream.text
+						text
 					)
 				);
 			}

--- a/src/vs/workbench/services/positronHistory/common/sessionExecutionHistory.ts
+++ b/src/vs/workbench/services/positronHistory/common/sessionExecutionHistory.ts
@@ -155,8 +155,24 @@ export class SessionExecutionHistory extends Disposable {
 		};
 
 		const handleDidReceiveRuntimeMessageStream = (message: ILanguageRuntimeMessageStream) => {
-			// Get the output.
-			const output = message.text;
+			let output = message.text;
+
+			// In R, cat("\014") / cat("\f") clears the console. When
+			// a form feed is present, only record the text after the
+			// last form feed so replay matches what the user saw.
+			if (session.runtimeMetadata.languageId === 'r') {
+				const lastFF = output.lastIndexOf('\f');
+				if (lastFF !== -1) {
+					// Clear previously recorded output for this
+					// execution since the console was cleared.
+					const pending = this._pendingExecutions.get(message.parent_id);
+					if (pending) {
+						pending.output = '';
+					}
+					output = output.substring(lastFF + 1);
+				}
+			}
+
 			if (output) {
 				this.recordOutput(message, output);
 			}


### PR DESCRIPTION
Addresses #12582.

In RStudio, `cat("\014")` or `cat("\f")` clears the console. This PR matches that behavior for R sessions: when a form feed character appears in stream output from an R runtime, the console is cleared and only text after the last form feed is kept. The session execution history is updated the same way so replay matches what the user saw. As a defensive measure, `ANSIOutput` also strips bare form feed characters so they never render as visible text.

*Note:* this only applies to R, and not Python, to stay try to how other interpreters (Python REPL, IPython) handle `'\f'`.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Support clearing the R console via `cat("\014")` / `cat("\f")` (#12582)

### QA Notes

@:console

In an R session, run `cat("\014")` and `cat("\f")` and verify the console is cleared. Run `cat("hello\014world")` and verify only `world` remains. Confirm Python sessions are unaffected (form feed still renders as before for non-R languages, but should not appear as visible text).