### PR TITLE
Assistant: remove preview tag from positAI provider config

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -867,9 +867,6 @@
             "type": "boolean",
             "default": true,
             "markdownDescription": "%configuration.provider.positAI.enable.description%",
-            "tags": [
-              "preview"
-            ],
             "order": 8
           },
           "positron.assistant.provider.google.enable": {


### PR DESCRIPTION
- addresses https://github.com/posit-dev/positron/issues/13120

### Release Notes

#### New Features

- Assistant: Posit AI provider is out of preview (#13120)

### QA Notes

No preview badge next to the config setting:

<img width="586" height="116" alt="image" src="https://github.com/user-attachments/assets/7a7ff835-644f-4f0a-8677-449f4aa3b3cf" />

Posit AI is enabled as a provider by default on desktop, but not enabled by default for Positron on Workbench.
