### PR TITLE
Fail build when a bootstrap extension download isn't a VSIX

### DIFF
--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -338,7 +338,8 @@ export function fromMarketplace(serviceUrl: string, { name: extensionName, versi
 				return fetchUrls('', {
 					base: url,
 					nodeFetchOptions: { headers: baseHeaders },
-					checksumSha256: sha256
+					checksumSha256: sha256,
+					expectZip: true
 				})
 					.pipe(buffer())
 					.pipe(rename(p => {
@@ -352,7 +353,8 @@ export function fromMarketplace(serviceUrl: string, { name: extensionName, versi
 				nodeFetchOptions: {
 					headers: baseHeaders
 				},
-				checksumSha256: sha256
+				checksumSha256: sha256,
+				expectZip: true
 			})
 				.pipe(buffer());
 		}

--- a/build/lib/fetch.ts
+++ b/build/lib/fetch.ts
@@ -22,6 +22,7 @@ export interface IFetchOptions {
 	checksumSha256?: string;
 	// --- Start Positron ---
 	timeoutSeconds?: number;
+	expectZip?: boolean;
 	// --- End Positron ---
 }
 
@@ -75,6 +76,27 @@ export async function fetchUrl(url: string, options: IFetchOptions, retries = 10
 			}
 			if (response.ok && (response.status >= 200 && response.status < 300)) {
 				const contents = Buffer.from(await response.arrayBuffer());
+				// --- Start Positron ---
+				// When a caller expects a ZIP archive (e.g. a VSIX download), check
+				// the first four bytes against the ZIP local-file-header magic
+				// (PK\x03\x04). This catches cases where the origin returns a 200
+				// with an HTML error body, which would otherwise be silently saved
+				// as the extension file.
+				// See https://github.com/posit-dev/positron-builds/issues/824
+				if (options.expectZip) {
+					const isZip = contents.length >= 4 &&
+						contents[0] === 0x50 && contents[1] === 0x4B &&
+						contents[2] === 0x03 && contents[3] === 0x04;
+					if (!isZip) {
+						const preview = contents.subarray(0, 64).toString('utf8').replace(/\s+/g, ' ').trim();
+						throw new Error(
+							`Response from ${ansiColors.cyan(url)} is not a ZIP archive ` +
+							`(${contents.length} bytes, starts with: ${JSON.stringify(preview)}). ` +
+							`The server may have returned an error page with a 200 status.`
+						);
+					}
+				}
+				// --- End Positron ---
 				if (options.checksumSha256) {
 					const actualSHA256Checksum = crypto.createHash('sha256').update(contents).digest('hex');
 					if (actualSHA256Checksum !== options.checksumSha256) {


### PR DESCRIPTION
Addresses posit-dev/positron-builds#824

This PR catches the case where OpenVSX (or any other source, for example P3M) returns a 200 response with an HTML error body instead of a VSIX file. We hit this for months on Windows arm64; a `posit.publisher` "VSIX" was actually an OpenVSX rate-limit error page, shipped without failing any build checks.

To keep this from happening again, this PR adds an `expectZip` option to `IFetchOptions` that validates the first four bytes of the response against the ZIP local-file-header magic (`PK\x03\x04`). When set, a mismatched body throws with a short preview of what the server actually sent. This is now enabled on both bootstrap callsites in `fromMarketplace` (single-platform and multi-platform).

When I dug into this, I realized that we can't rely on per-file checksums for multi-platform extensions such as `posit.publisher` (one hash can't match N per-arch binaries), so a content-sniff catches HTML error pages regardless of checksum coverage. It's probably still worth really checking the checksums that we _do_ have access to.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fail the bootstrap build when an extension download is not a valid VSIX, preventing HTML error pages from shipping as extensions (posit-dev/positron-builds#824)

### QA Notes

@:extensions

**Normal path:** A full build downloads all real bootstrap extensions and completes successfully.

**Failure path:** To verify the new error fires, temporarily add an env-var-gated override inside the `expectZip` block in `build/lib/fetch.ts`, right before the magic-bytes check:

```typescript
// Change `const contents` to `let contents` above, then:
if (options.expectZip) {
    if (process.env.POSITRON_FAKE_BAD_VSIX) {
        contents = Buffer.from('<!DOCTYPE html><html><body>rate limit error</body></html>');
    }
    const isZip = contents.length >= 4 && ...
}
```

Then run a local release build with `CI=1 POSITRON_FAKE_BAD_VSIX=1 npm run gulp vscode`. Each bootstrap download will be swapped for HTML bytes and fail the check with an error like:

```
[12:16:08] Fetching https://open-vsx.org/api/charliermarsh/ruff/darwin-x64/2026.38.0/file/charliermarsh.ruff-2026.38.0@darwin-x64.vsix failed: Error: Response from https://open-vsx.org/api/charliermarsh/ruff/darwin-x64/2026.38.0/file/charliermarsh.ruff-2026.38.0@darwin-x64.vsix is not a ZIP archive (57 bytes, starts with: "<!DOCTYPE html><html><body>rate limit error</body></html>"). The server may have returned an error page with a 200 status.
[12:16:08] [Fetch queue] failed fetching https://open-vsx.org/api/charliermarsh/ruff/darwin-x64/2026.38.0/file/charliermarsh.ruff-2026.38.0@darwin-x64.vsix (9 remaining): Error: Response from https://open-vsx.org/api/charliermarsh/ruff/darwin-x64/2026.38.0/file/charliermarsh.ruff-2026.38.0@darwin-x64.vsix is not a ZIP archive (57 bytes, starts with: "<!DOCTYPE html><html><body>rate limit error</body></html>"). The server may have returned an error page with a 200 status.
[12:16:08] 'vscode' errored after 2.15 min
[12:16:08] Error: Response from https://open-vsx.org/api/charliermarsh/ruff/darwin-x64/2026.38.0/file/charliermarsh.ruff-2026.38.0@darwin-x64.vsix is not a ZIP archive (57 bytes, starts with: "<!DOCTYPE html><html><body>rate limit error</body></html>"). The server may have returned an error page with a 200 status.
    at fetchUrl (file:///Users/juliasilge/Work/posit/positron/build/lib/fetch.ts:96:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
FAIL
```

If you don't prefix with `CI=1` there are some silent retries FYI. 

> [!IMPORTANT]  
> Be sure to revert the two-line override once verified.
