### PR TITLE
Revert Chat view for copilot-chat

### DIFF
--- a/product.json
+++ b/product.json
@@ -328,16 +328,16 @@
 		"https://support.posit.co"
 	],
 	"defaultChatAgent": {
-		"extensionId": "positron.positron-assistant",
-		"chatExtensionId": "positron.positron-assistant",
+		"extensionId": "GitHub.copilot-chat",
+		"chatExtensionId": "GitHub.copilot-chat",
 		"provider": {
 			"default": {
-				"id": "positron.assistant",
-				"name": "Positron Assistant"
+				"id": "github",
+				"name": "GitHub"
 			},
 			"enterprise": {
-				"id": "positron.assistant",
-				"name": "Positron Assistant"
+				"id": "github-enterprise",
+				"name": "GitHub Enterprise"
 			}
 		},
 		"providerExtensionId": "vscode.github-authentication",

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -97,8 +97,8 @@ else {
 				'https://login.staging.posit.cloud'
 			],
 			defaultChatAgent: {
-				extensionId: 'positron.positron-assistant',
-				chatExtensionId: 'positron.positron-assistant',
+				extensionId: 'GitHub.copilot-chat',
+				chatExtensionId: 'GitHub.copilot-chat',
 				chatExtensionOutputId: '',
 				documentationUrl: '',
 				skusDocumentationUrl: '',
@@ -111,8 +111,8 @@ else {
 				termsStatementUrl: '',
 				privacyStatementUrl: '',
 				provider: {
-					default: { id: 'positron.assistant', name: 'Positron Assistant' },
-					enterprise: { id: 'positron.assistant', name: 'Positron Assistant' },
+					default: { id: 'github', name: 'GitHub' },
+					enterprise: { id: 'github-enterprise', name: 'GitHub Enterprise' },
 					google: { id: '', name: '' },
 					apple: { id: '', name: '' },
 				},

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -172,7 +172,6 @@ import { PlanAgentDefaultModel } from './planAgentDefaultModel.js';
 
 // --- Start Positron ---
 import { PositronBuiltinToolsContribution } from './tools/tools.js';
-import { ChatRuntimeSessionContextContribution } from './widget/input/editor/chatRuntimeSessionContext.js';
 // eslint-disable-next-line no-duplicate-imports
 import { INSTRUCTIONS_POSITRON_SOURCE_FOLDER, PROMPT_POSITRON_SOURCE_FOLDER, LEGACY_MODE_POSITRON_SOURCE_FOLDER, AGENTS_POSITRON_SOURCE_FOLDER } from '../common/promptSyntax/config/promptFileLocations.js';
 // --- End Positron ---
@@ -279,38 +278,6 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: nls.localize('chat.implicitContext.suggestedContext', "Controls whether the new implicit context flow is shown. In Ask and Edit modes, the context will automatically be included. When using an agent, context will be suggested as an attachment. Selections are always included as context."),
 			default: true,
 		},
-		// --- Start Positron ---
-		'chat.implicitSessionContext.enabled': {
-			type: 'object',
-			tags: ['experimental'],
-			description: nls.localize('chat.implicitSessionContext.enabled.1', "Enables automatically using the active interpreter session as chat context for specified chat locations."),
-			additionalProperties: {
-				type: 'string',
-				enum: ['never', 'first', 'always'],
-				description: nls.localize('chat.implicitSessionContext.value', "The value for the implicit runtime context."),
-				enumDescriptions: [
-					nls.localize('chat.implicitSessionContext.value.never', "Implicit session context is never enabled."),
-					nls.localize('chat.implicitSessionContext.value.first', "Implicit session context is enabled for the first interaction."),
-					nls.localize('chat.implicitSessionContext.value.always', "Implicit session context is always enabled.")
-				]
-			},
-			default: {
-				'panel': 'always',
-			}
-		},
-		'chat.runtimeSessionContext.maxExecutionHistoryCharacters': {
-			type: 'number',
-			tags: ['experimental'],
-			description: nls.localize('chat.runtimeSessionContext.maxExecutionHistoryCharacters', "The maximum character count for the runtime session execution history context. This is used to limit the size of the context that is sent to the model. The default is 8192 characters."),
-			default: 8192, // 8k characters
-			minimum: 1024,
-		},
-		'chat.useCopilotParticipantsWithOtherProviders': {
-			type: 'boolean',
-			markdownDescription: nls.localize('chat.useCopilotParticipantsWithOtherProviders', "Allow any model in Positron Assistant to use chat participants provided by GitHub Copilot.\n\nThis requires that you are signed into Copilot, and **may send data to Copilot models regardless of the selected provider when Copilot participants are used**.\n\nFor example, if you enable this setting and you are using Anthropic as a provider, GitHub Copilot participants are available. When invoked, the participants may send data to Copilot models.\n\n See also: `#positron.assistant.alwaysIncludeCopilotTools#`"),
-			default: false
-		},
-		// --- End Positron ---
 		'chat.editing.autoAcceptDelay': {
 			type: 'number',
 			markdownDescription: nls.localize('chat.editing.autoAcceptDelay', "Delay after which changes made by chat are automatically accepted. Values are in seconds, `0` means disabled and `100` seconds is the maximum."),
@@ -1819,7 +1786,6 @@ registerWorkbenchContribution2(AgentPluginsViewsContribution.ID, AgentPluginsVie
 
 // --- Start Positron ---
 registerWorkbenchContribution2(PositronBuiltinToolsContribution.ID, PositronBuiltinToolsContribution, WorkbenchPhase.Eventually);
-registerWorkbenchContribution2(ChatRuntimeSessionContextContribution.ID, ChatRuntimeSessionContextContribution, WorkbenchPhase.Eventually);
 // --- End Positron ---
 
 registerChatActions();

--- a/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
@@ -17,10 +17,7 @@ import { ExtensionIdentifier, IExtensionManifest } from '../../../../platform/ex
 import { SyncDescriptor } from '../../../../platform/instantiation/common/descriptors.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
-// --- Start Positron ---
-// Positron uses Codicon.positronAssistant instead of registerIcon for the chat view icon
-// import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
-// --- End Positron ---
+import { registerIcon } from '../../../../platform/theme/common/iconRegistry.js';
 import { ViewPaneContainer } from '../../../browser/parts/views/viewPaneContainer.js';
 import { IWorkbenchContribution } from '../../../common/contributions.js';
 import { IViewContainersRegistry, IViewDescriptor, IViewsRegistry, ViewContainer, ViewContainerLocation, Extensions as ViewExtensions } from '../../../common/views.js';
@@ -38,18 +35,12 @@ import { ChatViewPane } from './widgetHosts/viewPane/chatViewPane.js';
 
 // --- Chat Container &  View Registration
 
-// --- Start Positron ---
-// Upstream uses chatViewIcon; Positron overrides with its own icon.
-// const chatViewIcon = registerIcon('chat-view-icon', Codicon.chatSparkle, localize('chatViewIcon', 'View icon of the chat view.'));
-// --- End Positron ---
+const chatViewIcon = registerIcon('chat-view-icon', Codicon.chatSparkle, localize('chatViewIcon', 'View icon of the chat view.'));
 
 const chatViewContainer: ViewContainer = Registry.as<IViewContainersRegistry>(ViewExtensions.ViewContainersRegistry).registerViewContainer({
 	id: ChatViewContainerId,
 	title: localize2('chat.viewContainer.label', "Chat"),
-	// --- Start Positron ---
-	// icon: chatViewIcon,
-	icon: Codicon.positronAssistant,
-	// --- End Positron ---
+	icon: chatViewIcon,
 	ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [ChatViewContainerId, { mergeViewWithContainerWhenSingleView: true }]),
 	storageId: ChatViewContainerId,
 	hideIfEmpty: true,

--- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard.ts
@@ -196,10 +196,7 @@ export class ChatStatusDashboard extends DomWidget {
 			}
 
 			if (this.chatEntitlementService.entitlement === ChatEntitlement.Free && (Number(chatQuota?.percentRemaining) <= 25 || Number(completionsQuota?.percentRemaining) <= 25)) {
-				// --- Start Positron ---
-				// Add configuration service param to `canUseChat` call
-				const upgradeProButton = this._store.add(new Button(this.element, { ...defaultButtonStyles, hoverDelegate: nativeHoverDelegate, secondary: this.canUseChat(this.configurationService, this.chatEntitlementService) /* use secondary color when chat can still be used */ }));
-				// --- End Positron ---
+				const upgradeProButton = this._store.add(new Button(this.element, { ...defaultButtonStyles, hoverDelegate: nativeHoverDelegate, secondary: this.canUseChat() /* use secondary color when chat can still be used */ }));
 				upgradeProButton.label = localize('upgradeToCopilotPro', "Upgrade to GitHub Copilot Pro");
 				this._store.add(upgradeProButton.onDidClick(() => this.runCommandAndClose('workbench.action.chat.upgradePlan')));
 			}
@@ -454,13 +451,10 @@ export class ChatStatusDashboard extends DomWidget {
 		}
 
 		// Completions Snooze
-		// --- Start Positron ---
-		// Add configuration service param to `canUseChat` call
-		if (this.canUseChat(this.configurationService, this.chatEntitlementService)) {
+		if (this.canUseChat()) {
 			const snooze = append(this.element, $('div.snooze-completions'));
 			this.createCompletionsSnooze(snooze, localize('settings.snooze', "Snooze"), this._store);
 		}
-		// --- End Positron ---
 
 		// New to Chat / Signed out
 		// --- Start Positron ---
@@ -521,15 +515,7 @@ export class ChatStatusDashboard extends DomWidget {
 		}
 	}
 
-	// --- Start Positron ---
-	// Add config service param and consider
-	private canUseChat(configService: IConfigurationService, chatEntitlementService: IChatEntitlementService): boolean {
-		// If Assistant is explicitly enabled, allow chat usage
-		const result = !!configService.getValue<boolean>('positron.assistant.enable');
-		if (result) {
-			return true;
-		}
-
+	private canUseChat(): boolean {
 		if (!this.chatEntitlementService.sentiment.installed || this.chatEntitlementService.sentiment.disabled || this.chatEntitlementService.sentiment.untrusted) {
 			return false; // chat not installed or not enabled
 		}
@@ -544,7 +530,6 @@ export class ChatStatusDashboard extends DomWidget {
 
 		return true;
 	}
-	// --- End Positron ---
 
 	private getUsageTitle(): string {
 		const planName = getChatPlanName(this.chatEntitlementService.entitlement);
@@ -743,7 +728,7 @@ export class ChatStatusDashboard extends DomWidget {
 			}
 		}));
 
-		if (!this.canUseChat(this.configurationService, this.chatEntitlementService)) {
+		if (!this.canUseChat()) {
 			container.classList.add('disabled');
 			checkbox.disable();
 			checkbox.checked = false;
@@ -809,7 +794,7 @@ export class ChatStatusDashboard extends DomWidget {
 
 		disposables.add(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(completionsSettingId)) {
-				if (completionsSettingAccessor.readSetting() && this.canUseChat(this.configurationService, this.chatEntitlementService)) {
+				if (completionsSettingAccessor.readSetting() && this.canUseChat()) {
 					checkbox.enable();
 					container.classList.remove('disabled');
 				} else {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatAttachmentsContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatContentParts/chatAttachmentsContentPart.ts
@@ -16,12 +16,6 @@ import { ChatResponseReferencePartStatusKind, IChatContentReference } from '../.
 import { DefaultChatAttachmentWidget, ElementChatAttachmentWidget, FileAttachmentWidget, ImageAttachmentWidget, NotebookCellOutputChatAttachmentWidget, PasteAttachmentWidget, PromptFileAttachmentWidget, PromptTextAttachmentWidget, SCMHistoryItemAttachmentWidget, SCMHistoryItemChangeAttachmentWidget, SCMHistoryItemChangeRangeAttachmentWidget, TerminalCommandAttachmentWidget, ToolSetOrToolItemAttachmentWidget } from '../../attachments/chatAttachmentWidgets.js';
 import { IChatAttachmentWidgetRegistry } from '../../attachments/chatAttachmentWidgetRegistry.js';
 
-// --- Start Positron ---
-// eslint-disable-next-line no-duplicate-imports
-import { isRuntimeSessionEntry } from '../../../common/attachments/chatVariableEntries.js';
-import { RuntimeSessionAttachmentWidget } from '../../chatRuntimeAttachmentWidget.js';
-// --- End Positron ---
-
 export interface IChatAttachmentsContentPartOptions {
 	readonly variables: readonly IChatRequestVariableEntry[];
 	readonly contentReferences?: ReadonlyArray<IChatContentReference>;
@@ -174,10 +168,6 @@ export class ChatAttachmentsContentPart extends Disposable {
 		} else if (isWorkspaceVariableEntry(attachment)) {
 			// skip workspace attachments
 			return;
-			// --- Start Positron ---
-		} else if (isRuntimeSessionEntry(attachment)) {
-			widget = this.instantiationService.createInstance(RuntimeSessionAttachmentWidget, attachment, undefined, { shouldFocusClearButton: false, supportsDeletion: false }, container, this._contextResourceLabels);
-			// --- End Positron ---
 		} else {
 			widget = this.chatAttachmentWidgetRegistry.createWidget(attachment, { shouldFocusClearButton: false, supportsDeletion: false }, container)
 				?? this.instantiationService.createInstance(DefaultChatAttachmentWidget, resource, range, attachment, correspondingContentReference, undefined, { shouldFocusClearButton: false, supportsDeletion: false }, container, this._contextResourceLabels);

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -89,8 +89,6 @@ import { IChatDebugService } from '../../common/chatDebugService.js';
 // --- Start Positron ---
 import './media/positronChat.css';
 import { ILanguageModelsService } from '../../common/languageModels.js';
-import { IPositronAssistantConfigurationService } from '../../../positronAssistant/common/interfaces/positronAssistantService.js';
-import { IPositronDocsService } from '../../../../services/positronDocs/browser/positronDocsService.js';
 // --- End Positron ---
 
 const $ = dom.$;
@@ -397,8 +395,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		@ILanguageModelToolsService private readonly toolsService: ILanguageModelToolsService,
 		// --- Start Positron ---
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
-		@IPositronAssistantConfigurationService private readonly positronAssistantConfigurationService: IPositronAssistantConfigurationService,
-		@IPositronDocsService private readonly docsService: IPositronDocsService,
 		// --- End Positron ---
 		@IChatModeService private readonly chatModeService: IChatModeService,
 		@IChatLayoutService private readonly chatLayoutService: IChatLayoutService,
@@ -722,13 +718,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this.createInput(this.container, { renderFollowups, renderStyle, renderInputToolbarBelowInput });
 		}
 
-		// --- Start Positron ---
-		// Don't show the input part if the assistant is disabled
-		if (!this.configurationService.getValue('positron.assistant.enable')) {
-			dom.hide(this.inputPart.element);
-		}
-		// --- End Positron ---
-
 		this.renderWelcomeViewContentIfNeeded();
 		this.createList(this.listContainer, { editable: !isInlineChat(this) && !isQuickChat(this), ...this.viewOptions.rendererOptions, renderStyle });
 
@@ -1041,20 +1030,11 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				} else {
 					additionalMessage = defaultAgent?.metadata.additionalWelcomeMessage;
 				}
-				// --- Start Positron ---
-				// Hide additional message
-				/*
 				if (!additionalMessage && !this._lockedAgent) {
-				*/
-				if (!additionalMessage && !this._lockedAgent && numItems) {
 					additionalMessage = this._getGenerateInstructionsMessage();
 				}
 
-				// Use Positron's welcome view content
-				// const welcomeContent = this.getWelcomeViewContent(additionalMessage);
-				const welcomeContent = numItems ? this.getWelcomeViewContent(additionalMessage) :
-					this.getPositronWelcomeViewContent(additionalMessage);
-				// --- End Positron ---
+				const welcomeContent = this.getWelcomeViewContent(additionalMessage);
 				if (!this.welcomePart.value || this.welcomePart.value.needsRerender(welcomeContent)) {
 					dom.clearNode(this.welcomeMessageContainer);
 
@@ -1208,62 +1188,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			additionalMessage,
 		};
 	}
-
-	// --- Start Positron ---
-	private getPositronWelcomeViewContent(additionalMessage: string | IMarkdownString | undefined): IChatViewWelcomeContent {
-		let welcomeText;
-		let welcomeTitle;
-		let tips: IMarkdownString | undefined;
-
-		// Show a link to enable the assistant if it's not yet enabled
-		if (!this.configurationService.getValue('positron.assistant.enable')) {
-			welcomeTitle = localize('positronAssistant.comingSoonTitle', "Welcome to Positron Assistant");
-			const enableAssistantMessage = localize('positronAssistant.enableAssistantMessage', "Enable Positron Assistant");
-			welcomeText = localize('positronAssistant.comingSoonMessage', "Positron Assistant is under development and is currently available as a preview feature of Positron.\n");
-			welcomeText += `\n\n[${enableAssistantMessage}](command:positron-assistant.enableAssistantSetting)`;
-		} else if (!this.languageModelsService.currentProvider) {
-			// No provider is configured/authenticated - show appropriate setup message
-			const hasEnabledProviders = this.positronAssistantConfigurationService.getEnabledProviders().length > 0;
-			welcomeTitle = localize('positronAssistant.gettingStartedTitle', "Set Up Positron Assistant");
-
-			if (hasEnabledProviders) {
-				// Providers are enabled but user needs to sign in
-				const signInMessage = localize('positronAssistant.signInMessage', "Sign in to a provider");
-				welcomeText = localize('positronAssistant.signInSetupMessage', "To start using Positron Assistant, sign in to a provider.");
-				welcomeText += `\n\n[${signInMessage}](command:positron-assistant.configureProviders)`;
-			} else {
-				// No providers enabled - need to enable first
-				const enableProviderMessage = localize('positronAssistant.enableProviderMessage', "Enable a provider");
-				welcomeText = localize('positronAssistant.enableSetupMessage', "To start using Positron Assistant, enable a provider in Settings.");
-				welcomeText += `\n\n[${enableProviderMessage}](command:workbench.action.openSettings?%22positron.assistant.provider%20enable%22)`;
-			}
-		} else {
-			const guideLinkMessage = localize('positronAssistant.guideLinkMessage', "Positron Assistant User Guide");
-			welcomeTitle = localize('positronAssistant.welcomeMessageTitle', "Welcome to Positron Assistant");
-			// eslint-disable-next-line local/code-no-unexternalized-strings
-			welcomeText = localize('positronAssistant.welcomeMessageReady', `Positron Assistant is an AI coding companion designed to accelerate and enhance your data science projects.
-
-The {guide-link} explains the possibilities and capabilities of Positron Assistant.
-
-Always verify results. AI assistants can sometimes produce incorrect code.`);
-			// eslint-disable-next-line local/code-no-unexternalized-strings
-			tips = new MarkdownString(localize('positronAssistant.welcomeMessageReadyTips', `Click on or type $(mention) to select a Chat Participant.
-
-Click on $(attach) or type \`#\` to add context, such as files to your chat.
-
-Type \`/\` to use predefined commands such as \`/help\`.`,
-			), { supportThemeIcons: true, isTrusted: true });
-			welcomeText = welcomeText.replace('{guide-link}', `[${guideLinkMessage}](${this.docsService.getUrl('assistant')})`);
-		}
-		return {
-			title: welcomeTitle,
-			message: new MarkdownString(welcomeText, { supportThemeIcons: true, isTrusted: true }),
-			icon: Codicon.positronAssistant,
-			tips,
-			additionalMessage,
-		};
-	}
-	// --- End Positron ---
 
 	private async renderChatEditingSessionState() {
 		if (!this.input) {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -958,11 +958,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			}
 
 			this.renderFollowups();
-
-			// --- Start Positron ---
-			// Update token usage display when items change
-			this.input.updateTokenUsageDisplay(this.viewModel);
-			// --- End Positron ---
 		}
 	}
 
@@ -1448,10 +1443,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 					// Do it after a timeout because the container is not visible yet (it should be but offsetHeight returns 0 here)
 					if (this._visible) {
 						this.onDidChangeItems(true);
-						// --- Start Positron ---
-						// Update token usage display when widget becomes visible
-						this.input.updateTokenUsageDisplay(this.viewModel);
-						// --- End Positron ---
 					}
 				}, 0);
 

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatInputPart.ts
@@ -129,13 +129,6 @@ import { ChatContextUsageWidget } from '../../widgetHosts/viewPane/chatContextUs
 import { Target } from '../../../common/promptSyntax/promptTypes.js';
 import { EnhancedModelPickerActionItem } from './modelPickerActionItem2.js';
 
-// --- Start Positron ---
-import { ChatRuntimeSessionContext } from './editor/chatRuntimeSessionContext.js';
-import { RuntimeSessionContextAttachmentWidget } from '../../attachments/runtimeSessionContextAttachment.js';
-import { RuntimeSessionAttachmentWidget } from '../../chatRuntimeAttachmentWidget.js';
-import { IPositronAssistantConfigurationService } from '../../../../positronAssistant/common/interfaces/positronAssistantService.js';
-// --- End Positron ---
-
 const $ = dom.$;
 
 const INPUT_EDITOR_MAX_HEIGHT = 250;
@@ -279,14 +272,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			contextArr.add(...implicitChatVariables);
 		}
 
-		// --- Start Positron ---
-		// Add runtime session context if enabled and has value
-		if (this.runtimeContext?.enabled && this.runtimeContext.value) {
-			const runtimeChatVariables = this.runtimeContext.toBaseEntries();
-			contextArr.add(...runtimeChatVariables);
-		}
-		// --- End Positron ---
-
 		return contextArr;
 	}
 
@@ -294,13 +279,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private _indexOfLastOpenedContext: number = -1;
 
 	private _implicitContext: ChatImplicitContexts | undefined;
-
-	// --- Start Positron ---
-	private _runtimeContext: ChatRuntimeSessionContext | undefined;
-	public get runtimeContext(): ChatRuntimeSessionContext | undefined {
-		return this._runtimeContext;
-	}
-	// --- End Positron ---
 
 	public get implicitContext(): ChatImplicitContexts | undefined {
 		return this._implicitContext;
@@ -338,10 +316,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private chatInputWidgetsContainer!: HTMLElement;
 	private inputContainer!: HTMLElement;
 	private readonly _widgetController = this._register(new MutableDisposable<ChatInputPartWidgetController>());
-
-	// --- Start Positron ---
-	private tokenUsageContainer!: HTMLElement;
-	// --- End Positron ---
 
 	private contextUsageWidget?: ChatContextUsageWidget;
 	private contextUsageWidgetContainer!: HTMLElement;
@@ -411,9 +385,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private chatSessionPickerContainer: HTMLElement | undefined;
 	private _lastSessionPickerAction: MenuItemAction | undefined;
 	private readonly _waitForPersistedLanguageModel: MutableDisposable<IDisposable> = this._register(new MutableDisposable<IDisposable>());
-	// --- Start Positron ---
-	private _onDidChangeModelList: Emitter<void> = this._register(new Emitter<void>());
-	// --- End Positron ---
 	private readonly _chatSessionOptionEmitters: Map<string, Emitter<IChatSessionProviderOptionItem>> = new Map();
 
 	/**
@@ -571,9 +542,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IViewDescriptorService private readonly viewDescriptorService: IViewDescriptorService,
 		@IChatAttachmentWidgetRegistry private readonly _chatAttachmentWidgetRegistry: IChatAttachmentWidgetRegistry,
-		// --- Start Positron ---
-		@IPositronAssistantConfigurationService private readonly positronAssistantConfigService: IPositronAssistantConfigurationService,
-		// --- End Positron ---
 	) {
 		super();
 
@@ -649,14 +617,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				this.agentSessionTypeKey.set(initialSessionType);
 			}
 		}
-		// --- Start Positron ---
-		// Default to 'local' session type when no delegate is provided.
-		// Without this, the model picker is hidden in the welcome view because
-		// the upstream `when` clause requires agentSessionType === 'local'.
-		else {
-			this.agentSessionTypeKey.set(localChatSessionType);
-		}
-		// --- End Positron ---
 		this.chatSessionHasCustomAgentTarget = ChatContextKeys.chatSessionHasCustomAgentTarget.bindTo(contextKeyService);
 		this.chatSessionHasTargetedModels = ChatContextKeys.chatSessionHasTargetedModels.bindTo(contextKeyService);
 
@@ -693,26 +653,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			if (shouldResetOnModelListChange(this._currentLanguageModel.get()?.identifier, this.getModels())) {
 				this.setCurrentLanguageModelToDefault();
 			}
-
-			// --- Start Positron ---
-			// Fire event to notify model picker that the model list has changed
-			this._onDidChangeModelList.fire();
-			// --- End Positron ---
 		}));
-
-		// --- Start Positron ---
-		// Listen for provider enablement configuration changes
-		this._register(this.positronAssistantConfigService.onChangeEnabledProviders(() => {
-			// Provider filtering changed - notify UI
-			this._onDidChangeModelList.fire();
-
-			// May need to switch current model if it's no longer in enabled providers
-			const currentModel = this._currentLanguageModel.get();
-			if (currentModel && !this.positronAssistantConfigService.isProviderEnabled(currentModel.metadata.vendor)) {
-				this.setCurrentLanguageModelToDefault();
-			}
-		}));
-		// --- End Positron ---
 
 		this._register(this.onDidChangeCurrentChatMode(() => {
 			this.accessibilityService.alert(this._currentModeObservable.get().label.get());
@@ -769,11 +710,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		// Validate the initial mode - if Agent mode is set by default but disabled by policy, switch to Ask
 		this.validateCurrentChatMode();
-
-		// --- Start Positron ---
-		// 1.109.0: onDidChangeCurrentProvider was removed upstream.
-		// Provider switching is now handled via model selection directly.
-		// --- End Positron ---
 	}
 
 	private setImplicitContextEnablement() {
@@ -803,29 +739,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		return `chat.currentLanguageModel.${this.location}.isDefault`;
 	}
 
-	// --- Start Positron ---
-	// 1.109.0: determineSelectedModel was removed because its only caller
-	// (onDidChangeCurrentProvider) was removed upstream. Model selection logic
-	// now lives in initSelectedModel and the model picker action.
-	// --- End Positron ---
-
 	private initSelectedModel() {
-		// --- Start Positron ---
-		// Allow user to override application persisted model with config setting
-		let persistedSelection = this.storageService.get(this.getSelectedModelStorageKey(), StorageScope.APPLICATION);
-		let persistedAsDefault = this.storageService.getBoolean(this.getSelectedModelIsDefaultStorageKey(), StorageScope.APPLICATION, true);
-
-		// Only apply global preference if there's no model marked as default by byProvider preference
-		const models = this.getModels();
-		const hasProviderDefault = models.some(m => m.metadata.isDefaultForLocation[this.location]);
-		if (!hasProviderDefault) {
-			const globalPreference = this.configurationService.getValue<string>('positron.assistant.models.preference.global');
-			if (globalPreference) {
-				persistedSelection = globalPreference;
-				persistedAsDefault = false;
-			}
-		}
-		// --- End Positron ---
+		const persistedSelection = this.storageService.get(this.getSelectedModelStorageKey(), StorageScope.APPLICATION);
+		const persistedAsDefault = this.storageService.getBoolean(this.getSelectedModelIsDefaultStorageKey(), StorageScope.APPLICATION, true);
 
 		if (persistedSelection) {
 			const result = shouldRestorePersistedModel(persistedSelection, persistedAsDefault, this.getModels(), this.location);
@@ -834,30 +750,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				this.checkModelSupported();
 			} else if (!result.model) {
 				this._waitForPersistedLanguageModel.value = this.languageModelsService.onDidChangeLanguageModels(e => {
-					// --- Start Positron ---
-					// Also search for the model partially and by name, and only restore if the provider is enabled.
-					/*
 					const persistedModel = this.languageModelsService.lookupLanguageModel(persistedSelection);
-					*/
-
-					let persistedModel = this.languageModelsService.lookupLanguageModel(persistedSelection);
-					if (!persistedModel) {
-						const allModels = this.languageModelsService.getLanguageModelIds();
-						for (const modelId of allModels) {
-							const model = this.languageModelsService.lookupLanguageModel(modelId);
-							if (model && (model.id.includes(persistedSelection) || model.name.includes(persistedSelection))) {
-								persistedModel = model;
-							}
-							if (model && (model.id === persistedSelection || model.name === persistedSelection)) {
-								break;
-							}
-						}
-					}
-					// Don't restore the model if its provider is disabled
-					if (persistedModel && !this.positronAssistantConfigService.isProviderEnabled(persistedModel.vendor)) {
-						persistedModel = undefined;
-					}
-					// --- End Positron ---
 
 					if (persistedModel) {
 						this._waitForPersistedLanguageModel.clear();
@@ -1102,21 +995,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				});
 				if (syncResult.action === 'apply') {
 					this.setCurrentLanguageModel(state.selectedModel);
-					// --- Start Positron ---
-					// Validate that the persisted model is still available from
-					// an enabled provider before restoring it. Without this
-					// check, stale session state (e.g. a Copilot "Auto" model
-					// from a previous session) can be blindly a	pplied even when
-					// no providers are configured, causing the model picker to
-					// show a stale label.
-					const availableModels = this.getModels();
-					const isModelAvailable = availableModels.some(m => m.identifier === state.selectedModel!.identifier);
-					if (isModelAvailable) {
-						this.setCurrentLanguageModel(state.selectedModel);
-					} else {
-						this.setCurrentLanguageModelToDefault();
-					}
-					// --- End Positron ---
 				} else if (syncResult.action === 'default') {
 					this.setCurrentLanguageModelToDefault();
 				}
@@ -1168,18 +1046,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	public setCurrentLanguageModel(model: ILanguageModelChatMetadataAndIdentifier) {
 		this._currentLanguageModel.set(model, undefined);
-
-		// --- Start Positron ---
-		// Update the current provider when the model vendor changes, so that
-		// the chatCurrentProvider context key stays in sync and picker
-		// visibility is re-evaluated (e.g. session target picker is only
-		// shown for the copilot provider).
-		const newVendor = model.metadata.vendor;
-		if (this.languageModelsService.currentProvider?.id !== newVendor) {
-			const knownProvider = this.languageModelsService.getLanguageModelProviders().find(p => p.id === newVendor);
-			this.languageModelsService.currentProvider = knownProvider ?? { id: newVendor, displayName: newVendor };
-		}
-		// --- End Positron ---
 
 		if (this.cachedWidth) {
 			// For quick chat and editor chat, relayout because the input may need to shrink to accomodate the model name
@@ -1252,32 +1118,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		return models;
 	}
 
-	// --- Start Positron ---
-	/**
-	 * Helper to filter models for user-selectable, mode-supported, and provider-enabled models.
-	 */
-	private filterAvailableModels(models: ILanguageModelChatMetadataAndIdentifier[]): ILanguageModelChatMetadataAndIdentifier[] {
-		return models.filter(entry => {
-			// Must be from an enabled provider
-			if (!this.positronAssistantConfigService.isProviderEnabled(entry.metadata?.vendor)) {
-				return false;
-			}
-			// Must be user-selectable
-			if (!entry.metadata?.isUserSelectable) {
-				return false;
-			}
-			return true;
-		});
-	}
-	// --- End Positron ---
-
 	private getModels(): ILanguageModelChatMetadataAndIdentifier[] {
-		// --- Start Positron ---
-		let models = this.getAllMergedModels();
-
-		// Filter for user-selectable models that are supported in the current mode and enabled via config
-		models = this.filterAvailableModels(models);
-		// --- End Positron ---
+		const models = this.getAllMergedModels();
 
 		models.sort((a, b) => a.metadata.name.localeCompare(b.metadata.name));
 
@@ -1385,14 +1227,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const defaultModel = findDefaultModel(allModels, this.location);
 		if (defaultModel) {
 			this.setCurrentLanguageModel(defaultModel);
-			// --- Start Positron ---
-		} else {
-			// Clear the selected model when no models are available (e.g. after
-			// provider sign-out) so the picker button shows a placeholder instead
-			// of a stale model name.
-			this._currentLanguageModel.set(undefined, undefined);
-			this._onDidChangeModelList.fire();
-			// --- End Positron ---
 		}
 	}
 
@@ -2132,10 +1966,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		if (this.options.renderStyle === 'compact') {
 			elements = dom.h('.interactive-input-part', [
 				dom.h('.interactive-input-and-edit-session', [
-					// --- Start Positron ---
-					// 1.107.0
-					dom.h('.chat-token-usage-status@tokenUsageContainer'),
-					// --- End Positron ---
 					dom.h('.chat-question-carousel-widget-container@chatQuestionCarouselContainer'),
 					dom.h('.chat-input-widgets-container@chatInputWidgetsContainer'),
 					dom.h('.chat-todo-list-widget-container@chatInputTodoListWidgetContainer'),
@@ -2160,10 +1990,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			elements = dom.h('.interactive-input-part', [
 				dom.h('.chat-question-carousel-widget-container@chatQuestionCarouselContainer'),
 				dom.h('.interactive-input-followups@followupsContainer'),
-				// --- Start Positron ---
-				// 1.107.0
-				dom.h('.chat-token-usage-status@tokenUsageContainer'),
-				// --- End Positron ---
 				dom.h('.chat-input-widgets-container@chatInputWidgetsContainer'),
 				dom.h('.chat-todo-list-widget-container@chatInputTodoListWidgetContainer'),
 				dom.h('.chat-editing-session@chatEditingSessionWidgetContainer'),
@@ -2220,11 +2046,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.contextUsageWidget = this._register(this.instantiationService.createInstance(ChatContextUsageWidget));
 		this.contextUsageWidgetContainer.appendChild(this.contextUsageWidget.domNode);
 
-		// --- Start Positron ---
-		this.tokenUsageContainer = elements.tokenUsageContainer;
-		this.tokenUsageContainer.style.display = 'none'; // Initially hidden
-		// --- End Positron ---
-
 		if (this.options.enableImplicitContext && !this._implicitContext) {
 			this._implicitContext = this._register(
 				this.instantiationService.createInstance(ChatImplicitContexts),
@@ -2235,15 +2056,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				this._indexOfLastAttachedContextDeletedWithKeyboard = -1;
 				this._handleAttachedContextChange();
 			}));
-
-			// --- Start Positron ---
-			// Add the runtime session implicit context
-			this._runtimeContext = this._register(
-				this.instantiationService.createInstance(ChatRuntimeSessionContext),
-			);
-
-			this._register(this._runtimeContext.onDidChangeValue(() => this._handleAttachedContextChange()));
-			// --- End Positron ---
 		} else if (!this.options.enableImplicitContext && this._implicitContext) {
 			this._implicitContext?.dispose();
 			this._implicitContext = undefined;
@@ -2406,23 +2218,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 						this.setCurrentLanguageModelToDefault();
 					}
 
-					// --- Start Positron ---
-					const models = this.getModels();
-					if (!this._currentLanguageModel.get() && models.length > 0) {
-						const defaultModel = models.find(m => m.metadata.isDefaultForLocation[this.location]);
-						if (defaultModel) {
-							this.setCurrentLanguageModel(defaultModel);
-						} else if (models.length > 0) {
-							this.setCurrentLanguageModel(models[0]);
-						}
-					}
-					// --- End Positron ---
-
 					const itemDelegate: IModelPickerDelegate = {
 						currentModel: this._currentLanguageModel,
-						// --- Start Positron ---
-						onDidChangeModelList: this._onDidChangeModelList.event,
-						// --- End Positron ---
 						setModel: (model: ILanguageModelChatMetadataAndIdentifier) => {
 							this._waitForPersistedLanguageModel.clear();
 							this.setCurrentLanguageModel(model);
@@ -2680,10 +2477,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}));
 
 		const attachments = [...this.attachmentModel.attachments.entries()];
-		// --- Start Positron ---
-		// Add runtime session context to the attachments
-		const hasAttachments = Boolean(attachments.length) || Boolean(this.implicitContext?.hasValue) || Boolean(this.runtimeContext?.value);
-		// --- End Positron ---
+		const hasAttachments = Boolean(attachments.length) || Boolean(this.implicitContext?.hasValue);
 
 		// Render implicit context (active editor in Ask mode, or selection)
 		let hasImplicitContext = false;
@@ -2729,14 +2523,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}
 
 
-		// --- Start Positron ---
-		if (this.runtimeContext?.value) {
-			const runtimePart = store.add(this.instantiationService.createInstance(RuntimeSessionContextAttachmentWidget, this.runtimeContext, this._contextResourceLabels));
-			container.appendChild(runtimePart.domNode);
-		}
-		// --- End Positron ---
-
-
 		for (const [index, attachment] of attachments) {
 			const resource = URI.isUri(attachment.value) ? attachment.value : isLocation(attachment.value) ? attachment.value.uri : undefined;
 			const range = isLocation(attachment.value) ? attachment.value.range : undefined;
@@ -2765,10 +2551,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				attachmentWidget = this.instantiationService.createInstance(PasteAttachmentWidget, attachment, lm, options, container, this._contextResourceLabels);
 			} else if (isSCMHistoryItemVariableEntry(attachment)) {
 				attachmentWidget = this.instantiationService.createInstance(SCMHistoryItemAttachmentWidget, attachment, lm, options, container, this._contextResourceLabels);
-				// --- Start Positron ---
-			} else if (attachment.kind === 'runtimeSession') {
-				attachmentWidget = this.instantiationService.createInstance(RuntimeSessionAttachmentWidget, attachment, lm, options, container, this._contextResourceLabels);
-				// --- End Positron ---
 			} else if (isSCMHistoryItemChangeVariableEntry(attachment)) {
 				attachmentWidget = this.instantiationService.createInstance(SCMHistoryItemChangeAttachmentWidget, attachment, lm, options, container, this._contextResourceLabels);
 			} else if (isSCMHistoryItemChangeRangeVariableEntry(attachment)) {
@@ -3385,71 +3167,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			sideToolbarWidth: inputSideToolbarWidth > 0 ? inputSideToolbarWidth + 4 /*gap*/ : 0,
 		};
 	}
-
-	// --- Start Positron ---
-	/**
-	 * Calculate the total token usage from a view model's items
-	 */
-	private calculateTotalTokenUsage(viewModel: any): { totalInputTokens: number; totalOutputTokens: number; totalCachedTokens: number } | undefined {
-		if (!viewModel) {
-			return undefined;
-		}
-
-		let totalInputTokens = 0;
-		let totalOutputTokens = 0;
-		let totalCachedTokens = 0;
-		let hasAnyTokenUsage = false;
-
-		for (const item of viewModel.getItems()) {
-			if (isResponseVM(item) && item.tokenUsage && item.isComplete) {
-				totalInputTokens += item.tokenUsage.tokens.inputTokens;
-				totalOutputTokens += item.tokenUsage.tokens.outputTokens;
-				totalCachedTokens += item.tokenUsage.tokens.cachedTokens;
-				hasAnyTokenUsage = true;
-			}
-		}
-
-		return hasAnyTokenUsage ? { totalInputTokens, totalOutputTokens, totalCachedTokens } : undefined;
-	}
-
-	/**
-	 * Update the token usage status display
-	 */
-	updateTokenUsageDisplay(viewModel: any): void {
-		if (!this.tokenUsageContainer) {
-			return;
-		}
-
-		const previousDisplay = this.tokenUsageContainer.style.display;
-		const showTokens = this.configurationService.getValue<boolean>('positron.assistant.showTokenUsage.enable');
-		if (!showTokens) {
-			this.tokenUsageContainer.style.display = 'none';
-		} else {
-			const totalTokens = this.calculateTotalTokenUsage(viewModel);
-			if (totalTokens && totalTokens.totalInputTokens > 0 && totalTokens.totalOutputTokens > 0) {
-				dom.clearNode(this.tokenUsageContainer);
-				this.tokenUsageContainer.appendChild(
-					dom.$('.token-usage-total', undefined,
-						localize('totalTokenUsage', "Total tokens: ↑{0} ↓{1} ↩{2}", totalTokens.totalInputTokens, totalTokens.totalOutputTokens, totalTokens.totalCachedTokens)
-					)
-				);
-				this.tokenUsageContainer.style.display = 'block';
-			} else {
-				this.tokenUsageContainer.style.display = 'none';
-			}
-		}
-
-		// Trigger re-layout if visibility changed so the height observable updates
-		if (previousDisplay !== this.tokenUsageContainer.style.display && this.cachedWidth) {
-			this.layout(this.cachedWidth);
-		}
-	}
-
-	get tokenUsageHeight(): number {
-		return (this.tokenUsageContainer && this.tokenUsageContainer.style.display !== 'none')
-			? this.tokenUsageContainer.offsetHeight : 0;
-	}
-	// --- End Positron ---
 
 	/**
 	 * Gets the location of the chat widget and whether that location is maximized.

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -28,9 +28,6 @@ import { ChatEntitlement, IChatEntitlementService, isProUser } from '../../../..
 import * as semver from '../../../../../../base/common/semver/semver.js';
 import { IModelPickerDelegate } from './modelPickerActionItem.js';
 import { IUpdateService, StateType } from '../../../../../../platform/update/common/update.js';
-// --- Start Positron ---
-import { getProviderIcon } from './providerIcons.js';
-// --- End Positron ---
 
 function isVersionAtLeast(current: string, required: string): boolean {
 	const currentSemver = semver.coerce(current);
@@ -98,13 +95,6 @@ function createModelAction(
 	onSelect: (model: ILanguageModelChatMetadataAndIdentifier) => void,
 	section?: string,
 ): IActionWidgetDropdownAction & { section?: string } {
-	// --- Start Positron ---
-	// Check if this model is marked as the default for its provider
-	const isDefaultForLocation = model.metadata.isDefaultForLocation;
-	const isDefault = isDefaultForLocation && Object.values(isDefaultForLocation).some(v => v);
-	// Add "(default)" suffix to label if this is the default model
-	const label = isDefault ? localize('chat.modelPicker.defaultModel', "{0} (default)", model.metadata.name) : model.metadata.name;
-	// --- End Positron ---
 	return {
 		id: model.identifier,
 		enabled: true,
@@ -113,7 +103,7 @@ function createModelAction(
 		class: undefined,
 		description: model.metadata.multiplier ?? model.metadata.detail,
 		tooltip: model.metadata.name,
-		label: label,
+		label: model.metadata.name,
 		section,
 		run: () => onSelect(model),
 	};
@@ -142,9 +132,6 @@ export function buildModelPickerItems(
 	canManageModels: boolean,
 	commandService: ICommandService,
 	chatEntitlementService: IChatEntitlementService,
-	// --- Start Positron ---
-	vendorDisplayNames?: ReadonlyMap<string, string>,
-	// --- End Positron ---
 ): IActionListItem<IActionWidgetDropdownAction>[] {
 	const items: IActionListItem<IActionWidgetDropdownAction>[] = [];
 	if (models.length === 0) {
@@ -590,9 +577,6 @@ export class ModelPickerWidget extends Disposable {
 			this._delegate.canManageModels(),
 			this._commandService,
 			this._entitlementService,
-			// --- Start Positron ---
-			new Map(this._languageModelsService.getVendors().map(v => [v.vendor, v.displayName])),
-			// --- End Positron ---
 		);
 
 		const listOptions = {
@@ -656,30 +640,8 @@ export class ModelPickerWidget extends Disposable {
 			return;
 		}
 
-		const { name, statusIcon, vendor } = this._selectedModel?.metadata || {};
+		const { name, statusIcon } = this._selectedModel?.metadata || {};
 		const domChildren: (HTMLElement | string)[] = [];
-
-		// --- Start Positron ---
-		// Show provider icon for the selected model
-		if (vendor) {
-			const providerIcon = getProviderIcon(vendor);
-			if (providerIcon) {
-				if (providerIcon.svgContent) {
-					// SVG-based icons: render as background image
-					const base64 = btoa(providerIcon.svgContent);
-					const providerIconElement = dom.$('span.chat-model-picker-provider-icon');
-					providerIconElement.style.backgroundImage = `url(data:image/svg+xml;base64,${base64})`;
-					providerIconElement.style.marginRight = '4px';
-					domChildren.push(providerIconElement);
-				} else {
-					// Codicon-based icons (e.g., posit-ai): use renderIcon
-					const providerIconElement = renderIcon(providerIcon.themeIcon);
-					providerIconElement.classList.add('chat-model-picker-provider-icon');
-					domChildren.push(providerIconElement);
-				}
-			}
-		}
-		// --- End Positron ---
 
 		if (statusIcon) {
 			const iconElement = renderIcon(statusIcon);
@@ -708,19 +670,7 @@ function getModelHoverContent(model: ILanguageModelChatMetadataAndIdentifier): M
 	const isAuto = model.metadata.id === 'auto' && model.metadata.vendor === 'copilot';
 	const markdown = new MarkdownString('', { isTrusted: true, supportThemeIcons: true });
 	const providerLabel = model.metadata.auth?.providerLabel ?? model.metadata.vendor;
-
-	// --- Start Positron ---
-	// Show provider icon in hover if available
-	const providerIcon = getProviderIcon(model.metadata.vendor);
-	if (providerIcon?.svgContent) {
-		const base64 = btoa(providerIcon.svgContent);
-		markdown.appendMarkdown(`![${providerLabel}](data:image/svg+xml;base64,${base64}|height=14)&nbsp;**${model.metadata.name}**`);
-	} else if (providerIcon?.themeIcon) {
-		markdown.appendMarkdown(`$(${providerIcon.themeIcon.id})&nbsp;**${model.metadata.name}**`);
-	} else {
-		markdown.appendMarkdown(`**${providerLabel} - ${model.metadata.name}**`);
-	}
-	// --- End Positron ---
+	markdown.appendMarkdown(`**${providerLabel} - ${model.metadata.name}**`);
 	markdown.appendText(`\n`);
 
 	if (model.metadata.statusIcon && model.metadata.tooltip) {

--- a/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/chatModelPicker.ts
@@ -171,23 +171,9 @@ export function buildModelPickerItems(
 				const vendorCmp = a.metadata.vendor.localeCompare(b.metadata.vendor);
 				return vendorCmp !== 0 ? vendorCmp : a.metadata.name.localeCompare(b.metadata.name);
 			});
-		// --- Start Positron ---
-		// Group models by vendor and add provider separators
-		let lastVendor: string | undefined;
 		for (const model of sortedModels) {
-			if (model.metadata.vendor !== lastVendor) {
-				lastVendor = model.metadata.vendor;
-				const providerIcon = getProviderIcon(model.metadata.vendor);
-				const providerLabel = model.metadata.auth?.providerLabel ?? vendorDisplayNames?.get(model.metadata.vendor) ?? model.metadata.vendor;
-				items.push({
-					kind: ActionListItemKind.Separator,
-					label: providerLabel,
-					group: providerIcon ? { title: providerLabel, icon: providerIcon.themeIcon } : { title: providerLabel }
-				});
-			}
 			items.push(createModelItem(createModelAction(model, selectedModelId, onSelect), model));
 		}
-		// --- End Positron ---
 		return items;
 	}
 
@@ -223,23 +209,17 @@ export function buildModelPickerItems(
 			return 'admin';
 		};
 
-		// --- Start Positron ---
 		// --- 1. Auto ---
 		const autoModel = models.find(m => m.metadata.id === 'auto' && m.metadata.vendor === 'copilot');
-		// Auto model is not promoted to the first position in Positron - it appears with other models grouped by provider
-		/*
 		if (autoModel) {
 			markPlaced(autoModel.identifier, autoModel.metadata.id);
 			items.push(createModelItem(createModelAction(autoModel, selectedModelId, onSelect), autoModel));
 		}
-		*/
 
 		// --- 2. Promoted section (selected + recently used + featured) ---
-		// Add vendor field to PromotedItem for grouping with provider separators
 		type PromotedItem =
-			| { kind: 'available'; model: ILanguageModelChatMetadataAndIdentifier; vendor: string; providerLabel: string }
-			| { kind: 'unavailable'; id: string; entry: IModelControlEntry; reason: 'upgrade' | 'update' | 'admin'; vendor: string; providerLabel: string };
-		// --- End Positron ---
+			| { kind: 'available'; model: ILanguageModelChatMetadataAndIdentifier }
+			| { kind: 'unavailable'; id: string; entry: IModelControlEntry; reason: 'upgrade' | 'update' | 'admin' };
 
 		const promotedItems: PromotedItem[] = [];
 
@@ -252,14 +232,10 @@ export function buildModelPickerItems(
 			if (model && !placed.has(model.identifier)) {
 				markPlaced(model.identifier, model.metadata.id);
 				const entry = controlModels[model.metadata.id];
-				// --- Start Positron ---
-				const vendor = model.metadata.vendor;
-				const providerLabel = model.metadata.auth?.providerLabel ?? vendorDisplayNames?.get(vendor) ?? vendor;
-				// --- End Positron ---
 				if (entry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
-					promotedItems.push({ kind: 'unavailable', id: model.metadata.id, entry, reason: 'update', vendor, providerLabel });
+					promotedItems.push({ kind: 'unavailable', id: model.metadata.id, entry, reason: 'update' });
 				} else {
-					promotedItems.push({ kind: 'available', model, vendor, providerLabel });
+					promotedItems.push({ kind: 'available', model });
 				}
 				return true;
 			}
@@ -267,10 +243,7 @@ export function buildModelPickerItems(
 				const entry = controlModels[id];
 				if (entry && !entry.exists) {
 					markPlaced(id);
-					// --- Start Positron ---
-					// For unavailable models without a resolved model, use 'unknown' as vendor
-					promotedItems.push({ kind: 'unavailable', id, entry, reason: getUnavailableReason(entry), vendor: 'unknown', providerLabel: 'Unknown' });
-					// --- End Positron ---
+					promotedItems.push({ kind: 'unavailable', id, entry, reason: getUnavailableReason(entry) });
 					return true;
 				}
 			}
@@ -295,56 +268,31 @@ export function buildModelPickerItems(
 			const model = resolveModel(entryId);
 			if (model && !placed.has(model.identifier)) {
 				markPlaced(model.identifier, model.metadata.id);
-				// --- Start Positron ---
-				const vendor = model.metadata.vendor;
-				const providerLabel = model.metadata.auth?.providerLabel ?? vendorDisplayNames?.get(vendor) ?? vendor;
-				// --- End Positron ---
 				if (entry.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
-					promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: 'update', vendor, providerLabel });
+					promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: 'update' });
 				} else {
-					promotedItems.push({ kind: 'available', model, vendor, providerLabel });
+					promotedItems.push({ kind: 'available', model });
 				}
 			} else if (!model && !entry.exists) {
 				markPlaced(entryId);
-				// --- Start Positron ---
-				promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: getUnavailableReason(entry), vendor: 'unknown', providerLabel: 'Unknown' });
-				// --- End Positron ---
+				promotedItems.push({ kind: 'unavailable', id: entryId, entry, reason: getUnavailableReason(entry) });
 			}
 		}
 
-		// --- Start Positron ---
-		// Render promoted section: group by vendor with separators, then by availability, then alphabetically
+		// Render promoted section: available first, then sorted alphabetically by name
 		if (promotedItems.length > 0) {
 			promotedItems.sort((a, b) => {
-				// Sort by vendor first
-				const vendorCmp = a.vendor.localeCompare(b.vendor);
-				if (vendorCmp !== 0) {
-					return vendorCmp;
-				}
-				// Then by availability
 				const aAvail = a.kind === 'available' ? 0 : 1;
 				const bAvail = b.kind === 'available' ? 0 : 1;
 				if (aAvail !== bAvail) {
 					return aAvail - bAvail;
 				}
-				// Then alphabetically by name
 				const aName = a.kind === 'available' ? a.model.metadata.name : a.entry.label;
 				const bName = b.kind === 'available' ? b.model.metadata.name : b.entry.label;
 				return aName.localeCompare(bName);
 			});
 
-			let promotedLastVendor: string | undefined;
 			for (const item of promotedItems) {
-				// Add provider separator when vendor changes
-				if (item.vendor !== promotedLastVendor && item.vendor !== 'unknown') {
-					promotedLastVendor = item.vendor;
-					const providerIcon = getProviderIcon(item.vendor);
-					items.push({
-						kind: ActionListItemKind.Separator,
-						label: item.providerLabel,
-						group: providerIcon ? { title: item.providerLabel, icon: providerIcon.themeIcon } : { title: item.providerLabel }
-					});
-				}
 				if (item.kind === 'available') {
 					items.push(createModelItem(createModelAction(item.model, selectedModelId, onSelect), item.model));
 				} else {
@@ -352,7 +300,6 @@ export function buildModelPickerItems(
 				}
 			}
 		}
-		// --- End Positron ---
 
 		// --- 3. Other Models (collapsible) ---
 		otherModels = models
@@ -365,14 +312,11 @@ export function buildModelPickerItems(
 				if (aAvail !== bAvail) {
 					return aAvail - bAvail;
 				}
-				// --- Start Positron ---
-				// Prioritize posit-ai models first
-				const aPosit = a.metadata.vendor === 'posit-ai' ? 0 : 1;
-				const bPosit = b.metadata.vendor === 'posit-ai' ? 0 : 1;
-				if (aPosit !== bPosit) {
-					return aPosit - bPosit;
+				const aCopilot = a.metadata.vendor === 'copilot' ? 0 : 1;
+				const bCopilot = b.metadata.vendor === 'copilot' ? 0 : 1;
+				if (aCopilot !== bCopilot) {
+					return aCopilot - bCopilot;
 				}
-				// --- End Positron ---
 				const vendorCmp = a.metadata.vendor.localeCompare(b.metadata.vendor);
 				return vendorCmp !== 0 ? vendorCmp : a.metadata.name.localeCompare(b.metadata.name);
 			});
@@ -398,25 +342,7 @@ export function buildModelPickerItems(
 				section: ModelPickerSection.Other,
 				isSectionToggle: true,
 			});
-			// --- Start Positron ---
-			// Group models by vendor and add provider separators
-			let otherLastVendor: string | undefined;
-			// --- End Positron ---
 			for (const model of otherModels) {
-				// --- Start Positron ---
-				// Add provider separator when vendor changes
-				if (model.metadata.vendor !== otherLastVendor) {
-					otherLastVendor = model.metadata.vendor;
-					const providerIcon = getProviderIcon(model.metadata.vendor);
-					const providerLabel = model.metadata.auth?.providerLabel ?? vendorDisplayNames?.get(model.metadata.vendor) ?? model.metadata.vendor;
-					items.push({
-						kind: ActionListItemKind.Separator,
-						label: providerLabel,
-						group: providerIcon ? { title: providerLabel, icon: providerIcon.themeIcon } : { title: providerLabel },
-						section: ModelPickerSection.Other,
-					});
-				}
-				// --- End Positron ---
 				const entry = controlModels[model.metadata.id] ?? controlModels[model.identifier];
 				if (entry?.minVSCodeVersion && !isVersionAtLeast(currentVSCodeVersion, entry.minVSCodeVersion)) {
 					items.push(createUnavailableModelItem(model.metadata.id, entry, 'update', manageSettingsUrl, updateStateType, ModelPickerSection.Other));
@@ -428,10 +354,6 @@ export function buildModelPickerItems(
 	}
 
 	if (
-		// --- Start Positron ---
-		// In Positron, we want to show "Manage Models" to all users regardless of entitlement
-		chatEntitlementService.entitlement === ChatEntitlement.Unknown ||
-		// --- End Positron ---
 		chatEntitlementService.entitlement === ChatEntitlement.Free ||
 		chatEntitlementService.entitlement === ChatEntitlement.Pro ||
 		chatEntitlementService.entitlement === ChatEntitlement.ProPlus ||
@@ -439,8 +361,7 @@ export function buildModelPickerItems(
 		chatEntitlementService.entitlement === ChatEntitlement.Enterprise ||
 		chatEntitlementService.isInternal
 	) {
-		// Modified from upstream to always show separator
-		items.push({ kind: ActionListItemKind.Separator });
+		items.push({ kind: ActionListItemKind.Separator, section: otherModels.length ? ModelPickerSection.Other : undefined });
 		items.push({
 			item: {
 				id: 'manageModels',
@@ -455,31 +376,10 @@ export function buildModelPickerItems(
 			label: localize('chat.manageModels', "Manage Models..."),
 			group: { title: '', icon: Codicon.blank },
 			hideIcon: false,
-			// In Positron, "Manage Models" is not placed in the Other collapsible section - it is always visible in the footer
-			// section: otherModels.length ? ModelPickerSection.Other : undefined,
+			section: otherModels.length ? ModelPickerSection.Other : undefined,
 			showAlways: true,
 		});
 	}
-
-	// --- Start Positron ---
-	// Add footer actions for Positron
-	items.push({
-		item: {
-			id: 'configureProviders',
-			enabled: true,
-			checked: false,
-			class: undefined,
-			tooltip: localize('chat.configureProviders.tooltip', "Add and Configure Language Model Providers"),
-			label: localize('chat.configureProviders', "Configure Model Providers..."),
-			run: () => { commandService.executeCommand('positron-assistant.configureProviders'); }
-		},
-		kind: ActionListItemKind.Action,
-		label: localize('chat.configureProviders', "Configure Model Providers..."),
-		group: { title: '', icon: Codicon.blank },
-		hideIcon: false,
-		showAlways: true,
-	});
-	// --- End Positron ---
 
 	return items;
 }

--- a/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem.ts
@@ -8,7 +8,6 @@ import { IActionProvider } from '../../../../../../base/browser/ui/dropdown/drop
 import { IManagedHoverContent } from '../../../../../../base/browser/ui/hover/hover.js';
 import { renderIcon, renderLabelWithIcons } from '../../../../../../base/browser/ui/iconLabel/iconLabels.js';
 import { IAction } from '../../../../../../base/common/actions.js';
-import { Event } from '../../../../../../base/common/event.js';
 import { IDisposable } from '../../../../../../base/common/lifecycle.js';
 import { autorun, IObservable } from '../../../../../../base/common/observable.js';
 import { localize } from '../../../../../../nls.js';
@@ -17,29 +16,17 @@ import { IActionWidgetDropdownAction, IActionWidgetDropdownActionProvider, IActi
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
-// --- Start Positron ---
-/*
 import { DEFAULT_MODEL_PICKER_CATEGORY } from '../../../common/widget/input/modelPickerWidget.js';
-*/
-// --- End Positron ---
 import { IProductService } from '../../../../../../platform/product/common/productService.js';
 import { ITelemetryService } from '../../../../../../platform/telemetry/common/telemetry.js';
 import { TelemetryTrustedValue } from '../../../../../../platform/telemetry/common/telemetryUtils.js';
 import { ChatEntitlement, IChatEntitlementService } from '../../../../../services/chat/common/chatEntitlementService.js';
 import { MANAGE_CHAT_COMMAND_ID } from '../../../common/constants.js';
-import { ILanguageModelChatMetadataAndIdentifier, ILanguageModelsService } from '../../../common/languageModels.js';
+import { ILanguageModelChatMetadataAndIdentifier } from '../../../common/languageModels.js';
 import { ChatInputPickerActionViewItem, IChatInputPickerOptions } from './chatInputPickerActionItem.js';
-// --- Start Positron ---
-import { getProviderIcon } from './providerIcons.js';
-import { IThemeService } from '../../../../../../platform/theme/common/themeService.js';
-import { isDark } from '../../../../../../platform/theme/common/theme.js';
-// --- End Positron ---
 
 export interface IModelPickerDelegate {
 	readonly currentModel: IObservable<ILanguageModelChatMetadataAndIdentifier | undefined>;
-	// --- Start Positron ---
-	readonly onDidChangeModelList: Event<void>;
-	// --- End Positron ---
 	setModel(model: ILanguageModelChatMetadataAndIdentifier): void;
 	getModels(): ILanguageModelChatMetadataAndIdentifier[];
 	canManageModels(): boolean;
@@ -57,20 +44,11 @@ type ChatModelChangeEvent = {
 	toModel: string | TelemetryTrustedValue<string>;
 };
 
-// --- Start Positron ---
-// The entire function has been replaced to group models by vendor with
-// separators, indicate default models, and pass themeService so provider
-// icons can adapt to light/dark themes.
-// function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, telemetryService: ITelemetryService): IActionWidgetDropdownActionProvider {
-function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, telemetryService: ITelemetryService, pickerOptions: IChatInputPickerOptions, themeService: IThemeService, languageModelsService: ILanguageModelsService): IActionWidgetDropdownActionProvider {
+function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, telemetryService: ITelemetryService, pickerOptions: IChatInputPickerOptions): IActionWidgetDropdownActionProvider {
 	return {
 		getActions: () => {
 			const models = delegate.getModels();
-			const actions: IActionWidgetDropdownAction[] = [];
 
-			// Disable fake "Auto" entry since it won't work with Positron Assistant
-			// --- Start CodeOSS ---
-			/*
 			if (models.length === 0) {
 				// Show a fake "Auto" entry when no models are available
 				return [{
@@ -85,128 +63,38 @@ function modelDelegateToWidgetActionsProvider(delegate: IModelPickerDelegate, te
 					run: () => { }
 				} satisfies IActionWidgetDropdownAction];
 			}
-			*/
-			// --- End CodeOSS ---
 
-			// Group models by vendor
-			const modelsByVendor = new Map<string, typeof models>();
+			const actions: IActionWidgetDropdownAction[] = [];
 			for (const model of models) {
-				const vendor = model.metadata.vendor;
-				if (!modelsByVendor.has(vendor)) {
-					modelsByVendor.set(vendor, []);
-				}
-				modelsByVendor.get(vendor)!.push(model);
-			}
+				const category = model.metadata.modelPickerCategory ?? DEFAULT_MODEL_PICKER_CATEGORY;
+				const tooltip = model.metadata.tooltip ?? model.metadata.name;
+				const hoverContent = model.metadata.tooltip;
 
-			// Sort each vendor's models to place the default model first
-			// This improves UX by making the default model immediately visible
-			// without scrolling, especially for providers with long model lists
-			for (const [vendor, vendorModels] of modelsByVendor.entries()) {
-				// Find the default model for this vendor
-				// Check if model is default for any location
-				const defaultModel = vendorModels.find(m => {
-					const isDefaultForLocation = m.metadata.isDefaultForLocation;
-					return isDefaultForLocation && Object.values(isDefaultForLocation).some(v => v);
-				});
-
-				if (defaultModel) {
-					// Separate default from non-default models
-					const nonDefaultModels = vendorModels.filter(m => {
-						const isDefaultForLocation = m.metadata.isDefaultForLocation;
-						return !(isDefaultForLocation && Object.values(isDefaultForLocation).some(v => v));
-					});
-
-					// Place default first, followed by remaining models in original order
-					modelsByVendor.set(vendor, [defaultModel, ...nonDefaultModels]);
-				}
-				// If no default, keep original order
-			}
-
-			// Sort vendors for consistent ordering
-			const sortedVendors = Array.from(modelsByVendor.entries())
-				.sort((a, b) => {
-					// --- Start Positron ---
-					// Prioritize Posit AI, then alphabetically
-					if (a[0] === 'posit-ai') { return -1; }
-					if (b[0] === 'posit-ai') { return 1; }
-					// Don't show Copilot at the top anymore
-					/*
-					// Prioritize Copilot, then alphabetically
-					if (a[0] === 'copilot') { return -1; }
-					if (b[0] === 'copilot') { return 1; }
-					*/
-					// --- End Positron ---
-					return a[0].localeCompare(b[0]);
-				});
-
-			let vendorOrder = 0;
-			for (const [vendor, vendorModels] of sortedVendors) {
-				// Add separator with provider name before each group
-				// Get provider display name from the first model in the group
-				const firstModel = vendorModels[0];
-				const vendorDescriptor = languageModelsService.getVendors().find(v => v.vendor === vendor);
-				const providerName = firstModel.metadata.auth?.providerLabel ?? vendorDescriptor?.displayName ?? vendor;
-
-				// Get provider icon based on vendor ID
-				const providerIcon = getProviderIcon(vendor, isDark(themeService.getColorTheme().type));
-
-				// Use a special category prefix to indicate this is a separator
 				actions.push({
-					id: `separator-${vendor}`,
-					label: providerName,
-					enabled: false,
-					checked: false,
+					id: model.metadata.id,
+					enabled: true,
+					icon: model.metadata.statusIcon,
+					checked: model.identifier === delegate.currentModel.get()?.identifier,
+					category,
 					class: undefined,
-					tooltip: '',
-					icon: providerIcon?.themeIcon,
-					category: { label: `__separator_${vendor}`, order: vendorOrder * 1000 - 1 },
-					hover: undefined,
-					run: () => { /* separator - no action */ }
+					description: model.metadata.multiplier ?? model.metadata.detail,
+					tooltip,
+					hover: hoverContent ? { content: hoverContent, position: pickerOptions.hoverPosition } : undefined,
+					label: model.metadata.name,
+					run: () => {
+						const previousModel = delegate.currentModel.get();
+						telemetryService.publicLog2<ChatModelChangeEvent, ChatModelChangeClassification>('chat.modelChange', {
+							fromModel: previousModel?.metadata.vendor === 'copilot' ? new TelemetryTrustedValue(previousModel.identifier) : 'unknown',
+							toModel: model.metadata.vendor === 'copilot' ? new TelemetryTrustedValue(model.identifier) : 'unknown'
+						});
+						delegate.setModel(model);
+					}
 				} satisfies IActionWidgetDropdownAction);
-
-				// Add all models for this vendor
-				for (const model of vendorModels) {
-					// Check if this model is marked as the default for its provider
-					// Check if model is default for any location
-					const isDefaultForLocation = model.metadata.isDefaultForLocation;
-					const isDefault = isDefaultForLocation && Object.values(isDefaultForLocation).some(v => v);
-					// Add "(default)" suffix to label if this is the default model
-					const label = isDefault ? `${model.metadata.name} (default)` : model.metadata.name;
-					// Add "(default)" to tooltip if this is the default model
-					const tooltip = isDefault
-						? localize('chat.defaultModel', "{0} (default)", model.metadata.tooltip ?? model.metadata.name)
-						: (model.metadata.tooltip ?? model.metadata.name);
-					const hoverContent = model.metadata.tooltip;
-
-					actions.push({
-						id: model.metadata.id,
-						enabled: true,
-						icon: model.metadata.statusIcon,
-						checked: model.identifier === delegate.currentModel.get()?.identifier,
-						category: { label: `vendor_${vendor}`, order: vendorOrder * 1000 },
-						class: undefined,
-						description: model.metadata.multiplier ?? model.metadata.detail,
-						tooltip: tooltip,
-						hover: hoverContent ? { content: hoverContent, position: pickerOptions.hoverPosition } : undefined,
-						label: label,
-						run: () => {
-							const previousModel = delegate.currentModel.get();
-							telemetryService.publicLog2<ChatModelChangeEvent, ChatModelChangeClassification>('chat.modelChange', {
-								fromModel: previousModel?.metadata.vendor === 'copilot' ? new TelemetryTrustedValue(previousModel.identifier) : 'unknown',
-								toModel: model.metadata.vendor === 'copilot' ? new TelemetryTrustedValue(model.identifier) : 'unknown'
-							});
-							delegate.setModel(model);
-						}
-					} satisfies IActionWidgetDropdownAction);
-				}
-
-				vendorOrder++;
 			}
 
 			return actions;
 		}
 	};
-	// --- End Positron ---
 }
 
 function getModelPickerActionBarActionProvider(commandService: ICommandService, chatEntitlementService: IChatEntitlementService, productService: IProductService): IActionProvider {
@@ -214,12 +102,7 @@ function getModelPickerActionBarActionProvider(commandService: ICommandService, 
 	const actionProvider: IActionProvider = {
 		getActions: () => {
 			const additionalActions: IAction[] = [];
-			// --- Start Positron ---
-			// Override the entitlement check to always show manage models option
-			const useManageModelsAction = true;
 			if (
-				useManageModelsAction ||
-				// --- End Positron ---
 				chatEntitlementService.entitlement === ChatEntitlement.Free ||
 				chatEntitlementService.entitlement === ChatEntitlement.Pro ||
 				chatEntitlementService.entitlement === ChatEntitlement.ProPlus ||
@@ -258,25 +141,6 @@ function getModelPickerActionBarActionProvider(commandService: ICommandService, 
 				});
 			}
 
-			// --- Start Positron ---
-			// Remove the moreModels action and add configureProviders action instead
-			const moreModelsIndex = additionalActions.findIndex(action => action.id === 'moreModels');
-			if (moreModelsIndex !== -1) {
-				additionalActions.splice(moreModelsIndex, 1);
-			}
-			additionalActions.push({
-				id: 'configureProviders',
-				label: localize('chat.configureProviders', "Configure Model Providers..."),
-				enabled: true,
-				tooltip: localize('chat.configureProviders.tooltip', "Add and Configure Language Model Providers"),
-				class: undefined,
-				run: () => {
-					const commandId = 'positron-assistant.configureProviders';
-					commandService.executeCommand(commandId);
-				}
-			});
-			// --- End Positron ---
-
 			return additionalActions;
 		}
 	};
@@ -301,30 +165,17 @@ export class ModelPickerActionItem extends ChatInputPickerActionViewItem {
 		@IKeybindingService keybindingService: IKeybindingService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IProductService productService: IProductService,
-		// --- Start Positron ---
-		@IThemeService private readonly themeService: IThemeService,
-		@ILanguageModelsService languageModelsService: ILanguageModelsService,
-		// --- End Positron ---
 	) {
 		// Modify the original action with a different label and make it show the current model
 		const actionWithLabel: IAction = {
 			...action,
-			// --- Start Positron ---
-			// Change "Auto" to "Pick Model"
-			label: delegate.currentModel.get()?.metadata.name ?? localize('chat.modelPicker.label', "Pick Model"),
-			// --- End Positron ---
+			label: delegate.currentModel.get()?.metadata.name ?? localize('chat.modelPicker.auto', "Auto"),
 			run: () => { }
 		};
 
 		const baseActionBarActionProvider = getModelPickerActionBarActionProvider(commandService, chatEntitlementService, productService);
 		const modelPickerActionWidgetOptions: Omit<IActionWidgetDropdownOptions, 'label' | 'labelRenderer'> = {
-			// --- Start Positron ---
-			// Pass themeService so provider icons can adapt to light/dark themes
-			/*
 			actionProvider: modelDelegateToWidgetActionsProvider(delegate, telemetryService, pickerOptions),
-			*/
-			actionProvider: modelDelegateToWidgetActionsProvider(delegate, telemetryService, pickerOptions, themeService, languageModelsService),
-			// --- End Positron ---
 			actionBarActionProvider: { getActions: () => baseActionBarActionProvider.getActions() },
 			reporter: { id: 'ChatModelPicker', name: 'ChatModelPicker', includeOptions: true },
 		};
@@ -341,27 +192,6 @@ export class ModelPickerActionItem extends ChatInputPickerActionViewItem {
 				this.renderLabel(this.element);
 			}
 		}));
-
-		// --- Start Positron ---
-		// Listen for model list changes (e.g., when provider settings change)
-		this._register(delegate.onDidChangeModelList(() => {
-			// Sync current model from delegate in case it was cleared
-			this.currentModel = delegate.currentModel.get();
-			// Update the label in case the current model changed
-			if (this.element) {
-				this.renderLabel(this.element);
-			}
-			// Note: The dropdown will automatically get fresh models from getModels()
-			// when it's opened, so no need to force refresh here
-		}));
-
-		// Re-render label when theme changes so provider icons use the correct fill
-		this._register(themeService.onDidColorThemeChange(() => {
-			if (this.element) {
-				this.renderLabel(this.element);
-			}
-		}));
-		// --- End Positron ---
 	}
 
 	protected override getHoverContents(): IManagedHoverContent | undefined {
@@ -379,35 +209,13 @@ export class ModelPickerActionItem extends ChatInputPickerActionViewItem {
 	protected override renderLabel(element: HTMLElement): IDisposable | null {
 		const { name, statusIcon } = this.currentModel?.metadata || {};
 		const domChildren = [];
-		// --- Start Positron ---
-		// Add provider icon if available
-		if (this.currentModel?.metadata.vendor) {
-			const providerIcon = getProviderIcon(this.currentModel.metadata.vendor, isDark(this.themeService.getColorTheme().type));
-			if (providerIcon?.themeIcon) {
-				const iconId = providerIcon.themeIcon.id;
-				if (iconId.startsWith('data:image/svg+xml')) {
-					// Render SVG as background image
-					const iconElement = dom.$('span.provider-icon');
-					iconElement.style.backgroundImage = `url('${iconId}')`;
-					domChildren.push(iconElement);
-				} else {
-					// Regular codicon
-					domChildren.push(...renderLabelWithIcons(`\$(${iconId})`));
-				}
-			}
-		}
-		// --- End Positron ---
 
 		if (statusIcon) {
 			const iconElement = renderIcon(statusIcon);
 			domChildren.push(iconElement);
 		}
 
-		// --- Start Positron ---
-		// Change "Auto" to "Pick Model"
-		// domChildren.push(dom.$('span.chat-input-picker-label', undefined, name ?? localize('chat.modelPicker.auto', "Auto")));
-		domChildren.push(dom.$('span.chat-input-picker-label', undefined, name ?? localize('chat.modelPicker.pickModel', "Pick Model")));
-		// --- End Positron ---
+		domChildren.push(dom.$('span.chat-input-picker-label', undefined, name ?? localize('chat.modelPicker.auto', "Auto")));
 		domChildren.push(...renderLabelWithIcons(`$(chevron-down)`));
 
 		dom.reset(element, ...domChildren);

--- a/src/vs/workbench/contrib/chat/browser/widgetHosts/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/widgetHosts/chatQuick.ts
@@ -446,14 +446,6 @@ class QuickChat extends Disposable {
 			}
 			// Update attachments
 			this.widget.attachmentModel.clearAndSetContext(...mainChatWidget.attachmentModel.attachments);
-			// Update console context
-			if (this.widget.input.runtimeContext) {
-				// Set the Console context
-				this.widget.input.runtimeContext.setValue(mainChatWidget.input.runtimeContext?.value);
-				// Set whether the Console context is enabled
-				this.widget.input.runtimeContext.enabled = mainChatWidget.input.runtimeContext?.enabled ?? false;
-			}
-
 		}
 	}
 	// --- End Positron ---

--- a/src/vs/workbench/contrib/chat/common/attachments/chatVariableEntries.ts
+++ b/src/vs/workbench/contrib/chat/common/attachments/chatVariableEntries.ts
@@ -262,27 +262,6 @@ export interface ISCMHistoryItemVariableEntry extends IBaseChatRequestVariableEn
 	readonly historyItem: ISCMHistoryItem;
 }
 
-// --- Start Positron ---
-export interface IChatRequestRuntimeSessionEntry extends IBaseChatRequestVariableEntry {
-	readonly kind: 'runtimeSession';
-	readonly value: {
-		activeSession?: {
-			identifier: string;
-			language: string;
-			version: string;
-			mode: string;
-			notebookUri?: any;
-			executions: {
-				input: string;
-				output: string;
-				error?: any;
-			}[];
-		};
-		variables: any[];
-	};
-}
-// --- End Positron ---
-
 export interface ISCMHistoryItemChangeVariableEntry extends IBaseChatRequestVariableEntry {
 	readonly kind: 'scmHistoryItemChange';
 	readonly value: URI;
@@ -344,10 +323,6 @@ export type IChatRequestVariableEntry = IGenericChatRequestVariableEntry | IChat
 	| IChatRequestDirectoryEntry | IChatRequestFileEntry | INotebookOutputVariableEntry | IElementVariableEntry
 	| IPromptFileVariableEntry | IPromptTextVariableEntry
 	| ISCMHistoryItemVariableEntry | ISCMHistoryItemChangeVariableEntry | ISCMHistoryItemChangeRangeVariableEntry | ITerminalVariableEntry
-	// --- Start Positron ---
-	// Add Positron runtime session variable entry
-	| IChatRequestRuntimeSessionEntry
-	// --- End Positron ---
 	| IChatRequestStringVariableEntry | IChatRequestWorkspaceVariableEntry | IDebugVariableEntry | IAgentFeedbackVariableEntry
 	| IChatRequestDebugEventsVariableEntry;
 
@@ -469,12 +444,6 @@ export function isChatRequestVariableEntry(obj: unknown): obj is IChatRequestVar
 export function isSCMHistoryItemVariableEntry(obj: IChatRequestVariableEntry): obj is ISCMHistoryItemVariableEntry {
 	return obj.kind === 'scmHistoryItem';
 }
-
-// --- Start Positron ---
-export function isRuntimeSessionEntry(obj: IChatRequestVariableEntry): obj is IChatRequestRuntimeSessionEntry {
-	return obj.kind === 'runtimeSession';
-}
-// --- End Positron ---
 
 export function isSCMHistoryItemChangeVariableEntry(obj: IChatRequestVariableEntry): obj is ISCMHistoryItemChangeVariableEntry {
 	return obj.kind === 'scmHistoryItemChange';

--- a/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
@@ -364,19 +364,8 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 		let extensionAgentRegistered = false;
 		let defaultAgentRegistered = false;
 		let toolsAgentRegistered = false;
-		// --- Start Positron ---
-		let testAgentRegistered = false;
-		// --- End Positron ---
 		for (const agent of this.getAgents()) {
-			// --- Start Positron ---
-			if (agent.extensionId.value === 'vscode.vscode-api-tests') {
-				testAgentRegistered = true;
-			}
-			// --- End Positron ---
 			if (agent.isDefault) {
-				// --- Start Positron ---
-				defaultAgentRegistered = true;
-				// --- End Positron ---
 				if (!agent.isCore) {
 					extensionAgentRegistered = true;
 				}
@@ -388,14 +377,7 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 				}
 			}
 		}
-		// --- Start Positron ---
-		// Do not register default agents when Assistant is disabled, except for
-		// the API test agent from upstream.
-		// this._defaultAgentRegistered.set(defaultAgentRegistered);
-		if (testAgentRegistered || this.configurationService.getValue('positron.assistant.enable')) {
-			this._defaultAgentRegistered.set(defaultAgentRegistered);
-		}
-		// --- End Positron ---
+		this._defaultAgentRegistered.set(defaultAgentRegistered);
 		this._extensionAgentRegistered.set(extensionAgentRegistered);
 		if (toolsAgentRegistered !== this._hasToolsAgent) {
 			this._hasToolsAgent = toolsAgentRegistered;
@@ -536,9 +518,12 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 	private _agentIsEnabled(idOrAgent: string | IChatAgentEntry): boolean {
 		const entry = typeof idOrAgent === 'string' ? this._agents.get(idOrAgent) : idOrAgent;
 		// --- Start Positron ---
-		// Special handling for Copilot Chat participants
+		// Special handling for Copilot Chat participants when Positron Assistant
+		// is gating providers. When Positron Assistant isn't running (no
+		// provider metadata registered), this filter is bypassed so that
+		// Copilot Chat participants pass through normally.
 		const isCopilotParticipant = ExtensionIdentifier.equals(entry?.data.extensionId, COPILOT_CHAT_EXTENSION_ID);
-		if (isCopilotParticipant) {
+		if (isCopilotParticipant && this.positronAssistantConfigurationService.isActive) {
 			// Disable Copilot Chat agent if Copilot is not enabled
 			const isCopilotEnabled = this.positronAssistantConfigurationService.copilotEnabled;
 			if (!isCopilotEnabled) {

--- a/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
+++ b/src/vs/workbench/contrib/chat/test/browser/widget/input/chatModelPicker.test.ts
@@ -116,34 +116,21 @@ suite('buildModelPickerItems', () => {
 		const modelA = createModel('gpt-4o', 'GPT-4o');
 		const items = callBuild([modelA, auto]);
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// In Positron, Auto is not promoted to first position - it appears grouped with other models by provider
-		assert.ok(actions[0].label === 'Other Models');
-		assert.ok(actions[1].label === 'Auto');
-		// --- End Positron ---
+		assert.ok(actions[0].label === 'Auto');
 	});
 
 	test('empty models list produces auto and manage models entries', () => {
 		const items = callBuild([]);
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// Positron adds additional footer items and Auto is not promoted to first position
 		assert.ok(actions[0].label === 'Auto');
-		// --- End Positron ---
 	});
 
 	test('only auto model produces auto and manage models with separator', () => {
 		const items = callBuild([createAutoModel()]);
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// In Positron: Other Models toggle, Auto, then footer items
-		assert.strictEqual(actions[0].label, 'Other Models');
-		assert.strictEqual(actions[0].isSectionToggle, true);
-		assert.strictEqual(actions[1].label, 'Auto');
-		assert.strictEqual(actions[2].item?.id, 'manageModels');
-		assert.strictEqual(actions[3].item?.id, 'configureProviders');
-		assert.ok(getSeparatorCount(items) >= 2);
-		// --- End Positron ---
+		assert.strictEqual(actions[0].label, 'Auto');
+		assert.strictEqual(actions[1].item?.id, 'manageModels');
+		assert.ok(getSeparatorCount(items) >= 1);
 	});
 
 	test('selected model appears in promoted section', () => {
@@ -154,16 +141,12 @@ suite('buildModelPickerItems', () => {
 			selectedModelId: modelA.identifier,
 		});
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// In Positron: selected model in promoted, then Other Models toggle, then remaining models
-		assert.strictEqual(actions[0].label, 'GPT-4o');
-		assert.ok(actions[0].item?.checked);
-		assert.strictEqual(actions[1].label, 'Other Models');
-		assert.strictEqual(actions[1].isSectionToggle, true);
-		// Auto and Claude in Other Models section (sorted alphabetically)
-		assert.strictEqual(actions[2].label, 'Auto');
+		assert.strictEqual(actions[0].label, 'Auto');
+		assert.strictEqual(actions[1].label, 'GPT-4o');
+		assert.ok(actions[1].item?.checked);
+		assert.strictEqual(actions[2].label, 'Other Models');
+		assert.strictEqual(actions[2].isSectionToggle, true);
 		assert.strictEqual(actions[3].label, 'Claude');
-		// --- End Positron ---
 	});
 
 	test('selected model with failing minVSCodeVersion shows as unavailable with reason update', () => {
@@ -193,16 +176,12 @@ suite('buildModelPickerItems', () => {
 			recentModelIds: [modelB.identifier],
 		});
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// In Positron: Claude (recent) in promoted, then Other Models with remaining models
-		assert.strictEqual(actions[0].label, 'Claude');
-		assert.strictEqual(actions[1].label, 'Other Models');
-		assert.strictEqual(actions[1].isSectionToggle, true);
-		// Remaining models in Other Models section (sorted alphabetically)
-		assert.strictEqual(actions[2].label, 'Auto');
+		assert.strictEqual(actions[0].label, 'Auto');
+		assert.strictEqual(actions[1].label, 'Claude');
+		assert.strictEqual(actions[2].label, 'Other Models');
+		assert.strictEqual(actions[2].isSectionToggle, true);
 		assert.strictEqual(actions[3].label, 'Gemini');
 		assert.strictEqual(actions[4].label, 'GPT-4o');
-		// --- End Positron ---
 	});
 
 	test('recently used model not in models list but in controlModels shows as unavailable (upgrade for free user)', () => {
@@ -259,15 +238,11 @@ suite('buildModelPickerItems', () => {
 			},
 		});
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// In Positron: GPT-4o (featured) in promoted, then Other Models with remaining models
-		assert.strictEqual(actions[0].label, 'GPT-4o');
-		assert.strictEqual(actions[1].label, 'Other Models');
-		assert.strictEqual(actions[1].isSectionToggle, true);
-		// Auto and Claude in Other Models section (sorted alphabetically)
-		assert.strictEqual(actions[2].label, 'Auto');
+		assert.strictEqual(actions[0].label, 'Auto');
+		assert.strictEqual(actions[1].label, 'GPT-4o');
+		assert.strictEqual(actions[2].label, 'Other Models');
+		assert.strictEqual(actions[2].isSectionToggle, true);
 		assert.strictEqual(actions[3].label, 'Claude');
-		// --- End Positron ---
 	});
 
 	test('featured model not in models list shows as unavailable for free users (upgrade)', () => {
@@ -321,20 +296,14 @@ suite('buildModelPickerItems', () => {
 				'gpt-4o': { label: 'GPT-4o', featured: false, exists: true },
 			},
 		});
-		// With no selected, no recent, and no featured, all models should be in Other
 		const seps = items.filter(i => i.kind === ActionListItemKind.Separator);
-		// --- Start Positron ---
-		// Positron adds provider separators
 		assert.ok(seps.length >= 2);
 		const actions = getActionItems(items);
-		// All models in Other Models section
-		assert.strictEqual(actions[0].label, 'Other Models');
-		assert.strictEqual(actions[0].isSectionToggle, true);
-		// Models sorted alphabetically
-		assert.strictEqual(actions[1].label, 'Auto');
+		assert.strictEqual(actions[0].label, 'Auto');
+		assert.strictEqual(actions[1].label, 'Other Models');
+		assert.strictEqual(actions[1].isSectionToggle, true);
 		assert.strictEqual(actions[2].label, 'Claude');
 		assert.strictEqual(actions[3].label, 'GPT-4o');
-		// --- End Positron ---
 	});
 
 	test('available promoted models are sorted alphabetically', () => {
@@ -346,15 +315,10 @@ suite('buildModelPickerItems', () => {
 			recentModelIds: [modelA.identifier, modelB.identifier, modelC.identifier],
 		});
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// In Positron: promoted models sorted alphabetically, then Other Models with Auto
-		assert.strictEqual(actions[0].label, 'Claude');
-		assert.strictEqual(actions[1].label, 'Gemini');
-		assert.strictEqual(actions[2].label, 'GPT-4o');
-		assert.strictEqual(actions[3].label, 'Other Models');
-		assert.strictEqual(actions[3].isSectionToggle, true);
-		assert.strictEqual(actions[4].label, 'Auto');
-		// --- End Positron ---
+		assert.strictEqual(actions[0].label, 'Auto');
+		assert.strictEqual(actions[1].label, 'Claude');
+		assert.strictEqual(actions[2].label, 'Gemini');
+		assert.strictEqual(actions[3].label, 'GPT-4o');
 	});
 
 	test('unavailable promoted models appear after available ones', () => {
@@ -368,16 +332,11 @@ suite('buildModelPickerItems', () => {
 			entitlement: ChatEntitlement.Free,
 		});
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// In Positron: available promoted first, then unavailable, then Other Models
-		assert.strictEqual(actions[0].label, 'GPT-4o');
-		assert.ok(!actions[0].disabled);
-		assert.strictEqual(actions[1].label, 'Missing Model');
-		assert.strictEqual(actions[1].disabled, true);
-		assert.strictEqual(actions[2].label, 'Other Models');
-		assert.strictEqual(actions[2].isSectionToggle, true);
-		assert.strictEqual(actions[3].label, 'Auto');
-		// --- End Positron ---
+		assert.strictEqual(actions[0].label, 'Auto');
+		assert.strictEqual(actions[1].label, 'GPT-4o');
+		assert.ok(!actions[1].disabled);
+		assert.strictEqual(actions[2].label, 'Missing Model');
+		assert.strictEqual(actions[2].disabled, true);
 	});
 
 	test('models not in promoted section appear in Other Models section', () => {
@@ -386,15 +345,11 @@ suite('buildModelPickerItems', () => {
 		const modelB = createModel('claude', 'Claude');
 		const items = callBuild([auto, modelA, modelB]);
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// In Positron: all models in Other Models section (no promoted items)
-		assert.strictEqual(actions[0].label, 'Other Models');
-		assert.strictEqual(actions[0].isSectionToggle, true);
-		// Models sorted alphabetically
-		assert.strictEqual(actions[1].label, 'Auto');
+		assert.strictEqual(actions[0].label, 'Auto');
+		assert.strictEqual(actions[1].label, 'Other Models');
+		assert.strictEqual(actions[1].isSectionToggle, true);
 		assert.strictEqual(actions[2].label, 'Claude');
 		assert.strictEqual(actions[3].label, 'GPT-4o');
-		// --- End Positron ---
 	});
 
 	test('Other Models section includes section toggle', () => {
@@ -441,16 +396,12 @@ suite('buildModelPickerItems', () => {
 			currentVSCodeVersion: '1.90.0',
 		});
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// In Positron: Other Models toggle, then available models, then unavailable models
-		assert.strictEqual(actions[0].label, 'Other Models');
-		assert.strictEqual(actions[0].isSectionToggle, true);
-		// Available models first (Auto, Zeta), then unavailable (Alpha)
-		assert.strictEqual(actions[1].label, 'Auto');
+		assert.strictEqual(actions[0].label, 'Auto');
+		assert.strictEqual(actions[1].label, 'Other Models');
+		assert.strictEqual(actions[1].isSectionToggle, true);
 		assert.strictEqual(actions[2].label, 'Zeta');
 		assert.strictEqual(actions[3].label, 'Alpha');
 		assert.strictEqual(actions[3].disabled, true);
-		// --- End Positron ---
 	});
 
 	test('no duplicate models across sections', () => {
@@ -466,10 +417,7 @@ suite('buildModelPickerItems', () => {
 				'claude': { label: 'Claude', featured: true, exists: true },
 			},
 		});
-		// --- Start Positron ---
-		// Filter out footer items (Manage Models, Configure Model Providers)
-		const labels = getActionLabels(items).filter(l => l !== 'Other Models' && !l.includes('Manage Models') && !l.includes('Configure'));
-		// --- End Positron ---
+		const labels = getActionLabels(items).filter(l => l !== 'Other Models' && !l.includes('Manage Models'));
 		const uniqueLabels = new Set(labels);
 		assert.strictEqual(labels.length, uniqueLabels.size, `Duplicate labels found: ${labels.join(', ')}`);
 	});
@@ -497,15 +445,11 @@ suite('buildModelPickerItems', () => {
 			controlModels: {},
 		});
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// In Positron: all models in Other Models section
-		assert.strictEqual(actions[0].label, 'Other Models');
-		assert.strictEqual(actions[0].isSectionToggle, true);
-		// Models sorted alphabetically
-		assert.strictEqual(actions[1].label, 'Auto');
+		assert.strictEqual(actions[0].label, 'Auto');
+		assert.strictEqual(actions[1].label, 'Other Models');
+		assert.strictEqual(actions[1].isSectionToggle, true);
 		assert.strictEqual(actions[2].label, 'Claude');
 		assert.strictEqual(actions[3].label, 'GPT-4o');
-		// --- End Positron ---
 	});
 
 	test('Other Models sorted by vendor then name', () => {
@@ -515,16 +459,12 @@ suite('buildModelPickerItems', () => {
 		const modelC = createModel('beta', 'Beta', 'copilot');
 		const items = callBuild([auto, modelA, modelB, modelC]);
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// In Positron: Other Models toggle, then models sorted by vendor then name
-		assert.strictEqual(actions[0].label, 'Other Models');
-		assert.strictEqual(actions[0].isSectionToggle, true);
-		// copilot models first (Auto, Beta, Zebra sorted by name), then other-vendor (Alpha)
-		assert.strictEqual(actions[1].label, 'Auto');
+		assert.strictEqual(actions[0].label, 'Auto');
+		assert.strictEqual(actions[1].label, 'Other Models');
+		assert.strictEqual(actions[1].isSectionToggle, true);
 		assert.strictEqual(actions[2].label, 'Beta');
 		assert.strictEqual(actions[3].label, 'Zebra');
 		assert.strictEqual(actions[4].label, 'Alpha');
-		// --- End Positron ---
 	});
 
 	test('onSelect callback is wired into action items', () => {
@@ -574,14 +514,11 @@ suite('buildModelPickerItems', () => {
 			selectedModelId: auto.identifier,
 		});
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// In Positron: Auto is not promoted even when selected - it stays in Other Models but is checked
-		assert.strictEqual(actions[0].label, 'Other Models');
-		assert.strictEqual(actions[0].isSectionToggle, true);
-		assert.strictEqual(actions[1].label, 'Auto');
-		assert.ok(actions[1].item?.checked);
+		assert.strictEqual(actions[0].label, 'Auto');
+		assert.ok(actions[0].item?.checked);
+		assert.strictEqual(actions[1].label, 'Other Models');
+		assert.strictEqual(actions[1].isSectionToggle, true);
 		assert.strictEqual(actions[2].label, 'GPT-4o');
-		// --- End Positron ---
 	});
 
 	test('recently used model resolved by metadata id', () => {
@@ -593,15 +530,11 @@ suite('buildModelPickerItems', () => {
 			recentModelIds: ['claude'],
 		});
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// In Positron: Claude (recent) in promoted, then Other Models with remaining
-		assert.strictEqual(actions[0].label, 'Claude');
-		assert.strictEqual(actions[1].label, 'Other Models');
-		assert.strictEqual(actions[1].isSectionToggle, true);
-		// Auto and GPT-4o in Other Models (sorted alphabetically)
-		assert.strictEqual(actions[2].label, 'Auto');
+		assert.strictEqual(actions[0].label, 'Auto');
+		assert.strictEqual(actions[1].label, 'Claude');
+		assert.strictEqual(actions[2].label, 'Other Models');
+		assert.strictEqual(actions[2].isSectionToggle, true);
 		assert.strictEqual(actions[3].label, 'GPT-4o');
-		// --- End Positron ---
 	});
 
 	test('multiple featured and recent models all promoted correctly', () => {
@@ -617,17 +550,13 @@ suite('buildModelPickerItems', () => {
 			},
 		});
 		const actions = getActionItems(items);
-		// --- Start Positron ---
-		// In Positron: promoted models (Alpha featured, Gamma recent) sorted alphabetically, then Other Models
-		assert.strictEqual(actions[0].label, 'Alpha');
-		assert.strictEqual(actions[1].label, 'Gamma');
-		assert.strictEqual(actions[2].label, 'Other Models');
-		assert.strictEqual(actions[2].isSectionToggle, true);
-		// Remaining models in Other Models (Auto, Beta, Delta sorted alphabetically)
-		assert.strictEqual(actions[3].label, 'Auto');
+		assert.strictEqual(actions[0].label, 'Auto');
+		assert.strictEqual(actions[1].label, 'Alpha');
+		assert.strictEqual(actions[2].label, 'Gamma');
+		assert.strictEqual(actions[3].label, 'Other Models');
+		assert.strictEqual(actions[3].isSectionToggle, true);
 		assert.strictEqual(actions[4].label, 'Beta');
 		assert.strictEqual(actions[5].label, 'Delta');
-		// --- End Positron ---
 	});
 
 	test('admin unavailable model shows manage settings link in description', () => {

--- a/src/vs/workbench/contrib/chat/test/common/participants/chatAgents.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/participants/chatAgents.test.ts
@@ -91,6 +91,7 @@ suite('ChatAgents', function () {
 	let contextKeyService: TestingContextKeyService;
 	// --- Start Positron ---
 	let configurationService: TestConfigurationService;
+	let positronAssistantConfigurationService: TestPositronAssistantConfigurationService;
 	// --- End Positron ---
 	setup(() => {
 		contextKeyService = new TestingContextKeyService();
@@ -99,8 +100,7 @@ suite('ChatAgents', function () {
 		configurationService = new TestConfigurationService();
 		const logService = new NullLogService();
 		const languageModelsService = new TestLanguageModelsService();
-		const positronAssistantConfigurationService = new TestPositronAssistantConfigurationService();
-		configurationService.setUserConfiguration('positron.assistant.enable', true);
+		positronAssistantConfigurationService = new TestPositronAssistantConfigurationService();
 		chatAgentService = store.add(new ChatAgentService(contextKeyService, configurationService, logService, languageModelsService, positronAssistantConfigurationService));
 		// --- End Positron ---
 	});
@@ -168,4 +168,31 @@ suite('ChatAgents', function () {
 			assert.throws(() => chatAgentService.registerAgentImplementation(testAgentId, agentImpl));
 		});
 	});
+
+	// --- Start Positron ---
+	suite('Copilot Chat participant gating', function () {
+		const copilotAgentId = 'copilotAgent';
+		const copilotAgentData: IChatAgentData = {
+			...testAgentData,
+			id: copilotAgentId,
+			extensionId: new ExtensionIdentifier('github.copilot-chat'),
+		};
+
+		test('Copilot participant is bypassed when Positron Assistant is inactive', () => {
+			positronAssistantConfigurationService.isActive = false;
+			positronAssistantConfigurationService.copilotEnabled = false;
+			store.add(chatAgentService.registerAgent(copilotAgentId, copilotAgentData));
+
+			assert.ok(chatAgentService.getAgent(copilotAgentId), 'Copilot agent should be enabled when Positron Assistant is inactive, regardless of copilotEnabled');
+		});
+
+		test('Copilot participant is filtered out when Positron Assistant is active and Copilot is disabled', () => {
+			positronAssistantConfigurationService.isActive = true;
+			positronAssistantConfigurationService.copilotEnabled = false;
+			store.add(chatAgentService.registerAgent(copilotAgentId, copilotAgentData));
+
+			assert.strictEqual(chatAgentService.getAgent(copilotAgentId), undefined, 'Copilot agent should be filtered when Positron Assistant gates it');
+		});
+	});
+	// --- End Positron ---
 });

--- a/src/vs/workbench/contrib/positAssistant/browser/positAssistant.contribution.ts
+++ b/src/vs/workbench/contrib/positAssistant/browser/positAssistant.contribution.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Event } from '../../../../base/common/event.js';
+import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
+import { IWorkbenchContribution, IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from '../../../common/contributions.js';
+import { LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
+import { IWorkbenchExtensionEnablementService } from '../../../services/extensionManagement/common/extensionManagement.js';
+import { IExtension, IExtensionsWorkbenchService } from '../../extensions/common/extensions.js';
+import { POSIT_ASSISTANT_AVAILABLE, POSIT_ASSISTANT_EXTENSION_ID } from '../common/positAssistantContextKeys.js';
+
+/**
+ * Contribution that tracks whether the optional `posit.assistant` extension is
+ * installed and enabled, and exposes that as the `positron.positAssistantAvailable`
+ * context key.
+ */
+export class PositAssistantContextKeyContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.positAssistantContextKey';
+
+	private readonly _positAssistantAvailable: IContextKey<boolean>;
+
+	readonly whenInitialized: Promise<void>;
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IExtensionsWorkbenchService private readonly extensionsWorkbenchService: IExtensionsWorkbenchService,
+		@IWorkbenchExtensionEnablementService private readonly extensionEnablementService: IWorkbenchExtensionEnablementService,
+		@ILogService private readonly logService: ILogService,
+	) {
+		super();
+		this._positAssistantAvailable = POSIT_ASSISTANT_AVAILABLE.bindTo(contextKeyService);
+		this.whenInitialized = this._initialize().catch(err => this.logService.error(err));
+	}
+
+	private async _initialize(): Promise<void> {
+		await this.extensionsWorkbenchService.queryLocal();
+
+		this._register(Event.runAndSubscribe<IExtension | undefined>(this.extensionsWorkbenchService.onChange, e => {
+			if (e && !ExtensionIdentifier.equals(e.identifier.id, POSIT_ASSISTANT_EXTENSION_ID)) {
+				return;
+			}
+			this._update();
+		}));
+
+		this._register(this.extensionEnablementService.onEnablementChanged(() => this._update()));
+	}
+
+	private _update(): void {
+		const extension = this.extensionsWorkbenchService.local.find(e => ExtensionIdentifier.equals(e.identifier.id, POSIT_ASSISTANT_EXTENSION_ID));
+		const local = extension?.local;
+		const enabled = !!local && this.extensionEnablementService.isEnabled(local);
+		this._positAssistantAvailable.set(enabled);
+	}
+}
+
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(PositAssistantContextKeyContribution, LifecyclePhase.Restored);

--- a/src/vs/workbench/contrib/positAssistant/common/positAssistantContextKeys.ts
+++ b/src/vs/workbench/contrib/positAssistant/common/positAssistantContextKeys.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+
+/**
+ * The id of the Posit Assistant extension. Posit Assistant is the optional
+ * successor to the built-in Positron Assistant.
+ */
+export const POSIT_ASSISTANT_EXTENSION_ID = 'posit.assistant';
+
+/**
+ * Context key that is `true` when the Posit Assistant extension is installed
+ * and enabled in the current workbench. Used to gate Posit-Assistant-flavored
+ * UI (notebook actions, layout) so it only appears when the optional extension
+ * is present.
+ */
+export const POSIT_ASSISTANT_AVAILABLE = new RawContextKey<boolean>('positron.positAssistantAvailable', false);

--- a/src/vs/workbench/contrib/positAssistant/test/browser/positAssistant.contribution.vitest.ts
+++ b/src/vs/workbench/contrib/positAssistant/test/browser/positAssistant.contribution.vitest.ts
@@ -1,0 +1,141 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Emitter } from '../../../../../base/common/event.js';
+import { ILocalExtension } from '../../../../../platform/extensionManagement/common/extensionManagement.js';
+import { IExtension as IPlatformExtension } from '../../../../../platform/extensions/common/extensions.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { IWorkbenchExtensionEnablementService } from '../../../../services/extensionManagement/common/extensionManagement.js';
+import { IExtension, IExtensionsWorkbenchService } from '../../../extensions/common/extensions.js';
+import { PositAssistantContextKeyContribution } from '../../browser/positAssistant.contribution.js';
+import { POSIT_ASSISTANT_AVAILABLE, POSIT_ASSISTANT_EXTENSION_ID } from '../../common/positAssistantContextKeys.js';
+
+describe('PositAssistantContextKeyContribution', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	function makeExtension(id: string, isInstalled: boolean): IExtension {
+		return stubInterface<IExtension>({
+			identifier: { id },
+			local: isInstalled ? stubInterface<ILocalExtension>() : undefined,
+		});
+	}
+
+	interface SetupOptions {
+		installedExtensions?: IExtension[];
+		isEnabled?: (extension: IPlatformExtension) => boolean;
+	}
+
+	function setup({ installedExtensions = [], isEnabled = () => true }: SetupOptions = {}) {
+		const contextKeyService = new MockContextKeyService();
+		// `localExtensions` is shared with the stub via reference identity:
+		// `extensionsWorkbenchService.local` returns the same array the test
+		// pushes/splices to simulate installs and uninstalls.
+		const localExtensions: IExtension[] = [...installedExtensions];
+		const onChange = disposables.add(new Emitter<IExtension | undefined>());
+		const onEnablementChanged = disposables.add(new Emitter<readonly IExtension[]>());
+
+		const extensionsWorkbenchService = stubInterface<IExtensionsWorkbenchService>({
+			queryLocal: async () => localExtensions,
+			onChange: onChange.event,
+			local: localExtensions,
+		});
+		const extensionEnablementService = stubInterface<IWorkbenchExtensionEnablementService>({
+			onEnablementChanged: onEnablementChanged.event,
+			isEnabled,
+		});
+
+		const contribution = disposables.add(new PositAssistantContextKeyContribution(
+			contextKeyService,
+			extensionsWorkbenchService,
+			extensionEnablementService,
+			new NullLogService(),
+		));
+
+		return {
+			contribution,
+			localExtensions,
+			onChange,
+			onEnablementChanged,
+			getValue: () => contextKeyService.getContextKeyValue<boolean>(POSIT_ASSISTANT_AVAILABLE.key),
+		};
+	}
+
+	it('is unavailable when posit.assistant is not installed', async () => {
+		const { contribution, getValue } = setup();
+		await contribution.whenInitialized;
+
+		expect(getValue()).toBe(false);
+	});
+
+	it('is available when posit.assistant is installed and enabled', async () => {
+		const { contribution, getValue } = setup({
+			installedExtensions: [makeExtension(POSIT_ASSISTANT_EXTENSION_ID, true)],
+			isEnabled: () => true,
+		});
+		await contribution.whenInitialized;
+
+		expect(getValue()).toBe(true);
+	});
+
+	it('is unavailable when posit.assistant is installed but disabled', async () => {
+		const { contribution, getValue } = setup({
+			installedExtensions: [makeExtension(POSIT_ASSISTANT_EXTENSION_ID, true)],
+			isEnabled: () => false,
+		});
+		await contribution.whenInitialized;
+
+		expect(getValue()).toBe(false);
+	});
+
+	it('flips when extension enablement state changes', async () => {
+		let enabled = true;
+		const { contribution, onEnablementChanged, getValue } = setup({
+			installedExtensions: [makeExtension(POSIT_ASSISTANT_EXTENSION_ID, true)],
+			isEnabled: () => enabled,
+		});
+		await contribution.whenInitialized;
+		expect(getValue()).toBe(true);
+
+		enabled = false;
+		onEnablementChanged.fire([]);
+		expect(getValue()).toBe(false);
+
+		enabled = true;
+		onEnablementChanged.fire([]);
+		expect(getValue()).toBe(true);
+	});
+
+	it('updates when posit.assistant is added via onChange', async () => {
+		const { contribution, localExtensions, onChange, getValue } = setup();
+		await contribution.whenInitialized;
+		expect(getValue()).toBe(false);
+
+		const positExtension = makeExtension(POSIT_ASSISTANT_EXTENSION_ID, true);
+		localExtensions.push(positExtension);
+		onChange.fire(positExtension);
+
+		expect(getValue()).toBe(true);
+	});
+
+	it('ignores onChange events for unrelated extensions', async () => {
+		const { contribution, localExtensions, onChange, getValue } = setup();
+		await contribution.whenInitialized;
+
+		// Add posit.assistant to local but only fire onChange for an unrelated extension.
+		// The filter should skip the update; the value should stay false.
+		localExtensions.push(makeExtension(POSIT_ASSISTANT_EXTENSION_ID, true));
+		onChange.fire(makeExtension('some.other.extension', true));
+		expect(getValue()).toBe(false);
+
+		// Sanity: firing onChange for posit.assistant does run the update.
+		onChange.fire(makeExtension(POSIT_ASSISTANT_EXTENSION_ID, true));
+		expect(getValue()).toBe(true);
+	});
+});

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistantService.ts
@@ -59,7 +59,22 @@ export class PositronAssistantConfigurationService extends Disposable implements
 		this._providerMetadata.set(metadata.id, metadata);
 	}
 
+	/**
+	 * Positron Assistant is "active" once at least one provider has been
+	 * registered. Until then the extension is either disabled or hasn't
+	 * activated yet, and gating callers should pass through to the upstream
+	 * Copilot Chat path rather than apply Positron's provider rules.
+	 */
+	get isActive(): boolean {
+		return this._providerMetadata.size > 0;
+	}
+
 	get copilotEnabled(): boolean {
+		// When inactive, treat Copilot as enabled so the upstream Copilot Chat
+		// path is not gated.
+		if (!this.isActive) {
+			return true;
+		}
 		return this._copilotEnabled;
 	}
 
@@ -83,6 +98,11 @@ export class PositronAssistantConfigurationService extends Disposable implements
 	}
 
 	isProviderEnabled(providerId: string): boolean {
+		// When inactive, treat all providers as enabled so the upstream model
+		// picker behavior applies.
+		if (!this.isActive) {
+			return true;
+		}
 		const enabledProviders = this.getEnabledProviders();
 		return enabledProviders.includes(providerId) ||
 			// Special case: 'copilot' vendor is enabled via 'copilot-auth' provider id's setting

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -125,6 +125,15 @@ export interface IPositronAssistantConfigurationService {
 	readonly _serviceBrand: undefined;
 
 	/**
+	 * Whether Positron Assistant is currently gating providers. False when no
+	 * provider metadata has been registered (i.e., the Positron Assistant
+	 * extension is disabled or not installed); in that case `copilotEnabled`
+	 * and `isProviderEnabled` pass through so the upstream Copilot Chat path
+	 * is not gated.
+	 */
+	readonly isActive: boolean;
+
+	/**
 	 * Flag indicating whether GitHub Copilot is enabled (via disabled extension, or lack of authentication).
 	 */
 	readonly copilotEnabled: boolean;

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/positronAssistantConfigurationService.vitest.ts
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/positronAssistantConfigurationService.vitest.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { PositronAssistantConfigurationService } from '../../browser/positronAssistantService.js';
+import { IPositronProviderMetadata } from '../../common/interfaces/positronAssistantService.js';
+
+describe('PositronAssistantConfigurationService', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	let configService: TestConfigurationService;
+	let service: PositronAssistantConfigurationService;
+
+	const copilotAuthMetadata: IPositronProviderMetadata = {
+		id: 'copilot-auth',
+		displayName: 'GitHub Copilot',
+		settingName: 'copilot',
+	};
+	const anthropicMetadata: IPositronProviderMetadata = {
+		id: 'anthropic-api',
+		displayName: 'Anthropic',
+		settingName: 'anthropic',
+	};
+
+	beforeEach(() => {
+		configService = new TestConfigurationService();
+		service = disposables.add(new PositronAssistantConfigurationService(configService));
+	});
+
+	describe('with no provider metadata registered (Positron Assistant inactive)', () => {
+		it('reports isActive = false', () => {
+			expect(service.isActive).toBe(false);
+		});
+
+		it('reports copilotEnabled = true so upstream Copilot Chat is not gated', () => {
+			expect(service.copilotEnabled).toBe(true);
+		});
+
+		it('reports isProviderEnabled = true for any provider id', () => {
+			expect(service.isProviderEnabled('copilot')).toBe(true);
+			expect(service.isProviderEnabled('anthropic-api')).toBe(true);
+			expect(service.isProviderEnabled('made-up-provider')).toBe(true);
+		});
+
+		it('returns no enabled providers', () => {
+			expect(service.getEnabledProviders()).toEqual([]);
+		});
+	});
+
+	describe('with provider metadata registered (Positron Assistant active)', () => {
+		beforeEach(() => {
+			service.registerProviderMetadata(copilotAuthMetadata);
+			service.registerProviderMetadata(anthropicMetadata);
+		});
+
+		it('reports isActive = true', () => {
+			expect(service.isActive).toBe(true);
+		});
+
+		it('honors the underlying _copilotEnabled flag', () => {
+			expect(service.copilotEnabled).toBe(false);
+			service.copilotEnabled = true;
+			expect(service.copilotEnabled).toBe(true);
+		});
+
+		it('reads enabled providers from per-provider settings', async () => {
+			await configService.setUserConfiguration('positron.assistant.provider.anthropic.enable', true);
+			await configService.setUserConfiguration('positron.assistant.provider.copilot.enable', false);
+			expect(service.getEnabledProviders()).toEqual(['anthropic-api']);
+		});
+
+		it('treats the copilot vendor as enabled when the copilot-auth provider is enabled', async () => {
+			await configService.setUserConfiguration('positron.assistant.provider.copilot.enable', true);
+			expect(service.isProviderEnabled('copilot-auth')).toBe(true);
+			expect(service.isProviderEnabled('copilot')).toBe(true);
+		});
+
+		it('reports unknown providers as disabled', () => {
+			expect(service.isProviderEnabled('made-up-provider')).toBe(false);
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronKeybindings/browser/positronKeybindings.contribution.ts
+++ b/src/vs/workbench/contrib/positronKeybindings/browser/positronKeybindings.contribution.ts
@@ -14,6 +14,11 @@ import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keyb
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { ExtensionIdentifier } from '../../../../platform/extensions/common/extensions.js';
+import { IExtensionService } from '../../../services/extensions/common/extensions.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+
+const COPILOT_CHAT_EXTENSION_ID = 'github.copilot-chat';
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(
 	Extensions.Configuration
@@ -37,7 +42,9 @@ class PositronKeybindingsContribution extends Disposable {
 	private readonly _registrations: DisposableStore = new DisposableStore();
 
 	constructor(
-		@IConfigurationService private readonly _configurationService: IConfigurationService
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IExtensionService private readonly _extensionService: IExtensionService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 		super();
 
@@ -237,18 +244,9 @@ class PositronKeybindingsContribution extends Disposable {
 			primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter
 		}));
 
-		// Reindent selected lines. We only bind this if Assistant is not enabled,
-		// since this binding is used to invoke inline chat with Assistant.
-		const positronAssistantEnabled =
-			this._configurationService.getValue('positron.assistant.enable');
-		if (!positronAssistantEnabled) {
-			this._registrations.add(KeybindingsRegistry.registerKeybindingRule({
-				id: 'editor.action.reindentselectedlines',
-				weight: KeybindingWeight.BuiltinExtension,
-				when: EditorContextKeys.editorTextFocus,
-				primary: KeyMod.CtrlCmd | KeyCode.KeyI
-			}));
-		}
+		// Reindent selected lines. We only bind this if Copilot Chat is not
+		// installed/enabled, since Cmd+I is reserved for inline chat there.
+		this._registerReindentIfCopilotChatAbsent().catch(err => this._logService.error(err));
 
 		// Format selection
 		this._registrations.add(KeybindingsRegistry.registerKeybindingRule({
@@ -334,6 +332,21 @@ class PositronKeybindingsContribution extends Disposable {
 			id: 'workbench.action.setWorkingDirectory',
 			weight: KeybindingWeight.BuiltinExtension,
 			primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyH
+		}));
+	}
+
+	private async _registerReindentIfCopilotChatAbsent(): Promise<void> {
+		await this._extensionService.whenInstalledExtensionsRegistered();
+		const copilotChatPresent = this._extensionService.extensions.some(
+			e => ExtensionIdentifier.equals(e.identifier, COPILOT_CHAT_EXTENSION_ID));
+		if (copilotChatPresent) {
+			return;
+		}
+		this._registrations.add(KeybindingsRegistry.registerKeybindingRule({
+			id: 'editor.action.reindentselectedlines',
+			weight: KeybindingWeight.BuiltinExtension,
+			when: EditorContextKeys.editorTextFocus,
+			primary: KeyMod.CtrlCmd | KeyCode.KeyI
 		}));
 	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
@@ -17,6 +17,7 @@ import { ChatModeKind } from '../../chat/common/constants.js';
 import { IChatEditingService } from '../../chat/common/editing/chatEditingService.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
+import { POSIT_ASSISTANT_AVAILABLE } from '../../positAssistant/common/positAssistantContextKeys.js';
 import { PositronModalReactRenderer } from '../../../../base/browser/positronModalReactRenderer.js';
 import { AssistantPanel } from './AssistantPanel/AssistantPanel.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
@@ -52,7 +53,7 @@ export class AskAssistantAction extends Action2 {
 				order: 50,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
-					ContextKeyExpr.has('config.positron.assistant.enable'),
+					POSIT_ASSISTANT_AVAILABLE,
 				)
 			}
 		});

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
@@ -13,6 +13,7 @@ import { useCallback, useMemo } from 'react';
 import { localize } from '../../../../../nls.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { usePositronConfiguration, usePositronContextKey } from '../../../../../base/browser/positronReactHooks.js';
+import { POSIT_ASSISTANT_AVAILABLE } from '../../../positAssistant/common/positAssistantContextKeys.js';
 import { IAction } from '../../../../../base/common/actions.js';
 import { removeAnsiEscapeCodes } from '../../../../../base/common/strings.js';
 import { CHAT_OPEN_ACTION_ID, ACTION_ID_NEW_CHAT } from '../../../chat/browser/actions/chatActions.js';
@@ -42,12 +43,12 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 	const { commandService, contextMenuService } = services;
 
 	// Configuration hooks to conditionally show the quick-fix buttons
-	const enableAssistant = usePositronConfiguration<boolean>('positron.assistant.enable');
+	const positAssistantAvailable = usePositronContextKey<boolean>(POSIT_ASSISTANT_AVAILABLE.key);
 	const enableNotebookMode = usePositronConfiguration<boolean>(POSITRON_NOTEBOOK_ENABLED_KEY);
 	const hasChatModels = usePositronContextKey<boolean>('positron-assistant.hasChatModels');
 
-	// Only show buttons if assistant is enabled, notebook mode is enabled, and chat models are available
-	const showQuickFix = enableAssistant && enableNotebookMode && hasChatModels;
+	// Only show buttons if Posit Assistant is available, notebook mode is enabled, and chat models are available
+	const showQuickFix = positAssistantAvailable && enableNotebookMode && hasChatModels;
 
 	/**
 	 * Builds a query string for asking the assistant to fix the erroring cell.

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.vitest.tsx
@@ -20,6 +20,7 @@ import { IPositronNotebookInstance } from '../../../browser/IPositronNotebookIns
 import { NotebookInstanceProvider } from '../../../browser/NotebookInstanceProvider.js';
 import { CellTextOutput } from '../../../browser/notebookCells/CellTextOutput.js';
 import { ParsedTextOutput } from '../../../browser/PositronNotebookCells/IPositronNotebookCell.js';
+import { POSIT_ASSISTANT_AVAILABLE } from '../../../../positAssistant/common/positAssistantContextKeys.js';
 import { stubInterface } from '../../../../../../test/vitest/stubInterface.js';
 
 /** Generate multiline content with the given number of lines. */
@@ -88,8 +89,8 @@ describe('CellTextOutput', () => {
 		// here gives isolated state without any manual reset.
 		const configurationService = ctx.get(IConfigurationService) as TestConfigurationService;
 		const contextKeyService = ctx.get(IContextKeyService) as MockContextKeyService;
-		configurationService.setUserConfiguration('positron.assistant.enable', true);
 		configurationService.setUserConfiguration('positron.notebook.enabled', true);
+		contextKeyService.createKey(POSIT_ASSISTANT_AVAILABLE.key, true);
 		contextKeyService.createKey('positron-assistant.hasChatModels', true);
 
 		renderCellTextOutput({ content: 'NameError: name "x" is not defined', type: 'error' });
@@ -98,7 +99,7 @@ describe('CellTextOutput', () => {
 		expect(screen.getByRole('group', { name: /quick fix/i })).toBeInTheDocument();
 	});
 
-	it('does not render quick-fix for errors when assistant is disabled', () => {
+	it('does not render quick-fix for errors when Posit Assistant is not available', () => {
 		renderCellTextOutput({ content: 'NameError: name "x" is not defined', type: 'error' });
 
 		expect(screen.getByTestId('cell-text-output')).toHaveClass('notebook-error');

--- a/src/vs/workbench/services/positronLayout/browser/layouts/positronAssistantLayout.ts
+++ b/src/vs/workbench/services/positronLayout/browser/layouts/positronAssistantLayout.ts
@@ -5,8 +5,8 @@
 
 import { localize2 } from '../../../../../nls.js';
 import { registerAction2 } from '../../../../../platform/actions/common/actions.js';
-import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { Parts } from '../../../layout/browser/layoutService.js';
+import { POSIT_ASSISTANT_AVAILABLE } from '../../../../contrib/positAssistant/common/positAssistantContextKeys.js';
 import { PositronLayoutAction, PositronLayoutInfo } from './layoutAction.js';
 
 
@@ -14,7 +14,7 @@ export const positronAssistantLayout: PositronLayoutInfo = {
 	id: 'workbench.action.positronAssistantLayout',
 	codicon: 'positron-assistant-layout',
 	label: localize2('choseLayout.assistant', 'Assistant Layout'),
-	precondition: ContextKeyExpr.has('config.positron.assistant.enable'),
+	precondition: POSIT_ASSISTANT_AVAILABLE,
 	layoutDescriptor: {
 		[Parts.SIDEBAR_PART]: {
 			size: '30%',

--- a/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
+++ b/src/vs/workbench/test/common/positronWorkbenchTestServices.ts
@@ -292,6 +292,7 @@ export { TestPositronConsoleService, TestPositronConsoleInstance } from '../../s
 export class TestPositronAssistantConfigurationService implements IPositronAssistantConfigurationService {
 	_serviceBrand: undefined;
 
+	isActive = false;
 	copilotEnabled = true;
 	onChangeCopilotEnabled = Event.None;
 	onChangeEnabledProviders = Event.None;

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -478,6 +478,7 @@ import './contrib/opener/browser/opener.contribution.js';
 
 // Contributions
 import './contrib/positronAssistant/browser/positronAssistant.contribution.js';
+import './contrib/positAssistant/browser/positAssistant.contribution.js';
 import './contrib/positronConsole/browser/positronConsole.contribution.js';
 import './contrib/positronConsole/browser/positronConsoleView.js';
 import './contrib/positronDataExplorerEditor/browser/positronDataExplorerEditor.contribution.js';


### PR DESCRIPTION
Address #13222

Allow for a stock Copilot Chat view. Positron Assistant can be disabled. Posit Assistant can access models using the GitHub authentication.

#### New Features

- N/A

#### Bug Fixes

- N/A


### QA Notes

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information for QA on how to validate the change,
  paying special attention to the level of risk, adjacent areas that
  could be affected by the change, and any important contextual
  information not present in the linked issues.
-->
