### PR TITLE
feat(positron-notebook): visualize dataframe walkthrough

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/applyVisualizeResult.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/applyVisualizeResult.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CellKind } from '../../../../notebook/common/notebookCommon.js';
+import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
+import { PositronNotebookCodeCell } from '../../PositronNotebookCells/PositronNotebookCodeCell.js';
+import { CodeSnippet, codeSnippetToCellSource } from './generateVizCode.js';
+
+export type InsertMode = 'newCell' | 'append';
+
+/**
+ * Heuristic: returns true when every line of the import block already appears
+ * as its own line in the cell. Line-anchored to avoid matching a prefix of
+ * a longer import (e.g. `import pandas` should not match `import pandas as pd`).
+ * Misses formatting variations like `import x as y` vs `import x`; if a
+ * stricter check is needed, replace this with an AST-based pass.
+ */
+export function hasImportsVerbatim(existing: string, imports: string): boolean {
+	const existingLines = new Set(existing.split('\n').map(l => l.trim()).filter(Boolean));
+	const importLines = imports.split('\n').map(l => l.trim()).filter(Boolean);
+	return importLines.every(line => existingLines.has(line));
+}
+
+/**
+ * Build the text to append to an existing cell. Prepends the imports if they
+ * don't already appear verbatim, otherwise just adds the body.
+ */
+export function buildAppendText(existing: string, snippet: CodeSnippet): string {
+	if (hasImportsVerbatim(existing, snippet.imports)) {
+		return `\n\n${snippet.body}\n`;
+	}
+	return `\n\n${snippet.imports}\n\n${snippet.body}\n`;
+}
+
+/**
+ * Apply a visualize result to the source cell. Inserts a new code cell below
+ * the source cell, or appends the generated code to it, depending on the
+ * chosen mode.
+ */
+export async function applyVisualizeResult(
+	notebookInstance: IPositronNotebookInstance,
+	cell: PositronNotebookCodeCell,
+	snippet: CodeSnippet,
+	mode: InsertMode,
+): Promise<void> {
+	if (mode === 'newCell') {
+		notebookInstance.addCell(
+			CellKind.Code,
+			cell.index + 1,
+			false,
+			codeSnippetToCellSource(snippet),
+			cell.model.language,
+		);
+		return;
+	}
+
+	const textModel = await cell.getTextEditorModel();
+	const lineCount = textModel.getLineCount();
+	const endCol = textModel.getLineMaxColumn(lineCount);
+	const existing = textModel.getValue();
+	const toAppend = buildAppendText(existing, snippet);
+	// pushEditOperations (rather than applyEdits) so the user can Undo the
+	// append in a single step.
+	textModel.pushEditOperations(
+		null,
+		[{
+			range: {
+				startLineNumber: lineCount,
+				startColumn: endCol,
+				endLineNumber: lineCount,
+				endColumn: endCol,
+			},
+			text: toAppend,
+		}],
+		() => null,
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/generateVizCode.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/generateVizCode.ts
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export type VizLibrary = 'plotly' | 'matplotlib' | 'seaborn';
+export type ChartType = 'bar' | 'line' | 'scatter' | 'histogram';
+
+export interface VizAnswers {
+	library: VizLibrary;
+	chartType: ChartType;
+	dfName: string;
+	x: string;
+	y?: string;
+}
+
+export interface CodeSnippet {
+	imports: string;
+	body: string;
+}
+
+const SEABORN_FN: Record<ChartType, string> = {
+	bar: 'barplot',
+	line: 'lineplot',
+	scatter: 'scatterplot',
+	histogram: 'histplot',
+};
+
+const MATPLOTLIB_IMPORT = 'import matplotlib.pyplot as plt';
+
+/**
+ * Safely quote a string as a Python literal using double quotes.
+ * Escapes backslashes, double quotes, newlines, carriage returns, and tabs.
+ * Keeps the output compact and side-effect-free; the caller is responsible
+ * for passing a single column/value, not arbitrary untrusted text.
+ */
+export function pythonString(value: string): string {
+	const escaped = value
+		.replace(/\\/g, '\\\\')
+		.replace(/"/g, '\\"')
+		.replace(/\n/g, '\\n')
+		.replace(/\r/g, '\\r')
+		.replace(/\t/g, '\\t');
+	return `"${escaped}"`;
+}
+
+/**
+ * Check that a user-provided dataframe expression is safe to interpolate as a
+ * Python reference. Accepts bare identifiers and conservative dotted / bracketed
+ * access chains such as `df`, `self.data`, `frames["main"]`. Rejects anything
+ * with statement delimiters, spaces, or other syntax that would let arbitrary
+ * expressions through.
+ */
+export function isValidDataFrameExpr(expr: string): boolean {
+	const trimmed = expr.trim();
+	if (trimmed.length === 0) { return false; }
+	// Allow only: ident(.ident)* with optional ["literal"] / ['literal'] segments.
+	// The first segment must be a bare identifier; subsequent segments can be
+	// either .ident or a bracket-with-string-literal access.
+	// Identifier rules match Python: leading letter or underscore, then
+	// letters / digits / underscores.
+	const ident = String.raw`[A-Za-z_][A-Za-z0-9_]*`;
+	const bracket = String.raw`\["[^"\\\n]*"\]|\['[^'\\\n]*'\]`;
+	const pattern = new RegExp(`^${ident}(\\.${ident}|${bracket})*$`);
+	return pattern.test(trimmed);
+}
+
+export function generateVizCode(answers: VizAnswers): CodeSnippet {
+	const { library, chartType, dfName, x, y } = answers;
+	const xLit = pythonString(x);
+	const yLit = y ? pythonString(y) : undefined;
+	const xAccess = `${dfName}[${xLit}]`;
+	const yAccess = yLit ? `${dfName}[${yLit}]` : undefined;
+
+	if (library === 'plotly') {
+		const fn = chartType === 'histogram' ? 'histogram' : chartType;
+		const yArg = yLit ? `, y=${yLit}` : '';
+		return {
+			imports: `import plotly.express as px`,
+			body: `fig = px.${fn}(${dfName}, x=${xLit}${yArg})\nfig.show()`,
+		};
+	}
+
+	if (library === 'seaborn') {
+		const fn = SEABORN_FN[chartType];
+		const yArg = yLit ? `, y=${yLit}` : '';
+		return {
+			imports: `import seaborn as sns\n${MATPLOTLIB_IMPORT}`,
+			body: `sns.${fn}(data=${dfName}, x=${xLit}${yArg})\nplt.show()`,
+		};
+	}
+
+	// matplotlib
+	if (chartType === 'histogram') {
+		return {
+			imports: MATPLOTLIB_IMPORT,
+			body: `plt.hist(${xAccess})\nplt.xlabel(${xLit})\nplt.show()`,
+		};
+	}
+	if (chartType === 'bar') {
+		const yExpr = yAccess ?? `${xAccess}.value_counts().values`;
+		const xExpr = yAccess ? xAccess : `${xAccess}.value_counts().index`;
+		return {
+			imports: MATPLOTLIB_IMPORT,
+			body: `plt.bar(${xExpr}, ${yExpr})\nplt.xlabel(${xLit})${yLit ? `\nplt.ylabel(${yLit})` : ''}\nplt.show()`,
+		};
+	}
+	const plotFn = chartType === 'line' ? 'plot' : 'scatter';
+	const yExpr = yAccess ?? `${dfName}.index`;
+	return {
+		imports: MATPLOTLIB_IMPORT,
+		body: `plt.${plotFn}(${xAccess}, ${yExpr})\nplt.xlabel(${xLit})${yLit ? `\nplt.ylabel(${yLit})` : ''}\nplt.show()`,
+	};
+}
+
+export function codeSnippetToCellSource(snippet: CodeSnippet): string {
+	return `${snippet.imports}\n\n${snippet.body}\n`;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.css
@@ -1,0 +1,324 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.visualize-modal-content {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	min-height: 100%;
+}
+
+/* Step indicator */
+
+.visualize-step-indicator {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	padding: 4px 0 8px;
+}
+
+.visualize-step-dot {
+	width: 24px;
+	height: 4px;
+	border-radius: 2px;
+	background-color: var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+	transition: background-color 160ms ease, width 160ms ease;
+}
+
+.visualize-step-dot.completed {
+	background-color: var(--vscode-button-background);
+	opacity: 0.6;
+}
+
+.visualize-step-dot.active {
+	width: 40px;
+	background-color: var(--vscode-button-background);
+}
+
+/* Step body */
+
+.visualize-step-body {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+
+.visualize-step-title {
+	margin: 0;
+	font-size: 18px;
+	font-weight: 600;
+	line-height: 1.2;
+	color: var(--vscode-foreground);
+}
+
+.visualize-step-subtitle {
+	margin: 0;
+	font-size: 13px;
+	color: var(--vscode-descriptionForeground);
+	line-height: 1.45;
+}
+
+/* Suggestion banner */
+
+.visualize-suggestion-banner {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+	padding: 10px 12px;
+	border-radius: 6px;
+	border: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+	background-color: var(--vscode-editorWidget-background);
+	font-size: 12px;
+	line-height: 1.45;
+}
+
+.visualize-suggestion-banner.loading {
+	color: var(--vscode-descriptionForeground);
+	font-style: italic;
+}
+
+.visualize-suggestion-banner.failed {
+	color: var(--vscode-descriptionForeground);
+}
+
+.visualize-suggestion-banner.done {
+	border-color: var(--vscode-focusBorder);
+	background-color: var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground));
+	color: var(--vscode-list-activeSelectionForeground, var(--vscode-foreground));
+}
+
+.visualize-suggestion-banner > .codicon {
+	margin-top: 1px;
+	font-size: 14px !important;
+	flex-shrink: 0;
+}
+
+.visualize-suggestion-banner.done > .codicon {
+	color: var(--vscode-focusBorder);
+}
+
+.visualize-suggestion-banner-text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	flex: 1;
+	min-width: 0;
+}
+
+.visualize-suggestion-banner-label {
+	font-weight: 500;
+}
+
+.visualize-suggestion-banner-reason {
+	opacity: 0.85;
+}
+
+/* Choice grid */
+
+.visualize-choice-grid {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	grid-auto-rows: 1fr;
+	gap: 10px;
+}
+
+.visualize-choice-card {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 12px;
+	border-radius: 6px;
+	border: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+	background-color: var(--vscode-editorWidget-background);
+	color: var(--vscode-foreground);
+	cursor: pointer;
+	text-align: left;
+	transition: border-color 120ms ease, background-color 120ms ease, transform 120ms ease;
+}
+
+.visualize-choice-card:hover {
+	border-color: var(--vscode-focusBorder);
+	background-color: var(--vscode-list-hoverBackground);
+}
+
+.visualize-choice-card:focus-visible {
+	outline: 2px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
+.visualize-choice-card.selected {
+	border-color: var(--vscode-focusBorder);
+	background-color: var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground));
+	box-shadow: 0 0 0 1px var(--vscode-focusBorder) inset;
+}
+
+.visualize-choice-card.suggested {
+	border-color: var(--vscode-focusBorder);
+	box-shadow: 0 0 0 1px var(--vscode-focusBorder) inset;
+}
+
+.visualize-choice-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 3px;
+	margin-left: 6px;
+	padding: 1px 6px;
+	border-radius: 8px;
+	background-color: var(--vscode-focusBorder);
+	color: var(--vscode-editor-background);
+	font-size: 9.5px;
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	text-transform: uppercase;
+	vertical-align: middle;
+}
+
+.visualize-choice-badge .codicon {
+	font-size: 10px !important;
+}
+
+.visualize-choice-icon {
+	font-size: 22px !important;
+	color: var(--vscode-textLink-foreground);
+	flex-shrink: 0;
+}
+
+.visualize-choice-card.selected .visualize-choice-icon {
+	color: var(--vscode-focusBorder);
+}
+
+.visualize-choice-text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	flex: 1;
+	min-width: 0;
+}
+
+.visualize-choice-title {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+}
+
+.visualize-choice-description {
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+	line-height: 1.35;
+}
+
+/* Columns form */
+
+.visualize-columns-form {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.visualize-columns-form .labeled-text-input {
+	margin-bottom: 0;
+}
+
+/* Column picker */
+
+.visualize-column-picker {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.visualize-column-picker-label {
+	font-size: 12px;
+	color: var(--vscode-foreground);
+}
+
+/* Insert step */
+
+.visualize-code-preview {
+	margin: 0;
+	padding: 10px 12px;
+	border-radius: 6px;
+	background-color: var(--vscode-textCodeBlock-background, var(--vscode-editor-background));
+	border: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+	color: var(--vscode-editor-foreground);
+	font-family: var(--monaco-monospace-font);
+	font-size: 11.5px;
+	line-height: 1.45;
+	white-space: pre;
+	overflow: auto;
+	max-height: 160px;
+}
+
+.visualize-code-preview code {
+	font-family: inherit;
+	color: inherit;
+	background: transparent;
+}
+
+.visualize-insert-mode {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.visualize-insert-option {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 10px 12px;
+	border-radius: 6px;
+	border: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+	background-color: var(--vscode-editorWidget-background);
+	color: var(--vscode-foreground);
+	cursor: pointer;
+	text-align: left;
+	transition: border-color 120ms ease, background-color 120ms ease;
+}
+
+.visualize-insert-option:hover {
+	border-color: var(--vscode-focusBorder);
+	background-color: var(--vscode-list-hoverBackground);
+}
+
+.visualize-insert-option:focus-visible {
+	outline: 2px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
+.visualize-insert-option.selected {
+	border-color: var(--vscode-focusBorder);
+	background-color: var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground));
+	box-shadow: 0 0 0 1px var(--vscode-focusBorder) inset;
+}
+
+.visualize-insert-icon {
+	font-size: 18px !important;
+	color: var(--vscode-textLink-foreground);
+	flex-shrink: 0;
+}
+
+.visualize-insert-option.selected .visualize-insert-icon {
+	color: var(--vscode-focusBorder);
+}
+
+.visualize-insert-text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	flex: 1;
+	min-width: 0;
+}
+
+.visualize-insert-title {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+}
+
+.visualize-insert-description {
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
@@ -1,0 +1,640 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './visualizeModalDialog.css';
+
+// React.
+import { useEffect, useRef, useState } from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../../nls.js';
+import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
+import { PositronModalDialog } from '../../../../../browser/positronComponents/positronModalDialog/positronModalDialog.js';
+import { ContentArea } from '../../../../../browser/positronComponents/positronModalDialog/components/contentArea.js';
+import { LabeledTextInput } from '../../../../../browser/positronComponents/positronModalDialog/components/labeledTextInput.js';
+import { OKCancelBackNextActionBar } from '../../../../../browser/positronComponents/positronModalDialog/components/okCancelBackNextActionBar.js';
+import { DropDownListBox, DropDownListBoxEntry } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBox.js';
+import { DropDownListBoxItem } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBoxItem.js';
+import { DropDownListBoxSeparator } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBoxSeparator.js';
+import { positronClassNames } from '../../../../../../base/common/positronUtilities.js';
+import { ChartType, codeSnippetToCellSource, generateVizCode, isValidDataFrameExpr, VizAnswers, VizLibrary } from './generateVizCode.js';
+import { InsertMode } from './applyVisualizeResult.js';
+
+export type { InsertMode };
+
+export interface VisualizeResult {
+	answers: VizAnswers;
+	mode: InsertMode;
+}
+
+export interface DataFrameColumn {
+	name: string;
+	type: string;
+}
+
+/**
+ * IMPORTANT: This type is mirrored on the extension side in
+ *   extensions/positron-assistant/src/visualizationSuggestions.ts
+ * (as `VisualizationSuggestion`, with `VizLibrary` and `VizChartType`).
+ *
+ * The workbench cannot import from extensions, so drift is prevented by
+ * keeping the allow-list literals and field shape identical on both
+ * sides. `validateVisualizationSuggestion` below guards the IPC
+ * boundary as defence in depth. When adding a field or changing a
+ * literal, update BOTH.
+ *
+ * The producer that fills this in (the `suggestVisualization` command
+ * in `positron-assistant`) lands in a follow-up; this type, the
+ * validator, and `SuggestionBanner` are the dormant landing pad so the
+ * dialog can accept a `suggestionPromise` without retrofitting later.
+ */
+export interface VisualizationSuggestion {
+	library: VizLibrary;
+	chartType: ChartType;
+	xCol: string;
+	yCol: string | null;
+	reasoning: {
+		library: string;
+		chartType: string;
+		columns: string;
+	};
+	modelName?: string;
+}
+
+const VALID_LIBRARIES: ReadonlySet<string> = new Set(['plotly', 'matplotlib', 'seaborn']);
+const VALID_CHART_TYPES: ReadonlySet<string> = new Set(['bar', 'line', 'scatter', 'histogram']);
+
+/**
+ * Guard an unknown value crossing the extension/workbench IPC boundary into
+ * the strongly-typed VisualizationSuggestion shape. Returns null on any
+ * validation failure -- the extension-side parser is already the first line
+ * of defense; this is defence in depth so a bad model response can't throw
+ * inside React state updates.
+ */
+export function validateVisualizationSuggestion(value: unknown): VisualizationSuggestion | null {
+	if (!value || typeof value !== 'object') { return null; }
+	const s = value as Partial<Record<keyof VisualizationSuggestion, unknown>> & { reasoning?: unknown };
+	if (typeof s.library !== 'string' || !VALID_LIBRARIES.has(s.library)) { return null; }
+	if (typeof s.chartType !== 'string' || !VALID_CHART_TYPES.has(s.chartType)) { return null; }
+	if (typeof s.xCol !== 'string') { return null; }
+	if (s.yCol !== null && typeof s.yCol !== 'string') { return null; }
+	const r = s.reasoning;
+	if (!r || typeof r !== 'object') { return null; }
+	const rr = r as Record<string, unknown>;
+	if (typeof rr.library !== 'string' || typeof rr.chartType !== 'string' || typeof rr.columns !== 'string') {
+		return null;
+	}
+	return {
+		library: s.library as VizLibrary,
+		chartType: s.chartType as ChartType,
+		xCol: s.xCol,
+		yCol: s.yCol as string | null,
+		reasoning: { library: rr.library, chartType: rr.chartType, columns: rr.columns },
+		modelName: typeof s.modelName === 'string' ? s.modelName : undefined,
+	};
+}
+
+export const showVisualizeModalDialog = (
+	initialDfName: string,
+	columns: DataFrameColumn[] = [],
+	suggestionPromise?: Promise<VisualizationSuggestion | null>,
+): Promise<VisualizeResult | undefined> => {
+	return new Promise(resolve => {
+		const renderer = new PositronModalReactRenderer();
+		let resolved = false;
+		const finish = (r: VisualizeResult | undefined) => {
+			if (resolved) { return; }
+			resolved = true;
+			renderer.dispose();
+			resolve(r);
+		};
+		renderer.render(
+			<VisualizeModalDialog
+				columns={columns}
+				initialDfName={initialDfName}
+				renderer={renderer}
+				suggestionPromise={suggestionPromise}
+				onCancel={() => finish(undefined)}
+				onFinish={(r) => finish(r)}
+			/>
+		);
+	});
+};
+
+interface Props {
+	renderer: PositronModalReactRenderer;
+	initialDfName: string;
+	columns: DataFrameColumn[];
+	suggestionPromise?: Promise<VisualizationSuggestion | null>;
+	onCancel: () => void;
+	onFinish: (r: VisualizeResult) => void;
+}
+
+type Step = 'library' | 'chart' | 'columns' | 'insert';
+const STEP_ORDER: Step[] = ['library', 'chart', 'columns', 'insert'];
+
+interface Choice<T extends string> {
+	id: T;
+	title: string;
+	description: string;
+	icon: string;
+}
+
+const LIBRARY_CHOICES: Choice<VizLibrary>[] = [
+	{
+		id: 'plotly',
+		title: localize('positron.notebook.visualize.library.plotly.title', 'Plotly'),
+		description: localize('positron.notebook.visualize.library.plotly.description', 'Interactive charts, great for exploration'),
+		icon: 'codicon-preview',
+	},
+	{
+		id: 'matplotlib',
+		title: localize('positron.notebook.visualize.library.matplotlib.title', 'Matplotlib'),
+		description: localize('positron.notebook.visualize.library.matplotlib.description', 'Classic Python plotting, static output'),
+		icon: 'codicon-graph',
+	},
+	{
+		id: 'seaborn',
+		title: localize('positron.notebook.visualize.library.seaborn.title', 'Seaborn'),
+		description: localize('positron.notebook.visualize.library.seaborn.description', 'Statistical viz with nice defaults'),
+		icon: 'codicon-color-mode',
+	},
+];
+
+const CHART_CHOICES: Choice<ChartType>[] = [
+	{
+		id: 'bar',
+		title: localize('positron.notebook.visualize.chart.bar.title', 'Bar'),
+		description: localize('positron.notebook.visualize.chart.bar.description', 'Compare categories'),
+		icon: 'codicon-graph',
+	},
+	{
+		id: 'line',
+		title: localize('positron.notebook.visualize.chart.line.title', 'Line'),
+		description: localize('positron.notebook.visualize.chart.line.description', 'Trends over a series'),
+		icon: 'codicon-graph-line',
+	},
+	{
+		id: 'scatter',
+		title: localize('positron.notebook.visualize.chart.scatter.title', 'Scatter'),
+		description: localize('positron.notebook.visualize.chart.scatter.description', 'Relationships between two variables'),
+		icon: 'codicon-graph-scatter',
+	},
+	{
+		id: 'histogram',
+		title: localize('positron.notebook.visualize.chart.histogram.title', 'Histogram'),
+		description: localize('positron.notebook.visualize.chart.histogram.description', 'Distribution of one variable'),
+		icon: 'codicon-graph-left',
+	},
+];
+
+const VisualizeModalDialog = (props: Props) => {
+	const [step, setStep] = useState<Step>('library');
+	const [library, setLibrary] = useState<VizLibrary>('plotly');
+	const [chartType, setChartType] = useState<ChartType>('bar');
+	const [dfName, setDfName] = useState(props.initialDfName);
+	const [xCol, setXCol] = useState('');
+	const [yCol, setYCol] = useState('');
+	const [insertMode, setInsertMode] = useState<InsertMode>('newCell');
+
+	// Track whether the user has manually changed each field so we don't
+	// stomp on their choice when the LLM suggestion arrives.
+	const userEditedLibrary = useRef(false);
+	const userEditedChart = useRef(false);
+	const userEditedColumns = useRef(false);
+
+	const [suggestion, setSuggestion] = useState<VisualizationSuggestion | null>(null);
+	const [suggestionState, setSuggestionState] = useState<'idle' | 'loading' | 'done' | 'failed'>(
+		props.suggestionPromise ? 'loading' : 'idle'
+	);
+
+	useEffect(() => {
+		if (!props.suggestionPromise) { return; }
+		let cancelled = false;
+		props.suggestionPromise.then((s) => {
+			if (cancelled) { return; }
+			if (!s) {
+				setSuggestionState('failed');
+				return;
+			}
+			setSuggestion(s);
+			setSuggestionState('done');
+			if (!userEditedLibrary.current) { setLibrary(s.library); }
+			if (!userEditedChart.current) { setChartType(s.chartType); }
+			if (!userEditedColumns.current) {
+				setXCol(s.xCol);
+				setYCol(s.yCol ?? '');
+			}
+		}).catch(() => {
+			if (!cancelled) { setSuggestionState('failed'); }
+		});
+		return () => { cancelled = true; };
+	}, [props.suggestionPromise]);
+
+	const onLibraryChange = (v: VizLibrary) => { userEditedLibrary.current = true; setLibrary(v); };
+	const onChartChange = (v: ChartType) => { userEditedChart.current = true; setChartType(v); };
+	const onXChange = (v: string) => { userEditedColumns.current = true; setXCol(v); };
+	const onYChange = (v: string) => { userEditedColumns.current = true; setYCol(v); };
+
+	const currentIdx = STEP_ORDER.indexOf(step);
+	const goBack = () => currentIdx > 0 && setStep(STEP_ORDER[currentIdx - 1]);
+	const goNext = () => currentIdx < STEP_ORDER.length - 1 && setStep(STEP_ORDER[currentIdx + 1]);
+
+	const trimmedDfName = dfName.trim();
+	const dfNameValid = isValidDataFrameExpr(trimmedDfName);
+	const xColPresent = xCol.trim().length > 0;
+	const yColPresent = yCol.trim().length > 0;
+	const canAdvance = step === 'columns'
+		? xColPresent && dfNameValid
+		: true;
+
+	const answers: VizAnswers = {
+		library,
+		chartType,
+		dfName: trimmedDfName,
+		x: xCol,
+		y: chartType !== 'histogram' && yColPresent ? yCol : undefined,
+	};
+
+	const isLastStep = step === 'insert';
+	const canInsert = dfNameValid && xColPresent;
+	const onOk = () => {
+		if (!canInsert) { return; }
+		props.onFinish({ answers, mode: insertMode });
+	};
+
+	const advanceOrSubmit = () => {
+		if (isLastStep) { onOk(); return; }
+		if (canAdvance) { goNext(); }
+	};
+
+	const generatedSource = codeSnippetToCellSource(generateVizCode(answers));
+
+	return (
+		<PositronModalDialog
+			height={560}
+			renderer={props.renderer}
+			title={localize('positron.notebook.visualize.title', 'Visualize dataframe')}
+			width={900}
+			onCancel={props.onCancel}
+		>
+			<ContentArea>
+				<div className='visualize-modal-content'>
+					<StepIndicator currentIdx={currentIdx} total={STEP_ORDER.length} />
+
+					{step === 'library' && (
+						<StepBody
+							subtitle={localize('positron.notebook.visualize.step.library.subtitle', 'We will generate code using the library you pick.')}
+							title={localize('positron.notebook.visualize.step.library.title', 'Choose a plotting library')}
+						>
+							<SuggestionBanner
+								reasoning={suggestion?.reasoning.library}
+								state={suggestionState}
+								suggestedLabel={suggestion && LIBRARY_CHOICES.find(c => c.id === suggestion.library)?.title}
+							/>
+							<ChoiceGrid
+								choices={LIBRARY_CHOICES}
+								selectedId={library}
+								suggestedId={suggestion?.library}
+								onSelect={onLibraryChange}
+							/>
+						</StepBody>
+					)}
+
+					{step === 'chart' && (
+						<StepBody
+							subtitle={localize('positron.notebook.visualize.step.chart.subtitle', 'Pick the shape that best fits your data.')}
+							title={localize('positron.notebook.visualize.step.chart.title', 'What kind of chart?')}
+						>
+							<SuggestionBanner
+								reasoning={suggestion?.reasoning.chartType}
+								state={suggestionState}
+								suggestedLabel={suggestion && CHART_CHOICES.find(c => c.id === suggestion.chartType)?.title}
+							/>
+							<ChoiceGrid
+								choices={CHART_CHOICES}
+								selectedId={chartType}
+								suggestedId={suggestion?.chartType}
+								onSelect={onChartChange}
+							/>
+						</StepBody>
+					)}
+
+					{step === 'columns' && (
+						<StepBody
+							subtitle={props.columns.length
+								? localize('positron.notebook.visualize.step.columns.subtitle.withColumns', 'Pick columns from your dataframe.')
+								: localize('positron.notebook.visualize.step.columns.subtitle.noColumns', 'Enter column names from your dataframe.')}
+							title={localize('positron.notebook.visualize.step.columns.title', 'Map your columns')}
+						>
+							<SuggestionBanner
+								reasoning={suggestion?.reasoning.columns}
+								state={suggestionState}
+								suggestedLabel={suggestion
+									? `x: ${suggestion.xCol}${suggestion.yCol ? `, y: ${suggestion.yCol}` : ''}`
+									: undefined}
+							/>
+							<div className='visualize-columns-form'>
+								<LabeledTextInput
+									error={trimmedDfName.length > 0 && !dfNameValid}
+									errorMsg={trimmedDfName.length > 0 && !dfNameValid
+										? localize('positron.notebook.visualize.dfName.invalid', 'Must be a Python name like "df" or "self.data".')
+										: undefined}
+									label={localize('positron.notebook.visualize.dfName.label', 'DataFrame variable')}
+									value={dfName}
+									onChange={(e) => setDfName(e.target.value)}
+								/>
+								<ColumnPicker
+									autoFocus
+									columns={props.columns}
+									label={localize('positron.notebook.visualize.xColumn.label', 'X column')}
+									value={xCol}
+									onChange={onXChange}
+								/>
+								{chartType !== 'histogram' && (
+									<ColumnPicker
+										allowClear
+										columns={props.columns}
+										label={localize('positron.notebook.visualize.yColumn.label', 'Y column (optional)')}
+										value={yCol}
+										onChange={onYChange}
+									/>
+								)}
+							</div>
+						</StepBody>
+					)}
+
+					{step === 'insert' && (
+						<StepBody
+							subtitle={localize('positron.notebook.visualize.step.insert.subtitle', 'Review the code and choose where it should land.')}
+							title={localize('positron.notebook.visualize.step.insert.title', 'Ready to visualize')}
+						>
+							<CodePreview source={generatedSource} />
+							<div className='visualize-insert-mode'>
+								<InsertModeOption
+									description={localize('positron.notebook.visualize.insertMode.newCell.description', 'Keep your exploration cell unchanged.')}
+									icon='codicon-add'
+									selected={insertMode === 'newCell'}
+									title={localize('positron.notebook.visualize.insertMode.newCell.title', 'Insert as new cell below')}
+									onSelect={() => setInsertMode('newCell')}
+								/>
+								<InsertModeOption
+									description={localize('positron.notebook.visualize.insertMode.append.description', 'Add the plot to the end of the current cell.')}
+									icon='codicon-arrow-down'
+									selected={insertMode === 'append'}
+									title={localize('positron.notebook.visualize.insertMode.append.title', 'Append to this cell')}
+									onSelect={() => setInsertMode('append')}
+								/>
+							</div>
+						</StepBody>
+					)}
+				</div>
+			</ContentArea>
+
+			<OKCancelBackNextActionBar
+				backButtonConfig={{
+					disable: currentIdx === 0,
+					onClick: goBack,
+				}}
+				cancelButtonConfig={{ onClick: props.onCancel }}
+				nextButtonConfig={isLastStep ? undefined : {
+					disable: !canAdvance,
+					onClick: advanceOrSubmit,
+				}}
+				okButtonConfig={isLastStep ? {
+					title: localize('positron.notebook.visualize.insert', 'Insert'),
+					disable: !canInsert,
+					onClick: advanceOrSubmit,
+				} : undefined}
+			/>
+		</PositronModalDialog>
+	);
+};
+
+function StepIndicator({ currentIdx, total }: { currentIdx: number; total: number }) {
+	return (
+		<div aria-hidden className='visualize-step-indicator'>
+			{Array.from({ length: total }, (_, i) => (
+				<span
+					key={i}
+					className={positronClassNames('visualize-step-dot', {
+						active: i === currentIdx,
+						completed: i < currentIdx,
+					})}
+				/>
+			))}
+		</div>
+	);
+}
+
+function StepBody({ title, subtitle, children }: { title: string; subtitle: string; children: React.ReactNode }) {
+	return (
+		<div className='visualize-step-body'>
+			<h2 className='visualize-step-title'>{title}</h2>
+			<p className='visualize-step-subtitle'>{subtitle}</p>
+			{children}
+		</div>
+	);
+}
+
+function ChoiceGrid<T extends string>({ choices, selectedId, suggestedId, onSelect }: {
+	choices: Choice<T>[];
+	selectedId: T;
+	suggestedId?: T;
+	onSelect: (id: T) => void;
+}) {
+	return (
+		<div className='visualize-choice-grid'>
+			{choices.map((c) => {
+				const isSelected = c.id === selectedId;
+				const isSuggested = c.id === suggestedId;
+				return (
+					<button
+						key={c.id}
+						aria-pressed={isSelected}
+						className={positronClassNames('visualize-choice-card', {
+							selected: isSelected,
+							suggested: isSuggested && !isSelected,
+						})}
+						type='button'
+						onClick={() => onSelect(c.id)}
+					>
+						<span className={positronClassNames('visualize-choice-icon', 'codicon', c.icon)} />
+						<span className='visualize-choice-text'>
+							<span className='visualize-choice-title'>
+								{c.title}
+								{isSuggested && (
+									<span
+										className='visualize-choice-badge'
+										title={localize('positron.notebook.visualize.suggestion.badgeTooltip', 'Suggested by the assistant')}
+									>
+										<span className='codicon codicon-sparkle' />
+										{localize('positron.notebook.visualize.suggestion.badge', 'Suggested')}
+									</span>
+								)}
+							</span>
+							<span className='visualize-choice-description'>{c.description}</span>
+						</span>
+					</button>
+				);
+			})}
+		</div>
+	);
+}
+
+/**
+ * Status banner for the LLM suggestion path: idle/loading/done/failed.
+ * Mounted in this change but only ever sees `idle` because no
+ * `suggestionPromise` is supplied yet -- the producer lands in a
+ * follow-up.
+ */
+function SuggestionBanner({ state, reasoning, suggestedLabel }: {
+	state: 'idle' | 'loading' | 'done' | 'failed';
+	reasoning?: string;
+	suggestedLabel?: string | null;
+}) {
+	if (state === 'idle') { return null; }
+	if (state === 'loading') {
+		return (
+			<div className='visualize-suggestion-banner loading'>
+				<span className='codicon codicon-loading codicon-modifier-spin' />
+				<span>{localize('positron.notebook.visualize.suggestion.loading', 'Thinking about the best choice for your data...')}</span>
+			</div>
+		);
+	}
+	if (state === 'failed') {
+		return (
+			<div className='visualize-suggestion-banner failed'>
+				<span className='codicon codicon-info' />
+				<span>{localize('positron.notebook.visualize.suggestion.failed', 'Assistant suggestion unavailable. Pick manually below.')}</span>
+			</div>
+		);
+	}
+	if (!reasoning && !suggestedLabel) { return null; }
+	return (
+		<div className='visualize-suggestion-banner done'>
+			<span className='codicon codicon-sparkle' />
+			<div className='visualize-suggestion-banner-text'>
+				{suggestedLabel && (
+					<span className='visualize-suggestion-banner-label'>
+						{localize('positron.notebook.visualize.suggestion.suggestedPrefix', 'Suggested:')} <strong>{suggestedLabel}</strong>
+					</span>
+				)}
+				{reasoning && (
+					<span className='visualize-suggestion-banner-reason'>{reasoning}</span>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function InsertModeOption({ title, description, icon, selected, onSelect }: {
+	title: string;
+	description: string;
+	icon: string;
+	selected: boolean;
+	onSelect: () => void;
+}) {
+	return (
+		<button
+			aria-pressed={selected}
+			className={positronClassNames('visualize-insert-option', { selected })}
+			type='button'
+			onClick={onSelect}
+		>
+			<span className={positronClassNames('visualize-insert-icon', 'codicon', icon)} />
+			<span className='visualize-insert-text'>
+				<span className='visualize-insert-title'>{title}</span>
+				<span className='visualize-insert-description'>{description}</span>
+			</span>
+		</button>
+	);
+}
+
+function CodePreview({ source }: { source: string }) {
+	return (
+		<pre className='visualize-code-preview'>
+			<code>{source}</code>
+		</pre>
+	);
+}
+
+function ColumnPicker({ label, value, onChange, columns, autoFocus, allowClear }: {
+	label: string;
+	value: string;
+	onChange: (v: string) => void;
+	columns: DataFrameColumn[];
+	autoFocus?: boolean;
+	allowClear?: boolean;
+}) {
+	const hasColumns = columns.length > 0;
+
+	// Dropdown autoFocus: LabeledTextInput handles its own autoFocus via
+	// the native input attribute; DropDownListBox doesn't, so focus the
+	// button ourselves on mount.
+	const dropdownRef = useRef<HTMLButtonElement>(null);
+	const didAutoFocusRef = useRef(false);
+	useEffect(() => {
+		if (autoFocus && hasColumns && !didAutoFocusRef.current) {
+			dropdownRef.current?.focus();
+			didAutoFocusRef.current = true;
+		}
+	}, [autoFocus, hasColumns]);
+
+	// Fallback when the dataframe wasn't inspectable -- the dropdown would
+	// be empty, so let the user type a column name.
+	if (!hasColumns) {
+		return (
+			<LabeledTextInput
+				autoFocus={autoFocus}
+				label={label}
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+			/>
+		);
+	}
+
+	const entries: DropDownListBoxEntry<string, string>[] = columns.map(c =>
+		new DropDownListBoxItem<string, string>({
+			identifier: c.name,
+			title: `${c.name}   ${c.type}`,
+			value: c.name,
+		})
+	);
+	// Identify the "None" / clear entry by reference rather than by
+	// identifier string, so a column literally named (e.g.) "None" can't
+	// be misinterpreted as a clear action.
+	const clearEntry = allowClear
+		? new DropDownListBoxItem<string, string>({
+			identifier: '',
+			title: localize('positron.notebook.visualize.columnPicker.none', 'None'),
+			value: '',
+		})
+		: null;
+	if (clearEntry) {
+		entries.push(new DropDownListBoxSeparator());
+		entries.push(clearEntry);
+	}
+
+	return (
+		<div className='visualize-column-picker'>
+			<span className='visualize-column-picker-label'>{label}</span>
+			<DropDownListBox<string, string>
+				ref={dropdownRef}
+				entries={entries}
+				selectedIdentifier={value || undefined}
+				title={localize('positron.notebook.visualize.columnPicker.placeholder', 'Select a column')}
+				onSelectionChanged={(item) => {
+					if (item === clearEntry) {
+						onChange('');
+					} else {
+						onChange(item.options.value);
+					}
+				}}
+			/>
+		</div>
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DataExplorerCellOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/DataExplorerCellOutput.tsx
@@ -9,6 +9,7 @@ import React, { useState, useCallback } from 'react';
 // Other dependencies.
 import { IOutputItemDto } from '../../../notebook/common/notebookCommon.js';
 import { ParsedDataExplorerOutput } from '../PositronNotebookCells/IPositronNotebookCell.js';
+import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
 import { parseOutputData } from '../getOutputContents.js';
 import { renderHtml } from '../../../../../base/browser/positron/renderHtml.js';
 import { InlineDataExplorer } from './InlineDataExplorer.js';
@@ -20,9 +21,10 @@ import { POSITRON_NOTEBOOK_INLINE_DATA_EXPLORER_ENABLED_KEY } from '../../common
  * Wrapper component for data explorer outputs that handles fallback to HTML
  * when the data explorer comm is unavailable (e.g. after notebook reload).
  */
-export const DataExplorerCellOutput = React.memo(function DataExplorerCellOutput({ parsed, outputs }: {
+export const DataExplorerCellOutput = React.memo(function DataExplorerCellOutput({ parsed, outputs, cell }: {
 	parsed: ParsedDataExplorerOutput;
 	outputs: IOutputItemDto[];
+	cell?: PositronNotebookCodeCell;
 }) {
 	const services = PositronReactServices.services;
 	const enabled = services.configurationService.getValue<boolean>(
@@ -68,9 +70,10 @@ export const DataExplorerCellOutput = React.memo(function DataExplorerCellOutput
 		</div>;
 	}
 
-	return <InlineDataExplorer {...parsed} onFallback={handleFallback} />;
+	return <InlineDataExplorer {...parsed} cell={cell} onFallback={handleFallback} />;
 }, (prevProps, nextProps) => {
-	// Custom comparison: only rerender if commId changes or outputs change
+	// Custom comparison: only rerender if commId, outputs, or cell changes
 	return prevProps.parsed.commId === nextProps.parsed.commId &&
-		prevProps.outputs === nextProps.outputs;
+		prevProps.outputs === nextProps.outputs &&
+		prevProps.cell === nextProps.cell;
 });

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/InlineDataExplorer.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/InlineDataExplorer.css
@@ -32,6 +32,12 @@
 	gap: 8px;
 }
 
+.inline-data-explorer-header-actions {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
 .inline-data-explorer-title {
 	font-weight: 500;
 	color: var(--vscode-foreground);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/InlineDataExplorer.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/InlineDataExplorer.tsx
@@ -17,9 +17,13 @@ import { TableDataCache } from '../../../../services/positronDataExplorer/common
 import { PositronDataGrid } from '../../../../browser/positronDataGrid/positronDataGrid.js';
 import { ParsedDataExplorerOutput } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
-import { POSITRON_NOTEBOOK_INLINE_DATA_EXPLORER_MAX_HEIGHT_KEY } from '../../common/positronNotebookConfig.js';
+import { POSITRON_NOTEBOOK_EXPERIMENTAL_KEY, POSITRON_NOTEBOOK_INLINE_DATA_EXPLORER_MAX_HEIGHT_KEY } from '../../common/positronNotebookConfig.js';
 import { isMacintosh } from '../../../../../base/common/platform.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
+import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
+import { showVisualizeModalDialog } from '../contrib/visualize/visualizeModalDialog.js';
+import { generateVizCode, isValidDataFrameExpr } from '../contrib/visualize/generateVizCode.js';
+import { applyVisualizeResult } from '../contrib/visualize/applyVisualizeResult.js';
 
 // Height calculation constants (from inlineTableDataGridInstance.tsx constructor options)
 const HEADER_HEIGHT = 28;  // columnHeadersHeight
@@ -42,6 +46,8 @@ interface InlineDataExplorerProps extends ParsedDataExplorerOutput {
 	/** Called when the data explorer instance can't be found quickly, signaling
 	 *  the parent to render a fallback (e.g. HTML table) instead. */
 	onFallback?: () => void;
+	/** The cell this output belongs to. Used to wire up the Visualize button. */
+	cell?: PositronNotebookCodeCell;
 }
 
 /**
@@ -56,10 +62,11 @@ type InlineDataExplorerState =
 /**
  * InlineDataExplorerHeader component.
  */
-export function InlineDataExplorerHeader({ title, shape, onOpenInExplorer }: {
+export function InlineDataExplorerHeader({ title, shape, onOpenInExplorer, onVisualize }: {
 	title: string;
 	shape: { rows: number; columns: number };
 	onOpenInExplorer?: () => void;
+	onVisualize?: () => void;
 }) {
 	return (
 		<div className='inline-data-explorer-header'>
@@ -69,16 +76,29 @@ export function InlineDataExplorerHeader({ title, shape, onOpenInExplorer }: {
 					{shape.rows.toLocaleString()} {localize('rows', 'rows')} x {shape.columns.toLocaleString()} {localize('columns', 'columns')}
 				</span>
 			</div>
-			{onOpenInExplorer && (
-				<button
-					className='inline-data-explorer-open-button'
-					title={localize('openInDataExplorer', 'Open in Data Explorer')}
-					onClick={onOpenInExplorer}
-				>
-					<span className='codicon codicon-go-to-file' />
-					{localize('openInDataExplorer', 'Open in Data Explorer')}
-				</button>
-			)}
+			<div className='inline-data-explorer-header-actions'>
+				{onVisualize && (
+					<button
+						className='inline-data-explorer-open-button'
+						title={localize('positron.notebook.visualize.inlineButton', 'Visualize...')}
+						type='button'
+						onClick={onVisualize}
+					>
+						<span className='codicon codicon-graph' />
+						{localize('positron.notebook.visualize.inlineButton', 'Visualize...')}
+					</button>
+				)}
+				{onOpenInExplorer && (
+					<button
+						className='inline-data-explorer-open-button'
+						title={localize('openInDataExplorer', 'Open in Data Explorer')}
+						onClick={onOpenInExplorer}
+					>
+						<span className='codicon codicon-go-to-file' />
+						{localize('openInDataExplorer', 'Open in Data Explorer')}
+					</button>
+				)}
+			</div>
 		</div>
 	);
 }
@@ -89,10 +109,21 @@ export function InlineDataExplorerHeader({ title, shape, onOpenInExplorer }: {
  * Renders a simplified data explorer inline in notebook cell outputs.
  */
 export function InlineDataExplorer(props: InlineDataExplorerProps) {
-	const { commId, shape, title, variablePath, onFallback } = props;
+	const { commId, shape, title, variablePath, onFallback, cell } = props;
 	const services = PositronReactServices.services;
 	const notebookInstance = useNotebookInstance();
 	const [state, setState] = useState<InlineDataExplorerState>({ status: 'loading' });
+	const [experimentalEnabled, setExperimentalEnabled] = useState(() =>
+		services.configurationService.getValue<boolean>(POSITRON_NOTEBOOK_EXPERIMENTAL_KEY) ?? false
+	);
+
+	useEffect(() => {
+		const listener = services.configurationService.onDidChangeConfiguration(e => {
+			if (!e.affectsConfiguration(POSITRON_NOTEBOOK_EXPERIMENTAL_KEY)) { return; }
+			setExperimentalEnabled(services.configurationService.getValue<boolean>(POSITRON_NOTEBOOK_EXPERIMENTAL_KEY) ?? false);
+		});
+		return () => listener.dispose();
+	}, [services.configurationService]);
 	const containerRef = useRef<HTMLDivElement>(null);
 	// Don't create DisposableStore in useRef - it will leak on remount.
 	// The store is created in the effect below.
@@ -210,6 +241,31 @@ export function InlineDataExplorer(props: InlineDataExplorerProps) {
 		});
 	};
 
+	const handleVisualize = async () => {
+		try {
+			if (!cell) { return; }
+			const columns: { name: string; type: string }[] = [];
+			if (state.status === 'connected') {
+				for (let i = 0; i < state.gridInstance.columns; i++) {
+					const col = state.gridInstance.column(i);
+					if (col) {
+						columns.push({ name: col.name, type: col.description });
+					}
+				}
+			}
+
+			const initialDfName = variablePath && variablePath.length > 0 && isValidDataFrameExpr(title)
+				? title
+				: '';
+			const result = await showVisualizeModalDialog(initialDfName, columns);
+			if (!result) { return; }
+			const snippet = generateVizCode(result.answers);
+			await applyVisualizeResult(notebookInstance, cell, snippet, result.mode);
+		} catch (err) {
+			console.error('handleVisualize failed', err);
+		}
+	};
+
 	// Check if grid instance has become stale (no data but still "connected")
 	const isGridStale = state.status === 'connected' &&
 		(state.gridInstance.columns === 0 || state.gridInstance.rows === 0);
@@ -236,6 +292,7 @@ export function InlineDataExplorer(props: InlineDataExplorerProps) {
 				shape={shape}
 				title={title}
 				onOpenInExplorer={state.status === 'connected' && !isGridStale ? handleOpenInExplorer : undefined}
+				onVisualize={experimentalEnabled && state.status === 'connected' && !isGridStale && cell && cell.model.language === 'python' ? handleVisualize : undefined}
 			/>
 			<div className='inline-data-explorer-content' onKeyDownCapture={handleKeyDown}>
 				{state.status === 'loading' && (

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -232,6 +232,7 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 							>
 								<CellOutput
 									{...output}
+									cell={cell}
 									outputScrolling={outputScrolling}
 									onShowFullOutput={() => cell.showFullOutput()}
 								/>
@@ -293,6 +294,7 @@ export const NotebookCodeCell = React.memo(function NotebookCodeCell({ cell }: {
 interface CellOutputProps extends NotebookCellOutputs {
 	outputScrolling: boolean;
 	onShowFullOutput: () => void;
+	cell: PositronNotebookCodeCell;
 }
 
 const CellOutput = React.memo(function CellOutput(output: CellOutputProps) {
@@ -300,7 +302,7 @@ const CellOutput = React.memo(function CellOutput(output: CellOutputProps) {
 		return <PreloadMessageOutput preloadMessageResult={output.preloadMessageResult} />;
 	}
 
-	const { parsed, outputs, outputScrolling, onShowFullOutput } = output;
+	const { parsed, outputs, outputScrolling, onShowFullOutput, cell } = output;
 
 	if (isParsedTextOutput(parsed)) {
 		return <CellTextOutput
@@ -322,7 +324,7 @@ const CellOutput = React.memo(function CellOutput(output: CellOutputProps) {
 		case 'markdown':
 			return <Markdown content={parsed.content} />;
 		case 'dataExplorer':
-			return <DataExplorerCellOutput outputs={outputs} parsed={parsed} />;
+			return <DataExplorerCellOutput cell={cell} outputs={outputs} parsed={parsed} />;
 		case 'unknown':
 			return <div className='unknown-mime-type'>
 				{parsed.content}
@@ -332,7 +334,8 @@ const CellOutput = React.memo(function CellOutput(output: CellOutputProps) {
 	// Reference equality on parsed is correct - new execution creates new parsed objects
 	return prevProps.outputId === nextProps.outputId &&
 		prevProps.parsed === nextProps.parsed &&
-		prevProps.outputScrolling === nextProps.outputScrolling;
+		prevProps.outputScrolling === nextProps.outputScrolling &&
+		prevProps.cell === nextProps.cell;
 });
 
 const CollapsedOutputLabel = ({ onExpand }: { onExpand: () => void }) => {

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookConfig.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookConfig.ts
@@ -32,6 +32,9 @@ export const POSITRON_NOTEBOOK_INLINE_DATA_EXPLORER_ENABLED_KEY = 'positron.note
 // Configuration key for inline data explorer max height
 export const POSITRON_NOTEBOOK_INLINE_DATA_EXPLORER_MAX_HEIGHT_KEY = 'positron.notebook.inlineDataExplorer.maxHeight';
 
+// Configuration key that gates experimental Positron notebook features (Visualize dialog, etc.)
+export const POSITRON_NOTEBOOK_EXPERIMENTAL_KEY = 'positron.notebook.experimental';
+
 // Register the configuration setting
 const configurationRegistry = Registry.as<IConfigurationRegistry>(
 	Extensions.Configuration
@@ -108,6 +111,16 @@ configurationRegistry.registerConfiguration({
 				'positron.notebook.inlineDataExplorer.maxHeight',
 				'Maximum height in pixels for inline data explorers in notebook and Quarto outputs.'
 			),
+			scope: ConfigurationScope.WINDOW,
+		},
+		[POSITRON_NOTEBOOK_EXPERIMENTAL_KEY]: {
+			type: 'boolean',
+			default: false,
+			markdownDescription: localize(
+				'positron.notebook.experimental',
+				'Enable experimental Positron Notebook features. These features are under active development and may change without notice.'
+			),
+			tags: ['experimental'],
 			scope: ConfigurationScope.WINDOW,
 		},
 	},

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/applyVisualizeResult.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/applyVisualizeResult.vitest.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import {
+	buildAppendText,
+	hasImportsVerbatim,
+} from '../../../../browser/contrib/visualize/applyVisualizeResult.js';
+
+describe('applyVisualizeResult helpers', () => {
+	describe('hasImportsVerbatim', () => {
+		it('returns true when every import line appears as its own line in the cell', () => {
+			const existing = `import numpy as np\nimport pandas as pd\n\ndf = pd.read_csv("x.csv")\n`;
+			expect(hasImportsVerbatim(existing, 'import pandas as pd')).toBe(true);
+		});
+
+		it('returns true for a multi-line import block where every line matches', () => {
+			const existing = `import numpy as np\nimport pandas as pd\nimport plotly.express as px\n`;
+			expect(hasImportsVerbatim(existing, 'import pandas as pd\nimport plotly.express as px')).toBe(true);
+		});
+
+		it('returns false when the import line is only a prefix of an existing line', () => {
+			const existing = `import pandas as pd\n`;
+			expect(hasImportsVerbatim(existing, 'import pandas')).toBe(false);
+		});
+
+		it('returns false when the import block is absent', () => {
+			const existing = `import pandas as pd\n`;
+			expect(hasImportsVerbatim(existing, 'from pandas import DataFrame')).toBe(false);
+		});
+	});
+
+	describe('buildAppendText', () => {
+		const snippet = { imports: 'import plotly.express as px', body: 'fig = px.bar(df, x="a")\nfig.show()' };
+
+		it('prepends imports when not already present', () => {
+			const existing = `df = pd.DataFrame()\ndf`;
+			const appended = buildAppendText(existing, snippet);
+			expect(appended.startsWith('\n\nimport plotly.express as px')).toBe(true);
+			expect(appended).toContain('fig = px.bar(df, x="a")');
+		});
+
+		it('omits imports when already present verbatim', () => {
+			const existing = `import plotly.express as px\n\ndf`;
+			const appended = buildAppendText(existing, snippet);
+			expect(appended.includes('import plotly.express as px')).toBe(false);
+			expect(appended.startsWith('\n\nfig =')).toBe(true);
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/generateVizCode.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/generateVizCode.vitest.ts
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import {
+	codeSnippetToCellSource,
+	generateVizCode,
+	isValidDataFrameExpr,
+	pythonString,
+	VizAnswers,
+} from '../../../../browser/contrib/visualize/generateVizCode.js';
+
+describe('generateVizCode', () => {
+	describe('pythonString', () => {
+		it('wraps plain text in double quotes', () => {
+			expect(pythonString('price')).toBe('"price"');
+		});
+
+		it('escapes embedded double quotes', () => {
+			expect(pythonString(`customer's "price"`)).toBe(`"customer's \\"price\\""`);
+		});
+
+		it('escapes backslashes, newlines, tabs, and carriage returns', () => {
+			expect(pythonString('a\\b\nc\td\re')).toBe('"a\\\\b\\nc\\td\\re"');
+		});
+	});
+
+	describe('isValidDataFrameExpr', () => {
+		it('accepts bare identifiers', () => {
+			expect(isValidDataFrameExpr('df')).toBe(true);
+			expect(isValidDataFrameExpr('my_frame')).toBe(true);
+			expect(isValidDataFrameExpr('_DF')).toBe(true);
+		});
+
+		it('accepts dotted attribute paths', () => {
+			expect(isValidDataFrameExpr('self.data')).toBe(true);
+			expect(isValidDataFrameExpr('obj.nested.frame')).toBe(true);
+		});
+
+		it('accepts bracket access with string literal', () => {
+			expect(isValidDataFrameExpr('frames["main"]')).toBe(true);
+			expect(isValidDataFrameExpr(`frames['main']`)).toBe(true);
+		});
+
+		it('rejects invalid expressions', () => {
+			expect(isValidDataFrameExpr('1df')).toBe(false);
+			expect(isValidDataFrameExpr('df; import os')).toBe(false);
+			expect(isValidDataFrameExpr('df()')).toBe(false);
+			expect(isValidDataFrameExpr('df + 1')).toBe(false);
+			expect(isValidDataFrameExpr('')).toBe(false);
+			expect(isValidDataFrameExpr('   ')).toBe(false);
+			expect(isValidDataFrameExpr('df[0]')).toBe(false); // must be string literal, not int index
+		});
+	});
+
+	describe('library-specific templates', () => {
+		const base: VizAnswers = { library: 'plotly', chartType: 'bar', dfName: 'df', x: 'price', y: 'qty' };
+
+		it('plotly bar with x and y', () => {
+			const snippet = generateVizCode({ ...base, library: 'plotly', chartType: 'bar' });
+			expect(snippet.imports).toContain('plotly.express');
+			expect(snippet.body).toBe(`fig = px.bar(df, x="price", y="qty")\nfig.show()`);
+		});
+
+		it('plotly histogram includes y when provided', () => {
+			const snippet = generateVizCode({ ...base, library: 'plotly', chartType: 'histogram' });
+			expect(snippet.body).toBe(`fig = px.histogram(df, x="price", y="qty")\nfig.show()`);
+		});
+
+		it('seaborn uses an explicit chart-type function mapping', () => {
+			const hist = generateVizCode({ ...base, library: 'seaborn', chartType: 'histogram' });
+			expect(hist.body.startsWith('sns.histplot(')).toBe(true);
+			const scatter = generateVizCode({ ...base, library: 'seaborn', chartType: 'scatter' });
+			expect(scatter.body.startsWith('sns.scatterplot(')).toBe(true);
+		});
+
+		it('matplotlib bar with y uses explicit axes', () => {
+			const snippet = generateVizCode({ ...base, library: 'matplotlib', chartType: 'bar' });
+			expect(snippet.body).toContain(`plt.bar(df["price"], df["qty"])`);
+			expect(snippet.body).toContain('plt.xlabel("price")');
+			expect(snippet.body).toContain('plt.ylabel("qty")');
+		});
+
+		it('matplotlib bar without y uses value_counts()', () => {
+			const snippet = generateVizCode({ ...base, library: 'matplotlib', chartType: 'bar', y: undefined });
+			expect(snippet.body).toContain('value_counts().values');
+			expect(snippet.body).toContain('value_counts().index');
+		});
+
+		it('matplotlib scatter without y falls back to the index', () => {
+			const snippet = generateVizCode({ ...base, library: 'matplotlib', chartType: 'scatter', y: undefined });
+			expect(snippet.body).toContain(`plt.scatter(df["price"], df.index)`);
+		});
+
+		it('matplotlib histogram uses plt.hist', () => {
+			const snippet = generateVizCode({ ...base, library: 'matplotlib', chartType: 'histogram', y: undefined });
+			expect(snippet.body.startsWith('plt.hist(df["price"])')).toBe(true);
+		});
+	});
+
+	describe('column-name safety', () => {
+		it('quotes a column with a space', () => {
+			const snippet = generateVizCode({
+				library: 'plotly', chartType: 'bar', dfName: 'df', x: 'total sales', y: 'region',
+			});
+			expect(snippet.body).toContain(`x="total sales"`);
+			expect(snippet.body).toContain(`y="region"`);
+		});
+
+		it('escapes a column name with a quote', () => {
+			const snippet = generateVizCode({
+				library: 'matplotlib', chartType: 'histogram', dfName: 'df', x: `customer's "age"`,
+			});
+			expect(snippet.body).toContain(`df["customer's \\"age\\""]`);
+		});
+
+		it('supports dotted dataframe references', () => {
+			const snippet = generateVizCode({
+				library: 'plotly', chartType: 'bar', dfName: 'self.data', x: 'a', y: 'b',
+			});
+			expect(snippet.body).toContain(`px.bar(self.data, x="a", y="b")`);
+		});
+	});
+
+	describe('codeSnippetToCellSource', () => {
+		it('joins imports and body with a blank line and trailing newline', () => {
+			const result = codeSnippetToCellSource({ imports: 'import x', body: 'x.do()' });
+			expect(result).toBe('import x\n\nx.do()\n');
+		});
+	});
+});


### PR DESCRIPTION
Adds a four-step modal that turns an inline data-explorer view in a notebook into a plotting cell.

### Summary

The walkthrough has four steps:

1. **Library** -- Plotly, Matplotlib, or Seaborn
2. **Chart type** -- Bar, Line, Scatter, Histogram
3. **Columns** -- pick X (and Y where applicable) from the dataframe
4. **Insert mode** -- new cell after, or append to the current cell

Code generation produces a safe Python snippet per (library x chart) with `pythonString` escaping and a regex check on the dataframe expression. Cell insertion uses a single `pushEditOperations` edit so the whole insertion collapses under one undo step.

<img width="748" height="240" alt="image" src="https://github.com/user-attachments/assets/cde6f77a-242e-416a-9bbe-c492bb846a79" />


The Visualize button is gated behind `positron.notebook.experimental` (default `false`) and only appears when the cell is Python and the inline grid is connected.

https://github.com/user-attachments/assets/0514b00f-1f11-4425-9dc4-809657bdc52a




The dialog accepts an optional `suggestionPromise` and renders a `SuggestionBanner` for the LLM-suggestion path, but no producer is wired in this change. The producer (a `suggestVisualization` extension command) lands in a follow-up PR.

#### Tests

24 Vitest tests cover `generateVizCode` (per-library snippets, escaping, validation) and `applyVisualizeResult` (new-cell vs append modes, undo collapsing). The dialog component itself is intentionally untested at the RTL level in this PR -- its surface stabilizes once the suggestion and preview paths land.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:positron-notebooks @:data-explorer @:modal

To exercise the feature:

1. Enable `positron.notebook.experimental` in settings
2. Open a Positron notebook with a Python cell that produces a dataframe (e.g. `df = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})`)
3. Run the cell -- the inline data explorer renders below
4. Click the **Visualize...** button in the inline grid header
5. Walk through library -> chart -> columns -> insert mode
6. Confirm the dialog inserts a snippet (new cell or appended to the current cell)
7. Verify single undo collapses the entire insertion