### PR TITLE
Use the language runtime quickpick in the notebook kernel selectors

### DIFF
--- a/src/vs/test/vitest/testQuickPick.ts
+++ b/src/vs/test/vitest/testQuickPick.ts
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Emitter } from '../../base/common/event.js';
+import { Disposable } from '../../base/common/lifecycle.js';
+import { IQuickInputHideEvent, IQuickPick, IQuickPickItem, QuickInputHideReason, QuickPickInput } from '../../platform/quickinput/common/quickInput.js';
+import { stubInterface } from './stubInterface.js';
+
+/**
+ * Test double for `IQuickPick<T>`. Implements the surface that test-driven
+ * picker flows actually exercise -- settable state, the two events the helper
+ * waits on (`onDidAccept` / `onDidHide`), `show` / `hide` spies, and a couple
+ * of convenience methods for driving user actions. Properties not explicitly
+ * implemented here throw on read (via `stubInterface`) when the test tries
+ * to use them, so growing dependencies are caught instead of silently passing
+ * `undefined`.
+ *
+ * Wire it into the `IQuickInputService` stub:
+ *
+ * ```ts
+ * let pick: TestQuickPick<IQuickPickItem>;
+ *
+ * const ctx = createTestContainer()
+ *     .withRuntimeServices()
+ *     .stub(IQuickInputService, stubInterface<IQuickInputService>({
+ *         createQuickPick: () => pick.asQuickPick(),
+ *     }))
+ *     .build();
+ *
+ * beforeEach(() => {
+ *     pick = ctx.disposables.add(new TestQuickPick<IQuickPickItem>());
+ * });
+ *
+ * it('resolves to the selected runtime', async () => {
+ *     const promise = runHelperUnderTest();
+ *     await vi.waitFor(() => expect(pick.show).toHaveBeenCalled());
+ *
+ *     pick.accept(pick.items.find(i => i.id === 'wanted')!);
+ *     await expect(promise).resolves.toEqual(...);
+ * });
+ * ```
+ *
+ * If your test needs a property not implement here (e.g. `step`, `buttons`,
+ * `onDidTriggerButton`), add it here. The goal is for this to stay reusable
+ * as more pickers adopt it.
+ */
+export class TestQuickPick<T extends IQuickPickItem> extends Disposable {
+
+	private readonly _onDidAccept = this._register(new Emitter<void>());
+	private readonly _onDidHide = this._register(new Emitter<IQuickInputHideEvent>());
+	private readonly _onDidChangeActive = this._register(new Emitter<readonly T[]>());
+	private readonly _onDidChangeSelection = this._register(new Emitter<readonly T[]>());
+
+	title: string | undefined;
+	placeholder: string | undefined;
+	description: string | undefined;
+	canSelectMany = false;
+	items: ReadonlyArray<QuickPickInput<T>> = [];
+	activeItems: ReadonlyArray<T> = [];
+	selectedItems: ReadonlyArray<T> = [];
+	busy = false;
+	enabled = true;
+	matchOnDescription = false;
+	matchOnDetail = false;
+	matchOnLabel = true;
+	sortByLabel = true;
+
+	readonly onDidAccept = this._onDidAccept.event;
+	readonly onDidHide = this._onDidHide.event;
+	readonly onDidChangeActive = this._onDidChangeActive.event;
+	readonly onDidChangeSelection = this._onDidChangeSelection.event;
+
+	/** Spy: the helper calls `show()` once setup is complete. Tests typically
+	 *  await `vi.waitFor(() => expect(pick.show).toHaveBeenCalled())` to
+	 *  synchronize on "picker is open and ready for interaction." */
+	readonly show = vi.fn();
+
+	/** Spy: the helper calls `hide()` after accepting. We mirror the real
+	 *  picker's behavior by firing `onDidHide` so the helper's hide-handler
+	 *  (which runs the resolve flow) actually runs. */
+	readonly hide = vi.fn((): void => {
+		this._onDidHide.fire({ reason: QuickInputHideReason.Other });
+	});
+
+	/** Simulate the user accepting `item`: sets activeItems and selectedItems
+	 *  (mirroring the real QuickPick's single-select on-accept behavior), then
+	 *  fires onDidAccept. */
+	accept(item: T): void {
+		this.activeItems = [item];
+		this.selectedItems = [item];
+		this._onDidAccept.fire();
+	}
+
+	/** Simulate the user dismissing the picker. */
+	cancel(reason: QuickInputHideReason = QuickInputHideReason.Other): void {
+		this._onDidHide.fire({ reason });
+	}
+
+	/**
+	 * Wrap this double in a `stubInterface`-backed `IQuickPick<T>` so that:
+	 *   - The properties this class implements are reachable by the helper.
+	 *   - Reads of properties this class does NOT implement throw with a
+	 *     clear error (instead of returning `undefined` silently).
+	 *
+	 * Use in a `createQuickPick` stub:
+	 *   `createQuickPick: () => pick.asQuickPick()`
+	 */
+	asQuickPick(): IQuickPick<T> {
+		// `stubInterface` will complain about missing properties, so we have to
+		//  cast `this` to `Partial<IQuickPick<T>>` to tell it "these properties
+		//  are implemented, just not declared on the class." We then assert the
+		//  full `IQuickPick<T>` return type to satisfy the `createQuickPick`
+		//  contract.
+		return stubInterface<IQuickPick<T>>(this as unknown as Partial<IQuickPick<T>>);
+	}
+}

