### PR TITLE
Change runtime session icons

### DIFF
--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.tsx
@@ -12,7 +12,6 @@ import { useEffect, useState } from 'react';
 // Other dependencies.
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
-import { IModelService } from '../../../../../editor/common/services/model.js';
 import { LanguageRuntimeSessionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ActionBarCommandButton } from '../../../../../platform/positronActionBar/browser/components/actionBarCommandButton.js';
 import { CommandCenter } from '../../../../../platform/commandCenter/common/commandCenter.js';
@@ -20,43 +19,12 @@ import { IRuntimeSessionDisplayInfo } from '../../../../services/runtimeSession/
 import { localize } from '../../../../../nls.js';
 import { LANGUAGE_RUNTIME_SELECT_SESSION_ID, LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID } from '../../../../contrib/languageRuntime/browser/languageRuntimeActions.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
-import { RuntimeStatus, getSessionDisplayName, getSessionIcon, getSessionIconStyle, runtimeStateToRuntimeStatus } from '../../../../contrib/positronConsole/common/sessionDisplayUtils.js';
+import { getSessionDisplayName, runtimeStateToRuntimeStatus } from '../../../../contrib/positronConsole/common/sessionDisplayUtils.js';
 import { RuntimeStatusIcon } from '../../../../contrib/positronConsole/browser/components/runtimeStatus.js';
+import { RuntimeIcon } from '../../../../contrib/positronConsole/browser/components/runtimeIcon.js';
 import { ActionBarButtonIcon, ActionBarButtonLabel } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
 
 const startSession = localize('positron.console.startSession', "Start Session");
