### PR TITLE
Use non-interactive mode when executing code from Assistant

### DIFF
--- a/extensions/positron-assistant/src/tools.ts
+++ b/extensions/positron-assistant/src/tools.ts
@@ -263,7 +263,9 @@ export function registerAssistantTools(
 						options.input.code,
 						true,  // focus console
 						true,  // allow incomplete input, so that incomplete statements error right away
-						positron.RuntimeCodeExecutionMode.Interactive,
+						// Use non-interactive mode so that code doesn't get combined with
+						// anything pending in the console
+						positron.RuntimeCodeExecutionMode.NonInteractive,
 						positron.RuntimeErrorBehavior.Stop,
 						observer,
 						options.input.sessionIdentifier);


### PR DESCRIPTION
Quick change to address https://github.com/posit-dev/positron/issues/12730.

The problem is pretty simple; Assistant executions are being tagged as `Interactive` which gets combined with pending user input. The fix is to tag them as `NonInteractive` so we get the stash/replace behavior.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix issue causing pending console input to be combined with commands run from Assistant (#12730)