### PR TITLE
Show notebook restart kernel action in notebook action bar

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -91,6 +91,15 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<IPositro
 	private _containerScopedContextKeyService: IScopedContextKeyService | undefined;
 
 	/**
+	 * Expose the notebook's scoped context to the editor pane so that `when`
+	 * clauses for menus and `precondition` clausess for actions on the editor
+	 * action bar can resolve notebook scoped context keys (e.g. NOTEBOOK_KERNEL).
+	 */
+	override get scopedContextKeyService(): IContextKeyService | undefined {
+		return this._containerScopedContextKeyService;
+	}
+
+	/**
 	 * The editor control, used by other features to access the code editor widget of the selected cell.
 	 */
 	private readonly _control = this._register(new MutableDisposable<PositronNotebookEditorControl>());

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelActions.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelActions.ts
@@ -22,7 +22,7 @@ import { NOTEBOOK_KERNEL } from '../../notebook/common/notebookContextKeys.js';
 import { IPositronNotebookInstance } from '../../positronNotebook/browser/IPositronNotebookInstance.js';
 import { POSITRON_NOTEBOOK_COMMAND_MODE } from '../../positronNotebook/browser/positronNotebook.contribution.js';
 import { PositronNotebookInstance } from '../../positronNotebook/browser/PositronNotebookInstance.js';
-import { usingPositronNotebooks } from '../../positronNotebook/common/positronNotebookCommon.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID, usingPositronNotebooks } from '../../positronNotebook/common/positronNotebookCommon.js';
 import { ActiveNotebookHasRunningRuntime, isNotebookEditorInput } from '../common/activeRuntimeNotebookContextManager.js';
 import { IRuntimeNotebookKernelService } from '../common/interfaces/runtimeNotebookKernelService.js';
 import { POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID } from '../common/runtimeNotebookKernelConfig.js';
@@ -51,6 +51,11 @@ function isPositronNotebookActionBarContext(obj: unknown): obj is IPositronNoteb
 		context.instance instanceof PositronNotebookInstance;
 }
 
