### PR TITLE
Address console rendering and scrollback performance

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
 		"files.insertFinalNewline": false
 	},
 	"[typescript]": {
-		"editor.defaultFormatter": "TypeScriptTeam.native-preview",
+		"editor.defaultFormatter": "vscode.typescript-language-features",
 		"editor.formatOnSave": true
 	},
 	"[javascript]": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
 		"files.insertFinalNewline": false
 	},
 	"[typescript]": {
-		"editor.defaultFormatter": "vscode.typescript-language-features",
+		"editor.defaultFormatter": "TypeScriptTeam.native-preview",
 		"editor.formatOnSave": true
 	},
 	"[javascript]": {

--- a/src/vs/base/browser/ui/positronComponents/splitters/horizontalSplitter.tsx
+++ b/src/vs/base/browser/ui/positronComponents/splitters/horizontalSplitter.tsx
@@ -117,6 +117,11 @@ export const HorizontalSplitter = (props: {
 		// a click (or double-click) from a drag on pointer release.
 		let didDrag = false;
 
+		// Track the last cursor we wrote to the global stylesheet. Rewriting `* { cursor }`
+		// on every pointermove invalidates style on every element in the document, which is
+		// the dominant cost during drag when the document tree is large. Only write on change.
+		let currentCursor: string | undefined = undefined;
+
 		/**
 		 * pointermove event handler.
 		 * @param e A PointerEvent that describes a user interaction with the pointer.
@@ -147,7 +152,13 @@ export const HorizontalSplitter = (props: {
 			// Update the style sheet's text content with the desired cursor and
 			// disable text selection during the resize operation. This is a clever
 			// technique adopted from src/vs/base/browser/ui/sash/sash.ts.
-			styleSheet.textContent = `* { cursor: ${cursor} !important; user-select: none !important; }`;
+			//
+			// Only write on change. Rewriting this rule invalidates style on every element
+			// matching `*`, so doing it every pointermove is expensive on large DOMs.
+			if (cursor !== currentCursor) {
+				currentCursor = cursor;
+				styleSheet.textContent = `* { cursor: ${cursor} !important; user-select: none !important; }`;
+			}
 
 			// Call the onResize callback.
 			props.onResize(newHeight);

--- a/src/vs/base/browser/ui/positronComponents/splitters/verticalSplitter.tsx
+++ b/src/vs/base/browser/ui/positronComponents/splitters/verticalSplitter.tsx
@@ -297,6 +297,11 @@ export const VerticalSplitter = ({
 		const clientX = e.clientX;
 		const styleSheet = createStyleSheet(body);
 
+		// Track the last cursor we wrote to the global stylesheet. Rewriting `* { cursor }`
+		// on every pointermove invalidates style on every element in the document, which is
+		// the dominant cost during drag when the document tree is large. Only write on change.
+		let currentCursor: string | undefined = undefined;
+
 		/**
 		 * pointermove event handler.
 		 * @param e A PointerEvent that describes a user interaction with the pointer.
@@ -334,8 +339,11 @@ export const VerticalSplitter = ({
 				cursor = isMacintosh ? 'col-resize' : 'ew-resize';
 			}
 
-			// Set the cursor.
-			if (cursor) {
+			// Set the cursor only when it changes. Writing to the stylesheet invalidates
+			// style on every element matching `*` (the whole document), so this must not
+			// run every pointermove.
+			if (cursor && cursor !== currentCursor) {
+				currentCursor = cursor;
 				styleSheet.textContent = `* { cursor: ${cursor} !important; }`;
 			}
 

--- a/src/vs/base/common/ansiOutput.ts
+++ b/src/vs/base/common/ansiOutput.ts
@@ -402,11 +402,12 @@ export class ANSIOutput {
 	/**
 	 * Scrolls lines off the top of the output.
 	 * @param count The number of lines to scroll off the top of the output.
+	 * @returns The number of lines actually dropped (clamped to the number of committed lines above the cursor).
 	 */
-	public scrollOff(count: number): void {
+	public scrollOff(count: number): number {
 		// Sanity check the count.
 		if (count <= 0) {
-			return;
+			return 0;
 		}
 
 		// Materialize any buffered characters so `_outputLine` refers to a real line.
@@ -415,11 +416,13 @@ export class ANSIOutput {
 		// Only lines above the cursor line are safe to drop.
 		const trimmable = Math.min(count, this._outputLine);
 		if (trimmable === 0) {
-			return;
+			return 0;
 		}
 
+		// Scroll lines off the top, adjust the output line, and return the number of lines dropped.
 		this._outputLines.splice(0, trimmable);
 		this._outputLine -= trimmable;
+		return trimmable;
 	}
 
 	//#endregion Public Methods

--- a/src/vs/base/common/ansiOutput.ts
+++ b/src/vs/base/common/ansiOutput.ts
@@ -400,11 +400,11 @@ export class ANSIOutput {
 	}
 
 	/**
-	 * Scrolls lines off the top of the output.
-	 * @param count The number of lines to scroll off the top of the output.
-	 * @returns The number of lines actually dropped (clamped to the number of committed lines above the cursor).
+	 * Drops lines from the top of the output.
+	 * @param count The number of lines to drop from the top of the output.
+	 * @returns The number of lines actually dropped (clamped to the number of lines above the cursor).
 	 */
-	public scrollOff(count: number): number {
+	public dropTop(count: number): number {
 		// Sanity check the count.
 		if (count <= 0) {
 			return 0;
@@ -414,15 +414,15 @@ export class ANSIOutput {
 		this.flushBuffer();
 
 		// Only lines above the cursor line are safe to drop.
-		const trimmable = Math.min(count, this._outputLine);
-		if (trimmable === 0) {
+		const dropCount = Math.min(count, this._outputLine);
+		if (dropCount === 0) {
 			return 0;
 		}
 
-		// Scroll lines off the top, adjust the output line, and return the number of lines dropped.
-		this._outputLines.splice(0, trimmable);
-		this._outputLine -= trimmable;
-		return trimmable;
+		// Drop the lines from the top, adjust the output line, and return the number of lines dropped.
+		this._outputLines.splice(0, dropCount);
+		this._outputLine -= dropCount;
+		return dropCount;
 	}
 
 	//#endregion Public Methods

--- a/src/vs/base/common/ansiOutput.ts
+++ b/src/vs/base/common/ansiOutput.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -397,27 +397,6 @@ export class ANSIOutput {
 
 		// Flush the buffer at the end of the output.
 		this.flushBuffer();
-	}
-
-	/**
-	 * Truncates the output lines.
-	 * @param maxOutputLines The maximum output lines.
-	 * @returns The truncated output lines.
-	 */
-	truncatedOutputLines(maxOutputLines: number) {
-		// If the max output lines is less than or equal to zero, return an empty array.
-		// (It should never be negative, but check anyway.)
-		if (maxOutputLines <= 0) {
-			return [];
-		}
-
-		// If there are fewer output lines than the max output lines, return the output lines.
-		if (this.outputLines.length <= maxOutputLines) {
-			return this.outputLines;
-		}
-
-		// Truncate the output lines.
-		return this._outputLines.slice(-maxOutputLines);
 	}
 
 	//#endregion Public Methods

--- a/src/vs/base/common/ansiOutput.ts
+++ b/src/vs/base/common/ansiOutput.ts
@@ -399,6 +399,29 @@ export class ANSIOutput {
 		this.flushBuffer();
 	}
 
+	/**
+	 * Scrolls lines off the top of the output.
+	 * @param count The number of lines to scroll off the top of the output.
+	 */
+	public scrollOff(count: number): void {
+		// Sanity check the count.
+		if (count <= 0) {
+			return;
+		}
+
+		// Materialize any buffered characters so `_outputLine` refers to a real line.
+		this.flushBuffer();
+
+		// Only lines above the cursor line are safe to drop.
+		const trimmable = Math.min(count, this._outputLine);
+		if (trimmable === 0) {
+			return;
+		}
+
+		this._outputLines.splice(0, trimmable);
+		this._outputLine -= trimmable;
+	}
+
 	//#endregion Public Methods
 
 	//#region Private Methods

--- a/src/vs/base/test/common/ansiOutput.test.ts
+++ b/src/vs/base/test/common/ansiOutput.test.ts
@@ -747,9 +747,9 @@ suite('ANSIOutput', () => {
 		ansiOutput.processOutput(`${makeSGR(SGRParam.ForegroundBlue)}0123456789${makeSGR()}`);
 		ansiOutput.processOutput(`${makeSGR(SGRParam.ForegroundGreen)}0123456789${makeSGR()}`);
 		ansiOutput.processOutput(CR);
-		ansiOutput.processOutput("                              ");
+		ansiOutput.processOutput('                              ');
 		ansiOutput.processOutput(CR);
-		ansiOutput.processOutput("0123456789");
+		ansiOutput.processOutput('0123456789');
 		const outputLines = ansiOutput.outputLines;
 
 		// Test.
@@ -767,9 +767,9 @@ suite('ANSIOutput', () => {
 		ansiOutput.processOutput(`${makeSGR(SGRParam.ForegroundBlue)}0123456789${makeSGR()}`);
 		ansiOutput.processOutput(`${makeSGR(SGRParam.ForegroundGreen)}0123456789${makeSGR()}`);
 		ansiOutput.processOutput(CR);
-		ansiOutput.processOutput("                                        ");
+		ansiOutput.processOutput('                                        ');
 		ansiOutput.processOutput(CR);
-		ansiOutput.processOutput("0123456789");
+		ansiOutput.processOutput('0123456789');
 		const outputLines = ansiOutput.outputLines;
 
 		// Test.
@@ -863,7 +863,7 @@ suite('ANSIOutput', () => {
 	test('Test CUF (Cursor Forward)', () => {
 		// Setup.
 		const ansiOutput = new ANSIOutput();
-		ansiOutput.processOutput("0".repeat(80));
+		ansiOutput.processOutput('0'.repeat(80));
 		ansiOutput.processOutput(makeCUP());
 
 		// Test.
@@ -928,7 +928,7 @@ suite('ANSIOutput', () => {
 		assert.equal(outputLines[0].outputRuns[0].text, '0000000000000000000000000000000000000000000000000000000000000000000000XXXXXXXXXX');
 	});
 
-	test("Tests CUP (Cursor Position)", () => {
+	test('Tests CUP (Cursor Position)', () => {
 		// Setup.
 		const ansiOutput = setupStandardScreen();
 
@@ -943,7 +943,7 @@ suite('ANSIOutput', () => {
 		checkOutputPosition(ansiOutput, 8191, 8191);
 	});
 
-	test("Tests CUU (Cursor Up)", () => {
+	test('Tests CUU (Cursor Up)', () => {
 		// Setup.
 		const ansiOutput = setupStandardScreen();
 
@@ -1057,12 +1057,12 @@ suite('ANSIOutput', () => {
 		}
 	});
 
-	test("Tests EL 0 when there is nothing to clear", () => {
+	test('Tests EL 0 when there is nothing to clear', () => {
 		// Setup.
 		const ansiOutput = new ANSIOutput();
 
 		// Test.
-		ansiOutput.processOutput(makeEL("end-of-line"));
+		ansiOutput.processOutput(makeEL('end-of-line'));
 		assert.equal(ansiOutput.outputLines[0].outputRuns.length, 0);
 	});
 
@@ -1666,7 +1666,7 @@ suite('ANSIOutput', () => {
 		assert.equal(outputLines[0].outputRuns[2].text, '00000000000000000000000000000000000');
 	});
 
-	test("Tests styles", () => {
+	test('Tests styles', () => {
 		const testStyle = (sgr: SGRParam, ansiStyle: ANSIStyle) => {
 			// Setup.
 			const ansiOutput = new ANSIOutput();

--- a/src/vs/base/test/common/ansiOutput.test.ts
+++ b/src/vs/base/test/common/ansiOutput.test.ts
@@ -1849,24 +1849,24 @@ suite('ANSIOutput', () => {
 		assert.equal(outputLines[3].outputRuns[0].text, PANGRAM);
 	});
 
-	test('scrollOff: no-op for non-positive counts', () => {
+	test('dropTop: no-op for non-positive counts', () => {
 		const ansiOutput = new ANSIOutput();
 		ansiOutput.processOutput(`A${LF}B${LF}C`);
 
-		assert.equal(ansiOutput.scrollOff(0), 0);
-		assert.equal(ansiOutput.scrollOff(-5), 0);
+		assert.equal(ansiOutput.dropTop(0), 0);
+		assert.equal(ansiOutput.dropTop(-5), 0);
 		assert.equal(ansiOutput.outputLines.length, 3);
 		checkOutputPosition(ansiOutput, 2, 1);
 	});
 
-	test('scrollOff: drops committed lines above the cursor', () => {
+	test('dropTop: drops lines above the cursor', () => {
 		const ansiOutput = new ANSIOutput();
 		ansiOutput.processOutput(`A${LF}B${LF}C${LF}D`);
 		// Four lines: A, B, C, D. Cursor is on line 3 (the "D" line).
 		assert.equal(ansiOutput.outputLines.length, 4);
 		checkOutputPosition(ansiOutput, 3, 1);
 
-		assert.equal(ansiOutput.scrollOff(2), 2);
+		assert.equal(ansiOutput.dropTop(2), 2);
 
 		const remaining = ansiOutput.outputLines;
 		assert.equal(remaining.length, 2);
@@ -1875,14 +1875,14 @@ suite('ANSIOutput', () => {
 		checkOutputPosition(ansiOutput, 1, 1);
 	});
 
-	test('scrollOff: clamps to keep the cursor line', () => {
+	test('dropTop: clamps to keep the cursor line', () => {
 		const ansiOutput = new ANSIOutput();
 		ansiOutput.processOutput(`A${LF}B${LF}C`);
 		// Cursor on line 2 ("C"), so at most 2 head lines can be dropped.
 		assert.equal(ansiOutput.outputLines.length, 3);
 		checkOutputPosition(ansiOutput, 2, 1);
 
-		assert.equal(ansiOutput.scrollOff(10), 2);
+		assert.equal(ansiOutput.dropTop(10), 2);
 
 		const remaining = ansiOutput.outputLines;
 		assert.equal(remaining.length, 1);
@@ -1890,24 +1890,24 @@ suite('ANSIOutput', () => {
 		checkOutputPosition(ansiOutput, 0, 1);
 	});
 
-	test('scrollOff: no-op when cursor is already on the first line', () => {
+	test('dropTop: no-op when cursor is already on the first line', () => {
 		const ansiOutput = new ANSIOutput();
 		ansiOutput.processOutput('only line');
 		checkOutputPosition(ansiOutput, 0, 9);
 
-		assert.equal(ansiOutput.scrollOff(5), 0);
+		assert.equal(ansiOutput.dropTop(5), 0);
 		assert.equal(ansiOutput.outputLines.length, 1);
 		checkOutputPosition(ansiOutput, 0, 9);
 	});
 
-	test('scrollOff: subsequent input keeps SGR styling after drop', () => {
+	test('dropTop: subsequent input keeps SGR styling after drop', () => {
 		const ansiOutput = new ANSIOutput();
 		// Enter red, write three lines, scroll off, then append another line without a new SGR;
 		// it should still render red because the SGR state is preserved.
 		ansiOutput.processOutput(`${makeSGR(SGRParam.ForegroundRed)}A${LF}B${LF}C`);
 		assert.equal(ansiOutput.outputLines.length, 3);
 
-		ansiOutput.scrollOff(2);
+		ansiOutput.dropTop(2);
 		ansiOutput.processOutput(`${LF}D${makeSGR()}`);
 
 		const lines = ansiOutput.outputLines;
@@ -1918,10 +1918,10 @@ suite('ANSIOutput', () => {
 		assert.equal(lines[1].outputRuns[0].format!.foregroundColor, ANSIColor.Red);
 	});
 
-	test('scrollOff: further appends index correctly relative to the retained tail', () => {
+	test('dropTop: further appends index correctly relative to the retained tail', () => {
 		const ansiOutput = new ANSIOutput();
 		ansiOutput.processOutput(`A${LF}B${LF}C`);
-		ansiOutput.scrollOff(2);
+		ansiOutput.dropTop(2);
 		// Now only "C" remains; cursor on line 0 at column 1.
 		ansiOutput.processOutput(`${LF}D${LF}E`);
 

--- a/src/vs/base/test/common/ansiOutput.test.ts
+++ b/src/vs/base/test/common/ansiOutput.test.ts
@@ -1849,6 +1849,90 @@ suite('ANSIOutput', () => {
 		assert.equal(outputLines[3].outputRuns[0].text, PANGRAM);
 	});
 
+	test('scrollOff: no-op for non-positive counts', () => {
+		const ansiOutput = new ANSIOutput();
+		ansiOutput.processOutput(`A${LF}B${LF}C`);
+
+		ansiOutput.scrollOff(0);
+		ansiOutput.scrollOff(-5);
+		assert.equal(ansiOutput.outputLines.length, 3);
+		checkOutputPosition(ansiOutput, 2, 1);
+	});
+
+	test('scrollOff: drops committed lines above the cursor', () => {
+		const ansiOutput = new ANSIOutput();
+		ansiOutput.processOutput(`A${LF}B${LF}C${LF}D`);
+		// Four lines: A, B, C, D. Cursor is on line 3 (the "D" line).
+		assert.equal(ansiOutput.outputLines.length, 4);
+		checkOutputPosition(ansiOutput, 3, 1);
+
+		ansiOutput.scrollOff(2);
+
+		const remaining = ansiOutput.outputLines;
+		assert.equal(remaining.length, 2);
+		assert.equal(remaining[0].outputRuns[0].text, 'C');
+		assert.equal(remaining[1].outputRuns[0].text, 'D');
+		checkOutputPosition(ansiOutput, 1, 1);
+	});
+
+	test('scrollOff: clamps to keep the cursor line', () => {
+		const ansiOutput = new ANSIOutput();
+		ansiOutput.processOutput(`A${LF}B${LF}C`);
+		// Cursor on line 2 ("C"), so at most 2 head lines can be dropped.
+		assert.equal(ansiOutput.outputLines.length, 3);
+		checkOutputPosition(ansiOutput, 2, 1);
+
+		ansiOutput.scrollOff(10);
+
+		const remaining = ansiOutput.outputLines;
+		assert.equal(remaining.length, 1);
+		assert.equal(remaining[0].outputRuns[0].text, 'C');
+		checkOutputPosition(ansiOutput, 0, 1);
+	});
+
+	test('scrollOff: no-op when cursor is already on the first line', () => {
+		const ansiOutput = new ANSIOutput();
+		ansiOutput.processOutput('only line');
+		checkOutputPosition(ansiOutput, 0, 9);
+
+		ansiOutput.scrollOff(5);
+		assert.equal(ansiOutput.outputLines.length, 1);
+		checkOutputPosition(ansiOutput, 0, 9);
+	});
+
+	test('scrollOff: subsequent input keeps SGR styling after drop', () => {
+		const ansiOutput = new ANSIOutput();
+		// Enter red, write three lines, scroll off, then append another line without a new SGR;
+		// it should still render red because the SGR state is preserved.
+		ansiOutput.processOutput(`${makeSGR(SGRParam.ForegroundRed)}A${LF}B${LF}C`);
+		assert.equal(ansiOutput.outputLines.length, 3);
+
+		ansiOutput.scrollOff(2);
+		ansiOutput.processOutput(`${LF}D${makeSGR()}`);
+
+		const lines = ansiOutput.outputLines;
+		assert.equal(lines.length, 2);
+		assert.equal(lines[0].outputRuns[0].text, 'C');
+		assert.equal(lines[0].outputRuns[0].format!.foregroundColor, ANSIColor.Red);
+		assert.equal(lines[1].outputRuns[0].text, 'D');
+		assert.equal(lines[1].outputRuns[0].format!.foregroundColor, ANSIColor.Red);
+	});
+
+	test('scrollOff: further appends index correctly relative to the retained tail', () => {
+		const ansiOutput = new ANSIOutput();
+		ansiOutput.processOutput(`A${LF}B${LF}C`);
+		ansiOutput.scrollOff(2);
+		// Now only "C" remains; cursor on line 0 at column 1.
+		ansiOutput.processOutput(`${LF}D${LF}E`);
+
+		const lines = ansiOutput.outputLines;
+		assert.equal(lines.length, 3);
+		assert.equal(lines[0].outputRuns[0].text, 'C');
+		assert.equal(lines[1].outputRuns[0].text, 'D');
+		assert.equal(lines[2].outputRuns[0].text, 'E');
+		checkOutputPosition(ansiOutput, 2, 1);
+	});
+
 	const testOutputLines = (count: number, terminator: string) => {
 		// Setup.
 		const lines = makeLines(count);

--- a/src/vs/base/test/common/ansiOutput.test.ts
+++ b/src/vs/base/test/common/ansiOutput.test.ts
@@ -1853,8 +1853,8 @@ suite('ANSIOutput', () => {
 		const ansiOutput = new ANSIOutput();
 		ansiOutput.processOutput(`A${LF}B${LF}C`);
 
-		ansiOutput.scrollOff(0);
-		ansiOutput.scrollOff(-5);
+		assert.equal(ansiOutput.scrollOff(0), 0);
+		assert.equal(ansiOutput.scrollOff(-5), 0);
 		assert.equal(ansiOutput.outputLines.length, 3);
 		checkOutputPosition(ansiOutput, 2, 1);
 	});
@@ -1866,7 +1866,7 @@ suite('ANSIOutput', () => {
 		assert.equal(ansiOutput.outputLines.length, 4);
 		checkOutputPosition(ansiOutput, 3, 1);
 
-		ansiOutput.scrollOff(2);
+		assert.equal(ansiOutput.scrollOff(2), 2);
 
 		const remaining = ansiOutput.outputLines;
 		assert.equal(remaining.length, 2);
@@ -1882,7 +1882,7 @@ suite('ANSIOutput', () => {
 		assert.equal(ansiOutput.outputLines.length, 3);
 		checkOutputPosition(ansiOutput, 2, 1);
 
-		ansiOutput.scrollOff(10);
+		assert.equal(ansiOutput.scrollOff(10), 2);
 
 		const remaining = ansiOutput.outputLines;
 		assert.equal(remaining.length, 1);
@@ -1895,7 +1895,7 @@ suite('ANSIOutput', () => {
 		ansiOutput.processOutput('only line');
 		checkOutputPosition(ansiOutput, 0, 9);
 
-		ansiOutput.scrollOff(5);
+		assert.equal(ansiOutput.scrollOff(5), 0);
 		assert.equal(ansiOutput.outputLines.length, 1);
 		checkOutputPosition(ansiOutput, 0, 9);
 	});

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
@@ -7,7 +7,7 @@
 import './activityPrompt.css';
 
 // React.
-import { KeyboardEvent, useCallback, useEffect, useRef } from 'react';
+import { KeyboardEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 // Other dependencies.
 import { Emitter } from '../../../../../base/common/event.js';
@@ -61,9 +61,31 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 	const editorContainerRef = useRef<HTMLDivElement>(null);
 	const editorRef = useRef<CodeEditorWidget | null>(null);
 
-	// Whether to use the password input (HTML input) or the editor (CodeEditorWidget).
+	// State hooks.
+	const [state, setState] = useState(props.activityItemPrompt.state);
+
+	// State change useEffect. Subscribes to prompt state changes and updates local state to trigger re-render.
+	useEffect(() => {
+		// Create a disposable store for the prompt state change subscription, and clean it up on unmount or when the prompt changes.
+		const disposableStore = new DisposableStore();
+
+		// Subscribe to prompt state changes and update local state to trigger re-render.
+		disposableStore.add(props.activityItemPrompt.onStateChanged(() => {
+			setState(props.activityItemPrompt.state);
+		}));
+
+		// Re-sync in case the state changed between render and this effect running.
+		setState(props.activityItemPrompt.state);
+
+		// Clean up subscription on unmount or when prompt changes.
+		return () => disposableStore.dispose();
+	}, [props.activityItemPrompt]);
+
+	// A value that indicates whether to use the password input (HTML input) or the editor (CodeEditorWidget).
 	const isPassword = props.activityItemPrompt.password;
-	const isUnanswered = props.activityItemPrompt.state === ActivityItemPromptState.Unanswered;
+
+	// A value that indicates whether the prompt is currently unanswered.
+	const isUnanswered = state === ActivityItemPromptState.Unanswered;
 
 	/**
 	 * Focuses the appropriate input element.
@@ -312,7 +334,7 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 
 	// Determine what to render based on prompt state.
 	let prompt;
-	switch (props.activityItemPrompt.state) {
+	switch (state) {
 		// When the prompt is unanswered, render the appropriate input.
 		case ActivityItemPromptState.Unanswered:
 			if (isPassword) {

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.tsx
@@ -79,7 +79,7 @@ export const ConsoleCore = (props: ConsoleCoreProps) => {
 
 		// Initialize the width for the console pane and console tab list if it hasn't been
 		if (consoleWidth === 0) {
-			setConsoleTabListWidth(MAXIMUM_CONSOLE_TAB_LIST_WIDTH)
+			setConsoleTabListWidth(MAXIMUM_CONSOLE_TAB_LIST_WIDTH);
 			// Allocate the remaining width to the console pane
 			setConsolePaneWidth(props.width - MAXIMUM_CONSOLE_TAB_LIST_WIDTH);
 		} else if (props.width >= consoleWidth) {
@@ -89,7 +89,7 @@ export const ConsoleCore = (props: ConsoleCoreProps) => {
 			const newConsolePaneWidth = props.width - consoleTabListWidth;
 			// Decrease the console pane width first as long as we have not hit the minimum width
 			if (newConsolePaneWidth >= MINIMUM_CONSOLE_PANE_WIDTH) {
-				setConsolePaneWidth(newConsolePaneWidth)
+				setConsolePaneWidth(newConsolePaneWidth);
 			} else {
 				// Decrease the tab list width when the console pane can no longer be decreased in width
 				setConsoleTabListWidth(Math.max(props.width - consolePaneWidth, MINIMUM_CONSOLE_TAB_LIST_WIDTH));
@@ -97,8 +97,8 @@ export const ConsoleCore = (props: ConsoleCoreProps) => {
 		}
 
 		// Track the console width to accurately resize in future
-		setConsoleWidth(props.width)
-	}, [consolePaneWidth, consoleTabListWidth, consoleWidth, props.width, positronConsoleContext.consoleSessionListCollapsed])
+		setConsoleWidth(props.width);
+	}, [consolePaneWidth, consoleTabListWidth, consoleWidth, props.width, positronConsoleContext.consoleSessionListCollapsed]);
 
 	/**
 	 * onBeginResize handler.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -286,7 +286,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 
 		disposableStore.add(props.reactComponentContainer.onSizeChanged(_ => {
 			if (!props.positronConsoleInstance.scrollLocked) {
-				scrollToBottom();
+				// scrollToBottom(); NOOOOO
 			}
 		}));
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -286,7 +286,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 
 		disposableStore.add(props.reactComponentContainer.onSizeChanged(_ => {
 			if (!props.positronConsoleInstance.scrollLocked) {
-				// scrollToBottom(); NOOOOO
+				scrollToBottom();
 			}
 		}));
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceItems.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceItems.tsx
@@ -77,32 +77,86 @@ export class ConsoleInstanceItems extends Component<ConsoleInstanceItemsProps> {
 	 * @returns The rendered component.
 	 */
 	override render() {
+		console.log(`${Date.now()} ConsoleInstanceItems rendering ${this.props.positronConsoleInstance.runtimeItems.length} runtime items`);
+
+
 		return (
 			<>
 				<div className='top-spacer' />
-				{this.props.positronConsoleInstance.runtimeItems.filter(runtimeItem => !runtimeItem.isHidden).map(runtimeItem => {
+				{this.props.positronConsoleInstance.runtimeItems.map(runtimeItem => {
 					if (runtimeItem instanceof RuntimeItemActivity) {
-						return <RuntimeActivity key={runtimeItem.id} fontInfo={this.props.fontInfo} positronConsoleInstance={this.props.positronConsoleInstance} runtimeItemActivity={runtimeItem} />;
+						console.log(`RuntimeItemActivity rendering ${runtimeItem.activityItems.length} activity items`);
+						return (
+							<RuntimeActivity
+								key={runtimeItem.id}
+								fontInfo={this.props.fontInfo}
+								positronConsoleInstance={this.props.positronConsoleInstance}
+								runtimeItemActivity={runtimeItem}
+								version={runtimeItem.version}
+							/>);
 					} else if (runtimeItem instanceof RuntimeItemPendingInput) {
-						return <RuntimePendingInput key={runtimeItem.id} fontInfo={this.props.fontInfo} runtimeItemPendingInput={runtimeItem} />;
+						return (
+							<RuntimePendingInput
+								key={runtimeItem.id}
+								fontInfo={this.props.fontInfo}
+								runtimeItemPendingInput={runtimeItem}
+							/>);
 					} else if (runtimeItem instanceof RuntimeItemStartup) {
-						return <RuntimeStartup key={runtimeItem.id} runtimeItemStartup={runtimeItem} />;
+						return (
+							<RuntimeStartup
+								key={runtimeItem.id}
+								runtimeItemStartup={runtimeItem}
+							/>
+						);
 					} else if (runtimeItem instanceof RuntimeItemReconnected) {
+						// Not rendered.
 						return null;
 					} else if (runtimeItem instanceof RuntimeItemStarting) {
-						return <RuntimeStarting key={runtimeItem.id} runtimeItemStarting={runtimeItem} />;
+						return (
+							<RuntimeStarting
+								key={runtimeItem.id}
+								runtimeItemStarting={runtimeItem} />
+						);
 					} else if (runtimeItem instanceof RuntimeItemStarted) {
-						return <RuntimeStarted key={runtimeItem.id} runtimeItemStarted={runtimeItem} />;
+						return (
+							<RuntimeStarted
+								key={runtimeItem.id}
+								runtimeItemStarted={runtimeItem}
+							/>
+						);
 					} else if (runtimeItem instanceof RuntimeItemOffline) {
-						return <RuntimeOffline key={runtimeItem.id} runtimeItemOffline={runtimeItem} />;
+						return (
+							<RuntimeOffline
+								key={runtimeItem.id}
+								runtimeItemOffline={runtimeItem} />
+						);
 					} else if (runtimeItem instanceof RuntimeItemExited) {
-						return <RuntimeExited key={runtimeItem.id} runtimeItemExited={runtimeItem} />;
+						return (
+							<RuntimeExited
+								key={runtimeItem.id}
+								runtimeItemExited={runtimeItem} />
+						);
 					} else if (runtimeItem instanceof RuntimeItemRestartButton) {
-						return <RuntimeRestartButton key={runtimeItem.id} positronConsoleInstance={this.props.positronConsoleInstance} runtimeItemRestartButton={runtimeItem} />;
+						return (
+							<RuntimeRestartButton
+								key={runtimeItem.id}
+								positronConsoleInstance={this.props.positronConsoleInstance}
+								runtimeItemRestartButton={runtimeItem}
+							/>);
 					} else if (runtimeItem instanceof RuntimeItemStartupFailure) {
-						return <RuntimeStartupFailure key={runtimeItem.id} runtimeItemStartupFailure={runtimeItem} />;
+						return (
+							<RuntimeStartupFailure
+								key={runtimeItem.id}
+								runtimeItemStartupFailure={runtimeItem}
+							/>
+						);
 					} else if (runtimeItem instanceof RuntimeItemTrace) {
-						return this.props.trace && <RuntimeTrace key={runtimeItem.id} runtimeItemTrace={runtimeItem} />;
+						return this.props.trace && (
+							<RuntimeTrace
+								key={runtimeItem.id}
+								runtimeItemTrace={runtimeItem}
+							/>
+						);
 					} else {
 						// This indicates a bug. A new runtime item was added but not handled here.
 						return null;

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceItems.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstanceItems.tsx
@@ -77,15 +77,11 @@ export class ConsoleInstanceItems extends Component<ConsoleInstanceItemsProps> {
 	 * @returns The rendered component.
 	 */
 	override render() {
-		console.log(`${Date.now()} ConsoleInstanceItems rendering ${this.props.positronConsoleInstance.runtimeItems.length} runtime items`);
-
-
 		return (
 			<>
 				<div className='top-spacer' />
 				{this.props.positronConsoleInstance.runtimeItems.map(runtimeItem => {
 					if (runtimeItem instanceof RuntimeItemActivity) {
-						console.log(`RuntimeItemActivity rendering ${runtimeItem.activityItems.length} activity items`);
 						return (
 							<RuntimeActivity
 								key={runtimeItem.id}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeActivity.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeActivity.tsx
@@ -6,6 +6,9 @@
 // CSS.
 import './runtimeActivity.css';
 
+// React.
+import { memo } from 'react';
+
 // Other dependencies.
 import { FontInfo } from '../../../../../editor/common/config/fontInfo.js';
 import { ActivityInput } from './activityInput.js';
@@ -30,41 +33,85 @@ import { ActivityItemStream, ActivityItemStreamType } from '../../../../services
 export interface RuntimeActivityProps {
 	fontInfo: FontInfo;
 	runtimeItemActivity: RuntimeItemActivity;
+	version: number;
 	positronConsoleInstance: IPositronConsoleInstance;
 }
 
-/**
- * RuntimeActivity component.
- * @param props A RuntimeActivityProps that contains the component properties.
- * @returns The rendered component.
- */
-export const RuntimeActivity = (props: RuntimeActivityProps) => {
-	// Render.
+// Memoized on a scalar `version` prop that bumps on every mutation affecting
+// this component's render (see RuntimeItemActivity). The version MUST be passed
+// as its own prop - reading it off runtimeItemActivity in the compare function
+// would read the live value from the same mutable instance on both sides, so
+// every comparison would trivially be equal. Per-item state changes that the
+// leaf components subscribe to directly (e.g. ActivityItemInput.onStateChanged)
+// do not need to bump version, because those leaves update themselves without
+// a parent re-render.
+export const RuntimeActivity = memo((props: RuntimeActivityProps) => {
 	return (
 		<div className='runtime-activity' data-execution-id={props.runtimeItemActivity.id}>
-			{props.runtimeItemActivity.activityItems.filter(activityItem => !activityItem.isHidden).map(activityItem => {
-
+			{props.runtimeItemActivity.activityItems.map(activityItem => {
 				if (activityItem instanceof ActivityItemInput) {
-					return <ActivityInput key={activityItem.id} activityItemInput={activityItem} fontInfo={props.fontInfo} positronConsoleInstance={props.positronConsoleInstance} />;
+					return (
+						<ActivityInput
+							key={activityItem.id}
+							activityItemInput={activityItem}
+							fontInfo={props.fontInfo}
+							positronConsoleInstance={props.positronConsoleInstance}
+						/>
+					);
 				} else if (activityItem instanceof ActivityItemStream) {
 					if (activityItem.type === ActivityItemStreamType.OUTPUT) {
-						return <ActivityOutputStream key={activityItem.id} activityItemStream={activityItem} />;
+						return (
+							<ActivityOutputStream
+								key={activityItem.id}
+								activityItemStream={activityItem}
+							/>);
 					} else if (activityItem.type === ActivityItemStreamType.ERROR) {
-						return <ActivityErrorStream key={activityItem.id} activityItemStream={activityItem} />;
+						return (
+							<ActivityErrorStream
+								key={activityItem.id}
+								activityItemStream={activityItem}
+							/>
+						);
 					} else {
 						// This indicates a bug. A new stream type was added but not handled here.
 						return null;
 					}
 				} else if (activityItem instanceof ActivityItemPrompt) {
-					return <ActivityPrompt key={activityItem.id} activityItemPrompt={activityItem} positronConsoleInstance={props.positronConsoleInstance} />;
+					return (
+						<ActivityPrompt
+							key={activityItem.id}
+							activityItemPrompt={activityItem}
+							positronConsoleInstance={props.positronConsoleInstance}
+						/>
+					);
 				} else if (activityItem instanceof ActivityItemOutputHtml) {
-					return <ActivityOutputHtml key={activityItem.id} activityItemOutputHtml={activityItem} />;
+					return (
+						<ActivityOutputHtml
+							key={activityItem.id}
+							activityItemOutputHtml={activityItem}
+						/>
+					);
 				} else if (activityItem instanceof ActivityItemOutputMessage) {
-					return <ActivityOutputMessage key={activityItem.id} activityItemOutputMessage={activityItem} />;
+					return (
+						<ActivityOutputMessage
+							key={activityItem.id}
+							activityItemOutputMessage={activityItem}
+						/>
+					);
 				} else if (activityItem instanceof ActivityItemOutputPlot) {
-					return <ActivityOutputPlot key={activityItem.id} activityItemOutputPlot={activityItem} />;
+					return (
+						<ActivityOutputPlot
+							key={activityItem.id}
+							activityItemOutputPlot={activityItem}
+						/>
+					);
 				} else if (activityItem instanceof ActivityItemErrorMessage) {
-					return <ActivityErrorMessage key={activityItem.id} activityItemErrorMessage={activityItem} />;
+					return (
+						<ActivityErrorMessage
+							key={activityItem.id}
+							activityItemErrorMessage={activityItem}
+						/>
+					);
 				} else {
 					// This indicates a bug. A new activity item was added but not handled here.
 					return null;
@@ -72,4 +119,14 @@ export const RuntimeActivity = (props: RuntimeActivityProps) => {
 			})}
 		</div>
 	);
-};
+}, (prev, next) =>
+	// Skip re-render when the activity instance, its mutation version, and
+	// the other referenced props are all unchanged. `version` is compared as
+	// a scalar snapshot rather than via runtimeItemActivity.version because
+	// prev and next hold the same instance - reading .version off both would
+	// always return the current value and defeat memoization.
+	prev.runtimeItemActivity === next.runtimeItemActivity &&
+	prev.version === next.version &&
+	prev.fontInfo === next.fontInfo &&
+	prev.positronConsoleInstance === next.positronConsoleInstance
+);

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeActivity.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeActivity.tsx
@@ -37,14 +37,11 @@ export interface RuntimeActivityProps {
 	positronConsoleInstance: IPositronConsoleInstance;
 }
 
-// Memoized on a scalar `version` prop that bumps on every mutation affecting
-// this component's render (see RuntimeItemActivity). The version MUST be passed
-// as its own prop - reading it off runtimeItemActivity in the compare function
-// would read the live value from the same mutable instance on both sides, so
-// every comparison would trivially be equal. Per-item state changes that the
-// leaf components subscribe to directly (e.g. ActivityItemInput.onStateChanged)
-// do not need to bump version, because those leaves update themselves without
-// a parent re-render.
+/**
+ * RuntimeActivity component.
+ * @param props A RuntimeActivityProps that contains the component properties.
+ * @returns The memoized component.
+ */
 export const RuntimeActivity = memo((props: RuntimeActivityProps) => {
 	return (
 		<div className='runtime-activity' data-execution-id={props.runtimeItemActivity.id}>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeExited.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeExited.tsx
@@ -6,6 +6,9 @@
 // CSS.
 import './runtimeExited.css';
 
+// React.
+import { memo } from 'react';
+
 // Other dependencies.
 import { ConsoleOutputLines } from './consoleOutputLines.js';
 import { RuntimeItemExited } from '../../../../services/positronConsole/browser/classes/runtimeItemExited.js';
@@ -15,16 +18,13 @@ export interface RuntimeExitedProps {
 	runtimeItemExited: RuntimeItemExited;
 }
 
-/**
- * RuntimeExited component.
- * @param props A RuntimeExitedProps that contains the component properties.
- * @returns The rendered component.
- */
-export const RuntimeExited = (props: RuntimeExitedProps) => {
-	// Render.
+// RuntimeItemExited is write-once after construction, so memo with the default
+// shallow compare on runtimeItemExited lets us skip re-renders whenever the
+// parent list re-renders (e.g. on every stream chunk).
+export const RuntimeExited = memo((props: RuntimeExitedProps) => {
 	return (
 		<div className='runtime-exited'>
 			<ConsoleOutputLines outputLines={props.runtimeItemExited.outputLines} />
 		</div>
 	);
-};
+});

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeExited.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeExited.tsx
@@ -18,9 +18,11 @@ export interface RuntimeExitedProps {
 	runtimeItemExited: RuntimeItemExited;
 }
 
-// RuntimeItemExited is write-once after construction, so memo with the default
-// shallow compare on runtimeItemExited lets us skip re-renders whenever the
-// parent list re-renders (e.g. on every stream chunk).
+/**
+ * RuntimeExited component.
+ * @param props A RuntimeExitedProps that contains the component properties.
+ * @returns The memoized component.
+ */
 export const RuntimeExited = memo((props: RuntimeExitedProps) => {
 	return (
 		<div className='runtime-exited'>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeOffline.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeOffline.tsx
@@ -18,9 +18,11 @@ export interface RuntimeOfflineProps {
 	runtimeItemOffline: RuntimeItemOffline;
 }
 
-// RuntimeItemOffline is write-once after construction, so memo with the default
-// shallow compare on runtimeItemOffline lets us skip re-renders whenever the
-// parent list re-renders (e.g. on every stream chunk).
+/**
+ * RuntimeOffline component.
+ * @param props A RuntimeOfflineProps that contains the component properties.
+ * @returns The memoized component.
+ */
 export const RuntimeOffline = memo((props: RuntimeOfflineProps) => {
 	return (
 		<div className='runtime-offline'>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeOffline.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeOffline.tsx
@@ -6,6 +6,9 @@
 // CSS.
 import './runtimeOffline.css';
 
+// React.
+import { memo } from 'react';
+
 // Other dependencies.
 import { ConsoleOutputLines } from './consoleOutputLines.js';
 import { RuntimeItemOffline } from '../../../../services/positronConsole/browser/classes/runtimeItemOffline.js';
@@ -15,16 +18,13 @@ export interface RuntimeOfflineProps {
 	runtimeItemOffline: RuntimeItemOffline;
 }
 
-/**
- * RuntimeOffline component.
- * @param props A RuntimeOfflineProps that contains the component properties.
- * @returns The rendered component.
- */
-export const RuntimeOffline = (props: RuntimeOfflineProps) => {
-	// Render.
+// RuntimeItemOffline is write-once after construction, so memo with the default
+// shallow compare on runtimeItemOffline lets us skip re-renders whenever the
+// parent list re-renders (e.g. on every stream chunk).
+export const RuntimeOffline = memo((props: RuntimeOfflineProps) => {
 	return (
 		<div className='runtime-offline'>
 			<ConsoleOutputLines outputLines={props.runtimeItemOffline.outputLines} />
 		</div>
 	);
-};
+});

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimePendingInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimePendingInput.tsx
@@ -6,6 +6,9 @@
 // CSS.
 import './runtimePendingInput.css';
 
+// React.
+import { memo } from 'react';
+
 // Other dependencies.
 import { FontInfo } from '../../../../../editor/common/config/fontInfo.js';
 import { OutputRun } from '../../../../browser/positronAnsiRenderer/outputRun.js';
@@ -17,19 +20,17 @@ export interface RuntimePendingInputProps {
 	runtimeItemPendingInput: RuntimeItemPendingInput;
 }
 
-/**
- * RuntimePendingInput component.
- * @param props A RuntimePendingInputProps that contains the component properties.
- * @returns The rendered component.
- */
-export const RuntimePendingInput = (props: RuntimePendingInputProps) => {
+// RuntimeItemPendingInput is write-once after construction and fontInfo is a
+// stable reference updated only when the font configuration changes, so memo
+// with the default shallow compare lets us skip re-renders whenever the parent
+// list re-renders (e.g. on every stream chunk).
+export const RuntimePendingInput = memo((props: RuntimePendingInputProps) => {
 	// Calculate the prompt width.
 	const promptWidth = Math.ceil(
 		(props.runtimeItemPendingInput.inputPrompt.length + 1) *
 		props.fontInfo.typicalHalfwidthCharacterWidth
 	);
 
-	// Render.
 	return (
 		<div className='pending-input'>
 			{props.runtimeItemPendingInput.outputLines.map((outputLine, index) =>
@@ -44,4 +45,4 @@ export const RuntimePendingInput = (props: RuntimePendingInputProps) => {
 			)}
 		</div>
 	);
-};
+});

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimePendingInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimePendingInput.tsx
@@ -20,10 +20,11 @@ export interface RuntimePendingInputProps {
 	runtimeItemPendingInput: RuntimeItemPendingInput;
 }
 
-// RuntimeItemPendingInput is write-once after construction and fontInfo is a
-// stable reference updated only when the font configuration changes, so memo
-// with the default shallow compare lets us skip re-renders whenever the parent
-// list re-renders (e.g. on every stream chunk).
+/**
+ * RuntimePendingInput component.
+ * @param props A RuntimePendingInputProps that contains the component properties.
+ * @returns The memoized component.
+ */
 export const RuntimePendingInput = memo((props: RuntimePendingInputProps) => {
 	// Calculate the prompt width.
 	const promptWidth = Math.ceil(

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeRestartButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeRestartButton.tsx
@@ -7,7 +7,7 @@
 import './runtimeRestartButton.css';
 
 // React.
-import React, { useEffect } from 'react';
+import React, { memo, useEffect } from 'react';
 
 // Other dependencies.
 import * as nls from '../../../../../nls.js';
@@ -23,11 +23,10 @@ export interface RuntimeRestartButtonProps {
 
 /**
  * RuntimeRestartButton component.
- *
  * @param props A RuntimeRestartButtonProps that contains the component properties.
- * @returns The rendered component.
+ * @returns The memoized component.
  */
-export const RuntimeRestartButton = (props: RuntimeRestartButtonProps) => {
+export const RuntimeRestartButton = memo((props: RuntimeRestartButtonProps) => {
 
 	const restartRef = React.useRef<HTMLButtonElement>(null);
 	const restartLabel = nls.localize('positron.restartLabel', "Restart {0}", props.runtimeItemRestartButton.languageName);
@@ -63,4 +62,4 @@ export const RuntimeRestartButton = (props: RuntimeRestartButtonProps) => {
 			<span className='label'>{restartLabel}</span>
 		</button>
 	);
-};
+});

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStarted.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStarted.tsx
@@ -18,9 +18,11 @@ export interface RuntimeStartedProps {
 	runtimeItemStarted: RuntimeItemStarted;
 }
 
-// RuntimeItemStarted is write-once after construction, so memo with the default
-// shallow compare on runtimeItemStarted lets us skip re-renders whenever the
-// parent list re-renders (e.g. on every stream chunk).
+/**
+ * RuntimeStarted component.
+ * @param props A RuntimeStartedProps that contains the component properties.
+ * @returns The memoized component.
+ */
 export const RuntimeStarted = memo((props: RuntimeStartedProps) => {
 	return (
 		<ConsoleOutputLines outputLines={props.runtimeItemStarted.outputLines} />

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStarted.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStarted.tsx
@@ -6,6 +6,9 @@
 // CSS.
 import './runtimeStarted.css';
 
+// React.
+import { memo } from 'react';
+
 // Other dependencies.
 import { ConsoleOutputLines } from './consoleOutputLines.js';
 import { RuntimeItemStarted } from '../../../../services/positronConsole/browser/classes/runtimeItemStarted.js';
@@ -15,14 +18,11 @@ export interface RuntimeStartedProps {
 	runtimeItemStarted: RuntimeItemStarted;
 }
 
-/**
- * RuntimeStarted component.
- * @param props A RuntimeStartedProps that contains the component properties.
- * @returns The rendered component.
- */
-export const RuntimeStarted = (props: RuntimeStartedProps) => {
-	// Render.
+// RuntimeItemStarted is write-once after construction, so memo with the default
+// shallow compare on runtimeItemStarted lets us skip re-renders whenever the
+// parent list re-renders (e.g. on every stream chunk).
+export const RuntimeStarted = memo((props: RuntimeStartedProps) => {
 	return (
 		<ConsoleOutputLines outputLines={props.runtimeItemStarted.outputLines} />
 	);
-};
+});

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStarting.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStarting.tsx
@@ -18,10 +18,11 @@ export interface RuntimeStartingProps {
 	runtimeItemStarting: RuntimeItemStarting;
 }
 
-// RuntimeItemStarting is effectively write-once after construction (attachMode
-// is declared public but is never mutated), so memo with the default shallow
-// compare on runtimeItemStarting lets us skip re-renders whenever the parent
-// list re-renders (e.g. on every stream chunk).
+/**
+ * RuntimeStarting component.
+ * @param props A RuntimeStartingProps that contains the component properties.
+ * @returns The memoized component.
+ */
 export const RuntimeStarting = memo((props: RuntimeStartingProps) => {
 	return (
 		<div className='console-item-starting runtime-starting'>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStarting.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStarting.tsx
@@ -6,6 +6,9 @@
 // CSS.
 import './runtimeStarting.css';
 
+// React.
+import { memo } from 'react';
+
 // Other dependencies.
 import { ConsoleOutputLines } from './consoleOutputLines.js';
 import { RuntimeItemStarting } from '../../../../services/positronConsole/browser/classes/runtimeItemStarting.js';
@@ -15,13 +18,11 @@ export interface RuntimeStartingProps {
 	runtimeItemStarting: RuntimeItemStarting;
 }
 
-/**
- * RuntimeStarting component.
- * @param props A RuntimeStartingProps that contains the component properties.
- * @returns The rendered component.
- */
-export const RuntimeStarting = (props: RuntimeStartingProps) => {
-	// Render.
+// RuntimeItemStarting is effectively write-once after construction (attachMode
+// is declared public but is never mutated), so memo with the default shallow
+// compare on runtimeItemStarting lets us skip re-renders whenever the parent
+// list re-renders (e.g. on every stream chunk).
+export const RuntimeStarting = memo((props: RuntimeStartingProps) => {
 	return (
 		<div className='console-item-starting runtime-starting'>
 			<div className='left-bar' />
@@ -30,4 +31,4 @@ export const RuntimeStarting = (props: RuntimeStartingProps) => {
 			</div>
 		</div>
 	);
-};
+});

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartup.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartup.tsx
@@ -18,9 +18,11 @@ export interface RuntimeStartupProps {
 	runtimeItemStartup: RuntimeItemStartup;
 }
 
-// RuntimeItemStartup is write-once after construction, so memo with the default
-// shallow compare on runtimeItemStartup lets us skip re-renders whenever the
-// parent list re-renders (e.g. on every stream chunk).
+/**
+ * RuntimeStartup component.
+ * @param props A RuntimeStartupProps that contains the component properties.
+ * @returns The memoized component.
+ */
 export const RuntimeStartup = memo((props: RuntimeStartupProps) => {
 	return (
 		<ConsoleOutputLines outputLines={props.runtimeItemStartup.outputLines} />

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartup.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartup.tsx
@@ -6,6 +6,9 @@
 // CSS.
 import './runtimeStartup.css';
 
+// React.
+import { memo } from 'react';
+
 // Other dependencies.
 import { ConsoleOutputLines } from './consoleOutputLines.js';
 import { RuntimeItemStartup } from '../../../../services/positronConsole/browser/classes/runtimeItemStartup.js';
@@ -15,14 +18,11 @@ export interface RuntimeStartupProps {
 	runtimeItemStartup: RuntimeItemStartup;
 }
 
-/**
- * RuntimeStartup component.
- * @param props A RuntimeStartupProps that contains the component properties.
- * @returns The rendered component.
- */
-export const RuntimeStartup = (props: RuntimeStartupProps) => {
-	// Render.
+// RuntimeItemStartup is write-once after construction, so memo with the default
+// shallow compare on runtimeItemStartup lets us skip re-renders whenever the
+// parent list re-renders (e.g. on every stream chunk).
+export const RuntimeStartup = memo((props: RuntimeStartupProps) => {
 	return (
 		<ConsoleOutputLines outputLines={props.runtimeItemStartup.outputLines} />
 	);
-};
+});

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure.tsx
@@ -18,9 +18,11 @@ export interface RuntimeStartupFailureProps {
 	runtimeItemStartupFailure: RuntimeItemStartupFailure;
 }
 
-// RuntimeItemStartupFailure is write-once after construction, so memo with the
-// default shallow compare on runtimeItemStartupFailure lets us skip re-renders
-// whenever the parent list re-renders (e.g. on every stream chunk).
+/**
+ * RuntimeStartupFailure component.
+ * @param props A RuntimeStartupFailureProps that contains the component properties.
+ * @returns The memoized component.
+ */
 export const RuntimeStartupFailure = memo((props: RuntimeStartupFailureProps) => {
 	return (
 		<div className='runtime-startup-failure'>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeStartupFailure.tsx
@@ -6,6 +6,9 @@
 // CSS.
 import './runtimeStartupFailure.css';
 
+// React.
+import { memo } from 'react';
+
 // Other dependencies.
 import { ConsoleOutputLines } from './consoleOutputLines.js';
 import { RuntimeItemStartupFailure } from '../../../../services/positronConsole/browser/classes/runtimeItemStartupFailure.js';
@@ -15,17 +18,14 @@ export interface RuntimeStartupFailureProps {
 	runtimeItemStartupFailure: RuntimeItemStartupFailure;
 }
 
-/**
- * RuntimeStartupFailure component.
- * @param props A RuntimeStartupFailureProps that contains the component properties.
- * @returns The rendered component.
- */
-export const RuntimeStartupFailure = (props: RuntimeStartupFailureProps) => {
-	// Render.
+// RuntimeItemStartupFailure is write-once after construction, so memo with the
+// default shallow compare on runtimeItemStartupFailure lets us skip re-renders
+// whenever the parent list re-renders (e.g. on every stream chunk).
+export const RuntimeStartupFailure = memo((props: RuntimeStartupFailureProps) => {
 	return (
 		<div className='runtime-startup-failure'>
 			<div className='message'>{props.runtimeItemStartupFailure.message}</div>
 			<ConsoleOutputLines outputLines={props.runtimeItemStartupFailure.outputLines} />
 		</div>
 	);
-};
+});

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeTrace.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeTrace.tsx
@@ -29,9 +29,11 @@ const formatTimestamp = (timestamp: Date) => {
 	return `${toTwoDigits(timestamp.getHours())}:${toTwoDigits(timestamp.getMinutes())}:${toTwoDigits(timestamp.getSeconds())}.${toFourDigits(timestamp.getMilliseconds())}`;
 };
 
-// RuntimeItemTrace is write-once after construction, so memo with the default
-// shallow compare on runtimeItemTrace lets us skip re-renders whenever the
-// parent list re-renders (e.g. on every stream chunk).
+/**
+ * RuntimeTrace component.
+ * @param props A RuntimeTraceProps that contains the component properties.
+ * @returns The memoized component.
+ */
 export const RuntimeTrace = memo((props: RuntimeTraceProps) => {
 	return (
 		<div className='runtime-trace'>

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeTrace.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeTrace.tsx
@@ -6,6 +6,9 @@
 // CSS.
 import './runtimeTrace.css';
 
+// React.
+import { memo } from 'react';
+
 // Other dependencies.
 import { ConsoleOutputLines } from './consoleOutputLines.js';
 import { RuntimeItemTrace } from '../../../../services/positronConsole/browser/classes/runtimeItemTrace.js';
@@ -26,13 +29,10 @@ const formatTimestamp = (timestamp: Date) => {
 	return `${toTwoDigits(timestamp.getHours())}:${toTwoDigits(timestamp.getMinutes())}:${toTwoDigits(timestamp.getSeconds())}.${toFourDigits(timestamp.getMilliseconds())}`;
 };
 
-/**
- * RuntimeTrace component.
- * @param props A RuntimeTraceProps that contains the component properties.
- * @returns The rendered component.
- */
-export const RuntimeTrace = (props: RuntimeTraceProps) => {
-	// Render.
+// RuntimeItemTrace is write-once after construction, so memo with the default
+// shallow compare on runtimeItemTrace lets us skip re-renders whenever the
+// parent list re-renders (e.g. on every stream chunk).
+export const RuntimeTrace = memo((props: RuntimeTraceProps) => {
 	return (
 		<div className='runtime-trace'>
 			<div>
@@ -41,4 +41,4 @@ export const RuntimeTrace = (props: RuntimeTraceProps) => {
 			<ConsoleOutputLines outputLines={props.runtimeItemTrace.outputLines} />
 		</div>
 	);
-};
+});

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItem.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItem.ts
@@ -7,15 +7,6 @@
  * ActivityItem class.
  */
 export abstract class ActivityItem {
-	//#region Private Properties
-
-	/**
-	 * Gets or sets a value which indicates whether the item is hidden.
-	 */
-	private _isHidden = false;
-
-	//#endregion Private Properties
-
 	//#region Constructor
 
 	/**
@@ -29,17 +20,6 @@ export abstract class ActivityItem {
 
 	//#endregion Constructor
 
-	//#region Public Properties
-
-	/**
-	 * Gets a value which indicates whether the item is hidden.
-	 */
-	public get isHidden(): boolean {
-		return this._isHidden;
-	}
-
-	//#endregion Public Properties
-
 	//#region Public Methods
 
 	/**
@@ -48,24 +28,6 @@ export abstract class ActivityItem {
 	 * @returns The clipboard representation of the activity item.
 	 */
 	public abstract getClipboardRepresentation(commentPrefix: string): string[];
-
-	/**
-	 * Optimizes scrollback. This is the default implementation which treats an activity item
-	 * as a single item, so it is either entirely visible or entirely hidden.
-	 * @param scrollbackSize The scrollback size.
-	 * @returns The remaining scrollback size.
-	 */
-	public optimizeScrollback(scrollbackSize: number): number {
-		// If scrollback size is zero, hide the item and return zero.
-		if (!scrollbackSize) {
-			this._isHidden = true;
-			return 0;
-		}
-
-		// Unhide the item and return the scrollback size minus one.
-		this._isHidden = false;
-		return scrollbackSize - 1;
-	}
 
 	//#endregion Public Methods
 }

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItem.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItem.ts
@@ -23,6 +23,13 @@ export abstract class ActivityItem {
 	//#region Public Methods
 
 	/**
+	 * Trim scrollback.
+	 * @param scrollbackSize A number representing the scrollback size.
+	 * @returns A number representing the remaining scrollback size.
+	 */
+	public abstract trimScrollback(scrollbackSize: number): number;
+
+	/**
 	 * Gets the clipboard representation of the activity item.
 	 * @param commentPrefix The comment prefix to use.
 	 * @returns The clipboard representation of the activity item.

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItem.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItem.ts
@@ -4,6 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 /**
+ * TrimScrollbackResult interface.
+ */
+export interface TrimScrollbackResult {
+	// A value which indicates whether the item actually trimmed any content.
+	readonly trimmed: boolean;
+
+	// The remaining scrollback size after trimming this item.
+	readonly remainingScrollbackSize: number;
+}
+
+/**
  * ActivityItem class.
  */
 export abstract class ActivityItem {
@@ -25,9 +36,9 @@ export abstract class ActivityItem {
 	/**
 	 * Trim scrollback.
 	 * @param scrollbackSize A number representing the scrollback size.
-	 * @returns A number representing the remaining scrollback size.
+	 * @returns A TrimScrollbackResult indicating the result of the trim scrollback operation.
 	 */
-	public abstract trimScrollback(scrollbackSize: number): number;
+	public abstract trimScrollback(scrollbackSize: number): TrimScrollbackResult;
 
 	/**
 	 * Gets the clipboard representation of the activity item.

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemErrorMessage.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemErrorMessage.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ActivityItem } from './activityItem.js';
+import { ActivityItem, TrimScrollbackResult } from './activityItem.js';
 import { formatOutputLinesForClipboard } from '../utils/clipboardUtils.js';
 import { ANSIOutput, ANSIOutputLine } from '../../../../../base/common/ansiOutput.js';
 
@@ -65,16 +65,22 @@ export class ActivityItemErrorMessage extends ActivityItem {
 	/**
 	 * Trim scrollback.
 	 * @param scrollbackSize A number representing the scrollback size.
-	 * @returns A number representing the remaining scrollback size.
+	 * @returns A TrimScrollbackResult indicating the result of the trim scrollback operation.
 	 */
-	public override trimScrollback(scrollbackSize: number): number {
+	public override trimScrollback(scrollbackSize: number): TrimScrollbackResult {
 		// We should never be called with a scrollback size <= 0.
 		if (scrollbackSize <= 0) {
-			return 0;
+			return {
+				trimmed: false,
+				remainingScrollbackSize: 0
+			};
 		}
 
-		// Counts as one scrollback item.
-		return scrollbackSize - 1;
+		// Counts as one scrollback item; nothing is trimmed in place.
+		return {
+			trimmed: false,
+			remainingScrollbackSize: scrollbackSize - 1
+		};
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemErrorMessage.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemErrorMessage.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -11,24 +11,19 @@ import { ANSIOutput, ANSIOutputLine } from '../../../../../base/common/ansiOutpu
  * ActivityItemErrorMessage class.
  */
 export class ActivityItemErrorMessage extends ActivityItem {
-	//#region Private Properties
+	//#region Public Properties
 
 	/**
 	 * Gets the message output lines.
 	 */
-	private _messageOutputLines: ANSIOutputLine[];
+	readonly messageOutputLines: ANSIOutputLine[];
 
 	/**
 	 * Gets the traceback output lines.
 	 */
-	private _tracebackOutputLines: ANSIOutputLine[];
+	readonly tracebackOutputLines: ANSIOutputLine[];
 
-	/**
-	 * Gets or sets the scrollback size. This is used to truncate the output lines for display.
-	 */
-	private _scrollbackSize?: number;
-
-	//#endregion Private Properties
+	//#endregion Public Properties
 
 	//#region Constructor
 
@@ -57,61 +52,13 @@ export class ActivityItemErrorMessage extends ActivityItem {
 		const detailedMessage = !name ? message : `\x1b[31m${name}\x1b[0m: ${message}`;
 
 		// Set the message output lines and the traceback output lines.
-		this._messageOutputLines = ANSIOutput.processOutput(detailedMessage);
-		this._tracebackOutputLines = !traceback.length ?
+		this.messageOutputLines = ANSIOutput.processOutput(detailedMessage);
+		this.tracebackOutputLines = !traceback.length ?
 			[] :
 			ANSIOutput.processOutput(traceback.join('\n'));
 	}
 
 	//#endregion Constructor
-
-	//#region Public Properties
-
-	/**
-	 * Gets the message output lines.
-	 */
-	get messageOutputLines(): ANSIOutputLine[] {
-		// If scrollback size is undefined, return the message output lines.
-		if (this._scrollbackSize === undefined) {
-			return this._messageOutputLines;
-		}
-
-		// Calculate the scrollback size for the message output lines.
-		const scrollbackSize = Math.max(0, this._scrollbackSize - this._tracebackOutputLines.length);
-
-		// If no message output lines will be displayed, return an empty array.
-		if (!scrollbackSize) {
-			return [];
-		}
-
-		// If all of the message output lines should be displayed, return the message output lines.
-		if (this._messageOutputLines.length <= scrollbackSize) {
-			return this._messageOutputLines;
-		}
-
-		// Return the truncated message output lines.
-		return this._messageOutputLines.slice(-scrollbackSize);
-	}
-
-	/**
-	 * Gets the traceback output lines.
-	 */
-	get tracebackOutputLines(): ANSIOutputLine[] {
-		// If scrollback size is undefined, return all of the traceback output lines.
-		if (this._scrollbackSize === undefined) {
-			return this._tracebackOutputLines;
-		}
-
-		// If all of the traceback output lines should be displayed, return all of them.
-		if (this._tracebackOutputLines.length <= this._scrollbackSize) {
-			return this._tracebackOutputLines;
-		}
-
-		// Return the truncated traceback output lines.
-		return this._tracebackOutputLines.slice(-this._scrollbackSize);
-	}
-
-	//#endregion Public Properties
 
 	//#region Public Methods
 
@@ -122,8 +69,8 @@ export class ActivityItemErrorMessage extends ActivityItem {
 	 */
 	public override getClipboardRepresentation(commentPrefix: string): string[] {
 		return [
-			...formatOutputLinesForClipboard(this._messageOutputLines, commentPrefix),
-			...formatOutputLinesForClipboard(this._tracebackOutputLines, commentPrefix)
+			...formatOutputLinesForClipboard(this.messageOutputLines, commentPrefix),
+			...formatOutputLinesForClipboard(this.tracebackOutputLines, commentPrefix)
 		];
 	}
 

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemErrorMessage.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemErrorMessage.ts
@@ -127,26 +127,5 @@ export class ActivityItemErrorMessage extends ActivityItem {
 		];
 	}
 
-	/**
-	 * Optimizes scrollback.
-	 * @param scrollbackSize The scrollback size.
-	 * @returns The remaining scrollback size.
-	 */
-	public override optimizeScrollback(scrollbackSize: number) {
-		// Calculate the total number of output lines.
-		const outputLines = this._messageOutputLines.length + this._tracebackOutputLines.length;
-
-		// If there are fewer output lines than the scrollback size, clear the scrollback size
-		// as all of them will be displayed, and return the remaining scrollback size.
-		if (outputLines <= scrollbackSize) {
-			this._scrollbackSize = undefined;
-			return scrollbackSize - outputLines;
-		}
-
-		// Set the scrollback size and return 0
-		this._scrollbackSize = scrollbackSize;
-		return 0;
-	}
-
 	//#endregion Public Methods
 }

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemErrorMessage.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemErrorMessage.ts
@@ -16,12 +16,12 @@ export class ActivityItemErrorMessage extends ActivityItem {
 	/**
 	 * Gets the message output lines.
 	 */
-	readonly messageOutputLines: ANSIOutputLine[];
+	messageOutputLines: ANSIOutputLine[];
 
 	/**
 	 * Gets the traceback output lines.
 	 */
-	readonly tracebackOutputLines: ANSIOutputLine[];
+	tracebackOutputLines: ANSIOutputLine[];
 
 	//#endregion Public Properties
 
@@ -61,6 +61,21 @@ export class ActivityItemErrorMessage extends ActivityItem {
 	//#endregion Constructor
 
 	//#region Public Methods
+
+	/**
+	 * Trim scrollback.
+	 * @param scrollbackSize A number representing the scrollback size.
+	 * @returns A number representing the remaining scrollback size.
+	 */
+	public override trimScrollback(scrollbackSize: number): number {
+		// We should never be called with a scrollback size <= 0.
+		if (scrollbackSize <= 0) {
+			return 0;
+		}
+
+		// Counts as one scrollback item.
+		return scrollbackSize - 1;
+	}
 
 	/**
 	 * Gets the clipboard representation of the activity item.

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemInput.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemInput.ts
@@ -1,9 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ActivityItem } from './activityItem.js';
+import { ActivityItem, TrimScrollbackResult } from './activityItem.js';
 import { Emitter } from '../../../../../base/common/event.js';
 import { formatOutputLinesForClipboard } from '../utils/clipboardUtils.js';
 import { ANSIOutput, ANSIOutputLine } from '../../../../../base/common/ansiOutput.js';
@@ -115,16 +115,22 @@ export class ActivityItemInput extends ActivityItem {
 	/**
 	 * Trim scrollback.
 	 * @param scrollbackSize A number representing the scrollback size.
-	 * @returns A number representing the remaining scrollback size.
+	 * @returns A TrimScrollbackResult indicating the result of the trim scrollback operation.
 	 */
-	public override trimScrollback(scrollbackSize: number): number {
+	public override trimScrollback(scrollbackSize: number): TrimScrollbackResult {
 		// We should never be called with a scrollback size <= 0.
 		if (scrollbackSize <= 0) {
-			return 0;
+			return {
+				trimmed: false,
+				remainingScrollbackSize: 0
+			};
 		}
 
-		// Counts as one scrollback item.
-		return scrollbackSize - 1;
+		// Counts as one scrollback item; nothing is trimmed in place.
+		return {
+			trimmed: false,
+			remainingScrollbackSize: scrollbackSize - 1
+		};
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemInput.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemInput.ts
@@ -32,7 +32,7 @@ export class ActivityItemInput extends ActivityItem {
 	/**
 	 * Gets the code output lines.
 	 */
-	private readonly _codeOutputLines: readonly ANSIOutputLine[] = [];
+	private _codeOutputLines: ANSIOutputLine[] = [];
 
 	/**
 	 * onStateChanged event emitter.
@@ -111,6 +111,21 @@ export class ActivityItemInput extends ActivityItem {
 	//#endregion Constructor
 
 	//#region Public Methods
+
+	/**
+	 * Trim scrollback.
+	 * @param scrollbackSize A number representing the scrollback size.
+	 * @returns A number representing the remaining scrollback size.
+	 */
+	public override trimScrollback(scrollbackSize: number): number {
+		// We should never be called with a scrollback size <= 0.
+		if (scrollbackSize <= 0) {
+			return 0;
+		}
+
+		// Counts as one scrollback item.
+		return scrollbackSize - 1;
+	}
 
 	/**
 	 * Gets the clipboard representation of the activity item.

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputHtml.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputHtml.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from '../../../../../nls.js';
-import { ActivityItem } from './activityItem.js';
+import { ActivityItem, TrimScrollbackResult } from './activityItem.js';
 
 /**
  * Localized strings.
@@ -46,16 +46,22 @@ export class ActivityItemOutputHtml extends ActivityItem {
 	/**
 	 * Trim scrollback.
 	 * @param scrollbackSize A number representing the scrollback size.
-	 * @returns A number representing the remaining scrollback size.
+	 * @returns A TrimScrollbackResult indicating the result of the trim scrollback operation.
 	 */
-	public override trimScrollback(scrollbackSize: number): number {
+	public override trimScrollback(scrollbackSize: number): TrimScrollbackResult {
 		// We should never be called with a scrollback size <= 0.
 		if (scrollbackSize <= 0) {
-			return 0;
+			return {
+				trimmed: false,
+				remainingScrollbackSize: 0
+			};
 		}
 
-		// Counts as one scrollback item.
-		return scrollbackSize - 1;
+		// Counts as one scrollback item; nothing is trimmed in place.
+		return {
+			trimmed: false,
+			remainingScrollbackSize: scrollbackSize - 1
+		};
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputHtml.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputHtml.ts
@@ -44,6 +44,21 @@ export class ActivityItemOutputHtml extends ActivityItem {
 	//#region Public Methods
 
 	/**
+	 * Trim scrollback.
+	 * @param scrollbackSize A number representing the scrollback size.
+	 * @returns A number representing the remaining scrollback size.
+	 */
+	public override trimScrollback(scrollbackSize: number): number {
+		// We should never be called with a scrollback size <= 0.
+		if (scrollbackSize <= 0) {
+			return 0;
+		}
+
+		// Counts as one scrollback item.
+		return scrollbackSize - 1;
+	}
+
+	/**
 	 * Gets the clipboard representation of the activity item.
 	 * @param commentPrefix The comment prefix to use.
 	 * @returns The clipboard representation of the activity item.

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputMessage.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputMessage.ts
@@ -84,23 +84,5 @@ export class ActivityItemOutputMessage extends ActivityItem {
 		return formatOutputLinesForClipboard(this._outputLines, commentPrefix);
 	}
 
-	/**
-	 * Optimizes scrollback.
-	 * @param scrollbackSize The scrollback size.
-	 * @returns The remaining scrollback size.
-	 */
-	public override optimizeScrollback(scrollbackSize: number) {
-		// If there are fewer output lines than the scrollback size, clear the scrollback size
-		// as all of them will be displayed, and return the remaining scrollback size.
-		if (this._outputLines.length <= scrollbackSize) {
-			this._scrollbackSize = undefined;
-			return scrollbackSize - this._outputLines.length;
-		}
-
-		// Set the scrollback size and return 0
-		this._scrollbackSize = scrollbackSize;
-		return 0;
-	}
-
 	//#endregion Public Methods
 }

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputMessage.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputMessage.ts
@@ -17,7 +17,7 @@ export class ActivityItemOutputMessage extends ActivityItem {
 	/**
 	 * Gets the output lines.
 	 */
-	readonly outputLines: readonly ANSIOutputLine[];
+	outputLines: ANSIOutputLine[];
 
 	//#endregion Public Properties
 
@@ -52,6 +52,33 @@ export class ActivityItemOutputMessage extends ActivityItem {
 	//#endregion Constructor
 
 	//#region Public Methods
+
+	/**
+	 * Trim scrollback.
+	 * @param scrollbackSize A number representing the scrollback size.
+	 * @returns A number representing the remaining scrollback size.
+	 */
+	public override trimScrollback(scrollbackSize: number): number {
+		// We should never be called with a scrollback size of 0.
+		if (scrollbackSize <= 0) {
+			// Defensive: if this happens, trim all lines and report the scrollback as fully consumed.
+			console.warn(`ActivityItemOutputMessage.trimScrollback called with non-positive scrollbackSize ${scrollbackSize}; trimming all lines.`);
+			this.outputLines = [];
+			return 0;
+		}
+
+		// If our lines fit in the remaining scrollback budget, keep them all and return what's
+		// left of the budget.
+		if (this.outputLines.length <= scrollbackSize) {
+			return scrollbackSize - this.outputLines.length;
+		}
+
+		// Otherwise, trim to the tail of most-recent lines that fit.
+		this.outputLines = this.outputLines.slice(-scrollbackSize);
+
+		// Report the scrollback as fully consumed.
+		return 0;
+	}
 
 	/**
 	 * Gets the clipboard representation of the activity item.

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputMessage.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputMessage.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -12,19 +12,14 @@ import { ILanguageRuntimeMessageOutputData } from '../../../languageRuntime/comm
  * ActivityItemOutputMessage class.
  */
 export class ActivityItemOutputMessage extends ActivityItem {
-	//#region Private Properties
+	//#region Public Properties
 
 	/**
-	 * Gets the cached output lines.
+	 * Gets the output lines.
 	 */
-	private readonly _outputLines: readonly ANSIOutputLine[];
+	readonly outputLines: readonly ANSIOutputLine[];
 
-	/**
-	 * Gets or sets the scrollback size. This is used to truncate the output lines for display.
-	 */
-	private _scrollbackSize?: number;
-
-	//#endregion Private Properties
+	//#endregion Public Properties
 
 	//#region Constructor
 
@@ -51,27 +46,10 @@ export class ActivityItemOutputMessage extends ActivityItem {
 
 		// If the output is empty, don't render any output lines; otherwise, process the output into
 		// output lines.
-		this._outputLines = !output ? [] : ANSIOutput.processOutput(output);
+		this.outputLines = !output ? [] : ANSIOutput.processOutput(output);
 	}
 
 	//#endregion Constructor
-
-	//#region Public Properties
-
-	/**
-	 * Gets the output lines.
-	 */
-	get outputLines(): readonly ANSIOutputLine[] {
-		// If scrollback size is undefined, return all of the output lines.
-		if (this._scrollbackSize === undefined) {
-			return this._outputLines;
-		}
-
-		// Truncate the output lines.
-		return this._outputLines.slice(-this._scrollbackSize);
-	}
-
-	//#endregion Public Properties
 
 	//#region Public Methods
 
@@ -81,7 +59,7 @@ export class ActivityItemOutputMessage extends ActivityItem {
 	 * @returns The clipboard representation of the activity item.
 	 */
 	public override getClipboardRepresentation(commentPrefix: string): string[] {
-		return formatOutputLinesForClipboard(this._outputLines, commentPrefix);
+		return formatOutputLinesForClipboard(this.outputLines, commentPrefix);
 	}
 
 	//#endregion Public Methods

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputMessage.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputMessage.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ActivityItem } from './activityItem.js';
+import { ActivityItem, TrimScrollbackResult } from './activityItem.js';
 import { formatOutputLinesForClipboard } from '../utils/clipboardUtils.js';
 import { ANSIOutput, ANSIOutputLine } from '../../../../../base/common/ansiOutput.js';
 import { ILanguageRuntimeMessageOutputData } from '../../../languageRuntime/common/languageRuntimeService.js';
@@ -56,22 +56,31 @@ export class ActivityItemOutputMessage extends ActivityItem {
 	/**
 	 * Trim scrollback.
 	 * @param scrollbackSize A number representing the scrollback size.
-	 * @returns A number representing the remaining scrollback size.
+	 * @returns A TrimScrollbackResult indicating the result of the trim scrollback operation.
 	 */
-	public override trimScrollback(scrollbackSize: number): number {
+	public override trimScrollback(scrollbackSize: number): TrimScrollbackResult {
 		// We should never be called with a scrollback size <= 0.
 		if (scrollbackSize <= 0) {
-			return 0;
+			return {
+				trimmed: false,
+				remainingScrollbackSize: 0
+			};
 		}
 
 		// If no trimming is needed, return the remaining scrollback size.
 		if (this.outputLines.length <= scrollbackSize) {
-			return scrollbackSize - this.outputLines.length;
+			return {
+				trimmed: false,
+				remainingScrollbackSize: scrollbackSize - this.outputLines.length
+			};
 		}
 
 		// Otherwise, trim output lines and report the scrollback as fully consumed.
 		this.outputLines = this.outputLines.slice(-scrollbackSize);
-		return 0;
+		return {
+			trimmed: true,
+			remainingScrollbackSize: 0
+		};
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputMessage.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputMessage.ts
@@ -59,24 +59,18 @@ export class ActivityItemOutputMessage extends ActivityItem {
 	 * @returns A number representing the remaining scrollback size.
 	 */
 	public override trimScrollback(scrollbackSize: number): number {
-		// We should never be called with a scrollback size of 0.
+		// We should never be called with a scrollback size <= 0.
 		if (scrollbackSize <= 0) {
-			// Defensive: if this happens, trim all lines and report the scrollback as fully consumed.
-			console.warn(`ActivityItemOutputMessage.trimScrollback called with non-positive scrollbackSize ${scrollbackSize}; trimming all lines.`);
-			this.outputLines = [];
 			return 0;
 		}
 
-		// If our lines fit in the remaining scrollback budget, keep them all and return what's
-		// left of the budget.
+		// If no trimming is needed, return the remaining scrollback size.
 		if (this.outputLines.length <= scrollbackSize) {
 			return scrollbackSize - this.outputLines.length;
 		}
 
-		// Otherwise, trim to the tail of most-recent lines that fit.
+		// Otherwise, trim output lines and report the scrollback as fully consumed.
 		this.outputLines = this.outputLines.slice(-scrollbackSize);
-
-		// Report the scrollback as fully consumed.
 		return 0;
 	}
 

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputPlot.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputPlot.ts
@@ -79,6 +79,21 @@ export class ActivityItemOutputPlot extends ActivityItem {
 	//#region Public Methods
 
 	/**
+	 * Trim scrollback.
+	 * @param scrollbackSize A number representing the scrollback size.
+	 * @returns A number representing the remaining scrollback size.
+	 */
+	public override trimScrollback(scrollbackSize: number): number {
+		// We should never be called with a scrollback size <= 0.
+		if (scrollbackSize <= 0) {
+			return 0;
+		}
+
+		// Counts as one scrollback item.
+		return scrollbackSize - 1;
+	}
+
+	/**
 	 * Gets the clipboard representation of the activity item.
 	 * @param commentPrefix The comment prefix to use.
 	 * @returns The clipboard representation of the activity item.

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputPlot.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputPlot.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -12,21 +12,12 @@ import { ILanguageRuntimeMessageOutputData } from '../../../languageRuntime/comm
  * ActivityItemOutputPlot class.
  */
 export class ActivityItemOutputPlot extends ActivityItem {
-	//#region Private Properties
+	//#region Public Properties
 
 	/**
 	 * Gets the output lines.
 	 */
-	private readonly _outputLines: readonly ANSIOutputLine[];
-
-	/**
-	 * Gets or sets the scrollback size. This is used to truncate the output lines for display.
-	 */
-	private _scrollbackSize?: number;
-
-	//#endregion Private Properties
-
-	//#region Public Properties
+	readonly outputLines: readonly ANSIOutputLine[];
 
 	/**
 	 * Gets the plot data, as a Base64-encoded string suitable for use in a data URI.
@@ -80,27 +71,10 @@ export class ActivityItemOutputPlot extends ActivityItem {
 
 		// If the output is empty, don't render any output lines; otherwise, process the output into
 		// output lines.
-		this._outputLines = !output ? [] : ANSIOutput.processOutput(output);
+		this.outputLines = !output ? [] : ANSIOutput.processOutput(output);
 	}
 
 	//#endregion Constructor
-
-	//#region Public Properties
-
-	/**
-	 * Gets the output lines.
-	 */
-	get outputLines(): readonly ANSIOutputLine[] {
-		// If scrollback size is undefined, return all of the output lines.
-		if (this._scrollbackSize === undefined) {
-			return this._outputLines;
-		}
-
-		// Truncate the output lines.
-		return this._outputLines.slice(-this._scrollbackSize);
-	}
-
-	//#endregion Public Properties
 
 	//#region Public Methods
 
@@ -110,7 +84,7 @@ export class ActivityItemOutputPlot extends ActivityItem {
 	 * @returns The clipboard representation of the activity item.
 	 */
 	public override getClipboardRepresentation(commentPrefix: string): string[] {
-		return formatOutputLinesForClipboard(this._outputLines, commentPrefix);
+		return formatOutputLinesForClipboard(this.outputLines, commentPrefix);
 	}
 
 	//#endregion Public Methods

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputPlot.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputPlot.ts
@@ -113,23 +113,5 @@ export class ActivityItemOutputPlot extends ActivityItem {
 		return formatOutputLinesForClipboard(this._outputLines, commentPrefix);
 	}
 
-	/**
-	 * Optimizes scrollback.
-	 * @param scrollbackSize The scrollback size.
-	 * @returns The remaining scrollback size.
-	 */
-	public override optimizeScrollback(scrollbackSize: number) {
-		// If there are fewer output lines than the scrollback size, clear the scrollback size
-		// as all of them will be displayed, and return the remaining scrollback size.
-		if (this._outputLines.length <= scrollbackSize) {
-			this._scrollbackSize = undefined;
-			return scrollbackSize - this._outputLines.length;
-		}
-
-		// Set the scrollback size and return 0
-		this._scrollbackSize = scrollbackSize;
-		return 0;
-	}
-
 	//#endregion Public Methods
 }

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputPlot.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemOutputPlot.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ActivityItem } from './activityItem.js';
+import { ActivityItem, TrimScrollbackResult } from './activityItem.js';
 import { formatOutputLinesForClipboard } from '../utils/clipboardUtils.js';
 import { ANSIOutput, ANSIOutputLine } from '../../../../../base/common/ansiOutput.js';
 import { ILanguageRuntimeMessageOutputData } from '../../../languageRuntime/common/languageRuntimeService.js';
@@ -81,16 +81,22 @@ export class ActivityItemOutputPlot extends ActivityItem {
 	/**
 	 * Trim scrollback.
 	 * @param scrollbackSize A number representing the scrollback size.
-	 * @returns A number representing the remaining scrollback size.
+	 * @returns A TrimScrollbackResult indicating the result of the trim scrollback operation.
 	 */
-	public override trimScrollback(scrollbackSize: number): number {
+	public override trimScrollback(scrollbackSize: number): TrimScrollbackResult {
 		// We should never be called with a scrollback size <= 0.
 		if (scrollbackSize <= 0) {
-			return 0;
+			return {
+				trimmed: false,
+				remainingScrollbackSize: 0
+			};
 		}
 
-		// Counts as one scrollback item.
-		return scrollbackSize - 1;
+		// Counts as one scrollback item; nothing is trimmed in place.
+		return {
+			trimmed: false,
+			remainingScrollbackSize: scrollbackSize - 1
+		};
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemPrompt.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemPrompt.ts
@@ -1,8 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Emitter } from '../../../../../base/common/event.js';
 import { ActivityItem, TrimScrollbackResult } from './activityItem.js';
 import { formatOutputLinesForClipboard } from '../utils/clipboardUtils.js';
 import { ANSIOutput, ANSIOutputLine } from '../../../../../base/common/ansiOutput.js';
@@ -20,7 +21,38 @@ export const enum ActivityItemPromptState {
  * ActivityItemPrompt class.
  */
 export class ActivityItemPrompt extends ActivityItem {
+	//#region Private Properties
+
+	/**
+	 * The state of the prompt.
+	 */
+	private _state = ActivityItemPromptState.Unanswered;
+
+	/**
+	 * An emitter that fires when the state of the prompt changes.
+	 */
+	private readonly _onStateChangedEmitter = new Emitter<void>();
+
+	//#endregion Private Properties
+
 	//#region Public Properties
+
+	/**
+	 * Gets the state.
+	 */
+	get state() {
+		return this._state;
+	}
+
+	/**
+	 * Sets the state.
+	 */
+	set state(state: ActivityItemPromptState) {
+		if (state !== this._state) {
+			this._state = state;
+			this._onStateChangedEmitter.fire();
+		}
+	}
 
 	/**
 	 * Gets the output lines.
@@ -28,16 +60,20 @@ export class ActivityItemPrompt extends ActivityItem {
 	readonly outputLines: readonly ANSIOutputLine[];
 
 	/**
-	 * Gets or sets the state.
-	 */
-	state = ActivityItemPromptState.Unanswered;
-
-	/**
 	 * Gets or sets the answer.
 	 */
 	answer?: string = undefined;
 
 	//#endregion Public Properties
+
+	//#region Public Events
+
+	/**
+	 * An event that fires when the state changes.
+	 */
+	public onStateChanged = this._onStateChangedEmitter.event;
+
+	//#endregion Public Events
 
 	//#region Constructor
 

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemPrompt.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemPrompt.ts
@@ -68,6 +68,21 @@ export class ActivityItemPrompt extends ActivityItem {
 	//#region Public Methods
 
 	/**
+	 * Trim scrollback.
+	 * @param scrollbackSize A number representing the scrollback size.
+	 * @returns A number representing the remaining scrollback size.
+	 */
+	public override trimScrollback(scrollbackSize: number): number {
+		// We should never be called with a scrollback size <= 0.
+		if (scrollbackSize <= 0) {
+			return 0;
+		}
+
+		// Counts as one scrollback item.
+		return scrollbackSize - 1;
+	}
+
+	/**
 	 * Gets the clipboard representation of the activity item.
 	 * @param commentPrefix The comment prefix to use.
 	 * @returns The clipboard representation of the activity item.

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemPrompt.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemPrompt.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ActivityItem } from './activityItem.js';
+import { ActivityItem, TrimScrollbackResult } from './activityItem.js';
 import { formatOutputLinesForClipboard } from '../utils/clipboardUtils.js';
 import { ANSIOutput, ANSIOutputLine } from '../../../../../base/common/ansiOutput.js';
 
@@ -70,16 +70,22 @@ export class ActivityItemPrompt extends ActivityItem {
 	/**
 	 * Trim scrollback.
 	 * @param scrollbackSize A number representing the scrollback size.
-	 * @returns A number representing the remaining scrollback size.
+	 * @returns A TrimScrollbackResult indicating the result of the trim scrollback operation.
 	 */
-	public override trimScrollback(scrollbackSize: number): number {
+	public override trimScrollback(scrollbackSize: number): TrimScrollbackResult {
 		// We should never be called with a scrollback size <= 0.
 		if (scrollbackSize <= 0) {
-			return 0;
+			return {
+				trimmed: false,
+				remainingScrollbackSize: 0
+			};
 		}
 
-		// Counts as one scrollback item.
-		return scrollbackSize - 1;
+		// Counts as one scrollback item; nothing is trimmed in place.
+		return {
+			trimmed: false,
+			remainingScrollbackSize: scrollbackSize - 1
+		};
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemStream.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemStream.ts
@@ -141,6 +141,28 @@ export class ActivityItemStream extends ActivityItem {
 	}
 
 	/**
+	 * Trim scrollback.
+	 * @param scrollbackSize A number representing the scrollback size.
+	 * @returns A number representing the remaining scrollback size.
+	 */
+	public override trimScrollback(scrollbackSize: number): number {
+		// We should never be called with a scrollback size of 0.
+		if (scrollbackSize <= 0) {
+			// Defensive: if this happens, report the scrollback as fully consumed.
+			console.warn(`ActivityItemStream.trimScrollback called with non-positive scrollbackSize ${scrollbackSize}; doing nothing.`);
+			return 0;
+		}
+
+		// Flush any pending streams so the line count reflects everything received so far.
+		// We report our weight in lines and rely on the containing runtime item to drop us
+		// wholesale if the budget is exhausted; the stream's internal buffer is not trimmed
+		// here because its parser state (cursor, styles) needs to stay consistent with the
+		// lines it has emitted.
+		const lines = this.outputLines;
+		return scrollbackSize - lines.length;
+	}
+
+	/**
 	 * Gets the clipboard representation of the activity item.
 	 * @param commentPrefix The comment prefix to use.
 	 * @returns The clipboard representation of the activity item.

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemStream.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemStream.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ActivityItem } from './activityItem.js';
+import { ActivityItem, TrimScrollbackResult } from './activityItem.js';
 import { formatOutputLinesForClipboard } from '../utils/clipboardUtils.js';
 import { ANSIOutput, ANSIOutputLine } from '../../../../../base/common/ansiOutput.js';
 
@@ -143,12 +143,15 @@ export class ActivityItemStream extends ActivityItem {
 	/**
 	 * Trim scrollback.
 	 * @param scrollbackSize A number representing the scrollback size.
-	 * @returns A number representing the remaining scrollback size.
+	 * @returns A TrimScrollbackResult indicating the result of the trim scrollback operation.
 	 */
-	public override trimScrollback(scrollbackSize: number): number {
+	public override trimScrollback(scrollbackSize: number): TrimScrollbackResult {
 		// We should never be called with a scrollback size <= 0.
 		if (scrollbackSize <= 0) {
-			return 0;
+			return {
+				trimmed: false,
+				remainingScrollbackSize: 0
+			};
 		}
 
 		// Get the line count. This processes any pending activity item streams.
@@ -156,12 +159,20 @@ export class ActivityItemStream extends ActivityItem {
 
 		// If no trimming is needed, return the remaining scrollback size.
 		if (lineCount <= scrollbackSize) {
-			return scrollbackSize - lineCount;
+			return {
+				trimmed: false,
+				remainingScrollbackSize: scrollbackSize - lineCount
+			};
 		}
 
-		// Otherwise, trim output lines and report the scrollback as fully consumed.
-		this._ansiOutput.scrollOff(lineCount - scrollbackSize);
-		return 0;
+		// Otherwise, scroll lines off the top. scrollOff returns the count actually dropped, which
+		// may be less than requested if the cursor line sits higher than the overshoot; we only
+		// report trimmed=true when something really went.
+		const dropped = this._ansiOutput.scrollOff(lineCount - scrollbackSize);
+		return {
+			trimmed: dropped > 0,
+			remainingScrollbackSize: 0
+		};
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemStream.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemStream.ts
@@ -146,20 +146,22 @@ export class ActivityItemStream extends ActivityItem {
 	 * @returns A number representing the remaining scrollback size.
 	 */
 	public override trimScrollback(scrollbackSize: number): number {
-		// We should never be called with a scrollback size of 0.
+		// We should never be called with a scrollback size <= 0.
 		if (scrollbackSize <= 0) {
-			// Defensive: if this happens, report the scrollback as fully consumed.
-			console.warn(`ActivityItemStream.trimScrollback called with non-positive scrollbackSize ${scrollbackSize}; doing nothing.`);
 			return 0;
 		}
 
-		// Flush any pending streams so the line count reflects everything received so far.
-		// We report our weight in lines and rely on the containing runtime item to drop us
-		// wholesale if the budget is exhausted; the stream's internal buffer is not trimmed
-		// here because its parser state (cursor, styles) needs to stay consistent with the
-		// lines it has emitted.
-		const lines = this.outputLines;
-		return scrollbackSize - lines.length;
+		// Get the line count. This processes any pending activity item streams.
+		const lineCount = this.outputLines.length;
+
+		// If no trimming is needed, return the remaining scrollback size.
+		if (lineCount <= scrollbackSize) {
+			return scrollbackSize - lineCount;
+		}
+
+		// Otherwise, trim output lines and report the scrollback as fully consumed.
+		this._ansiOutput.scrollOff(lineCount - scrollbackSize);
+		return 0;
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemStream.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemStream.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -36,11 +36,6 @@ export class ActivityItemStream extends ActivityItem {
 	 */
 	private _ansiOutput = new ANSIOutput();
 
-	/**
-	 * Gets or sets the scrollback size. This is used to truncate the output lines for display.
-	 */
-	private _scrollbackSize?: number;
-
 	//#endregion Private Properties
 
 	//#region Public Properties
@@ -52,13 +47,8 @@ export class ActivityItemStream extends ActivityItem {
 		// Process the activity items streams.
 		this.processActivityItemStreams();
 
-		// If scrollback size is undefined, return all of the output lines.
-		if (this._scrollbackSize === undefined) {
-			return this._ansiOutput.outputLines;
-		}
-
-		// Return the truncated output lines.
-		return this._ansiOutput.truncatedOutputLines(this._scrollbackSize);
+		// Return the output lines.
+		return this._ansiOutput.outputLines;
 	}
 
 	//#endregion Public Properties

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemStream.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemStream.ts
@@ -159,27 +159,6 @@ export class ActivityItemStream extends ActivityItem {
 		return formatOutputLinesForClipboard(this._ansiOutput.outputLines, commentPrefix);
 	}
 
-	/**
-	 * Optimizes scrollback.
-	 * @param scrollbackSize The scrollback size.
-	 * @returns The remaining scrollback size.
-	 */
-	public override optimizeScrollback(scrollbackSize: number) {
-		// Process the activity items streams.
-		this.processActivityItemStreams();
-
-		// If there are fewer output lines than the scrollback size, clear the scrollback size
-		// as all of them will be displayed, and return the remaining scrollback size.
-		if (this._ansiOutput.outputLines.length <= scrollbackSize) {
-			this._scrollbackSize = undefined;
-			return scrollbackSize - this._ansiOutput.outputLines.length;
-		}
-
-		// Set the scrollback size and return 0
-		this._scrollbackSize = scrollbackSize;
-		return 0;
-	}
-
 	//#endregion Public Methods
 
 	//#region Private Methods

--- a/src/vs/workbench/services/positronConsole/browser/classes/activityItemStream.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/activityItemStream.ts
@@ -165,12 +165,10 @@ export class ActivityItemStream extends ActivityItem {
 			};
 		}
 
-		// Otherwise, scroll lines off the top. scrollOff returns the count actually dropped, which
-		// may be less than requested if the cursor line sits higher than the overshoot; we only
-		// report trimmed=true when something really went.
-		const dropped = this._ansiOutput.scrollOff(lineCount - scrollbackSize);
+		// Otherwise, drop output lines and report the scrollback as fully consumed.
+		const dropCount = this._ansiOutput.dropTop(lineCount - scrollbackSize);
 		return {
-			trimmed: dropped > 0,
+			trimmed: dropCount > 0,
 			remainingScrollbackSize: 0
 		};
 	}

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItem.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItem.ts
@@ -32,10 +32,6 @@ export abstract class RuntimeItem {
 	 * @param commentPrefix The comment prefix to use.
 	 * @returns The clipboard representation of the runtime item.
 	 */
-	public agetClipboardRepresentation(commentPrefix: string): string[] {
-		return [];
-	}
-
 	public abstract getClipboardRepresentation(commentPrefix: string): string[];
 
 	//#endregion Public Methods

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItem.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItem.ts
@@ -1,15 +1,12 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
-
-import { formatOutputLinesForClipboard } from '../utils/clipboardUtils.js';
-import { ANSIOutput, ANSIOutputLine } from '../../../../../base/common/ansiOutput.js';
 
 /**
  * RuntimeItem class.
  */
-export class RuntimeItem {
+export abstract class RuntimeItem {
 	//#region Constructor
 
 	/**
@@ -31,50 +28,6 @@ export class RuntimeItem {
 	 */
 	public getClipboardRepresentation(commentPrefix: string): string[] {
 		return [];
-	}
-
-	//#endregion Public Methods
-}
-
-/**
- * RuntimeItemStandard class.
- */
-export class RuntimeItemStandard extends RuntimeItem {
-	//#region Public Properties
-
-	/**
-	 * Gets the output lines.
-	 */
-	readonly outputLines: readonly ANSIOutputLine[];
-
-	//#endregion Public Properties
-
-	//#region Constructor
-
-	/**
-	 * Constructor.
-	 * @param id The identifier.
-	 * @param message The message.
-	 */
-	constructor(id: string, message: string) {
-		// Call the base class's constructor.
-		super(id);
-
-		// Process the message directly into ANSI output lines suitable for rendering.
-		this.outputLines = ANSIOutput.processOutput(message);
-	}
-
-	//#endregion Constructor
-
-	//#region Public Methods
-
-	/**
-	 * Gets the clipboard representation of the activity item.
-	 * @param commentPrefix The comment prefix to use.
-	 * @returns The clipboard representation of the activity item.
-	 */
-	public override getClipboardRepresentation(commentPrefix: string): string[] {
-		return formatOutputLinesForClipboard(this.outputLines, commentPrefix);
 	}
 
 	//#endregion Public Methods

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItem.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItem.ts
@@ -10,15 +10,6 @@ import { ANSIOutput, ANSIOutputLine } from '../../../../../base/common/ansiOutpu
  * RuntimeItem class.
  */
 export class RuntimeItem {
-	//#region Protected Properties
-
-	/**
-	 * Gets or sets a value which indicates whether the item is hidden.
-	 */
-	protected _isHidden = false;
-
-	//#endregion Protected Properties
-
 	//#region Constructor
 
 	/**
@@ -30,17 +21,6 @@ export class RuntimeItem {
 
 	//#endregion Constructor
 
-	//#region Public Properties
-
-	/**
-	 * Gets a value which indicates whether the item is hidden.
-	 */
-	public get isHidden(): boolean {
-		return this._isHidden;
-	}
-
-	//#endregion Public Properties
-
 	//#region Public Methods
 
 	/**
@@ -51,26 +31,6 @@ export class RuntimeItem {
 	 */
 	public getClipboardRepresentation(commentPrefix: string): string[] {
 		return [];
-	}
-
-	/**
-	 * Optimizes scrollback.
-	 * @param scrollbackSize The scrollback size.
-	 * @note The default implementation treats a runtime item as a single item, so it is either
-	 * entirely visible or entirely hidden. Override in derived classes to provide a different
-	 * behavior.
-	 * @returns The remaining scrollback size.
-	 */
-	public optimizeScrollback(scrollbackSize: number) {
-		// If scrollback size is zero, hide the item and return zero.
-		if (!scrollbackSize) {
-			this._isHidden = true;
-			return 0;
-		}
-
-		// Unhide the item and return the scrollback size minus one.
-		this._isHidden = false;
-		return scrollbackSize - 1;
 	}
 
 	//#endregion Public Methods

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItem.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItem.ts
@@ -21,21 +21,22 @@ export abstract class RuntimeItem {
 	//#region Public Methods
 
 	/**
-	 * Adjust scrollback.
+	 * Trim scrollback.
 	 * @param scrollbackSize A number representing the scrollback size.
 	 * @returns A number representing the remaining scrollback size.
 	 */
-	public abstract adjustScrollback(scrollbackSize: number): number;
+	public abstract trimScrollback(scrollbackSize: number): number;
 
 	/**
 	 * Gets the clipboard representation of the runtime item.
 	 * @param commentPrefix The comment prefix to use.
-	 * @note Override in derived classes to provide a clipboard representation.
 	 * @returns The clipboard representation of the runtime item.
 	 */
-	public getClipboardRepresentation(commentPrefix: string): string[] {
+	public agetClipboardRepresentation(commentPrefix: string): string[] {
 		return [];
 	}
+
+	public abstract getClipboardRepresentation(commentPrefix: string): string[];
 
 	//#endregion Public Methods
 }

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItem.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItem.ts
@@ -23,7 +23,7 @@ export abstract class RuntimeItem {
 	/**
 	 * Adjust scrollback.
 	 * @param scrollbackSize A number representing the scrollback size.
-	 * @returns The adjusted scrollback size.
+	 * @returns A number representing the remaining scrollback size.
 	 */
 	public abstract adjustScrollback(scrollbackSize: number): number;
 

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItem.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItem.ts
@@ -21,6 +21,13 @@ export abstract class RuntimeItem {
 	//#region Public Methods
 
 	/**
+	 * Adjust scrollback.
+	 * @param scrollbackSize A number representing the scrollback size.
+	 * @returns The adjusted scrollback size.
+	 */
+	public abstract adjustScrollback(scrollbackSize: number): number;
+
+	/**
 	 * Gets the clipboard representation of the runtime item.
 	 * @param commentPrefix The comment prefix to use.
 	 * @note Override in derived classes to provide a clipboard representation.

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
@@ -172,8 +172,32 @@ export class RuntimeItemActivity extends RuntimeItem {
 			return 0;
 		}
 
-		// Counts as one scrollback item.
-		return scrollbackSize - 1;
+		// Walk from the tail (newest) toward the head (oldest), letting each activity item declare
+		// its weight. Mirrors the outer runtime-item walk in PositronConsoleInstance.trimScrollback.
+		let remainingBudget = scrollbackSize;
+		let firstKeepIndex = 0;
+		for (let i = this._activityItems.length - 1; i >= 0; i--) {
+			// Adjust the scrollback on the activity item, which returns the remaining budget.
+			remainingBudget = this._activityItems[i].trimScrollback(remainingBudget);
+
+			// Adjust the first keep index.
+			firstKeepIndex = i;
+
+			// If the budget is exhausted, break; we will drop everything before the first keep index.
+			if (remainingBudget <= 0) {
+				break;
+			}
+		}
+
+		// Drop anything before the first activity item that still fit. Bump the mutation version so
+		// React.memo drops the cached render for this activity.
+		if (firstKeepIndex > 0) {
+			this._activityItems.splice(0, firstKeepIndex);
+			this._version++;
+		}
+
+		// Return the remaining budget.
+		return Math.max(remainingBudget, 0);
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
@@ -53,10 +53,8 @@ export class RuntimeItemActivity extends RuntimeItem {
 	private _activityItems: ActivityItem[] = [];
 
 	/**
-	 * Monotonically increasing counter bumped on every mutation that affects
-	 * what RuntimeActivity renders (add/replace/stream-merge of activity items,
-	 * and scrollback-driven visibility changes). Used by React.memo to skip
-	 * re-rendering activities whose contents have not changed.
+	 * Monotonically increasing counter that is bumped whenever content rendered by RuntimeActivity
+	 * changes. Used by React.memo to determine whether to re-render or not.
 	 */
 	private _version = 0;
 
@@ -180,7 +178,7 @@ export class RuntimeItemActivity extends RuntimeItem {
 			// Trim scrollback on the activity item.
 			const result = this._activityItems[i].trimScrollback(remainingScrollbackSize);
 
-			// Adjust the first keep index, any trimmed flag, and remaining scrollback size.
+			// Adjust the first keep index, bump version flag, and remaining scrollback size.
 			firstKeepIndex = i;
 			bumpVersion ||= result.trimmed;
 			remainingScrollbackSize = Math.max(result.remainingScrollbackSize, 0);

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
@@ -162,11 +162,17 @@ export class RuntimeItemActivity extends RuntimeItem {
 	}
 
 	/**
-	 * Adjust scrollback.
+	 * Trim scrollback.
 	 * @param scrollbackSize A number representing the scrollback size.
 	 * @returns A number representing the remaining scrollback size.
 	 */
-	public override adjustScrollback(scrollbackSize: number): number {
+	public override trimScrollback(scrollbackSize: number): number {
+		// We should never be called with a scrollback size <= 0.
+		if (scrollbackSize <= 0) {
+			return 0;
+		}
+
+		// Counts as one scrollback item.
 		return scrollbackSize - 1;
 	}
 

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
@@ -102,8 +102,7 @@ export class RuntimeItemActivity extends RuntimeItem {
 	 * @param activityItem The activity item to add.
 	 */
 	public addActivityItem(activityItem: ActivityItem) {
-		// Every path through this method mutates state (push, in-place replace,
-		// or in-place stream merge), so bump the version once up front.
+		// Bump the version to indicate that a mutation is occurring.
 		this._version++;
 
 		// Perform activity item processing if this is not the first activity item.

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
@@ -99,10 +99,6 @@ export class RuntimeItemActivity extends RuntimeItem {
 
 	//#region Public Methods
 
-	public override adjustScrollback(scrollbackSize: number): number {
-		return scrollbackSize - 1;
-	}
-
 	/**
 	 * Adds an activity item.
 	 * @param activityItem The activity item to add.
@@ -163,6 +159,15 @@ export class RuntimeItemActivity extends RuntimeItem {
 
 		// Push the activity item.
 		this._activityItems.push(activityItem);
+	}
+
+	/**
+	 * Adjust scrollback.
+	 * @param scrollbackSize A number representing the scrollback size.
+	 * @returns A number representing the remaining scrollback size.
+	 */
+	public override adjustScrollback(scrollbackSize: number): number {
+		return scrollbackSize - 1;
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
@@ -52,6 +52,14 @@ export class RuntimeItemActivity extends RuntimeItem {
 	 */
 	private _activityItems: ActivityItem[] = [];
 
+	/**
+	 * Monotonically increasing counter bumped on every mutation that affects
+	 * what RuntimeActivity renders (add/replace/stream-merge of activity items,
+	 * and scrollback-driven visibility changes). Used by React.memo to skip
+	 * re-rendering activities whose contents have not changed.
+	 */
+	private _version = 0;
+
 	//#endregion Private Properties
 
 	//#region Public Properties
@@ -61,6 +69,13 @@ export class RuntimeItemActivity extends RuntimeItem {
 	 */
 	public get activityItems() {
 		return this._activityItems;
+	}
+
+	/**
+	 * Gets the current mutation version. See `_version`.
+	 */
+	public get version() {
+		return this._version;
 	}
 
 	//#endregion Public Properties
@@ -89,6 +104,10 @@ export class RuntimeItemActivity extends RuntimeItem {
 	 * @param activityItem The activity item to add.
 	 */
 	public addActivityItem(activityItem: ActivityItem) {
+		// Every path through this method mutates state (push, in-place replace,
+		// or in-place stream merge), so bump the version once up front.
+		this._version++;
+
 		// Perform activity item processing if this is not the first activity item.
 		if (this._activityItems.length) {
 			// If the activity item being added is an ActivityItemStream, see if we can append it to
@@ -151,30 +170,6 @@ export class RuntimeItemActivity extends RuntimeItem {
 		return this._activityItems.flatMap(activityItem =>
 			activityItem.getClipboardRepresentation(commentPrefix)
 		);
-	}
-
-	/**
-	 * Optimizes scrollback.
-	 * @param scrollbackSize The scrollback size.
-	 * @returns The remaining scrollback size.
-	 */
-	public override optimizeScrollback(scrollbackSize: number) {
-		// If scrollback size is zero, hide the item and return zero.
-		if (scrollbackSize === 0) {
-			this._isHidden = true;
-			return 0;
-		}
-
-		// Unhide the item.
-		this._isHidden = false;
-
-		// Optimize scrollback for each activity item in reverse order.
-		for (let i = this._activityItems.length - 1; i >= 0; i--) {
-			scrollbackSize = this._activityItems[i].optimizeScrollback(scrollbackSize);
-		}
-
-		// Return the remaining scrollback size.
-		return scrollbackSize;
 	}
 
 	//#endregion Public Methods

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
@@ -172,32 +172,34 @@ export class RuntimeItemActivity extends RuntimeItem {
 			return 0;
 		}
 
-		// Walk from the tail (newest) toward the head (oldest), letting each activity item declare
-		// its weight. Mirrors the outer runtime-item walk in PositronConsoleInstance.trimScrollback.
-		let remainingBudget = scrollbackSize;
+		// Walk the activity items in reverse, trimming scrollback.
 		let firstKeepIndex = 0;
-		for (let i = this._activityItems.length - 1; i >= 0; i--) {
-			// Adjust the scrollback on the activity item, which returns the remaining budget.
-			remainingBudget = this._activityItems[i].trimScrollback(remainingBudget);
+		let bumpVersion = false;
+		let remainingScrollbackSize = scrollbackSize;
+		for (let i = this._activityItems.length - 1; remainingScrollbackSize > 0 && i >= 0; i--) {
+			// Trim scrollback on the activity item.
+			const result = this._activityItems[i].trimScrollback(remainingScrollbackSize);
 
-			// Adjust the first keep index.
+			// Adjust the first keep index, any trimmed flag, and remaining scrollback size.
 			firstKeepIndex = i;
-
-			// If the budget is exhausted, break; we will drop everything before the first keep index.
-			if (remainingBudget <= 0) {
-				break;
-			}
+			bumpVersion ||= result.trimmed;
+			remainingScrollbackSize = Math.max(result.remainingScrollbackSize, 0);
 		}
 
-		// Drop anything before the first activity item that still fit. Bump the mutation version so
-		// React.memo drops the cached render for this activity.
+		// Drop activity items before the first activity item.
 		if (firstKeepIndex > 0) {
 			this._activityItems.splice(0, firstKeepIndex);
+			bumpVersion = true;
+		}
+
+		// Bump the render version only when something actually changed so React.memo keeps its
+		// cached render for activities that were walked-but-untouched.
+		if (bumpVersion) {
 			this._version++;
 		}
 
-		// Return the remaining budget.
-		return Math.max(remainingBudget, 0);
+		// Return the remaining scrollback size.
+		return remainingScrollbackSize;
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemActivity.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -98,6 +98,10 @@ export class RuntimeItemActivity extends RuntimeItem {
 	//#endregion Constructor
 
 	//#region Public Methods
+
+	public override adjustScrollback(scrollbackSize: number): number {
+		return scrollbackSize - 1;
+	}
 
 	/**
 	 * Adds an activity item.

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemExited.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemExited.ts
@@ -1,10 +1,10 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RuntimeItemStandard } from './runtimeItem.js';
 import { RuntimeExitReason } from '../../../languageRuntime/common/languageRuntimeService.js';
+import { RuntimeItemStandard } from './runtimeItemStandard.js';
 
 /**
  * RuntimeItemExited class.

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemOffline.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemOffline.ts
@@ -1,9 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RuntimeItemStandard } from './runtimeItem.js';
+import { RuntimeItemStandard } from './runtimeItemStandard.js';
 
 /**
  * RuntimeItemOffline class.

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemPendingInput.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemPendingInput.ts
@@ -1,11 +1,11 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import { RuntimeCodeExecutionMode } from '../../../languageRuntime/common/languageRuntimeService.js';
 import { IConsoleCodeAttribution } from '../../common/positronConsoleCodeExecution.js';
-import { RuntimeItemStandard } from './runtimeItem.js';
+import { RuntimeItemStandard } from './runtimeItemStandard.js';
 
 /**
  * RuntimeItemPendingInput class.

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemReconnected.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemReconnected.ts
@@ -1,9 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RuntimeItemStandard } from './runtimeItem.js';
+import { RuntimeItemStandard } from './runtimeItemStandard.js';
 
 /**
  * RuntimeItemReconnected class.

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemRestartButton.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemRestartButton.ts
@@ -30,12 +30,27 @@ export class RuntimeItemRestartButton extends RuntimeItem {
 	//#region Public Methods
 
 	/**
-	 * Adjust scrollback.
+	 * Trim scrollback.
 	 * @param scrollbackSize A number representing the scrollback size.
 	 * @returns A number representing the remaining scrollback size.
 	 */
-	public override adjustScrollback(scrollbackSize: number): number {
+	public override trimScrollback(scrollbackSize: number): number {
+		// We should never be called with a scrollback size <= 0.
+		if (scrollbackSize <= 0) {
+			return 0;
+		}
+
+		// Counts as one scrollback item.
 		return scrollbackSize - 1;
+	}
+
+	/**
+	 * Gets the clipboard representation of the runtime item.
+	 * @param commentPrefix The comment prefix to use.
+	 * @returns The clipboard representation of the runtime item.
+	 */
+	public override getClipboardRepresentation(commentPrefix: string): string[] {
+		return [];
 	}
 
 	//#endregion Public Methods

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemRestartButton.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemRestartButton.ts
@@ -29,6 +29,11 @@ export class RuntimeItemRestartButton extends RuntimeItem {
 
 	//#region Public Methods
 
+	/**
+	 * Adjust scrollback.
+	 * @param scrollbackSize A number representing the scrollback size.
+	 * @returns A number representing the remaining scrollback size.
+	 */
 	public override adjustScrollback(scrollbackSize: number): number {
 		return scrollbackSize - 1;
 	}

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemRestartButton.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemRestartButton.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -26,4 +26,12 @@ export class RuntimeItemRestartButton extends RuntimeItem {
 	}
 
 	//#endregion Constructor
+
+	//#region Public Methods
+
+	public override adjustScrollback(scrollbackSize: number): number {
+		return scrollbackSize - 1;
+	}
+
+	//#endregion Public Methods
 }

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStandard.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStandard.ts
@@ -45,24 +45,18 @@ export class RuntimeItemStandard extends RuntimeItem {
 	 * @returns A number representing the remaining scrollback size.
 	 */
 	public override trimScrollback(scrollbackSize: number): number {
-		// We should never be called with a scrollback size of 0.
+		// We should never be called with a scrollback size <= 0.
 		if (scrollbackSize <= 0) {
-			// Defensive: if this happens, trim all lines and report the scrollback as fully consumed.
-			console.warn(`RuntimeItemStandard.trimScrollback called with non-positive scrollbackSize ${scrollbackSize}; trimming all lines.`);
-			this.outputLines = [];
 			return 0;
 		}
 
-		// If our lines fit in the remaining scrollback budget, keep them all and return what's
-		// left of the budget.
+		// If no trimming is needed, return the remaining scrollback size.
 		if (this.outputLines.length <= scrollbackSize) {
 			return scrollbackSize - this.outputLines.length;
 		}
 
-		// Otherwise, trim to the tail of most-recent lines that fit.
+		// Otherwise, trim output lines and report the scrollback as fully consumed.
 		this.outputLines = this.outputLines.slice(-scrollbackSize);
-
-		// Report the scrollback as fully consumed.
 		return 0;
 	}
 

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStandard.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStandard.ts
@@ -39,6 +39,11 @@ export class RuntimeItemStandard extends RuntimeItem {
 
 	//#region Public Methods
 
+	/**
+	 * Adjust scrollback.
+	 * @param scrollbackSize A number representing the scrollback size.
+	 * @returns A number representing the remaining scrollback size.
+	 */
 	public override adjustScrollback(scrollbackSize: number): number {
 		return scrollbackSize - 1;
 	}

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStandard.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStandard.ts
@@ -11,12 +11,24 @@ import { RuntimeItem } from './runtimeItem.js';
  * RuntimeItemStandard class.
  */
 export class RuntimeItemStandard extends RuntimeItem {
+	//#region Private Properties
+
+	/**
+	 * The output lines, processed and ready for rendering. Initialized in the constructor and
+	 * mutated by trimScrollback.
+	 */
+	private _outputLines: readonly ANSIOutputLine[];
+
+	//#endregion Private Properties
+
 	//#region Public Properties
 
 	/**
 	 * Gets the output lines.
 	 */
-	outputLines: readonly ANSIOutputLine[];
+	public get outputLines(): readonly ANSIOutputLine[] {
+		return this._outputLines;
+	}
 
 	//#endregion Public Properties
 
@@ -32,7 +44,7 @@ export class RuntimeItemStandard extends RuntimeItem {
 		super(id);
 
 		// Process the message directly into ANSI output lines suitable for rendering.
-		this.outputLines = ANSIOutput.processOutput(message);
+		this._outputLines = ANSIOutput.processOutput(message);
 	}
 
 	//#endregion Constructor
@@ -51,12 +63,12 @@ export class RuntimeItemStandard extends RuntimeItem {
 		}
 
 		// If no trimming is needed, return the remaining scrollback size.
-		if (this.outputLines.length <= scrollbackSize) {
-			return scrollbackSize - this.outputLines.length;
+		if (this._outputLines.length <= scrollbackSize) {
+			return scrollbackSize - this._outputLines.length;
 		}
 
 		// Otherwise, trim output lines and report the scrollback as fully consumed.
-		this.outputLines = this.outputLines.slice(-scrollbackSize);
+		this._outputLines = this._outputLines.slice(-scrollbackSize);
 		return 0;
 	}
 

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStandard.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStandard.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { formatOutputLinesForClipboard } from '../utils/clipboardUtils.js';
+import { ANSIOutput, ANSIOutputLine } from '../../../../../base/common/ansiOutput.js';
+import { RuntimeItem } from './runtimeItem.js';
+
+/**
+ * RuntimeItemStandard class.
+ */
+export class RuntimeItemStandard extends RuntimeItem {
+	//#region Public Properties
+
+	/**
+	 * Gets the output lines.
+	 */
+	readonly outputLines: readonly ANSIOutputLine[];
+
+	//#endregion Public Properties
+
+	//#region Constructor
+
+	/**
+	 * Constructor.
+	 * @param id The identifier.
+	 * @param message The message.
+	 */
+	constructor(id: string, message: string) {
+		// Call the base class's constructor.
+		super(id);
+
+		// Process the message directly into ANSI output lines suitable for rendering.
+		this.outputLines = ANSIOutput.processOutput(message);
+	}
+
+	//#endregion Constructor
+
+	//#region Public Methods
+
+	/**
+	 * Gets the clipboard representation of the activity item.
+	 * @param commentPrefix The comment prefix to use.
+	 * @returns The clipboard representation of the activity item.
+	 */
+	public override getClipboardRepresentation(commentPrefix: string): string[] {
+		return formatOutputLinesForClipboard(this.outputLines, commentPrefix);
+	}
+
+	//#endregion Public Methods
+}

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStandard.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStandard.ts
@@ -16,7 +16,7 @@ export class RuntimeItemStandard extends RuntimeItem {
 	/**
 	 * Gets the output lines.
 	 */
-	readonly outputLines: readonly ANSIOutputLine[];
+	outputLines: readonly ANSIOutputLine[];
 
 	//#endregion Public Properties
 
@@ -40,12 +40,30 @@ export class RuntimeItemStandard extends RuntimeItem {
 	//#region Public Methods
 
 	/**
-	 * Adjust scrollback.
+	 * Trim scrollback.
 	 * @param scrollbackSize A number representing the scrollback size.
 	 * @returns A number representing the remaining scrollback size.
 	 */
-	public override adjustScrollback(scrollbackSize: number): number {
-		return scrollbackSize - 1;
+	public override trimScrollback(scrollbackSize: number): number {
+		// We should never be called with a scrollback size of 0.
+		if (scrollbackSize <= 0) {
+			// Defensive: if this happens, trim all lines and report the scrollback as fully consumed.
+			console.warn(`RuntimeItemStandard.trimScrollback called with non-positive scrollbackSize ${scrollbackSize}; trimming all lines.`);
+			this.outputLines = [];
+			return 0;
+		}
+
+		// If our lines fit in the remaining scrollback budget, keep them all and return what's
+		// left of the budget.
+		if (this.outputLines.length <= scrollbackSize) {
+			return scrollbackSize - this.outputLines.length;
+		}
+
+		// Otherwise, trim to the tail of most-recent lines that fit.
+		this.outputLines = this.outputLines.slice(-scrollbackSize);
+
+		// Report the scrollback as fully consumed.
+		return 0;
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStandard.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStandard.ts
@@ -39,6 +39,10 @@ export class RuntimeItemStandard extends RuntimeItem {
 
 	//#region Public Methods
 
+	public override adjustScrollback(scrollbackSize: number): number {
+		return scrollbackSize - 1;
+	}
+
 	/**
 	 * Gets the clipboard representation of the activity item.
 	 * @param commentPrefix The comment prefix to use.

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStarted.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStarted.ts
@@ -1,9 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RuntimeItemStandard } from './runtimeItem.js';
+import { RuntimeItemStandard } from './runtimeItemStandard.js';
 
 /**
  * RuntimeItemStarted class.

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStarting.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStarting.ts
@@ -18,7 +18,7 @@ export class RuntimeItemStarting extends RuntimeItemStandard {
 	 * @param message The message.
 	 * @param attachMode The attach mode.
 	 */
-	constructor(id: string, message: string, public attachMode: SessionAttachMode) {
+	constructor(id: string, message: string, public readonly attachMode: SessionAttachMode) {
 		// Call the base class's constructor.
 		super(id, message);
 	}

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStarting.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStarting.ts
@@ -1,10 +1,10 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RuntimeItemStandard } from './runtimeItem.js';
 import { SessionAttachMode } from '../interfaces/positronConsoleService.js';
+import { RuntimeItemStandard } from './runtimeItemStandard.js';
 
 /**
  * RuntimeItemStarting class.

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStartup.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStartup.ts
@@ -1,9 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RuntimeItemStandard } from './runtimeItem.js';
+import { RuntimeItemStandard } from './runtimeItemStandard.js';
 
 /**
  * RuntimeItemStartup class.

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStartupFailure.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemStartupFailure.ts
@@ -1,9 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RuntimeItemStandard } from './runtimeItem.js';
+import { RuntimeItemStandard } from './runtimeItemStandard.js';
 
 /**
  * RuntimeItemStartupFailure class.

--- a/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemTrace.ts
+++ b/src/vs/workbench/services/positronConsole/browser/classes/runtimeItemTrace.ts
@@ -1,9 +1,9 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RuntimeItemStandard } from './runtimeItem.js';
+import { RuntimeItemStandard } from './runtimeItemStandard.js';
 
 /**
  * RuntimeItemTrace class.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -11,7 +11,8 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { ISettableObservable, observableValue } from '../../../../base/common/observable.js';
 import { IViewsService } from '../../views/common/viewsService.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ConfigurationTarget, IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { INotificationService, Severity } from '../../../../platform/notification/common/notification.js';
 import { RuntimeItem } from './classes/runtimeItem.js';
@@ -186,6 +187,15 @@ const consoleServiceConfigurationBaseNode = Object.freeze<IConfigurationNode>({
  * Console configuration settings.
  */
 export const scrollbackSizeSettingId = 'console.scrollbackSize';
+
+/**
+ * Storage key guarding the one-time migration that clears any pre-existing user override of
+ * `console.scrollbackSize`. The default was raised (thanks to render memoization ) so most
+ * previously-picked values are obsolete; we reset once per profile and then let the user set
+ * whatever they want from there.
+ */
+const scrollbackSizeResetMigrationKey = 'positronConsole.scrollbackSize.resetUserOverride.v1';
+
 configurationRegistry.registerConfiguration({
 	...consoleServiceConfigurationBaseNode,
 	properties: {
@@ -264,9 +274,9 @@ configurationRegistry.registerConfiguration({
 		// Scrollback size.
 		'console.scrollbackSize': {
 			type: 'number',
-			'minimum': 500,
-			'maximum': 5000,
-			'default': 1000,
+			'minimum': 1_000,
+			'maximum': 20_000,
+			'default': 10_000,
 			markdownDescription: localize('console.scrollbackSize', "The number of console output items to display."),
 		},
 		// Whether to automatically create consoles for notebook sessions
@@ -358,19 +368,26 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 	 * @param _logService The log service service.
 	 * @param _runtimeSessionService The runtime session service.
 	 * @param _runtimeStartupService The runtime affiliation service.
+	 * @param _storageService The storage service.
 	 * @param _viewsService The views service.
+	 * @param _notificationService The notification service.
 	 */
 	constructor(
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IExecutionHistoryService private readonly _executionHistoryService: IExecutionHistoryService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ILogService private readonly _logService: ILogService,
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
 		@IRuntimeStartupService private readonly _runtimeStartupService: IRuntimeStartupService,
+		@IStorageService private readonly _storageService: IStorageService,
 		@IViewsService private readonly _viewsService: IViewsService,
 		@INotificationService private readonly _notificationService: INotificationService
 	) {
 		// Call the disposable constructor.
 		super();
+
+		// Run one-time migrations.
+		this.resetScrollbackSizeUserOverrideOnce();
 
 		// Start a Positron console instance for each session that will be restored.
 		//
@@ -1052,6 +1069,37 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 		this._onDidChangeActivePositronConsoleInstanceEmitter.fire(positronConsoleInstance);
 	}
 
+	/**
+	 * Clears any pre-existing user override of `console.scrollbackSize` exactly once per profile.
+	 * The default was raised (and rendering was memoized) so previously-picked values are obsolete;
+	 * after this runs, the flag is stored and we never touch the user's setting again.
+	 */
+	private resetScrollbackSizeUserOverrideOnce(): void {
+		// If the flag is already set, we know we've done the reset for this profile before, so we can skip it.
+		if (this._storageService.getBoolean(scrollbackSizeResetMigrationKey, StorageScope.PROFILE, false)) {
+			return;
+		}
+
+		// Otherwise, we need to do the reset. This involves removing any user override of the
+		// setting, which will cause it to fall back to the new default value. We only remove the
+		// user override (as opposed to changing the default) because we don't want to mess with
+		// any workspace or machine overrides that may be in place.
+		this._configurationService.updateValue(
+			scrollbackSizeSettingId,
+			undefined,
+			ConfigurationTarget.USER
+		).then(() => {
+			this._storageService.store(
+				scrollbackSizeResetMigrationKey,
+				true,
+				StorageScope.PROFILE,
+				StorageTarget.MACHINE
+			);
+		}, err => {
+			this._logService.warn(`Failed to reset ${scrollbackSizeSettingId} user override: ${err}`);
+		});
+	}
+
 	//#endregion Private Methods
 }
 
@@ -1318,8 +1366,6 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 
 		// Initialize the scrollback configuration.
 		this._scrollbackSize = this._configurationService.getValue<number>(scrollbackSizeSettingId);
-
-		console.log(`PositronConsoleInstance created for scrollback size ${this._scrollbackSize}`);
 
 		// Register the onDidChangeConfiguration event handler so we can update the console scrollback
 		// configuration.
@@ -3353,9 +3399,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			// Add the activity item to the activity runtime item.
 			runtimeItemActivity.addActivityItem(activityItem);
 
+			// Trim the scrollback after each activity item is added.
+			this.trimScrollback();
+
 			// Fire the onDidChangeRuntimeItems event.
 			this._onDidChangeRuntimeItemsEmitter.fire();
 		} else {
+			// No activity runtime item was found, so create a new one and add the activity item to it.
 			const runtimeItemActivity = new RuntimeItemActivity(parentId, activityItem);
 			this._runtimeItemActivities.set(parentId, runtimeItemActivity);
 			this.addRuntimeItem(runtimeItemActivity);

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1325,7 +1325,22 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		// configuration.
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(scrollbackSizeSettingId)) {
-				this._scrollbackSize = this._configurationService.getValue<number>(scrollbackSizeSettingId);
+				// Get the new scrollback size from the configuration.
+				const newScrollbackSize = this._configurationService.getValue<number>(
+					scrollbackSizeSettingId
+				);
+
+				// Determine whether or not we need to trim the scrollback.
+				const trimScrollback = newScrollbackSize < this._scrollbackSize;
+
+				// Update the scrollback size.
+				this._scrollbackSize = newScrollbackSize;
+
+				// Trim the scrollback and fire the onDidChangeRuntimeItems event, as needed.
+				if (trimScrollback) {
+					this.trimScrollback();
+					this._onDidChangeRuntimeItemsEmitter.fire();
+				}
 			}
 		}));
 
@@ -1945,6 +1960,9 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 				this._runtimeItems.push(startupItem);
 			}
 		}
+
+		// Trim scrollback now that the batch replay is complete.
+		this.trimScrollback();
 
 		// Enter the reconnecting state.
 		this.emitStartRuntimeItems(SessionAttachMode.Reconnecting);
@@ -3355,8 +3373,52 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			this._runtimeItemActivities.set(runtimeItem.id, runtimeItem);
 		}
 
+		// Trim the scrollback after each runtime item is added.
+		this.trimScrollback();
+
 		// Fire the onDidChangeRuntimeItems event.
 		this._onDidChangeRuntimeItemsEmitter.fire();
+	}
+
+	/**
+	 * Trims the front of _runtimeItems to fit within the current scrollback budget.
+	 *
+	 * Walks the items from tail (most recent) toward head, letting each item declare how much of
+	 * the budget it consumes via trimScrollback(). Once the budget is exhausted, everything before
+	 * the first item that still fit is spliced off.
+	 *
+	 * Callers own firing onDidChangeRuntimeItemsEmitter; this method does not fire it, because the
+	 * trim is typically paired with another mutation and a single emit covers both.
+	 */
+	private trimScrollback(): void {
+		// Set the remaining budget to the configured scrollback size, and the first keep index to
+		// 0 (the head of the list).
+		let remainingBudget = this._scrollbackSize;
+		let firstKeepIndex = 0;
+
+		// Walk from the tail (newest) toward the head (oldest), letting each item declare its weight.
+		for (let i = this._runtimeItems.length - 1; i >= 0; i--) {
+			// Adjust the scrollback on the item, which returns the remaining budget.
+			remainingBudget = this._runtimeItems[i].trimScrollback(remainingBudget);
+
+			// Adjust the first keep index.
+			firstKeepIndex = i;
+
+			// If the budget is exhausted, break; we will drop everything before the first keep index.
+			if (remainingBudget <= 0) {
+				break;
+			}
+		}
+
+		// Drop anything before the first item that still fit, keeping the activity map in sync.
+		if (firstKeepIndex > 0) {
+			const dropped = this._runtimeItems.splice(0, firstKeepIndex);
+			for (const item of dropped) {
+				if (item instanceof RuntimeItemActivity) {
+					this._runtimeItemActivities.delete(item.id);
+				}
+			}
+		}
 	}
 
 	//#endregion Private Methods

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1071,11 +1071,18 @@ export class PositronConsoleService extends Disposable implements IPositronConso
 
 	/**
 	 * Clears any pre-existing user override of `console.scrollbackSize` exactly once per profile.
-	 * The default was raised (and rendering was memoized) so previously-picked values are obsolete;
-	 * after this runs, the flag is stored and we never touch the user's setting again.
+	 * The default was raised because of performance improvements, so previously-picked values are
+	 * obsolete. After this runs, the flag is stored and we never touch the user's setting again.
+	 *
+	 * Note: `updateValue` is async, and the flag is stored only after it resolves. Any
+	 * PositronConsoleInstance created in the same tick may observe the old override; each
+	 * instance's `onDidChangeConfiguration` handler reconciles `_scrollbackSize` once the update
+	 * lands. If `updateValue` rejects, the flag is not stored and the migration retries on the
+	 * next startup.
 	 */
 	private resetScrollbackSizeUserOverrideOnce(): void {
-		// If the flag is already set, we know we've done the reset for this profile before, so we can skip it.
+		// If the flag is already set, we know we've done the reset for this profile before, so we
+		// can skip it.
 		if (this._storageService.getBoolean(scrollbackSizeResetMigrationKey, StorageScope.PROFILE, false)) {
 			return;
 		}

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -3467,12 +3467,14 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			}
 		}
 
-		// Drop anything before the first item that still fit, keeping the activity map in sync.
+		// Drop runtime items before the first keep index.
 		if (firstKeepIndex > 0) {
-			const dropped = this._runtimeItems.splice(0, firstKeepIndex);
-			for (const item of dropped) {
-				if (item instanceof RuntimeItemActivity) {
-					this._runtimeItemActivities.delete(item.id);
+			const droppedRuntimeItems = this._runtimeItems.splice(0, firstKeepIndex);
+			for (const runtimeItem of droppedRuntimeItems) {
+				if (runtimeItem instanceof RuntimeItemActivity) {
+					this._runtimeItemActivities.delete(runtimeItem.id);
+				} else if (runtimeItem === this._runtimeItemPendingInput) {
+					this._runtimeItemPendingInput = undefined;
 				}
 			}
 		}

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1319,6 +1319,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		// Initialize the scrollback configuration.
 		this._scrollbackSize = this._configurationService.getValue<number>(scrollbackSizeSettingId);
 
+		console.log(`PositronConsoleInstance created for scrollback size ${this._scrollbackSize}`);
+
 		// Register the onDidChangeConfiguration event handler so we can update the console scrollback
 		// configuration.
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
@@ -3333,9 +3335,6 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			// Add the activity item to the activity runtime item.
 			runtimeItemActivity.addActivityItem(activityItem);
 
-			// Optimize scrollback.
-			this.optimizeScrollback();
-
 			// Fire the onDidChangeRuntimeItems event.
 			this._onDidChangeRuntimeItemsEmitter.fire();
 		} else {
@@ -3356,21 +3355,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 			this._runtimeItemActivities.set(runtimeItem.id, runtimeItem);
 		}
 
-		// Optimize scrollback.
-		this.optimizeScrollback();
-
 		// Fire the onDidChangeRuntimeItems event.
 		this._onDidChangeRuntimeItemsEmitter.fire();
-	}
-
-	/**
-	 * Optimizes scrollback.
-	 */
-	private optimizeScrollback() {
-		// Optimize scrollback for each runtime item in reverse order.
-		for (let scrollbackSize = this._scrollbackSize, i = this._runtimeItems.length - 1; i >= 0; i--) {
-			scrollbackSize = this._runtimeItems[i].optimizeScrollback(scrollbackSize);
-		}
 	}
 
 	//#endregion Private Methods

--- a/src/vs/workbench/services/positronConsole/test/browser/classes/runtimeItemActivity.test.ts
+++ b/src/vs/workbench/services/positronConsole/test/browser/classes/runtimeItemActivity.test.ts
@@ -5,161 +5,196 @@
 
 import assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { ActivityItem, TrimScrollbackResult } from '../../../browser/classes/activityItem.js';
-import { ActivityItem as ActivityItemUnion, RuntimeItemActivity } from '../../../browser/classes/runtimeItemActivity.js';
+import { ActivityItemErrorMessage } from '../../../browser/classes/activityItemErrorMessage.js';
+import { ActivityItemInput, ActivityItemInputState } from '../../../browser/classes/activityItemInput.js';
+import { ActivityItemOutputMessage } from '../../../browser/classes/activityItemOutputMessage.js';
+import { ActivityItemStream, ActivityItemStreamType } from '../../../browser/classes/activityItemStream.js';
+import { RuntimeItemActivity } from '../../../browser/classes/runtimeItemActivity.js';
 
-/**
- * Minimal ActivityItem subclass for tests. Driven by a `trimFn` that takes the incoming budget
- * and returns a TrimScrollbackResult, so each mock participates in the walk's budget accounting
- * (instead of clobbering it with a static value). Records callCount for walk-shape assertions.
- *
- * Note: the RuntimeItemActivity API is typed against an `ActivityItem` *union* of concrete
- * subclasses (ActivityItemStream | ActivityItemErrorMessage | ...) — not the abstract base.
- * This test item extends the abstract base and is cast through the union at call sites. The
- * cast is safe because trimScrollback only uses the abstract-class methods; the instanceof
- * branches in addActivityItem (stream merge, input replacement) simply don't fire for a
- * TestActivityItem, which is exactly what we want in these tests.
- */
-class TestActivityItem extends ActivityItem {
-	public callCount = 0;
+// A weight-1 activity item that never self-trims. ActivityItemErrorMessage fits: simple
+// constructor, counts as 1 scrollback unit, and has no merge logic in addActivityItem.
+const errItem = (id: string) =>
+	new ActivityItemErrorMessage(id, 'parent', new Date(0), '', 'message', []);
 
-	constructor(
-		id: string,
-		private readonly _trimFn: (budget: number) => TrimScrollbackResult
-	) {
-		super(id, 'parent', new Date(0));
-	}
+// A multi-line activity item that can self-trim. ActivityItemOutputMessage slices its output
+// lines to fit the incoming scrollbackSize, which makes it easy to construct an over-sized
+// item and watch it shrink.
+const linesItem = (id: string, lineCount: number) =>
+	new ActivityItemOutputMessage(
+		id,
+		'parent',
+		new Date(0),
+		{ 'text/plain': Array.from({ length: lineCount }, (_, i) => `line${i}`).join('\n') }
+	);
 
-	public override trimScrollback(scrollbackSize: number): TrimScrollbackResult {
-		this.callCount++;
-		return this._trimFn(scrollbackSize);
-	}
+const stream = (id: string, parentId: string, text: string) =>
+	new ActivityItemStream(id, parentId, new Date(0), ActivityItemStreamType.OUTPUT, text);
 
-	public override getClipboardRepresentation(_commentPrefix: string): string[] {
-		return [];
-	}
-}
-
-/** A weight-only item: declares weight N, never reports trimmed. Matches ActivityItemInput et al. */
-const weightItem = (id: string, weight: number) => new TestActivityItem(id, (budget) => ({
-	trimmed: false,
-	remainingScrollbackSize: Math.max(budget - weight, 0),
-}));
-
-/** A self-trimming item: always reports trimmed:true and consumes the full budget. */
-const selfTrimmingItem = (id: string) => new TestActivityItem(id, (_budget) => ({
-	trimmed: true,
-	remainingScrollbackSize: 0,
-}));
-
-/**
- * Bridges the abstract-class TestActivityItem to the union type the RuntimeItemActivity API
- * expects. Keeps the casts isolated to one place.
- */
-const asUnion = (item: TestActivityItem): ActivityItemUnion => item as unknown as ActivityItemUnion;
-
-/**
- * Reads RuntimeItemActivity._version through the public getter in a way that's stable against
- * future renames — all tests go through this.
- */
-const versionOf = (activity: RuntimeItemActivity): number => activity.version;
+const input = (id: string, parentId: string, state: ActivityItemInputState, code = 'x') =>
+	new ActivityItemInput(id, parentId, new Date(0), state, '>', '+', code);
 
 suite('RuntimeItemActivity.trimScrollback', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	test('single item that fits without trimming: no version bump, no splice, returns remaining budget', () => {
-		const item = weightItem('a', 1);
-		const activity = new RuntimeItemActivity('activity', asUnion(item));
-		const initialVersion = versionOf(activity);
+	test('single weight-1 item that fits: no version bump, no splice', () => {
+		const item = errItem('a');
+		const activity = new RuntimeItemActivity('activity', item);
+		const initialVersion = activity.version;
 
 		const remaining = activity.trimScrollback(10);
 
-		assert.strictEqual(remaining, 9, 'remaining budget passes through from the item');
-		assert.strictEqual(activity.activityItems.length, 1, 'no splice happened');
-		assert.strictEqual(versionOf(activity), initialVersion, '_version should not bump when nothing trimmed');
-		assert.strictEqual(item.callCount, 1, 'the single item was walked once');
+		assert.strictEqual(remaining, 9, 'weight-1 item consumed one unit out of 10');
+		assert.strictEqual(activity.activityItems.length, 1);
+		assert.strictEqual(activity.version, initialVersion, 'no version bump when nothing trimmed');
 	});
 
-	test('single item reports trimmed: bumps version without a splice', () => {
-		const item = selfTrimmingItem('a');
-		const activity = new RuntimeItemActivity('activity', asUnion(item));
-		const initialVersion = versionOf(activity);
-
-		const remaining = activity.trimScrollback(5);
-
-		assert.strictEqual(remaining, 0);
-		assert.strictEqual(activity.activityItems.length, 1, 'no splice — the trimming item is the only one');
-		assert.strictEqual(versionOf(activity), initialVersion + 1, 'version bumps because the item reported trimmed');
-	});
-
-	test('multiple items all fit with no trimming: no version bump, no splice', () => {
-		// Three weight-1 items. Walk consumes three units of budget; none reports trimmed.
-		const items = [weightItem('a', 1), weightItem('b', 1), weightItem('c', 1)];
-		const activity = new RuntimeItemActivity('activity', asUnion(items[0]));
-		// The constructor added items[0] via addActivityItem (which bumps _version once). Record
-		// that post-construction baseline so we can assert *no further* bumps.
-		activity.addActivityItem(asUnion(items[1]));
-		activity.addActivityItem(asUnion(items[2]));
-		const baselineVersion = versionOf(activity);
-
-		const remaining = activity.trimScrollback(10);
-
-		assert.strictEqual(remaining, 7, 'each of three weight-1 items consumed one unit (10 → 9 → 8 → 7)');
-		assert.strictEqual(activity.activityItems.length, 3, 'no splice');
-		assert.strictEqual(versionOf(activity), baselineVersion, '_version untouched — no trim occurred');
-		assert.strictEqual(items[0].callCount, 1);
-		assert.strictEqual(items[1].callCount, 1);
-		assert.strictEqual(items[2].callCount, 1);
-	});
-
-	test('budget exhausted mid-walk: splices older items and bumps version', () => {
-		// Budget 2, three weight-1 items. Walking tail-first: c fits (budget → 1), b fits
-		// (budget → 0), loop exits without visiting a. firstKeepIndex = 1 → splice(0, 1) drops a.
-		const items = [weightItem('a', 1), weightItem('b', 1), weightItem('c', 1)];
-		const activity = new RuntimeItemActivity('activity', asUnion(items[0]));
-		activity.addActivityItem(asUnion(items[1]));
-		activity.addActivityItem(asUnion(items[2]));
-		const baselineVersion = versionOf(activity);
+	test('single multi-line item that self-trims: bumps version without a splice', () => {
+		// 5 output lines, scrollbackSize 2 -> item trims in place and fills the scrollback.
+		const item = linesItem('a', 5);
+		const activity = new RuntimeItemActivity('activity', item);
+		const initialVersion = activity.version;
 
 		const remaining = activity.trimScrollback(2);
 
-		assert.strictEqual(remaining, 0, 'budget exhausted by b');
-		assert.strictEqual(activity.activityItems.length, 2, 'a was spliced off; b and c remain');
-		assert.strictEqual(activity.activityItems[0].id, 'b');
-		assert.strictEqual(activity.activityItems[1].id, 'c');
-		assert.strictEqual(versionOf(activity), baselineVersion + 1, 'splice forces a version bump');
-		assert.strictEqual(items[0].callCount, 0, 'a was never walked — loop exited first');
-		assert.strictEqual(items[1].callCount, 1);
-		assert.strictEqual(items[2].callCount, 1);
+		assert.strictEqual(remaining, 0, 'over-sized item consumed the full scrollbackSize');
+		assert.strictEqual(activity.activityItems.length, 1, 'no splice - the trimming item is the only one');
+		assert.strictEqual(activity.version, initialVersion + 1, 'version bumps because the item self-trimmed');
+		assert.strictEqual(item.outputLines.length, 2, 'item was trimmed in-place to scrollbackSize');
 	});
 
-	test('item self-trims and exhausts budget: splice AND trim-signal both hit; one bump', () => {
-		// Walking tail-first with budget 3: c fits weight-1 (budget → 2), b self-trims and reports
-		// remaining=0. Loop exits at b (firstKeepIndex = 1) → splice(0, 1) drops a. Both signals
-		// (b.trimmed = true AND splice happened) would independently bump version; assert exactly
-		// one bump.
-		const items = [weightItem('a', 1), selfTrimmingItem('b'), weightItem('c', 1)];
-		const activity = new RuntimeItemActivity('activity', asUnion(items[0]));
-		activity.addActivityItem(asUnion(items[1]));
-		activity.addActivityItem(asUnion(items[2]));
-		const baselineVersion = versionOf(activity);
+	test('multiple items all fit: no version bump, no splice', () => {
+		const items = [errItem('a'), errItem('b'), errItem('c')];
+		const activity = new RuntimeItemActivity('activity', items[0]);
+		activity.addActivityItem(items[1]);
+		activity.addActivityItem(items[2]);
+		const baselineVersion = activity.version;
+
+		const remaining = activity.trimScrollback(10);
+
+		assert.strictEqual(remaining, 7, 'three weight-1 items consumed 3 units out of 10');
+		assert.strictEqual(activity.activityItems.length, 3);
+		assert.strictEqual(activity.version, baselineVersion, 'no trim occurred, no version bump');
+	});
+
+	test('scrollback exhausted mid-walk: splices older items and bumps version', () => {
+		// Walking tail-first with scrollbackSize 2 over 3 weight-1 items: c fits (remaining=1),
+		// b fits (remaining=0), loop exits before visiting a. firstKeepIndex=1 splices a.
+		const items = [errItem('a'), errItem('b'), errItem('c')];
+		const activity = new RuntimeItemActivity('activity', items[0]);
+		activity.addActivityItem(items[1]);
+		activity.addActivityItem(items[2]);
+		const baselineVersion = activity.version;
+
+		const remaining = activity.trimScrollback(2);
+
+		assert.strictEqual(remaining, 0);
+		assert.strictEqual(activity.activityItems.length, 2);
+		assert.strictEqual(activity.activityItems[0].id, 'b', 'a was spliced off');
+		assert.strictEqual(activity.activityItems[1].id, 'c');
+		assert.strictEqual(activity.version, baselineVersion + 1, 'splice forces a version bump');
+	});
+
+	test('item self-trims AND scrollback exhausts: one version bump, not two', () => {
+		// Walking tail-first with scrollbackSize 3: c fits weight-1 (remaining=2), b self-trims
+		// to 2 lines and fills the rest (remaining=0). Loop exits at b; firstKeepIndex=1 splices
+		// a. Both signals (b.trimmed AND splice) would independently bump version - assert
+		// exactly one bump.
+		const b = linesItem('b', 5);
+		const activity = new RuntimeItemActivity('activity', errItem('a'));
+		activity.addActivityItem(b);
+		activity.addActivityItem(errItem('c'));
+		const baselineVersion = activity.version;
 
 		activity.trimScrollback(3);
 
 		assert.strictEqual(activity.activityItems.length, 2, 'a spliced; b and c remain');
 		assert.strictEqual(activity.activityItems[0].id, 'b');
-		assert.strictEqual(versionOf(activity), baselineVersion + 1, 'exactly one bump even though both trim-signal and splice fire');
+		assert.strictEqual(activity.activityItems[1].id, 'c');
+		assert.strictEqual(b.outputLines.length, 2, 'b was trimmed in place');
+		assert.strictEqual(activity.version, baselineVersion + 1, 'exactly one bump');
 	});
 
-	test('non-positive scrollback size short-circuits: returns 0, no work done', () => {
-		const item = selfTrimmingItem('a');
-		const activity = new RuntimeItemActivity('activity', asUnion(item));
-		const baselineVersion = versionOf(activity);
+	test('non-positive scrollback size short-circuits: no work, no version bump', () => {
+		const item = linesItem('a', 5);
+		const activity = new RuntimeItemActivity('activity', item);
+		const baselineVersion = activity.version;
 
 		assert.strictEqual(activity.trimScrollback(0), 0);
 		assert.strictEqual(activity.trimScrollback(-5), 0);
-		assert.strictEqual(item.callCount, 0, 'no item was consulted');
-		assert.strictEqual(versionOf(activity), baselineVersion, 'no version bump on the guard path');
+		assert.strictEqual(item.outputLines.length, 5, 'item untouched on the guard path');
+		assert.strictEqual(activity.version, baselineVersion);
+	});
+});
+
+suite('RuntimeItemActivity.addActivityItem - version bump semantics', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('stream-merge that absorbs (no newline): length unchanged, version still bumps', () => {
+		// The second stream has no newline, so addActivityItemStream on the first returns
+		// undefined and addActivityItem early-returns without pushing. _version must still
+		// advance because content was appended into the existing stream.
+		const first = stream('s1', 'p', 'hello');
+		const activity = new RuntimeItemActivity('activity', first);
+		const baselineVersion = activity.version;
+
+		activity.addActivityItem(stream('s2', 'p', ' world'));
+
+		assert.strictEqual(activity.activityItems.length, 1, 'second stream was absorbed into the first');
+		assert.strictEqual(activity.version, baselineVersion + 1, 'absorbed merges must still bump version');
+	});
+
+	test('stream-merge across different parentIds: pushes as new item, bumps version', () => {
+		const first = stream('s1', 'pA', 'hello');
+		const activity = new RuntimeItemActivity('activity', first);
+		const baselineVersion = activity.version;
+
+		activity.addActivityItem(stream('s2', 'pB', ' world'));
+
+		assert.strictEqual(activity.activityItems.length, 2, 'different parentId - no merge');
+		assert.strictEqual(activity.version, baselineVersion + 1);
+	});
+
+	test('provisional ActivityItemInput replaced by non-provisional: in-place swap, version bumps', () => {
+		const provisional = input('i1', 'p', ActivityItemInputState.Provisional);
+		const activity = new RuntimeItemActivity('activity', provisional);
+		const baselineVersion = activity.version;
+
+		const executing = input('i2', 'p', ActivityItemInputState.Executing);
+		activity.addActivityItem(executing);
+
+		assert.strictEqual(activity.activityItems.length, 1, 'replacement, not append');
+		assert.strictEqual(activity.activityItems[0], executing, 'slot now holds the new input');
+		assert.strictEqual(executing.state, ActivityItemInputState.Executing, 'state not forced - prior was Provisional');
+		assert.strictEqual(activity.version, baselineVersion + 1);
+	});
+
+	test('replacing an already-Completed input forces the new input to Completed', () => {
+		// Simulates idle arriving before the input message: the ActivityItemInput already sitting
+		// in the list is Completed. When the "real" Executing ActivityItemInput arrives later,
+		// the replacement logic propagates the Completed state so the UI doesn't regress to
+		// Executing.
+		const alreadyCompleted = input('i1', 'p', ActivityItemInputState.Completed);
+		const activity = new RuntimeItemActivity('activity', alreadyCompleted);
+		const baselineVersion = activity.version;
+
+		const executing = input('i2', 'p', ActivityItemInputState.Executing);
+		activity.addActivityItem(executing);
+
+		assert.strictEqual(activity.activityItems.length, 1);
+		assert.strictEqual(activity.activityItems[0], executing, 'slot holds the replacement');
+		assert.strictEqual(executing.state, ActivityItemInputState.Completed, 'Completed state propagated to replacement');
+		assert.strictEqual(activity.version, baselineVersion + 1);
+	});
+
+	test('non-provisional input with no matching predecessor: plain append', () => {
+		const activity = new RuntimeItemActivity('activity', stream('s1', 'p', 'hi'));
+		const baselineVersion = activity.version;
+
+		activity.addActivityItem(input('i1', 'p', ActivityItemInputState.Executing));
+
+		assert.strictEqual(activity.activityItems.length, 2);
+		assert.strictEqual(activity.version, baselineVersion + 1);
 	});
 });

--- a/src/vs/workbench/services/positronConsole/test/browser/classes/runtimeItemActivity.test.ts
+++ b/src/vs/workbench/services/positronConsole/test/browser/classes/runtimeItemActivity.test.ts
@@ -1,0 +1,165 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
+import { ActivityItem, TrimScrollbackResult } from '../../../browser/classes/activityItem.js';
+import { ActivityItem as ActivityItemUnion, RuntimeItemActivity } from '../../../browser/classes/runtimeItemActivity.js';
+
+/**
+ * Minimal ActivityItem subclass for tests. Driven by a `trimFn` that takes the incoming budget
+ * and returns a TrimScrollbackResult, so each mock participates in the walk's budget accounting
+ * (instead of clobbering it with a static value). Records callCount for walk-shape assertions.
+ *
+ * Note: the RuntimeItemActivity API is typed against an `ActivityItem` *union* of concrete
+ * subclasses (ActivityItemStream | ActivityItemErrorMessage | ...) — not the abstract base.
+ * This test item extends the abstract base and is cast through the union at call sites. The
+ * cast is safe because trimScrollback only uses the abstract-class methods; the instanceof
+ * branches in addActivityItem (stream merge, input replacement) simply don't fire for a
+ * TestActivityItem, which is exactly what we want in these tests.
+ */
+class TestActivityItem extends ActivityItem {
+	public callCount = 0;
+
+	constructor(
+		id: string,
+		private readonly _trimFn: (budget: number) => TrimScrollbackResult
+	) {
+		super(id, 'parent', new Date(0));
+	}
+
+	public override trimScrollback(scrollbackSize: number): TrimScrollbackResult {
+		this.callCount++;
+		return this._trimFn(scrollbackSize);
+	}
+
+	public override getClipboardRepresentation(_commentPrefix: string): string[] {
+		return [];
+	}
+}
+
+/** A weight-only item: declares weight N, never reports trimmed. Matches ActivityItemInput et al. */
+const weightItem = (id: string, weight: number) => new TestActivityItem(id, (budget) => ({
+	trimmed: false,
+	remainingScrollbackSize: Math.max(budget - weight, 0),
+}));
+
+/** A self-trimming item: always reports trimmed:true and consumes the full budget. */
+const selfTrimmingItem = (id: string) => new TestActivityItem(id, (_budget) => ({
+	trimmed: true,
+	remainingScrollbackSize: 0,
+}));
+
+/**
+ * Bridges the abstract-class TestActivityItem to the union type the RuntimeItemActivity API
+ * expects. Keeps the casts isolated to one place.
+ */
+const asUnion = (item: TestActivityItem): ActivityItemUnion => item as unknown as ActivityItemUnion;
+
+/**
+ * Reads RuntimeItemActivity._version through the public getter in a way that's stable against
+ * future renames — all tests go through this.
+ */
+const versionOf = (activity: RuntimeItemActivity): number => activity.version;
+
+suite('RuntimeItemActivity.trimScrollback', () => {
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('single item that fits without trimming: no version bump, no splice, returns remaining budget', () => {
+		const item = weightItem('a', 1);
+		const activity = new RuntimeItemActivity('activity', asUnion(item));
+		const initialVersion = versionOf(activity);
+
+		const remaining = activity.trimScrollback(10);
+
+		assert.strictEqual(remaining, 9, 'remaining budget passes through from the item');
+		assert.strictEqual(activity.activityItems.length, 1, 'no splice happened');
+		assert.strictEqual(versionOf(activity), initialVersion, '_version should not bump when nothing trimmed');
+		assert.strictEqual(item.callCount, 1, 'the single item was walked once');
+	});
+
+	test('single item reports trimmed: bumps version without a splice', () => {
+		const item = selfTrimmingItem('a');
+		const activity = new RuntimeItemActivity('activity', asUnion(item));
+		const initialVersion = versionOf(activity);
+
+		const remaining = activity.trimScrollback(5);
+
+		assert.strictEqual(remaining, 0);
+		assert.strictEqual(activity.activityItems.length, 1, 'no splice — the trimming item is the only one');
+		assert.strictEqual(versionOf(activity), initialVersion + 1, 'version bumps because the item reported trimmed');
+	});
+
+	test('multiple items all fit with no trimming: no version bump, no splice', () => {
+		// Three weight-1 items. Walk consumes three units of budget; none reports trimmed.
+		const items = [weightItem('a', 1), weightItem('b', 1), weightItem('c', 1)];
+		const activity = new RuntimeItemActivity('activity', asUnion(items[0]));
+		// The constructor added items[0] via addActivityItem (which bumps _version once). Record
+		// that post-construction baseline so we can assert *no further* bumps.
+		activity.addActivityItem(asUnion(items[1]));
+		activity.addActivityItem(asUnion(items[2]));
+		const baselineVersion = versionOf(activity);
+
+		const remaining = activity.trimScrollback(10);
+
+		assert.strictEqual(remaining, 7, 'each of three weight-1 items consumed one unit (10 → 9 → 8 → 7)');
+		assert.strictEqual(activity.activityItems.length, 3, 'no splice');
+		assert.strictEqual(versionOf(activity), baselineVersion, '_version untouched — no trim occurred');
+		assert.strictEqual(items[0].callCount, 1);
+		assert.strictEqual(items[1].callCount, 1);
+		assert.strictEqual(items[2].callCount, 1);
+	});
+
+	test('budget exhausted mid-walk: splices older items and bumps version', () => {
+		// Budget 2, three weight-1 items. Walking tail-first: c fits (budget → 1), b fits
+		// (budget → 0), loop exits without visiting a. firstKeepIndex = 1 → splice(0, 1) drops a.
+		const items = [weightItem('a', 1), weightItem('b', 1), weightItem('c', 1)];
+		const activity = new RuntimeItemActivity('activity', asUnion(items[0]));
+		activity.addActivityItem(asUnion(items[1]));
+		activity.addActivityItem(asUnion(items[2]));
+		const baselineVersion = versionOf(activity);
+
+		const remaining = activity.trimScrollback(2);
+
+		assert.strictEqual(remaining, 0, 'budget exhausted by b');
+		assert.strictEqual(activity.activityItems.length, 2, 'a was spliced off; b and c remain');
+		assert.strictEqual(activity.activityItems[0].id, 'b');
+		assert.strictEqual(activity.activityItems[1].id, 'c');
+		assert.strictEqual(versionOf(activity), baselineVersion + 1, 'splice forces a version bump');
+		assert.strictEqual(items[0].callCount, 0, 'a was never walked — loop exited first');
+		assert.strictEqual(items[1].callCount, 1);
+		assert.strictEqual(items[2].callCount, 1);
+	});
+
+	test('item self-trims and exhausts budget: splice AND trim-signal both hit; one bump', () => {
+		// Walking tail-first with budget 3: c fits weight-1 (budget → 2), b self-trims and reports
+		// remaining=0. Loop exits at b (firstKeepIndex = 1) → splice(0, 1) drops a. Both signals
+		// (b.trimmed = true AND splice happened) would independently bump version; assert exactly
+		// one bump.
+		const items = [weightItem('a', 1), selfTrimmingItem('b'), weightItem('c', 1)];
+		const activity = new RuntimeItemActivity('activity', asUnion(items[0]));
+		activity.addActivityItem(asUnion(items[1]));
+		activity.addActivityItem(asUnion(items[2]));
+		const baselineVersion = versionOf(activity);
+
+		activity.trimScrollback(3);
+
+		assert.strictEqual(activity.activityItems.length, 2, 'a spliced; b and c remain');
+		assert.strictEqual(activity.activityItems[0].id, 'b');
+		assert.strictEqual(versionOf(activity), baselineVersion + 1, 'exactly one bump even though both trim-signal and splice fire');
+	});
+
+	test('non-positive scrollback size short-circuits: returns 0, no work done', () => {
+		const item = selfTrimmingItem('a');
+		const activity = new RuntimeItemActivity('activity', asUnion(item));
+		const baselineVersion = versionOf(activity);
+
+		assert.strictEqual(activity.trimScrollback(0), 0);
+		assert.strictEqual(activity.trimScrollback(-5), 0);
+		assert.strictEqual(item.callCount, 0, 'no item was consulted');
+		assert.strictEqual(versionOf(activity), baselineVersion, 'no version bump on the guard path');
+	});
+});

--- a/src/vs/workbench/services/positronConsole/test/browser/classes/runtimeItemActivity.vitest.ts
+++ b/src/vs/workbench/services/positronConsole/test/browser/classes/runtimeItemActivity.vitest.ts
@@ -3,13 +3,13 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import assert from 'assert';
-import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
-import { ActivityItemErrorMessage } from '../../../browser/classes/activityItemErrorMessage.js';
-import { ActivityItemInput, ActivityItemInputState } from '../../../browser/classes/activityItemInput.js';
-import { ActivityItemOutputMessage } from '../../../browser/classes/activityItemOutputMessage.js';
-import { ActivityItemStream, ActivityItemStreamType } from '../../../browser/classes/activityItemStream.js';
+/// <reference types="vitest/globals" />
+
 import { RuntimeItemActivity } from '../../../browser/classes/runtimeItemActivity.js';
+import { ActivityItemErrorMessage } from '../../../browser/classes/activityItemErrorMessage.js';
+import { ActivityItemOutputMessage } from '../../../browser/classes/activityItemOutputMessage.js';
+import { ActivityItemInput, ActivityItemInputState } from '../../../browser/classes/activityItemInput.js';
+import { ActivityItemStream, ActivityItemStreamType } from '../../../browser/classes/activityItemStream.js';
 
 // A weight-1 activity item that never self-trims. ActivityItemErrorMessage fits: simple
 // constructor, counts as 1 scrollback unit, and has no merge logic in addActivityItem.
@@ -33,23 +33,21 @@ const stream = (id: string, parentId: string, text: string) =>
 const input = (id: string, parentId: string, state: ActivityItemInputState, code = 'x') =>
 	new ActivityItemInput(id, parentId, new Date(0), state, '>', '+', code);
 
-suite('RuntimeItemActivity.trimScrollback', () => {
+describe('RuntimeItemActivity.trimScrollback', () => {
 
-	ensureNoDisposablesAreLeakedInTestSuite();
-
-	test('single weight-1 item that fits: no version bump, no splice', () => {
+	it('single weight-1 item that fits: no version bump, no splice', () => {
 		const item = errItem('a');
 		const activity = new RuntimeItemActivity('activity', item);
 		const initialVersion = activity.version;
 
 		const remaining = activity.trimScrollback(10);
 
-		assert.strictEqual(remaining, 9, 'weight-1 item consumed one unit out of 10');
-		assert.strictEqual(activity.activityItems.length, 1);
-		assert.strictEqual(activity.version, initialVersion, 'no version bump when nothing trimmed');
+		expect(remaining, 'weight-1 item consumed one unit out of 10').toBe(9);
+		expect(activity.activityItems.length).toBe(1);
+		expect(activity.version, 'no version bump when nothing trimmed').toBe(initialVersion);
 	});
 
-	test('single multi-line item that self-trims: bumps version without a splice', () => {
+	it('single multi-line item that self-trims: bumps version without a splice', () => {
 		// 5 output lines, scrollbackSize 2 -> item trims in place and fills the scrollback.
 		const item = linesItem('a', 5);
 		const activity = new RuntimeItemActivity('activity', item);
@@ -57,13 +55,13 @@ suite('RuntimeItemActivity.trimScrollback', () => {
 
 		const remaining = activity.trimScrollback(2);
 
-		assert.strictEqual(remaining, 0, 'over-sized item consumed the full scrollbackSize');
-		assert.strictEqual(activity.activityItems.length, 1, 'no splice - the trimming item is the only one');
-		assert.strictEqual(activity.version, initialVersion + 1, 'version bumps because the item self-trimmed');
-		assert.strictEqual(item.outputLines.length, 2, 'item was trimmed in-place to scrollbackSize');
+		expect(remaining, 'over-sized item consumed the full scrollbackSize').toBe(0);
+		expect(activity.activityItems.length, 'no splice - the trimming item is the only one').toBe(1);
+		expect(activity.version, 'version bumps because the item self-trimmed').toBe(initialVersion + 1);
+		expect(item.outputLines.length, 'item was trimmed in-place to scrollbackSize').toBe(2);
 	});
 
-	test('multiple items all fit: no version bump, no splice', () => {
+	it('multiple items all fit: no version bump, no splice', () => {
 		const items = [errItem('a'), errItem('b'), errItem('c')];
 		const activity = new RuntimeItemActivity('activity', items[0]);
 		activity.addActivityItem(items[1]);
@@ -72,12 +70,12 @@ suite('RuntimeItemActivity.trimScrollback', () => {
 
 		const remaining = activity.trimScrollback(10);
 
-		assert.strictEqual(remaining, 7, 'three weight-1 items consumed 3 units out of 10');
-		assert.strictEqual(activity.activityItems.length, 3);
-		assert.strictEqual(activity.version, baselineVersion, 'no trim occurred, no version bump');
+		expect(remaining, 'three weight-1 items consumed 3 units out of 10').toBe(7);
+		expect(activity.activityItems.length).toBe(3);
+		expect(activity.version, 'no trim occurred, no version bump').toBe(baselineVersion);
 	});
 
-	test('scrollback exhausted mid-walk: splices older items and bumps version', () => {
+	it('scrollback exhausted mid-walk: splices older items and bumps version', () => {
 		// Walking tail-first with scrollbackSize 2 over 3 weight-1 items: c fits (remaining=1),
 		// b fits (remaining=0), loop exits before visiting a. firstKeepIndex=1 splices a.
 		const items = [errItem('a'), errItem('b'), errItem('c')];
@@ -88,14 +86,14 @@ suite('RuntimeItemActivity.trimScrollback', () => {
 
 		const remaining = activity.trimScrollback(2);
 
-		assert.strictEqual(remaining, 0);
-		assert.strictEqual(activity.activityItems.length, 2);
-		assert.strictEqual(activity.activityItems[0].id, 'b', 'a was spliced off');
-		assert.strictEqual(activity.activityItems[1].id, 'c');
-		assert.strictEqual(activity.version, baselineVersion + 1, 'splice forces a version bump');
+		expect(remaining).toBe(0);
+		expect(activity.activityItems.length).toBe(2);
+		expect(activity.activityItems[0].id, 'a was spliced off').toBe('b');
+		expect(activity.activityItems[1].id).toBe('c');
+		expect(activity.version, 'splice forces a version bump').toBe(baselineVersion + 1);
 	});
 
-	test('item self-trims AND scrollback exhausts: one version bump, not two', () => {
+	it('item self-trims AND scrollback exhausts: one version bump, not two', () => {
 		// Walking tail-first with scrollbackSize 3: c fits weight-1 (remaining=2), b self-trims
 		// to 2 lines and fills the rest (remaining=0). Loop exits at b; firstKeepIndex=1 splices
 		// a. Both signals (b.trimmed AND splice) would independently bump version - assert
@@ -108,30 +106,28 @@ suite('RuntimeItemActivity.trimScrollback', () => {
 
 		activity.trimScrollback(3);
 
-		assert.strictEqual(activity.activityItems.length, 2, 'a spliced; b and c remain');
-		assert.strictEqual(activity.activityItems[0].id, 'b');
-		assert.strictEqual(activity.activityItems[1].id, 'c');
-		assert.strictEqual(b.outputLines.length, 2, 'b was trimmed in place');
-		assert.strictEqual(activity.version, baselineVersion + 1, 'exactly one bump');
+		expect(activity.activityItems.length, 'a spliced; b and c remain').toBe(2);
+		expect(activity.activityItems[0].id).toBe('b');
+		expect(activity.activityItems[1].id).toBe('c');
+		expect(b.outputLines.length, 'b was trimmed in place').toBe(2);
+		expect(activity.version, 'exactly one bump').toBe(baselineVersion + 1);
 	});
 
-	test('non-positive scrollback size short-circuits: no work, no version bump', () => {
+	it('non-positive scrollback size short-circuits: no work, no version bump', () => {
 		const item = linesItem('a', 5);
 		const activity = new RuntimeItemActivity('activity', item);
 		const baselineVersion = activity.version;
 
-		assert.strictEqual(activity.trimScrollback(0), 0);
-		assert.strictEqual(activity.trimScrollback(-5), 0);
-		assert.strictEqual(item.outputLines.length, 5, 'item untouched on the guard path');
-		assert.strictEqual(activity.version, baselineVersion);
+		expect(activity.trimScrollback(0)).toBe(0);
+		expect(activity.trimScrollback(-5)).toBe(0);
+		expect(item.outputLines.length, 'item untouched on the guard path').toBe(5);
+		expect(activity.version).toBe(baselineVersion);
 	});
 });
 
-suite('RuntimeItemActivity.addActivityItem - version bump semantics', () => {
+describe('RuntimeItemActivity.addActivityItem - version bump semantics', () => {
 
-	ensureNoDisposablesAreLeakedInTestSuite();
-
-	test('stream-merge that absorbs (no newline): length unchanged, version still bumps', () => {
+	it('stream-merge that absorbs (no newline): length unchanged, version still bumps', () => {
 		// The second stream has no newline, so addActivityItemStream on the first returns
 		// undefined and addActivityItem early-returns without pushing. _version must still
 		// advance because content was appended into the existing stream.
@@ -141,22 +137,22 @@ suite('RuntimeItemActivity.addActivityItem - version bump semantics', () => {
 
 		activity.addActivityItem(stream('s2', 'p', ' world'));
 
-		assert.strictEqual(activity.activityItems.length, 1, 'second stream was absorbed into the first');
-		assert.strictEqual(activity.version, baselineVersion + 1, 'absorbed merges must still bump version');
+		expect(activity.activityItems.length, 'second stream was absorbed into the first').toBe(1);
+		expect(activity.version, 'absorbed merges must still bump version').toBe(baselineVersion + 1);
 	});
 
-	test('stream-merge across different parentIds: pushes as new item, bumps version', () => {
+	it('stream-merge across different parentIds: pushes as new item, bumps version', () => {
 		const first = stream('s1', 'pA', 'hello');
 		const activity = new RuntimeItemActivity('activity', first);
 		const baselineVersion = activity.version;
 
 		activity.addActivityItem(stream('s2', 'pB', ' world'));
 
-		assert.strictEqual(activity.activityItems.length, 2, 'different parentId - no merge');
-		assert.strictEqual(activity.version, baselineVersion + 1);
+		expect(activity.activityItems.length, 'different parentId - no merge').toBe(2);
+		expect(activity.version).toBe(baselineVersion + 1);
 	});
 
-	test('provisional ActivityItemInput replaced by non-provisional: in-place swap, version bumps', () => {
+	it('provisional ActivityItemInput replaced by non-provisional: in-place swap, version bumps', () => {
 		const provisional = input('i1', 'p', ActivityItemInputState.Provisional);
 		const activity = new RuntimeItemActivity('activity', provisional);
 		const baselineVersion = activity.version;
@@ -164,13 +160,13 @@ suite('RuntimeItemActivity.addActivityItem - version bump semantics', () => {
 		const executing = input('i2', 'p', ActivityItemInputState.Executing);
 		activity.addActivityItem(executing);
 
-		assert.strictEqual(activity.activityItems.length, 1, 'replacement, not append');
-		assert.strictEqual(activity.activityItems[0], executing, 'slot now holds the new input');
-		assert.strictEqual(executing.state, ActivityItemInputState.Executing, 'state not forced - prior was Provisional');
-		assert.strictEqual(activity.version, baselineVersion + 1);
+		expect(activity.activityItems.length, 'replacement, not append').toBe(1);
+		expect(activity.activityItems[0], 'slot now holds the new input').toBe(executing);
+		expect(executing.state, 'state not forced - prior was Provisional').toBe(ActivityItemInputState.Executing);
+		expect(activity.version).toBe(baselineVersion + 1);
 	});
 
-	test('replacing an already-Completed input forces the new input to Completed', () => {
+	it('replacing an already-Completed input forces the new input to Completed', () => {
 		// Simulates idle arriving before the input message: the ActivityItemInput already sitting
 		// in the list is Completed. When the "real" Executing ActivityItemInput arrives later,
 		// the replacement logic propagates the Completed state so the UI doesn't regress to
@@ -182,19 +178,19 @@ suite('RuntimeItemActivity.addActivityItem - version bump semantics', () => {
 		const executing = input('i2', 'p', ActivityItemInputState.Executing);
 		activity.addActivityItem(executing);
 
-		assert.strictEqual(activity.activityItems.length, 1);
-		assert.strictEqual(activity.activityItems[0], executing, 'slot holds the replacement');
-		assert.strictEqual(executing.state, ActivityItemInputState.Completed, 'Completed state propagated to replacement');
-		assert.strictEqual(activity.version, baselineVersion + 1);
+		expect(activity.activityItems.length).toBe(1);
+		expect(activity.activityItems[0], 'slot holds the replacement').toBe(executing);
+		expect(executing.state, 'Completed state propagated to replacement').toBe(ActivityItemInputState.Completed);
+		expect(activity.version).toBe(baselineVersion + 1);
 	});
 
-	test('non-provisional input with no matching predecessor: plain append', () => {
+	it('non-provisional input with no matching predecessor: plain append', () => {
 		const activity = new RuntimeItemActivity('activity', stream('s1', 'p', 'hi'));
 		const baselineVersion = activity.version;
 
 		activity.addActivityItem(input('i1', 'p', ActivityItemInputState.Executing));
 
-		assert.strictEqual(activity.activityItems.length, 2);
-		assert.strictEqual(activity.version, baselineVersion + 1);
+		expect(activity.activityItems.length).toBe(2);
+		expect(activity.version).toBe(baselineVersion + 1);
 	});
 });


### PR DESCRIPTION
### Description

Addresses #9852.

#### Console performance improvements: memoized rendering + scrollback trimming

The console had two related performance problems. First, every item re-rendered on every append, so as the console grew, each new line got more expensive to show. Second, the existing scrollback cap wasn't actually freeing memory or work: the old code flipped a hidden flag on items that fell off the edge but left them in the list, so every render still walked the full history and every streamed output item kept its full ANSI state alive. The cap could also only act at the whole-item level, so a single long-running streamed activity (which accumulates many thousands of output lines into one item) was untouched regardless of its size.

This branch memoizes every runtime item the console can render. For static items that means a default memo comparison is enough; for mutable ones (notably the activity item that accumulates streamed output) a monotonic version counter is bumped whenever its content actually changes, and React uses that to decide whether to re-render. Items that didn't change are skipped entirely.

On top of that, every runtime item now participates in a unified scrollback trim. When the configured cap is exceeded the console walks its items from newest to oldest, letting each one report how much scrollback it takes and whether it trimmed itself in place, and splices off anything that fell out of scope. The trim runs on every append and also when the user lowers the scrollback setting.

Because rendering is now a lot cheaper, the default `console.scrollbackSize` has been raised to 10,000 items (with a new range of 1,000–20,000). A one-time-per-profile migration clears any stale user override so everyone picks up the new default, unless they explicitly set their own value from here on.

New unit tests cover the trim walk, the version-bump semantics for activity-item mutations, and the new ANSI-output helper used when trimming streamed output.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #9852 Improved console performance.

### QA Notes

Tests:
@:console

I've added additional tests in this PR.
I tested this on Windows and macOS.