### PR TITLE
Fix Anthropic custom base URL handling in authentication extension

### DIFF
--- a/extensions/authentication/package.nls.json
+++ b/extensions/authentication/package.nls.json
@@ -2,7 +2,7 @@
 	"configuration.aws.credentials.description": "Variables used to configure AWS credentials.\n\nExample: to set the AWS region and profile, add items with keys `AWS_REGION` and `AWS_PROFILE`.",
 	"configuration.aws.inferenceProfileRegion.description": "Override the inference profile region for AWS services.\n\nBy default, the inference profile region is derived from `AWS_REGION` (e.g., 'us-east-1' -> 'us'). Use this setting to explicitly specify a different region.\n\nExamples: 'global', 'us', 'eu', 'apac'.",
 	"configuration.snowflake.credentials.description": "Variables used to configure Snowflake Cortex provider.\n\nExample: to set the Snowflake account and connections path, add items with keys `SNOWFLAKE_ACCOUNT` and `SNOWFLAKE_HOME`.",
-	"configuration.anthropic.baseUrl.description": "Custom Anthropic API base URL. Overrides the default https://api.anthropic.com endpoint. Also set automatically from the ANTHROPIC_BASE_URL environment variable.",
+	"configuration.anthropic.baseUrl.description": "Custom Anthropic API base URL. Overrides the default https://api.anthropic.com/v1 endpoint. Also set automatically from the ANTHROPIC_BASE_URL environment variable.",
 	"configuration.foundry.baseUrl.description": "Microsoft Foundry endpoint URL.",
 	"configuration.openai-api.baseUrl.description": "Custom OpenAI API base URL. Overrides the default https://api.openai.com/v1 endpoint. Also set automatically from the OPENAI_BASE_URL environment variable.",
 	"configuration.google.baseUrl.description": "Custom Gemini API base URL. Overrides the default https://generativelanguage.googleapis.com/v1beta endpoint. Also set automatically from the GEMINI_BASE_URL environment variable.",

