### PR TITLE
Contribute `positron.environments.enable` setting for Packages pane

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -31,7 +31,7 @@ import { PositronPackagesView } from './positronPackagesView.js';
 
 export const POSITRON_PACKAGES_VIEW_CONTAINER_ID = 'workbench.viewContainer.positronPackages';
 
-const POSITRON_PACKAGES_ENABLED = ContextKeyExpr.equals('config.positron.environments.enable', true);
+const POSITRON_PACKAGES_ENABLED = ContextKeyExpr.equals('config.positron.packages.enable', true);
 
 const viewContainer = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry).registerViewContainer({
 	id: POSITRON_PACKAGES_VIEW_CONTAINER_ID,
@@ -75,11 +75,11 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 	type: 'object',
 	title: nls.localize('packagesConfigurationTitle', 'Packages'),
 	properties: {
-		'positron.environments.enable': {
+		'positron.packages.enable': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.APPLICATION,
-			description: nls.localize('positron.environments.enable', 'Show the Packages pane.'),
+			description: nls.localize('positron.packages.enable', 'Show the Packages pane.'),
 			tags: ['preview'],
 		}
 	}

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -10,6 +10,7 @@ import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import * as nls from '../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
@@ -67,6 +68,21 @@ Registry.as<IViewsRegistry>(ViewContainerExtensions.ViewsRegistry).registerViews
 	],
 	viewContainer
 );
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	id: 'packages',
+	order: 100,
+	type: 'object',
+	title: nls.localize('packagesConfigurationTitle', 'Packages'),
+	properties: {
+		'positron.environments.enable': {
+			type: 'boolean',
+			default: true,
+			scope: ConfigurationScope.APPLICATION,
+			description: nls.localize('positron.environments.enable', 'Show the Packages pane.'),
+		}
+	}
+});
 
 export const PACKAGES_INSTALL_COMMAND_ID = 'positronPackages.installPackage';
 export const PACKAGES_UPDATE_COMMAND_ID = 'positronPackages.updatePackage';

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -80,6 +80,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			default: true,
 			scope: ConfigurationScope.APPLICATION,
 			description: nls.localize('positron.environments.enable', 'Show the Packages pane.'),
+			tags: ['preview'],
 		}
 	}
 });

--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -289,7 +289,7 @@ export const tocData: ITOCEntry<string> = {
 				{
 					id: 'features/packages',
 					label: localize('packages', "Packages"),
-					settings: ['positron.environments.*']
+					settings: ['positron.packages.*']
 				},
 				{
 					id: 'features/plots',

--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -212,11 +212,6 @@ export const tocData: ITOCEntry<string> = {
 					label: localize('environment', "Environment"),
 					settings: ['environment.*']
 				},
-				{
-					id: 'features/packages',
-					label: localize('packages', "Packages"),
-					settings: ['positron.environments.*']
-				},
 				// --- End Positron ---
 				{
 					id: 'features/testing',
@@ -291,6 +286,11 @@ export const tocData: ITOCEntry<string> = {
 					settings: ['chat.*', 'inlineChat.*', 'mcp']
 				},
 				// --- Start Positron ---
+				{
+					id: 'features/packages',
+					label: localize('packages', "Packages"),
+					settings: ['positron.environments.*']
+				},
 				{
 					id: 'features/plots',
 					label: localize('plots', 'Plots'),

--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -212,6 +212,11 @@ export const tocData: ITOCEntry<string> = {
 					label: localize('environment', "Environment"),
 					settings: ['environment.*']
 				},
+				{
+					id: 'features/packages',
+					label: localize('packages', "Packages"),
+					settings: ['positron.environments.*']
+				},
 				// --- End Positron ---
 				{
 					id: 'features/testing',

--- a/test/e2e/tests/environment-pane/environment-pane.test.ts
+++ b/test/e2e/tests/environment-pane/environment-pane.test.ts
@@ -17,7 +17,7 @@ test.describe('Environment Pane', {
 
 	test.beforeAll(async function ({ settings }) {
 		await settings.set({
-			'positron.environments.enable': true
+			'positron.packages.enable': true
 		}, { reload: 'web' });
 	});
 


### PR DESCRIPTION
Register the Packages pane feature switch as a contributed setting defaulting to true, making the pane available to all users while providing an opt-out for those who prefer to hide it.

See #13249

<img width="460" height="91" alt="Screenshot 2026-04-28 at 3 01 04 PM" src="https://github.com/user-attachments/assets/d3ae9a5a-17b4-408b-924a-deca13bfd1a4" />
<img width="1023" height="511" alt="Screenshot 2026-04-28 at 3 00 41 PM" src="https://github.com/user-attachments/assets/630a4de3-a198-4dd3-838d-fc704f938163" />

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:packages-pane