### PR TITLE
Positron notebooks fix scrolling over webviews

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
@@ -6,13 +6,12 @@
 import * as React from 'react';
 import { getWindow, addDisposableListener } from '../../../../../../base/browser/dom.js';
 import { INotebookOutputWebview } from '../../../../positronOutputWebview/browser/notebookOutputWebviewService.js';
-import { isHTMLOutputWebviewMessage } from '../../../../positronWebviewPreloads/browser/notebookOutputUtils.js';
+import { isHTMLOutputWebviewMessage, isWheelForwardMessage } from '../../../../positronWebviewPreloads/browser/notebookOutputUtils.js';
 import { useNotebookInstance } from '../../NotebookInstanceProvider.js';
 import { IOverlayWebview } from '../../../../webview/browser/webview.js';
 import { DisposableStore, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { useNotebookVisibility } from '../../NotebookVisibilityContext.js';
 import { Event } from '../../../../../../base/common/event.js';
-import { IMouseWheelEvent } from '../../../../../../base/browser/mouseEvent.js';
 import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
 import { autorun } from '../../../../../../base/common/observable.js';
 
@@ -28,14 +27,14 @@ const WHEEL_LINE_HEIGHT_PX = 40;
  * DOM_DELTA_LINE / DOM_DELTA_PAGE values (e.g. Firefox) don't scroll by
  * a single pixel per tick.
  */
-function normalizeWheelDeltaY(e: IMouseWheelEvent, container: HTMLElement): number {
-	switch (e.deltaMode) {
+function normalizeWheelDeltaY(deltaMode: number, deltaY: number, container: HTMLElement): number {
+	switch (deltaMode) {
 		case WheelEvent.DOM_DELTA_LINE:
-			return e.deltaY * WHEEL_LINE_HEIGHT_PX;
+			return deltaY * WHEEL_LINE_HEIGHT_PX;
 		case WheelEvent.DOM_DELTA_PAGE:
-			return e.deltaY * container.clientHeight;
+			return deltaY * container.clientHeight;
 		default: // DOM_DELTA_PIXEL
-			return e.deltaY;
+			return deltaY;
 	}
 }
 
@@ -78,16 +77,28 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
 
 	// Memoize the webview message handler
 	const handleWebviewMessage = React.useCallback(({ message }: { message: unknown }) => {
-		if (!isHTMLOutputWebviewMessage(message) || !containerRef.current) {
+		if (isHTMLOutputWebviewMessage(message) && containerRef.current) {
+			let boundedHeight = Math.min(message.bodyScrollHeight, MAX_OUTPUT_HEIGHT);
+			// Avoid undesired default 150px "empty output" height
+			if (boundedHeight === EMPTY_OUTPUT_HEIGHT) {
+				boundedHeight = 0;
+			}
+			containerRef.current.style.height = `${boundedHeight}px`;
 			return;
 		}
-		let boundedHeight = Math.min(message.bodyScrollHeight, MAX_OUTPUT_HEIGHT);
-		// Avoid undesired default 150px "empty output" height
-		if (boundedHeight === EMPTY_OUTPUT_HEIGHT) {
-			boundedHeight = 0;
+
+		// Forward wheel events across the iframe boundary so the notebook
+		// scrolls when the cursor is over a webview output (e.g. plotly).
+		// The webview preload has already filtered out wheel events that
+		// an inner scrollable element consumed, so every message here is
+		// safe to apply to the cells container.
+		if (isWheelForwardMessage(message)) {
+			const container = notebookInstance.cellsContainer;
+			if (container) {
+				container.scrollTop += normalizeWheelDeltaY(message.deltaMode, message.deltaY, container);
+			}
 		}
-		containerRef.current.style.height = `${boundedHeight}px`;
-	}, []);
+	}, [notebookInstance]);
 
 	React.useEffect(() => {
 		// Abort controller for canceling ongoing tasks if needed
@@ -203,19 +214,6 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
 				disposables.add(notebookInstance.onDidScrollCellsContainer(() =>
 					updateWebviewLayout(true)
 				));
-
-				// Forward wheel events across the iframe boundary so the notebook
-				// scrolls when the cursor is over a webview output (e.g. plotly).
-				// Only vertical deltas are forwarded; horizontally scrollable
-				// content inside the webview already scrolls natively, and
-				// forwarding deltaX would double-scroll those targets.
-				disposables.add(webviewElement.onDidWheel(e => {
-					const container = notebookInstance.cellsContainer;
-					if (!container) {
-						return;
-					}
-					container.scrollTop += normalizeWheelDeltaY(e, container);
-				}));
 
 				// When focus leaves the notebook container, update layout to ensure correct size
 				if (notebookInstance.cellsContainer) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
@@ -87,11 +87,11 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
 			return;
 		}
 
-		// Forward wheel events across the iframe boundary so the notebook
-		// scrolls when the cursor is over a webview output (e.g. plotly).
-		// The webview preload has already filtered out wheel events that
-		// an inner scrollable element consumed, so every message here is
-		// safe to apply to the cells container.
+		// Scroll the notebook when the cursor is over a webview output
+		// that has nothing scrollable inside it (e.g. a plotly plot or a
+		// static image). The preload only forwards wheel events when no
+		// inner element can consume the scroll, so if we got a message
+		// here we know moving the cells container is the right response.
 		if (isWheelForwardMessage(message)) {
 			const container = notebookInstance.cellsContainer;
 			if (container) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
@@ -19,7 +19,9 @@ import { autorun } from '../../../../../../base/common/observable.js';
 const MAX_OUTPUT_HEIGHT = 1000;
 const EMPTY_OUTPUT_HEIGHT = 150;
 // Approximate line height used when a wheel event reports DOM_DELTA_LINE.
-// Matches the divisor used by StandardWheelEvent's pixel-to-line conversion.
+// Matches the divisor in StandardWheelEvent (base/browser/mouseEvent.ts,
+// the `/ 40` in its pixel-to-line conversion), which is not exported.
+// Keep this in sync if that constant moves.
 const WHEEL_LINE_HEIGHT_PX = 40;
 
 /**

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
@@ -12,12 +12,32 @@ import { IOverlayWebview } from '../../../../webview/browser/webview.js';
 import { DisposableStore, toDisposable } from '../../../../../../base/common/lifecycle.js';
 import { useNotebookVisibility } from '../../NotebookVisibilityContext.js';
 import { Event } from '../../../../../../base/common/event.js';
+import { IMouseWheelEvent } from '../../../../../../base/browser/mouseEvent.js';
 import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
 import { autorun } from '../../../../../../base/common/observable.js';
 
 // Constants
 const MAX_OUTPUT_HEIGHT = 1000;
 const EMPTY_OUTPUT_HEIGHT = 150;
+// Approximate line height used when a wheel event reports DOM_DELTA_LINE.
+// Matches the divisor used by StandardWheelEvent's pixel-to-line conversion.
+const WHEEL_LINE_HEIGHT_PX = 40;
+
+/**
+ * Convert a forwarded wheel event's vertical delta into pixels so raw
+ * DOM_DELTA_LINE / DOM_DELTA_PAGE values (e.g. Firefox) don't scroll by
+ * a single pixel per tick.
+ */
+function normalizeWheelDeltaY(e: IMouseWheelEvent, container: HTMLElement): number {
+	switch (e.deltaMode) {
+		case WheelEvent.DOM_DELTA_LINE:
+			return e.deltaY * WHEEL_LINE_HEIGHT_PX;
+		case WheelEvent.DOM_DELTA_PAGE:
+			return e.deltaY * container.clientHeight;
+		default: // DOM_DELTA_PIXEL
+			return e.deltaY;
+	}
+}
 
 /**
  * Custom error class for webview-specific errors
@@ -186,15 +206,15 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
 
 				// Forward wheel events across the iframe boundary so the notebook
 				// scrolls when the cursor is over a webview output (e.g. plotly).
-				// Preloads inside the webview let inner scrollables consume the
-				// wheel first (see eventTargetShouldHandleScroll in webviewPreloads.ts).
+				// Only vertical deltas are forwarded; horizontally scrollable
+				// content inside the webview already scrolls natively, and
+				// forwarding deltaX would double-scroll those targets.
 				disposables.add(webviewElement.onDidWheel(e => {
 					const container = notebookInstance.cellsContainer;
 					if (!container) {
 						return;
 					}
-					container.scrollTop += e.deltaY;
-					container.scrollLeft += e.deltaX;
+					container.scrollTop += normalizeWheelDeltaY(e, container);
 				}));
 
 				// When focus leaves the notebook container, update layout to ensure correct size

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
@@ -87,11 +87,12 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
 			return;
 		}
 
-		// Scroll the notebook when the cursor is over a webview output
-		// that has nothing scrollable inside it (e.g. a plotly plot or a
-		// static image). The preload only forwards wheel events when no
-		// inner element can consume the scroll, so if we got a message
-		// here we know moving the cells container is the right response.
+		// Scroll the notebook when no scrollable element inside the
+		// output can consume more scroll in the wheel direction. That
+		// covers outputs with nothing scrollable (plotly, static images)
+		// and outputs whose inner scroller has exhausted its range. The
+		// preload already ran that check, so any message we see here
+		// should move the cells container.
 		if (isWheelForwardMessage(message)) {
 			const container = notebookInstance.cellsContainer;
 			if (container) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/hooks/useWebviewMount.ts
@@ -184,6 +184,19 @@ export function useWebviewMount(webview: Promise<INotebookOutputWebview>) {
 					updateWebviewLayout(true)
 				));
 
+				// Forward wheel events across the iframe boundary so the notebook
+				// scrolls when the cursor is over a webview output (e.g. plotly).
+				// Preloads inside the webview let inner scrollables consume the
+				// wheel first (see eventTargetShouldHandleScroll in webviewPreloads.ts).
+				disposables.add(webviewElement.onDidWheel(e => {
+					const container = notebookInstance.cellsContainer;
+					if (!container) {
+						return;
+					}
+					container.scrollTop += e.deltaY;
+					container.scrollLeft += e.deltaX;
+				}));
+
 				// When focus leaves the notebook container, update layout to ensure correct size
 				if (notebookInstance.cellsContainer) {
 					disposables.add(addDisposableListener(

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
@@ -103,10 +103,20 @@ function webviewMessageCode() {
 		console.error('Error observing documentElement', e);
 	}
 
-	// Only forward the wheel event to the host when no ancestor inside the
-	// webview can consume the vertical scroll. Mirrors the pattern used by
-	// the notebook webview preload so scrollable outputs (e.g. overflow
-	// tables) don't double-scroll when they move under the cursor.
+	// Two things can happen when the user wheels over a webview output:
+	//
+	// 1. The output contains a scrollable element (e.g. a big pandas
+	//    DataFrame rendered with its own scrollbar). The browser scrolls
+	//    that element on its own -- we don't want to also scroll the
+	//    notebook around it, or the whole page lurches with the table.
+	//
+	// 2. The output has nothing scrollable inside (e.g. a plotly plot,
+	//    a static image). Wheeling does nothing unless we forward the
+	//    event out to the notebook container.
+	//
+	// So we walk up from the wheel target: if we find an ancestor that
+	// can still scroll in this direction, the browser will handle it and
+	// we stay quiet. Otherwise we forward the event to the host.
 	const canConsumeVerticalWheel = (event: WheelEvent): boolean => {
 		for (let node: Node | null = event.target as Node | null; node; node = node.parentNode) {
 			// eslint-disable-next-line no-restricted-syntax

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
@@ -117,27 +117,55 @@ function webviewMessageCode() {
 	//    reached its top/bottom edge. In both cases, wheeling should
 	//    move the notebook, so we forward the event.
 	//
+	// The viewport has at most one element that scrolls on wheel. This
+	// returns that element when viewport scrolling is enabled, or null
+	// when the page disables it via overflow-y: hidden or clip. CSS
+	// propagates body's overflow to the viewport when html is `visible`
+	// (the default), so the effective overflow is html's unless that is
+	// visible, in which case body's wins.
+	const getViewportScrollConsumer = (): Element | null => {
+		// eslint-disable-next-line no-restricted-syntax
+		const root = document.documentElement;
+		// eslint-disable-next-line no-restricted-syntax
+		const body = document.body;
+		// eslint-disable-next-line no-restricted-globals
+		const rootOverflow = window.getComputedStyle(root).overflowY;
+		let effectiveOverflow = rootOverflow;
+		if (rootOverflow === 'visible' && body) {
+			// eslint-disable-next-line no-restricted-globals
+			effectiveOverflow = window.getComputedStyle(body).overflowY;
+		}
+		if (effectiveOverflow === 'hidden' || effectiveOverflow === 'clip') {
+			return null;
+		}
+		// eslint-disable-next-line no-restricted-syntax
+		return document.scrollingElement;
+	};
+
 	// findVerticalWheelConsumer walks up from the wheel target and
 	// returns the first scrollable ancestor that still has room in the
 	// wheel direction, or null when nothing can consume the scroll.
 	const findVerticalWheelConsumer = (event: WheelEvent): Element | null => {
+		const viewportConsumer = getViewportScrollConsumer();
 		for (let node: Node | null = event.target as Node | null; node; node = node.parentNode) {
 			if (!(node instanceof Element)) {
 				return null;
 			}
 			// eslint-disable-next-line no-restricted-syntax
 			const isBodyOrRoot = node === document.body || node === document.documentElement;
-			// eslint-disable-next-line no-restricted-globals
-			const overflowY = window.getComputedStyle(node).overflowY;
 			if (isBodyOrRoot) {
-				// Body/root scroll implicitly when content overflows the
-				// viewport, unless the page explicitly disables it with
-				// overflow-y: hidden or clip.
-				if (overflowY === 'hidden' || overflowY === 'clip') {
+				// Only the single viewport scroller implicitly scrolls on
+				// wheel -- skip the other of body/documentElement, and
+				// skip both when viewport scrolling is disabled.
+				if (node !== viewportConsumer) {
 					continue;
 				}
-			} else if (overflowY !== 'auto' && overflowY !== 'scroll') {
-				continue;
+			} else {
+				// eslint-disable-next-line no-restricted-globals
+				const overflowY = window.getComputedStyle(node).overflowY;
+				if (overflowY !== 'auto' && overflowY !== 'scroll') {
+					continue;
+				}
 			}
 			if (node.scrollHeight <= node.clientHeight) {
 				continue;
@@ -158,11 +186,15 @@ function webviewMessageCode() {
 	// jerk the notebook. Briefly keep routing to the element that last
 	// consumed a wheel event: as long as the cursor is still inside that
 	// element, suppress forwarding so momentum stays with that scroller
-	// rather than the notebook around it. Moving the pointer elsewhere
-	// (or letting the grace window lapse) lets new wheels through.
+	// rather than the notebook around it. Moving the pointer elsewhere,
+	// letting the grace window lapse, or starting a fresh gesture (a
+	// direction reversal or a sudden jump in |deltaY|, since tail events
+	// decay monotonically) all lift the suppression.
 	const MOMENTUM_GRACE_MS = 200;
+	const NEW_GESTURE_DELTA_JUMP = 8;
 	let lastConsumer: Element | null = null;
 	let lastConsumedAt = 0;
+	let lastSeenDelta = 0;
 	// eslint-disable-next-line no-restricted-globals
 	window.addEventListener('wheel', (event: WheelEvent) => {
 		if (event.defaultPrevented || event.deltaY === 0) {
@@ -172,13 +204,20 @@ function webviewMessageCode() {
 		if (consumer) {
 			lastConsumer = consumer;
 			lastConsumedAt = Date.now();
+			lastSeenDelta = event.deltaY;
 			return;
 		}
 		if (lastConsumer
 			&& event.target instanceof Node
 			&& lastConsumer.contains(event.target)
 			&& Date.now() - lastConsumedAt < MOMENTUM_GRACE_MS) {
-			return;
+			const sameDirection = Math.sign(event.deltaY) === Math.sign(lastSeenDelta);
+			const jumped = Math.abs(event.deltaY) > Math.abs(lastSeenDelta) + NEW_GESTURE_DELTA_JUMP;
+			if (sameDirection && !jumped) {
+				lastSeenDelta = event.deltaY;
+				return;
+			}
+			lastConsumer = null;
 		}
 		vscode.postMessage({
 			type: 'wheelForward',

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
@@ -192,32 +192,40 @@ function webviewMessageCode() {
 	// element, suppress forwarding so momentum stays with that scroller
 	// rather than the notebook around it. Moving the pointer elsewhere,
 	// letting the grace window lapse, or starting a fresh gesture (a
-	// direction reversal or a sudden jump in |deltaY|, since tail events
-	// decay monotonically) all lift the suppression.
+	// direction reversal, a sudden jump in |deltaY|, or a gap between
+	// events longer than momentum cadence -- tail events decay
+	// monotonically and fire densely, so any of these signals a human
+	// input) all lift the suppression.
 	const MOMENTUM_GRACE_MS = 200;
 	const NEW_GESTURE_DELTA_JUMP = 8;
+	const GESTURE_GAP_MS = 50;
 	let lastConsumer: Element | null = null;
 	let lastConsumedAt = 0;
 	let lastSeenDelta = 0;
+	let lastEventAt = 0;
 	// eslint-disable-next-line no-restricted-globals
 	window.addEventListener('wheel', (event: WheelEvent) => {
 		if (event.defaultPrevented || event.deltaY === 0) {
 			return;
 		}
+		const now = Date.now();
+		const gapSincePrev = now - lastEventAt;
+		lastEventAt = now;
 		const consumer = findVerticalWheelConsumer(event);
 		if (consumer) {
 			lastConsumer = consumer;
-			lastConsumedAt = Date.now();
+			lastConsumedAt = now;
 			lastSeenDelta = event.deltaY;
 			return;
 		}
 		if (lastConsumer
 			&& event.target instanceof Node
 			&& lastConsumer.contains(event.target)
-			&& Date.now() - lastConsumedAt < MOMENTUM_GRACE_MS) {
+			&& now - lastConsumedAt < MOMENTUM_GRACE_MS) {
 			const sameDirection = Math.sign(event.deltaY) === Math.sign(lastSeenDelta);
 			const jumped = Math.abs(event.deltaY) > Math.abs(lastSeenDelta) + NEW_GESTURE_DELTA_JUMP;
-			if (sameDirection && !jumped) {
+			const gappedOut = gapSincePrev > GESTURE_GAP_MS;
+			if (sameDirection && !jumped && !gappedOut) {
 				lastSeenDelta = event.deltaY;
 				return;
 			}

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
@@ -40,15 +40,30 @@ tr:nth-child(even) {
 }
 `;
 
-type HTMLOutputWebviewMessage = {
+type HTMLOutputMetricsMessage = {
 	type: 'webviewMetrics';
 	bodyScrollHeight: number;
 	bodyScrollWidth: number;
 };
 
+type WheelForwardMessage = {
+	type: 'wheelForward';
+	deltaMode: number;
+	deltaY: number;
+};
 
-export function isHTMLOutputWebviewMessage(message: any): message is HTMLOutputWebviewMessage {
-	return message?.type === 'webviewMetrics';
+type HTMLOutputWebviewMessage = HTMLOutputMetricsMessage | WheelForwardMessage;
+
+
+export function isHTMLOutputWebviewMessage(message: unknown): message is HTMLOutputMetricsMessage {
+	return (message as HTMLOutputMetricsMessage | undefined)?.type === 'webviewMetrics';
+}
+
+export function isWheelForwardMessage(message: unknown): message is WheelForwardMessage {
+	const m = message as Partial<WheelForwardMessage> | undefined;
+	return m?.type === 'wheelForward'
+		&& typeof m.deltaMode === 'number'
+		&& typeof m.deltaY === 'number';
 }
 
 // Helper function for TypeScript typing
@@ -87,6 +102,48 @@ function webviewMessageCode() {
 	} catch (e) {
 		console.error('Error observing documentElement', e);
 	}
+
+	// Only forward the wheel event to the host when no ancestor inside the
+	// webview can consume the vertical scroll. Mirrors the pattern used by
+	// the notebook webview preload so scrollable outputs (e.g. overflow
+	// tables) don't double-scroll when they move under the cursor.
+	const canConsumeVerticalWheel = (event: WheelEvent): boolean => {
+		for (let node: Node | null = event.target as Node | null; node; node = node.parentNode) {
+			// eslint-disable-next-line no-restricted-syntax
+			if (!(node instanceof Element) || node === document.body || node === document.documentElement) {
+				return false;
+			}
+			// eslint-disable-next-line no-restricted-globals
+			const style = window.getComputedStyle(node);
+			const overflowY = style.overflowY;
+			if (overflowY !== 'auto' && overflowY !== 'scroll') {
+				continue;
+			}
+			if (node.scrollHeight <= node.clientHeight) {
+				continue;
+			}
+			if (event.deltaY < 0 && node.scrollTop > 0) {
+				return true;
+			}
+			if (event.deltaY > 0 && node.scrollTop + node.clientHeight < node.scrollHeight - 1) {
+				return true;
+			}
+		}
+		return false;
+	};
+
+	// eslint-disable-next-line no-restricted-globals
+	window.addEventListener('wheel', (event: WheelEvent) => {
+		if (event.defaultPrevented || event.deltaY === 0 || canConsumeVerticalWheel(event)) {
+			return;
+		}
+		vscode.postMessage({
+			type: 'wheelForward',
+			deltaMode: event.deltaMode,
+			deltaY: event.deltaY,
+		});
+	}, { passive: true });
+
 	// Send message on load back to Positron
 	// eslint-disable-next-line no-restricted-globals
 	window.onload = sendSizeMessage;

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
@@ -106,9 +106,10 @@ function webviewMessageCode() {
 	// Two things can happen when the user wheels over a webview output:
 	//
 	// 1. The output contains a scrollable element (e.g. a big pandas
-	//    DataFrame rendered with its own scrollbar). The browser scrolls
-	//    that element on its own -- we don't want to also scroll the
-	//    notebook around it, or the whole page lurches with the table.
+	//    DataFrame rendered with its own scrollbar, or a tall raw HTML
+	//    page where the body itself scrolls). The browser scrolls that
+	//    element on its own -- we don't want to also scroll the notebook
+	//    around it, or the whole page lurches with the content.
 	//
 	// 2. The output has nothing scrollable inside (e.g. a plotly plot,
 	//    a static image). Wheeling does nothing unless we forward the
@@ -119,14 +120,16 @@ function webviewMessageCode() {
 	// we stay quiet. Otherwise we forward the event to the host.
 	const canConsumeVerticalWheel = (event: WheelEvent): boolean => {
 		for (let node: Node | null = event.target as Node | null; node; node = node.parentNode) {
-			// eslint-disable-next-line no-restricted-syntax
-			if (!(node instanceof Element) || node === document.body || node === document.documentElement) {
+			if (!(node instanceof Element)) {
 				return false;
 			}
+			// eslint-disable-next-line no-restricted-syntax
+			const isBodyOrRoot = node === document.body || node === document.documentElement;
 			// eslint-disable-next-line no-restricted-globals
-			const style = window.getComputedStyle(node);
-			const overflowY = style.overflowY;
-			if (overflowY !== 'auto' && overflowY !== 'scroll') {
+			const overflowY = window.getComputedStyle(node).overflowY;
+			// Body and documentElement scroll implicitly when content overflows
+			// the viewport even without an explicit overflow-y style.
+			if (!isBodyOrRoot && overflowY !== 'auto' && overflowY !== 'scroll') {
 				continue;
 			}
 			if (node.scrollHeight <= node.clientHeight) {
@@ -142,9 +145,23 @@ function webviewMessageCode() {
 		return false;
 	};
 
+	// Trackpad momentum scrolling fires wheel events for a while after the
+	// user's fingers leave the pad. When an inner scroller hits its edge
+	// mid-gesture, the tail events would otherwise leak out and jerk the
+	// notebook. Suppress forwarding briefly after an inner consumer handled
+	// a wheel event so those tail events stay inside the output.
+	const MOMENTUM_GRACE_MS = 200;
+	let lastConsumedAt = 0;
 	// eslint-disable-next-line no-restricted-globals
 	window.addEventListener('wheel', (event: WheelEvent) => {
-		if (event.defaultPrevented || event.deltaY === 0 || canConsumeVerticalWheel(event)) {
+		if (event.defaultPrevented || event.deltaY === 0) {
+			return;
+		}
+		if (canConsumeVerticalWheel(event)) {
+			lastConsumedAt = Date.now();
+			return;
+		}
+		if (Date.now() - lastConsumedAt < MOMENTUM_GRACE_MS) {
 			return;
 		}
 		vscode.postMessage({

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
@@ -105,63 +105,79 @@ function webviewMessageCode() {
 
 	// Two things can happen when the user wheels over a webview output:
 	//
-	// 1. The output contains a scrollable element (e.g. a big pandas
-	//    DataFrame rendered with its own scrollbar, or a tall raw HTML
-	//    page where the body itself scrolls). The browser scrolls that
-	//    element on its own -- we don't want to also scroll the notebook
-	//    around it, or the whole page lurches with the content.
+	// 1. Something inside the output can still scroll in the current
+	//    direction: a pandas DataFrame with its own scrollbar, a tall
+	//    raw HTML page where the body itself scrolls, etc. The browser
+	//    handles those natively, so we stay out of the way -- otherwise
+	//    the notebook around it lurches along with the content.
 	//
-	// 2. The output has nothing scrollable inside (e.g. a plotly plot,
-	//    a static image). Wheeling does nothing unless we forward the
-	//    event out to the notebook container.
+	// 2. Nothing inside can consume more scroll in this direction.
+	//    That covers outputs with nothing scrollable (a plotly plot, a
+	//    static image) and outputs where an inner scroller has already
+	//    reached its top/bottom edge. In both cases, wheeling should
+	//    move the notebook, so we forward the event.
 	//
-	// So we walk up from the wheel target: if we find an ancestor that
-	// can still scroll in this direction, the browser will handle it and
-	// we stay quiet. Otherwise we forward the event to the host.
-	const canConsumeVerticalWheel = (event: WheelEvent): boolean => {
+	// findVerticalWheelConsumer walks up from the wheel target and
+	// returns the first scrollable ancestor that still has room in the
+	// wheel direction, or null when nothing can consume the scroll.
+	const findVerticalWheelConsumer = (event: WheelEvent): Element | null => {
 		for (let node: Node | null = event.target as Node | null; node; node = node.parentNode) {
 			if (!(node instanceof Element)) {
-				return false;
+				return null;
 			}
 			// eslint-disable-next-line no-restricted-syntax
 			const isBodyOrRoot = node === document.body || node === document.documentElement;
 			// eslint-disable-next-line no-restricted-globals
 			const overflowY = window.getComputedStyle(node).overflowY;
-			// Body and documentElement scroll implicitly when content overflows
-			// the viewport even without an explicit overflow-y style.
-			if (!isBodyOrRoot && overflowY !== 'auto' && overflowY !== 'scroll') {
+			if (isBodyOrRoot) {
+				// Body/root scroll implicitly when content overflows the
+				// viewport, unless the page explicitly disables it with
+				// overflow-y: hidden or clip.
+				if (overflowY === 'hidden' || overflowY === 'clip') {
+					continue;
+				}
+			} else if (overflowY !== 'auto' && overflowY !== 'scroll') {
 				continue;
 			}
 			if (node.scrollHeight <= node.clientHeight) {
 				continue;
 			}
 			if (event.deltaY < 0 && node.scrollTop > 0) {
-				return true;
+				return node;
 			}
 			if (event.deltaY > 0 && node.scrollTop + node.clientHeight < node.scrollHeight - 1) {
-				return true;
+				return node;
 			}
 		}
-		return false;
+		return null;
 	};
 
-	// Trackpad momentum scrolling fires wheel events for a while after the
-	// user's fingers leave the pad. When an inner scroller hits its edge
-	// mid-gesture, the tail events would otherwise leak out and jerk the
-	// notebook. Suppress forwarding briefly after an inner consumer handled
-	// a wheel event so those tail events stay inside the output.
+	// Trackpad momentum scrolling fires wheel events for a while after
+	// the user's fingers leave the pad. When the inner scroller hits its
+	// edge mid-gesture, the tail events would otherwise leak out and
+	// jerk the notebook. Briefly keep routing to the element that last
+	// consumed a wheel event: as long as the cursor is still inside that
+	// element, suppress forwarding so momentum stays with that scroller
+	// rather than the notebook around it. Moving the pointer elsewhere
+	// (or letting the grace window lapse) lets new wheels through.
 	const MOMENTUM_GRACE_MS = 200;
+	let lastConsumer: Element | null = null;
 	let lastConsumedAt = 0;
 	// eslint-disable-next-line no-restricted-globals
 	window.addEventListener('wheel', (event: WheelEvent) => {
 		if (event.defaultPrevented || event.deltaY === 0) {
 			return;
 		}
-		if (canConsumeVerticalWheel(event)) {
+		const consumer = findVerticalWheelConsumer(event);
+		if (consumer) {
+			lastConsumer = consumer;
 			lastConsumedAt = Date.now();
 			return;
 		}
-		if (Date.now() - lastConsumedAt < MOMENTUM_GRACE_MS) {
+		if (lastConsumer
+			&& event.target instanceof Node
+			&& lastConsumer.contains(event.target)
+			&& Date.now() - lastConsumedAt < MOMENTUM_GRACE_MS) {
 			return;
 		}
 		vscode.postMessage({

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
@@ -138,7 +138,6 @@ function webviewMessageCode() {
 		if (effectiveOverflow === 'hidden' || effectiveOverflow === 'clip') {
 			return null;
 		}
-		// eslint-disable-next-line no-restricted-syntax
 		return document.scrollingElement;
 	};
 

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
@@ -147,6 +147,11 @@ function webviewMessageCode() {
 	const findVerticalWheelConsumer = (event: WheelEvent): Element | null => {
 		const viewportConsumer = getViewportScrollConsumer();
 		for (let node: Node | null = event.target as Node | null; node; node = node.parentNode) {
+			// parentNode stops at a ShadowRoot; hop to its host so an
+			// ancestor scroller outside the shadow tree is still reached.
+			if (node instanceof ShadowRoot) {
+				node = node.host;
+			}
 			if (!(node instanceof Element)) {
 				return null;
 			}


### PR DESCRIPTION
Addresses #12317.

Webview-based notebook outputs (e.g. plotly charts, complex html) were a scroll dead zone: wheel events landed in the webview sandbox, found nothing to consume them, and stopped. Hovering over a plot would freeze the notebook scroll until the cursor moved off.

### Summary

The fix adds a `wheel` listener inside each webview's preload that walks up the DOM (crossing shadow-root boundaries) looking for an ancestor that can still scroll in the wheel's direction. If it finds one, it just lets the browser scroll natively. If nothing inside can consume the scroll, it posts a `wheelForward` message back to the notebook with the wheel's `deltaY` and `deltaMode`; the notebook mount hook applies that delta to the cells container. (Note: we did some normalizing `DOM_DELTA_LINE` (Firefox) and `DOM_DELTA_PAGE` to pixels. This is not an exact science but testing makes it seem like it works well enough.)

Trackpad momentum gets special handling. After the user lifts their fingers, wheel events keep firing for a few hundred milliseconds as the scroll coasts. If an inner scroller hits its edge mid-coast, those tail events would otherwise leak out and jerk the notebook. The preload remembers the last-consumed scroller and keeps routing momentum to it for a short grace window, breaking out only on signals that look like a fresh human gesture (direction reversal, sudden jump in delta magnitude, or a gap too long to be momentum decay).

### Demo

_Scrolling around over the webview works as expected._

https://github.com/user-attachments/assets/21ac700c-5c3a-4f21-90b4-f3aff62dd973



### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed scrolling over plotly charts and other webview-hosted outputs in Positron notebooks (#12317)

### QA Notes

@:positron-notebooks @:plots

1. Open a new Positron notebook with a Python interpreter.
2. Add the following plotly plot

```python
import plotly.express as px
import pandas as pd

px.line(pd.DataFrame({
    'date': pd.date_range('2024-01-01', periods=2),
    'price': [100, 102]
}), x='date', y='price').show()
```
3. Verify you can scroll as you would expect through the notebook even with the mouse over the plot.