### PR TITLE
Add "item size" to toggle between rows / cards for the Packages pane

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -8,11 +8,12 @@ import importlib.metadata
 import inspect
 import logging
 import os
+import re
 import sys
 import types
 import webbrowser
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Union
 from urllib.parse import urlparse
 
 from comm.base_comm import BaseComm
@@ -160,12 +161,29 @@ def _get_packages_installed(kernel: "PositronIPyKernel", _params: List[JsonData]
         if canonical not in packages_dict:
             import_names = _import_names_for_dist(dist, canonical)
             attached = any(import_name in user_top_levels for import_name in import_names)
+            # PackageMetadata (the 3.14 protocol) doesn't expose .get(), but the
+            # runtime object (email.message.Message) always has it.
+            metadata: Any = dist.metadata
+            summary = metadata.get("Summary")
+            # Fall back through Author, Author-email, Maintainer, Maintainer-email so
+            # packages that set only a maintainer (e.g. click's `Pallets`) still show one.
+            author = ""
+            for field in ("Author", "Author-email", "Maintainer", "Maintainer-email"):
+                value = metadata.get(field)
+                if value and value != "UNKNOWN":
+                    # Strip trailing email addresses in angle brackets to match the R side.
+                    stripped = re.sub(r"\s*<[^>]+>", "", value).strip()
+                    if stripped:
+                        author = stripped
+                        break
             packages_dict[canonical] = {
                 "id": f"{canonical}-{dist.version}",
                 "name": name,
                 "displayName": canonical,
                 "version": dist.version,
                 "attached": attached,
+                "description": summary if summary and summary != "UNKNOWN" else "",
+                "author": author,
             }
     return sorted(packages_dict.values(), key=lambda p: p["displayName"])
 

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -126,11 +126,15 @@ def _get_packages_installed(_kernel: "PositronIPyKernel", _params: List[JsonData
         canonical = canonicalize_name(name)
         # Dedupe by canonical name - keeps first occurrence (the one that would be imported)
         if canonical not in packages_dict:
+            summary = dist.metadata.get("Summary")
+            author = dist.metadata.get("Author") or dist.metadata.get("Author-email")
             packages_dict[canonical] = {
                 "id": f"{canonical}-{dist.version}",
                 "name": name,
                 "displayName": canonical,
                 "version": dist.version,
+                "description": summary if summary and summary != "UNKNOWN" else "",
+                "author": author if author and author != "UNKNOWN" else "",
             }
     return sorted(packages_dict.values(), key=lambda p: p["displayName"])
 

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -12,7 +12,7 @@ import re
 import sys
 import webbrowser
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 from comm.base_comm import BaseComm
@@ -127,12 +127,15 @@ def _get_packages_installed(_kernel: "PositronIPyKernel", _params: List[JsonData
         canonical = canonicalize_name(name)
         # Dedupe by canonical name - keeps first occurrence (the one that would be imported)
         if canonical not in packages_dict:
-            summary = dist.metadata.get("Summary")
+            # PackageMetadata (the 3.14 protocol) doesn't expose .get(), but the
+            # runtime object (email.message.Message) always has it.
+            metadata: Any = dist.metadata
+            summary = metadata.get("Summary")
             # Fall back through Author → Author-email → Maintainer → Maintainer-email so
             # packages that set only a maintainer (e.g. click's `Pallets`) still show one.
             author = ""
             for field in ("Author", "Author-email", "Maintainer", "Maintainer-email"):
-                value = dist.metadata.get(field)
+                value = metadata.get(field)
                 if value and value != "UNKNOWN":
                     # Strip trailing email addresses in angle brackets to match the R side.
                     stripped = re.sub(r"\s*<[^>]+>", "", value).strip()

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -8,7 +8,6 @@ import importlib.metadata
 import inspect
 import logging
 import os
-import re
 import sys
 import types
 import webbrowser
@@ -165,17 +164,6 @@ def _get_packages_installed(kernel: "PositronIPyKernel", _params: List[JsonData]
             # runtime object (email.message.Message) always has it.
             metadata: Any = dist.metadata
             summary = metadata.get("Summary")
-            # Fall back through Author, Author-email, Maintainer, Maintainer-email so
-            # packages that set only a maintainer (e.g. click's `Pallets`) still show one.
-            author = ""
-            for field in ("Author", "Author-email", "Maintainer", "Maintainer-email"):
-                value = metadata.get(field)
-                if value and value != "UNKNOWN":
-                    # Strip trailing email addresses in angle brackets to match the R side.
-                    stripped = re.sub(r"\s*<[^>]+>", "", value).strip()
-                    if stripped:
-                        author = stripped
-                        break
             packages_dict[canonical] = {
                 "id": f"{canonical}-{dist.version}",
                 "name": name,
@@ -183,7 +171,6 @@ def _get_packages_installed(kernel: "PositronIPyKernel", _params: List[JsonData]
                 "version": dist.version,
                 "attached": attached,
                 "description": summary if summary and summary != "UNKNOWN" else "",
-                "author": author,
             }
     return sorted(packages_dict.values(), key=lambda p: p["displayName"])
 

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -8,6 +8,7 @@ import importlib.metadata
 import inspect
 import logging
 import os
+import re
 import sys
 import webbrowser
 from pathlib import Path
@@ -127,14 +128,24 @@ def _get_packages_installed(_kernel: "PositronIPyKernel", _params: List[JsonData
         # Dedupe by canonical name - keeps first occurrence (the one that would be imported)
         if canonical not in packages_dict:
             summary = dist.metadata.get("Summary")
-            author = dist.metadata.get("Author") or dist.metadata.get("Author-email")
+            # Fall back through Author → Author-email → Maintainer → Maintainer-email so
+            # packages that set only a maintainer (e.g. click's `Pallets`) still show one.
+            author = ""
+            for field in ("Author", "Author-email", "Maintainer", "Maintainer-email"):
+                value = dist.metadata.get(field)
+                if value and value != "UNKNOWN":
+                    # Strip trailing email addresses in angle brackets to match the R side.
+                    stripped = re.sub(r"\s*<[^>]+>", "", value).strip()
+                    if stripped:
+                        author = stripped
+                        break
             packages_dict[canonical] = {
                 "id": f"{canonical}-{dist.version}",
                 "name": name,
                 "displayName": canonical,
                 "version": dist.version,
                 "description": summary if summary and summary != "UNKNOWN" else "",
-                "author": author if author and author != "UNKNOWN" else "",
+                "author": author,
             }
     return sorted(packages_dict.values(), key=lambda p: p["displayName"])
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1159,6 +1159,8 @@ declare module 'positron' {
 
 		/** Optional short description or summary shown in the Packages pane card view. */
 		description?: string;
+		/** Optional author shown in the Packages pane card view. */
+		author?: string;
 	}
 
 	/**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1156,6 +1156,9 @@ declare module 'positron' {
 
 		/** Publication/release date */
 		publishedDate?: string;
+
+		/** Optional short description or summary shown in the Packages pane card view. */
+		description?: string;
 	}
 
 	/**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1235,9 +1235,6 @@ declare module 'positron' {
 
 		/** Optional short description or summary shown in the Packages pane card view. */
 		description?: string;
-
-		/** Optional author shown in the Packages pane card view. */
-		author?: string;
 	}
 
 	/**

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1232,6 +1232,12 @@ declare module 'positron' {
 		 * can be loaded as a transitive dependency without being attached.
 		 */
 		attached?: boolean;
+
+		/** Optional short description or summary shown in the Packages pane card view. */
+		description?: string;
+
+		/** Optional author shown in the Packages pane card view. */
+		author?: string;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -52,7 +52,8 @@
 .packages-list-item.item-size-card {
 	flex-direction: column;
 	justify-content: center;
-	padding-left: 16px;
+	/* Match the search input's text-start position: filter-container 8px + input border 1px + text-input padding 8px. */
+	padding-left: 10px;
 	padding-right: 11px;
 	padding-top: 6px;
 	padding-bottom: 6px;

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -35,18 +35,51 @@
 }
 
 .packages-list-item {
-	margin-top: 5px;
 	padding-left: 8px;
 	padding-right: 8px;
-	display: flex;
-	align-items: center;
 	cursor: pointer;
 	overflow: hidden;
+	display: flex;
+	box-sizing: border-box;
+}
+
+.packages-list-item.item-size-row {
+	flex-direction: row;
+	align-items: center;
+	margin-top: 5px;
+}
+
+.packages-list-item.item-size-card {
+	flex-direction: column;
+	justify-content: center;
+	padding-left: 16px;
+	padding-right: 11px;
+	padding-top: 6px;
+	padding-bottom: 6px;
+}
+
+.packages-list-item-header {
+	display: flex;
+	flex-direction: row;
+	align-items: baseline;
+	overflow: hidden;
+	min-width: 0;
+}
+
+.packages-list-item.item-size-row .packages-list-item-header {
+	flex: 1 1 auto;
 }
 
 .packages-list-item-name {
-	flex: 0 0 auto;
+	flex: 0 1 auto;
+	min-width: 0;
 	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.packages-list-item.item-size-card .packages-list-item-name {
+	font-weight: bold;
 }
 
 .packages-list-item-version {
@@ -65,6 +98,24 @@
 	margin-left: 0.5em;
 	color: var(--vscode-notificationsInfoIcon-foreground);
 	font-size: 0.9em;
+}
+
+.packages-list-item-description {
+	color: var(--vscode-descriptionForeground);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
+}
+
+.packages-list-item-author {
+	font-size: 90%;
+	color: var(--vscode-descriptionForeground);
+	opacity: 0.85;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
 }
 
 .packages-list-item:hover {

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -48,9 +48,54 @@
 	padding-left: 8px;
 	padding-right: 8px;
 	display: flex;
-	align-items: center;
 	cursor: pointer;
 	overflow: hidden;
+}
+
+.packages-list-item.item-size-row {
+	align-items: center;
+}
+
+.packages-list-item.item-size-card {
+	align-items: flex-start;
+	/* Align with the search input's outer-left edge (filter-container 8px + input border 1px), plus the 0.5px nudge from .packages-list-container. */
+	padding-left: 10px;
+	padding-right: 11px;
+	padding-top: 6px;
+	padding-bottom: 6px;
+}
+
+.packages-list-item-content {
+	flex: 1 1 auto;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+}
+
+.packages-list-item.item-size-row .packages-list-item-content {
+	flex-direction: row;
+	align-items: baseline;
+	overflow: hidden;
+}
+
+.packages-list-item-header {
+	display: flex;
+	flex-direction: row;
+	align-items: baseline;
+	overflow: hidden;
+	min-width: 0;
+}
+
+.packages-list-item.item-size-row .packages-list-item-header {
+	flex: 1 1 auto;
+}
+
+/*
+ * In card mode, drop the dot ~4px below the top edge so it reads as belonging
+ * to the whole card (title + description), not the title alone.
+ */
+.packages-list-item.item-size-card .packages-list-item-attached {
+	margin-top: 4px;
 }
 
 /*
@@ -84,8 +129,15 @@
 }
 
 .packages-list-item-name {
-	flex: 0 0 auto;
+	flex: 0 1 auto;
+	min-width: 0;
 	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.packages-list-item.item-size-card .packages-list-item-name {
+	font-weight: bold;
 }
 
 .packages-list-item-version {
@@ -104,6 +156,24 @@
 	margin-left: 0.5em;
 	color: var(--vscode-notificationsInfoIcon-foreground);
 	font-size: 0.9em;
+}
+
+.packages-list-item-description {
+	color: var(--vscode-descriptionForeground);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
+}
+
+.packages-list-item-author {
+	font-size: 90%;
+	color: var(--vscode-descriptionForeground);
+	opacity: 0.85;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
 }
 
 .positron-packages-list .positron-list-empty {

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -158,22 +158,39 @@
 	font-size: 0.9em;
 }
 
-.packages-list-item-description {
-	color: var(--vscode-descriptionForeground);
-	white-space: nowrap;
+.packages-list-item-description-row {
+	display: flex;
+	flex-direction: row;
+	align-items: flex-start;
+	min-width: 0;
 	overflow: hidden;
-	text-overflow: ellipsis;
+	gap: 0.5em;
+}
+
+.packages-list-item-description {
+	flex: 1 1 auto;
+	color: var(--vscode-descriptionForeground);
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
 	min-width: 0;
 }
 
-.packages-list-item-author {
+.packages-list-item-update-button.positron-button {
+	flex: 0 0 auto;
+	padding: 1px 8px;
 	font-size: 90%;
-	color: var(--vscode-descriptionForeground);
-	opacity: 0.85;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	min-width: 0;
+	line-height: 1.4;
+	border: 1px solid var(--vscode-button-border, transparent);
+	border-radius: 3px;
+	background-color: var(--vscode-button-background);
+	color: var(--vscode-button-foreground);
+}
+
+.packages-list-item-update-button.positron-button:hover:not(.disabled) {
+	background-color: var(--vscode-button-hoverBackground);
 }
 
 .positron-packages-list .positron-list-empty {

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -32,6 +32,7 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { applyFilterToQuery, applySortToQuery, PackagesFilter, PackagesSortOrder, parseQuery } from './packagesQuery.js';
 import { PositronList } from '../../../../browser/positronList/positronList.js';
 import { ListEntry, PositronListInstance, PositronListItemContext } from '../../../../browser/positronList/classes/positronListInstance.js';
+import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 
 const positronUninstallPackage = localize(
 	'positronUninstallPackage',
@@ -262,7 +263,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	// instance.
 	useEffect(() => {
 		const renderItem = (pkg: ILanguageRuntimePackage, ctx: PositronListItemContext) => {
-			const { name, displayName, version, latestVersion, attached, description, author } = pkg;
+			const { name, displayName, version, latestVersion, attached, description } = pkg;
 			const hasUpdate = latestVersion && latestVersion !== version;
 
 			const showRowContextMenu = (anchor: { x: number; y: number }) => {
@@ -348,7 +349,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 						<div className='packages-list-item-header'>
 							<div className='packages-list-item-name'>{displayName}</div>
 							<div className='packages-list-item-version'>{version}</div>
-							{hasUpdate && (
+							{itemSize === 'row' && hasUpdate && (
 								<div
 									className='packages-list-item-update'
 									title={localize('positronPackages.updateAvailable', "Update available: {0}", latestVersion)}
@@ -358,14 +359,21 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 							)}
 						</div>
 						{itemSize === 'card' && (
-							<>
+							<div className='packages-list-item-description-row'>
 								<div className='packages-list-item-description' title={description ?? ''}>
 									{description ?? ''}
 								</div>
-								<div className='packages-list-item-author' title={author ?? ''}>
-									{author ?? ''}
-								</div>
-							</>
+								{hasUpdate && (
+									<Button
+										ariaLabel={localize('positronPackages.updatePackageAria', "Update {0} to {1}", name, latestVersion)}
+										className='packages-list-item-update-button'
+										tooltip={localize('positronPackages.updateAvailable', "Update available: {0}", latestVersion)}
+										onPressed={() => services.commandService.executeCommand('positronPackages.updatePackage', name)}
+									>
+										{localize('positronPackages.update', "Update")}
+									</Button>
+								)}
+							</div>
 						)}
 					</div>
 				</div>

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -43,8 +43,9 @@ const positronUpdatePackage = localize(
 	'Update Package',
 );
 
-// Row height for package list items in pixels
-const ITEM_HEIGHT = 26;
+// Row heights for each item size mode.
+const ROW_ITEM_HEIGHT = 26;
+const CARD_ITEM_HEIGHT = 72;
 
 export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	const {
@@ -53,6 +54,15 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	const services = usePositronReactServicesContext();
 
 	const [packages, setPackages] = useState<ILanguageRuntimePackage[]>([]);
+
+	// Item size mode ('card' or 'row'), driven by the packages service.
+	const [itemSize, setItemSize] = useState(() => services.positronPackagesService.itemSize);
+	useEffect(() => {
+		const disposable = services.positronPackagesService.onDidChangeItemSize((size) => {
+			setItemSize(size);
+		});
+		return () => disposable.dispose();
+	}, [services.positronPackagesService]);
 
 	// Progress Bar
 	const progressRef = useRef<HTMLDivElement>(null);
@@ -158,12 +168,13 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	const currentSort = currentQuery.sort;
 	const currentFilter = currentQuery.filter;
 
-	// PositronListInstance. The renderer is set later via setItemRenderer so it can close over
-	// the latest packages/services state without recreating the instance.
-	const [listInstance] = useState(() => new PositronListInstance<ILanguageRuntimePackage>({
-		defaultItemHeight: ITEM_HEIGHT,
+	// PositronListInstance. Recreated when itemSize changes so each mode gets its own row
+	// height; the renderer is set later via setItemRenderer so it can close over the latest
+	// packages/services state without forcing another recreation.
+	const listInstance = useMemo(() => new PositronListInstance<ILanguageRuntimePackage>({
+		defaultItemHeight: itemSize === 'card' ? CARD_ITEM_HEIGHT : ROW_ITEM_HEIGHT,
 		itemRenderer: () => null,
-	}));
+	}), [itemSize]);
 
 	// Clear selection when filter text changes.
 	const handleFilterTextChanged = (text: string) => {
@@ -251,7 +262,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	// instance.
 	useEffect(() => {
 		const renderItem = (pkg: ILanguageRuntimePackage, ctx: PositronListItemContext) => {
-			const { name, displayName, version, latestVersion, attached } = pkg;
+			const { name, displayName, version, latestVersion, attached, description, author } = pkg;
 			const hasUpdate = latestVersion && latestVersion !== version;
 
 			const showRowContextMenu = (anchor: { x: number; y: number }) => {
@@ -299,7 +310,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 			return (
 				// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 				<div
-					className='packages-list-item'
+					className={positronClassNames('packages-list-item', `item-size-${itemSize}`)}
 					onContextMenu={(e) => {
 						// Right-click. The data grid's row cell calls e.stopPropagation() on
 						// mousedown, so right-click handling lives on contextmenu instead.
@@ -333,22 +344,36 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 								: localize('positronPackages.notAttachedTooltip', "{0} is not attached", name)}
 						/>
 					)}
-					<div className='packages-list-item-name'>{displayName}</div>
-					<div className='packages-list-item-version'>{version}</div>
-					{hasUpdate && (
-						<div
-							className='packages-list-item-update'
-							title={localize('positronPackages.updateAvailable', "Update available: {0}", latestVersion)}
-						>
-							&#x2191;
+					<div className='packages-list-item-content'>
+						<div className='packages-list-item-header'>
+							<div className='packages-list-item-name'>{displayName}</div>
+							<div className='packages-list-item-version'>{version}</div>
+							{hasUpdate && (
+								<div
+									className='packages-list-item-update'
+									title={localize('positronPackages.updateAvailable', "Update available: {0}", latestVersion)}
+								>
+									&#x2191;
+								</div>
+							)}
 						</div>
-					)}
+						{itemSize === 'card' && (
+							<>
+								<div className='packages-list-item-description' title={description ?? ''}>
+									{description ?? ''}
+								</div>
+								<div className='packages-list-item-author' title={author ?? ''}>
+									{author ?? ''}
+								</div>
+							</>
+						)}
+					</div>
 				</div>
 			);
 		};
 
 		listInstance.setItemRenderer(renderItem);
-	}, [listInstance, deduplicatedPackages, services]);
+	}, [listInstance, deduplicatedPackages, services, itemSize]);
 
 	// Enter on the focused row sets selection to that row.
 	useEffect(() => {

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -48,6 +48,10 @@ const positronUpdatePackage = localize(
 // Height of the filter container in pixels
 const FILTER_HEIGHT = 34;
 
+// Row heights for each item size mode.
+const ROW_ITEM_HEIGHT = 26;
+const CARD_ITEM_HEIGHT = 72;
+
 export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	const {
 		activeInstance,
@@ -56,6 +60,15 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	const services = usePositronReactServicesContext();
 
 	const [packages, setPackages] = useState<ILanguageRuntimePackage[]>([]);
+
+	// Item size mode ('card' or 'row'), driven by the packages service.
+	const [itemSize, setItemSize] = useState(() => services.positronPackagesService.itemSize);
+	useEffect(() => {
+		const disposable = services.positronPackagesService.onDidChangeItemSize((size) => {
+			setItemSize(size);
+		});
+		return () => disposable.dispose();
+	}, [services.positronPackagesService]);
 
 	// Progress Bar
 	const progressRef = useRef<HTMLDivElement>(null);
@@ -251,7 +264,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	// Item renderer
 	const ItemEntry = (props: { index: number; style: CSSProperties }) => {
 		const itemProps = filteredPackages[props.index];
-		const { id, name, displayName, version, latestVersion } = itemProps;
+		const { id, name, displayName, version, latestVersion, description, author } = itemProps;
 
 		// Check if package has an update available
 		const hasUpdate = latestVersion && latestVersion !== version;
@@ -259,7 +272,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 		return (
 			// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 			<div
-				className={positronClassNames('packages-list-item', {
+				className={positronClassNames('packages-list-item', `item-size-${itemSize}`, {
 					selected: id === selectedItem,
 				})}
 				style={props.style}
@@ -311,15 +324,27 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 					}
 				}}
 			>
-				<div className='packages-list-item-name'>{displayName}</div>
-				<div className='packages-list-item-version'>{version}</div>
-				{hasUpdate && (
-					<div
-						className='packages-list-item-update'
-						title={localize('positronPackages.updateAvailable', "Update available: {0}", latestVersion)}
-					>
-						&#x2191;
-					</div>
+				<div className='packages-list-item-header'>
+					<div className='packages-list-item-name'>{displayName}</div>
+					<div className='packages-list-item-version'>{version}</div>
+					{hasUpdate && (
+						<div
+							className='packages-list-item-update'
+							title={localize('positronPackages.updateAvailable', "Update available: {0}", latestVersion)}
+						>
+							&#x2191;
+						</div>
+					)}
+				</div>
+				{itemSize === 'card' && (
+					<>
+						<div className='packages-list-item-description' title={description ?? ''}>
+							{description ?? ''}
+						</div>
+						<div className='packages-list-item-author' title={author ?? ''}>
+							{author ?? ''}
+						</div>
+					</>
 				)}
 			</div >
 		);
@@ -410,7 +435,8 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 						innerRef={innerRef}
 						itemCount={filteredPackages.length}
 						itemKey={(index) => filteredPackages[index].id}
-						itemSize={26}
+						itemSize={itemSize === 'card' ? CARD_ITEM_HEIGHT : ROW_ITEM_HEIGHT}
+						style={{ overflowX: 'hidden' }}
 						width={'calc(100% - 2px)'}
 					>
 						{ItemEntry}

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -203,8 +203,9 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	// Parse the debounced query so filtering and sorting run off the same snapshot.
 	const debouncedQuery = useMemo(() => parseQuery(debouncedQueryText), [debouncedQueryText]);
 
-	// Filter packages based on the debounced free-text (case-insensitive, matches name or displayName)
-	// and sort according to the current sort order.
+	// Filter packages based on the debounced free-text (case-insensitive, matches
+	// name, displayName, description, or author) and sort according to the
+	// current sort order.
 	const filteredPackages = useMemo(() => {
 		let result = deduplicatedPackages;
 
@@ -212,7 +213,9 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 			const lowerFilter = debouncedQuery.text.toLowerCase();
 			result = result.filter((pkg) =>
 				pkg.name.toLowerCase().includes(lowerFilter) ||
-				pkg.displayName.toLowerCase().includes(lowerFilter)
+				pkg.displayName.toLowerCase().includes(lowerFilter) ||
+				(pkg.description?.toLowerCase().includes(lowerFilter) ?? false) ||
+				(pkg.author?.toLowerCase().includes(lowerFilter) ?? false)
 			);
 		}
 

--- a/src/vs/workbench/contrib/positronPackages/browser/interfaces/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/interfaces/positronPackagesService.ts
@@ -8,6 +8,7 @@ import { Event } from '../../../../../base/common/event.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILanguageRuntimePackage, ILanguageRuntimeSession, IPackageSpec } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IPositronPackagesInstance } from '../positronPackagesInstance.js';
+import { PackagesItemSize } from '../positronPackagesContextKeys.js';
 
 // Create the decorator for the Positron packages service (used in dependency injection).
 export const IPositronPackagesService = createDecorator<IPositronPackagesService>('positronPackagesService');
@@ -35,6 +36,22 @@ export interface IPositronPackagesService {
 	 * @param packageName The package name, or undefined to clear selection
 	 */
 	setSelectedPackage(packageName: string | undefined): void;
+
+	/**
+	 * The current item size mode for the packages list.
+	 */
+	readonly itemSize: PackagesItemSize;
+
+	/**
+	 * Sets the item size mode for the packages list. The choice is persisted
+	 * globally (per-user).
+	 */
+	setItemSize(itemSize: PackagesItemSize): void;
+
+	/**
+	 * Fired when the item size mode changes.
+	 */
+	readonly onDidChangeItemSize: Event<PackagesItemSize>;
 
 	/**
 	 * The onDidRefreshPackagesInstance event.

--- a/src/vs/workbench/contrib/positronPackages/browser/interfaces/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/interfaces/positronPackagesService.ts
@@ -8,6 +8,7 @@ import { Event } from '../../../../../base/common/event.js';
 import { createDecorator } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILanguageRuntimePackage, ILanguageRuntimeSession, IPackageSpec } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IPositronPackagesInstance } from '../positronPackagesInstance.js';
+import { PackagesItemSize } from '../positronPackagesContextKeys.js';
 
 // Create the decorator for the Positron packages service (used in dependency injection).
 export const IPositronPackagesService = createDecorator<IPositronPackagesService>('positronPackagesService');
@@ -35,6 +36,21 @@ export interface IPositronPackagesService {
 	 * @param packageName The package name, or undefined to clear selection
 	 */
 	setSelectedPackage(packageName: string | undefined): void;
+
+	/**
+	 * The current item size mode for the packages list.
+	 */
+	readonly itemSize: PackagesItemSize;
+
+	/**
+	 * Sets the item size mode for the packages list.
+	 */
+	setItemSize(itemSize: PackagesItemSize): void;
+
+	/**
+	 * Fired when the item size mode changes.
+	 */
+	readonly onDidChangeItemSize: Event<PackagesItemSize>;
 
 	/**
 	 * The onDidRefreshPackagesInstance event.

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -24,7 +24,7 @@ import { IViewContainersRegistry, IViewsRegistry, Extensions as ViewContainerExt
 import { ILanguageRuntimePackage, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { positronSessionViewIcon } from '../../positronSession/browser/positronSessionContainer.js';
 import { IPositronPackagesService } from './interfaces/positronPackagesService.js';
-import { PACKAGES_CAN_RUN_ACTION, PACKAGES_HAS_SELECTION, PACKAGES_VIEW_VISIBLE, POSITRON_PACKAGES_VIEW_ID } from './positronPackagesContextKeys.js';
+import { PACKAGES_CAN_RUN_ACTION, PACKAGES_HAS_SELECTION, PACKAGES_VIEW_VISIBLE, POSITRON_PACKAGES_ITEM_SIZE, POSITRON_PACKAGES_VIEW_ID } from './positronPackagesContextKeys.js';
 import { installPackage, uninstallPackage, updatePackage } from './positronPackagesQuickPick.js';
 import { PositronPackagesService } from './positronPackagesService.js';
 import { PositronPackagesView } from './positronPackagesView.js';
@@ -597,6 +597,75 @@ class RefreshMetadataAction extends Action2 {
 	}
 }
 
+/**
+ * Switches the Packages view to the expanded card layout.
+ * Only visible in the view title when the view is currently showing compact rows.
+ */
+class SetPackagesCardViewAction extends Action2 {
+	constructor() {
+		super({
+			id: 'positronPackages.setCardView',
+			title: nls.localize2('positronPackages.showAsCards', 'Show as Cards'),
+			category: PACKAGES_CATEGORY,
+			icon: Codicon.listSelection,
+			precondition: POSITRON_PACKAGES_ENABLED,
+			menu: {
+				id: MenuId.ViewTitle,
+				when: ContextKeyExpr.and(PACKAGES_VIEW_VISIBLE, POSITRON_PACKAGES_ITEM_SIZE.isEqualTo('row')),
+				group: 'navigation',
+				order: 2,
+			},
+		});
+	}
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get<IPositronPackagesService>(IPositronPackagesService).setItemSize('card');
+	}
+}
+
+/**
+ * Switches the Packages view to the compact row layout.
+ * Only visible in the view title when the view is currently showing cards.
+ */
+class SetPackagesRowViewAction extends Action2 {
+	constructor() {
+		super({
+			id: 'positronPackages.setRowView',
+			title: nls.localize2('positronPackages.showAsRows', 'Show as Rows'),
+			category: PACKAGES_CATEGORY,
+			icon: Codicon.listFlat,
+			precondition: POSITRON_PACKAGES_ENABLED,
+			menu: {
+				id: MenuId.ViewTitle,
+				when: ContextKeyExpr.and(PACKAGES_VIEW_VISIBLE, POSITRON_PACKAGES_ITEM_SIZE.isEqualTo('card')),
+				group: 'navigation',
+				order: 2,
+			},
+		});
+	}
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get<IPositronPackagesService>(IPositronPackagesService).setItemSize('row');
+	}
+}
+
+/**
+ * Toggles between card and row layouts. Exposed via the command palette.
+ */
+class TogglePackagesItemSizeAction extends Action2 {
+	constructor() {
+		super({
+			id: 'positronPackages.toggleItemSize',
+			title: nls.localize2('positronPackages.toggleItemSize', 'Toggle Packages List Layout'),
+			category: PACKAGES_CATEGORY,
+			f1: true,
+			precondition: POSITRON_PACKAGES_ENABLED,
+		});
+	}
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const service = accessor.get<IPositronPackagesService>(IPositronPackagesService);
+		service.setItemSize(service.itemSize === 'card' ? 'row' : 'card');
+	}
+}
+
 registerAction2(InstallPackageAction);
 registerAction2(RefreshPackagesAction);
 registerAction2(RefreshMetadataAction);
@@ -605,4 +674,7 @@ registerAction2(UpdatePackageAction);
 registerAction2(UpdateAllPackagesAction);
 registerAction2(UpdateSelectedPackageAction);
 registerAction2(UninstallSelectedPackageAction);
+registerAction2(SetPackagesCardViewAction);
+registerAction2(SetPackagesRowViewAction);
+registerAction2(TogglePackagesItemSizeAction);
 registerSingleton(IPositronPackagesService, PositronPackagesService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -23,7 +23,7 @@ import { IViewContainersRegistry, IViewsRegistry, Extensions as ViewContainerExt
 import { ILanguageRuntimePackage, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { positronSessionViewIcon } from '../../positronSession/browser/positronSessionContainer.js';
 import { IPositronPackagesService } from './interfaces/positronPackagesService.js';
-import { PACKAGES_CAN_RUN_ACTION, PACKAGES_HAS_SELECTION, PACKAGES_VIEW_VISIBLE, POSITRON_PACKAGES_VIEW_ID } from './positronPackagesContextKeys.js';
+import { PACKAGES_CAN_RUN_ACTION, PACKAGES_HAS_SELECTION, PACKAGES_VIEW_VISIBLE, POSITRON_PACKAGES_ITEM_SIZE, POSITRON_PACKAGES_VIEW_ID } from './positronPackagesContextKeys.js';
 import { installPackage, uninstallPackage, updatePackage } from './positronPackagesQuickPick.js';
 import { PositronPackagesService } from './positronPackagesService.js';
 import { PositronPackagesView } from './positronPackagesView.js';
@@ -580,6 +580,75 @@ class RefreshMetadataAction extends Action2 {
 	}
 }
 
+/**
+ * Switches the Packages view to the expanded card layout.
+ * Only visible in the view title when the view is currently showing compact rows.
+ */
+class SetPackagesCardViewAction extends Action2 {
+	constructor() {
+		super({
+			id: 'positronPackages.setCardView',
+			title: nls.localize2('positronPackages.showAsCards', 'Show as Cards'),
+			category: PACKAGES_CATEGORY,
+			icon: Codicon.listSelection,
+			precondition: POSITRON_PACKAGES_ENABLED,
+			menu: {
+				id: MenuId.ViewTitle,
+				when: ContextKeyExpr.and(PACKAGES_VIEW_VISIBLE, POSITRON_PACKAGES_ITEM_SIZE.isEqualTo('row')),
+				group: 'navigation',
+				order: 2,
+			},
+		});
+	}
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get<IPositronPackagesService>(IPositronPackagesService).setItemSize('card');
+	}
+}
+
+/**
+ * Switches the Packages view to the compact row layout.
+ * Only visible in the view title when the view is currently showing cards.
+ */
+class SetPackagesRowViewAction extends Action2 {
+	constructor() {
+		super({
+			id: 'positronPackages.setRowView',
+			title: nls.localize2('positronPackages.showAsRows', 'Show as Rows'),
+			category: PACKAGES_CATEGORY,
+			icon: Codicon.listFlat,
+			precondition: POSITRON_PACKAGES_ENABLED,
+			menu: {
+				id: MenuId.ViewTitle,
+				when: ContextKeyExpr.and(PACKAGES_VIEW_VISIBLE, POSITRON_PACKAGES_ITEM_SIZE.isEqualTo('card')),
+				group: 'navigation',
+				order: 2,
+			},
+		});
+	}
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		accessor.get<IPositronPackagesService>(IPositronPackagesService).setItemSize('row');
+	}
+}
+
+/**
+ * Toggles between card and row layouts. Exposed via the command palette.
+ */
+class TogglePackagesItemSizeAction extends Action2 {
+	constructor() {
+		super({
+			id: 'positronPackages.toggleItemSize',
+			title: nls.localize2('positronPackages.toggleItemSize', 'Toggle Packages List Layout'),
+			category: PACKAGES_CATEGORY,
+			f1: true,
+			precondition: POSITRON_PACKAGES_ENABLED,
+		});
+	}
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const service = accessor.get<IPositronPackagesService>(IPositronPackagesService);
+		service.setItemSize(service.itemSize === 'card' ? 'row' : 'card');
+	}
+}
+
 registerAction2(InstallPackageAction);
 registerAction2(RefreshPackagesAction);
 registerAction2(RefreshMetadataAction);
@@ -588,4 +657,7 @@ registerAction2(UpdatePackageAction);
 registerAction2(UpdateAllPackagesAction);
 registerAction2(UpdateSelectedPackageAction);
 registerAction2(UninstallSelectedPackageAction);
+registerAction2(SetPackagesCardViewAction);
+registerAction2(SetPackagesRowViewAction);
+registerAction2(TogglePackagesItemSizeAction);
 registerSingleton(IPositronPackagesService, PositronPackagesService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesContextKeys.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesContextKeys.ts
@@ -13,6 +13,10 @@ export const POSITRON_PACKAGES_HAS_ACTIVE_SESSION = new RawContextKey<boolean>('
 export const POSITRON_PACKAGES_IS_BUSY = new RawContextKey<boolean>('positronPackages.isBusy', false);
 export const POSITRON_PACKAGES_SELECTED_PACKAGE = new RawContextKey<string>('positronPackages.selectedPackage', '');
 
+// Item size mode for the packages list: 'card' or 'row'.
+export type PackagesItemSize = 'card' | 'row';
+export const POSITRON_PACKAGES_ITEM_SIZE = new RawContextKey<PackagesItemSize>('positronPackages.itemSize', 'row');
+
 // Context key expressions for menu enablement
 export const PACKAGES_VIEW_VISIBLE = ContextKeyExpr.equals('view', POSITRON_PACKAGES_VIEW_ID);
 export const PACKAGES_CAN_RUN_ACTION = ContextKeyExpr.and(

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesContextKeys.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesContextKeys.ts
@@ -15,7 +15,7 @@ export const POSITRON_PACKAGES_SELECTED_PACKAGE = new RawContextKey<string>('pos
 
 // Item size mode for the packages list: 'card' or 'row'.
 export type PackagesItemSize = 'card' | 'row';
-export const POSITRON_PACKAGES_ITEM_SIZE = new RawContextKey<PackagesItemSize>('positronPackages.itemSize', 'row');
+export const POSITRON_PACKAGES_ITEM_SIZE = new RawContextKey<PackagesItemSize>('positronPackages.itemSize', 'card');
 
 // Context key expressions for menu enablement
 export const PACKAGES_VIEW_VISIBLE = ContextKeyExpr.equals('view', POSITRON_PACKAGES_VIEW_ID);

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
@@ -18,7 +18,7 @@ import { IPositronPackagesInstance, PositronPackagesInstance } from './positronP
 
 const TIMEOUT_REFRESH_MS = 5_000; // 5 seconds
 
-const ITEM_SIZE_STORAGE_KEY = 'positronPackages.itemSize';
+const ITEM_SIZE_STORAGE_KEY = 'positron.packages.itemSize';
 
 /**
  * PositronPackagesService class.

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
@@ -33,8 +33,6 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 
 	private _activeInstance: PositronPackagesInstance | undefined;
 
-	private _itemSize: PackagesItemSize = 'row';
-
 	// Context keys
 	private readonly _hasActiveSessionContextKey: IContextKey<boolean>;
 	private readonly _isBusyContextKey: IContextKey<boolean>;
@@ -67,7 +65,6 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		this._isBusyContextKey = POSITRON_PACKAGES_IS_BUSY.bindTo(this._contextKeyService);
 		this._selectedPackageContextKey = POSITRON_PACKAGES_SELECTED_PACKAGE.bindTo(this._contextKeyService);
 		this._itemSizeContextKey = POSITRON_PACKAGES_ITEM_SIZE.bindTo(this._contextKeyService);
-		this._itemSizeContextKey.set(this._itemSize);
 
 		// Create new instances
 		this._register(this._runtimeSessionService.onWillStartSession((e) => {
@@ -186,14 +183,13 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 	}
 
 	get itemSize(): PackagesItemSize {
-		return this._itemSize;
+		return this._itemSizeContextKey.get() ?? 'row';
 	}
 
 	setItemSize(itemSize: PackagesItemSize): void {
-		if (this._itemSize === itemSize) {
+		if (this.itemSize === itemSize) {
 			return;
 		}
-		this._itemSize = itemSize;
 		this._itemSizeContextKey.set(itemSize);
 		this._onDidChangeItemSize.fire(itemSize);
 	}

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
@@ -9,13 +9,15 @@ import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { LanguageRuntimeSessionMode } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimePackage, ILanguageRuntimeSession, IPackageSpec, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IPositronPackagesService } from './interfaces/positronPackagesService.js';
-import { POSITRON_PACKAGES_HAS_ACTIVE_SESSION, POSITRON_PACKAGES_IS_BUSY, POSITRON_PACKAGES_SELECTED_PACKAGE } from './positronPackagesContextKeys.js';
+import { PackagesItemSize, POSITRON_PACKAGES_HAS_ACTIVE_SESSION, POSITRON_PACKAGES_IS_BUSY, POSITRON_PACKAGES_ITEM_SIZE, POSITRON_PACKAGES_SELECTED_PACKAGE } from './positronPackagesContextKeys.js';
 import { IPositronPackagesInstance, PositronPackagesInstance } from './positronPackagesInstance.js';
 
 const TIMEOUT_REFRESH_MS = 5_000; // 5 seconds
+const ITEM_SIZE_STORAGE_KEY = 'positronPackages.itemSize';
 
 /**
  * PositronPackagesService class.
@@ -27,14 +29,19 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 
 	private readonly _onDidStopPositronPackagesInstanceEmitter = this._register(new Emitter<IPositronPackagesInstance>());
 
+	private readonly _onDidChangeItemSize = this._register(new Emitter<PackagesItemSize>());
+
 	private readonly _instancesBySessionId = this._register(new DisposableMap<string, PositronPackagesInstance>());
 
 	private _activeInstance: PositronPackagesInstance | undefined;
+
+	private _itemSize: PackagesItemSize;
 
 	// Context keys
 	private readonly _hasActiveSessionContextKey: IContextKey<boolean>;
 	private readonly _isBusyContextKey: IContextKey<boolean>;
 	private readonly _selectedPackageContextKey: IContextKey<string>;
+	private readonly _itemSizeContextKey: IContextKey<PackagesItemSize>;
 
 	// Disposables for tracking busy state of the active instance
 	private readonly _activeInstanceDisposables = this._register(new DisposableStore());
@@ -53,6 +60,7 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
 		@ILogService private readonly _logService: ILogService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IStorageService private readonly _storageService: IStorageService,
 	) {
 		// Call the disposable constructor.
 		super();
@@ -61,6 +69,12 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		this._hasActiveSessionContextKey = POSITRON_PACKAGES_HAS_ACTIVE_SESSION.bindTo(this._contextKeyService);
 		this._isBusyContextKey = POSITRON_PACKAGES_IS_BUSY.bindTo(this._contextKeyService);
 		this._selectedPackageContextKey = POSITRON_PACKAGES_SELECTED_PACKAGE.bindTo(this._contextKeyService);
+		this._itemSizeContextKey = POSITRON_PACKAGES_ITEM_SIZE.bindTo(this._contextKeyService);
+
+		// Load the item size from global storage, defaulting to 'row'.
+		const stored = this._storageService.get(ITEM_SIZE_STORAGE_KEY, StorageScope.APPLICATION);
+		this._itemSize = stored === 'card' ? 'card' : 'row';
+		this._itemSizeContextKey.set(this._itemSize);
 
 		// Create new instances
 		this._register(this._runtimeSessionService.onWillStartSession((e) => {
@@ -177,6 +191,22 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 	setSelectedPackage(packageName: string | undefined): void {
 		this._selectedPackageContextKey.set(packageName ?? '');
 	}
+
+	get itemSize(): PackagesItemSize {
+		return this._itemSize;
+	}
+
+	setItemSize(itemSize: PackagesItemSize): void {
+		if (this._itemSize === itemSize) {
+			return;
+		}
+		this._itemSize = itemSize;
+		this._itemSizeContextKey.set(itemSize);
+		this._storageService.store(ITEM_SIZE_STORAGE_KEY, itemSize, StorageScope.APPLICATION, StorageTarget.USER);
+		this._onDidChangeItemSize.fire(itemSize);
+	}
+
+	readonly onDidChangeItemSize = this._onDidChangeItemSize.event;
 
 	async refreshPackages(token?: CancellationToken): Promise<ILanguageRuntimePackage[]> {
 		const instance = this._activeInstance;

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
@@ -71,8 +71,8 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		this._selectedPackageContextKey = POSITRON_PACKAGES_SELECTED_PACKAGE.bindTo(this._contextKeyService);
 		this._itemSizeContextKey = POSITRON_PACKAGES_ITEM_SIZE.bindTo(this._contextKeyService);
 
-		// Load the item size from global storage, defaulting to 'row'.
-		const stored = this._storageService.get(ITEM_SIZE_STORAGE_KEY, StorageScope.APPLICATION);
+		// Load the item size from profile storage, defaulting to 'row'.
+		const stored = this._storageService.get(ITEM_SIZE_STORAGE_KEY, StorageScope.PROFILE);
 		this._itemSize = stored === 'card' ? 'card' : 'row';
 		this._itemSizeContextKey.set(this._itemSize);
 
@@ -202,7 +202,7 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		}
 		this._itemSize = itemSize;
 		this._itemSizeContextKey.set(itemSize);
-		this._storageService.store(ITEM_SIZE_STORAGE_KEY, itemSize, StorageScope.APPLICATION, StorageTarget.USER);
+		this._storageService.store(ITEM_SIZE_STORAGE_KEY, itemSize, StorageScope.PROFILE, StorageTarget.USER);
 		this._onDidChangeItemSize.fire(itemSize);
 	}
 

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
@@ -9,7 +9,6 @@ import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { LanguageRuntimeSessionMode } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimePackage, ILanguageRuntimeSession, IPackageSpec, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IPositronPackagesService } from './interfaces/positronPackagesService.js';
@@ -17,7 +16,6 @@ import { PackagesItemSize, POSITRON_PACKAGES_HAS_ACTIVE_SESSION, POSITRON_PACKAG
 import { IPositronPackagesInstance, PositronPackagesInstance } from './positronPackagesInstance.js';
 
 const TIMEOUT_REFRESH_MS = 5_000; // 5 seconds
-const ITEM_SIZE_STORAGE_KEY = 'positronPackages.itemSize';
 
 /**
  * PositronPackagesService class.
@@ -35,7 +33,7 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 
 	private _activeInstance: PositronPackagesInstance | undefined;
 
-	private _itemSize: PackagesItemSize;
+	private _itemSize: PackagesItemSize = 'row';
 
 	// Context keys
 	private readonly _hasActiveSessionContextKey: IContextKey<boolean>;
@@ -60,7 +58,6 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
 		@ILogService private readonly _logService: ILogService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
-		@IStorageService private readonly _storageService: IStorageService,
 	) {
 		// Call the disposable constructor.
 		super();
@@ -70,10 +67,6 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		this._isBusyContextKey = POSITRON_PACKAGES_IS_BUSY.bindTo(this._contextKeyService);
 		this._selectedPackageContextKey = POSITRON_PACKAGES_SELECTED_PACKAGE.bindTo(this._contextKeyService);
 		this._itemSizeContextKey = POSITRON_PACKAGES_ITEM_SIZE.bindTo(this._contextKeyService);
-
-		// Load the item size from profile storage, defaulting to 'row'.
-		const stored = this._storageService.get(ITEM_SIZE_STORAGE_KEY, StorageScope.PROFILE);
-		this._itemSize = stored === 'card' ? 'card' : 'row';
 		this._itemSizeContextKey.set(this._itemSize);
 
 		// Create new instances
@@ -202,7 +195,6 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		}
 		this._itemSize = itemSize;
 		this._itemSizeContextKey.set(itemSize);
-		this._storageService.store(ITEM_SIZE_STORAGE_KEY, itemSize, StorageScope.PROFILE, StorageTarget.USER);
 		this._onDidChangeItemSize.fire(itemSize);
 	}
 

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
@@ -176,6 +176,8 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 
 	readonly onDidChangeActivePackagesInstance = this._onDidChangeActivePackagesInstance.event;
 
+	readonly onDidChangeItemSize = this._onDidChangeItemSize.event;
+
 	readonly onDidStopPackagesInstance = this._onDidStopPositronPackagesInstanceEmitter.event;
 
 	get activeSession(): ILanguageRuntimeSession | undefined {
@@ -206,8 +208,6 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		this._storageService.store(ITEM_SIZE_STORAGE_KEY, itemSize, StorageScope.PROFILE, StorageTarget.USER);
 		this._onDidChangeItemSize.fire(itemSize);
 	}
-
-	readonly onDidChangeItemSize = this._onDidChangeItemSize.event;
 
 	async refreshPackages(token?: CancellationToken): Promise<ILanguageRuntimePackage[]> {
 		const instance = this._activeInstance;

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
@@ -71,7 +71,7 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		this._itemSizeContextKey = POSITRON_PACKAGES_ITEM_SIZE.bindTo(this._contextKeyService);
 
 		// Seed the item-size context key from persisted storage so the user's preferred
-		// mode (card vs row) survives reloads. The context key's own default ('row')
+		// mode (card vs row) survives reloads. The context key's own default ('card')
 		// applies when nothing is persisted.
 		const storedItemSize = this._storageService.get(ITEM_SIZE_STORAGE_KEY, StorageScope.PROFILE);
 		if (storedItemSize === 'card' || storedItemSize === 'row') {
@@ -195,7 +195,7 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 	}
 
 	get itemSize(): PackagesItemSize {
-		return this._itemSizeContextKey.get() ?? 'row';
+		return this._itemSizeContextKey.get() ?? 'card';
 	}
 
 	setItemSize(itemSize: PackagesItemSize): void {

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
@@ -9,6 +9,7 @@ import { Emitter } from '../../../../base/common/event.js';
 import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { LanguageRuntimeSessionMode } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimePackage, ILanguageRuntimeSession, IPackageSpec, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IPositronPackagesService } from './interfaces/positronPackagesService.js';
@@ -16,6 +17,8 @@ import { PackagesItemSize, POSITRON_PACKAGES_HAS_ACTIVE_SESSION, POSITRON_PACKAG
 import { IPositronPackagesInstance, PositronPackagesInstance } from './positronPackagesInstance.js';
 
 const TIMEOUT_REFRESH_MS = 5_000; // 5 seconds
+
+const ITEM_SIZE_STORAGE_KEY = 'positronPackages.itemSize';
 
 /**
  * PositronPackagesService class.
@@ -56,6 +59,7 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
 		@ILogService private readonly _logService: ILogService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IStorageService private readonly _storageService: IStorageService,
 	) {
 		// Call the disposable constructor.
 		super();
@@ -65,6 +69,14 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		this._isBusyContextKey = POSITRON_PACKAGES_IS_BUSY.bindTo(this._contextKeyService);
 		this._selectedPackageContextKey = POSITRON_PACKAGES_SELECTED_PACKAGE.bindTo(this._contextKeyService);
 		this._itemSizeContextKey = POSITRON_PACKAGES_ITEM_SIZE.bindTo(this._contextKeyService);
+
+		// Seed the item-size context key from persisted storage so the user's preferred
+		// mode (card vs row) survives reloads. The context key's own default ('row')
+		// applies when nothing is persisted.
+		const storedItemSize = this._storageService.get(ITEM_SIZE_STORAGE_KEY, StorageScope.PROFILE);
+		if (storedItemSize === 'card' || storedItemSize === 'row') {
+			this._itemSizeContextKey.set(storedItemSize);
+		}
 
 		// Create new instances
 		this._register(this._runtimeSessionService.onWillStartSession((e) => {
@@ -191,6 +203,7 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 			return;
 		}
 		this._itemSizeContextKey.set(itemSize);
+		this._storageService.store(ITEM_SIZE_STORAGE_KEY, itemSize, StorageScope.PROFILE, StorageTarget.USER);
 		this._onDidChangeItemSize.fire(itemSize);
 	}
 

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesService.ts
@@ -12,7 +12,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { LanguageRuntimeSessionMode } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimePackage, ILanguageRuntimeSession, IPackageSpec, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IPositronPackagesService } from './interfaces/positronPackagesService.js';
-import { POSITRON_PACKAGES_HAS_ACTIVE_SESSION, POSITRON_PACKAGES_IS_BUSY, POSITRON_PACKAGES_SELECTED_PACKAGE } from './positronPackagesContextKeys.js';
+import { PackagesItemSize, POSITRON_PACKAGES_HAS_ACTIVE_SESSION, POSITRON_PACKAGES_IS_BUSY, POSITRON_PACKAGES_ITEM_SIZE, POSITRON_PACKAGES_SELECTED_PACKAGE } from './positronPackagesContextKeys.js';
 import { IPositronPackagesInstance, PositronPackagesInstance } from './positronPackagesInstance.js';
 
 const TIMEOUT_REFRESH_MS = 5_000; // 5 seconds
@@ -27,6 +27,8 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 
 	private readonly _onDidStopPositronPackagesInstanceEmitter = this._register(new Emitter<IPositronPackagesInstance>());
 
+	private readonly _onDidChangeItemSize = this._register(new Emitter<PackagesItemSize>());
+
 	private readonly _instancesBySessionId = this._register(new DisposableMap<string, PositronPackagesInstance>());
 
 	private _activeInstance: PositronPackagesInstance | undefined;
@@ -35,6 +37,7 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 	private readonly _hasActiveSessionContextKey: IContextKey<boolean>;
 	private readonly _isBusyContextKey: IContextKey<boolean>;
 	private readonly _selectedPackageContextKey: IContextKey<string>;
+	private readonly _itemSizeContextKey: IContextKey<PackagesItemSize>;
 
 	// Disposables for tracking busy state of the active instance
 	private readonly _activeInstanceDisposables = this._register(new DisposableStore());
@@ -61,6 +64,7 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 		this._hasActiveSessionContextKey = POSITRON_PACKAGES_HAS_ACTIVE_SESSION.bindTo(this._contextKeyService);
 		this._isBusyContextKey = POSITRON_PACKAGES_IS_BUSY.bindTo(this._contextKeyService);
 		this._selectedPackageContextKey = POSITRON_PACKAGES_SELECTED_PACKAGE.bindTo(this._contextKeyService);
+		this._itemSizeContextKey = POSITRON_PACKAGES_ITEM_SIZE.bindTo(this._contextKeyService);
 
 		// Create new instances
 		this._register(this._runtimeSessionService.onWillStartSession((e) => {
@@ -177,6 +181,20 @@ export class PositronPackagesService extends Disposable implements IPositronPack
 	setSelectedPackage(packageName: string | undefined): void {
 		this._selectedPackageContextKey.set(packageName ?? '');
 	}
+
+	get itemSize(): PackagesItemSize {
+		return this._itemSizeContextKey.get() ?? 'row';
+	}
+
+	setItemSize(itemSize: PackagesItemSize): void {
+		if (this.itemSize === itemSize) {
+			return;
+		}
+		this._itemSizeContextKey.set(itemSize);
+		this._onDidChangeItemSize.fire(itemSize);
+	}
+
+	readonly onDidChangeItemSize = this._onDidChangeItemSize.event;
 
 	async refreshPackages(token?: CancellationToken): Promise<ILanguageRuntimePackage[]> {
 		const instance = this._activeInstance;

--- a/src/vs/workbench/contrib/positronPackages/test/browser/packagesQuery.vitest.ts
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/packagesQuery.vitest.ts
@@ -80,7 +80,7 @@ describe('packagesQuery', () => {
 		});
 
 		it('unknown @key:value token is stripped from free text', () => {
-			const result = parseQuery('foo @author:hadley bar');
+			const result = parseQuery('foo @unknown:value bar');
 			expect(result.text).toBe('foo bar');
 			expect(result.sort).toBe(PackagesSortOrder.NameAsc);
 		});

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -298,6 +298,9 @@ export interface ILanguageRuntimePackage {
 
 	/** Publication/release date */
 	publishedDate?: string;
+
+	description?: string;
+	author?: string;
 }
 
 /**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -306,6 +306,12 @@ export interface ILanguageRuntimePackage {
 	 * transitively loaded dependencies.
 	 */
 	attached?: boolean;
+
+	/** Optional short description or summary. */
+	description?: string;
+
+	/** Optional package author. */
+	author?: string;
 }
 
 /**

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -309,9 +309,6 @@ export interface ILanguageRuntimePackage {
 
 	/** Optional short description or summary. */
 	description?: string;
-
-	/** Optional package author. */
-	author?: string;
 }
 
 /**


### PR DESCRIPTION
See #12925 

Adds "Item Size" action button to the Packages pane.

* Toggles between two views: One that looks like a row and the other a card.
* Adds description metadata to the get packages API.
* Adds an Update button to the card view
* Drops the up arrow out of date iconography when in the card view
* Persists the latest state to the database so it is remembered

This PR adds ark support to supplement R packages https://github.com/posit-dev/ark/pull/1224

<img width="317" height="980" alt="Screenshot 2026-05-19 at 3 25 33 PM" src="https://github.com/user-attachments/assets/031b0e27-80a0-435a-8d1b-59b6039e93bc" />

<img width="379" height="977" alt="Screenshot 2026-05-19 at 12 27 30 PM" src="https://github.com/user-attachments/assets/f59fdc9a-6001-4229-854a-bf95fa6e63e3" />


### Release Notes

#### New Features

- Add support for card / row views on the Packages pane.
- Add additional metadata including description to the Packages pane.

#### Bug Fixes

- N/A


### QA Notes

Until the ark PR lands, you'll want to build that.
Otherwise, you can test for python.
When you expand to card view, everything should kinda just stay the same but turn into cards.

@:packages-pane