### PR TITLE
E2E test: add handling for the @:jupyter tag

### DIFF
--- a/.github/actions/setup-jupyter-docker/action.yml
+++ b/.github/actions/setup-jupyter-docker/action.yml
@@ -1,0 +1,97 @@
+name: 'Setup Jupyter Docker'
+description: 'Start Docker Compose services and install Jupyter with Positron in container'
+
+inputs:
+  jupyter-password:
+    description: 'Jupyter admin password'
+    required: true
+  github-token:
+    description: 'GitHub token for authentication'
+    required: true
+  run-id:
+    description: 'GitHub run ID for Docker Compose project name'
+    required: true
+  positron-license:
+    description: 'Positron license file content'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Start Docker Compose Services
+      shell: bash
+      run: |
+        docker compose \
+          -p "${{ inputs.run-id }}" \
+          -f dockerfiles/docker-compose.jupyter.yml \
+          up -d
+
+    - name: Wait for container to be ready
+      shell: bash
+      run: |
+        echo "Waiting for systemd to initialize..."
+        sleep 10
+        # Wait for systemd to reach running or degraded state (both are functional)
+        for i in {1..30}; do
+          status=$(docker exec jupyter-test systemctl is-system-running 2>/dev/null || true)
+          echo "System status: $status"
+          if [[ "$status" == "running" || "$status" == "degraded" ]]; then
+            echo "Container is ready (status: $status)"
+            break
+          fi
+          echo "Waiting for container... ($i/30)"
+          sleep 2
+        done
+        # Verify container is responsive
+        docker exec jupyter-test echo "Container is responsive"
+
+    - name: Download and setup Jupyter scripts
+      shell: bash
+      run: |
+        # Download install-jupyter-positron.sh
+        curl -L -o install-jupyter-positron.sh https://raw.githubusercontent.com/posit-dev/qa-example-content/main/dockerfiles/jupyter-local/install-jupyter-positron.sh
+
+        # Download positronDownload.sh
+        curl -L -o positronDownload.sh https://raw.githubusercontent.com/posit-dev/qa-example-content/main/dockerfiles/jupyter-local/positronDownload.sh
+
+        # Copy scripts into the container (use /opt instead of /tmp since /tmp is tmpfs)
+        docker cp install-jupyter-positron.sh jupyter-test:/opt/install-jupyter-positron.sh
+        docker cp positronDownload.sh jupyter-test:/opt/positronDownload.sh
+
+        # Make scripts executable
+        docker exec jupyter-test chmod +x /opt/install-jupyter-positron.sh
+        docker exec jupyter-test chmod +x /opt/positronDownload.sh
+
+    - name: Setup Positron license
+      shell: bash
+      if: inputs.positron-license != ''
+      run: |
+        # Create license file from secret
+        echo "${{ inputs.positron-license }}" > positron.lic
+
+        # Copy license into container at /opt/license.lic (expected by install script)
+        docker cp positron.lic jupyter-test:/opt/license.lic
+
+        # Clean up local copy
+        rm positron.lic
+
+        echo "Positron license file installed"
+
+    - name: Install Jupyter with Positron in container
+      shell: bash
+      run: |
+        docker exec -e GITHUB_TOKEN="${{ inputs.github-token }}" -e ARCH_SUFFIX=amd64 jupyter-test /bin/bash -c "/opt/install-jupyter-positron.sh --ci"
+
+    - name: Show container logs on failure
+      shell: bash
+      if: failure()
+      run: |
+        echo "=== Container Status ==="
+        docker ps -a
+        echo ""
+        echo "=== Container Logs ==="
+        docker logs jupyter-test || true
+        echo ""
+        echo "=== Container Inspect ==="
+        docker inspect jupyter-test || true

--- a/.github/workflows/build-jupyter-linux.yml
+++ b/.github/workflows/build-jupyter-linux.yml
@@ -1,0 +1,71 @@
+name: "Build: Positron Server (Linux x64)"
+
+on:
+  workflow_call:
+    outputs:
+      artifact-name:
+        description: "Name of the server artifact uploaded"
+        value: ${{ jobs.build-server.outputs.artifact-name }}
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build-server:
+    name: Build Positron Server Linux x64
+    runs-on: ubuntu-latest-8x
+    timeout-minutes: 180
+    outputs:
+      artifact-name: positron-server-linux-x64
+    container:
+      image: ghcr.io/posit-dev/positron-builds-rocky8:2
+      credentials:
+        username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
+        password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Configure Git safe directory
+        run: |
+          git config --global --add safe.directory '*'
+          git rev-parse --show-toplevel
+
+      - name: Install build dependencies
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+          npm_config_arch: x64
+        shell: scl enable gcc-toolset-14 -- bash -eo pipefail {0}
+        run: |
+          npm install --prefix build --fetch-timeout 120000
+          npm ci --fetch-timeout 120000
+
+      - name: Build Positron Server
+        env:
+          npm_config_arch: x64
+          MANGLER_WORKER_POOL_SIZE: 1
+        run: |
+          npm run gulp vscode-reh-web-linux-x64
+
+      - name: Package server tar.gz
+        run: |
+          cd ..
+          tar czvf positron/positron-server-linux-x64-branch.tar.gz vscode-reh-web-linux-x64
+
+      - name: Upload server artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: positron-server-linux-x64
+          path: positron-server-linux-x64-branch.tar.gz
+          retention-days: 1

