### PR TITLE
fix: gracefully handle no-update case in checkForDevBuildUpdate

### DIFF
--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -418,8 +418,19 @@ export class PositAssistant {
 
 		const toasts = new Toasts(this.code);
 
-		// 3. Wait for the "newer dev build available" toast and click "Update Now".
-		await toasts.waitForAppear(/newer Posit Assistant dev build is available/i, { timeout: toastTimeout });
+		// 3. Wait for the "newer dev build available" toast. If it doesn't appear
+		//    (already up to date or update server unreachable), treat as a no-op.
+		let updateAvailable = true;
+		try {
+			await toasts.waitForAppear(/newer Posit Assistant dev build is available/i, { timeout: toastTimeout });
+		} catch {
+			updateAvailable = false;
+		}
+
+		if (!updateAvailable) {
+			return;
+		}
+
 		await toasts.clickButton('Update Now');
 
 		// 4. Wait for the follow-up "reload to apply changes" toast and click "Reload".


### PR DESCRIPTION
Fixes a flake in posit-assistant tests when no new dev build of the extension is available.

## What changed

`checkForDevBuildUpdate` in `test/e2e/pages/positAssistant.ts` previously unconditionally awaited a "newer Posit Assistant dev build is available" toast after running the `posit-assistant.checkForDevBuildUpdate` command. When the extension is already up to date or the update server is unreachable, no toast appears and the method would time out — causing the entire `beforeAll` in `posit-assistant.test.ts` to fail and marking all Posit Assistant tests as hard failures.

## Fix

Wrapped the first `waitForAppear` call in a try/catch. If the toast doesn't appear within the timeout, the method now returns early (no-op) instead of throwing. The "Update Now" click and the follow-up reload toast are only attempted when an update toast actually appeared.

## QA Notes
@:posit-assistant