### PR TITLE
feat(positron-assistant): suggestVisualization command

### DIFF
--- a/extensions/positron-assistant/src/asyncUtils.ts
+++ b/extensions/positron-assistant/src/asyncUtils.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as vscode from 'vscode';
+
+/**
+ * Returns true when `t` looks like a `vscode.CancellationToken` -- i.e. has
+ * a function-typed `onCancellationRequested` and a boolean-typed
+ * `isCancellationRequested`. Used to guard cross-boundary command args
+ * where serialization may strip method members or where untrusted callers
+ * may pass arbitrary shapes.
+ *
+ * Property reads are wrapped so an object with a throwing getter on either
+ * field returns `false` rather than propagating the throw -- the whole
+ * point of this helper is to make malformed inputs fail safely.
+ */
+export function isCancellationTokenLike(t: unknown): t is vscode.CancellationToken {
+	if (!t || typeof t !== 'object') { return false; }
+	try {
+		const candidate = t as Partial<vscode.CancellationToken>;
+		return typeof candidate.onCancellationRequested === 'function'
+			&& typeof candidate.isCancellationRequested === 'boolean';
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Race a promise against a timeout. Returns the promise result, or
+ * `undefined` if the timeout fires first. The timer is cleaned up
+ * internally. An optional `onTimeout` callback runs when the timeout fires.
+ *
+ * If the timeout wins and the input promise rejects later, the rejection is
+ * silently swallowed (so it does not surface as an unhandled rejection). If
+ * the input promise wins the race, the caller still observes its rejection
+ * normally.
+ */
+export async function raceTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+	onTimeout?: () => void,
+): Promise<T | undefined> {
+	// Attach a no-op handler so a late rejection (after the timeout has
+	// already won) does not become an unhandled rejection. The original
+	// promise's settlement is still observed by Promise.race below.
+	promise.catch(() => { });
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<undefined>(resolve => {
+				timer = setTimeout(() => {
+					onTimeout?.();
+					resolve(undefined);
+				}, timeoutMs);
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -16,6 +16,8 @@ import { registerCodeActionProvider } from './codeActions.js';
 import { generateCommitMessage } from './git.js';
 import { generateNotebookSuggestions, type NotebookSuggestionsResult } from './notebookSuggestions.js';
 import { generateGhostCellSuggestion, type GhostCellSuggestionResult } from './ghostCellSuggestions.js';
+import { generateVisualizationSuggestion, type VisualizationSuggestion } from './visualizationSuggestions.js';
+import { isCancellationTokenLike } from './asyncUtils.js';
 import { initializeTokenTracking } from './tokens.js';
 import { exportChatToUserSpecifiedLocation, exportChatToFileInWorkspace } from './export.js';
 import { registerParticipantDetectionProvider } from './participantDetection.js';
@@ -142,6 +144,48 @@ function registerGenerateGhostCellSuggestionCommand(
 				}
 			}
 		)
+	);
+}
+
+function registerSuggestVisualizationCommand(
+	context: vscode.ExtensionContext,
+	participantService: ParticipantService,
+	log: vscode.LogOutputChannel,
+) {
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'positron-assistant.suggestVisualization',
+			async (
+				notebookUri: string,
+				executedCellIndex: number,
+				dfName: string,
+				columns: { name: string; type: string }[],
+				token?: vscode.CancellationToken,
+			): Promise<VisualizationSuggestion | null> => {
+				// Guard the token: cross-boundary command marshalling is not
+				// guaranteed to preserve method members on CancellationToken,
+				// and external callers may pass anything. Fall back to a
+				// fresh CTS when the token is missing or malformed -- the
+				// caller loses the ability to cancel us, but we don't crash.
+				let tokenSource: vscode.CancellationTokenSource | undefined;
+				const cancellationToken = isCancellationTokenLike(token)
+					? token
+					: (tokenSource = new vscode.CancellationTokenSource()).token;
+				try {
+					return await generateVisualizationSuggestion(
+						notebookUri,
+						executedCellIndex,
+						dfName,
+						columns ?? [],
+						participantService,
+						log,
+						cancellationToken,
+					);
+				} finally {
+					tokenSource?.dispose();
+				}
+			},
+		),
 	);
 }
 
