### PR TITLE
jupyterhub: update license path

### DIFF
--- a/.github/actions/setup-jupyter-docker/action.yml
+++ b/.github/actions/setup-jupyter-docker/action.yml
@@ -67,8 +67,13 @@ runs:
         # Create license file from secret
         echo "${{ inputs.positron-license }}" > positron.lic
 
-        # Copy license into container at /opt/license.lic (expected by install script)
-        docker cp positron.lic jupyter-test:/opt/license.lic
+        # Copy license into container at arch specific location (expected by install script)
+        ARCH=$(docker exec jupyter-test uname -m)
+        if [[ "$ARCH" == "aarch64" ]]; then
+          docker cp positron.lic jupyter-test:/opt/positron-server/resources/activation/linux/aarch64/positron.lic
+        else
+          docker cp positron.lic jupyter-test:/opt/positron-server/resources/activation/linux/x86_64/positron.lic
+        fi
 
         # Clean up local copy
         rm positron.lic


### PR DESCRIPTION
follow up to #13232 changing default path from `opt/license.lic` to `opt/positron-server/resources/activation/linux/{ARCH}/license.lic` 

note the license name no longer matters, we check for any *.lic in that location

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

@:jupyter