### PR TITLE
Server: add option to delete license key file after use

### DIFF
--- a/src/vs/server/node/remoteLicenseKey.ts
+++ b/src/vs/server/node/remoteLicenseKey.ts
@@ -79,6 +79,16 @@ vAb1iFBg5jrsvhZzzZbIah1XHYAT+X43WaExwme18pzBAgMBAAE=
 -----END PUBLIC KEY-----`;
 
 /**
+ * Strict env-var boolean parse. Mirrors systemd / Go's `strconv.ParseBool` --
+ * everything else (including `0`, `false`, `no`, `off`, garbage, or unset)
+ * reads as `false`. Keeps `=0` from being silently truthy.
+ */
+function isTruthyEnvValue(value: string | undefined): boolean {
+	if (value === undefined) { return false; }
+	return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+}
+
+/**
  * Validates a license key. If any errors are encountered, they are logged to
  * the console.
  *
@@ -94,6 +104,14 @@ vAb1iFBg5jrsvhZzzZbIah1XHYAT+X43WaExwme18pzBAgMBAAE=
  */
 export async function validateLicenseKey(connectionToken: string, args: ServerParsedArgs): Promise<ILicenseValidationResult> {
 
+	// Set via --license-key-file-delete-after-use or
+	// POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE. Applies only to the two
+	// file-based sources below; the user-data-dir fallback is the persistent
+	// store and is intentionally exempt.
+	const shouldDelete =
+		!!args['license-key-file-delete-after-use'] ||
+		isTruthyEnvValue(process.env.POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE);
+
 	// Check the command-line arguments for a license key.
 	if (args['license-key']) {
 		console.log('Checking Positron license key from the --license-key argument.');
@@ -104,7 +122,7 @@ export async function validateLicenseKey(connectionToken: string, args: ServerPa
 	// argument.
 	if (args['license-key-file']) {
 		console.log('Checking Positron license key from the file in the --license-key-file argument.');
-		return validateLicenseFile(connectionToken, args['license-key-file']);
+		return validateAndMaybeDeleteFile(connectionToken, args['license-key-file'], shouldDelete);
 	}
 
 	// Check the POSITRON_LICENSE_KEY environment variable.
@@ -116,7 +134,7 @@ export async function validateLicenseKey(connectionToken: string, args: ServerPa
 	// Check the POSITRON_LICENSE_KEY_FILE environment variable.
 	if (process.env.POSITRON_LICENSE_KEY_FILE) {
 		console.log('Checking Positron license key from the file in the POSITRON_LICENSE_KEY_FILE environment variable.');
-		return validateLicenseFile(connectionToken, process.env.POSITRON_LICENSE_KEY_FILE);
+		return validateAndMaybeDeleteFile(connectionToken, process.env.POSITRON_LICENSE_KEY_FILE, shouldDelete);
 	}
 
 	// If none of these were specified, check the user data directory for a
@@ -132,6 +150,42 @@ export async function validateLicenseKey(connectionToken: string, args: ServerPa
 	console.error('No license key provided. A license key is required to use Positron in a hosted environment. Provide a license key with the --license-key or --license-key-file command-line arguments, or set the POSITRON_LICENSE_KEY or POSITRON_LICENSE_KEY_FILE environment variables.');
 
 	return { valid: false };
+}
+
+/**
+ * Validates the license at `licenseFile`, then (if `shouldDelete`) removes the
+ * file. Used only for the ephemeral arg/env-var file sources, never for the
+ * user-data-dir persistent store.
+ *
+ * If deletion fails (other than ENOENT), the failure is treated as a policy
+ * violation: the validation result is collapsed to `{ valid: false }` so that
+ * the caller's `process.exit(1)` path triggers, even when the underlying
+ * license itself was valid.
+ */
+async function validateAndMaybeDeleteFile(
+	connectionToken: string,
+	licenseFile: string,
+	shouldDelete: boolean,
+): Promise<ILicenseValidationResult> {
+	const result = await validateLicenseFile(connectionToken, licenseFile);
+	if (!shouldDelete) {
+		return result;
+	}
+	try {
+		fs.unlinkSync(licenseFile);
+	} catch (e: any) {
+		if (e && e.code === 'ENOENT') {
+			// Already gone -- the desired post-condition is satisfied.
+			return result;
+		}
+		console.error(
+			`FATAL: Failed to delete license key file '${licenseFile}' after use. ` +
+			`Refusing to start because delete-after-use is required.`
+		);
+		console.error(e);
+		return { valid: false };
+	}
+	return result;
 }
 
 /**

--- a/src/vs/server/node/remoteLicenseKey.ts
+++ b/src/vs/server/node/remoteLicenseKey.ts
@@ -173,8 +173,8 @@ async function validateAndMaybeDeleteFile(
 	}
 	try {
 		fs.unlinkSync(licenseFile);
-	} catch (e: any) {
-		if (e && e.code === 'ENOENT') {
+	} catch (e) {
+		if ((e as NodeJS.ErrnoException)?.code === 'ENOENT') {
 			// Already gone -- the desired post-condition is satisfied.
 			return result;
 		}

--- a/src/vs/server/node/serverEnvironmentService.ts
+++ b/src/vs/server/node/serverEnvironmentService.ts
@@ -111,6 +111,7 @@ export const serverOptions: OptionDescriptions<Required<ServerParsedArgs>> = {
 	// --- Start Positron ---
 	'license-key-file': { type: 'string', description: nls.localize('license-key-file', "Path to a file that contains the license key.") },
 	'license-key': { type: 'string', description: nls.localize('license-key', "A license key") },
+	'license-key-file-delete-after-use': { type: 'boolean', description: nls.localize('license-key-file-delete-after-use', "If set, delete the license key file after reading it. Applies only to files supplied via --license-key-file or POSITRON_LICENSE_KEY_FILE. The directory containing the file must be writable by the server process; an unsuccessful delete will abort server startup. Equivalent env var POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE enables deletion with '1', 'true', 'yes', or 'on'.") },
 	// --- End Positron ---
 
 	_: OPTIONS['_']
@@ -268,6 +269,7 @@ export interface ServerParsedArgs {
 	// authorized (licensed) source.
 	'license-key-file'?: string;
 	'license-key'?: string;
+	'license-key-file-delete-after-use'?: boolean;
 	// --- End Positron ---
 }
 

--- a/src/vs/server/test/node/remoteLicenseKeyDeleteAfterUse.vitest.ts
+++ b/src/vs/server/test/node/remoteLicenseKeyDeleteAfterUse.vitest.ts
@@ -1,0 +1,222 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import * as fs from 'fs';
+import * as os from 'os';
+import { join } from '../../../base/common/path.js';
+import { FileAccess } from '../../../base/common/network.js';
+import { ServerParsedArgs } from '../../node/serverEnvironmentService.js';
+
+// Mock the license-manager binary wrapper -- we never want to invoke the real
+// binary in unit tests. RSA-routed validation returns this canned result.
+const { mockActivate } = vi.hoisted(() => ({
+	mockActivate: vi.fn(),
+}));
+vi.mock('../../node/licenseManager.js', () => ({
+	activateWithManager: mockActivate,
+}));
+
+// Wrap fs.unlinkSync in a vi.fn so we can spy on calls and override per-test.
+// Real unlink runs by default (so files actually get removed); per-test
+// overrides simulate failure modes (EACCES, ENOENT).
+vi.mock('fs', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('fs')>();
+	return { ...actual, unlinkSync: vi.fn(actual.unlinkSync) };
+});
+
+const RSA_LICENSE_CONTENT = '-----BEGIN RSTUDIO LICENSE-----\nfake-rsa-payload\n-----END RSTUDIO LICENSE-----\n';
+const RSA_RESULT = { valid: true, licensee: 'Test Licensee' };
+
+const { validateLicenseKey } = await import('../../node/remoteLicenseKey.js');
+
+describe('validateLicenseKey delete-after-use', () => {
+	const originalEnvKey = process.env.POSITRON_LICENSE_KEY;
+	const originalEnvFile = process.env.POSITRON_LICENSE_KEY_FILE;
+	const originalEnvDelete = process.env.POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE;
+	let tmpDir: string;
+
+	beforeEach(() => {
+		vi.spyOn(console, 'error').mockImplementation(() => { });
+		vi.spyOn(console, 'log').mockImplementation(() => { });
+		// FileAccess.asFileUri('') throws in plain-Node test contexts (no AMD
+		// loader). Stub it so the RSA branch can compute its installPath.
+		vi.spyOn(FileAccess, 'asFileUri').mockReturnValue({ fsPath: '/fake/install/path' } as any);
+		delete process.env.POSITRON_LICENSE_KEY;
+		delete process.env.POSITRON_LICENSE_KEY_FILE;
+		delete process.env.POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE;
+		tmpDir = fs.mkdtempSync(join(os.tmpdir(), 'positron-license-delete-test-'));
+		mockActivate.mockResolvedValue(RSA_RESULT);
+	});
+
+	afterEach(() => {
+		const restore = (name: string, value: string | undefined) => {
+			if (value === undefined) { delete process.env[name]; }
+			else { process.env[name] = value; }
+		};
+		restore('POSITRON_LICENSE_KEY', originalEnvKey);
+		restore('POSITRON_LICENSE_KEY_FILE', originalEnvFile);
+		restore('POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE', originalEnvDelete);
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	const writeRsaFile = (name = 'license.lic') => {
+		const file = join(tmpDir, name);
+		fs.writeFileSync(file, RSA_LICENSE_CONTENT);
+		return file;
+	};
+
+	it('deletes the file when arg flag is set + --license-key-file is the source', async () => {
+		const file = writeRsaFile();
+		const result = await validateLicenseKey('token', {
+			'license-key-file': file,
+			'license-key-file-delete-after-use': true,
+		} as ServerParsedArgs);
+		expect(result).toEqual(RSA_RESULT);
+		expect(fs.existsSync(file)).toBe(false);
+	});
+
+	it('deletes the file when env flag is set + POSITRON_LICENSE_KEY_FILE is the source', async () => {
+		const file = writeRsaFile();
+		process.env.POSITRON_LICENSE_KEY_FILE = file;
+		process.env.POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE = '1';
+		const result = await validateLicenseKey('token', {} as ServerParsedArgs);
+		expect(result).toEqual(RSA_RESULT);
+		expect(fs.existsSync(file)).toBe(false);
+	});
+
+	it('does not delete the file when no flag is set', async () => {
+		const file = writeRsaFile();
+		const result = await validateLicenseKey('token', {
+			'license-key-file': file,
+		} as ServerParsedArgs);
+		expect(result).toEqual(RSA_RESULT);
+		expect(fs.existsSync(file)).toBe(true);
+	});
+
+	it('does not call unlink when the source is inline --license-key', async () => {
+		// Inline content goes through validateLicense (JSON-only); '{...' is
+		// enough to take that branch -- we only care that no file delete is
+		// attempted, regardless of validation outcome.
+		await validateLicenseKey('token', {
+			'license-key': '{}',
+			'license-key-file-delete-after-use': true,
+		} as ServerParsedArgs);
+		expect(vi.mocked(fs.unlinkSync)).not.toHaveBeenCalled();
+	});
+
+	it('does not call unlink when the source is inline POSITRON_LICENSE_KEY', async () => {
+		process.env.POSITRON_LICENSE_KEY = '{}';
+		process.env.POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE = '1';
+		await validateLicenseKey('token', {} as ServerParsedArgs);
+		expect(vi.mocked(fs.unlinkSync)).not.toHaveBeenCalled();
+	});
+
+	it('does not delete the file when the source is the user-data-dir fallback', async () => {
+		// The persistent license-key store is intentionally exempt from
+		// delete-after-use even when the flag is set.
+		const file = join(tmpDir, 'license-key');
+		fs.writeFileSync(file, RSA_LICENSE_CONTENT);
+		const result = await validateLicenseKey('token', {
+			'user-data-dir': tmpDir,
+			'license-key-file-delete-after-use': true,
+		} as ServerParsedArgs);
+		expect(result).toEqual(RSA_RESULT);
+		expect(fs.existsSync(file)).toBe(true);
+	});
+
+	it('deletes the file even when validation fails', async () => {
+		// Malformed JSON content so validation rejects, but the file is still
+		// ephemeral and must be cleaned up.
+		const file = join(tmpDir, 'license.lic');
+		fs.writeFileSync(file, '{ not valid json');
+		const result = await validateLicenseKey('token', {
+			'license-key-file': file,
+			'license-key-file-delete-after-use': true,
+		} as ServerParsedArgs);
+		expect(result).toEqual({ valid: false });
+		expect(fs.existsSync(file)).toBe(false);
+	});
+
+	it('returns invalid and logs FATAL when unlink fails with a non-ENOENT error', async () => {
+		const file = writeRsaFile();
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+		const accessError: NodeJS.ErrnoException = Object.assign(new Error('EACCES'), { code: 'EACCES' });
+		vi.mocked(fs.unlinkSync).mockImplementationOnce(() => { throw accessError; });
+
+		const result = await validateLicenseKey('token', {
+			'license-key-file': file,
+			'license-key-file-delete-after-use': true,
+		} as ServerParsedArgs);
+
+		expect(result).toEqual({ valid: false });
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('FATAL'));
+		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(file));
+	});
+
+	it('treats ENOENT on unlink as success and returns the original result', async () => {
+		const file = writeRsaFile();
+		const enoentError: NodeJS.ErrnoException = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+		vi.mocked(fs.unlinkSync).mockImplementationOnce(() => { throw enoentError; });
+
+		const result = await validateLicenseKey('token', {
+			'license-key-file': file,
+			'license-key-file-delete-after-use': true,
+		} as ServerParsedArgs);
+
+		expect(result).toEqual(RSA_RESULT);
+	});
+
+	it('cross-source: arg sets flag, env var sets file path', async () => {
+		const file = writeRsaFile();
+		process.env.POSITRON_LICENSE_KEY_FILE = file;
+		const result = await validateLicenseKey('token', {
+			'license-key-file-delete-after-use': true,
+		} as ServerParsedArgs);
+		expect(result).toEqual(RSA_RESULT);
+		expect(fs.existsSync(file)).toBe(false);
+	});
+
+	it('cross-source: env var sets flag, arg sets file path', async () => {
+		const file = writeRsaFile();
+		process.env.POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE = '1';
+		const result = await validateLicenseKey('token', {
+			'license-key-file': file,
+		} as ServerParsedArgs);
+		expect(result).toEqual(RSA_RESULT);
+		expect(fs.existsSync(file)).toBe(false);
+	});
+
+	describe('env-var truthiness', () => {
+		// The strict parser accepts only 1/true/yes/on (case-insensitive).
+		// Crucially, `=0` and `=false` must NOT enable deletion, since
+		// operators commonly read those as "off" but a permissive
+		// `!!process.env.X` would treat them as truthy.
+		it.each(['1', 'true', 'TRUE', 'True', 'yes', 'YES', 'on', 'ON', '  true  '])(
+			'enables deletion when env var is %j',
+			async (value) => {
+				const file = writeRsaFile();
+				process.env.POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE = value;
+				await validateLicenseKey('token', {
+					'license-key-file': file,
+				} as ServerParsedArgs);
+				expect(fs.existsSync(file)).toBe(false);
+			},
+		);
+
+		it.each(['0', 'false', 'FALSE', 'no', 'off', '', '   ', 'enabled', 'garbage'])(
+			'does NOT enable deletion when env var is %j',
+			async (value) => {
+				const file = writeRsaFile();
+				process.env.POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE = value;
+				await validateLicenseKey('token', {
+					'license-key-file': file,
+				} as ServerParsedArgs);
+				expect(fs.existsSync(file)).toBe(true);
+			},
+		);
+	});
+});

--- a/src/vs/server/test/node/remoteLicenseKeyDeleteAfterUse.vitest.ts
+++ b/src/vs/server/test/node/remoteLicenseKeyDeleteAfterUse.vitest.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { join } from '../../../base/common/path.js';
 import { FileAccess } from '../../../base/common/network.js';
+import { URI } from '../../../base/common/uri.js';
 import { ServerParsedArgs } from '../../node/serverEnvironmentService.js';
 
 // Mock the license-manager binary wrapper -- we never want to invoke the real
@@ -33,6 +34,17 @@ const RSA_RESULT = { valid: true, licensee: 'Test Licensee' };
 
 const { validateLicenseKey } = await import('../../node/remoteLicenseKey.js');
 
+const buildArgs = (overrides: Partial<ServerParsedArgs> = {}): ServerParsedArgs => ({
+	'accept-server-license-terms': false,
+	workspace: '',
+	folder: '',
+	help: false,
+	version: false,
+	compatibility: '',
+	_: [],
+	...overrides,
+});
+
 describe('validateLicenseKey delete-after-use', () => {
 	const originalEnvKey = process.env.POSITRON_LICENSE_KEY;
 	const originalEnvFile = process.env.POSITRON_LICENSE_KEY_FILE;
@@ -44,7 +56,7 @@ describe('validateLicenseKey delete-after-use', () => {
 		vi.spyOn(console, 'log').mockImplementation(() => { });
 		// FileAccess.asFileUri('') throws in plain-Node test contexts (no AMD
 		// loader). Stub it so the RSA branch can compute its installPath.
-		vi.spyOn(FileAccess, 'asFileUri').mockReturnValue({ fsPath: '/fake/install/path' } as any);
+		vi.spyOn(FileAccess, 'asFileUri').mockReturnValue(URI.file('/fake/install/path'));
 		delete process.env.POSITRON_LICENSE_KEY;
 		delete process.env.POSITRON_LICENSE_KEY_FILE;
 		delete process.env.POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE;
@@ -71,10 +83,10 @@ describe('validateLicenseKey delete-after-use', () => {
 
 	it('deletes the file when arg flag is set + --license-key-file is the source', async () => {
 		const file = writeRsaFile();
-		const result = await validateLicenseKey('token', {
+		const result = await validateLicenseKey('token', buildArgs({
 			'license-key-file': file,
 			'license-key-file-delete-after-use': true,
-		} as ServerParsedArgs);
+		}));
 		expect(result).toEqual(RSA_RESULT);
 		expect(fs.existsSync(file)).toBe(false);
 	});
@@ -83,16 +95,16 @@ describe('validateLicenseKey delete-after-use', () => {
 		const file = writeRsaFile();
 		process.env.POSITRON_LICENSE_KEY_FILE = file;
 		process.env.POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE = '1';
-		const result = await validateLicenseKey('token', {} as ServerParsedArgs);
+		const result = await validateLicenseKey('token', buildArgs());
 		expect(result).toEqual(RSA_RESULT);
 		expect(fs.existsSync(file)).toBe(false);
 	});
 
 	it('does not delete the file when no flag is set', async () => {
 		const file = writeRsaFile();
-		const result = await validateLicenseKey('token', {
+		const result = await validateLicenseKey('token', buildArgs({
 			'license-key-file': file,
-		} as ServerParsedArgs);
+		}));
 		expect(result).toEqual(RSA_RESULT);
 		expect(fs.existsSync(file)).toBe(true);
 	});
@@ -101,17 +113,17 @@ describe('validateLicenseKey delete-after-use', () => {
 		// Inline content goes through validateLicense (JSON-only); '{...' is
 		// enough to take that branch -- we only care that no file delete is
 		// attempted, regardless of validation outcome.
-		await validateLicenseKey('token', {
+		await validateLicenseKey('token', buildArgs({
 			'license-key': '{}',
 			'license-key-file-delete-after-use': true,
-		} as ServerParsedArgs);
+		}));
 		expect(vi.mocked(fs.unlinkSync)).not.toHaveBeenCalled();
 	});
 
 	it('does not call unlink when the source is inline POSITRON_LICENSE_KEY', async () => {
 		process.env.POSITRON_LICENSE_KEY = '{}';
 		process.env.POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE = '1';
-		await validateLicenseKey('token', {} as ServerParsedArgs);
+		await validateLicenseKey('token', buildArgs());
 		expect(vi.mocked(fs.unlinkSync)).not.toHaveBeenCalled();
 	});
 
@@ -120,10 +132,10 @@ describe('validateLicenseKey delete-after-use', () => {
 		// delete-after-use even when the flag is set.
 		const file = join(tmpDir, 'license-key');
 		fs.writeFileSync(file, RSA_LICENSE_CONTENT);
-		const result = await validateLicenseKey('token', {
+		const result = await validateLicenseKey('token', buildArgs({
 			'user-data-dir': tmpDir,
 			'license-key-file-delete-after-use': true,
-		} as ServerParsedArgs);
+		}));
 		expect(result).toEqual(RSA_RESULT);
 		expect(fs.existsSync(file)).toBe(true);
 	});
@@ -133,10 +145,10 @@ describe('validateLicenseKey delete-after-use', () => {
 		// ephemeral and must be cleaned up.
 		const file = join(tmpDir, 'license.lic');
 		fs.writeFileSync(file, '{ not valid json');
-		const result = await validateLicenseKey('token', {
+		const result = await validateLicenseKey('token', buildArgs({
 			'license-key-file': file,
 			'license-key-file-delete-after-use': true,
-		} as ServerParsedArgs);
+		}));
 		expect(result).toEqual({ valid: false });
 		expect(fs.existsSync(file)).toBe(false);
 	});
@@ -147,10 +159,10 @@ describe('validateLicenseKey delete-after-use', () => {
 		const accessError: NodeJS.ErrnoException = Object.assign(new Error('EACCES'), { code: 'EACCES' });
 		vi.mocked(fs.unlinkSync).mockImplementationOnce(() => { throw accessError; });
 
-		const result = await validateLicenseKey('token', {
+		const result = await validateLicenseKey('token', buildArgs({
 			'license-key-file': file,
 			'license-key-file-delete-after-use': true,
-		} as ServerParsedArgs);
+		}));
 
 		expect(result).toEqual({ valid: false });
 		expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('FATAL'));
@@ -162,10 +174,10 @@ describe('validateLicenseKey delete-after-use', () => {
 		const enoentError: NodeJS.ErrnoException = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
 		vi.mocked(fs.unlinkSync).mockImplementationOnce(() => { throw enoentError; });
 
-		const result = await validateLicenseKey('token', {
+		const result = await validateLicenseKey('token', buildArgs({
 			'license-key-file': file,
 			'license-key-file-delete-after-use': true,
-		} as ServerParsedArgs);
+		}));
 
 		expect(result).toEqual(RSA_RESULT);
 	});
@@ -173,9 +185,9 @@ describe('validateLicenseKey delete-after-use', () => {
 	it('cross-source: arg sets flag, env var sets file path', async () => {
 		const file = writeRsaFile();
 		process.env.POSITRON_LICENSE_KEY_FILE = file;
-		const result = await validateLicenseKey('token', {
+		const result = await validateLicenseKey('token', buildArgs({
 			'license-key-file-delete-after-use': true,
-		} as ServerParsedArgs);
+		}));
 		expect(result).toEqual(RSA_RESULT);
 		expect(fs.existsSync(file)).toBe(false);
 	});
@@ -183,9 +195,9 @@ describe('validateLicenseKey delete-after-use', () => {
 	it('cross-source: env var sets flag, arg sets file path', async () => {
 		const file = writeRsaFile();
 		process.env.POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE = '1';
-		const result = await validateLicenseKey('token', {
+		const result = await validateLicenseKey('token', buildArgs({
 			'license-key-file': file,
-		} as ServerParsedArgs);
+		}));
 		expect(result).toEqual(RSA_RESULT);
 		expect(fs.existsSync(file)).toBe(false);
 	});
@@ -200,9 +212,9 @@ describe('validateLicenseKey delete-after-use', () => {
 			async (value) => {
 				const file = writeRsaFile();
 				process.env.POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE = value;
-				await validateLicenseKey('token', {
+				await validateLicenseKey('token', buildArgs({
 					'license-key-file': file,
-				} as ServerParsedArgs);
+				}));
 				expect(fs.existsSync(file)).toBe(false);
 			},
 		);
@@ -212,9 +224,9 @@ describe('validateLicenseKey delete-after-use', () => {
 			async (value) => {
 				const file = writeRsaFile();
 				process.env.POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE = value;
-				await validateLicenseKey('token', {
+				await validateLicenseKey('token', buildArgs({
 					'license-key-file': file,
-				} as ServerParsedArgs);
+				}));
 				expect(fs.existsSync(file)).toBe(true);
 			},
 		);


### PR DESCRIPTION
## Summary

Adds a configuration option that, when set, deletes a license key file after the server reads it. Intended for Posit Cloud deployments where the platform injects an ephemeral license file at process start and the IDE should not leave it on disk after consumption.

- New CLI flag: `--license-key-file-delete-after-use`
- Equivalent env var: `POSITRON_LICENSE_KEY_FILE_DELETE_AFTER_USE` (strict parse: `1`/`true`/`yes`/`on` case-insensitive; `0`/`false`/empty all read as off, so operators don't get a surprise delete from `=0`)
- Scoped to `--license-key-file` and `POSITRON_LICENSE_KEY_FILE`. Inline keys (`--license-key`, `POSITRON_LICENSE_KEY`) and the `<user-data-dir>/license-key` persistent fallback are exempt.
- Deletion runs unconditionally after read (an invalid license still gets cleaned up). `ENOENT` on unlink is non-fatal (idempotent under concurrent starts); other errors collapse the result to `{ valid: false }`, tripping the existing `process.exit(1)` path so an undeleted file aborts startup as a policy violation.

## Test plan

- [x] Unit tests: 29 cases in `src/vs/server/test/node/remoteLicenseKeyDeleteAfterUse.vitest.ts` (file/env-var sources, inline-key exemption, user-data-dir exemption, validation-failure-still-deletes, EACCES fatal, ENOENT tolerated, cross-source flag/path combinations, env-var truthiness with 9 truthy + 9 falsy cases).
- [x] `npm run build-check` clean on `watch-client` and `watch-extensions`.
- [x] End-to-end smoke against a running REH server: file deleted with arg flag set, file deleted with env var set, file preserved with no flag, env var values `0`/`false` correctly read as off.

## Notes for reviewers

- No edits to `remoteExtensionHostAgentServer.ts` -- the existing `process.exit(1)` on `!valid` carries the failure surface for the new "delete failed" case as well.
- Existing `cmd-line-flag/env-var` patterns for license sources are mirrored, so nothing new to learn for operators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)