### PR TITLE
Add /idle endpoint for hosting platform idle tracking

### DIFF
--- a/src/vs/platform/positronIdleTracking/common/positronIdleTracking.ts
+++ b/src/vs/platform/positronIdleTracking/common/positronIdleTracking.ts
@@ -8,35 +8,28 @@ import { createDecorator } from '../../instantiation/common/instantiation.js';
 export const IPositronIdleTrackingService = createDecorator<IPositronIdleTrackingService>('positronIdleTrackingService');
 
 export interface IPositronIdleInfo {
-	/** Seconds since the last user interaction across all connected clients. */
+	/** Seconds since the last reported user activity. */
 	secondsIdle: number;
-	/** Epoch milliseconds of the last user interaction. */
+	/** Epoch milliseconds of the last reported user activity. */
 	lastActivityEpochMs: number;
-	/** Number of clients that have reported activity (may include disconnected clients not yet cleaned up). */
-	connectedClients: number;
 }
 
 /**
  * Server-side service that tracks user activity reported by browser clients.
  *
- * Browser clients report activity timestamps over IPC. The server aggregates
- * these and exposes idle information via the /idle HTTP endpoint for use by
- * hosting platforms like Posit Cloud.
+ * Browser clients report activity timestamps over IPC. The server keeps the
+ * most recent timestamp seen (monotonic) and exposes idle information via
+ * the /idle HTTP endpoint for use by hosting platforms like Posit Cloud.
  */
 export interface IPositronIdleTrackingService {
 	readonly _serviceBrand: undefined;
 
 	/**
-	 * Report that a client is active.
-	 * @param clientId Unique identifier for the client (e.g., reconnection token).
+	 * Report that a user is active.
 	 * @param timestampMs Epoch milliseconds when activity was detected.
+	 *                    Timestamps older than the current tracked value are ignored.
 	 */
-	reportActivity(clientId: string, timestampMs: number): void;
-
-	/**
-	 * Remove a client from tracking (e.g., on disconnect).
-	 */
-	removeClient(clientId: string): void;
+	reportActivity(timestampMs: number): void;
 
 	/**
 	 * Get the current idle information.

--- a/src/vs/platform/positronIdleTracking/common/positronIdleTracking.ts
+++ b/src/vs/platform/positronIdleTracking/common/positronIdleTracking.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from '../../instantiation/common/instantiation.js';
+
+export const IPositronIdleTrackingService = createDecorator<IPositronIdleTrackingService>('positronIdleTrackingService');
+
+export interface IPositronIdleInfo {
+	/** Seconds since the last user interaction across all connected clients. */
+	secondsIdle: number;
+	/** Epoch milliseconds of the last user interaction. */
+	lastActivityEpochMs: number;
+	/** Number of clients that have reported activity (may include disconnected clients not yet cleaned up). */
+	connectedClients: number;
+}
+
+/**
+ * Server-side service that tracks user activity reported by browser clients.
+ *
+ * Browser clients report activity timestamps over IPC. The server aggregates
+ * these and exposes idle information via the /idle HTTP endpoint for use by
+ * hosting platforms like Posit Cloud.
+ */
+export interface IPositronIdleTrackingService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Report that a client is active.
+	 * @param clientId Unique identifier for the client (e.g., reconnection token).
+	 * @param timestampMs Epoch milliseconds when activity was detected.
+	 */
+	reportActivity(clientId: string, timestampMs: number): void;
+
+	/**
+	 * Remove a client from tracking (e.g., on disconnect).
+	 */
+	removeClient(clientId: string): void;
+
+	/**
+	 * Get the current idle information.
+	 */
+	getIdleInfo(): IPositronIdleInfo;
+}

