### PR TITLE
feat: visualize dataframe from inline data explorer

### DIFF
--- a/extensions/positron-assistant/src/asyncUtils.ts
+++ b/extensions/positron-assistant/src/asyncUtils.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as vscode from 'vscode';
+
+/**
+ * Returns true when `t` looks like a `vscode.CancellationToken` -- i.e. has
+ * a function-typed `onCancellationRequested` and a boolean-typed
+ * `isCancellationRequested`. Used to guard cross-boundary command args
+ * where serialization may strip method members or where untrusted callers
+ * may pass arbitrary shapes.
+ *
+ * Property reads are wrapped so an object with a throwing getter on either
+ * field returns `false` rather than propagating the throw -- the whole
+ * point of this helper is to make malformed inputs fail safely.
+ */
+export function isCancellationTokenLike(t: unknown): t is vscode.CancellationToken {
+	if (!t || typeof t !== 'object') { return false; }
+	try {
+		const candidate = t as Partial<vscode.CancellationToken>;
+		return typeof candidate.onCancellationRequested === 'function'
+			&& typeof candidate.isCancellationRequested === 'boolean';
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Race a promise against a timeout. Returns the promise result, or
+ * `undefined` if the timeout fires first. The timer is cleaned up
+ * internally. An optional `onTimeout` callback runs when the timeout fires.
+ *
+ * If the timeout wins and the input promise rejects later, the rejection is
+ * silently swallowed (so it does not surface as an unhandled rejection). If
+ * the input promise wins the race, the caller still observes its rejection
+ * normally.
+ */
+export async function raceTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+	onTimeout?: () => void,
+): Promise<T | undefined> {
+	// Attach a no-op handler so a late rejection (after the timeout has
+	// already won) does not become an unhandled rejection. The original
+	// promise's settlement is still observed by Promise.race below.
+	promise.catch(() => { });
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<undefined>(resolve => {
+				timer = setTimeout(() => {
+					onTimeout?.();
+					resolve(undefined);
+				}, timeoutMs);
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}

--- a/extensions/positron-assistant/src/extension.ts
+++ b/extensions/positron-assistant/src/extension.ts
@@ -16,6 +16,8 @@ import { registerCodeActionProvider } from './codeActions.js';
 import { generateCommitMessage } from './git.js';
 import { generateNotebookSuggestions, type NotebookSuggestionsResult } from './notebookSuggestions.js';
 import { generateGhostCellSuggestion, type GhostCellSuggestionResult } from './ghostCellSuggestions.js';
+import { generateVisualizationSuggestion, type VisualizationSuggestion } from './visualizationSuggestions.js';
+import { isCancellationTokenLike } from './asyncUtils.js';
 import { initializeTokenTracking } from './tokens.js';
 import { exportChatToUserSpecifiedLocation, exportChatToFileInWorkspace } from './export.js';
 import { registerParticipantDetectionProvider } from './participantDetection.js';
@@ -142,6 +144,48 @@ function registerGenerateGhostCellSuggestionCommand(
 				}
 			}
 		)
+	);
+}
+
+function registerSuggestVisualizationCommand(
+	context: vscode.ExtensionContext,
+	participantService: ParticipantService,
+	log: vscode.LogOutputChannel,
+) {
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			'positron-assistant.suggestVisualization',
+			async (
+				notebookUri: string,
+				executedCellIndex: number,
+				dfName: string,
+				columns: { name: string; type: string }[],
+				token?: vscode.CancellationToken,
+			): Promise<VisualizationSuggestion | null> => {
+				// Guard the token: cross-boundary command marshalling is not
+				// guaranteed to preserve method members on CancellationToken,
+				// and external callers may pass anything. Fall back to a
+				// fresh CTS when the token is missing or malformed -- the
+				// caller loses the ability to cancel us, but we don't crash.
+				let tokenSource: vscode.CancellationTokenSource | undefined;
+				const cancellationToken = isCancellationTokenLike(token)
+					? token
+					: (tokenSource = new vscode.CancellationTokenSource()).token;
+				try {
+					return await generateVisualizationSuggestion(
+						notebookUri,
+						executedCellIndex,
+						dfName,
+						columns ?? [],
+						participantService,
+						log,
+						cancellationToken,
+					);
+				} finally {
+					tokenSource?.dispose();
+				}
+			},
+		),
 	);
 }
 
