### PR TITLE
Update axios to 1.15.2

### DIFF
--- a/extensions/positron-supervisor/package-lock.json
+++ b/extensions/positron-supervisor/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "axios": "^1.13.5",
+        "axios": "^1.15.2",
         "tail": "^2.2.6",
         "ws": "^8.18.0"
       },
@@ -250,14 +250,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1646,10 +1646,13 @@
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",

--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -198,7 +198,7 @@
   "dependencies": {
     "tail": "^2.2.6",
     "ws": "^8.18.0",
-    "axios": "^1.13.5"
+    "axios": "^1.15.2"
   },
   "overrides": {
 	"request": {


### PR DESCRIPTION
Maintenance work on the Axios dependency in positron-supervisor; bumps to [1.15.2](https://github.com/axios/axios/releases/tag/v1.15.2) and supersedes https://github.com/posit-dev/positron/pull/12976. 

Note that we have previously taken on Axios dependency bumps to address security concerns only to discover significant regressions. See https://github.com/posit-dev/positron/pull/11872, https://github.com/posit-dev/positron/pull/11937. Consequently, some caution is warranted here.

I've built and done some sanity checks locally. In lieu of attempting to guess at which tests this might affect, I've done a full E2E run: https://github.com/posit-dev/positron/actions/runs/24807345162