--- a/src/vs/platform/positronIdleTracking/common/positronIdleTrackingIpc.ts
+++ b/src/vs/platform/positronIdleTracking/common/positronIdleTrackingIpc.ts
@@ -17,10 +17,13 @@ export class PositronIdleTrackingChannel implements IServerChannel {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	async call<T>(_ctx: any, command: string, args?: any): Promise<T> {
+	async call<T>(_ctx: any, command: string, _args?: any): Promise<T> {
 		switch (command) {
 			case 'reportActivity': {
-				this.service.reportActivity(args.timestampMs);
+				// Use server-side Date.now() so the tracked timestamp is immune to
+				// browser clock skew (ahead or behind). The client timestamp is not
+				// needed: the server just needs to know "activity arrived now".
+				this.service.reportActivity(Date.now());
 				return undefined as unknown as T;
 			}
 		}

--- a/src/vs/platform/positronIdleTracking/common/positronIdleTrackingIpc.ts
+++ b/src/vs/platform/positronIdleTracking/common/positronIdleTrackingIpc.ts
@@ -20,11 +20,7 @@ export class PositronIdleTrackingChannel implements IServerChannel {
 	async call<T>(_ctx: any, command: string, args?: any): Promise<T> {
 		switch (command) {
 			case 'reportActivity': {
-				this.service.reportActivity(args.clientId, args.timestampMs);
-				return undefined as unknown as T;
-			}
-			case 'removeClient': {
-				this.service.removeClient(args.clientId);
+				this.service.reportActivity(args.timestampMs);
 				return undefined as unknown as T;
 			}
 		}
@@ -44,11 +40,7 @@ export class PositronIdleTrackingChannel implements IServerChannel {
 export class PositronIdleTrackingChannelClient {
 	constructor(private readonly _channel: IChannel) { }
 
-	reportActivity(clientId: string, timestampMs: number): Promise<void> {
-		return this._channel.call('reportActivity', { clientId, timestampMs });
-	}
-
-	removeClient(clientId: string): Promise<void> {
-		return this._channel.call('removeClient', { clientId });
+	reportActivity(timestampMs: number): Promise<void> {
+		return this._channel.call('reportActivity', { timestampMs });
 	}
 }

--- a/src/vs/platform/positronIdleTracking/common/positronIdleTrackingIpc.ts
+++ b/src/vs/platform/positronIdleTracking/common/positronIdleTrackingIpc.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from '../../../base/common/event.js';
+import { IChannel, IServerChannel } from '../../../base/parts/ipc/common/ipc.js';
+import { IPositronIdleTrackingService } from './positronIdleTracking.js';
+
+export const POSITRON_IDLE_TRACKING_CHANNEL_NAME = 'positronIdleTracking';
+
+/**
+ * Server-side IPC channel that forwards calls to the idle tracking service.
+ */
+export class PositronIdleTrackingChannel implements IServerChannel {
+	constructor(private readonly service: IPositronIdleTrackingService) {
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	async call<T>(_ctx: any, command: string, args?: any): Promise<T> {
+		switch (command) {
+			case 'reportActivity': {
+				this.service.reportActivity(args.clientId, args.timestampMs);
+				return undefined as unknown as T;
+			}
+			case 'removeClient': {
+				this.service.removeClient(args.clientId);
+				return undefined as unknown as T;
+			}
+		}
+		throw new Error(`Command not found: ${command}`);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	listen<T>(_ctx: any, _event: string, _arg?: any): Event<T> {
+		throw new Error('Method not implemented.');
+	}
+}
+
+/**
+ * Client-side IPC channel wrapper used by the browser to report activity
+ * to the server.
+ */
+export class PositronIdleTrackingChannelClient {
+	constructor(private readonly _channel: IChannel) { }
+
+	reportActivity(clientId: string, timestampMs: number): Promise<void> {
+		return this._channel.call('reportActivity', { clientId, timestampMs });
+	}
+
+	removeClient(clientId: string): Promise<void> {
+		return this._channel.call('removeClient', { clientId });
+	}
+}

--- a/src/vs/platform/positronIdleTracking/common/positronIdleTrackingIpc.ts
+++ b/src/vs/platform/positronIdleTracking/common/positronIdleTrackingIpc.ts
@@ -16,8 +16,7 @@ export class PositronIdleTrackingChannel implements IServerChannel {
 	constructor(private readonly service: IPositronIdleTrackingService) {
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	async call<T>(_ctx: any, command: string, _args?: any): Promise<T> {
+	async call<T>(_ctx: unknown, command: string, _args?: unknown): Promise<T> {
 		switch (command) {
 			case 'reportActivity': {
 				// Use server-side Date.now() so the tracked timestamp is immune to
@@ -30,8 +29,7 @@ export class PositronIdleTrackingChannel implements IServerChannel {
 		throw new Error(`Command not found: ${command}`);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	listen<T>(_ctx: any, _event: string, _arg?: any): Event<T> {
+	listen<T>(_ctx: unknown, _event: string, _arg?: unknown): Event<T> {
 		throw new Error('Method not implemented.');
 	}
 }

--- a/src/vs/platform/positronIdleTracking/common/positronIdleTrackingIpc.ts
+++ b/src/vs/platform/positronIdleTracking/common/positronIdleTrackingIpc.ts
@@ -41,7 +41,7 @@ export class PositronIdleTrackingChannel implements IServerChannel {
 export class PositronIdleTrackingChannelClient {
 	constructor(private readonly _channel: IChannel) { }
 
-	reportActivity(timestampMs: number): Promise<void> {
-		return this._channel.call('reportActivity', { timestampMs });
+	reportActivity(): Promise<void> {
+		return this._channel.call('reportActivity');
 	}
 }

--- a/src/vs/platform/positronIdleTracking/node/positronIdleTrackingService.ts
+++ b/src/vs/platform/positronIdleTracking/node/positronIdleTrackingService.ts
@@ -6,45 +6,26 @@
 import { IPositronIdleInfo, IPositronIdleTrackingService } from '../common/positronIdleTracking.js';
 
 /**
- * Server-side implementation that aggregates activity reports from browser
- * clients. Each client is identified by a unique ID (typically the
- * reconnection token) and reports its last-activity timestamp over IPC.
+ * Server-side implementation that tracks the most recent user activity
+ * reported by any browser client. Timestamps advance monotonically: an
+ * older timestamp never overrides a newer one.
  */
 export class PositronIdleTrackingService implements IPositronIdleTrackingService {
 	declare readonly _serviceBrand: undefined;
 
-	/** Map of clientId to last-activity epoch milliseconds. */
-	private readonly _clients = new Map<string, number>();
+	/** Epoch milliseconds of the most recent reported activity. Initialized to server start time. */
+	private _lastActivityEpochMs: number = Date.now();
 
-	/** Epoch milliseconds when the server started, used as fallback. */
-	private readonly _serverStartMs = Date.now();
-
-	reportActivity(clientId: string, timestampMs: number): void {
-		const existing = this._clients.get(clientId);
-		// Only accept timestamps that move forward to avoid clock skew issues.
-		if (existing === undefined || timestampMs > existing) {
-			this._clients.set(clientId, timestampMs);
+	reportActivity(timestampMs: number): void {
+		if (timestampMs > this._lastActivityEpochMs) {
+			this._lastActivityEpochMs = timestampMs;
 		}
-	}
-
-	removeClient(clientId: string): void {
-		this._clients.delete(clientId);
 	}
 
 	getIdleInfo(): IPositronIdleInfo {
-		let lastActivityEpochMs = this._serverStartMs;
-		for (const ts of this._clients.values()) {
-			if (ts > lastActivityEpochMs) {
-				lastActivityEpochMs = ts;
-			}
-		}
-
-		const secondsIdle = Math.max(0, Math.floor((Date.now() - lastActivityEpochMs) / 1000));
-
 		return {
-			secondsIdle,
-			lastActivityEpochMs,
-			connectedClients: this._clients.size,
+			secondsIdle: Math.max(0, Math.floor((Date.now() - this._lastActivityEpochMs) / 1000)),
+			lastActivityEpochMs: this._lastActivityEpochMs,
 		};
 	}
 }

--- a/src/vs/platform/positronIdleTracking/node/positronIdleTrackingService.ts
+++ b/src/vs/platform/positronIdleTracking/node/positronIdleTrackingService.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IPositronIdleInfo, IPositronIdleTrackingService } from '../common/positronIdleTracking.js';
+
+/**
+ * Server-side implementation that aggregates activity reports from browser
+ * clients. Each client is identified by a unique ID (typically the
+ * reconnection token) and reports its last-activity timestamp over IPC.
+ */
+export class PositronIdleTrackingService implements IPositronIdleTrackingService {
+	declare readonly _serviceBrand: undefined;
+
+	/** Map of clientId to last-activity epoch milliseconds. */
+	private readonly _clients = new Map<string, number>();
+
+	/** Epoch milliseconds when the server started, used as fallback. */
+	private readonly _serverStartMs = Date.now();
+
+	reportActivity(clientId: string, timestampMs: number): void {
+		const existing = this._clients.get(clientId);
+		// Only accept timestamps that move forward to avoid clock skew issues.
+		if (existing === undefined || timestampMs > existing) {
+			this._clients.set(clientId, timestampMs);
+		}
+	}
+
+	removeClient(clientId: string): void {
+		this._clients.delete(clientId);
+	}
+
+	getIdleInfo(): IPositronIdleInfo {
+		let lastActivityEpochMs = this._serverStartMs;
+		for (const ts of this._clients.values()) {
+			if (ts > lastActivityEpochMs) {
+				lastActivityEpochMs = ts;
+			}
+		}
+
+		const secondsIdle = Math.max(0, Math.floor((Date.now() - lastActivityEpochMs) / 1000));
+
+		return {
+			secondsIdle,
+			lastActivityEpochMs,
+			connectedClients: this._clients.size,
+		};
+	}
+}

--- a/src/vs/platform/positronIdleTracking/test/common/positronIdleTrackingIpc.test.ts
+++ b/src/vs/platform/positronIdleTracking/test/common/positronIdleTrackingIpc.test.ts
@@ -13,20 +13,15 @@ suite('Positron - PositronIdleTrackingChannel (server-side)', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
 	let channel: PositronIdleTrackingChannel;
-	let reportActivityCalls: { clientId: string; timestampMs: number }[];
-	let removeClientCalls: string[];
+	let reportActivityCalls: number[];
 
 	setup(() => {
 		reportActivityCalls = [];
-		removeClientCalls = [];
 
 		const mockService: IPositronIdleTrackingService = {
 			_serviceBrand: undefined,
-			reportActivity(clientId, timestampMs) {
-				reportActivityCalls.push({ clientId, timestampMs });
-			},
-			removeClient(clientId) {
-				removeClientCalls.push(clientId);
+			reportActivity(timestampMs) {
+				reportActivityCalls.push(timestampMs);
 			},
 			getIdleInfo() {
 				throw new Error('not expected in this test');
@@ -37,18 +32,10 @@ suite('Positron - PositronIdleTrackingChannel (server-side)', () => {
 	});
 
 	test('reportActivity delegates to service', async () => {
-		await channel.call(undefined, 'reportActivity', { clientId: 'c1', timestampMs: 12345 });
+		await channel.call(undefined, 'reportActivity', { timestampMs: 12345 });
 
 		assert.strictEqual(reportActivityCalls.length, 1);
-		assert.strictEqual(reportActivityCalls[0].clientId, 'c1');
-		assert.strictEqual(reportActivityCalls[0].timestampMs, 12345);
-	});
-
-	test('removeClient delegates to service', async () => {
-		await channel.call(undefined, 'removeClient', { clientId: 'c1' });
-
-		assert.strictEqual(removeClientCalls.length, 1);
-		assert.strictEqual(removeClientCalls[0], 'c1');
+		assert.strictEqual(reportActivityCalls[0], 12345);
 	});
 
 	test('unknown command throws', async () => {
@@ -97,18 +84,10 @@ suite('Positron - PositronIdleTrackingChannelClient (client-side)', () => {
 	});
 
 	test('reportActivity sends correct command and args', async () => {
-		await client.reportActivity('c1', 99999);
+		await client.reportActivity(99999);
 
 		assert.strictEqual(callLog.length, 1);
 		assert.strictEqual(callLog[0].command, 'reportActivity');
-		assert.deepStrictEqual(callLog[0].arg, { clientId: 'c1', timestampMs: 99999 });
-	});
-
-	test('removeClient sends correct command and args', async () => {
-		await client.removeClient('c1');
-
-		assert.strictEqual(callLog.length, 1);
-		assert.strictEqual(callLog[0].command, 'removeClient');
-		assert.deepStrictEqual(callLog[0].arg, { clientId: 'c1' });
+		assert.deepStrictEqual(callLog[0].arg, { timestampMs: 99999 });
 	});
 });

--- a/src/vs/platform/positronIdleTracking/test/common/positronIdleTrackingIpc.test.ts
+++ b/src/vs/platform/positronIdleTracking/test/common/positronIdleTrackingIpc.test.ts
@@ -31,11 +31,23 @@ suite('Positron - PositronIdleTrackingChannel (server-side)', () => {
 		channel = new PositronIdleTrackingChannel(mockService);
 	});
 
-	test('reportActivity delegates to service', async () => {
+	test('reportActivity delegates to service with server timestamp', async () => {
+		const before = Date.now();
 		await channel.call(undefined, 'reportActivity', { timestampMs: 12345 });
+		const after = Date.now();
 
 		assert.strictEqual(reportActivityCalls.length, 1);
-		assert.strictEqual(reportActivityCalls[0], 12345);
+		// The channel stamps with server Date.now(), not the client-supplied value.
+		assert.ok(reportActivityCalls[0] >= before && reportActivityCalls[0] <= after);
+	});
+
+	test('reportActivity works even with no args (clock-skew fix)', async () => {
+		const before = Date.now();
+		await channel.call(undefined, 'reportActivity');
+		const after = Date.now();
+
+		assert.strictEqual(reportActivityCalls.length, 1);
+		assert.ok(reportActivityCalls[0] >= before && reportActivityCalls[0] <= after);
 	});
 
 	test('unknown command throws', async () => {

--- a/src/vs/platform/positronIdleTracking/test/common/positronIdleTrackingIpc.test.ts
+++ b/src/vs/platform/positronIdleTracking/test/common/positronIdleTrackingIpc.test.ts
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { IPositronIdleTrackingService } from '../../common/positronIdleTracking.js';
+import { PositronIdleTrackingChannel, PositronIdleTrackingChannelClient } from '../../common/positronIdleTrackingIpc.js';
+
+suite('Positron - PositronIdleTrackingChannel (server-side)', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	let channel: PositronIdleTrackingChannel;
+	let reportActivityCalls: { clientId: string; timestampMs: number }[];
+	let removeClientCalls: string[];
+
+	setup(() => {
+		reportActivityCalls = [];
+		removeClientCalls = [];
+
+		const mockService: IPositronIdleTrackingService = {
+			_serviceBrand: undefined,
+			reportActivity(clientId, timestampMs) {
+				reportActivityCalls.push({ clientId, timestampMs });
+			},
+			removeClient(clientId) {
+				removeClientCalls.push(clientId);
+			},
+			getIdleInfo() {
+				throw new Error('not expected in this test');
+			},
+		};
+
+		channel = new PositronIdleTrackingChannel(mockService);
+	});
+
+	test('reportActivity delegates to service', async () => {
+		await channel.call(undefined, 'reportActivity', { clientId: 'c1', timestampMs: 12345 });
+
+		assert.strictEqual(reportActivityCalls.length, 1);
+		assert.strictEqual(reportActivityCalls[0].clientId, 'c1');
+		assert.strictEqual(reportActivityCalls[0].timestampMs, 12345);
+	});
+
+	test('removeClient delegates to service', async () => {
+		await channel.call(undefined, 'removeClient', { clientId: 'c1' });
+
+		assert.strictEqual(removeClientCalls.length, 1);
+		assert.strictEqual(removeClientCalls[0], 'c1');
+	});
+
+	test('unknown command throws', async () => {
+		await assert.rejects(
+			() => channel.call(undefined, 'bogusCommand'),
+			/Command not found: bogusCommand/
+		);
+	});
+
+	test('getIdleInfo is not exposed as an IPC command', async () => {
+		await assert.rejects(
+			() => channel.call(undefined, 'getIdleInfo'),
+			/Command not found: getIdleInfo/
+		);
+	});
+
+	test('listen throws', () => {
+		assert.throws(
+			() => channel.listen(undefined, 'someEvent'),
+			/Method not implemented/
+		);
+	});
+});
+
+suite('Positron - PositronIdleTrackingChannelClient (client-side)', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	let client: PositronIdleTrackingChannelClient;
+	let callLog: { command: string; arg: any }[];
+
+	setup(() => {
+		callLog = [];
+
+		const mockChannel = {
+			call<T>(command: string, arg?: any): Promise<T> {
+				callLog.push({ command, arg });
+				return Promise.resolve(undefined as unknown as T);
+			},
+			listen(): never {
+				throw new Error('not expected');
+			},
+		};
+
+		client = new PositronIdleTrackingChannelClient(mockChannel);
+	});
+
+	test('reportActivity sends correct command and args', async () => {
+		await client.reportActivity('c1', 99999);
+
+		assert.strictEqual(callLog.length, 1);
+		assert.strictEqual(callLog[0].command, 'reportActivity');
+		assert.deepStrictEqual(callLog[0].arg, { clientId: 'c1', timestampMs: 99999 });
+	});
+
+	test('removeClient sends correct command and args', async () => {
+		await client.removeClient('c1');
+
+		assert.strictEqual(callLog.length, 1);
+		assert.strictEqual(callLog[0].command, 'removeClient');
+		assert.deepStrictEqual(callLog[0].arg, { clientId: 'c1' });
+	});
+});

--- a/src/vs/platform/positronIdleTracking/test/common/positronIdleTrackingIpc.test.ts
+++ b/src/vs/platform/positronIdleTracking/test/common/positronIdleTrackingIpc.test.ts
@@ -96,10 +96,11 @@ suite('Positron - PositronIdleTrackingChannelClient (client-side)', () => {
 	});
 
 	test('reportActivity sends correct command and args', async () => {
-		await client.reportActivity(99999);
+		await client.reportActivity();
 
 		assert.strictEqual(callLog.length, 1);
 		assert.strictEqual(callLog[0].command, 'reportActivity');
-		assert.deepStrictEqual(callLog[0].arg, { timestampMs: 99999 });
+		// Should pass no arguments (timestamp is generated server-side)
+		assert.strictEqual(callLog[0].arg, undefined);
 	});
 });

--- a/src/vs/platform/positronIdleTracking/test/node/positronIdleTrackingService.test.ts
+++ b/src/vs/platform/positronIdleTracking/test/node/positronIdleTrackingService.test.ts
@@ -19,97 +19,74 @@ suite('Positron - PositronIdleTrackingService', () => {
 		service = new PositronIdleTrackingService();
 	});
 
-	test('initial state has zero clients and falls back to server start time', () => {
+	test('initial state falls back to construction time', () => {
 		const info = service.getIdleInfo();
-		assert.strictEqual(info.connectedClients, 0);
-		// lastActivityEpochMs should be approximately the construction time
 		assert.ok(info.lastActivityEpochMs >= constructionTime - 1);
 		assert.ok(info.lastActivityEpochMs <= Date.now());
 	});
 
-	test('reportActivity tracks a single client', () => {
+	test('reportActivity advances the tracked timestamp', () => {
 		const now = Date.now();
-		service.reportActivity('client-1', now);
+		service.reportActivity(now);
 
 		const info = service.getIdleInfo();
-		assert.strictEqual(info.connectedClients, 1);
 		assert.strictEqual(info.lastActivityEpochMs, now);
 		assert.strictEqual(info.secondsIdle, 0);
 	});
 
-	test('multiple clients are tracked independently', () => {
-		const earlier = Date.now() - 5000;
-		const later = Date.now();
-
-		service.reportActivity('client-1', earlier);
-		service.reportActivity('client-2', later);
-
-		const info = service.getIdleInfo();
-		assert.strictEqual(info.connectedClients, 2);
-		// lastActivityEpochMs should reflect the most recent across all clients
-		assert.strictEqual(info.lastActivityEpochMs, later);
-	});
-
-	test('ignores timestamps that go backward for the same client', () => {
+	test('ignores timestamps that go backward', () => {
 		const later = Date.now();
 		const earlier = later - 10000;
 
-		service.reportActivity('client-1', later);
-		service.reportActivity('client-1', earlier);
+		service.reportActivity(later);
+		service.reportActivity(earlier);
 
 		const info = service.getIdleInfo();
 		assert.strictEqual(info.lastActivityEpochMs, later);
 	});
 
-	test('accepts timestamps that move forward for the same client', () => {
-		const earlier = Date.now() - 5000;
-		const later = Date.now();
+	test('accepts timestamps that move forward', () => {
+		const earlier = Date.now();
+		const later = earlier + 5000;
 
-		service.reportActivity('client-1', earlier);
-		service.reportActivity('client-1', later);
+		service.reportActivity(earlier);
+		service.reportActivity(later);
 
 		const info = service.getIdleInfo();
 		assert.strictEqual(info.lastActivityEpochMs, later);
 	});
 
-	test('removeClient decrements connectedClients', () => {
-		service.reportActivity('client-1', Date.now());
-		service.reportActivity('client-2', Date.now());
-		assert.strictEqual(service.getIdleInfo().connectedClients, 2);
-
-		service.removeClient('client-1');
-		assert.strictEqual(service.getIdleInfo().connectedClients, 1);
-	});
-
-	test('removing all clients falls back to server start time', () => {
-		const activityTime = Date.now();
-		service.reportActivity('client-1', activityTime);
-		service.removeClient('client-1');
+	test('ignores duplicate timestamps', () => {
+		const ts = Date.now();
+		service.reportActivity(ts);
+		service.reportActivity(ts);
 
 		const info = service.getIdleInfo();
-		assert.strictEqual(info.connectedClients, 0);
-		// After removing all clients, lastActivityEpochMs reverts to server start
-		assert.ok(info.lastActivityEpochMs <= activityTime);
-		assert.ok(info.lastActivityEpochMs >= constructionTime - 1);
+		assert.strictEqual(info.lastActivityEpochMs, ts);
 	});
 
-	test('removing a non-existent client is a no-op', () => {
-		service.reportActivity('client-1', Date.now());
-		service.removeClient('non-existent');
+	test('takes the most recent across multiple calls', () => {
+		const earlier = Date.now() + 1000;
+		const later = Date.now() + 2000;
 
-		assert.strictEqual(service.getIdleInfo().connectedClients, 1);
+		// Simulate two clients reporting interleaved
+		service.reportActivity(earlier);
+		service.reportActivity(later);
+		service.reportActivity(earlier); // stale report from "client A" ignored
+
+		const info = service.getIdleInfo();
+		assert.strictEqual(info.lastActivityEpochMs, later);
 	});
 
 	test('secondsIdle is zero immediately after activity', () => {
-		service.reportActivity('client-1', Date.now());
+		service.reportActivity(Date.now());
 
 		const info = service.getIdleInfo();
 		assert.strictEqual(info.secondsIdle, 0);
 	});
 
 	test('secondsIdle is consistent with lastActivityEpochMs', () => {
-		// Report activity and verify the relationship between fields
-		service.reportActivity('client-1', Date.now());
+		service.reportActivity(Date.now());
 		const info = service.getIdleInfo();
 
 		const expectedIdle = Math.floor((Date.now() - info.lastActivityEpochMs) / 1000);
@@ -119,37 +96,11 @@ suite('Positron - PositronIdleTrackingService', () => {
 		);
 	});
 
-	test('ignores duplicate timestamps for the same client', () => {
-		const ts = Date.now();
-		service.reportActivity('client-1', ts);
-		service.reportActivity('client-1', ts); // same timestamp
-
-		const info = service.getIdleInfo();
-		assert.strictEqual(info.connectedClients, 1);
-		assert.strictEqual(info.lastActivityEpochMs, ts);
-	});
-
-	test('secondsIdle is never negative even with future timestamps', () => {
-		const futureTime = Date.now() + 60000; // 60 seconds in the future
-		service.reportActivity('client-1', futureTime);
+	test('secondsIdle is never negative with future timestamps', () => {
+		const futureTime = Date.now() + 60000;
+		service.reportActivity(futureTime);
 
 		const info = service.getIdleInfo();
 		assert.strictEqual(info.secondsIdle, 0);
-	});
-
-	test('lastActivityEpochMs reflects only remaining clients after removal', () => {
-		// Use timestamps after server start so they override the _serverStartMs floor
-		const olderTime = Date.now() + 10000;
-		const newerTime = Date.now() + 20000;
-
-		service.reportActivity('client-old', olderTime);
-		service.reportActivity('client-new', newerTime);
-
-		// Remove the newer client
-		service.removeClient('client-new');
-
-		const info = service.getIdleInfo();
-		assert.strictEqual(info.connectedClients, 1);
-		assert.strictEqual(info.lastActivityEpochMs, olderTime);
 	});
 });

--- a/src/vs/platform/positronIdleTracking/test/node/positronIdleTrackingService.test.ts
+++ b/src/vs/platform/positronIdleTracking/test/node/positronIdleTrackingService.test.ts
@@ -1,0 +1,155 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../base/test/common/utils.js';
+import { PositronIdleTrackingService } from '../../node/positronIdleTrackingService.js';
+
+suite('Positron - PositronIdleTrackingService', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	let service: PositronIdleTrackingService;
+	let constructionTime: number;
+
+	setup(() => {
+		constructionTime = Date.now();
+		service = new PositronIdleTrackingService();
+	});
+
+	test('initial state has zero clients and falls back to server start time', () => {
+		const info = service.getIdleInfo();
+		assert.strictEqual(info.connectedClients, 0);
+		// lastActivityEpochMs should be approximately the construction time
+		assert.ok(info.lastActivityEpochMs >= constructionTime - 1);
+		assert.ok(info.lastActivityEpochMs <= Date.now());
+	});
+
+	test('reportActivity tracks a single client', () => {
+		const now = Date.now();
+		service.reportActivity('client-1', now);
+
+		const info = service.getIdleInfo();
+		assert.strictEqual(info.connectedClients, 1);
+		assert.strictEqual(info.lastActivityEpochMs, now);
+		assert.strictEqual(info.secondsIdle, 0);
+	});
+
+	test('multiple clients are tracked independently', () => {
+		const earlier = Date.now() - 5000;
+		const later = Date.now();
+
+		service.reportActivity('client-1', earlier);
+		service.reportActivity('client-2', later);
+
+		const info = service.getIdleInfo();
+		assert.strictEqual(info.connectedClients, 2);
+		// lastActivityEpochMs should reflect the most recent across all clients
+		assert.strictEqual(info.lastActivityEpochMs, later);
+	});
+
+	test('ignores timestamps that go backward for the same client', () => {
+		const later = Date.now();
+		const earlier = later - 10000;
+
+		service.reportActivity('client-1', later);
+		service.reportActivity('client-1', earlier);
+
+		const info = service.getIdleInfo();
+		assert.strictEqual(info.lastActivityEpochMs, later);
+	});
+
+	test('accepts timestamps that move forward for the same client', () => {
+		const earlier = Date.now() - 5000;
+		const later = Date.now();
+
+		service.reportActivity('client-1', earlier);
+		service.reportActivity('client-1', later);
+
+		const info = service.getIdleInfo();
+		assert.strictEqual(info.lastActivityEpochMs, later);
+	});
+
+	test('removeClient decrements connectedClients', () => {
+		service.reportActivity('client-1', Date.now());
+		service.reportActivity('client-2', Date.now());
+		assert.strictEqual(service.getIdleInfo().connectedClients, 2);
+
+		service.removeClient('client-1');
+		assert.strictEqual(service.getIdleInfo().connectedClients, 1);
+	});
+
+	test('removing all clients falls back to server start time', () => {
+		const activityTime = Date.now();
+		service.reportActivity('client-1', activityTime);
+		service.removeClient('client-1');
+
+		const info = service.getIdleInfo();
+		assert.strictEqual(info.connectedClients, 0);
+		// After removing all clients, lastActivityEpochMs reverts to server start
+		assert.ok(info.lastActivityEpochMs <= activityTime);
+		assert.ok(info.lastActivityEpochMs >= constructionTime - 1);
+	});
+
+	test('removing a non-existent client is a no-op', () => {
+		service.reportActivity('client-1', Date.now());
+		service.removeClient('non-existent');
+
+		assert.strictEqual(service.getIdleInfo().connectedClients, 1);
+	});
+
+	test('secondsIdle is zero immediately after activity', () => {
+		service.reportActivity('client-1', Date.now());
+
+		const info = service.getIdleInfo();
+		assert.strictEqual(info.secondsIdle, 0);
+	});
+
+	test('secondsIdle is consistent with lastActivityEpochMs', () => {
+		// Report activity and verify the relationship between fields
+		service.reportActivity('client-1', Date.now());
+		const info = service.getIdleInfo();
+
+		const expectedIdle = Math.floor((Date.now() - info.lastActivityEpochMs) / 1000);
+		assert.ok(
+			Math.abs(info.secondsIdle - expectedIdle) <= 1,
+			`secondsIdle (${info.secondsIdle}) should be close to computed value (${expectedIdle})`
+		);
+	});
+
+	test('ignores duplicate timestamps for the same client', () => {
+		const ts = Date.now();
+		service.reportActivity('client-1', ts);
+		service.reportActivity('client-1', ts); // same timestamp
+
+		const info = service.getIdleInfo();
+		assert.strictEqual(info.connectedClients, 1);
+		assert.strictEqual(info.lastActivityEpochMs, ts);
+	});
+
+	test('secondsIdle is never negative even with future timestamps', () => {
+		const futureTime = Date.now() + 60000; // 60 seconds in the future
+		service.reportActivity('client-1', futureTime);
+
+		const info = service.getIdleInfo();
+		assert.strictEqual(info.secondsIdle, 0);
+	});
+
+	test('lastActivityEpochMs reflects only remaining clients after removal', () => {
+		// Use timestamps after server start so they override the _serverStartMs floor
+		const olderTime = Date.now() + 10000;
+		const newerTime = Date.now() + 20000;
+
+		service.reportActivity('client-old', olderTime);
+		service.reportActivity('client-new', newerTime);
+
+		// Remove the newer client
+		service.removeClient('client-new');
+
+		const info = service.getIdleInfo();
+		assert.strictEqual(info.connectedClients, 1);
+		assert.strictEqual(info.lastActivityEpochMs, olderTime);
+	});
+});

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -180,7 +180,6 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 			const body = JSON.stringify({
 				seconds_idle: idleInfo.secondsIdle,
 				last_activity_epoch_ms: idleInfo.lastActivityEpochMs,
-				connected_clients: idleInfo.connectedClients,
 			});
 			res.writeHead(200, { 'Content-Type': 'application/json' });
 			return void res.end(body);

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -49,6 +49,7 @@ import { PositronBootstrapExtensionsInitializer } from '../../platform/extension
 import { INativeEnvironmentService } from '../../platform/environment/common/environment.js';
 import { IExtensionManagementService } from '../../platform/extensionManagement/common/extensionManagement.js';
 import { IFileService } from '../../platform/files/common/files.js';
+import { IPositronIdleTrackingService } from '../../platform/positronIdleTracking/common/positronIdleTracking.js';
 // --- End Positron ---
 
 // --- Start PWB: Server proxy support ---
@@ -95,6 +96,9 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 		@IProductService private readonly _productService: IProductService,
 		@ILogService private readonly _logService: ILogService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		// --- Start Positron ---
+		@IPositronIdleTrackingService private readonly _idleTrackingService: IPositronIdleTrackingService,
+		// --- End Positron ---
 	) {
 		super();
 		this._webEndpointOriginChecker = WebEndpointOriginChecker.create(this._productService);
@@ -168,6 +172,20 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 			// invalid connection token
 			return serveError(req, res, 403, `Forbidden.`);
 		}
+
+		// --- Start Positron ---
+		// Idle tracking endpoint for hosting platforms (e.g., Posit Cloud)
+		if (pathname === '/idle') {
+			const idleInfo = this._idleTrackingService.getIdleInfo();
+			const body = JSON.stringify({
+				seconds_idle: idleInfo.secondsIdle,
+				last_activity_epoch_ms: idleInfo.lastActivityEpochMs,
+				connected_clients: idleInfo.connectedClients,
+			});
+			res.writeHead(200, { 'Content-Type': 'application/json' });
+			return void res.end(body);
+		}
+		// --- End Positron ---
 
 		if (pathname === '/vscode-remote-resource') {
 			// Handle HTTP requests for resources rendered in the rich client (images, fonts, etc.)

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -178,7 +178,6 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 		if (pathname === '/idle') {
 			const idleInfo = this._idleTrackingService.getIdleInfo();
 			const body = JSON.stringify({
-			const body = JSON.stringify({
 				seconds_idle: idleInfo.secondsIdle,
 				last_activity_epoch_ms: idleInfo.lastActivityEpochMs,
 				connections: Object.keys(this._extHostConnections).length

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -180,6 +180,7 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 			const body = JSON.stringify({
 				seconds_idle: idleInfo.secondsIdle,
 				last_activity_epoch_ms: idleInfo.lastActivityEpochMs,
+				connections: this._extHostConnections.length
 			});
 			res.writeHead(200, { 'Content-Type': 'application/json' });
 			return void res.end(body);

--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -178,9 +178,10 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 		if (pathname === '/idle') {
 			const idleInfo = this._idleTrackingService.getIdleInfo();
 			const body = JSON.stringify({
+			const body = JSON.stringify({
 				seconds_idle: idleInfo.secondsIdle,
 				last_activity_epoch_ms: idleInfo.lastActivityEpochMs,
-				connections: this._extHostConnections.length
+				connections: Object.keys(this._extHostConnections).length
 			});
 			res.writeHead(200, { 'Content-Type': 'application/json' });
 			return void res.end(body);

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -105,6 +105,9 @@ import { PositronMemoryUsageServerService } from '../../platform/positronMemoryU
 import { POSITRON_MEMORY_INFO_CHANNEL_NAME, PositronMemoryInfoChannel } from '../../platform/positronMemoryUsage/common/positronMemoryUsageIpc.js';
 // eslint-disable-next-line no-duplicate-imports
 import { IPositronLicenseeInfo } from '../../platform/remote/common/remoteAgentEnvironment.js';
+import { IPositronIdleTrackingService } from '../../platform/positronIdleTracking/common/positronIdleTracking.js';
+import { PositronIdleTrackingService } from '../../platform/positronIdleTracking/node/positronIdleTrackingService.js';
+import { POSITRON_IDLE_TRACKING_CHANNEL_NAME, PositronIdleTrackingChannel } from '../../platform/positronIdleTracking/common/positronIdleTrackingIpc.js';
 // --- End Positron ---
 
 const eventPrefix = 'monacoworkbench';
@@ -262,6 +265,8 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 	// --- Start Positron ---
 	const ephemeralStateService = new EphemeralStateService();
 	services.set(IEphemeralStateService, ephemeralStateService);
+	const idleTrackingService = new PositronIdleTrackingService();
+	services.set(IPositronIdleTrackingService, idleTrackingService);
 	// --- End Positron ---
 
 	instantiationService.invokeFunction(accessor => {
@@ -305,6 +310,10 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 		const memoryUsageServerService = new PositronMemoryUsageServerService();
 		const memoryInfoChannel = new PositronMemoryInfoChannel(memoryUsageServerService);
 		socketServer.registerChannel(POSITRON_MEMORY_INFO_CHANNEL_NAME, memoryInfoChannel);
+
+		// Idle Tracking
+		const idleTrackingChannel = new PositronIdleTrackingChannel(accessor.get(IPositronIdleTrackingService));
+		socketServer.registerChannel(POSITRON_IDLE_TRACKING_CHANNEL_NAME, idleTrackingChannel);
 		// --- End Positron ---
 		// clean up extensions folder
 		remoteExtensionsScanner.whenExtensionsReady().then(() => extensionManagementService.cleanUp());

--- a/src/vs/workbench/contrib/positronIdleReporter/browser/positronIdleReporter.ts
+++ b/src/vs/workbench/contrib/positronIdleReporter/browser/positronIdleReporter.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { mainWindow } from '../../../../base/browser/window.js';
+import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
+import { POSITRON_IDLE_TRACKING_CHANNEL_NAME, PositronIdleTrackingChannelClient } from '../../../../platform/positronIdleTracking/common/positronIdleTrackingIpc.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+import { IRemoteAgentService } from '../../../services/remote/common/remoteAgentService.js';
+import { IUserActivityService } from '../../../services/userActivity/common/userActivityService.js';
+
+/** Interval at which heartbeats are sent while the user is active. */
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
+/**
+ * Browser workbench contribution that forwards user activity state to the
+ * server via IPC. This allows the server to track how long the user has been
+ * idle, which hosting platforms like Posit Cloud can query via the /idle
+ * HTTP endpoint.
+ *
+ * Only activates when a remote connection exists (i.e., web/server mode).
+ */
+class PositronIdleReporterContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.positronIdleReporter';
+
+	private readonly _clientId = generateUuid();
+	private readonly _heartbeatTimer = this._register(new MutableDisposable());
+
+	constructor(
+		@IRemoteAgentService remoteAgentService: IRemoteAgentService,
+		@IUserActivityService userActivityService: IUserActivityService,
+	) {
+		super();
+
+		const connection = remoteAgentService.getConnection();
+		if (!connection) {
+			// Not in a remote/server context; nothing to do.
+			return;
+		}
+
+		const channel = new PositronIdleTrackingChannelClient(
+			connection.getChannel(POSITRON_IDLE_TRACKING_CHANNEL_NAME)
+		);
+
+		// Report activity immediately on startup since the user just opened the
+		// window (which is itself an activity signal).
+		channel.reportActivity(this._clientId, Date.now());
+
+		// When the user becomes active, report it and start periodic heartbeats.
+		// When the user becomes inactive, stop heartbeats (the server's idle
+		// timer will naturally grow from the last reported timestamp).
+		this._register(userActivityService.onDidChangeIsActive(isActive => {
+			if (isActive) {
+				channel.reportActivity(this._clientId, Date.now());
+				this._startHeartbeat(channel);
+			} else {
+				this._heartbeatTimer.clear();
+			}
+		}));
+
+		// If already active at construction time, start heartbeats.
+		if (userActivityService.isActive) {
+			this._startHeartbeat(channel);
+		}
+	}
+
+	private _startHeartbeat(channel: PositronIdleTrackingChannelClient): void {
+		const timer = mainWindow.setInterval(() => {
+			channel.reportActivity(this._clientId, Date.now());
+		}, HEARTBEAT_INTERVAL_MS);
+
+		this._heartbeatTimer.value = { dispose: () => mainWindow.clearInterval(timer) };
+	}
+}
+
+registerWorkbenchContribution2(
+	PositronIdleReporterContribution.ID,
+	PositronIdleReporterContribution,
+	WorkbenchPhase.Eventually,
+);

--- a/src/vs/workbench/contrib/positronIdleReporter/browser/positronIdleReporter.ts
+++ b/src/vs/workbench/contrib/positronIdleReporter/browser/positronIdleReporter.ts
@@ -5,7 +5,6 @@
 
 import { mainWindow } from '../../../../base/browser/window.js';
 import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
-import { generateUuid } from '../../../../base/common/uuid.js';
 import { POSITRON_IDLE_TRACKING_CHANNEL_NAME, PositronIdleTrackingChannelClient } from '../../../../platform/positronIdleTracking/common/positronIdleTrackingIpc.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 import { IRemoteAgentService } from '../../../services/remote/common/remoteAgentService.js';
@@ -26,7 +25,6 @@ class PositronIdleReporterContribution extends Disposable implements IWorkbenchC
 
 	static readonly ID = 'workbench.contrib.positronIdleReporter';
 
-	private readonly _clientId = generateUuid();
 	private readonly _heartbeatTimer = this._register(new MutableDisposable());
 
 	constructor(
@@ -47,14 +45,14 @@ class PositronIdleReporterContribution extends Disposable implements IWorkbenchC
 
 		// Report activity immediately on startup since the user just opened the
 		// window (which is itself an activity signal).
-		channel.reportActivity(this._clientId, Date.now());
+		channel.reportActivity(Date.now());
 
 		// When the user becomes active, report it and start periodic heartbeats.
 		// When the user becomes inactive, stop heartbeats (the server's idle
 		// timer will naturally grow from the last reported timestamp).
 		this._register(userActivityService.onDidChangeIsActive(isActive => {
 			if (isActive) {
-				channel.reportActivity(this._clientId, Date.now());
+				channel.reportActivity(Date.now());
 				this._startHeartbeat(channel);
 			} else {
 				this._heartbeatTimer.clear();
@@ -69,7 +67,7 @@ class PositronIdleReporterContribution extends Disposable implements IWorkbenchC
 
 	private _startHeartbeat(channel: PositronIdleTrackingChannelClient): void {
 		const timer = mainWindow.setInterval(() => {
-			channel.reportActivity(this._clientId, Date.now());
+			channel.reportActivity(Date.now());
 		}, HEARTBEAT_INTERVAL_MS);
 
 		this._heartbeatTimer.value = { dispose: () => mainWindow.clearInterval(timer) };

--- a/src/vs/workbench/contrib/positronIdleReporter/browser/positronIdleReporter.ts
+++ b/src/vs/workbench/contrib/positronIdleReporter/browser/positronIdleReporter.ts
@@ -5,13 +5,15 @@
 
 import { mainWindow } from '../../../../base/browser/window.js';
 import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import * as platform from '../../../../base/common/platform.js';
 import { POSITRON_IDLE_TRACKING_CHANNEL_NAME, PositronIdleTrackingChannelClient } from '../../../../platform/positronIdleTracking/common/positronIdleTrackingIpc.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 import { IRemoteAgentService } from '../../../services/remote/common/remoteAgentService.js';
 import { IUserActivityService } from '../../../services/userActivity/common/userActivityService.js';
+import { UIKind } from '../../../services/extensions/common/extensionHostProtocol.js';
 
 /** Interval at which heartbeats are sent while the user is active. */
-const HEARTBEAT_INTERVAL_MS = 30_000;
+const HEARTBEAT_INTERVAL_MS = 300_000;
 
 /**
  * Browser workbench contribution that forwards user activity state to the
@@ -36,6 +38,15 @@ class PositronIdleReporterContribution extends Disposable implements IWorkbenchC
 		const connection = remoteAgentService.getConnection();
 		if (!connection) {
 			// Not in a remote/server context; nothing to do.
+			return;
+		}
+
+		// Check if running on PWB (Posit Workbench) - PWB has its own polling
+		// eslint-disable-next-line local/code-no-any-casts
+		const isRunningOnPWB = !!(globalThis as any).RS_SERVER_URL &&
+			(platform.isWeb ? UIKind.Web : UIKind.Desktop) === UIKind.Web;
+		if (isRunningOnPWB) {
+			// Running on PWB which does its own polling; nothing to do.
 			return;
 		}
 

--- a/src/vs/workbench/contrib/positronIdleReporter/browser/positronIdleReporter.ts
+++ b/src/vs/workbench/contrib/positronIdleReporter/browser/positronIdleReporter.ts
@@ -45,14 +45,14 @@ class PositronIdleReporterContribution extends Disposable implements IWorkbenchC
 
 		// Report activity immediately on startup since the user just opened the
 		// window (which is itself an activity signal).
-		channel.reportActivity(Date.now());
+		channel.reportActivity();
 
 		// When the user becomes active, report it and start periodic heartbeats.
 		// When the user becomes inactive, stop heartbeats (the server's idle
 		// timer will naturally grow from the last reported timestamp).
 		this._register(userActivityService.onDidChangeIsActive(isActive => {
 			if (isActive) {
-				channel.reportActivity(Date.now());
+				channel.reportActivity();
 				this._startHeartbeat(channel);
 			} else {
 				this._heartbeatTimer.clear();
@@ -67,7 +67,7 @@ class PositronIdleReporterContribution extends Disposable implements IWorkbenchC
 
 	private _startHeartbeat(channel: PositronIdleTrackingChannelClient): void {
 		const timer = mainWindow.setInterval(() => {
-			channel.reportActivity(Date.now());
+			channel.reportActivity();
 		}, HEARTBEAT_INTERVAL_MS);
 
 		this._heartbeatTimer.value = { dispose: () => mainWindow.clearInterval(timer) };

--- a/src/vs/workbench/contrib/positronIdleReporter/browser/positronIdleReporter.ts
+++ b/src/vs/workbench/contrib/positronIdleReporter/browser/positronIdleReporter.ts
@@ -5,12 +5,10 @@
 
 import { mainWindow } from '../../../../base/browser/window.js';
 import { Disposable, MutableDisposable } from '../../../../base/common/lifecycle.js';
-import * as platform from '../../../../base/common/platform.js';
 import { POSITRON_IDLE_TRACKING_CHANNEL_NAME, PositronIdleTrackingChannelClient } from '../../../../platform/positronIdleTracking/common/positronIdleTrackingIpc.js';
 import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
 import { IRemoteAgentService } from '../../../services/remote/common/remoteAgentService.js';
 import { IUserActivityService } from '../../../services/userActivity/common/userActivityService.js';
-import { UIKind } from '../../../services/extensions/common/extensionHostProtocol.js';
 
 /** Interval at which heartbeats are sent while the user is active. */
 const HEARTBEAT_INTERVAL_MS = 300_000;

--- a/src/vs/workbench/contrib/positronIdleReporter/browser/positronIdleReporter.ts
+++ b/src/vs/workbench/contrib/positronIdleReporter/browser/positronIdleReporter.ts
@@ -41,14 +41,7 @@ class PositronIdleReporterContribution extends Disposable implements IWorkbenchC
 			return;
 		}
 
-		// Check if running on PWB (Posit Workbench) - PWB has its own polling
-		// eslint-disable-next-line local/code-no-any-casts
-		const isRunningOnPWB = !!(globalThis as any).RS_SERVER_URL &&
-			(platform.isWeb ? UIKind.Web : UIKind.Desktop) === UIKind.Web;
-		if (isRunningOnPWB) {
-			// Running on PWB which does its own polling; nothing to do.
-			return;
-		}
+		// TODO : Return early if we're running on Workbench
 
 		const channel = new PositronIdleTrackingChannelClient(
 			connection.getChannel(POSITRON_IDLE_TRACKING_CHANNEL_NAME)

--- a/src/vs/workbench/workbench.web.main.ts
+++ b/src/vs/workbench/workbench.web.main.ts
@@ -180,6 +180,7 @@ import './contrib/processExplorer/browser/processExplorer.web.contribution.js';
 // --- Start Positron ---
 import './contrib/positronPreview/browser/positronPreview.web.contribution.js';
 import './contrib/positronLicenseeInfo/browser/positronLicenseeInfo.contribution.js';
+import './contrib/positronIdleReporter/browser/positronIdleReporter.js';
 // --- End Positron
 
 //#endregion


### PR DESCRIPTION
Opening duplicate PR [based off these instructions](https://connect.posit.it/positron-wiki/community-prs.html)

BELOW COPIED FROM #13146 

---

### Summary

Adds a `/idle` HTTP endpoint on the Positron server/REH build that Posit Cloud can query to determine how long the user has been idle.


### Architecture

The existing `IUserActivityService` keeps track of DOM events (e.g. `keydown`, `mousedown`, `touchstart`. A new browser-side workbench contribution, `PositronIdleReporterContribution`, registers a callback to watch activity changes, upon which it forwards timestamps to a new IPC channel every 30s. A new service, `PositronIdleTrackingService`, keeps the most recent timestamp monotonically and exposes the result via the HTTP endpoint.


### Response format

```json
GET /idle?tkn=<connection-token>

{
  "seconds_idle": 142,
  "last_activity_epoch_ms": 1718900000000
}
```

### Behavior notes

Since timestamps are sent every 30 seconds, the idle time may be reported up to 30s even while Positron is in use.

**Opening a tab counts as activity for ~60-70s**. `IUserActivityService` initializes `isActive = true` on construction, treating the act of opening the window as an implicit activity signal (see [the service's own comment](https://github.com/posit-dev/positron/blob/main/src/vs/workbench/services/userActivity/common/userActivityService.ts#L60-L66)). The bundled `DomActivityTracker` then verifies continued activity via DOM events: after 2 poll intervals (~60s) with no `keydown`/`mousedown`/`touchstart`, plus a 10s debounce, it flips to `isActive = false`.

In practice: if a user opens a tab and walks away without interacting, `seconds_idle` will report `0` for approximately 60-70 seconds before it begins to climb. This is expected and acceptable for session-management use cases where idle timeouts are on the order of minutes or hours, but it's worth noting for any consumer that expects sub-minute precision.

### Release Notes

#### New Features
- N/A (internal server/REH feature; no user-visible change)

#### Bug Fixes
- N/A

### QA Notes

@:sessions

This feature only activates in the server/REH build and requires Linux (license manager is Linux-only).

#### Automated tests
\`\`\`bash
./scripts/test.sh --run src/vs/platform/positronIdleTracking/test/node/positronIdleTrackingService.test.ts
./scripts/test.sh --run src/vs/platform/positronIdleTracking/test/common/positronIdleTrackingIpc.test.ts
\`\`\`

#### Manual verification (Linux only)

1. Build and start the server:
   \`\`\`bash
   npm run build-start && npm run build-check
   ./scripts/code-server.sh --connection-token test-token --license-key-file /path/to/license.lic
   \`\`\`
2. Open the URL printed by the server in a browser.
3. Wait ~10s, then query \`/idle\`:
   \`\`\`bash
   curl -s "http://localhost:<port>/idle?tkn=test-token" | jq .
   \`\`\`
4. Verify:
   - \`seconds_idle\` near 0 when interacting
   - \`seconds_idle\` oscillates between 0 and ~30s when actively interacting (heartbeat interval)
   - \`seconds_idle\` grows unboundedly when the user stops interacting (after the ~60-70s grace period described above)
   - HTTP 403 when \`?tkn=\` is missing or wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)