### PR TITLE
feat(positron-notebook): live chart preview in visualize dialog

### DIFF
--- a/src/vs/base/browser/positronReactServices.tsx
+++ b/src/vs/base/browser/positronReactServices.tsx
@@ -29,6 +29,7 @@ import { IContextMenuService } from '../../platform/contextview/browser/contextV
 import { IEditorService } from '../../workbench/services/editor/common/editorService.js';
 import { INotificationService } from '../../platform/notification/common/notification.js';
 import { IConfigurationService } from '../../platform/configuration/common/configuration.js';
+import { IStorageService } from '../../platform/storage/common/storage.js';
 import { IAccessibilityService } from '../../platform/accessibility/common/accessibility.js';
 import { IInstantiationService, ServiceIdentifier } from '../../platform/instantiation/common/instantiation.js';
 import { ILanguageModelsService } from '../../workbench/contrib/chat/common/languageModels.js';
@@ -134,6 +135,7 @@ export class PositronReactServices {
 		@IQuickInputService public readonly quickInputService: IQuickInputService,
 		@IRuntimeSessionService public readonly runtimeSessionService: IRuntimeSessionService,
 		@IRuntimeStartupService public readonly runtimeStartupService: IRuntimeStartupService,
+		@IStorageService public readonly storageService: IStorageService,
 		@ITerminalService public readonly terminalService: ITerminalService,
 		@ITextModelService public readonly textModelService: ITextModelService,
 		@IThemeService public readonly themeService: IThemeService,

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.css
@@ -3,11 +3,214 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+.visualize-split {
+	display: flex;
+	gap: 18px;
+	min-height: 100%;
+	align-items: stretch;
+}
+
+.visualize-split > .visualize-modal-content {
+	flex: 1 1 420px;
+	min-width: 0;
+}
+
+.visualize-split-preview {
+	flex: 1 1 420px;
+	min-width: 0;
+	display: flex;
+}
+
 .visualize-modal-content {
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
 	min-height: 100%;
+}
+
+/* Live preview panel */
+
+.visualize-preview {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
+	min-width: 0;
+	border-radius: 6px;
+	border: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+	background-color: var(--vscode-editorWidget-background);
+	overflow: hidden;
+}
+
+.visualize-preview-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 12px;
+	border-bottom: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+	color: var(--vscode-descriptionForeground);
+	font-size: 11px;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	font-weight: 600;
+	background-color: var(--vscode-editorWidget-background);
+	flex-shrink: 0;
+}
+
+.visualize-preview-header-title {
+	flex: 1;
+}
+
+.visualize-preview-header > .codicon {
+	font-size: 14px !important;
+	color: var(--vscode-textLink-foreground);
+}
+
+/* Toggle switch */
+
+.visualize-preview-toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 2px 6px 2px 4px;
+	border: none;
+	border-radius: 999px;
+	background: transparent;
+	color: var(--vscode-descriptionForeground);
+	font-size: 10.5px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	cursor: pointer;
+	transition: color 100ms ease;
+}
+
+.visualize-preview-toggle:hover {
+	color: var(--vscode-foreground);
+}
+
+.visualize-preview-toggle:focus-visible {
+	outline: 2px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
+.visualize-preview-toggle-track {
+	position: relative;
+	width: 26px;
+	height: 14px;
+	border-radius: 999px;
+	background: var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.4));
+	transition: background-color 160ms ease;
+}
+
+.visualize-preview-toggle.on .visualize-preview-toggle-track {
+	background: var(--vscode-focusBorder);
+}
+
+.visualize-preview-toggle-thumb {
+	position: absolute;
+	top: 2px;
+	left: 2px;
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	background: var(--vscode-editor-background, white);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+	transition: transform 160ms ease;
+}
+
+.visualize-preview-toggle.on .visualize-preview-toggle-thumb {
+	transform: translateX(12px);
+}
+
+.visualize-preview-toggle.on {
+	color: var(--vscode-foreground);
+}
+
+.visualize-preview-body {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 12px;
+	background-color: var(--vscode-editor-background);
+	overflow: hidden;
+}
+
+.visualize-preview-iframe {
+	width: 100%;
+	max-width: 100%;
+	height: 100%;
+	border: none;
+	background: white;
+	border-radius: 4px;
+}
+
+.visualize-preview-image {
+	max-width: 100%;
+	max-height: 100%;
+	object-fit: contain;
+}
+
+.visualize-preview-message {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 6px;
+	padding: 16px;
+	text-align: center;
+	color: var(--vscode-descriptionForeground);
+}
+
+.visualize-preview-message.error {
+	color: var(--vscode-errorForeground);
+}
+
+.visualize-preview-message-icon {
+	font-size: 20px !important;
+	opacity: 0.8;
+}
+
+.visualize-preview-message-title {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+}
+
+.visualize-preview-message.error .visualize-preview-message-title {
+	color: var(--vscode-errorForeground);
+}
+
+.visualize-preview-message-hint {
+	font-size: 11.5px;
+	line-height: 1.45;
+	max-width: 280px;
+	font-family: var(--monaco-monospace-font);
+	color: inherit;
+	opacity: 0.9;
+	word-break: break-word;
+}
+
+.visualize-preview-message-action {
+	margin-top: 8px;
+	padding: 4px 12px;
+	border-radius: 4px;
+	border: 1px solid var(--vscode-focusBorder);
+	background: transparent;
+	color: var(--vscode-foreground);
+	font-family: inherit;
+	font-size: 11.5px;
+	cursor: pointer;
+}
+
+.visualize-preview-message-action:hover {
+	background: var(--vscode-list-hoverBackground);
+}
+
+.visualize-preview-message-action:focus-visible {
+	outline: 2px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
 }
 
 /* Step indicator */

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
@@ -20,8 +20,10 @@ import { DropDownListBox, DropDownListBoxEntry } from '../../../../../browser/po
 import { DropDownListBoxItem } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBoxItem.js';
 import { DropDownListBoxSeparator } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBoxSeparator.js';
 import { positronClassNames } from '../../../../../../base/common/positronUtilities.js';
