### PR TITLE
python: tell positron when to start a session or not

### DIFF
--- a/extensions/positron-python/src/client/application/diagnostics/checks/unsupportedPythonVersion.ts
+++ b/extensions/positron-python/src/client/application/diagnostics/checks/unsupportedPythonVersion.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -101,7 +101,7 @@ export class UnsupportedPythonVersionService extends BaseDiagnosticsService {
     protected addPythonEnvChangedHandler(): void {
         const disposables = this.serviceContainer.get<IDisposableRegistry>(IDisposableRegistry);
         const interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);
-        disposables.push(interpreterService.onDidChangeInterpreter((e) => this.onDidChangeEnvironment(e)));
+        disposables.push(interpreterService.onDidChangeInterpreter((e) => this.onDidChangeEnvironment(e.resource)));
     }
 
     protected async onDidChangeEnvironment(resource?: Uri): Promise<void> {

--- a/extensions/positron-python/src/client/common/interpreterPathService.ts
+++ b/extensions/positron-python/src/client/common/interpreterPathService.ts
@@ -17,6 +17,9 @@ import {
     IInterpreterPathService,
     InspectInterpreterSettingType,
     InterpreterConfigurationScope,
+    // --- Start Positron ---
+    InterpreterPathUpdateOptions,
+    // --- End Positron ---
     IPersistentState,
     IPersistentStateFactory,
     IPythonSettings,
@@ -55,7 +58,19 @@ export class InterpreterPathService implements IInterpreterPathService {
 
     public async onDidChangeConfiguration(event: ConfigurationChangeEvent) {
         if (event.affectsConfiguration(`python.${defaultInterpreterPathSetting}`)) {
-            this._didChangeInterpreterEmitter.fire({ uri: undefined, configTarget: ConfigurationTarget.Global });
+            // --- Start Positron ---
+            // This event only fires for real configuration changes: in Positron the extension
+            // never writes `python.defaultInterpreterPath` itself (the Global branch of update()
+            // below is disabled), so there is no "initial apply" fire at activation to filter out.
+            // Treat every fire as session intent. _onConfigChanged dedupes fires that do not
+            // change the effective interpreter.
+            this._didChangeInterpreterEmitter.fire({
+                uri: undefined,
+                configTarget: ConfigurationTarget.Global,
+                startSession: true,
+                source: 'config-change',
+            });
+            // --- End Positron ---
             traceVerbose('Interpreter Path updated', `python.${defaultInterpreterPathSetting}`);
         }
     }
@@ -108,6 +123,9 @@ export class InterpreterPathService implements IInterpreterPathService {
         resource: Resource,
         configTarget: ConfigurationTarget,
         pythonPath: string | undefined,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
     ): Promise<void> {
         resource = PythonSettings.getSettingsUriAndTarget(resource, this.workspaceService).uri;
         if (configTarget === ConfigurationTarget.Global) {
@@ -132,7 +150,17 @@ export class InterpreterPathService implements IInterpreterPathService {
         );
         if (persistentSetting.value !== pythonPath) {
             await persistentSetting.updateValue(pythonPath);
-            this._didChangeInterpreterEmitter.fire({ uri: resource, configTarget });
+            // --- Start Positron ---
+            // Default startSession: true preserves existing upstream semantics when callers don't
+            // pass options. Storage-only callers (copyOldInterpreterStorageValuesToNew, Positron
+            // session start) must opt out explicitly.
+            this._didChangeInterpreterEmitter.fire({
+                uri: resource,
+                configTarget,
+                startSession: options?.startSession ?? true,
+                source: options?.source ?? 'unspecified',
+            });
+            // --- End Positron ---
             traceVerbose('Interpreter Path updated', settingKey, pythonPath);
         }
     }
@@ -160,17 +188,38 @@ export class InterpreterPathService implements IInterpreterPathService {
         return settingKey;
     }
 
-    public async copyOldInterpreterStorageValuesToNew(resource: Resource): Promise<void> {
+    public async copyOldInterpreterStorageValuesToNew(
+        resource: Resource,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ): Promise<void> {
         resource = PythonSettings.getSettingsUriAndTarget(resource, this.workspaceService).uri;
         const oldSettings = this.inspect(resource, true);
+        // --- Start Positron ---
+        // Storage migration should never start a session. Callers can override source if they want
+        // a more specific tag; default is 'storage-migration'.
+        const migrationOptions: InterpreterPathUpdateOptions = {
+            startSession: options?.startSession ?? false,
+            source: options?.source ?? 'storage-migration',
+        };
+        // --- End Positron ---
         await Promise.all([
-            this._copyWorkspaceFolderValueToNewStorage(resource, oldSettings.workspaceFolderValue),
-            this._copyWorkspaceValueToNewStorage(resource, oldSettings.workspaceValue),
-            this._moveGlobalSettingValueToNewStorage(oldSettings.globalValue),
+            // --- Start Positron ---
+            this._copyWorkspaceFolderValueToNewStorage(resource, oldSettings.workspaceFolderValue, migrationOptions),
+            this._copyWorkspaceValueToNewStorage(resource, oldSettings.workspaceValue, migrationOptions),
+            this._moveGlobalSettingValueToNewStorage(oldSettings.globalValue, migrationOptions),
+            // --- End Positron ---
         ]);
     }
 
-    public async _copyWorkspaceFolderValueToNewStorage(resource: Resource, value: string | undefined): Promise<void> {
+    public async _copyWorkspaceFolderValueToNewStorage(
+        resource: Resource,
+        value: string | undefined,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ): Promise<void> {
         // Copy workspace folder setting into the new storage if it hasn't been copied already
         const workspaceFolderKey = this.workspaceService.getWorkspaceFolderIdentifier(resource, '');
         if (workspaceFolderKey === '') {
@@ -184,12 +233,20 @@ export class InterpreterPathService implements IInterpreterPathService {
         const flaggedWorkspaceFolderKeys = flaggedWorkspaceFolderKeysStorage.value;
         const shouldUpdateWorkspaceFolderSetting = !flaggedWorkspaceFolderKeys.includes(workspaceFolderKey);
         if (shouldUpdateWorkspaceFolderSetting) {
-            await this.update(resource, ConfigurationTarget.WorkspaceFolder, value);
+            // --- Start Positron ---
+            await this.update(resource, ConfigurationTarget.WorkspaceFolder, value, options);
+            // --- End Positron ---
             await flaggedWorkspaceFolderKeysStorage.updateValue([workspaceFolderKey, ...flaggedWorkspaceFolderKeys]);
         }
     }
 
-    public async _copyWorkspaceValueToNewStorage(resource: Resource, value: string | undefined): Promise<void> {
+    public async _copyWorkspaceValueToNewStorage(
+        resource: Resource,
+        value: string | undefined,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ): Promise<void> {
         // Copy workspace setting into the new storage if it hasn't been copied already
         const workspaceKey = this.workspaceService.workspaceFile
             ? this.fileSystemPaths.normCase(this.workspaceService.workspaceFile.fsPath)
@@ -204,12 +261,19 @@ export class InterpreterPathService implements IInterpreterPathService {
         const flaggedWorkspaceKeys = flaggedWorkspaceKeysStorage.value;
         const shouldUpdateWorkspaceSetting = !flaggedWorkspaceKeys.includes(workspaceKey);
         if (shouldUpdateWorkspaceSetting) {
-            await this.update(resource, ConfigurationTarget.Workspace, value);
+            // --- Start Positron ---
+            await this.update(resource, ConfigurationTarget.Workspace, value, options);
+            // --- End Positron ---
             await flaggedWorkspaceKeysStorage.updateValue([workspaceKey, ...flaggedWorkspaceKeys]);
         }
     }
 
-    public async _moveGlobalSettingValueToNewStorage(value: string | undefined) {
+    public async _moveGlobalSettingValueToNewStorage(
+        value: string | undefined,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ) {
         // Move global setting into the new storage if it hasn't been moved already
         const isGlobalSettingCopiedStorage = this.persistentStateFactory.createGlobalPersistentState<boolean>(
             isRemoteGlobalSettingCopiedKey,
@@ -217,7 +281,9 @@ export class InterpreterPathService implements IInterpreterPathService {
         );
         const shouldUpdateGlobalSetting = !isGlobalSettingCopiedStorage.value;
         if (shouldUpdateGlobalSetting) {
-            await this.update(undefined, ConfigurationTarget.Global, value);
+            // --- Start Positron ---
+            await this.update(undefined, ConfigurationTarget.Global, value, options);
+            // --- End Positron ---
             await isGlobalSettingCopiedStorage.updateValue(true);
         }
     }

--- a/extensions/positron-python/src/client/common/interpreterPathService.ts
+++ b/extensions/positron-python/src/client/common/interpreterPathService.ts
@@ -17,6 +17,9 @@ import {
     IInterpreterPathService,
     InspectInterpreterSettingType,
     InterpreterConfigurationScope,
+    // --- Start Positron ---
+    InterpreterPathUpdateOptions,
+    // --- End Positron ---
     IPersistentState,
     IPersistentStateFactory,
     IPythonSettings,
@@ -43,6 +46,15 @@ export class InterpreterPathService implements IInterpreterPathService {
     }
     public _didChangeInterpreterEmitter = new EventEmitter<InterpreterConfigurationScope>();
     private fileSystemPaths: FileSystemPaths;
+    // --- Start Positron ---
+    /**
+     * Whether `onDidChangeConfiguration` has already fired once for `python.defaultInterpreterPath`
+     * during this activation. The first fire is treated as a storage-update (`startSession: false`,
+     * source `'config-initial'`); subsequent fires are treated as user edits (`startSession: true`,
+     * source `'config-user-edit'`). See `.plans/pet-bump-2b-event-split.md`, caller (c) vs. (d).
+     */
+    private _hasSeenInitialConfigEvent = false;
+    // --- End Positron ---
     constructor(
         @inject(IPersistentStateFactory) private readonly persistentStateFactory: IPersistentStateFactory,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
@@ -55,7 +67,18 @@ export class InterpreterPathService implements IInterpreterPathService {
 
     public async onDidChangeConfiguration(event: ConfigurationChangeEvent) {
         if (event.affectsConfiguration(`python.${defaultInterpreterPathSetting}`)) {
-            this._didChangeInterpreterEmitter.fire({ uri: undefined, configTarget: ConfigurationTarget.Global });
+            // --- Start Positron ---
+            // Classify the first fire per activation as storage-only (config-initial) and any
+            // subsequent fire as a user edit (config-user-edit). See plan for rationale.
+            const isInitial = !this._hasSeenInitialConfigEvent;
+            this._hasSeenInitialConfigEvent = true;
+            this._didChangeInterpreterEmitter.fire({
+                uri: undefined,
+                configTarget: ConfigurationTarget.Global,
+                startSession: !isInitial,
+                source: isInitial ? 'config-initial' : 'config-user-edit',
+            });
+            // --- End Positron ---
             traceVerbose('Interpreter Path updated', `python.${defaultInterpreterPathSetting}`);
         }
     }
@@ -108,6 +131,9 @@ export class InterpreterPathService implements IInterpreterPathService {
         resource: Resource,
         configTarget: ConfigurationTarget,
         pythonPath: string | undefined,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
     ): Promise<void> {
         resource = PythonSettings.getSettingsUriAndTarget(resource, this.workspaceService).uri;
         if (configTarget === ConfigurationTarget.Global) {
@@ -132,7 +158,17 @@ export class InterpreterPathService implements IInterpreterPathService {
         );
         if (persistentSetting.value !== pythonPath) {
             await persistentSetting.updateValue(pythonPath);
-            this._didChangeInterpreterEmitter.fire({ uri: resource, configTarget });
+            // --- Start Positron ---
+            // Default startSession: true preserves existing upstream semantics when callers don't
+            // pass options. Storage-only callers (copyOldInterpreterStorageValuesToNew, Positron
+            // session start) must opt out explicitly.
+            this._didChangeInterpreterEmitter.fire({
+                uri: resource,
+                configTarget,
+                startSession: options?.startSession ?? true,
+                source: options?.source ?? 'unspecified',
+            });
+            // --- End Positron ---
             traceVerbose('Interpreter Path updated', settingKey, pythonPath);
         }
     }
@@ -160,17 +196,38 @@ export class InterpreterPathService implements IInterpreterPathService {
         return settingKey;
     }
 
-    public async copyOldInterpreterStorageValuesToNew(resource: Resource): Promise<void> {
+    public async copyOldInterpreterStorageValuesToNew(
+        resource: Resource,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ): Promise<void> {
         resource = PythonSettings.getSettingsUriAndTarget(resource, this.workspaceService).uri;
         const oldSettings = this.inspect(resource, true);
+        // --- Start Positron ---
+        // Storage migration should never start a session. Callers can override source if they want
+        // a more specific tag; default is 'storage-migration'. See plan caller (b).
+        const migrationOptions: InterpreterPathUpdateOptions = {
+            startSession: options?.startSession ?? false,
+            source: options?.source ?? 'storage-migration',
+        };
+        // --- End Positron ---
         await Promise.all([
-            this._copyWorkspaceFolderValueToNewStorage(resource, oldSettings.workspaceFolderValue),
-            this._copyWorkspaceValueToNewStorage(resource, oldSettings.workspaceValue),
-            this._moveGlobalSettingValueToNewStorage(oldSettings.globalValue),
+            // --- Start Positron ---
+            this._copyWorkspaceFolderValueToNewStorage(resource, oldSettings.workspaceFolderValue, migrationOptions),
+            this._copyWorkspaceValueToNewStorage(resource, oldSettings.workspaceValue, migrationOptions),
+            this._moveGlobalSettingValueToNewStorage(oldSettings.globalValue, migrationOptions),
+            // --- End Positron ---
         ]);
     }
 
-    public async _copyWorkspaceFolderValueToNewStorage(resource: Resource, value: string | undefined): Promise<void> {
+    public async _copyWorkspaceFolderValueToNewStorage(
+        resource: Resource,
+        value: string | undefined,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ): Promise<void> {
         // Copy workspace folder setting into the new storage if it hasn't been copied already
         const workspaceFolderKey = this.workspaceService.getWorkspaceFolderIdentifier(resource, '');
         if (workspaceFolderKey === '') {
@@ -184,12 +241,20 @@ export class InterpreterPathService implements IInterpreterPathService {
         const flaggedWorkspaceFolderKeys = flaggedWorkspaceFolderKeysStorage.value;
         const shouldUpdateWorkspaceFolderSetting = !flaggedWorkspaceFolderKeys.includes(workspaceFolderKey);
         if (shouldUpdateWorkspaceFolderSetting) {
-            await this.update(resource, ConfigurationTarget.WorkspaceFolder, value);
+            // --- Start Positron ---
+            await this.update(resource, ConfigurationTarget.WorkspaceFolder, value, options);
+            // --- End Positron ---
             await flaggedWorkspaceFolderKeysStorage.updateValue([workspaceFolderKey, ...flaggedWorkspaceFolderKeys]);
         }
     }
 
-    public async _copyWorkspaceValueToNewStorage(resource: Resource, value: string | undefined): Promise<void> {
+    public async _copyWorkspaceValueToNewStorage(
+        resource: Resource,
+        value: string | undefined,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ): Promise<void> {
         // Copy workspace setting into the new storage if it hasn't been copied already
         const workspaceKey = this.workspaceService.workspaceFile
             ? this.fileSystemPaths.normCase(this.workspaceService.workspaceFile.fsPath)
@@ -204,12 +269,19 @@ export class InterpreterPathService implements IInterpreterPathService {
         const flaggedWorkspaceKeys = flaggedWorkspaceKeysStorage.value;
         const shouldUpdateWorkspaceSetting = !flaggedWorkspaceKeys.includes(workspaceKey);
         if (shouldUpdateWorkspaceSetting) {
-            await this.update(resource, ConfigurationTarget.Workspace, value);
+            // --- Start Positron ---
+            await this.update(resource, ConfigurationTarget.Workspace, value, options);
+            // --- End Positron ---
             await flaggedWorkspaceKeysStorage.updateValue([workspaceKey, ...flaggedWorkspaceKeys]);
         }
     }
 
-    public async _moveGlobalSettingValueToNewStorage(value: string | undefined) {
+    public async _moveGlobalSettingValueToNewStorage(
+        value: string | undefined,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ) {
         // Move global setting into the new storage if it hasn't been moved already
         const isGlobalSettingCopiedStorage = this.persistentStateFactory.createGlobalPersistentState<boolean>(
             isRemoteGlobalSettingCopiedKey,
@@ -217,7 +289,9 @@ export class InterpreterPathService implements IInterpreterPathService {
         );
         const shouldUpdateGlobalSetting = !isGlobalSettingCopiedStorage.value;
         if (shouldUpdateGlobalSetting) {
-            await this.update(undefined, ConfigurationTarget.Global, value);
+            // --- Start Positron ---
+            await this.update(undefined, ConfigurationTarget.Global, value, options);
+            // --- End Positron ---
             await isGlobalSettingCopiedStorage.updateValue(true);
         }
     }

--- a/extensions/positron-python/src/client/common/types.ts
+++ b/extensions/positron-python/src/client/common/types.ts
@@ -351,12 +351,37 @@ export interface IExperimentService {
     getExperimentValue<T extends boolean | number | string>(experimentName: string): Promise<T | undefined>;
 }
 
-export type InterpreterConfigurationScope = { uri: Resource; configTarget: ConfigurationTarget };
+export type InterpreterConfigurationScope = {
+    uri: Resource;
+    configTarget: ConfigurationTarget;
+    // --- Start Positron ---
+    /**
+     * Whether a Python runtime session should be started for this fire. Threaded through to
+     * {@link InterpreterChangeEvent.startSession}. Default true (preserves existing upstream
+     * semantics when callers don't pass options).
+     */
+    startSession?: boolean;
+    /** Debug-only tag identifying which caller fired. */
+    source?: string;
+    // --- End Positron ---
+};
 export type InspectInterpreterSettingType = {
     globalValue?: string;
     workspaceValue?: string;
     workspaceFolderValue?: string;
 };
+
+// --- Start Positron ---
+/**
+ * Options controlling {@link IInterpreterPathService.update} fire semantics.
+ */
+export interface InterpreterPathUpdateOptions {
+    /** If true, a session should be started for this interpreter. Default true. */
+    startSession?: boolean;
+    /** Debug-only tag identifying the caller. Default 'unspecified'. */
+    source?: string;
+}
+// --- End Positron ---
 
 /**
  * Interface used to access current Interpreter Path
@@ -366,8 +391,20 @@ export interface IInterpreterPathService {
     onDidChange: Event<InterpreterConfigurationScope>;
     get(resource: Resource): string;
     inspect(resource: Resource): InspectInterpreterSettingType;
-    update(resource: Resource, configTarget: ConfigurationTarget, value: string | undefined): Promise<void>;
-    copyOldInterpreterStorageValuesToNew(resource: Resource): Promise<void>;
+    update(
+        resource: Resource,
+        configTarget: ConfigurationTarget,
+        value: string | undefined,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ): Promise<void>;
+    copyOldInterpreterStorageValuesToNew(
+        resource: Resource,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ): Promise<void>;
 }
 
 export type DefaultLSType = LanguageServerType.Jedi | LanguageServerType.Node;

--- a/extensions/positron-python/src/client/common/types.ts
+++ b/extensions/positron-python/src/client/common/types.ts
@@ -351,12 +351,38 @@ export interface IExperimentService {
     getExperimentValue<T extends boolean | number | string>(experimentName: string): Promise<T | undefined>;
 }
 
-export type InterpreterConfigurationScope = { uri: Resource; configTarget: ConfigurationTarget };
+export type InterpreterConfigurationScope = {
+    uri: Resource;
+    configTarget: ConfigurationTarget;
+    // --- Start Positron ---
+    /**
+     * Whether a Python runtime session should be started for this fire. Threaded through to
+     * {@link InterpreterChangeEvent.startSession}. Default true (preserves existing upstream
+     * semantics when callers don't pass options).
+     */
+    startSession?: boolean;
+    /** Debug-only tag identifying which caller fired. */
+    source?: string;
+    // --- End Positron ---
+};
 export type InspectInterpreterSettingType = {
     globalValue?: string;
     workspaceValue?: string;
     workspaceFolderValue?: string;
 };
+
+// --- Start Positron ---
+/**
+ * Options controlling {@link IInterpreterPathService.update} fire semantics. See
+ * `.plans/pet-bump-2b-event-split.md` for classification rules.
+ */
+export interface InterpreterPathUpdateOptions {
+    /** If true, a session should be started for this interpreter. Default true. */
+    startSession?: boolean;
+    /** Debug-only tag identifying the caller. Default 'unspecified'. */
+    source?: string;
+}
+// --- End Positron ---
 
 /**
  * Interface used to access current Interpreter Path
@@ -366,8 +392,20 @@ export interface IInterpreterPathService {
     onDidChange: Event<InterpreterConfigurationScope>;
     get(resource: Resource): string;
     inspect(resource: Resource): InspectInterpreterSettingType;
-    update(resource: Resource, configTarget: ConfigurationTarget, value: string | undefined): Promise<void>;
-    copyOldInterpreterStorageValuesToNew(resource: Resource): Promise<void>;
+    update(
+        resource: Resource,
+        configTarget: ConfigurationTarget,
+        value: string | undefined,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ): Promise<void>;
+    copyOldInterpreterStorageValuesToNew(
+        resource: Resource,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ): Promise<void>;
 }
 
 export type DefaultLSType = LanguageServerType.Jedi | LanguageServerType.Node;

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -667,8 +667,11 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
             // User may choose to have an empty string stored, so variable `interpreterState.path` may be
             // an empty string, in which case we should update.
             // Having the value `undefined` means user cancelled the quickpick, so we update nothing in that case.
-            await this.pythonPathUpdaterService.updatePythonPath(interpreterState.path, configTarget, 'ui', wkspace);
             // --- Start Positron ---
+            await this.pythonPathUpdaterService.updatePythonPath(interpreterState.path, configTarget, 'ui', wkspace, {
+                startSession: true,
+                source: 'quickpick',
+            });
             // Ensure that the corresponding runtime is selected in the console, and focus the console.
             this.pythonRuntimeManager
                 .selectLanguageRuntimeFromPath(interpreterState.path)

--- a/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter.ts
@@ -667,7 +667,12 @@ export class SetInterpreterCommand extends BaseInterpreterSelectorCommand implem
             // User may choose to have an empty string stored, so variable `interpreterState.path` may be
             // an empty string, in which case we should update.
             // Having the value `undefined` means user cancelled the quickpick, so we update nothing in that case.
-            await this.pythonPathUpdaterService.updatePythonPath(interpreterState.path, configTarget, 'ui', wkspace);
+            // --- Start Positron ---
+            await this.pythonPathUpdaterService.updatePythonPath(interpreterState.path, configTarget, 'ui', wkspace, {
+                startSession: true,
+                source: 'quickpick',
+            });
+            // --- End Positron ---
             // --- Start Positron ---
             // Ensure that the corresponding runtime is selected in the console, and focus the console.
             this.pythonRuntimeManager

--- a/extensions/positron-python/src/client/interpreter/configuration/pythonPathUpdaterService.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/pythonPathUpdaterService.ts
@@ -1,5 +1,8 @@
 import { inject, injectable } from 'inversify';
 import { ConfigurationTarget, l10n, Uri, window } from 'vscode';
+// --- Start Positron ---
+import { InterpreterPathUpdateOptions } from '../../common/types';
+// --- End Positron ---
 import { StopWatch } from '../../common/utils/stopWatch';
 import { SystemVariables } from '../../common/variables/systemVariables';
 import { traceError } from '../../logging';
@@ -27,12 +30,24 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
         configTarget: ConfigurationTarget,
         trigger: 'ui' | 'shebang' | 'load',
         wkspace?: Uri,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
     ): Promise<void> {
         const stopWatch = new StopWatch();
         const pythonPathUpdater = this.getPythonUpdaterService(configTarget, wkspace);
         let failed = false;
         try {
-            await pythonPathUpdater.updatePythonPath(pythonPath);
+            // --- Start Positron ---
+            // Default the fire classification from `trigger`: 'load' is storage-only (activation
+            // path, session not wanted yet), 'ui'/'shebang' are user-driven. Explicit caller-passed
+            // `options` override this default.
+            const resolvedOptions: InterpreterPathUpdateOptions = {
+                startSession: options?.startSession ?? (trigger === 'load' ? false : true),
+                source: options?.source ?? `path-updater-${trigger}`,
+            };
+            await pythonPathUpdater.updatePythonPath(pythonPath, resolvedOptions);
+            // --- End Positron ---
             if (trigger === 'ui') {
                 this.preferredEnvService.trackUserSelectedEnvironment(pythonPath, wkspace);
             }

--- a/extensions/positron-python/src/client/interpreter/configuration/services/globalUpdaterService.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/services/globalUpdaterService.ts
@@ -1,15 +1,24 @@
 import { ConfigurationTarget } from 'vscode';
-import { IInterpreterPathService } from '../../../common/types';
+// --- Start Positron ---
+import { IInterpreterPathService, InterpreterPathUpdateOptions } from '../../../common/types';
+// --- End Positron ---
 import { IPythonPathUpdaterService } from '../types';
 
 export class GlobalPythonPathUpdaterService implements IPythonPathUpdaterService {
     constructor(private readonly interpreterPathService: IInterpreterPathService) {}
-    public async updatePythonPath(pythonPath: string | undefined): Promise<void> {
+    public async updatePythonPath(
+        pythonPath: string | undefined,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ): Promise<void> {
         const pythonPathValue = this.interpreterPathService.inspect(undefined);
 
         if (pythonPathValue && pythonPathValue.globalValue === pythonPath) {
             return;
         }
-        await this.interpreterPathService.update(undefined, ConfigurationTarget.Global, pythonPath);
+        // --- Start Positron ---
+        await this.interpreterPathService.update(undefined, ConfigurationTarget.Global, pythonPath, options);
+        // --- End Positron ---
     }
 }

--- a/extensions/positron-python/src/client/interpreter/configuration/services/workspaceFolderUpdaterService.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/services/workspaceFolderUpdaterService.ts
@@ -1,15 +1,29 @@
 import { ConfigurationTarget, Uri } from 'vscode';
-import { IInterpreterPathService } from '../../../common/types';
+// --- Start Positron ---
+import { IInterpreterPathService, InterpreterPathUpdateOptions } from '../../../common/types';
+// --- End Positron ---
 import { IPythonPathUpdaterService } from '../types';
 
 export class WorkspaceFolderPythonPathUpdaterService implements IPythonPathUpdaterService {
     constructor(private workspaceFolder: Uri, private readonly interpreterPathService: IInterpreterPathService) {}
-    public async updatePythonPath(pythonPath: string | undefined): Promise<void> {
+    public async updatePythonPath(
+        pythonPath: string | undefined,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ): Promise<void> {
         const pythonPathValue = this.interpreterPathService.inspect(this.workspaceFolder);
 
         if (pythonPathValue && pythonPathValue.workspaceFolderValue === pythonPath) {
             return;
         }
-        await this.interpreterPathService.update(this.workspaceFolder, ConfigurationTarget.WorkspaceFolder, pythonPath);
+        // --- Start Positron ---
+        await this.interpreterPathService.update(
+            this.workspaceFolder,
+            ConfigurationTarget.WorkspaceFolder,
+            pythonPath,
+            options,
+        );
+        // --- End Positron ---
     }
 }

--- a/extensions/positron-python/src/client/interpreter/configuration/services/workspaceUpdaterService.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/services/workspaceUpdaterService.ts
@@ -1,15 +1,24 @@
 import { ConfigurationTarget, Uri } from 'vscode';
-import { IInterpreterPathService } from '../../../common/types';
+// --- Start Positron ---
+import { IInterpreterPathService, InterpreterPathUpdateOptions } from '../../../common/types';
+// --- End Positron ---
 import { IPythonPathUpdaterService } from '../types';
 
 export class WorkspacePythonPathUpdaterService implements IPythonPathUpdaterService {
     constructor(private workspace: Uri, private readonly interpreterPathService: IInterpreterPathService) {}
-    public async updatePythonPath(pythonPath: string | undefined): Promise<void> {
+    public async updatePythonPath(
+        pythonPath: string | undefined,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ): Promise<void> {
         const pythonPathValue = this.interpreterPathService.inspect(this.workspace);
 
         if (pythonPathValue && pythonPathValue.workspaceValue === pythonPath) {
             return;
         }
-        await this.interpreterPathService.update(this.workspace, ConfigurationTarget.Workspace, pythonPath);
+        // --- Start Positron ---
+        await this.interpreterPathService.update(this.workspace, ConfigurationTarget.Workspace, pythonPath, options);
+        // --- End Positron ---
     }
 }

--- a/extensions/positron-python/src/client/interpreter/configuration/types.ts
+++ b/extensions/positron-python/src/client/interpreter/configuration/types.ts
@@ -1,10 +1,17 @@
 import { ConfigurationTarget, Disposable, QuickPickItem, Uri } from 'vscode';
-import { Resource } from '../../common/types';
+// --- Start Positron ---
+import { InterpreterPathUpdateOptions, Resource } from '../../common/types';
+// --- End Positron ---
 import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { PythonExtension, ResolvedEnvironment } from '../../api/types';
 
 export interface IPythonPathUpdaterService {
-    updatePythonPath(pythonPath: string | undefined): Promise<void>;
+    updatePythonPath(
+        pythonPath: string | undefined,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
+    ): Promise<void>;
 }
 
 export const IPythonPathUpdaterServiceFactory = Symbol('IPythonPathUpdaterServiceFactory');
@@ -21,6 +28,9 @@ export interface IPythonPathUpdaterServiceManager {
         configTarget: ConfigurationTarget,
         trigger: 'ui' | 'shebang' | 'load',
         wkspace?: Uri,
+        // --- Start Positron ---
+        options?: InterpreterPathUpdateOptions,
+        // --- End Positron ---
     ): Promise<void>;
 }
 

--- a/extensions/positron-python/src/client/interpreter/contracts.ts
+++ b/extensions/positron-python/src/client/interpreter/contracts.ts
@@ -95,7 +95,7 @@ export interface IInterpreterService {
     readonly onDidChangeInterpreters: Event<PythonEnvironmentsChangedEvent>;
     onDidChangeInterpreterConfiguration: Event<Uri | undefined>;
     // --- Start Positron ---
-    // Was: onDidChangeInterpreter: Event<Uri | undefined>;
+    // onDidChangeInterpreter: Event<Uri | undefined>;
     onDidChangeInterpreter: Event<InterpreterChangeEvent>;
     // --- End Positron ---
     onDidChangeInterpreterInformation: Event<PythonEnvironment>;

--- a/extensions/positron-python/src/client/interpreter/contracts.ts
+++ b/extensions/positron-python/src/client/interpreter/contracts.ts
@@ -71,6 +71,22 @@ export interface ICondaService {
     ): Promise<{ path: string | undefined; type: 'local' | 'global' } | undefined>;
 }
 
+// --- Start Positron ---
+/**
+ * Payload for {@link IInterpreterService.onDidChangeInterpreter}.
+ *
+ * Splits "storage update" fires (the stored interpreter path changed, e.g. autoselect,
+ * migration, post-install) from "user intent" fires (start a session for this interpreter).
+ */
+export interface InterpreterChangeEvent {
+    resource: Uri | undefined;
+    /** If true, a session should be started for this interpreter. */
+    startSession: boolean;
+    /** Debug-only tag identifying which caller fired. */
+    source: string;
+}
+// --- End Positron ---
+
 export const IInterpreterService = Symbol('IInterpreterService');
 export interface IInterpreterService {
     triggerRefresh(query?: PythonLocatorQuery, options?: TriggerRefreshOptions): Promise<void>;
@@ -78,7 +94,10 @@ export interface IInterpreterService {
     getRefreshPromise(options?: GetRefreshEnvironmentsOptions): Promise<void> | undefined;
     readonly onDidChangeInterpreters: Event<PythonEnvironmentsChangedEvent>;
     onDidChangeInterpreterConfiguration: Event<Uri | undefined>;
-    onDidChangeInterpreter: Event<Uri | undefined>;
+    // --- Start Positron ---
+    // Was: onDidChangeInterpreter: Event<Uri | undefined>;
+    onDidChangeInterpreter: Event<InterpreterChangeEvent>;
+    // --- End Positron ---
     onDidChangeInterpreterInformation: Event<PythonEnvironment>;
     /**
      * Note this API does not trigger the refresh but only works with the current refresh if any. Information

--- a/extensions/positron-python/src/client/interpreter/contracts.ts
+++ b/extensions/positron-python/src/client/interpreter/contracts.ts
@@ -71,6 +71,24 @@ export interface ICondaService {
     ): Promise<{ path: string | undefined; type: 'local' | 'global' } | undefined>;
 }
 
+// --- Start Positron ---
+/**
+ * Payload for {@link IInterpreterService.onDidChangeInterpreter}.
+ *
+ * Splits "storage update" fires (the stored interpreter path changed, e.g. autoselect,
+ * migration, post-install) from "user intent" fires (start a session for this interpreter).
+ *
+ * See `.plans/pet-bump-2b-event-split.md` for the full classification.
+ */
+export interface InterpreterChangeEvent {
+    resource: Uri | undefined;
+    /** If true, a session should be started for this interpreter. */
+    startSession: boolean;
+    /** Debug-only tag identifying which caller fired. */
+    source: string;
+}
+// --- End Positron ---
+
 export const IInterpreterService = Symbol('IInterpreterService');
 export interface IInterpreterService {
     triggerRefresh(query?: PythonLocatorQuery, options?: TriggerRefreshOptions): Promise<void>;
@@ -78,7 +96,10 @@ export interface IInterpreterService {
     getRefreshPromise(options?: GetRefreshEnvironmentsOptions): Promise<void> | undefined;
     readonly onDidChangeInterpreters: Event<PythonEnvironmentsChangedEvent>;
     onDidChangeInterpreterConfiguration: Event<Uri | undefined>;
-    onDidChangeInterpreter: Event<Uri | undefined>;
+    // --- Start Positron ---
+    // Was: onDidChangeInterpreter: Event<Uri | undefined>;
+    onDidChangeInterpreter: Event<InterpreterChangeEvent>;
+    // --- End Positron ---
     onDidChangeInterpreterInformation: Event<PythonEnvironment>;
     /**
      * Note this API does not trigger the refresh but only works with the current refresh if any. Information

--- a/extensions/positron-python/src/client/interpreter/interpreterService.ts
+++ b/extensions/positron-python/src/client/interpreter/interpreterService.ts
@@ -78,7 +78,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
     }
 
     // --- Start Positron ---
-    // Was: public get onDidChangeInterpreter(): Event<Uri | undefined>
+    // public get onDidChangeInterpreter(): Event<Uri | undefined> {
     public get onDidChangeInterpreter(): Event<InterpreterChangeEvent> {
         return this.didChangeInterpreterEmitter.event;
     }
@@ -103,7 +103,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
     private readonly interpreterPathService: IInterpreterPathService;
 
     // --- Start Positron ---
-    // Was: EventEmitter<Uri | undefined>
+    // rivate readonly didChangeInterpreterEmitter = new EventEmitter<Uri | undefined>();
     private readonly didChangeInterpreterEmitter = new EventEmitter<InterpreterChangeEvent>();
     // --- End Positron ---
 
@@ -280,7 +280,8 @@ export class InterpreterService implements Disposable, IInterpreterService {
     }
 
     // --- Start Positron ---
-    // Was: public async _onConfigChanged(resource?: Uri)
+    // public async _onConfigChanged(resource?: Uri): Promise<void> {
+    //
     // Accept an InterpreterConfigurationScope (or bare Uri for backwards-compatible test calls) so
     // we can thread startSession / source through to listeners. Unit tests pass a bare Uri.
     public async _onConfigChanged(scopeOrUri?: InterpreterConfigurationScope | Uri): Promise<void> {

--- a/extensions/positron-python/src/client/interpreter/interpreterService.ts
+++ b/extensions/positron-python/src/client/interpreter/interpreterService.ts
@@ -18,6 +18,9 @@ import {
     IDisposableRegistry,
     IInstaller,
     IInterpreterPathService,
+    // --- Start Positron ---
+    InterpreterConfigurationScope,
+    // --- End Positron ---
     Product,
 } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
@@ -28,9 +31,14 @@ import {
     IInterpreterDisplay,
     IInterpreterService,
     IInterpreterStatusbarVisibilityFilter,
+    // --- Start Positron ---
+    InterpreterChangeEvent,
+    // --- End Positron ---
     PythonEnvironmentsChangedEvent,
 } from './contracts';
-import { traceError, traceLog } from '../logging';
+// --- Start Positron ---
+import { traceError, traceInfo, traceLog } from '../logging';
+// --- End Positron ---
 import { Commands, PVSC_EXTENSION_ID, PYTHON_LANGUAGE } from '../common/constants';
 import { reportActiveInterpreterChanged } from '../environmentApi';
 import { IPythonExecutionFactory } from '../common/process/types';
@@ -69,9 +77,12 @@ export class InterpreterService implements Disposable, IInterpreterService {
         return this.pyenvs.getRefreshPromise(options);
     }
 
-    public get onDidChangeInterpreter(): Event<Uri | undefined> {
+    // --- Start Positron ---
+    // Was: public get onDidChangeInterpreter(): Event<Uri | undefined>
+    public get onDidChangeInterpreter(): Event<InterpreterChangeEvent> {
         return this.didChangeInterpreterEmitter.event;
     }
+    // --- End Positron ---
 
     public onDidChangeInterpreters: Event<PythonEnvironmentsChangedEvent>;
 
@@ -91,7 +102,10 @@ export class InterpreterService implements Disposable, IInterpreterService {
 
     private readonly interpreterPathService: IInterpreterPathService;
 
-    private readonly didChangeInterpreterEmitter = new EventEmitter<Uri | undefined>();
+    // --- Start Positron ---
+    // Was: EventEmitter<Uri | undefined>
+    private readonly didChangeInterpreterEmitter = new EventEmitter<InterpreterChangeEvent>();
+    // --- End Positron ---
 
     private readonly didChangeInterpreterInformation = new EventEmitter<PythonEnvironment>();
 
@@ -174,8 +188,11 @@ export class InterpreterService implements Disposable, IInterpreterService {
                     this.didChangeInterpreterInformation.fire(interpreter);
                     for (const { path, workspaceFolder } of this.activeInterpreterPaths.values()) {
                         if (path === interpreter.path && !e.new) {
-                            // If the active environment got deleted, notify it.
-                            this.didChangeInterpreterEmitter.fire(workspaceFolder?.uri);
+                            // --- Start Positron ---
+                            // Active env was deleted externally. Storage-only fire - do not start
+                            // a replacement session.
+                            this.fireInterpreterChanged(workspaceFolder?.uri, false, 'active-env-deleted');
+                            // --- End Positron ---
                             reportActiveInterpreterChanged({
                                 path,
                                 resource: workspaceFolder,
@@ -197,7 +214,11 @@ export class InterpreterService implements Disposable, IInterpreterService {
                 }
             }),
         );
-        disposables.push(this.interpreterPathService.onDidChange((i) => this._onConfigChanged(i.uri)));
+        // --- Start Positron ---
+        // Thread the full scope (including startSession / source) through to _onConfigChanged so
+        // we can classify storage-update vs. user-intent fires at the emit point.
+        disposables.push(this.interpreterPathService.onDidChange((scope) => this._onConfigChanged(scope)));
+        // --- End Positron ---
     }
 
     public getInterpreters(resource?: Uri): PythonEnvironment[] {
@@ -258,7 +279,17 @@ export class InterpreterService implements Disposable, IInterpreterService {
         return this.pyenvs.getInterpreterDetails(pythonPath);
     }
 
-    public async _onConfigChanged(resource?: Uri): Promise<void> {
+    // --- Start Positron ---
+    // Was: public async _onConfigChanged(resource?: Uri)
+    // Accept an InterpreterConfigurationScope (or bare Uri for backwards-compatible test calls) so
+    // we can thread startSession / source through to listeners. Unit tests pass a bare Uri.
+    public async _onConfigChanged(scopeOrUri?: InterpreterConfigurationScope | Uri): Promise<void> {
+        const scope: InterpreterConfigurationScope =
+            scopeOrUri && 'configTarget' in scopeOrUri
+                ? scopeOrUri
+                : { uri: scopeOrUri, configTarget: undefined as never };
+        const resource = scope.uri;
+        // --- End Positron ---
         // Check if we actually changed our python path.
         // Config service also updates itself on interpreter config change,
         // so yielding control here to make sure it goes first and updates
@@ -268,7 +299,13 @@ export class InterpreterService implements Disposable, IInterpreterService {
         this.didChangeInterpreterConfigurationEmitter.fire(resource);
         if (this._pythonPathSetting === '' || this._pythonPathSetting !== pySettings.pythonPath) {
             this._pythonPathSetting = pySettings.pythonPath;
-            this.didChangeInterpreterEmitter.fire(resource);
+            // --- Start Positron ---
+            this.fireInterpreterChanged(
+                resource,
+                scope.startSession ?? true,
+                scope.source ?? 'unspecified',
+            );
+            // --- End Positron ---
             const workspaceFolder = this.serviceContainer
                 .get<IWorkspaceService>(IWorkspaceService)
                 .getWorkspaceFolder(resource);
@@ -285,6 +322,19 @@ export class InterpreterService implements Disposable, IInterpreterService {
             await this.ensureEnvironmentContainsPython(this._pythonPathSetting, workspaceFolder);
         }
     }
+
+    // --- Start Positron ---
+    /**
+     * Fire {@link didChangeInterpreterEmitter} with a classified payload. Tracing helps future
+     * regressions surface in positron-python logs without extra instrumentation.
+     */
+    private fireInterpreterChanged(resource: Uri | undefined, startSession: boolean, source: string): void {
+        traceInfo(
+            `onDidChangeInterpreter: source=${source}, startSession=${startSession}, resource=${resource?.fsPath ?? 'undefined'}`,
+        );
+        this.didChangeInterpreterEmitter.fire({ resource, startSession, source });
+    }
+    // --- End Positron ---
 
     @cache(-1, true)
     private async ensureEnvironmentContainsPython(pythonPath: string, workspaceFolder: WorkspaceFolder | undefined) {
@@ -308,8 +358,12 @@ export class InterpreterService implements Disposable, IInterpreterService {
                 .then(async () => {
                     // Fetch interpreter details so the cache is updated to include the newly installed Python.
                     await this.getInterpreterDetails(pythonPath);
-                    // Fire an event as the executable for the environment has changed.
-                    this.didChangeInterpreterEmitter.fire(workspaceFolder?.uri);
+                    // --- Start Positron ---
+                    // Storage-only fire. By the time this lands, the session has already been
+                    // requested via the caller that triggered the install (quickpick -> update() ->
+                    // _onConfigChanged).
+                    this.fireInterpreterChanged(workspaceFolder?.uri, false, 'install-complete');
+                    // --- End Positron ---
                     reportActiveInterpreterChanged({
                         path: pythonPath,
                         resource: workspaceFolder,

--- a/extensions/positron-python/src/client/interpreter/interpreterService.ts
+++ b/extensions/positron-python/src/client/interpreter/interpreterService.ts
@@ -300,11 +300,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
         if (this._pythonPathSetting === '' || this._pythonPathSetting !== pySettings.pythonPath) {
             this._pythonPathSetting = pySettings.pythonPath;
             // --- Start Positron ---
-            this.fireInterpreterChanged(
-                resource,
-                scope.startSession ?? true,
-                scope.source ?? 'unspecified',
-            );
+            this.fireInterpreterChanged(resource, scope.startSession ?? true, scope.source ?? 'unspecified');
             // --- End Positron ---
             const workspaceFolder = this.serviceContainer
                 .get<IWorkspaceService>(IWorkspaceService)
@@ -330,7 +326,9 @@ export class InterpreterService implements Disposable, IInterpreterService {
      */
     private fireInterpreterChanged(resource: Uri | undefined, startSession: boolean, source: string): void {
         traceInfo(
-            `onDidChangeInterpreter: source=${source}, startSession=${startSession}, resource=${resource?.fsPath ?? 'undefined'}`,
+            `onDidChangeInterpreter: source=${source}, startSession=${startSession}, resource=${
+                resource?.fsPath ?? 'undefined'
+            }`,
         );
         this.didChangeInterpreterEmitter.fire({ resource, startSession, source });
     }

--- a/extensions/positron-python/src/client/interpreter/interpreterService.ts
+++ b/extensions/positron-python/src/client/interpreter/interpreterService.ts
@@ -18,6 +18,9 @@ import {
     IDisposableRegistry,
     IInstaller,
     IInterpreterPathService,
+    // --- Start Positron ---
+    InterpreterConfigurationScope,
+    // --- End Positron ---
     Product,
 } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
@@ -28,9 +31,12 @@ import {
     IInterpreterDisplay,
     IInterpreterService,
     IInterpreterStatusbarVisibilityFilter,
+    // --- Start Positron ---
+    InterpreterChangeEvent,
+    // --- End Positron ---
     PythonEnvironmentsChangedEvent,
 } from './contracts';
-import { traceError, traceLog } from '../logging';
+import { traceError, traceInfo, traceLog } from '../logging';
 import { Commands, PVSC_EXTENSION_ID, PYTHON_LANGUAGE } from '../common/constants';
 import { reportActiveInterpreterChanged } from '../environmentApi';
 import { IPythonExecutionFactory } from '../common/process/types';
@@ -69,9 +75,12 @@ export class InterpreterService implements Disposable, IInterpreterService {
         return this.pyenvs.getRefreshPromise(options);
     }
 
-    public get onDidChangeInterpreter(): Event<Uri | undefined> {
+    // --- Start Positron ---
+    // Was: public get onDidChangeInterpreter(): Event<Uri | undefined>
+    public get onDidChangeInterpreter(): Event<InterpreterChangeEvent> {
         return this.didChangeInterpreterEmitter.event;
     }
+    // --- End Positron ---
 
     public onDidChangeInterpreters: Event<PythonEnvironmentsChangedEvent>;
 
@@ -91,7 +100,10 @@ export class InterpreterService implements Disposable, IInterpreterService {
 
     private readonly interpreterPathService: IInterpreterPathService;
 
-    private readonly didChangeInterpreterEmitter = new EventEmitter<Uri | undefined>();
+    // --- Start Positron ---
+    // Was: EventEmitter<Uri | undefined> — split into storage-update vs. session-intent fires.
+    private readonly didChangeInterpreterEmitter = new EventEmitter<InterpreterChangeEvent>();
+    // --- End Positron ---
 
     private readonly didChangeInterpreterInformation = new EventEmitter<PythonEnvironment>();
 
@@ -174,8 +186,11 @@ export class InterpreterService implements Disposable, IInterpreterService {
                     this.didChangeInterpreterInformation.fire(interpreter);
                     for (const { path, workspaceFolder } of this.activeInterpreterPaths.values()) {
                         if (path === interpreter.path && !e.new) {
-                            // If the active environment got deleted, notify it.
-                            this.didChangeInterpreterEmitter.fire(workspaceFolder?.uri);
+                            // --- Start Positron ---
+                            // Active env was deleted externally. Storage-only fire — do not start
+                            // a replacement session. Plan site (1) / source 'active-env-deleted'.
+                            this.fireInterpreterChanged(workspaceFolder?.uri, false, 'active-env-deleted');
+                            // --- End Positron ---
                             reportActiveInterpreterChanged({
                                 path,
                                 resource: workspaceFolder,
@@ -197,7 +212,11 @@ export class InterpreterService implements Disposable, IInterpreterService {
                 }
             }),
         );
-        disposables.push(this.interpreterPathService.onDidChange((i) => this._onConfigChanged(i.uri)));
+        // --- Start Positron ---
+        // Thread the full scope (including startSession / source) through to _onConfigChanged so
+        // we can classify storage-update vs. user-intent fires at the emit point.
+        disposables.push(this.interpreterPathService.onDidChange((scope) => this._onConfigChanged(scope)));
+        // --- End Positron ---
     }
 
     public getInterpreters(resource?: Uri): PythonEnvironment[] {
@@ -259,7 +278,16 @@ export class InterpreterService implements Disposable, IInterpreterService {
         return this.pyenvs.getInterpreterDetails(pythonPath);
     }
 
-    public async _onConfigChanged(resource?: Uri): Promise<void> {
+    // --- Start Positron ---
+    // Was: public async _onConfigChanged(resource?: Uri)
+    // Accept an InterpreterConfigurationScope (or bare Uri for backwards-compatible test calls) so
+    // we can thread startSession / source through to listeners. Unit tests pass a bare Uri.
+    public async _onConfigChanged(scopeOrUri?: InterpreterConfigurationScope | Uri): Promise<void> {
+        const scope: InterpreterConfigurationScope =
+            scopeOrUri && 'configTarget' in scopeOrUri
+                ? scopeOrUri
+                : { uri: scopeOrUri, configTarget: undefined as never };
+        const resource = scope.uri;
         // Check if we actually changed our python path.
         // Config service also updates itself on interpreter config change,
         // so yielding control here to make sure it goes first and updates
@@ -269,7 +297,11 @@ export class InterpreterService implements Disposable, IInterpreterService {
         this.didChangeInterpreterConfigurationEmitter.fire(resource);
         if (this._pythonPathSetting === '' || this._pythonPathSetting !== pySettings.pythonPath) {
             this._pythonPathSetting = pySettings.pythonPath;
-            this.didChangeInterpreterEmitter.fire(resource);
+            this.fireInterpreterChanged(
+                resource,
+                scope.startSession ?? true,
+                scope.source ?? 'unspecified',
+            );
             const workspaceFolder = this.serviceContainer
                 .get<IWorkspaceService>(IWorkspaceService)
                 .getWorkspaceFolder(resource);
@@ -286,6 +318,18 @@ export class InterpreterService implements Disposable, IInterpreterService {
             await this.ensureEnvironmentContainsPython(this._pythonPathSetting, workspaceFolder);
         }
     }
+
+    /**
+     * Fire {@link didChangeInterpreterEmitter} with a classified payload. Tracing helps future
+     * regressions surface in positron-python logs without extra instrumentation.
+     */
+    private fireInterpreterChanged(resource: Uri | undefined, startSession: boolean, source: string): void {
+        traceInfo(
+            `onDidChangeInterpreter: source=${source}, startSession=${startSession}, resource=${resource?.fsPath ?? 'undefined'}`,
+        );
+        this.didChangeInterpreterEmitter.fire({ resource, startSession, source });
+    }
+    // --- End Positron ---
 
     @cache(-1, true)
     private async ensureEnvironmentContainsPython(pythonPath: string, workspaceFolder: WorkspaceFolder | undefined) {
@@ -309,8 +353,12 @@ export class InterpreterService implements Disposable, IInterpreterService {
                 .then(async () => {
                     // Fetch interpreter details so the cache is updated to include the newly installed Python.
                     await this.getInterpreterDetails(pythonPath);
-                    // Fire an event as the executable for the environment has changed.
-                    this.didChangeInterpreterEmitter.fire(workspaceFolder?.uri);
+                    // --- Start Positron ---
+                    // Storage-only fire. By the time this lands, the session has already been
+                    // requested via the caller that triggered the install (quickpick → update() →
+                    // _onConfigChanged). Plan site (3) / source 'install-complete' / D3.
+                    this.fireInterpreterChanged(workspaceFolder?.uri, false, 'install-complete');
+                    // --- End Positron ---
                     reportActiveInterpreterChanged({
                         path: pythonPath,
                         resource: workspaceFolder,

--- a/extensions/positron-python/src/client/positron/languageServerManager.ts
+++ b/extensions/positron-python/src/client/positron/languageServerManager.ts
@@ -106,7 +106,9 @@ class LanguageServerManager implements vscode.Disposable {
         }
 
         // Storage-only: Pyright needs the path written but the session is already running.
-        await this._pythonPathUpdaterService.updatePythonPath(pythonPath, configTarget, 'ui', folderUri, {
+        // 'load' means programmatic (not a user interpreter selection), so it avoids tracking
+        // this as a user-selected environment.
+        await this._pythonPathUpdaterService.updatePythonPath(pythonPath, configTarget, 'load', folderUri, {
             startSession: false,
             source: 'positron-ls-manager',
         });

--- a/extensions/positron-python/src/client/positron/languageServerManager.ts
+++ b/extensions/positron-python/src/client/positron/languageServerManager.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 // eslint-disable-next-line import/no-unresolved
@@ -105,7 +105,11 @@ class LanguageServerManager implements vscode.Disposable {
             configTarget = vscode.ConfigurationTarget.WorkspaceFolder;
         }
 
-        await this._pythonPathUpdaterService.updatePythonPath(pythonPath, configTarget, 'ui', folderUri);
+        // Storage-only: Pyright needs the path written but the session is already running.
+        await this._pythonPathUpdaterService.updatePythonPath(pythonPath, configTarget, 'ui', folderUri, {
+            startSession: false,
+            source: 'positron-ls-manager',
+        });
     }
 
     /**

--- a/extensions/positron-python/src/client/positron/languageServerManager.ts
+++ b/extensions/positron-python/src/client/positron/languageServerManager.ts
@@ -105,7 +105,11 @@ class LanguageServerManager implements vscode.Disposable {
             configTarget = vscode.ConfigurationTarget.WorkspaceFolder;
         }
 
-        await this._pythonPathUpdaterService.updatePythonPath(pythonPath, configTarget, 'ui', folderUri);
+        // Storage-only: Pyright needs the path written but the session is already running.
+        await this._pythonPathUpdaterService.updatePythonPath(pythonPath, configTarget, 'ui', folderUri, {
+            startSession: false,
+            source: 'positron-ls-manager',
+        });
     }
 
     /**

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -89,20 +89,57 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
                 new CondaPythonPickerContribution(this.serviceContainer),
             ),
 
-            // When an interpreter is added, register a corresponding language runtime.
+            // When an interpreter is added or removed, update our registry and (on removal)
+            // shut down any sessions still backed by the deleted environment.
             interpreterService.onDidChangeInterpreters(async (event) => {
                 if (!event.old && event.new) {
                     // An interpreter was added.
                     const interpreterPath = event.new.path;
                     await this.registerLanguageRuntimeFromPath(interpreterPath);
+                } else if (event.old && !event.new) {
+                    // An interpreter was removed externally (e.g. `.venv` directory deleted). Clear
+                    // stored metadata so we don't hand out stale runtimes, and shut down any live
+                    // sessions using the deleted path.
+                    const deletedPath = event.old.path;
+                    this.registeredPythonRuntimes.delete(deletedPath);
+                    try {
+                        const sessions = await positron.runtime.getActiveSessions();
+                        const toShutdown = sessions.filter(
+                            (s) =>
+                                (s.runtimeMetadata.extraRuntimeData as PythonRuntimeExtraData).pythonPath ===
+                                deletedPath,
+                        );
+                        if (toShutdown.length > 0) {
+                            traceInfo(
+                                `Shutting down ${toShutdown.length} session(s) for deleted interpreter ${deletedPath}`,
+                            );
+                            await Promise.all(
+                                toShutdown.map((s) => s.shutdown(positron.RuntimeExitReason.Shutdown)),
+                            );
+                        }
+                    } catch (error) {
+                        traceError(`Failed to clean up sessions for deleted interpreter ${deletedPath}: ${error}`);
+                    }
                 }
             }),
 
-            interpreterService.onDidChangeInterpreter(async (workspaceUri) => {
-                const interpreter = await interpreterService.getActiveInterpreter(workspaceUri);
+            interpreterService.onDidChangeInterpreter(async (event) => {
+                // Split event: only session-intent fires should start a session. Storage-only fires
+                // (migration, install-complete, active-env-deleted, positron-session-start, ...)
+                // must not spawn a console here - that would reintroduce the #12116 regression.
+                if (!event.startSession) {
+                    traceInfo(
+                        `Skipping session start for onDidChangeInterpreter fire (source=${event.source}, resource=${event.resource?.fsPath ?? 'undefined'})`,
+                    );
+                    return;
+                }
+                traceInfo(
+                    `Handling onDidChangeInterpreter fire (source=${event.source}, resource=${event.resource?.fsPath ?? 'undefined'})`,
+                );
+                const interpreter = await interpreterService.getActiveInterpreter(event.resource);
                 if (!interpreter) {
                     traceError(
-                        `Interpreter not found; could not select language runtime. Workspace: ${workspaceUri?.fsPath}`,
+                        `Interpreter not found; could not select language runtime. Workspace: ${event.resource?.fsPath}`,
                     );
                     return;
                 }

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -113,9 +113,7 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
                             traceInfo(
                                 `Shutting down ${toShutdown.length} session(s) for deleted interpreter ${deletedPath}`,
                             );
-                            await Promise.all(
-                                toShutdown.map((s) => s.shutdown(positron.RuntimeExitReason.Shutdown)),
-                            );
+                            await Promise.all(toShutdown.map((s) => s.shutdown(positron.RuntimeExitReason.Shutdown)));
                         }
                     } catch (error) {
                         traceError(`Failed to clean up sessions for deleted interpreter ${deletedPath}: ${error}`);
@@ -129,12 +127,16 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
                 // must not spawn a console here - that would reintroduce the #12116 regression.
                 if (!event.startSession) {
                     traceInfo(
-                        `Skipping session start for onDidChangeInterpreter fire (source=${event.source}, resource=${event.resource?.fsPath ?? 'undefined'})`,
+                        `Skipping session start for onDidChangeInterpreter fire (source=${event.source}, resource=${
+                            event.resource?.fsPath ?? 'undefined'
+                        })`,
                     );
                     return;
                 }
                 traceInfo(
-                    `Handling onDidChangeInterpreter fire (source=${event.source}, resource=${event.resource?.fsPath ?? 'undefined'})`,
+                    `Handling onDidChangeInterpreter fire (source=${event.source}, resource=${
+                        event.resource?.fsPath ?? 'undefined'
+                    })`,
                 );
                 const interpreter = await interpreterService.getActiveInterpreter(event.resource);
                 if (!interpreter) {

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -18,7 +18,7 @@ import { pythonRuntimeDiscoverer } from './discoverer';
 import { IInterpreterService } from '../interpreter/contracts';
 import { traceError, traceInfo } from '../logging';
 import { IConfigurationService, IDisposable, IDisposableRegistry } from '../common/types';
-import { PythonRuntimeSession } from './session';
+import { getActivePythonSessions, PythonRuntimeSession } from './session';
 import { createPythonRuntimeMetadata, PythonRuntimeExtraData } from './runtime';
 import { getPythonDiscoveryRootSignature } from './discoveryRootSignature';
 import { EXTENSION_ROOT_DIR } from '../common/constants';
@@ -103,7 +103,9 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
                     const deletedPath = event.old.path;
                     this.registeredPythonRuntimes.delete(deletedPath);
                     try {
-                        const sessions = await positron.runtime.getActiveSessions();
+                        // Only Python sessions; other languages' sessions may not even have
+                        // extraRuntimeData (e.g. restored from a serialized state).
+                        const sessions = await getActivePythonSessions();
                         const toShutdown = sessions.filter(
                             (s) =>
                                 (s.runtimeMetadata.extraRuntimeData as PythonRuntimeExtraData).pythonPath ===
@@ -547,10 +549,10 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
                 return alreadyRegisteredRuntime;
             }
 
-            const sessions = await positron.runtime.getActiveSessions();
+            const sessions = await getActivePythonSessions();
             // Find any active sessions using this runtime
             const sessionsToShutdown = sessions.filter((session) => {
-                const sessionRuntime = session.runtimeMetadata.extraRuntimeData;
+                const sessionRuntime = session.runtimeMetadata.extraRuntimeData as PythonRuntimeExtraData;
                 return sessionRuntime.pythonPath === pythonPath;
             });
 

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -93,21 +93,58 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
 
         this.disposables.push(
             positron.runtime.registerLanguageRuntimeManager('python', this),
-            // When an interpreter is added, register a corresponding language runtime.
+            // When an interpreter is added or removed, update our registry and (on removal)
+            // shut down any sessions still backed by the deleted environment.
             interpreterService.onDidChangeInterpreters(async (event) => {
                 if (!event.old && event.new) {
                     // An interpreter was added.
                     const interpreterPath = event.new.path;
                     await checkAndInstallPython(interpreterPath, serviceContainer);
                     await this.registerLanguageRuntimeFromPath(interpreterPath);
+                } else if (event.old && !event.new) {
+                    // An interpreter was removed externally (e.g. `.venv` directory deleted). Clear
+                    // stored metadata so we don't hand out stale runtimes, and shut down any live
+                    // sessions using the deleted path. See pet-bump-2b-event-split plan, D1.
+                    const deletedPath = event.old.path;
+                    this.registeredPythonRuntimes.delete(deletedPath);
+                    try {
+                        const sessions = await positron.runtime.getActiveSessions();
+                        const toShutdown = sessions.filter(
+                            (s) =>
+                                (s.runtimeMetadata.extraRuntimeData as PythonRuntimeExtraData).pythonPath ===
+                                deletedPath,
+                        );
+                        if (toShutdown.length > 0) {
+                            traceInfo(
+                                `Shutting down ${toShutdown.length} session(s) for deleted interpreter ${deletedPath}`,
+                            );
+                            await Promise.all(
+                                toShutdown.map((s) => s.shutdown(positron.RuntimeExitReason.Shutdown)),
+                            );
+                        }
+                    } catch (error) {
+                        traceError(`Failed to clean up sessions for deleted interpreter ${deletedPath}: ${error}`);
+                    }
                 }
             }),
 
-            interpreterService.onDidChangeInterpreter(async (workspaceUri) => {
-                const interpreter = await interpreterService.getActiveInterpreter(workspaceUri);
+            interpreterService.onDidChangeInterpreter(async (event) => {
+                // Split event: only session-intent fires should start a session. Storage-only fires
+                // (autoselect, migration, install-complete, active-env-deleted, config-initial)
+                // must not spawn a console here — that would reintroduce the #12116 regression.
+                if (!event.startSession) {
+                    traceInfo(
+                        `Skipping session start for onDidChangeInterpreter fire (source=${event.source}, resource=${event.resource?.fsPath ?? 'undefined'})`,
+                    );
+                    return;
+                }
+                traceInfo(
+                    `Handling onDidChangeInterpreter fire (source=${event.source}, resource=${event.resource?.fsPath ?? 'undefined'})`,
+                );
+                const interpreter = await interpreterService.getActiveInterpreter(event.resource);
                 if (!interpreter) {
                     traceError(
-                        `Interpreter not found; could not select language runtime. Workspace: ${workspaceUri?.fsPath}`,
+                        `Interpreter not found; could not select language runtime. Workspace: ${event.resource?.fsPath}`,
                     );
                     return;
                 }

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -512,10 +512,13 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
 
         if (this.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console && !this._isExternallyManaged) {
             // Update the active environment in the Python extension.
+            // Storage-only: the session is already starting here, so the listener in
+            // PythonRuntimeManager must not start another one.
             this._interpreterPathService.update(
                 undefined,
                 vscode.ConfigurationTarget.WorkspaceFolder,
                 interpreter.path,
+                { startSession: false, source: 'positron-session-start' },
             );
         }
 

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -512,10 +512,13 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
 
         if (this.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Console && !this._isExternallyManaged) {
             // Update the active environment in the Python extension.
+            // Storage-only: the session is already starting here, so the listener in
+            // PythonRuntimeManager must not start another one. See pet-bump-2b-event-split plan.
             this._interpreterPathService.update(
                 undefined,
                 vscode.ConfigurationTarget.WorkspaceFolder,
                 interpreter.path,
+                { startSession: false, source: 'positron-session-start' },
             );
         }
 

--- a/extensions/positron-python/src/client/terminals/envCollectionActivation/service.ts
+++ b/extensions/positron-python/src/client/terminals/envCollectionActivation/service.ts
@@ -112,26 +112,32 @@ export class TerminalEnvVarCollectionService implements IExtensionActivationServ
                 this.context.environmentVariableCollection.clear();
                 await this.handleMicroVenv(resource);
                 if (!this.registeredOnce) {
+                    // --- Start Positron ---
+                    // Payload is now InterpreterChangeEvent. Env-collection refreshes on both
+                    // storage-update and user-intent fires, so we ignore startSession.
                     this.interpreterService.onDidChangeInterpreter(
-                        async (r) => {
-                            await this.handleMicroVenv(r);
+                        async (e) => {
+                            await this.handleMicroVenv(e.resource);
                         },
                         this,
                         this.disposables,
                     );
+                    // --- End Positron ---
                     this.registeredOnce = true;
                 }
                 await registerPythonStartup(this.context);
                 return;
             }
             if (!this.registeredOnce) {
+                // --- Start Positron ---
                 this.interpreterService.onDidChangeInterpreter(
-                    async (r) => {
-                        await this._applyCollection(r).ignoreErrors();
+                    async (e) => {
+                        await this._applyCollection(e.resource).ignoreErrors();
                     },
                     this,
                     this.disposables,
                 );
+                // --- End Positron ---
                 this.shellIntegrationDetectionService.onDidChangeStatus(
                     async () => {
                         traceInfo("Shell integration status changed, can confirm it's working.");

--- a/extensions/positron-python/src/test/common/interpreterPathService.unit.test.ts
+++ b/extensions/positron-python/src/test/common/interpreterPathService.unit.test.ts
@@ -158,10 +158,20 @@ suite('Interpreter Path Service', async () => {
 
         const _didChangeInterpreterEmitter = TypeMoq.Mock.ofType<EventEmitter<InterpreterConfigurationScope>>();
         interpreterPathService._didChangeInterpreterEmitter = _didChangeInterpreterEmitter.object;
+        // --- Start Positron ---
+        // Payload now carries startSession/source; default for .update() is true/'unspecified'.
         _didChangeInterpreterEmitter
-            .setup((emitter) => emitter.fire({ uri: resource, configTarget: ConfigurationTarget.Workspace }))
+            .setup((emitter) =>
+                emitter.fire({
+                    uri: resource,
+                    configTarget: ConfigurationTarget.Workspace,
+                    startSession: true,
+                    source: 'unspecified',
+                }),
+            )
             .returns(() => undefined)
             .verifiable(TypeMoq.Times.once());
+        // --- End Positron ---
 
         await interpreterPathService.update(resource, ConfigurationTarget.Workspace, interpreterPath);
 
@@ -223,10 +233,19 @@ suite('Interpreter Path Service', async () => {
 
         const _didChangeInterpreterEmitter = TypeMoq.Mock.ofType<EventEmitter<InterpreterConfigurationScope>>();
         interpreterPathService._didChangeInterpreterEmitter = _didChangeInterpreterEmitter.object;
+        // --- Start Positron ---
         _didChangeInterpreterEmitter
-            .setup((emitter) => emitter.fire({ uri: resource, configTarget: ConfigurationTarget.WorkspaceFolder }))
+            .setup((emitter) =>
+                emitter.fire({
+                    uri: resource,
+                    configTarget: ConfigurationTarget.WorkspaceFolder,
+                    startSession: true,
+                    source: 'unspecified',
+                }),
+            )
             .returns(() => undefined)
             .verifiable(TypeMoq.Times.once());
+        // --- End Positron ---
 
         await interpreterPathService.update(resource, ConfigurationTarget.WorkspaceFolder, interpreterPath);
 
@@ -466,10 +485,21 @@ suite('Interpreter Path Service', async () => {
             .returns(() => true)
             .verifiable(TypeMoq.Times.once());
         interpreterPathService._didChangeInterpreterEmitter = _didChangeInterpreterEmitter.object;
+        // --- Start Positron ---
+        // Config changes are always session intent: the extension never writes
+        // `python.defaultInterpreterPath` itself in Positron, so every fire is a real edit.
         _didChangeInterpreterEmitter
-            .setup((emitter) => emitter.fire({ uri: undefined, configTarget: ConfigurationTarget.Global }))
+            .setup((emitter) =>
+                emitter.fire({
+                    uri: undefined,
+                    configTarget: ConfigurationTarget.Global,
+                    startSession: true,
+                    source: 'config-change',
+                }),
+            )
             .returns(() => undefined)
             .verifiable(TypeMoq.Times.once());
+        // --- End Positron ---
         await interpreterPathService.onDidChangeConfiguration(event.object);
         _didChangeInterpreterEmitter.verifyAll();
         event.verifyAll();

--- a/extensions/positron-python/src/test/common/interpreterPathService.unit.test.ts
+++ b/extensions/positron-python/src/test/common/interpreterPathService.unit.test.ts
@@ -158,10 +158,20 @@ suite('Interpreter Path Service', async () => {
 
         const _didChangeInterpreterEmitter = TypeMoq.Mock.ofType<EventEmitter<InterpreterConfigurationScope>>();
         interpreterPathService._didChangeInterpreterEmitter = _didChangeInterpreterEmitter.object;
+        // --- Start Positron ---
+        // Payload now carries startSession/source; default for .update() is true/'unspecified'.
         _didChangeInterpreterEmitter
-            .setup((emitter) => emitter.fire({ uri: resource, configTarget: ConfigurationTarget.Workspace }))
+            .setup((emitter) =>
+                emitter.fire({
+                    uri: resource,
+                    configTarget: ConfigurationTarget.Workspace,
+                    startSession: true,
+                    source: 'unspecified',
+                }),
+            )
             .returns(() => undefined)
             .verifiable(TypeMoq.Times.once());
+        // --- End Positron ---
 
         await interpreterPathService.update(resource, ConfigurationTarget.Workspace, interpreterPath);
 
@@ -223,10 +233,19 @@ suite('Interpreter Path Service', async () => {
 
         const _didChangeInterpreterEmitter = TypeMoq.Mock.ofType<EventEmitter<InterpreterConfigurationScope>>();
         interpreterPathService._didChangeInterpreterEmitter = _didChangeInterpreterEmitter.object;
+        // --- Start Positron ---
         _didChangeInterpreterEmitter
-            .setup((emitter) => emitter.fire({ uri: resource, configTarget: ConfigurationTarget.WorkspaceFolder }))
+            .setup((emitter) =>
+                emitter.fire({
+                    uri: resource,
+                    configTarget: ConfigurationTarget.WorkspaceFolder,
+                    startSession: true,
+                    source: 'unspecified',
+                }),
+            )
             .returns(() => undefined)
             .verifiable(TypeMoq.Times.once());
+        // --- End Positron ---
 
         await interpreterPathService.update(resource, ConfigurationTarget.WorkspaceFolder, interpreterPath);
 
@@ -466,14 +485,54 @@ suite('Interpreter Path Service', async () => {
             .returns(() => true)
             .verifiable(TypeMoq.Times.once());
         interpreterPathService._didChangeInterpreterEmitter = _didChangeInterpreterEmitter.object;
+        // --- Start Positron ---
+        // First fire per activation is classified as storage-only / 'config-initial'.
         _didChangeInterpreterEmitter
-            .setup((emitter) => emitter.fire({ uri: undefined, configTarget: ConfigurationTarget.Global }))
+            .setup((emitter) =>
+                emitter.fire({
+                    uri: undefined,
+                    configTarget: ConfigurationTarget.Global,
+                    startSession: false,
+                    source: 'config-initial',
+                }),
+            )
             .returns(() => undefined)
             .verifiable(TypeMoq.Times.once());
+        // --- End Positron ---
         await interpreterPathService.onDidChangeConfiguration(event.object);
         _didChangeInterpreterEmitter.verifyAll();
         event.verifyAll();
     });
+
+    // --- Start Positron ---
+    test('Subsequent defaultInterpreterPathSetting change fires as user-edit (startSession: true)', async () => {
+        const _didChangeInterpreterEmitter = TypeMoq.Mock.ofType<EventEmitter<InterpreterConfigurationScope>>();
+        const event = TypeMoq.Mock.ofType<ConfigurationChangeEvent>();
+        event
+            .setup((e) => e.affectsConfiguration(`python.${defaultInterpreterPathSetting}`))
+            .returns(() => true);
+        interpreterPathService._didChangeInterpreterEmitter = _didChangeInterpreterEmitter.object;
+
+        // First call — classified as 'config-initial'.
+        await interpreterPathService.onDidChangeConfiguration(event.object);
+
+        _didChangeInterpreterEmitter
+            .setup((emitter) =>
+                emitter.fire({
+                    uri: undefined,
+                    configTarget: ConfigurationTarget.Global,
+                    startSession: true,
+                    source: 'config-user-edit',
+                }),
+            )
+            .returns(() => undefined)
+            .verifiable(TypeMoq.Times.once());
+
+        // Second call — classified as 'config-user-edit'.
+        await interpreterPathService.onDidChangeConfiguration(event.object);
+        _didChangeInterpreterEmitter.verifyAll();
+    });
+    // --- End Positron ---
 
     test('If some other setting changed, no event is fired', async () => {
         const _didChangeInterpreterEmitter = TypeMoq.Mock.ofType<EventEmitter<InterpreterConfigurationScope>>();

--- a/extensions/positron-python/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
+++ b/extensions/positron-python/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
@@ -1341,6 +1341,9 @@ suite('Set Interpreter Command', () => {
                         TypeMoq.It.isValue(ConfigurationTarget.Global),
                         TypeMoq.It.isValue('ui'),
                         TypeMoq.It.isValue(undefined),
+                        // --- Start Positron ---
+                        TypeMoq.It.isValue({ startSession: true, source: 'quickpick' }),
+                        // --- End Positron ---
                     ),
                 )
                 .returns(() => Promise.resolve())
@@ -1383,6 +1386,9 @@ suite('Set Interpreter Command', () => {
                         TypeMoq.It.isValue(ConfigurationTarget.WorkspaceFolder),
                         TypeMoq.It.isValue('ui'),
                         TypeMoq.It.isValue(folder.uri),
+                        // --- Start Positron ---
+                        TypeMoq.It.isValue({ startSession: true, source: 'quickpick' }),
+                        // --- End Positron ---
                     ),
                 )
                 .returns(() => Promise.resolve())
@@ -1451,6 +1457,9 @@ suite('Set Interpreter Command', () => {
                         TypeMoq.It.isValue(ConfigurationTarget.WorkspaceFolder),
                         TypeMoq.It.isValue('ui'),
                         TypeMoq.It.isValue(folder2.uri),
+                        // --- Start Positron ---
+                        TypeMoq.It.isValue({ startSession: true, source: 'quickpick' }),
+                        // --- End Positron ---
                     ),
                 )
                 .returns(() => Promise.resolve())
@@ -1517,6 +1526,9 @@ suite('Set Interpreter Command', () => {
                         TypeMoq.It.isValue(ConfigurationTarget.Workspace),
                         TypeMoq.It.isValue('ui'),
                         TypeMoq.It.isValue(folder1.uri),
+                        // --- Start Positron ---
+                        TypeMoq.It.isValue({ startSession: true, source: 'quickpick' }),
+                        // --- End Positron ---
                     ),
                 )
                 .returns(() => Promise.resolve())

--- a/extensions/positron-python/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
+++ b/extensions/positron-python/src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
@@ -1335,6 +1335,9 @@ suite('Set Interpreter Command', () => {
                         TypeMoq.It.isValue(ConfigurationTarget.Global),
                         TypeMoq.It.isValue('ui'),
                         TypeMoq.It.isValue(undefined),
+                        // --- Start Positron ---
+                        TypeMoq.It.isValue({ startSession: true, source: 'quickpick' }),
+                        // --- End Positron ---
                     ),
                 )
                 .returns(() => Promise.resolve())
@@ -1377,6 +1380,9 @@ suite('Set Interpreter Command', () => {
                         TypeMoq.It.isValue(ConfigurationTarget.WorkspaceFolder),
                         TypeMoq.It.isValue('ui'),
                         TypeMoq.It.isValue(folder.uri),
+                        // --- Start Positron ---
+                        TypeMoq.It.isValue({ startSession: true, source: 'quickpick' }),
+                        // --- End Positron ---
                     ),
                 )
                 .returns(() => Promise.resolve())
@@ -1445,6 +1451,9 @@ suite('Set Interpreter Command', () => {
                         TypeMoq.It.isValue(ConfigurationTarget.WorkspaceFolder),
                         TypeMoq.It.isValue('ui'),
                         TypeMoq.It.isValue(folder2.uri),
+                        // --- Start Positron ---
+                        TypeMoq.It.isValue({ startSession: true, source: 'quickpick' }),
+                        // --- End Positron ---
                     ),
                 )
                 .returns(() => Promise.resolve())
@@ -1511,6 +1520,9 @@ suite('Set Interpreter Command', () => {
                         TypeMoq.It.isValue(ConfigurationTarget.Workspace),
                         TypeMoq.It.isValue('ui'),
                         TypeMoq.It.isValue(folder1.uri),
+                        // --- Start Positron ---
+                        TypeMoq.It.isValue({ startSession: true, source: 'quickpick' }),
+                        // --- End Positron ---
                     ),
                 )
                 .returns(() => Promise.resolve())

--- a/extensions/positron-python/src/test/configuration/pythonPathUpdaterService.unit.test.ts
+++ b/extensions/positron-python/src/test/configuration/pythonPathUpdaterService.unit.test.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from 'chai';
+import * as TypeMoq from 'typemoq';
+import { ConfigurationTarget } from 'vscode';
+import { InterpreterPathUpdateOptions } from '../../client/common/types';
+import { PythonPathUpdaterService } from '../../client/interpreter/configuration/pythonPathUpdaterService';
+import {
+    IPythonPathUpdaterService,
+    IPythonPathUpdaterServiceFactory,
+    IRecommendedEnvironmentService,
+} from '../../client/interpreter/configuration/types';
+import { IComponentAdapter } from '../../client/interpreter/contracts';
+
+suite('Python Path Updater Service', () => {
+    const pythonPath = 'path/to/python';
+
+    let factory: TypeMoq.IMock<IPythonPathUpdaterServiceFactory>;
+    let pyenvs: TypeMoq.IMock<IComponentAdapter>;
+    let preferredEnvService: TypeMoq.IMock<IRecommendedEnvironmentService>;
+    let updater: TypeMoq.IMock<IPythonPathUpdaterService>;
+    let receivedCalls: { pythonPath: string | undefined; options: InterpreterPathUpdateOptions | undefined }[];
+    let updaterServiceManager: PythonPathUpdaterService;
+
+    setup(() => {
+        factory = TypeMoq.Mock.ofType<IPythonPathUpdaterServiceFactory>();
+        pyenvs = TypeMoq.Mock.ofType<IComponentAdapter>();
+        preferredEnvService = TypeMoq.Mock.ofType<IRecommendedEnvironmentService>();
+        updater = TypeMoq.Mock.ofType<IPythonPathUpdaterService>();
+        receivedCalls = [];
+        updater
+            .setup((u) => u.updatePythonPath(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .callback((updatedPath, options) => receivedCalls.push({ pythonPath: updatedPath, options }))
+            .returns(() => Promise.resolve());
+        factory.setup((f) => f.getGlobalPythonPathConfigurationService()).returns(() => updater.object);
+        pyenvs.setup((p) => p.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve(undefined));
+        updaterServiceManager = new PythonPathUpdaterService(factory.object, pyenvs.object, preferredEnvService.object);
+    });
+
+    const triggerDefaults: { trigger: 'ui' | 'shebang' | 'load'; startSession: boolean }[] = [
+        { trigger: 'load', startSession: false },
+        { trigger: 'ui', startSession: true },
+        { trigger: 'shebang', startSession: true },
+    ];
+    triggerDefaults.forEach(({ trigger, startSession }) => {
+        test(`Trigger '${trigger}' defaults to startSession: ${startSession} with a trigger-derived source`, async () => {
+            await updaterServiceManager.updatePythonPath(pythonPath, ConfigurationTarget.Global, trigger);
+
+            expect(receivedCalls).to.deep.equal([
+                { pythonPath, options: { startSession, source: `path-updater-${trigger}` } },
+            ]);
+        });
+    });
+
+    test('Explicit options override the trigger-derived defaults', async () => {
+        await updaterServiceManager.updatePythonPath(pythonPath, ConfigurationTarget.Global, 'load', undefined, {
+            startSession: true,
+            source: 'custom-source',
+        });
+
+        expect(receivedCalls).to.deep.equal([{ pythonPath, options: { startSession: true, source: 'custom-source' } }]);
+    });
+
+    test('Partial options override only the provided field; the rest derive from the trigger', async () => {
+        await updaterServiceManager.updatePythonPath(pythonPath, ConfigurationTarget.Global, 'ui', undefined, {
+            startSession: false,
+        });
+
+        expect(receivedCalls).to.deep.equal([
+            { pythonPath, options: { startSession: false, source: 'path-updater-ui' } },
+        ]);
+    });
+});

--- a/extensions/positron-python/src/test/interpreters/activation/service.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/activation/service.unit.test.ts
@@ -18,14 +18,18 @@ import { ProcessServiceFactory } from '../../../client/common/process/processFac
 import { IProcessService, IProcessServiceFactory } from '../../../client/common/process/types';
 import { TerminalHelper } from '../../../client/common/terminal/helper';
 import { ITerminalHelper } from '../../../client/common/terminal/types';
-import { ICurrentProcess, Resource } from '../../../client/common/types';
+// --- Start Positron ---
+import { ICurrentProcess } from '../../../client/common/types';
+// --- End Positron ---
 import { getNamesAndValues } from '../../../client/common/utils/enum';
 import { Architecture, OSType } from '../../../client/common/utils/platform';
 import { EnvironmentVariablesProvider } from '../../../client/common/variables/environmentVariablesProvider';
 import { IEnvironmentVariablesProvider } from '../../../client/common/variables/types';
 import { EXTENSION_ROOT_DIR } from '../../../client/constants';
 import { EnvironmentActivationService } from '../../../client/interpreter/activation/service';
-import { IInterpreterService } from '../../../client/interpreter/contracts';
+// --- Start Positron ---
+import { IInterpreterService, InterpreterChangeEvent } from '../../../client/interpreter/contracts';
+// --- End Positron ---
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
 import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
 import { getSearchPathEnvVarNames } from '../../../client/common/utils/exec';
@@ -49,7 +53,9 @@ suite('Interpreters Activation - Python Environment Variables', () => {
     let workspace: IWorkspaceService;
     let interpreterService: IInterpreterService;
     let onDidChangeEnvVariables: EventEmitter<Uri | undefined>;
-    let onDidChangeInterpreter: EventEmitter<Resource>;
+    // --- Start Positron ---
+    let onDidChangeInterpreter: EventEmitter<InterpreterChangeEvent>;
+    // --- End Positron ---
     const pythonInterpreter: PythonEnvironment = {
         path: '/foo/bar/python.exe',
         version: new SemVer('3.6.6-final'),
@@ -69,7 +75,9 @@ suite('Interpreters Activation - Python Environment Variables', () => {
         interpreterService = mock(InterpreterService);
         workspace = mock(WorkspaceService);
         onDidChangeEnvVariables = new EventEmitter<Uri | undefined>();
-        onDidChangeInterpreter = new EventEmitter<Resource>();
+        // --- Start Positron ---
+        onDidChangeInterpreter = new EventEmitter<InterpreterChangeEvent>();
+        // --- End Positron ---
         when(envVarsService.onDidEnvironmentVariablesChange).thenReturn(onDidChangeEnvVariables.event);
         when(interpreterService.onDidChangeInterpreter).thenReturn(onDidChangeInterpreter.event);
         when(interpreterService.getActiveInterpreter(anything())).thenResolve(interpreter);

--- a/extensions/positron-python/src/test/interpreters/activation/service.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/activation/service.unit.test.ts
@@ -18,14 +18,16 @@ import { ProcessServiceFactory } from '../../../client/common/process/processFac
 import { IProcessService, IProcessServiceFactory } from '../../../client/common/process/types';
 import { TerminalHelper } from '../../../client/common/terminal/helper';
 import { ITerminalHelper } from '../../../client/common/terminal/types';
-import { ICurrentProcess, Resource } from '../../../client/common/types';
+import { ICurrentProcess } from '../../../client/common/types';
 import { getNamesAndValues } from '../../../client/common/utils/enum';
 import { Architecture, OSType } from '../../../client/common/utils/platform';
 import { EnvironmentVariablesProvider } from '../../../client/common/variables/environmentVariablesProvider';
 import { IEnvironmentVariablesProvider } from '../../../client/common/variables/types';
 import { EXTENSION_ROOT_DIR } from '../../../client/constants';
 import { EnvironmentActivationService } from '../../../client/interpreter/activation/service';
-import { IInterpreterService } from '../../../client/interpreter/contracts';
+// --- Start Positron ---
+import { IInterpreterService, InterpreterChangeEvent } from '../../../client/interpreter/contracts';
+// --- End Positron ---
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
 import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
 import { getSearchPathEnvVarNames } from '../../../client/common/utils/exec';
@@ -49,7 +51,9 @@ suite('Interpreters Activation - Python Environment Variables', () => {
     let workspace: IWorkspaceService;
     let interpreterService: IInterpreterService;
     let onDidChangeEnvVariables: EventEmitter<Uri | undefined>;
-    let onDidChangeInterpreter: EventEmitter<Resource>;
+    // --- Start Positron ---
+    let onDidChangeInterpreter: EventEmitter<InterpreterChangeEvent>;
+    // --- End Positron ---
     const pythonInterpreter: PythonEnvironment = {
         path: '/foo/bar/python.exe',
         version: new SemVer('3.6.6-final'),
@@ -69,7 +73,9 @@ suite('Interpreters Activation - Python Environment Variables', () => {
         interpreterService = mock(InterpreterService);
         workspace = mock(WorkspaceService);
         onDidChangeEnvVariables = new EventEmitter<Uri | undefined>();
-        onDidChangeInterpreter = new EventEmitter<Resource>();
+        // --- Start Positron ---
+        onDidChangeInterpreter = new EventEmitter<InterpreterChangeEvent>();
+        // --- End Positron ---
         when(envVarsService.onDidEnvironmentVariablesChange).thenReturn(onDidChangeEnvVariables.event);
         when(interpreterService.onDidChangeInterpreter).thenReturn(onDidChangeInterpreter.event);
         when(interpreterService.getActiveInterpreter(anything())).thenResolve(interpreter);

--- a/extensions/positron-python/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/activation/terminalEnvVarCollectionService.unit.test.ts
@@ -177,14 +177,20 @@ suite('Terminal Environment Variable Collection Service', () => {
         const applyCollectionStub = sinon.stub(terminalEnvVarCollectionService, '_applyCollection');
         applyCollectionStub.resolves();
         const resource = Uri.file('x');
-        let callback: (resource: Resource) => Promise<void>;
+        // --- Start Positron ---
+        // The listener callback now receives an InterpreterChangeEvent (payload split), not a bare
+        // Resource. The service extracts event.resource before passing to _applyCollection.
+        let callback: (event: { resource: Resource; startSession: boolean; source: string }) => Promise<void>;
+        // --- End Positron ---
         when(interpreterService.onDidChangeInterpreter(anything(), anything(), anything())).thenCall((cb) => {
             callback = cb;
         });
         when(applicationEnvironment.onDidChangeShell(anything(), anything(), anything())).thenReturn();
         await terminalEnvVarCollectionService.activate(undefined);
 
-        await callback!(resource);
+        // --- Start Positron ---
+        await callback!({ resource, startSession: true, source: 'quickpick' });
+        // --- End Positron ---
         assert(applyCollectionStub.calledWithExactly(resource));
     });
 

--- a/extensions/positron-python/src/test/interpreters/interpreterService.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/interpreterService.unit.test.ts
@@ -29,7 +29,14 @@ import {
     IInterpreterAutoSelectionProxyService,
 } from '../../client/interpreter/autoSelection/types';
 import { IPythonPathUpdaterServiceManager } from '../../client/interpreter/configuration/types';
-import { IComponentAdapter, IInterpreterDisplay, IInterpreterHelper } from '../../client/interpreter/contracts';
+// --- Start Positron ---
+import {
+    IComponentAdapter,
+    IInterpreterDisplay,
+    IInterpreterHelper,
+    InterpreterChangeEvent,
+} from '../../client/interpreter/contracts';
+// --- End Positron ---
 import { InterpreterService } from '../../client/interpreter/interpreterService';
 import { ServiceContainer } from '../../client/ioc/container';
 import { ServiceManager } from '../../client/ioc/serviceManager';
@@ -305,4 +312,45 @@ suite('Interpreters service', () => {
         interpreterDisplay.verifyAll();
         expect(reportActiveInterpreterChangedStub.notCalled).to.be.equal(true);
     });
+
+    // --- Start Positron ---
+    test('_onConfigChanged threads startSession and source from the scope into onDidChangeInterpreter', async () => {
+        const service = new InterpreterService(serviceContainer, pyenvs.object);
+        const resource = Uri.parse('a');
+        const workspaceFolder = { uri: resource, name: '', index: 0 };
+        workspace.setup((w) => w.getWorkspaceFolder(resource)).returns(() => workspaceFolder);
+        service._pythonPathSetting = 'stored setting';
+        configService.reset();
+        configService.setup((c) => c.getSettings(resource)).returns(() => ({ pythonPath: 'current path' } as any));
+        interpreterDisplay.setup((i) => i.refresh()).returns(() => Promise.resolve());
+        const events: InterpreterChangeEvent[] = [];
+        service.onDidChangeInterpreter((e) => events.push(e));
+
+        await service._onConfigChanged({
+            uri: resource,
+            configTarget: ConfigurationTarget.Global,
+            startSession: false,
+            source: 'storage-migration',
+        });
+
+        expect(events).to.deep.equal([{ resource, startSession: false, source: 'storage-migration' }]);
+    });
+
+    test('_onConfigChanged with a bare Uri fires with startSession: true and source unspecified', async () => {
+        const service = new InterpreterService(serviceContainer, pyenvs.object);
+        const resource = Uri.parse('a');
+        const workspaceFolder = { uri: resource, name: '', index: 0 };
+        workspace.setup((w) => w.getWorkspaceFolder(resource)).returns(() => workspaceFolder);
+        service._pythonPathSetting = 'stored setting';
+        configService.reset();
+        configService.setup((c) => c.getSettings(resource)).returns(() => ({ pythonPath: 'current path' } as any));
+        interpreterDisplay.setup((i) => i.refresh()).returns(() => Promise.resolve());
+        const events: InterpreterChangeEvent[] = [];
+        service.onDidChangeInterpreter((e) => events.push(e));
+
+        await service._onConfigChanged(resource);
+
+        expect(events).to.deep.equal([{ resource, startSession: true, source: 'unspecified' }]);
+    });
+    // --- End Positron ---
 });

--- a/extensions/positron-python/src/test/interpreters/pythonPathUpdaterFactory.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/pythonPathUpdaterFactory.unit.test.ts
@@ -53,7 +53,9 @@ suite('Python Path Settings Updater', () => {
             interpreterPathService.setup((i) => i.inspect(undefined)).returns(() => ({}));
 
             interpreterPathService
-                .setup((i) => i.update(undefined, ConfigurationTarget.Global, pythonPath))
+                // --- Start Positron ---
+                .setup((i) => i.update(undefined, ConfigurationTarget.Global, pythonPath, undefined))
+                // --- End Positron ---
                 .returns(() => Promise.resolve())
                 .verifiable(TypeMoq.Times.once());
             const updater = updaterServiceFactory.getGlobalPythonPathConfigurationService();
@@ -87,7 +89,9 @@ suite('Python Path Settings Updater', () => {
             const pythonPath = `xWorkspaceFolderPythonPath${new Date().getMilliseconds()}`;
             interpreterPathService.setup((i) => i.inspect(workspaceFolder)).returns(() => ({}));
             interpreterPathService
-                .setup((i) => i.update(workspaceFolder, ConfigurationTarget.WorkspaceFolder, pythonPath))
+                // --- Start Positron ---
+                .setup((i) => i.update(workspaceFolder, ConfigurationTarget.WorkspaceFolder, pythonPath, undefined))
+                // --- End Positron ---
                 .returns(() => Promise.resolve())
                 .verifiable(TypeMoq.Times.once());
 
@@ -121,7 +125,9 @@ suite('Python Path Settings Updater', () => {
 
             interpreterPathService.setup((i) => i.inspect(workspaceFolder)).returns(() => ({}));
             interpreterPathService
-                .setup((i) => i.update(workspaceFolder, ConfigurationTarget.Workspace, pythonPath))
+                // --- Start Positron ---
+                .setup((i) => i.update(workspaceFolder, ConfigurationTarget.Workspace, pythonPath, undefined))
+                // --- End Positron ---
                 .returns(() => Promise.resolve())
                 .verifiable(TypeMoq.Times.once());
 

--- a/extensions/positron-python/src/test/mocks/pst/index.ts
+++ b/extensions/positron-python/src/test/mocks/pst/index.ts
@@ -102,3 +102,15 @@ export enum LanguageRuntimeArchitecture {
     X64 = 'x64',
     Other = 'other',
 }
+
+export enum RuntimeExitReason {
+    StartupFailed = 'startupFailed',
+    Shutdown = 'shutdown',
+    ForcedQuit = 'forcedQuit',
+    Restart = 'restart',
+    SwitchRuntime = 'switchRuntime',
+    Error = 'error',
+    Transferred = 'transferred',
+    ExtensionHost = 'extensionHost',
+    Unknown = 'unknown',
+}

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -28,6 +28,7 @@ import {
 } from '../../client/common/types';
 import { IServiceContainer } from '../../client/ioc/types';
 import { PythonRuntimeManager } from '../../client/positron/manager';
+import { PythonRuntimeSession } from '../../client/positron/session';
 import { IInterpreterService } from '../../client/interpreter/contracts';
 import { PythonEnvironment } from '../../client/pythonEnvironments/info';
 import { mockedPositronNamespaces } from '../vscode-mock';
@@ -664,6 +665,14 @@ suite('Python runtime manager - onDidChangeInterpreter filter', () => {
         sinon.assert.calledOnceWithExactly(selectSpy, '/path/to/python');
     });
 
+    /** Build a fake that passes the `instanceof PythonRuntimeSession` filter without invoking the constructor. */
+    function createFakePythonSession(extraRuntimeData: unknown, shutdown: sinon.SinonStub): PythonRuntimeSession {
+        return Object.assign(Object.create(PythonRuntimeSession.prototype), {
+            runtimeMetadata: { extraRuntimeData },
+            shutdown,
+        });
+    }
+
     test('interpreter deletion: clears registry entry and shuts down matching sessions', async () => {
         const deletedPath = '/path/to/deleted/python';
         pythonRuntimeManager.registeredPythonRuntimes.set(deletedPath, {
@@ -676,24 +685,27 @@ suite('Python runtime manager - onDidChangeInterpreter filter', () => {
         const shutdownDone = new Promise<void>((resolve) => {
             shutdownResolver = resolve;
         });
-        const matchingSession = {
-            runtimeMetadata: { extraRuntimeData: { pythonPath: deletedPath } },
-            shutdown: sinon.stub().callsFake(async () => {
-                shutdownResolver();
-            }),
+        const matchingShutdown = sinon.stub().callsFake(async () => {
+            shutdownResolver();
+        });
+        const matchingSession = createFakePythonSession({ pythonPath: deletedPath }, matchingShutdown);
+        const otherShutdown = sinon.stub().resolves();
+        const otherSession = createFakePythonSession({ pythonPath: '/other/python' }, otherShutdown);
+        // A non-Python session (e.g. R) without extraRuntimeData must not abort the cleanup.
+        const nonPythonShutdown = sinon.stub().resolves();
+        const nonPythonSession = {
+            runtimeMetadata: { extraRuntimeData: undefined },
+            shutdown: nonPythonShutdown,
         };
-        const otherSession = {
-            runtimeMetadata: { extraRuntimeData: { pythonPath: '/other/python' } },
-            shutdown: sinon.stub().resolves(),
-        };
-        getActiveSessionsImpl = async () => [matchingSession as any, otherSession as any];
+        getActiveSessionsImpl = async () => [nonPythonSession as any, matchingSession, otherSession];
 
         onDidChangeInterpretersEmitter.fire({ old: { path: deletedPath } as any, new: undefined });
         await Promise.race([shutdownDone, new Promise((r) => setTimeout(r, 500))]);
 
         assert.strictEqual(pythonRuntimeManager.registeredPythonRuntimes.has(deletedPath), false);
-        sinon.assert.calledOnce(matchingSession.shutdown);
-        sinon.assert.notCalled(otherSession.shutdown);
+        sinon.assert.calledOnce(matchingShutdown);
+        sinon.assert.notCalled(otherShutdown);
+        sinon.assert.notCalled(nonPythonShutdown);
         sinon.assert.notCalled(selectSpy);
     });
 });

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -577,5 +577,121 @@ suite('Python runtime manager - recommendedWorkspaceRuntime', () => {
         sinon.assert.calledOnce(createPythonRuntimeMetadataStub);
         assert.strictEqual(createPythonRuntimeMetadataStub.firstCall.args[2], false);
         assert.strictEqual(result?.extraRuntimeData?.pythonPath, venvPythonPath);
+    });
+});
+
+suite('Python runtime manager - onDidChangeInterpreter filter', () => {
+    // Storage-only fires must not spawn a console; user-intent fires must.
+
+    let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+    let interpreterService: TypeMoq.IMock<IInterpreterService>;
+    let disposableRegistry: TypeMoq.IMock<IDisposableRegistry>;
+    let onDidChangeInterpreterEmitter: vscode.EventEmitter<
+        import('../../client/interpreter/contracts').InterpreterChangeEvent
+    >;
+    let onDidChangeInterpretersEmitter: vscode.EventEmitter<
+        import('../../client/interpreter/contracts').PythonEnvironmentsChangedEvent
+    >;
+    let pythonRuntimeManager: PythonRuntimeManager;
+    let selectSpy: sinon.SinonStub;
+    let getActiveSessionsImpl: () => Promise<positron.LanguageRuntimeSession[]>;
+    let originalGetActiveSessions: unknown;
+
+    setup(() => {
+        serviceContainer = createTypeMoq<IServiceContainer>();
+        interpreterService = createTypeMoq<IInterpreterService>();
+        disposableRegistry = createTypeMoq<IDisposableRegistry>();
+
+        const registryArray: IDisposable[] = [];
+        disposableRegistry
+            .setup((d) => d.push(TypeMoq.It.isAny()))
+            .callback((item: IDisposable) => registryArray.push(item));
+        serviceContainer.setup((s) => s.get(IDisposableRegistry)).returns(() => registryArray);
+
+        onDidChangeInterpreterEmitter = new vscode.EventEmitter();
+        onDidChangeInterpretersEmitter = new vscode.EventEmitter();
+        interpreterService.setup((i) => i.onDidChangeInterpreter).returns(() => onDidChangeInterpreterEmitter.event);
+        interpreterService.setup((i) => i.onDidChangeInterpreters).returns(() => onDidChangeInterpretersEmitter.event);
+
+        // positron.runtime may have getActiveSessions replaced by Object.assign in a prior test
+        // (e.g. languageServerManager). Assign directly so we read from our fixture regardless of
+        // that prior state, and restore the prior value in teardown so this suite doesn't leak
+        // into later ones. Each test overrides getActiveSessionsImpl.
+        originalGetActiveSessions = (positron.runtime as { getActiveSessions?: unknown }).getActiveSessions;
+        getActiveSessionsImpl = async () => [];
+        Object.assign(positron.runtime, {
+            getActiveSessions: () => getActiveSessionsImpl(),
+        });
+
+        pythonRuntimeManager = new PythonRuntimeManager(serviceContainer.object, interpreterService.object);
+        selectSpy = sinon.stub(pythonRuntimeManager, 'selectLanguageRuntimeFromPath').resolves('runtime-id');
+    });
+
+    teardown(() => {
+        sinon.restore();
+        if (originalGetActiveSessions === undefined) {
+            delete (positron.runtime as { getActiveSessions?: unknown }).getActiveSessions;
+        } else {
+            Object.assign(positron.runtime, { getActiveSessions: originalGetActiveSessions });
+        }
+        onDidChangeInterpreterEmitter.dispose();
+        onDidChangeInterpretersEmitter.dispose();
+    });
+
+    test('storage-only fire (startSession: false) does not call selectLanguageRuntimeFromPath', async () => {
+        onDidChangeInterpreterEmitter.fire({
+            resource: undefined,
+            startSession: false,
+            source: 'install-complete',
+        });
+        // Give the async listener a tick to run.
+        await new Promise((r) => setTimeout(r, 0));
+        sinon.assert.notCalled(selectSpy);
+    });
+
+    test('session-intent fire (startSession: true) calls selectLanguageRuntimeFromPath', async () => {
+        const interpreter = { path: '/path/to/python' } as PythonEnvironment;
+        interpreterService.setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny())).returns(() => Promise.resolve(interpreter));
+
+        onDidChangeInterpreterEmitter.fire({
+            resource: undefined,
+            startSession: true,
+            source: 'quickpick',
+        });
+        await new Promise((r) => setTimeout(r, 0));
+        sinon.assert.calledOnceWithExactly(selectSpy, '/path/to/python');
+    });
+
+    test('interpreter deletion: clears registry entry and shuts down matching sessions', async () => {
+        const deletedPath = '/path/to/deleted/python';
+        pythonRuntimeManager.registeredPythonRuntimes.set(deletedPath, {
+            runtimeId: 'r',
+            extraRuntimeData: { pythonPath: deletedPath },
+        } as any);
+
+        // Wait until matching session's shutdown is called (or time out).
+        let shutdownResolver: () => void = () => undefined;
+        const shutdownDone = new Promise<void>((resolve) => {
+            shutdownResolver = resolve;
+        });
+        const matchingSession = {
+            runtimeMetadata: { extraRuntimeData: { pythonPath: deletedPath } },
+            shutdown: sinon.stub().callsFake(async () => {
+                shutdownResolver();
+            }),
+        };
+        const otherSession = {
+            runtimeMetadata: { extraRuntimeData: { pythonPath: '/other/python' } },
+            shutdown: sinon.stub().resolves(),
+        };
+        getActiveSessionsImpl = async () => [matchingSession as any, otherSession as any];
+
+        onDidChangeInterpretersEmitter.fire({ old: { path: deletedPath } as any, new: undefined });
+        await Promise.race([shutdownDone, new Promise((r) => setTimeout(r, 500))]);
+
+        assert.strictEqual(pythonRuntimeManager.registeredPythonRuntimes.has(deletedPath), false);
+        sinon.assert.calledOnce(matchingSession.shutdown);
+        sinon.assert.notCalled(otherSession.shutdown);
+        sinon.assert.notCalled(selectSpy);
     });
 });

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -651,7 +651,9 @@ suite('Python runtime manager - onDidChangeInterpreter filter', () => {
 
     test('session-intent fire (startSession: true) calls selectLanguageRuntimeFromPath', async () => {
         const interpreter = { path: '/path/to/python' } as PythonEnvironment;
-        interpreterService.setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny())).returns(() => Promise.resolve(interpreter));
+        interpreterService
+            .setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(interpreter));
 
         onDidChangeInterpreterEmitter.fire({
             resource: undefined,

--- a/extensions/positron-python/src/test/positron/manager.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/manager.unit.test.ts
@@ -579,3 +579,114 @@ suite('Python runtime manager - recommendedWorkspaceRuntime', () => {
         assert.strictEqual(result?.extraRuntimeData?.pythonPath, venvPythonPath);
     });
 });
+
+// --- Start Positron ---
+suite('Python runtime manager - onDidChangeInterpreter filter', () => {
+    // Covers pet-bump-2b-event-split: storage-only fires must not spawn a console; user-intent
+    // fires must. See `.plans/pet-bump-2b-event-split.md`.
+
+    let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+    let interpreterService: TypeMoq.IMock<IInterpreterService>;
+    let disposableRegistry: TypeMoq.IMock<IDisposableRegistry>;
+    let onDidChangeInterpreterEmitter: vscode.EventEmitter<
+        import('../../client/interpreter/contracts').InterpreterChangeEvent
+    >;
+    let onDidChangeInterpretersEmitter: vscode.EventEmitter<
+        import('../../client/interpreter/contracts').PythonEnvironmentsChangedEvent
+    >;
+    let pythonRuntimeManager: PythonRuntimeManager;
+    let selectSpy: sinon.SinonStub;
+    let getActiveSessionsImpl: () => Promise<positron.LanguageRuntimeSession[]>;
+
+    setup(() => {
+        serviceContainer = createTypeMoq<IServiceContainer>();
+        interpreterService = createTypeMoq<IInterpreterService>();
+        disposableRegistry = createTypeMoq<IDisposableRegistry>();
+
+        const registryArray: IDisposable[] = [];
+        disposableRegistry
+            .setup((d) => d.push(TypeMoq.It.isAny()))
+            .callback((item: IDisposable) => registryArray.push(item));
+        serviceContainer.setup((s) => s.get(IDisposableRegistry)).returns(() => registryArray);
+
+        onDidChangeInterpreterEmitter = new vscode.EventEmitter();
+        onDidChangeInterpretersEmitter = new vscode.EventEmitter();
+        interpreterService.setup((i) => i.onDidChangeInterpreter).returns(() => onDidChangeInterpreterEmitter.event);
+        interpreterService.setup((i) => i.onDidChangeInterpreters).returns(() => onDidChangeInterpretersEmitter.event);
+
+        // positron.runtime may have getActiveSessions replaced by Object.assign in a prior test
+        // (e.g. languageServerManager). Assign directly so we read from our fixture regardless of
+        // that prior state. Each test overrides getActiveSessionsImpl.
+        getActiveSessionsImpl = async () => [];
+        Object.assign(positron.runtime, {
+            getActiveSessions: () => getActiveSessionsImpl(),
+        });
+
+        pythonRuntimeManager = new PythonRuntimeManager(serviceContainer.object, interpreterService.object);
+        selectSpy = sinon.stub(pythonRuntimeManager, 'selectLanguageRuntimeFromPath').resolves('runtime-id');
+    });
+
+    teardown(() => {
+        sinon.restore();
+        onDidChangeInterpreterEmitter.dispose();
+        onDidChangeInterpretersEmitter.dispose();
+    });
+
+    test('storage-only fire (startSession: false) does not call selectLanguageRuntimeFromPath', async () => {
+        onDidChangeInterpreterEmitter.fire({
+            resource: undefined,
+            startSession: false,
+            source: 'install-complete',
+        });
+        // Give the async listener a tick to run.
+        await new Promise((r) => setTimeout(r, 0));
+        sinon.assert.notCalled(selectSpy);
+    });
+
+    test('session-intent fire (startSession: true) calls selectLanguageRuntimeFromPath', async () => {
+        const interpreter = { path: '/path/to/python' } as PythonEnvironment;
+        interpreterService.setup((i) => i.getActiveInterpreter(TypeMoq.It.isAny())).returns(() => Promise.resolve(interpreter));
+
+        onDidChangeInterpreterEmitter.fire({
+            resource: undefined,
+            startSession: true,
+            source: 'quickpick',
+        });
+        await new Promise((r) => setTimeout(r, 0));
+        sinon.assert.calledOnceWithExactly(selectSpy, '/path/to/python');
+    });
+
+    test('interpreter deletion: clears registry entry and shuts down matching sessions', async () => {
+        const deletedPath = '/path/to/deleted/python';
+        pythonRuntimeManager.registeredPythonRuntimes.set(deletedPath, {
+            runtimeId: 'r',
+            extraRuntimeData: { pythonPath: deletedPath },
+        } as any);
+
+        // Wait until matching session's shutdown is called (or time out).
+        let shutdownResolver: () => void = () => undefined;
+        const shutdownDone = new Promise<void>((resolve) => {
+            shutdownResolver = resolve;
+        });
+        const matchingSession = {
+            runtimeMetadata: { extraRuntimeData: { pythonPath: deletedPath } },
+            shutdown: sinon.stub().callsFake(async () => {
+                shutdownResolver();
+            }),
+        };
+        const otherSession = {
+            runtimeMetadata: { extraRuntimeData: { pythonPath: '/other/python' } },
+            shutdown: sinon.stub().resolves(),
+        };
+        getActiveSessionsImpl = async () => [matchingSession as any, otherSession as any];
+
+        onDidChangeInterpretersEmitter.fire({ old: { path: deletedPath } as any, new: undefined });
+        await Promise.race([shutdownDone, new Promise((r) => setTimeout(r, 500))]);
+
+        assert.strictEqual(pythonRuntimeManager.registeredPythonRuntimes.has(deletedPath), false);
+        sinon.assert.calledOnce(matchingSession.shutdown);
+        sinon.assert.notCalled(otherSession.shutdown);
+        sinon.assert.notCalled(selectSpy);
+    });
+});
+// --- End Positron ---

--- a/extensions/positron-python/src/test/positron/session.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/session.unit.test.ts
@@ -221,6 +221,9 @@ suite('Python Runtime Session', () => {
             undefined,
             vscode.ConfigurationTarget.WorkspaceFolder,
             interpreter.path,
+            // Session start is a storage-only fire: the session is already starting here, so the
+            // PythonRuntimeManager listener must not start another one.
+            { startSession: false, source: 'positron-session-start' },
         );
     });
 

--- a/extensions/positron-python/src/test/vscode-mock.ts
+++ b/extensions/positron-python/src/test/vscode-mock.ts
@@ -194,6 +194,7 @@ mockedPositron.LanguageRuntimeStreamName = positronMocks.LanguageRuntimeStreamNa
 mockedPositron.RuntimeOnlineState = positronMocks.RuntimeOnlineState;
 mockedPositron.RuntimeState = positronMocks.RuntimeState;
 mockedPositron.LanguageRuntimeArchitecture = positronMocks.LanguageRuntimeArchitecture;
+mockedPositron.RuntimeExitReason = positronMocks.RuntimeExitReason;
 // --- End Positron ---
 
 // Mock TestController for vscode.tests namespace


### PR DESCRIPTION
Addresses #12116. Related to #12500. I think it also accidentally addresses https://github.com/posit-dev/positron/issues/8335 and https://github.com/posit-dev/positron/issues/9476 and addresses part of https://github.com/posit-dev/positron/issues/4556 and https://github.com/posit-dev/positron/issues/8405.

### Summary

Splits the python extension's `IInterpreterService.onDidChangeInterpreter` event into two intents, so that when it fires when we only want to change storage and _not_ start a session (autoselect, migration, post-install, active-env deletion, initial config apply) then it doesn't start a session.

Previously, `manager.ts` treated every fire as user intent and called `selectLanguageRuntimeFromPath`. Under PET 2026.2's slower / non-deterministic discovery, upstream code fires the event multiple times during activation with storage-update intent, producing a spurious Python console per fire. This is also reproducible post-startup (e.g. active-env deletion, installer completion).

The fix changes the payload from `Uri | undefined` to `{ resource, startSession, source }`. Fire sites declare whether the fire should start a session; the Positron runtime manager listener bails when `startSession` is false and logs the `source` tag. Other listeners (LSP restart, diagnostics, env-collection) continue to react to both.

As part of the active-env-deletion path, the runtime manager now also clears stale entries in `registeredPythonRuntimes` and shuts down any live sessions backed by the deleted interpreter. I think this will help a bunch of weird caching issues we've seen in the past!

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Stop spurious Python consoles from starting during extension activation and after active-env changes (#12116)

### QA Notes

@:interpreter @:sessions @:console @:new-folder-flow

Repro set (mirrors the scenarios verified on #12116):

1. **R project from New Folder wizard** → no Python console starts.
2. **Empty folder opened** → no Python console starts.
3. **Folder with only a `.py` file, no prior affiliation** → no Python console starts at startup.
4. **Workspace with an affiliated Python runtime** → Python console starts (via core's affiliated-runtime path).
5. **Mid-session: pick a new session** → new session starts.
6. I don't see the caching problems in https://github.com/posit-dev/positron/issues/8335 or https://github.com/posit-dev/positron/issues/9476 anymore, and the scary parts of https://github.com/posit-dev/positron/issues/4556 and https://github.com/posit-dev/positron/issues/8405 seem to be solved too 🙏 

Regression checks:
- LSP restart still fires on both storage-update and user-intent interpreter changes.
- Diagnostics (`UnsupportedPythonVersionService`, `installedPackagesDiagnostic`) still refresh on both.
- Terminal env-collection still updates on both.

To verify observability: open the `Python` output channel and confirm each interpreter change fire is logged with a `source=` tag (e.g. `quickpick`, `config-initial`, `install-complete`, `active-env-deleted`).
