### PR TITLE
python: fix for failing test

### DIFF
--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -344,17 +344,17 @@ enum ExistingEnvAction {
 
 type ExistingEnvResult =
     | {
-        reason: ExistingEnvAction.KeepExistingEnv;
-        existingEnv: PythonEnvInfo;
-    }
+          reason: ExistingEnvAction.KeepExistingEnv;
+          existingEnv: PythonEnvInfo;
+      }
     | {
-        reason: ExistingEnvAction.AddNewEnv;
-        existingEnv: undefined;
-    }
+          reason: ExistingEnvAction.AddNewEnv;
+          existingEnv: undefined;
+      }
     | {
-        reason: ExistingEnvAction.ReplaceExistingEnv;
-        existingEnv: PythonEnvInfo;
-    };
+          reason: ExistingEnvAction.ReplaceExistingEnv;
+          existingEnv: PythonEnvInfo;
+      };
 // --- End Positron ---
 
 class NativePythonEnvironments implements IDiscoveryAPI, Disposable {

--- a/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/nativeAPI.ts
@@ -344,17 +344,17 @@ enum ExistingEnvAction {
 
 type ExistingEnvResult =
     | {
-          reason: ExistingEnvAction.KeepExistingEnv;
-          existingEnv: PythonEnvInfo;
-      }
+        reason: ExistingEnvAction.KeepExistingEnv;
+        existingEnv: PythonEnvInfo;
+    }
     | {
-          reason: ExistingEnvAction.AddNewEnv;
-          existingEnv: undefined;
-      }
+        reason: ExistingEnvAction.AddNewEnv;
+        existingEnv: undefined;
+    }
     | {
-          reason: ExistingEnvAction.ReplaceExistingEnv;
-          existingEnv: PythonEnvInfo;
-      };
+        reason: ExistingEnvAction.ReplaceExistingEnv;
+        existingEnv: PythonEnvInfo;
+    };
 // --- End Positron ---
 
 class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
@@ -382,6 +382,12 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
     // invalidated in addEnv()/removeEnv() so a late-arriving discovery
     // immediately supersedes any cached state.
     private _resolveEnvCache = new Map<string, { info: PythonEnvInfo; expiry: number }>();
+
+    // In-flight promise deduplication for resolveEnv(). Concurrent callers for
+    // the same envPath share a single PET round-trip. The entry is cleared on
+    // settle so undefined results are never pinned (unlike the old @cache
+    // decorator whose cachePromise=true mode cached the promise itself).
+    private _resolveEnvInFlight = new Map<string, Promise<PythonEnvInfo | undefined>>();
 
     private static readonly _resolveEnvCacheMs = 30_000;
     // --- End Positron ---
@@ -662,6 +668,7 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
     // This decorator stored the pending promise immediately, so an undefined resolution
     // was pinned for 30s even after PET had since discovered the env. Use an explicit cache
     // that only caches successful resolutions and is invalidated on addEnv()/removeEnv().
+    // The in-flight map deduplicates concurrent callers without caching undefined results.
     // @cache(30_000, true)
     // --- End Positron ---
     async resolveEnv(envPath?: string): Promise<PythonEnvInfo | undefined> {
@@ -673,6 +680,24 @@ class NativePythonEnvironments implements IDiscoveryAPI, Disposable {
         if (cached && cached.expiry > Date.now()) {
             return cached.info;
         }
+
+        const inFlight = this._resolveEnvInFlight.get(envPath);
+        if (inFlight) {
+            return inFlight;
+        }
+
+        const promise = this._doResolveEnv(envPath);
+        this._resolveEnvInFlight.set(envPath, promise);
+        try {
+            return await promise;
+        } finally {
+            this._resolveEnvInFlight.delete(envPath);
+        }
+        // --- End Positron ---
+    }
+
+    // --- Start Positron ---
+    private async _doResolveEnv(envPath: string): Promise<PythonEnvInfo | undefined> {
         // --- End Positron ---
         try {
             const native = await this.finder.resolve(envPath);

--- a/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/nativeAPI.unit.test.ts
@@ -634,6 +634,24 @@ suite('Native Python API', () => {
             await api.resolveEnv(pythonPath);
             assert.equal(resolveCount, 2, 'cache should be cleared by removeEnv');
         });
+
+        test('concurrent resolveEnv calls share a single PET round-trip', async () => {
+            let resolveCount = 0;
+            mockFinder
+                .setup((f) => f.resolve(pythonPath))
+                .returns(() => {
+                    resolveCount += 1;
+                    return Promise.resolve(basicEnv);
+                });
+
+            // Fire two concurrent calls for the same path.
+            const [first, second] = await Promise.all([api.resolveEnv(pythonPath), api.resolveEnv(pythonPath)]);
+            assert.isDefined(first);
+            assert.isDefined(second);
+            assert.equal(first?.executable.filename, pythonPath);
+            assert.equal(second?.executable.filename, pythonPath);
+            assert.equal(resolveCount, 1, 'concurrent calls should share a single finder.resolve');
+        });
     });
     // --- End Positron ---
 });


### PR DESCRIPTION
Follow up to #13168 based off test failures. Concurrent callers for the same envPath now share a single PET round-trip instead of firing redundant requests. 


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

green CI, particularly that the test below passes

```
  1 failing
  1) positron API - executeInlineCell
       executeInlineCell executes code in the correct session:
     Error: Timeout: test runtime should be registered after 20 seconds.
Did not pass accept function
      at poll (extensions/vscode-api-tests/src/utils.ts:176:10)
      at Context.<anonymous> (extensions/vscode-api-tests/src/singlefolder-tests/positron/executeInlineCell.test.ts:264:3)
```

Python discovery should act as anticipated