--- a/.github/workflows/test-e2e-jupyter-ubuntu.yml
+++ b/.github/workflows/test-e2e-jupyter-ubuntu.yml
@@ -1,0 +1,172 @@
+name: "Test: E2E Jupyter (Ubuntu)"
+
+on:
+  workflow_call:
+    inputs:
+      grep:
+        required: false
+        description: "Only run tests matching this regex. Supports tags (comma-separated), titles, filenames."
+        default: "@:jupyter"
+        type: string
+      display_name:
+        required: false
+        description: "The name of the job as it will appear in the GitHub Actions UI."
+        default: "e2e-jupyter"
+        type: string
+      install_license:
+        required: false
+        description: "Whether or not to install positron-license"
+        type: boolean
+        default: true
+      upload_logs:
+        required: false
+        description: "Whether or not to upload e2e test logs."
+        type: boolean
+        default: true
+      allow_soft_fail:
+        required: false
+        description: "Whether to allow tests marked with :soft-fail to fail without failing the job."
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
+jobs:
+  e2e-jupyter:
+    name: ${{ inputs.display_name || 'e2e-jupyter' }}
+    timeout-minutes: 120
+    runs-on: ubuntu-latest-8x
+
+    env:
+      POSITRON_BUILD_NUMBER: 0
+      E2E_POSTGRES_USER: ${{ secrets.E2E_POSTGRES_USER }}
+      E2E_POSTGRES_PASSWORD: ${{ secrets.E2E_POSTGRES_PASSWORD }}
+      E2E_POSTGRES_DB: ${{ secrets.E2E_POSTGRES_DB }}
+      JUPYTER_PASSWORD: ${{ secrets.JUPYTER_PASSWORD }}
+      CONNECT_BOOTSTRAP_SECRETKEY: ${{ secrets.CONNECT_BOOTSTRAP_SECRETKEY }}
+      E2E_CONNECT_SERVER: http://localhost:3939
+      E2E_CONNECT_APIKEY: ${{ secrets.E2E_CONNECT_APIKEY }}
+      HOME: /home/runner
+      AWS_S3_BUCKET: positron-test-reports
+      R_LIBS_SITE: /usr/local/lib/R/site-library
+      R_LIBS_USER: /usr/local/lib/R/site-library
+      GH_SUMMARY_REPORT: true
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Generate access token for private repos
+        id: access-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
+          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Setup AWS S3 Access
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
+          aws-region: ${{ secrets.QA_AWS_REGION }}
+
+      - name: Load secret
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
+          OPENAI_KEY: "op://Positron/OpenAI/credential"
+          POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
+          POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
+          POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Install jq for JSON parsing
+        run: |
+          sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Download server artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: "positron-server-linux-x64"
+          path: /tmp/artifacts
+
+      - name: Docker login
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
+          password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
+
+      - name: Setup Jupyter Docker Environment
+        uses: ./.github/actions/setup-jupyter-docker
+        with:
+          jupyter-password: ${{ secrets.JUPYTER_PASSWORD }}
+          github-token: ${{ steps.access-token.outputs.token }}
+          run-id: ${{ github.run_id }}
+          positron-license: ${{ secrets.POSITRON_LICENSE }}
+
+      - name: Setup test dependencies and compile tests
+        uses: ./.github/actions/setup-e2e-test-dependencies
+
+      - name: Alter AppArmor Restrictions for Playwright
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Setup Xvfb
+        uses: ./.github/actions/setup-xvfb
+
+      - name: Generate Report Directory
+        uses: ./.github/actions/gen-report-dir
+        with:
+          identifier: e2e-jupyter
+
+      - name: 🧪 Run Playwright Jupyter Tests
+        shell: bash
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: .playwright-browsers
+          POSITRON_PY_VER_SEL: "3.10.12"
+          POSITRON_R_VER_SEL: 4.5.2
+          POSITRON_PY_ALT_VER_SEL: "3.13.0"
+          POSITRON_R_ALT_VER_SEL: 4.4.2
+          POSITRON_HIDDEN_PY: "3.12.10 Module"
+          POSITRON_HIDDEN_R: 4.4.1
+          COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
+          CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+          USE_KEY: true
+          PW_PROJECT_NAME: e2e-jupyter
+          REPORTER_REPO_NAME: positron
+        run: |
+          export DISPLAY=:10
+          npx playwright test --project e2e-jupyter --retries=1 --workers=1
+
+      - name: Upload HTML report to S3
+        if: always()
+        uses: ./.github/actions/upload-report-to-s3
+        with:
+          role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
+          report-dir: ${{ env.REPORT_DIR }}
+
+      - name: Upload Test Logs
+        if: ${{ always() && inputs.upload_logs }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-jupyter-ubuntu-logs
+          path: test-logs
+          retention-days: 3
+          if-no-files-found: ignore
+
+      - name: Stop Docker containers
+        if: always()
+        run: |
+          docker compose -p ${{ github.run_id }} -f dockerfiles/docker-compose.jupyter.yml down || true

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -29,6 +29,7 @@ jobs:
       debian_web_tag_found: ${{ steps.pr-tags.outputs.debian_web_tag_found }}
       pyrefly_tag_found: ${{ steps.pr-tags.outputs.pyrefly_tag_found }}
       workbench_tag_found: ${{ steps.pr-tags.outputs.workbench_tag_found }}
+      jupyter_tag_found: ${{ steps.pr-tags.outputs.jupyter_tag_found }}
 
     steps:
       - uses: actions/checkout@v6
@@ -221,6 +222,26 @@ jobs:
       grep: ${{ needs.pr-tags.outputs.tags }}
       display_name: "workbench"
       install_license: false
+      upload_logs: false
+      allow_soft_fail: false
+    secrets: inherit
+
+  build-jupyter:
+    needs: pr-tags
+    if: ${{ needs.pr-tags.outputs.jupyter_tag_found == 'true' }}
+    name: build
+    uses: ./.github/workflows/build-jupyter-linux.yml
+    secrets: inherit
+
+  e2e-jupyter:
+    needs: [pr-tags, build-jupyter]
+    if: ${{ needs.pr-tags.outputs.jupyter_tag_found == 'true' }}
+    name: e2e
+    uses: ./.github/workflows/test-e2e-jupyter-ubuntu.yml
+    with:
+      grep: ${{ needs.pr-tags.outputs.tags }}
+      display_name: "jupyter"
+      install_license: true
       upload_logs: false
       allow_soft_fail: false
     secrets: inherit

--- a/dockerfiles/docker-compose.jupyter.yml
+++ b/dockerfiles/docker-compose.jupyter.yml
@@ -1,0 +1,40 @@
+version: '3.8'
+
+services:
+  jupyter-test:
+    image: ghcr.io/posit-dev/positron-ubuntu24-amd64:116
+    container_name: jupyter-test
+    ports:
+      - "8888:80"    # JupyterHub (TLJH uses port 80 internally)
+      - "8080:8080"  # Positron server
+      - "5900:5900"
+    command: /lib/systemd/systemd
+    tty: true
+    stdin_open: true
+    privileged: true
+    cgroup: host
+    networks:
+      - mynetwork
+    environment:
+      - POSIT_WORKBENCH_PASSWORD=${POSIT_WORKBENCH_PASSWORD:-testpassword}
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
+      - container=docker
+    volumes:
+      - jupyter-data:/home
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /tmp
+      - /run
+      - /run/lock
+    ulimits:
+      nproc: 4096
+      nofile:
+        soft: 65536
+        hard: 65536
+
+networks:
+  mynetwork:
+    driver: bridge
+
+volumes:
+  jupyter-data:

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -79,6 +79,10 @@ if echo "$PR_BODY" | grep -q "@:workbench"; then
 	echo "Found workbench tag in PR body. Setting to run workbench tests."
 	echo "workbench_tag_found=true" >> "$GITHUB_OUTPUT"
 fi
+if echo "$PR_BODY" | grep -q "@:jupyter"; then
+	echo "Found jupyter tag in PR body. Setting to run jupyter tests."
+	echo "jupyter_tag_found=true" >> "$GITHUB_OUTPUT"
+fi
 
 # Check if @:all is present in the PR body
 if echo "$PR_BODY" | grep -q "@:all"; then


### PR DESCRIPTION
## Summary

Adds support for the `at-colon-jupyter` tag to trigger Jupyter integration tests on pull requests, similar to the existing `at-colon-workbench` tag functionality.

## Changes

### Tag Parsing
- Updated `scripts/pr-tags-parse.sh` to detect `at-colon-jupyter` tag in PR descriptions
- Updated `.github/workflows/test-pull-request.yml` to wire up the jupyter workflow jobs

### Build Workflow
- Created `.github/workflows/build-jupyter-linux.yml` to build Positron server for x64
  - Uses `npm run gulp vscode-reh-web-linux-x64` (not the workbench version)
  - Uploads artifact as `positron-server-linux-x64`
  - Does NOT include license key replacement step (license is handled in test environment instead)

### Test Workflow
- Created `.github/workflows/test-e2e-jupyter-ubuntu.yml` to run Jupyter e2e tests
  - Downloads the x64 server artifact
  - Uses new `setup-jupyter-docker` action
  - Installs `POSITRON_LICENSE` secret in the test environment
  - Runs tests with `--project e2e-jupyter`

### Docker Setup
- Created `dockerfiles/docker-compose.jupyter.yml` for Jupyter test environment
- Created `.github/actions/setup-jupyter-docker/action.yml` to setup Jupyter with Positron
  - Starts docker compose services
  - Downloads and runs Jupyter installation scripts from qa-example-content
  - Handles Positron license file installation

## Usage

Add `at-colon-jupyter` to your PR description to trigger Jupyter integration tests:

