### PR TITLE
fix: update topActionBarSessionManager vitest for filename-only label

### DIFF
--- a/src/vs/workbench/browser/parts/positronTopActionBar/test/browser/topActionBarSessionManager.vitest.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/test/browser/topActionBarSessionManager.vitest.tsx
@@ -153,13 +153,13 @@ describe('TopActionBarSessionManager', () => {
 			.build();
 		const rtl = setupRTLRenderer(() => ctx.reactServices);
 
-		it('renders "notebookName - sessionName" label for notebook session', () => {
+		it('renders notebook filename as label for notebook session', () => {
 			const { container } = rtl.render(
 				<TopActionBarSessionManager />
 			);
 
 			const label = container.querySelector('.action-bar-button-label');
-			expect(label?.textContent).toBe('analysis.ipynb - Python 3.12.1');
+			expect(label?.textContent).toBe('analysis.ipynb');
 		});
 
 		it('renders notebook icon for notebook session', () => {
@@ -241,7 +241,7 @@ describe('TopActionBarSessionManager', () => {
 				}));
 			});
 
-			expect(container.querySelector('.action-bar-button-label')?.textContent).toBe('report.ipynb - Python 3.12.1');
+			expect(container.querySelector('.action-bar-button-label')?.textContent).toBe('report.ipynb');
 		});
 
 		it('updates icon when session changes from none to console', () => {


### PR DESCRIPTION
## Summary

- `topActionBarSessionManager.vitest.tsx` is failing on main bc it expects the old `"filename - runtime"` label format, but #13070 intentionally changed the top action bar button to show just the filename for notebook/quarto sessions.

## How this snuck in

- the head branch for the PR was last based on a commit from before vitest migration landed, so its CI ran against a tree where this vitest file did not yet exist. The broken combination only materialized after both merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)