### PR TITLE
Add notebook markdown cell translation (prototype)

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/translate/config.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/translate/config.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../../../nls.js';
+import {
+	ConfigurationScope,
+	Extensions,
+	IConfigurationRegistry,
+} from '../../../../../../platform/configuration/common/configurationRegistry.js';
+import { Registry } from '../../../../../../platform/registry/common/platform.js';
+
+export const POSITRON_NOTEBOOK_TRANSLATE_ENABLED_KEY = 'positron.notebook.translate.enabled';
+
+const configurationRegistry = Registry.as<IConfigurationRegistry>(
+	Extensions.Configuration
+);
+configurationRegistry.registerConfiguration({
+	id: 'positron.notebook.translate',
+	order: 8,
+	title: localize('positronNotebookTranslateConfigurationTitle', "Positron Notebook Translation"),
+	type: 'object',
+	properties: {
+		[POSITRON_NOTEBOOK_TRANSLATE_ENABLED_KEY]: {
+			type: 'boolean',
+			default: false,
+			markdownDescription: localize(
+				'positron.notebook.translate.enabled',
+				'Enable notebook markdown cell translation. Translates markdown cells between English and supported languages, creating a new translated notebook file.'
+			),
+			scope: ConfigurationScope.WINDOW,
+			tags: ['experimental'],
+		},
+	},
+});

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/translate/markdownProtection.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/translate/markdownProtection.ts
@@ -1,0 +1,216 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Splits markdown text into translatable and non-translatable segments.
+ *
+ * Non-translatable segments (preserved verbatim):
+ * - Fenced code blocks (``` ... ```)
+ * - LaTeX environments (\begin{...}...\end{...})
+ * - Block math ($$...$$)
+ * - Inline code (`...`)
+ * - Inline math ($...$)
+ * - Markdown images (![alt](url))
+ * - Markdown link URLs (the (url) part of [text](url))
+ * - Bare URLs (http:// and https://)
+ * - Heading prefixes (# through ######)
+ * - List item markers (-, *, +, 1.)
+ *
+ * This avoids inline placeholders entirely, which translation APIs corrupt.
+ */
+
+export interface Segment {
+	readonly text: string;
+	readonly translatable: boolean;
+}
+
+// Multi-line patterns extracted first (before line splitting).
+const BLOCK_PATTERNS: RegExp[] = [
+	// Fenced code blocks (``` or ~~~, with optional language tag)
+	/^(```|~~~)[^\n]*\n[\s\S]*?\n\1\s*$/gm,
+	// LaTeX environments
+	/\\begin\{[^}]+\}[\s\S]*?\\end\{[^}]+\}/g,
+	// Block math
+	/\$\$[\s\S]+?\$\$/g,
+];
+
+// Inline patterns applied per-line after block extraction.
+const INLINE_PATTERN = new RegExp(
+	[
+		/`[^`\n]+`/.source,
+		/(?<![\\$])\$(?!\$)(?!\s)[^$\n]+?(?<!\s)\$/.source,
+		/!\[[^\]]*\]\([^)]+\)/.source,
+		/\]\([^)]+\)/.source,
+		/https?:\/\/[^\s)\]>]+/.source,
+	].join('|'),
+	'g'
+);
+
+const HEADING_PREFIX = /^(#{1,6}\s)/;
+const LIST_MARKER = /^(\s*(?:[-*+]|\d+[.)]) )/;
+
+/**
+ * Splits markdown source into an array of segments, each marked as
+ * translatable or not. Reassembling all segment texts reproduces the
+ * original source exactly.
+ */
+export function splitMarkdown(source: string): Segment[] {
+	// Phase 1: Extract multi-line blocks as non-translatable
+	const phase1 = extractBlocks(source);
+
+	// Phase 2: For each translatable chunk, split into lines and handle
+	// headings, list markers, and inline non-translatable spans
+	const segments: Segment[] = [];
+	for (const chunk of phase1) {
+		if (!chunk.translatable) {
+			segments.push(chunk);
+		} else {
+			splitLineByLine(chunk.text, segments);
+		}
+	}
+
+	return segments;
+}
+
+function extractBlocks(source: string): Segment[] {
+	const regions: { start: number; end: number }[] = [];
+
+	for (const pattern of BLOCK_PATTERNS) {
+		pattern.lastIndex = 0;
+		let match: RegExpExecArray | null;
+		while ((match = pattern.exec(source)) !== null) {
+			regions.push({ start: match.index, end: match.index + match[0].length });
+		}
+	}
+
+	if (regions.length === 0) {
+		return [{ text: source, translatable: true }];
+	}
+
+	// Sort by start position and merge overlaps
+	regions.sort((a, b) => a.start - b.start);
+	const merged: { start: number; end: number }[] = [regions[0]];
+	for (let i = 1; i < regions.length; i++) {
+		const last = merged[merged.length - 1];
+		if (regions[i].start <= last.end) {
+			last.end = Math.max(last.end, regions[i].end);
+		} else {
+			merged.push(regions[i]);
+		}
+	}
+
+	const segments: Segment[] = [];
+	let pos = 0;
+	for (const region of merged) {
+		if (region.start > pos) {
+			segments.push({ text: source.slice(pos, region.start), translatable: true });
+		}
+		segments.push({ text: source.slice(region.start, region.end), translatable: false });
+		pos = region.end;
+	}
+	if (pos < source.length) {
+		segments.push({ text: source.slice(pos), translatable: true });
+	}
+
+	return segments;
+}
+
+function splitLineByLine(text: string, segments: Segment[]): void {
+	const lines = text.split('\n');
+
+	for (let i = 0; i < lines.length; i++) {
+		if (i > 0) {
+			segments.push({ text: '\n', translatable: false });
+		}
+		splitSingleLine(lines[i], segments);
+	}
+}
+
+function splitSingleLine(line: string, segments: Segment[]): void {
+	let remaining = line;
+
+	// Strip heading prefix
+	const headingMatch = remaining.match(HEADING_PREFIX);
+	if (headingMatch) {
+		segments.push({ text: headingMatch[1], translatable: false });
+		remaining = remaining.slice(headingMatch[1].length);
+	}
+
+	// Strip list marker
+	const listMatch = remaining.match(LIST_MARKER);
+	if (listMatch) {
+		segments.push({ text: listMatch[1], translatable: false });
+		remaining = remaining.slice(listMatch[1].length);
+	}
+
+	if (!remaining) {
+		return;
+	}
+
+	// Split on inline non-translatable spans
+	INLINE_PATTERN.lastIndex = 0;
+	let lastEnd = 0;
+	let match: RegExpExecArray | null;
+
+	while ((match = INLINE_PATTERN.exec(remaining)) !== null) {
+		if (match.index > lastEnd) {
+			segments.push({ text: remaining.slice(lastEnd, match.index), translatable: true });
+		}
+		segments.push({ text: match[0], translatable: false });
+		lastEnd = match.index + match[0].length;
+	}
+
+	if (lastEnd < remaining.length) {
+		segments.push({ text: remaining.slice(lastEnd), translatable: true });
+	}
+}
+
+/**
+ * Reassembles segments back into a string.
+ */
+export function reassemble(segments: Segment[]): string {
+	return segments.map(s => s.text).join('');
+}
+
+/**
+ * Extracts only the translatable text from segments, joining with newlines
+ * so that translation APIs receive a contiguous block of prose.
+ * Returns the indices of translatable segments for reconstruction.
+ */
+export function extractTranslatable(segments: Segment[]): {
+	text: string;
+	indices: number[];
+} {
+	const indices: number[] = [];
+	const texts: string[] = [];
+
+	for (let i = 0; i < segments.length; i++) {
+		if (segments[i].translatable && segments[i].text.trim()) {
+			indices.push(i);
+			texts.push(segments[i].text);
+		}
+	}
+
+	return { text: texts.join('\n'), indices };
+}
+
+/**
+ * Applies translated text back into the segments array, returning a new
+ * segments array with translatable segments replaced.
+ */
+export function applyTranslated(
+	segments: Segment[],
+	translatedText: string,
+	indices: number[],
+): Segment[] {
+	const translatedParts = translatedText.split('\n');
+	const result = [...segments];
+
+	for (let i = 0; i < indices.length && i < translatedParts.length; i++) {
+		result[indices[i]] = { text: translatedParts[i], translatable: true };
+	}
+
+	return result;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/translate/positronNotebookTranslate.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/translate/positronNotebookTranslate.contribution.ts
@@ -1,0 +1,361 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize, localize2 } from '../../../../../../nls.js';
+import { registerAction2, MenuId } from '../../../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService, Severity } from '../../../../../../platform/notification/common/notification.js';
+import { IQuickInputService, IQuickPickItem } from '../../../../../../platform/quickinput/common/quickInput.js';
+import { IProgressService, ProgressLocation } from '../../../../../../platform/progress/common/progress.js';
+import { ThemeIcon } from '../../../../../../base/common/themables.js';
+import { VSBuffer } from '../../../../../../base/common/buffer.js';
+import { basename, dirname, extname, joinPath } from '../../../../../../base/common/resources.js';
+import { IFileService } from '../../../../../../platform/files/common/files.js';
+import { IEditorService } from '../../../../../services/editor/common/editorService.js';
+import { IDialogService } from '../../../../../../platform/dialogs/common/dialogs.js';
+import { NotebookAction2 } from '../../NotebookAction2.js';
+import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
+import { ILanguageModelsService } from '../../../../chat/common/languageModels.js';
+import { POSITRON_NOTEBOOK_TRANSLATE_ENABLED_KEY } from './config.js';
+import { SUPPORTED_LANGUAGES, isKnownLanguageCode, ITranslationProvider } from './translationLanguages.js';
+import { AssistantTranslationProvider } from './translationProvider.js';
+import { splitMarkdown, reassemble, Segment } from './markdownProtection.js';
+
+const POSITRON_NOTEBOOK_CATEGORY = localize2('positronNotebook.category', 'Notebook');
+
+registerAction2(class TranslateMarkdownCellsAction extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.translateMarkdownCells',
+			title: localize2('positronNotebook.translateMarkdownCells', "Translate Markdown Cells"),
+			icon: ThemeIcon.fromId('globe'),
+			f1: true,
+			category: POSITRON_NOTEBOOK_CATEGORY,
+			precondition: ContextKeyExpr.equals(`config.${POSITRON_NOTEBOOK_TRANSLATE_ENABLED_KEY}`, true),
+			menu: {
+				id: MenuId.EditorActionsLeft,
+				group: 'navigation',
+				order: 50,
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+					ContextKeyExpr.equals(`config.${POSITRON_NOTEBOOK_TRANSLATE_ENABLED_KEY}`, true),
+				),
+			},
+		});
+	}
+
+	override async runNotebookAction(
+		notebook: IPositronNotebookInstance,
+		accessor: ServicesAccessor,
+	): Promise<void> {
+		const quickInputService = accessor.get(IQuickInputService);
+		const notificationService = accessor.get(INotificationService);
+		const progressService = accessor.get(IProgressService);
+		const fileService = accessor.get(IFileService);
+		const editorService = accessor.get(IEditorService);
+		const dialogService = accessor.get(IDialogService);
+		const languageModelsService = accessor.get(ILanguageModelsService);
+
+		const sourceUri = notebook.uri;
+
+		if (sourceUri.scheme === 'untitled') {
+			notificationService.notify({
+				severity: Severity.Info,
+				message: localize(
+					'positronNotebook.translate.unsaved',
+					'Please save the notebook before translating.'
+				),
+			});
+			return;
+		}
+
+		const ext = extname(sourceUri);
+		const base = basename(sourceUri);
+		const nameWithoutExt = base.slice(0, base.length - ext.length);
+		const detectedCode = detectLanguageFromFilename(nameWithoutExt);
+
+		let sourceCode: string;
+		let targetCode: string;
+
+		if (detectedCode) {
+			// Already-translated file: skip source picker, go straight to target
+			sourceCode = detectedCode;
+			const sourceLang = SUPPORTED_LANGUAGES.find(l => l.code === detectedCode);
+			const targetPick = await pickLanguage(
+				quickInputService,
+				SUPPORTED_LANGUAGES
+					.filter(lang => lang.code !== detectedCode)
+					.map(lang => ({ id: lang.code, label: lang.label })),
+				localize(
+					'positronNotebook.translate.titleTargetDetected',
+					'Translate from {0} to...',
+					sourceLang?.label ?? detectedCode
+				),
+				localize('positronNotebook.translate.pickTarget', 'Select the target language'),
+			);
+			if (!targetPick?.id) {
+				return;
+			}
+			targetCode = targetPick.id;
+		} else {
+			// No language detected: show both pickers
+			const sourcePick = await pickLanguage(
+				quickInputService,
+				SUPPORTED_LANGUAGES.map(lang => ({
+					id: lang.code,
+					label: lang.label,
+				})),
+				localize('positronNotebook.translate.titleSource', 'Translate Markdown Cells - Source Language'),
+				localize('positronNotebook.translate.pickSource', 'Select the source language of the notebook'),
+			);
+			if (!sourcePick?.id) {
+				return;
+			}
+			sourceCode = sourcePick.id;
+
+			const targetPick = await pickLanguage(
+				quickInputService,
+				SUPPORTED_LANGUAGES
+					.filter(lang => lang.code !== sourcePick.id)
+					.map(lang => ({ id: lang.code, label: lang.label })),
+				localize('positronNotebook.translate.titleTarget', 'Translate Markdown Cells - Target Language'),
+				localize('positronNotebook.translate.pickTarget', 'Select the target language'),
+			);
+			if (!targetPick?.id) {
+				return;
+			}
+			targetCode = targetPick.id;
+		}
+
+		let ipynb: IpynbNotebook;
+		try {
+			const fileContent = await fileService.readFile(sourceUri);
+			ipynb = JSON.parse(fileContent.value.toString());
+		} catch (err) {
+			notificationService.notify({
+				severity: Severity.Error,
+				message: localize(
+					'positronNotebook.translate.readError',
+					'Failed to read notebook: {0}',
+					err instanceof Error ? err.message : String(err)
+				),
+			});
+			return;
+		}
+
+		const markdownCells = ipynb.cells.filter(c => c.cell_type === 'markdown');
+		if (markdownCells.length === 0) {
+			notificationService.notify({
+				severity: Severity.Info,
+				message: localize(
+					'positronNotebook.translate.noMarkdown',
+					'No Markdown cells found in this notebook.'
+				),
+			});
+			return;
+		}
+
+		const strippedBase = stripLanguageSuffixes(nameWithoutExt);
+		const newName = `${strippedBase}-${targetCode}${ext}`;
+		const targetUri = joinPath(dirname(sourceUri), newName);
+
+		if (await fileService.exists(targetUri)) {
+			const { confirmed } = await dialogService.confirm({
+				message: localize(
+					'positronNotebook.translate.overwrite',
+					'"{0}" already exists. Overwrite it?',
+					newName
+				),
+			});
+			if (!confirmed) {
+				return;
+			}
+		}
+
+		const targetLabel = SUPPORTED_LANGUAGES.find(l => l.code === targetCode)?.label ?? targetCode;
+		let cancelled = false;
+
+		await progressService.withProgress(
+			{
+				location: ProgressLocation.Notification,
+				title: localize(
+					'positronNotebook.translate.progress',
+					'Translating markdown cells to {0}...',
+					targetLabel
+				),
+				cancellable: true,
+			},
+			async (progress) => {
+				const provider = new AssistantTranslationProvider(languageModelsService);
+				let translatedCount = 0;
+				let errorCount = 0;
+
+				for (let i = 0; i < markdownCells.length; i++) {
+					if (cancelled) {
+						break;
+					}
+
+					const cell = markdownCells[i];
+					const originalSource = Array.isArray(cell.source)
+						? cell.source.join('')
+						: cell.source;
+
+					if (!originalSource.trim()) {
+						continue;
+					}
+
+					progress.report({
+						increment: (100 / markdownCells.length),
+						message: localize(
+							'positronNotebook.translate.progressCell',
+							'Cell {0} of {1}',
+							i + 1,
+							markdownCells.length
+						),
+					});
+
+					try {
+						const result = await translateMarkdownSource(originalSource, sourceCode, targetCode, provider);
+
+						if (result !== originalSource) {
+							cell.source = result.split('\n').map(
+								(line, idx, arr) => idx < arr.length - 1 ? line + '\n' : line
+							);
+							translatedCount++;
+						}
+					} catch (err) {
+						errorCount++;
+						if (errorCount <= 3) {
+							notificationService.notify({
+								severity: Severity.Warning,
+								message: localize(
+									'positronNotebook.translate.cellError',
+									'Failed to translate cell {0}: {1}',
+									i + 1,
+									err instanceof Error ? err.message : String(err)
+								),
+							});
+						}
+					}
+				}
+
+				if (cancelled) {
+					return;
+				}
+
+				if (errorCount > 3) {
+					notificationService.notify({
+						severity: Severity.Warning,
+						message: localize(
+							'positronNotebook.translate.moreErrors',
+							'{0} more cell(s) failed to translate.',
+							errorCount - 3
+						),
+					});
+				}
+
+				if (translatedCount === 0) {
+					notificationService.notify({
+						severity: Severity.Info,
+						message: errorCount > 0
+							? localize(
+								'positronNotebook.translate.allFailed',
+								'Translation failed for all cells. Check that a language model provider is configured and try again.'
+							)
+							: localize(
+								'positronNotebook.translate.noChanges',
+								'No cells were translated. The content may already be in the target language.'
+							),
+					});
+					return;
+				}
+
+				const content = VSBuffer.fromString(JSON.stringify(ipynb, null, 1));
+				await fileService.writeFile(targetUri, content);
+				await editorService.openEditor({ resource: targetUri });
+
+				notificationService.notify({
+					severity: Severity.Info,
+					message: localize(
+						'positronNotebook.translate.done',
+						'Translated {0} cell(s). Saved as "{1}".',
+						translatedCount,
+						newName
+					),
+				});
+			},
+			() => { cancelled = true; },
+		);
+	}
+});
+
+async function pickLanguage(
+	quickInputService: IQuickInputService,
+	items: IQuickPickItem[],
+	title: string,
+	placeHolder: string,
+): Promise<IQuickPickItem | undefined> {
+	return quickInputService.pick(items, { title, placeHolder });
+}
+
+/**
+ * Translates markdown source segment-by-segment to avoid line-count mismatches.
+ * Each translatable segment is sent individually, and failures fall back to the original text.
+ */
+async function translateMarkdownSource(
+	source: string,
+	sourceLanguage: string,
+	targetLanguage: string,
+	provider: ITranslationProvider,
+): Promise<string> {
+	const segments = splitMarkdown(source);
+	const result: Segment[] = [...segments];
+	let anyTranslated = false;
+
+	for (let i = 0; i < segments.length; i++) {
+		const seg = segments[i];
+		if (!seg.translatable || !seg.text.trim()) {
+			continue;
+		}
+
+		const translated = await provider.translate(seg.text, sourceLanguage, targetLanguage);
+		if (translated && translated !== seg.text) {
+			result[i] = { text: translated, translatable: true };
+			anyTranslated = true;
+		}
+	}
+
+	return anyTranslated ? reassemble(result) : source;
+}
+
+export function detectLanguageFromFilename(nameWithoutExt: string): string | undefined {
+	const parts = nameWithoutExt.split('-');
+	if (parts.length < 2) {
+		return undefined;
+	}
+	const last = parts[parts.length - 1];
+	return isKnownLanguageCode(last) ? last : undefined;
+}
+
+export function stripLanguageSuffixes(nameWithoutExt: string): string {
+	const parts = nameWithoutExt.split('-');
+	while (parts.length > 1 && isKnownLanguageCode(parts[parts.length - 1])) {
+		parts.pop();
+	}
+	return parts.join('-');
+}
+
+interface IpynbCell {
+	cell_type: string;
+	source: string | string[];
+	[key: string]: unknown;
+}
+
+interface IpynbNotebook {
+	cells: IpynbCell[];
+	[key: string]: unknown;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/translate/translationLanguages.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/translate/translationLanguages.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export interface ITranslationProvider {
+	translate(text: string, sourceLanguage: string, targetLanguage: string): Promise<string>;
+}
+
+export interface TranslationLanguage {
+	readonly id: string;
+	readonly label: string;
+	readonly code: string;
+}
+
+export const SUPPORTED_LANGUAGES: TranslationLanguage[] = [
+	{ id: 'en', label: 'English', code: 'en' },
+	{ id: 'pt', label: 'Portuguese', code: 'pt' },
+	{ id: 'es', label: 'Spanish', code: 'es' },
+	{ id: 'fr', label: 'French', code: 'fr' },
+	{ id: 'de', label: 'German', code: 'de' },
+	{ id: 'ar', label: 'Arabic', code: 'ar' },
+];
+
+const LANGUAGE_LABELS = new Map(SUPPORTED_LANGUAGES.map(l => [l.code, l.label]));
+const LANGUAGE_CODES = new Set(SUPPORTED_LANGUAGES.map(l => l.code));
+
+export function isKnownLanguageCode(code: string): boolean {
+	return LANGUAGE_CODES.has(code);
+}
+
+export function getLanguageLabel(code: string): string {
+	return LANGUAGE_LABELS.get(code) ?? code;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/translate/translationProvider.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/translate/translationProvider.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from '../../../../../../base/common/cancellation.js';
+import { ExtensionIdentifier } from '../../../../../../platform/extensions/common/extensions.js';
+import { ChatMessageRole, ILanguageModelsService } from '../../../../chat/common/languageModels.js';
+import { ITranslationProvider, getLanguageLabel } from './translationLanguages.js';
+
+export class AssistantTranslationProvider implements ITranslationProvider {
+
+	constructor(
+		private readonly _languageModelsService: ILanguageModelsService,
+		private readonly _token: CancellationToken = CancellationToken.None,
+	) { }
+
+	async translate(text: string, sourceLanguage: string, targetLanguage: string): Promise<string> {
+		if (!text.trim()) {
+			return text;
+		}
+
+		const modelId = await this._resolveModelId();
+
+		const sourceLabel = getLanguageLabel(sourceLanguage);
+		const targetLabel = getLanguageLabel(targetLanguage);
+
+		const prompt = [
+			`Translate the following text from ${sourceLabel} to ${targetLabel}.`,
+			'Return ONLY the translated text, with no explanation, no commentary, and no surrounding quotes.',
+			'Preserve all formatting, whitespace, and line breaks exactly as they appear.',
+			'',
+			text,
+		].join('\n');
+
+		const response = await this._languageModelsService.sendChatRequest(
+			modelId,
+			new ExtensionIdentifier('positron-notebooks'),
+			[{ role: ChatMessageRole.User, content: [{ type: 'text', value: prompt }] }],
+			{},
+			this._token,
+		);
+
+		let result = '';
+		for await (const part of response.stream) {
+			if (Array.isArray(part)) {
+				for (const p of part) {
+					if (p.type === 'text') {
+						result += p.value;
+					}
+				}
+			} else if (part.type === 'text') {
+				result += part.value;
+			}
+		}
+
+		await response.result;
+		return result.trim();
+	}
+
+	private async _resolveModelId(): Promise<string> {
+		const provider = this._languageModelsService.currentProvider;
+		if (provider) {
+			const models = await this._languageModelsService.selectLanguageModels({
+				vendor: provider.id,
+			});
+			if (models.length > 0) {
+				return models[0];
+			}
+		}
+
+		const allModels = this._languageModelsService.getLanguageModelIds();
+		if (allModels.length > 0) {
+			return allModels[0];
+		}
+
+		throw new Error(
+			'No language model is available. Please configure a provider in the Positron Assistant settings.'
+		);
+	}
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -9,6 +9,7 @@ import './contrib/assistant/positronNotebookAssistant.contribution.js';
 import './contrib/ghostCell/positronNotebookGhostCell.contribution.js';
 import './contrib/outline/positronNotebookOutline.contribution.js';
 import './contrib/dataExplorer/positronNotebookDataExplorer.contribution.js';
+import './contrib/translate/positronNotebookTranslate.contribution.js';
 
 import { isCopyImageMenuArg, toBase64DataUrl } from './copyImageUtils.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/translate/markdownProtection.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/translate/markdownProtection.test.ts
@@ -1,0 +1,236 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { createTestContainer } from '../../../../../../test/browser/positronTestContainer.js';
+import { splitMarkdown, extractTranslatable, applyTranslated, reassemble } from '../../../../browser/contrib/translate/markdownProtection.js';
+
+suite('markdownProtection', () => {
+	createTestContainer().build();
+
+	suite('splitMarkdown', () => {
+		test('plain prose is fully translatable', () => {
+			const segments = splitMarkdown('Hello, world!');
+			assert.strictEqual(segments.length, 1);
+			assert.strictEqual(segments[0].translatable, true);
+			assert.strictEqual(segments[0].text, 'Hello, world!');
+		});
+
+		test('heading prefix is non-translatable', () => {
+			const segments = splitMarkdown('### My heading');
+			const nonTranslatable = segments.filter(s => !s.translatable);
+			assert.ok(nonTranslatable.some(s => s.text === '### '));
+			assert.strictEqual(reassemble(segments), '### My heading');
+		});
+
+		test('all heading levels are preserved', () => {
+			const md = '# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6';
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+			const headingPrefixes = segments.filter(s => !s.translatable && /^#{1,6}\s$/.test(s.text));
+			assert.strictEqual(headingPrefixes.length, 6);
+		});
+
+		test('list markers are non-translatable', () => {
+			const md = '- item one\n* item two\n1. item three';
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+			const markers = segments.filter(s => !s.translatable && /^\s*[-*+]|\d+[.)]/.test(s.text.trim()));
+			assert.strictEqual(markers.length, 3);
+		});
+
+		test('fenced code blocks are non-translatable', () => {
+			const md = '# Title\n\n```python\nprint("hello")\n```\n\nSome text.';
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+			const codeSegments = segments.filter(s => !s.translatable && s.text.includes('print'));
+			assert.ok(codeSegments.length > 0);
+		});
+
+		test('inline code is non-translatable', () => {
+			const md = 'Use `console.log()` to debug.';
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+			const codeSegments = segments.filter(s => !s.translatable && s.text.includes('console.log'));
+			assert.ok(codeSegments.length > 0);
+		});
+
+		test('inline math is non-translatable', () => {
+			const md = 'Einstein showed that $E = mc^2$ is fundamental.';
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+			const mathSegments = segments.filter(s => !s.translatable && s.text.includes('E = mc^2'));
+			assert.ok(mathSegments.length > 0);
+		});
+
+		test('block math is non-translatable', () => {
+			const md = 'The integral:\n\n$$\\int_0^1 x^2 dx$$\n\nis one-third.';
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+			const mathSegments = segments.filter(s => !s.translatable && s.text.includes('\\int'));
+			assert.ok(mathSegments.length > 0);
+		});
+
+		test('LaTeX environments are non-translatable', () => {
+			const md = 'Consider:\n\n\\begin{equation}\na^2 + b^2 = c^2\n\\end{equation}\n\nwhich is Pythagoras.';
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+		});
+
+		test('image references are non-translatable', () => {
+			const md = 'See the diagram: ![alt text](images/figure1.png)';
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+		});
+
+		test('link URLs are non-translatable', () => {
+			const md = 'Visit [our docs](https://example.com/docs) for more info.';
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+			const urlSegments = segments.filter(s => !s.translatable && s.text.includes('https://example.com'));
+			assert.ok(urlSegments.length > 0);
+		});
+
+		test('bare URLs are non-translatable', () => {
+			const md = 'Check out https://example.com for details.';
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+		});
+
+		test('empty string round-trips', () => {
+			const segments = splitMarkdown('');
+			assert.strictEqual(reassemble(segments), '');
+		});
+
+		test('whitespace-only text round-trips', () => {
+			const md = '   \n\n   ';
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+		});
+
+		test('heading with inline code round-trips', () => {
+			const md = '# Title with `code`';
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+			assert.ok(segments.some(s => !s.translatable && s.text === '# '));
+			assert.ok(segments.some(s => !s.translatable && s.text === '`code`'));
+		});
+
+		test('unicode text round-trips', () => {
+			const md = 'Hello world. 你好世界.';
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+		});
+	});
+
+	suite('round-trip', () => {
+		test('reassemble always reproduces original', () => {
+			const md = [
+				'# Analysis',
+				'',
+				'The formula $E = mc^2$ is well-known.',
+				'',
+				'```python',
+				'result = compute()',
+				'```',
+				'',
+				'- first item',
+				'- second item',
+				'',
+				'See [docs](https://example.com) for more.',
+			].join('\n');
+
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+		});
+
+		test('extract and apply preserves non-translatable content', () => {
+			const md = '### Title\n\nSome prose here.\n\n`code block`';
+			const segments = splitMarkdown(md);
+			const { text, indices } = extractTranslatable(segments);
+
+			const translated = text.toUpperCase();
+			const result = applyTranslated(segments, translated, indices);
+			const output = reassemble(result);
+
+			assert.ok(output.startsWith('### '));
+			assert.ok(output.includes('`code block`'));
+			assert.ok(output.includes('TITLE') || output.includes('SOME PROSE HERE'));
+		});
+
+		test('complex document with all features round-trips', () => {
+			const md = [
+				'# Main Title',
+				'',
+				'Some introductory text with `inline code` and a [link](https://example.com).',
+				'',
+				'## Section with Math',
+				'',
+				'The formula $E = mc^2$ shows that:',
+				'',
+				'$$\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}$$',
+				'',
+				'### List of Items',
+				'',
+				'- first item with `code`',
+				'- second item',
+				'* third item',
+				'1. numbered item',
+				'',
+				'```python',
+				'import numpy as np',
+				'result = np.sqrt(2)',
+				'```',
+				'',
+				'Final paragraph with https://example.com and ![image](img.png).',
+			].join('\n');
+
+			const segments = splitMarkdown(md);
+			assert.strictEqual(reassemble(segments), md);
+		});
+	});
+
+	suite('extractTranslatable', () => {
+		test('skips empty translatable segments', () => {
+			const md = '# Title\n\n\n\nSome text.';
+			const segments = splitMarkdown(md);
+			const { indices } = extractTranslatable(segments);
+			const texts = indices.map(i => segments[i].text);
+			assert.ok(texts.every(t => t.trim().length > 0));
+		});
+
+		test('returns empty indices for non-translatable-only input', () => {
+			const md = '```python\nprint("hello")\n```';
+			const segments = splitMarkdown(md);
+			const { text, indices } = extractTranslatable(segments);
+			assert.strictEqual(indices.length, 0);
+			assert.strictEqual(text, '');
+		});
+	});
+
+	suite('applyTranslated edge cases', () => {
+		test('handles fewer translated parts than indices', () => {
+			const segments = splitMarkdown('Hello\nWorld\nTest');
+			const { indices } = extractTranslatable(segments);
+			const result = applyTranslated(segments, 'Hola', indices);
+			const output = reassemble(result);
+			assert.ok(output.includes('Hola'));
+		});
+
+		test('handles more translated parts than indices', () => {
+			const segments = splitMarkdown('Hello');
+			const { indices } = extractTranslatable(segments);
+			const result = applyTranslated(segments, 'Hola\nExtra\nMore', indices);
+			reassemble(result);
+		});
+
+		test('handles empty translated text', () => {
+			const segments = splitMarkdown('Hello');
+			const { indices } = extractTranslatable(segments);
+			const result = applyTranslated(segments, '', indices);
+			reassemble(result);
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/translate/notebookTranslate.test.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/translate/notebookTranslate.test.ts
@@ -1,0 +1,223 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { createTestContainer } from '../../../../../../test/browser/positronTestContainer.js';
+import {
+	ITranslationProvider,
+	SUPPORTED_LANGUAGES,
+	isKnownLanguageCode,
+	getLanguageLabel,
+} from '../../../../browser/contrib/translate/translationLanguages.js';
+import { splitMarkdown, extractTranslatable, applyTranslated, reassemble } from '../../../../browser/contrib/translate/markdownProtection.js';
+import { detectLanguageFromFilename, stripLanguageSuffixes } from '../../../../browser/contrib/translate/positronNotebookTranslate.contribution.js';
+
+class MockTranslationProvider implements ITranslationProvider {
+	calls: { text: string; sourceLanguage: string; targetLanguage: string }[] = [];
+
+	async translate(text: string, sourceLanguage: string, targetLanguage: string): Promise<string> {
+		this.calls.push({ text, sourceLanguage, targetLanguage });
+		return `[${sourceLanguage}->${targetLanguage}] ${text}`;
+	}
+}
+
+suite('notebookTranslate', () => {
+	createTestContainer().build();
+
+	suite('translation provider', () => {
+		test('supported languages includes English', () => {
+			assert.ok(SUPPORTED_LANGUAGES.some(l => l.code === 'en'));
+		});
+
+		test('supported languages list has multiple entries', () => {
+			assert.ok(SUPPORTED_LANGUAGES.length >= 2);
+		});
+
+		test('mock provider receives source and target language', async () => {
+			const mock = new MockTranslationProvider();
+
+			await mock.translate('hello', 'en', 'pt');
+			assert.strictEqual(mock.calls.length, 1);
+			assert.strictEqual(mock.calls[0].sourceLanguage, 'en');
+			assert.strictEqual(mock.calls[0].targetLanguage, 'pt');
+		});
+
+		test('each supported language has matching id and code', () => {
+			for (const lang of SUPPORTED_LANGUAGES) {
+				assert.strictEqual(lang.id, lang.code);
+				assert.ok(lang.label.length > 0);
+			}
+		});
+	});
+
+	suite('isKnownLanguageCode', () => {
+		test('recognizes supported language codes', () => {
+			for (const lang of SUPPORTED_LANGUAGES) {
+				assert.strictEqual(isKnownLanguageCode(lang.code), true, `${lang.code} should be recognized`);
+			}
+		});
+
+		test('rejects unknown codes', () => {
+			assert.strictEqual(isKnownLanguageCode('zz'), false);
+			assert.strictEqual(isKnownLanguageCode(''), false);
+			assert.strictEqual(isKnownLanguageCode('english'), false);
+		});
+
+		test('is case-sensitive', () => {
+			assert.strictEqual(isKnownLanguageCode('EN'), false);
+			assert.strictEqual(isKnownLanguageCode('Pt'), false);
+		});
+	});
+
+	suite('detectLanguageFromFilename', () => {
+		test('detects language code at end of filename', () => {
+			assert.strictEqual(detectLanguageFromFilename('notebook-pt'), 'pt');
+			assert.strictEqual(detectLanguageFromFilename('my-analysis-es'), 'es');
+		});
+
+		test('returns undefined for no language suffix', () => {
+			assert.strictEqual(detectLanguageFromFilename('notebook'), undefined);
+			assert.strictEqual(detectLanguageFromFilename('my-analysis'), undefined);
+		});
+
+		test('returns undefined for unknown suffix', () => {
+			assert.strictEqual(detectLanguageFromFilename('notebook-zz'), undefined);
+		});
+
+		test('handles names with multiple dashes', () => {
+			assert.strictEqual(detectLanguageFromFilename('my-cool-notebook-fr'), 'fr');
+		});
+
+		test('returns undefined for empty string', () => {
+			assert.strictEqual(detectLanguageFromFilename(''), undefined);
+		});
+
+		test('does not detect language code at start', () => {
+			assert.strictEqual(detectLanguageFromFilename('en-notebook'), undefined);
+		});
+
+		test('detects last suffix only', () => {
+			assert.strictEqual(detectLanguageFromFilename('notebook-en-pt'), 'pt');
+		});
+	});
+
+	suite('stripLanguageSuffixes', () => {
+		test('strips single language suffix', () => {
+			assert.strictEqual(stripLanguageSuffixes('notebook-pt'), 'notebook');
+		});
+
+		test('strips accumulated language suffixes', () => {
+			assert.strictEqual(stripLanguageSuffixes('notebook-pt-es'), 'notebook');
+			assert.strictEqual(stripLanguageSuffixes('notebook-en-pt-es-fr'), 'notebook');
+		});
+
+		test('preserves names without language suffix', () => {
+			assert.strictEqual(stripLanguageSuffixes('notebook'), 'notebook');
+			assert.strictEqual(stripLanguageSuffixes('my-analysis'), 'my-analysis');
+		});
+
+		test('preserves non-language dashed parts', () => {
+			assert.strictEqual(stripLanguageSuffixes('my-cool-notebook-fr'), 'my-cool-notebook');
+		});
+
+		test('does not strip the entire name', () => {
+			assert.strictEqual(stripLanguageSuffixes('en'), 'en');
+			assert.strictEqual(stripLanguageSuffixes('pt'), 'pt');
+		});
+
+		test('stops stripping at non-language part', () => {
+			assert.strictEqual(stripLanguageSuffixes('my-analysis-data-pt'), 'my-analysis-data');
+		});
+	});
+
+	suite('end-to-end translation pipeline', () => {
+		test('translates prose, preserves inline code', async () => {
+			const mock = new MockTranslationProvider();
+
+			const md = 'Use `console.log()` to debug.';
+			const segments = splitMarkdown(md);
+			const { text, indices } = extractTranslatable(segments);
+			const translated = await mock.translate(text, 'en', 'es');
+			const result = reassemble(applyTranslated(segments, translated, indices));
+
+			assert.ok(result.includes('`console.log()`'));
+			assert.ok(result.includes('[en->es]'));
+		});
+
+		test('translates prose, preserves inline math', async () => {
+			const mock = new MockTranslationProvider();
+
+			const md = 'The formula $E = mc^2$ is important.';
+			const segments = splitMarkdown(md);
+			const { text, indices } = extractTranslatable(segments);
+			const translated = await mock.translate(text, 'en', 'pt');
+			const result = reassemble(applyTranslated(segments, translated, indices));
+
+			assert.ok(result.includes('$E = mc^2$'));
+		});
+
+		test('translates prose, preserves headings', async () => {
+			const mock = new MockTranslationProvider();
+
+			const md = '### My heading';
+			const segments = splitMarkdown(md);
+			const { text, indices } = extractTranslatable(segments);
+			const translated = await mock.translate(text, 'en', 'pt');
+			const result = reassemble(applyTranslated(segments, translated, indices));
+
+			assert.ok(result.startsWith('### '));
+		});
+
+		test('translates prose, preserves list markers', async () => {
+			const mock = new MockTranslationProvider();
+
+			const md = '- item one\n- item two';
+			const segments = splitMarkdown(md);
+			const { text, indices } = extractTranslatable(segments);
+			const translated = await mock.translate(text, 'en', 'de');
+			const result = reassemble(applyTranslated(segments, translated, indices));
+
+			const lines = result.split('\n');
+			assert.ok(lines[0].startsWith('- '));
+			assert.ok(lines[1].startsWith('- '));
+		});
+
+		test('code cells are not affected by splitMarkdown', () => {
+			const code = 'import pandas as pd\ndf = pd.read_csv("data.csv")\ndf.head()';
+			const segments = splitMarkdown(code);
+			const result = reassemble(segments);
+			assert.strictEqual(result, code);
+		});
+
+		test('applyTranslated handles fewer translated segments gracefully', () => {
+			const segments = splitMarkdown('Hello world\nGoodbye world');
+			const { indices } = extractTranslatable(segments);
+			const result = applyTranslated(segments, 'Hola mundo', indices);
+			const output = reassemble(result);
+			assert.ok(output.includes('Hola mundo'));
+		});
+
+		test('applyTranslated handles extra translated segments gracefully', () => {
+			const segments = splitMarkdown('Hello');
+			const { indices } = extractTranslatable(segments);
+			const result = applyTranslated(segments, 'Hola\nExtra line', indices);
+			const output = reassemble(result);
+			assert.ok(output.includes('Hola'));
+		});
+	});
+
+	suite('getLanguageLabel', () => {
+		test('returns label for known language codes', () => {
+			assert.strictEqual(getLanguageLabel('en'), 'English');
+			assert.strictEqual(getLanguageLabel('pt'), 'Portuguese');
+			assert.strictEqual(getLanguageLabel('es'), 'Spanish');
+		});
+
+		test('returns code itself for unknown language codes', () => {
+			assert.strictEqual(getLanguageLabel('zz'), 'zz');
+			assert.strictEqual(getLanguageLabel(''), '');
+		});
+	});
+});


### PR DESCRIPTION
## Recording of prototype

### Part 1

https://github.com/user-attachments/assets/40c666be-1e21-4107-a7c0-2f6bedf85096

### Part 2

https://github.com/user-attachments/assets/e9d595d7-370b-4c52-899b-1fc5e3ea5ac8

## Summary
- Adds an experimental notebook markdown cell translation feature gated behind `positron.notebook.translate.enabled`
- Uses the configured Positron Assistant language model provider (Anthropic, OpenAI, etc.) to translate markdown cells while preserving code blocks, math, LaTeX, inline code, headings, list markers, URLs, and images
- Creates a new translated notebook file (e.g. `notebook-pt.ipynb`) rather than editing in place, with auto-detection of source language from filename suffix and suffix stripping to prevent accumulation

## Details
- **Segment-based markdown protection**: Splits markdown into translatable prose and non-translatable syntax (code, math, URLs, etc.), translates segment-by-segment to avoid line-count mismatches, then reassembles
- **Smart file handling**: Detects language from filename (`notebook-pt.ipynb` -> Portuguese), strips accumulated suffixes (`notebook-pt-es` -> `notebook-es`), overwrite confirmation dialog
- **UX**: Progress notification with cancellation, error aggregation (caps at 3 per-cell warnings), clear messages for edge cases (unsaved notebook, no markdown cells, no model configured)
- **54 tests** covering markdown protection, round-trip preservation, filename detection, language utilities, and edge cases

## Test plan
- [ ] Enable `positron.notebook.translate.enabled` in settings
- [ ] Open a saved `.ipynb` with markdown cells
- [ ] Click the globe icon in the editor toolbar
- [ ] For a fresh notebook: verify source then target language pickers appear
- [ ] For a translated file (e.g. `notebook-pt.ipynb`): verify source is auto-detected and only target picker shows
- [ ] Verify translated file is created with correct name and opens automatically
- [ ] Verify code blocks, math, headings, list markers, inline code, URLs are preserved
- [ ] Verify overwrite confirmation when target file already exists
- [ ] Verify unsaved notebook shows "Please save" message
- [ ] Verify cancellation works during translation
- [ ] Run `./scripts/test.sh --runGlob '**/contrib/translate/*.test.js'` -- all 54 tests pass

## Note

Table of Contents in notebooks should _not_ be translated OR they should be translated in a better way/logic so that they don't break due to notebook being translated. 