### PR TITLE
e2e: capture metrics for positron notebooks

### DIFF
--- a/test/e2e/fixtures/test-setup/metrics.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/metrics.fixtures.ts
@@ -4,7 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { recordDataFileLoad, recordDataFilter, recordDataSort, recordToCode, type DataExplorerAutoContext, type DataExplorerShortcutOptions } from '../../utils/metrics/metric-data-explorer.js';
-import { recordRunCell, type NotebookShortcutOptions } from '../../utils/metrics/metric-notebooks.js';
+import {
+	recordRunCell,
+	recordRenderOnOpen,
+	recordRenderOnNavBack,
+	type NotebookShortcutOptions,
+	type NotebookRenderOptions,
+} from '../../utils/metrics/metric-notebooks.js';
 import { recordAssistantEval, type AssistantEvalInput } from '../../utils/metrics/metric-assistant.js';
 import { type RecordMetric, type MetricResult, type MetricContext, type MetricTargetType } from '../../utils/metrics/metric-base.js';
 import { Application, MultiLogger } from '../../infra/index.js';
@@ -66,7 +72,21 @@ export function MetricsFixture(app: Application, logger: MultiLogger): RecordMet
 					additionalContext: context
 				};
 				return recordRunCell(operation, targetType, !app.web, logger, language, options);
