### PR TITLE
Add attached indicator to the Packages pane

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -179,11 +179,7 @@ def test_get_packages_installed_attached(
     result = _get_packages_installed(kernel, [])
     assert isinstance(result, list)
     numpy_entry = next(
-        (
-            pkg
-            for pkg in result
-            if isinstance(pkg, dict) and pkg.get("displayName") == "numpy"
-        ),
+        (pkg for pkg in result if isinstance(pkg, dict) and pkg.get("displayName") == "numpy"),
         None,
     )
     assert numpy_entry is not None, "numpy distribution should be present in the test environment"

--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -178,7 +178,14 @@ def test_get_packages_installed_attached(
 
     result = _get_packages_installed(kernel, [])
     assert isinstance(result, list)
-    numpy_entry = next((pkg for pkg in result if pkg["displayName"] == "numpy"), None)  # type: ignore[union-attr]
+    numpy_entry = next(
+        (
+            pkg
+            for pkg in result
+            if isinstance(pkg, dict) and pkg.get("displayName") == "numpy"
+        ),
+        None,
+    )
     assert numpy_entry is not None, "numpy distribution should be present in the test environment"
     assert numpy_entry["attached"] is expected_attached
 

--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -133,6 +133,56 @@ def test_open_editor_preview(ui_service: UiService, ui_comm: DummyComm) -> None:
     ]
 
 
+@pytest.mark.parametrize(
+    ("binding_name", "binding_target", "expected_attached"),
+    [
+        # `import numpy` -- binds 'numpy' to the numpy module. This case
+        # also stands in for `import numpy.linalg`, which binds the same
+        # 'numpy' top-level (the submodule is reachable as an attribute).
+        ("numpy", "numpy", True),
+        # `import numpy as np` -- binds 'np' to the numpy module
+        # (module's __name__ is still 'numpy').
+        ("np", "numpy", True),
+        # `from numpy import linalg` -- binds 'linalg' to the numpy.linalg
+        # submodule. The submodule's __name__ is 'numpy.linalg', so the
+        # detector's top-level extraction matches numpy.
+        ("linalg", "numpy.linalg", True),
+        # Defensive: a non-module value bound under the same name as a
+        # distribution must not produce a false positive.
+        ("numpy", "not-a-module", False),
+    ],
+    ids=["import-x", "import-x-as-y", "from-pkg-import-sub", "non-module-value"],
+)
+def test_get_packages_installed_attached(
+    kernel: PositronIPyKernel,
+    shell: PositronShell,
+    binding_name: str,
+    binding_target: str,
+    expected_attached: bool,  # noqa: FBT001
+) -> None:
+    """Verify `attached` detection across the import patterns we document.
+
+    Covers `import x`, `import x as y`, and `from pkg import sub` (when
+    sub is a module), and asserts that a non-module value bound under a
+    distribution name does not falsely trigger the indicator.
+    """
+    import importlib
+
+    from positron.ui import _get_packages_installed
+
+    if binding_target == "not-a-module":
+        value: object = "not a module"
+    else:
+        value = importlib.import_module(binding_target)
+    shell.user_ns[binding_name] = value
+
+    result = _get_packages_installed(kernel, [])
+    assert isinstance(result, list)
+    numpy_entry = next((pkg for pkg in result if pkg["displayName"] == "numpy"), None)  # type: ignore[union-attr]
+    assert numpy_entry is not None, "numpy distribution should be present in the test environment"
+    assert numpy_entry["attached"] is expected_attached
+
+
 def test_is_module_loaded(ui_comm: DummyComm) -> None:
     """Test the `isModuleLoaded` RPC method called from Positron."""
     module = "fallingStars"

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -9,9 +9,10 @@ import inspect
 import logging
 import os
 import sys
+import types
 import webbrowser
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Union
 from urllib.parse import urlparse
 
 from comm.base_comm import BaseComm
@@ -136,7 +137,19 @@ def _import_names_for_dist(dist: importlib.metadata.Distribution, canonical: str
 
 # Get all installed packages
 def _get_packages_installed(kernel: "PositronIPyKernel", _params: List[JsonData]) -> JsonData:
-    user_ns = kernel.shell.user_ns
+    # `attached` mirrors R's search()-membership semantics: true when the
+    # user explicitly bound the package in the REPL. We walk user_ns once
+    # to find every module the user has bound, by *any* name -- this
+    # catches `import x`, `import x as y`, `import x.sub` (binds x), and
+    # `from pkg import sub` when sub is a module. Transitive sys.modules
+    # entries pulled in by other packages are deliberately ignored.
+    user_top_levels: Set[str] = set()
+    for value in kernel.shell.user_ns.values():
+        if isinstance(value, types.ModuleType):
+            module_name = getattr(value, "__name__", None)
+            if module_name:
+                user_top_levels.add(module_name.partition(".")[0])
+
     packages_dict = {}
     for dist in importlib.metadata.distributions():
         name = dist.metadata["Name"]
@@ -145,16 +158,8 @@ def _get_packages_installed(kernel: "PositronIPyKernel", _params: List[JsonData]
         canonical = canonicalize_name(name)
         # Dedupe by canonical name - keeps first occurrence (the one that would be imported)
         if canonical not in packages_dict:
-            # `attached` mirrors R's search()-membership semantics: true
-            # when the user explicitly bound the package in the REPL via
-            # `import x`. We check IPython's user_ns rather than sys.modules
-            # so transitive imports (numpy pulled in by pandas) don't show
-            # as attached.
             import_names = _import_names_for_dist(dist, canonical)
-            attached = any(
-                isinstance(user_ns.get(import_name), type(sys))
-                for import_name in import_names
-            )
+            attached = any(import_name in user_top_levels for import_name in import_names)
             packages_dict[canonical] = {
                 "id": f"{canonical}-{dist.version}",
                 "name": name,

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -118,9 +118,9 @@ def _set_console_width(_kernel: "PositronIPyKernel", params: List[JsonData]) -> 
 
 
 def _import_names_for_dist(dist: importlib.metadata.Distribution, canonical: str) -> List[str]:
-    """
-    Best-effort list of names a user would `import` to bring this distribution
-    in. Wheels typically ship a `top_level.txt`; when missing, fall back to the
+    """Best-effort list of names a user would `import` to bring this distribution in.
+
+    Wheels typically ship a `top_level.txt`; when missing, fall back to the
     distribution's canonical name with hyphens turned into underscores
     (matches the convention for most pure-Python packages).
     """

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -116,8 +116,27 @@ def _set_console_width(_kernel: "PositronIPyKernel", params: List[JsonData]) -> 
         torch.set_printoptions(linewidth=width)
 
 
+def _import_names_for_dist(dist: importlib.metadata.Distribution, canonical: str) -> List[str]:
+    """
+    Best-effort list of names a user would `import` to bring this distribution
+    in. Wheels typically ship a `top_level.txt`; when missing, fall back to the
+    distribution's canonical name with hyphens turned into underscores
+    (matches the convention for most pure-Python packages).
+    """
+    try:
+        top_level = dist.read_text("top_level.txt")
+    except (FileNotFoundError, OSError):
+        top_level = None
+    if top_level:
+        names = [line.strip() for line in top_level.splitlines() if line.strip()]
+        if names:
+            return names
+    return [canonical.replace("-", "_")]
+
+
 # Get all installed packages
-def _get_packages_installed(_kernel: "PositronIPyKernel", _params: List[JsonData]) -> JsonData:
+def _get_packages_installed(kernel: "PositronIPyKernel", _params: List[JsonData]) -> JsonData:
+    user_ns = kernel.shell.user_ns
     packages_dict = {}
     for dist in importlib.metadata.distributions():
         name = dist.metadata["Name"]
@@ -126,11 +145,22 @@ def _get_packages_installed(_kernel: "PositronIPyKernel", _params: List[JsonData
         canonical = canonicalize_name(name)
         # Dedupe by canonical name - keeps first occurrence (the one that would be imported)
         if canonical not in packages_dict:
+            # `attached` mirrors R's search()-membership semantics: true
+            # when the user explicitly bound the package in the REPL via
+            # `import x`. We check IPython's user_ns rather than sys.modules
+            # so transitive imports (numpy pulled in by pandas) don't show
+            # as attached.
+            import_names = _import_names_for_dist(dist, canonical)
+            attached = any(
+                isinstance(user_ns.get(import_name), type(sys))
+                for import_name in import_names
+            )
             packages_dict[canonical] = {
                 "id": f"{canonical}-{dist.version}",
                 "name": name,
                 "displayName": canonical,
                 "version": dist.version,
+                "attached": attached,
             }
     return sorted(packages_dict.values(), key=lambda p: p["displayName"])
 

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1156,6 +1156,14 @@ declare module 'positron' {
 
 		/** Publication/release date */
 		publishedDate?: string;
+
+		/**
+		 * Whether the package is currently attached to the runtime's search
+		 * path (e.g. R's `search()`, Python's bound names in the user
+		 * namespace). Distinct from "loaded" in R parlance, where a package
+		 * can be loaded as a transitive dependency without being attached.
+		 */
+		attached?: boolean;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -70,8 +70,8 @@
 }
 
 .packages-list-item-attached.attached::before {
-	background: #89d185;
-	border-color: #89d185;
+	background: var(--vscode-charts-green);
+	border-color: var(--vscode-charts-green);
 }
 
 .packages-list-item-name {

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -44,6 +44,36 @@
 	overflow: hidden;
 }
 
+/*
+ * 7x7 status dot inside a 16x16 box so the visual aligns with surrounding
+ * controls. Detached is a 1px ring; attached fills with green. The
+ * indicator is a non-interactive read-only status (no hover, no pointer).
+ */
+.packages-list-item-attached {
+	flex: 0 0 auto;
+	width: 16px;
+	height: 16px;
+	margin-right: 2px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.packages-list-item-attached::before {
+	content: '';
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	box-sizing: border-box;
+	border: 1px solid var(--vscode-descriptionForeground);
+	background: transparent;
+}
+
+.packages-list-item-attached.attached::before {
+	background: #89d185;
+	border-color: #89d185;
+}
+
 .packages-list-item-name {
 	flex: 0 0 auto;
 	white-space: nowrap;

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -257,7 +257,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	// Item renderer
 	const ItemEntry = (props: { index: number; style: CSSProperties }) => {
 		const itemProps = filteredPackages[props.index];
-		const { id, name, displayName, version, latestVersion } = itemProps;
+		const { id, name, displayName, version, latestVersion, attached } = itemProps;
 
 		// Check if package has an update available
 		const hasUpdate = latestVersion && latestVersion !== version;
@@ -317,6 +317,18 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 					}
 				}}
 			>
+				{attached !== undefined && (
+					<span
+						aria-label={attached
+							? localize('positronPackages.attachedAriaLabel', "{0} is attached", name)
+							: localize('positronPackages.notAttachedAriaLabel', "{0} is not attached", name)}
+						className={positronClassNames('packages-list-item-attached', { attached })}
+						role='img'
+						title={attached
+							? localize('positronPackages.attachedTooltip', "{0} is attached", name)
+							: localize('positronPackages.notAttachedTooltip', "{0} is not attached", name)}
+					/>
+				)}
 				<div className='packages-list-item-name'>{displayName}</div>
 				<div className='packages-list-item-version'>{version}</div>
 				{hasUpdate && (

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -199,6 +199,8 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 
 		if (debouncedQuery.filter === PackagesFilter.Outdated) {
 			result = result.filter((pkg) => pkg.latestVersion && pkg.latestVersion !== pkg.version);
+		} else if (debouncedQuery.filter === PackagesFilter.Attached) {
+			result = result.filter((pkg) => pkg.attached === true);
 		}
 
 		if (debouncedQuery.text) {
@@ -383,6 +385,11 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 			label: localize('positronPackages.filterByOutdated', "Outdated"),
 			checked: currentFilter === PackagesFilter.Outdated,
 			onSelected: () => selectFilter(PackagesFilter.Outdated),
+		}),
+		new CustomContextMenuItem({
+			label: localize('positronPackages.filterByAttached', "Attached"),
+			checked: currentFilter === PackagesFilter.Attached,
+			onSelected: () => selectFilter(PackagesFilter.Attached),
 		}),
 	];
 

--- a/src/vs/workbench/contrib/positronPackages/browser/components/packagesQuery.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/packagesQuery.ts
@@ -17,6 +17,7 @@ export enum PackagesSortOrder {
 export enum PackagesFilter {
 	All = 'all',
 	Outdated = 'outdated',
+	Attached = 'attached',
 }
 
 // Token value <-> PackagesSortOrder mapping used to (de)serialize the
@@ -36,11 +37,13 @@ const SORT_ORDER_TO_TOKEN: Record<PackagesSortOrder, string> = {
 // `all` is the implicit default and is never serialized into the input.
 const FILTER_TOKEN_TO_FILTER: Record<string, PackagesFilter> = {
 	'outdated': PackagesFilter.Outdated,
+	'attached': PackagesFilter.Attached,
 };
 
 const FILTER_TO_TOKEN: Record<PackagesFilter, string> = {
 	[PackagesFilter.All]: 'all',
 	[PackagesFilter.Outdated]: 'outdated',
+	[PackagesFilter.Attached]: 'attached',
 };
 
 /** Matches `@key` or `@key:value` tokens in the filter input. */

--- a/src/vs/workbench/contrib/positronPackages/test/browser/packagesQuery.vitest.ts
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/packagesQuery.vitest.ts
@@ -148,6 +148,12 @@ describe('packagesQuery', () => {
 			expect(result.filter).toBe(PackagesFilter.Outdated);
 		});
 
+		it('@filter:attached sets Attached filter', () => {
+			const result = parseQuery('@filter:attached');
+			expect(result.text).toBe('');
+			expect(result.filter).toBe(PackagesFilter.Attached);
+		});
+
 		it('@filter:all explicitly sets All filter', () => {
 			const result = parseQuery('@filter:all');
 			expect(result.text).toBe('');
@@ -194,6 +200,10 @@ describe('packagesQuery', () => {
 
 		it('Outdated filter on empty input produces a bare token', () => {
 			expect(applyFilterToQuery('', PackagesFilter.Outdated)).toBe('@filter:outdated');
+		});
+
+		it('Attached filter on empty input produces a bare token', () => {
+			expect(applyFilterToQuery('', PackagesFilter.Attached)).toBe('@filter:attached');
 		});
 
 		it('Outdated filter with free text prepends the token', () => {

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -298,6 +298,14 @@ export interface ILanguageRuntimePackage {
 
 	/** Publication/release date */
 	publishedDate?: string;
+
+	/**
+	 * Whether the package is currently attached to the runtime's search path.
+	 * In R, this is `paste0("package:", name) %in% search()` - distinct from
+	 * "loaded" (loadedNamespaces()), which is a strict superset that includes
+	 * transitively loaded dependencies.
+	 */
+	attached?: boolean;
 }
 
 /**


### PR DESCRIPTION
See #13184 

This PR adds an "attached" indicator to the packages pane. There is an empty gray circle, but when attached it will be filled with a green dot.

The semantics for `attached` are being explicitly imported. So transitive dependencies won't appear attached.

New loading indicator:

<img width="309" height="160" alt="Screenshot 2026-04-29 at 6 26 37 AM" src="https://github.com/user-attachments/assets/c123c23e-42a3-4588-a3c5-1122eef9bfb8" />

With search query support:

<img width="716" height="280" alt="Screenshot 2026-04-29 at 9 48 52 AM" src="https://github.com/user-attachments/assets/a155703c-d568-4cc0-84fa-fb6759d8720c" />

We likely will have some follow-up work in a separate ticket to toggle this state, like RStudio provides.

### QA Notes

In order to get the latest state, you will need to click the refresh button on your packages pane.

You can use scripts like this to easily test:

```script.py
import cowsay
cowsay.cow('Hello World!')
```

```script.R
library(cowsay)
say("Hello! I am a cow in R.")
```

Assuming you have `cowsay` already installed (use the packages pane to do it!), you should be able to click to run these scripts. If you then click the refresh button in the Packages pane, the green dot should appear

@:packages-pane