@@ -436,6 +480,7 @@ function registerAssistant(context: vscode.ExtensionContext) {
 	registerGenerateCommitMessageCommand(context, participantService, log);
 	registerGenerateNotebookSuggestionsCommand(context, participantService, log);
 	registerGenerateGhostCellSuggestionCommand(context, participantService, log);
+	registerSuggestVisualizationCommand(context, participantService, log);
 	registerExportChatCommands(context);
 	registerToggleInlineCompletionsCommand(context);
 	registerCollectDiagnosticsCommand(context);

--- a/extensions/positron-assistant/src/test/asyncUtils.test.ts
+++ b/extensions/positron-assistant/src/test/asyncUtils.test.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { isCancellationTokenLike, raceTimeout } from '../asyncUtils.js';
+
+suite('raceTimeout', () => {
+	test('returns the resolved value when the promise wins', async () => {
+		const result = await raceTimeout(Promise.resolve(42), 100);
+		assert.strictEqual(result, 42);
+	});
+
+	test('returns undefined when the timeout wins', async () => {
+		const slow = new Promise<number>(resolve => setTimeout(() => resolve(1), 100));
+		const result = await raceTimeout(slow, 10);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('propagates rejection when the promise rejects before the timeout', async () => {
+		const failed = Promise.reject(new Error('boom'));
+		await assert.rejects(() => raceTimeout(failed, 100), /boom/);
+	});
+
+	test('does not surface unhandled rejection when the promise rejects after the timeout', async () => {
+		// Capture unhandled rejections during this test only.
+		const seen: unknown[] = [];
+		const onUnhandled = (reason: unknown) => { seen.push(reason); };
+		process.on('unhandledRejection', onUnhandled);
+		try {
+			const lateFail = new Promise<number>((_resolve, reject) =>
+				setTimeout(() => reject(new Error('late')), 30));
+			const result = await raceTimeout(lateFail, 5);
+			assert.strictEqual(result, undefined);
+			// Wait past the rejection so the runtime has a chance to flag it.
+			await new Promise(r => setTimeout(r, 80));
+			assert.deepStrictEqual(seen, [], 'late rejection should be swallowed by raceTimeout');
+		} finally {
+			process.off('unhandledRejection', onUnhandled);
+		}
+	});
+
+	test('invokes onTimeout exactly once when the timeout wins', async () => {
+		let calls = 0;
+		const slow = new Promise<number>(resolve => setTimeout(() => resolve(1), 50));
+		await raceTimeout(slow, 10, () => { calls++; });
+		// Wait long enough that the slow promise has settled too.
+		await new Promise(r => setTimeout(r, 80));
+		assert.strictEqual(calls, 1);
+	});
+
+	test('does not invoke onTimeout when the promise wins', async () => {
+		let calls = 0;
+		await raceTimeout(Promise.resolve('ok'), 100, () => { calls++; });
+		assert.strictEqual(calls, 0);
+	});
+});
+
+suite('isCancellationTokenLike', () => {
+	test('accepts a well-formed token', () => {
+		const token = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose: () => { } }) };
+		assert.strictEqual(isCancellationTokenLike(token), true);
+	});
+
+	test('rejects undefined and null', () => {
+		assert.strictEqual(isCancellationTokenLike(undefined), false);
+		assert.strictEqual(isCancellationTokenLike(null), false);
+	});
+
+	test('rejects primitives', () => {
+		assert.strictEqual(isCancellationTokenLike(0), false);
+		assert.strictEqual(isCancellationTokenLike(''), false);
+		assert.strictEqual(isCancellationTokenLike(true), false);
+		assert.strictEqual(isCancellationTokenLike('token'), false);
+	});
+
+	test('rejects an object missing onCancellationRequested', () => {
+		assert.strictEqual(isCancellationTokenLike({ isCancellationRequested: false }), false);
+	});
+
+	test('rejects an object missing isCancellationRequested', () => {
+		assert.strictEqual(isCancellationTokenLike({ onCancellationRequested: () => ({ dispose: () => { } }) }), false);
+	});
+
+	test('rejects an object with the wrong field types', () => {
+		assert.strictEqual(isCancellationTokenLike({ isCancellationRequested: 'no', onCancellationRequested: 'no' }), false);
+	});
+
+	test('returns false (does not throw) when a getter throws', () => {
+		const trap = Object.defineProperty(
+			{ onCancellationRequested: () => ({ dispose: () => { } }) },
+			'isCancellationRequested',
+			{ get: () => { throw new Error('boom'); } },
+		);
+		assert.strictEqual(isCancellationTokenLike(trap), false);
+	});
+});