--- a/extensions/authentication/src/test/anthropic.test.ts
+++ b/extensions/authentication/src/test/anthropic.test.ts
@@ -1,0 +1,123 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as positron from 'positron';
+import { validateAnthropicApiKey } from '../validation/anthropic';
+
+suite('validateAnthropicApiKey', () => {
+	let originalFetch: typeof globalThis.fetch;
+	let requestedUrls: string[];
+
+	setup(() => {
+		originalFetch = globalThis.fetch;
+		requestedUrls = [];
+	});
+
+	teardown(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	function makeConfig(baseUrl?: string): positron.ai.LanguageModelConfig {
+		return {
+			provider: 'anthropic-api',
+			name: 'Anthropic',
+			model: '',
+			type: positron.PositronLanguageModelType.Chat,
+			...(baseUrl !== undefined && { baseUrl }),
+		};
+	}
+
+	test('uses https://api.anthropic.com/v1 when no baseUrl is provided', async () => {
+		globalThis.fetch = async (url) => {
+			requestedUrls.push(url as string);
+			return { ok: true, status: 200 } as Response;
+		};
+
+		await validateAnthropicApiKey('sk-ant-valid', makeConfig());
+
+		assert.strictEqual(requestedUrls.length, 1);
+		assert.strictEqual(requestedUrls[0], 'https://api.anthropic.com/v1/models');
+	});
+
+	test('uses provided baseUrl without modification', async () => {
+		globalThis.fetch = async (url) => {
+			requestedUrls.push(url as string);
+			return { ok: true, status: 200 } as Response;
+		};
+
+		await validateAnthropicApiKey('sk-ant-valid', makeConfig('https://my.proxy.com/v2'));
+
+		assert.strictEqual(requestedUrls.length, 1);
+		assert.strictEqual(requestedUrls[0], 'https://my.proxy.com/v2/models');
+	});
+
+	test('falls back to /v1/ on non-auth HTTP failure', async () => {
+		let callCount = 0;
+		globalThis.fetch = async (url) => {
+			requestedUrls.push(url as string);
+			callCount++;
+			return { ok: callCount > 1, status: callCount === 1 ? 404 : 200 } as Response;
+		};
+
+		await validateAnthropicApiKey('sk-ant-valid', makeConfig('https://api.anthropic.com'));
+
+		assert.strictEqual(requestedUrls.length, 2);
+		assert.strictEqual(requestedUrls[0], 'https://api.anthropic.com/models');
+		assert.strictEqual(requestedUrls[1], 'https://api.anthropic.com/v1/models');
+	});
+
+	test('does not fall back on 401 auth error', async () => {
+		globalThis.fetch = async (url) => {
+			requestedUrls.push(url as string);
+			return { ok: false, status: 401 } as Response;
+		};
+
+		await assert.rejects(
+			validateAnthropicApiKey('sk-ant-invalid', makeConfig()),
+			(error: Error) => error.message.includes('Invalid Anthropic API key')
+		);
+
+		assert.strictEqual(requestedUrls.length, 1, 'should not retry on auth error');
+	});
+
+	test('does not fall back on 403 auth error', async () => {
+		globalThis.fetch = async (url) => {
+			requestedUrls.push(url as string);
+			return { ok: false, status: 403 } as Response;
+		};
+
+		await assert.rejects(
+			validateAnthropicApiKey('sk-ant-invalid', makeConfig()),
+			(error: Error) => error.message.includes('Invalid Anthropic API key')
+		);
+
+		assert.strictEqual(requestedUrls.length, 1, 'should not retry on auth error');
+	});
+
+	test('throws with HTTP status when fallback also fails', async () => {
+		let callCount = 0;
+		globalThis.fetch = async () => {
+			callCount++;
+			return { ok: false, status: callCount === 1 ? 404 : 500 } as Response;
+		};
+
+		await assert.rejects(
+			validateAnthropicApiKey('sk-ant-valid', makeConfig('https://api.anthropic.com')),
+			(error: Error) => error.message.includes('500')
+		);
+	});
+
+	test('strips trailing slash from baseUrl', async () => {
+		globalThis.fetch = async (url) => {
+			requestedUrls.push(url as string);
+			return { ok: true, status: 200 } as Response;
+		};
+
+		await validateAnthropicApiKey('sk-ant-valid', makeConfig('https://api.anthropic.com/v1/'));
+
+		assert.strictEqual(requestedUrls[0], 'https://api.anthropic.com/v1/models');
+	});
+});

--- a/extensions/authentication/src/test/anthropic.test.ts
+++ b/extensions/authentication/src/test/anthropic.test.ts
@@ -120,4 +120,32 @@ suite('validateAnthropicApiKey', () => {
 
 		assert.strictEqual(requestedUrls[0], 'https://api.anthropic.com/v1/models');
 	});
+
+	test('does not append /v1 when baseUrl already ends with /v1', async () => {
+		globalThis.fetch = async (url) => {
+			requestedUrls.push(url as string);
+			return { ok: false, status: 404 } as Response;
+		};
+
+		await assert.rejects(
+			validateAnthropicApiKey('sk-ant-valid', makeConfig('https://api.anthropic.com/v1')),
+			(error: Error) => error.message.includes('404')
+		);
+
+		assert.strictEqual(requestedUrls.length, 1, 'should not retry when URL already has /v1');
+	});
+
+	test('does not append /v1 when baseUrl already ends with /v1/', async () => {
+		globalThis.fetch = async (url) => {
+			requestedUrls.push(url as string);
+			return { ok: false, status: 404 } as Response;
+		};
+
+		await assert.rejects(
+			validateAnthropicApiKey('sk-ant-valid', makeConfig('https://api.anthropic.com/v1/')),
+			(error: Error) => error.message.includes('404')
+		);
+
+		assert.strictEqual(requestedUrls.length, 1, 'should not retry when URL already has /v1/');
+	});
 });

