### PR TITLE
Pull in latest from vscode-server

### DIFF
--- a/build/gulpfile.reh.ts
+++ b/build/gulpfile.reh.ts
@@ -40,6 +40,11 @@ import { positronBuildNumber, releaseChannel } from './utils.ts';
 import { compileBuildWithoutManglingTask } from './gulpfile.compile.ts';
 import { getQuartoBinaries } from './lib/quarto.ts';
 // --- End Positron ---
+// --- Start PWB: build-time gzip compression ---
+import through2 from 'through2';
+import { gzip } from 'zlib';
+import { promisify } from 'util';
+// --- End PWB ---
 
 const REPO_ROOT = path.dirname(import.meta.dirname);
 const commit = getVersion(REPO_ROOT);
@@ -299,6 +304,53 @@ function nodejs(platform: string, arch: string): NodeJS.ReadWriteStream | undefi
 	}
 }
 
+// --- Start PWB: build-time gzip compression ---
+const gzipAsync = promisify(gzip);
+const COMPRESSIBLE = /\.(js|css|json|html|svg|wasm)$/;
+const MIN_SIZE_BYTES = 1024;
+
+function addCompressedSiblings(): NodeJS.ReadWriteStream {
+	let compressed = 0;
+	let skipped = 0;
+
+	return through2.obj(
+		async function (file: File, _enc: BufferEncoding, cb: (err?: Error | null) => void) {
+			this.push(file);
+
+			if (!file.isBuffer() || !COMPRESSIBLE.test(file.path)) { return cb(); }
+			if ((file.contents as Buffer).length < MIN_SIZE_BYTES) { return cb(); }
+
+			try {
+				const gz = await gzipAsync(file.contents as Buffer, { level: 9 });
+				if (gz.length >= (file.contents as Buffer).length) {
+					skipped++;
+					return cb();
+				}
+
+				const gzFile = file.clone({ contents: false });
+				gzFile.path = file.path + '.gz';
+				gzFile.contents = gz;
+				gzFile.stat = Object.assign({}, file.stat ?? {}, {
+					mode: 0o644,
+					mtime: file.stat?.mtime ?? new Date(),
+					atime: file.stat?.atime ?? new Date(),
+				}) as import('fs').Stats;
+
+				this.push(gzFile);
+				compressed++;
+				cb();
+			} catch (err) {
+				cb(err instanceof Error ? err : new Error(String(err)));
+			}
+		},
+		function (cb: () => void) {
+			log(`[compress] ${compressed} files compressed, ${skipped} skipped (already compressed or smaller)`);
+			cb();
+		}
+	);
+}
+// --- End PWB ---
+
 function packageTask(type: string, platform: string, arch: string, sourceFolderName: string, destinationFolderName: string) {
 	const destination = path.join(BUILD_ROOT, destinationFolderName);
 
@@ -547,6 +599,13 @@ function packageTask(type: string, platform: string, arch: string, sourceFolderN
 			productJsonFn: () => productJsonContents
 		});
 
+		// --- Start PWB: build-time gzip compression (web builds only) ---
+		if (isWebType(type)) {
+			return result
+				.pipe(addCompressedSiblings())
+				.pipe(vfs.dest(destination));
+		}
+		// --- End PWB ---
 		return result.pipe(vfs.dest(destination));
 	};
 }

--- a/product.json
+++ b/product.json
@@ -94,10 +94,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "2026.5.2",
+			"version": "2026.5.4",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web-pwb",
-			"sha256": "dcab9474334bb9ede3639277c0034baa3d482b12057abba2308d2756e2bc69e1",
+			"sha256": "af0786f6732b28c929892c2fbefde5ddf65bb68bb7742c7e1047438068365dc2",
 			"metadata": {
 				"publisherDisplayName": "Posit PBC"
 			}

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -83,6 +83,29 @@ export async function serveFile(filePath: string, cacheControl: CacheControl, lo
 
 		responseHeaders['Content-Type'] = textMimeType[extname(filePath)] || getMediaMime(filePath) || 'text/plain';
 
+		// --- Start PWB: serve pre-compressed .gz sibling when available ---
+		const acceptsGzip = /\bgzip\b/.test(req.headers['accept-encoding'] ?? '');
+		if (acceptsGzip) {
+			try {
+				const gzContents = await promises.readFile(filePath + '.gz');
+				responseHeaders['Content-Encoding'] = 'gzip';
+				const existingVary = responseHeaders['Vary'];
+				responseHeaders['Vary'] = existingVary ? `${existingVary}, Accept-Encoding` : 'Accept-Encoding';
+				// Content-Length must be set explicitly: the C++ proxy (ServerSessionProxy.cpp)
+				// strips Transfer-Encoding: chunked, so omitting it truncates the response.
+				responseHeaders['Content-Length'] = String(gzContents.byteLength);
+				res.writeHead(200, responseHeaders);
+				res.end(gzContents);
+				return;
+			} catch (err: unknown) {
+				if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+					logService.error(err instanceof Error ? err : new Error(String(err)));
+				}
+				// .gz not present - fall through to uncompressed
+			}
+		}
+		// --- End PWB ---
+
 		res.writeHead(200, responseHeaders);
 
 		// Data


### PR DESCRIPTION
Part of https://github.com/rstudio/rstudio-pro/issues/10721
Brings in:
- rstudio/vscode-server#345: Pre-compress static assets at build time, serve .gz when client accepts gzip
- rstudio/vscode-server#346: Bump rstudio.rstudio-workbench to version 2026.5.4

### Release Notes

#### New Features

- Positron Server static assets are now pre-compressed at build time, reducing load times in the browser.

#### Bug Fixes

- N/A

### QA Notes

@:workbench @:web