--- a/extensions/positron-assistant/src/test/visualizationSuggestions.test.ts
+++ b/extensions/positron-assistant/src/test/visualizationSuggestions.test.ts
@@ -1,0 +1,113 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { parseVizSuggestion } from '../visualizationSuggestions.js';
+
+function mockLog(): vscode.LogOutputChannel {
+	return {
+		debug: () => { },
+		info: () => { },
+		warn: () => { },
+		error: () => { },
+		trace: () => { },
+	} as unknown as vscode.LogOutputChannel;
+}
+
+const COLUMNS = [
+	{ name: 'price', type: 'float64' },
+	{ name: 'region', type: 'object' },
+];
+
+const VALID_JSON = JSON.stringify({
+	library: 'plotly',
+	chartType: 'bar',
+	xCol: 'region',
+	yCol: 'price',
+	reasoning: {
+		library: 'plotly imported in notebook',
+		chartType: 'categorical vs numeric',
+		columns: 'region (category) vs price (numeric)',
+	},
+});
+
+suite('parseVizSuggestion', () => {
+	const log = mockLog();
+
+	test('parses a well-formed JSON payload', () => {
+		const result = parseVizSuggestion(VALID_JSON, COLUMNS, log);
+		assert.ok(result);
+		assert.strictEqual(result.library, 'plotly');
+		assert.strictEqual(result.chartType, 'bar');
+		assert.strictEqual(result.xCol, 'region');
+		assert.strictEqual(result.yCol, 'price');
+		assert.strictEqual(result.reasoning.library, 'plotly imported in notebook');
+	});
+
+	test('strips ```json fences', () => {
+		const raw = '```json\n' + VALID_JSON + '\n```';
+		const result = parseVizSuggestion(raw, COLUMNS, log);
+		assert.ok(result);
+		assert.strictEqual(result.library, 'plotly');
+	});
+
+	test('ignores prose surrounding the JSON object', () => {
+		const raw = 'Sure, here is my suggestion:\n' + VALID_JSON + '\nHope that helps!';
+		const result = parseVizSuggestion(raw, COLUMNS, log);
+		assert.ok(result);
+		assert.strictEqual(result.chartType, 'bar');
+	});
+
+	test('returns empty reasoning strings when reasoning fields are missing', () => {
+		const raw = JSON.stringify({
+			library: 'matplotlib',
+			chartType: 'scatter',
+			xCol: 'price',
+			yCol: null,
+			reasoning: {},
+		});
+		const result = parseVizSuggestion(raw, COLUMNS, log);
+		assert.ok(result);
+		assert.strictEqual(result.reasoning.library, '');
+		assert.strictEqual(result.reasoning.chartType, '');
+		assert.strictEqual(result.reasoning.columns, '');
+	});
+
+	test('returns null for an unknown library', () => {
+		const raw = JSON.stringify({ ...JSON.parse(VALID_JSON), library: 'ggplot2' });
+		assert.strictEqual(parseVizSuggestion(raw, COLUMNS, log), null);
+	});
+
+	test('returns null for an unknown chart type', () => {
+		const raw = JSON.stringify({ ...JSON.parse(VALID_JSON), chartType: 'heatmap' });
+		assert.strictEqual(parseVizSuggestion(raw, COLUMNS, log), null);
+	});
+
+	test('falls back to first column when xCol is not in the provided list', () => {
+		const raw = JSON.stringify({ ...JSON.parse(VALID_JSON), xCol: 'nonexistent' });
+		const result = parseVizSuggestion(raw, COLUMNS, log);
+		assert.ok(result);
+		assert.strictEqual(result.xCol, 'price'); // first column name in COLUMNS
+	});
+
+	test('discards yCol that is not in the provided list', () => {
+		const raw = JSON.stringify({ ...JSON.parse(VALID_JSON), yCol: 'missing' });
+		const result = parseVizSuggestion(raw, COLUMNS, log);
+		assert.ok(result);
+		assert.strictEqual(result.yCol, null);
+	});
+
+	test('returns null for completely malformed input', () => {
+		assert.strictEqual(parseVizSuggestion('not json at all', COLUMNS, log), null);
+		assert.strictEqual(parseVizSuggestion('', COLUMNS, log), null);
+		assert.strictEqual(parseVizSuggestion('{', COLUMNS, log), null);
+	});
+
+	test('returns null when xCol is invalid and no columns are provided', () => {
+		const raw = JSON.stringify({ ...JSON.parse(VALID_JSON), xCol: 'nonexistent' });
+		assert.strictEqual(parseVizSuggestion(raw, [], log), null);
+	});
+});

