### PR TITLE
Add notebook debugging support for Ark

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -1094,7 +1094,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "ark": "0.1.250"
+      "ark": "0.1.251"
     },
     "minimumRVersion": "4.2.0",
     "minimumRenvVersion": "1.0.9"

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -238,7 +238,11 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 	}
 
 	async debug(request: positron.DebugProtocolRequest): Promise<positron.DebugProtocolResponse> {
-		throw new Error(`Debugging is not supported in R sessions`);
+		if (this._kernel) {
+			return await this._kernel.debug(request);
+		} else {
+			throw new Error('Cannot debug; kernel not started');
+		}
 	}
 
 	execute(

--- a/extensions/positron-runtime-debugger/src/breakpointSync.ts
+++ b/extensions/positron-runtime-debugger/src/breakpointSync.ts
@@ -102,8 +102,9 @@ export class BreakpointSyncService extends Disposable {
 
 	private async syncNotebookBreakpoints(notebookUri: vscode.Uri): Promise<void> {
 		// During an active debug session the RuntimeDebugAdapter handles
-		// `setBreakpoints`. Sending them here as well would race and cause
-		// breakpoint ID churn. See `breakpoint-sync-followups.md`.
+		// `setBreakpoints`. Sending them here as well would collide. For Ark in
+		// console mode, we'll probably want a single source of truth with BP sync
+		// via Jupyter.
 		if (this.hasActiveDebugSession(notebookUri)) {
 			return;
 		}

--- a/extensions/positron-runtime-debugger/src/breakpointSync.ts
+++ b/extensions/positron-runtime-debugger/src/breakpointSync.ts
@@ -1,0 +1,315 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+import { DebugProtocol } from '@vscode/debugprotocol';
+import { DumpCellArguments, DebugInfoResponseBody } from './jupyterDebugProtocol.js';
+import { PathEncoder } from './pathEncoder.js';
+import { Disposable } from './util.js';
+import { getNotebookSession } from './notebookDebugService.js';
+import { log } from './extension.js';
+
+// Placeholder value for the `seq` field of DAP requests. Sequencing is
+// handled by the Jupyter transport layer, not DAP.
+const PLACEHOLDER_SEQ = 0;
+
+/**
+ * Keeps the kernel's breakpoint table in sync with the editor's breakpoints
+ * at all times, not only during debug sessions. Communicates with the kernel
+ * via the Control channel's debug request/reply protocol.
+ *
+ * Used with Ark to allow injection of breakpoints at parse-time while code is
+ * executed outside of debugging sessions. Without this, users would need to
+ * first start a debugging session, then re-execute all code/cells containing
+ * breakpoints.
+ */
+export class BreakpointSyncService extends Disposable {
+	/** PathEncoder per runtime session ID. */
+	private readonly _encoderBySession = new Map<string, PathEncoder>();
+
+	/** Tracks whether we've initialized (sent debugInfo) for a given runtime session. */
+	private readonly _initializedSessions = new Set<string>();
+
+	/** Tracks source URIs that have been synced to the kernel, per session ID. */
+	private readonly _syncedSourcesBySession = new Map<string, Set<string>>();
+
+	/** Pending sync promise per notebook URI, used to serialize overlapping syncs. */
+	private readonly _pendingSync = new Map<string, Promise<void>>();
+
+	constructor() {
+		super();
+
+		this._register(vscode.debug.onDidChangeBreakpoints((event) => {
+			this.onBreakpointsChanged(event);
+		}));
+	}
+
+	private onBreakpointsChanged(event: vscode.BreakpointsChangeEvent): void {
+		const changedUris = new Set<string>();
+
+		// Collect URIs where breakpoints have changed. The handler reads the whole
+		// breakpoint state later on so we do not need to track deltas here.
+		for (const bp of [...event.added, ...event.changed, ...event.removed]) {
+			if (bp instanceof vscode.SourceBreakpoint) {
+				changedUris.add(bp.location.uri.toString());
+			}
+		}
+
+		for (const uriStr of changedUris) {
+			const uri = vscode.Uri.parse(uriStr, true);
+			switch (uri.scheme) {
+				case 'vscode-notebook-cell': {
+					const notebookUri = uri.with({ scheme: 'file', fragment: '' });
+					this.enqueueSync(notebookUri);
+					break;
+				}
+				// TODO: Handle `file:` scheme for console sessions (for Ark)
+			}
+		}
+	}
+
+	// --- Notebook-specific sync -------------------------------------------------
+
+	/**
+	 * Enqueue a sync for a notebook, chaining onto any in-flight sync so
+	 * overlapping breakpoint events don't race.
+	 */
+	private enqueueSync(notebookUri: vscode.Uri): void {
+		const key = notebookUri.toString();
+		const previous = this._pendingSync.get(key) ?? Promise.resolve();
+		const next = previous.then(() =>
+			this.syncNotebookBreakpoints(notebookUri).catch((error) => {
+				log.error(`[breakpoint-sync] Failed to sync breakpoints for ${key}:`, error);
+			})
+		).then(() => {
+			// Clean up once the chain settles, but only if we're still the
+			// latest entry (a newer sync may have chained on in the meantime).
+			if (this._pendingSync.get(key) === next) {
+				this._pendingSync.delete(key);
+			}
+		});
+		this._pendingSync.set(key, next);
+	}
+
+	private async syncNotebookBreakpoints(notebookUri: vscode.Uri): Promise<void> {
+		// During an active debug session the RuntimeDebugAdapter handles
+		// `setBreakpoints`. Sending them here as well would race and cause
+		// breakpoint ID churn. See `breakpoint-sync-followups.md`.
+		if (this.hasActiveDebugSession(notebookUri)) {
+			return;
+		}
+
+		const notebook = vscode.workspace.notebookDocuments.find(
+			(doc) => doc.uri.toString() === notebookUri.toString()
+		);
+		if (!notebook) {
+			return;
+		}
+
+		const runtimeSession = await getNotebookSession(notebookUri);
+		if (!runtimeSession) {
+			return;
+		}
+		const sessionId = runtimeSession.metadata.sessionId;
+
+		const encoder = await this.ensureNotebookEncoder(runtimeSession);
+		if (!encoder) {
+			return;
+		}
+
+		const allBreakpoints = vscode.debug.breakpoints;
+		const breakpointsByCell = new Map<string, vscode.SourceBreakpoint[]>();
+
+		// Collect all breakpoints for this notebook, grouped by cell. Cell identity
+		// is determined by the breakpoint's Source URI (each cell is a separate
+		// source in notebook context).
+		for (const bp of allBreakpoints) {
+			if (!(bp instanceof vscode.SourceBreakpoint) || !bp.enabled) {
+				continue;
+			}
+			const bpUri = bp.location.uri;
+			if (bpUri.scheme !== 'vscode-notebook-cell') {
+				continue;
+			}
+
+			// Extract the notebook URI from the cell URI by stripping the
+			// scheme and fragment (which encodes the cell identity).
+			// Skip breakpoints that belong to a different notebook.
+			const bpNotebookUri = bpUri.with({ scheme: 'file', fragment: '' });
+			if (bpNotebookUri.toString() !== notebookUri.toString()) {
+				continue;
+			}
+
+			const key = bpUri.toString();
+			if (!breakpointsByCell.has(key)) {
+				breakpointsByCell.set(key, []);
+			}
+			breakpointsByCell.get(key)!.push(bp);
+		}
+
+		// For each cell with breakpoints, dump and set.
+		for (const [cellUriStr, breakpoints] of breakpointsByCell) {
+			const cellUri = vscode.Uri.parse(cellUriStr, true);
+			const cell = notebook.getCells().find(
+				(c) => c.document.uri.toString() === cellUri.toString()
+			);
+			if (!cell) {
+				continue;
+			}
+
+			try {
+				const code = cell.document.getText();
+				const sourcePath = encoder.encode(code);
+
+				// Notebook cells don't exist as files on disk. The Jupyter Debug
+				// Protocol's `dumpCell` writes the cell source to a content-addressed
+				// temp file so `setBreakpoints` can reference it. This mirrors what
+				// `RuntimeDebugAdapter` does during active debug sessions.
+				await this.dumpCell(runtimeSession, code);
+
+				const dapBreakpoints: DebugProtocol.SourceBreakpoint[] = breakpoints.map((bp) => ({
+					line: bp.location.range.start.line + 1, // DAP is 1-based
+					condition: bp.condition,
+					hitCondition: bp.hitCondition,
+					logMessage: bp.logMessage,
+				}));
+
+				await this.setBreakpoints(runtimeSession, sourcePath, dapBreakpoints);
+				this.getSyncedSources(sessionId).add(cellUriStr);
+			} catch (error) {
+				log.warn(`[breakpoint-sync] Failed to sync breakpoints for cell ${cellUriStr}:`, error);
+			}
+		}
+
+		// Clear breakpoints for sources that were previously synced but no longer
+		// have breakpoints
+		const syncedSources = this.getSyncedSources(sessionId);
+		for (const sourceUriStr of Array.from(syncedSources)) {
+			if (breakpointsByCell.has(sourceUriStr)) {
+				continue;
+			}
+			const sourceUri = vscode.Uri.parse(sourceUriStr, true);
+			if (sourceUri.scheme !== 'vscode-notebook-cell') {
+				continue;
+			}
+			const bpNotebookUri = sourceUri.with({ scheme: 'file', fragment: '' });
+			if (bpNotebookUri.toString() !== notebookUri.toString()) {
+				continue;
+			}
+			const cell = notebook.getCells().find(
+				(c) => c.document.uri.toString() === sourceUri.toString()
+			);
+			if (!cell) {
+				syncedSources.delete(sourceUriStr);
+				continue;
+			}
+			try {
+				const code = cell.document.getText();
+				const sourcePath = encoder.encode(code);
+				await this.setBreakpoints(runtimeSession, sourcePath, []);
+			} catch (error) {
+				log.warn(`[breakpoint-sync] Failed to clear breakpoints for ${sourceUriStr}:`, error);
+			}
+			syncedSources.delete(sourceUriStr);
+		}
+	}
+
+	// Initialize a `PathEncoder` from the kernel's `debugInfo` (hash method,
+	// seed, temp file prefix/suffix). Cached for the lifetime of the session.
+	private async ensureNotebookEncoder(
+		runtimeSession: positron.LanguageRuntimeSession,
+	): Promise<PathEncoder | undefined> {
+		const sessionId = runtimeSession.metadata.sessionId;
+
+		if (this._encoderBySession.has(sessionId) && this._initializedSessions.has(sessionId)) {
+			return this._encoderBySession.get(sessionId)!;
+		}
+
+		try {
+			const debugInfo = await this.debugInfo(runtimeSession);
+			const encoder = new PathEncoder();
+			encoder.setOptions({
+				hashMethod: debugInfo.hashMethod,
+				hashSeed: debugInfo.hashSeed,
+				tmpFilePrefix: debugInfo.tmpFilePrefix,
+				tmpFileSuffix: debugInfo.tmpFileSuffix,
+			});
+			this._encoderBySession.set(sessionId, encoder);
+			this._initializedSessions.add(sessionId);
+
+			// Clean up cached state when the session ends.
+			this._register(runtimeSession.onDidEndSession(() => {
+				this._encoderBySession.delete(sessionId);
+				this._initializedSessions.delete(sessionId);
+				this._syncedSourcesBySession.delete(sessionId);
+			}));
+
+			return encoder;
+		} catch (error) {
+			log.warn(`[breakpoint-sync] Failed to get debugInfo for session ${sessionId}:`, error);
+			return undefined;
+		}
+	}
+
+	private getSyncedSources(sessionId: string): Set<string> {
+		let set = this._syncedSourcesBySession.get(sessionId);
+		if (!set) {
+			set = new Set();
+			this._syncedSourcesBySession.set(sessionId, set);
+		}
+		return set;
+	}
+
+	private hasActiveDebugSession(notebookUri: vscode.Uri): boolean {
+		const uriStr = notebookUri.toString();
+		return vscode.debug.activeDebugSession?.type === 'notebook' &&
+			vscode.debug.activeDebugSession.configuration.__notebookUri === uriStr;
+	}
+
+	// --- Debug channel helpers --------------------------------------------------
+
+	// These send DAP requests to the kernel via `runtimeSession.debug()`, which
+	// wraps them as `debug_request` messages on the Jupyter control channel.
+
+	private async sendDebugRequest(
+		runtimeSession: positron.LanguageRuntimeSession,
+		command: string,
+		args: object,
+	): Promise<DebugProtocol.Response> {
+		const request: DebugProtocol.Request = {
+			type: 'request',
+			seq: PLACEHOLDER_SEQ,
+			command,
+			arguments: args,
+		};
+		const response = await runtimeSession.debug(request) as unknown as DebugProtocol.Response;
+		if (response.success === false) {
+			throw new Error(`Debug request '${command}' failed: ${response.message ?? 'unknown error'}`);
+		}
+		return response;
+	}
+
+	private async debugInfo(runtimeSession: positron.LanguageRuntimeSession): Promise<DebugInfoResponseBody> {
+		const response = await this.sendDebugRequest(runtimeSession, 'debugInfo', {});
+		return response.body as DebugInfoResponseBody;
+	}
+
+	private async setBreakpoints(
+		runtimeSession: positron.LanguageRuntimeSession,
+		sourcePath: string,
+		breakpoints: DebugProtocol.SourceBreakpoint[]
+	): Promise<void> {
+		await this.sendDebugRequest(runtimeSession, 'setBreakpoints', {
+			source: { path: sourcePath },
+			breakpoints,
+			sourceModified: false,
+		} satisfies DebugProtocol.SetBreakpointsArguments);
+	}
+
+	private async dumpCell(runtimeSession: positron.LanguageRuntimeSession, code: string): Promise<void> {
+		await this.sendDebugRequest(runtimeSession, 'dumpCell', { code } satisfies DumpCellArguments);
+	}
+}

--- a/extensions/positron-runtime-debugger/src/breakpointSync.ts
+++ b/extensions/positron-runtime-debugger/src/breakpointSync.ts
@@ -86,17 +86,23 @@ export class BreakpointSyncService extends Disposable {
 	private enqueueSync(notebookUri: vscode.Uri): void {
 		const key = notebookUri.toString();
 		const previous = this._pendingSync.get(key) ?? Promise.resolve();
-		const next = previous.then(() =>
-			this.syncNotebookBreakpoints(notebookUri).catch((error) => {
+
+		let next!: Promise<void>;
+		next = (async () => {
+			try {
+				await previous;
+				await this.syncNotebookBreakpoints(notebookUri);
+			} catch (error) {
 				log.error(`[breakpoint-sync] Failed to sync breakpoints for ${key}:`, error);
-			})
-		).then(() => {
-			// Clean up once the chain settles, but only if we're still the
-			// latest entry (a newer sync may have chained on in the meantime).
-			if (this._pendingSync.get(key) === next) {
-				this._pendingSync.delete(key);
+			} finally {
+				// Clean up once the chain settles, but only if we're still the
+				// latest entry (a newer sync may have chained on in the meantime).
+				if (this._pendingSync.get(key) === next) {
+					this._pendingSync.delete(key);
+				}
 			}
-		});
+		})();
+
 		this._pendingSync.set(key, next);
 	}
 

--- a/extensions/positron-runtime-debugger/src/breakpointSync.ts
+++ b/extensions/positron-runtime-debugger/src/breakpointSync.ts
@@ -16,6 +16,12 @@ import { log } from './extension.js';
 // handled by the Jupyter transport layer, not DAP.
 const PLACEHOLDER_SEQ = 0;
 
+// Tag reported by kernels that support proactive breakpoint syncing (i.e.
+// breakpoints sent outside of debug sessions). Currently only Ark reports this
+// so breakpoints can be injected at parse time during normal cell execution
+// outside of debug sessions.
+const PROACTIVE_BREAKPOINTS_FEATURE = 'proactive breakpoints';
+
 /**
  * Keeps the kernel's breakpoint table in sync with the editor's breakpoints
  * at all times, not only during debug sessions. Communicates with the kernel
@@ -111,6 +117,13 @@ export class BreakpointSyncService extends Disposable {
 
 		const runtimeSession = await getNotebookSession(notebookUri);
 		if (!runtimeSession) {
+			return;
+		}
+
+		// Only sync breakpoints to kernels that support proactive
+		// breakpoint syncing (parse-time breakpoint injection).
+		const features = runtimeSession.runtimeInfo?.supported_features ?? [];
+		if (!features.includes(PROACTIVE_BREAKPOINTS_FEATURE)) {
 			return;
 		}
 		const sessionId = runtimeSession.metadata.sessionId;

--- a/extensions/positron-runtime-debugger/src/extension.ts
+++ b/extensions/positron-runtime-debugger/src/extension.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as vscode from 'vscode';
+import { BreakpointSyncService } from './breakpointSync.js';
 import { NotebookDebugService } from './notebookDebugService.js';
 import { RuntimeErrorViewer } from './runtimeErrorViewer.js';
 import { DisposableStore } from './util.js';
@@ -14,6 +15,7 @@ export function activate(context: vscode.ExtensionContext): void {
 	context.subscriptions.push(disposables);
 
 	disposables.add(log);
+	disposables.add(new BreakpointSyncService());
 	disposables.add(new NotebookDebugService());
 	disposables.add(new RuntimeErrorViewer());
 }

--- a/extensions/positron-runtime-debugger/src/notebookLocationMapper.ts
+++ b/extensions/positron-runtime-debugger/src/notebookLocationMapper.ts
@@ -41,7 +41,7 @@ export class NotebookLocationMapper extends Disposable implements LocationMapper
 	 * @returns The client location (cell URI).
 	 */
 	public toClientLocation<T extends Location>(location: T): T {
-		const cellUri = location.source?.path && this._cellUriByRuntimeSourcePath.get(location.source.path);
+		const cellUri = location.source?.path && this._cellUriByRuntimeSourcePath.get(this.normalizeSourcePath(location.source.path));
 		if (!cellUri) {
 			return location;
 		}
@@ -61,7 +61,7 @@ export class NotebookLocationMapper extends Disposable implements LocationMapper
 	 * @returns The runtime location.
 	 */
 	public toRuntimeLocation<T extends Location>(location: T): T {
-		const path = location.source?.path && this._runtimeSourcePathByCellUri.get(location.source.path);
+		const path = location.source?.path && this._runtimeSourcePathByCellUri.get(this.normalizeSourcePath(location.source.path));
 		if (!path) {
 			return location;
 		}
@@ -97,6 +97,18 @@ export class NotebookLocationMapper extends Disposable implements LocationMapper
 			this._cellUriByRuntimeSourcePath.delete(sourcePath);
 			this._runtimeSourcePathByCellUri.delete(cellUri);
 		}
+	}
+
+	/**
+	 * Normalizes a source path for map lookups. The kernel may send paths
+	 * as `file:///` URIs while the PathEncoder produces plain filesystem
+	 * paths. Convert to a consistent form so lookups succeed either way.
+	 */
+	private normalizeSourcePath(path: string): string {
+		if (path.startsWith('file://')) {
+			return vscode.Uri.parse(path, true).fsPath;
+		}
+		return path;
 	}
 
 	/* Rebuilds all entries from current notebook state. */

--- a/extensions/positron-supervisor/src/KallichoreSession.ts
+++ b/extensions/positron-supervisor/src/KallichoreSession.ts
@@ -805,8 +805,14 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 			stop_on_error: errorBehavior === positron.RuntimeErrorBehavior.Stop,
 		};
 
+		// `cellId` is passed separately as Jupyter message metadata (not as
+		// part of the request body), following the JupyterLab/ipykernel
+		// convention. Ark uses this for breakpoint injection to identify
+		// notebook cell executions.
+		const { cellId, ...positronMetadata } = executionMetadata ?? {};
+
 		// If a code location or execution metadata is provided, include it in the request
-		if (codeLocation || executionMetadata) {
+		if (codeLocation || Object.keys(positronMetadata).length > 0) {
 			request.positron = {
 				...(codeLocation ? {
 					code_location: {
@@ -814,12 +820,12 @@ export class KallichoreSession implements JupyterLanguageRuntimeSession {
 						range: codeLocation.range
 					}
 				} : {}),
-				...executionMetadata
+				...positronMetadata
 			};
 		}
 
-		// Create and send the execute request
-		const execute = new ExecuteRequest(id, request);
+		// Create and send the execute request.
+		const execute = new ExecuteRequest(id, request, cellId as string);
 		this.sendRequest(execute).then((reply) => {
 			this.log(`Execution result: ${JSON.stringify(reply)}`, vscode.LogLevel.Debug);
 		}).catch((err) => {

--- a/extensions/positron-supervisor/src/jupyter/ExecuteRequest.ts
+++ b/extensions/positron-supervisor/src/jupyter/ExecuteRequest.ts
@@ -11,11 +11,20 @@ import { JupyterRequest } from './JupyterRequest';
 
 
 export class ExecuteRequest extends JupyterRequest<JupyterExecuteRequest, JupyterExecuteResult> {
-	constructor(readonly requestId: string, req: JupyterExecuteRequest) {
+	private readonly _cellId?: string;
+
+	constructor(readonly requestId: string, req: JupyterExecuteRequest, cellId?: string) {
 		super(JupyterMessageType.ExecuteRequest, req, JupyterMessageType.ExecuteResult, JupyterChannel.Shell);
+		this._cellId = cellId;
 	}
 	protected override createMsgId(): string {
 		return this.requestId;
+	}
+	protected override get metadata(): any {
+		if (this._cellId) {
+			return { cellId: this._cellId };
+		}
+		return {};
 	}
 }
 

--- a/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
+++ b/src/vs/workbench/api/browser/positron/mainThreadLanguageRuntime.ts
@@ -567,9 +567,8 @@ class ExtHostLanguageRuntimeSessionAdapter extends Disposable implements ILangua
 
 		let codeLocation: ICodeLocation | undefined = undefined;
 
-		// For now we only provide source locations for scripts, but we might be
-		// able to provide it for notebooks as well
-		if (attribution?.source === CodeAttributionSource.Script) {
+		if (attribution?.source === CodeAttributionSource.Script ||
+			attribution?.source === CodeAttributionSource.Notebook) {
 			codeLocation = attribution.metadata?.codeLocation;
 		}
 

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernel.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernel.ts
@@ -325,7 +325,9 @@ export class RuntimeNotebookKernel extends Disposable implements INotebookKernel
 		// appropriately (e.g. for plot rendering).
 		const executionMetadata = this._getExecutionMetadata(notebook.uri);
 
-		// Execute the code.
+		// Execute the code. Include `cellId` in execution metadata so the
+		// kernel can identify this as a notebook cell execution and look up
+		// breakpoints via the Jupyter Debug Protocol's temp file mapping.
 		try {
 			session.execute(
 				code,
@@ -333,7 +335,7 @@ export class RuntimeNotebookKernel extends Disposable implements INotebookKernel
 				RuntimeCodeExecutionMode.Interactive,
 				errorBehavior,
 				undefined,
-				{ ...executionMetadata },
+				{ ...executionMetadata, cellId: cell.uri.toString() },
 			);
 		} catch (err) {
 			execution.error(err);


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/12104
Backend-side at https://github.com/posit-dev/ark/pull/1171

- Enable debugging Ark notebooks via Jupyter.

- Add a `BreakpointSyncService` to `positron-runtime-debugger`. This allows syncing breakpoints to Ark _outside_ of debugging sessions, which is needed so we can inject breakpoints when executing cells _before_ the "Debug Cell" action. This is needed because Ark injects breakpoints at parse-time. Without being able to inject them outside of debuggin sessions, users would need to go back and reexecute all cells after they click "Debug Cell", which is rather poor UX.

   The nice thing is that we'll be able to reuse that infrastructure for Console-mode Ark to update it with breakpoints outside of debug sessions too. And then go back to our previous debug sessions approach where the backend initiates a debug session when it detects a browser prompt. We had to switch to a new approach where the debug session is enabled at all time so Ark can receive breakpoints updates, which required patching up all context keys related to debug sessions. By using the Jupyter channel for Console-mode Ark, we'll be able to simplify all of that.

  This breakpoint sync service is opt-in, behing the `supported_features` flag `proactive breakpoints`. The space separation is consitent with `kernel subshells` from https://jupyter.org/enhancement-proposals/91-kernel-subshells/kernel-subshells.html.

- For the same reason, we now send `cellId` as part of execute request metadata. This is not part of the Jupyter protocol but a convention established by JuyterLab and ipykernel. With the `cellId`, Ark is able to map breakpoints to the dumpCell tempfile. cc @jmcphers 

https://github.com/user-attachments/assets/8ebbc213-5601-427e-9248-e63d56021e91

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- R notebooks can now be debugged with breakpoints and the "Debug Cell" action (https://github.com/posit-dev/positron/issues/12104).

#### Bug Fixes

- N/A


### QA Notes

- Breakpoints should drop you in a debugging session when you click Debug Cell.

- You can set breakpoints in previous cells evaluated with Run Cell rather than Debug Cell. They will work for ulterior Debug Cell actions in other cells. This is the same behaviour as expected for other languages, but for Ark we had to implement a special breakpoint synchronisation path to make this work since breakpoints are injected at parse time.

- Should work with both legacy and modern notebooks.

- Breakpoints are disabled and should never hit when evaluating with Run Cell.

- You can still force R to break with Run Cell via `browser()` or `debug()` calls. In this case, debugging falls back to the sdtin / readline UI (command palette). This is a stopgap workaround until we implement backend-initiated debug sessions.

- Variable pane is expected to work. Watch pane doesn't work yet.

- You can now stop a debug session, either a "real" one (breakpoints) or a fallback one (`browser()`) with the interrupt button (used to hang).

<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->

@:notebooks
@:positron-notebooks