### PR TITLE
e2e: skip flaky plot tests

### DIFF
--- a/test/e2e/tests/plots/plot-updates.test.ts
+++ b/test/e2e/tests/plots/plot-updates.test.ts
@@ -52,7 +52,12 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			}).toPass({ timeout: 15000 });
 		});
 
-		test('Python - plot should not be updated after initial appearance', { tag: [tags.WEB] }, async function ({ app, python }) {
+		test.skip('Python - plot should not be updated after initial appearance', {
+			annotation: {
+				type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13066'
+			},
+			tag: [tags.WEB]
+		}, async function ({ app, python }) {
 
 			const code = `
 import matplotlib.pyplot as plt

--- a/test/e2e/tests/plots/plots.test.ts
+++ b/test/e2e/tests/plots/plots.test.ts
@@ -197,7 +197,12 @@ test.describe('Plots', { tag: [tags.PLOTS, tags.EDITOR] }, () => {
 			await verifyPlotInNewWindow(app, 'Python', pythonDynamicPlot);
 		});
 
-		test('Python - Verify saving a Python plot', { tag: [tags.WIN, tags.CRITICAL] }, async function ({ app }) {
+		test.skip('Python - Verify saving a Python plot', {
+			annotation: {
+				type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13066'
+			},
+			tag: [tags.WIN, tags.CRITICAL]
+		}, async function ({ app }) {
 			await test.step('Sending code to console to create plot', async () => {
 				await app.workbench.console.executeCode('Python', pythonDynamicPlot);
 				await app.workbench.plots.waitForCurrentPlot();


### PR DESCRIPTION
## Summary
- Skip "Python - plot should not be updated after initial appearance" (tracked by #13066)
- Skip "Python - Verify saving a Python plot" (tracked by #13066)
