### PR TITLE
test: migrate   nb focus & selection coverage to vitest

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/NotebookAction2.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/NotebookAction2.ts
@@ -69,7 +69,5 @@ export abstract class NotebookAction2 extends Action2 {
 		}
 	}
 
-	// Public so tests can invoke action behavior directly without standing up an
-	// active editor pane. Production callers should still go through `run()`.
-	public abstract runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor, ...args: unknown[]): Promise<void> | void;
+	protected abstract runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor, ...args: unknown[]): Promise<void> | void;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/NotebookAction2.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/NotebookAction2.ts
@@ -69,5 +69,7 @@ export abstract class NotebookAction2 extends Action2 {
 		}
 	}
 
-	protected abstract runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor, ...args: unknown[]): Promise<void> | void;
+	// Public so tests can invoke action behavior directly without standing up an
+	// active editor pane. Production callers should still go through `run()`.
+	public abstract runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor, ...args: unknown[]): Promise<void> | void;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -459,7 +459,7 @@ export class SelectDownAction extends NotebookAction2 {
 }
 registerAction2(SelectDownAction);
 
-registerAction2(class extends NotebookAction2 {
+export class AddSelectionDownAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.addSelectionDown',
@@ -476,9 +476,10 @@ registerAction2(class extends NotebookAction2 {
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
 		notebook.selectionStateMachine.moveSelectionDown(true);
 	}
-});
+}
+registerAction2(AddSelectionDownAction);
 