-			}
+			},
+			renderOnOpen: async <T>(
+				operation: () => Promise<T>,
+				targetType: MetricTargetType,
+				options?: NotebookRenderOptions
+			): Promise<MetricResult<T>> => {
+				return recordRenderOnOpen(operation, targetType, !app.web, logger, options);
+			},
+			renderOnNavBack: async <T>(
+				operation: () => Promise<T>,
+				targetType: MetricTargetType,
+				options?: NotebookRenderOptions
+			): Promise<MetricResult<T>> => {
+				return recordRenderOnNavBack(operation, targetType, !app.web, logger, options);
+			},
 		},
 		assistant: {
 			evalResponse: async (

--- a/test/e2e/fixtures/test-setup/metrics.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/metrics.fixtures.ts
@@ -9,7 +9,6 @@ import {
 	recordRenderOnOpen,
 	recordRenderOnNavBack,
 	type NotebookShortcutOptions,
-	type NotebookRenderOptions,
 } from '../../utils/metrics/metric-notebooks.js';
 import { recordAssistantEval, type AssistantEvalInput } from '../../utils/metrics/metric-assistant.js';
 import { type RecordMetric, type MetricResult, type MetricContext, type MetricTargetType } from '../../utils/metrics/metric-base.js';
@@ -76,14 +75,14 @@ export function MetricsFixture(app: Application, logger: MultiLogger): RecordMet
 			renderOnOpen: async <T>(
 				operation: () => Promise<T>,
 				targetType: MetricTargetType,
-				options?: NotebookRenderOptions
+				options?: NotebookShortcutOptions
 			): Promise<MetricResult<T>> => {
 				return recordRenderOnOpen(operation, targetType, !app.web, logger, options);
 			},
 			renderOnNavBack: async <T>(
 				operation: () => Promise<T>,
 				targetType: MetricTargetType,
-				options?: NotebookRenderOptions
+				options?: NotebookShortcutOptions
 			): Promise<MetricResult<T>> => {
 				return recordRenderOnNavBack(operation, targetType, !app.web, logger, options);
 			},

--- a/test/e2e/tests/notebooks-positron/notebook-performance.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-performance.test.ts
@@ -22,8 +22,6 @@ test.describe('Positron Notebooks: Performance', {
 	test.beforeEach(async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		await notebooksPositron.openNotebook(NOTEBOOK_PATH);
-		await notebooksPositron.expectToBeVisible();
-		await expect(notebooksPositron.cell.first()).toBeVisible();
 	});
 
 	test('render_on_open: reopen notebook from disk', async function ({ app, hotKeys, metric }) {

--- a/test/e2e/tests/notebooks-positron/notebook-performance.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-performance.test.ts
@@ -24,45 +24,40 @@ test.describe('Positron Notebooks: Performance', {
 		await notebooksPositron.openNotebook(NOTEBOOK_PATH);
 	});
 
-	test('render_on_open: reopen notebook from disk', async function ({ app, hotKeys, metric }) {
+	test('render_on_open: reopen notebook from disk', async function ({ app, hotKeys, runCommand, metric }) {
 		const { notebooksPositron } = app.workbench;
 
-		// Close the notebook tab so we can measure the reopen from disk.
-		// Note: OS file cache is already warm from beforeEach, so this is
-		// not a true cold open -- it measures the editor open + parse + render
-		// path with a warm OS cache.
+		// Close the notebook tab so we can measure the reopen.
 		await hotKeys.closeAllEditors();
 
+		// Use "Reopen Closed Editor" to avoid the Quick Access picker UI
+		// (typing the filename, fuzzy-match, select) that openNotebook
+		// goes through -- that UI latency is noise unrelated to notebook
+		// render time. This restores the most recently closed editor,
+		// which is the notebook opened by beforeEach.
 		const { duration_ms } = await metric.notebooks.renderOnOpen(async () => {
-			await notebooksPositron.openNotebook(NOTEBOOK_PATH);
-			await notebooksPositron.expectToBeVisible();
+			await runCommand('workbench.action.reopenClosedEditor');
 			await expect(notebooksPositron.cell.first()).toBeVisible();
 		}, 'file.ipynb', {
 			description: `Reopen ${NOTEBOOK_FILE} in Positron notebook editor`,
 		});
 
-		// Pure telemetry for v1: log the duration, no hard assertion.
-		console.log(`[perf] render_on_open: ${duration_ms} ms`);
+		if (!process.env.CI) { console.log(`[perf] render_on_open: ${duration_ms} ms`); }
 	});
 
 	test('render_on_nav_back: switch back to notebook tab', async function ({ app, metric }) {
 		const { notebooksPositron, editors } = app.workbench;
 
-		// Background the notebook by opening a second tab (canonical source tab).
-		// Matches the pattern used by notebook-scroll-position.test.ts.
+		// Background the notebook by opening a second tab
 		await editors.newUntitledFile();
 
 		const { duration_ms } = await metric.notebooks.renderOnNavBack(async () => {
-			// Click the notebook tab directly. We can't use editors.selectTab()
-			// because it expects a Monaco editor to receive focus, but the
-			// Positron notebook is a custom editor.
-			await app.code.driver.page.getByRole('tab', { name: NOTEBOOK_FILE }).click();
-			await notebooksPositron.expectToBeVisible();
+			await editors.clickTab(NOTEBOOK_FILE);
 			await expect(notebooksPositron.cell.first()).toBeVisible();
 		}, 'file.ipynb', {
 			description: `Nav back to ${NOTEBOOK_FILE} from untitled file`,
 		});
 
-		console.log(`[perf] render_on_nav_back: ${duration_ms} ms`);
+		if (!process.env.CI) { console.log(`[perf] render_on_nav_back: ${duration_ms} ms`); }
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-performance.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-performance.test.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import path from 'path';
+import { tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+
+const NOTEBOOK_FILE = 'spotify.ipynb';
+const NOTEBOOK_PATH = path.join('workspaces', 'large_py_notebook', NOTEBOOK_FILE);
+const EXPECTED_CELL_COUNT = 32;
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Positron Notebooks: Performance', {
+	tag: [tags.WIN, tags.POSITRON_NOTEBOOKS, tags.PERFORMANCE]
+}, () => {
+
+	test.beforeEach(async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		await notebooksPositron.openNotebook(NOTEBOOK_PATH);
+		await notebooksPositron.expectToBeVisible();
+		await notebooksPositron.expectCellCountToBe(EXPECTED_CELL_COUNT);
+	});
+
+	test('render_on_open: reopen notebook from disk', async function ({ app, hotKeys, metric }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Close the notebook tab so we can measure the cold reopen.
+		await hotKeys.closeAllEditors();
+
+		const { duration_ms } = await metric.notebooks.renderOnOpen(async () => {
+			await notebooksPositron.openNotebook(NOTEBOOK_PATH);
+			await notebooksPositron.expectToBeVisible();
+			await notebooksPositron.expectCellCountToBe(EXPECTED_CELL_COUNT);
+		}, 'file.ipynb', {
+			cellCount: EXPECTED_CELL_COUNT,
+			description: `Reopen ${NOTEBOOK_FILE} in Positron notebook editor`,
+		});
+
+		// Pure telemetry for v1: log the duration, no hard assertion.
+		// eslint-disable-next-line no-console
+		console.log(`[perf] render_on_open: ${duration_ms} ms`);
+	});
+
+	test('render_on_nav_back: switch back to notebook tab', async function ({ app, metric }) {
+		const { notebooksPositron, editors } = app.workbench;
+
+		// Background the notebook by opening a second tab (canonical source tab).
+		// Matches the pattern used by notebook-scroll-position.test.ts.
+		await editors.newUntitledFile();
+
+		const { duration_ms } = await metric.notebooks.renderOnNavBack(async () => {
+			// Click the notebook tab directly. We can't use editors.selectTab()
+			// because it expects a Monaco editor to receive focus, but the
+			// Positron notebook is a custom editor.
+			await app.code.driver.page.getByRole('tab', { name: NOTEBOOK_FILE }).click();
+			await notebooksPositron.expectToBeVisible();
+			await notebooksPositron.expectCellCountToBe(EXPECTED_CELL_COUNT);
+		}, 'file.ipynb', {
+			cellCount: EXPECTED_CELL_COUNT,
+			description: `Nav back to ${NOTEBOOK_FILE} from untitled file`,
+		});
+
+		// eslint-disable-next-line no-console
+		console.log(`[perf] render_on_nav_back: ${duration_ms} ms`);
+	});
+});

--- a/test/e2e/tests/notebooks-positron/notebook-performance.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-performance.test.ts
@@ -27,7 +27,10 @@ test.describe('Positron Notebooks: Performance', {
 	test('render_on_open: reopen notebook from disk', async function ({ app, hotKeys, metric }) {
 		const { notebooksPositron } = app.workbench;
 
-		// Close the notebook tab so we can measure the cold reopen.
+		// Close the notebook tab so we can measure the reopen from disk.
+		// Note: OS file cache is already warm from beforeEach, so this is
+		// not a true cold open -- it measures the editor open + parse + render
+		// path with a warm OS cache.
 		await hotKeys.closeAllEditors();
 
 		const { duration_ms } = await metric.notebooks.renderOnOpen(async () => {

--- a/test/e2e/tests/notebooks-positron/notebook-performance.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-performance.test.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path from 'path';
-import { tags } from '../_test.setup';
+import { tags, expect } from '../_test.setup';
 import { test } from './_test.setup.js';
-import { expect } from '@playwright/test';
 
 const NOTEBOOK_FILE = 'spotify.ipynb';
 const NOTEBOOK_PATH = path.join('workspaces', 'large_py_notebook', NOTEBOOK_FILE);
@@ -20,8 +19,7 @@ test.describe('Positron Notebooks: Performance', {
 }, () => {
 
 	test.beforeEach(async function ({ app }) {
-		const { notebooksPositron } = app.workbench;
-		await notebooksPositron.openNotebook(NOTEBOOK_PATH);
+		await app.workbench.notebooksPositron.openNotebook(NOTEBOOK_PATH);
 	});
 
 	test('render_on_open: reopen notebook from disk', async function ({ app, hotKeys, runCommand, metric }) {
@@ -30,16 +28,13 @@ test.describe('Positron Notebooks: Performance', {
 		// Close the notebook tab so we can measure the reopen.
 		await hotKeys.closeAllEditors();
 
-		// Use "Reopen Closed Editor" to avoid the Quick Access picker UI
-		// (typing the filename, fuzzy-match, select) that openNotebook
-		// goes through -- that UI latency is noise unrelated to notebook
-		// render time. This restores the most recently closed editor,
-		// which is the notebook opened by beforeEach.
+		// Use "Reopen Closed Editor" to avoid UI latency noise unrelated
+		// to notebook render time.
 		const { duration_ms } = await metric.notebooks.renderOnOpen(async () => {
 			await runCommand('workbench.action.reopenClosedEditor');
 			await expect(notebooksPositron.cell.first()).toBeVisible();
 		}, 'file.ipynb', {
-			description: `Reopen ${NOTEBOOK_FILE} in Positron notebook editor`,
+			description: `Reopen ${NOTEBOOK_FILE} in Positron notebooks`,
 		});
 
 		if (!process.env.CI) { console.log(`[perf] render_on_open: ${duration_ms} ms`); }

--- a/test/e2e/tests/notebooks-positron/notebook-performance.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-performance.test.ts
@@ -6,10 +6,10 @@
 import path from 'path';
 import { tags } from '../_test.setup';
 import { test } from './_test.setup.js';
+import { expect } from '@playwright/test';
 
 const NOTEBOOK_FILE = 'spotify.ipynb';
 const NOTEBOOK_PATH = path.join('workspaces', 'large_py_notebook', NOTEBOOK_FILE);
-const EXPECTED_CELL_COUNT = 32;
 
 test.use({
 	suiteId: __filename
@@ -23,7 +23,7 @@ test.describe('Positron Notebooks: Performance', {
 		const { notebooksPositron } = app.workbench;
 		await notebooksPositron.openNotebook(NOTEBOOK_PATH);
 		await notebooksPositron.expectToBeVisible();
-		await notebooksPositron.expectCellCountToBe(EXPECTED_CELL_COUNT);
+		await expect(notebooksPositron.cell.first()).toBeVisible();
 	});
 
 	test('render_on_open: reopen notebook from disk', async function ({ app, hotKeys, metric }) {
@@ -35,14 +35,12 @@ test.describe('Positron Notebooks: Performance', {
 		const { duration_ms } = await metric.notebooks.renderOnOpen(async () => {
 			await notebooksPositron.openNotebook(NOTEBOOK_PATH);
 			await notebooksPositron.expectToBeVisible();
-			await notebooksPositron.expectCellCountToBe(EXPECTED_CELL_COUNT);
+			await expect(notebooksPositron.cell.first()).toBeVisible();
 		}, 'file.ipynb', {
-			cellCount: EXPECTED_CELL_COUNT,
 			description: `Reopen ${NOTEBOOK_FILE} in Positron notebook editor`,
 		});
 
 		// Pure telemetry for v1: log the duration, no hard assertion.
-		// eslint-disable-next-line no-console
 		console.log(`[perf] render_on_open: ${duration_ms} ms`);
 	});
 
@@ -59,13 +57,11 @@ test.describe('Positron Notebooks: Performance', {
 			// Positron notebook is a custom editor.
 			await app.code.driver.page.getByRole('tab', { name: NOTEBOOK_FILE }).click();
 			await notebooksPositron.expectToBeVisible();
-			await notebooksPositron.expectCellCountToBe(EXPECTED_CELL_COUNT);
+			await expect(notebooksPositron.cell.first()).toBeVisible();
 		}, 'file.ipynb', {
-			cellCount: EXPECTED_CELL_COUNT,
 			description: `Nav back to ${NOTEBOOK_FILE} from untitled file`,
 		});
 
-		// eslint-disable-next-line no-console
 		console.log(`[perf] render_on_nav_back: ${duration_ms} ms`);
 	});
 });

--- a/test/e2e/utils/metrics/metric-base.ts
+++ b/test/e2e/utils/metrics/metric-base.ts
@@ -5,7 +5,6 @@
 
 import os from 'os';
 import { DataExplorerShortcutOptions } from './metric-data-explorer.js';
-import type { NotebookRenderOptions } from './metric-notebooks.js';
 import { getPositronVersion } from '../../infra/test-runner/test-setup.js';
 
 export const CONNECT_API_KEY = process.env.CONNECT_API_KEY!;
@@ -82,8 +81,8 @@ export type RecordMetric = {
 	};
 	notebooks: {
 		runCell: <T>(operation: () => Promise<T>, targetType: MetricTargetType, language?: string, description?: string, context?: MetricContext | (() => Promise<MetricContext>)) => Promise<MetricResult<T>>;
-		renderOnOpen: <T>(operation: () => Promise<T>, targetType: MetricTargetType, options?: NotebookRenderOptions) => Promise<MetricResult<T>>;
-		renderOnNavBack: <T>(operation: () => Promise<T>, targetType: MetricTargetType, options?: NotebookRenderOptions) => Promise<MetricResult<T>>;
+		renderOnOpen: <T>(operation: () => Promise<T>, targetType: MetricTargetType, options?: { description?: string; additionalContext?: MetricContext | (() => Promise<MetricContext>) }) => Promise<MetricResult<T>>;
+		renderOnNavBack: <T>(operation: () => Promise<T>, targetType: MetricTargetType, options?: { description?: string; additionalContext?: MetricContext | (() => Promise<MetricContext>) }) => Promise<MetricResult<T>>;
 	};
 	assistant: {
 		evalResponse: (input: AssistantEvalMetricInput, durationMs: number) => Promise<void>;

--- a/test/e2e/utils/metrics/metric-base.ts
+++ b/test/e2e/utils/metrics/metric-base.ts
@@ -5,6 +5,7 @@
 
 import os from 'os';
 import { DataExplorerShortcutOptions } from './metric-data-explorer.js';
+import type { NotebookRenderOptions } from './metric-notebooks.js';
 import { getPositronVersion } from '../../infra/test-runner/test-setup.js';
 
 export const CONNECT_API_KEY = process.env.CONNECT_API_KEY!;
@@ -82,6 +83,8 @@ export type RecordMetric = {
 	};
 	notebooks: {
 		runCell: <T>(operation: () => Promise<T>, targetType: MetricTargetType, language?: string, description?: string, context?: MetricContext | (() => Promise<MetricContext>)) => Promise<MetricResult<T>>;
+		renderOnOpen: <T>(operation: () => Promise<T>, targetType: MetricTargetType, options?: NotebookRenderOptions) => Promise<MetricResult<T>>;
+		renderOnNavBack: <T>(operation: () => Promise<T>, targetType: MetricTargetType, options?: NotebookRenderOptions) => Promise<MetricResult<T>>;
 	};
 	assistant: {
 		evalResponse: (input: AssistantEvalMetricInput, durationMs: number) => Promise<void>;

--- a/test/e2e/utils/metrics/metric-base.ts
+++ b/test/e2e/utils/metrics/metric-base.ts
@@ -43,6 +43,7 @@ export type MetricContext = {
 	sort_applied?: boolean;
 	filter_applied?: boolean;
 	preview_enabled?: boolean;
+	cell_count?: number;
 };
 
 export type MetricResult<T> = {
@@ -135,6 +136,9 @@ export type MetricTargetType =
 	// Notebook cells
 	| 'cell.r'                // R notebook cell
 	| 'cell.python'           // Python notebook cell
+
+	// Notebook files
+	| 'file.ipynb'            // Jupyter notebook file
 
 	// Assistant eval categories
 	| 'eval.notebooks'        // Notebook-related assistant evals

--- a/test/e2e/utils/metrics/metric-base.ts
+++ b/test/e2e/utils/metrics/metric-base.ts
@@ -44,7 +44,6 @@ export type MetricContext = {
 	sort_applied?: boolean;
 	filter_applied?: boolean;
 	preview_enabled?: boolean;
-	cell_count?: number;
 };
 
 export type MetricResult<T> = {

--- a/test/e2e/utils/metrics/metric-notebooks.ts
+++ b/test/e2e/utils/metrics/metric-notebooks.ts
@@ -54,18 +54,9 @@ export { recordNotebookMetric };
 //-----------------------
 
 /**
- * Options for notebook shortcut metric functions
+ * Options for notebook shortcut metric functions.
  */
 export interface NotebookShortcutOptions {
-	description?: string;
-	additionalContext?: MetricContext | (() => Promise<MetricContext>);
-}
-
-/**
- * Options for notebook render-timing shortcuts
- * (recordRenderOnOpen, recordRenderOnNavBack).
- */
-export interface NotebookRenderOptions {
 	description?: string;
 	additionalContext?: MetricContext | (() => Promise<MetricContext>);
 }
@@ -125,7 +116,7 @@ export async function recordRenderOnOpen<T>(
 	targetType: MetricTargetType,
 	isElectronApp: boolean,
 	logger: MultiLogger,
-	options: NotebookRenderOptions = {}
+	options: NotebookShortcutOptions = {}
 ): Promise<MetricResult<T>> {
 	return recordRender('render_on_open', operation, targetType, isElectronApp, logger, options);
 }
@@ -140,7 +131,7 @@ export async function recordRenderOnNavBack<T>(
 	targetType: MetricTargetType,
 	isElectronApp: boolean,
 	logger: MultiLogger,
-	options: NotebookRenderOptions = {}
+	options: NotebookShortcutOptions = {}
 ): Promise<MetricResult<T>> {
 	return recordRender('render_on_nav_back', operation, targetType, isElectronApp, logger, options);
 }
@@ -151,7 +142,7 @@ async function recordRender<T>(
 	targetType: MetricTargetType,
 	isElectronApp: boolean,
 	logger: MultiLogger,
-	options: NotebookRenderOptions
+	options: NotebookShortcutOptions
 ): Promise<MetricResult<T>> {
 	const { description, additionalContext } = options;
 

--- a/test/e2e/utils/metrics/metric-notebooks.ts
+++ b/test/e2e/utils/metrics/metric-notebooks.ts
@@ -89,7 +89,7 @@ export async function recordRunCell<T>(
 
 	if (language || additionalContext) {
 		context_json = async () => {
-			let baseContext: MetricContext = {};
+			const baseContext: MetricContext = {};
 
 			if (language) {
 				baseContext.language = language;

--- a/test/e2e/utils/metrics/metric-notebooks.ts
+++ b/test/e2e/utils/metrics/metric-notebooks.ts
@@ -67,7 +67,6 @@ export interface NotebookShortcutOptions {
  */
 export interface NotebookRenderOptions {
 	description?: string;
-	cellCount?: number;
 	additionalContext?: MetricContext | (() => Promise<MetricContext>);
 }
 
@@ -154,26 +153,12 @@ async function recordRender<T>(
 	logger: MultiLogger,
 	options: NotebookRenderOptions
 ): Promise<MetricResult<T>> {
-	const { description, cellCount, additionalContext } = options;
-
-	const context_json: (() => Promise<MetricContext>) | undefined =
-		(cellCount !== undefined || additionalContext)
-			? async () => {
-				const base: MetricContext = cellCount !== undefined ? { cell_count: cellCount } : {};
-				if (additionalContext) {
-					const extra = typeof additionalContext === 'function'
-						? await additionalContext()
-						: additionalContext;
-					return { ...base, ...extra };
-				}
-				return base;
-			}
-			: undefined;
+	const { description, additionalContext } = options;
 
 	return recordNotebookMetric(operation, {
 		action,
 		target_type: targetType,
 		target_description: description || `${action} ${targetType}`,
-		context_json,
+		context_json: additionalContext,
 	}, isElectronApp, logger);
 }

--- a/test/e2e/utils/metrics/metric-notebooks.ts
+++ b/test/e2e/utils/metrics/metric-notebooks.ts
@@ -11,7 +11,12 @@ import { createFeatureMetricFactory } from './metric-factory.js';
 // Feature-specific Types
 //-----------------------
 
-export type NotebooksAction = 'run_cell' | 'open_notebook' | 'save_notebook';
+export type NotebooksAction =
+	| 'run_cell'
+	| 'open_notebook'
+	| 'save_notebook'
+	| 'render_on_open'
+	| 'render_on_nav_back';
 
 export type NotebookMetric = BaseMetric & {
 	feature_area: 'notebooks';
@@ -57,6 +62,16 @@ export interface NotebookShortcutOptions {
 }
 
 /**
+ * Options for notebook render-timing shortcuts
+ * (recordRenderOnOpen, recordRenderOnNavBack).
+ */
+export interface NotebookRenderOptions {
+	description?: string;
+	cellCount?: number;
+	additionalContext?: MetricContext | (() => Promise<MetricContext>);
+}
+
+/**
  * Shortcut for recording notebook cell execution with language context
  */
 export async function recordRunCell<T>(
@@ -98,5 +113,67 @@ export async function recordRunCell<T>(
 		target_type: targetType,
 		target_description: description || `Running ${language || targetType} cell`,
 		context_json
+	}, isElectronApp, logger);
+}
+
+/**
+ * Shortcut for recording the time to render a notebook after reopening
+ * it from disk (tab closed, file reopened). Measures the notebook
+ * open + parse + render path, isolated from app-startup noise.
+ */
+export async function recordRenderOnOpen<T>(
+	operation: () => Promise<T>,
+	targetType: MetricTargetType,
+	isElectronApp: boolean,
+	logger: MultiLogger,
+	options: NotebookRenderOptions = {}
+): Promise<MetricResult<T>> {
+	return recordRender('render_on_open', operation, targetType, isElectronApp, logger, options);
+}
+
+/**
+ * Shortcut for recording the time to render a notebook after switching
+ * back to its editor tab from another tab. Matches the bug scenario in
+ * posit-dev/positron#12604 (slow tab-switch-back on large notebooks).
+ */
+export async function recordRenderOnNavBack<T>(
+	operation: () => Promise<T>,
+	targetType: MetricTargetType,
+	isElectronApp: boolean,
+	logger: MultiLogger,
+	options: NotebookRenderOptions = {}
+): Promise<MetricResult<T>> {
+	return recordRender('render_on_nav_back', operation, targetType, isElectronApp, logger, options);
+}
+
+async function recordRender<T>(
+	action: 'render_on_open' | 'render_on_nav_back',
+	operation: () => Promise<T>,
+	targetType: MetricTargetType,
+	isElectronApp: boolean,
+	logger: MultiLogger,
+	options: NotebookRenderOptions
+): Promise<MetricResult<T>> {
+	const { description, cellCount, additionalContext } = options;
+
+	const context_json: (() => Promise<MetricContext>) | undefined =
+		(cellCount !== undefined || additionalContext)
+			? async () => {
+				const base: MetricContext = cellCount !== undefined ? { cell_count: cellCount } : {};
+				if (additionalContext) {
+					const extra = typeof additionalContext === 'function'
+						? await additionalContext()
+						: additionalContext;
+					return { ...base, ...extra };
+				}
+				return base;
+			}
+			: undefined;
+
+	return recordNotebookMetric(operation, {
+		action,
+		target_type: targetType,
+		target_description: description || `${action} ${targetType}`,
+		context_json,
 	}, isElectronApp, logger);
 }


### PR DESCRIPTION
Addresses #12605.

### Summary

Extends the e2e metrics pipeline (`test/e2e/utils/metrics/`) to capture render-time for the Positron notebooks.

- `render_on_open`: time to render a notebook after closing and reopening the tab. Uses `workbench.action.reopenClosedEditor` so the measurement isolates editor open + parse + render, without app reload or quick access picker.
- `render_on_nav_back`: time to render after switching to another tab and switching back.

Local baseline, both close to the ~2s figure in #12604.
* `render_on_open ~ 2200 ms`
* `render_on_nav_back ~ 1900 ms`.

Note: these metrics will appear in e2e insights dashboard once tests runs against `main`.

### QA Notes

@:win @:performance