-
-/**
- * Gets the label text from session display info, or the default start session
- * label if no session is active.
- */
-const getLabel = (info: IRuntimeSessionDisplayInfo | undefined): string => {
-	if (!info) {
-		return startSession;
-	}
-	return getSessionDisplayName({ notebookUri: info.notebookUri, sessionName: info.sessionName });
-};
-
-/**
- * Gets the session mode icon from display info.
- */
-const getIcon = (info: IRuntimeSessionDisplayInfo | undefined, modelService: IModelService) => {
-	if (!info) {
-		return Codicon.arrowSwap;
-	}
-	return getSessionIcon(info, modelService);
-};
-
-/**
- * Gets the runtime status from session display info.
- * Returns undefined when there is no foreground session.
- */
-const getRuntimeStatus = (info: IRuntimeSessionDisplayInfo | undefined): RuntimeStatus | undefined => {
-	if (!info) {
-		return undefined;
-	}
-	return runtimeStateToRuntimeStatus[info.sessionState];
-};
 
 /**
  * This component allows users to manage the foreground session.
@@ -67,15 +35,8 @@ const getRuntimeStatus = (info: IRuntimeSessionDisplayInfo | undefined): Runtime
 export const TopActionBarSessionManager = () => {
 	const services = usePositronReactServicesContext();
 
-	const [labelText, setLabelText] = useState<string>(
-		getLabel(services.runtimeSessionService.foregroundSessionDisplayInfo));
-	const [sessionIcon, setSessionIcon] = useState(
-		getIcon(services.runtimeSessionService.foregroundSessionDisplayInfo, services.modelService));
-	const info = services.runtimeSessionService.foregroundSessionDisplayInfo;
-	const [iconStyle, setIconStyle] = useState(
-		info ? getSessionIconStyle(info, services.modelService) : undefined);
-	const [runtimeStatus, setRuntimeStatus] = useState<RuntimeStatus | undefined>(
-		getRuntimeStatus(services.runtimeSessionService.foregroundSessionDisplayInfo));
+	const [displayInfo, setDisplayInfo] = useState<IRuntimeSessionDisplayInfo | undefined>(
+		services.runtimeSessionService.foregroundSessionDisplayInfo);
 
 	// Check if there are any active console sessions to determine if the
 	// active session picker or the create session picker should be shown.
@@ -85,27 +46,24 @@ export const TopActionBarSessionManager = () => {
 		? LANGUAGE_RUNTIME_SELECT_SESSION_ID
 		: LANGUAGE_RUNTIME_START_NEW_CONSOLE_SESSION_ID;
 
-	// Main useEffect.
+	// Subscribe to foreground session changes. This event fires when the
+	// foreground session changes, when the session's runtime state changes,
+	// and when an exited notebook session is attempted to be set as the
+	// foreground session.
 	useEffect(() => {
-		// Create the disposable store for cleanup.
 		const disposableStore = new DisposableStore();
-
-		// Use _foregroundSessionDisplayInfo as the single source of truth for
-		// the interpreter. This event should fire when the foreground session
-		// changes, the session's runtime state changes, and when an exited
-		// notebook session is attempted to be set as the foreground session.
 		disposableStore.add(
 			services.runtimeSessionService.onDidChangeForegroundSessionDisplayInfo(info => {
-				setLabelText(getLabel(info));
-				setSessionIcon(getIcon(info, services.modelService));
-				setIconStyle(info ? getSessionIconStyle(info, services.modelService) : undefined);
-				setRuntimeStatus(getRuntimeStatus(info));
+				setDisplayInfo(info);
 			})
 		);
-
-		// Return the cleanup function that will dispose of the disposables.
 		return () => disposableStore.dispose();
-	}, [services.runtimeSessionService, services.modelService]);
+	}, [services.runtimeSessionService]);
+
+	const labelText = displayInfo
+		? getSessionDisplayName({ notebookUri: displayInfo.notebookUri, sessionName: displayInfo.sessionName })
+		: startSession;
+	const runtimeStatus = displayInfo ? runtimeStateToRuntimeStatus[displayInfo.sessionState] : undefined;
 
 	return (
 		<ActionBarCommandButton
@@ -114,14 +72,18 @@ export const TopActionBarSessionManager = () => {
 			commandId={command}
 			height={24}
 		>
-			<div className='top-action-bar-session-manager-face'>
+			<div className='top-action-bar-session-manager-face show-file-icons'>
 				{runtimeStatus !== undefined &&
 					<RuntimeStatusIcon status={runtimeStatus} />
 				}
-				<ActionBarButtonIcon
-					icon={sessionIcon}
-					style={iconStyle}
-				/>
+				{displayInfo
+					? <RuntimeIcon
+						languageId={displayInfo.languageId}
+						notebookUri={displayInfo.notebookUri}
+						sessionMode={displayInfo.sessionMode}
+					/>
+					: <ActionBarButtonIcon icon={Codicon.arrowSwap} />
+				}
 				<ActionBarButtonLabel
 					hasIcon={true}
 					label={labelText}

--- a/src/vs/workbench/browser/parts/positronTopActionBar/test/browser/topActionBarSessionManager.vitest.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/test/browser/topActionBarSessionManager.vitest.tsx
@@ -5,7 +5,6 @@
 
 /// <reference types="vitest/globals" />
 
-import React from 'react';
 import { act, fireEvent } from '@testing-library/react';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { URI } from '../../../../../../base/common/uri.js';
@@ -33,6 +32,7 @@ function makeDisplayInfo(
 		sessionMode: LanguageRuntimeSessionMode.Console,
 		notebookUri: undefined,
 		runtimeId: 'python-3.12.1',
+		runtimeName: 'Python',
 		languageName: 'Python',
 		languageId: 'python',
 		base64EncodedIconSvg: undefined,
@@ -87,6 +87,9 @@ describe('TopActionBarSessionManager', () => {
 				<TopActionBarSessionManager />
 			);
 
+			// No session => we render <ActionBarButtonIcon icon={Codicon.arrowSwap} />
+			// rather than <RuntimeIcon>, so the session-icon span is absent.
+			expect(container.querySelector('.runtime-session-icon')).toBeNull();
 			const icon = container.querySelector('.action-bar-button-icon');
 			expect(icon?.className).toBe('action-bar-button-icon codicon codicon-arrow-swap');
 		});
@@ -126,13 +129,15 @@ describe('TopActionBarSessionManager', () => {
 			expect(label?.textContent).toBe('Python 3.12.1');
 		});
 
-		it('renders positron-new-console icon for console session', () => {
+		it('renders a runtime-session-icon with the language class for a console session', () => {
 			const { container } = rtl.render(
 				<TopActionBarSessionManager />
 			);
 
-			const icon = container.querySelector('.action-bar-button-icon');
-			expect(icon?.className).toBe('action-bar-button-icon codicon codicon-positron-new-console');
+			const icon = container.querySelector('.runtime-session-icon');
+			expect(icon).not.toBeNull();
+			expect(icon?.classList.contains('file-icon')).toBe(true);
+			expect(icon?.classList.contains('python-lang-file-icon')).toBe(true);
 		});
 	});
 
@@ -162,13 +167,15 @@ describe('TopActionBarSessionManager', () => {
 			expect(label?.textContent).toBe('analysis.ipynb');
 		});
 
-		it('renders notebook icon for notebook session', () => {
+		it('renders a runtime-session-icon with the file-extension class for a notebook session', () => {
 			const { container } = rtl.render(
 				<TopActionBarSessionManager />
 			);
 
-			const icon = container.querySelector('.action-bar-button-icon');
-			expect(icon?.className).toBe('action-bar-button-icon codicon codicon-notebook');
+			const icon = container.querySelector('.runtime-session-icon');
+			expect(icon).not.toBeNull();
+			expect(icon?.classList.contains('file-icon')).toBe(true);
+			expect(icon?.classList.contains('ipynb-ext-file-icon')).toBe(true);
 		});
 	});
 
@@ -221,6 +228,7 @@ describe('TopActionBarSessionManager', () => {
 			act(() => {
 				displayInfoEmitter.fire(makeDisplayInfo({
 					sessionName: 'R 4.3.2',
+					languageId: 'r',
 					sessionMode: LanguageRuntimeSessionMode.Console,
 				}));
 			});
@@ -244,21 +252,25 @@ describe('TopActionBarSessionManager', () => {
 			expect(container.querySelector('.action-bar-button-label')?.textContent).toBe('report.ipynb');
 		});
 
-		it('updates icon when session changes from none to console', () => {
+		it('swaps from the arrow-swap fallback to a runtime-session-icon when a console session appears', () => {
 			const { container } = rtl.render(
 				<TopActionBarSessionManager />
 			);
 
-			expect(container.querySelector('.action-bar-button-icon')?.className).toBe('action-bar-button-icon codicon codicon-arrow-swap');
+			expect(container.querySelector('.action-bar-button-icon.codicon-arrow-swap')).not.toBeNull();
+			expect(container.querySelector('.runtime-session-icon')).toBeNull();
 
 			act(() => {
 				displayInfoEmitter.fire(makeDisplayInfo());
 			});
 
-			expect(container.querySelector('.action-bar-button-icon')?.className).toBe('action-bar-button-icon codicon codicon-positron-new-console');
+			expect(container.querySelector('.action-bar-button-icon.codicon-arrow-swap')).toBeNull();
+			const icon = container.querySelector('.runtime-session-icon');
+			expect(icon).not.toBeNull();
+			expect(icon?.classList.contains('python-lang-file-icon')).toBe(true);
 		});
 
-		it('updates icon when session changes to notebook', () => {
+		it('swaps to a runtime-session-icon with the notebook extension class when switching to a notebook session', () => {
 			const { container } = rtl.render(
 				<TopActionBarSessionManager />
 			);
@@ -270,7 +282,9 @@ describe('TopActionBarSessionManager', () => {
 				}));
 			});
 
-			expect(container.querySelector('.action-bar-button-icon')?.className).toBe('action-bar-button-icon codicon codicon-notebook');
+			const icon = container.querySelector('.runtime-session-icon');
+			expect(icon).not.toBeNull();
+			expect(icon?.classList.contains('ipynb-ext-file-icon')).toBe(true);
 		});
 
 		it('reverts to "Start Session" when session is cleared', () => {
@@ -289,7 +303,7 @@ describe('TopActionBarSessionManager', () => {
 			expect(container.querySelector('.action-bar-button-label')?.textContent).toBe('Start Session');
 		});
 
-		it('reverts to arrow-swap icon when session is cleared', () => {
+		it('reverts to the arrow-swap fallback icon when session is cleared', () => {
 			const { container } = rtl.render(
 				<TopActionBarSessionManager />
 			);
@@ -297,12 +311,13 @@ describe('TopActionBarSessionManager', () => {
 			act(() => {
 				displayInfoEmitter.fire(makeDisplayInfo());
 			});
-			expect(container.querySelector('.action-bar-button-icon')?.className).toBe('action-bar-button-icon codicon codicon-positron-new-console');
+			expect(container.querySelector('.runtime-session-icon')).not.toBeNull();
 
 			act(() => {
 				displayInfoEmitter.fire(undefined);
 			});
-			expect(container.querySelector('.action-bar-button-icon')?.className).toBe('action-bar-button-icon codicon codicon-arrow-swap');
+			expect(container.querySelector('.runtime-session-icon')).toBeNull();
+			expect(container.querySelector('.action-bar-button-icon.codicon-arrow-swap')).not.toBeNull();
 		});
 	});
 

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1677,14 +1677,6 @@ export const POSITRON_RUNTIME_STATE_ICON_IDLE = registerColor('positronRuntime.s
 	hcLight: '#2eb77c'
 }, localize('positronRuntime.stateIconIdle', "Positron runtime idle state icon color."));
 
-// Positron Quarto icon color.
-export const POSITRON_QUARTO_ICON = registerColor('positronConsole.quartoIcon', {
-	dark: '#4E97B4',
-	light: '#4E97B4',
-	hcDark: '#4E97B4',
-	hcLight: '#4E97B4'
-}, localize('positronConsole.quartoIcon', "Positron Quarto session icon color."));
-
 //  < --- Positron Data Grid --- >
 
 // Positron data grid background color.

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -18,10 +18,7 @@ import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionService
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../editor/common/services/model.js';
-import { ThemeIcon } from '../../../../base/common/themables.js';
-import { getSessionDisplayName, getSessionIcon, isQuartoSession } from '../../positronConsole/common/sessionDisplayUtils.js';
-import { registerThemingParticipant } from '../../../../platform/theme/common/themeService.js';
-import { POSITRON_QUARTO_ICON } from '../../../common/theme.js';
+import { getSessionDisplayName, getSessionIconClasses, isQuartoSession } from '../../positronConsole/common/sessionDisplayUtils.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
 import { dispose } from '../../../../base/common/lifecycle.js';
@@ -39,17 +36,6 @@ import { getErrorMessage } from '../../../../base/common/errors.js';
 
 // The category for language runtime actions.
 const category: ILocalizedString = { value: LANGUAGE_RUNTIME_ACTION_CATEGORY, original: 'Interpreter' };
-
-// Class applied to the Quarto icon in the session quickpick so it picks up the
-// Quarto theme color. IQuickPickItem only accepts a CSS class name (not a React
-// style), so we register a themed rule keyed on this class.
-const QUARTO_QUICKPICK_ICON_CLASS = 'positron-quickpick-quarto-icon';
-registerThemingParticipant((theme, collector) => {
-	const quartoColor = theme.getColor(POSITRON_QUARTO_ICON);
-	if (quartoColor) {
-		collector.addRule(`.quick-input-list-icon.${QUARTO_QUICKPICK_ICON_CLASS}.codicon { color: ${quartoColor}; }`);
-	}
-});
 
 /**
  * Builds a display label that includes the runtime name for notebook sessions
@@ -178,8 +164,20 @@ const selectLanguageRuntimeSession = async (
 	const runtimeSessionService = accessor.get(IRuntimeSessionService);
 	const commandService = accessor.get(ICommandService);
 	const modelService = accessor.get(IModelService);
+	const languageService = accessor.get(ILanguageService);
 
 	const includeNotebookSessions = options?.includeNotebookSessions ?? true;
+
+	const iconClassesForSession = (session: ILanguageRuntimeSession): string[] =>
+		getSessionIconClasses(
+			{
+				sessionMode: session.metadata.sessionMode,
+				notebookUri: session.metadata.notebookUri,
+				languageId: session.runtimeMetadata.languageId,
+			},
+			modelService,
+			languageService,
+		);
 
 	// Filter active sessions by runtime state (exclude exited/uninitialized sessions).
 	const isActiveState = (session: ILanguageRuntimeSession) => {
@@ -214,7 +212,7 @@ const selectLanguageRuntimeSession = async (
 			description: session.sessionId === foregroundSessionId
 				? localize('positron.languageRuntime.currentlySelected', 'Currently Selected')
 				: undefined,
-			iconClass: ThemeIcon.asClassName(getSessionIcon(session.metadata, modelService)),
+			iconClasses: iconClassesForSession(session),
 			picked: session.sessionId === foregroundSessionId,
 		}));
 
@@ -243,7 +241,7 @@ const selectLanguageRuntimeSession = async (
 				description: session.sessionId === foregroundSessionId
 					? localize('positron.languageRuntime.currentlySelected', 'Currently Selected')
 					: undefined,
-				iconClass: ThemeIcon.asClassName(getSessionIcon(session.metadata, modelService)),
+				iconClasses: iconClassesForSession(session),
 				picked: session.sessionId === foregroundSessionId,
 			}));
 
@@ -265,7 +263,7 @@ const selectLanguageRuntimeSession = async (
 				description: session.sessionId === foregroundSessionId
 					? localize('positron.languageRuntime.currentlySelected', 'Currently Selected')
 					: undefined,
-				iconClass: `${ThemeIcon.asClassName(getSessionIcon(session.metadata, modelService))} ${QUARTO_QUICKPICK_ICON_CLASS}`,
+				iconClasses: iconClassesForSession(session),
 				picked: session.sessionId === foregroundSessionId,
 			}));
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
@@ -47,12 +47,6 @@
 	background-color: var(--vscode-list-activeSelectionBackground);
 }
 
-.tab-button .icon {
-	height: 15px;
-	width: 15px;
-	margin: 0 6px
-}
-
 .tab-button .session-name {
 	/* Grow items after session name to fill available space */
 	flex: 1;

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.tsx
@@ -475,11 +475,10 @@ export const ConsoleTab = ({ positronConsoleInstance, width, onChangeSession }: 
 			onMouseDown={handleMouseDown}
 		>
 			{/* Header row with session info */}
-			<div className='tab-header'>
+			<div className='tab-header show-file-icons'>
 				<ConsoleSessionStatusIcon positronConsoleInstance={positronConsoleInstance} />
 				<RuntimeIcon
-					base64EncodedIconSvg={positronConsoleInstance.runtimeMetadata.base64EncodedIconSvg}
-					modelService={services.modelService}
+					languageId={positronConsoleInstance.runtimeMetadata.languageId}
 					notebookUri={positronConsoleInstance.sessionMetadata.notebookUri}
 					sessionMode={positronConsoleInstance.sessionMetadata.sessionMode}
 				/>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeIcon.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeIcon.css
@@ -1,4 +1,31 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
+
+.runtime-session-icon {
+	display: inline-flex;
+	align-items: center;
+	flex-shrink: 0;
+	width: 20px;
+	height: 20px;
+}
+
+/**
+ * File icon themes scope all their CSS to `.show-file-icons`.
+ * Without this class nothing renders. Each surface using RuntimeIcon
+ * has to add the class to its container.
+ *
+ * The sizing strategy used here matches IconLabel (see iconLabel.css)
+ * so Seti font glyphs and language-contributed SVGs end up the same
+ * visual size.
+ */
+.show-file-icons .runtime-session-icon::before {
+	display: inline-block;
+	font-size: 20px !important; /* override the show-file-icons default font size */
+	line-height: 20px;
+	background-size: 16px;
+	background-position: left center;
+	background-repeat: no-repeat;
+	flex-shrink: 0;
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeIcon.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeIcon.tsx
@@ -4,38 +4,27 @@
  *--------------------------------------------------------------------------------------------*/
 
 // CSS.
-import './runtimeStatus.css';
+import './runtimeIcon.css';
 
 // Other dependencies.
-import { IModelService } from '../../../../../editor/common/services/model.js';
 import { LanguageRuntimeSessionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
-import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
-import { getSessionIcon, getSessionIconStyle } from '../../common/sessionDisplayUtils.js';
+import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { getSessionIconClasses } from '../../common/sessionDisplayUtils.js';
 import { URI } from '../../../../../base/common/uri.js';
 
 export interface RuntimeIconProps {
-	base64EncodedIconSvg: string | undefined;
 	sessionMode: LanguageRuntimeSessionMode;
 	notebookUri?: URI;
-	modelService: IModelService;
+	languageId: string;
 }
 
-export const RuntimeIcon = ({ base64EncodedIconSvg, sessionMode, notebookUri, modelService }: RuntimeIconProps) => {
-	const classNames = ['icon'];
-
-	if (sessionMode === LanguageRuntimeSessionMode.Notebook) {
-		const icon = getSessionIcon({ sessionMode, notebookUri }, modelService);
-		const style = getSessionIconStyle({ sessionMode, notebookUri }, modelService);
-		classNames.push(...ThemeIcon.asClassNameArray(icon));
-		return <span className={positronClassNames(...classNames)} style={style}></span>;
-	}
-
-	if (base64EncodedIconSvg === undefined) {
-		return null;
-	}
-	return <img
-		className={positronClassNames(...classNames)}
-		src={`data:image/svg+xml;base64,${base64EncodedIconSvg}`}
-	/>;
+export const RuntimeIcon = ({ sessionMode, notebookUri, languageId }: RuntimeIconProps) => {
+	const services = usePositronReactServicesContext();
+	const iconClasses = getSessionIconClasses(
+		{ sessionMode, notebookUri, languageId },
+		services.modelService,
+		services.languageService,
+	);
+	return <span className={positronClassNames('runtime-session-icon', ...iconClasses)}></span>;
 };

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStatus.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStatus.tsx
@@ -58,5 +58,5 @@ export const RuntimeStatusIcon = ({ status }: RuntimeStatusIconProps) => {
 		className={status === RuntimeStatus.Active ? 'animate-spin' : undefined}
 		icon={icon}
 		style={{ color }}
-	/>
+	/>;
 };

--- a/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
+++ b/src/vs/workbench/contrib/positronConsole/common/sessionDisplayUtils.ts
@@ -5,12 +5,11 @@
 
 import { URI } from '../../../../base/common/uri.js';
 import { basename, extname } from '../../../../base/common/path.js';
-import { Codicon } from '../../../../base/common/codicons.js';
-import { ThemeIcon } from '../../../../base/common/themables.js';
 import { IModelService } from '../../../../editor/common/services/model.js';
-import { asCssVariable } from '../../../../platform/theme/common/colorUtils.js';
+import { ILanguageService } from '../../../../editor/common/languages/language.js';
+import { getIconClasses, getIconClassesForLanguageId } from '../../../../editor/common/services/getIconClasses.js';
+import { FileKind } from '../../../../platform/files/common/files.js';
 import { LanguageRuntimeSessionMode, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
-import { POSITRON_QUARTO_ICON } from '../../../common/theme.js';
 import { isQuartoDocument } from '../../positronQuarto/common/positronQuartoConfig.js';
 
 /**
@@ -49,38 +48,29 @@ export function getSessionDisplayName(
 }
 
 /**
- * The subset of session display info needed to determine the session icon.
+ * The subset of session info needed to determine the session icon.
  */
 interface SessionIconInfo {
 	readonly sessionMode: LanguageRuntimeSessionMode;
 	readonly notebookUri?: URI;
+	readonly languageId: string;
 }
 
 /**
- * Gets the icon for a session based on its mode. Returns the Quarto icon for
- * Quarto notebook sessions, the notebook icon for other notebook sessions,
- * and the console icon for console sessions.
+ * Resolves the CSS classes used to render a session's icon via the file icon.
+ * Notebook sessions (including Quarto) match against the notebook
+ * URI so the session picks up the same glyph the Explorer shows for that file.
+ * Console sessions match against the runtime language id (python / r / etc).
  */
-export function getSessionIcon(info: SessionIconInfo, modelService: IModelService): ThemeIcon {
-	if (info.sessionMode === LanguageRuntimeSessionMode.Notebook) {
-		if (isQuartoSession({ notebookUri: info.notebookUri, modelService })) {
-			return Codicon.positronQuarto;
-		}
-		return Codicon.notebook;
+export function getSessionIconClasses(
+	info: SessionIconInfo,
+	modelService: IModelService,
+	languageService: ILanguageService,
+): string[] {
+	if (info.sessionMode === LanguageRuntimeSessionMode.Notebook && info.notebookUri) {
+		return getIconClasses(modelService, languageService, info.notebookUri, FileKind.FILE);
 	}
-	return Codicon.positronNewConsole;
-}
-
-/**
- * Gets the icon style for a session. Returns a color style for Quarto
- * sessions and undefined for all other sessions.
- */
-export function getSessionIconStyle(info: SessionIconInfo, modelService: IModelService): React.CSSProperties | undefined {
-	if (info.sessionMode === LanguageRuntimeSessionMode.Notebook &&
-		isQuartoSession({ notebookUri: info.notebookUri, modelService })) {
-		return { color: asCssVariable(POSITRON_QUARTO_ICON) };
-	}
-	return undefined;
+	return getIconClassesForLanguageId(info.languageId);
 }
 
 /**


### PR DESCRIPTION
Follow up to #11905 and #12741 which added notebook sessions to the interpreter quick pick and the quarto icon to the console tab view.

We received feedback from folks that they didn't like:
1.  the lack of color in the icons
2. the console icon being hard to read (known issue)
3. the lack of consistency in icon styles being introduced (codicons vs language-pack provided SVGs)

To try and address this we've landed on a middle ground: use the file icons that are used in the Explorer pane, breadcrumbs, etc. The file icon themes can be changed but the default one used is called `Seti`. 

The downside to using file icons is that user can change the file icons and override what they see in the interpreter picker, console tab list, and session quick pick. The file icon theme can be changed by searching for "Preferences: File Icon Theme" (`workbench.action.selectIconTheme`) in the command palette and picking a different file icon theme. You can see that setting the file icon theme to `Minimal` or `Disabled` will override the icons we show. 

The only time we show the language pack icons now is when you are selecting a runtime via a quickpick. If you're working with sessions, we use the file icon theme. 

The `positronQuarto` codicon (`codiconsLibrary.ts:763`) has no remaining consumers after this PR. I'll remove the registration plus the glyph in a separate cleanup PR.

### Screenshot

<img width="1840" height="1072" alt="Screenshot 2026-04-22 at 4 40 32 PM" src="https://github.com/user-attachments/assets/dc971252-766e-4409-b45e-9219166c93a7" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Change icons shown for runtime sessions (#11905, #12741)

#### Bug Fixes

- N/A


### QA Notes
 @:interpreter @:sessions @:console @:notebooks @:quarto @:top-action-bar
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
