### PR TITLE
Fix clipping of inline data explorer in Quarto inline output

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoInlineDataExplorer.css
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoInlineDataExplorer.css
@@ -15,3 +15,17 @@
 	font-family: var(--vscode-font-family);
 	font-size: var(--vscode-font-size);
 }
+
+/*
+ * The shared .inline-data-explorer-container has margin: 4px 0 and a 1px
+ * border with default content-box sizing, which makes its visual height
+ * exceed the configured pixel height (the value calculated by
+ * quartoInlineDataExplorerLayout.ts and applied to both this element and
+ * its overflow:hidden wrapper). The notebook usage works around this with
+ * negative margins; in Quarto we instead drop the margin and use border-box
+ * so the box's rendered height matches the wrapper exactly.
+ */
+.quarto-output-data-explorer .inline-data-explorer-container {
+	box-sizing: border-box;
+	margin: 0;
+}


### PR DESCRIPTION
Quick CSS only change which addresses one of the glitches noted in https://github.com/posit-dev/positron/issues/13163.

Namely: we currently don't set the height for inline data explorers exactly correct, with the result that the bottom few pixels get cut off. It's not normally easy to see, but in a theme with strong borders, it's pretty obvious.

Before fix:

<img width="719" height="342" alt="image" src="https://github.com/user-attachments/assets/b8378009-0e9c-4087-b268-8cc998708485" />

After fix (also with a non default font to show that works):

<img width="684" height="338" alt="image" src="https://github.com/user-attachments/assets/e3942718-73dc-44d3-ac3d-f3b4ae9cb798" />

