### PR TITLE
Fix assistant reset and diagnostics after auth extension migration

### DIFF
--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -23,24 +23,35 @@ import { AuthProviderLogger } from './authProviderLogger';
 export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(log);
 
-	await registerAnthropicProvider(context);
-	registerPositAIProvider(context);
-	registerFoundryProvider(context);
+	const anthropic = await registerAnthropicProvider(context);
+	const positAI = registerPositAIProvider(context);
+	const foundry = registerFoundryProvider(context);
 
 	// Migrate settings before registering providers so they
 	// read the migrated values during initialization.
-	await registerAwsProvider(context);
+	const aws = await registerAwsProvider(context);
 
 	await migrateSnowflakeSettings().catch(err =>
 		log.error(`Snowflake settings migration failed: ${err}`)
 	);
-	registerSnowflakeProvider(context);
+	const snowflake = registerSnowflakeProvider(context);
 
-	await registerOpenaiProvider(context);
-	await registerGeminiProvider(context);
-	registerCustomProvider(context);
+	const openai = await registerOpenaiProvider(context);
+	const gemini = await registerGeminiProvider(context);
+	const custom = registerCustomProvider(context);
 
 	log.info('Authentication extension activated');
+
+	const providerMap = new Map<string, AuthProvider>([
+		[ANTHROPIC_AUTH_PROVIDER_ID, anthropic],
+		[POSIT_AUTH_PROVIDER_ID, positAI],
+		[FOUNDRY_AUTH_PROVIDER_ID, foundry],
+		[AWS_AUTH_PROVIDER_ID, aws],
+		['snowflake-cortex', snowflake],
+		[OPENAI_AUTH_PROVIDER_ID, openai],
+		[GEMINI_AUTH_PROVIDER_ID, gemini],
+		[CUSTOM_PROVIDER_AUTH_PROVIDER_ID, custom],
+	]);
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
@@ -52,13 +63,28 @@ export async function activate(context: vscode.ExtensionContext) {
 				return showConfigurationDialog(sources ?? [], options);
 			}
 		),
+		vscode.commands.registerCommand(
+			'authentication.signOutAll',
+			async () => {
+				for (const [providerId, provider] of providerMap) {
+					try {
+						const accounts = await vscode.authentication.getAccounts(providerId);
+						for (const account of accounts) {
+							await provider.removeSession(account.id);
+						}
+					} catch (err) {
+						log.error(`Failed to sign out of ${providerId}: ${err}`);
+					}
+				}
+			}
+		),
 	);
 	registerMigrateApiKeyCommand(context);
 }
 
 async function registerAnthropicProvider(
 	context: vscode.ExtensionContext
-): Promise<void> {
+): Promise<AuthProvider> {
 	const logger = new AuthProviderLogger('Anthropic');
 
 	// Sync ANTHROPIC_BASE_URL env var to the config setting before
@@ -130,9 +156,10 @@ async function registerAnthropicProvider(
 	);
 
 	logger.info('Registered auth provider');
+	return provider;
 }
 
