### PR TITLE
Upstream vscode-server fix for language-scoped enforced settings

### DIFF
--- a/src/vs/platform/configuration/common/configurationModels.ts
+++ b/src/vs/platform/configuration/common/configurationModels.ts
@@ -989,16 +989,19 @@ export class Configuration {
 
 	private getConsolidatedConfigurationModel(section: string | undefined, overrides: IConfigurationOverrides, workspace: Workspace | undefined): ConfigurationModel {
 		let configurationModel = this.getConsolidatedConfigurationModelForResource(overrides, workspace);
-		if (overrides.overrideIdentifier) {
-			configurationModel = configurationModel.override(overrides.overrideIdentifier);
-		}
-		if (!this._policyConfiguration.isEmpty() && this._policyConfiguration.getValue(section) !== undefined) {
+		// --- Start PWB: Apply policy before overrides so language-scoped policy keys participate in override flattening ---
+		// if (!this._policyConfiguration.isEmpty() && this._policyConfiguration.getValue(section) !== undefined) {
+		if (!this._policyConfiguration.isEmpty()) {
 			// clone by merging
 			configurationModel = configurationModel.merge();
 			for (const key of this._policyConfiguration.keys) {
 				configurationModel.setValue(key, this._policyConfiguration.getValue(key));
 			}
 		}
+		if (overrides.overrideIdentifier) {
+			configurationModel = configurationModel.override(overrides.overrideIdentifier);
+		}
+		// --- End PWB ---
 		return configurationModel;
 	}
 

--- a/src/vs/platform/configuration/test/common/configurationModels.test.ts
+++ b/src/vs/platform/configuration/test/common/configurationModels.test.ts
@@ -852,6 +852,26 @@ suite('Configuration', () => {
 		assert.deepStrictEqual(overrideIdentifiers, ['l1', 'l3', 'l4']);
 	});
 
+	// --- Start PWB: Apply policy before overrides so language-scoped policy keys participate in override flattening ---
+	test('getValue applies language-scoped policy overrides', () => {
+		const policyConfigurationModel = parseConfigurationModel({
+			'[r]': { 'editor.formatOnSave': true }
+		});
+		const userConfigurationModel = parseConfigurationModel({
+			'editor.formatOnSave': false
+		});
+		const testObject: Configuration = new TestConfiguration(
+			ConfigurationModel.createEmptyModel(new NullLogService()),
+			policyConfigurationModel,
+			ConfigurationModel.createEmptyModel(new NullLogService()),
+			userConfigurationModel,
+		);
+
+		assert.strictEqual(testObject.getValue('editor.formatOnSave', { overrideIdentifier: 'r' }, undefined), true);
+		assert.strictEqual(testObject.getValue('editor.formatOnSave', {}, undefined), false);
+	});
+	// --- End PWB ---
+
 	test('Test update value', () => {
 		const parser = new ConfigurationModelParser('test', new NullLogService());
 		parser.parse(JSON.stringify({ 'a': 1 }));


### PR DESCRIPTION
Addresses #12380

Brings in rstudio/vscode-server#343, which fixes a bug where enforced settings (`POSITRON_ENFORCED_SETTINGS`) with language-scoped keys like `[r]` or `[quarto]` were silently dropped during configuration resolution. Top-level enforced settings work correctly; only language-scoped overrides were affected.

The original enforced-settings feature was brought over to Positron in #10082 (upstream: rstudio/vscode-server#264).

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Language-scoped enforced settings (e.g., `[r]`) now apply correctly.

### QA Notes

With `POSITRON_ENFORCED_SETTINGS='{"[r]": {"editor.formatOnSave": true, "editor.defaultFormatter": "Posit.air-vscode"}}'`:

- Saving a messy `.R` file should trigger the Air formatter even if you don't have those settings set as a user.
- Top-level enforced settings (`workbench.colorTheme`, etc.) should continue to work as before.