### PR TITLE
python: better cache in PET resolveEnv()

### DIFF
--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -24,7 +24,9 @@ import {
 import { createDeferred, Deferred } from '../common/utils/async';
 import { Architecture, getPathEnvVariable, getUserHomeDir } from '../common/utils/platform';
 import { getShortVersionString, parseVersion } from './base/info/pythonVersion';
-import { cache } from '../common/utils/decorators';
+// --- Start Positron ---
+// import { cache } from '../common/utils/decorators';
+// --- End Positron ---
 import { traceError, traceInfo, traceLog, traceVerbose, traceWarn } from '../logging';
 import { StopWatch } from '../common/utils/stopWatch';
 import { FileChangeType } from '../common/platform/fileSystemWatcher';
@@ -374,6 +376,14 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
     // can do O(1) lookups instead of re-resolving all existing envs on every
     // new env addition (which was O(N^2) total).
     private _resolvedSymlinks = new Map<string, string>();
+
+    // Cache of resolved environments, keyed by the executable path passed to
+    // resolveEnv(). Only successful resolutions are cached. Entries are
+    // invalidated in addEnv()/removeEnv() so a late-arriving discovery
+    // immediately supersedes any cached state.
+    private _resolveEnvCache = new Map<string, { info: PythonEnvInfo; expiry: number }>();
+
+    private static readonly _resolveEnvCacheMs = 30_000;
     // --- End Positron ---
 
     constructor(private readonly finder: NativePythonFinder) {
@@ -599,6 +609,9 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
                 // in _envs yet).
                 const oldFilename = old.executable.filename;
                 this._resolvedSymlinks.delete(oldFilename);
+                // Drop any stale resolveEnv cache entry for the replaced path
+                // so late callers don't see the superseded env.
+                this._resolveEnvCache.delete(oldFilename);
                 this._envs = this._envs.filter(
                     (item) =>
                         item.executable.filename !== info.executable.filename &&
@@ -613,6 +626,14 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
                 this._envs.push(info);
                 this._onChanged.fire({ type: FileChangeType.Created, new: info, searchLocation });
             }
+            // --- Start Positron ---
+            // Publish the freshly resolved env to the resolveEnv cache so later
+            // callers hit it without spawning another PET round-trip.
+            this._resolveEnvCache.set(info.executable.filename, {
+                info,
+                expiry: Date.now() + NativePythonEnvironments._resolveEnvCacheMs,
+            });
+            // --- End Positron ---
         }
 
         return info;
@@ -624,6 +645,7 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
             this._envs = this._envs.filter((item) => item.executable.filename !== env);
             // --- Start Positron ---
             this._resolvedSymlinks.delete(env);
+            this._resolveEnvCache.delete(env);
             // --- End Positron ---
             this._onChanged.fire({ type: FileChangeType.Deleted, old });
             return;
@@ -631,15 +653,27 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
         this._envs = this._envs.filter((item) => item.executable.filename !== env.executable.filename);
         // --- Start Positron ---
         this._resolvedSymlinks.delete(env.executable.filename);
+        this._resolveEnvCache.delete(env.executable.filename);
         // --- End Positron ---
         this._onChanged.fire({ type: FileChangeType.Deleted, old: env });
     }
 