+import { URI } from '../../../../../../base/common/uri.js';
 import { ChartType, codeSnippetToCellSource, generateVizCode, isValidDataFrameExpr, VizAnswers, VizLibrary } from './generateVizCode.js';
 import { InsertMode } from './applyVisualizeResult.js';
+import { VisualizePreview } from './visualizePreview.js';
 
 export type { InsertMode };
 
@@ -101,6 +103,7 @@ export const showVisualizeModalDialog = (
 	initialDfName: string,
 	columns: DataFrameColumn[] = [],
 	suggestionPromise?: Promise<VisualizationSuggestion | null>,
+	notebookUri?: URI,
 ): Promise<VisualizeResult | undefined> => {
 	return new Promise(resolve => {
 		const renderer = new PositronModalReactRenderer();
@@ -115,6 +118,7 @@ export const showVisualizeModalDialog = (
 			<VisualizeModalDialog
 				columns={columns}
 				initialDfName={initialDfName}
+				notebookUri={notebookUri}
 				renderer={renderer}
 				suggestionPromise={suggestionPromise}
 				onCancel={() => finish(undefined)}
@@ -128,6 +132,7 @@ interface Props {
 	renderer: PositronModalReactRenderer;
 	initialDfName: string;
 	columns: DataFrameColumn[];
+	notebookUri?: URI;
 	suggestionPromise?: Promise<VisualizationSuggestion | null>;
 	onCancel: () => void;
 	onFinish: (r: VisualizeResult) => void;
@@ -272,6 +277,7 @@ const VisualizeModalDialog = (props: Props) => {
 	};
 
 	const generatedSource = codeSnippetToCellSource(generateVizCode(answers));
+	const previewReady = answers.x.trim().length > 0;
 
 	return (
 		<PositronModalDialog
@@ -282,114 +288,124 @@ const VisualizeModalDialog = (props: Props) => {
 			onCancel={props.onCancel}
 		>
 			<ContentArea>
-				<div className='visualize-modal-content'>
-					<StepIndicator currentIdx={currentIdx} total={STEP_ORDER.length} />
+				<div className='visualize-split'>
+					<div className='visualize-modal-content'>
+						<StepIndicator currentIdx={currentIdx} total={STEP_ORDER.length} />
 
-					{step === 'library' && (
-						<StepBody
-							subtitle={localize('positron.notebook.visualize.step.library.subtitle', 'We will generate code using the library you pick.')}
-							title={localize('positron.notebook.visualize.step.library.title', 'Choose a plotting library')}
-						>
-							<SuggestionBanner
-								reasoning={suggestion?.reasoning.library}
-								state={suggestionState}
-								suggestedLabel={suggestion && LIBRARY_CHOICES.find(c => c.id === suggestion.library)?.title}
-							/>
-							<ChoiceGrid
-								choices={LIBRARY_CHOICES}
-								selectedId={library}
-								suggestedId={suggestion?.library}
-								onSelect={onLibraryChange}
-							/>
-						</StepBody>
-					)}
+						{step === 'library' && (
+							<StepBody
+								subtitle={localize('positron.notebook.visualize.step.library.subtitle', 'We will generate code using the library you pick.')}
+								title={localize('positron.notebook.visualize.step.library.title', 'Choose a plotting library')}
+							>
+								<SuggestionBanner
+									reasoning={suggestion?.reasoning.library}
+									state={suggestionState}
+									suggestedLabel={suggestion && LIBRARY_CHOICES.find(c => c.id === suggestion.library)?.title}
+								/>
+								<ChoiceGrid
+									choices={LIBRARY_CHOICES}
+									selectedId={library}
+									suggestedId={suggestion?.library}
+									onSelect={onLibraryChange}
+								/>
+							</StepBody>
+						)}
 
-					{step === 'chart' && (
-						<StepBody
-							subtitle={localize('positron.notebook.visualize.step.chart.subtitle', 'Pick the shape that best fits your data.')}
-							title={localize('positron.notebook.visualize.step.chart.title', 'What kind of chart?')}
-						>
-							<SuggestionBanner
-								reasoning={suggestion?.reasoning.chartType}
-								state={suggestionState}
-								suggestedLabel={suggestion && CHART_CHOICES.find(c => c.id === suggestion.chartType)?.title}
-							/>
-							<ChoiceGrid
-								choices={CHART_CHOICES}
-								selectedId={chartType}
-								suggestedId={suggestion?.chartType}
-								onSelect={onChartChange}
-							/>
-						</StepBody>
-					)}
+						{step === 'chart' && (
+							<StepBody
+								subtitle={localize('positron.notebook.visualize.step.chart.subtitle', 'Pick the shape that best fits your data.')}
+								title={localize('positron.notebook.visualize.step.chart.title', 'What kind of chart?')}
+							>
+								<SuggestionBanner
+									reasoning={suggestion?.reasoning.chartType}
+									state={suggestionState}
+									suggestedLabel={suggestion && CHART_CHOICES.find(c => c.id === suggestion.chartType)?.title}
+								/>
+								<ChoiceGrid
+									choices={CHART_CHOICES}
+									selectedId={chartType}
+									suggestedId={suggestion?.chartType}
+									onSelect={onChartChange}
+								/>
+							</StepBody>
+						)}
 
-					{step === 'columns' && (
-						<StepBody
-							subtitle={props.columns.length
-								? localize('positron.notebook.visualize.step.columns.subtitle.withColumns', 'Pick columns from your dataframe.')
-								: localize('positron.notebook.visualize.step.columns.subtitle.noColumns', 'Enter column names from your dataframe.')}
-							title={localize('positron.notebook.visualize.step.columns.title', 'Map your columns')}
-						>
-							<SuggestionBanner
-								reasoning={suggestion?.reasoning.columns}
-								state={suggestionState}
-								suggestedLabel={suggestion
-									? `x: ${suggestion.xCol}${suggestion.yCol ? `, y: ${suggestion.yCol}` : ''}`
-									: undefined}
-							/>
-							<div className='visualize-columns-form'>
-								<LabeledTextInput
-									error={trimmedDfName.length > 0 && !dfNameValid}
-									errorMsg={trimmedDfName.length > 0 && !dfNameValid
-										? localize('positron.notebook.visualize.dfName.invalid', 'Must be a Python name like "df" or "self.data".')
+						{step === 'columns' && (
+							<StepBody
+								subtitle={props.columns.length
+									? localize('positron.notebook.visualize.step.columns.subtitle.withColumns', 'Pick columns from your dataframe.')
+									: localize('positron.notebook.visualize.step.columns.subtitle.noColumns', 'Enter column names from your dataframe.')}
+								title={localize('positron.notebook.visualize.step.columns.title', 'Map your columns')}
+							>
+								<SuggestionBanner
+									reasoning={suggestion?.reasoning.columns}
+									state={suggestionState}
+									suggestedLabel={suggestion
+										? `x: ${suggestion.xCol}${suggestion.yCol ? `, y: ${suggestion.yCol}` : ''}`
 										: undefined}
-									label={localize('positron.notebook.visualize.dfName.label', 'DataFrame variable')}
-									value={dfName}
-									onChange={(e) => setDfName(e.target.value)}
 								/>
-								<ColumnPicker
-									autoFocus
-									columns={props.columns}
-									label={localize('positron.notebook.visualize.xColumn.label', 'X column')}
-									value={xCol}
-									onChange={onXChange}
-								/>
-								{chartType !== 'histogram' && (
-									<ColumnPicker
-										allowClear
-										columns={props.columns}
-										label={localize('positron.notebook.visualize.yColumn.label', 'Y column (optional)')}
-										value={yCol}
-										onChange={onYChange}
+								<div className='visualize-columns-form'>
+									<LabeledTextInput
+										error={trimmedDfName.length > 0 && !dfNameValid}
+										errorMsg={trimmedDfName.length > 0 && !dfNameValid
+											? localize('positron.notebook.visualize.dfName.invalid', 'Must be a Python name like "df" or "self.data".')
+											: undefined}
+										label={localize('positron.notebook.visualize.dfName.label', 'DataFrame variable')}
+										value={dfName}
+										onChange={(e) => setDfName(e.target.value)}
 									/>
-								)}
-							</div>
-						</StepBody>
-					)}
+									<ColumnPicker
+										autoFocus
+										columns={props.columns}
+										label={localize('positron.notebook.visualize.xColumn.label', 'X column')}
+										value={xCol}
+										onChange={onXChange}
+									/>
+									{chartType !== 'histogram' && (
+										<ColumnPicker
+											allowClear
+											columns={props.columns}
+											label={localize('positron.notebook.visualize.yColumn.label', 'Y column (optional)')}
+											value={yCol}
+											onChange={onYChange}
+										/>
+									)}
+								</div>
+							</StepBody>
+						)}
 
-					{step === 'insert' && (
-						<StepBody
-							subtitle={localize('positron.notebook.visualize.step.insert.subtitle', 'Review the code and choose where it should land.')}
-							title={localize('positron.notebook.visualize.step.insert.title', 'Ready to visualize')}
-						>
-							<CodePreview source={generatedSource} />
-							<div className='visualize-insert-mode'>
-								<InsertModeOption
-									description={localize('positron.notebook.visualize.insertMode.newCell.description', 'Keep your exploration cell unchanged.')}
-									icon='codicon-add'
-									selected={insertMode === 'newCell'}
-									title={localize('positron.notebook.visualize.insertMode.newCell.title', 'Insert as new cell below')}
-									onSelect={() => setInsertMode('newCell')}
-								/>
-								<InsertModeOption
-									description={localize('positron.notebook.visualize.insertMode.append.description', 'Add the plot to the end of the current cell.')}
-									icon='codicon-arrow-down'
-									selected={insertMode === 'append'}
-									title={localize('positron.notebook.visualize.insertMode.append.title', 'Append to this cell')}
-									onSelect={() => setInsertMode('append')}
-								/>
-							</div>
-						</StepBody>
+						{step === 'insert' && (
+							<StepBody
+								subtitle={localize('positron.notebook.visualize.step.insert.subtitle', 'Review the code and choose where it should land.')}
+								title={localize('positron.notebook.visualize.step.insert.title', 'Ready to visualize')}
+							>
+								<CodePreview source={generatedSource} />
+								<div className='visualize-insert-mode'>
+									<InsertModeOption
+										description={localize('positron.notebook.visualize.insertMode.newCell.description', 'Keep your exploration cell unchanged.')}
+										icon='codicon-add'
+										selected={insertMode === 'newCell'}
+										title={localize('positron.notebook.visualize.insertMode.newCell.title', 'Insert as new cell below')}
+										onSelect={() => setInsertMode('newCell')}
+									/>
+									<InsertModeOption
+										description={localize('positron.notebook.visualize.insertMode.append.description', 'Add the plot to the end of the current cell.')}
+										icon='codicon-arrow-down'
+										selected={insertMode === 'append'}
+										title={localize('positron.notebook.visualize.insertMode.append.title', 'Append to this cell')}
+										onSelect={() => setInsertMode('append')}
+									/>
+								</div>
+							</StepBody>
+						)}
+					</div>
+					{props.notebookUri && (
+						<div className='visualize-split-preview'>
+							<VisualizePreview
+								code={previewReady ? generatedSource : ''}
+								notebookUri={props.notebookUri}
+							/>
+						</div>
 					)}
 				</div>
 			</ContentArea>

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizePreview.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizePreview.tsx
@@ -1,0 +1,299 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { useEffect, useRef, useState } from 'react';
+import { localize } from '../../../../../../nls.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
+import {
+	ILanguageRuntimeMessageError,
+	ILanguageRuntimeMessageOutput,
+	ILanguageRuntimeMessageResult,
+	RuntimeCodeExecutionMode,
+	RuntimeErrorBehavior,
+} from '../../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
+
+// Workspace-scoped key for the live preview on/off preference. Lives in
+// IStorageService so flipping the toggle does not dirty the notebook file.
+const LIVE_PREVIEW_STORAGE_KEY = 'positronNotebook.visualize.livePreview';
+
+const DEBOUNCE_MS = 400;
+const CLEANUP_TIMEOUT_MS = 15_000;
+
+type PreviewState =
+	| { status: 'idle' }
+	| { status: 'disabled' }
+	| { status: 'no-runtime' }
+	| { status: 'loading' }
+	| { status: 'success'; mime: 'text/html' | 'image/png' | 'image/svg+xml'; data: string }
+	| { status: 'error'; message: string };
+
+interface Props {
+	/** The full Python snippet to execute. Pass empty string to clear. */
+	code: string;
+	/** The notebook's URI, used to find the runtime session. */
+	notebookUri: URI;
+}
+
+export function VisualizePreview({ code, notebookUri }: Props) {
+	const services = usePositronReactServicesContext();
+	const [state, setState] = useState<PreviewState>({ status: 'idle' });
+	const latestExecIdRef = useRef<string>('');
+	// Track the in-flight subscription store and its auto-dispose timer so
+	// effect re-runs (rapid edits, code cleared) tear them down immediately
+	// instead of waiting out the 15s grace period.
+	const activeDisposablesRef = useRef<DisposableStore | null>(null);
+	const cleanupTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+	// Preference is persisted per-workspace via IStorageService so toggling
+	// does not dirty the notebook file or require a contributed user setting.
+	// Default: on.
+	const [enabled, setEnabled] = useState(() =>
+		services.storageService.getBoolean(LIVE_PREVIEW_STORAGE_KEY, StorageScope.WORKSPACE, true)
+	);
+
+	const toggleEnabled = () => {
+		const next = !enabled;
+		setEnabled(next);
+		services.storageService.store(
+			LIVE_PREVIEW_STORAGE_KEY,
+			next,
+			StorageScope.WORKSPACE,
+			StorageTarget.USER,
+		);
+	};
+
+	useEffect(() => {
+		if (!enabled) {
+			setState({ status: 'disabled' });
+			return;
+		}
+		if (!code.trim()) {
+			setState({ status: 'idle' });
+			return;
+		}
+
+		const session = services.runtimeSessionService.getNotebookSessionForNotebookUri(notebookUri);
+		if (!session) {
+			setState({ status: 'no-runtime' });
+			return;
+		}
+
+		const debounceTimer = setTimeout(() => {
+			// Tear down any prior run that slipped through (e.g. the outer
+			// cleanup hasn't fired yet) before starting a new one.
+			activeDisposablesRef.current?.dispose();
+			clearTimeout(cleanupTimerRef.current);
+
+			const execId = `viz-preview-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+			latestExecIdRef.current = execId;
+			setState({ status: 'loading' });
+
+			const disposables = new DisposableStore();
+			activeDisposablesRef.current = disposables;
+
+			const matches = (msg: { parent_id: string }) =>
+				msg.parent_id === execId && latestExecIdRef.current === execId;
+
+			const handleDisplay = (msg: ILanguageRuntimeMessageOutput | ILanguageRuntimeMessageResult) => {
+				if (!matches(msg)) { return; }
+				const html = msg.data['text/html'];
+				const png = msg.data['image/png'];
+				const svg = msg.data['image/svg+xml'];
+				if (html) {
+					setState({ status: 'success', mime: 'text/html', data: html });
+				} else if (svg) {
+					setState({ status: 'success', mime: 'image/svg+xml', data: svg });
+				} else if (png) {
+					setState({ status: 'success', mime: 'image/png', data: png });
+				} else {
+					// A matching message arrived but carried no MIME we can render.
+					// Without this terminal transition the preview would stay on
+					// 'loading' until the cleanup timer fires.
+					setState({
+						status: 'error',
+						message: localize('positron.notebook.visualize.preview.error.unsupportedMime', 'Preview format not supported.'),
+					});
+				}
+			};
+
+			disposables.add(session.onDidReceiveRuntimeMessageOutput(handleDisplay));
+			disposables.add(session.onDidReceiveRuntimeMessageResult(handleDisplay));
+			disposables.add(session.onDidReceiveRuntimeMessageError((msg: ILanguageRuntimeMessageError) => {
+				if (!matches(msg)) { return; }
+				const raw = msg.message || msg.name
+					|| localize('positron.notebook.visualize.preview.error.fallback', 'Execution error');
+				// Trim common Python traceback noise to the last meaningful line.
+				const lines = raw.split(/\r?\n/).filter(l => l.trim().length > 0);
+				const summary = lines[lines.length - 1] ?? raw;
+				setState({ status: 'error', message: summary });
+			}));
+
+			try {
+				session.execute(
+					code,
+					execId,
+					RuntimeCodeExecutionMode.Silent,
+					RuntimeErrorBehavior.Continue,
+				);
+			} catch (err) {
+				setState({ status: 'error', message: err instanceof Error ? err.message : String(err) });
+				disposables.dispose();
+				return;
+			}
+
+			// Auto-dispose subscriptions after a generous timeout to catch
+			// trailing messages that arrive after the success/error path
+			// fires. `latestExecIdRef` still skips stale messages, so this
+			// is belt-and-suspenders.
+			cleanupTimerRef.current = setTimeout(() => {
+				disposables.dispose();
+				if (activeDisposablesRef.current === disposables) {
+					activeDisposablesRef.current = null;
+				}
+			}, CLEANUP_TIMEOUT_MS);
+		}, DEBOUNCE_MS);
+
+		return () => {
+			clearTimeout(debounceTimer);
+			clearTimeout(cleanupTimerRef.current);
+			activeDisposablesRef.current?.dispose();
+			activeDisposablesRef.current = null;
+			latestExecIdRef.current = '';
+		};
+	}, [code, notebookUri, services.runtimeSessionService, enabled]);
+
+	return (
+		<div className='visualize-preview'>
+			<div className='visualize-preview-header'>
+				<span className='codicon codicon-graph' />
+				<span className='visualize-preview-header-title'>
+					{localize('positron.notebook.visualize.preview.header', 'Live preview')}
+				</span>
+				<button
+					aria-checked={enabled}
+					aria-label={localize('positron.notebook.visualize.preview.toggle.label', 'Toggle live preview')}
+					className={`visualize-preview-toggle${enabled ? ' on' : ''}`}
+					role='switch'
+					title={enabled
+						? localize('positron.notebook.visualize.preview.toggle.tooltipOn', 'Live preview is on. Click to turn off.')
+						: localize('positron.notebook.visualize.preview.toggle.tooltipOff', 'Live preview is off. Click to turn on.')}
+					type='button'
+					onClick={toggleEnabled}
+				>
+					<span className='visualize-preview-toggle-track'>
+						<span className='visualize-preview-toggle-thumb' />
+					</span>
+					<span className='visualize-preview-toggle-label'>
+						{enabled
+							? localize('positron.notebook.visualize.preview.toggle.on', 'On')
+							: localize('positron.notebook.visualize.preview.toggle.off', 'Off')}
+					</span>
+				</button>
+			</div>
+			<div className='visualize-preview-body'>
+				{renderBody(state, toggleEnabled)}
+			</div>
+		</div>
+	);
+}
+
+function renderBody(state: PreviewState, onToggle: () => void) {
+	switch (state.status) {
+		case 'idle':
+			return (
+				<PreviewMessage
+					hint={localize('positron.notebook.visualize.preview.idle.hint', 'Pick a library, chart type, and columns.')}
+					icon='codicon-info'
+					title={localize('positron.notebook.visualize.preview.idle.title', 'Nothing to preview yet')}
+				/>
+			);
+		case 'disabled':
+			return (
+				<PreviewMessage
+					action={{
+						label: localize('positron.notebook.visualize.preview.disabled.action', 'Turn preview on'),
+						onClick: onToggle,
+					}}
+					hint={localize('positron.notebook.visualize.preview.disabled.hint', 'Skip running code in the kernel until you turn it back on.')}
+					icon='codicon-eye-closed'
+					title={localize('positron.notebook.visualize.preview.disabled.title', 'Live preview is off')}
+				/>
+			);
+		case 'no-runtime':
+			return (
+				<PreviewMessage
+					hint={localize('positron.notebook.visualize.preview.noRuntime.hint', 'Start a kernel for this notebook and try again.')}
+					icon='codicon-debug-disconnect'
+					title={localize('positron.notebook.visualize.preview.noRuntime.title', 'No runtime attached')}
+				/>
+			);
+		case 'loading':
+			return (
+				<PreviewMessage
+					hint={localize('positron.notebook.visualize.preview.loading.hint', 'Running your snippet in the kernel.')}
+					icon='codicon-loading codicon-modifier-spin'
+					title={localize('positron.notebook.visualize.preview.loading.title', 'Rendering preview...')}
+				/>
+			);
+		case 'success':
+			if (state.mime === 'text/html') {
+				return (
+					<iframe
+						className='visualize-preview-iframe'
+						sandbox='allow-scripts'
+						srcDoc={state.data}
+						title={localize('positron.notebook.visualize.preview.iframeTitle', 'Chart preview')}
+					/>
+				);
+			}
+			// PNG arrives base64-encoded; SVG arrives as raw XML (URL-encoded for the data URI).
+			return (
+				<img
+					alt={localize('positron.notebook.visualize.preview.imageAlt', 'Generated chart preview')}
+					className='visualize-preview-image'
+					src={state.mime === 'image/svg+xml'
+						? `data:image/svg+xml;utf8,${encodeURIComponent(state.data)}`
+						: `data:image/png;base64,${state.data}`}
+				/>
+			);
+		case 'error':
+			return (
+				<PreviewMessage
+					hint={state.message}
+					icon='codicon-warning'
+					title={localize('positron.notebook.visualize.preview.error.title', 'Preview failed')}
+					tone='error'
+				/>
+			);
+	}
+}
+
+function PreviewMessage({ icon, title, hint, tone, action }: {
+	icon: string;
+	title: string;
+	hint?: string;
+	tone?: 'error';
+	action?: { label: string; onClick: () => void };
+}) {
+	return (
+		<div className={`visualize-preview-message${tone ? ` ${tone}` : ''}`}>
+			<span className={`visualize-preview-message-icon codicon ${icon}`} />
+			<span className='visualize-preview-message-title'>{title}</span>
+			{hint && <span className='visualize-preview-message-hint'>{hint}</span>}
+			{action && (
+				<button
+					className='visualize-preview-message-action'
+					type='button'
+					onClick={action.onClick}
+				>
+					{action.label}
+				</button>
+			)}
+		</div>
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/InlineDataExplorer.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/InlineDataExplorer.tsx
@@ -277,7 +277,7 @@ export function InlineDataExplorer(props: InlineDataExplorerProps) {
 					.then((r) => validateVisualizationSuggestion(r))
 					.catch(() => null);
 
-				const result = await showVisualizeModalDialog(initialDfName, columns, suggestionPromise);
+				const result = await showVisualizeModalDialog(initialDfName, columns, suggestionPromise, notebookInstance.uri);
 				if (!result) { return; }
 				const snippet = generateVizCode(result.answers);
 				await applyVisualizeResult(notebookInstance, cell, snippet, result.mode);


### PR DESCRIPTION
Builds on #13236. Adds a live chart preview pane to the visualize dialog so the user sees the chart update as they pick columns.

### Summary



https://github.com/user-attachments/assets/e82e5e9c-57ee-46a0-a672-aa62c132f595


The preview pane sits beside the column picker and re-renders whenever the user changes library, chart type, or columns. It reuses the notebook's existing renderer pipeline so themed (Plotly), SVG (Matplotlib), and PNG outputs all surface correctly. SVG and unknown-MIME outputs are handled gracefully (no white panel on edge cases).

A toggle in the preview header collapses/restores the panel; visibility persists across sessions via `IConfigurationService`.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:positron-notebooks @:plots @:modal

Requires #13235 and #13236. Steps:

1. Enable `positron.notebook.experimental` in settings
2. Open a Positron notebook, run a cell that produces a dataframe
3. Click **Visualize...** on the inline data explorer
4. Pick a library and chart type -- the preview pane shows the rendered chart
5. Change columns -- the preview re-renders
6. Click the toggle in the preview header -- the pane collapses
7. Reload Positron -- the toggle state should persist