@@ -436,6 +480,7 @@ function registerAssistant(context: vscode.ExtensionContext) {
 	registerGenerateCommitMessageCommand(context, participantService, log);
 	registerGenerateNotebookSuggestionsCommand(context, participantService, log);
 	registerGenerateGhostCellSuggestionCommand(context, participantService, log);
+	registerSuggestVisualizationCommand(context, participantService, log);
 	registerExportChatCommands(context);
 	registerToggleInlineCompletionsCommand(context);
 	registerCollectDiagnosticsCommand(context);

--- a/extensions/positron-assistant/src/ghostCellSuggestions.ts
+++ b/extensions/positron-assistant/src/ghostCellSuggestions.ts
@@ -14,6 +14,7 @@ import { raceTimeout } from './asyncUtils.js';
 import { MARKDOWN_DIR } from './constants';
 import { StreamingTagLexer } from './streamingTagLexer.js';
 import { resolveGhostCellSuggestions } from './notebookAssistantMetadata.js';
+import { selectPreferredModel } from './modelSelection.js';
 
 /**
  * Result of a ghost cell suggestion generation
@@ -520,13 +521,6 @@ async function fetchVariablesFromSession(
 }
 
 /**
- * Escape special regex characters in a string for safe use in a RegExp constructor.
- */
-function escapeRegExp(s: string): string {
-	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/**
  * Result of model selection
  */
 interface ModelSelectionResult {
@@ -544,78 +538,17 @@ async function getModel(
 	log: vscode.LogOutputChannel,
 	token?: vscode.CancellationToken
 ): Promise<ModelSelectionResult | null> {
-	// Log all available models for debugging
-	const allModels = await vscode.lm.selectChatModels();
-	if (token?.isCancellationRequested) { return null; }
-	log.debug(`[ghost-cell] Available models: ${allModels.length} total`);
-
-	// Check configuration setting first (highest priority)
 	const config = vscode.workspace.getConfiguration('positron.assistant.notebook');
 	const configuredPatterns = config.get<string[]>('ghostCellSuggestions.model') || [];
-	const hasConfiguredModel = configuredPatterns.length > 0 && configuredPatterns.some(p => p && p.trim() !== '');
-
-	if (hasConfiguredModel) {
-		log.debug(`[ghost-cell] Checking configured model patterns: ${JSON.stringify(configuredPatterns)}`);
-		for (const pattern of configuredPatterns) {
-			if (!pattern || pattern.trim() === '') {
-				continue;
-			}
-			const patternLower = pattern.toLowerCase();
-			// Try exact ID match first
-			const exactMatch = allModels.find(m => m.id === pattern);
-			if (exactMatch) {
-				log.debug(`[ghost-cell] Using configured model (exact match): ${exactMatch.name}`);
-				return { model: exactMatch, usedFallback: false };
-			}
-			// Try word-boundary match (e.g., "mini" matches "gpt-4o-mini" but not "gemini")
-			const boundaryPattern = new RegExp(`(^|[\\s\\-_./])${escapeRegExp(patternLower)}($|[\\s\\-_./])`, 'i');
-			const boundaryMatch = allModels.find(m =>
-				boundaryPattern.test(m.id) || boundaryPattern.test(m.name)
-			);
-			if (boundaryMatch) {
-				log.debug(`[ghost-cell] Using configured model (boundary match): ${boundaryMatch.name}`);
-				return { model: boundaryMatch, usedFallback: false };
-			}
-		}
-		// User configured a model but none matched - we'll fall back but mark it
-		log.warn(`[ghost-cell] Configured model patterns not found: ${JSON.stringify(configuredPatterns)}`);
-	}
-
-	if (token?.isCancellationRequested) { return null; }
-
-	// Check for the latest chat session and use its model
-	const sessionModelId = participantService.getCurrentSessionModel();
-	if (sessionModelId) {
-		const models = await vscode.lm.selectChatModels({ 'id': sessionModelId });
-		if (models && models.length > 0) {
-			log.debug(`[ghost-cell] Using session model: ${models[0].name}`);
-			return { model: models[0], usedFallback: hasConfiguredModel };
-		}
-	}
-
-	if (token?.isCancellationRequested) { return null; }
-
-	// Fall back to the first model for the currently selected provider
-	const currentProvider = await positron.ai.getCurrentProvider();
-	if (token?.isCancellationRequested) { return null; }
-	if (currentProvider) {
-		const models = await vscode.lm.selectChatModels({ vendor: currentProvider.id });
-		if (token?.isCancellationRequested) { return null; }
-		if (models && models.length > 0) {
-			log.debug(`[ghost-cell] Using provider model: ${models[0].name}`);
-			return { model: models[0], usedFallback: hasConfiguredModel };
-		}
-	}
-
-	if (token?.isCancellationRequested) { return null; }
-
-	// Fall back to any available model
-	const [firstModel] = await vscode.lm.selectChatModels();
-	if (token?.isCancellationRequested) { return null; }
-	if (firstModel) {
-		log.debug(`[ghost-cell] Using fallback model: ${firstModel.name}`);
-		return { model: firstModel, usedFallback: hasConfiguredModel };
-	}
-
-	return null;
+	const selection = await selectPreferredModel({
+		participantService,
+		log,
+		logPrefix: 'ghost-cell',
+		token,
+		configuredModels: {
+			patterns: configuredPatterns,
+			matchMode: 'boundary',
+		},
+	});
+	return selection ? { model: selection.model, usedFallback: selection.usedFallback } : null;
 }

--- a/extensions/positron-assistant/src/ghostCellSuggestions.ts
+++ b/extensions/positron-assistant/src/ghostCellSuggestions.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 
 import { ParticipantService } from './participants.js';
 import { isFileExcludedFromAI } from './fileExclusion.js';
+import { raceTimeout } from './asyncUtils.js';
 import { MARKDOWN_DIR } from './constants';
 import { StreamingTagLexer } from './streamingTagLexer.js';
 import { resolveGhostCellSuggestions } from './notebookAssistantMetadata.js';
@@ -523,32 +524,6 @@ async function fetchVariablesFromSession(
  */
 function escapeRegExp(s: string): string {
 	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/**
- * Race a promise against a timeout. Returns the promise result, or
- * `undefined` if the timeout fires first. The timer is cleaned up
- * internally. An optional `onTimeout` callback runs when the timeout fires.
- */
-async function raceTimeout<T>(
-	promise: Promise<T>,
-	timeoutMs: number,
-	onTimeout?: () => void
-): Promise<T | undefined> {
-	let timer: ReturnType<typeof setTimeout> | undefined;
-	try {
-		return await Promise.race([
-			promise,
-			new Promise<undefined>(resolve => {
-				timer = setTimeout(() => {
-					onTimeout?.();
-					resolve(undefined);
-				}, timeoutMs);
-			})
-		]);
-	} finally {
-		clearTimeout(timer);
-	}
 }
 
 /**

--- a/extensions/positron-assistant/src/git.ts
+++ b/extensions/positron-assistant/src/git.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import * as positron from 'positron';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -12,6 +11,7 @@ import { ParticipantService } from './participants.js';
 import { API as GitAPI, GitExtension, Repository, Status, Change } from '../../git/src/api/git.js';
 import { MARKDOWN_DIR } from './constants';
 import { PROVIDER_METADATA } from './providerMetadata.js';
+import { getCandidateModels as getOrderedCandidateModels } from './modelSelection.js';
 
 const generatingGitCommitKey = 'positron-assistant.generatingCommitMessage';
 
@@ -206,41 +206,10 @@ export async function generateCommitMessage(
 }
 
 export async function getCandidateModels(participantService: ParticipantService): Promise<vscode.LanguageModelChat[]> {
-	const candidates: vscode.LanguageModelChat[] = [];
-	const seen = new Set<string>();
-	const addCandidate = (model: vscode.LanguageModelChat) => {
-		if (!seen.has(model.id)) {
-			seen.add(model.id);
-			candidates.push(model);
-		}
-	};
-
-	// First priority: the latest chat session model.
-	const sessionModelId = participantService.getCurrentSessionModel();
-	if (sessionModelId) {
-		const models = await vscode.lm.selectChatModels({ 'id': sessionModelId });
-		if (models && models.length > 0) {
-			addCandidate(models[0]);
-		}
-	}
-
-	// Second priority: models for the currently selected provider.
-	const currentProvider = await positron.ai.getCurrentProvider();
-	if (currentProvider) {
-		const models = await vscode.lm.selectChatModels({ vendor: currentProvider.id });
-		for (const model of models) {
-			addCandidate(model);
-		}
-	}
-
-	// Third priority: all available models from any provider.
-	const models = await vscode.lm.selectChatModels();
-	for (const model of models) {
-		if (model.family !== PROVIDER_METADATA.echo.id && model.family !== PROVIDER_METADATA.error.id) {
-			addCandidate(model);
-		}
-	}
-
+	const candidates = await getOrderedCandidateModels({
+		participantService,
+		fallbackModelFilter: model => model.family !== PROVIDER_METADATA.echo.id && model.family !== PROVIDER_METADATA.error.id,
+	}) ?? [];
 	if (candidates.length === 0) {
 		throw new Error('No language models available for git commit message generation');
 	}

--- a/extensions/positron-assistant/src/modelSelection.ts
+++ b/extensions/positron-assistant/src/modelSelection.ts
@@ -1,0 +1,194 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+
+import { ParticipantService } from './participants.js';
+
+export type ModelSelectionSource = 'configured' | 'session' | 'provider' | 'fallback';
+export type ConfiguredModelMatchMode = 'partial' | 'boundary';
+
+export interface ModelSelectionResult {
+	model: vscode.LanguageModelChat;
+	source: ModelSelectionSource;
+	/** True when configured model patterns existed but selection fell back to another source. */
+	usedFallback: boolean;
+}
+
+interface ConfiguredModelOptions {
+	patterns: string[];
+	matchMode: ConfiguredModelMatchMode;
+}
+
+export interface SelectPreferredModelOptions {
+	participantService: ParticipantService;
+	log: vscode.LogOutputChannel;
+	logPrefix: string;
+	token?: vscode.CancellationToken;
+	configuredModels?: ConfiguredModelOptions;
+}
+
+export interface GetCandidateModelsOptions {
+	participantService: ParticipantService;
+	token?: vscode.CancellationToken;
+	fallbackModelFilter?: (model: vscode.LanguageModelChat) => boolean;
+}
+
+function isCancelled(token?: vscode.CancellationToken): boolean {
+	return token?.isCancellationRequested ?? false;
+}
+
+function escapeRegExp(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function hasConfiguredPatterns(patterns: string[] | undefined): patterns is string[] {
+	return !!patterns?.some(pattern => pattern.trim().length > 0);
+}
+
+function findConfiguredModel(
+	models: vscode.LanguageModelChat[],
+	patterns: string[],
+	matchMode: ConfiguredModelMatchMode,
+	log: vscode.LogOutputChannel,
+	logPrefix: string,
+): vscode.LanguageModelChat | undefined {
+	log.debug(`[${logPrefix}] Checking configured model patterns: ${JSON.stringify(patterns)}`);
+	for (const pattern of patterns) {
+		if (!pattern || pattern.trim() === '') {
+			continue;
+		}
+
+		const exactMatch = models.find(m => m.id === pattern);
+		if (exactMatch) {
+			log.debug(`[${logPrefix}] Using configured model (exact match): ${exactMatch.name}`);
+			return exactMatch;
+		}
+
+		const patternLower = pattern.toLowerCase();
+		if (matchMode === 'partial') {
+			const partialMatch = models.find(m =>
+				m.id.toLowerCase().includes(patternLower) || m.name.toLowerCase().includes(patternLower)
+			);
+			if (partialMatch) {
+				log.debug(`[${logPrefix}] Using configured model (partial match): ${partialMatch.name}`);
+				return partialMatch;
+			}
+			log.debug(`[${logPrefix}] Pattern "${pattern}" did not match any model, trying next pattern`);
+			continue;
+		}
+
+		const boundaryPattern = new RegExp(`(^|[\\s\\-_./])${escapeRegExp(patternLower)}($|[\\s\\-_./])`, 'i');
+		const boundaryMatch = models.find(m =>
+			boundaryPattern.test(m.id) || boundaryPattern.test(m.name)
+		);
+		if (boundaryMatch) {
+			log.debug(`[${logPrefix}] Using configured model (boundary match): ${boundaryMatch.name}`);
+			return boundaryMatch;
+		}
+	}
+
+	log.warn(`[${logPrefix}] Configured model patterns not found: ${JSON.stringify(patterns)}`);
+	return undefined;
+}
+
+export async function selectPreferredModel(options: SelectPreferredModelOptions): Promise<ModelSelectionResult | null> {
+	const { participantService, log, logPrefix, token, configuredModels } = options;
+	const configuredPatterns = configuredModels?.patterns;
+	const hasConfiguredModel = hasConfiguredPatterns(configuredPatterns);
+
+	if (hasConfiguredModel) {
+		const allModels = await vscode.lm.selectChatModels();
+		if (isCancelled(token)) { return null; }
+		log.debug(`[${logPrefix}] Available models: ${allModels.length} total`);
+		const configured = findConfiguredModel(
+			allModels,
+			configuredPatterns,
+			configuredModels.matchMode,
+			log,
+			logPrefix,
+		);
+		if (configured) {
+			return { model: configured, source: 'configured', usedFallback: false };
+		}
+	}
+
+	if (isCancelled(token)) { return null; }
+	const sessionModelId = participantService.getCurrentSessionModel();
+	if (sessionModelId) {
+		log.debug(`[${logPrefix}] Checking session model: ${sessionModelId}`);
+		const models = await vscode.lm.selectChatModels({ id: sessionModelId });
+		if (isCancelled(token)) { return null; }
+		if (models && models.length > 0) {
+			log.debug(`[${logPrefix}] Using session model: ${models[0].name}`);
+			return { model: models[0], source: 'session', usedFallback: hasConfiguredModel };
+		}
+	}
+
+	if (isCancelled(token)) { return null; }
+	const currentProvider = await positron.ai.getCurrentProvider();
+	if (isCancelled(token)) { return null; }
+	if (currentProvider) {
+		log.debug(`[${logPrefix}] Checking current provider: ${currentProvider.id}`);
+		const models = await vscode.lm.selectChatModels({ vendor: currentProvider.id });
+		if (isCancelled(token)) { return null; }
+		if (models && models.length > 0) {
+			log.debug(`[${logPrefix}] Using provider model: ${models[0].name}`);
+			return { model: models[0], source: 'provider', usedFallback: hasConfiguredModel };
+		}
+	}
+
+	if (isCancelled(token)) { return null; }
+	const [firstModel] = await vscode.lm.selectChatModels();
+	if (isCancelled(token)) { return null; }
+	if (firstModel) {
+		log.debug(`[${logPrefix}] Using fallback model: ${firstModel.name}`);
+		return { model: firstModel, source: 'fallback', usedFallback: hasConfiguredModel };
+	}
+
+	return null;
+}
+
+export async function getCandidateModels(options: GetCandidateModelsOptions): Promise<vscode.LanguageModelChat[] | null> {
+	const { participantService, token, fallbackModelFilter } = options;
+	const candidates: vscode.LanguageModelChat[] = [];
+	const seen = new Set<string>();
+	const addCandidate = (model: vscode.LanguageModelChat) => {
+		if (!seen.has(model.id)) {
+			seen.add(model.id);
+			candidates.push(model);
+		}
+	};
+
+	const sessionModelId = participantService.getCurrentSessionModel();
+	if (sessionModelId) {
+		const models = await vscode.lm.selectChatModels({ id: sessionModelId });
+		if (isCancelled(token)) { return null; }
+		if (models && models.length > 0) {
+			addCandidate(models[0]);
+		}
+	}
+
+	const currentProvider = await positron.ai.getCurrentProvider();
+	if (isCancelled(token)) { return null; }
+	if (currentProvider) {
+		const models = await vscode.lm.selectChatModels({ vendor: currentProvider.id });
+		if (isCancelled(token)) { return null; }
+		for (const model of models) {
+			addCandidate(model);
+		}
+	}
+
+	const models = await vscode.lm.selectChatModels();
+	if (isCancelled(token)) { return null; }
+	for (const model of models) {
+		if (!fallbackModelFilter || fallbackModelFilter(model)) {
+			addCandidate(model);
+		}
+	}
+
+	return candidates;
+}

--- a/extensions/positron-assistant/src/notebookSuggestions.ts
+++ b/extensions/positron-assistant/src/notebookSuggestions.ts
@@ -194,7 +194,7 @@ async function parseStreamingXML(
 						currentFieldContent = '';
 					} else if (chunk.kind === 'close' && currentField && currentSuggestion) {
 						// Save the field content
-						currentSuggestion[currentField] = currentFieldContent.trim() as NotebookActionSuggestion['mode'];;
+						currentSuggestion[currentField] = currentFieldContent.trim() as NotebookActionSuggestion['mode'];
 						currentField = null;
 						currentFieldContent = '';
 					}

--- a/extensions/positron-assistant/src/notebookSuggestions.ts
+++ b/extensions/positron-assistant/src/notebookSuggestions.ts
@@ -13,6 +13,7 @@ import { isFileExcludedFromAI } from './fileExclusion.js';
 import { MARKDOWN_DIR } from './constants';
 import { serializeNotebookContext } from './tools/notebookUtils.js';
 import { StreamingTagLexer } from './streamingTagLexer.js';
+import { selectPreferredModel } from './modelSelection.js';
 
 /**
  * Interface for notebook action suggestions returned to the workbench
@@ -269,73 +270,20 @@ function completeSuggestion(
  * @returns The selected language model
  */
 async function getModel(participantService: ParticipantService, log: vscode.LogOutputChannel): Promise<vscode.LanguageModelChat> {
-	// Log all available models for debugging
-	const allModels = await vscode.lm.selectChatModels();
-	log.debug(`[notebook-suggestions] Available models: ${allModels.length} total`);
-	allModels.forEach((model, index) => {
-		log.debug(`[notebook-suggestions] Model ${index + 1}: id="${model.id}", name="${model.name}", vendor="${model.vendor}"`);
-	});
-
-	// Check configuration setting first (highest priority)
 	const config = vscode.workspace.getConfiguration('positron.assistant');
 	const configuredPatterns = config.get<string[]>('notebookSuggestions.model') || [];
-	if (configuredPatterns.length > 0) {
-		log.debug(`[notebook-suggestions] Checking configured model patterns: ${JSON.stringify(configuredPatterns)}`);
-		// Iterate through patterns in order
-		for (const pattern of configuredPatterns) {
-			if (!pattern || pattern.trim() === '') {
-				continue;
-			}
-			log.debug(`[notebook-suggestions] Trying pattern: "${pattern}"`);
-			const patternLower = pattern.toLowerCase();
-			// Try exact ID match first (case-sensitive for exact matches)
-			const exactMatch = allModels.find(m => m.id === pattern);
-			if (exactMatch) {
-				log.debug(`[notebook-suggestions] Using configured model (exact ID match): ${exactMatch.name} (${exactMatch.id})`);
-				return exactMatch;
-			}
-			// Try partial match on ID or name (case-insensitive)
-			const partialMatch = allModels.find(m =>
-				m.id.toLowerCase().includes(patternLower) || m.name.toLowerCase().includes(patternLower)
-			);
-			if (partialMatch) {
-				log.debug(`[notebook-suggestions] Using configured model (partial match): ${partialMatch.name} (${partialMatch.id})`);
-				return partialMatch;
-			}
-			log.debug(`[notebook-suggestions] Pattern "${pattern}" did not match any model, trying next pattern`);
-		}
-		log.warn(`[notebook-suggestions] None of the configured patterns matched any model, falling back to default selection`);
-	}
-
-	// Check for the latest chat session and use its model
-	const sessionModelId = participantService.getCurrentSessionModel();
-	if (sessionModelId) {
-		log.debug(`[notebook-suggestions] Checking session model: ${sessionModelId}`);
-		const models = await vscode.lm.selectChatModels({ 'id': sessionModelId });
-		if (models && models.length > 0) {
-			log.debug(`[notebook-suggestions] Using session model: ${models[0].name} (${models[0].id})`);
-			return models[0];
-		}
-	}
-
-	// Fall back to the first model for the currently selected provider
-	const currentProvider = await positron.ai.getCurrentProvider();
-	if (currentProvider) {
-		log.debug(`[notebook-suggestions] Checking current provider: ${currentProvider.id}`);
-		const models = await vscode.lm.selectChatModels({ vendor: currentProvider.id });
-		if (models && models.length > 0) {
-			log.debug(`[notebook-suggestions] Using provider model: ${models[0].name} (${models[0].id})`);
-			return models[0];
-		}
-	}
-
-	// Fall back to any available model
-	log.debug(`[notebook-suggestions] Falling back to first available model`);
-	const [firstModel] = await vscode.lm.selectChatModels();
-	if (!firstModel) {
+	const selection = await selectPreferredModel({
+		participantService,
+		log,
+		logPrefix: 'notebook-suggestions',
+		configuredModels: {
+			patterns: configuredPatterns,
+			matchMode: 'partial',
+		},
+	});
+	if (!selection) {
 		throw new Error('No language model available');
 	}
 
-	log.debug(`[notebook-suggestions] Using fallback model: ${firstModel.name} (${firstModel.id})`);
-	return firstModel;
+	return selection.model;
 }

--- a/extensions/positron-assistant/src/test/asyncUtils.test.ts
+++ b/extensions/positron-assistant/src/test/asyncUtils.test.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { isCancellationTokenLike, raceTimeout } from '../asyncUtils.js';
+
+suite('raceTimeout', () => {
+	test('returns the resolved value when the promise wins', async () => {
+		const result = await raceTimeout(Promise.resolve(42), 100);
+		assert.strictEqual(result, 42);
+	});
+
+	test('returns undefined when the timeout wins', async () => {
+		const slow = new Promise<number>(resolve => setTimeout(() => resolve(1), 100));
+		const result = await raceTimeout(slow, 10);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('propagates rejection when the promise rejects before the timeout', async () => {
+		const failed = Promise.reject(new Error('boom'));
+		await assert.rejects(() => raceTimeout(failed, 100), /boom/);
+	});
+
+	test('does not surface unhandled rejection when the promise rejects after the timeout', async () => {
+		// Capture unhandled rejections during this test only.
+		const seen: unknown[] = [];
+		const onUnhandled = (reason: unknown) => { seen.push(reason); };
+		process.on('unhandledRejection', onUnhandled);
+		try {
+			const lateFail = new Promise<number>((_resolve, reject) =>
+				setTimeout(() => reject(new Error('late')), 30));
+			const result = await raceTimeout(lateFail, 5);
+			assert.strictEqual(result, undefined);
+			// Wait past the rejection so the runtime has a chance to flag it.
+			await new Promise(r => setTimeout(r, 80));
+			assert.deepStrictEqual(seen, [], 'late rejection should be swallowed by raceTimeout');
+		} finally {
+			process.off('unhandledRejection', onUnhandled);
+		}
+	});
+
+	test('invokes onTimeout exactly once when the timeout wins', async () => {
+		let calls = 0;
+		const slow = new Promise<number>(resolve => setTimeout(() => resolve(1), 50));
+		await raceTimeout(slow, 10, () => { calls++; });
+		// Wait long enough that the slow promise has settled too.
+		await new Promise(r => setTimeout(r, 80));
+		assert.strictEqual(calls, 1);
+	});
+
+	test('does not invoke onTimeout when the promise wins', async () => {
+		let calls = 0;
+		await raceTimeout(Promise.resolve('ok'), 100, () => { calls++; });
+		assert.strictEqual(calls, 0);
+	});
+});
+
+suite('isCancellationTokenLike', () => {
+	test('accepts a well-formed token', () => {
+		const token = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose: () => { } }) };
+		assert.strictEqual(isCancellationTokenLike(token), true);
+	});
+
+	test('rejects undefined and null', () => {
+		assert.strictEqual(isCancellationTokenLike(undefined), false);
+		assert.strictEqual(isCancellationTokenLike(null), false);
+	});
+
+	test('rejects primitives', () => {
+		assert.strictEqual(isCancellationTokenLike(0), false);
+		assert.strictEqual(isCancellationTokenLike(''), false);
+		assert.strictEqual(isCancellationTokenLike(true), false);
+		assert.strictEqual(isCancellationTokenLike('token'), false);
+	});
+
+	test('rejects an object missing onCancellationRequested', () => {
+		assert.strictEqual(isCancellationTokenLike({ isCancellationRequested: false }), false);
+	});
+
+	test('rejects an object missing isCancellationRequested', () => {
+		assert.strictEqual(isCancellationTokenLike({ onCancellationRequested: () => ({ dispose: () => { } }) }), false);
+	});
+
+	test('rejects an object with the wrong field types', () => {
+		assert.strictEqual(isCancellationTokenLike({ isCancellationRequested: 'no', onCancellationRequested: 'no' }), false);
+	});
+
+	test('returns false (does not throw) when a getter throws', () => {
+		const trap = Object.defineProperty(
+			{ onCancellationRequested: () => ({ dispose: () => { } }) },
+			'isCancellationRequested',
+			{ get: () => { throw new Error('boom'); } },
+		);
+		assert.strictEqual(isCancellationTokenLike(trap), false);
+	});
+});

--- a/extensions/positron-assistant/src/test/modelSelection.test.ts
+++ b/extensions/positron-assistant/src/test/modelSelection.test.ts
@@ -1,0 +1,213 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as positron from 'positron';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+
+import { getCandidateModels, selectPreferredModel } from '../modelSelection.js';
+import { ParticipantService } from '../participants.js';
+import { mock } from './utils.js';
+
+function createMockModel(id: string, vendor: string, name = id, family = 'test'): vscode.LanguageModelChat {
+	return {
+		id,
+		name,
+		vendor,
+		family,
+		version: '1.0.0',
+		maxInputTokens: 2048,
+		async sendRequest() {
+			return {
+				stream: (async function* () { yield 'ok'; })(),
+				text: (async function* () { yield 'ok'; })(),
+			} as vscode.LanguageModelChatResponse;
+		},
+		async countTokens() { return 0; },
+	};
+}
+
+suite('modelSelection', () => {
+	let participantService: ParticipantService;
+	let log: vscode.LogOutputChannel;
+
+	setup(() => {
+		participantService = new ParticipantService();
+		log = mock<vscode.LogOutputChannel>({
+			debug: () => { },
+			info: () => { },
+			warn: () => { },
+			error: () => { },
+			trace: () => { },
+		});
+	});
+
+	teardown(() => {
+		participantService.dispose();
+		sinon.restore();
+	});
+
+	test('configured exact match wins', async () => {
+		const configuredModel = createMockModel('configured-model', 'vendor-a');
+		const sessionModel = createMockModel('session-model', 'vendor-b');
+		participantService.trackSessionModel('session-1', 'session-model');
+
+		sinon.stub(vscode.lm, 'selectChatModels').callsFake(async (selector) => {
+			if (selector?.id === 'session-model') {
+				return [sessionModel];
+			}
+			return [configuredModel, sessionModel];
+		});
+		sinon.stub(positron.ai, 'getCurrentProvider').resolves(undefined);
+
+		const result = await selectPreferredModel({
+			participantService,
+			log,
+			logPrefix: 'test',
+			configuredModels: { patterns: ['configured-model'], matchMode: 'partial' },
+		});
+
+		assert.ok(result);
+		assert.strictEqual(result.model.id, 'configured-model');
+		assert.strictEqual(result.source, 'configured');
+		assert.strictEqual(result.usedFallback, false);
+	});
+
+	test('configured partial match works for notebook suggestions', async () => {
+		const model = createMockModel('openai/gpt-4.1-mini', 'openai');
+		sinon.stub(vscode.lm, 'selectChatModels').resolves([model]);
+		sinon.stub(positron.ai, 'getCurrentProvider').resolves(undefined);
+
+		const result = await selectPreferredModel({
+			participantService,
+			log,
+			logPrefix: 'test',
+			configuredModels: { patterns: ['4.1'], matchMode: 'partial' },
+		});
+
+		assert.ok(result);
+		assert.strictEqual(result.model.id, model.id);
+		assert.strictEqual(result.source, 'configured');
+	});
+
+	test('configured boundary match works for ghost cells and does not match inside a word', async () => {
+		const gemini = createMockModel('google/gemini-pro', 'google', 'Gemini Pro');
+		const mini = createMockModel('openai/gpt-4o-mini', 'openai', 'GPT 4o Mini');
+		sinon.stub(vscode.lm, 'selectChatModels').resolves([gemini, mini]);
+		sinon.stub(positron.ai, 'getCurrentProvider').resolves(undefined);
+
+		const result = await selectPreferredModel({
+			participantService,
+			log,
+			logPrefix: 'test',
+			configuredModels: { patterns: ['mini'], matchMode: 'boundary' },
+		});
+
+		assert.ok(result);
+		assert.strictEqual(result.model.id, mini.id);
+		assert.strictEqual(result.source, 'configured');
+	});
+
+	test('session model beats provider and fallback when configured model is unavailable', async () => {
+		const sessionModel = createMockModel('session-model', 'vendor-a');
+		const providerModel = createMockModel('provider-model', 'vendor-b');
+		const fallbackModel = createMockModel('fallback-model', 'vendor-c');
+		participantService.trackSessionModel('session-1', 'session-model');
+
+		sinon.stub(vscode.lm, 'selectChatModels').callsFake(async (selector) => {
+			if (selector?.id === 'session-model') {
+				return [sessionModel];
+			}
+			if (selector?.vendor === 'vendor-b') {
+				return [providerModel];
+			}
+			return [fallbackModel];
+		});
+		sinon.stub(positron.ai, 'getCurrentProvider').resolves({ id: 'vendor-b', displayName: 'Vendor B' });
+
+		const result = await selectPreferredModel({
+			participantService,
+			log,
+			logPrefix: 'test',
+			configuredModels: { patterns: ['missing'], matchMode: 'partial' },
+		});
+
+		assert.ok(result);
+		assert.strictEqual(result.model.id, sessionModel.id);
+		assert.strictEqual(result.source, 'session');
+		assert.strictEqual(result.usedFallback, true);
+	});
+
+	test('provider model beats all-model fallback', async () => {
+		const providerModel = createMockModel('provider-model', 'vendor-b');
+		const fallbackModel = createMockModel('fallback-model', 'vendor-c');
+
+		sinon.stub(vscode.lm, 'selectChatModels').callsFake(async (selector) => {
+			if (selector?.vendor === 'vendor-b') {
+				return [providerModel];
+			}
+			return [fallbackModel];
+		});
+		sinon.stub(positron.ai, 'getCurrentProvider').resolves({ id: 'vendor-b', displayName: 'Vendor B' });
+
+		const result = await selectPreferredModel({ participantService, log, logPrefix: 'test' });
+
+		assert.ok(result);
+		assert.strictEqual(result.model.id, providerModel.id);
+		assert.strictEqual(result.source, 'provider');
+	});
+
+	test('cancellation returns null between async selection steps', async () => {
+		const cts = new vscode.CancellationTokenSource();
+
+		sinon.stub(vscode.lm, 'selectChatModels').callsFake(async () => {
+			cts.cancel();
+			return [createMockModel('configured-model', 'vendor-a')];
+		});
+		sinon.stub(positron.ai, 'getCurrentProvider').resolves(undefined);
+
+		const result = await selectPreferredModel({
+			participantService,
+			log,
+			logPrefix: 'test',
+			token: cts.token,
+			configuredModels: { patterns: ['configured-model'], matchMode: 'partial' },
+		});
+		cts.dispose();
+
+		assert.strictEqual(result, null);
+	});
+
+	test('candidate list deduplicates and filters fallback models for git', async () => {
+		const sharedModel = createMockModel('shared-model', 'vendor-a');
+		const providerModel = createMockModel('provider-model', 'vendor-b');
+		const filteredModel = createMockModel('filtered-model', 'vendor-c', 'filtered-model', 'filtered');
+		const fallbackModel = createMockModel('fallback-model', 'vendor-c');
+		participantService.trackSessionModel('session-1', 'shared-model');
+
+		sinon.stub(vscode.lm, 'selectChatModels').callsFake(async (selector) => {
+			if (selector?.id === 'shared-model') {
+				return [sharedModel];
+			}
+			if (selector?.vendor === 'vendor-b') {
+				return [sharedModel, providerModel];
+			}
+			return [sharedModel, providerModel, filteredModel, fallbackModel];
+		});
+		sinon.stub(positron.ai, 'getCurrentProvider').resolves({ id: 'vendor-b', displayName: 'Vendor B' });
+
+		const candidates = await getCandidateModels({
+			participantService,
+			fallbackModelFilter: model => model.family !== 'filtered',
+		});
+
+		assert.ok(candidates);
+		assert.deepStrictEqual(
+			candidates.map(model => model.id),
+			['shared-model', 'provider-model', 'fallback-model'],
+		);
+	});
+});

--- a/extensions/positron-assistant/src/test/visualizationSuggestions.test.ts
+++ b/extensions/positron-assistant/src/test/visualizationSuggestions.test.ts
@@ -1,0 +1,113 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { parseVizSuggestion } from '../visualizationSuggestions.js';
+
+function mockLog(): vscode.LogOutputChannel {
+	return {
+		debug: () => { },
+		info: () => { },
+		warn: () => { },
+		error: () => { },
+		trace: () => { },
+	} as unknown as vscode.LogOutputChannel;
+}
+
+const COLUMNS = [
+	{ name: 'price', type: 'float64' },
+	{ name: 'region', type: 'object' },
+];
+
+const VALID_JSON = JSON.stringify({
+	library: 'plotly',
+	chartType: 'bar',
+	xCol: 'region',
+	yCol: 'price',
+	reasoning: {
+		library: 'plotly imported in notebook',
+		chartType: 'categorical vs numeric',
+		columns: 'region (category) vs price (numeric)',
+	},
+});
+
+suite('parseVizSuggestion', () => {
+	const log = mockLog();
+
+	test('parses a well-formed JSON payload', () => {
+		const result = parseVizSuggestion(VALID_JSON, COLUMNS, log);
+		assert.ok(result);
+		assert.strictEqual(result.library, 'plotly');
+		assert.strictEqual(result.chartType, 'bar');
+		assert.strictEqual(result.xCol, 'region');
+		assert.strictEqual(result.yCol, 'price');
+		assert.strictEqual(result.reasoning.library, 'plotly imported in notebook');
+	});
+
+	test('strips ```json fences', () => {
+		const raw = '```json\n' + VALID_JSON + '\n```';
+		const result = parseVizSuggestion(raw, COLUMNS, log);
+		assert.ok(result);
+		assert.strictEqual(result.library, 'plotly');
+	});
+
+	test('ignores prose surrounding the JSON object', () => {
+		const raw = 'Sure, here is my suggestion:\n' + VALID_JSON + '\nHope that helps!';
+		const result = parseVizSuggestion(raw, COLUMNS, log);
+		assert.ok(result);
+		assert.strictEqual(result.chartType, 'bar');
+	});
+
+	test('returns empty reasoning strings when reasoning fields are missing', () => {
+		const raw = JSON.stringify({
+			library: 'matplotlib',
+			chartType: 'scatter',
+			xCol: 'price',
+			yCol: null,
+			reasoning: {},
+		});
+		const result = parseVizSuggestion(raw, COLUMNS, log);
+		assert.ok(result);
+		assert.strictEqual(result.reasoning.library, '');
+		assert.strictEqual(result.reasoning.chartType, '');
+		assert.strictEqual(result.reasoning.columns, '');
+	});
+
+	test('returns null for an unknown library', () => {
+		const raw = JSON.stringify({ ...JSON.parse(VALID_JSON), library: 'ggplot2' });
+		assert.strictEqual(parseVizSuggestion(raw, COLUMNS, log), null);
+	});
+
+	test('returns null for an unknown chart type', () => {
+		const raw = JSON.stringify({ ...JSON.parse(VALID_JSON), chartType: 'heatmap' });
+		assert.strictEqual(parseVizSuggestion(raw, COLUMNS, log), null);
+	});
+
+	test('falls back to first column when xCol is not in the provided list', () => {
+		const raw = JSON.stringify({ ...JSON.parse(VALID_JSON), xCol: 'nonexistent' });
+		const result = parseVizSuggestion(raw, COLUMNS, log);
+		assert.ok(result);
+		assert.strictEqual(result.xCol, 'price'); // first column name in COLUMNS
+	});
+
+	test('discards yCol that is not in the provided list', () => {
+		const raw = JSON.stringify({ ...JSON.parse(VALID_JSON), yCol: 'missing' });
+		const result = parseVizSuggestion(raw, COLUMNS, log);
+		assert.ok(result);
+		assert.strictEqual(result.yCol, null);
+	});
+
+	test('returns null for completely malformed input', () => {
+		assert.strictEqual(parseVizSuggestion('not json at all', COLUMNS, log), null);
+		assert.strictEqual(parseVizSuggestion('', COLUMNS, log), null);
+		assert.strictEqual(parseVizSuggestion('{', COLUMNS, log), null);
+	});
+
+	test('returns null when xCol is invalid and no columns are provided', () => {
+		const raw = JSON.stringify({ ...JSON.parse(VALID_JSON), xCol: 'nonexistent' });
+		assert.strictEqual(parseVizSuggestion(raw, [], log), null);
+	});
+});

--- a/extensions/positron-assistant/src/visualizationSuggestions.ts
+++ b/extensions/positron-assistant/src/visualizationSuggestions.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import * as positron from 'positron';
 
 import { ParticipantService } from './participants.js';
 import { isFileExcludedFromAI } from './fileExclusion.js';
 import { raceTimeout } from './asyncUtils.js';
+import { selectPreferredModel } from './modelSelection.js';
 
 const MODEL_SELECTION_TIMEOUT_MS = 10_000;
 const GENERATION_TIMEOUT_MS = 30_000;
@@ -312,35 +312,11 @@ async function getModel(
 	log: vscode.LogOutputChannel,
 	token: vscode.CancellationToken,
 ): Promise<ModelSelectionResult | null> {
-	const sessionModelId = participantService.getCurrentSessionModel();
-	if (sessionModelId) {
-		const models = await vscode.lm.selectChatModels({ id: sessionModelId });
-		if (token.isCancellationRequested) { return null; }
-		if (models && models.length > 0) {
-			log.debug(`[viz-suggest] Using session model: ${models[0].name}`);
-			return { model: models[0] };
-		}
-	}
-
-	if (token.isCancellationRequested) { return null; }
-	const currentProvider = await positron.ai.getCurrentProvider();
-	if (token.isCancellationRequested) { return null; }
-	if (currentProvider) {
-		const models = await vscode.lm.selectChatModels({ vendor: currentProvider.id });
-		if (token.isCancellationRequested) { return null; }
-		if (models && models.length > 0) {
-			log.debug(`[viz-suggest] Using provider model: ${models[0].name}`);
-			return { model: models[0] };
-		}
-	}
-
-	if (token.isCancellationRequested) { return null; }
-	const [firstModel] = await vscode.lm.selectChatModels();
-	if (token.isCancellationRequested) { return null; }
-	if (firstModel) {
-		log.debug(`[viz-suggest] Using fallback model: ${firstModel.name}`);
-		return { model: firstModel };
-	}
-
-	return null;
+	const selection = await selectPreferredModel({
+		participantService,
+		log,
+		logPrefix: 'viz-suggest',
+		token,
+	});
+	return selection ? { model: selection.model } : null;
 }

--- a/extensions/positron-assistant/src/visualizationSuggestions.ts
+++ b/extensions/positron-assistant/src/visualizationSuggestions.ts
@@ -1,0 +1,346 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+
+import { ParticipantService } from './participants.js';
+import { isFileExcludedFromAI } from './fileExclusion.js';
+import { raceTimeout } from './asyncUtils.js';
+
+const MODEL_SELECTION_TIMEOUT_MS = 10_000;
+const GENERATION_TIMEOUT_MS = 30_000;
+
+/**
+ * IMPORTANT: `VisualizationSuggestion` is mirrored on the workbench side in
+ *   src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
+ *
+ * The two copies are not byte-identical -- the workbench imports `VizLibrary`
+ * and `ChartType` from `generateVizCode.js`, while this file declares
+ * `VizLibrary` and `VizChartType` locally. The allow-list literals and the
+ * field shape must stay identical on both sides; the workbench copy is
+ * validated at the IPC boundary as defence in depth. When adding a field
+ * or changing a literal, update BOTH.
+ */
+type VizLibrary = 'plotly' | 'matplotlib' | 'seaborn';
+type VizChartType = 'bar' | 'line' | 'scatter' | 'histogram';
+
+interface VizReasoning {
+	library: string;
+	chartType: string;
+	columns: string;
+}
+
+export interface VisualizationSuggestion {
+	library: VizLibrary;
+	chartType: VizChartType;
+	xCol: string;
+	yCol: string | null;
+	reasoning: VizReasoning;
+	modelName?: string;
+}
+
+interface InputColumn {
+	name: string;
+	type: string;
+}
+
+const SYSTEM_PROMPT = `You are a data visualization expert helping a user explore a dataframe inside a Positron notebook.
+
+The user is opening a "Visualize" wizard on a dataframe output in a Python notebook cell. V1 is Python-only -- do not suggest R, Julia, or any non-Python library. Based on:
+- the notebook code and output context
+- the dataframe's columns and dtypes
+- any imports already present in the notebook
+
+Suggest the most useful first visualization.
+
+Rules:
+1. Only Python plotting libraries are supported in V1: plotly, matplotlib, seaborn.
+2. Prefer a library that is ALREADY imported in the notebook. If none is imported, pick the most ergonomic one for the data shape.
+3. The chart type should suit the column dtypes (e.g. histogram for a single numeric column, scatter for two numerics, bar for a categorical vs numeric).
+4. Pick xCol (and yCol if appropriate) from the provided column list. For histograms, leave yCol as null.
+5. Keep each reasoning to one concise sentence that a user can scan in under two seconds. Reference concrete context ("the notebook already imports plotly.express", "uniform is numeric so a histogram shows its distribution").
+
+Return ONLY valid JSON matching this TypeScript type, with no prose or markdown fences:
+
+{
+\t"library": "plotly" | "matplotlib" | "seaborn",
+\t"chartType": "bar" | "line" | "scatter" | "histogram",
+\t"xCol": string,            // must be one of the provided column names
+\t"yCol": string | null,     // must be a column name or null
+\t"reasoning": {
+\t\t"library":   string,     // one sentence
+\t\t"chartType": string,     // one sentence
+\t\t"columns":   string      // one sentence
+\t}
+}`;
+
+export async function generateVisualizationSuggestion(
+	notebookUri: string,
+	executedCellIndex: number,
+	dfName: string,
+	columns: InputColumn[],
+	participantService: ParticipantService,
+	log: vscode.LogOutputChannel,
+	token: vscode.CancellationToken,
+): Promise<VisualizationSuggestion | null> {
+	const uri = vscode.Uri.parse(notebookUri);
+	const notebook = vscode.workspace.notebookDocuments.find(nb => nb.uri.toString() === uri.toString());
+	if (!notebook) {
+		log.warn('[viz-suggest] Notebook not found', notebookUri);
+		return null;
+	}
+	if (isFileExcludedFromAI(uri)) {
+		log.debug('[viz-suggest] Notebook excluded from AI features');
+		return null;
+	}
+	if (executedCellIndex < 0 || executedCellIndex >= notebook.cellCount) {
+		log.warn('[viz-suggest] Invalid cell index', executedCellIndex);
+		return null;
+	}
+
+	// V1 only supports Python. Bail out quietly for other languages so the
+	// dialog falls through to manual selection.
+	const cellLang = notebook.cellAt(executedCellIndex).document.languageId;
+	if (cellLang !== 'python') {
+		log.debug(`[viz-suggest] Skipping non-Python cell (language: ${cellLang})`);
+		return null;
+	}
+
+	const modelSelectionCts = new vscode.CancellationTokenSource();
+	const cancelListener = token.onCancellationRequested(() => modelSelectionCts.cancel());
+	let modelSelection: { model: vscode.LanguageModelChat } | null | undefined;
+	try {
+		modelSelection = await raceTimeout(
+			getModel(participantService, log, modelSelectionCts.token),
+			MODEL_SELECTION_TIMEOUT_MS,
+			() => modelSelectionCts.cancel(),
+		);
+	} finally {
+		cancelListener.dispose();
+		modelSelectionCts.dispose();
+	}
+	if (!modelSelection) {
+		log.warn('[viz-suggest] No language model available');
+		return null;
+	}
+	const { model } = modelSelection;
+
+	const contextMessage = buildContextMessage(notebook, executedCellIndex, dfName, columns);
+
+	const generationCts = new vscode.CancellationTokenSource();
+	const parentCancelListener = token.onCancellationRequested(() => generationCts.cancel());
+	// Guard the case where the parent token is already cancelled before the
+	// listener registered above could observe it.
+	if (token.isCancellationRequested) { generationCts.cancel(); }
+	try {
+		const messages = [
+			new vscode.LanguageModelChatMessage(vscode.LanguageModelChatMessageRole.System, SYSTEM_PROMPT),
+			vscode.LanguageModelChatMessage.User(contextMessage),
+		];
+		const fullText = await raceTimeout(
+			(async () => {
+				const response = await model.sendRequest(messages, {}, generationCts.token);
+				let out = '';
+				for await (const chunk of response.text) {
+					if (generationCts.token.isCancellationRequested) { return undefined; }
+					out += chunk;
+				}
+				return out;
+			})(),
+			GENERATION_TIMEOUT_MS,
+			() => generationCts.cancel(),
+		);
+		if (fullText === undefined || token.isCancellationRequested) {
+			log.warn('[viz-suggest] Generation did not complete (timeout or cancellation)');
+			return null;
+		}
+		const parsed = parseVizSuggestion(fullText, columns, log);
+		if (!parsed) { return null; }
+		parsed.modelName = model.name;
+		return parsed;
+	} catch (error) {
+		if (token.isCancellationRequested) { return null; }
+		log.error(`[viz-suggest] Error generating suggestion: ${error instanceof Error ? error.message : String(error)}`);
+		return null;
+	} finally {
+		parentCancelListener.dispose();
+		generationCts.dispose();
+	}
+}
+
+function buildContextMessage(
+	notebook: vscode.NotebookDocument,
+	executedCellIndex: number,
+	dfName: string,
+	columns: InputColumn[],
+): string {
+	const parts: string[] = [];
+	// User-controlled fields (dfName, column names, column types) are
+	// JSON-stringified so embedded newlines / quotes can't smuggle prompt
+	// instructions into the system. The parser allow-list (library / chart
+	// enums and column-name membership) is the authoritative trust boundary;
+	// this is defence in depth.
+	parts.push('## Dataframe');
+	parts.push(`- Variable: ${JSON.stringify(dfName)}`);
+	parts.push(`- Column count: ${columns.length}`);
+	if (columns.length) {
+		parts.push('- Columns:');
+		for (const c of columns) {
+			parts.push(`  - ${JSON.stringify(c.name)} (${JSON.stringify(c.type)})`);
+		}
+	}
+	parts.push('');
+
+	parts.push('## Just-executed cell');
+	const executedCell = notebook.cellAt(executedCellIndex);
+	parts.push('```' + executedCell.document.languageId);
+	parts.push(truncate(executedCell.document.getText(), 1000));
+	parts.push('```');
+	parts.push('');
+
+	const prevToInclude = Math.min(5, executedCellIndex);
+	if (prevToInclude > 0) {
+		parts.push(`## Previous cells (last ${prevToInclude}, for library / import context)`);
+		for (let i = executedCellIndex - prevToInclude; i < executedCellIndex; i++) {
+			const cell = notebook.cellAt(i);
+			if (cell.kind !== vscode.NotebookCellKind.Code) { continue; }
+			parts.push(`Cell ${i + 1}:`);
+			parts.push('```' + cell.document.languageId);
+			parts.push(truncate(cell.document.getText(), 400));
+			parts.push('```');
+		}
+		parts.push('');
+	}
+
+	parts.push('Return the JSON now. Do not wrap it in markdown or add commentary.');
+	return parts.join('\n');
+}
+
+function truncate(text: string, max: number): string {
+	if (text.length <= max) { return text; }
+	return text.substring(0, max) + '...';
+}
+
+export function parseVizSuggestion(
+	raw: string,
+	columns: InputColumn[],
+	log: vscode.LogOutputChannel,
+): VisualizationSuggestion | null {
+	// Strip code fences if the model added them.
+	const cleaned = raw
+		.trim()
+		.replace(/^```(?:json)?\s*/i, '')
+		.replace(/```\s*$/, '')
+		.trim();
+
+	// Extract first {...} block if the model wrapped it with prose.
+	const firstBrace = cleaned.indexOf('{');
+	const lastBrace = cleaned.lastIndexOf('}');
+	if (firstBrace === -1 || lastBrace === -1 || lastBrace < firstBrace) {
+		log.warn('[viz-suggest] No JSON object found in response');
+		return null;
+	}
+	const jsonText = cleaned.substring(firstBrace, lastBrace + 1);
+
+	let obj: unknown;
+	try {
+		obj = JSON.parse(jsonText);
+	} catch (err) {
+		log.warn(`[viz-suggest] Failed to parse JSON: ${err instanceof Error ? err.message : String(err)}`);
+		return null;
+	}
+
+	if (typeof obj !== 'object' || obj === null) { return null; }
+	const o = obj as Record<string, unknown>;
+
+	const library = coerceLibrary(o.library);
+	const chartType = coerceChartType(o.chartType);
+	if (!library || !chartType) {
+		log.warn('[viz-suggest] Invalid library or chartType in response');
+		return null;
+	}
+
+	const columnNames = new Set(columns.map(c => c.name));
+	const xColRaw = typeof o.xCol === 'string' ? o.xCol : '';
+	const yColRaw = typeof o.yCol === 'string' ? o.yCol : null;
+
+	let xCol: string;
+	if (columnNames.has(xColRaw)) {
+		xCol = xColRaw;
+	} else if (columns.length > 0) {
+		xCol = columns[0].name;
+	} else {
+		log.warn('[viz-suggest] Rejecting suggestion: no valid xCol and no columns to fall back to');
+		return null;
+	}
+	const yCol = yColRaw && columnNames.has(yColRaw) ? yColRaw : null;
+
+	const reasoningObj = (typeof o.reasoning === 'object' && o.reasoning !== null)
+		? o.reasoning as Record<string, unknown>
+		: {};
+	const reasoning: VizReasoning = {
+		library: typeof reasoningObj.library === 'string' ? reasoningObj.library : '',
+		chartType: typeof reasoningObj.chartType === 'string' ? reasoningObj.chartType : '',
+		columns: typeof reasoningObj.columns === 'string' ? reasoningObj.columns : '',
+	};
+
+	return { library, chartType, xCol, yCol, reasoning };
+}
+
+function coerceLibrary(v: unknown): VizLibrary | null {
+	return v === 'plotly' || v === 'matplotlib' || v === 'seaborn' ? v : null;
+}
+
+function coerceChartType(v: unknown): VizChartType | null {
+	return v === 'bar' || v === 'line' || v === 'scatter' || v === 'histogram' ? v : null;
+}
+
+interface ModelSelectionResult {
+	model: vscode.LanguageModelChat;
+}
+
+// Simplified version of the model selection used by ghost cells. Ghost
+// cells can be disabled per-model via user configuration (because they
+// fire on every edit). Visualize is user-initiated, so it ignores that
+// allow/deny list and uses whichever model the user currently has
+// selected, falling back to the default provider.
+async function getModel(
+	participantService: ParticipantService,
+	log: vscode.LogOutputChannel,
+	token: vscode.CancellationToken,
+): Promise<ModelSelectionResult | null> {
+	const sessionModelId = participantService.getCurrentSessionModel();
+	if (sessionModelId) {
+		const models = await vscode.lm.selectChatModels({ id: sessionModelId });
+		if (token.isCancellationRequested) { return null; }
+		if (models && models.length > 0) {
+			log.debug(`[viz-suggest] Using session model: ${models[0].name}`);
+			return { model: models[0] };
+		}
+	}
+
+	if (token.isCancellationRequested) { return null; }
+	const currentProvider = await positron.ai.getCurrentProvider();
+	if (token.isCancellationRequested) { return null; }
+	if (currentProvider) {
+		const models = await vscode.lm.selectChatModels({ vendor: currentProvider.id });
+		if (token.isCancellationRequested) { return null; }
+		if (models && models.length > 0) {
+			log.debug(`[viz-suggest] Using provider model: ${models[0].name}`);
+			return { model: models[0] };
+		}
+	}
+
+	if (token.isCancellationRequested) { return null; }
+	const [firstModel] = await vscode.lm.selectChatModels();
+	if (token.isCancellationRequested) { return null; }
+	if (firstModel) {
+		log.debug(`[viz-suggest] Using fallback model: ${firstModel.name}`);
+		return { model: firstModel };
+	}
+
+	return null;
+}

--- a/src/vs/base/browser/positronReactServices.tsx
+++ b/src/vs/base/browser/positronReactServices.tsx
@@ -29,6 +29,7 @@ import { IContextMenuService } from '../../platform/contextview/browser/contextV
 import { IEditorService } from '../../workbench/services/editor/common/editorService.js';
 import { INotificationService } from '../../platform/notification/common/notification.js';
 import { IConfigurationService } from '../../platform/configuration/common/configuration.js';
+import { IStorageService } from '../../platform/storage/common/storage.js';
 import { IAccessibilityService } from '../../platform/accessibility/common/accessibility.js';
 import { IInstantiationService, ServiceIdentifier } from '../../platform/instantiation/common/instantiation.js';
 import { ILanguageModelsService } from '../../workbench/contrib/chat/common/languageModels.js';
@@ -134,6 +135,7 @@ export class PositronReactServices {
 		@IQuickInputService public readonly quickInputService: IQuickInputService,
 		@IRuntimeSessionService public readonly runtimeSessionService: IRuntimeSessionService,
 		@IRuntimeStartupService public readonly runtimeStartupService: IRuntimeStartupService,
+		@IStorageService public readonly storageService: IStorageService,
 		@ITerminalService public readonly terminalService: ITerminalService,
 		@ITextModelService public readonly textModelService: ITextModelService,
 		@IThemeService public readonly themeService: IThemeService,

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
@@ -123,6 +123,12 @@ export class VisualizeDataFrameAction extends Action2 {
 			// the inline data explorer only mounts inside a real notebook so this is safe.
 			try {
 				await applyVisualizeResult(ctx.notebookInstance, ctx.cell as PositronNotebookCodeCell, snippet, result.mode);
+				const cellToRun = result.mode === 'newCell'
+					? ctx.notebookInstance.cells.get()[ctx.cell.index + 1]
+					: ctx.cell;
+				if (cellToRun) {
+					await ctx.notebookInstance.runCells([cellToRun]);
+				}
 			} catch (err) {
 				// Surface insertion failures (e.g. the cell model couldn't be
 				// resolved) instead of swallowing them silently. The user has

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
@@ -16,6 +16,22 @@ import { applyVisualizeResult } from './applyVisualizeResult.js';
 import { generateVizCode, isValidDataFrameExpr } from './generateVizCode.js';
 import { showVisualizeModalDialog, validateVisualizationSuggestion, DataFrameColumn } from './visualizeModalDialog.js';
 
+/**
+ * Decode one segment of a `variablePath` array. The kernel encodes each
+ * segment via `encode_access_key`, producing a JSON string like
+ * `{"type":"str","data":"my_df"}`. Returns the raw `data` string for
+ * string-typed keys, or `undefined` for non-string keys or parse failures.
+ */
+function decodeAccessKey(encoded: string): string | undefined {
+	try {
+		const parsed = JSON.parse(encoded);
+		if (parsed && typeof parsed === 'object' && parsed.type === 'str' && typeof parsed.data === 'string') {
+			return parsed.data;
+		}
+	} catch { /* not JSON -- might be a raw string from an older kernel */ }
+	return undefined;
+}
+
 export class VisualizeDataFrameAction extends Action2 {
 	static readonly ID = 'positronNotebook.inlineDataExplorer.visualize';
 
@@ -63,20 +79,18 @@ export class VisualizeDataFrameAction extends Action2 {
 		}
 
 		// Prefer source-path metadata over display title for the dataframe
-		// prefill. `variablePath` identifies the actual variable behind the
-		// inline grid, while `title` is display-oriented and can be valid Python
-		// but point at a different object. Only single-segment paths are usable
-		// as Python expressions; multi-segment paths are runtime access keys
-		// (dict/list indices, attribute lookups) that we can't reconstruct
-		// safely, so we leave the field empty rather than fall back to title in
-		// that case -- the source-path metadata told us we don't have a valid
-		// expression.
+		// prefill. `variablePath` entries are encoded access keys (JSON
+		// objects like `{"type":"str","data":"df"}`), so we decode the first
+		// segment to recover the raw variable name. Only single-segment
+		// paths are usable as Python expressions.
 		let initialDfName = '';
-		if (ctx.variablePath && ctx.variablePath.length > 0) {
-			if (ctx.variablePath.length === 1 && isValidDataFrameExpr(ctx.variablePath[0])) {
-				initialDfName = ctx.variablePath[0];
+		if (ctx.variablePath && ctx.variablePath.length === 1) {
+			const decoded = decodeAccessKey(ctx.variablePath[0]);
+			if (decoded !== undefined && isValidDataFrameExpr(decoded)) {
+				initialDfName = decoded;
 			}
-		} else if (isValidDataFrameExpr(ctx.title)) {
+		}
+		if (!initialDfName && isValidDataFrameExpr(ctx.title)) {
 			initialDfName = ctx.title;
 		}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
@@ -62,12 +62,21 @@ export class VisualizeDataFrameAction extends Action2 {
 			}
 		}
 
-		// Prefill from the variable expression that produced the inline grid;
-		// `title` is display-oriented and isn't always a valid Python expression.
-		const candidateDfName = ctx.variablePath && ctx.variablePath.length > 0
-			? ctx.variablePath.join('.')
-			: '';
-		const initialDfName = isValidDataFrameExpr(candidateDfName) ? candidateDfName : '';
+		// Pick a Python-valid prefill for the dataframe field. `title` from the
+		// inline grid metadata is usually the variable name itself for top-level
+		// frames (e.g. "df"), so try it first. Fall back to a single-segment
+		// `variablePath` for the case where the kernel set a display-only title
+		// but still tagged the source variable. We deliberately don't synthesize
+		// from multi-segment paths -- they're runtime access keys (dict/list
+		// indices, attribute lookups), not Python syntax, and joining them with
+		// "." would generate code that targets the wrong object.
+		let candidateDfName = '';
+		if (isValidDataFrameExpr(ctx.title)) {
+			candidateDfName = ctx.title;
+		} else if (ctx.variablePath && ctx.variablePath.length === 1 && isValidDataFrameExpr(ctx.variablePath[0])) {
+			candidateDfName = ctx.variablePath[0];
+		}
+		const initialDfName = candidateDfName;
 
 		// Fire the LLM suggestion request in parallel with the dialog so the
 		// user sees fields populate without waiting. Cancel if the dialog

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
@@ -62,21 +62,23 @@ export class VisualizeDataFrameAction extends Action2 {
 			}
 		}
 
-		// Pick a Python-valid prefill for the dataframe field. `title` from the
-		// inline grid metadata is usually the variable name itself for top-level
-		// frames (e.g. "df"), so try it first. Fall back to a single-segment
-		// `variablePath` for the case where the kernel set a display-only title
-		// but still tagged the source variable. We deliberately don't synthesize
-		// from multi-segment paths -- they're runtime access keys (dict/list
-		// indices, attribute lookups), not Python syntax, and joining them with
-		// "." would generate code that targets the wrong object.
-		let candidateDfName = '';
-		if (isValidDataFrameExpr(ctx.title)) {
-			candidateDfName = ctx.title;
-		} else if (ctx.variablePath && ctx.variablePath.length === 1 && isValidDataFrameExpr(ctx.variablePath[0])) {
-			candidateDfName = ctx.variablePath[0];
+		// Prefer source-path metadata over display title for the dataframe
+		// prefill. `variablePath` identifies the actual variable behind the
+		// inline grid, while `title` is display-oriented and can be valid Python
+		// but point at a different object. Only single-segment paths are usable
+		// as Python expressions; multi-segment paths are runtime access keys
+		// (dict/list indices, attribute lookups) that we can't reconstruct
+		// safely, so we leave the field empty rather than fall back to title in
+		// that case -- the source-path metadata told us we don't have a valid
+		// expression.
+		let initialDfName = '';
+		if (ctx.variablePath && ctx.variablePath.length > 0) {
+			if (ctx.variablePath.length === 1 && isValidDataFrameExpr(ctx.variablePath[0])) {
+				initialDfName = ctx.variablePath[0];
+			}
+		} else if (isValidDataFrameExpr(ctx.title)) {
+			initialDfName = ctx.title;
 		}
-		const initialDfName = candidateDfName;
 
 		// Fire the LLM suggestion request in parallel with the dialog so the
 		// user sees fields populate without waiting. Cancel if the dialog

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationTokenSource } from '../../../../../../base/common/cancellation.js';
+import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { localize } from '../../../../../../nls.js';
+import { Action2, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
+import type { PositronNotebookCodeCell } from '../../PositronNotebookCells/PositronNotebookCodeCell.js';
+import type { IInlineDataExplorerActionContext } from '../../notebookCells/InlineDataExplorerActions.js';
+import { applyVisualizeResult } from './applyVisualizeResult.js';
+import { generateVizCode, isValidDataFrameExpr } from './generateVizCode.js';
+import { showVisualizeModalDialog, validateVisualizationSuggestion, DataFrameColumn } from './visualizeModalDialog.js';
+
+export class VisualizeDataFrameAction extends Action2 {
+	static readonly ID = 'positronNotebook.inlineDataExplorer.visualize';
+
+	constructor() {
+		super({
+			id: VisualizeDataFrameAction.ID,
+			title: localize('positron.notebook.visualize.inlineButton', 'Visualize...'),
+			icon: { id: 'graph' },
+			f1: false,
+			menu: {
+				id: MenuId.PositronNotebookInlineDataExplorerHeader,
+				when: ContextKeyExpr.has('positronNotebook.experimental'),
+				group: 'navigation',
+				order: 10,
+			},
+		});
+	}
+
+	async run(accessor: ServicesAccessor, ctx: IInlineDataExplorerActionContext): Promise<void> {
+		// Surface-agnostic gates: skip languages we don't support and surfaces
+		// that don't have a connected grid yet.
+		if (ctx.sourceLanguage !== 'python') { return; }
+		if (!ctx.gridInstance) { return; }
+		// V1 only inserts code into notebook cells. Quarto and other surfaces
+		// will need a document-side applyVisualizeResult equivalent before they
+		// can host this action.
+		if (!ctx.cell || !ctx.notebookInstance) { return; }
+
+		const commandService = accessor.get(ICommandService);
+
+		const columns: DataFrameColumn[] = [];
+		for (let i = 0; i < ctx.gridInstance.columns; i++) {
+			const col = ctx.gridInstance.column(i);
+			if (col) {
+				columns.push({ name: col.name, type: col.description });
+			}
+		}
+
+		const initialDfName = ctx.variablePath && ctx.variablePath.length > 0 && isValidDataFrameExpr(ctx.title)
+			? ctx.title
+			: '';
+
+		// Fire the LLM suggestion request in parallel with the dialog so the
+		// user sees fields populate without waiting. Cancel if the dialog
+		// closes before the request resolves.
+		const suggestionCts = new CancellationTokenSource();
+		try {
+			const suggestionPromise = commandService
+				.executeCommand<unknown>(
+					'positron-assistant.suggestVisualization',
+					ctx.documentUri.toString(),
+					ctx.cell.index,
+					initialDfName,
+					columns,
+					suggestionCts.token,
+				)
+				.then((r) => validateVisualizationSuggestion(r))
+				.catch(() => null);
+
+			const result = await showVisualizeModalDialog(initialDfName, columns, suggestionPromise, ctx.documentUri);
+			if (!result) { return; }
+			const snippet = generateVizCode(result.answers);
+			// applyVisualizeResult needs the concrete class (model + getTextEditorModel);
+			// the inline data explorer only mounts inside a real notebook so this is safe.
+			await applyVisualizeResult(ctx.notebookInstance, ctx.cell as PositronNotebookCodeCell, snippet, result.mode);
+		} finally {
+			suggestionCts.cancel();
+			suggestionCts.dispose();
+		}
+	}
+}
+
+registerAction2(VisualizeDataFrameAction);

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
@@ -20,7 +20,8 @@ import { showVisualizeModalDialog, validateVisualizationSuggestion, DataFrameCol
  * Decode one segment of a `variablePath` array. The kernel encodes each
  * segment via `encode_access_key`, producing a JSON string like
  * `{"type":"str","data":"my_df"}`. Returns the raw `data` string for
- * string-typed keys, or `undefined` for non-string keys or parse failures.
+ * string-typed keys. Falls back to the raw input for non-JSON segments
+ * (older kernels may emit plain variable names).
  */
 function decodeAccessKey(encoded: string): string | undefined {
 	try {
@@ -28,8 +29,10 @@ function decodeAccessKey(encoded: string): string | undefined {
 		if (parsed && typeof parsed === 'object' && parsed.type === 'str' && typeof parsed.data === 'string') {
 			return parsed.data;
 		}
-	} catch { /* not JSON -- might be a raw string from an older kernel */ }
-	return undefined;
+		return undefined;
+	} catch {
+		return encoded;
+	}
 }
 
 export class VisualizeDataFrameAction extends Action2 {
@@ -82,7 +85,9 @@ export class VisualizeDataFrameAction extends Action2 {
 		// prefill. `variablePath` entries are encoded access keys (JSON
 		// objects like `{"type":"str","data":"df"}`), so we decode the first
 		// segment to recover the raw variable name. Only single-segment
-		// paths are usable as Python expressions.
+		// paths are usable as Python expressions; multi-segment paths mean
+		// the object isn't a simple top-level variable, so we leave the
+		// field empty rather than guessing from `title`.
 		let initialDfName = '';
 		if (ctx.variablePath && ctx.variablePath.length === 1) {
 			const decoded = decodeAccessKey(ctx.variablePath[0]);
@@ -90,7 +95,7 @@ export class VisualizeDataFrameAction extends Action2 {
 				initialDfName = decoded;
 			}
 		}
-		if (!initialDfName && isValidDataFrameExpr(ctx.title)) {
+		if (!initialDfName && (!ctx.variablePath || ctx.variablePath.length === 0) && isValidDataFrameExpr(ctx.title)) {
 			initialDfName = ctx.title;
 		}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/VisualizeAction.ts
@@ -8,6 +8,7 @@ import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/con
 import { localize } from '../../../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
 import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { INotificationService, Severity } from '../../../../../../platform/notification/common/notification.js';
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import type { PositronNotebookCodeCell } from '../../PositronNotebookCells/PositronNotebookCodeCell.js';
 import type { IInlineDataExplorerActionContext } from '../../notebookCells/InlineDataExplorerActions.js';
@@ -26,7 +27,14 @@ export class VisualizeDataFrameAction extends Action2 {
 			f1: false,
 			menu: {
 				id: MenuId.PositronNotebookInlineDataExplorerHeader,
-				when: ContextKeyExpr.has('positronNotebook.experimental'),
+				// `positronNotebookCellIsCode` is bound only on the cell-scoped
+				// context key service (see useCellContextKeys). Quarto inline data
+				// explorers render with the global service, so this gate hides the
+				// button there -- visualize today only inserts into notebook cells.
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.has('positronNotebook.experimental'),
+					ContextKeyExpr.has('positronNotebookCellIsCode'),
+				),
 				group: 'navigation',
 				order: 10,
 			},
@@ -44,6 +52,7 @@ export class VisualizeDataFrameAction extends Action2 {
 		if (!ctx.cell || !ctx.notebookInstance) { return; }
 
 		const commandService = accessor.get(ICommandService);
+		const notificationService = accessor.get(INotificationService);
 
 		const columns: DataFrameColumn[] = [];
 		for (let i = 0; i < ctx.gridInstance.columns; i++) {
@@ -53,9 +62,12 @@ export class VisualizeDataFrameAction extends Action2 {
 			}
 		}
 
-		const initialDfName = ctx.variablePath && ctx.variablePath.length > 0 && isValidDataFrameExpr(ctx.title)
-			? ctx.title
+		// Prefill from the variable expression that produced the inline grid;
+		// `title` is display-oriented and isn't always a valid Python expression.
+		const candidateDfName = ctx.variablePath && ctx.variablePath.length > 0
+			? ctx.variablePath.join('.')
 			: '';
+		const initialDfName = isValidDataFrameExpr(candidateDfName) ? candidateDfName : '';
 
 		// Fire the LLM suggestion request in parallel with the dialog so the
 		// user sees fields populate without waiting. Cancel if the dialog
@@ -79,7 +91,23 @@ export class VisualizeDataFrameAction extends Action2 {
 			const snippet = generateVizCode(result.answers);
 			// applyVisualizeResult needs the concrete class (model + getTextEditorModel);
 			// the inline data explorer only mounts inside a real notebook so this is safe.
-			await applyVisualizeResult(ctx.notebookInstance, ctx.cell as PositronNotebookCodeCell, snippet, result.mode);
+			try {
+				await applyVisualizeResult(ctx.notebookInstance, ctx.cell as PositronNotebookCodeCell, snippet, result.mode);
+			} catch (err) {
+				// Surface insertion failures (e.g. the cell model couldn't be
+				// resolved) instead of swallowing them silently. The user has
+				// already committed via the modal so a notification is the
+				// right channel for the failure signal.
+				const message = err instanceof Error ? err.message : String(err);
+				notificationService.notify({
+					severity: Severity.Error,
+					message: localize(
+						'positron.notebook.visualize.insertFailed',
+						"Couldn't insert visualization code: {0}",
+						message,
+					),
+				});
+			}
 		} finally {
 			suggestionCts.cancel();
 			suggestionCts.dispose();

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/applyVisualizeResult.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/applyVisualizeResult.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CellKind } from '../../../../notebook/common/notebookCommon.js';
+import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
+import { PositronNotebookCodeCell } from '../../PositronNotebookCells/PositronNotebookCodeCell.js';
+import { CodeSnippet, codeSnippetToCellSource } from './generateVizCode.js';
+
+export type InsertMode = 'newCell' | 'append';
+
+/**
+ * Heuristic: returns true when every line of the import block already appears
+ * as its own line in the cell. Line-anchored to avoid matching a prefix of
+ * a longer import (e.g. `import pandas` should not match `import pandas as pd`).
+ * Misses formatting variations like `import x as y` vs `import x`; if a
+ * stricter check is needed, replace this with an AST-based pass.
+ */
+export function hasImportsVerbatim(existing: string, imports: string): boolean {
+	const existingLines = new Set(existing.split('\n').map(l => l.trim()).filter(Boolean));
+	const importLines = imports.split('\n').map(l => l.trim()).filter(Boolean);
+	return importLines.every(line => existingLines.has(line));
+}
+
+/**
+ * Build the text to append to an existing cell. Prepends the imports if they
+ * don't already appear verbatim, otherwise just adds the body.
+ */
+export function buildAppendText(existing: string, snippet: CodeSnippet): string {
+	if (hasImportsVerbatim(existing, snippet.imports)) {
+		return `\n\n${snippet.body}\n`;
+	}
+	return `\n\n${snippet.imports}\n\n${snippet.body}\n`;
+}
+
+/**
+ * Apply a visualize result to the source cell. Inserts a new code cell below
+ * the source cell, or appends the generated code to it, depending on the
+ * chosen mode.
+ */
+export async function applyVisualizeResult(
+	notebookInstance: IPositronNotebookInstance,
+	cell: PositronNotebookCodeCell,
+	snippet: CodeSnippet,
+	mode: InsertMode,
+): Promise<void> {
+	if (mode === 'newCell') {
+		notebookInstance.addCell(
+			CellKind.Code,
+			cell.index + 1,
+			false,
+			codeSnippetToCellSource(snippet),
+			cell.model.language,
+		);
+		return;
+	}
+
+	const textModel = await cell.getTextEditorModel();
+	const lineCount = textModel.getLineCount();
+	const endCol = textModel.getLineMaxColumn(lineCount);
+	const existing = textModel.getValue();
+	const toAppend = buildAppendText(existing, snippet);
+	// pushEditOperations (rather than applyEdits) so the user can Undo the
+	// append in a single step.
+	textModel.pushEditOperations(
+		null,
+		[{
+			range: {
+				startLineNumber: lineCount,
+				startColumn: endCol,
+				endLineNumber: lineCount,
+				endColumn: endCol,
+			},
+			text: toAppend,
+		}],
+		() => null,
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/generateVizCode.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/generateVizCode.ts
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export type VizLibrary = 'plotly' | 'matplotlib' | 'seaborn';
+export type ChartType = 'bar' | 'line' | 'scatter' | 'histogram';
+
+export interface VizAnswers {
+	library: VizLibrary;
+	chartType: ChartType;
+	dfName: string;
+	x: string;
+	y?: string;
+}
+
+export interface CodeSnippet {
+	imports: string;
+	body: string;
+}
+
+const SEABORN_FN: Record<ChartType, string> = {
+	bar: 'barplot',
+	line: 'lineplot',
+	scatter: 'scatterplot',
+	histogram: 'histplot',
+};
+
+const MATPLOTLIB_IMPORT = 'import matplotlib.pyplot as plt';
+
+/**
+ * Safely quote a string as a Python literal using double quotes.
+ * Escapes backslashes, double quotes, newlines, carriage returns, and tabs.
+ * Keeps the output compact and side-effect-free; the caller is responsible
+ * for passing a single column/value, not arbitrary untrusted text.
+ */
+export function pythonString(value: string): string {
+	const escaped = value
+		.replace(/\\/g, '\\\\')
+		.replace(/"/g, '\\"')
+		.replace(/\n/g, '\\n')
+		.replace(/\r/g, '\\r')
+		.replace(/\t/g, '\\t');
+	return `"${escaped}"`;
+}
+
+/**
+ * Check that a user-provided dataframe expression is safe to interpolate as a
+ * Python reference. Accepts bare identifiers and conservative dotted / bracketed
+ * access chains such as `df`, `self.data`, `frames["main"]`. Rejects anything
+ * with statement delimiters, spaces, or other syntax that would let arbitrary
+ * expressions through.
+ */
+export function isValidDataFrameExpr(expr: string): boolean {
+	const trimmed = expr.trim();
+	if (trimmed.length === 0) { return false; }
+	// Allow only: ident(.ident)* with optional ["literal"] / ['literal'] segments.
+	// The first segment must be a bare identifier; subsequent segments can be
+	// either .ident or a bracket-with-string-literal access.
+	// Identifier rules match Python: leading letter or underscore, then
+	// letters / digits / underscores.
+	const ident = String.raw`[A-Za-z_][A-Za-z0-9_]*`;
+	const bracket = String.raw`\["[^"\\\n]*"\]|\['[^'\\\n]*'\]`;
+	const pattern = new RegExp(`^${ident}(\\.${ident}|${bracket})*$`);
+	return pattern.test(trimmed);
+}
+
+export function generateVizCode(answers: VizAnswers): CodeSnippet {
+	const { library, chartType, dfName, x, y } = answers;
+	const xLit = pythonString(x);
+	const yLit = y ? pythonString(y) : undefined;
+	const xAccess = `${dfName}[${xLit}]`;
+	const yAccess = yLit ? `${dfName}[${yLit}]` : undefined;
+
+	if (library === 'plotly') {
+		const fn = chartType === 'histogram' ? 'histogram' : chartType;
+		const yArg = yLit ? `, y=${yLit}` : '';
+		return {
+			imports: `import plotly.express as px`,
+			body: `fig = px.${fn}(${dfName}, x=${xLit}${yArg})\nfig.show()`,
+		};
+	}
+
+	if (library === 'seaborn') {
+		const fn = SEABORN_FN[chartType];
+		const yArg = yLit ? `, y=${yLit}` : '';
+		return {
+			imports: `import seaborn as sns\n${MATPLOTLIB_IMPORT}`,
+			body: `sns.${fn}(data=${dfName}, x=${xLit}${yArg})\nplt.show()`,
+		};
+	}
+
+	// matplotlib
+	if (chartType === 'histogram') {
+		return {
+			imports: MATPLOTLIB_IMPORT,
+			body: `plt.hist(${xAccess})\nplt.xlabel(${xLit})\nplt.show()`,
+		};
+	}
+	if (chartType === 'bar') {
+		const yExpr = yAccess ?? `${xAccess}.value_counts().values`;
+		const xExpr = yAccess ? xAccess : `${xAccess}.value_counts().index`;
+		return {
+			imports: MATPLOTLIB_IMPORT,
+			body: `plt.bar(${xExpr}, ${yExpr})\nplt.xlabel(${xLit})${yLit ? `\nplt.ylabel(${yLit})` : ''}\nplt.show()`,
+		};
+	}
+	const plotFn = chartType === 'line' ? 'plot' : 'scatter';
+	const yExpr = yAccess ?? `${dfName}.index`;
+	return {
+		imports: MATPLOTLIB_IMPORT,
+		body: `plt.${plotFn}(${xAccess}, ${yExpr})\nplt.xlabel(${xLit})${yLit ? `\nplt.ylabel(${yLit})` : ''}\nplt.show()`,
+	};
+}
+
+export function codeSnippetToCellSource(snippet: CodeSnippet): string {
+	return `${snippet.imports}\n\n${snippet.body}\n`;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.css
@@ -3,11 +3,214 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+.visualize-split {
+	display: flex;
+	gap: 18px;
+	min-height: 100%;
+	align-items: stretch;
+}
+
+.visualize-split > .visualize-modal-content {
+	flex: 1 1 420px;
+	min-width: 0;
+}
+
+.visualize-split-preview {
+	flex: 1 1 420px;
+	min-width: 0;
+	display: flex;
+}
+
 .visualize-modal-content {
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
 	min-height: 100%;
+}
+
+/* Live preview panel */
+
+.visualize-preview {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
+	min-width: 0;
+	border-radius: 6px;
+	border: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+	background-color: var(--vscode-editorWidget-background);
+	overflow: hidden;
+}
+
+.visualize-preview-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 12px;
+	border-bottom: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+	color: var(--vscode-descriptionForeground);
+	font-size: 11px;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	font-weight: 600;
+	background-color: var(--vscode-editorWidget-background);
+	flex-shrink: 0;
+}
+
+.visualize-preview-header-title {
+	flex: 1;
+}
+
+.visualize-preview-header > .codicon {
+	font-size: 14px !important;
+	color: var(--vscode-textLink-foreground);
+}
+
+/* Toggle switch */
+
+.visualize-preview-toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 2px 6px 2px 4px;
+	border: none;
+	border-radius: 999px;
+	background: transparent;
+	color: var(--vscode-descriptionForeground);
+	font-size: 10.5px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	cursor: pointer;
+	transition: color 100ms ease;
+}
+
+.visualize-preview-toggle:hover {
+	color: var(--vscode-foreground);
+}
+
+.visualize-preview-toggle:focus-visible {
+	outline: 2px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
+.visualize-preview-toggle-track {
+	position: relative;
+	width: 26px;
+	height: 14px;
+	border-radius: 999px;
+	background: var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.4));
+	transition: background-color 160ms ease;
+}
+
+.visualize-preview-toggle.on .visualize-preview-toggle-track {
+	background: var(--vscode-focusBorder);
+}
+
+.visualize-preview-toggle-thumb {
+	position: absolute;
+	top: 2px;
+	left: 2px;
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	background: var(--vscode-editor-background, white);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+	transition: transform 160ms ease;
+}
+
+.visualize-preview-toggle.on .visualize-preview-toggle-thumb {
+	transform: translateX(12px);
+}
+
+.visualize-preview-toggle.on {
+	color: var(--vscode-foreground);
+}
+
+.visualize-preview-body {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 12px;
+	background-color: var(--vscode-editor-background);
+	overflow: hidden;
+}
+
+.visualize-preview-iframe {
+	width: 100%;
+	max-width: 100%;
+	height: 100%;
+	border: none;
+	background: white;
+	border-radius: 4px;
+}
+
+.visualize-preview-image {
+	max-width: 100%;
+	max-height: 100%;
+	object-fit: contain;
+}
+
+.visualize-preview-message {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 6px;
+	padding: 16px;
+	text-align: center;
+	color: var(--vscode-descriptionForeground);
+}
+
+.visualize-preview-message.error {
+	color: var(--vscode-errorForeground);
+}
+
+.visualize-preview-message-icon {
+	font-size: 20px !important;
+	opacity: 0.8;
+}
+
+.visualize-preview-message-title {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+}
+
+.visualize-preview-message.error .visualize-preview-message-title {
+	color: var(--vscode-errorForeground);
+}
+
+.visualize-preview-message-hint {
+	font-size: 11.5px;
+	line-height: 1.45;
+	max-width: 280px;
+	font-family: var(--monaco-monospace-font);
+	color: inherit;
+	opacity: 0.9;
+	word-break: break-word;
+}
+
+.visualize-preview-message-action {
+	margin-top: 8px;
+	padding: 4px 12px;
+	border-radius: 4px;
+	border: 1px solid var(--vscode-focusBorder);
+	background: transparent;
+	color: var(--vscode-foreground);
+	font-family: inherit;
+	font-size: 11.5px;
+	cursor: pointer;
+}
+
+.visualize-preview-message-action:hover {
+	background: var(--vscode-list-hoverBackground);
+}
+
+.visualize-preview-message-action:focus-visible {
+	outline: 2px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
 }
 
 /* Step indicator */

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.css
@@ -1,0 +1,324 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.visualize-modal-content {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	min-height: 100%;
+}
+
+/* Step indicator */
+
+.visualize-step-indicator {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	padding: 4px 0 8px;
+}
+
+.visualize-step-dot {
+	width: 24px;
+	height: 4px;
+	border-radius: 2px;
+	background-color: var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+	transition: background-color 160ms ease, width 160ms ease;
+}
+
+.visualize-step-dot.completed {
+	background-color: var(--vscode-button-background);
+	opacity: 0.6;
+}
+
+.visualize-step-dot.active {
+	width: 40px;
+	background-color: var(--vscode-button-background);
+}
+
+/* Step body */
+
+.visualize-step-body {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+
+.visualize-step-title {
+	margin: 0;
+	font-size: 18px;
+	font-weight: 600;
+	line-height: 1.2;
+	color: var(--vscode-foreground);
+}
+
+.visualize-step-subtitle {
+	margin: 0;
+	font-size: 13px;
+	color: var(--vscode-descriptionForeground);
+	line-height: 1.45;
+}
+
+/* Suggestion banner */
+
+.visualize-suggestion-banner {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+	padding: 10px 12px;
+	border-radius: 6px;
+	border: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+	background-color: var(--vscode-editorWidget-background);
+	font-size: 12px;
+	line-height: 1.45;
+}
+
+.visualize-suggestion-banner.loading {
+	color: var(--vscode-descriptionForeground);
+	font-style: italic;
+}
+
+.visualize-suggestion-banner.failed {
+	color: var(--vscode-descriptionForeground);
+}
+
+.visualize-suggestion-banner.done {
+	border-color: var(--vscode-focusBorder);
+	background-color: var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground));
+	color: var(--vscode-list-activeSelectionForeground, var(--vscode-foreground));
+}
+
+.visualize-suggestion-banner > .codicon {
+	margin-top: 1px;
+	font-size: 14px !important;
+	flex-shrink: 0;
+}
+
+.visualize-suggestion-banner.done > .codicon {
+	color: var(--vscode-focusBorder);
+}
+
+.visualize-suggestion-banner-text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	flex: 1;
+	min-width: 0;
+}
+
+.visualize-suggestion-banner-label {
+	font-weight: 500;
+}
+
+.visualize-suggestion-banner-reason {
+	opacity: 0.85;
+}
+
+/* Choice grid */
+
+.visualize-choice-grid {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	grid-auto-rows: 1fr;
+	gap: 10px;
+}
+
+.visualize-choice-card {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 12px;
+	border-radius: 6px;
+	border: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+	background-color: var(--vscode-editorWidget-background);
+	color: var(--vscode-foreground);
+	cursor: pointer;
+	text-align: left;
+	transition: border-color 120ms ease, background-color 120ms ease, transform 120ms ease;
+}
+
+.visualize-choice-card:hover {
+	border-color: var(--vscode-focusBorder);
+	background-color: var(--vscode-list-hoverBackground);
+}
+
+.visualize-choice-card:focus-visible {
+	outline: 2px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
+.visualize-choice-card.selected {
+	border-color: var(--vscode-focusBorder);
+	background-color: var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground));
+	box-shadow: 0 0 0 1px var(--vscode-focusBorder) inset;
+}
+
+.visualize-choice-card.suggested {
+	border-color: var(--vscode-focusBorder);
+	box-shadow: 0 0 0 1px var(--vscode-focusBorder) inset;
+}
+
+.visualize-choice-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 3px;
+	margin-left: 6px;
+	padding: 1px 6px;
+	border-radius: 8px;
+	background-color: var(--vscode-focusBorder);
+	color: var(--vscode-editor-background);
+	font-size: 9.5px;
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	text-transform: uppercase;
+	vertical-align: middle;
+}
+
+.visualize-choice-badge .codicon {
+	font-size: 10px !important;
+}
+
+.visualize-choice-icon {
+	font-size: 22px !important;
+	color: var(--vscode-textLink-foreground);
+	flex-shrink: 0;
+}
+
+.visualize-choice-card.selected .visualize-choice-icon {
+	color: var(--vscode-focusBorder);
+}
+
+.visualize-choice-text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	flex: 1;
+	min-width: 0;
+}
+
+.visualize-choice-title {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+}
+
+.visualize-choice-description {
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+	line-height: 1.35;
+}
+
+/* Columns form */
+
+.visualize-columns-form {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.visualize-columns-form .labeled-text-input {
+	margin-bottom: 0;
+}
+
+/* Column picker */
+
+.visualize-column-picker {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.visualize-column-picker-label {
+	font-size: 12px;
+	color: var(--vscode-foreground);
+}
+
+/* Insert step */
+
+.visualize-code-preview {
+	margin: 0;
+	padding: 10px 12px;
+	border-radius: 6px;
+	background-color: var(--vscode-textCodeBlock-background, var(--vscode-editor-background));
+	border: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+	color: var(--vscode-editor-foreground);
+	font-family: var(--monaco-monospace-font);
+	font-size: 11.5px;
+	line-height: 1.45;
+	white-space: pre;
+	overflow: auto;
+	max-height: 160px;
+}
+
+.visualize-code-preview code {
+	font-family: inherit;
+	color: inherit;
+	background: transparent;
+}
+
+.visualize-insert-mode {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.visualize-insert-option {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 10px 12px;
+	border-radius: 6px;
+	border: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+	background-color: var(--vscode-editorWidget-background);
+	color: var(--vscode-foreground);
+	cursor: pointer;
+	text-align: left;
+	transition: border-color 120ms ease, background-color 120ms ease;
+}
+
+.visualize-insert-option:hover {
+	border-color: var(--vscode-focusBorder);
+	background-color: var(--vscode-list-hoverBackground);
+}
+
+.visualize-insert-option:focus-visible {
+	outline: 2px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+}
+
+.visualize-insert-option.selected {
+	border-color: var(--vscode-focusBorder);
+	background-color: var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground));
+	box-shadow: 0 0 0 1px var(--vscode-focusBorder) inset;
+}
+
+.visualize-insert-icon {
+	font-size: 18px !important;
+	color: var(--vscode-textLink-foreground);
+	flex-shrink: 0;
+}
+
+.visualize-insert-option.selected .visualize-insert-icon {
+	color: var(--vscode-focusBorder);
+}
+
+.visualize-insert-text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	flex: 1;
+	min-width: 0;
+}
+
+.visualize-insert-title {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+}
+
+.visualize-insert-description {
+	font-size: 11px;
+	color: var(--vscode-descriptionForeground);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
@@ -276,8 +276,8 @@ const VisualizeModalDialog = (props: Props) => {
 		if (canAdvance) { goNext(); }
 	};
 
-	const generatedSource = codeSnippetToCellSource(generateVizCode(answers));
-	const previewReady = answers.x.trim().length > 0;
+	const generatedSource = dfNameValid ? codeSnippetToCellSource(generateVizCode(answers)) : '';
+	const previewReady = dfNameValid && answers.x.trim().length > 0;
 
 	return (
 		<PositronModalDialog
@@ -404,6 +404,7 @@ const VisualizeModalDialog = (props: Props) => {
 							<VisualizePreview
 								code={previewReady ? generatedSource : ''}
 								library={library}
+								needsDfName={!dfNameValid && xColPresent}
 								notebookUri={props.notebookUri}
 							/>
 						</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
@@ -20,8 +20,10 @@ import { DropDownListBox, DropDownListBoxEntry } from '../../../../../browser/po
 import { DropDownListBoxItem } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBoxItem.js';
 import { DropDownListBoxSeparator } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBoxSeparator.js';
 import { positronClassNames } from '../../../../../../base/common/positronUtilities.js';
+import { URI } from '../../../../../../base/common/uri.js';
 import { ChartType, codeSnippetToCellSource, generateVizCode, isValidDataFrameExpr, VizAnswers, VizLibrary } from './generateVizCode.js';
 import { InsertMode } from './applyVisualizeResult.js';
+import { VisualizePreview } from './visualizePreview.js';
 
 export type { InsertMode };
 
@@ -101,6 +103,7 @@ export const showVisualizeModalDialog = (
 	initialDfName: string,
 	columns: DataFrameColumn[] = [],
 	suggestionPromise?: Promise<VisualizationSuggestion | null>,
+	notebookUri?: URI,
 ): Promise<VisualizeResult | undefined> => {
 	return new Promise(resolve => {
 		const renderer = new PositronModalReactRenderer();
@@ -115,6 +118,7 @@ export const showVisualizeModalDialog = (
 			<VisualizeModalDialog
 				columns={columns}
 				initialDfName={initialDfName}
+				notebookUri={notebookUri}
 				renderer={renderer}
 				suggestionPromise={suggestionPromise}
 				onCancel={() => finish(undefined)}
@@ -128,6 +132,7 @@ interface Props {
 	renderer: PositronModalReactRenderer;
 	initialDfName: string;
 	columns: DataFrameColumn[];
+	notebookUri?: URI;
 	suggestionPromise?: Promise<VisualizationSuggestion | null>;
 	onCancel: () => void;
 	onFinish: (r: VisualizeResult) => void;
@@ -272,6 +277,7 @@ const VisualizeModalDialog = (props: Props) => {
 	};
 
 	const generatedSource = codeSnippetToCellSource(generateVizCode(answers));
+	const previewReady = answers.x.trim().length > 0;
 
 	return (
 		<PositronModalDialog
@@ -282,114 +288,124 @@ const VisualizeModalDialog = (props: Props) => {
 			onCancel={props.onCancel}
 		>
 			<ContentArea>
-				<div className='visualize-modal-content'>
-					<StepIndicator currentIdx={currentIdx} total={STEP_ORDER.length} />
+				<div className='visualize-split'>
+					<div className='visualize-modal-content'>
+						<StepIndicator currentIdx={currentIdx} total={STEP_ORDER.length} />
 
-					{step === 'library' && (
-						<StepBody
-							subtitle={localize('positron.notebook.visualize.step.library.subtitle', 'We will generate code using the library you pick.')}
-							title={localize('positron.notebook.visualize.step.library.title', 'Choose a plotting library')}
-						>
-							<SuggestionBanner
-								reasoning={suggestion?.reasoning.library}
-								state={suggestionState}
-								suggestedLabel={suggestion && LIBRARY_CHOICES.find(c => c.id === suggestion.library)?.title}
-							/>
-							<ChoiceGrid
-								choices={LIBRARY_CHOICES}
-								selectedId={library}
-								suggestedId={suggestion?.library}
-								onSelect={onLibraryChange}
-							/>
-						</StepBody>
-					)}
+						{step === 'library' && (
+							<StepBody
+								subtitle={localize('positron.notebook.visualize.step.library.subtitle', 'We will generate code using the library you pick.')}
+								title={localize('positron.notebook.visualize.step.library.title', 'Choose a plotting library')}
+							>
+								<SuggestionBanner
+									reasoning={suggestion?.reasoning.library}
+									state={suggestionState}
+									suggestedLabel={suggestion && LIBRARY_CHOICES.find(c => c.id === suggestion.library)?.title}
+								/>
+								<ChoiceGrid
+									choices={LIBRARY_CHOICES}
+									selectedId={library}
+									suggestedId={suggestion?.library}
+									onSelect={onLibraryChange}
+								/>
+							</StepBody>
+						)}
 
-					{step === 'chart' && (
-						<StepBody
-							subtitle={localize('positron.notebook.visualize.step.chart.subtitle', 'Pick the shape that best fits your data.')}
-							title={localize('positron.notebook.visualize.step.chart.title', 'What kind of chart?')}
-						>
-							<SuggestionBanner
-								reasoning={suggestion?.reasoning.chartType}
-								state={suggestionState}
-								suggestedLabel={suggestion && CHART_CHOICES.find(c => c.id === suggestion.chartType)?.title}
-							/>
-							<ChoiceGrid
-								choices={CHART_CHOICES}
-								selectedId={chartType}
-								suggestedId={suggestion?.chartType}
-								onSelect={onChartChange}
-							/>
-						</StepBody>
-					)}
+						{step === 'chart' && (
+							<StepBody
+								subtitle={localize('positron.notebook.visualize.step.chart.subtitle', 'Pick the shape that best fits your data.')}
+								title={localize('positron.notebook.visualize.step.chart.title', 'What kind of chart?')}
+							>
+								<SuggestionBanner
+									reasoning={suggestion?.reasoning.chartType}
+									state={suggestionState}
+									suggestedLabel={suggestion && CHART_CHOICES.find(c => c.id === suggestion.chartType)?.title}
+								/>
+								<ChoiceGrid
+									choices={CHART_CHOICES}
+									selectedId={chartType}
+									suggestedId={suggestion?.chartType}
+									onSelect={onChartChange}
+								/>
+							</StepBody>
+						)}
 
-					{step === 'columns' && (
-						<StepBody
-							subtitle={props.columns.length
-								? localize('positron.notebook.visualize.step.columns.subtitle.withColumns', 'Pick columns from your dataframe.')
-								: localize('positron.notebook.visualize.step.columns.subtitle.noColumns', 'Enter column names from your dataframe.')}
-							title={localize('positron.notebook.visualize.step.columns.title', 'Map your columns')}
-						>
-							<SuggestionBanner
-								reasoning={suggestion?.reasoning.columns}
-								state={suggestionState}
-								suggestedLabel={suggestion
-									? `x: ${suggestion.xCol}${suggestion.yCol ? `, y: ${suggestion.yCol}` : ''}`
-									: undefined}
-							/>
-							<div className='visualize-columns-form'>
-								<LabeledTextInput
-									error={trimmedDfName.length > 0 && !dfNameValid}
-									errorMsg={trimmedDfName.length > 0 && !dfNameValid
-										? localize('positron.notebook.visualize.dfName.invalid', 'Must be a Python name like "df" or "self.data".')
+						{step === 'columns' && (
+							<StepBody
+								subtitle={props.columns.length
+									? localize('positron.notebook.visualize.step.columns.subtitle.withColumns', 'Pick columns from your dataframe.')
+									: localize('positron.notebook.visualize.step.columns.subtitle.noColumns', 'Enter column names from your dataframe.')}
+								title={localize('positron.notebook.visualize.step.columns.title', 'Map your columns')}
+							>
+								<SuggestionBanner
+									reasoning={suggestion?.reasoning.columns}
+									state={suggestionState}
+									suggestedLabel={suggestion
+										? `x: ${suggestion.xCol}${suggestion.yCol ? `, y: ${suggestion.yCol}` : ''}`
 										: undefined}
-									label={localize('positron.notebook.visualize.dfName.label', 'DataFrame variable')}
-									value={dfName}
-									onChange={(e) => setDfName(e.target.value)}
 								/>
-								<ColumnPicker
-									autoFocus
-									columns={props.columns}
-									label={localize('positron.notebook.visualize.xColumn.label', 'X column')}
-									value={xCol}
-									onChange={onXChange}
-								/>
-								{chartType !== 'histogram' && (
-									<ColumnPicker
-										allowClear
-										columns={props.columns}
-										label={localize('positron.notebook.visualize.yColumn.label', 'Y column (optional)')}
-										value={yCol}
-										onChange={onYChange}
+								<div className='visualize-columns-form'>
+									<LabeledTextInput
+										error={trimmedDfName.length > 0 && !dfNameValid}
+										errorMsg={trimmedDfName.length > 0 && !dfNameValid
+											? localize('positron.notebook.visualize.dfName.invalid', 'Must be a Python name like "df" or "self.data".')
+											: undefined}
+										label={localize('positron.notebook.visualize.dfName.label', 'DataFrame variable')}
+										value={dfName}
+										onChange={(e) => setDfName(e.target.value)}
 									/>
-								)}
-							</div>
-						</StepBody>
-					)}
+									<ColumnPicker
+										autoFocus
+										columns={props.columns}
+										label={localize('positron.notebook.visualize.xColumn.label', 'X column')}
+										value={xCol}
+										onChange={onXChange}
+									/>
+									{chartType !== 'histogram' && (
+										<ColumnPicker
+											allowClear
+											columns={props.columns}
+											label={localize('positron.notebook.visualize.yColumn.label', 'Y column (optional)')}
+											value={yCol}
+											onChange={onYChange}
+										/>
+									)}
+								</div>
+							</StepBody>
+						)}
 
-					{step === 'insert' && (
-						<StepBody
-							subtitle={localize('positron.notebook.visualize.step.insert.subtitle', 'Review the code and choose where it should land.')}
-							title={localize('positron.notebook.visualize.step.insert.title', 'Ready to visualize')}
-						>
-							<CodePreview source={generatedSource} />
-							<div className='visualize-insert-mode'>
-								<InsertModeOption
-									description={localize('positron.notebook.visualize.insertMode.newCell.description', 'Keep your exploration cell unchanged.')}
-									icon='codicon-add'
-									selected={insertMode === 'newCell'}
-									title={localize('positron.notebook.visualize.insertMode.newCell.title', 'Insert as new cell below')}
-									onSelect={() => setInsertMode('newCell')}
-								/>
-								<InsertModeOption
-									description={localize('positron.notebook.visualize.insertMode.append.description', 'Add the plot to the end of the current cell.')}
-									icon='codicon-arrow-down'
-									selected={insertMode === 'append'}
-									title={localize('positron.notebook.visualize.insertMode.append.title', 'Append to this cell')}
-									onSelect={() => setInsertMode('append')}
-								/>
-							</div>
-						</StepBody>
+						{step === 'insert' && (
+							<StepBody
+								subtitle={localize('positron.notebook.visualize.step.insert.subtitle', 'Review the code and choose where it should land.')}
+								title={localize('positron.notebook.visualize.step.insert.title', 'Ready to visualize')}
+							>
+								<CodePreview source={generatedSource} />
+								<div className='visualize-insert-mode'>
+									<InsertModeOption
+										description={localize('positron.notebook.visualize.insertMode.newCell.description', 'Keep your exploration cell unchanged.')}
+										icon='codicon-add'
+										selected={insertMode === 'newCell'}
+										title={localize('positron.notebook.visualize.insertMode.newCell.title', 'Insert as new cell below')}
+										onSelect={() => setInsertMode('newCell')}
+									/>
+									<InsertModeOption
+										description={localize('positron.notebook.visualize.insertMode.append.description', 'Add the plot to the end of the current cell.')}
+										icon='codicon-arrow-down'
+										selected={insertMode === 'append'}
+										title={localize('positron.notebook.visualize.insertMode.append.title', 'Append to this cell')}
+										onSelect={() => setInsertMode('append')}
+									/>
+								</div>
+							</StepBody>
+						)}
+					</div>
+					{props.notebookUri && (
+						<div className='visualize-split-preview'>
+							<VisualizePreview
+								code={previewReady ? generatedSource : ''}
+								notebookUri={props.notebookUri}
+							/>
+						</div>
 					)}
 				</div>
 			</ContentArea>

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
@@ -403,6 +403,7 @@ const VisualizeModalDialog = (props: Props) => {
 						<div className='visualize-split-preview'>
 							<VisualizePreview
 								code={previewReady ? generatedSource : ''}
+								library={library}
 								notebookUri={props.notebookUri}
 							/>
 						</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
@@ -47,11 +47,6 @@ export interface DataFrameColumn {
  * sides. `validateVisualizationSuggestion` below guards the IPC
  * boundary as defence in depth. When adding a field or changing a
  * literal, update BOTH.
- *
- * The producer that fills this in (the `suggestVisualization` command
- * in `positron-assistant`) lands in a follow-up; this type, the
- * validator, and `SuggestionBanner` are the dormant landing pad so the
- * dialog can accept a `suggestionPromise` without retrofitting later.
  */
 export interface VisualizationSuggestion {
 	library: VizLibrary;
@@ -503,12 +498,7 @@ function ChoiceGrid<T extends string>({ choices, selectedId, suggestedId, onSele
 	);
 }
 
-/**
- * Status banner for the LLM suggestion path: idle/loading/done/failed.
- * Mounted in this change but only ever sees `idle` because no
- * `suggestionPromise` is supplied yet -- the producer lands in a
- * follow-up.
- */
+/** Status banner for the LLM suggestion path: idle/loading/done/failed. */
 function SuggestionBanner({ state, reasoning, suggestedLabel }: {
 	state: 'idle' | 'loading' | 'done' | 'failed';
 	reasoning?: string;

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
@@ -1,0 +1,640 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './visualizeModalDialog.css';
+
+// React.
+import { useEffect, useRef, useState } from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../../nls.js';
+import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
+import { PositronModalDialog } from '../../../../../browser/positronComponents/positronModalDialog/positronModalDialog.js';
+import { ContentArea } from '../../../../../browser/positronComponents/positronModalDialog/components/contentArea.js';
+import { LabeledTextInput } from '../../../../../browser/positronComponents/positronModalDialog/components/labeledTextInput.js';
+import { OKCancelBackNextActionBar } from '../../../../../browser/positronComponents/positronModalDialog/components/okCancelBackNextActionBar.js';
+import { DropDownListBox, DropDownListBoxEntry } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBox.js';
+import { DropDownListBoxItem } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBoxItem.js';
+import { DropDownListBoxSeparator } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBoxSeparator.js';
+import { positronClassNames } from '../../../../../../base/common/positronUtilities.js';
+import { ChartType, codeSnippetToCellSource, generateVizCode, isValidDataFrameExpr, VizAnswers, VizLibrary } from './generateVizCode.js';
+import { InsertMode } from './applyVisualizeResult.js';
+
+export type { InsertMode };
+
+export interface VisualizeResult {
+	answers: VizAnswers;
+	mode: InsertMode;
+}
+
+export interface DataFrameColumn {
+	name: string;
+	type: string;
+}
+
+/**
+ * IMPORTANT: This type is mirrored on the extension side in
+ *   extensions/positron-assistant/src/visualizationSuggestions.ts
+ * (as `VisualizationSuggestion`, with `VizLibrary` and `VizChartType`).
+ *
+ * The workbench cannot import from extensions, so drift is prevented by
+ * keeping the allow-list literals and field shape identical on both
+ * sides. `validateVisualizationSuggestion` below guards the IPC
+ * boundary as defence in depth. When adding a field or changing a
+ * literal, update BOTH.
+ *
+ * The producer that fills this in (the `suggestVisualization` command
+ * in `positron-assistant`) lands in a follow-up; this type, the
+ * validator, and `SuggestionBanner` are the dormant landing pad so the
+ * dialog can accept a `suggestionPromise` without retrofitting later.
+ */
+export interface VisualizationSuggestion {
+	library: VizLibrary;
+	chartType: ChartType;
+	xCol: string;
+	yCol: string | null;
+	reasoning: {
+		library: string;
+		chartType: string;
+		columns: string;
+	};
+	modelName?: string;
+}
+
+const VALID_LIBRARIES: ReadonlySet<string> = new Set(['plotly', 'matplotlib', 'seaborn']);
+const VALID_CHART_TYPES: ReadonlySet<string> = new Set(['bar', 'line', 'scatter', 'histogram']);
+
+/**
+ * Guard an unknown value crossing the extension/workbench IPC boundary into
+ * the strongly-typed VisualizationSuggestion shape. Returns null on any
+ * validation failure -- the extension-side parser is already the first line
+ * of defense; this is defence in depth so a bad model response can't throw
+ * inside React state updates.
+ */
+export function validateVisualizationSuggestion(value: unknown): VisualizationSuggestion | null {
+	if (!value || typeof value !== 'object') { return null; }
+	const s = value as Partial<Record<keyof VisualizationSuggestion, unknown>> & { reasoning?: unknown };
+	if (typeof s.library !== 'string' || !VALID_LIBRARIES.has(s.library)) { return null; }
+	if (typeof s.chartType !== 'string' || !VALID_CHART_TYPES.has(s.chartType)) { return null; }
+	if (typeof s.xCol !== 'string') { return null; }
+	if (s.yCol !== null && typeof s.yCol !== 'string') { return null; }
+	const r = s.reasoning;
+	if (!r || typeof r !== 'object') { return null; }
+	const rr = r as Record<string, unknown>;
+	if (typeof rr.library !== 'string' || typeof rr.chartType !== 'string' || typeof rr.columns !== 'string') {
+		return null;
+	}
+	return {
+		library: s.library as VizLibrary,
+		chartType: s.chartType as ChartType,
+		xCol: s.xCol,
+		yCol: s.yCol as string | null,
+		reasoning: { library: rr.library, chartType: rr.chartType, columns: rr.columns },
+		modelName: typeof s.modelName === 'string' ? s.modelName : undefined,
+	};
+}
+
+export const showVisualizeModalDialog = (
+	initialDfName: string,
+	columns: DataFrameColumn[] = [],
+	suggestionPromise?: Promise<VisualizationSuggestion | null>,
+): Promise<VisualizeResult | undefined> => {
+	return new Promise(resolve => {
+		const renderer = new PositronModalReactRenderer();
+		let resolved = false;
+		const finish = (r: VisualizeResult | undefined) => {
+			if (resolved) { return; }
+			resolved = true;
+			renderer.dispose();
+			resolve(r);
+		};
+		renderer.render(
+			<VisualizeModalDialog
+				columns={columns}
+				initialDfName={initialDfName}
+				renderer={renderer}
+				suggestionPromise={suggestionPromise}
+				onCancel={() => finish(undefined)}
+				onFinish={(r) => finish(r)}
+			/>
+		);
+	});
+};
+
+interface Props {
+	renderer: PositronModalReactRenderer;
+	initialDfName: string;
+	columns: DataFrameColumn[];
+	suggestionPromise?: Promise<VisualizationSuggestion | null>;
+	onCancel: () => void;
+	onFinish: (r: VisualizeResult) => void;
+}
+
+type Step = 'library' | 'chart' | 'columns' | 'insert';
+const STEP_ORDER: Step[] = ['library', 'chart', 'columns', 'insert'];
+
+interface Choice<T extends string> {
+	id: T;
+	title: string;
+	description: string;
+	icon: string;
+}
+
+const LIBRARY_CHOICES: Choice<VizLibrary>[] = [
+	{
+		id: 'plotly',
+		title: localize('positron.notebook.visualize.library.plotly.title', 'Plotly'),
+		description: localize('positron.notebook.visualize.library.plotly.description', 'Interactive charts, great for exploration'),
+		icon: 'codicon-preview',
+	},
+	{
+		id: 'matplotlib',
+		title: localize('positron.notebook.visualize.library.matplotlib.title', 'Matplotlib'),
+		description: localize('positron.notebook.visualize.library.matplotlib.description', 'Classic Python plotting, static output'),
+		icon: 'codicon-graph',
+	},
+	{
+		id: 'seaborn',
+		title: localize('positron.notebook.visualize.library.seaborn.title', 'Seaborn'),
+		description: localize('positron.notebook.visualize.library.seaborn.description', 'Statistical viz with nice defaults'),
+		icon: 'codicon-color-mode',
+	},
+];
+
+const CHART_CHOICES: Choice<ChartType>[] = [
+	{
+		id: 'bar',
+		title: localize('positron.notebook.visualize.chart.bar.title', 'Bar'),
+		description: localize('positron.notebook.visualize.chart.bar.description', 'Compare categories'),
+		icon: 'codicon-graph',
+	},
+	{
+		id: 'line',
+		title: localize('positron.notebook.visualize.chart.line.title', 'Line'),
+		description: localize('positron.notebook.visualize.chart.line.description', 'Trends over a series'),
+		icon: 'codicon-graph-line',
+	},
+	{
+		id: 'scatter',
+		title: localize('positron.notebook.visualize.chart.scatter.title', 'Scatter'),
+		description: localize('positron.notebook.visualize.chart.scatter.description', 'Relationships between two variables'),
+		icon: 'codicon-graph-scatter',
+	},
+	{
+		id: 'histogram',
+		title: localize('positron.notebook.visualize.chart.histogram.title', 'Histogram'),
+		description: localize('positron.notebook.visualize.chart.histogram.description', 'Distribution of one variable'),
+		icon: 'codicon-graph-left',
+	},
+];
+
+const VisualizeModalDialog = (props: Props) => {
+	const [step, setStep] = useState<Step>('library');
+	const [library, setLibrary] = useState<VizLibrary>('plotly');
+	const [chartType, setChartType] = useState<ChartType>('bar');
+	const [dfName, setDfName] = useState(props.initialDfName);
+	const [xCol, setXCol] = useState('');
+	const [yCol, setYCol] = useState('');
+	const [insertMode, setInsertMode] = useState<InsertMode>('newCell');
+
+	// Track whether the user has manually changed each field so we don't
+	// stomp on their choice when the LLM suggestion arrives.
+	const userEditedLibrary = useRef(false);
+	const userEditedChart = useRef(false);
+	const userEditedColumns = useRef(false);
+
+	const [suggestion, setSuggestion] = useState<VisualizationSuggestion | null>(null);
+	const [suggestionState, setSuggestionState] = useState<'idle' | 'loading' | 'done' | 'failed'>(
+		props.suggestionPromise ? 'loading' : 'idle'
+	);
+
+	useEffect(() => {
+		if (!props.suggestionPromise) { return; }
+		let cancelled = false;
+		props.suggestionPromise.then((s) => {
+			if (cancelled) { return; }
+			if (!s) {
+				setSuggestionState('failed');
+				return;
+			}
+			setSuggestion(s);
+			setSuggestionState('done');
+			if (!userEditedLibrary.current) { setLibrary(s.library); }
+			if (!userEditedChart.current) { setChartType(s.chartType); }
+			if (!userEditedColumns.current) {
+				setXCol(s.xCol);
+				setYCol(s.yCol ?? '');
+			}
+		}).catch(() => {
+			if (!cancelled) { setSuggestionState('failed'); }
+		});
+		return () => { cancelled = true; };
+	}, [props.suggestionPromise]);
+
+	const onLibraryChange = (v: VizLibrary) => { userEditedLibrary.current = true; setLibrary(v); };
+	const onChartChange = (v: ChartType) => { userEditedChart.current = true; setChartType(v); };
+	const onXChange = (v: string) => { userEditedColumns.current = true; setXCol(v); };
+	const onYChange = (v: string) => { userEditedColumns.current = true; setYCol(v); };
+
+	const currentIdx = STEP_ORDER.indexOf(step);
+	const goBack = () => currentIdx > 0 && setStep(STEP_ORDER[currentIdx - 1]);
+	const goNext = () => currentIdx < STEP_ORDER.length - 1 && setStep(STEP_ORDER[currentIdx + 1]);
+
+	const trimmedDfName = dfName.trim();
+	const dfNameValid = isValidDataFrameExpr(trimmedDfName);
+	const xColPresent = xCol.trim().length > 0;
+	const yColPresent = yCol.trim().length > 0;
+	const canAdvance = step === 'columns'
+		? xColPresent && dfNameValid
+		: true;
+
+	const answers: VizAnswers = {
+		library,
+		chartType,
+		dfName: trimmedDfName,
+		x: xCol,
+		y: chartType !== 'histogram' && yColPresent ? yCol : undefined,
+	};
+
+	const isLastStep = step === 'insert';
+	const canInsert = dfNameValid && xColPresent;
+	const onOk = () => {
+		if (!canInsert) { return; }
+		props.onFinish({ answers, mode: insertMode });
+	};
+
+	const advanceOrSubmit = () => {
+		if (isLastStep) { onOk(); return; }
+		if (canAdvance) { goNext(); }
+	};
+
+	const generatedSource = codeSnippetToCellSource(generateVizCode(answers));
+
+	return (
+		<PositronModalDialog
+			height={560}
+			renderer={props.renderer}
+			title={localize('positron.notebook.visualize.title', 'Visualize dataframe')}
+			width={900}
+			onCancel={props.onCancel}
+		>
+			<ContentArea>
+				<div className='visualize-modal-content'>
+					<StepIndicator currentIdx={currentIdx} total={STEP_ORDER.length} />
+
+					{step === 'library' && (
+						<StepBody
+							subtitle={localize('positron.notebook.visualize.step.library.subtitle', 'We will generate code using the library you pick.')}
+							title={localize('positron.notebook.visualize.step.library.title', 'Choose a plotting library')}
+						>
+							<SuggestionBanner
+								reasoning={suggestion?.reasoning.library}
+								state={suggestionState}
+								suggestedLabel={suggestion && LIBRARY_CHOICES.find(c => c.id === suggestion.library)?.title}
+							/>
+							<ChoiceGrid
+								choices={LIBRARY_CHOICES}
+								selectedId={library}
+								suggestedId={suggestion?.library}
+								onSelect={onLibraryChange}
+							/>
+						</StepBody>
+					)}
+
+					{step === 'chart' && (
+						<StepBody
+							subtitle={localize('positron.notebook.visualize.step.chart.subtitle', 'Pick the shape that best fits your data.')}
+							title={localize('positron.notebook.visualize.step.chart.title', 'What kind of chart?')}
+						>
+							<SuggestionBanner
+								reasoning={suggestion?.reasoning.chartType}
+								state={suggestionState}
+								suggestedLabel={suggestion && CHART_CHOICES.find(c => c.id === suggestion.chartType)?.title}
+							/>
+							<ChoiceGrid
+								choices={CHART_CHOICES}
+								selectedId={chartType}
+								suggestedId={suggestion?.chartType}
+								onSelect={onChartChange}
+							/>
+						</StepBody>
+					)}
+
+					{step === 'columns' && (
+						<StepBody
+							subtitle={props.columns.length
+								? localize('positron.notebook.visualize.step.columns.subtitle.withColumns', 'Pick columns from your dataframe.')
+								: localize('positron.notebook.visualize.step.columns.subtitle.noColumns', 'Enter column names from your dataframe.')}
+							title={localize('positron.notebook.visualize.step.columns.title', 'Map your columns')}
+						>
+							<SuggestionBanner
+								reasoning={suggestion?.reasoning.columns}
+								state={suggestionState}
+								suggestedLabel={suggestion
+									? `x: ${suggestion.xCol}${suggestion.yCol ? `, y: ${suggestion.yCol}` : ''}`
+									: undefined}
+							/>
+							<div className='visualize-columns-form'>
+								<LabeledTextInput
+									error={trimmedDfName.length > 0 && !dfNameValid}
+									errorMsg={trimmedDfName.length > 0 && !dfNameValid
+										? localize('positron.notebook.visualize.dfName.invalid', 'Must be a Python name like "df" or "self.data".')
+										: undefined}
+									label={localize('positron.notebook.visualize.dfName.label', 'DataFrame variable')}
+									value={dfName}
+									onChange={(e) => setDfName(e.target.value)}
+								/>
+								<ColumnPicker
+									autoFocus
+									columns={props.columns}
+									label={localize('positron.notebook.visualize.xColumn.label', 'X column')}
+									value={xCol}
+									onChange={onXChange}
+								/>
+								{chartType !== 'histogram' && (
+									<ColumnPicker
+										allowClear
+										columns={props.columns}
+										label={localize('positron.notebook.visualize.yColumn.label', 'Y column (optional)')}
+										value={yCol}
+										onChange={onYChange}
+									/>
+								)}
+							</div>
+						</StepBody>
+					)}
+
+					{step === 'insert' && (
+						<StepBody
+							subtitle={localize('positron.notebook.visualize.step.insert.subtitle', 'Review the code and choose where it should land.')}
+							title={localize('positron.notebook.visualize.step.insert.title', 'Ready to visualize')}
+						>
+							<CodePreview source={generatedSource} />
+							<div className='visualize-insert-mode'>
+								<InsertModeOption
+									description={localize('positron.notebook.visualize.insertMode.newCell.description', 'Keep your exploration cell unchanged.')}
+									icon='codicon-add'
+									selected={insertMode === 'newCell'}
+									title={localize('positron.notebook.visualize.insertMode.newCell.title', 'Insert as new cell below')}
+									onSelect={() => setInsertMode('newCell')}
+								/>
+								<InsertModeOption
+									description={localize('positron.notebook.visualize.insertMode.append.description', 'Add the plot to the end of the current cell.')}
+									icon='codicon-arrow-down'
+									selected={insertMode === 'append'}
+									title={localize('positron.notebook.visualize.insertMode.append.title', 'Append to this cell')}
+									onSelect={() => setInsertMode('append')}
+								/>
+							</div>
+						</StepBody>
+					)}
+				</div>
+			</ContentArea>
+
+			<OKCancelBackNextActionBar
+				backButtonConfig={{
+					disable: currentIdx === 0,
+					onClick: goBack,
+				}}
+				cancelButtonConfig={{ onClick: props.onCancel }}
+				nextButtonConfig={isLastStep ? undefined : {
+					disable: !canAdvance,
+					onClick: advanceOrSubmit,
+				}}
+				okButtonConfig={isLastStep ? {
+					title: localize('positron.notebook.visualize.insert', 'Insert'),
+					disable: !canInsert,
+					onClick: advanceOrSubmit,
+				} : undefined}
+			/>
+		</PositronModalDialog>
+	);
+};
+
+function StepIndicator({ currentIdx, total }: { currentIdx: number; total: number }) {
+	return (
+		<div aria-hidden className='visualize-step-indicator'>
+			{Array.from({ length: total }, (_, i) => (
+				<span
+					key={i}
+					className={positronClassNames('visualize-step-dot', {
+						active: i === currentIdx,
+						completed: i < currentIdx,
+					})}
+				/>
+			))}
+		</div>
+	);
+}
+
+function StepBody({ title, subtitle, children }: { title: string; subtitle: string; children: React.ReactNode }) {
+	return (
+		<div className='visualize-step-body'>
+			<h2 className='visualize-step-title'>{title}</h2>
+			<p className='visualize-step-subtitle'>{subtitle}</p>
+			{children}
+		</div>
+	);
+}
+
+function ChoiceGrid<T extends string>({ choices, selectedId, suggestedId, onSelect }: {
+	choices: Choice<T>[];
+	selectedId: T;
+	suggestedId?: T;
+	onSelect: (id: T) => void;
+}) {
+	return (
+		<div className='visualize-choice-grid'>
+			{choices.map((c) => {
+				const isSelected = c.id === selectedId;
+				const isSuggested = c.id === suggestedId;
+				return (
+					<button
+						key={c.id}
+						aria-pressed={isSelected}
+						className={positronClassNames('visualize-choice-card', {
+							selected: isSelected,
+							suggested: isSuggested && !isSelected,
+						})}
+						type='button'
+						onClick={() => onSelect(c.id)}
+					>
+						<span className={positronClassNames('visualize-choice-icon', 'codicon', c.icon)} />
+						<span className='visualize-choice-text'>
+							<span className='visualize-choice-title'>
+								{c.title}
+								{isSuggested && (
+									<span
+										className='visualize-choice-badge'
+										title={localize('positron.notebook.visualize.suggestion.badgeTooltip', 'Suggested by the assistant')}
+									>
+										<span className='codicon codicon-sparkle' />
+										{localize('positron.notebook.visualize.suggestion.badge', 'Suggested')}
+									</span>
+								)}
+							</span>
+							<span className='visualize-choice-description'>{c.description}</span>
+						</span>
+					</button>
+				);
+			})}
+		</div>
+	);
+}
+
+/**
+ * Status banner for the LLM suggestion path: idle/loading/done/failed.
+ * Mounted in this change but only ever sees `idle` because no
+ * `suggestionPromise` is supplied yet -- the producer lands in a
+ * follow-up.
+ */
+function SuggestionBanner({ state, reasoning, suggestedLabel }: {
+	state: 'idle' | 'loading' | 'done' | 'failed';
+	reasoning?: string;
+	suggestedLabel?: string | null;
+}) {
+	if (state === 'idle') { return null; }
+	if (state === 'loading') {
+		return (
+			<div className='visualize-suggestion-banner loading'>
+				<span className='codicon codicon-loading codicon-modifier-spin' />
+				<span>{localize('positron.notebook.visualize.suggestion.loading', 'Thinking about the best choice for your data...')}</span>
+			</div>
+		);
+	}
+	if (state === 'failed') {
+		return (
+			<div className='visualize-suggestion-banner failed'>
+				<span className='codicon codicon-info' />
+				<span>{localize('positron.notebook.visualize.suggestion.failed', 'Assistant suggestion unavailable. Pick manually below.')}</span>
+			</div>
+		);
+	}
+	if (!reasoning && !suggestedLabel) { return null; }
+	return (
+		<div className='visualize-suggestion-banner done'>
+			<span className='codicon codicon-sparkle' />
+			<div className='visualize-suggestion-banner-text'>
+				{suggestedLabel && (
+					<span className='visualize-suggestion-banner-label'>
+						{localize('positron.notebook.visualize.suggestion.suggestedPrefix', 'Suggested:')} <strong>{suggestedLabel}</strong>
+					</span>
+				)}
+				{reasoning && (
+					<span className='visualize-suggestion-banner-reason'>{reasoning}</span>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function InsertModeOption({ title, description, icon, selected, onSelect }: {
+	title: string;
+	description: string;
+	icon: string;
+	selected: boolean;
+	onSelect: () => void;
+}) {
+	return (
+		<button
+			aria-pressed={selected}
+			className={positronClassNames('visualize-insert-option', { selected })}
+			type='button'
+			onClick={onSelect}
+		>
+			<span className={positronClassNames('visualize-insert-icon', 'codicon', icon)} />
+			<span className='visualize-insert-text'>
+				<span className='visualize-insert-title'>{title}</span>
+				<span className='visualize-insert-description'>{description}</span>
+			</span>
+		</button>
+	);
+}
+
+function CodePreview({ source }: { source: string }) {
+	return (
+		<pre className='visualize-code-preview'>
+			<code>{source}</code>
+		</pre>
+	);
+}
+
+function ColumnPicker({ label, value, onChange, columns, autoFocus, allowClear }: {
+	label: string;
+	value: string;
+	onChange: (v: string) => void;
+	columns: DataFrameColumn[];
+	autoFocus?: boolean;
+	allowClear?: boolean;
+}) {
+	const hasColumns = columns.length > 0;
+
+	// Dropdown autoFocus: LabeledTextInput handles its own autoFocus via
+	// the native input attribute; DropDownListBox doesn't, so focus the
+	// button ourselves on mount.
+	const dropdownRef = useRef<HTMLButtonElement>(null);
+	const didAutoFocusRef = useRef(false);
+	useEffect(() => {
+		if (autoFocus && hasColumns && !didAutoFocusRef.current) {
+			dropdownRef.current?.focus();
+			didAutoFocusRef.current = true;
+		}
+	}, [autoFocus, hasColumns]);
+
+	// Fallback when the dataframe wasn't inspectable -- the dropdown would
+	// be empty, so let the user type a column name.
+	if (!hasColumns) {
+		return (
+			<LabeledTextInput
+				autoFocus={autoFocus}
+				label={label}
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+			/>
+		);
+	}
+
+	const entries: DropDownListBoxEntry<string, string>[] = columns.map(c =>
+		new DropDownListBoxItem<string, string>({
+			identifier: c.name,
+			title: `${c.name}   ${c.type}`,
+			value: c.name,
+		})
+	);
+	// Identify the "None" / clear entry by reference rather than by
+	// identifier string, so a column literally named (e.g.) "None" can't
+	// be misinterpreted as a clear action.
+	const clearEntry = allowClear
+		? new DropDownListBoxItem<string, string>({
+			identifier: '',
+			title: localize('positron.notebook.visualize.columnPicker.none', 'None'),
+			value: '',
+		})
+		: null;
+	if (clearEntry) {
+		entries.push(new DropDownListBoxSeparator());
+		entries.push(clearEntry);
+	}
+
+	return (
+		<div className='visualize-column-picker'>
+			<span className='visualize-column-picker-label'>{label}</span>
+			<DropDownListBox<string, string>
+				ref={dropdownRef}
+				entries={entries}
+				selectedIdentifier={value || undefined}
+				title={localize('positron.notebook.visualize.columnPicker.placeholder', 'Select a column')}
+				onSelectionChanged={(item) => {
+					if (item === clearEntry) {
+						onChange('');
+					} else {
+						onChange(item.options.value);
+					}
+				}}
+			/>
+		</div>
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizePreview.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizePreview.tsx
@@ -16,6 +16,7 @@ import {
 	RuntimeErrorBehavior,
 } from '../../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
+import { VizLibrary } from './generateVizCode.js';
 
 // Workspace-scoped key for the live preview on/off preference. Lives in
 // IStorageService so flipping the toggle does not dirty the notebook file.
@@ -27,6 +28,7 @@ const CLEANUP_TIMEOUT_MS = 15_000;
 type PreviewState =
 	| { status: 'idle' }
 	| { status: 'disabled' }
+	| { status: 'unsupported-library' }
 	| { status: 'no-runtime' }
 	| { status: 'loading' }
 	| { status: 'success'; mime: 'text/html' | 'image/png' | 'image/svg+xml'; data: string }
@@ -37,11 +39,22 @@ interface Props {
 	code: string;
 	/** The notebook's URI, used to find the runtime session. */
 	notebookUri: URI;
+	/**
+	 * Library the user picked. Plotly emits an `application/vnd.plotly.v1+json`
+	 * mime bundle that the simple iframe path here doesn't render, so we
+	 * surface a clear "not supported" state instead of leaving the user on
+	 * "Rendering preview..." until the cleanup timer fires.
+	 */
+	library: VizLibrary;
 }
 
-export function VisualizePreview({ code, notebookUri }: Props) {
+export function VisualizePreview({ code, notebookUri, library }: Props) {
 	const services = usePositronReactServicesContext();
 	const [state, setState] = useState<PreviewState>({ status: 'idle' });
+	// Bumped when a runtime session for `notebookUri` becomes available, so
+	// the main effect re-runs and we transition out of `no-runtime` instead
+	// of staying stuck after a kernel attaches mid-dialog.
+	const [sessionAttachTick, setSessionAttachTick] = useState(0);
 	const latestExecIdRef = useRef<string>('');
 	// Track the in-flight subscription store and its auto-dispose timer so
 	// effect re-runs (rapid edits, code cleared) tear them down immediately
@@ -67,9 +80,29 @@ export function VisualizePreview({ code, notebookUri }: Props) {
 		);
 	};
 
+	// While we don't have a runtime session attached, listen for one starting
+	// against this notebookUri and bump a tick so the main effect re-evaluates.
+	// Doing it in its own effect (rather than reaching into the main effect's
+	// state) keeps the subscription scope independent of debounce/cleanup.
+	useEffect(() => {
+		const disposable = services.runtimeSessionService.onDidStartRuntime((session) => {
+			if (session.metadata.notebookUri?.toString() === notebookUri.toString()) {
+				setSessionAttachTick(t => t + 1);
+			}
+		});
+		return () => disposable.dispose();
+	}, [services.runtimeSessionService, notebookUri]);
+
 	useEffect(() => {
 		if (!enabled) {
 			setState({ status: 'disabled' });
+			return;
+		}
+		if (library === 'plotly') {
+			// Plotly's renderer emits a non-HTML mime bundle that we don't
+			// route through a webview yet. Bail out before scheduling the
+			// kernel run -- the result wouldn't be displayable.
+			setState({ status: 'unsupported-library' });
 			return;
 		}
 		if (!code.trim()) {
@@ -165,7 +198,7 @@ export function VisualizePreview({ code, notebookUri }: Props) {
 			activeDisposablesRef.current = null;
 			latestExecIdRef.current = '';
 		};
-	}, [code, notebookUri, services.runtimeSessionService, enabled]);
+	}, [code, notebookUri, services.runtimeSessionService, enabled, library, sessionAttachTick]);
 
 	return (
 		<div className='visualize-preview'>
@@ -230,6 +263,14 @@ function renderBody(state: PreviewState, onToggle: () => void) {
 					hint={localize('positron.notebook.visualize.preview.noRuntime.hint', 'Start a kernel for this notebook and try again.')}
 					icon='codicon-debug-disconnect'
 					title={localize('positron.notebook.visualize.preview.noRuntime.title', 'No runtime attached')}
+				/>
+			);
+		case 'unsupported-library':
+			return (
+				<PreviewMessage
+					hint={localize('positron.notebook.visualize.preview.unsupportedLibrary.hint', 'Live preview is only available for Matplotlib and Seaborn right now. Inserting still works.')}
+					icon='codicon-info'
+					title={localize('positron.notebook.visualize.preview.unsupportedLibrary.title', 'Preview not available for this library')}
 				/>
 			);
 		case 'loading':

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizePreview.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizePreview.tsx
@@ -30,6 +30,7 @@ type PreviewState =
 	| { status: 'disabled' }
 	| { status: 'unsupported-library' }
 	| { status: 'no-runtime' }
+	| { status: 'needs-dfname' }
 	| { status: 'loading' }
 	| { status: 'success'; mime: 'text/html' | 'image/png' | 'image/svg+xml'; data: string }
 	| { status: 'error'; message: string };
@@ -46,9 +47,11 @@ interface Props {
 	 * "Rendering preview..." until the cleanup timer fires.
 	 */
 	library: VizLibrary;
+	/** True when the user has chosen columns but dfName is missing or invalid. */
+	needsDfName?: boolean;
 }
 
-export function VisualizePreview({ code, notebookUri, library }: Props) {
+export function VisualizePreview({ code, notebookUri, library, needsDfName }: Props) {
 	const services = usePositronReactServicesContext();
 	const [state, setState] = useState<PreviewState>({ status: 'idle' });
 	// Bumped when a runtime session for `notebookUri` becomes available, so
@@ -103,6 +106,10 @@ export function VisualizePreview({ code, notebookUri, library }: Props) {
 			// route through a webview yet. Bail out before scheduling the
 			// kernel run -- the result wouldn't be displayable.
 			setState({ status: 'unsupported-library' });
+			return;
+		}
+		if (needsDfName) {
+			setState({ status: 'needs-dfname' });
 			return;
 		}
 		if (!code.trim()) {
@@ -198,7 +205,7 @@ export function VisualizePreview({ code, notebookUri, library }: Props) {
 			activeDisposablesRef.current = null;
 			latestExecIdRef.current = '';
 		};
-	}, [code, notebookUri, services.runtimeSessionService, enabled, library, sessionAttachTick]);
+	}, [code, notebookUri, services.runtimeSessionService, enabled, library, needsDfName, sessionAttachTick]);
 
 	return (
 		<div className='visualize-preview'>
@@ -255,6 +262,14 @@ function renderBody(state: PreviewState, onToggle: () => void) {
 					hint={localize('positron.notebook.visualize.preview.disabled.hint', 'Skip running code in the kernel until you turn it back on.')}
 					icon='codicon-eye-closed'
 					title={localize('positron.notebook.visualize.preview.disabled.title', 'Live preview is off')}
+				/>
+			);
+		case 'needs-dfname':
+			return (
+				<PreviewMessage
+					hint={localize('positron.notebook.visualize.preview.needsDfName.hint', 'Enter a valid DataFrame variable name on the columns step.')}
+					icon='codicon-info'
+					title={localize('positron.notebook.visualize.preview.needsDfName.title', 'DataFrame variable needed')}
 				/>
 			);
 		case 'no-runtime':

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizePreview.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizePreview.tsx
@@ -1,0 +1,299 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { useEffect, useRef, useState } from 'react';
+import { localize } from '../../../../../../nls.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
+import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
+import {
+	ILanguageRuntimeMessageError,
+	ILanguageRuntimeMessageOutput,
+	ILanguageRuntimeMessageResult,
+	RuntimeCodeExecutionMode,
+	RuntimeErrorBehavior,
+} from '../../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { StorageScope, StorageTarget } from '../../../../../../platform/storage/common/storage.js';
+
+// Workspace-scoped key for the live preview on/off preference. Lives in
+// IStorageService so flipping the toggle does not dirty the notebook file.
+const LIVE_PREVIEW_STORAGE_KEY = 'positronNotebook.visualize.livePreview';
+
+const DEBOUNCE_MS = 400;
+const CLEANUP_TIMEOUT_MS = 15_000;
+
+type PreviewState =
+	| { status: 'idle' }
+	| { status: 'disabled' }
+	| { status: 'no-runtime' }
+	| { status: 'loading' }
+	| { status: 'success'; mime: 'text/html' | 'image/png' | 'image/svg+xml'; data: string }
+	| { status: 'error'; message: string };
+
+interface Props {
+	/** The full Python snippet to execute. Pass empty string to clear. */
+	code: string;
+	/** The notebook's URI, used to find the runtime session. */
+	notebookUri: URI;
+}
+
+export function VisualizePreview({ code, notebookUri }: Props) {
+	const services = usePositronReactServicesContext();
+	const [state, setState] = useState<PreviewState>({ status: 'idle' });
+	const latestExecIdRef = useRef<string>('');
+	// Track the in-flight subscription store and its auto-dispose timer so
+	// effect re-runs (rapid edits, code cleared) tear them down immediately
+	// instead of waiting out the 15s grace period.
+	const activeDisposablesRef = useRef<DisposableStore | null>(null);
+	const cleanupTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+	// Preference is persisted per-workspace via IStorageService so toggling
+	// does not dirty the notebook file or require a contributed user setting.
+	// Default: on.
+	const [enabled, setEnabled] = useState(() =>
+		services.storageService.getBoolean(LIVE_PREVIEW_STORAGE_KEY, StorageScope.WORKSPACE, true)
+	);
+
+	const toggleEnabled = () => {
+		const next = !enabled;
+		setEnabled(next);
+		services.storageService.store(
+			LIVE_PREVIEW_STORAGE_KEY,
+			next,
+			StorageScope.WORKSPACE,
+			StorageTarget.USER,
+		);
+	};
+
+	useEffect(() => {
+		if (!enabled) {
+			setState({ status: 'disabled' });
+			return;
+		}
+		if (!code.trim()) {
+			setState({ status: 'idle' });
+			return;
+		}
+
+		const session = services.runtimeSessionService.getNotebookSessionForNotebookUri(notebookUri);
+		if (!session) {
+			setState({ status: 'no-runtime' });
+			return;
+		}
+
+		const debounceTimer = setTimeout(() => {
+			// Tear down any prior run that slipped through (e.g. the outer
+			// cleanup hasn't fired yet) before starting a new one.
+			activeDisposablesRef.current?.dispose();
+			clearTimeout(cleanupTimerRef.current);
+
+			const execId = `viz-preview-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+			latestExecIdRef.current = execId;
+			setState({ status: 'loading' });
+
+			const disposables = new DisposableStore();
+			activeDisposablesRef.current = disposables;
+
+			const matches = (msg: { parent_id: string }) =>
+				msg.parent_id === execId && latestExecIdRef.current === execId;
+
+			const handleDisplay = (msg: ILanguageRuntimeMessageOutput | ILanguageRuntimeMessageResult) => {
+				if (!matches(msg)) { return; }
+				const html = msg.data['text/html'];
+				const png = msg.data['image/png'];
+				const svg = msg.data['image/svg+xml'];
+				if (html) {
+					setState({ status: 'success', mime: 'text/html', data: html });
+				} else if (svg) {
+					setState({ status: 'success', mime: 'image/svg+xml', data: svg });
+				} else if (png) {
+					setState({ status: 'success', mime: 'image/png', data: png });
+				} else {
+					// A matching message arrived but carried no MIME we can render.
+					// Without this terminal transition the preview would stay on
+					// 'loading' until the cleanup timer fires.
+					setState({
+						status: 'error',
+						message: localize('positron.notebook.visualize.preview.error.unsupportedMime', 'Preview format not supported.'),
+					});
+				}
+			};
+
+			disposables.add(session.onDidReceiveRuntimeMessageOutput(handleDisplay));
+			disposables.add(session.onDidReceiveRuntimeMessageResult(handleDisplay));
+			disposables.add(session.onDidReceiveRuntimeMessageError((msg: ILanguageRuntimeMessageError) => {
+				if (!matches(msg)) { return; }
+				const raw = msg.message || msg.name
+					|| localize('positron.notebook.visualize.preview.error.fallback', 'Execution error');
+				// Trim common Python traceback noise to the last meaningful line.
+				const lines = raw.split(/\r?\n/).filter(l => l.trim().length > 0);
+				const summary = lines[lines.length - 1] ?? raw;
+				setState({ status: 'error', message: summary });
+			}));
+
+			try {
+				session.execute(
+					code,
+					execId,
+					RuntimeCodeExecutionMode.Silent,
+					RuntimeErrorBehavior.Continue,
+				);
+			} catch (err) {
+				setState({ status: 'error', message: err instanceof Error ? err.message : String(err) });
+				disposables.dispose();
+				return;
+			}
+
+			// Auto-dispose subscriptions after a generous timeout to catch
+			// trailing messages that arrive after the success/error path
+			// fires. `latestExecIdRef` still skips stale messages, so this
+			// is belt-and-suspenders.
+			cleanupTimerRef.current = setTimeout(() => {
+				disposables.dispose();
+				if (activeDisposablesRef.current === disposables) {
+					activeDisposablesRef.current = null;
+				}
+			}, CLEANUP_TIMEOUT_MS);
+		}, DEBOUNCE_MS);
+
+		return () => {
+			clearTimeout(debounceTimer);
+			clearTimeout(cleanupTimerRef.current);
+			activeDisposablesRef.current?.dispose();
+			activeDisposablesRef.current = null;
+			latestExecIdRef.current = '';
+		};
+	}, [code, notebookUri, services.runtimeSessionService, enabled]);
+
+	return (
+		<div className='visualize-preview'>
+			<div className='visualize-preview-header'>
+				<span className='codicon codicon-graph' />
+				<span className='visualize-preview-header-title'>
+					{localize('positron.notebook.visualize.preview.header', 'Live preview')}
+				</span>
+				<button
+					aria-checked={enabled}
+					aria-label={localize('positron.notebook.visualize.preview.toggle.label', 'Toggle live preview')}
+					className={`visualize-preview-toggle${enabled ? ' on' : ''}`}
+					role='switch'
+					title={enabled
+						? localize('positron.notebook.visualize.preview.toggle.tooltipOn', 'Live preview is on. Click to turn off.')
+						: localize('positron.notebook.visualize.preview.toggle.tooltipOff', 'Live preview is off. Click to turn on.')}
+					type='button'
+					onClick={toggleEnabled}
+				>
+					<span className='visualize-preview-toggle-track'>
+						<span className='visualize-preview-toggle-thumb' />
+					</span>
+					<span className='visualize-preview-toggle-label'>
+						{enabled
+							? localize('positron.notebook.visualize.preview.toggle.on', 'On')
+							: localize('positron.notebook.visualize.preview.toggle.off', 'Off')}
+					</span>
+				</button>
+			</div>
+			<div className='visualize-preview-body'>
+				{renderBody(state, toggleEnabled)}
+			</div>
+		</div>
+	);
+}
+
+function renderBody(state: PreviewState, onToggle: () => void) {
+	switch (state.status) {
+		case 'idle':
+			return (
+				<PreviewMessage
+					hint={localize('positron.notebook.visualize.preview.idle.hint', 'Pick a library, chart type, and columns.')}
+					icon='codicon-info'
+					title={localize('positron.notebook.visualize.preview.idle.title', 'Nothing to preview yet')}
+				/>
+			);
+		case 'disabled':
+			return (
+				<PreviewMessage
+					action={{
+						label: localize('positron.notebook.visualize.preview.disabled.action', 'Turn preview on'),
+						onClick: onToggle,
+					}}
+					hint={localize('positron.notebook.visualize.preview.disabled.hint', 'Skip running code in the kernel until you turn it back on.')}
+					icon='codicon-eye-closed'
+					title={localize('positron.notebook.visualize.preview.disabled.title', 'Live preview is off')}
+				/>
+			);
+		case 'no-runtime':
+			return (
+				<PreviewMessage
+					hint={localize('positron.notebook.visualize.preview.noRuntime.hint', 'Start a kernel for this notebook and try again.')}
+					icon='codicon-debug-disconnect'
+					title={localize('positron.notebook.visualize.preview.noRuntime.title', 'No runtime attached')}
+				/>
+			);
+		case 'loading':
+			return (
+				<PreviewMessage
+					hint={localize('positron.notebook.visualize.preview.loading.hint', 'Running your snippet in the kernel.')}
+					icon='codicon-loading codicon-modifier-spin'
+					title={localize('positron.notebook.visualize.preview.loading.title', 'Rendering preview...')}
+				/>
+			);
+		case 'success':
+			if (state.mime === 'text/html') {
+				return (
+					<iframe
+						className='visualize-preview-iframe'
+						sandbox='allow-scripts'
+						srcDoc={state.data}
+						title={localize('positron.notebook.visualize.preview.iframeTitle', 'Chart preview')}
+					/>
+				);
+			}
+			// PNG arrives base64-encoded; SVG arrives as raw XML (URL-encoded for the data URI).
+			return (
+				<img
+					alt={localize('positron.notebook.visualize.preview.imageAlt', 'Generated chart preview')}
+					className='visualize-preview-image'
+					src={state.mime === 'image/svg+xml'
+						? `data:image/svg+xml;utf8,${encodeURIComponent(state.data)}`
+						: `data:image/png;base64,${state.data}`}
+				/>
+			);
+		case 'error':
+			return (
+				<PreviewMessage
+					hint={state.message}
+					icon='codicon-warning'
+					title={localize('positron.notebook.visualize.preview.error.title', 'Preview failed')}
+					tone='error'
+				/>
+			);
+	}
+}
+
+function PreviewMessage({ icon, title, hint, tone, action }: {
+	icon: string;
+	title: string;
+	hint?: string;
+	tone?: 'error';
+	action?: { label: string; onClick: () => void };
+}) {
+	return (
+		<div className={`visualize-preview-message${tone ? ` ${tone}` : ''}`}>
+			<span className={`visualize-preview-message-icon codicon ${icon}`} />
+			<span className='visualize-preview-message-title'>{title}</span>
+			{hint && <span className='visualize-preview-message-hint'>{hint}</span>}
+			{action && (
+				<button
+					className='visualize-preview-message-action'
+					type='button'
+					onClick={action.onClick}
+				>
+					{action.label}
+				</button>
+			)}
+		</div>
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/InlineDataExplorer.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/InlineDataExplorer.css
@@ -63,6 +63,12 @@ with the Quarto-style overlay layout. */
 	min-width: 0;
 }
 
+.inline-data-explorer-header-actions {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
 .inline-data-explorer-title {
 	font-weight: 500;
 	color: var(--vscode-foreground);

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -11,6 +11,7 @@ import './contrib/outline/positronNotebookOutline.contribution.js';
 
 // Self-registering Action2 contributions
 import './notebookCells/InlineDataExplorerActions.js';
+import './contrib/visualize/VisualizeAction.js';
 
 import { isCopyImageMenuArg, toBase64DataUrl } from './copyImageUtils.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/applyVisualizeResult.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/applyVisualizeResult.vitest.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import {
+	buildAppendText,
+	hasImportsVerbatim,
+} from '../../../../browser/contrib/visualize/applyVisualizeResult.js';
+
+describe('applyVisualizeResult helpers', () => {
+	describe('hasImportsVerbatim', () => {
+		it('returns true when every import line appears as its own line in the cell', () => {
+			const existing = `import numpy as np\nimport pandas as pd\n\ndf = pd.read_csv("x.csv")\n`;
+			expect(hasImportsVerbatim(existing, 'import pandas as pd')).toBe(true);
+		});
+
+		it('returns true for a multi-line import block where every line matches', () => {
+			const existing = `import numpy as np\nimport pandas as pd\nimport plotly.express as px\n`;
+			expect(hasImportsVerbatim(existing, 'import pandas as pd\nimport plotly.express as px')).toBe(true);
+		});
+
+		it('returns false when the import line is only a prefix of an existing line', () => {
+			const existing = `import pandas as pd\n`;
+			expect(hasImportsVerbatim(existing, 'import pandas')).toBe(false);
+		});
+
+		it('returns false when the import block is absent', () => {
+			const existing = `import pandas as pd\n`;
+			expect(hasImportsVerbatim(existing, 'from pandas import DataFrame')).toBe(false);
+		});
+	});
+
+	describe('buildAppendText', () => {
+		const snippet = { imports: 'import plotly.express as px', body: 'fig = px.bar(df, x="a")\nfig.show()' };
+
+		it('prepends imports when not already present', () => {
+			const existing = `df = pd.DataFrame()\ndf`;
+			const appended = buildAppendText(existing, snippet);
+			expect(appended.startsWith('\n\nimport plotly.express as px')).toBe(true);
+			expect(appended).toContain('fig = px.bar(df, x="a")');
+		});
+
+		it('omits imports when already present verbatim', () => {
+			const existing = `import plotly.express as px\n\ndf`;
+			const appended = buildAppendText(existing, snippet);
+			expect(appended.includes('import plotly.express as px')).toBe(false);
+			expect(appended.startsWith('\n\nfig =')).toBe(true);
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/generateVizCode.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/generateVizCode.vitest.ts
@@ -1,0 +1,134 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import {
+	codeSnippetToCellSource,
+	generateVizCode,
+	isValidDataFrameExpr,
+	pythonString,
+	VizAnswers,
+} from '../../../../browser/contrib/visualize/generateVizCode.js';
+
+describe('generateVizCode', () => {
+	describe('pythonString', () => {
+		it('wraps plain text in double quotes', () => {
+			expect(pythonString('price')).toBe('"price"');
+		});
+
+		it('escapes embedded double quotes', () => {
+			expect(pythonString(`customer's "price"`)).toBe(`"customer's \\"price\\""`);
+		});
+
+		it('escapes backslashes, newlines, tabs, and carriage returns', () => {
+			expect(pythonString('a\\b\nc\td\re')).toBe('"a\\\\b\\nc\\td\\re"');
+		});
+	});
+
+	describe('isValidDataFrameExpr', () => {
+		it('accepts bare identifiers', () => {
+			expect(isValidDataFrameExpr('df')).toBe(true);
+			expect(isValidDataFrameExpr('my_frame')).toBe(true);
+			expect(isValidDataFrameExpr('_DF')).toBe(true);
+		});
+
+		it('accepts dotted attribute paths', () => {
+			expect(isValidDataFrameExpr('self.data')).toBe(true);
+			expect(isValidDataFrameExpr('obj.nested.frame')).toBe(true);
+		});
+
+		it('accepts bracket access with string literal', () => {
+			expect(isValidDataFrameExpr('frames["main"]')).toBe(true);
+			expect(isValidDataFrameExpr(`frames['main']`)).toBe(true);
+		});
+
+		it('rejects invalid expressions', () => {
+			expect(isValidDataFrameExpr('1df')).toBe(false);
+			expect(isValidDataFrameExpr('df; import os')).toBe(false);
+			expect(isValidDataFrameExpr('df()')).toBe(false);
+			expect(isValidDataFrameExpr('df + 1')).toBe(false);
+			expect(isValidDataFrameExpr('')).toBe(false);
+			expect(isValidDataFrameExpr('   ')).toBe(false);
+			expect(isValidDataFrameExpr('df[0]')).toBe(false); // must be string literal, not int index
+		});
+	});
+
+	describe('library-specific templates', () => {
+		const base: VizAnswers = { library: 'plotly', chartType: 'bar', dfName: 'df', x: 'price', y: 'qty' };
+
+		it('plotly bar with x and y', () => {
+			const snippet = generateVizCode({ ...base, library: 'plotly', chartType: 'bar' });
+			expect(snippet.imports).toContain('plotly.express');
+			expect(snippet.body).toBe(`fig = px.bar(df, x="price", y="qty")\nfig.show()`);
+		});
+
+		it('plotly histogram includes y when provided', () => {
+			const snippet = generateVizCode({ ...base, library: 'plotly', chartType: 'histogram' });
+			expect(snippet.body).toBe(`fig = px.histogram(df, x="price", y="qty")\nfig.show()`);
+		});
+
+		it('seaborn uses an explicit chart-type function mapping', () => {
+			const hist = generateVizCode({ ...base, library: 'seaborn', chartType: 'histogram' });
+			expect(hist.body.startsWith('sns.histplot(')).toBe(true);
+			const scatter = generateVizCode({ ...base, library: 'seaborn', chartType: 'scatter' });
+			expect(scatter.body.startsWith('sns.scatterplot(')).toBe(true);
+		});
+
+		it('matplotlib bar with y uses explicit axes', () => {
+			const snippet = generateVizCode({ ...base, library: 'matplotlib', chartType: 'bar' });
+			expect(snippet.body).toContain(`plt.bar(df["price"], df["qty"])`);
+			expect(snippet.body).toContain('plt.xlabel("price")');
+			expect(snippet.body).toContain('plt.ylabel("qty")');
+		});
+
+		it('matplotlib bar without y uses value_counts()', () => {
+			const snippet = generateVizCode({ ...base, library: 'matplotlib', chartType: 'bar', y: undefined });
+			expect(snippet.body).toContain('value_counts().values');
+			expect(snippet.body).toContain('value_counts().index');
+		});
+
+		it('matplotlib scatter without y falls back to the index', () => {
+			const snippet = generateVizCode({ ...base, library: 'matplotlib', chartType: 'scatter', y: undefined });
+			expect(snippet.body).toContain(`plt.scatter(df["price"], df.index)`);
+		});
+
+		it('matplotlib histogram uses plt.hist', () => {
+			const snippet = generateVizCode({ ...base, library: 'matplotlib', chartType: 'histogram', y: undefined });
+			expect(snippet.body.startsWith('plt.hist(df["price"])')).toBe(true);
+		});
+	});
+
+	describe('column-name safety', () => {
+		it('quotes a column with a space', () => {
+			const snippet = generateVizCode({
+				library: 'plotly', chartType: 'bar', dfName: 'df', x: 'total sales', y: 'region',
+			});
+			expect(snippet.body).toContain(`x="total sales"`);
+			expect(snippet.body).toContain(`y="region"`);
+		});
+
+		it('escapes a column name with a quote', () => {
+			const snippet = generateVizCode({
+				library: 'matplotlib', chartType: 'histogram', dfName: 'df', x: `customer's "age"`,
+			});
+			expect(snippet.body).toContain(`df["customer's \\"age\\""]`);
+		});
+
+		it('supports dotted dataframe references', () => {
+			const snippet = generateVizCode({
+				library: 'plotly', chartType: 'bar', dfName: 'self.data', x: 'a', y: 'b',
+			});
+			expect(snippet.body).toContain(`px.bar(self.data, x="a", y="b")`);
+		});
+	});
+
+	describe('codeSnippetToCellSource', () => {
+		it('joins imports and body with a blank line and trailing newline', () => {
+			const result = codeSnippetToCellSource({ imports: 'import x', body: 'x.do()' });
+			expect(result).toBe('import x\n\nx.do()\n');
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizeAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizeAction.vitest.ts
@@ -174,13 +174,13 @@ describe('VisualizeDataFrameAction', () => {
 			expect(getInitialDfName()).toBe('df');
 		});
 
-		it('falls back to title for multi-segment variablePath', async () => {
+		it('leaves prefill empty for multi-segment variablePath even when title is valid', async () => {
 			await run(buildContext({
 				title: 'main',
 				variablePath: [encodeAccessKey('frames'), encodeAccessKey('main')],
 			}));
 
-			expect(getInitialDfName()).toBe('main');
+			expect(getInitialDfName()).toBe('');
 		});
 
 		it('falls back to title when variablePath is missing and title is valid', async () => {
@@ -195,10 +195,10 @@ describe('VisualizeDataFrameAction', () => {
 			expect(getInitialDfName()).toBe('');
 		});
 
-		it('handles a raw (non-JSON) variablePath segment as a fallback', async () => {
+		it('handles a raw (non-JSON) variablePath segment from an older kernel', async () => {
 			await run(buildContext({ title: 'other', variablePath: ['df'] }));
 
-			expect(getInitialDfName()).toBe('other');
+			expect(getInitialDfName()).toBe('df');
 		});
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizeAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizeAction.vitest.ts
@@ -70,12 +70,16 @@ describe('VisualizeDataFrameAction', () => {
 		return stubInterface<IPositronNotebookInstance>({});
 	}
 
+	function encodeAccessKey(name: string): string {
+		return JSON.stringify({ type: 'str', data: name });
+	}
+
 	function buildContext(overrides: Partial<IInlineDataExplorerActionContext> = {}): IInlineDataExplorerActionContext {
 		return {
 			documentUri: URI.parse('file:///nb.ipynb'),
 			sourceLanguage: 'python',
 			commId: 'comm-1',
-			variablePath: ['df'],
+			variablePath: [encodeAccessKey('df')],
 			title: 'df',
 			shape: { rows: 10, columns: 2 },
 			gridInstance: fakeGrid(),
@@ -164,18 +168,19 @@ describe('VisualizeDataFrameAction', () => {
 			mockShowVisualizeModalDialog.mockResolvedValue(undefined);
 		});
 
-		it('prefers a valid single-segment variablePath over a different valid title', async () => {
-			// Display title is syntactically valid but points at a different
-			// object; source-path metadata is authoritative.
-			await run(buildContext({ title: 'main', variablePath: ['df'] }));
+		it('decodes an encoded access key from variablePath', async () => {
+			await run(buildContext({ title: 'main', variablePath: [encodeAccessKey('df')] }));
 
 			expect(getInitialDfName()).toBe('df');
 		});
 
-		it('leaves prefill empty for multi-segment variablePath even when title is valid', async () => {
-			await run(buildContext({ title: 'main', variablePath: ['frames', 'main'] }));
+		it('falls back to title for multi-segment variablePath', async () => {
+			await run(buildContext({
+				title: 'main',
+				variablePath: [encodeAccessKey('frames'), encodeAccessKey('main')],
+			}));
 
-			expect(getInitialDfName()).toBe('');
+			expect(getInitialDfName()).toBe('main');
 		});
 
 		it('falls back to title when variablePath is missing and title is valid', async () => {
@@ -188,6 +193,12 @@ describe('VisualizeDataFrameAction', () => {
 			await run(buildContext({ title: 'data (1000 rows)', variablePath: undefined }));
 
 			expect(getInitialDfName()).toBe('');
+		});
+
+		it('handles a raw (non-JSON) variablePath segment as a fallback', async () => {
+			await run(buildContext({ title: 'other', variablePath: ['df'] }));
+
+			expect(getInitialDfName()).toBe('other');
 		});
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizeAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizeAction.vitest.ts
@@ -151,4 +151,43 @@ describe('VisualizeDataFrameAction', () => {
 			expect.anything(),
 		);
 	});
+
+	describe('dataframe prefill', () => {
+		// Capture what the action passes to the dialog as `initialDfName`
+		// without depending on its exact argument index.
+		function getInitialDfName(): string {
+			const call = mockShowVisualizeModalDialog.mock.calls[0];
+			return call[0] as string;
+		}
+
+		beforeEach(() => {
+			mockShowVisualizeModalDialog.mockResolvedValue(undefined);
+		});
+
+		it('prefers a valid single-segment variablePath over a different valid title', async () => {
+			// Display title is syntactically valid but points at a different
+			// object; source-path metadata is authoritative.
+			await run(buildContext({ title: 'main', variablePath: ['df'] }));
+
+			expect(getInitialDfName()).toBe('df');
+		});
+
+		it('leaves prefill empty for multi-segment variablePath even when title is valid', async () => {
+			await run(buildContext({ title: 'main', variablePath: ['frames', 'main'] }));
+
+			expect(getInitialDfName()).toBe('');
+		});
+
+		it('falls back to title when variablePath is missing and title is valid', async () => {
+			await run(buildContext({ title: 'df', variablePath: undefined }));
+
+			expect(getInitialDfName()).toBe('df');
+		});
+
+		it('leaves prefill empty when neither variablePath nor a valid title is available', async () => {
+			await run(buildContext({ title: 'data (1000 rows)', variablePath: undefined }));
+
+			expect(getInitialDfName()).toBe('');
+		});
+	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizeAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizeAction.vitest.ts
@@ -1,0 +1,151 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { URI } from '../../../../../../../base/common/uri.js';
+import { ICommandService } from '../../../../../../../platform/commands/common/commands.js';
+import { createTestContainer } from '../../../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../../../test/vitest/stubInterface.js';
+import { VisualizeDataFrameAction } from '../../../../browser/contrib/visualize/VisualizeAction.js';
+import type { IInlineDataExplorerActionContext } from '../../../../browser/notebookCells/InlineDataExplorerActions.js';
+import type { InlineTableDataGridInstance } from '../../../../../../services/positronDataExplorer/browser/inlineTableDataGridInstance.js';
+import type { IPositronNotebookCodeCell } from '../../../../browser/PositronNotebookCells/IPositronNotebookCell.js';
+import type { IPositronNotebookInstance } from '../../../../browser/IPositronNotebookInstance.js';
+
+const { mockShowVisualizeModalDialog, mockApplyVisualizeResult, mockGenerateVizCode } = vi.hoisted(() => ({
+	mockShowVisualizeModalDialog: vi.fn(),
+	mockApplyVisualizeResult: vi.fn(),
+	mockGenerateVizCode: vi.fn(() => ({ imports: '', body: '' })),
+}));
+
+vi.mock('../../../../browser/contrib/visualize/visualizeModalDialog.js', () => ({
+	showVisualizeModalDialog: mockShowVisualizeModalDialog,
+	validateVisualizationSuggestion: (v: unknown) => v,
+}));
+
+vi.mock('../../../../browser/contrib/visualize/applyVisualizeResult.js', () => ({
+	applyVisualizeResult: mockApplyVisualizeResult,
+}));
+
+vi.mock('../../../../browser/contrib/visualize/generateVizCode.js', () => ({
+	generateVizCode: mockGenerateVizCode,
+	isValidDataFrameExpr: (s: string) => /^[A-Za-z_][\w.[\]'"]*$/.test(s),
+}));
+
+describe('VisualizeDataFrameAction', () => {
+	const ctx = createTestContainer()
+		.withWorkbenchServices()
+		.build();
+
+	let executeCommand: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		executeCommand = vi.fn().mockResolvedValue(null);
+		ctx.instantiationService.stub(ICommandService, { executeCommand });
+		mockShowVisualizeModalDialog.mockReset();
+		mockApplyVisualizeResult.mockReset();
+	});
+
+	function fakeGrid(): InlineTableDataGridInstance {
+		return stubInterface<InlineTableDataGridInstance>({
+			columns: 2,
+			column: (i: number) => ({
+				name: `col${i}`,
+				description: 'int',
+			} as ReturnType<InlineTableDataGridInstance['column']>),
+		});
+	}
+
+	function fakeCell(): IPositronNotebookCodeCell {
+		return stubInterface<IPositronNotebookCodeCell>({ index: 3 });
+	}
+
+	function fakeNotebook(): IPositronNotebookInstance {
+		return stubInterface<IPositronNotebookInstance>({});
+	}
+
+	function buildContext(overrides: Partial<IInlineDataExplorerActionContext> = {}): IInlineDataExplorerActionContext {
+		return {
+			documentUri: URI.parse('file:///nb.ipynb'),
+			sourceLanguage: 'python',
+			commId: 'comm-1',
+			variablePath: ['df'],
+			title: 'df',
+			shape: { rows: 10, columns: 2 },
+			gridInstance: fakeGrid(),
+			cell: fakeCell(),
+			notebookInstance: fakeNotebook(),
+			...overrides,
+		};
+	}
+
+	async function run(actionCtx: IInlineDataExplorerActionContext): Promise<void> {
+		const action = new VisualizeDataFrameAction();
+		await ctx.instantiationService.invokeFunction(accessor => action.run(accessor, actionCtx));
+	}
+
+	it('returns without opening the dialog when source language is not python', async () => {
+		await run(buildContext({ sourceLanguage: 'r' }));
+
+		expect(mockShowVisualizeModalDialog).not.toHaveBeenCalled();
+		expect(mockApplyVisualizeResult).not.toHaveBeenCalled();
+	});
+
+	it('returns when there is no grid instance', async () => {
+		await run(buildContext({ gridInstance: undefined }));
+
+		expect(mockShowVisualizeModalDialog).not.toHaveBeenCalled();
+	});
+
+	it('returns when called from a non-notebook surface (no cell or notebookInstance)', async () => {
+		await run(buildContext({ cell: undefined, notebookInstance: undefined }));
+
+		expect(mockShowVisualizeModalDialog).not.toHaveBeenCalled();
+	});
+
+	it('applies the visualize result when the dialog returns a selection', async () => {
+		mockShowVisualizeModalDialog.mockResolvedValue({
+			answers: { library: 'plotly', chartType: 'bar', xCol: 'col0', yCol: 'col1', dfName: 'df' },
+			mode: 'newCell',
+		});
+
+		await run(buildContext());
+
+		expect(mockShowVisualizeModalDialog).toHaveBeenCalledTimes(1);
+		expect(mockApplyVisualizeResult).toHaveBeenCalledTimes(1);
+		expect(mockApplyVisualizeResult).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			expect.anything(),
+			'newCell',
+		);
+	});
+
+	it('does not apply the visualize result when the dialog is cancelled', async () => {
+		mockShowVisualizeModalDialog.mockResolvedValue(undefined);
+
+		await run(buildContext());
+
+		expect(mockShowVisualizeModalDialog).toHaveBeenCalledTimes(1);
+		expect(mockApplyVisualizeResult).not.toHaveBeenCalled();
+	});
+
+	it('forwards the suggestion request to positron-assistant.suggestVisualization', async () => {
+		mockShowVisualizeModalDialog.mockResolvedValue(undefined);
+
+		const actionCtx = buildContext();
+		await run(actionCtx);
+
+		expect(executeCommand).toHaveBeenCalledWith(
+			'positron-assistant.suggestVisualization',
+			actionCtx.documentUri.toString(),
+			actionCtx.cell!.index,
+			'df',
+			[{ name: 'col0', type: 'int' }, { name: 'col1', type: 'int' }],
+			expect.anything(),
+		);
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizeAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/visualizeAction.vitest.ts
@@ -50,12 +50,15 @@ describe('VisualizeDataFrameAction', () => {
 	});
 
 	function fakeGrid(): InlineTableDataGridInstance {
+		// VisualizeAction only reads .name and .description off each column;
+		// stubInterface narrows the column shape to those two fields.
+		const fakeColumn = (i: number) => stubInterface<NonNullable<ReturnType<InlineTableDataGridInstance['column']>>>({
+			name: `col${i}`,
+			description: 'int',
+		});
 		return stubInterface<InlineTableDataGridInstance>({
 			columns: 2,
-			column: (i: number) => ({
-				name: `col${i}`,
-				description: 'int',
-			} as ReturnType<InlineTableDataGridInstance['column']>),
+			column: fakeColumn,
 		});
 	}
 


### PR DESCRIPTION
Continuation of #13238, rebased after PRs A (#13271) and B (#13273) landed.

The visualize-dataframe feature lets a notebook user turn an inline data-explorer view into a plotting cell via a four-step modal walkthrough, with optional LLM pre-fill and a live chart preview.


_Experimental flag needed to try feature_
<img width="748" height="240" alt="image" src="https://github.com/user-attachments/assets/bbe55a94-370a-45ab-b3a1-2e6d2c30fa3a" />


https://github.com/user-attachments/assets/7e85b17d-39ed-4b1c-b3eb-363f5d8ea797


## Summary

- Multi-step "Visualize..." dialog on the inline data explorer header (gated behind `positronNotebook.experimental`)
- Code generation for Plotly, Matplotlib, and Seaborn (bar, line, scatter, histogram)
- Live preview panel that silently executes the generated snippet in the kernel
- LLM-powered column/library suggestions via `positron-assistant.suggestVisualization`
- Insert as new cell or append to current cell

## Changes since #13238

- Rebased onto main (removed PR A/B infrastructure commits, now consumed from main)
- Fixed dfName prefill: decode kernel's encoded access keys in `variablePath`
- Guard live preview against empty/invalid dfName (shows "DataFrame variable needed" instead of broken plots)
- Multi-segment variablePath no longer falls back to display title

## Test plan

- [ ] Open a notebook, run `df = pd.DataFrame({'a': [1,2,3], 'b': [4,5,6]})`, click Visualize on the inline data explorer
- [ ] Verify dfName prefills as "df"
- [ ] Pick Matplotlib > Scatter > map columns, confirm live preview renders
- [ ] Pick Plotly, confirm "Preview not available for this library" message
- [ ] Insert as new cell, verify code is correct
- [ ] Toggle live preview off/on
- [ ] Vitest: `npx vitest run src/vs/workbench/contrib/positronNotebook/test/browser/contrib/visualize/`