--- a/src/vs/test/vitest/testQuickPick.vitest.ts
+++ b/src/vs/test/vitest/testQuickPick.vitest.ts
@@ -1,0 +1,105 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { IQuickPickItem, QuickInputHideReason } from '../../platform/quickinput/common/quickInput.js';
+import { ensureNoLeakedDisposables } from './vitestUtils.js';
+import { TestQuickPick } from './testQuickPick.js';
+
+describe('TestQuickPick', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	it('starts with empty default state', () => {
+		const pick = disposables.add(new TestQuickPick<IQuickPickItem>());
+
+		expect(pick.title).toBeUndefined();
+		expect(pick.items).toEqual([]);
+		expect(pick.activeItems).toEqual([]);
+		expect(pick.selectedItems).toEqual([]);
+		expect(pick.canSelectMany).toBe(false);
+		expect(pick.busy).toBe(false);
+	});
+
+	it('accept() sets selectedItems and fires onDidAccept', () => {
+		const pick = disposables.add(new TestQuickPick<IQuickPickItem>());
+		const acceptSpy = vi.fn();
+		disposables.add(pick.onDidAccept(acceptSpy));
+
+		const item: IQuickPickItem = { id: 'one', label: 'One' };
+		pick.accept(item);
+
+		expect(pick.activeItems).toEqual([item]);
+		expect(pick.selectedItems).toEqual([item]);
+		expect(acceptSpy).toHaveBeenCalledOnce();
+	});
+
+	it('cancel() fires onDidHide with Other by default', () => {
+		const pick = disposables.add(new TestQuickPick<IQuickPickItem>());
+		const hideSpy = vi.fn();
+		disposables.add(pick.onDidHide(hideSpy));
+
+		pick.cancel();
+
+		expect(hideSpy).toHaveBeenCalledExactlyOnceWith({ reason: QuickInputHideReason.Other });
+	});
+
+	it('cancel() forwards the supplied reason', () => {
+		const pick = disposables.add(new TestQuickPick<IQuickPickItem>());
+		const hideSpy = vi.fn();
+		disposables.add(pick.onDidHide(hideSpy));
+
+		pick.cancel(QuickInputHideReason.Gesture);
+
+		expect(hideSpy).toHaveBeenCalledExactlyOnceWith({ reason: QuickInputHideReason.Gesture });
+	});
+
+	it('hide() fires onDidHide so callers that hide(after-accept) get the resolve signal', () => {
+		const pick = disposables.add(new TestQuickPick<IQuickPickItem>());
+		const hideSpy = vi.fn();
+		disposables.add(pick.onDidHide(hideSpy));
+
+		pick.hide();
+
+		expect(pick.hide).toHaveBeenCalledOnce();
+		expect(hideSpy).toHaveBeenCalledOnce();
+	});
+
+	it('show() is a spy that does not fire any event by itself', () => {
+		const pick = disposables.add(new TestQuickPick<IQuickPickItem>());
+		const acceptSpy = vi.fn();
+		const hideSpy = vi.fn();
+		disposables.add(pick.onDidAccept(acceptSpy));
+		disposables.add(pick.onDidHide(hideSpy));
+
+		pick.show();
+
+		expect(pick.show).toHaveBeenCalledOnce();
+		expect(acceptSpy).not.toHaveBeenCalled();
+		expect(hideSpy).not.toHaveBeenCalled();
+	});
+
+	it('asQuickPick() returns a proxy that delegates reads/writes to the underlying instance', () => {
+		const pick = disposables.add(new TestQuickPick<IQuickPickItem>());
+		const stub = pick.asQuickPick();
+
+		stub.title = 'pick something';
+		expect(pick.title).toBe('pick something');
+
+		const items = [{ id: 'a', label: 'A' }];
+		stub.items = items;
+		expect(pick.items).toEqual(items);
+	});
+
+	it('asQuickPick() throws on reads of properties the double does not implement', () => {
+		const pick = disposables.add(new TestQuickPick<IQuickPickItem>());
+		const stub = pick.asQuickPick();
+
+		// `step` is on IQuickPick but not implemented by TestQuickPick, so
+		// stubInterface throws on read. Catches "helper grew a new
+		// dependency" without us having to update every test.
+		expect(() => stub.step).toThrow(/test read property 'step'/);
+	});
+});

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -374,12 +374,18 @@ const createInterpreterGroups = (
  * This can be used to start a session for a registered language runtime.
  *
  * @param accessor The service accessor.
- * @returns
+ * @param options Picker options.
+ * @param options.title Title shown in the quickpick header.
+ * @param options.languageId Restricts the runtimes shown in the picker
+ *   to the provided language id. When omittedm all languages are shown.
+ * @returns The selected runtime metadata, or undefined if the user
+ *   cancelled.
  */
 export const selectNewLanguageRuntime = async (
 	accessor: ServicesAccessor,
 	options?: {
 		title?: string;
+		languageId?: string;
 	}): Promise<ILanguageRuntimeMetadata | undefined> => {
 	// Access services.
 	const quickInputService = accessor.get(IQuickInputService);
@@ -397,7 +403,7 @@ export const selectNewLanguageRuntime = async (
 			contributionResults = [];
 			return;
 		}
-		const contributions = languageRuntimeService.getPickerContributions();
+		const contributions = languageRuntimeService.getPickerContributions(options?.languageId);
 		// Fetch items from all contributions in parallel
 		contributionResults = await Promise.all(
 			contributions.map(async (contribution) => {
@@ -419,8 +425,9 @@ export const selectNewLanguageRuntime = async (
 		contributedItemMap.clear();
 
 		// Group runtimes by language. Re-evaluated on each rebuild so newly
-		// registered runtimes show up.
-		const interpreterGroups = createInterpreterGroups(languageRuntimeService, runtimeStartupService);
+		// registered runtimes show up. Restricted to options.languageId when set.
+		const interpreterGroups = createInterpreterGroups(languageRuntimeService, runtimeStartupService)
+			.filter(group => !options?.languageId || group.primaryRuntime.languageId === options.languageId);
 
 		// Add separator for suggested runtimes
 		const suggestedRuntimes = interpreterGroups

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -377,7 +377,10 @@ const createInterpreterGroups = (
  * @param options Picker options.
  * @param options.title Title shown in the quickpick header.
  * @param options.languageId Restricts the runtimes shown in the picker
- *   to the provided language id. When omittedm all languages are shown.
+ *   to the provided language id. When omitted all languages are shown.
+ * @param options.currentRuntimeId Runtime id to focus when the picker
+ *   opens initially. Only applied to the initial list so subsequent
+ *   rebuilds don't overwrite the user's keyboard navigation.
  * @returns The selected runtime metadata, or undefined if the user
  *   cancelled.
  */
@@ -386,6 +389,7 @@ export const selectNewLanguageRuntime = async (
 	options?: {
 		title?: string;
 		languageId?: string;
+		currentRuntimeId?: string;
 	}): Promise<ILanguageRuntimeMetadata | undefined> => {
 	// Access services.
 	const quickInputService = accessor.get(IQuickInputService);
@@ -548,12 +552,42 @@ export const selectNewLanguageRuntime = async (
 	const quickPick = disposables.add(quickInputService.createQuickPick<IQuickPickItem>({ useSeparators: true }));
 	quickPick.title = options?.title || localize('positron.languageRuntime.startSession', 'Start New Interpreter Session');
 	quickPick.canSelectMany = false;
+
+	// Reassigning quickPick.items resets activeItems to the first row, so
+	// rebuilds via this helper preserve the previously focused item (whether
+	// it was the caller's currentRuntimeId or a row the user keyboard-
+	// navigated to). Falls back to the default reset if the previous item
+	// is no longer present.
+	const rebuildItems = () => {
+		const previouslyActiveId = quickPick.activeItems[0]?.id;
+		quickPick.items = buildItems();
+		if (previouslyActiveId) {
+			const stillPresent = quickPick.items.find(
+				(item): item is IQuickPickItem => item.type !== 'separator' && item.id === previouslyActiveId
+			);
+			if (stillPresent) {
+				quickPick.activeItems = [stillPresent];
+			}
+		}
+	};
+
 	quickPick.items = buildItems();
+
+	// Pre-focus the caller-supplied current runtime, if any. Subsequent
+	// rebuilds carry this forward via rebuildItems' restore logic.
+	if (options?.currentRuntimeId) {
+		const currentItem = quickPick.items.find(
+			(item): item is IQuickPickItem => item.type !== 'separator' && item.id === options.currentRuntimeId
+		);
+		if (currentItem) {
+			quickPick.activeItems = [currentItem];
+		}
+	}
 
 	// Rebuild when a new runtime registers - covers late initial discovery
 	// and post-startup rediscovery.
 	disposables.add(languageRuntimeService.onDidRegisterRuntime(() => {
-		quickPick.items = buildItems();
+		rebuildItems();
 	}));
 
 	// If startup completes while the picker is open, re-fetch contributions
@@ -561,7 +595,7 @@ export const selectNewLanguageRuntime = async (
 	disposables.add(languageRuntimeService.onDidChangeRuntimeStartupPhase(async phase => {
 		if (phase === RuntimeStartupPhase.Complete) {
 			await fetchContributedItems();
-			quickPick.items = buildItems();
+			rebuildItems();
 		}
 	}));
 

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -376,7 +376,7 @@ const createInterpreterGroups = (
  * @param accessor The service accessor.
  * @returns
  */
-const selectNewLanguageRuntime = async (
+export const selectNewLanguageRuntime = async (
 	accessor: ServicesAccessor,
 	options?: {
 		title?: string;

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -383,32 +383,11 @@ export const selectNewLanguageRuntime = async (
 	}): Promise<ILanguageRuntimeMetadata | undefined> => {
 	// Access services.
 	const quickInputService = accessor.get(IQuickInputService);
-	const runtimeSessionService = accessor.get(IRuntimeSessionService);
 	const runtimeStartupService = accessor.get(IRuntimeStartupService);
 	const languageRuntimeService = accessor.get(ILanguageRuntimeService);
 
 	// Group runtimes by language.
 	const interpreterGroups = createInterpreterGroups(languageRuntimeService, runtimeStartupService);
-
-	// Grab the current runtime.
-	const currentRuntime = runtimeSessionService.foregroundSession?.runtimeMetadata;
-
-	// Grab the active runtimes.
-	const activeRuntimes = runtimeSessionService.activeSessions
-		// Sort by last used, descending.
-		.sort((a, b) => b.lastUsed - a.lastUsed)
-		// Map from session to runtime metadata.
-		.map(session => session.runtimeMetadata)
-		// Remove duplicates, and current runtime.
-		.filter((runtime, index, runtimes) =>
-			runtime.runtimeId !== currentRuntime?.runtimeId && runtimes.findIndex(r => r.runtimeId === runtime.runtimeId) === index
-		);
-
-	// Add current runtime first, if present.
-	// Allows for "plus" + enter behavior to clone session.
-	if (currentRuntime) {
-		activeRuntimes.unshift(currentRuntime);
-	}
 
 	// Generate quick pick items for runtimes.
 	const runtimeItems: QuickPickItem[] = [];
@@ -497,7 +476,6 @@ export const selectNewLanguageRuntime = async (
 						iconPath: {
 							dark: URI.parse(`data:image/svg+xml;base64, ${runtime.base64EncodedIconSvg}`),
 						},
-						picked: (runtime.runtimeId === runtimeSessionService.foregroundSession?.runtimeMetadata.runtimeId),
 						neverShowWhenFiltered: false
 					});
 				});

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -13,7 +13,7 @@ import { IQuickInputService, IQuickPickItem, QuickPickItem } from '../../../../p
 import { IKeybindingRule, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { LANGUAGE_RUNTIME_ACTION_CATEGORY } from '../common/languageRuntime.js';
 import { IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
-import { ILanguageRuntimeMetadata, ILanguageRuntimeService, LanguageRuntimeSessionMode, RuntimeCodeExecutionMode, RuntimeErrorBehavior, RuntimeStartupPhase, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService, IRuntimePickerContribution, IRuntimePickerItem, LanguageRuntimeSessionMode, RuntimeCodeExecutionMode, RuntimeErrorBehavior, RuntimeStartupPhase, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionService, RuntimeClientType, RuntimeStartMode } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
@@ -389,112 +389,20 @@ export const selectNewLanguageRuntime = async (
 	// Group runtimes by language.
 	const interpreterGroups = createInterpreterGroups(languageRuntimeService, runtimeStartupService);
 
-	// Generate quick pick items for runtimes.
-	const runtimeItems: QuickPickItem[] = [];
-
-	// Add separator for suggested runtimes
-	const suggestedRuntimes = interpreterGroups
-		.map(group => group.primaryRuntime);
-
-	if (suggestedRuntimes.length > 0) {
-		runtimeItems.push({
-			type: 'separator',
-			label: localize('positron.languageRuntime.suggestedRuntimes', 'Suggested')
-		});
-
-		suggestedRuntimes.forEach(runtime => {
-			runtimeItems.push({
-				id: runtime.runtimeId,
-				label: runtime.runtimeName,
-				detail: runtime.runtimePath,
-				iconPath: {
-					dark: URI.parse(`data:image/svg+xml;base64, ${runtime.base64EncodedIconSvg}`),
-				},
-				neverShowWhenFiltered: true
-			});
-		});
-	}
-
-
-	interpreterGroups.forEach(group => {
-		// Group runtimes by environment type
-		const runtimesByEnvType = new Map<string, ILanguageRuntimeMetadata[]>();
-		const allRuntimes = [group.primaryRuntime, ...group.alternateRuntimes];
-
-		allRuntimes.forEach(runtime => {
-			const envType = `${runtime.runtimeSource}`;
-			if (!runtimesByEnvType.has(envType)) {
-				runtimesByEnvType.set(envType, []);
-			}
-			runtimesByEnvType.get(envType)!.push(runtime);
-
-		});
-
-		const envTypes = Array.from(runtimesByEnvType.keys());
-
-		// Sort runtimes by version (decreasing), then alphabetically
-		envTypes.forEach(envType => {
-			runtimeItems.push({ type: 'separator', label: envType });
-			runtimesByEnvType.get(envType)!
-				.sort((a, b) => {
-					// If both have version numbers, compare them
-					if (a.languageVersion && b.languageVersion) {
-						const aVersion = a.languageVersion.split('.').map(Number);
-						const bVersion = b.languageVersion.split('.').map(Number);
-
-						// Always list unsupported versions last
-						if (!(a.extraRuntimeData as { supported?: boolean })?.supported) {
-							return 1;
-						}
-						if (!(b.extraRuntimeData as { supported?: boolean })?.supported) {
-							return -1;
-						}
-						// Compare major version
-						if (aVersion[0] !== bVersion[0]) {
-							return bVersion[0] - aVersion[0];
-						}
-
-						// Compare minor version
-						if (aVersion[1] !== bVersion[1]) {
-							return bVersion[1] - aVersion[1];
-						}
-
-						// Compare patch version
-						if (aVersion[2] !== bVersion[2]) {
-							return bVersion[2] - aVersion[2];
-						}
-					}
-
-					// If versions are equal or not found, sort alphabetically
-					return a.runtimeName.localeCompare(b.runtimeName);
-				})
-				.forEach(runtime => {
-					runtimeItems.push({
-						id: runtime.runtimeId,
-						label: runtime.runtimeName,
-						detail: runtime.runtimePath,
-						iconPath: {
-							dark: URI.parse(`data:image/svg+xml;base64, ${runtime.base64EncodedIconSvg}`),
-						},
-						neverShowWhenFiltered: false
-					});
-				});
-
-		});
-	});
-
-	// Get contributed items from extensions (e.g., "Install Python via uv")
 	// Map to track which contribution owns which item
-	const contributedItemMap = new Map<string, { contribution: { handle: number; onSelect: (itemId: string) => Promise<string | undefined> }; originalId: string }>();
+	const contributedItemMap = new Map<string, { contribution: IRuntimePickerContribution; originalId: string }>();
+	let contributionResults: { contribution: IRuntimePickerContribution; items: IRuntimePickerItem[] }[] = [];
 
-	// Only show contributed items after discovery is complete
-	// TODO: right now, these are added to the end of the list, but we may want to
-	// group by language in the future
-	if (languageRuntimeService.startupPhase === RuntimeStartupPhase.Complete) {
+	// Get contributed items from extensions (e.g., "Install Python via uv").
+	// Only show contributed items after discovery is complete.
+	const fetchContributedItems = async () => {
+		if (languageRuntimeService.startupPhase !== RuntimeStartupPhase.Complete) {
+			contributionResults = [];
+			return;
+		}
 		const contributions = languageRuntimeService.getPickerContributions();
-
 		// Fetch items from all contributions in parallel
-		const contributionResults = await Promise.all(
+		contributionResults = await Promise.all(
 			contributions.map(async (contribution) => {
 				try {
 					const items = await contribution.getItems();
@@ -506,24 +414,128 @@ export const selectNewLanguageRuntime = async (
 				}
 			})
 		);
+	};
 
-		for (const { contribution, items } of contributionResults) {
-			for (const item of items) {
+	const buildItems = (): QuickPickItem[] => {
+		// Generate quick pick items for runtimes.
+		const items: QuickPickItem[] = [];
+		contributedItemMap.clear();
+
+		// Add separator for suggested runtimes
+		const suggestedRuntimes = interpreterGroups
+			.map(group => group.primaryRuntime);
+
+		if (suggestedRuntimes.length > 0) {
+			items.push({
+				type: 'separator',
+				label: localize('positron.languageRuntime.suggestedRuntimes', 'Suggested')
+			});
+
+			suggestedRuntimes.forEach(runtime => {
+				items.push({
+					id: runtime.runtimeId,
+					label: runtime.runtimeName,
+					detail: runtime.runtimePath,
+					iconPath: {
+						dark: URI.parse(`data:image/svg+xml;base64, ${runtime.base64EncodedIconSvg}`),
+					},
+					neverShowWhenFiltered: true
+				});
+			});
+		}
+
+
+		interpreterGroups.forEach(group => {
+			// Group runtimes by environment type
+			const runtimesByEnvType = new Map<string, ILanguageRuntimeMetadata[]>();
+			const allRuntimes = [group.primaryRuntime, ...group.alternateRuntimes];
+
+			allRuntimes.forEach(runtime => {
+				const envType = `${runtime.runtimeSource}`;
+				if (!runtimesByEnvType.has(envType)) {
+					runtimesByEnvType.set(envType, []);
+				}
+				runtimesByEnvType.get(envType)!.push(runtime);
+
+			});
+
+			const envTypes = Array.from(runtimesByEnvType.keys());
+
+			// Sort runtimes by version (decreasing), then alphabetically
+			envTypes.forEach(envType => {
+				items.push({ type: 'separator', label: envType });
+				runtimesByEnvType.get(envType)!
+					.sort((a, b) => {
+						// If both have version numbers, compare them
+						if (a.languageVersion && b.languageVersion) {
+							const aVersion = a.languageVersion.split('.').map(Number);
+							const bVersion = b.languageVersion.split('.').map(Number);
+
+							// Always list unsupported versions last
+							if (!(a.extraRuntimeData as { supported?: boolean })?.supported) {
+								return 1;
+							}
+							if (!(b.extraRuntimeData as { supported?: boolean })?.supported) {
+								return -1;
+							}
+							// Compare major version
+							if (aVersion[0] !== bVersion[0]) {
+								return bVersion[0] - aVersion[0];
+							}
+
+							// Compare minor version
+							if (aVersion[1] !== bVersion[1]) {
+								return bVersion[1] - aVersion[1];
+							}
+
+							// Compare patch version
+							if (aVersion[2] !== bVersion[2]) {
+								return bVersion[2] - aVersion[2];
+							}
+						}
+
+						// If versions are equal or not found, sort alphabetically
+						return a.runtimeName.localeCompare(b.runtimeName);
+					})
+					.forEach(runtime => {
+						items.push({
+							id: runtime.runtimeId,
+							label: runtime.runtimeName,
+							detail: runtime.runtimePath,
+							iconPath: {
+								dark: URI.parse(`data:image/svg+xml;base64, ${runtime.base64EncodedIconSvg}`),
+							},
+							neverShowWhenFiltered: false
+						});
+					});
+
+			});
+		});
+
+		// TODO: right now, these are added to the end of the list, but we may want to
+		// group by language in the future
+		for (const { contribution, items: contribItems } of contributionResults) {
+			for (const item of contribItems) {
 				// Create a unique ID for this item that includes the contribution handle
 				const uniqueId = `${CONTRIBUTED_ITEM_PREFIX}${contribution.handle}_${item.id}`;
 				contributedItemMap.set(uniqueId, { contribution, originalId: item.id });
 
 				if (item.separatorLabel) {
-					runtimeItems.push({ type: 'separator', label: item.separatorLabel });
+					items.push({ type: 'separator', label: item.separatorLabel });
 				}
-				runtimeItems.push({
+				items.push({
 					id: uniqueId,
 					label: item.label,
 					detail: item.detail,
 				});
 			}
 		}
-	}
+
+		return items;
+	};
+
+	await fetchContributedItems();
+	const runtimeItems = buildItems();
 
 	const selectedRuntime = await quickInputService.pick(runtimeItems, {
 		title: options?.title || localize('positron.languageRuntime.startSession', 'Start New Interpreter Session'),

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -603,7 +603,11 @@ export const selectNewLanguageRuntime = async (
 		let accepted: IQuickPickItem | undefined;
 
 		disposables.add(quickPick.onDidAccept(() => {
-			accepted = quickPick.selectedItems[0];
+			const selected = quickPick.activeItems[0];
+			if (!selected) {
+				return;
+			}
+			accepted = selected;
 			quickPick.hide();
 		}));
 

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -21,7 +21,7 @@ import { IModelService } from '../../../../editor/common/services/model.js';
 import { getSessionDisplayName, getSessionIconClasses, isQuartoSession } from '../../positronConsole/common/sessionDisplayUtils.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
-import { dispose } from '../../../../base/common/lifecycle.js';
+import { DisposableStore, dispose } from '../../../../base/common/lifecycle.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ExplorerFolderContext } from '../../files/common/files.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -386,9 +386,6 @@ export const selectNewLanguageRuntime = async (
 	const runtimeStartupService = accessor.get(IRuntimeStartupService);
 	const languageRuntimeService = accessor.get(ILanguageRuntimeService);
 
-	// Group runtimes by language.
-	const interpreterGroups = createInterpreterGroups(languageRuntimeService, runtimeStartupService);
-
 	// Map to track which contribution owns which item
 	const contributedItemMap = new Map<string, { contribution: IRuntimePickerContribution; originalId: string }>();
 	let contributionResults: { contribution: IRuntimePickerContribution; items: IRuntimePickerItem[] }[] = [];
@@ -420,6 +417,10 @@ export const selectNewLanguageRuntime = async (
 		// Generate quick pick items for runtimes.
 		const items: QuickPickItem[] = [];
 		contributedItemMap.clear();
+
+		// Group runtimes by language. Re-evaluated on each rebuild so newly
+		// registered runtimes show up.
+		const interpreterGroups = createInterpreterGroups(languageRuntimeService, runtimeStartupService);
 
 		// Add separator for suggested runtimes
 		const suggestedRuntimes = interpreterGroups
@@ -535,37 +536,73 @@ export const selectNewLanguageRuntime = async (
 	};
 
 	await fetchContributedItems();
-	const runtimeItems = buildItems();
 
-	const selectedRuntime = await quickInputService.pick(runtimeItems, {
-		title: options?.title || localize('positron.languageRuntime.startSession', 'Start New Interpreter Session'),
-		canPickMany: false
-	});
+	const disposables = new DisposableStore();
+	const quickPick = disposables.add(quickInputService.createQuickPick<IQuickPickItem>({ useSeparators: true }));
+	quickPick.title = options?.title || localize('positron.languageRuntime.startSession', 'Start New Interpreter Session');
+	quickPick.canSelectMany = false;
+	quickPick.items = buildItems();
 
-	if (!selectedRuntime?.id) {
-		return undefined;
-	}
+	// Rebuild when a new runtime registers - covers late initial discovery
+	// and post-startup rediscovery.
+	disposables.add(languageRuntimeService.onDidRegisterRuntime(() => {
+		quickPick.items = buildItems();
+	}));
 
-	// Handle contributed items
-	if (selectedRuntime.id.startsWith(CONTRIBUTED_ITEM_PREFIX)) {
-		const contributedItem = contributedItemMap.get(selectedRuntime.id);
-		if (contributedItem) {
-			try {
-				const runtimeId = await contributedItem.contribution.onSelect(contributedItem.originalId);
-				if (runtimeId) {
-					// Use quiet mode to suppress notifications since the picker
-					// contribution already handled registration.
-					await runtimeStartupService.rediscoverAllRuntimes(/* quiet */ true);
-					return languageRuntimeService.getRegisteredRuntime(runtimeId);
-				}
-			} catch (error) {
-				console.error(`Failed to handle contributed item selection: ${error}`);
-			}
+	// If startup completes while the picker is open, re-fetch contributions
+	// (which we previously skipped) and rebuild.
+	disposables.add(languageRuntimeService.onDidChangeRuntimeStartupPhase(async phase => {
+		if (phase === RuntimeStartupPhase.Complete) {
+			await fetchContributedItems();
+			quickPick.items = buildItems();
 		}
-		return undefined;
-	}
+	}));
 
-	return languageRuntimeService.getRegisteredRuntime(selectedRuntime.id);
+	return new Promise<ILanguageRuntimeMetadata | undefined>(resolve => {
+		let accepted: IQuickPickItem | undefined;
+
+		disposables.add(quickPick.onDidAccept(() => {
+			accepted = quickPick.selectedItems[0];
+			quickPick.hide();
+		}));
+
+		disposables.add(quickPick.onDidHide(async () => {
+			const selectedRuntime = accepted;
+			disposables.dispose();
+
+			if (!selectedRuntime?.id) {
+				resolve(undefined);
+				return;
+			}
+
+			// Handle contributed items
+			if (selectedRuntime.id.startsWith(CONTRIBUTED_ITEM_PREFIX)) {
+				const contributedItem = contributedItemMap.get(selectedRuntime.id);
+				if (!contributedItem) {
+					resolve(undefined);
+					return;
+				}
+				try {
+					const runtimeId = await contributedItem.contribution.onSelect(contributedItem.originalId);
+					if (runtimeId) {
+						// Use quiet mode to suppress notifications since the picker
+						// contribution already handled registration.
+						await runtimeStartupService.rediscoverAllRuntimes(/* quiet */ true);
+						resolve(languageRuntimeService.getRegisteredRuntime(runtimeId));
+						return;
+					}
+				} catch (error) {
+					console.error(`Failed to handle contributed item selection: ${error}`);
+				}
+				resolve(undefined);
+				return;
+			}
+
+			resolve(languageRuntimeService.getRegisteredRuntime(selectedRuntime.id));
+		}));
+
+		quickPick.show();
+	});
 };
 
 /**

--- a/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
+++ b/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
@@ -1,0 +1,401 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
+import { IQuickInputService, IQuickPickItem, QuickInputHideReason } from '../../../../../platform/quickinput/common/quickInput.js';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService, IRuntimePickerContribution, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, RuntimeStartupPhase } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { IRuntimeStartupService } from '../../../../services/runtimeStartup/common/runtimeStartupService.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { TestQuickPick } from '../../../../../test/vitest/testQuickPick.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { selectNewLanguageRuntime } from '../../browser/languageRuntimeActions.js';
+
+function makeRuntime(overrides: Partial<ILanguageRuntimeMetadata> = {}): ILanguageRuntimeMetadata {
+	const languageId = overrides.languageId ?? 'python';
+	const base: ILanguageRuntimeMetadata = {
+		extensionId: new ExtensionIdentifier('test-extension'),
+		base64EncodedIconSvg: '',
+		extraRuntimeData: { supported: true },
+		runtimeId: `${languageId}-${Math.random().toString(36).slice(2)}`,
+		runtimePath: '/usr/bin/test',
+		runtimeVersion: '0.0.0',
+		sessionLocation: LanguageRuntimeSessionLocation.Browser,
+		startupBehavior: LanguageRuntimeStartupBehavior.Implicit,
+		languageId,
+		languageName: 'Python',
+		languageVersion: '3.12.0',
+		runtimeName: 'Python 3.12 (System)',
+		runtimeShortName: '3.12',
+		runtimeSource: 'System',
+	};
+	return { ...base, ...overrides };
+}
+
+describe('selectNewLanguageRuntime', () => {
+	let preferredByLanguage: Map<string, ILanguageRuntimeMetadata>;
+	// `pick` is reassigned in beforeEach (and once mid-test in the title fallback
+	// case). The IQuickInputService stub captures it by closure so each
+	// createQuickPick() call returns whichever double is current.
+	let pick: TestQuickPick<IQuickPickItem>;
+
+	// Stubbed at describe scope so vi.spyOn can attach in individual tests.
+	const rediscoverAllRuntimes = vi.fn(async (_quiet?: boolean) => undefined);
+
+	const ctx = createTestContainer()
+		.withRuntimeServices()
+		.stub(IRuntimeStartupService, {
+			getPreferredRuntime: (langId: string) => preferredByLanguage.get(langId),
+			rediscoverAllRuntimes,
+		})
+		.stub(IQuickInputService, stubInterface<IQuickInputService>({
+			createQuickPick: () => pick.asQuickPick(),
+		}))
+		.build();
+
+	beforeEach(() => {
+		preferredByLanguage = new Map();
+		pick = ctx.disposables.add(new TestQuickPick<IQuickPickItem>());
+		// Default to Complete so contribution-fetching path runs unless a test overrides.
+		ctx.get(ILanguageRuntimeService).setStartupPhase(RuntimeStartupPhase.Complete);
+	});
+
+	function runPicker(options?: Parameters<typeof selectNewLanguageRuntime>[1]) {
+		return ctx.instantiationService.invokeFunction(accessor => selectNewLanguageRuntime(accessor, options));
+	}
+
+	// The helper does `await fetchContributedItems()` before setting up the
+	// picker, so the items array isn't populated until pick.show() is called.
+	// Poll until that happens before reading items / firing events from tests.
+	async function waitUntilOpened(): Promise<void> {
+		await vi.waitFor(() => expect(pick.show).toHaveBeenCalled());
+	}
+
+	function registerRuntime(metadata: ILanguageRuntimeMetadata): ILanguageRuntimeMetadata {
+		ctx.disposables.add(ctx.get(ILanguageRuntimeService).registerRuntime(metadata));
+		if (!preferredByLanguage.has(metadata.languageId)) {
+			preferredByLanguage.set(metadata.languageId, metadata);
+		}
+		return metadata;
+	}
+
+	function pickItemById(id: string): IQuickPickItem | undefined {
+		return pick.items.find(
+			(item): item is IQuickPickItem => item.type !== 'separator' && item.id === id,
+		);
+	}
+
+
+	describe('resolution', () => {
+		it('resolves undefined when the picker is hidden without acceptance', async () => {
+			const promise = runPicker();
+			await waitUntilOpened();
+			pick.cancel(QuickInputHideReason.Gesture);
+			await expect(promise).resolves.toBeUndefined();
+		});
+
+		it('resolves to the selected runtime metadata', async () => {
+			const py = registerRuntime(makeRuntime({ runtimeId: 'py-1' }));
+			const promise = runPicker();
+			await waitUntilOpened();
+			const item = pickItemById('py-1')!;
+			pick.accept(item);
+			await expect(promise).resolves.toEqual(py);
+		});
+
+		it('uses options.title when provided, defaults otherwise', async () => {
+			const promise1 = runPicker({ title: 'Pick something' });
+			await waitUntilOpened();
+			expect(pick.title).toBe('Pick something');
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise1;
+
+			pick = ctx.disposables.add(new TestQuickPick<IQuickPickItem>());
+			const promise2 = runPicker();
+			await waitUntilOpened();
+			expect(pick.title).toBe('Start New Interpreter Session');
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise2;
+		});
+	});
+
+	describe('options.languageId', () => {
+		it('filters runtimes to the given languageId', async () => {
+			registerRuntime(makeRuntime({ runtimeId: 'py-1', languageId: 'python', languageName: 'Python' }));
+			registerRuntime(makeRuntime({ runtimeId: 'r-1', languageId: 'r', languageName: 'R', runtimeName: 'R 4.4' }));
+
+			const promise = runPicker({ languageId: 'python' });
+			await waitUntilOpened();
+			const ids = pick.items
+				.filter((item): item is IQuickPickItem => item.type !== 'separator')
+				.map(item => item.id);
+			expect(ids).toContain('py-1');
+			expect(ids).not.toContain('r-1');
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+
+		it('passes languageId through to getPickerContributions', async () => {
+			registerRuntime(makeRuntime({ runtimeId: 'py-1' }));
+			const spy = vi.spyOn(ctx.get(ILanguageRuntimeService), 'getPickerContributions');
+			const promise = runPicker({ languageId: 'python' });
+			await waitUntilOpened();
+			expect(spy).toHaveBeenCalledWith('python');
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+	});
+
+	describe('options.currentRuntimeId', () => {
+		it('pre-focuses the matching item via activeItems', async () => {
+			registerRuntime(makeRuntime({ runtimeId: 'py-1' }));
+			registerRuntime(makeRuntime({ runtimeId: 'py-2', languageVersion: '3.10.0', runtimeName: 'Python 3.10' }));
+
+			const promise = runPicker({ currentRuntimeId: 'py-2' });
+			await waitUntilOpened();
+			expect(pick.activeItems).toHaveLength(1);
+			expect(pick.activeItems[0].id).toBe('py-2');
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+
+		it('leaves activeItems untouched when no item matches the id', async () => {
+			registerRuntime(makeRuntime({ runtimeId: 'py-1' }));
+			const promise = runPicker({ currentRuntimeId: 'unknown-id' });
+			await waitUntilOpened();
+			expect(pick.activeItems).toEqual([]);
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+	});
+
+	describe('item structure', () => {
+		it('groups Suggested + per-environment-type runtimes with separators', async () => {
+			registerRuntime(makeRuntime({ runtimeId: 'py-system', runtimeSource: 'System', runtimeName: 'Python (System)' }));
+			registerRuntime(makeRuntime({ runtimeId: 'py-conda', runtimeSource: 'Conda', runtimeName: 'Python (Conda)' }));
+
+			const promise = runPicker();
+			await waitUntilOpened();
+			const shape = pick.items.map(item =>
+				item.type === 'separator' ? `[${item.label}]` : `${item.id}=${item.label}`
+			);
+			expect(shape).toMatchInlineSnapshot(`
+				[
+				  "[Suggested]",
+				  "py-system=Python (System)",
+				  "[System]",
+				  "py-system=Python (System)",
+				  "[Conda]",
+				  "py-conda=Python (Conda)",
+				]
+			`);
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+
+		it('sorts within an env type by version descending, unsupported runtimes last', async () => {
+			registerRuntime(makeRuntime({ runtimeId: 'py-310', languageVersion: '3.10.0', runtimeName: 'Python 3.10' }));
+			registerRuntime(makeRuntime({ runtimeId: 'py-312', languageVersion: '3.12.0', runtimeName: 'Python 3.12' }));
+			registerRuntime(makeRuntime({
+				runtimeId: 'py-old', languageVersion: '3.8.0', runtimeName: 'Python 3.8 (unsupported)',
+				extraRuntimeData: { supported: false },
+			}));
+
+			const promise = runPicker();
+			await waitUntilOpened();
+			// Find the System group (everything is runtimeSource: 'System' here) and read the order after the separator.
+			const items = pick.items;
+			const systemIdx = items.findIndex(i => i.type === 'separator' && i.label === 'System');
+			const groupIds = items.slice(systemIdx + 1)
+				.filter((item): item is IQuickPickItem => item.type !== 'separator')
+				.map(item => item.id);
+			expect(groupIds).toEqual(['py-312', 'py-310', 'py-old']);
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+	});
+
+	describe('reactive rebuild', () => {
+		it('rebuilds when onDidRegisterRuntime fires mid-pick', async () => {
+			registerRuntime(makeRuntime({ runtimeId: 'py-1' }));
+			const promise = runPicker();
+			await waitUntilOpened();
+			expect(pickItemById('py-1')).toBeDefined();
+			expect(pickItemById('py-2')).toBeUndefined();
+
+			registerRuntime(makeRuntime({ runtimeId: 'py-2', languageVersion: '3.10.0' }));
+			expect(pickItemById('py-2')).toBeDefined();
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+
+		it('preserves the previously focused item across rebuilds', async () => {
+			registerRuntime(makeRuntime({ runtimeId: 'py-1' }));
+			registerRuntime(makeRuntime({ runtimeId: 'py-2', languageVersion: '3.10.0' }));
+			const promise = runPicker({ currentRuntimeId: 'py-2' });
+			await waitUntilOpened();
+			expect(pick.activeItems[0].id).toBe('py-2');
+
+			registerRuntime(makeRuntime({ runtimeId: 'py-3', languageVersion: '3.13.0' }));
+			expect(pick.activeItems[0].id).toBe('py-2');
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+	});
+
+	describe('startup phase', () => {
+		it('re-fetches contributions when phase transitions to Complete', async () => {
+			registerRuntime(makeRuntime({ runtimeId: 'py-1' }));
+			const runtimeService = ctx.get(ILanguageRuntimeService);
+			runtimeService.setStartupPhase(RuntimeStartupPhase.Discovering);
+
+			const contribution: IRuntimePickerContribution = {
+				handle: 1,
+				languageId: 'python',
+				getItems: vi.fn(async () => [{ id: 'install-uv', label: 'Install Python via uv' }]),
+				onSelect: vi.fn(),
+			};
+			ctx.disposables.add(runtimeService.registerPickerContribution(contribution));
+
+			const promise = runPicker();
+			await waitUntilOpened();
+			// While in Discovering, contributions are skipped.
+			const labels = pick.items.map(i => i.label);
+			expect(labels).not.toContain('Install Python via uv');
+
+			runtimeService.setStartupPhase(RuntimeStartupPhase.Complete);
+			// The async listener fetches contributions and rebuilds; poll until
+			// the contributed item appears in the items array.
+			await vi.waitFor(() => {
+				const refreshed = pick.items.map(i => i.label);
+				expect(refreshed).toContain('Install Python via uv');
+			});
+			expect(contribution.getItems).toHaveBeenCalled();
+
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+
+		it('skips contributions when phase is not yet Complete', async () => {
+			const runtimeService = ctx.get(ILanguageRuntimeService);
+			runtimeService.setStartupPhase(RuntimeStartupPhase.Discovering);
+
+			const contribution: IRuntimePickerContribution = {
+				handle: 2,
+				languageId: 'python',
+				getItems: vi.fn(async () => [{ id: 'install-uv', label: 'Install Python via uv' }]),
+				onSelect: vi.fn(),
+			};
+			ctx.disposables.add(runtimeService.registerPickerContribution(contribution));
+
+			const promise = runPicker();
+			await waitUntilOpened();
+			expect(contribution.getItems).not.toHaveBeenCalled();
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+	});
+
+	describe('contributed items', () => {
+		it('resolves the registered runtime and triggers a quiet rediscovery on selection', async () => {
+			const installedRuntime = makeRuntime({ runtimeId: 'py-installed-by-uv' });
+			const runtimeService = ctx.get(ILanguageRuntimeService);
+
+			const contribution: IRuntimePickerContribution = {
+				handle: 3,
+				languageId: 'python',
+				getItems: async () => [{ id: 'install-uv', label: 'Install Python via uv' }],
+				onSelect: vi.fn(async () => {
+					// Simulate the contribution registering a new runtime as part of onSelect.
+					ctx.disposables.add(runtimeService.registerRuntime(installedRuntime));
+					return installedRuntime.runtimeId;
+				}),
+			};
+			ctx.disposables.add(runtimeService.registerPickerContribution(contribution));
+
+			const promise = runPicker();
+			await waitUntilOpened();
+
+			const installItem = pick.items
+				.find((item): item is IQuickPickItem => item.type !== 'separator' && item.label === 'Install Python via uv')!;
+			pick.accept(installItem);
+
+			await expect(promise).resolves.toEqual(installedRuntime);
+			expect(contribution.onSelect).toHaveBeenCalledWith('install-uv');
+			expect(rediscoverAllRuntimes).toHaveBeenCalledWith(/* quiet */ true);
+		});
+
+		it('resolves undefined when onSelect returns undefined', async () => {
+			const runtimeService = ctx.get(ILanguageRuntimeService);
+			const contribution: IRuntimePickerContribution = {
+				handle: 4,
+				languageId: 'python',
+				getItems: async () => [{ id: 'install-noop', label: 'No-op installer' }],
+				onSelect: vi.fn(async () => undefined),
+			};
+			ctx.disposables.add(runtimeService.registerPickerContribution(contribution));
+
+			const promise = runPicker();
+			await waitUntilOpened();
+
+			const item = pick.items
+				.find((it): it is IQuickPickItem => it.type !== 'separator' && it.label === 'No-op installer')!;
+			pick.accept(item);
+			await expect(promise).resolves.toBeUndefined();
+		});
+
+		it('resolves undefined and logs when onSelect throws', async () => {
+			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+			const runtimeService = ctx.get(ILanguageRuntimeService);
+			const contribution: IRuntimePickerContribution = {
+				handle: 5,
+				languageId: 'python',
+				getItems: async () => [{ id: 'install-fail', label: 'Failing installer' }],
+				onSelect: vi.fn(async () => { throw new Error('install failed'); }),
+			};
+			ctx.disposables.add(runtimeService.registerPickerContribution(contribution));
+
+			const promise = runPicker();
+			await waitUntilOpened();
+
+			const item = pick.items
+				.find((it): it is IQuickPickItem => it.type !== 'separator' && it.label === 'Failing installer')!;
+			pick.accept(item);
+			await expect(promise).resolves.toBeUndefined();
+			expect(consoleErrorSpy).toHaveBeenCalled();
+		});
+
+		it('skips a contribution whose getItems() rejects', async () => {
+			const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+			const runtimeService = ctx.get(ILanguageRuntimeService);
+
+			const failing: IRuntimePickerContribution = {
+				handle: 6,
+				languageId: 'python',
+				getItems: async () => { throw new Error('cannot list items'); },
+				onSelect: vi.fn(),
+			};
+			const working: IRuntimePickerContribution = {
+				handle: 7,
+				languageId: 'python',
+				getItems: async () => [{ id: 'works', label: 'Working option' }],
+				onSelect: vi.fn(),
+			};
+			ctx.disposables.add(runtimeService.registerPickerContribution(failing));
+			ctx.disposables.add(runtimeService.registerPickerContribution(working));
+
+			const promise = runPicker();
+			await waitUntilOpened();
+
+			const labels = pick.items.map(i => i.label);
+			expect(labels).toContain('Working option');
+			expect(consoleErrorSpy).toHaveBeenCalled();
+
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
@@ -3,16 +3,16 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize2, localize } from '../../../../nls.js';
+import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
-import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
-import { INotebookKernelService, INotebookKernel } from '../../notebook/common/notebookKernelService.js';
+import { INotebookKernelService } from '../../notebook/common/notebookKernelService.js';
 import { POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID } from '../../runtimeNotebookKernel/common/runtimeNotebookKernelConfig.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { getNotebookInstanceFromActiveEditorPane } from './notebookUtils.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { selectNewLanguageRuntime } from '../../languageRuntime/browser/languageRuntimeActions.js';
 
 export const SELECT_KERNEL_ID_POSITRON = 'positronNotebook.selectKernel';
 const NOTEBOOK_ACTIONS_CATEGORY_POSITRON = localize2('positronNotebookActions.category', 'Positron Notebook');
@@ -38,7 +38,6 @@ class SelectPositronNotebookKernelAction extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<boolean> {
 		const notebookKernelService = accessor.get(INotebookKernelService);
 		const activeNotebook = getNotebookInstanceFromActiveEditorPane(accessor.get(IEditorService));
-		const quickInputService = accessor.get(IQuickInputService);
 
 		if (!activeNotebook) {
 			return false;
@@ -49,54 +48,24 @@ class SelectPositronNotebookKernelAction extends Action2 {
 			return false;
 		}
 
-		// Show quick-pick with all kernels that match notebook, aka positronKernels
-		const quickPick = quickInputService.createQuickPick<IQuickPickItem & { kernel?: INotebookKernel }>();
-		quickPick.title = localize('positronNotebookActions.selectKernel.title', 'Select Positron Notebook Kernel');
-
-		const gatherKernelPicks = () => {
-			const kernelMatches = notebookKernelService.getMatchingKernel(notebook);
-			const positronKernels = kernelMatches.all.filter(k =>
-				k.extension.value === POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID);
-			if (positronKernels.length === 0) {
-				quickPick.busy = true;
-				quickPick.items = [{ label: localize('positronNotebookActions.selectKernel.noKernel', 'No Positron Notebook Kernel found'), picked: true }];
-			} else {
-				quickPick.busy = false;
-				quickPick.items = positronKernels.map(kernel => ({
-					label: kernel.label,
-					description: kernel.description,
-					kernel,
-					picked: kernelMatches.selected?.id === kernel.id
-				}));
-			}
-		};
-
-		// Watch for new kernels being added so we can update the quick-pick
-		const onDidAddKernelDisposable = notebookKernelService.onDidAddKernel(gatherKernelPicks);
-
-		gatherKernelPicks();
-
-		return new Promise<boolean>(resolve => {
-			let didSelectKernel: boolean = false;
-			quickPick.onDidAccept(() => {
-				const selectedKernel = quickPick.selectedItems[0].kernel;
-				if (selectedKernel) {
-					// Link kernel with notebook
-					notebookKernelService.selectKernelForNotebook(selectedKernel, notebook);
-					didSelectKernel = true;
-					activeNotebook.grabFocus();
-				}
-				quickPick.hide();
-			});
-
-			quickPick.show();
-
-			quickPick.onDidHide(() => {
-				onDidAddKernelDisposable.dispose();
-				quickPick.dispose();
-				resolve(didSelectKernel);
-			});
+		const runtime = await selectNewLanguageRuntime(accessor, {
+			title: localize('positronNotebookActions.selectKernel.title', 'Select Positron Notebook Kernel'),
 		});
+
+		if (!runtime) {
+			return false;
+		}
+
+		const kernel = notebookKernelService.getMatchingKernel(notebook).all.find(
+			k => k.id === `${POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID}/${runtime.runtimeId}`
+		);
+		if (!kernel) {
+			return false;
+		}
+
+		notebookKernelService.selectKernelForNotebook(kernel, notebook);
+		activeNotebook.grabFocus();
+		return true;
 	}
 }
 registerAction2(SelectPositronNotebookKernelAction);

--- a/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
@@ -48,8 +48,14 @@ class SelectPositronNotebookKernelAction extends Action2 {
 			return false;
 		}
 
+		const selectedKernel = notebookKernelService.getMatchingKernel(notebook).selected;
+		const currentRuntimeId = selectedKernel?.extension.value === POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID
+			? selectedKernel.id.slice(POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID.length + 1)
+			: undefined;
+
 		const runtime = await selectNewLanguageRuntime(accessor, {
 			title: localize('positronNotebookActions.selectKernel.title', 'Select Positron Notebook Kernel'),
+			currentRuntimeId,
 		});
 
 		if (!runtime) {

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
@@ -332,6 +332,7 @@ registerAction2(class ChangeKernelAction extends Action2 {
 			selectNewLanguageRuntime(accessor, {
 				title: localize('quarto.changeKernel.title', "Select Quarto Kernel"),
 				languageId: language,
+				currentRuntimeId,
 			})
 		);
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
@@ -13,10 +13,9 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 import { ITextModel } from '../../../../editor/common/model.js';
 import { IQuartoExecutionManager, IQuartoOutputCacheService } from '../common/quartoExecutionTypes.js';
 import { IQuartoKernelManager } from './quartoKernelManager.js';
-import { IQuartoOutputManager } from './quartoOutputManager.js';
+import { IQuartoOutputManager, QuartoOutputContribution } from './quartoOutputManager.js';
 import { IS_QUARTO_DOCUMENT, QUARTO_INLINE_OUTPUT_ENABLED, QUARTO_KERNEL_BUSY, QUARTO_KERNEL_RUNNING, isQuartoDocument } from '../common/positronQuartoConfig.js';
-import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
-import { QuartoOutputContribution } from './quartoOutputManager.js';
+import { ICodeEditor, isCodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { IPositronModalDialogsService } from '../../../services/positronModalDialogs/common/positronModalDialogs.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
@@ -68,13 +67,12 @@ function getQuartoContext(editorService: IEditorService): {
 	textModel: ITextModel;
 	documentUri: import('../../../../base/common/uri.js').URI;
 } | undefined {
-	const activeEditor = editorService.activeTextEditorControl;
+	const editor = editorService.activeTextEditorControl;
 
-	if (!activeEditor || !('getModel' in activeEditor)) {
+	if (!isCodeEditor(editor)) {
 		return undefined;
 	}
 
-	const editor = activeEditor as ICodeEditor;
 	const textModel = editor.getModel();
 	if (!textModel) {
 		return undefined;

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCommands.ts
@@ -5,7 +5,7 @@
 
 import { localize, localize2 } from '../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
-import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
@@ -18,9 +18,8 @@ import { IS_QUARTO_DOCUMENT, QUARTO_INLINE_OUTPUT_ENABLED, QUARTO_KERNEL_BUSY, Q
 import { ICodeEditor, isCodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { IPositronModalDialogsService } from '../../../services/positronModalDialogs/common/positronModalDialogs.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
-import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
-import { ILanguageRuntimeMetadata, ILanguageRuntimeService } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ByteSize, IFileService } from '../../../../platform/files/common/files.js';
+import { selectNewLanguageRuntime } from '../../languageRuntime/browser/languageRuntimeActions.js';
 import { basename } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 
@@ -287,7 +286,6 @@ registerAction2(class ShutdownKernelAction extends Action2 {
 
 /**
  * Change the kernel for the current Quarto document.
- * Shows a quick pick with available runtimes matching the document's language.
  */
 registerAction2(class ChangeKernelAction extends Action2 {
 	constructor() {
@@ -311,8 +309,9 @@ registerAction2(class ChangeKernelAction extends Action2 {
 	async run(accessor: ServicesAccessor): Promise<void> {
 		const editorService = accessor.get(IEditorService);
 		const kernelManager = accessor.get(IQuartoKernelManager);
-		const quickInputService = accessor.get(IQuickInputService);
-		const languageRuntimeService = accessor.get(ILanguageRuntimeService);
+		// Resolved synchronously so we can re-enter a fresh accessor scope after
+		// the awaits below (the run-method accessor is only valid synchronously).
+		const instantiationService = accessor.get(IInstantiationService);
 
 		const context = getQuartoContext(editorService);
 		if (!context) {
@@ -321,71 +320,26 @@ registerAction2(class ChangeKernelAction extends Action2 {
 
 		const { documentUri } = context;
 
-		// Get the document's primary language to filter runtimes
+		// Get the document's primary language to scope the picker.
 		const language = await kernelManager.getDocumentLanguage(documentUri);
 		if (!language) {
 			return;
 		}
 
-		// Get the current session's runtime ID to mark as selected
-		const currentSession = kernelManager.getSessionForDocument(documentUri);
-		const currentRuntimeId = currentSession?.runtimeMetadata.runtimeId;
+		const currentRuntimeId = kernelManager.getSessionForDocument(documentUri)?.runtimeMetadata.runtimeId;
 
-		const quickPick = quickInputService.createQuickPick<IQuickPickItem & { runtime?: ILanguageRuntimeMetadata }>();
-		quickPick.title = localize('quarto.changeKernel.title', "Select Quarto Kernel");
+		const runtime = await instantiationService.invokeFunction(accessor =>
+			selectNewLanguageRuntime(accessor, {
+				title: localize('quarto.changeKernel.title', "Select Quarto Kernel"),
+				languageId: language,
+			})
+		);
 
-		const gatherRuntimePicks = () => {
-			const runtimes = languageRuntimeService.registeredRuntimes
-				.filter(r => r.languageId === language);
-
-			if (runtimes.length === 0) {
-				quickPick.busy = true;
-				quickPick.items = [{
-					label: localize('quarto.changeKernel.noRuntime', "No {0} runtimes found", language),
-				}];
-			} else {
-				quickPick.busy = false;
-				quickPick.items = runtimes.map(runtime => ({
-					label: runtime.runtimeName,
-					description: runtime.runtimePath,
-					runtime,
-				}));
-
-				// Pre-select the current runtime
-				const currentItem = quickPick.items.find(
-					item => (item as any).runtime?.runtimeId === currentRuntimeId
-				);
-				if (currentItem) {
-					quickPick.activeItems = [currentItem];
-				}
-			}
-		};
-
-		// Watch for new runtimes being registered
-		const onDidRegisterDisposable = languageRuntimeService.onDidRegisterRuntime(gatherRuntimePicks);
-
-		gatherRuntimePicks();
-
-		return new Promise<void>(resolve => {
-			quickPick.onDidAccept(() => {
-				const selected = quickPick.selectedItems[0];
-				if (selected?.runtime && selected.runtime.runtimeId !== currentRuntimeId) {
-					// Fire and forget; the kernel state badge will show
-					// progress as the old kernel shuts down and the new
-					// one starts up.
-					kernelManager.changeKernelForDocument(documentUri, selected.runtime.runtimeId);
-				}
-				quickPick.hide();
-			});
-
-			quickPick.show();
-
-			quickPick.onDidHide(() => {
-				onDidRegisterDisposable.dispose();
-				quickPick.dispose();
-				resolve();
-			});
-		});
+		if (runtime && runtime.runtimeId !== currentRuntimeId) {
+			// Fire and forget; the kernel state badge will show progress as
+			// the old kernel shuts down and the new one starts up.
+			kernelManager.changeKernelForDocument(documentUri, runtime.runtimeId);
+		}
 	}
 });
 


### PR DESCRIPTION
Fixes #11708 

Consolidates the kernel selectors for Positron notebooks and Quarto documents to share the language runtime quickpick implementation that the console's "Start New Console Session" action already uses. 

The `selectNewLanguageRuntime` helper has been updated so the picker updates itself to show runtimes as they become registered while its open. This covers the "kernels show up as they register" behavior the old notebook picker had via `INotebookKernelService.onDidAddKernel`, but at the runtime layer where the helper now lives.
We had to switch to `createQuickPick()` instead of the one-shot `quickInputService.pick()` so we could listen for `onDidRegisterRuntime` and `onDidChangeRuntimeStartupPhase` events. The quick pick rebuilds items as runtimes arrive. 

The `selectNewLanguageRuntime` helper has been updated with two new parameters:
- `languageId`: Filter the runtimes shown in the quickpick to a single langauge. Quarto uses this to scope the picker to the document's primary language. NOTE: We can easily update this in the future to be a list of languages if needed, or we can remove it later if its not needed by Quarto!
- `currentRuntimeId`: focus the runtime backing the current kernel when the quicpick is opened. This was added to keep the "currently selected runtime" behavior that the old Quarto and notebook pickers had.

A new `TestQuickPick<T>` test double has also been added. The existing upstream `TestQuickInputService` only stubs the one-shot `pick()` API and throws on `createQuickPick`. Created a new file for the test double instead of touching the upstream test file.

### Screenshots

**Runtime Registration Picker Updates**


https://github.com/user-attachments/assets/76496c54-cead-4b7b-b4e6-d988d0bcd245


**Positron Notebook Editor Kernel Selector**

NOTE: I noticed when changing notebook kernels that the foreground session switches temporarily to a different session (when the notebook session gets shutdown) before changing back to the new notebook session. This behavior already exists on main and will be fixed in a separate PR!

https://github.com/user-attachments/assets/409d8742-c106-4dcb-9136-5ec0cd351e70


**Quarto Kernel Selector**


https://github.com/user-attachments/assets/8c9af472-2bb5-49dc-a5f7-5759342b6b63




### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Unify the notebook and quarto kernel selectors with the interpreter selector so they share ordering, grouping, and icons (#11708)


#### Bug Fixes

- N/A


### QA Notes

@:interpreter
@:positron-notebooks 
@:quarto  
@:sessions

**Positron Notebook Editor:**
1. Open a `.ipynb` file. Select "Change Kernel..." from the Quarto kernel selector.
2. Verify that all languages appear in the kernel selector.
3. Confirm the document's current kernel is focused in the quick pick, and grouping/sort matches the notebook picker.

**Quarto:**
1. Open a `.qmd` file with a Python primary chunk. Select "Change Kernel..." from the Quarto kernel selector.
2. Verify only Python runtimes appear.
3. Confirm the document's current kernel is focused in the quick pick, and grouping/sort matches the notebook picker.