### PR TITLE
Add preference for gallery switcher

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifest.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifest.ts
@@ -98,3 +98,7 @@ export function getExtensionGalleryManifestResourceUri(manifest: IExtensionGalle
 }
 
 export const ExtensionGalleryServiceUrlConfigKey = 'extensions.gallery.serviceUrl';
+
+// --- Start Positron ---
+export const PositronGallerySourceConfigKey = 'positron.extensions.gallerySource';
+// --- End Positron ---

--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
@@ -9,7 +9,9 @@ import { IProductService } from '../../product/common/productService.js';
 import { ExtensionGalleryResourceType, Flag, IExtensionGalleryManifest, IExtensionGalleryManifestService, ExtensionGalleryManifestStatus } from './extensionGalleryManifest.js';
 import { FilterType, SortBy } from './extensionManagement.js';
 
+// --- Start Positron ---
 export type ExtensionGalleryConfig = {
+	// --- End Positron ---
 	readonly serviceUrl: string;
 	readonly itemUrl: string;
 	readonly publisherUrl: string;

--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
@@ -9,7 +9,7 @@ import { IProductService } from '../../product/common/productService.js';
 import { ExtensionGalleryResourceType, Flag, IExtensionGalleryManifest, IExtensionGalleryManifestService, ExtensionGalleryManifestStatus } from './extensionGalleryManifest.js';
 import { FilterType, SortBy } from './extensionManagement.js';
 
-type ExtensionGalleryConfig = {
+export type ExtensionGalleryConfig = {
 	readonly serviceUrl: string;
 	readonly itemUrl: string;
 	readonly publisherUrl: string;
@@ -18,6 +18,30 @@ type ExtensionGalleryConfig = {
 	readonly controlUrl: string;
 	readonly nlsBaseUrl: string;
 };
+
+// --- Start Positron ---
+export const POSITRON_GALLERY_PRESETS: Record<string, ExtensionGalleryConfig> = {
+	'posit-p3m': {
+		serviceUrl: 'https://p3m.dev/openvsx/latest/vscode/gallery',
+		itemUrl: 'https://p3m.dev/openvsx/latest/vscode/item',
+		resourceUrlTemplate: 'https://p3m.dev/openvsx/latest/vscode/asset/{publisher}/{name}/{version}/Microsoft.VisualStudio.Code.WebResources/{path}',
+		controlUrl: '',
+		extensionUrlTemplate: 'https://p3m.dev/openvsx/latest/vscode/gallery/{publisher}/{name}/latest',
+		nlsBaseUrl: '',
+		publisherUrl: '',
+	},
+	'open-vsx': {
+		serviceUrl: 'https://open-vsx.org/vscode/gallery',
+		itemUrl: 'https://open-vsx.org/vscode/item',
+		resourceUrlTemplate: 'https://open-vsx.org/vscode/asset/{publisher}/{name}/{version}/Microsoft.VisualStudio.Code.WebResources/{path}',
+		controlUrl: '',
+		extensionUrlTemplate: 'https://open-vsx.org/vscode/gallery/{publisher}/{name}/latest',
+		nlsBaseUrl: '',
+		publisherUrl: '',
+	},
+};
+
+// --- End Positron ---
 
 export class ExtensionGalleryManifestService extends Disposable implements IExtensionGalleryManifestService {
 
@@ -35,8 +59,16 @@ export class ExtensionGalleryManifestService extends Disposable implements IExte
 		super();
 	}
 
+	// --- Start Positron ---
+	protected getGalleryConfig(): ExtensionGalleryConfig | undefined {
+		return this.productService.extensionsGallery as ExtensionGalleryConfig | undefined;
+	}
+	// --- End Positron ---
+
 	async getExtensionGalleryManifest(): Promise<IExtensionGalleryManifest | null> {
-		const extensionsGallery = this.productService.extensionsGallery as ExtensionGalleryConfig | undefined;
+		// --- Start Positron ---
+		const extensionsGallery = this.getGalleryConfig();
+		// --- End Positron ---
 		if (!extensionsGallery?.serviceUrl) {
 			return null;
 		}

--- a/src/vs/platform/extensionManagement/test/common/positronGalleryManifestService.vitest.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronGalleryManifestService.vitest.ts
@@ -1,0 +1,150 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { ExtensionGalleryManifestService, ExtensionGalleryConfig, POSITRON_GALLERY_PRESETS } from '../../common/extensionGalleryManifestService.js';
+import { ExtensionGalleryResourceType, getExtensionGalleryManifestResourceUri } from '../../common/extensionGalleryManifest.js';
+import { IProductService } from '../../../product/common/productService.js';
+
+function createProductService(extensionsGallery?: ExtensionGalleryConfig): IProductService {
+	// eslint-disable-next-line local/code-no-dangerous-type-assertions
+	return { _serviceBrand: undefined, extensionsGallery } as IProductService;
+}
+
+describe('POSITRON_GALLERY_PRESETS', () => {
+
+	it('should have posit-p3m preset with p3m.dev URLs', () => {
+		const preset = POSITRON_GALLERY_PRESETS['posit-p3m'];
+		expect(preset).toBeDefined();
+		expect(preset.serviceUrl).toBe('https://p3m.dev/openvsx/latest/vscode/gallery');
+		expect(preset.itemUrl).toBe('https://p3m.dev/openvsx/latest/vscode/item');
+		expect(preset.resourceUrlTemplate).toContain('p3m.dev');
+	});
+
+	it('should have open-vsx preset with open-vsx.org URLs', () => {
+		const preset = POSITRON_GALLERY_PRESETS['open-vsx'];
+		expect(preset).toBeDefined();
+		expect(preset.serviceUrl).toBe('https://open-vsx.org/vscode/gallery');
+		expect(preset.itemUrl).toBe('https://open-vsx.org/vscode/item');
+		expect(preset.resourceUrlTemplate).toContain('open-vsx.org');
+	});
+
+	it('should have all required fields in each preset', () => {
+		const requiredFields: (keyof ExtensionGalleryConfig)[] = [
+			'serviceUrl', 'itemUrl', 'publisherUrl', 'resourceUrlTemplate',
+			'extensionUrlTemplate', 'controlUrl', 'nlsBaseUrl',
+		];
+		for (const [name, preset] of Object.entries(POSITRON_GALLERY_PRESETS)) {
+			for (const field of requiredFields) {
+				expect(preset).toHaveProperty(field);
+			}
+			expect(preset.serviceUrl).toBeTruthy();
+			expect(preset.itemUrl).toBeTruthy();
+		}
+	});
+});
+
+describe('ExtensionGalleryManifestService', () => {
+
+	it('should return null when no gallery is configured', async () => {
+		const service = new ExtensionGalleryManifestService(createProductService());
+		const manifest = await service.getExtensionGalleryManifest();
+		expect(manifest).toBeNull();
+	});
+
+	it('should build manifest from product gallery config', async () => {
+		const service = new ExtensionGalleryManifestService(
+			createProductService(POSITRON_GALLERY_PRESETS['posit-p3m'])
+		);
+		const manifest = await service.getExtensionGalleryManifest();
+		expect(manifest).not.toBeNull();
+
+		const queryUrl = getExtensionGalleryManifestResourceUri(
+			manifest!, ExtensionGalleryResourceType.ExtensionQueryService
+		);
+		expect(queryUrl).toBe('https://p3m.dev/openvsx/latest/vscode/gallery/extensionquery');
+	});
+
+	it('should build manifest with open-vsx preset', async () => {
+		const service = new ExtensionGalleryManifestService(
+			createProductService(POSITRON_GALLERY_PRESETS['open-vsx'])
+		);
+		const manifest = await service.getExtensionGalleryManifest();
+		expect(manifest).not.toBeNull();
+
+		const queryUrl = getExtensionGalleryManifestResourceUri(
+			manifest!, ExtensionGalleryResourceType.ExtensionQueryService
+		);
+		expect(queryUrl).toBe('https://open-vsx.org/vscode/gallery/extensionquery');
+	});
+
+	it('should include item and resource URLs in manifest when configured', async () => {
+		const service = new ExtensionGalleryManifestService(
+			createProductService(POSITRON_GALLERY_PRESETS['open-vsx'])
+		);
+		const manifest = await service.getExtensionGalleryManifest();
+		expect(manifest).not.toBeNull();
+
+		const detailsUrl = getExtensionGalleryManifestResourceUri(
+			manifest!, ExtensionGalleryResourceType.ExtensionDetailsViewUri
+		);
+		expect(detailsUrl).toContain('open-vsx.org');
+
+		const resourceUrl = getExtensionGalleryManifestResourceUri(
+			manifest!, ExtensionGalleryResourceType.ExtensionResourceUri
+		);
+		expect(resourceUrl).toContain('open-vsx.org');
+	});
+
+	it('should omit publisher and item resources when URLs are empty', async () => {
+		const config: ExtensionGalleryConfig = {
+			serviceUrl: 'https://example.com/gallery',
+			itemUrl: '',
+			publisherUrl: '',
+			resourceUrlTemplate: '',
+			extensionUrlTemplate: '',
+			controlUrl: '',
+			nlsBaseUrl: '',
+		};
+		const service = new ExtensionGalleryManifestService(createProductService(config));
+		const manifest = await service.getExtensionGalleryManifest();
+		expect(manifest).not.toBeNull();
+
+		// Query service should always be present
+		const queryUrl = getExtensionGalleryManifestResourceUri(
+			manifest!, ExtensionGalleryResourceType.ExtensionQueryService
+		);
+		expect(queryUrl).toBe('https://example.com/gallery/extensionquery');
+
+		// Optional resources should be absent
+		const detailsUrl = getExtensionGalleryManifestResourceUri(
+			manifest!, ExtensionGalleryResourceType.ExtensionDetailsViewUri
+		);
+		expect(detailsUrl).toBeUndefined();
+
+		const publisherUrl = getExtensionGalleryManifestResourceUri(
+			manifest!, ExtensionGalleryResourceType.PublisherViewUri
+		);
+		expect(publisherUrl).toBeUndefined();
+
+		const resourceUrl = getExtensionGalleryManifestResourceUri(
+			manifest!, ExtensionGalleryResourceType.ExtensionResourceUri
+		);
+		expect(resourceUrl).toBeUndefined();
+	});
+
+	it('should report Available status when gallery is configured', () => {
+		const service = new ExtensionGalleryManifestService(
+			createProductService(POSITRON_GALLERY_PRESETS['posit-p3m'])
+		);
+		expect(service.extensionGalleryManifestStatus).toBe('available');
+	});
+
+	it('should report Unavailable status when gallery is not configured', () => {
+		const service = new ExtensionGalleryManifestService(createProductService());
+		expect(service.extensionGalleryManifestStatus).toBe('unavailable');
+	});
+});

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -25,7 +25,7 @@ import { CommandsRegistry, ICommandService } from '../../../../platform/commands
 import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService, IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
-import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService, PositronGallerySourceConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 import { EXTENSION_INSTALL_SOURCE_CONTEXT, ExtensionInstallSource, ExtensionRequestsTimeoutConfigKey, ExtensionsLocalizedLabel, FilterType, IExtensionGalleryService, IExtensionManagementService, PreferencesLocalizedLabel, SortBy, VerifyExtensionSignatureConfigKey } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { areSameExtensions, getIdAndVersion } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
 import { ExtensionStorageService } from '../../../../platform/extensionManagement/common/extensionStorage.js';
@@ -309,6 +309,24 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 					}
 				},
 			},
+			// --- Start Positron ---
+			[PositronGallerySourceConfigKey]: {
+				type: 'string',
+				enum: ['posit-p3m', 'open-vsx'],
+				enumDescriptions: [
+					localize('positron.extensions.gallerySource.positP3m', "Posit Public Package Manager (p3m.dev) - Posit's curated extension registry (default)"),
+					localize('positron.extensions.gallerySource.openVsx', "Open VSX Registry (open-vsx.org) - the upstream open-source extension registry"),
+				],
+				enumItemLabels: [
+					localize('positron.extensions.gallerySource.positP3m.label', "Posit Public Package Manager"),
+					localize('positron.extensions.gallerySource.openVsx.label', "Open VSX Registry"),
+				],
+				description: localize('positron.extensions.gallerySource', "Choose which extension gallery (marketplace) to use for browsing and installing extensions. Changes require a restart."),
+				default: 'posit-p3m',
+				scope: ConfigurationScope.APPLICATION,
+				tags: ['usesOnlineServices'],
+			},
+			// --- End Positron ---
 			'extensions.supportNodeGlobalNavigator': {
 				type: 'boolean',
 				description: localize('extensionsSupportNodeGlobalNavigator', "When enabled, Node.js navigator object is exposed on the global scope."),

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -25,7 +25,11 @@ import { CommandsRegistry, ICommandService } from '../../../../platform/commands
 import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { ContextKeyExpr, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService, IFileDialogService } from '../../../../platform/dialogs/common/dialogs.js';
-import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService, PositronGallerySourceConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { ExtensionGalleryManifestStatus, ExtensionGalleryResourceType, ExtensionGalleryServiceUrlConfigKey, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { PositronGallerySourceConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+// --- End Positron ---
 import { EXTENSION_INSTALL_SOURCE_CONTEXT, ExtensionInstallSource, ExtensionRequestsTimeoutConfigKey, ExtensionsLocalizedLabel, FilterType, IExtensionGalleryService, IExtensionManagementService, PreferencesLocalizedLabel, SortBy, VerifyExtensionSignatureConfigKey } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { areSameExtensions, getIdAndVersion } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
 import { ExtensionStorageService } from '../../../../platform/extensionManagement/common/extensionStorage.js';

--- a/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
@@ -9,8 +9,8 @@ import { IHeaders } from '../../../../base/parts/request/common/request.js';
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
-import { IExtensionGalleryManifestService, IExtensionGalleryManifest, ExtensionGalleryServiceUrlConfigKey, ExtensionGalleryManifestStatus } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
-import { ExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
+import { IExtensionGalleryManifestService, IExtensionGalleryManifest, ExtensionGalleryServiceUrlConfigKey, ExtensionGalleryManifestStatus, PositronGallerySourceConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+import { ExtensionGalleryManifestService, ExtensionGalleryConfig, POSITRON_GALLERY_PRESETS } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
 import { resolveMarketplaceHeaders } from '../../../../platform/externalServices/common/marketplace.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
@@ -74,6 +74,16 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 		});
 	}
 
+	// --- Start Positron ---
+	protected override getGalleryConfig(): ExtensionGalleryConfig | undefined {
+		const source = this.configurationService.getValue<string>(PositronGallerySourceConfigKey);
+		if (source === 'open-vsx') {
+			return POSITRON_GALLERY_PRESETS['open-vsx'];
+		}
+		return super.getGalleryConfig();
+	}
+	// --- End Positron ---
+
 	private extensionGalleryManifestPromise: Promise<void> | undefined;
 	override async getExtensionGalleryManifest(): Promise<IExtensionGalleryManifest | null> {
 		if (!this.extensionGalleryManifestPromise) {
@@ -99,6 +109,12 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 		}
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			// --- Start Positron ---
+			if (e.affectsConfiguration(PositronGallerySourceConfigKey)) {
+				this.requestRestart();
+				return;
+			}
+			// --- End Positron ---
 			if (!e.affectsConfiguration(ExtensionGalleryServiceUrlConfigKey)) {
 				return;
 			}

--- a/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
@@ -10,15 +10,7 @@ import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
 import { IExtensionGalleryManifestService, IExtensionGalleryManifest, ExtensionGalleryServiceUrlConfigKey, ExtensionGalleryManifestStatus } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
-// --- Start Positron ---
-// eslint-disable-next-line no-duplicate-imports
-import { PositronGallerySourceConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
-// --- End Positron ---
 import { ExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
-// --- Start Positron ---
-// eslint-disable-next-line no-duplicate-imports
-import { ExtensionGalleryConfig, POSITRON_GALLERY_PRESETS } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
-// --- End Positron ---
 import { resolveMarketplaceHeaders } from '../../../../platform/externalServices/common/marketplace.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
@@ -33,6 +25,13 @@ import { IRemoteAgentService } from '../../remote/common/remoteAgentService.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { IHostService } from '../../host/browser/host.js';
 import { IDefaultAccount } from '../../../../base/common/defaultAccount.js';
+
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { PositronGallerySourceConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+// eslint-disable-next-line no-duplicate-imports
+import { ExtensionGalleryConfig, POSITRON_GALLERY_PRESETS } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
+// --- End Positron ---
 
 export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryManifestService implements IExtensionGalleryManifestService {
 

--- a/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
@@ -9,8 +9,16 @@ import { IHeaders } from '../../../../base/parts/request/common/request.js';
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IEnvironmentService } from '../../../../platform/environment/common/environment.js';
-import { IExtensionGalleryManifestService, IExtensionGalleryManifest, ExtensionGalleryServiceUrlConfigKey, ExtensionGalleryManifestStatus, PositronGallerySourceConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
-import { ExtensionGalleryManifestService, ExtensionGalleryConfig, POSITRON_GALLERY_PRESETS } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
+import { IExtensionGalleryManifestService, IExtensionGalleryManifest, ExtensionGalleryServiceUrlConfigKey, ExtensionGalleryManifestStatus } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { PositronGallerySourceConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
+// --- End Positron ---
+import { ExtensionGalleryManifestService } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
+// --- Start Positron ---
+// eslint-disable-next-line no-duplicate-imports
+import { ExtensionGalleryConfig, POSITRON_GALLERY_PRESETS } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
+// --- End Positron ---
 import { resolveMarketplaceHeaders } from '../../../../platform/externalServices/common/marketplace.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
@@ -77,8 +85,9 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 	// --- Start Positron ---
 	protected override getGalleryConfig(): ExtensionGalleryConfig | undefined {
 		const source = this.configurationService.getValue<string>(PositronGallerySourceConfigKey);
-		if (source === 'open-vsx') {
-			return POSITRON_GALLERY_PRESETS['open-vsx'];
+		const preset = POSITRON_GALLERY_PRESETS[source];
+		if (preset) {
+			return preset;
 		}
 		return super.getGalleryConfig();
 	}


### PR DESCRIPTION
Address #12877 

### Release Notes
Adds a preference to switch back to OpenVSX for the extension gallery.

A preset preference has been added to change the extension gallery URL. This requires a restart after change and a notification will be presented to notify the user of this requirement.

<img width="606" height="215" alt="image" src="https://github.com/user-attachments/assets/27319770-eda8-4967-ac00-696c8cd0af8b" />

Currently installed extensions may present a notification that a manual update is required due to the metadata changing. This is a one-time switch each time the extension gallery URL changes.

<img width="590" height="208" alt="image" src="https://github.com/user-attachments/assets/baa08ef8-d1bd-4139-a897-70ed458c964a" />


#### New Features

- Add an extension gallery switcher to select OpenVSX or P3M

#### Bug Fixes

- N/A


### QA Notes