### PR TITLE
E2E test: wait for no startup messages with Jupyter browser launch

### DIFF
--- a/test/e2e/pages/jupyter/jupyter-lab.page.ts
+++ b/test/e2e/pages/jupyter/jupyter-lab.page.ts
@@ -60,6 +60,7 @@ export class JupyterLabPage {
 
 		// Wait for Positron to load
 		await page.waitForSelector('.monaco-workbench', { timeout: 60000 });
+		await this.positJupyter?.sessions.expectNoStartUpMessaging();
 	}
 
 	/**


### PR DESCRIPTION
Changes here don't yet affect positron, just positron-builds

### QA Notes