+function isNotebookEditorToolbarContext(obj: unknown): obj is INotebookEditorToolbarContext {
+	const context = obj as INotebookEditorToolbarContext;
+	return !!context && context.source === 'notebookToolbar' && !!context.notebookEditor?.textModel;
+}
+
 /** The context for actions in a notebook using a language runtime kernel. */
 interface IRuntimeNotebookKernelActionContext {
 	/** The notebook's URI */
@@ -69,28 +74,42 @@ interface IRuntimeNotebookKernelActionContext {
 abstract class BaseRuntimeNotebookKernelAction extends Action2 {
 	abstract runWithContext(accessor: ServicesAccessor, context: IRuntimeNotebookKernelActionContext): Promise<void>;
 
-	override async run(accessor: ServicesAccessor, context?: INotebookEditorToolbarContext | IPositronNotebookActionBarContext): Promise<void> {
+	override async run(
+		accessor: ServicesAccessor,
+		context?: INotebookEditorToolbarContext | IPositronNotebookActionBarContext | URI
+	): Promise<void> {
 		const editorService = accessor.get(IEditorService);
 		const runtimeSessionService = accessor.get(IRuntimeSessionService);
 
-		// Try to use the notebook URI from the context - set if run via the notebook editor toolbar.
+		/**
+		 * Resolve the notebook URI and source. The action is invoked from four places
+		 * and each has its own context shape:
+		 * - kernel badge dropdown: IPositronNotebookActionBarContext (instance)
+		 * - VSCode notebook toolbar: INotebookEditorToolbarContext (notebookEditor)
+		 * - editor action bar button: URI (the active editor's resource)
+		 * - command palette: undefined (look up active editor)
+		 */
 		let notebookUri: URI;
 		let source: IRuntimeNotebookKernelActionContext['source'];
-		if (context) {
-			if (isPositronNotebookActionBarContext(context)) {
-				source = {
-					id: 'positronNotebookActionBar',
-					debugMessage: `User clicked ${this.desc.id} button in Positron notebook editor toolbar`,
-				};
-				notebookUri = context.instance.uri;
-				context.instance.grabFocus();
-			} else {
-				source = {
-					id: 'vscodeNotebookToolbar',
-					debugMessage: `User clicked ${this.desc.id} button in VSCode notebook editor toolbar`
-				};
-				notebookUri = context.notebookEditor.textModel.uri;
-			}
+		if (isPositronNotebookActionBarContext(context)) {
+			source = {
+				id: 'positronNotebookActionBar',
+				debugMessage: `User clicked ${this.desc.id} button in Positron notebook editor toolbar`,
+			};
+			notebookUri = context.instance.uri;
+			context.instance.grabFocus();
+		} else if (isNotebookEditorToolbarContext(context)) {
+			source = {
+				id: 'vscodeNotebookToolbar',
+				debugMessage: `User clicked ${this.desc.id} button in VSCode notebook editor toolbar`
+			};
+			notebookUri = context.notebookEditor.textModel.uri;
+		} else if (URI.isUri(context)) {
+			source = {
+				id: 'positronNotebookActionBar',
+				debugMessage: `User clicked ${this.desc.id} button in Positron notebook editor action bar`,
+			};
+			notebookUri = context;
 		} else {
 			source = {
 				id: 'command',
@@ -140,8 +159,10 @@ export class RuntimeNotebookKernelRestartAction extends BaseRuntimeNotebookKerne
 				},
 				// Positron notebooks
 				{
-					id: MenuId.PositronNotebookKernelSubmenu,
+					id: MenuId.EditorActionsRight,
+					group: 'navigation',
 					order: 10,
+					when: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
 				}
 			]
 		});

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelActions.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelActions.ts
@@ -22,6 +22,7 @@ import { NOTEBOOK_KERNEL } from '../../notebook/common/notebookContextKeys.js';
 import { IPositronNotebookInstance } from '../../positronNotebook/browser/IPositronNotebookInstance.js';
 import { POSITRON_NOTEBOOK_COMMAND_MODE } from '../../positronNotebook/browser/positronNotebook.contribution.js';
 import { PositronNotebookInstance } from '../../positronNotebook/browser/PositronNotebookInstance.js';
+import { IPositronNotebookService } from '../../positronNotebook/browser/positronNotebookService.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID, usingPositronNotebooks } from '../../positronNotebook/common/positronNotebookCommon.js';
 import { ActiveNotebookHasRunningRuntime, isNotebookEditorInput } from '../common/activeRuntimeNotebookContextManager.js';
 import { IRuntimeNotebookKernelService } from '../common/interfaces/runtimeNotebookKernelService.js';
@@ -110,6 +111,7 @@ abstract class BaseRuntimeNotebookKernelAction extends Action2 {
 				debugMessage: `User clicked ${this.desc.id} button in Positron notebook editor action bar`,
 			};
 			notebookUri = context;
+			accessor.get(IPositronNotebookService).listInstances(notebookUri)[0]?.grabFocus();
 		} else {
 			source = {
 				id: 'command',

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -1666,6 +1666,7 @@ export class PositronNotebooks extends Notebooks {
  */
 class KernelBase {
 	statusBadge: Locator;
+	restartButton: Locator;
 	protected activeStatus: Locator;
 	protected idleStatus: Locator;
 	protected disconnectedStatus: Locator;
@@ -1676,6 +1677,7 @@ class KernelBase {
 		protected contextMenu: ContextMenu
 	) {
 		this.statusBadge = statusBadge;
+		this.restartButton = editorActionBar.getByRole('button', { name: 'Restart Kernel', exact: true });
 		this.activeStatus = editorActionBar.locator(ACTIVE_STATUS_ICON);
 		this.idleStatus = editorActionBar.locator(IDLE_STATUS_ICON);
 		this.disconnectedStatus = editorActionBar.locator(DISCONNECTED_STATUS_ICON);
@@ -1686,10 +1688,7 @@ class KernelBase {
 	 */
 	async restart({ waitForRestart = true }: { waitForRestart?: boolean } = {}): Promise<void> {
 		await test.step('Restart kernel', async () => {
-			await this.contextMenu.triggerAndClick({
-				menuTrigger: this.statusBadge,
-				menuItemLabel: /Restart Kernel/
-			});
+			await this.restartButton.click();
 
 			if (waitForRestart) {
 				await this.expectStatusToBe('idle', 30000);

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -22,17 +22,17 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		// create new notebook
 		await notebooksPositron.newNotebook();
 
-		// ensure when no kernel is selected, restart/shutdown are disabled
+		// ensure when no kernel is selected, restart toolbar button and shutdown menu item are disabled
+		await expect(notebooksPositron.kernel.restartButton).toBeDisabled();
 		await notebooksPositron.kernel.expectMenuToContain([
 			{ label: 'Change Kernel...', enabled: true },
-			{ label: 'Restart Kernel', enabled: false },
 			{ label: 'Shutdown Kernel', enabled: false },
 		]);
 
-		// select kernel and ensure while starting, restart is enabled & shutdown is disabled
+		// select kernel and ensure while starting, restart toolbar button is enabled & shutdown menu item is disabled
 		await notebooksPositron.kernel.select('Python', { waitForReady: false });
+		await expect(notebooksPositron.kernel.restartButton).toBeEnabled();
 		await notebooksPositron.kernel.expectMenuToContain([
-			{ label: 'Restart Kernel', enabled: true },
 			{ label: 'Shutdown Kernel', enabled: false },
 		]);
 
@@ -56,14 +56,14 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 			status: 'idle'
 		});
 
-		// shut down kernel and ensure menu options
+		// shut down kernel and ensure restart toolbar button stays enabled, shutdown menu item is disabled
 		await notebooksPositron.kernel.shutdown();
 		await notebooksPositron.kernel.expectKernelToBe({
 			kernelGroup: 'Python',
 			status: 'disconnected'
 		});
+		await expect(notebooksPositron.kernel.restartButton).toBeEnabled();
 		await notebooksPositron.kernel.expectMenuToContain([
-			{ label: 'Restart Kernel', enabled: true },
 			{ label: 'Shutdown Kernel', enabled: false },
 			{ label: 'Change Kernel...', enabled: true },
 		]);


### PR DESCRIPTION
Addresses #10246

Moves the "Restart Kernel" out of the kernel badge dropdown and into the Positron Notebook Editor action bar as a top-level icon button to the left of the kernel status badge.

`PositronNotebookEditor` now overrides `scopedContextKeyService` to expose its inner scoped context to the editor action bar (mirroring upstream `NotebookEditor`). This is what lets the existing `NOTEBOOK_POSITRON_KERNEL_SELECTED` precondition work in the editor action bar. Without this change the button would not be correctly enabled/disabled.

### Screenshots

<img width="1298" height="1020" alt="Screenshot 2026-04-28 at 6 27 15 PM" src="https://github.com/user-attachments/assets/78ddd8d0-a3cb-4b1e-a62d-d229472ca1b1" />

<img width="1298" height="1020" alt="Screenshot 2026-04-28 at 6 27 26 PM" src="https://github.com/user-attachments/assets/b21fb8ee-c586-4eba-ba60-24b66b56270b" />

<img width="1298" height="1020" alt="Screenshot 2026-04-28 at 6 27 39 PM" src="https://github.com/user-attachments/assets/8c37c773-811c-4c38-9fc5-dd77e444eefb" />

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Surface "Restart Kernel" as a top-level toolbar button in Positron notebooks instead of nesting
  it in the kernel badge dropdown (#10246)

#### Bug Fixes

- N/A


### QA Notes

@:editor-action-bar
@:positron-notebooks

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
