### PR TITLE
Fix default URL fallback when app provides URL template

### DIFF
--- a/extensions/positron-run-app/src/api-utils.ts
+++ b/extensions/positron-run-app/src/api-utils.ts
@@ -156,10 +156,12 @@ export function extractAppUrlFromString(str: string, appUrlStrings?: string[]) {
 				return match[1];
 			}
 		}
+
+		return undefined;
 	}
 
-	// Fall back to the default URL regex if no appUrlStrings were provided or matched.
-	log.debug('No appUrlStrings matched. Falling back to default URL regex to match URL.');
+	// Fall back to the default URL regex only when no appUrlStrings were provided.
+	log.debug('No appUrlStrings provided. Falling back to default URL regex to match URL.');
 	return str.match(HTTP_URL_REGEX)?.[0];
 }
 

--- a/extensions/positron-run-app/src/test/extractAppUrlFromString.test.ts
+++ b/extensions/positron-run-app/src/test/extractAppUrlFromString.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { extractAppUrlFromString } from '../api-utils';
+
+suite('extractAppUrlFromString', () => {
+	test('matches all builtin app URL patterns', () => {
+		const cases: Array<{ name: string; output: string; patterns: string[]; expected: string }> = [
+			{
+				name: 'Shiny',
+				output: 'Listening on http://127.0.0.1:52464',
+				patterns: ['Listening on {{APP_URL}}'],
+				expected: 'http://127.0.0.1:52464',
+			},
+			{
+				name: 'Dash',
+				output: 'Dash is running on http://127.0.0.1:8050/',
+				patterns: ['Dash is running on {{APP_URL}}'],
+				expected: 'http://127.0.0.1:8050/',
+			},
+			{
+				name: 'FastAPI',
+				output: 'Uvicorn running on http://127.0.0.1:8000',
+				patterns: ['Uvicorn running on {{APP_URL}}'],
+				expected: 'http://127.0.0.1:8000',
+			},
+			{
+				name: 'Flask',
+				output: ' * Running on http://127.0.0.1:5000',
+				patterns: ['Running on {{APP_URL}}'],
+				expected: 'http://127.0.0.1:5000',
+			},
+			{
+				name: 'Gradio',
+				output: 'Running on local URL:  http://127.0.0.1:7860',
+				patterns: ['Running on local URL:  {{APP_URL}}', 'Running on public URL:  {{APP_URL}}'],
+				expected: 'http://127.0.0.1:7860',
+			},
+			{
+				name: 'Streamlit',
+				output: '  Local URL: http://localhost:8501',
+				patterns: ['Local URL: {{APP_URL}}'],
+				expected: 'http://localhost:8501',
+			},
+		];
+
+		for (const { name, output, patterns, expected } of cases) {
+			const result = extractAppUrlFromString(output, patterns);
+			assert.strictEqual(result, expected, `Failed for ${name}`);
+		}
+	});
+
+	// https://github.com/posit-dev/positron/issues/13229
+	test('does not match unrelated URLs when appUrlStrings are provided (#13229)', () => {
+		const result = extractAppUrlFromString(
+			'You can use shinyjs to call your own JavaScript functions:\n\thttps://deanattali.com/shinyjs/extend',
+			['Listening on {{APP_URL}}'],
+		);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('falls back to generic HTTP URL matching when no appUrlStrings provided', () => {
+		const result = extractAppUrlFromString('Server at http://127.0.0.1:8080');
+		assert.strictEqual(result, 'http://127.0.0.1:8080');
+	});
+
+	test('returns undefined when no URL present and no appUrlStrings', () => {
+		const result = extractAppUrlFromString('no urls here');
+		assert.strictEqual(result, undefined);
+	});
+});


### PR DESCRIPTION
Addresses https://github.com/posit-dev/positron/issues/13229

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fixed incorrect URL matching when starting a Shiny app (https://github.com/posit-dev/positron/issues/13229).


### QA Notes

We're no longer matching http URLs if an app provides a URL template. This means that if one of our builtin apps misspecified its template, it would still have worked by accident via the fallback. With the change in this PR, they would now be fully broken. None of our apps are relying on the fallback template, they all provide their own template:

| App | `appUrlStrings` |
|---|---|
| **Dash** | `['Dash is running on {{APP_URL}}']` |
| **FastAPI** | `['Uvicorn running on {{APP_URL}}']` |
| **Flask** | `['Running on {{APP_URL}}']` |
| **Gradio** | `['Running on local URL:  {{APP_URL}}', 'Running on public URL:  {{APP_URL}}']` |
| **Streamlit** | `['Local URL: {{APP_URL}}']` |
| **Shiny** (via shiny-vscode) | `['Listening on {{APP_URL}}']`

I'm not familiar with these Python apps so if you could double check these that would be great.

@:apps