### PR TITLE
e2e:  Fix for Python Shiny test due to Shiny extension issue

### DIFF
--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -18,5 +18,6 @@
 	"editor.accessibilitySupport": "off",
 	"githubIssues.issueCompletions.enabled": false,
 	"posit.assistant.sidebarView": true,
-	"assistant.sidebarView": true
+	"assistant.sidebarView": true,
+	"shiny.previewType": "internal"
 }


### PR DESCRIPTION
Mitigation of an issue introduced by new Shiny extension. Due to https://github.com/posit-dev/shiny-vscode/issues/110

### Summary

`shiny-vscode` v1.4.1 (auto-updated at e2e runtime today) changed the default of `shiny.previewType` in its `package.json` from `"internal"` to `"default"`. The Python path's `openBrowser()` switch in `src/net-utils.ts` has no `case "default"` and falls through to `simpleBrowser.api.open`, so the Python Shiny app now opens in the Simple Browser editor instead of the Positron Viewer pane. That breaks `Python - Verify Basic Shiny App` in [test/e2e/tests/shiny/shiny.test.ts](test/e2e/tests/shiny/shiny.test.ts), which asserts on the Viewer frame.

The R path is unaffected because [shiny-vscode#108](https://github.com/posit-dev/shiny-vscode/pull/108) rewired R through `runApplicationInConsole`, which [shiny-vscode#109](https://github.com/posit-dev/shiny-vscode/pull/109) teaches to resolve `"default"` via Positron's `positron.runApp.previewMode` setting.

This PR pins `shiny.previewType: "internal"` in the e2e user-settings fixture (`test/e2e/fixtures/settings.json`) so tests exercise the Positron Viewer path until shiny-vscode handles `"default"` in the Python flow. Upstream fix to be filed separately on shiny-vscode.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:apps @:viewer @:win @:web

Automated — `Python - Verify Basic Shiny App` and `R - Verify Basic Shiny App` should both pass on Electron, Windows, and Web.