### PR TITLE
Console Fix & Explain: fall back to quick chat when sidebar disabled

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorQuickFix.tsx
@@ -16,12 +16,21 @@ import { Button } from '../../../../../base/browser/ui/positronComponents/button
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { ANSIOutputLine } from '../../../../../base/common/ansiOutput.js';
 import { encodeBase64, VSBuffer } from '../../../../../base/common/buffer.js';
+// --- Start Quick Chat fallback ---
+import { usePositronConfiguration } from '../../../../../base/browser/positronReactHooks.js';
+// --- End Quick Chat fallback ---
 
 const fixPrompt = localize('positronConsoleAssistantFixPrompt', "Fix this console error.");
 const explainPrompt = localize('positronConsoleAssistantExplainPrompt', "Explain this console error.");
 
 const NEW_CHAT_COMMAND = 'posit-assistant.newChat';
 const ATTACHMENT_NAME = 'console-error.txt';
+
+// --- Start Quick Chat fallback ---
+const quickChatFixPrompt = '/fix';
+const quickChatExplainPrompt = '/explain';
+const SIDEBAR_VIEW_SETTING = 'assistant.sidebarView';
+// --- End Quick Chat fallback ---
 
 interface ConsoleQuickFixProps {
 	outputLines: ANSIOutputLine[];
@@ -62,7 +71,12 @@ const buildAttachment = (text: string): NewChatFile | undefined => {
  */
 export const ConsoleQuickFix = (props: ConsoleQuickFixProps) => {
 	const buttonRef = useRef<HTMLDivElement>(undefined!);
-	const { commandService, notificationService } = usePositronReactServicesContext();
+	const services = usePositronReactServicesContext();
+	const { commandService, notificationService } = services;
+	// --- Start Quick Chat fallback ---
+	const { quickChatService } = services;
+	const sidebarViewEnabled = usePositronConfiguration<boolean>(SIDEBAR_VIEW_SETTING);
+	// --- End Quick Chat fallback ---
 
 	const attachment = useMemo(
 		() => buildAttachment(formatOutput(props.outputLines, props.tracebackLines)),
@@ -88,8 +102,32 @@ export const ConsoleQuickFix = (props: ConsoleQuickFixProps) => {
 		}
 	};
 
-	const pressedFixHandler = () => runNewChat(fixPrompt);
-	const pressedExplainHandler = () => runNewChat(explainPrompt);
+	// --- Start Quick Chat fallback ---
+	const runQuickChat = (slashPrompt: string) => {
+		const formatted = formatOutput(props.outputLines, props.tracebackLines);
+		quickChatService.open({
+			query: formatted ? `${slashPrompt}\n\`\`\`${formatted}\`\`\`` : slashPrompt,
+		});
+	};
+	// --- End Quick Chat fallback ---
+
+	const pressedFixHandler = () => {
+		// --- Start Quick Chat fallback ---
+		if (!sidebarViewEnabled) {
+			return runQuickChat(quickChatFixPrompt);
+		}
+		// --- End Quick Chat fallback ---
+		return runNewChat(fixPrompt);
+	};
+
+	const pressedExplainHandler = () => {
+		// --- Start Quick Chat fallback ---
+		if (!sidebarViewEnabled) {
+			return runQuickChat(quickChatExplainPrompt);
+		}
+		// --- End Quick Chat fallback ---
+		return runNewChat(explainPrompt);
+	};
 
 	// Render.
 	return (

--- a/src/vs/workbench/contrib/positronConsole/test/browser/activityErrorQuickFix.vitest.tsx
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/activityErrorQuickFix.vitest.tsx
@@ -6,7 +6,8 @@
 /// <reference types="vitest/globals" />
 
 import React from 'react';
-import { fireEvent, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { ANSIOutputLine } from '../../../../../base/common/ansiOutput.js';
@@ -14,6 +15,11 @@ import { decodeBase64, VSBuffer } from '../../../../../base/common/buffer.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { ConsoleQuickFix } from '../../browser/components/activityErrorQuickFix.js';
+// --- Start Quick Chat fallback ---
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IQuickChatService } from '../../../../../workbench/contrib/chat/browser/chat.js';
+import { Event } from '../../../../../base/common/event.js';
+// --- End Quick Chat fallback ---
 
 const line = (id: string, text: string): ANSIOutputLine => ({
 	id,
@@ -34,19 +40,35 @@ const decodeDataUri = (uri: string): string => {
 describe('ConsoleQuickFix', () => {
 	const executeCommand = vi.fn().mockResolvedValue(undefined);
 	const notifyError = vi.fn();
+	// --- Start Quick Chat fallback ---
+	const openQuickChat = vi.fn();
+	let sidebarViewEnabled = true;
+	// --- End Quick Chat fallback ---
 
 	const ctx = createTestContainer()
 		.withReactServices()
 		.stub(ICommandService, { executeCommand })
 		.stub(INotificationService, { error: notifyError })
+		// --- Start Quick Chat fallback ---
+		.stub(IQuickChatService, { open: openQuickChat })
+		.stub(IConfigurationService, {
+			getValue: (key: string) => key === 'assistant.sidebarView' ? sidebarViewEnabled : undefined,
+			onDidChangeConfiguration: Event.None,
+		})
+		// --- End Quick Chat fallback ---
 		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
+	// --- Start Quick Chat fallback ---
+	beforeEach(() => {
+		sidebarViewEnabled = true;
+	});
+	// --- End Quick Chat fallback ---
+
 	it('dispatches posit-assistant.newChat with a fix prompt and the error as a data URI attachment when Fix is clicked', async () => {
-		const { getByText } = rtl.render(
-			<ConsoleQuickFix outputLines={outputLines} tracebackLines={tracebackLines} />
-		);
-		fireEvent.click(getByText('Fix'));
+		const user = userEvent.setup();
+		rtl.render(<ConsoleQuickFix outputLines={outputLines} tracebackLines={tracebackLines} />);
+		await user.click(screen.getByText('Fix'));
 
 		await waitFor(() => expect(executeCommand).toHaveBeenCalledTimes(1));
 		const [cmd, payload] = executeCommand.mock.calls[0];
@@ -62,10 +84,9 @@ describe('ConsoleQuickFix', () => {
 	});
 
 	it('dispatches posit-assistant.newChat with an explain prompt when Explain is clicked', async () => {
-		const { getByText } = rtl.render(
-			<ConsoleQuickFix outputLines={outputLines} tracebackLines={tracebackLines} />
-		);
-		fireEvent.click(getByText('Explain'));
+		const user = userEvent.setup();
+		rtl.render(<ConsoleQuickFix outputLines={outputLines} tracebackLines={tracebackLines} />);
+		await user.click(screen.getByText('Explain'));
 
 		await waitFor(() => expect(executeCommand).toHaveBeenCalledTimes(1));
 		const [, payload] = executeCommand.mock.calls[0];
@@ -75,10 +96,9 @@ describe('ConsoleQuickFix', () => {
 	});
 
 	it('omits the attachment when there is no error output', async () => {
-		const { getByText } = rtl.render(
-			<ConsoleQuickFix outputLines={[]} tracebackLines={[]} />
-		);
-		fireEvent.click(getByText('Fix'));
+		const user = userEvent.setup();
+		rtl.render(<ConsoleQuickFix outputLines={[]} tracebackLines={[]} />);
+		await user.click(screen.getByText('Fix'));
 
 		await waitFor(() => expect(executeCommand).toHaveBeenCalledTimes(1));
 		const [, payload] = executeCommand.mock.calls[0];
@@ -88,12 +108,51 @@ describe('ConsoleQuickFix', () => {
 	it('surfaces a notification when the command throws (extension missing)', async () => {
 		executeCommand.mockRejectedValueOnce(new Error('command not found'));
 
-		const { getByText } = rtl.render(
-			<ConsoleQuickFix outputLines={outputLines} tracebackLines={tracebackLines} />
-		);
-		fireEvent.click(getByText('Fix'));
+		const user = userEvent.setup();
+		rtl.render(<ConsoleQuickFix outputLines={outputLines} tracebackLines={tracebackLines} />);
+		await user.click(screen.getByText('Fix'));
 
 		await waitFor(() => expect(notifyError).toHaveBeenCalledTimes(1));
 		expect(notifyError.mock.calls[0][0]).toMatch(/Posit Assistant is not available/);
 	});
+
+	// --- Start Quick Chat fallback ---
+	describe('with assistant.sidebarView disabled', () => {
+		beforeEach(() => {
+			sidebarViewEnabled = false;
+		});
+
+		it('opens the quick chat with the /fix slash command and fenced error block when Fix is clicked', async () => {
+			const user = userEvent.setup();
+			rtl.render(<ConsoleQuickFix outputLines={outputLines} tracebackLines={tracebackLines} />);
+			await user.click(screen.getByText('Fix'));
+
+			expect(openQuickChat).toHaveBeenCalledTimes(1);
+			const [options] = openQuickChat.mock.calls[0];
+			expect(options.query).toBe(`/fix\n\`\`\`${expectedAttachmentText}\`\`\``);
+			expect(executeCommand).not.toHaveBeenCalled();
+		});
+
+		it('opens the quick chat with the /explain slash command when Explain is clicked', async () => {
+			const user = userEvent.setup();
+			rtl.render(<ConsoleQuickFix outputLines={outputLines} tracebackLines={tracebackLines} />);
+			await user.click(screen.getByText('Explain'));
+
+			expect(openQuickChat).toHaveBeenCalledTimes(1);
+			const [options] = openQuickChat.mock.calls[0];
+			expect(options.query).toBe(`/explain\n\`\`\`${expectedAttachmentText}\`\`\``);
+			expect(executeCommand).not.toHaveBeenCalled();
+		});
+
+		it('opens the quick chat with just the slash command when there is no error output', async () => {
+			const user = userEvent.setup();
+			rtl.render(<ConsoleQuickFix outputLines={[]} tracebackLines={[]} />);
+			await user.click(screen.getByText('Fix'));
+
+			expect(openQuickChat).toHaveBeenCalledTimes(1);
+			const [options] = openQuickChat.mock.calls[0];
+			expect(options.query).toBe('/fix');
+		});
+	});
+	// --- End Quick Chat fallback ---
 });


### PR DESCRIPTION
Follow-up to #13197. Console Fix & Explain now route based on the `assistant.sidebarView` config: when the sidebar is enabled, the buttons dispatch `posit-assistant.newChat` (current behavior); when it is disabled (the default), the buttons fall back to the built-in quick chat with the legacy `/fix` / `/explain` slash command and the error wrapped in a fenced code block.

The fallback path, its imports, hook, and the `if (!sidebarViewEnabled) ...` guards in each handler are wrapped in `// --- Start Quick Chat fallback ---` / `// --- End Quick Chat fallback ---` markers in both source and test. Once Posit Assistant adoption is complete the fences can be stripped in a single pass, leaving the `newChat`-only implementation behind.

Gating in `activityErrorMessage.tsx` is unchanged (`positron.assistant.consoleActions.enable` + `posit.assistant` installed + `positron-assistant.hasChatModels`). Existing tests were converted from `fireEvent` / destructured queries to `userEvent` + `screen` to satisfy the `eslint-plugin-testing-library` rules now active on `main`.

Continues addressing #13195 

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Console Fix and Explain fall back to the built-in quick chat when the Posit Assistant sidebar is disabled, instead of always trying to launch Posit Assistant.

### QA Notes

@:console @:assistant

1. Install the Posit Assistant extension and ensure `positron.assistant.consoleActions.enable` is true.
2. With `assistant.sidebarView` unset (default `false`):
   - Trigger a console error (e.g. run `1/0` in Python or `stop("boom")` in R).
   - Click **Fix** -> the built-in quick-chat widget opens with `/fix` followed by a fenced block containing the error.
   - Click **Explain** -> same widget opens with `/explain` and the fenced error.
3. Set `"assistant.sidebarView": true` in user settings.
   - Trigger a console error and click **Fix** -> Posit Assistant opens (in the sidebar or editor per the user's preference) with the natural-language prompt "Fix this console error." and the error attached as `console-error.txt`.
   - Click **Explain** -> Posit Assistant opens with "Explain this console error." and the same attachment.
4. Toggle `assistant.sidebarView` at runtime and confirm subsequent clicks pick up the new value without a reload.
5. Set `positron.assistant.consoleActions.enable` to false -> Fix and Explain buttons no longer appear on console errors (gating regression check).