--- a/extensions/positron-assistant/src/visualizationSuggestions.ts
+++ b/extensions/positron-assistant/src/visualizationSuggestions.ts
@@ -1,0 +1,346 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+
+import { ParticipantService } from './participants.js';
+import { isFileExcludedFromAI } from './fileExclusion.js';
+import { raceTimeout } from './asyncUtils.js';
+
+const MODEL_SELECTION_TIMEOUT_MS = 10_000;
+const GENERATION_TIMEOUT_MS = 30_000;
+
+/**
+ * IMPORTANT: `VisualizationSuggestion` is mirrored on the workbench side in
+ *   src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
+ *
+ * The two copies are not byte-identical -- the workbench imports `VizLibrary`
+ * and `ChartType` from `generateVizCode.js`, while this file declares
+ * `VizLibrary` and `VizChartType` locally. The allow-list literals and the
+ * field shape must stay identical on both sides; the workbench copy is
+ * validated at the IPC boundary as defence in depth. When adding a field
+ * or changing a literal, update BOTH.
+ */
+type VizLibrary = 'plotly' | 'matplotlib' | 'seaborn';
+type VizChartType = 'bar' | 'line' | 'scatter' | 'histogram';
+
+interface VizReasoning {
+	library: string;
+	chartType: string;
+	columns: string;
+}
+
+export interface VisualizationSuggestion {
+	library: VizLibrary;
+	chartType: VizChartType;
+	xCol: string;
+	yCol: string | null;
+	reasoning: VizReasoning;
+	modelName?: string;
+}
+
+interface InputColumn {
+	name: string;
+	type: string;
+}
+
+const SYSTEM_PROMPT = `You are a data visualization expert helping a user explore a dataframe inside a Positron notebook.
+
+The user is opening a "Visualize" wizard on a dataframe output in a Python notebook cell. V1 is Python-only -- do not suggest R, Julia, or any non-Python library. Based on:
+- the notebook code and output context
+- the dataframe's columns and dtypes
+- any imports already present in the notebook
+
+Suggest the most useful first visualization.
+
+Rules:
+1. Only Python plotting libraries are supported in V1: plotly, matplotlib, seaborn.
+2. Prefer a library that is ALREADY imported in the notebook. If none is imported, pick the most ergonomic one for the data shape.
+3. The chart type should suit the column dtypes (e.g. histogram for a single numeric column, scatter for two numerics, bar for a categorical vs numeric).
+4. Pick xCol (and yCol if appropriate) from the provided column list. For histograms, leave yCol as null.
+5. Keep each reasoning to one concise sentence that a user can scan in under two seconds. Reference concrete context ("the notebook already imports plotly.express", "uniform is numeric so a histogram shows its distribution").
+
+Return ONLY valid JSON matching this TypeScript type, with no prose or markdown fences:
+
+{
+\t"library": "plotly" | "matplotlib" | "seaborn",
+\t"chartType": "bar" | "line" | "scatter" | "histogram",
+\t"xCol": string,            // must be one of the provided column names
+\t"yCol": string | null,     // must be a column name or null
+\t"reasoning": {
+\t\t"library":   string,     // one sentence
+\t\t"chartType": string,     // one sentence
+\t\t"columns":   string      // one sentence
+\t}
+}`;
+
+export async function generateVisualizationSuggestion(
+	notebookUri: string,
+	executedCellIndex: number,
+	dfName: string,
+	columns: InputColumn[],
+	participantService: ParticipantService,
+	log: vscode.LogOutputChannel,
+	token: vscode.CancellationToken,
+): Promise<VisualizationSuggestion | null> {
+	const uri = vscode.Uri.parse(notebookUri);
+	const notebook = vscode.workspace.notebookDocuments.find(nb => nb.uri.toString() === uri.toString());
+	if (!notebook) {
+		log.warn('[viz-suggest] Notebook not found', notebookUri);
+		return null;
+	}
+	if (isFileExcludedFromAI(uri)) {
+		log.debug('[viz-suggest] Notebook excluded from AI features');
+		return null;
+	}
+	if (executedCellIndex < 0 || executedCellIndex >= notebook.cellCount) {
+		log.warn('[viz-suggest] Invalid cell index', executedCellIndex);
+		return null;
+	}
+
+	// V1 only supports Python. Bail out quietly for other languages so the
+	// dialog falls through to manual selection.
+	const cellLang = notebook.cellAt(executedCellIndex).document.languageId;
+	if (cellLang !== 'python') {
+		log.debug(`[viz-suggest] Skipping non-Python cell (language: ${cellLang})`);
+		return null;
+	}
+
+	const modelSelectionCts = new vscode.CancellationTokenSource();
+	const cancelListener = token.onCancellationRequested(() => modelSelectionCts.cancel());
+	let modelSelection: { model: vscode.LanguageModelChat } | null | undefined;
+	try {
+		modelSelection = await raceTimeout(
+			getModel(participantService, log, modelSelectionCts.token),
+			MODEL_SELECTION_TIMEOUT_MS,
+			() => modelSelectionCts.cancel(),
+		);
+	} finally {
+		cancelListener.dispose();
+		modelSelectionCts.dispose();
+	}
+	if (!modelSelection) {
+		log.warn('[viz-suggest] No language model available');
+		return null;
+	}
+	const { model } = modelSelection;
+
+	const contextMessage = buildContextMessage(notebook, executedCellIndex, dfName, columns);
+
+	const generationCts = new vscode.CancellationTokenSource();
+	const parentCancelListener = token.onCancellationRequested(() => generationCts.cancel());
+	// Guard the case where the parent token is already cancelled before the
+	// listener registered above could observe it.
+	if (token.isCancellationRequested) { generationCts.cancel(); }
+	try {
+		const messages = [
+			new vscode.LanguageModelChatMessage(vscode.LanguageModelChatMessageRole.System, SYSTEM_PROMPT),
+			vscode.LanguageModelChatMessage.User(contextMessage),
+		];
+		const fullText = await raceTimeout(
+			(async () => {
+				const response = await model.sendRequest(messages, {}, generationCts.token);
+				let out = '';
+				for await (const chunk of response.text) {
+					if (generationCts.token.isCancellationRequested) { return undefined; }
+					out += chunk;
+				}
+				return out;
+			})(),
+			GENERATION_TIMEOUT_MS,
+			() => generationCts.cancel(),
+		);
+		if (fullText === undefined || token.isCancellationRequested) {
+			log.warn('[viz-suggest] Generation did not complete (timeout or cancellation)');
+			return null;
+		}
+		const parsed = parseVizSuggestion(fullText, columns, log);
+		if (!parsed) { return null; }
+		parsed.modelName = model.name;
+		return parsed;
+	} catch (error) {
+		if (token.isCancellationRequested) { return null; }
+		log.error(`[viz-suggest] Error generating suggestion: ${error instanceof Error ? error.message : String(error)}`);
+		return null;
+	} finally {
+		parentCancelListener.dispose();
+		generationCts.dispose();
+	}
+}
+
+function buildContextMessage(
+	notebook: vscode.NotebookDocument,
+	executedCellIndex: number,
+	dfName: string,
+	columns: InputColumn[],
+): string {
+	const parts: string[] = [];
+	// User-controlled fields (dfName, column names, column types) are
+	// JSON-stringified so embedded newlines / quotes can't smuggle prompt
+	// instructions into the system. The parser allow-list (library / chart
+	// enums and column-name membership) is the authoritative trust boundary;
+	// this is defence in depth.
+	parts.push('## Dataframe');
+	parts.push(`- Variable: ${JSON.stringify(dfName)}`);
+	parts.push(`- Column count: ${columns.length}`);
+	if (columns.length) {
+		parts.push('- Columns:');
+		for (const c of columns) {
+			parts.push(`  - ${JSON.stringify(c.name)} (${JSON.stringify(c.type)})`);
+		}
+	}
+	parts.push('');
+
+	parts.push('## Just-executed cell');
+	const executedCell = notebook.cellAt(executedCellIndex);
+	parts.push('```' + executedCell.document.languageId);
+	parts.push(truncate(executedCell.document.getText(), 1000));
+	parts.push('```');
+	parts.push('');
+
+	const prevToInclude = Math.min(5, executedCellIndex);
+	if (prevToInclude > 0) {
+		parts.push(`## Previous cells (last ${prevToInclude}, for library / import context)`);
+		for (let i = executedCellIndex - prevToInclude; i < executedCellIndex; i++) {
+			const cell = notebook.cellAt(i);
+			if (cell.kind !== vscode.NotebookCellKind.Code) { continue; }
+			parts.push(`Cell ${i + 1}:`);
+			parts.push('```' + cell.document.languageId);
+			parts.push(truncate(cell.document.getText(), 400));
+			parts.push('```');
+		}
+		parts.push('');
+	}
+
+	parts.push('Return the JSON now. Do not wrap it in markdown or add commentary.');
+	return parts.join('\n');
+}
+
+function truncate(text: string, max: number): string {
+	if (text.length <= max) { return text; }
+	return text.substring(0, max) + '...';
+}
+
+export function parseVizSuggestion(
+	raw: string,
+	columns: InputColumn[],
+	log: vscode.LogOutputChannel,
+): VisualizationSuggestion | null {
+	// Strip code fences if the model added them.
+	const cleaned = raw
+		.trim()
+		.replace(/^```(?:json)?\s*/i, '')
+		.replace(/```\s*$/, '')
+		.trim();
+
+	// Extract first {...} block if the model wrapped it with prose.
+	const firstBrace = cleaned.indexOf('{');
+	const lastBrace = cleaned.lastIndexOf('}');
+	if (firstBrace === -1 || lastBrace === -1 || lastBrace < firstBrace) {
+		log.warn('[viz-suggest] No JSON object found in response');
+		return null;
+	}
+	const jsonText = cleaned.substring(firstBrace, lastBrace + 1);
+
+	let obj: unknown;
+	try {
+		obj = JSON.parse(jsonText);
+	} catch (err) {
+		log.warn(`[viz-suggest] Failed to parse JSON: ${err instanceof Error ? err.message : String(err)}`);
+		return null;
+	}
+
+	if (typeof obj !== 'object' || obj === null) { return null; }
+	const o = obj as Record<string, unknown>;
+
+	const library = coerceLibrary(o.library);
+	const chartType = coerceChartType(o.chartType);
+	if (!library || !chartType) {
+		log.warn('[viz-suggest] Invalid library or chartType in response');
+		return null;
+	}
+
+	const columnNames = new Set(columns.map(c => c.name));
+	const xColRaw = typeof o.xCol === 'string' ? o.xCol : '';
+	const yColRaw = typeof o.yCol === 'string' ? o.yCol : null;
+
+	let xCol: string;
+	if (columnNames.has(xColRaw)) {
+		xCol = xColRaw;
+	} else if (columns.length > 0) {
+		xCol = columns[0].name;
+	} else {
+		log.warn('[viz-suggest] Rejecting suggestion: no valid xCol and no columns to fall back to');
+		return null;
+	}
+	const yCol = yColRaw && columnNames.has(yColRaw) ? yColRaw : null;
+
+	const reasoningObj = (typeof o.reasoning === 'object' && o.reasoning !== null)
+		? o.reasoning as Record<string, unknown>
+		: {};
+	const reasoning: VizReasoning = {
+		library: typeof reasoningObj.library === 'string' ? reasoningObj.library : '',
+		chartType: typeof reasoningObj.chartType === 'string' ? reasoningObj.chartType : '',
+		columns: typeof reasoningObj.columns === 'string' ? reasoningObj.columns : '',
+	};
+
+	return { library, chartType, xCol, yCol, reasoning };
+}
+
+function coerceLibrary(v: unknown): VizLibrary | null {
+	return v === 'plotly' || v === 'matplotlib' || v === 'seaborn' ? v : null;
+}
+
+function coerceChartType(v: unknown): VizChartType | null {
+	return v === 'bar' || v === 'line' || v === 'scatter' || v === 'histogram' ? v : null;
+}
+
+interface ModelSelectionResult {
+	model: vscode.LanguageModelChat;
+}
+
+// Simplified version of the model selection used by ghost cells. Ghost
+// cells can be disabled per-model via user configuration (because they
+// fire on every edit). Visualize is user-initiated, so it ignores that
+// allow/deny list and uses whichever model the user currently has
+// selected, falling back to the default provider.
+async function getModel(
+	participantService: ParticipantService,
+	log: vscode.LogOutputChannel,
+	token: vscode.CancellationToken,
+): Promise<ModelSelectionResult | null> {
+	const sessionModelId = participantService.getCurrentSessionModel();
+	if (sessionModelId) {
+		const models = await vscode.lm.selectChatModels({ id: sessionModelId });
+		if (token.isCancellationRequested) { return null; }
+		if (models && models.length > 0) {
+			log.debug(`[viz-suggest] Using session model: ${models[0].name}`);
+			return { model: models[0] };
+		}
+	}
+
+	if (token.isCancellationRequested) { return null; }
+	const currentProvider = await positron.ai.getCurrentProvider();
+	if (token.isCancellationRequested) { return null; }
+	if (currentProvider) {
+		const models = await vscode.lm.selectChatModels({ vendor: currentProvider.id });
+		if (token.isCancellationRequested) { return null; }
+		if (models && models.length > 0) {
+			log.debug(`[viz-suggest] Using provider model: ${models[0].name}`);
+			return { model: models[0] };
+		}
+	}
+
+	if (token.isCancellationRequested) { return null; }
+	const [firstModel] = await vscode.lm.selectChatModels();
+	if (token.isCancellationRequested) { return null; }
+	if (firstModel) {
+		log.debug(`[viz-suggest] Using fallback model: ${firstModel.name}`);
+		return { model: firstModel };
+	}
+
+	return null;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/InlineDataExplorer.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/InlineDataExplorer.tsx
@@ -21,7 +21,8 @@ import { POSITRON_NOTEBOOK_EXPERIMENTAL_KEY, POSITRON_NOTEBOOK_INLINE_DATA_EXPLO
 import { isMacintosh } from '../../../../../base/common/platform.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
-import { showVisualizeModalDialog } from '../contrib/visualize/visualizeModalDialog.js';
+import { showVisualizeModalDialog, validateVisualizationSuggestion } from '../contrib/visualize/visualizeModalDialog.js';
+import { CancellationTokenSource } from '../../../../../base/common/cancellation.js';
 import { generateVizCode, isValidDataFrameExpr } from '../contrib/visualize/generateVizCode.js';
 import { applyVisualizeResult } from '../contrib/visualize/applyVisualizeResult.js';
 
@@ -257,10 +258,33 @@ export function InlineDataExplorer(props: InlineDataExplorerProps) {
 			const initialDfName = variablePath && variablePath.length > 0 && isValidDataFrameExpr(title)
 				? title
 				: '';
-			const result = await showVisualizeModalDialog(initialDfName, columns);
-			if (!result) { return; }
-			const snippet = generateVizCode(result.answers);
-			await applyVisualizeResult(notebookInstance, cell, snippet, result.mode);
+			// Fire the LLM suggestion request in parallel with the dialog so the
+			// user sees it populate without having to wait. Cancels if the dialog
+			// closes before the request resolves. Positional args match the
+			// `positron-assistant.suggestVisualization` command signature, with
+			// the cancellation token as the trailing optional arg.
+			const suggestionCts = new CancellationTokenSource();
+			try {
+				const suggestionPromise = services.commandService
+					.executeCommand<unknown>(
+						'positron-assistant.suggestVisualization',
+						notebookInstance.uri.toString(),
+						cell.index,
+						initialDfName,
+						columns,
+						suggestionCts.token,
+					)
+					.then((r) => validateVisualizationSuggestion(r))
+					.catch(() => null);
+
+				const result = await showVisualizeModalDialog(initialDfName, columns, suggestionPromise);
+				if (!result) { return; }
+				const snippet = generateVizCode(result.answers);
+				await applyVisualizeResult(notebookInstance, cell, snippet, result.mode);
+			} finally {
+				suggestionCts.cancel();
+				suggestionCts.dispose();
+			}
 		} catch (err) {
 			console.error('handleVisualize failed', err);
 		}


### PR DESCRIPTION
Builds on #13235. Wires the LLM-backed suggestion path into the visualize dialog.

### Summary


https://github.com/user-attachments/assets/e899fd93-0e46-42f5-985f-d4ec36d08b91



The notebook fires a `positron-assistant.suggestVisualization` request in parallel with opening the dialog. The extension calls the active assistant model with the dataframe shape, parses the response into a `VisualizationSuggestion`, and resolves the dialog's `suggestionPromise`. On success the dialog pre-fills library/chart/columns and shows the model's reasoning; on failure or cancellation the banner stays in `idle`.

A `CancellationTokenSource` wraps the request -- closing the dialog cancels the in-flight model call. The `isCancellationTokenLike` helper guards against malformed tokens crossing the IPC boundary.

#### Tests

Mocha unit tests cover `parseVizSuggestion` (per-shape outputs, malformed inputs, schema drift) and `asyncUtils` (`raceTimeout`, `isCancellationTokenLike`).

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:positron-notebooks @:assistant @:modal

Requires #13235. Steps:

1. Enable `positron.notebook.experimental` in settings
2. Configure an assistant model (any provider that supports the active session)
3. Open a Positron notebook, run a cell that produces a dataframe
4. Click **Visualize...** on the inline data explorer
5. While the model is working, the suggestion banner shows "Thinking about the best choice for your data..."
6. Once it resolves, the banner shows the model's recommended library, chart, and columns; fields pre-fill
7. Close the dialog mid-request and verify no console spam (cancellation works)