### PR TITLE
fix: strip ANSI escapes when copying notebook output text

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -16,6 +16,7 @@ import { useObservedValue, useDebouncedObservedValue } from '../useObservedValue
 import { CellEditorMonacoWidget } from './CellEditorMonacoWidget.js';
 import { localize } from '../../../../../nls.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+import { removeAnsiEscapeCodes } from '../../../../../base/common/strings.js';
 import { CellTextOutput } from './CellTextOutput.js';
 import { NotebookCellWrapper } from './NotebookCellWrapper.js';
 import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
@@ -182,7 +183,7 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 								// Fall back to copying all text output from the cell
 								const textContent = outputs
 									.filter(o => isParsedTextOutput(o.parsed))
-									.map(o => (o.parsed as ParsedTextOutput).content)
+									.map(o => removeAnsiEscapeCodes((o.parsed as ParsedTextOutput).content))
 									.join('\n');
 								services.clipboardService.writeText(textContent);
 							}


### PR DESCRIPTION
Addresses #13244.

The "Copy Output Text" context-menu action had two branches: when the user has a text selection it delegates to `document.execCommand('copy')` (which copies clean text from the rendered DOM, since ANSI was already converted to span styling), but the no-selection fallback was joining the raw `ParsedTextOutput.content` strings and writing them straight to the clipboard - ANSI escapes and all.

Wrap the joined text with the existing `removeAnsiEscapeCodes` utility from `base/common/strings.ts` so the fallback path matches what the user sees on screen.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Strip ANSI escape codes when copying notebook cell output text via the cell context menu (#13244)

### QA Notes

@:positron-notebooks

1. Open a Positron notebook and add a Python cell with `raise ValueError("boom")`.
2. Run the cell to produce a colorized error traceback.
3. Right-click the output area with **no text selected** -> **Copy Output Text**.
4. Paste into a plain-text destination (Terminal, an empty `.txt` buffer, etc.).
5. Expect: clean, readable traceback. No `\x1b[...m` characters or `[31m`-style fragments.
6. Regression check: drag-select a portion of the output, right-click -> **Copy Output Text**, paste. Should still produce clean text.