### PR TITLE
Only enable interrupt when kernel is busy

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
@@ -220,9 +220,9 @@ registerAction2(class InterruptKernelAction extends Action2 {
 			title: localize2('quarto.interruptKernel', "Interrupt Kernel"),
 			category: QUARTO_CATEGORY,
 			f1: true,
-			precondition: QUARTO_PRECONDITION,
+			precondition: ContextKeyExpr.and(QUARTO_PRECONDITION, QUARTO_KERNEL_BUSY),
 			keybinding: {
-				when: QUARTO_PRECONDITION,
+				when: ContextKeyExpr.and(QUARTO_PRECONDITION, QUARTO_KERNEL_BUSY),
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyCode.Escape,
 			},


### PR DESCRIPTION
Addresses #13153. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Quarto inline output: disable "Interrupt Kernel" when kernel isn't running or busy (#13153)


