### PR TITLE
test(e2e): add Posit Assistant sign-in coverage per provider

### DIFF
--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -47,6 +47,7 @@ import { Notebooks } from '../pages/notebooks.js';
 import { PositronNotebooks } from '../pages/notebooksPositron.js';
 import { VsCodeNotebooks } from '../pages/notebooksVscode.js';
 import { PositAssistant } from '../pages/positAssistant.js';
+import { ModelProviderAuth } from '../pages/modelProviderAuth.js';
 import { InlineDataExplorer } from '../pages/inlineDataExplorer.js';
 import { InlineQuarto } from '../pages/inlineQuarto.js';
 import { Publisher } from '../pages/publisher.js';
@@ -100,6 +101,7 @@ export class Workbench {
 	readonly hotKeys: HotKeys;
 	readonly positConnect: PositConnect;
 	readonly positAssistant: PositAssistant;
+	readonly modelProviderAuth: ModelProviderAuth;
 	readonly inlineDataExplorer: InlineDataExplorer;
 	readonly inlineQuarto: InlineQuarto;
 	readonly publisher: Publisher;
@@ -148,6 +150,7 @@ export class Workbench {
 		this.assistant = new Assistant(code, this.quickaccess, this.toasts, this.modals);
 		this.positConnect = new PositConnect(code);
 		this.positAssistant = new PositAssistant(code);
+		this.modelProviderAuth = new ModelProviderAuth(code, this.modals);
 		this.inlineDataExplorer = new InlineDataExplorer(code.driver.page);
 		this.inlineQuarto = new InlineQuarto(code, this.quickaccess, this.hotKeys);
 		this.publisher = new Publisher(this.quickInput);

--- a/test/e2e/pages/modelProviderAuth.ts
+++ b/test/e2e/pages/modelProviderAuth.ts
@@ -1,0 +1,472 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, test, chromium, Browser, BrowserContext, Locator, Page } from '@playwright/test';
+import { Code } from '../infra/code';
+import { Modals } from './dialog-modals.js';
+import { HotKeys } from './hotKeys.js';
+
+// Page object for the shared "Configure Language Model Providers" component.
+// Both Positron Assistant and Posit Assistant use this component to
+// authenticate against model providers, so the auth flow is replicated here
+// independent of either assistant's page object.
+
+/**
+ * Fills an input element's value using evaluate() instead of Playwright's
+ * fill() to prevent the value from being recorded in Playwright trace files.
+ * Use this for sensitive values like API keys and passwords.
+ */
+async function fillSecretValue(locator: Locator, value: string): Promise<void> {
+	await locator.evaluate((el: HTMLInputElement, val) => {
+		const nativeSetter = Object.getOwnPropertyDescriptor(
+			window.HTMLInputElement.prototype, 'value'
+		)?.set;
+		if (nativeSetter) {
+			nativeSetter.call(el, val);
+		} else {
+			el.value = val;
+		}
+		el.dispatchEvent(new Event('input', { bubbles: true }));
+	}, value);
+}
+
+// Positron modal dialog selectors (used by Posit AI)
+const POSITRON_MODAL_DIALOG = '.positron-modal-dialog-box';
+
+// Configure Providers modal controls
+const APIKEY_INPUT = '#api-key-input input.text-input[type="password"]';
+const CLOSE_BUTTON = 'button.positron-button.action-bar-button.default:has-text("Close")';
+const SIGN_IN_BUTTON = 'button.positron-button.language-model.button.sign-in:has-text("Sign in")';
+const SIGN_OUT_BUTTON = 'button.positron-button.language-model.button.sign-in:has-text("Sign out")';
+const OAUTH_RADIO = '.language-model-authentication-method-container input#oauth[type="radio"]';
+const APIKEY_RADIO = '.language-model-authentication-method-container input#apiKey[type="radio"]';
+
+// Provider selection buttons
+const ANTHROPIC_BUTTON = 'button.positron-button.language-model.button:has(#anthropic-api-provider-button)';
+const AWS_BEDROCK_BUTTON = 'button.positron-button.language-model.button:has(#amazon-bedrock-provider-button)';
+const ECHO_MODEL_BUTTON = 'button.positron-button.language-model.button:has(div.codicon-info)';
+const ERROR_MODEL_BUTTON = 'button.positron-button.language-model.button:has(div.codicon-error)';
+const COPILOT_BUTTON = 'button.positron-button.language-model.button:has(#copilot-auth-provider-button)';
+const OPENAI_BUTTON = 'button.positron-button.language-model.button:has(#openai-api-provider-button)';
+const POSIT_AI_BUTTON = 'button.positron-button.language-model.button:has(#posit-ai-provider-button)';
+
+// Posit OAuth login page selectors
+const POSIT_EMAIL_FIELD = 'input[name="email"]';
+const POSIT_PASSWORD_FIELD = 'input[name="password"]';
+const POSIT_CONTINUE_BUTTON = 'button[type="submit"]:has-text("Continue")';
+const POSIT_LOGIN_BUTTON = 'button[type="submit"]:has-text("Log in")';
+
+/**
+ * Supported model providers for authentication.
+ */
+export type ModelProvider =
+	| 'anthropic-api'
+	| 'amazon-bedrock'
+	| 'Copilot'
+	| 'echo'
+	| 'error'
+	| 'openai-api'
+	| 'posit-ai';
+
+/**
+ * Authentication types for model providers.
+ */
+type ProviderAuthType = 'none' | 'apiKey' | 'aws' | 'oauth';
+
+/**
+ * Supported OAuth providers for device code flow.
+ */
+export type OAuthProvider = 'posit';
+
+/**
+ * Configuration for OAuth device code flow authentication.
+ */
+export interface OAuthDeviceCodeConfig {
+	/** The OAuth provider (e.g., 'posit') */
+	provider: OAuthProvider;
+	/** URL to navigate to for device code entry (empty if constructed from env var) */
+	verificationUrl: string;
+	/** Environment variable name for the auth host base URL (used to construct verification URL) */
+	authHostEnvVar?: string;
+	/** Environment variable names for credentials */
+	envVars: {
+		username: string;
+		password: string;
+		otp?: string;
+	};
+}
+
+/**
+ * Options for the loginModelProvider method.
+ */
+export interface LoginModelProviderOptions {
+	/** API key for providers that support API key authentication */
+	apiKey?: string;
+	/** Timeout for verifying sign-in success (default: 15000ms) */
+	timeout?: number;
+	/** Whether to run the OAuth browser in headless mode (default: false) */
+	headless?: boolean;
+}
+
+function getProviderAuthType(provider: ModelProvider): ProviderAuthType {
+	switch (provider.toLowerCase()) {
+		case 'echo':
+		case 'error':
+			return 'none';
+		case 'anthropic-api':
+		case 'openai-api':
+			return 'apiKey';
+		case 'amazon-bedrock':
+			return 'aws';
+		case 'posit-ai':
+			return 'oauth';
+		default:
+			throw new Error(`Unknown provider: ${provider}`);
+	}
+}
+
+function getOAuthConfig(provider: ModelProvider): OAuthDeviceCodeConfig {
+	switch (provider.toLowerCase()) {
+		case 'posit-ai':
+			return {
+				provider: 'posit',
+				verificationUrl: '',
+				authHostEnvVar: 'POSIT_AUTH_HOST',
+				envVars: {
+					username: 'POSIT_EMAIL',
+					password: 'POSIT_PASSWORD'
+				}
+			};
+		default:
+			throw new Error(`No OAuth configuration for provider: ${provider}`);
+	}
+}
+
+function getProviderEnvVarName(provider: ModelProvider): string {
+	switch (provider.toLowerCase()) {
+		case 'anthropic-api':
+			return 'ANTHROPIC_KEY';
+		case 'openai-api':
+			return 'OPENAI_KEY';
+		default:
+			return `${provider.toUpperCase().replace(/-/g, '_')}_KEY`;
+	}
+}
+
+function getProviderEnvKey(provider: ModelProvider): string | undefined {
+	return process.env[getProviderEnvVarName(provider)];
+}
+
+function getProviderAutoSignInEnvVarName(provider: ModelProvider): string | undefined {
+	switch (provider.toLowerCase()) {
+		case 'anthropic-api':
+			return 'ANTHROPIC_API_KEY';
+		case 'openai-api':
+			return 'OPENAI_API_KEY';
+		default:
+			return undefined;
+	}
+}
+
+function isProviderAutoSignedIn(provider: ModelProvider): boolean {
+	const envVarName = getProviderAutoSignInEnvVarName(provider);
+	return envVarName ? !!process.env[envVarName] : false;
+}
+
+/**
+ * Page object for the shared "Configure Language Model Providers" dialog.
+ * Used by both Positron Assistant and Posit Assistant to sign in and sign out
+ * of model providers.
+ */
+export class ModelProviderAuth {
+
+	private hotKeys: HotKeys;
+
+	constructor(private code: Code, private modals: Modals) {
+		this.hotKeys = new HotKeys(code);
+	}
+
+	/**
+	 * Opens the Configure Language Model Providers modal via the hotkey.
+	 */
+	async runConfigureProviders() {
+		await this.hotKeys.configureProviders();
+	}
+
+	/**
+	 * Clicks the provider tile in the Configure Providers modal.
+	 */
+	async selectModelProvider(provider: ModelProvider) {
+		switch (provider.toLowerCase()) {
+			case 'anthropic-api':
+				await this.code.driver.page.locator(ANTHROPIC_BUTTON).click();
+				break;
+			case 'amazon-bedrock':
+				await this.code.driver.page.locator(AWS_BEDROCK_BUTTON).click();
+				break;
+			case 'copilot':
+				await this.code.driver.page.locator(COPILOT_BUTTON).click();
+				break;
+			case 'echo':
+				await this.code.driver.page.locator(ECHO_MODEL_BUTTON).click();
+				break;
+			case 'error':
+				await this.code.driver.page.locator(ERROR_MODEL_BUTTON).click();
+				break;
+			case 'openai-api':
+				await this.code.driver.page.locator(OPENAI_BUTTON).click();
+				break;
+			case 'posit-ai':
+				await this.code.driver.page.locator(POSIT_AI_BUTTON).click();
+				break;
+			default:
+				throw new Error(`Unsupported model provider: ${provider}`);
+		}
+	}
+
+	/**
+	 * Signs in to a model provider with the appropriate authentication method.
+	 * If the provider is auto-signed-in via environment variable (e.g., ANTHROPIC_API_KEY),
+	 * the sign-in steps are skipped.
+	 *
+	 * @param provider - The model provider to sign in to
+	 * @param options.apiKey - API key for API-key providers; falls back to *_KEY env var
+	 * @param options.timeout - Timeout for verifying sign-in success (default: 15000ms)
+	 * @param options.headless - Whether the OAuth browser runs headless (default: false)
+	 */
+	async loginModelProvider(provider: ModelProvider, options: LoginModelProviderOptions = {}) {
+		const { timeout = 15000 } = options;
+
+		if (isProviderAutoSignedIn(provider)) {
+			return;
+		}
+
+		await test.step(`Sign in to ${provider} model provider`, async () => {
+			await this.hotKeys.configureProviders();
+
+			await this.selectModelProvider(provider);
+
+			const alreadySignedIn = await this.code.driver.page.locator(SIGN_OUT_BUTTON).isVisible();
+			if (alreadySignedIn) {
+				await this.clickCloseButton();
+				return;
+			}
+
+			const authType = getProviderAuthType(provider);
+
+			switch (authType) {
+				case 'none':
+					await this.clickSignInButton();
+					break;
+
+				case 'apiKey': {
+					const apiKey = options.apiKey ?? getProviderEnvKey(provider);
+					if (!apiKey) {
+						throw new Error(
+							`No API key provided for ${provider}. ` +
+							`Set the ${getProviderEnvVarName(provider)} environment variable or pass apiKey in options.`
+						);
+					}
+					await this.enterApiKey(apiKey);
+					await this.clickSignInButton();
+					break;
+				}
+
+				case 'aws':
+					await this.clickSignInButton();
+					break;
+
+				case 'oauth': {
+					const oauthConfig = getOAuthConfig(provider);
+					await this.completeOAuthDeviceCodeFlow(oauthConfig, options);
+					break;
+				}
+
+				default:
+					throw new Error(`Unknown authentication type for provider: ${provider}`);
+			}
+
+			await this.verifySignOutButtonVisible(timeout);
+			await this.clickCloseButton();
+		});
+	}
+
+	/**
+	 * Signs out from a model provider. If the provider is auto-signed-in via
+	 * environment variable, the sign-out steps are skipped.
+	 */
+	async logoutModelProvider(provider: ModelProvider, options: { timeout?: number } = {}) {
+		const { timeout = 15000 } = options;
+
+		if (isProviderAutoSignedIn(provider)) {
+			return;
+		}
+
+		await test.step(`Sign out from ${provider} model provider`, async () => {
+			await this.runConfigureProviders();
+			await this.selectModelProvider(provider);
+			await this.clickSignOutButton();
+			await this.verifySignInButtonVisible(timeout);
+			await this.clickCloseButton();
+		});
+	}
+
+	async enterApiKey(apiKey: string) {
+		await this.code.driver.page.locator(APIKEY_RADIO).check();
+		const apiKeyInput = this.code.driver.page.locator(APIKEY_INPUT);
+		await fillSecretValue(apiKeyInput, apiKey);
+	}
+
+	async clickSignInButton() {
+		await this.code.driver.page.locator(SIGN_IN_BUTTON).click();
+	}
+
+	async clickSignOutButton() {
+		await this.code.driver.page.locator(SIGN_OUT_BUTTON).click();
+	}
+
+	async clickCloseButton({ abandonChanges = true } = {}) {
+		await this.code.driver.page.locator(CLOSE_BUTTON).click();
+
+		const abandonModalisVisible = await this.modals.modalTitle.filter({ hasText: 'Authentication Incomplete' }).isVisible();
+		if (abandonModalisVisible) {
+			abandonChanges
+				? await this.modals.getButton('Yes').click()
+				: await this.modals.getButton('No').click();
+		}
+
+		await this.modals.expectToBeVisible(undefined, { visible: false });
+	}
+
+	async verifySignOutButtonVisible(timeout: number = 15000) {
+		await expect(this.code.driver.page.locator(SIGN_OUT_BUTTON)).toBeVisible({ timeout });
+		await expect(this.code.driver.page.locator(SIGN_OUT_BUTTON)).toHaveText('Sign out', { timeout });
+	}
+
+	async verifySignInButtonVisible(timeout: number = 15000) {
+		await expect(this.code.driver.page.locator(SIGN_IN_BUTTON)).toBeVisible({ timeout });
+		await expect(this.code.driver.page.locator(SIGN_IN_BUTTON)).toHaveText('Sign in', { timeout });
+	}
+
+	async verifyAuthMethod(type: 'oauth' | 'apiKey') {
+		switch (type) {
+			case 'oauth':
+				await expect(this.code.driver.page.locator(OAUTH_RADIO)).toBeChecked();
+				await expect(this.code.driver.page.locator(APIKEY_RADIO)).toBeDisabled();
+				break;
+			case 'apiKey':
+				await expect(this.code.driver.page.locator(APIKEY_RADIO)).toBeChecked();
+				await expect(this.code.driver.page.locator(OAUTH_RADIO)).toBeDisabled();
+				break;
+			default:
+				throw new Error(`Unsupported auth method: ${type}`);
+		}
+	}
+
+	/**
+	 * Completes an OAuth device code flow by launching a separate browser,
+	 * signing in to the OAuth provider, and entering the verification code.
+	 */
+	async completeOAuthDeviceCodeFlow(config: OAuthDeviceCodeConfig, options: LoginModelProviderOptions = {}) {
+		const { headless = false } = options;
+
+		await test.step(`Complete OAuth device code flow for ${config.provider}`, async () => {
+			await this.clickSignInButton();
+
+			const { verificationCode } = await this.extractDeviceCodeFromModal(config);
+
+			let finalVerificationUrl = config.verificationUrl;
+
+			if (!finalVerificationUrl && config.authHostEnvVar) {
+				const authHost = process.env[config.authHostEnvVar];
+				if (!authHost) {
+					throw new Error(
+						`OAuth auth host not configured. Please set ${config.authHostEnvVar} environment variable.`
+					);
+				}
+				const redirectPath = encodeURIComponent(`/oauth/device?user_code=${verificationCode}`);
+				finalVerificationUrl = `${authHost}/login?redirect=${redirectPath}`;
+			}
+
+			if (!finalVerificationUrl) {
+				throw new Error('No verification URL available for OAuth flow');
+			}
+
+			let browser: Browser | undefined;
+			let context: BrowserContext | undefined;
+			let page: Page | undefined;
+
+			try {
+				browser = await chromium.launch({ headless });
+				context = await browser.newContext();
+				page = await context.newPage();
+
+				await this.completePositLogin(page, config, verificationCode, finalVerificationUrl);
+			} finally {
+				if (context) {
+					await context.close();
+				}
+				if (browser) {
+					await browser.close();
+				}
+			}
+		});
+	}
+
+	private async extractDeviceCodeFromModal(_config: OAuthDeviceCodeConfig): Promise<{ verificationCode: string }> {
+		const deviceCodeModalLocator = this.code.driver.page.locator(`${POSITRON_MODAL_DIALOG}:has-text("You will need this code to sign in")`);
+		await expect(deviceCodeModalLocator).toBeVisible({ timeout: 30000 });
+
+		const modalHtml = await deviceCodeModalLocator.innerHTML();
+		if (!modalHtml) {
+			throw new Error('Could not read Positron device code modal content');
+		}
+
+		const codeMatch = modalHtml.match(/<code>([A-Z0-9-]+)<\/code>/i);
+		if (!codeMatch) {
+			throw new Error(`Could not extract verification code from Positron modal: "${modalHtml}"`);
+		}
+
+		const verificationCode = codeMatch[1];
+
+		const okButton = deviceCodeModalLocator.locator('button:has-text("OK"), button:has-text("Ok")');
+		await okButton.click();
+
+		return { verificationCode };
+	}
+
+	private async completePositLogin(page: Page, config: OAuthDeviceCodeConfig, _verificationCode: string, verificationUrl: string) {
+		const email = process.env[config.envVars.username];
+		const password = process.env[config.envVars.password];
+
+		if (!email || !password) {
+			throw new Error(
+				`Posit OAuth credentials not found. Please set ${config.envVars.username} and ${config.envVars.password} environment variables.`
+			);
+		}
+
+		await page.goto(verificationUrl);
+
+		await expect(page.locator(POSIT_EMAIL_FIELD)).toBeVisible({ timeout: 15000 });
+		await page.locator(POSIT_EMAIL_FIELD).fill(email);
+		await page.locator(POSIT_CONTINUE_BUTTON).click();
+
+		await expect(page.locator(POSIT_PASSWORD_FIELD)).toBeVisible({ timeout: 15000 });
+		await fillSecretValue(page.locator(POSIT_PASSWORD_FIELD), password);
+		await page.locator(POSIT_LOGIN_BUTTON).click();
+
+		const continueButton = page.locator('button[type="submit"]:has-text("Continue")');
+		await expect(continueButton).toBeVisible({ timeout: 15000 });
+		await continueButton.click();
+
+		const authorizeButton = page.locator('button[type="submit"]:has-text("Authorize")');
+		await expect(authorizeButton).toBeVisible({ timeout: 15000 });
+		await authorizeButton.click();
+
+		await expect(page.locator('body')).toContainText(/success|authorized|complete|congratulations/i, { timeout: 30000 });
+
+		await page.close();
+	}
+}

--- a/test/e2e/pages/modelProviderAuth.ts
+++ b/test/e2e/pages/modelProviderAuth.ts
@@ -48,7 +48,6 @@ const ANTHROPIC_BUTTON = 'button.positron-button.language-model.button:has(#anth
 const AWS_BEDROCK_BUTTON = 'button.positron-button.language-model.button:has(#amazon-bedrock-provider-button)';
 const ECHO_MODEL_BUTTON = 'button.positron-button.language-model.button:has(div.codicon-info)';
 const ERROR_MODEL_BUTTON = 'button.positron-button.language-model.button:has(div.codicon-error)';
-const COPILOT_BUTTON = 'button.positron-button.language-model.button:has(#copilot-auth-provider-button)';
 const OPENAI_BUTTON = 'button.positron-button.language-model.button:has(#openai-api-provider-button)';
 const POSIT_AI_BUTTON = 'button.positron-button.language-model.button:has(#posit-ai-provider-button)';
 
@@ -64,7 +63,6 @@ const POSIT_LOGIN_BUTTON = 'button[type="submit"]:has-text("Log in")';
 export type ModelProvider =
 	| 'anthropic-api'
 	| 'amazon-bedrock'
-	| 'Copilot'
 	| 'echo'
 	| 'error'
 	| 'openai-api'
@@ -205,9 +203,6 @@ export class ModelProviderAuth {
 				break;
 			case 'amazon-bedrock':
 				await this.code.driver.page.locator(AWS_BEDROCK_BUTTON).click();
-				break;
-			case 'copilot':
-				await this.code.driver.page.locator(COPILOT_BUTTON).click();
 				break;
 			case 'echo':
 				await this.code.driver.page.locator(ECHO_MODEL_BUTTON).click();
@@ -370,6 +365,8 @@ export class ModelProviderAuth {
 	 * signing in to the OAuth provider, and entering the verification code.
 	 */
 	async completeOAuthDeviceCodeFlow(config: OAuthDeviceCodeConfig, options: LoginModelProviderOptions = {}) {
+		// The Posit login page does not render in headless Chromium, so the
+		// default is headed. Callers may override per-invocation.
 		const { headless = false } = options;
 
 		await test.step(`Complete OAuth device code flow for ${config.provider}`, async () => {
@@ -426,7 +423,10 @@ export class ModelProviderAuth {
 
 		const codeMatch = modalHtml.match(/<code>([A-Z0-9-]+)<\/code>/i);
 		if (!codeMatch) {
-			throw new Error(`Could not extract verification code from Positron modal: "${modalHtml}"`);
+			// Do not embed modalHtml in the error: it contains the device code
+			// and other auth UI content that would otherwise leak into
+			// Playwright traces and CI logs.
+			throw new Error('Could not extract verification code from Positron device code modal (no <code> element found)');
 		}
 
 		const verificationCode = codeMatch[1];

--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -32,6 +32,10 @@ const CHAT_INPUT = 'textarea[placeholder="Ask Posit Assistant... Type / to see c
 const SEND_BUTTON = 'button:has(svg.lucide-arrow-up)';
 const STOP_BUTTON = 'button:has(svg.lucide-square)';
 
+// Chat-form overflow (...) menu — hosts the model picker for providers
+// (like OpenAI) that do not auto-select a default model.
+const CHAT_FORM_OVERFLOW_BUTTON = '.chat-form button[aria-haspopup="menu"]:has(svg.lucide-ellipsis)';
+
 // Chat message elements
 const CHAT_MESSAGE_USER = '.chat-message-user';
 const CHAT_MESSAGE_ASSISTANT = '.chat-message-assistant';
@@ -204,6 +208,47 @@ export class PositAssistant {
 	async waitForResponseComplete(timeout: number = 60000): Promise<void> {
 		await this.frame.locator(STOP_BUTTON).waitFor({ state: 'visible' });
 		await this.frame.locator(STOP_BUTTON).waitFor({ state: 'hidden', timeout });
+	}
+
+	// --- Model selection ---
+
+	/**
+	 * Selects a model for the current conversation.
+	 *
+	 * In narrow viewports the Posit Assistant renders the model picker in
+	 * "menu mode" (see `ModelSelector.tsx`). The chat-form overflow (`...`)
+	 * menu contains a `DropdownMenuSub` whose trigger has two spans:
+	 * `"Model"` (label) and either the currently-selected model name or
+	 * `"Select"` (value when none is selected). Clicking the trigger opens
+	 * a submenu with provider groups and their models.
+	 *
+	 * Each model is a `role="menuitem"` whose display name lives in a
+	 * child `<span class="flex-1">`; the accessible name of the menuitem
+	 * includes decorations (check icon column, trailing note/multiplier),
+	 * so we match on the span text instead.
+	 *
+	 * Some providers auto-pick a default and do not need this call. Models
+	 * beyond the initial slice are hidden behind a "More models" inline
+	 * disclosure — add that fallback when a test needs a non-top-tier model.
+	 *
+	 * @param modelName Exact model name as displayed in the menu (e.g. "GPT-5.4 Mini").
+	 */
+	async selectModel(modelName: string): Promise<void> {
+		// 1. Open the chat-form overflow menu.
+		await this.frame.locator(CHAT_FORM_OVERFLOW_BUTTON).click();
+
+		// 2. Open the "Model" submenu. The SubTrigger is identifiable as a
+		//    menuitem with aria-haspopup="menu" that contains the literal
+		//    "Model" label span; that label is stable across states.
+		await this.frame.locator('[role="menuitem"][aria-haspopup="menu"]:has(span:text-is("Model"))').click();
+
+		// 3. Click the desired model. `:text-is()` is exact-match so
+		//    "GPT-5.4" does not collide with "GPT-5.4 Mini".
+		await this.frame.locator(`[role="menuitem"]:has(span.flex-1:text-is("${modelName}"))`).click();
+
+		// Menu closes on selection; wait for the trigger to collapse so
+		// subsequent actions (e.g. Send) don't race an open overlay.
+		await expect(this.frame.locator(CHAT_FORM_OVERFLOW_BUTTON)).toHaveAttribute('aria-expanded', 'false');
 	}
 
 	// --- Chat messages ---

--- a/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
@@ -4,14 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test, tags } from '../_test.setup';
-import { ModelProvider } from '../../pages/positronAssistant';
+import { ModelProvider } from '../../pages/modelProviderAuth';
 
 test.use({
 	suiteId: __filename
 });
 
-// Posit Assistant and Positron Assistant share the same model provider
-// configuration and sign-in flow, so we reuse the `ModelProvider` type.
 const POSIT_ASSISTANT_SIGNIN_PROVIDERS: ModelProvider[] = [
 	'anthropic-api',
 	// 'openai-api',
@@ -25,7 +23,7 @@ test.describe('Posit Assistant Sign-in', {
 
 	for (const provider of POSIT_ASSISTANT_SIGNIN_PROVIDERS) {
 		test(`${provider} - Sign in, send hello, sign out`, async function ({ app }) {
-			await app.workbench.assistant.loginModelProvider(provider);
+			await app.workbench.modelProviderAuth.loginModelProvider(provider);
 
 			try {
 				await app.workbench.positAssistant.open();
@@ -37,7 +35,7 @@ test.describe('Posit Assistant Sign-in', {
 				const responseText = await app.workbench.positAssistant.getLastResponseText();
 				test.expect(responseText.length).toBeGreaterThan(0);
 			} finally {
-				await app.workbench.assistant.logoutModelProvider(provider);
+				await app.workbench.modelProviderAuth.logoutModelProvider(provider);
 			}
 		});
 	}

--- a/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../_test.setup';
+import { ModelProvider } from '../../pages/positronAssistant';
+
+test.use({
+	suiteId: __filename
+});
+
+// Posit Assistant and Positron Assistant share the same model provider
+// configuration and sign-in flow, so we reuse the `ModelProvider` type.
+const POSIT_ASSISTANT_SIGNIN_PROVIDERS: ModelProvider[] = [
+	'anthropic-api',
+	// 'openai-api',
+	// 'amazon-bedrock',
+	'posit-ai',
+];
+
+test.describe('Posit Assistant Sign-in', {
+	tag: [tags.POSIT_ASSISTANT, tags.ASSISTANT, tags.WEB, tags.WIN],
+}, () => {
+
+	for (const provider of POSIT_ASSISTANT_SIGNIN_PROVIDERS) {
+		test(`${provider} - Sign in, send hello, sign out`, async function ({ app }) {
+			await app.workbench.assistant.loginModelProvider(provider);
+
+			try {
+				await app.workbench.positAssistant.open();
+				await app.workbench.positAssistant.waitForReady();
+
+				await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: true });
+				await app.workbench.positAssistant.expectResponseVisible();
+
+				const responseText = await app.workbench.positAssistant.getLastResponseText();
+				test.expect(responseText.length).toBeGreaterThan(0);
+			} finally {
+				await app.workbench.assistant.logoutModelProvider(provider);
+			}
+		});
+	}
+});

--- a/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts
@@ -12,8 +12,8 @@ test.use({
 
 const POSIT_ASSISTANT_SIGNIN_PROVIDERS: ModelProvider[] = [
 	'anthropic-api',
-	// 'openai-api',
-	// 'amazon-bedrock',
+	'openai-api',
+	'amazon-bedrock',
 	'posit-ai',
 ];
 
@@ -28,8 +28,17 @@ test.describe('Posit Assistant Sign-in', {
 			try {
 				await app.workbench.positAssistant.open();
 				await app.workbench.positAssistant.waitForReady();
+				await app.workbench.positAssistant.startNewConversation();
 
-				await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: true });
+				if (provider === 'openai-api') {
+					// OpenAI does not auto-select a default model, so pick one
+					// explicitly. `newConversation: false` avoids starting a
+					// fresh chat after model selection, which would drop it.
+					await app.workbench.positAssistant.selectModel('GPT-5.4');
+					await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: false });
+				} else {
+					await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: true });
+				}
 				await app.workbench.positAssistant.expectResponseVisible();
 
 				const responseText = await app.workbench.positAssistant.getLastResponseText();


### PR DESCRIPTION
### Summary

Adds end-to-end coverage for Posit Assistant model-provider sign-in. For each supported provider (`anthropic-api`, `openai-api`, `amazon-bedrock`, `posit-ai`), the test signs in via the shared Configure Language Model Providers flow, opens Posit Assistant, sends a hello message, verifies a response, and signs out.

Supporting refactors:

- **New `ModelProviderAuth` page object.** Extracts the shared sign-in/sign-out flow out of `positronAssistant.ts` so Posit Assistant tests don't depend on the Positron Assistant POM for auth. The original `Assistant` class keeps its auth methods unchanged, so existing Positron Assistant tests are unaffected.
- **New `PositAssistant.selectModel(name)` helper.** Drives the chat-form overflow (`...`) → "Model" submenu → model item flow. Needed for providers like OpenAI that do not auto-select a default model.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:posit-assistant @:assistant @:web @:win

Covered by the new `test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts` file. Each per-provider test requires the provider's credential env var(s) to be set locally (`ANTHROPIC_KEY`/`ANTHROPIC_API_KEY`, `OPENAI_KEY`/`OPENAI_API_KEY`, AWS creds, `POSIT_EMAIL` + `POSIT_PASSWORD` + `POSIT_AUTH_HOST`).