### PR TITLE
e2e: remote-ssh flake

### DIFF
--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -153,12 +153,13 @@ test.describe('Remote SSH', {
 
 			await sshWorkbench.editors.newUntitledFile();
 			await sshWorkbench.editor.selectTabAndType(fileName, flaskAppCode);
-			await sshWin.keyboard.press('Enter');
 
 			await sshWorkbench.topActionBar.saveButton.click();
 
 			await sshWorkbench.quickInput.waitForQuickInputOpened();
-			await sshWin.keyboard.press('Backspace'); // clear any pre-filled text
+			// Clear any pre-filled text deterministically (single Backspace only deletes one char)
+			await sshWorkbench.hotKeys.selectAll();
+			await sshWin.keyboard.press('Delete');
 			await sshWorkbench.quickInput.type('test.py');
 
 			await expect(async () => {
@@ -166,7 +167,7 @@ test.describe('Remote SSH', {
 				await sshWorkbench.quickInput.waitForQuickInputClosed();
 			}).toPass({ timeout: 60000 });
 
-			await sshWin.waitForTimeout(3000); // wait for file to be saved
+			await sshWorkbench.editors.waitForTab('test.py', false);
 
 			await sshWorkbench.editor.pressPlay();
 
@@ -191,8 +192,8 @@ app = Flask(__name__)
 
 @app.route('/')
 def hello():
-    return 'Hello, World!'
+	return 'Hello, World!'
 
 if __name__ == '__main__':
-    app.run(debug=True)
+	app.run(debug=True)
 `;


### PR DESCRIPTION
The `Verify SSH connection into docker image` test has been flaking in CI. Three fixes in the "Check that apps work" step:

- Drop the bare `Enter` press after typing the Flask source — could accept IntelliSense suggestions and mutate the code.
- Replace single `Backspace` (clears one char) with `hotKeys.selectAll()` + `Delete` so the pre-filled save name is fully cleared regardless of length or auto-select state.
- Replace `waitForTimeout(3000)` with `editors.waitForTab('test.py', false)` so we wait on the actual saved/clean state instead of a hardcoded sleep.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

The remote-ssh suite does not run on PRs — it only runs in scheduled/nightly. Verify locally or via the next nightly:

- [ ] Run `tests/remote-ssh/remote-ssh.test.ts` locally a handful of times and confirm it passes consistently.
- [ ] Watch the next nightly run for stability.