### PR TITLE
Fix packages pane having unrendered content when hidden and reshown

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -456,7 +456,6 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 						itemCount={filteredPackages.length}
 						itemKey={(index) => filteredPackages[index].id}
 						itemSize={26}
-						overscanCount={10}
 						width={'calc(100% - 2px)'}
 					>
 						{ItemEntry}

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -253,6 +253,11 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 				}
 			}),
 		);
+		disposableStore.add(
+			reactComponentContainer.onVisibilityChanged((isVisible) => {
+				setVisible(isVisible);
+			}),
+		);
 		return () => disposableStore.dispose();
 	}, [reactComponentContainer, scrollStateRef, setScrollState]);
 

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -229,6 +229,8 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 		undefined,
 	);
 	const innerRef = useRef<HTMLElement>(undefined!);
+
+	const [visible, setVisible] = useState(true);
 	useEffect(() => {
 		const disposableStore = new DisposableStore();
 		disposableStore.add(
@@ -443,11 +445,13 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 					</div>
 				) : (
 					<List
+						key={visible ? 'visible' : 'hidden'}
 						height={height - FILTER_HEIGHT}
 						innerRef={innerRef}
 						itemCount={filteredPackages.length}
 						itemKey={(index) => filteredPackages[index].id}
 						itemSize={26}
+						overscanCount={10}
 						width={'calc(100% - 2px)'}
 					>
 						{ItemEntry}


### PR DESCRIPTION
See #12759 

Adding a `useState` with the visibility property and using its value as the List components `key` forces it to re-render when hidden and reshown. This will reset any scroll location and resolve the issue reported.

Ideally, it would remember the scroll position and whatnot, but I am having trouble getting that to work.

Long-term, I believe the intention is to not use react-window, but to instead use Positron's DataGrid. I think this is "good enough" to resolve the issue without sinking more effort into an implementation we don't want.

### QA Notes

The original bug can be reproduced by scrolling, hiding the pane, then showing the pane. It would produce a Packages pane that had a bunch of blank, unrendered content.

With this change, when you hide the pane and show it again, the scroll position will be reset to 0 and everything is properly rendered.

@:packages-pane