--- a/extensions/authentication/src/validation/anthropic.ts
+++ b/extensions/authentication/src/validation/anthropic.ts
@@ -15,15 +15,40 @@ class ApiKeyValidationError extends Error {
 }
 
 export async function validateAnthropicApiKey(apiKey: string, config: positron.ai.LanguageModelConfig): Promise<void> {
-	const rawBaseUrl = (config.baseUrl ?? 'https://api.anthropic.com')
-		.replace(/\/v1\/?$/, '')
-		.replace(/\/+$/, '');
-	const modelsEndpoint = `${rawBaseUrl}/v1/models`;
+	const baseUrl = (config.baseUrl ?? 'https://api.anthropic.com/v1').replace(/\/+$/, '');
+	const modelsEndpoint = `${baseUrl}/models`;
 
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), KEY_VALIDATION_TIMEOUT_MS);
 	try {
-		const response = await fetch(modelsEndpoint, {
+		let firstResponse: Response | undefined;
+		try {
+			firstResponse = await fetch(modelsEndpoint, {
+				method: 'GET',
+				headers: {
+					'x-api-key': apiKey,
+					'anthropic-version': ANTHROPIC_API_VERSION,
+				},
+				signal: controller.signal,
+			});
+		} catch (err) {
+			if (err instanceof Error && err.name === 'AbortError') {
+				throw new ApiKeyValidationError(vscode.l10n.t('Could not validate Anthropic API key within {0} seconds', String(KEY_VALIDATION_TIMEOUT_MS / 1000)));
+			}
+			// Network error on first attempt: fall through to /v1/ retry below
+		}
+
+		if (firstResponse?.ok) {
+			return;
+		}
+
+		if (firstResponse && (firstResponse.status === 401 || firstResponse.status === 403)) {
+			throw new ApiKeyValidationError(vscode.l10n.t('Invalid Anthropic API key'));
+		}
+
+		// First attempt failed with a non-auth error (HTTP or network). Try with /v1/ appended
+		// in case the user provided a base URL without the API version path segment.
+		const response = await fetch(`${baseUrl}/v1/models`, {
 			method: 'GET',
 			headers: {
 				'x-api-key': apiKey,

--- a/extensions/authentication/src/validation/anthropic.ts
+++ b/extensions/authentication/src/validation/anthropic.ts
@@ -48,6 +48,16 @@ export async function validateAnthropicApiKey(apiKey: string, config: positron.a
 
 		// First attempt failed with a non-auth error (HTTP or network). Try with /v1/ appended
 		// in case the user provided a base URL without the API version path segment.
+		// Skip the retry if the URL already ends with /v1 to avoid /v1/v1/models.
+		if (baseUrl.endsWith('/v1')) {
+			if (firstResponse) {
+				throw new ApiKeyValidationError(vscode.l10n.t(
+					'Unable to validate Anthropic API key (HTTP {0})',
+					String(firstResponse.status)
+				));
+			}
+			throw new ApiKeyValidationError(vscode.l10n.t('Could not validate Anthropic API key. Check your network connection and try again.'));
+		}
 		const response = await fetch(`${baseUrl}/v1/models`, {
 			method: 'GET',
 			headers: {


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/12974#issuecomment-4290946340

Previously, the validation code always stripped `/v1` from the user's URL and re-appended it, making it impossible to target future API versions (e.g. `/v2`). This PR removes that manipulation:

- The default base URL is now `https://api.anthropic.com/v1` (previously `https://api.anthropic.com`)
- The user's URL is passed through unchanged
- Validation first tries `{baseUrl}/models`; only if that fails with a non-auth error does it retry with `/v1/` appended — and only when the URL doesn't already end with `/v1`

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix Anthropic custom base URL being silently modified during API key validation

### QA Notes

@:assistant

Authentication should validate custom URLs with or without `v1`. 