### PR TITLE
Add support for local links in positron notebooks

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookLink.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookLink.tsx
@@ -16,12 +16,16 @@ import { usePositronReactServicesContext } from '../../../../../base/browser/pos
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 
 const FRAGMENT_REGEX = /^(.*)#([^#]*)$/;
+const SCHEME_REGEX = /^[\w\-]+:/;
 
 /**
  * Resolves a markdown link href against the notebook's location.
  * Mirrors upstream `_handleResourceOpening` in
  * src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
  * (which is private, so we port the logic locally per upstream-compat policy).
+ *
+ * Returns undefined for hrefs with a scheme (http, mailto, command, file, etc.)
+ * so the caller can pass them through to the opener service unchanged.
  */
 export async function resolveNotebookLinkTarget(
 	href: string,
@@ -29,6 +33,8 @@ export async function resolveNotebookLinkTarget(
 	pathService: IPathService,
 	workspaceContextService: IWorkspaceContextService,
 ): Promise<URI | undefined> {
+	if (SCHEME_REGEX.test(href)) { return undefined; }
+
 	// Separate the fragment so URI.joinPath doesn't URL-encode it.
 	let fragment: string | undefined;
 	const m = FRAGMENT_REGEX.exec(href);
@@ -73,8 +79,6 @@ export async function resolveNotebookLinkTarget(
 interface NotebookLinkProps extends React.ComponentPropsWithoutRef<'a'> {
 }
 
-const SCHEME_REGEX = /^[\w\-]+:/;
-
 function tryDecodeURIComponent(uri: string): string {
 	try { return decodeURIComponent(uri); } catch { return uri; }
 }
@@ -106,17 +110,13 @@ export function NotebookLink(props: NotebookLinkProps) {
 	const activateLink = async (): Promise<void> => {
 		if (!href) { return; }
 		if (href.trim().startsWith('#')) { return; }
-		if (SCHEME_REGEX.test(href)) {
-			services.openerService.open(href);
-			return;
-		}
 		const target = await resolveNotebookLinkTarget(
 			tryDecodeURIComponent(href),
 			instance.uri,
 			services.pathService,
 			services.workspaceContextService,
 		);
-		services.openerService.open(target ?? href);
+		await services.openerService.open(target ?? href);
 	};
 
 	// Heuristic: we'll handle anything non-empty that isn't a pure anchor.

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookLink.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookLink.tsx
@@ -7,18 +7,85 @@
 import React from 'react';
 
 // Other dependencies.
+import { URI } from '../../../../../base/common/uri.js';
+import { dirname } from '../../../../../base/common/resources.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { IPathService } from '../../../../services/path/common/pathService.js';
+import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { useNotebookInstance } from '../NotebookInstanceProvider.js';
+
+const FRAGMENT_REGEX = /^(.*)#([^#]*)$/;
+
+/**
+ * Resolves a markdown link href against the notebook's location.
+ * Mirrors upstream `_handleResourceOpening` in
+ * src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+ * (which is private, so we port the logic locally per upstream-compat policy).
+ */
+export async function resolveNotebookLinkTarget(
+	href: string,
+	notebookUri: URI,
+	pathService: IPathService,
+	workspaceContextService: IWorkspaceContextService,
+): Promise<URI | undefined> {
+	// Separate the fragment so URI.joinPath doesn't URL-encode it.
+	let fragment: string | undefined;
+	const m = FRAGMENT_REGEX.exec(href);
+	if (m) {
+		href = m[1];
+		fragment = m[2];
+	}
+
+	let target: URI | undefined;
+	if (href.startsWith('/')) {
+		target = await pathService.fileURI(href);
+		const folders = workspaceContextService.getWorkspace().folders;
+		if (folders.length) {
+			target = target.with({
+				scheme: folders[0].uri.scheme,
+				authority: folders[0].uri.authority,
+			});
+		}
+	} else if (href.startsWith('~')) {
+		const userHome = await pathService.userHome();
+		if (userHome) {
+			target = URI.joinPath(userHome, href.substring(2));
+		}
+	} else {
+		if (notebookUri.scheme === Schemas.untitled) {
+			const folders = workspaceContextService.getWorkspace().folders;
+			if (!folders.length) {
+				return undefined;
+			}
+			target = URI.joinPath(folders[0].uri, href);
+		} else {
+			target = URI.joinPath(dirname(notebookUri), href);
+		}
+	}
+
+	if (target && fragment !== undefined) {
+		target = target.with({ fragment });
+	}
+	return target;
+}
 
 interface NotebookLinkProps extends React.ComponentPropsWithoutRef<'a'> {
 }
 
+const SCHEME_REGEX = /^[\w\-]+:/;
+
+function tryDecodeURIComponent(uri: string): string {
+	try { return decodeURIComponent(uri); } catch { return uri; }
+}
+
 /**
- * Link component for notebook markdown cells that handles anchor links by letting
- * the browser handle them with default behavior. For other links, it delegates to
- * the opener service like ExternalLink does.
+ * Link component for notebook markdown cells. Resolves relative paths against
+ * the notebook's location, mirroring the legacy notebook editor's behavior.
+ * Anchors (#section) are left to the browser. Other schemed hrefs (http,
+ * command, mailto, file, etc.) are passed to openerService unchanged.
  *
- * This component also handles keyboard activation (Enter/Space) to ensure links
- * are accessible when tabbing through rendered markdown content.
+ * Keyboard activation (Enter/Space) is handled for accessibility.
  *
  * @param props The props for the link component.
  * @returns The rendered link component.
@@ -26,37 +93,41 @@ interface NotebookLinkProps extends React.ComponentPropsWithoutRef<'a'> {
 export function NotebookLink(props: NotebookLinkProps) {
 	// Context hooks.
 	const services = usePositronReactServicesContext();
+	const instance = useNotebookInstance();
 
 	const { href, ...otherProps } = props;
 
 	/**
-	 * Activates the link, either by letting the browser handle anchor links
-	 * or by using the opener service for other links.
-	 * @returns true if the link was handled by the opener service, false if handled by browser
+	 * Activates the link. Returns true if the opener service will handle it,
+	 * false if the browser should (anchors, or unresolvable hrefs).
 	 */
-	const activateLink = (): boolean => {
-		if (!href) {
-			return false;
+	const activateLink = async (): Promise<boolean> => {
+		if (!href) { return false; }
+		if (href.trim().startsWith('#')) { return false; }
+		if (SCHEME_REGEX.test(href)) {
+			services.openerService.open(href);
+			return true;
 		}
-
-		const isAnchorLink = href.trim().startsWith('#');
-
-		// For anchor links, let browser handle with default behavior
-		if (isAnchorLink) {
-			return false;
+		const target = await resolveNotebookLinkTarget(
+			tryDecodeURIComponent(href),
+			instance.uri,
+			services.pathService,
+			services.workspaceContextService,
+		);
+		if (target) {
+			services.openerService.open(target);
+			return true;
 		}
-
-		// For other links, use opener service
-		services.openerService.open(href);
-		return true;
+		return false;
 	};
 
+	// Heuristic: we'll handle anything non-empty that isn't a pure anchor.
+	// Must preventDefault synchronously -- can't wait on the async activate.
+	const willHandle = !!href && !href.trim().startsWith('#');
+
 	const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-		const linkHandled = activateLink();
-		// If the link was handled by the opener service, prevent default browser navigation
-		if (linkHandled) {
-			e.preventDefault();
-		}
+		if (willHandle) { e.preventDefault(); }
+		activateLink().catch(() => { /* errors surface via openerService dialogs */ });
 	};
 
 	/**
@@ -68,9 +139,8 @@ export function NotebookLink(props: NotebookLinkProps) {
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
 		if (e.key === 'Enter' || e.key === ' ') {
 			e.stopPropagation();
-			if (activateLink()) {
-				e.preventDefault();
-			}
+			if (willHandle) { e.preventDefault(); }
+			activateLink().catch(() => { /* see handleClick */ });
 		}
 	};
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookLink.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookLink.tsx
@@ -98,15 +98,17 @@ export function NotebookLink(props: NotebookLinkProps) {
 	const { href, ...otherProps } = props;
 
 	/**
-	 * Activates the link. Returns true if the opener service will handle it,
-	 * false if the browser should (anchors, or unresolvable hrefs).
+	 * Activates the link. Anchors and empty hrefs are left to the browser;
+	 * everything else is passed to openerService. If notebook-relative
+	 * resolution fails, we still open the raw href so the click is not
+	 * silently dropped after the synchronous preventDefault.
 	 */
-	const activateLink = async (): Promise<boolean> => {
-		if (!href) { return false; }
-		if (href.trim().startsWith('#')) { return false; }
+	const activateLink = async (): Promise<void> => {
+		if (!href) { return; }
+		if (href.trim().startsWith('#')) { return; }
 		if (SCHEME_REGEX.test(href)) {
 			services.openerService.open(href);
-			return true;
+			return;
 		}
 		const target = await resolveNotebookLinkTarget(
 			tryDecodeURIComponent(href),
@@ -114,11 +116,7 @@ export function NotebookLink(props: NotebookLinkProps) {
 			services.pathService,
 			services.workspaceContextService,
 		);
-		if (target) {
-			services.openerService.open(target);
-			return true;
-		}
-		return false;
+		services.openerService.open(target ?? href);
 	};
 
 	// Heuristic: we'll handle anything non-empty that isn't a pure anchor.

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/NotebookLink.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/NotebookLink.test.tsx
@@ -1,0 +1,210 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { URI } from '../../../../../../base/common/uri.js';
+import { IPathService } from '../../../../../services/path/common/pathService.js';
+import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../../platform/workspace/common/workspace.js';
+import { resolveNotebookLinkTarget } from '../../../browser/notebookCells/NotebookLink.js';
+
+/**
+ * Minimal IPathService fake. fileURI and userHome return deterministic URIs so
+ * tests can assert on the exact output. Unknown members throw so an unexpected
+ * access produces a clear error instead of a cryptic null-deref.
+ */
+function makePathService(opts: { userHome?: URI } = {}): IPathService {
+	const stub = {
+		fileURI: async (path: string) => URI.from({ scheme: 'file', path }),
+		userHome: async () => opts.userHome ?? URI.from({ scheme: 'file', path: '/home/test' }),
+	};
+	return new Proxy(stub, {
+		get(target, prop) {
+			if (prop in target) { return target[prop as keyof typeof target]; }
+			throw new Error(`Unexpected access to IPathService.${String(prop)}`);
+		},
+	}) as IPathService;
+}
+
+/**
+ * Minimal IWorkspaceContextService fake. getWorkspace().folders returns the
+ * folders passed in; everything else throws to catch unintended access.
+ */
+function makeWorkspaceContextService(folders: IWorkspaceFolder[] = []): IWorkspaceContextService {
+	const stub = { getWorkspace: () => ({ folders }) };
+	return new Proxy(stub, {
+		get(target, prop) {
+			if (prop in target) { return target[prop as keyof typeof target]; }
+			throw new Error(`Unexpected access to IWorkspaceContextService.${String(prop)}`);
+		},
+	}) as IWorkspaceContextService;
+}
+
+function folder(uri: URI): IWorkspaceFolder {
+	return { uri, name: uri.path, index: 0, toResource: (p: string) => URI.joinPath(uri, p) };
+}
+
+suite('Positron Notebook - resolveNotebookLinkTarget', () => {
+	test('resolves a bare relative filename against the notebook dir', async () => {
+		const nb = URI.parse('file:///a/b/nb.ipynb');
+		const result = await resolveNotebookLinkTarget(
+			'test.py',
+			nb,
+			makePathService(),
+			makeWorkspaceContextService(),
+		);
+		assert.strictEqual(result?.toString(), 'file:///a/b/test.py');
+	});
+
+	test('resolves ./file against the notebook dir', async () => {
+		const nb = URI.parse('file:///a/b/nb.ipynb');
+		const result = await resolveNotebookLinkTarget(
+			'./test.py',
+			nb,
+			makePathService(),
+			makeWorkspaceContextService(),
+		);
+		assert.strictEqual(result?.toString(), 'file:///a/b/test.py');
+	});
+
+	test('resolves ../file one dir up', async () => {
+		const nb = URI.parse('file:///a/b/nb.ipynb');
+		const result = await resolveNotebookLinkTarget(
+			'../test.py',
+			nb,
+			makePathService(),
+			makeWorkspaceContextService(),
+		);
+		assert.strictEqual(result?.toString(), 'file:///a/test.py');
+	});
+
+	test('resolves subdir/file into a subdirectory', async () => {
+		const nb = URI.parse('file:///a/b/nb.ipynb');
+		const result = await resolveNotebookLinkTarget(
+			'sub/test.py',
+			nb,
+			makePathService(),
+			makeWorkspaceContextService(),
+		);
+		assert.strictEqual(result?.toString(), 'file:///a/b/sub/test.py');
+	});
+
+	test('relative path on a remote notebook stays on remote', async () => {
+		const nb = URI.parse('vscode-remote://host/a/nb.ipynb');
+		const result = await resolveNotebookLinkTarget(
+			'test.py',
+			nb,
+			makePathService(),
+			makeWorkspaceContextService(),
+		);
+		assert.strictEqual(result?.toString(), 'vscode-remote://host/a/test.py');
+	});
+
+	test('preserves a #fragment when resolving a relative path', async () => {
+		const nb = URI.parse('file:///a/b/nb.ipynb');
+		const result = await resolveNotebookLinkTarget(
+			'file.md#section',
+			nb,
+			makePathService(),
+			makeWorkspaceContextService(),
+		);
+		assert.strictEqual(result?.path, '/a/b/file.md');
+		assert.strictEqual(result?.fragment, 'section');
+	});
+
+	test('handles empty fragment', async () => {
+		const nb = URI.parse('file:///a/b/nb.ipynb');
+		const result = await resolveNotebookLinkTarget(
+			'file.md#',
+			nb,
+			makePathService(),
+			makeWorkspaceContextService(),
+		);
+		assert.strictEqual(result?.path, '/a/b/file.md');
+		assert.strictEqual(result?.fragment, '');
+	});
+
+	test('absolute /path uses pathService and inherits workspace scheme/authority', async () => {
+		const nb = URI.parse('file:///a/b/nb.ipynb');
+		const ws = folder(URI.parse('vscode-remote://host/workspace'));
+		const result = await resolveNotebookLinkTarget(
+			'/abs/path.py',
+			nb,
+			makePathService(),
+			makeWorkspaceContextService([ws]),
+		);
+		assert.strictEqual(result?.scheme, 'vscode-remote');
+		assert.strictEqual(result?.authority, 'host');
+		assert.strictEqual(result?.path, '/abs/path.py');
+	});
+
+	test('absolute /path with no workspace folder stays on file://', async () => {
+		const nb = URI.parse('file:///a/b/nb.ipynb');
+		const result = await resolveNotebookLinkTarget(
+			'/abs/path.py',
+			nb,
+			makePathService(),
+			makeWorkspaceContextService(),
+		);
+		assert.strictEqual(result?.scheme, 'file');
+		assert.strictEqual(result?.path, '/abs/path.py');
+	});
+
+	test('absolute /path preserves a #fragment', async () => {
+		const nb = URI.parse('file:///a/b/nb.ipynb');
+		const result = await resolveNotebookLinkTarget(
+			'/abs/file.md#sec',
+			nb,
+			makePathService(),
+			makeWorkspaceContextService(),
+		);
+		assert.strictEqual(result?.path, '/abs/file.md');
+		assert.strictEqual(result?.fragment, 'sec');
+	});
+
+	test('~/file joins against userHome', async () => {
+		const nb = URI.parse('file:///a/b/nb.ipynb');
+		const result = await resolveNotebookLinkTarget(
+			'~/file.py',
+			nb,
+			makePathService({ userHome: URI.parse('file:///home/test') }),
+			makeWorkspaceContextService(),
+		);
+		assert.strictEqual(result?.toString(), 'file:///home/test/file.py');
+	});
+
+	test('~ alone with no trailing slash resolves to userHome root', async () => {
+		const nb = URI.parse('file:///a/b/nb.ipynb');
+		const result = await resolveNotebookLinkTarget(
+			'~',
+			nb,
+			makePathService({ userHome: URI.parse('file:///home/test') }),
+			makeWorkspaceContextService(),
+		);
+		assert.strictEqual(result?.toString(), 'file:///home/test');
+	});
+
+	test('untitled notebook with workspace folder resolves against the folder', async () => {
+		const nb = URI.parse('untitled:Untitled-1');
+		const ws = folder(URI.parse('file:///workspace'));
+		const result = await resolveNotebookLinkTarget(
+			'test.py',
+			nb,
+			makePathService(),
+			makeWorkspaceContextService([ws]),
+		);
+		assert.strictEqual(result?.toString(), 'file:///workspace/test.py');
+	});
+
+	test('untitled notebook with no workspace folder returns undefined', async () => {
+		const nb = URI.parse('untitled:Untitled-1');
+		const result = await resolveNotebookLinkTarget(
+			'test.py',
+			nb,
+			makePathService(),
+			makeWorkspaceContextService(),
+		);
+		assert.strictEqual(result, undefined);
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/NotebookLink.test.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/NotebookLink.test.tsx
@@ -207,4 +207,17 @@ suite('Positron Notebook - resolveNotebookLinkTarget', () => {
 		);
 		assert.strictEqual(result, undefined);
 	});
+
+	test('schemed hrefs return undefined so the caller passes them through unchanged', async () => {
+		const nb = URI.parse('file:///a/b/nb.ipynb');
+		for (const href of ['http://example.com', 'https://example.com/p', 'mailto:a@b.c', 'command:foo', 'file:///x/y']) {
+			const result = await resolveNotebookLinkTarget(
+				href,
+				nb,
+				makePathService(),
+				makeWorkspaceContextService(),
+			);
+			assert.strictEqual(result, undefined, `expected undefined for ${href}`);
+		}
+	});
 });


### PR DESCRIPTION
Addresses #12320.

Relative markdown links inside Positron notebook cells (e.g. `[test](test_b.py)`, `[readme](../README.md)`, `[helper](./helpers/util.py)`) now resolve against the notebook's location, matching the behavior of the legacy notebook editor. Previously these links were passed verbatim to the opener service, which couldn't find the file and showed "The editor could not be opened because the file was not found."

The resolver ports upstream `_handleResourceOpening` from `backLayerWebView.ts` (private upstream, so we copied it). It covers:

- Relative paths (`./x`, `../x`, `sub/x`) — resolved against the notebook's directory
- Absolute `/paths` — inherit the workspace folder's scheme/authority so remote workspaces work
- `~/...` — joined against `userHome`
- Untitled notebooks — fall back to the first workspace folder
- Schemed URIs (`http:`, `mailto:`, `command:`, `file:`, ...) and pure `#anchors` — passed through unchanged
- Fragments (`file.md#section`) — preserved on the resolved URI

If async resolution returns no target, the raw href is still handed to `openerService`.

### Demo

https://github.com/user-attachments/assets/07d527b5-f182-43b3-b83d-9c0d1327edd2


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Route relative markdown links in Positron notebook cells to the correct file (#12320)

### QA Notes

@:positron-notebooks

1. Enable the Positron notebook editor (`positron.notebook.enabled: true`).
2. Create a folder containing a notebook and a sibling file, e.g. `analysis.ipynb` and `test_b.py`.
3. In a markdown cell, add `[test](test_b.py)` and render it.
4. Click the link — `test_b.py` should open in an editor tab.
5. Repeat with `[up](../README.md)` (parent dir), `[sub](./helpers/util.py)` (subdirectory), and `[home](~/Desktop/note.md)`.
6. Confirm anchors (`[top](#heading)`) and external URLs (`[posit](https://posit.co)`) still work as before.
