### PR TITLE
e2e: skip restart host ext mem usage test

### DIFF
--- a/test/e2e/tests/variables/variables-memory-usage.test.ts
+++ b/test/e2e/tests/variables/variables-memory-usage.test.ts
@@ -56,7 +56,9 @@ test.describe('Variables: Memory Usage', {
 		});
 	});
 
-	test('Reconnected session reappears in memory usage meter after extension host restart', async function ({ app, sessions, settings }) {
+	test.skip('Reconnected session reappears in memory usage meter after extension host restart', {
+		annotation: { type: 'issue', description: 'https://github.com/posit-dev/positron/issues/12476' }
+	}, async function ({ app, sessions, settings }) {
 		const { console: consolePage, quickaccess, variables } = app.workbench;
 
 		// Set a fast polling interval so the memory meter updates quickly
@@ -83,7 +85,10 @@ test.describe('Variables: Memory Usage', {
 		await variables.expectSessionsInMemoryDropdown({ [rSession.name]: true });
 	});
 
-	test.skip('Restarted session reappears in memory usage meter', { tag: [tags.WEB], annotation: { type: 'issue', description: 'https://github.com/posit-dev/positron/issues/12476' } }, async function ({ app, sessions, settings }) {
+	test.skip('Restarted session reappears in memory usage meter', {
+		tag: [tags.WEB],
+		annotation: { type: 'issue', description: 'https://github.com/posit-dev/positron/issues/12476' }
+	}, async function ({ app, sessions, settings }) {
 		const { variables } = app.workbench;
 
 		// Set a fast polling interval so the memory meter updates quickly


### PR DESCRIPTION
Oops. I missed this one. Also impacted by the same bug: 
https://github.com/posit-dev/positron/issues/12476

Skipping because these tests are creating a lot of noise due to the known issue.