-registerAction2(class extends NotebookAction2 {
+export class AddSelectionUpAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.addSelectionUp',
@@ -495,7 +496,8 @@ registerAction2(class extends NotebookAction2 {
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
 		notebook.selectionStateMachine.moveSelectionUp(true);
 	}
-});
+}
+registerAction2(AddSelectionUpAction);
 
 // Enter key: Enter edit mode when cell is selected but NOT editing
 registerAction2(class extends NotebookAction2 {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -419,7 +419,7 @@ Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEdit
 
 
 //#region Notebook Commands
-registerAction2(class extends NotebookAction2 {
+export class SelectUpAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.selectUp',
@@ -436,9 +436,10 @@ registerAction2(class extends NotebookAction2 {
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
 		notebook.selectionStateMachine.moveSelectionUp(false);
 	}
-});
+}
+registerAction2(SelectUpAction);
 
-registerAction2(class extends NotebookAction2 {
+export class SelectDownAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.selectDown',
@@ -455,7 +456,8 @@ registerAction2(class extends NotebookAction2 {
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
 		notebook.selectionStateMachine.moveSelectionDown(false);
 	}
-});
+}
+registerAction2(SelectDownAction);
 
 registerAction2(class extends NotebookAction2 {
 	constructor() {
@@ -561,7 +563,7 @@ registerAction2(class extends NotebookAction2 {
  * Escape key: Reduce multi-selection to just the active cell when in command mode.
  * This allows users to quickly collapse a multi-selection back to a single cell.
  */
-registerAction2(class extends NotebookAction2 {
+export class ReduceSelectionToActiveCellAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.reduceSelectionToActiveCell',
@@ -582,7 +584,8 @@ registerAction2(class extends NotebookAction2 {
 			notebook.selectionStateMachine.selectCell(state.active);
 		}
 	}
-});
+}
+registerAction2(ReduceSelectionToActiveCellAction);
 
 // Z key: Undo in command mode (Jupyter-style)
 // Adds keybinding to existing 'undo' command that's handled by contrib/undoRedo/positronNotebookUndoRedo.ts

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCellWrapper.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCellWrapper.vitest.tsx
@@ -1,0 +1,200 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { CellKind } from '../../../notebook/common/notebookCommon.js';
+import { CellSelectionStatus } from '../../browser/PositronNotebookCells/IPositronNotebookCell.js';
+import { CellSelectionType } from '../../browser/selectionMachine.js';
+import { NotebookCellWrapper } from '../../browser/notebookCells/NotebookCellWrapper.js';
+import { NotebookInstanceProvider } from '../../browser/NotebookInstanceProvider.js';
+import { EnvironentProvider } from '../../browser/EnvironmentProvider.js';
+import { createTestPositronNotebookInstance, TestPositronNotebookInstance } from './testPositronNotebookInstance.js';
+import { ISize } from '../../../../../base/browser/positronReactRenderer.js';
+import { IScopedContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+
+// Each mock isolates the click-routing logic from a child that pulls in
+// heavy transitive deps. `.stub()` via the builder can't reach inside React
+// component imports, so module-level mocks are the right escape hatch here.
+
+// Avoids IMenuService + the entire menu/action wiring chain.
+vi.mock('../../browser/notebookCells/NotebookCellActionBar.js', () => ({
+	NotebookCellActionBar: () => null,
+}));
+// Avoids the context-key binding effect (subscribes to many cell observables
+// and creates a real scoped IContextKeyService per cell). Returning undefined
+// is what the wrapper sees during its initial render before cellElement attaches.
+vi.mock('../../browser/notebookCells/useCellContextKeys.js', () => ({
+	useCellContextKeys: () => undefined,
+}));
+// Passthrough so the wrapper renders even when useCellContextKeys returns undefined.
+vi.mock('../../browser/notebookCells/CellContextKeyServiceProvider.js', () => ({
+	CellScopedContextKeyServiceProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('NotebookCellWrapper onClick', () => {
+	const ctx = createTestContainer().withNotebookEditorServices().withReactServices().build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	function createNotebook(numCells = 2): TestPositronNotebookInstance {
+		const labels = Array.from({ length: numCells }, (_, i) => String.fromCharCode(65 + i));
+		return createTestPositronNotebookInstance(
+			labels.map(v => [v, 'python', CellKind.Code]),
+			ctx,
+		);
+	}
+
+	function renderCell(notebook: TestPositronNotebookInstance, cellIndex = 0, children: React.ReactNode = null) {
+		const cell = notebook.cells.get()[cellIndex];
+		const environmentBundle = {
+			size: observableValue<ISize>('test-size', { width: 800, height: 600 }),
+			// Never invoked: useCellContextKeys is mocked above.
+			scopedContextKeyProviderCallback: () => stubInterface<IScopedContextKeyService>({}),
+		};
+		rtl.render(
+			<NotebookInstanceProvider instance={notebook}>
+				<EnvironentProvider environmentBundle={environmentBundle}>
+					<NotebookCellWrapper cell={cell}>
+						{children}
+					</NotebookCellWrapper>
+				</EnvironentProvider>
+			</NotebookInstanceProvider>
+		);
+		return cell;
+	}
+
+	it('default click on cell body invokes selectCell(Normal)', async () => {
+		const notebook = createNotebook(2);
+		const cells = notebook.cells.get();
+		// Move the active selection away so clicking cells[1] is a state change.
+		notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+		const spy = vi.spyOn(notebook.selectionStateMachine, 'selectCell');
+
+		renderCell(notebook, 1);
+		const user = userEvent.setup();
+		await user.click(screen.getByRole('article'));
+
+		expect(spy).toHaveBeenCalledWith(cells[1], CellSelectionType.Normal);
+	});
+
+	it('shift-click invokes selectCell(Add)', async () => {
+		const notebook = createNotebook(2);
+		const cells = notebook.cells.get();
+		notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+		const spy = vi.spyOn(notebook.selectionStateMachine, 'selectCell');
+
+		renderCell(notebook, 1);
+		const user = userEvent.setup();
+		await user.keyboard('{Shift>}');
+		await user.click(screen.getByRole('article'));
+		await user.keyboard('{/Shift}');
+
+		expect(spy).toHaveBeenCalledWith(cells[1], CellSelectionType.Add);
+	});
+
+	it('meta-click (Cmd) invokes selectCell(Add)', async () => {
+		const notebook = createNotebook(2);
+		const cells = notebook.cells.get();
+		notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+		const spy = vi.spyOn(notebook.selectionStateMachine, 'selectCell');
+
+		renderCell(notebook, 1);
+		const user = userEvent.setup();
+		await user.keyboard('{Meta>}');
+		await user.click(screen.getByRole('article'));
+		await user.keyboard('{/Meta}');
+
+		expect(spy).toHaveBeenCalledWith(cells[1], CellSelectionType.Add);
+	});
+
+	it('click inside .positron-cell-editor-monaco-widget descendant is a no-op', async () => {
+		const notebook = createNotebook(2);
+		const cells = notebook.cells.get();
+		notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+		const spy = vi.spyOn(notebook.selectionStateMachine, 'selectCell');
+
+		renderCell(
+			notebook,
+			1,
+			<div className='positron-cell-editor-monaco-widget'>
+				<button>inside editor</button>
+			</div>,
+		);
+		const user = userEvent.setup();
+		await user.click(screen.getByRole('button', { name: 'inside editor' }));
+
+		// No selectCell call other than the initial setup call (which happened before spying).
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it('click on an <a> link descendant is a no-op (lets navigation proceed)', async () => {
+		const notebook = createNotebook(2);
+		const cells = notebook.cells.get();
+		notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+		const spy = vi.spyOn(notebook.selectionStateMachine, 'selectCell');
+
+		renderCell(
+			notebook,
+			1,
+			<a href='#'>link</a>,
+		);
+		const user = userEvent.setup();
+		await user.click(screen.getByRole('link'));
+
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it('click outside the editor while editing exits edit mode', async () => {
+		const notebook = createNotebook(2);
+		const cells = notebook.cells.get();
+		notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Edit);
+		expect(cells[1].selectionStatus.get()).toBe(CellSelectionStatus.Editing);
+		const exitSpy = vi.spyOn(notebook.selectionStateMachine, 'exitEditor');
+		const selectSpy = vi.spyOn(notebook.selectionStateMachine, 'selectCell');
+
+		renderCell(notebook, 1);
+		const user = userEvent.setup();
+		await user.click(screen.getByRole('article'));
+
+		expect(exitSpy).toHaveBeenCalled();
+		// The editing-exit branch returns before reaching selectCell.
+		expect(selectSpy).not.toHaveBeenCalled();
+	});
+
+	it('click on already-selected cell in SingleSelection is a no-op', async () => {
+		const notebook = createNotebook(2);
+		const cells = notebook.cells.get();
+		notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Normal);
+		const spy = vi.spyOn(notebook.selectionStateMachine, 'selectCell');
+
+		renderCell(notebook, 1);
+		const user = userEvent.setup();
+		await user.click(screen.getByRole('article'));
+
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it('click on a Multi-selected cell collapses to selectCell(Normal)', async () => {
+		const notebook = createNotebook(3);
+		const cells = notebook.cells.get();
+		notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+		notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
+		// cells[1] is selected and active; clicking its body in Multi state collapses to Single.
+		const spy = vi.spyOn(notebook.selectionStateMachine, 'selectCell');
+
+		renderCell(notebook, 1);
+		const user = userEvent.setup();
+		await user.click(screen.getByRole('article'));
+
+		expect(spy).toHaveBeenCalledWith(cells[1], CellSelectionType.Normal);
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCellWrapper.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCellWrapper.vitest.tsx
@@ -12,13 +12,12 @@ import { observableValue } from '../../../../../base/common/observable.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
-import { CellKind } from '../../../notebook/common/notebookCommon.js';
 import { CellSelectionStatus } from '../../browser/PositronNotebookCells/IPositronNotebookCell.js';
 import { CellSelectionType } from '../../browser/selectionMachine.js';
 import { NotebookCellWrapper } from '../../browser/notebookCells/NotebookCellWrapper.js';
 import { NotebookInstanceProvider } from '../../browser/NotebookInstanceProvider.js';
 import { EnvironentProvider } from '../../browser/EnvironmentProvider.js';
-import { createTestPositronNotebookInstance, TestPositronNotebookInstance } from './testPositronNotebookInstance.js';
+import { createLabelledTestNotebook, TestPositronNotebookInstance } from './testPositronNotebookInstance.js';
 import { ISize } from '../../../../../base/browser/positronReactRenderer.js';
 import { IScopedContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 
@@ -45,14 +44,6 @@ describe('NotebookCellWrapper onClick', () => {
 	const ctx = createTestContainer().withNotebookEditorServices().withReactServices().build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
-	function createNotebook(numCells = 2): TestPositronNotebookInstance {
-		const labels = Array.from({ length: numCells }, (_, i) => String.fromCharCode(65 + i));
-		return createTestPositronNotebookInstance(
-			labels.map(v => [v, 'python', CellKind.Code]),
-			ctx,
-		);
-	}
-
 	function renderCell(notebook: TestPositronNotebookInstance, cellIndex = 0, children: React.ReactNode = null) {
 		const cell = notebook.cells.get()[cellIndex];
 		const environmentBundle = {
@@ -73,7 +64,7 @@ describe('NotebookCellWrapper onClick', () => {
 	}
 
 	it('default click on cell body invokes selectCell(Normal)', async () => {
-		const notebook = createNotebook(2);
+		const notebook = createLabelledTestNotebook(2, ctx);
 		const cells = notebook.cells.get();
 		// Move the active selection away so clicking cells[1] is a state change.
 		notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
@@ -87,7 +78,7 @@ describe('NotebookCellWrapper onClick', () => {
 	});
 
 	it('shift-click invokes selectCell(Add)', async () => {
-		const notebook = createNotebook(2);
+		const notebook = createLabelledTestNotebook(2, ctx);
 		const cells = notebook.cells.get();
 		notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 		const spy = vi.spyOn(notebook.selectionStateMachine, 'selectCell');
@@ -102,7 +93,7 @@ describe('NotebookCellWrapper onClick', () => {
 	});
 
 	it('meta-click (Cmd) invokes selectCell(Add)', async () => {
-		const notebook = createNotebook(2);
+		const notebook = createLabelledTestNotebook(2, ctx);
 		const cells = notebook.cells.get();
 		notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 		const spy = vi.spyOn(notebook.selectionStateMachine, 'selectCell');
@@ -117,7 +108,7 @@ describe('NotebookCellWrapper onClick', () => {
 	});
 
 	it('click inside .positron-cell-editor-monaco-widget descendant is a no-op', async () => {
-		const notebook = createNotebook(2);
+		const notebook = createLabelledTestNotebook(2, ctx);
 		const cells = notebook.cells.get();
 		notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 		const spy = vi.spyOn(notebook.selectionStateMachine, 'selectCell');
@@ -137,7 +128,7 @@ describe('NotebookCellWrapper onClick', () => {
 	});
 
 	it('click on an <a> link descendant is a no-op (lets navigation proceed)', async () => {
-		const notebook = createNotebook(2);
+		const notebook = createLabelledTestNotebook(2, ctx);
 		const cells = notebook.cells.get();
 		notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 		const spy = vi.spyOn(notebook.selectionStateMachine, 'selectCell');
@@ -154,7 +145,7 @@ describe('NotebookCellWrapper onClick', () => {
 	});
 
 	it('click outside the editor while editing exits edit mode', async () => {
-		const notebook = createNotebook(2);
+		const notebook = createLabelledTestNotebook(2, ctx);
 		const cells = notebook.cells.get();
 		notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Edit);
 		expect(cells[1].selectionStatus.get()).toBe(CellSelectionStatus.Editing);
@@ -171,7 +162,7 @@ describe('NotebookCellWrapper onClick', () => {
 	});
 
 	it('click on already-selected cell in SingleSelection is a no-op', async () => {
-		const notebook = createNotebook(2);
+		const notebook = createLabelledTestNotebook(2, ctx);
 		const cells = notebook.cells.get();
 		notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Normal);
 		const spy = vi.spyOn(notebook.selectionStateMachine, 'selectCell');
@@ -184,7 +175,7 @@ describe('NotebookCellWrapper onClick', () => {
 	});
 
 	it('click on a Multi-selected cell collapses to selectCell(Normal)', async () => {
-		const notebook = createNotebook(3);
+		const notebook = createLabelledTestNotebook(3, ctx);
 		const cells = notebook.cells.get();
 		notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 		notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/selectionKeybindings.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/selectionKeybindings.vitest.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { KeyCode } from '../../../../../base/common/keyCodes.js';
+import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { CellSelectionType, SelectionState } from '../../browser/selectionMachine.js';
+import {
+	POSITRON_NOTEBOOK_COMMAND_MODE,
+	ReduceSelectionToActiveCellAction,
+	SelectDownAction,
+	SelectUpAction,
+} from '../../browser/positronNotebook.contribution.js';
+import { createLabelledTestNotebook } from './testPositronNotebookInstance.js';
+
+/**
+ * Verifies that the notebook's keyboard navigation actions (registered in
+ * positronNotebook.contribution.ts) are wired correctly. Each test asserts
+ * BOTH halves of the wiring:
+ *  - Keybinding metadata: the action declares the expected key and when-clause.
+ *  - Behavior: invoking the action calls the matching SelectionStateMachine method.
+ *
+ * This pair of assertions is what would have broken if a developer accidentally
+ * removed a keybinding entry, swapped the key, or rewired the action body to
+ * call the wrong state-machine method -- previously caught by e2e but now
+ * unit-tested.
+ */
+describe('Notebook selection keybinding actions', () => {
+	const ctx = createTestContainer().withNotebookEditorServices().build();
+
+	// runNotebookAction takes a ServicesAccessor that these actions never read.
+	// Pass a sentinel so any accidental .get() call would fail loudly.
+	const unusedAccessor = undefined as unknown as ServicesAccessor;
+
+	describe('SelectUpAction (ArrowUp / K)', () => {
+		it('declares ArrowUp keybinding scoped to command mode', () => {
+			const action = new SelectUpAction();
+			expect(action.desc.id).toBe('positronNotebook.selectUp');
+			expect(action.desc.keybinding?.primary).toBe(KeyCode.UpArrow);
+			expect(action.desc.keybinding?.secondary).toEqual([KeyCode.KeyK]);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_COMMAND_MODE);
+		});
+
+		it('calls moveSelectionUp(false) on the active notebook', () => {
+			const notebook = createLabelledTestNotebook(3, ctx);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
+
+			new SelectUpAction().runNotebookAction(notebook, unusedAccessor);
+
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(state.type === SelectionState.SingleSelection && state.active).toBe(cells[1]);
+		});
+	});
+
+	describe('SelectDownAction (ArrowDown / J)', () => {
+		it('declares ArrowDown keybinding scoped to command mode', () => {
+			const action = new SelectDownAction();
+			expect(action.desc.id).toBe('positronNotebook.selectDown');
+			expect(action.desc.keybinding?.primary).toBe(KeyCode.DownArrow);
+			expect(action.desc.keybinding?.secondary).toEqual([KeyCode.KeyJ]);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_COMMAND_MODE);
+		});
+
+		it('calls moveSelectionDown(false) on the active notebook', () => {
+			const notebook = createLabelledTestNotebook(3, ctx);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+
+			new SelectDownAction().runNotebookAction(notebook, unusedAccessor);
+
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(state.type === SelectionState.SingleSelection && state.active).toBe(cells[1]);
+		});
+	});
+
+	describe('ReduceSelectionToActiveCellAction (Escape)', () => {
+		it('declares Escape keybinding scoped to command mode', () => {
+			const action = new ReduceSelectionToActiveCellAction();
+			expect(action.desc.id).toBe('positronNotebook.reduceSelectionToActiveCell');
+			expect(action.desc.keybinding?.primary).toBe(KeyCode.Escape);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_COMMAND_MODE);
+		});
+
+		it('collapses MultiSelection to SingleSelection on the active cell', () => {
+			const notebook = createLabelledTestNotebook(3, ctx);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Add);
+
+			new ReduceSelectionToActiveCellAction().runNotebookAction(notebook, unusedAccessor);
+
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(state.type === SelectionState.SingleSelection && state.active).toBe(cells[2]);
+		});
+
+		it('is a no-op in SingleSelection', () => {
+			const notebook = createLabelledTestNotebook(3, ctx);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Normal);
+
+			new ReduceSelectionToActiveCellAction().runNotebookAction(notebook, unusedAccessor);
+
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(state.type === SelectionState.SingleSelection && state.active).toBe(cells[1]);
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/selectionKeybindings.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/selectionKeybindings.vitest.ts
@@ -8,7 +8,8 @@
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
-import { CellSelectionType, SelectionState } from '../../browser/selectionMachine.js';
+import { IPositronNotebookInstance } from '../../browser/IPositronNotebookInstance.js';
+import { CellSelectionType, getActiveCell, SelectionState } from '../../browser/selectionMachine.js';
 import {
 	POSITRON_NOTEBOOK_COMMAND_MODE,
 	ReduceSelectionToActiveCellAction,
@@ -32,9 +33,31 @@ import { createLabelledTestNotebook } from './testPositronNotebookInstance.js';
 describe('Notebook selection keybinding actions', () => {
 	const ctx = createTestContainer().withNotebookEditorServices().build();
 
+	// Test-only subclasses that expose the protected `runNotebookAction` so we
+	// can invoke action behavior without standing up an active editor pane.
+	// Keeping the parent method protected preserves the production API boundary
+	// (production callers must still go through `run()`).
+	class TestableSelectUpAction extends SelectUpAction {
+		public testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+	class TestableSelectDownAction extends SelectDownAction {
+		public testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+	class TestableReduceSelectionToActiveCellAction extends ReduceSelectionToActiveCellAction {
+		public testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+
 	// runNotebookAction takes a ServicesAccessor that these actions never read.
-	// Pass a sentinel so any accidental .get() call would fail loudly.
-	const unusedAccessor = undefined as unknown as ServicesAccessor;
+	// Pass a stub that throws clearly if any future implementation reaches for it.
+	const unusedAccessor: ServicesAccessor = {
+		get() { throw new Error('ServicesAccessor must not be used in this action test'); },
+	};
 
 	describe('SelectUpAction (ArrowUp / K)', () => {
 		it('declares ArrowUp keybinding scoped to command mode', () => {
@@ -50,11 +73,11 @@ describe('Notebook selection keybinding actions', () => {
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
 
-			new SelectUpAction().runNotebookAction(notebook, unusedAccessor);
+			new TestableSelectUpAction().testRun(notebook, unusedAccessor);
 
 			const state = notebook.selectionStateMachine.state.get();
 			expect(state.type).toBe(SelectionState.SingleSelection);
-			expect(state.type === SelectionState.SingleSelection && state.active).toBe(cells[1]);
+			expect(getActiveCell(state)).toBe(cells[1]);
 		});
 	});
 
@@ -72,11 +95,11 @@ describe('Notebook selection keybinding actions', () => {
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 
-			new SelectDownAction().runNotebookAction(notebook, unusedAccessor);
+			new TestableSelectDownAction().testRun(notebook, unusedAccessor);
 
 			const state = notebook.selectionStateMachine.state.get();
 			expect(state.type).toBe(SelectionState.SingleSelection);
-			expect(state.type === SelectionState.SingleSelection && state.active).toBe(cells[1]);
+			expect(getActiveCell(state)).toBe(cells[1]);
 		});
 	});
 
@@ -95,11 +118,11 @@ describe('Notebook selection keybinding actions', () => {
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
 			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Add);
 
-			new ReduceSelectionToActiveCellAction().runNotebookAction(notebook, unusedAccessor);
+			new TestableReduceSelectionToActiveCellAction().testRun(notebook, unusedAccessor);
 
 			const state = notebook.selectionStateMachine.state.get();
 			expect(state.type).toBe(SelectionState.SingleSelection);
-			expect(state.type === SelectionState.SingleSelection && state.active).toBe(cells[2]);
+			expect(getActiveCell(state)).toBe(cells[2]);
 		});
 
 		it('is a no-op in SingleSelection', () => {
@@ -107,11 +130,11 @@ describe('Notebook selection keybinding actions', () => {
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Normal);
 
-			new ReduceSelectionToActiveCellAction().runNotebookAction(notebook, unusedAccessor);
+			new TestableReduceSelectionToActiveCellAction().testRun(notebook, unusedAccessor);
 
 			const state = notebook.selectionStateMachine.state.get();
 			expect(state.type).toBe(SelectionState.SingleSelection);
-			expect(state.type === SelectionState.SingleSelection && state.active).toBe(cells[1]);
+			expect(getActiveCell(state)).toBe(cells[1]);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/selectionKeybindings.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/selectionKeybindings.vitest.ts
@@ -5,12 +5,14 @@
 
 /// <reference types="vitest/globals" />
 
-import { KeyCode } from '../../../../../base/common/keyCodes.js';
+import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { IPositronNotebookInstance } from '../../browser/IPositronNotebookInstance.js';
-import { CellSelectionType, getActiveCell, SelectionState } from '../../browser/selectionMachine.js';
+import { CellSelectionType, getActiveCell, getSelectedCells, SelectionState } from '../../browser/selectionMachine.js';
 import {
+	AddSelectionDownAction,
+	AddSelectionUpAction,
 	POSITRON_NOTEBOOK_COMMAND_MODE,
 	ReduceSelectionToActiveCellAction,
 	SelectDownAction,
@@ -48,6 +50,16 @@ describe('Notebook selection keybinding actions', () => {
 		}
 	}
 	class TestableReduceSelectionToActiveCellAction extends ReduceSelectionToActiveCellAction {
+		public testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+	class TestableAddSelectionDownAction extends AddSelectionDownAction {
+		public testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+	class TestableAddSelectionUpAction extends AddSelectionUpAction {
 		public testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
 			return this.runNotebookAction(notebook, accessor);
 		}
@@ -134,6 +146,52 @@ describe('Notebook selection keybinding actions', () => {
 
 			const state = notebook.selectionStateMachine.state.get();
 			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+	});
+
+	describe('AddSelectionDownAction (Shift+ArrowDown / Shift+J)', () => {
+		it('declares Shift+ArrowDown keybinding scoped to command mode', () => {
+			const action = new AddSelectionDownAction();
+			expect(action.desc.id).toBe('positronNotebook.addSelectionDown');
+			expect(action.desc.keybinding?.primary).toBe(KeyMod.Shift | KeyCode.DownArrow);
+			expect(action.desc.keybinding?.secondary).toEqual([KeyMod.Shift | KeyCode.KeyJ]);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_COMMAND_MODE);
+		});
+
+		it('calls moveSelectionDown(true) -- grows MultiSelection downward', () => {
+			const notebook = createLabelledTestNotebook(3, ctx);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+
+			new TestableAddSelectionDownAction().testRun(notebook, unusedAccessor);
+
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.MultiSelection);
+			expect(getSelectedCells(state)).toEqual([cells[0], cells[1]]);
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+	});
+
+	describe('AddSelectionUpAction (Shift+ArrowUp / Shift+K)', () => {
+		it('declares Shift+ArrowUp keybinding scoped to command mode', () => {
+			const action = new AddSelectionUpAction();
+			expect(action.desc.id).toBe('positronNotebook.addSelectionUp');
+			expect(action.desc.keybinding?.primary).toBe(KeyMod.Shift | KeyCode.UpArrow);
+			expect(action.desc.keybinding?.secondary).toEqual([KeyMod.Shift | KeyCode.KeyK]);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_COMMAND_MODE);
+		});
+
+		it('calls moveSelectionUp(true) -- grows MultiSelection upward', () => {
+			const notebook = createLabelledTestNotebook(3, ctx);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
+
+			new TestableAddSelectionUpAction().testRun(notebook, unusedAccessor);
+
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.MultiSelection);
+			expect(getSelectedCells(state)).toEqual([cells[1], cells[2]]);
 			expect(getActiveCell(state)).toBe(cells[1]);
 		});
 	});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/selectionKeybindings.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/selectionKeybindings.vitest.ts
@@ -80,7 +80,7 @@ describe('Notebook selection keybinding actions', () => {
 			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_COMMAND_MODE);
 		});
 
-		it('calls moveSelectionUp(false) on the active notebook', () => {
+		it('moves selection up by one cell from SingleSelection', () => {
 			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/selectionMachine.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/selectionMachine.vitest.ts
@@ -7,8 +7,7 @@
 
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
-import { createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
-import { CellKind } from '../../../notebook/common/notebookCommon.js';
+import { createLabelledTestNotebook, createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
 import { CellSelectionStatus, IPositronNotebookCell } from '../../browser/PositronNotebookCells/IPositronNotebookCell.js';
 import {
 	CellSelectionType,
@@ -22,15 +21,6 @@ import {
 describe('SelectionStateMachine', () => {
 	const ctx = createTestContainer().withNotebookEditorServices().build();
 
-	/** Build an N-cell notebook labelled A, B, C, ... for selection-machine tests. */
-	function createNotebookWithNCells(n: number) {
-		const labels = Array.from({ length: n }, (_, i) => String.fromCharCode(65 + i));
-		return createTestPositronNotebookInstance(
-			labels.map(v => [v, 'python', CellKind.Code]),
-			ctx,
-		);
-	}
-
 	describe('initial state', () => {
 		it('empty notebook is in NoCells state', () => {
 			const notebook = createTestPositronNotebookInstance([], ctx);
@@ -38,7 +28,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('populated notebook auto-selects the first cell after model is set', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			const state = notebook.selectionStateMachine.state.get();
 			expect(state.type).toBe(SelectionState.SingleSelection);
@@ -48,7 +38,7 @@ describe('SelectionStateMachine', () => {
 
 	describe('selectCell', () => {
 		it('Normal: single-selects the given cell', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Normal);
 			const state = notebook.selectionStateMachine.state.get();
@@ -59,7 +49,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('Edit: enters editing state for the given cell', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Edit);
 			const state = notebook.selectionStateMachine.state.get();
@@ -70,7 +60,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('Add from SingleSelection: expands to MultiSelection with new cell as active', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
@@ -81,7 +71,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('Add from EditingSelection: transitions to MultiSelection and clears editing on prior cell', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Edit);
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
@@ -93,16 +83,48 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('Add with the same editing cell is a no-op', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Edit);
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Add);
 			const state = notebook.selectionStateMachine.state.get();
 			expect(state.type).toBe(SelectionState.EditingSelection);
+			expect(getActiveCell(state)).toBe(cells[0]);
+			expect(cells[0].selectionStatus.get()).toBe(CellSelectionStatus.Editing);
+		});
+
+		it('Normal from EditingSelection: transitions to SingleSelection and clears editing status', () => {
+			const notebook = createLabelledTestNotebook(3, ctx);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Edit);
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Normal);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[1]);
+			expect(cells[0].selectionStatus.get()).toBe(CellSelectionStatus.Unselected);
+			expect(cells[1].selectionStatus.get()).toBe(CellSelectionStatus.Selected);
+		});
+
+		it('Normal on the active cell from MultiSelection collapses to SingleSelection', () => {
+			// Mirrors the Escape keybinding's `selectCell(state.active)` call --
+			// see positronNotebook.contribution.ts "Reduce Selection to Active Cell".
+			const notebook = createLabelledTestNotebook(3, ctx);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Add);
+			// Active is cells[2]; collapsing to active should leave cells[2] as the only selection.
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[2]);
+			expect(cells[0].selectionStatus.get()).toBe(CellSelectionStatus.Unselected);
+			expect(cells[1].selectionStatus.get()).toBe(CellSelectionStatus.Unselected);
+			expect(cells[2].selectionStatus.get()).toBe(CellSelectionStatus.Selected);
 		});
 
 		it('Add for an already-selected cell in Multi is a no-op', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
@@ -117,7 +139,7 @@ describe('SelectionStateMachine', () => {
 
 	describe('deselectCell', () => {
 		it('deselecting the active SingleSelection cell selects the first cell', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
 			notebook.selectionStateMachine.deselectCell(cells[2]);
@@ -127,7 +149,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('deselecting a non-active Multi cell reduces selection but keeps active', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
@@ -141,7 +163,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('deselecting the active Multi cell promotes the last remaining selected cell to active', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
@@ -155,7 +177,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('deselecting from Multi until one cell remains transitions to SingleSelection', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
@@ -166,7 +188,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('deselecting an unselected cell is a no-op', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 			notebook.selectionStateMachine.deselectCell(cells[2]);
@@ -178,7 +200,7 @@ describe('SelectionStateMachine', () => {
 
 	describe('moveSelection (no addMode)', () => {
 		it('moveSelectionDown moves to next cell from SingleSelection', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 			notebook.selectionStateMachine.moveSelectionDown(false);
@@ -188,7 +210,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('moveSelectionUp moves to previous cell from SingleSelection', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
 			notebook.selectionStateMachine.moveSelectionUp(false);
@@ -198,7 +220,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('moveSelectionUp at first cell is a no-op', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 			notebook.selectionStateMachine.moveSelectionUp(false);
@@ -207,7 +229,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('moveSelectionDown at last cell is a no-op', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
 			notebook.selectionStateMachine.moveSelectionDown(false);
@@ -216,7 +238,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('moveSelectionDown from MultiSelection collapses to next cell', () => {
-			const notebook = createNotebookWithNCells(4);
+			const notebook = createLabelledTestNotebook(4, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
@@ -227,7 +249,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('moveSelection while editing is a no-op', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Edit);
 			notebook.selectionStateMachine.moveSelectionDown(false);
@@ -239,7 +261,7 @@ describe('SelectionStateMachine', () => {
 
 	describe('moveSelection (addMode)', () => {
 		it('moveSelectionDown with addMode from SingleSelection grows to MultiSelection', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 			notebook.selectionStateMachine.moveSelectionDown(true);
@@ -250,7 +272,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('moveSelectionUp with addMode from SingleSelection grows to MultiSelection (reversed)', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
 			notebook.selectionStateMachine.moveSelectionUp(true);
@@ -261,7 +283,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('moveSelectionDown with addMode further grows MultiSelection', () => {
-			const notebook = createNotebookWithNCells(4);
+			const notebook = createLabelledTestNotebook(4, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 			notebook.selectionStateMachine.moveSelectionDown(true);
@@ -273,7 +295,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('moveSelectionUp with addMode shrinks MultiSelection when next cell is already selected', () => {
-			const notebook = createNotebookWithNCells(4);
+			const notebook = createLabelledTestNotebook(4, ctx);
 			const cells = notebook.cells.get();
 			// Build [0,1,2] with active=cells[2]
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
@@ -288,7 +310,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('moveSelectionUp with addMode at first cell is a no-op', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 			notebook.selectionStateMachine.moveSelectionUp(true);
@@ -298,7 +320,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('moveSelectionDown with addMode at last cell is a no-op', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
 			notebook.selectionStateMachine.moveSelectionDown(true);
@@ -310,7 +332,7 @@ describe('SelectionStateMachine', () => {
 
 	describe('enterEditor / exitEditor', () => {
 		it('enterEditor on the active cell transitions to EditingSelection', async () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Normal);
 			await notebook.selectionStateMachine.enterEditor();
@@ -320,7 +342,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('enterEditor with explicit cell switches editing target', async () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Edit);
 			await notebook.selectionStateMachine.enterEditor(cells[2]);
@@ -330,7 +352,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('exitEditor returns to SingleSelection on the same cell', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Edit);
 			notebook.selectionStateMachine.exitEditor();
@@ -340,7 +362,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('exitEditor with mismatched cell does not exit (race-condition guard)', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Edit);
 			// Pretend a focus event for cells[2] arrived while we're editing cells[1]
@@ -351,7 +373,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('exitEditor when not editing is a no-op', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Normal);
 			notebook.selectionStateMachine.exitEditor();
@@ -363,7 +385,7 @@ describe('SelectionStateMachine', () => {
 
 	describe('cell array changes', () => {
 		it('deleting the editing cell selects a neighboring cell', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Edit);
 			notebook.deleteCell(cells[1]);
@@ -375,7 +397,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('deleting the only selected cell when others remain promotes a neighbor', () => {
-			const notebook = createNotebookWithNCells(3);
+			const notebook = createLabelledTestNotebook(3, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
 			notebook.deleteCell(cells[2]);
@@ -387,7 +409,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('deleting a cell from MultiSelection retains remaining selected cells', () => {
-			const notebook = createNotebookWithNCells(4);
+			const notebook = createLabelledTestNotebook(4, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
@@ -401,7 +423,7 @@ describe('SelectionStateMachine', () => {
 		});
 
 		it('deleting all cells transitions to NoCells', () => {
-			const notebook = createNotebookWithNCells(2);
+			const notebook = createLabelledTestNotebook(2, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 			notebook.deleteCells([cells[0], cells[1]]);
@@ -471,6 +493,13 @@ describe('SelectionStateMachine', () => {
 			const fakeCell = stubInterface<IPositronNotebookCell>({ index: 3 });
 			expect(toCellRanges({ type: SelectionState.SingleSelection, active: fakeCell })).toEqual([
 				{ start: 3, end: 4 },
+			]);
+		});
+
+		it('toCellRanges returns single range for EditingSelection', () => {
+			const fakeCell = stubInterface<IPositronNotebookCell>({ index: 5 });
+			expect(toCellRanges({ type: SelectionState.EditingSelection, active: fakeCell })).toEqual([
+				{ start: 5, end: 6 },
 			]);
 		});
 	});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/selectionMachine.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/selectionMachine.vitest.ts
@@ -1,0 +1,477 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
+import { CellKind } from '../../../notebook/common/notebookCommon.js';
+import { CellSelectionStatus, IPositronNotebookCell } from '../../browser/PositronNotebookCells/IPositronNotebookCell.js';
+import {
+	CellSelectionType,
+	getActiveCell,
+	getEditingCell,
+	getSelectedCells,
+	SelectionState,
+	toCellRanges,
+} from '../../browser/selectionMachine.js';
+
+describe('SelectionStateMachine', () => {
+	const ctx = createTestContainer().withNotebookEditorServices().build();
+
+	/** Build an N-cell notebook labelled A, B, C, ... for selection-machine tests. */
+	function createNotebookWithNCells(n: number) {
+		const labels = Array.from({ length: n }, (_, i) => String.fromCharCode(65 + i));
+		return createTestPositronNotebookInstance(
+			labels.map(v => [v, 'python', CellKind.Code]),
+			ctx,
+		);
+	}
+
+	describe('initial state', () => {
+		it('empty notebook is in NoCells state', () => {
+			const notebook = createTestPositronNotebookInstance([], ctx);
+			expect(notebook.selectionStateMachine.state.get().type).toBe(SelectionState.NoCells);
+		});
+
+		it('populated notebook auto-selects the first cell after model is set', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[0]);
+		});
+	});
+
+	describe('selectCell', () => {
+		it('Normal: single-selects the given cell', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Normal);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[1]);
+			expect(cells[1].selectionStatus.get()).toBe(CellSelectionStatus.Selected);
+			expect(cells[0].selectionStatus.get()).toBe(CellSelectionStatus.Unselected);
+		});
+
+		it('Edit: enters editing state for the given cell', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Edit);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.EditingSelection);
+			expect(getActiveCell(state)).toBe(cells[2]);
+			expect(getEditingCell(state)).toBe(cells[2]);
+			expect(cells[2].selectionStatus.get()).toBe(CellSelectionStatus.Editing);
+		});
+
+		it('Add from SingleSelection: expands to MultiSelection with new cell as active', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.MultiSelection);
+			expect(getSelectedCells(state)).toEqual([cells[0], cells[1]]);
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+
+		it('Add from EditingSelection: transitions to MultiSelection and clears editing on prior cell', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Edit);
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.MultiSelection);
+			expect(getSelectedCells(state)).toEqual([cells[0], cells[1]]);
+			expect(getActiveCell(state)).toBe(cells[1]);
+			expect(cells[0].selectionStatus.get()).toBe(CellSelectionStatus.Selected);
+		});
+
+		it('Add with the same editing cell is a no-op', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Edit);
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Add);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.EditingSelection);
+		});
+
+		it('Add for an already-selected cell in Multi is a no-op', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Add);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.MultiSelection);
+			expect(getSelectedCells(state)).toEqual([cells[0], cells[1]]);
+			// Active should remain the cell from the first Add (cells[1])
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+	});
+
+	describe('deselectCell', () => {
+		it('deselecting the active SingleSelection cell selects the first cell', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
+			notebook.selectionStateMachine.deselectCell(cells[2]);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[0]);
+		});
+
+		it('deselecting a non-active Multi cell reduces selection but keeps active', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Add);
+			// Active is cells[2]; deselect cells[0]
+			notebook.selectionStateMachine.deselectCell(cells[0]);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.MultiSelection);
+			expect(getSelectedCells(state)).toEqual([cells[1], cells[2]]);
+			expect(getActiveCell(state)).toBe(cells[2]);
+		});
+
+		it('deselecting the active Multi cell promotes the last remaining selected cell to active', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Add);
+			// Active is cells[2]; deselect cells[2]
+			notebook.selectionStateMachine.deselectCell(cells[2]);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.MultiSelection);
+			expect(getSelectedCells(state)).toEqual([cells[0], cells[1]]);
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+
+		it('deselecting from Multi until one cell remains transitions to SingleSelection', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
+			notebook.selectionStateMachine.deselectCell(cells[0]);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+
+		it('deselecting an unselected cell is a no-op', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.deselectCell(cells[2]);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[0]);
+		});
+	});
+
+	describe('moveSelection (no addMode)', () => {
+		it('moveSelectionDown moves to next cell from SingleSelection', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.moveSelectionDown(false);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+
+		it('moveSelectionUp moves to previous cell from SingleSelection', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
+			notebook.selectionStateMachine.moveSelectionUp(false);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+
+		it('moveSelectionUp at first cell is a no-op', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.moveSelectionUp(false);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(getActiveCell(state)).toBe(cells[0]);
+		});
+
+		it('moveSelectionDown at last cell is a no-op', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
+			notebook.selectionStateMachine.moveSelectionDown(false);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(getActiveCell(state)).toBe(cells[2]);
+		});
+
+		it('moveSelectionDown from MultiSelection collapses to next cell', () => {
+			const notebook = createNotebookWithNCells(4);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
+			notebook.selectionStateMachine.moveSelectionDown(false);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[2]);
+		});
+
+		it('moveSelection while editing is a no-op', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Edit);
+			notebook.selectionStateMachine.moveSelectionDown(false);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.EditingSelection);
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+	});
+
+	describe('moveSelection (addMode)', () => {
+		it('moveSelectionDown with addMode from SingleSelection grows to MultiSelection', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.moveSelectionDown(true);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.MultiSelection);
+			expect(getSelectedCells(state)).toEqual([cells[0], cells[1]]);
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+
+		it('moveSelectionUp with addMode from SingleSelection grows to MultiSelection (reversed)', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
+			notebook.selectionStateMachine.moveSelectionUp(true);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.MultiSelection);
+			expect(getSelectedCells(state)).toEqual([cells[1], cells[2]]);
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+
+		it('moveSelectionDown with addMode further grows MultiSelection', () => {
+			const notebook = createNotebookWithNCells(4);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.moveSelectionDown(true);
+			notebook.selectionStateMachine.moveSelectionDown(true);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.MultiSelection);
+			expect(getSelectedCells(state)).toEqual([cells[0], cells[1], cells[2]]);
+			expect(getActiveCell(state)).toBe(cells[2]);
+		});
+
+		it('moveSelectionUp with addMode shrinks MultiSelection when next cell is already selected', () => {
+			const notebook = createNotebookWithNCells(4);
+			const cells = notebook.cells.get();
+			// Build [0,1,2] with active=cells[2]
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.moveSelectionDown(true);
+			notebook.selectionStateMachine.moveSelectionDown(true);
+			// Now move up with addMode: cells[1] is already selected, so this shrinks
+			notebook.selectionStateMachine.moveSelectionUp(true);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.MultiSelection);
+			expect(getSelectedCells(state)).toEqual([cells[0], cells[1]]);
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+
+		it('moveSelectionUp with addMode at first cell is a no-op', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.moveSelectionUp(true);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[0]);
+		});
+
+		it('moveSelectionDown with addMode at last cell is a no-op', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
+			notebook.selectionStateMachine.moveSelectionDown(true);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[2]);
+		});
+	});
+
+	describe('enterEditor / exitEditor', () => {
+		it('enterEditor on the active cell transitions to EditingSelection', async () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Normal);
+			await notebook.selectionStateMachine.enterEditor();
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.EditingSelection);
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+
+		it('enterEditor with explicit cell switches editing target', async () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Edit);
+			await notebook.selectionStateMachine.enterEditor(cells[2]);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.EditingSelection);
+			expect(getEditingCell(state)).toBe(cells[2]);
+		});
+
+		it('exitEditor returns to SingleSelection on the same cell', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Edit);
+			notebook.selectionStateMachine.exitEditor();
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+
+		it('exitEditor with mismatched cell does not exit (race-condition guard)', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Edit);
+			// Pretend a focus event for cells[2] arrived while we're editing cells[1]
+			notebook.selectionStateMachine.exitEditor(cells[2]);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.EditingSelection);
+			expect(getEditingCell(state)).toBe(cells[1]);
+		});
+
+		it('exitEditor when not editing is a no-op', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Normal);
+			notebook.selectionStateMachine.exitEditor();
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			expect(getActiveCell(state)).toBe(cells[1]);
+		});
+	});
+
+	describe('cell array changes', () => {
+		it('deleting the editing cell selects a neighboring cell', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Edit);
+			notebook.deleteCell(cells[1]);
+			const state = notebook.selectionStateMachine.state.get();
+			// After deletion, the cell that took position 1 should be selected
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			const remaining = notebook.cells.get();
+			expect(getActiveCell(state)).toBe(remaining[1]);
+		});
+
+		it('deleting the only selected cell when others remain promotes a neighbor', () => {
+			const notebook = createNotebookWithNCells(3);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Normal);
+			notebook.deleteCell(cells[2]);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			// cells[2] was the last, so promotion falls back to the new last cell
+			const remaining = notebook.cells.get();
+			expect(getActiveCell(state)).toBe(remaining[remaining.length - 1]);
+		});
+
+		it('deleting a cell from MultiSelection retains remaining selected cells', () => {
+			const notebook = createNotebookWithNCells(4);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.selectionStateMachine.selectCell(cells[1], CellSelectionType.Add);
+			notebook.selectionStateMachine.selectCell(cells[2], CellSelectionType.Add);
+			notebook.deleteCell(cells[1]);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.MultiSelection);
+			const remaining = notebook.cells.get();
+			// cells[0] and the cell formerly at index 2 (now at index 1) survive
+			expect(getSelectedCells(state)).toEqual([remaining[0], remaining[1]]);
+		});
+
+		it('deleting all cells transitions to NoCells', () => {
+			const notebook = createNotebookWithNCells(2);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			notebook.deleteCells([cells[0], cells[1]]);
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.NoCells);
+		});
+	});
+
+	describe('pure helpers', () => {
+		it('getSelectedCells returns [] for NoCells', () => {
+			expect(getSelectedCells({ type: SelectionState.NoCells })).toEqual([]);
+		});
+
+		it('getSelectedCells returns [active] for SingleSelection', () => {
+			const fakeCell = stubInterface<IPositronNotebookCell>({ index: 0 });
+			expect(getSelectedCells({ type: SelectionState.SingleSelection, active: fakeCell })).toEqual([fakeCell]);
+		});
+
+		it('getSelectedCells returns [active] for EditingSelection', () => {
+			const fakeCell = stubInterface<IPositronNotebookCell>({ index: 0 });
+			expect(getSelectedCells({ type: SelectionState.EditingSelection, active: fakeCell })).toEqual([fakeCell]);
+		});
+
+		it('getActiveCell returns null for NoCells', () => {
+			expect(getActiveCell({ type: SelectionState.NoCells })).toBeNull();
+		});
+
+		it('getEditingCell returns null when not editing', () => {
+			const fakeCell = stubInterface<IPositronNotebookCell>({ index: 0 });
+			expect(getEditingCell({ type: SelectionState.SingleSelection, active: fakeCell })).toBeNull();
+		});
+
+		it('toCellRanges groups consecutive selected cells into one range', () => {
+			const c0 = stubInterface<IPositronNotebookCell>({ index: 0 });
+			const c1 = stubInterface<IPositronNotebookCell>({ index: 1 });
+			const c2 = stubInterface<IPositronNotebookCell>({ index: 2 });
+			const ranges = toCellRanges({
+				type: SelectionState.MultiSelection,
+				selected: [c0, c1, c2],
+				active: c2,
+			});
+			expect(ranges).toEqual([{ start: 0, end: 3 }]);
+		});
+
+		it('toCellRanges splits non-consecutive cells into multiple ranges', () => {
+			const c0 = stubInterface<IPositronNotebookCell>({ index: 0 });
+			const c2 = stubInterface<IPositronNotebookCell>({ index: 2 });
+			const c4 = stubInterface<IPositronNotebookCell>({ index: 4 });
+			const c5 = stubInterface<IPositronNotebookCell>({ index: 5 });
+			const ranges = toCellRanges({
+				type: SelectionState.MultiSelection,
+				selected: [c0, c2, c4, c5],
+				active: c5,
+			});
+			expect(ranges).toEqual([
+				{ start: 0, end: 1 },
+				{ start: 2, end: 3 },
+				{ start: 4, end: 6 },
+			]);
+		});
+
+		it('toCellRanges returns [] for NoCells', () => {
+			expect(toCellRanges({ type: SelectionState.NoCells })).toEqual([]);
+		});
+
+		it('toCellRanges returns single range for SingleSelection', () => {
+			const fakeCell = stubInterface<IPositronNotebookCell>({ index: 3 });
+			expect(toCellRanges({ type: SelectionState.SingleSelection, active: fakeCell })).toEqual([
+				{ start: 3, end: 4 },
+			]);
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/testPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/testPositronNotebookInstance.ts
@@ -7,7 +7,7 @@ import { Disposable, DisposableStore } from '../../../../../base/common/lifecycl
 import { autorun } from '../../../../../base/common/observable.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
-import { ICellDto2 } from '../../../notebook/common/notebookCommon.js';
+import { CellKind, ICellDto2 } from '../../../notebook/common/notebookCommon.js';
 import { NotebookTextModel } from '../../../notebook/common/model/notebookTextModel.js';
 import { MockNotebookCell } from '../../../notebook/test/browser/testNotebookEditor.js';
 import { IPositronNotebookCell } from '../../browser/PositronNotebookCells/IPositronNotebookCell.js';
@@ -85,6 +85,22 @@ export function createTestPositronNotebookInstance(
 	ctx: { instantiationService: ITestInstantiationService; disposables: Pick<DisposableStore, 'add'> },
 ): TestPositronNotebookInstance {
 	return instantiateTestNotebookInstance(cells, ctx.instantiationService, ctx.disposables);
+}
+
+/**
+ * Creates an N-cell Python code notebook with cells labelled A, B, C, ...
+ * Convenience wrapper over {@link createTestPositronNotebookInstance} for
+ * tests that only care about cell ordering and identity, not content.
+ */
+export function createLabelledTestNotebook(
+	n: number,
+	ctx: { instantiationService: ITestInstantiationService; disposables: Pick<DisposableStore, 'add'> },
+): TestPositronNotebookInstance {
+	const labels = Array.from({ length: n }, (_, i) => String.fromCharCode(65 + i));
+	return createTestPositronNotebookInstance(
+		labels.map(v => [v, 'python', CellKind.Code]),
+		ctx,
+	);
 }
 
 /**

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -20,39 +20,6 @@ test.describe('Notebook Focus and Selection', {
 		await hotKeys.closeSecondarySidebar();
 	});
 
-	test('Arrow keys move cell selection up and down', async function ({ app }) {
-		const { notebooksPositron } = app.workbench;
-		const keyboard = app.code.driver.page.keyboard;
-		await notebooksPositron.newNotebook({ codeCells: 3, markdownCells: 2 });
-
-		// arrow down moves selection down
-		await notebooksPositron.selectCellAtIndex(1, { editMode: false });
-		await keyboard.press('ArrowDown');
-		await notebooksPositron.expectCellIndexToBeSelected(2, { inEditMode: false, isSelected: true });
-
-		// arrow up moves selection up
-		await notebooksPositron.selectCellAtIndex(3, { editMode: false });
-		await keyboard.press('ArrowUp');
-		await notebooksPositron.expectCellIndexToBeSelected(2, { inEditMode: false, isSelected: true });
-
-		// arrow down at last cell does not change selection
-		await notebooksPositron.selectCellAtIndex(4, { editMode: false });
-		await keyboard.press('ArrowDown');
-		await notebooksPositron.expectCellIndexToBeSelected(4, { inEditMode: false, isSelected: true });
-
-		// arrow up at first cell does not change selection
-		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
-		await keyboard.press('ArrowUp');
-		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: false, isSelected: true });
-
-		// Navigate down multiple times
-		await keyboard.press('ArrowDown');
-		await keyboard.press('ArrowDown');
-		await keyboard.press('ArrowDown');
-		await notebooksPositron.expectCellIndexToBeSelected(3, { inEditMode: false });
-	});
-
-
 	test('Click away and back: code cell re-enters edit mode, markdown stays in view mode', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
@@ -203,21 +170,6 @@ test.describe('Notebook Focus and Selection', {
 		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: true, isActive: true });
 	});
 
-	// From EditingSelection: plain click another cell's non-editor area selects without editing
-	test('From edit mode: click another cell non-editor area exits edit and selects', async function ({ app }) {
-		const { notebooksPositron } = app.workbench;
-		await notebooksPositron.newNotebook({ codeCells: 1, markdownCells: 2 });
-
-		await notebooksPositron.selectCellAtIndex(0, { editMode: true });
-		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: true });
-
-		// Click on markdown cell (rendered content, not an editor)
-		await notebooksPositron.cell.nth(2).click();
-
-		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false });
-		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: false, isActive: true });
-	});
-
 	// From EditingSelection: shift-click on the SAME cell is a no-op (preserves edit mode)
 	test('From edit mode: shift-click same cell editor preserves edit mode', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
@@ -264,43 +216,6 @@ test.describe('Notebook Focus and Selection', {
 		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: false });
 	});
 
-	// From MultiSelection: plain click on non-editor area collapses to single-select
-	test('From multi-selection: click non-editor area collapses to single-select', async function ({ app }) {
-		const { notebooksPositron } = app.workbench;
-		const keyboard = app.code.driver.page.keyboard;
-		await notebooksPositron.newNotebook({ codeCells: 1, markdownCells: 2 });
-
-		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
-		await keyboard.press('Shift+ArrowDown');
-		await keyboard.press('Shift+ArrowDown');
-		await notebooksPositron.expectCellsToBeSelected([0, 1, 2]);
-
-		// Click on markdown cell (rendered content, not an editor)
-		await notebooksPositron.cell.nth(2).click();
-
-		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false });
-		await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: false });
-		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: false, isActive: true });
-	});
-
-	// From MultiSelection: shift-click adds to selection
-	test('From multi-selection: shift-click adds cell to selection', async function ({ app }) {
-		const { notebooksPositron } = app.workbench;
-		const keyboard = app.code.driver.page.keyboard;
-		await notebooksPositron.newNotebook({ codeCells: 4 });
-
-		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
-		await keyboard.press('Shift+ArrowDown');
-		await notebooksPositron.expectCellsToBeSelected([0, 1]);
-
-		await notebooksPositron.editorWidgetAtIndex(3).click({ modifiers: ['Shift'] });
-
-		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: true });
-		await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: true });
-		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: false });
-		await notebooksPositron.expectCellIndexToBeSelected(3, { isSelected: true, inEditMode: false, isActive: true });
-	});
-
 	// From SingleSelection: click another cell's editor enters edit mode
 	test('From single-select: click another cell editor enters edit mode', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
@@ -313,57 +228,6 @@ test.describe('Notebook Focus and Selection', {
 
 		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false });
 		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: true, isActive: true });
-	});
-
-	// From SingleSelection: shift-click creates multi-selection
-	test('From single-select: shift-click creates multi-selection', async function ({ app }) {
-		const { notebooksPositron } = app.workbench;
-		await notebooksPositron.newNotebook({ codeCells: 3 });
-
-		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
-
-		await notebooksPositron.editorWidgetAtIndex(2).click({ modifiers: ['Shift'] });
-
-		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: true, inEditMode: false });
-		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: false, isActive: true });
-	});
-
-	test('Multi-select and deselect retains anchor/active cell', async function ({ app }) {
-		const { notebooksPositron } = app.workbench;
-		const keyboard = app.code.driver.page.keyboard;
-
-		// Create a new notebook with 5 cells and select cell 2
-		await notebooksPositron.newNotebook({ codeCells: 2, markdownCells: 3 });
-		await notebooksPositron.selectCellAtIndex(2, { editMode: false });
-
-		// Multi-select up to cell 0 and verify anchor is cell 0
-		await keyboard.press('Shift+ArrowUp');
-		await keyboard.press('Shift+ArrowUp');
-		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: true, isActive: true });
-		await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: true, isActive: false });
-		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, isActive: false });
-
-		// Deselect back down to cell 2 and verify anchor is cell 2
-		await keyboard.press('Shift+ArrowDown');
-		await keyboard.press('Shift+ArrowDown');
-		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false, isActive: false });
-		await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: false, isActive: false });
-		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, isActive: true });
-
-		// Multi-select down to cell 4 and verify anchor is cell 4
-		await keyboard.press('Shift+ArrowDown');
-		await keyboard.press('Shift+ArrowDown');
-		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, isActive: false });
-		await notebooksPositron.expectCellIndexToBeSelected(3, { isSelected: true, isActive: false });
-		await notebooksPositron.expectCellIndexToBeSelected(4, { isSelected: true, isActive: true });
-
-		// Deslect with Escape key and verify anchor is cell 4
-		await keyboard.press('Escape');
-		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false });
-		await notebooksPositron.expectCellIndexToBeSelected(1, { isSelected: false });
-		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: false });
-		await notebooksPositron.expectCellIndexToBeSelected(3, { isSelected: false });
-		await notebooksPositron.expectCellIndexToBeSelected(4, { isSelected: true, isActive: true });
 	});
 
 	test('Multi-select + Shift+Enter runs all selected code cells', async function ({ app }) {


### PR DESCRIPTION
## Summary
- Migrates 6 Playwright tests for notebook focus/selection to vitest. 3 new files, 65 tests; 6 e2e removed.
- Five inline action classes are now named and exported so they can be unit-tested. No behavior change.

## Coverage handoff: e2e → vitest

| E2E test removed | Vitest tests that now cover it |
|---|---|
| Arrow keys move cell selection up and down | `selectionKeybindings`: SelectUpAction / SelectDownAction (metadata + behavior); `selectionMachine`: moveSelection (no addMode) |
| From edit mode: click another cell non-editor area exits edit and selects | `notebookCellWrapper`: default click invokes selectCell(Normal); `selectionMachine`: Normal from EditingSelection |
| From multi-selection: click non-editor area collapses to single-select | `notebookCellWrapper`: click on a Multi-selected cell collapses to selectCell(Normal) |
| From multi-selection: shift-click adds cell to selection | `notebookCellWrapper`: shift-click + meta-click invoke selectCell(Add); `selectionKeybindings`: AddSelectionDownAction / AddSelectionUpAction |
| From single-select: shift-click creates multi-selection | `notebookCellWrapper`: shift-click invokes selectCell(Add); `selectionMachine`: Add from SingleSelection |
| Multi-select and deselect retains anchor/active cell | `selectionMachine`: moveSelection addMode grow/shrink + collapse-to-active; `selectionKeybindings`: ReduceSelectionToActiveCellAction (Escape) |

## What stays in e2e
The 18 remaining tests in `notebook-focus-and-selection.test.ts` cover Monaco click handling, Monaco edit-mode keys, kernel execution, multi-pane coordination, and auto-scroll viewport math — all need the full app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)