### PR TITLE
Route Console Fix & Explain to Posit Assistant newChat command

### DIFF
--- a/src/vs/base/browser/positronReactHooks.tsx
+++ b/src/vs/base/browser/positronReactHooks.tsx
@@ -6,6 +6,7 @@
 import { useEffect, useState } from 'react';
 import { usePositronReactServicesContext } from './positronReactRendererContext.js';
 import { ContextKeyValue } from '../../platform/contextkey/common/contextkey.js';
+import { ExtensionIdentifier } from '../../platform/extensions/common/extensions.js';
 
 
 /**
@@ -30,6 +31,36 @@ export const usePositronConfiguration = <T,>(key: string, watch: boolean = true)
 
 	return value;
 }
+
+/**
+ * usePositronExtensionInstalled hook.
+ *
+ * Returns true only when the extension is both installed and enabled.
+ * `IExtensionService.extensions` lists registered extensions, and the
+ * extension host filters out disabled ones before registering (via
+ * `filterEnabledExtensions` in abstractExtensionService.ts). The value
+ * updates on install, uninstall, enable, and disable.
+ *
+ * @param extensionId The identifier of the extension, either as a string
+ *   (e.g. 'posit.assistant') or an `ExtensionIdentifier`.
+ * @returns True if the extension is installed and enabled.
+ */
+export const usePositronExtensionInstalled = (extensionId: string | ExtensionIdentifier): boolean => {
+	const { extensionService } = usePositronReactServicesContext();
+	const key = ExtensionIdentifier.toKey(extensionId);
+	const [installed, setInstalled] = useState(() =>
+		extensionService.extensions.some(e => ExtensionIdentifier.toKey(e.identifier) === key)
+	);
+
+	useEffect(() => {
+		const disposable = extensionService.onDidChangeExtensions(() => {
+			setInstalled(extensionService.extensions.some(e => ExtensionIdentifier.toKey(e.identifier) === key));
+		});
+		return () => disposable.dispose();
+	}, [extensionService, key]);
+
+	return installed;
+};
 
 /**
  * usePositronContextKey hook.

--- a/src/vs/base/browser/positronReactServices.tsx
+++ b/src/vs/base/browser/positronReactServices.tsx
@@ -44,6 +44,7 @@ import { IPositronPreviewService } from '../../workbench/contrib/positronPreview
 import { IPositronNewFolderService } from '../../workbench/services/positronNewFolder/common/positronNewFolder.js';
 import { ILanguageRuntimeService } from '../../workbench/services/languageRuntime/common/languageRuntimeService.js';
 import { IExecutionHistoryService } from '../../workbench/services/positronHistory/common/executionHistoryService.js';
+import { IExtensionService } from '../../workbench/services/extensions/common/extensions.js';
 import { IPositronMemoryUsageService } from '../../platform/positronMemoryUsage/common/positronMemoryUsage.js';
 import { IPositronModalDialogsService } from '../../workbench/services/positronModalDialogs/common/positronModalDialogs.js';
 import { IPositronConsoleService } from '../../workbench/services/positronConsole/browser/interfaces/positronConsoleService.js';
@@ -94,6 +95,7 @@ export class PositronReactServices {
 		@IContextMenuService public readonly contextMenuService: IContextMenuService,
 		@IEditorService public readonly editorService: IEditorService,
 		@IExecutionHistoryService public readonly executionHistoryService: IExecutionHistoryService,
+		@IExtensionService public readonly extensionService: IExtensionService,
 		@IFileService public readonly fileService: IFileService,
 		@IFileDialogService public readonly fileDialogService: IFileDialogService,
 		@IHoverService public readonly hoverService: IHoverService,

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx
@@ -15,7 +15,7 @@ import { ConsoleOutputLines } from './consoleOutputLines.js';
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 import { ActivityItemErrorMessage } from '../../../../services/positronConsole/browser/classes/activityItemErrorMessage.js';
 import { ConsoleQuickFix } from './activityErrorQuickFix.js';
-import { usePositronConfiguration, usePositronContextKey } from '../../../../../base/browser/positronReactHooks.js';
+import { usePositronConfiguration, usePositronExtensionInstalled } from '../../../../../base/browser/positronReactHooks.js';
 
 // ActivityErrorProps interface.
 export interface ActivityErrorMessageProps {
@@ -35,10 +35,9 @@ export const ActivityErrorMessage = (props: ActivityErrorMessageProps) => {
 	const [showTraceback, setShowTraceback] = useState(false);
 
 	// Configuration hooks.
-	const enableAssistant = usePositronConfiguration<boolean>('positron.assistant.enable');
 	const enableAssistantActions = usePositronConfiguration<boolean>('positron.assistant.consoleActions.enable');
-	const hasChatModels = usePositronContextKey<boolean>('positron-assistant.hasChatModels');
-	const showAssistantActions = enableAssistant && hasChatModels && enableAssistantActions;
+	const positAssistantInstalled = usePositronExtensionInstalled('posit.assistant');
+	const showAssistantActions = enableAssistantActions && positAssistantInstalled;
 
 	// Traceback useEffect.
 	useEffect(() => {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx
@@ -15,7 +15,7 @@ import { ConsoleOutputLines } from './consoleOutputLines.js';
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 import { ActivityItemErrorMessage } from '../../../../services/positronConsole/browser/classes/activityItemErrorMessage.js';
 import { ConsoleQuickFix } from './activityErrorQuickFix.js';
-import { usePositronConfiguration, usePositronExtensionInstalled } from '../../../../../base/browser/positronReactHooks.js';
+import { usePositronConfiguration, usePositronContextKey, usePositronExtensionInstalled } from '../../../../../base/browser/positronReactHooks.js';
 
 // ActivityErrorProps interface.
 export interface ActivityErrorMessageProps {
@@ -37,7 +37,15 @@ export const ActivityErrorMessage = (props: ActivityErrorMessageProps) => {
 	// Configuration hooks.
 	const enableAssistantActions = usePositronConfiguration<boolean>('positron.assistant.consoleActions.enable');
 	const positAssistantInstalled = usePositronExtensionInstalled('posit.assistant');
-	const showAssistantActions = enableAssistantActions && positAssistantInstalled;
+	// Set by the built-in positron-assistant extension when any direct provider
+	// or vscode.lm model is available. Posit Assistant shares the same
+	// vscode.authentication credentials, so a true value here implies it has at
+	// least one usable provider too.
+	// TODO: When Positron Assistant is deprecated in favor of Posit Assistant,
+	// replace this with a signal owned by Posit Assistant (context key or
+	// equivalent) - this key goes away with the built-in extension.
+	const hasChatModels = usePositronContextKey<boolean>('positron-assistant.hasChatModels');
+	const showAssistantActions = enableAssistantActions && positAssistantInstalled && !!hasChatModels;
 
 	// Traceback useEffect.
 	useEffect(() => {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorQuickFix.tsx
@@ -15,17 +15,45 @@ import { localize } from '../../../../../nls.js';
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { ANSIOutputLine } from '../../../../../base/common/ansiOutput.js';
+import { encodeBase64, VSBuffer } from '../../../../../base/common/buffer.js';
 
-const fixPrompt = '/fix';
-const explainPrompt = '/explain';
+const fixPrompt = localize('positronConsoleAssistantFixPrompt', "Fix this console error.");
+const explainPrompt = localize('positronConsoleAssistantExplainPrompt', "Explain this console error.");
+
+const NEW_CHAT_COMMAND = 'posit-assistant.newChat';
+const ATTACHMENT_NAME = 'console-error.txt';
 
 interface ConsoleQuickFixProps {
 	outputLines: ANSIOutputLine[];
 	tracebackLines: ANSIOutputLine[];
 }
 
+interface NewChatFile {
+	uri: string;
+	name: string;
+}
+
+interface NewChatOptions {
+	prompt: string;
+	files?: NewChatFile[];
+	target: 'auto' | 'new';
+	behavior: 'submit' | 'prefill';
+}
+
 const formatOutput = (outputLines: ANSIOutputLine[], tracebackLines: ANSIOutputLine[]) => {
-	return outputLines.map(line => line.outputRuns.map(run => run.text).join('')).join('\n') + '\n' + tracebackLines.map(line => line.outputRuns.map(run => run.text).join('')).join('\n');
+	const lineText = (lines: ANSIOutputLine[]) =>
+		lines.map(line => line.outputRuns.map(run => run.text).join('')).join('\n');
+	const message = lineText(outputLines);
+	const traceback = lineText(tracebackLines);
+	return traceback ? `${message}\n${traceback}` : message;
+};
+
+const buildAttachment = (text: string): NewChatFile | undefined => {
+	if (!text) {
+		return undefined;
+	}
+	const base64 = encodeBase64(VSBuffer.fromString(text));
+	return { uri: `data:text/plain;base64,${base64}`, name: ATTACHMENT_NAME };
 };
 
 /**
@@ -34,27 +62,34 @@ const formatOutput = (outputLines: ANSIOutputLine[], tracebackLines: ANSIOutputL
  */
 export const ConsoleQuickFix = (props: ConsoleQuickFixProps) => {
 	const buttonRef = useRef<HTMLDivElement>(undefined!);
-	const { quickChatService } = usePositronReactServicesContext();
+	const { commandService, notificationService } = usePositronReactServicesContext();
 
-	const formattedOutput = useMemo(() => {
-		return formatOutput(props.outputLines, props.tracebackLines);
-	}, [props.outputLines, props.tracebackLines]);
-	/**
-	 * onClick handlers.
-	 */
-	const pressedFixHandler = async () => {
-		// Handle console quick fix action.
-		quickChatService.open({
-			query: props.outputLines ? `${fixPrompt}\n\`\`\`${formattedOutput}\`\`\`` : fixPrompt
-		});
+	const attachment = useMemo(
+		() => buildAttachment(formatOutput(props.outputLines, props.tracebackLines)),
+		[props.outputLines, props.tracebackLines]
+	);
+
+	const runNewChat = async (prompt: string) => {
+		const options: NewChatOptions = {
+			prompt,
+			target: 'auto',
+			behavior: 'submit',
+			...(attachment && { files: [attachment] }),
+		};
+		try {
+			await commandService.executeCommand(NEW_CHAT_COMMAND, options);
+		} catch {
+			notificationService.error(
+				localize(
+					'positronConsoleAssistantUnavailable',
+					"Posit Assistant is not available. Install the Posit Assistant extension to use Fix and Explain."
+				)
+			);
+		}
 	};
 
-	const pressedExplainHandler = async () => {
-		// Handle console quick explain action.
-		quickChatService.open({
-			query: props.outputLines ? `${explainPrompt}\n\`\`\`${formattedOutput}\`\`\`` : explainPrompt
-		});
-	};
+	const pressedFixHandler = () => runNewChat(fixPrompt);
+	const pressedExplainHandler = () => runNewChat(explainPrompt);
 
 	// Render.
 	return (

--- a/src/vs/workbench/contrib/positronConsole/test/browser/activityErrorQuickFix.vitest.tsx
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/activityErrorQuickFix.vitest.tsx
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import React from 'react';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { ANSIOutputLine } from '../../../../../base/common/ansiOutput.js';
+import { decodeBase64, VSBuffer } from '../../../../../base/common/buffer.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { ConsoleQuickFix } from '../../browser/components/activityErrorQuickFix.js';
+
+const line = (id: string, text: string): ANSIOutputLine => ({
+	id,
+	outputRuns: [{ id: `${id}-run`, text }],
+});
+
+const outputLines: ANSIOutputLine[] = [line('1', 'NameError: name "x" is not defined')];
+const tracebackLines: ANSIOutputLine[] = [line('2', '  File "<stdin>", line 1')];
+
+const expectedAttachmentText =
+	'NameError: name "x" is not defined\n  File "<stdin>", line 1';
+
+const decodeDataUri = (uri: string): string => {
+	const base64 = uri.slice(uri.indexOf(',') + 1);
+	return VSBuffer.wrap(decodeBase64(base64).buffer).toString();
+};
+
+describe('ConsoleQuickFix', () => {
+	const executeCommand = vi.fn().mockResolvedValue(undefined);
+	const notifyError = vi.fn();
+
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(ICommandService, { executeCommand })
+		.stub(INotificationService, { error: notifyError })
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	it('dispatches posit-assistant.newChat with a fix prompt and the error as a data URI attachment when Fix is clicked', async () => {
+		const { getByText } = rtl.render(
+			<ConsoleQuickFix outputLines={outputLines} tracebackLines={tracebackLines} />
+		);
+		fireEvent.click(getByText('Fix'));
+
+		await waitFor(() => expect(executeCommand).toHaveBeenCalledTimes(1));
+		const [cmd, payload] = executeCommand.mock.calls[0];
+		expect(cmd).toBe('posit-assistant.newChat');
+		expect(payload.prompt).toMatch(/fix/i);
+		expect(payload.prompt).not.toContain('/fix');
+		expect(payload.target).toBe('auto');
+		expect(payload.behavior).toBe('submit');
+		expect(payload.files).toHaveLength(1);
+		expect(payload.files[0].name).toBe('console-error.txt');
+		expect(payload.files[0].uri).toMatch(/^data:text\/plain;base64,/);
+		expect(decodeDataUri(payload.files[0].uri)).toBe(expectedAttachmentText);
+	});
+
+	it('dispatches posit-assistant.newChat with an explain prompt when Explain is clicked', async () => {
+		const { getByText } = rtl.render(
+			<ConsoleQuickFix outputLines={outputLines} tracebackLines={tracebackLines} />
+		);
+		fireEvent.click(getByText('Explain'));
+
+		await waitFor(() => expect(executeCommand).toHaveBeenCalledTimes(1));
+		const [, payload] = executeCommand.mock.calls[0];
+		expect(payload.prompt).toMatch(/explain/i);
+		expect(payload.prompt).not.toContain('/explain');
+		expect(payload.target).toBe('auto');
+	});
+
+	it('omits the attachment when there is no error output', async () => {
+		const { getByText } = rtl.render(
+			<ConsoleQuickFix outputLines={[]} tracebackLines={[]} />
+		);
+		fireEvent.click(getByText('Fix'));
+
+		await waitFor(() => expect(executeCommand).toHaveBeenCalledTimes(1));
+		const [, payload] = executeCommand.mock.calls[0];
+		expect(payload.files).toBeUndefined();
+	});
+
+	it('surfaces a notification when the command throws (extension missing)', async () => {
+		executeCommand.mockRejectedValueOnce(new Error('command not found'));
+
+		const { getByText } = rtl.render(
+			<ConsoleQuickFix outputLines={outputLines} tracebackLines={tracebackLines} />
+		);
+		fireEvent.click(getByText('Fix'));
+
+		await waitFor(() => expect(notifyError).toHaveBeenCalledTimes(1));
+		expect(notifyError.mock.calls[0][0]).toMatch(/Posit Assistant is not available/);
+	});
+});


### PR DESCRIPTION
Addresses #13195.

Console "Fix" and "Explain" buttons now dispatch `posit-assistant.newChat` (posit-dev/assistant#1044) with the error message + traceback attached as a base64 `data:text/plain` file, instead of opening the built-in quick-chat widget with a `/fix` or `/explain` slash-prefixed query. Prompt strings are terse natural language ("Fix this console error." / "Explain this console error.") since the external Posit Assistant participant doesn't understand slash commands. The button gate is simplified to the existing `positron.assistant.consoleActions.enable` setting plus a check that the `posit.assistant` extension is installed and enabled, using a new `usePositronExtensionInstalled` hook. If the command is missing (extension not installed or older version), the click surfaces a notification.

### Release Notes

#### New Features

- Console Fix and Explain buttons now route error context to the Posit Assistant extension's new chat API. (#13195)

#### Bug Fixes

- N/A

### QA Notes

@:console @:posit-assistant

Requires a Posit Assistant build with the `posit-assistant.newChat` command (posit-dev/assistant#1044).

1. Install Posit Assistant and sign in to a provider so a model is available.
2. In a Python console, run `1/0`. Confirm Fix and Explain buttons appear next to the traceback toggle.
3. Click **Fix**. Expected: Posit Assistant reveals, a new request submits with prompt "Fix this console error." and an attachment named `console-error.txt` containing the traceback.
4. Click **Explain** in a subsequent error. Expected: request appended to the same conversation (`target: "auto"`), prompt "Explain this console error.", same attachment shape.
5. Disable or uninstall the Posit Assistant extension. Reload the window and trigger an error. Expected: Fix and Explain buttons are hidden.
6. Re-enable Posit Assistant. Expected: buttons reappear without a reload.
7. Set `positron.assistant.consoleActions.enable` to `false`. Expected: buttons hidden regardless of extension state.
8. Regression: the existing "Fix with Assistant" / "Explain with Assistant" editor code actions still work (they route through `workbench.action.chat.open`, not this command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)