-function registerPositAIProvider(context: vscode.ExtensionContext): void {
+function registerPositAIProvider(context: vscode.ExtensionContext): AuthProvider {
 	const logger = new AuthProviderLogger('Posit AI');
 	const provider = new PositOAuthProvider(context);
 	context.subscriptions.push(
@@ -143,11 +170,12 @@ function registerPositAIProvider(context: vscode.ExtensionContext): void {
 	);
 	registerAuthProvider(POSIT_AUTH_PROVIDER_ID, provider);
 	logger.info('Registered auth provider');
+	return provider;
 }
 
 async function registerAwsProvider(
 	context: vscode.ExtensionContext
-): Promise<void> {
+): Promise<AuthProvider> {
 	const logger = new AuthProviderLogger('AWS');
 
 	await migrateAwsSettings().catch(err =>
@@ -204,9 +232,10 @@ async function registerAwsProvider(
 		)
 	);
 	logger.info('Registered auth provider');
+	return provider;
 }
 
-function registerFoundryProvider(context: vscode.ExtensionContext): void {
+function registerFoundryProvider(context: vscode.ExtensionContext): AuthProvider {
 	const logger = new AuthProviderLogger('Microsoft Foundry');
 	const provider = new AuthProvider(
 		FOUNDRY_AUTH_PROVIDER_ID, 'Microsoft Foundry', context,
@@ -261,9 +290,10 @@ function registerFoundryProvider(context: vscode.ExtensionContext): void {
 				);
 		}
 	}
+	return provider;
 }
 
-function registerSnowflakeProvider(context: vscode.ExtensionContext): void {
+function registerSnowflakeProvider(context: vscode.ExtensionContext): AuthProvider {
 	const logger = new AuthProviderLogger('Snowflake Cortex');
 	let lastTomlCheck: number | undefined;
 	let pendingMtime: number | undefined;
@@ -341,11 +371,12 @@ function registerSnowflakeProvider(context: vscode.ExtensionContext): void {
 		)
 	);
 	logger.info('Registered auth provider');
+	return provider;
 }
 
 async function registerOpenaiProvider(
 	context: vscode.ExtensionContext
-): Promise<void> {
+): Promise<AuthProvider> {
 	const envBaseUrl = process.env.OPENAI_BASE_URL;
 	if (envBaseUrl) {
 		await vscode.workspace
@@ -408,11 +439,12 @@ async function registerOpenaiProvider(
 	);
 
 	log.info(`Registered auth provider: ${OPENAI_AUTH_PROVIDER_ID}`);
+	return provider;
 }
 
 async function registerGeminiProvider(
 	context: vscode.ExtensionContext
-): Promise<void> {
+): Promise<AuthProvider> {
 	const envBaseUrl = process.env.GEMINI_BASE_URL;
 	if (envBaseUrl) {
 		await vscode.workspace
@@ -478,11 +510,12 @@ async function registerGeminiProvider(
 	);
 
 	log.info(`Registered auth provider: ${GEMINI_AUTH_PROVIDER_ID}`);
+	return provider;
 }
 
 function registerCustomProvider(
 	context: vscode.ExtensionContext
-): void {
+): AuthProvider {
 	const provider = new AuthProvider(
 		CUSTOM_PROVIDER_AUTH_PROVIDER_ID, 'Custom Provider', context
 	);
@@ -509,4 +542,5 @@ function registerCustomProvider(
 	log.info(
 		`Registered auth provider: ${CUSTOM_PROVIDER_AUTH_PROVIDER_ID}`
 	);
+	return provider;
 }

--- a/extensions/positron-assistant/src/diagnostics.ts
+++ b/extensions/positron-assistant/src/diagnostics.ts
@@ -8,6 +8,7 @@ import * as positron from 'positron';
 import { getStoredModels } from './config';
 import { BufferedLogOutputChannel } from './log.js';
 import { getModelProviders } from './providers';
+import { isAuthExtProvider } from './authExtRouting.js';
 
 function formatError(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
@@ -113,14 +114,24 @@ async function getConfiguredProviders(context: vscode.ExtensionContext, log: Buf
 				fields.push(`	- Base URL: ${firstModel.baseUrl}`);
 			}
 
-			// Report if an API key is configured (check first model's ID)
+			// Report credential status -- auth ext providers use vscode.authentication;
+			// legacy providers use the assistant's own secret storage.
 			try {
-				const apiKey = await context.secrets.get(`apiKey-${firstModel.id}`);
-				if (apiKey) {
-					fields.push(`	- API Key: Yes`);
+				if (isAuthExtProvider(provider)) {
+					const accounts = await vscode.authentication.getAccounts(provider);
+					if (accounts.length > 0) {
+						fields.push(`	- Auth Session: Active (${accounts.map(a => a.label).join(', ')})`);
+					} else {
+						fields.push(`	- Auth Session: None`);
+					}
+				} else {
+					const apiKey = await context.secrets.get(`apiKey-${firstModel.id}`);
+					if (apiKey) {
+						fields.push(`	- API Key: Yes`);
+					}
 				}
 			} catch (error) {
-				log.trace(`Failed to check API key for model ${firstModel.id}: ${formatError(error)}`);
+				log.trace(`Failed to check credentials for model ${firstModel.id}: ${formatError(error)}`);
 			}
 
 			return fields.join('\n');
@@ -179,7 +190,7 @@ async function getChatExportInfo(): Promise<string> {
 		// Currently selected mode in the Chat panel
 		const chatMode = await positron.ai.getCurrentChatMode();
 
-		// Cast to access internal structure (API returns object type for stability)
+		// eslint-disable-next-line local/code-no-any-casts -- API returns object type for stability
 		const chatData = chatExport as any;
 
 		if (!chatData.requests || !Array.isArray(chatData.requests)) {
@@ -211,7 +222,9 @@ function getEnvironmentConfiguredModels(): string {
 	const models = getModelProviders();
 	const envModels = models
 		.filter(model => {
+			// eslint-disable-next-line local/code-no-any-casts -- source.defaults shape varies by provider
 			const defaults = model.source.defaults as any;
+			// eslint-disable-next-line local/code-no-in-operator -- narrowing untyped external shape
 			if (!('apiKeyEnvVar' in defaults && defaults.apiKeyEnvVar)) {
 				return false;
 			}
@@ -221,6 +234,7 @@ function getEnvironmentConfiguredModels(): string {
 			return !!process.env[key];
 		})
 		.map(model => {
+			// eslint-disable-next-line local/code-no-any-casts -- source.defaults shape varies by provider
 			const defaults = model.source.defaults as any;
 			const envVarConfig = defaults.apiKeyEnvVar as { key: string; signedIn: boolean };
 			const key = envVarConfig.key;
@@ -240,10 +254,15 @@ function getEnvironmentConfiguredModels(): string {
 
 function getVersionInfo(): string {
 	const assistantExt = vscode.extensions.getExtension('positron.positron-assistant');
+	const authExt = vscode.extensions.getExtension('positron.authentication');
 	const copilotExt = vscode.extensions.getExtension('github.copilot-chat');
 
 	const assistantInfo = assistantExt
 		? `Version ${assistantExt.packageJSON.version}${assistantExt.isActive ? ' (Active)' : ' (Inactive)'}`
+		: 'Not installed';
+
+	const authInfo = authExt
+		? `Version ${authExt.packageJSON.version}${authExt.isActive ? ' (Active)' : ' (Inactive)'}`
 		: 'Not installed';
 
 	const copilotInfo = copilotExt
@@ -251,6 +270,7 @@ function getVersionInfo(): string {
 		: 'Not installed';
 
 	return `- Positron Assistant: ${assistantInfo}
+- Authentication: ${authInfo}
 - GitHub Copilot Chat: ${copilotInfo}
 - Positron: ${positron.version} (build ${positron.buildNumber})
 - Code OSS: ${vscode.version}

--- a/extensions/positron-assistant/src/reset.ts
+++ b/extensions/positron-assistant/src/reset.ts
@@ -134,6 +134,11 @@ export async function resetAssistantState(context: vscode.ExtensionContext): Pro
 			// Step 2: Sign out of providers
 			progress.report({ message: vscode.l10n.t('Signing out of providers...') });
 			await CopilotService.instance().signOut();
+			try {
+				await vscode.commands.executeCommand('authentication.signOutAll');
+			} catch (error) {
+				log.trace(`Failed to sign out of auth extension providers: ${formatError(error)}`);
+			}
 
 			// Step 3: Clear Assistant state
 			progress.report({ message: vscode.l10n.t('Clearing Assistant state...') });


### PR DESCRIPTION
## Summary

Since moving provider auth to the `authentication` extension, two debugging commands had broken behavior:

- **Reset command**: `CopilotService.signOut()` is a no-op, and `clearAssistantState()` only deleted legacy `apiKey-${model.id}` secrets from the assistant's own storage. Auth extension sessions (the actual credentials for all 8 providers) were never cleared.
- **Diagnostics command**: `getConfiguredProviders()` checked `context.secrets.get(`apiKey-${model.id}`)` — the old secret format. Auth extension providers store credentials separately, so this always returned nothing and never showed "API Key: Yes" for any configured provider.

## Changes

**`extensions/authentication/src/extension.ts`**
- Each `registerXxx` function now returns its `AuthProvider` instance
- `activate()` collects all providers in a map
- New `authentication.signOutAll` command iterates the map and calls `provider.removeSession()` for every active account (providers with `preventSignOut: true`, e.g. Anthropic via env var, will show an informational toast and remain — this is expected behavior)

**`extensions/positron-assistant/src/diagnostics.ts`**
- `getConfiguredProviders()` now uses `vscode.authentication.getAccounts()` for auth-extension-managed providers to show real session status
- `getVersionInfo()` now includes the `positron.authentication` extension version

**`extensions/positron-assistant/src/reset.ts`**
- Calls `authentication.signOutAll` after `CopilotService.signOut()`, wrapped in try/catch in case the auth extension is not yet active

Closes #13121