-    @cache(30_000, true)
+    // --- Start Positron ---
+    // This decorator stored the pending promise immediately, so an undefined resolution
+    // was pinned for 30s even after PET had since discovered the env. Use an explicit cache
+    // that only caches successful resolutions and is invalidated on addEnv()/removeEnv().
+    // @cache(30_000, true)
+    // --- End Positron ---
     async resolveEnv(envPath?: string): Promise<PythonEnvInfo | undefined> {
         if (envPath === undefined) {
             return undefined;
         }
+        // --- Start Positron ---
+        const cached = this._resolveEnvCache.get(envPath);
+        if (cached && cached.expiry > Date.now()) {
+            return cached.info;
+        }
+        // --- End Positron ---
         try {
             const native = await this.finder.resolve(envPath);
             if (native) {

--- a/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
@@ -538,9 +538,7 @@ suite('Native Python API', () => {
                 // which is exactly what we're regression-testing.
                 .returns(() => {
                     resolveCount += 1;
-                    return Promise.resolve(
-                        resolveCount === 1 ? (undefined as unknown as NativeEnvInfo) : basicEnv,
-                    );
+                    return Promise.resolve(resolveCount === 1 ? ((undefined as unknown) as NativeEnvInfo) : basicEnv);
                 });
 
             const first = await api.resolveEnv(pythonPath);

--- a/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
@@ -515,5 +515,127 @@ suite('Native Python API', () => {
         assert.equal(envs.length, 1, 'expected exactly one env (longer path should be replaced)');
         assert.equal(envs[0].executable.filename, shorterPath);
     });
+
+    // Regression tests for issue #12500: `resolveEnv` must not pin an
+    // `undefined` resolution for 30s when PET is still discovering the env.
+    suite('resolveEnv caching', () => {
+        const pythonPath = '/usr/bin/python';
+
+        setup(() => {
+            // basicEnv (path /usr/bin/python) is not under any additional env
+            // dir, but checkForExistingEnv unconditionally awaits this list
+            // when addEnv runs. Return [] so the test doesn't depend on the
+            // real vscode-configuration lookups.
+            sinon.stub(nativeFinder, 'getAdditionalEnvDirs').resolves([]);
+        });
+
+        test('does not cache undefined resolutions', async () => {
+            let resolveCount = 0;
+            mockFinder
+                .setup((f) => f.resolve(pythonPath))
+                // The typemoq setup types `resolve` as `Promise<NativeEnvInfo>`,
+                // but the runtime path treats undefined as "not yet resolved",
+                // which is exactly what we're regression-testing.
+                .returns(() => {
+                    resolveCount += 1;
+                    return Promise.resolve(
+                        resolveCount === 1 ? (undefined as unknown as NativeEnvInfo) : basicEnv,
+                    );
+                });
+
+            const first = await api.resolveEnv(pythonPath);
+            assert.isUndefined(first, 'first call should reflect the undefined resolution');
+
+            const second = await api.resolveEnv(pythonPath);
+            assert.isDefined(second, 'second call should return the now-resolved env');
+            assert.equal(second?.executable.filename, pythonPath);
+            assert.equal(resolveCount, 2, 'finder.resolve should be called twice (undefined is not cached)');
+        });
+
+        test('caches successful resolutions under the executable path', async () => {
+            let resolveCount = 0;
+            mockFinder
+                .setup((f) => f.resolve(pythonPath))
+                .returns(() => {
+                    resolveCount += 1;
+                    return Promise.resolve(basicEnv);
+                });
+
+            const first = await api.resolveEnv(pythonPath);
+            const second = await api.resolveEnv(pythonPath);
+            assert.deepEqual(first, expectedBasicEnv);
+            assert.deepEqual(second, expectedBasicEnv);
+            assert.equal(resolveCount, 1, 'second call should hit the cache and skip finder.resolve');
+        });
+
+        test('triggerRefresh refreshes the resolveEnv cache entry (late uv classification)', async () => {
+            let resolveCount = 0;
+            mockFinder
+                .setup((f) => f.resolve(pythonPath))
+                .returns(() => {
+                    resolveCount += 1;
+                    return Promise.resolve(basicEnv);
+                });
+            mockFinder
+                .setup((f) => f.refresh())
+                .returns(() => {
+                    async function* generator() {
+                        yield* [basicEnv];
+                    }
+                    return generator();
+                });
+
+            // Warm the cache while isUvEnvironment returns falsy (default stub behavior).
+            const warm = await api.resolveEnv(pythonPath);
+            assert.equal(warm?.kind, PythonEnvKind.System);
+
+            // Reclassify the same executable as uv before the next refresh.
+            isUvEnvironmentStub.withArgs(pythonPath).resolves(true);
+            await api.triggerRefresh();
+
+            // triggerRefresh routes the env through addEnv, which overwrites the
+            // cache entry with the uv-classified info. Next resolveEnv should see
+            // the updated kind without spawning another finder.resolve.
+            const refreshed = await api.resolveEnv(pythonPath);
+            assert.equal(refreshed?.kind, PythonEnvKind.Uv);
+            assert.equal(resolveCount, 1, 'cache update via addEnv should not trigger another finder.resolve');
+        });
+
+        test('removeEnv invalidates the resolveEnv cache', async () => {
+            let resolveCount = 0;
+            let yieldEnv = false;
+            mockFinder
+                .setup((f) => f.resolve(pythonPath))
+                .returns(() => {
+                    resolveCount += 1;
+                    return Promise.resolve(basicEnv);
+                });
+            mockFinder
+                .setup((f) => f.refresh())
+                .returns(() => {
+                    async function* generator() {
+                        if (yieldEnv) {
+                            yield* [basicEnv];
+                        }
+                    }
+                    return generator();
+                });
+
+            // Warm the cache via resolveEnv; addEnv also pushes into _envs.
+            await api.resolveEnv(pythonPath);
+            assert.equal(resolveCount, 1);
+            assert.equal(api.getEnvs().length, 1);
+
+            // Refresh yields nothing, so basicEnv falls off _envs via removeEnv,
+            // which must also drop the cache entry.
+            yieldEnv = false;
+            await api.triggerRefresh();
+            assert.equal(api.getEnvs().length, 0);
+
+            // With the cache cleared, the next resolveEnv must call finder.resolve again.
+            await api.resolveEnv(pythonPath);
+            assert.equal(resolveCount, 2, 'cache should be cleared by removeEnv');
+        });
+    });
     // --- End Positron ---
 });


### PR DESCRIPTION
Addresses part of #12500. Related to #12327, where some Python interpreters weren't getting resolved correctly after we bumped PET. Possibly will help with https://github.com/posit-dev/positron/issues/12253 too, where some Python interpreters weren't being discovered in the first pass of discovery after we bumped PET.

`resolveEnv()` was decorated with `@cache(30_000, true)`. But if PET hadn't discovered the env yet, `undefined` is pinned in the cache for 30 seconds, even after PET finished discovery. Any caller in that window got the stale `undefined` back. This PR replaces the decorator with an explicit cache on `NativePythonEnvironments` that:

1. Only caches successful `PythonEnvInfo` resolutions.
2. Never caches `undefined` or thrown errors.
3. Is invalidated in `addEnv`/`removeEnv`, so a late-arriving PET discovery automatically supersedes any prior cached state.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:interpreter

Reusing the #13064 QA trick to simulate a slow PET: add

```ts
await new Promise((r) => setTimeout(r, 30000));
```

inside `finder.refresh`'s loop in `nativeAPI.ts`.

Before this PR: picking an interpreter via the picker in the first 30s after a cold start would sometimes log `Tried to switch to a language runtime that has not been registered` and fail to start.

After this PR: selection should succeed as soon as PET has seen that env without a 30s penalty.

Unit tests covering the regression are included.
