### PR TITLE
disable `terminal.integrated.initialHint` by default

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration.ts
@@ -17,6 +17,9 @@ export const terminalInitialHintConfiguration: IStringDictionary<IConfigurationP
 		restricted: true,
 		markdownDescription: localize('terminal.integrated.initialHint', "Controls if the first terminal without input will show a hint about available actions when it is focused. This will only show when {0} is disabled.", `\`#${TerminalSettingId.SendKeybindingsToShell}#\``),
 		type: 'boolean',
-		default: true
+		// --- Start Positron ---
+		// Disable the terminal initial hint by default for https://github.com/posit-dev/positron/issues/13227
+		default: false
+		// --- End Positron ---
 	}
 };


### PR DESCRIPTION
- Addresses https://github.com/posit-dev/positron/issues/13227
- Flips the default for `terminal.integrated.initialHint` from true to false

### Release Notes

#### Bug Fixes

- Terminal: don't show initial hint by default (#13227)


### QA Notes

- By default, the terminal hint will no longer show
- Users can re-enable it to show the terminal hint