### PR TITLE
test: skip flaky e2e tests

### DIFF
--- a/test/e2e/tests/extensions/restart-host-ext.test.ts
+++ b/test/e2e/tests/extensions/restart-host-ext.test.ts
@@ -9,7 +9,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Restart Host Extension', {
+test.describe.skip('Restart Host Extension', {
 	tag: [tags.EXTENSIONS, tags.WIN, tags.SOFT_FAIL],
 	annotation: { type: 'issue', description: 'https://github.com/posit-dev/positron/issues/12476' }
 }, () => {

--- a/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
+++ b/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
@@ -29,7 +29,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] }, () => {
+test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS] }, () => {
 	test.beforeAll(async ({ vsCodeSettings: vscodeUserSettings, settings: positronUserSettings }) => {
 		await vscodeUserSettings.append({
 			'test': 'vs-code-settings',
@@ -50,7 +50,7 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] 
 	});
 
 	test.describe('Defer Import', () => {
-		test('Verify import prompt behavior on "Later"', async ({ app, hotKeys }) => {
+		test('Verify import prompt behavior on "Later"', { tag: [tags.WIN] }, async ({ app, hotKeys }) => {
 			const { toasts } = app.workbench;
 
 			// select "Later" and verify that the prompt is no longer visible
@@ -63,7 +63,7 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] 
 			await toasts.expectImportSettingsToastToBeVisible();
 		});
 
-		test('Verify import prompt behavior on "Don\'t Show Again"', async ({ sessions, app, hotKeys, page }) => {
+		test('Verify import prompt behavior on "Don\'t Show Again"', { tag: [tags.WIN] }, async ({ sessions, app, hotKeys, page }) => {
 			const { toasts } = app.workbench;
 
 			// select "Don't Show Again" and verify that the prompt is no longer visible
@@ -80,7 +80,7 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] 
 	});
 
 	test.describe('Import with Positron settings', () => {
-		test('Verify diff displays and rejected settings are not saved', async ({ app, page, hotKeys }) => {
+		test('Verify diff displays and rejected settings are not saved', { tag: [tags.WIN] }, async ({ app, page, hotKeys }) => {
 			const { toasts } = app.workbench;
 			const testSettingLocator = page.getByText('"test": "positron-settings"');
 
@@ -97,7 +97,7 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] 
 			await expect(testSettingLocator).toHaveCount(1);
 		});
 
-		test('Verify diff displays and accepted settings are saved', async ({ app, page, hotKeys }) => {
+		test('Verify diff displays and accepted settings are saved', { tag: [tags.WIN] }, async ({ app, page, hotKeys }) => {
 			const { toasts } = app.workbench;
 
 			// import settings and verify diff displays
@@ -119,7 +119,7 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS, tags.WIN] 
 			await settings.clear();
 		});
 
-		test('Verify import import occurs and is clean without a diff', async ({ app, page, hotKeys }) => {
+		test('Verify import import occurs and is clean without a diff', { tag: [tags.WIN] }, async ({ app, page, hotKeys }) => {
 			const { toasts } = app.workbench;
 
 			// import settings

--- a/test/e2e/tests/variables/variables-memory-usage.test.ts
+++ b/test/e2e/tests/variables/variables-memory-usage.test.ts
@@ -83,7 +83,7 @@ test.describe('Variables: Memory Usage', {
 		await variables.expectSessionsInMemoryDropdown({ [rSession.name]: true });
 	});
 
-	test('Restarted session reappears in memory usage meter', { tag: [tags.WEB] }, async function ({ app, sessions, settings }) {
+	test.skip('Restarted session reappears in memory usage meter', { tag: [tags.WEB], annotation: { type: 'issue', description: 'https://github.com/posit-dev/positron/issues/12476' } }, async function ({ app, sessions, settings }) {
 		const { variables } = app.workbench;
 
 		// Set a fast polling interval so the memory meter updates quickly


### PR DESCRIPTION
## Summary
- Skip Restart Host Extension suite
- Skip "Restarted session reappears in memory usage meter" variant 
- Move WIN tag from Import VSCode Settings describe to individual tests
