### PR TITLE
E2E test: language-scoped enforced settings in Workbench

### DIFF
--- a/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
+++ b/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
@@ -214,25 +214,34 @@ test.describe('Workbench: Language-scoped enforced settings', {
 	});
 
 	test('Enforced setting wins over conflicting user setting', async function ({ app, runDockerCommand, hotKeys, page }) {
-		// Write a user setting that attempts to turn formatOnSave off for R. The enforced
-		// `[r]: { formatOnSave: true }` should still win.
-		const userSettings = JSON.stringify({
-			'[r]': { 'editor.formatOnSave': false },
-		}, null, 2);
-
-		await test.step('Back up existing user settings.json and install conflicting user setting', async () => {
+		// Merge a conflicting `[r]: { formatOnSave: false }` into the existing user
+		// settings.json. Merging (rather than overwriting) is critical - the workbench
+		// test fixture pre-seeds settings.json with workspace-trust disablers like
+		// `"security.workspace.trust.enabled": false`, and losing those triggers a trust
+		// prompt that blocks the rest of the test.
+		await test.step('Merge a conflicting `[r]` setting into user settings.json', async () => {
 			await runDockerCommand(
 				`docker exec test bash -lc 'if [ -f ${USER_SETTINGS_PATH} ] && [ ! -f ${USER_SETTINGS_BACKUP_PATH} ]; then cp ${USER_SETTINGS_PATH} ${USER_SETTINGS_BACKUP_PATH}; fi'`,
 				'Back up user settings.json (if not already)'
 			);
 
+			const { stdout: currentStr } = await runDockerCommand(
+				`docker exec test bash -lc 'cat ${USER_SETTINGS_PATH} 2>/dev/null || echo "{}"'`,
+				'Read current user settings.json'
+			);
+			const current = currentStr.trim() ? JSON.parse(currentStr) : {};
+			const merged = {
+				...current,
+				'[r]': { ...(current['[r]'] ?? {}), 'editor.formatOnSave': false },
+			};
+
 			const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'user-settings-'));
 			const tmpFile = path.join(tmpDir, 'settings.json');
-			await fs.promises.writeFile(tmpFile, userSettings);
+			await fs.promises.writeFile(tmpFile, JSON.stringify(merged, null, 2));
 			try {
 				await runDockerCommand(
 					`docker cp "${tmpFile}" test:${USER_SETTINGS_PATH}`,
-					'Install conflicting user settings.json'
+					'Install merged user settings.json'
 				);
 			} finally {
 				await fs.promises.rm(tmpDir, { recursive: true, force: true });

--- a/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
+++ b/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
@@ -10,8 +10,18 @@
  * silently dropped during configuration resolution. Fixed upstream in
  * rstudio/vscode-server#343.
  *
- * Scenario: an admin enforces `editor.formatOnSave` + Air as the default formatter via the
- * `[r]` language scope. Saving a messy `.R` file should trigger the Air formatter.
+ * Enforced config for the whole suite (exercises both coexistence and scope):
+ *   {
+ *     "editor.formatOnSave": false,
+ *     "[r]": { "editor.formatOnSave": true, "editor.defaultFormatter": "Posit.air-vscode" }
+ *   }
+ *
+ * Covers:
+ *   1. Positive scope: saving a messy `.R` file triggers the Air formatter.
+ *   2. Negative scope / coexistence: saving a `.py` file does NOT format (top-level `false`
+ *      still applies; the `[r]` override did not leak globally).
+ *   3. Enforced-wins-over-user: with a conflicting `[r]: { formatOnSave: false }` in the
+ *      user's settings.json, a messy `.R` file still formats on save.
  */
 
 import * as fs from 'fs';
@@ -28,8 +38,8 @@ const ENFORCED_SETTINGS_PATH = '/etc/rstudio/enforced-settings.json';
 const PROFILES_PATH = '/etc/rstudio/profiles';
 const PROFILES_BACKUP_PATH = '/etc/rstudio/profiles.enforced-settings-test.bak';
 const WORKSPACE_PATH = '/home/user1/qa-example-content';
-const TEST_FILE_NAME = 'enforced-settings-format-on-save.R';
-const TEST_FILE_PATH = `${WORKSPACE_PATH}/${TEST_FILE_NAME}`;
+const USER_SETTINGS_PATH = '/home/user1/.positron-server/User/settings.json';
+const USER_SETTINGS_BACKUP_PATH = '/home/user1/.positron-server/User/settings.json.enforced-settings-test.bak';
 
 // Deliberately messy R content that Air will reformat.
 const MESSY_R_CONTENT = [
@@ -39,7 +49,20 @@ const MESSY_R_CONTENT = [
 	'',
 ].join('\n');
 
+// Deliberately messy Python content. We assert this is NOT reformatted on save,
+// so the exact contents don't matter as long as no built-in formatter would touch it.
+const MESSY_PY_CONTENT = [
+	'x=1',
+	'y   =   2',
+	'def f(  x  ):return x+1',
+	'',
+].join('\n');
+
+// Top-level `formatOnSave: false` + `[r]` override. Together these let one config
+// exercise (a) the `[r]` scope applying to R files, (b) the top-level `false` still
+// applying to non-R files - i.e. the `[r]` override did not leak globally.
 const ENFORCED_SETTINGS_JSON = JSON.stringify({
+	'editor.formatOnSave': false,
 	'[r]': {
 		'editor.formatOnSave': true,
 		'editor.defaultFormatter': 'Posit.air-vscode',
@@ -124,13 +147,18 @@ test.describe('Workbench: Language-scoped enforced settings', {
 	});
 
 	test.afterAll('Remove enforced settings and restart session', async function ({ app, runDockerCommand }) {
-		// Non-critical cleanup: removing temp files. Swallow errors here since a leftover
-		// file in /etc/rstudio or the workspace won't affect other tests once the profile
-		// is restored and the server is restarted.
+		// Non-critical cleanup: removing temp files and restoring user settings. Swallow
+		// errors here since a leftover file in /etc/rstudio or the workspace won't affect
+		// other tests once the profile is restored and the server is restarted.
 		try {
 			await runDockerCommand(
-				`docker exec test sudo rm -f ${ENFORCED_SETTINGS_PATH} ${TEST_FILE_PATH}`,
-				'Remove enforced settings file and test R file'
+				`docker exec test bash -lc 'sudo rm -f ${ENFORCED_SETTINGS_PATH}; rm -f ${WORKSPACE_PATH}/enforced-settings-*.R ${WORKSPACE_PATH}/enforced-settings-*.py'`,
+				'Remove enforced settings file and test files'
+			);
+			// Restore user settings.json if we backed one up during a test.
+			await runDockerCommand(
+				`docker exec test bash -lc 'if [ -f ${USER_SETTINGS_BACKUP_PATH} ]; then mv ${USER_SETTINGS_BACKUP_PATH} ${USER_SETTINGS_PATH}; fi'`,
+				'Restore user settings.json (if backup exists)'
 			);
 		} catch (error) {
 			console.warn('Non-critical teardown cleanup failed (continuing):', error);
@@ -156,68 +184,126 @@ test.describe('Workbench: Language-scoped enforced settings', {
 		await waitForRStudioServerReady(runDockerCommand);
 	});
 
-	test('Verify [r]-scoped editor.formatOnSave triggers Air formatter', async function ({ app, runDockerCommand, hotKeys, page }) {
+	test.beforeAll('Wait for Air bootstrap extension to be installed', async function ({ runDockerCommand }) {
+		// Air is a bootstrap extension that is downloaded lazily after container startup
+		// (not bundled in positron-workbench-linux-x64-branch.tar.gz). Without this, the
+		// formatter lookup on save silently no-ops.
+		await waitForAirExtensionInstalled(runDockerCommand);
+	});
 
-		await test.step('Wait for Air bootstrap extension to be installed', async () => {
-			// Air is a bootstrap extension that is downloaded lazily after container startup
-			// (not bundled in positron-workbench-linux-x64-branch.tar.gz). Without this, the
-			// formatter lookup on save silently no-ops.
-			await waitForAirExtensionInstalled(runDockerCommand);
-		});
+	test('`[r]` scope: messy .R file is reformatted by Air on save', async function ({ app, runDockerCommand, hotKeys, page }) {
+		const filePath = await writeOpenAndSave(app, runDockerCommand, hotKeys, page, 'enforced-settings-format-r.R', MESSY_R_CONTENT);
 
-		await test.step('Write messy R file into the workspace', async () => {
-			const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'messy-r-'));
-			const tmpFile = path.join(tmpDir, TEST_FILE_NAME);
-			await fs.promises.writeFile(tmpFile, MESSY_R_CONTENT);
+		await expect(async () => {
+			const saved = await readContainerFile(runDockerCommand, filePath);
+			expect(saved, 'file content should differ from the messy input after formatOnSave').not.toBe(MESSY_R_CONTENT);
+			expect(saved, 'formatter should normalize `x<-1` to `x <- 1`').toContain('x <- 1');
+			expect(saved, 'formatter should normalize `y  <-   2` to `y <- 2`').toContain('y <- 2');
+		}).toPass({ timeout: 15000, intervals: [500, 1000, 2000] });
+	});
+
+	test('`[r]` does not leak globally: messy .py file is NOT reformatted on save', async function ({ app, runDockerCommand, hotKeys, page }) {
+		// Enforced config has top-level `formatOnSave: false` plus a `[r]` override. For a
+		// Python file, formatOnSave should resolve to the top-level `false`. If the fix
+		// regressed and the `[r]` block leaked globally, `formatOnSave: true` + Air as
+		// the default formatter would apply to Python too - a noticeable file change.
+		const filePath = await writeOpenAndSave(app, runDockerCommand, hotKeys, page, 'enforced-settings-no-format-py.py', MESSY_PY_CONTENT);
+
+		const saved = await readContainerFile(runDockerCommand, filePath);
+		expect(saved, 'python file should be unchanged on save (no `[python]` policy; top-level `false` applies)').toBe(MESSY_PY_CONTENT);
+	});
+
+	test('Enforced setting wins over conflicting user setting', async function ({ app, runDockerCommand, hotKeys, page }) {
+		// Write a user setting that attempts to turn formatOnSave off for R. The enforced
+		// `[r]: { formatOnSave: true }` should still win.
+		const userSettings = JSON.stringify({
+			'[r]': { 'editor.formatOnSave': false },
+		}, null, 2);
+
+		await test.step('Back up existing user settings.json and install conflicting user setting', async () => {
+			await runDockerCommand(
+				`docker exec test bash -lc 'if [ -f ${USER_SETTINGS_PATH} ] && [ ! -f ${USER_SETTINGS_BACKUP_PATH} ]; then cp ${USER_SETTINGS_PATH} ${USER_SETTINGS_BACKUP_PATH}; fi'`,
+				'Back up user settings.json (if not already)'
+			);
+
+			const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'user-settings-'));
+			const tmpFile = path.join(tmpDir, 'settings.json');
+			await fs.promises.writeFile(tmpFile, userSettings);
 			try {
 				await runDockerCommand(
-					`docker cp "${tmpFile}" test:${TEST_FILE_PATH}`,
-					'Copy messy R file into container'
-				);
-				await runDockerCommand(
-					`docker exec test chown user1:user1g ${TEST_FILE_PATH}`,
-					'Chown messy R file'
+					`docker cp "${tmpFile}" test:${USER_SETTINGS_PATH}`,
+					'Install conflicting user settings.json'
 				);
 			} finally {
 				await fs.promises.rm(tmpDir, { recursive: true, force: true });
 			}
+
+			// VS Code watches settings.json, but reloading makes the observation deterministic.
+			await hotKeys.reloadWindow();
+			await app.code.driver.page.waitForSelector('.monaco-workbench', { timeout: 60000 });
 		});
 
-		await test.step('Open the R file in Positron', async () => {
-			await app.workbench.quickaccess.openFile(TEST_FILE_PATH);
-			await expect(page.getByRole('tab', { name: TEST_FILE_NAME })).toBeVisible();
-		});
+		const filePath = await writeOpenAndSave(app, runDockerCommand, hotKeys, page, 'enforced-settings-user-conflict.R', MESSY_R_CONTENT);
 
-		await test.step('Save the file to trigger formatOnSave', async () => {
-			// Click the editor to ensure focus, then trigger save.
-			await app.workbench.editor.editorPane.click();
-			// Opening the R file triggers onLanguage:r activation for Air. Give the Air
-			// language server enough time to start and register its formatter before saving.
-			await page.waitForTimeout(5000);
-			await hotKeys.save();
-			// Give the formatter a moment to run and the save to complete.
-			await page.waitForTimeout(2000);
-		});
-
-		await test.step('Verify the file on disk was reformatted by Air', async () => {
-			await expect(async () => {
-				const { stdout } = await runDockerCommand(
-					`docker exec test cat ${TEST_FILE_PATH}`,
-					'Read saved R file'
-				);
-				const saved = stdout;
-
-				// The messy content should no longer be present verbatim - Air normalizes
-				// spacing around `<-` and inside parentheses.
-				expect(saved, 'file content should differ from the messy input after formatOnSave').not.toBe(
-					MESSY_R_CONTENT
-				);
-				expect(saved, 'formatter should normalize `x<-1` to `x <- 1`').toContain('x <- 1');
-				expect(saved, 'formatter should normalize `y  <-   2` to `y <- 2`').toContain('y <- 2');
-			}).toPass({ timeout: 15000, intervals: [500, 1000, 2000] });
-		});
+		await expect(async () => {
+			const saved = await readContainerFile(runDockerCommand, filePath);
+			expect(saved, 'enforced [r] formatOnSave should win over user `[r]: { formatOnSave: false }`').not.toBe(MESSY_R_CONTENT);
+			expect(saved, 'Air should still normalize `x<-1` despite conflicting user setting').toContain('x <- 1');
+		}).toPass({ timeout: 15000, intervals: [500, 1000, 2000] });
 	});
 });
+
+/**
+ * Write a file into the workspace, open it in Positron, and save it. Returns the file's
+ * absolute path in the container.
+ */
+async function writeOpenAndSave(
+	app: Application,
+	runDockerCommand: RunDockerCommand,
+	hotKeys: { save: () => Promise<void> },
+	page: import('@playwright/test').Page,
+	fileName: string,
+	content: string,
+): Promise<string> {
+	const filePath = `${WORKSPACE_PATH}/${fileName}`;
+
+	await test.step(`Write ${fileName} into the workspace`, async () => {
+		const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'enforced-settings-file-'));
+		const tmpFile = path.join(tmpDir, fileName);
+		await fs.promises.writeFile(tmpFile, content);
+		try {
+			await runDockerCommand(`docker cp "${tmpFile}" test:${filePath}`, `Copy ${fileName} into container`);
+			await runDockerCommand(`docker exec test chown user1:user1g ${filePath}`, `Chown ${fileName}`);
+		} finally {
+			await fs.promises.rm(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	await test.step(`Open ${fileName} in Positron`, async () => {
+		await app.workbench.quickaccess.openFile(filePath);
+		await expect(page.getByRole('tab', { name: fileName })).toBeVisible();
+	});
+
+	await test.step('Save to trigger formatOnSave (if applicable)', async () => {
+		await app.workbench.editor.editorPane.click();
+		// Give language-server-backed formatters (e.g. Air for R) time to activate and
+		// register their formatter before the save keystroke.
+		await page.waitForTimeout(5000);
+		await hotKeys.save();
+		// Give the save (and any format-on-save) a moment to land on disk. For format tests
+		// callers additionally poll with expect.toPass; this baseline wait prevents the
+		// NOT-formatted case from racing and reading an empty / pre-save file.
+		await page.waitForTimeout(2000);
+	});
+
+	return filePath;
+}
+
+/** Read a file from the workbench container via `docker exec cat`. */
+async function readContainerFile(runDockerCommand: RunDockerCommand, filePath: string): Promise<string> {
+	const { stdout } = await runDockerCommand(`docker exec test cat ${filePath}`, `Read ${filePath}`);
+	return stdout;
+}
 
 type RunDockerCommand = (command: string, description: string) => Promise<{ stdout: string; stderr: string }>;
 

--- a/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
+++ b/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
@@ -1,0 +1,213 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Verifies that language-scoped keys in POSITRON_ENFORCED_SETTINGS (e.g. `[r]`) are applied.
+ *
+ * Regression test for posit-dev/positron#12380 - language-scoped enforced settings were
+ * silently dropped during configuration resolution. Fixed upstream in
+ * rstudio/vscode-server#343.
+ *
+ * Scenario: an admin enforces `editor.formatOnSave` + Air as the default formatter via the
+ * `[r]` language scope. Saving a messy `.R` file should trigger the Air formatter.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { test, tags, expect } from '../../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+const ENFORCED_SETTINGS_PATH = '/etc/rstudio/enforced-settings.json';
+const PROFILES_PATH = '/etc/rstudio/profiles';
+const PROFILES_BACKUP_PATH = '/etc/rstudio/profiles.enforced-settings-test.bak';
+const WORKSPACE_PATH = '/home/user1/qa-example-content';
+const TEST_FILE_NAME = 'enforced-settings-format-on-save.R';
+const TEST_FILE_PATH = `${WORKSPACE_PATH}/${TEST_FILE_NAME}`;
+
+// Deliberately messy R content that Air will reformat.
+const MESSY_R_CONTENT = [
+	'x<-1',
+	'y  <-   2',
+	'f <- function( x ){x+1}',
+	'',
+].join('\n');
+
+const ENFORCED_SETTINGS_JSON = JSON.stringify({
+	'[r]': {
+		'editor.formatOnSave': true,
+		'editor.defaultFormatter': 'posit.air-vscode',
+	},
+}, null, 2);
+
+const PROFILES_CONTENT = `[*]\npositron-enforced-settings = ${ENFORCED_SETTINGS_PATH}\n`;
+
+test.describe('Workbench: Language-scoped enforced settings', {
+	tag: [tags.WORKBENCH],
+}, () => {
+
+	test.beforeAll('Configure [r]-scoped enforced settings and restart session', async function ({ app, runDockerCommand }) {
+		// Write files on the host, then `docker cp` into the container. This avoids
+		// brittle multi-layer shell quoting for JSON payloads.
+		const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'enforced-settings-'));
+		const tmpSettings = path.join(tmpDir, 'enforced-settings.json');
+		const tmpProfiles = path.join(tmpDir, 'profiles');
+		await fs.promises.writeFile(tmpSettings, ENFORCED_SETTINGS_JSON);
+		await fs.promises.writeFile(tmpProfiles, PROFILES_CONTENT);
+
+		try {
+			// Ensure /etc/rstudio exists - the profiles file and enforced-settings.json
+			// are not guaranteed to be present in the test container.
+			await runDockerCommand(
+				`docker exec test sudo mkdir -p /etc/rstudio`,
+				'Ensure /etc/rstudio directory exists'
+			);
+
+			// Back up the existing profiles file (if present) so we can restore it on teardown.
+			await runDockerCommand(
+				`docker exec test bash -lc 'if [ -f ${PROFILES_PATH} ]; then sudo cp ${PROFILES_PATH} ${PROFILES_BACKUP_PATH}; fi'`,
+				'Back up existing profiles file'
+			);
+
+			// Copy enforced-settings.json into a user-writable location, then sudo-move it to /etc/rstudio.
+			await runDockerCommand(
+				`docker cp ${tmpSettings} test:/tmp/enforced-settings.json`,
+				'Copy enforced-settings.json into container'
+			);
+			await runDockerCommand(
+				`docker exec test sudo mv /tmp/enforced-settings.json ${ENFORCED_SETTINGS_PATH}`,
+				'Install enforced-settings.json'
+			);
+
+			await runDockerCommand(
+				`docker cp ${tmpProfiles} test:/tmp/profiles`,
+				'Copy profiles into container'
+			);
+			await runDockerCommand(
+				`docker exec test sudo mv /tmp/profiles ${PROFILES_PATH}`,
+				'Install profiles'
+			);
+		} finally {
+			await fs.promises.rm(tmpDir, { recursive: true, force: true });
+		}
+
+		// Restart rstudio-server so the new profile + enforced settings take effect.
+		// New Positron sessions launched after this will have POSITRON_ENFORCED_SETTINGS set.
+		await runDockerCommand(
+			`docker exec test sudo rstudio-server restart`,
+			'Restart rstudio-server'
+		);
+
+		// Reconnect: the current Positron session is dead after the server restart.
+		await app.positWorkbench.dashboard.goTo();
+		try {
+			await app.positWorkbench.dashboard.expectHeaderToBeVisible();
+		} catch {
+			// Need to re-authenticate.
+			await app.positWorkbench.auth.signIn();
+			await app.positWorkbench.dashboard.expectHeaderToBeVisible();
+		}
+
+		// Quit any leftover session (from before the restart) and open a fresh one,
+		// so the new Positron process inherits POSITRON_ENFORCED_SETTINGS.
+		try {
+			await app.positWorkbench.dashboard.quitSession('qa-example-content');
+		} catch {
+			// No leftover session to quit.
+		}
+		await app.positWorkbench.dashboard.openSession('qa-example-content');
+
+		await app.code.driver.page.waitForSelector('.monaco-workbench', { timeout: 60000 });
+		await app.workbench.sessions.expectNoStartUpMessaging();
+		await app.workbench.hotKeys.closeAllEditors();
+	});
+
+	test.afterAll('Remove enforced settings and restart session', async function ({ app, runDockerCommand }) {
+		// Best-effort teardown - don't fail the suite if cleanup hiccups.
+		try {
+			await runDockerCommand(
+				`docker exec test sudo rm -f ${ENFORCED_SETTINGS_PATH} ${TEST_FILE_PATH}`,
+				'Remove enforced settings file and test R file'
+			);
+			// Restore original profiles file if we backed one up, otherwise remove ours.
+			await runDockerCommand(
+				`docker exec test bash -lc 'if [ -f ${PROFILES_BACKUP_PATH} ]; then sudo mv ${PROFILES_BACKUP_PATH} ${PROFILES_PATH}; else sudo rm -f ${PROFILES_PATH}; fi'`,
+				'Restore original profiles file'
+			);
+			await runDockerCommand(
+				`docker exec test sudo rstudio-server restart`,
+				'Restart rstudio-server to drop enforced settings'
+			);
+
+			// Reconnect so the worker-scoped teardown (which calls quitSession) has a live session.
+			await app.positWorkbench.dashboard.goTo();
+			try {
+				await app.positWorkbench.dashboard.expectHeaderToBeVisible();
+			} catch {
+				await app.positWorkbench.auth.signIn();
+				await app.positWorkbench.dashboard.expectHeaderToBeVisible();
+			}
+			await app.positWorkbench.dashboard.openSession('qa-example-content');
+			await app.code.driver.page.waitForSelector('.monaco-workbench', { timeout: 60000 });
+		} catch (error) {
+			console.warn('Enforced-settings teardown hit an error (continuing):', error);
+		}
+	});
+
+	test('Verify [r]-scoped editor.formatOnSave triggers Air formatter', async function ({ app, runDockerCommand, hotKeys, page }) {
+
+		await test.step('Write messy R file into the workspace', async () => {
+			const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'messy-r-'));
+			const tmpFile = path.join(tmpDir, TEST_FILE_NAME);
+			await fs.promises.writeFile(tmpFile, MESSY_R_CONTENT);
+			try {
+				await runDockerCommand(
+					`docker cp ${tmpFile} test:${TEST_FILE_PATH}`,
+					'Copy messy R file into container'
+				);
+				await runDockerCommand(
+					`docker exec test chown user1:user1g ${TEST_FILE_PATH}`,
+					'Chown messy R file'
+				);
+			} finally {
+				await fs.promises.rm(tmpDir, { recursive: true, force: true });
+			}
+		});
+
+		await test.step('Open the R file in Positron', async () => {
+			await app.workbench.quickaccess.openFile(TEST_FILE_PATH);
+			await expect(page.getByRole('tab', { name: TEST_FILE_NAME })).toBeVisible();
+		});
+
+		await test.step('Save the file to trigger formatOnSave', async () => {
+			// Click the editor to ensure focus, then trigger save.
+			await app.workbench.editor.editorPane.click();
+			await hotKeys.save();
+			// Give the formatter a moment to run and the save to complete.
+			await page.waitForTimeout(2000);
+		});
+
+		await test.step('Verify the file on disk was reformatted by Air', async () => {
+			await expect(async () => {
+				const { stdout } = await runDockerCommand(
+					`docker exec test cat ${TEST_FILE_PATH}`,
+					'Read saved R file'
+				);
+				const saved = stdout;
+
+				// The messy content should no longer be present verbatim - Air normalizes
+				// spacing around `<-` and inside parentheses.
+				expect(saved, 'file content should differ from the messy input after formatOnSave').not.toBe(
+					MESSY_R_CONTENT
+				);
+				expect(saved, 'formatter should normalize `x<-1` to `x <- 1`').toContain('x <- 1');
+				expect(saved, 'formatter should normalize `y  <-   2` to `y <- 2`').toContain('y <- 2');
+			}).toPass({ timeout: 15000, intervals: [500, 1000, 2000] });
+		});
+	});
+});

--- a/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
+++ b/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
@@ -76,7 +76,7 @@ test.describe('Workbench: Language-scoped enforced settings', {
 
 			// Copy enforced-settings.json into a user-writable location, then sudo-move it to /etc/rstudio.
 			await runDockerCommand(
-				`docker cp ${tmpSettings} test:/tmp/enforced-settings.json`,
+				`docker cp "${tmpSettings}" test:/tmp/enforced-settings.json`,
 				'Copy enforced-settings.json into container'
 			);
 			await runDockerCommand(
@@ -85,7 +85,7 @@ test.describe('Workbench: Language-scoped enforced settings', {
 			);
 
 			await runDockerCommand(
-				`docker cp ${tmpProfiles} test:/tmp/profiles`,
+				`docker cp "${tmpProfiles}" test:/tmp/profiles`,
 				'Copy profiles into container'
 			);
 			await runDockerCommand(
@@ -128,35 +128,39 @@ test.describe('Workbench: Language-scoped enforced settings', {
 	});
 
 	test.afterAll('Remove enforced settings and restart session', async function ({ app, runDockerCommand }) {
-		// Best-effort teardown - don't fail the suite if cleanup hiccups.
+		// Non-critical cleanup: removing temp files. Swallow errors here since a leftover
+		// file in /etc/rstudio or the workspace won't affect other tests once the profile
+		// is restored and the server is restarted.
 		try {
 			await runDockerCommand(
 				`docker exec test sudo rm -f ${ENFORCED_SETTINGS_PATH} ${TEST_FILE_PATH}`,
 				'Remove enforced settings file and test R file'
 			);
-			// Restore original profiles file if we backed one up, otherwise remove ours.
-			await runDockerCommand(
-				`docker exec test bash -lc 'if [ -f ${PROFILES_BACKUP_PATH} ]; then sudo mv ${PROFILES_BACKUP_PATH} ${PROFILES_PATH}; else sudo rm -f ${PROFILES_PATH}; fi'`,
-				'Restore original profiles file'
-			);
-			await runDockerCommand(
-				`docker exec test sudo rstudio-server restart`,
-				'Restart rstudio-server to drop enforced settings'
-			);
-
-			// Reconnect so the worker-scoped teardown (which calls quitSession) has a live session.
-			await app.positWorkbench.dashboard.goTo();
-			try {
-				await app.positWorkbench.dashboard.expectHeaderToBeVisible();
-			} catch {
-				await app.positWorkbench.auth.signIn();
-				await app.positWorkbench.dashboard.expectHeaderToBeVisible();
-			}
-			await app.positWorkbench.dashboard.openSession('qa-example-content');
-			await app.code.driver.page.waitForSelector('.monaco-workbench', { timeout: 60000 });
 		} catch (error) {
-			console.warn('Enforced-settings teardown hit an error (continuing):', error);
+			console.warn('Non-critical teardown cleanup failed (continuing):', error);
 		}
+
+		// Critical cleanup: any failure here leaves the container with enforced settings
+		// active, which will contaminate subsequent test runs. Let these throw.
+		await runDockerCommand(
+			`docker exec test bash -lc 'if [ -f ${PROFILES_BACKUP_PATH} ]; then sudo mv ${PROFILES_BACKUP_PATH} ${PROFILES_PATH}; else sudo rm -f ${PROFILES_PATH}; fi'`,
+			'Restore original profiles file'
+		);
+		await runDockerCommand(
+			`docker exec test sudo rstudio-server restart`,
+			'Restart rstudio-server to drop enforced settings'
+		);
+
+		// Reconnect so the worker-scoped teardown (which calls quitSession) has a live session.
+		await app.positWorkbench.dashboard.goTo();
+		try {
+			await app.positWorkbench.dashboard.expectHeaderToBeVisible();
+		} catch {
+			await app.positWorkbench.auth.signIn();
+			await app.positWorkbench.dashboard.expectHeaderToBeVisible();
+		}
+		await app.positWorkbench.dashboard.openSession('qa-example-content');
+		await app.code.driver.page.waitForSelector('.monaco-workbench', { timeout: 60000 });
 	});
 
 	test('Verify [r]-scoped editor.formatOnSave triggers Air formatter', async function ({ app, runDockerCommand, hotKeys, page }) {
@@ -167,7 +171,7 @@ test.describe('Workbench: Language-scoped enforced settings', {
 			await fs.promises.writeFile(tmpFile, MESSY_R_CONTENT);
 			try {
 				await runDockerCommand(
-					`docker cp ${tmpFile} test:${TEST_FILE_PATH}`,
+					`docker cp "${tmpFile}" test:${TEST_FILE_PATH}`,
 					'Copy messy R file into container'
 				);
 				await runDockerCommand(

--- a/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
+++ b/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
@@ -156,6 +156,13 @@ test.describe('Workbench: Language-scoped enforced settings', {
 
 	test('Verify [r]-scoped editor.formatOnSave triggers Air formatter', async function ({ app, runDockerCommand, hotKeys, page }) {
 
+		await test.step('Wait for Air bootstrap extension to be installed', async () => {
+			// Air is a bootstrap extension that is downloaded lazily after container startup
+			// (not bundled in positron-workbench-linux-x64-branch.tar.gz). Without this, the
+			// formatter lookup on save silently no-ops.
+			await waitForAirExtensionInstalled(runDockerCommand);
+		});
+
 		await test.step('Write messy R file into the workspace', async () => {
 			const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'messy-r-'));
 			const tmpFile = path.join(tmpDir, TEST_FILE_NAME);
@@ -182,6 +189,9 @@ test.describe('Workbench: Language-scoped enforced settings', {
 		await test.step('Save the file to trigger formatOnSave', async () => {
 			// Click the editor to ensure focus, then trigger save.
 			await app.workbench.editor.editorPane.click();
+			// Opening the R file triggers onLanguage:r activation for Air. Give the Air
+			// language server enough time to start and register its formatter before saving.
+			await page.waitForTimeout(5000);
 			await hotKeys.save();
 			// Give the formatter a moment to run and the save to complete.
 			await page.waitForTimeout(2000);
@@ -238,6 +248,36 @@ async function waitForRStudioServerReady(runDockerCommand: RunDockerCommand, tim
 /**
  * Navigate to the dashboard, signing in if the session was invalidated by a server restart.
  */
+/**
+ * Poll the container's user-extensions directory until the Air bootstrap extension shows up.
+ * Air is downloaded lazily from the marketplace after container startup and is required for
+ * the `posit.air-vscode` formatter to exist.
+ */
+async function waitForAirExtensionInstalled(runDockerCommand: RunDockerCommand, timeoutMs = 120000): Promise<void> {
+	const extensionsDir = '/home/user1/.positron-server/extensions';
+	const deadline = Date.now() + timeoutMs;
+	let lastListing = '';
+	while (Date.now() < deadline) {
+		try {
+			const { stdout } = await runDockerCommand(
+				`docker exec test bash -lc 'ls -1 ${extensionsDir} 2>/dev/null || true'`,
+				'List installed extensions'
+			);
+			lastListing = stdout;
+			if (/(^|\n)\s*posit\.air-vscode[^\n]*/i.test(stdout)) {
+				return;
+			}
+		} catch {
+			// ignore and retry
+		}
+		await new Promise(resolve => setTimeout(resolve, 2000));
+	}
+	throw new Error(
+		`Air extension (posit.air-vscode) was not installed in ${extensionsDir} within ${timeoutMs}ms.\n` +
+		`Last directory listing:\n${lastListing}`
+	);
+}
+
 async function reconnectDashboard(app: Application): Promise<void> {
 	await app.positWorkbench.dashboard.goTo();
 	try {

--- a/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
+++ b/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
@@ -147,11 +147,13 @@ test.describe('Workbench: Language-scoped enforced settings', {
 			'Restart rstudio-server to drop enforced settings'
 		);
 
-		// Reconnect so the worker-scoped teardown (which calls quitSession) has a live session.
+		// Wait for the server to accept connections again. The worker-scoped teardown
+		// (WorkbenchApp.stop) will then navigate to the dashboard and attempt to quit the
+		// session itself. Its goTo + quitSession are already wrapped in try/catch and just
+		// warn on failure, so we don't need to reopen a session here - doing so would
+		// introduce a UI state (project shown as button after a server restart killed the
+		// session) that openSession's locator chain doesn't handle.
 		await waitForRStudioServerReady(runDockerCommand);
-		await reconnectDashboard(app);
-		await app.positWorkbench.dashboard.openSession('qa-example-content');
-		await app.code.driver.page.waitForSelector('.monaco-workbench', { timeout: 60000 });
 	});
 
 	test('Verify [r]-scoped editor.formatOnSave triggers Air formatter', async function ({ app, runDockerCommand, hotKeys, page }) {

--- a/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
+++ b/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
@@ -246,9 +246,6 @@ async function waitForRStudioServerReady(runDockerCommand: RunDockerCommand, tim
 }
 
 /**
- * Navigate to the dashboard, signing in if the session was invalidated by a server restart.
- */
-/**
  * Poll the container's user-extensions directory until the Air bootstrap extension shows up.
  * Air is downloaded lazily from the marketplace after container startup and is required for
  * the `posit.air-vscode` formatter to exist.
@@ -278,6 +275,9 @@ async function waitForAirExtensionInstalled(runDockerCommand: RunDockerCommand, 
 	);
 }
 
+/**
+ * Navigate to the dashboard, signing in if the session was invalidated by a server restart.
+ */
 async function reconnectDashboard(app: Application): Promise<void> {
 	await app.positWorkbench.dashboard.goTo();
 	try {

--- a/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
+++ b/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
@@ -42,7 +42,7 @@ const MESSY_R_CONTENT = [
 const ENFORCED_SETTINGS_JSON = JSON.stringify({
 	'[r]': {
 		'editor.formatOnSave': true,
-		'editor.defaultFormatter': 'posit.air-vscode',
+		'editor.defaultFormatter': 'Posit.air-vscode',
 	},
 }, null, 2);
 

--- a/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
+++ b/test/e2e/tests/workbench/enforced-settings/enforced-settings-language-scoped.test.ts
@@ -18,6 +18,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { test, tags, expect } from '../../_test.setup';
+import { Application } from '../../../infra/application.js';
 
 test.use({
 	suiteId: __filename
@@ -103,15 +104,10 @@ test.describe('Workbench: Language-scoped enforced settings', {
 			'Restart rstudio-server'
 		);
 
-		// Reconnect: the current Positron session is dead after the server restart.
-		await app.positWorkbench.dashboard.goTo();
-		try {
-			await app.positWorkbench.dashboard.expectHeaderToBeVisible();
-		} catch {
-			// Need to re-authenticate.
-			await app.positWorkbench.auth.signIn();
-			await app.positWorkbench.dashboard.expectHeaderToBeVisible();
-		}
+		// `rstudio-server restart` returns before the server is accepting connections again;
+		// poll until the dashboard responds, then reconnect.
+		await waitForRStudioServerReady(runDockerCommand);
+		await reconnectDashboard(app);
 
 		// Quit any leftover session (from before the restart) and open a fresh one,
 		// so the new Positron process inherits POSITRON_ENFORCED_SETTINGS.
@@ -152,13 +148,8 @@ test.describe('Workbench: Language-scoped enforced settings', {
 		);
 
 		// Reconnect so the worker-scoped teardown (which calls quitSession) has a live session.
-		await app.positWorkbench.dashboard.goTo();
-		try {
-			await app.positWorkbench.dashboard.expectHeaderToBeVisible();
-		} catch {
-			await app.positWorkbench.auth.signIn();
-			await app.positWorkbench.dashboard.expectHeaderToBeVisible();
-		}
+		await waitForRStudioServerReady(runDockerCommand);
+		await reconnectDashboard(app);
 		await app.positWorkbench.dashboard.openSession('qa-example-content');
 		await app.code.driver.page.waitForSelector('.monaco-workbench', { timeout: 60000 });
 	});
@@ -215,3 +206,44 @@ test.describe('Workbench: Language-scoped enforced settings', {
 		});
 	});
 });
+
+type RunDockerCommand = (command: string, description: string) => Promise<{ stdout: string; stderr: string }>;
+
+/**
+ * Poll rstudio-server inside the container until it returns a 2xx/3xx for the login page.
+ * `rstudio-server restart` returns before the listener is back, so navigating immediately
+ * yields ERR_CONNECTION_RESET.
+ */
+async function waitForRStudioServerReady(runDockerCommand: RunDockerCommand, timeoutMs = 60000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	let lastError: unknown;
+	while (Date.now() < deadline) {
+		try {
+			const { stdout } = await runDockerCommand(
+				`docker exec test bash -lc 'curl -s -o /dev/null -w "%{http_code}" http://localhost:8787/auth-sign-in || true'`,
+				'Probe rstudio-server readiness'
+			);
+			const code = parseInt(stdout.trim(), 10);
+			if (code >= 200 && code < 400) {
+				return;
+			}
+		} catch (error) {
+			lastError = error;
+		}
+		await new Promise(resolve => setTimeout(resolve, 1000));
+	}
+	throw new Error(`rstudio-server did not become ready within ${timeoutMs}ms${lastError ? `: ${lastError}` : ''}`);
+}
+
+/**
+ * Navigate to the dashboard, signing in if the session was invalidated by a server restart.
+ */
+async function reconnectDashboard(app: Application): Promise<void> {
+	await app.positWorkbench.dashboard.goTo();
+	try {
+		await app.positWorkbench.dashboard.expectHeaderToBeVisible();
+	} catch {
+		await app.positWorkbench.auth.signIn();
+		await app.positWorkbench.dashboard.expectHeaderToBeVisible();
+	}
+}


### PR DESCRIPTION
Adds an e2e regression test for [posit-dev/positron#12380](https://github.com/posit-dev/positron/issues/12380) — language-scoped keys (e.g. `[r]`) in `POSITRON_ENFORCED_SETTINGS` were silently dropped during configuration resolution. Upstream fix in [rstudio/vscode-server#343](https://github.com/rstudio/vscode-server/pull/343), merged into Positron in [#13084](https://github.com/posit-dev/positron/pull/13084).

### How the test sets up enforced settings

In `beforeAll`:

1. Writes `/etc/rstudio/enforced-settings.json` with a top-level `editor.formatOnSave: false` plus a `[r]` override enabling formatOnSave + Air.
2. Installs `/etc/rstudio/profiles` pointing `[*]` at the JSON (backs up any existing profiles).
3. Runs `sudo rstudio-server restart`, polls the server until it's accepting connections again, reconnects, and opens a fresh Positron session so it inherits the new `POSITRON_ENFORCED_SETTINGS` env var.
4. Polls `/home/user1/.positron-server/extensions` for the `posit.air-vscode` bootstrap extension (downloaded lazily at runtime, not bundled).

`afterAll` restores the original profiles file, restarts `rstudio-server`, and restores any backed-up user settings.json. Critical restore/restart steps throw on failure; temp-file removal is best-effort.

### Tests

One enforced config exercises three cases:

| Test | What it proves |
|---|---|
| `[r]` scope: messy .R file is reformatted by Air on save | The `[r]`-scoped enforced setting applies (the original regression). |
| `[r]` does not leak globally: messy .py file is NOT reformatted | Top-level `formatOnSave: false` is honored for non-R files; the `[r]` override is properly scoped. |
| Enforced setting wins over conflicting user setting | With `[r]: { formatOnSave: false }` in the user's settings.json, the enforced `true` still wins. |

Note.. I'm not the biggest fan of the 2 waits, but without them the test was pretty flaky.  I can revisit later if needed.

### QA Notes

Tags: `@:workbench`