### PR TITLE
Enforce bootstrap extension checksums at build time

### DIFF
--- a/product.json
+++ b/product.json
@@ -121,7 +121,7 @@
 		{
 			"name": "ms-toolsai.vscode-jupyter-cell-tags",
 			"version": "0.1.9",
-			"sha256sum": "7cd43af55cf562a001dc475e92d9f3fd4b7173011adca0c02da22fbf891c274b",
+			"sha256": "7cd43af55cf562a001dc475e92d9f3fd4b7173011adca0c02da22fbf891c274b",
 			"repo": "https://github.com/Microsoft/vscode-jupyter-cell-tags",
 			"metadata": {
 				"id": "ab4fb32a-befb-4102-adf9-1652d0cd6a5e",
@@ -137,7 +137,7 @@
 		{
 			"name": "ms-toolsai.jupyter-keymap",
 			"version": "1.1.2",
-			"sha256sum": "3d2998929bb43156f3b428116aee290543c437875df616ec755692219b4afa17",
+			"sha256": "3d2998929bb43156f3b428116aee290543c437875df616ec755692219b4afa17",
 			"repo": "https://github.com/Microsoft/vscode-jupyter-keymap",
 			"metadata": {
 				"id": "9f6dc8db-620c-4844-b8c5-e74914f1be27",
@@ -153,7 +153,7 @@
 		{
 			"name": "ms-toolsai.vscode-jupyter-slideshow",
 			"version": "0.1.6",
-			"sha256sum": "5b8dee0d569b7e0990bb4847c34748cdc0102078779351ed415d9d71cfa3e945",
+			"sha256": "5b8dee0d569b7e0990bb4847c34748cdc0102078779351ed415d9d71cfa3e945",
 			"repo": "https://github.com/Microsoft/vscode-jupyter-slideshow",
 			"metadata": {
 				"id": "e153ca70-b543-4865-b4c5-b31d34185948",
@@ -169,7 +169,7 @@
 		{
 			"name": "ms-toolsai.jupyter-renderers",
 			"version": "1.3.0",
-			"sha256sum": "d09f6c517a8090a932bb4e2c31bcb2de34ddb2a71133477f6c47f28f36eb76ae",
+			"sha256": "d09f6c517a8090a932bb4e2c31bcb2de34ddb2a71133477f6c47f28f36eb76ae",
 			"repo": "https://github.com/Microsoft/vscode-notebook-renderers",
 			"metadata": {
 				"id": "b15c72f8-d5fe-421a-a4f7-27ed9f6addbf",
@@ -185,7 +185,7 @@
 		{
 			"name": "ms-toolsai.jupyter",
 			"version": "2025.9.1",
-			"sha256sum": "110660656944c4ab0ff687db488c2e8c59c67ec121dcf09bcaa54b6edd9ce71f",
+			"sha256": "110660656944c4ab0ff687db488c2e8c59c67ec121dcf09bcaa54b6edd9ce71f",
 			"repo": "https://github.com/Microsoft/vscode-jupyter",
 			"metadata": {
 				"id": "6c2f1801-1e7f-45b2-9b5c-7782f1e076e8",
@@ -201,7 +201,6 @@
 		{
 			"name": "meta.pyrefly",
 			"version": "0.61.0",
-			"sha256sum": "ff5d2ce2fbf5e7bf59be94467f5c1bdbd354b5204f4ee4a8f9087951a18cc3b6",
 			"repo": "https://github.com/facebook/pyrefly",
 			"metadata": {
 				"publisherId": {
@@ -244,7 +243,7 @@
 		{
 			"name": "quarto.quarto",
 			"version": "1.131.0",
-			"sha256sum": "1fcae21883e96367a6e65a76d84cf8900138c4536774f9a5387f711538389a0c",
+			"sha256": "1fcae21883e96367a6e65a76d84cf8900138c4536774f9a5387f711538389a0c",
 			"repo": "https://github.com/quarto-dev/quarto/tree/main/apps/vscode",
 			"metadata": {
 				"id": "a1be81fc-0f3a-4f2e-92ee-3fdc7ab96c73",
@@ -271,7 +270,7 @@
 		{
 			"name": "posit.shiny",
 			"version": "1.4.0",
-			"sha256sum": "7a71a88360559de5de2da20fd9e508d64c305cb0c2477f8503b8dde77c4f1e05",
+			"sha256": "7a71a88360559de5de2da20fd9e508d64c305cb0c2477f8503b8dde77c4f1e05",
 			"repo": "https://github.com/posit-dev/shiny-vscode",
 			"metadata": {
 				"id": "7ffa9a66-85ab-44de-ab80-2eecce45b0fe",

--- a/scripts/update-extensions.sh
+++ b/scripts/update-extensions.sh
@@ -211,9 +211,6 @@ update_product_json() {
 			if echo "$extension_info" | jq -e 'has("sha256")' >/dev/null 2>&1; then
 				current_sha256=$(echo "$extension_info" | jq -r '.sha256 // empty')
 				has_sha256=true
-			elif echo "$extension_info" | jq -e 'has("sha256sum")' >/dev/null 2>&1; then
-				current_sha256=$(echo "$extension_info" | jq -r '.sha256sum // empty')
-				has_sha256=true
 			fi
 		else
 			echo -e "${RED}Error: Extension $extension_id not found in product.json${NC}" >&2
@@ -289,7 +286,7 @@ should_download() {
 	fi
 
 	local current_version=$(echo "$extension_info" | jq -r '.version // empty')
-	local has_sha256=$(echo "$extension_info" | jq -e 'has("sha256") or has("sha256sum")')
+	local has_sha256=$(echo "$extension_info" | jq -e 'has("sha256")')
 
 	# Decision logic:
 	# 1. If versions don't match → need to download
@@ -375,7 +372,6 @@ update_with_jq() {
 					if (.publisher == $pub and .name == $nm) or .name == $id then
 						.version = $ver |
 						if has("sha256") then .sha256 = $hash
-						elif has("sha256sum") then .sha256sum = $hash
 						else . end
 					else
 						with_entries(.value |= update_extension)


### PR DESCRIPTION
Related to posit-dev/positron-builds#824

The bootstrap extension code path used the field name `sha256` (matching upstream VSCode's `builtInExtensions` convention and our `IExtensionDefinition` interface at `build/lib/builtInExtensions.ts:21`), but most entries in `product.json` had drifted to `sha256sum` at some point, probably in #6919 ("add missing shas to packaged extensions"). The `fromMarketplace` destructuring in `build/lib/extensions.ts:305` silently got `undefined`, and `fetchUrl` logged "Skipping checksum verification" for every affected extension. As a result, 10 of 14 bootstrap extensions looked like they were protected by checksums, but weren't.

### What I'm proposing in this PR

- **`product.json`**: rename `sha256sum` → `sha256` on 7 extensions (the `ms-toolsai.*` family, `quarto.quarto`, `posit.shiny`).
- **`product.json`**: remove the stale `sha256sum` from `meta.pyrefly`. It has `multiPlatformServiceUrl`, so a single hash can only ever match one of its N per-arch binaries. The hash "worked" only because the field-name bug silently ignored it; after the rename the build would have started failing on whichever platform's binary didn't match.
- **`scripts/update-extensions.sh`**: remove the three `sha256sum` branches so future updates only read/write `sha256`.

The 4 multi-platform extensions (`charliermarsh.ruff`, `ms-python.debugpy`, `posit.publisher`, `posit.air-vscode`) still have no hash; that's a separate problem that needs a per-platform hash schema. The magic-bytes check in https://github.com/posit-dev/positron/pull/13095 at least covers those at build time via content-sniffing.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Re-enable SHA256 verification for bootstrap extensions, which had silently been skipped due to a field-name mismatch in `product.json` (posit-dev/positron-builds#824)

### QA Notes

@:extensions

**Happy path:** A fresh local build succeeds with the renamed hashes. Before building, clear the cache so verification actually runs against newly-downloaded bytes:

```
rm -rf .build/bootstrapExtensions
```

Then run your normal build. If you add `CI=1` to the build command, `fetch.ts` flips to verbose mode and you'll see per-extension log lines:

```
Verified SHA256 checksums match for https://open-vsx.org/api/ms-toolsai/jupyter/...
Skipping checksum verification for https://open-vsx.org/api/charliermarsh/ruff/... because no expected checksum was provided
```

Expect "Verified" for the 10 extensions with hashes, and "Skipping" for the 4 multi-platform ones without.

**Proving we are actually checking:** To confirm the check actually fails a bad hash (not just runs silently), flip the last character of any hash in `product.json`, clear the cache, and rebuild:

```
# Edit product.json - change the final char of any sha256 value, e.g.
# "sha256": "...ce71f" → "...ce71e"
rm -rf .build/bootstrapExtensions
# Run the build
```

The build should fail fairly fast with:

```
Checksum mismatch for https://open-vsx.org/api/... (expected ...ce71e, actual ...ce71f)
```

Revert the character, rebuild, and the green path should pass. This is the strongest evidence that the verification is live. I ran exactly this procedure locally and saw both sides.
