### PR TITLE
early return on successful license initialization

### DIFF
--- a/src/vs/server/node/licenseManager.ts
+++ b/src/vs/server/node/licenseManager.ts
@@ -14,10 +14,6 @@ const execFileAsync = promisify(execFile);
 
 const LicError = {
 	OK: 0,
-	FAIL: 1,
-	TRIAL_EXPIRED: 2,
-	VM: 3,
-	ALREADY_ACTIVATED: 4,
 } as const;
 
 interface LicenseCommandResult {
@@ -76,7 +72,7 @@ class LicenseManager {
 
 			const jsonStr = extractJson(stdout);
 			const parsed = JSON.parse(jsonStr);
-			if (!Object.values(LicError).includes(parsed?.result)) {
+			if (typeof parsed?.result !== 'number') {
 				throw new Error(`Invalid license-manager response: ${stdout}`);
 			}
 			return parsed;
@@ -86,7 +82,7 @@ class LicenseManager {
 				try {
 					const jsonStr = extractJson(execError.stdout);
 					const parsed = JSON.parse(jsonStr);
-					if (Object.values(LicError).includes(parsed?.result)) {
+					if (typeof parsed?.result === 'number') {
 						return parsed;
 					}
 				} catch { /* fall through */ }
@@ -96,51 +92,27 @@ class LicenseManager {
 		}
 	}
 
-	private async verifyLicense(): Promise<ILicenseValidationResult> {
-		const result = await this.runJsonCommand('verify');
-		const validated = validatedResult(result);
-		console.log(`Positron license verified: ${JSON.stringify(result)}`);
-		return validated;
-	}
-
 	async activateLicenseFile(licenseFilePath: string): Promise<ILicenseValidationResult> {
 		if (!fs.existsSync(licenseFilePath)) {
 			throw new Error(`License file not found: ${licenseFilePath}`);
 		}
 
-		const verifyResult = await this.runJsonCommand('get-verify');
-		if (verifyResult.result !== LicError.OK) {
-			throw new Error(`License system check failed: ${verifyResult.message || `code ${verifyResult.result}`}`);
+		// Place the license file next to the binary so the license manager
+		// picks it up without needing initialize or activate-file.
+		const licenseManagerDir = path.dirname(this.licenseManagerPath);
+		const targetPath = path.join(licenseManagerDir, 'license.lic');
+		if (!fs.existsSync(targetPath)) {
+			fs.copyFileSync(licenseFilePath, targetPath);
 		}
 
-		if (verifyResult.initialized) {
-			try {
-				return await this.verifyLicense();
-			} catch {
-				console.log('Existing license verification failed, proceeding to activation...');
-			}
-		} else {
-			console.log('Initializing license system...');
-			const initResult = await this.runJsonCommand('initialize');
-			if (initResult.result !== LicError.OK &&
-				initResult.result !== LicError.TRIAL_EXPIRED &&
-				initResult.result !== LicError.VM) {
-				throw new Error(`Failed to initialize license system: ${initResult.message || 'Unknown error'}`);
-			}
-		}
-
-		console.log('Activating license file...');
-		const result = await this.runJsonCommand('activate-file', [licenseFilePath]);
-
-		if (result.result === LicError.ALREADY_ACTIVATED) {
-			return await this.verifyLicense();
-		}
-
+		const result = await this.runJsonCommand('verify');
 		if (result.result !== LicError.OK) {
-			throw new Error(result.message || `Activation failed with code ${result.result}`);
+			throw new Error(`License verification failed: ${result.message || `code ${result.result}`}`);
 		}
 
-		return validatedResult(result);
+		const validated = validatedResult(result);
+		console.log(`Positron license verified: ${JSON.stringify(result)}`);
+		return validated;
 	}
 }
 

--- a/src/vs/server/node/licenseManager.ts
+++ b/src/vs/server/node/licenseManager.ts
@@ -32,7 +32,7 @@ interface LicenseCommandResult {
 	expiration?: number;
 }
 
-function validateLicenseStatus(result: LicenseCommandResult): void {
+function validatedResult(result: LicenseCommandResult): ILicenseValidationResult {
 	const status = result.status?.toLowerCase() || '';
 	if (status === 'expired') {
 		throw new Error('License has expired. Please renew your license.');
@@ -40,6 +40,7 @@ function validateLicenseStatus(result: LicenseCommandResult): void {
 	if (status !== 'activated' && status !== 'evaluation') {
 		throw new Error(`Invalid license result: ${JSON.stringify(result)}`);
 	}
+	return { valid: true, licensee: result.licensee };
 }
 
 /**
@@ -92,7 +93,19 @@ class LicenseManager {
 		}
 
 		const verifyResult = await this.runJsonCommand('get-verify');
-		if (verifyResult.result === LicError.OK && !verifyResult.initialized) {
+		if (verifyResult.result !== LicError.OK) {
+			throw new Error(`License system check failed: ${verifyResult.message || `code ${verifyResult.result}`}`);
+		}
+
+		if (verifyResult.initialized) {
+			try {
+				const verified = validatedResult(verifyResult);
+				console.log(`Positron license verified: ${JSON.stringify(verifyResult)}`);
+				return verified;
+			} catch {
+				console.log('Existing license verification failed, proceeding to activation...');
+			}
+		} else {
 			console.log('Initializing license system...');
 			const initResult = await this.runJsonCommand('initialize', ['--userspace']);
 			if (initResult.result !== LicError.OK &&
@@ -109,14 +122,9 @@ class LicenseManager {
 			throw new Error(result.message || `Activation failed with code ${result.result}`);
 		}
 
-		validateLicenseStatus(result);
-
+		const activated = validatedResult(result);
 		console.log(`Successfully activated Positron license: ${JSON.stringify(result)}`);
-
-		return {
-			valid: true,
-			licensee: result.licensee
-		};
+		return activated;
 	}
 }
 

--- a/src/vs/server/node/licenseManager.ts
+++ b/src/vs/server/node/licenseManager.ts
@@ -92,19 +92,7 @@ class LicenseManager {
 		}
 	}
 
-	async activateLicenseFile(licenseFilePath: string): Promise<ILicenseValidationResult> {
-		if (!fs.existsSync(licenseFilePath)) {
-			throw new Error(`License file not found: ${licenseFilePath}`);
-		}
-
-		// Place the license file next to the binary so the license manager
-		// picks it up without needing initialize or activate-file.
-		const licenseManagerDir = path.dirname(this.licenseManagerPath);
-		const targetPath = path.join(licenseManagerDir, 'license.lic');
-		if (!fs.existsSync(targetPath)) {
-			fs.copyFileSync(licenseFilePath, targetPath);
-		}
-
+	async verify(): Promise<ILicenseValidationResult> {
 		const result = await this.runJsonCommand('verify');
 		if (result.result !== LicError.OK) {
 			throw new Error(`License verification failed: ${result.message || `code ${result.result}`}`);
@@ -114,11 +102,26 @@ class LicenseManager {
 		console.log(`Positron license verified: ${JSON.stringify(result)}`);
 		return validated;
 	}
+
+	async activateLicenseFile(licenseFilePath: string): Promise<ILicenseValidationResult> {
+		const licenseManagerDir = path.dirname(this.licenseManagerPath);
+
+		// Check for a .lic file next to the license-manager binary first.
+		const localLic = fs.readdirSync(licenseManagerDir).find(f => f.endsWith('.lic'));
+		if (!localLic) {
+			// No .lic next to the binary -- copy the provided file there.
+			if (!fs.existsSync(licenseFilePath)) {
+				throw new Error(`License file not found: ${licenseFilePath}`);
+			}
+			fs.copyFileSync(licenseFilePath, path.join(licenseManagerDir, path.basename(licenseFilePath)));
+		}
+
+		return this.verify();
+	}
 }
 
 /**
  * Activates a Positron Server license file using the license-manager binary.
- * This installs the license into the system.
  */
 export async function activateWithManager(
 	installPath: string,
@@ -127,6 +130,30 @@ export async function activateWithManager(
 	const licenseManagerPath = findLicenseManagerPath(installPath);
 	const licenseManager = new LicenseManager(licenseManagerPath);
 	return licenseManager.activateLicenseFile(licenseFilePath);
+}
+
+/**
+ * Checks for a .lic file next to the license-manager binary and verifies it.
+ * Returns undefined if no .lic file is found or the binary doesn't exist.
+ */
+export async function verifyLocalLicense(
+	installPath: string,
+): Promise<ILicenseValidationResult | undefined> {
+	let licenseManagerPath: string;
+	try {
+		licenseManagerPath = findLicenseManagerPath(installPath);
+	} catch {
+		return undefined;
+	}
+
+	const licenseManagerDir = path.dirname(licenseManagerPath);
+	const localLic = fs.readdirSync(licenseManagerDir).find(f => f.endsWith('.lic'));
+	if (!localLic) {
+		return undefined;
+	}
+
+	const licenseManager = new LicenseManager(licenseManagerPath);
+	return licenseManager.verify();
 }
 
 /**

--- a/src/vs/server/node/licenseManager.ts
+++ b/src/vs/server/node/licenseManager.ts
@@ -14,6 +14,12 @@ const execFileAsync = promisify(execFile);
 
 const LicError = {
 	OK: 0,
+	FAIL: 1,
+	TRIAL_EXPIRED: 2,
+	VM: 3,
+	ALREADY_ACTIVATED: 4,
+	FILE_NOT_FOUND: 41,
+	ROOT_REQUIRED: 44,
 } as const;
 
 interface LicenseCommandResult {
@@ -40,6 +46,12 @@ function validatedResult(result: LicenseCommandResult): ILicenseValidationResult
 	return { valid: true, licensee: result.licensee };
 }
 
+type LicErrorCode = typeof LicError[keyof typeof LicError];
+const knownResultCodes: Set<number> = new Set(Object.values(LicError));
+function knownResultCode(code: unknown): code is LicErrorCode {
+	return typeof code === 'number' && knownResultCodes.has(code);
+}
+
 // The `verify` command prefixes its JSON output with a signature hash line.
 function extractJson(stdout: string): string {
 	const jsonStart = stdout.indexOf('{');
@@ -59,37 +71,31 @@ class LicenseManager {
 			LD_LIBRARY_PATH: licenseManagerDir,
 		};
 
+		let stdout: string;
 		try {
-			const { stdout, stderr } = await execFileAsync(
+			const result = await execFileAsync(
 				this.licenseManagerPath,
 				[command, ...args, '--output=json'],
 				{ maxBuffer: 1024 * 1024, timeout: 10000, env }
 			);
-
-			if (stderr && stderr.length > 0) {
-				console.warn(`license-manager stderr: ${stderr}`);
+			if (result.stderr && result.stderr.length > 0) {
+				console.warn(`license-manager stderr: ${result.stderr}`);
 			}
-
-			const jsonStr = extractJson(stdout);
-			const parsed = JSON.parse(jsonStr);
-			if (typeof parsed?.result !== 'number') {
-				throw new Error(`Invalid license-manager response: ${stdout}`);
-			}
-			return parsed;
+			stdout = result.stdout;
 		} catch (error) {
 			const execError = error as { stdout?: string; message?: string };
-			if (execError.stdout) {
-				try {
-					const jsonStr = extractJson(execError.stdout);
-					const parsed = JSON.parse(jsonStr);
-					if (typeof parsed?.result === 'number') {
-						return parsed;
-					}
-				} catch { /* fall through */ }
-				throw new Error(`Invalid license-manager response: ${execError.stdout}`);
+			stdout = execError.stdout ?? '';
+			if (!stdout) {
+				throw new Error(execError.message || 'Unknown error');
 			}
-			throw new Error(execError.message || 'Unknown error');
 		}
+
+		const jsonStr = extractJson(stdout);
+		const parsed = JSON.parse(jsonStr);
+		if (!knownResultCode(parsed?.result)) {
+			throw new Error(`Unexpected license-manager response: ${stdout}`);
+		}
+		return parsed;
 	}
 
 	async verify(): Promise<ILicenseValidationResult> {

--- a/src/vs/server/node/licenseManager.ts
+++ b/src/vs/server/node/licenseManager.ts
@@ -17,6 +17,7 @@ const LicError = {
 	FAIL: 1,
 	TRIAL_EXPIRED: 2,
 	VM: 3,
+	ALREADY_ACTIVATED: 4,
 } as const;
 
 interface LicenseCommandResult {
@@ -43,6 +44,12 @@ function validatedResult(result: LicenseCommandResult): ILicenseValidationResult
 	return { valid: true, licensee: result.licensee };
 }
 
+// The `verify` command prefixes its JSON output with a signature hash line.
+function extractJson(stdout: string): string {
+	const jsonStart = stdout.indexOf('{');
+	return jsonStart > 0 ? stdout.slice(jsonStart) : stdout;
+}
+
 /**
  * Wrapper for executing license-manager binary commands.
  */
@@ -67,7 +74,8 @@ class LicenseManager {
 				console.warn(`license-manager stderr: ${stderr}`);
 			}
 
-			const parsed = JSON.parse(stdout);
+			const jsonStr = extractJson(stdout);
+			const parsed = JSON.parse(jsonStr);
 			if (!Object.values(LicError).includes(parsed?.result)) {
 				throw new Error(`Invalid license-manager response: ${stdout}`);
 			}
@@ -76,7 +84,8 @@ class LicenseManager {
 			const execError = error as { stdout?: string; message?: string };
 			if (execError.stdout) {
 				try {
-					const parsed = JSON.parse(execError.stdout);
+					const jsonStr = extractJson(execError.stdout);
+					const parsed = JSON.parse(jsonStr);
 					if (Object.values(LicError).includes(parsed?.result)) {
 						return parsed;
 					}
@@ -85,6 +94,13 @@ class LicenseManager {
 			}
 			throw new Error(execError.message || 'Unknown error');
 		}
+	}
+
+	private async verifyLicense(): Promise<ILicenseValidationResult> {
+		const result = await this.runJsonCommand('verify');
+		const validated = validatedResult(result);
+		console.log(`Positron license verified: ${JSON.stringify(result)}`);
+		return validated;
 	}
 
 	async activateLicenseFile(licenseFilePath: string): Promise<ILicenseValidationResult> {
@@ -99,15 +115,13 @@ class LicenseManager {
 
 		if (verifyResult.initialized) {
 			try {
-				const verified = validatedResult(verifyResult);
-				console.log(`Positron license verified: ${JSON.stringify(verifyResult)}`);
-				return verified;
+				return await this.verifyLicense();
 			} catch {
 				console.log('Existing license verification failed, proceeding to activation...');
 			}
 		} else {
 			console.log('Initializing license system...');
-			const initResult = await this.runJsonCommand('initialize', ['--userspace']);
+			const initResult = await this.runJsonCommand('initialize');
 			if (initResult.result !== LicError.OK &&
 				initResult.result !== LicError.TRIAL_EXPIRED &&
 				initResult.result !== LicError.VM) {
@@ -118,13 +132,15 @@ class LicenseManager {
 		console.log('Activating license file...');
 		const result = await this.runJsonCommand('activate-file', [licenseFilePath]);
 
+		if (result.result === LicError.ALREADY_ACTIVATED) {
+			return await this.verifyLicense();
+		}
+
 		if (result.result !== LicError.OK) {
 			throw new Error(result.message || `Activation failed with code ${result.result}`);
 		}
 
-		const activated = validatedResult(result);
-		console.log(`Successfully activated Positron license: ${JSON.stringify(result)}`);
-		return activated;
+		return validatedResult(result);
 	}
 }
 

--- a/src/vs/server/node/licenseManager.ts
+++ b/src/vs/server/node/licenseManager.ts
@@ -47,12 +47,13 @@ function validatedResult(result: LicenseCommandResult): ILicenseValidationResult
 }
 
 type LicErrorCode = typeof LicError[keyof typeof LicError];
-const knownResultCodes: Set<number> = new Set(Object.values(LicError));
+const knownResultCodes = new Set(Object.values(LicError) as LicErrorCode[]);
 function knownResultCode(code: unknown): code is LicErrorCode {
-	return typeof code === 'number' && knownResultCodes.has(code);
+	return typeof code === 'number' && knownResultCodes.has(code as LicErrorCode);
 }
 
 // The `verify` command prefixes its JSON output with a signature hash line.
+// If stdout contains no '{', returns as-is; JSON.parse will throw upstream.
 function extractJson(stdout: string): string {
 	const jsonStart = stdout.indexOf('{');
 	return jsonStart > 0 ? stdout.slice(jsonStart) : stdout;
@@ -71,7 +72,7 @@ class LicenseManager {
 			LD_LIBRARY_PATH: licenseManagerDir,
 		};
 
-		let stdout: string;
+		let stdout = '';
 		try {
 			const result = await execFileAsync(
 				this.licenseManagerPath,
@@ -112,9 +113,18 @@ class LicenseManager {
 	async activateLicenseFile(licenseFilePath: string): Promise<ILicenseValidationResult> {
 		const licenseManagerDir = path.dirname(this.licenseManagerPath);
 
-		// Check for a .lic file next to the license-manager binary first.
-		const localLic = fs.readdirSync(licenseManagerDir).find(f => f.endsWith('.lic'));
-		if (!localLic) {
+		let localLic: string | undefined;
+		try {
+			localLic = fs.readdirSync(licenseManagerDir).find(f => f.endsWith('.lic'));
+		} catch {
+			throw new Error(`Cannot read license-manager directory: ${licenseManagerDir}`);
+		}
+
+		if (localLic) {
+			// A .lic file already exists next to the binary; the provided
+			// licenseFilePath is not copied. Verify the existing one.
+			console.log(`Using existing license file: ${path.join(licenseManagerDir, localLic)}`);
+		} else {
 			// No .lic next to the binary -- copy the provided file there.
 			if (!fs.existsSync(licenseFilePath)) {
 				throw new Error(`License file not found: ${licenseFilePath}`);
@@ -153,7 +163,12 @@ export async function verifyLocalLicense(
 	}
 
 	const licenseManagerDir = path.dirname(licenseManagerPath);
-	const localLic = fs.readdirSync(licenseManagerDir).find(f => f.endsWith('.lic'));
+	let localLic: string | undefined;
+	try {
+		localLic = fs.readdirSync(licenseManagerDir).find(f => f.endsWith('.lic'));
+	} catch {
+		return undefined;
+	}
 	if (!localLic) {
 		return undefined;
 	}

--- a/src/vs/server/node/remoteLicenseKey.ts
+++ b/src/vs/server/node/remoteLicenseKey.ts
@@ -7,7 +7,7 @@ import { ServerParsedArgs } from './serverEnvironmentService.js';
 import * as fs from 'fs';
 import * as path from '../../base/common/path.js';
 import * as crypto from 'crypto';
-import { activateWithManager } from './licenseManager.js';
+import { activateWithManager, verifyLocalLicense } from './licenseManager.js';
 import { FileAccess } from '../../base/common/network.js';
 
 /**
@@ -126,6 +126,14 @@ export async function validateLicenseKey(connectionToken: string, args: ServerPa
 		if (fs.existsSync(storageLocation)) {
 			return validateLicenseFile(connectionToken, storageLocation);
 		}
+	}
+
+	// Check for a .lic file next to the license-manager binary.
+	const installPath = path.join(FileAccess.asFileUri('').fsPath, '..');
+	const localResult = await verifyLocalLicense(installPath);
+	if (localResult) {
+		console.log('Verified license from license-manager directory.');
+		return localResult;
 	}
 
 	// We need at least one license key to proceed.


### PR DESCRIPTION
If we can verify the license has already been initialized, we do not need to activate it. This should accompany a change in `jupyter-positron-server` docs that recommends placing the license in `positron/resources/activation/linux/{arch}/license.lic`.

We will rely on the behaviour when a license is next to the `license-manager`. This flow also avoids potentially moving the license into too-visible locations, like a root `.positron/` directory

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:jupyter @:workbench

These should pass successfully.
