### PR TITLE
feat(positron-r): support portable Mac R builds

### DIFF
--- a/extensions/positron-r/src/r-installation.ts
+++ b/extensions/positron-r/src/r-installation.ts
@@ -412,20 +412,60 @@ function getRHomePathDarwin(binpath: string): string | undefined {
 		LOGGER.info(`Binary is not a shell script wrapping the executable: ${binpath}`);
 		return undefined;
 	}
+
+	// First try the R_HOME_DIR baked into the script. For system installs this
+	// points at the real R home. Examples:
+	//   macOS orthogonal:     R_HOME_DIR=/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
+	//   macOS non-orthogonal: R_HOME_DIR=/Library/Frameworks/R.framework/Resources
+	// Only trust the parsed value if binpath actually lives under it. Otherwise
+	// the script's R_HOME_DIR points at a *different* R install that happens to
+	// exist at the build-time path (e.g. portable R-4.5.3 with R_HOME_DIR baked
+	// to /Library/.../4.5-arm64/Resources where the user also has CRAN R 4.5.1
+	// installed). Without this guard we'd conflate the two installs.
 	const targetLine = binLines.find(line => line.match('R_HOME_DIR'));
-	if (!targetLine) {
-		LOGGER.info(`Can\'t determine R_HOME_DIR from the binary: ${binpath}`);
+	if (targetLine) {
+		const parsed = removeSurroundingQuotes(extractValue(targetLine, 'R_HOME_DIR'));
+		if (parsed !== '' && hasRBaseLibrary(parsed) && binpathIsUnder(binpath, parsed)) {
+			return parsed;
+		}
+	}
+
+	// Fallback: derive R_HOME from the binpath itself. The Mac R wrapper is
+	// always at <home>/bin/R, so dirname(dirname(binpath)) is R_HOME. Resolve
+	// symlinks first so a shim like /usr/local/bin/R points at the real script.
+	// This rescues portable R builds where the script's
+	// R_HOME_DIR is a stale absolute path from the build machine.
+	const derived = derivedRHomePathDarwin(binpath);
+	if (derived && hasRBaseLibrary(derived)) {
+		return derived;
+	}
+
+	LOGGER.info(`Can't determine R_HOME_DIR from the binary: ${binpath}`);
+	return undefined;
+}
+
+function derivedRHomePathDarwin(binpath: string): string | undefined {
+	try {
+		const realBinpath = fs.realpathSync(binpath);
+		return path.dirname(path.dirname(realBinpath));
+	} catch (err) {
+		LOGGER.info(`Could not resolve real path for ${binpath}: ${err}`);
 		return undefined;
 	}
-	// macOS: R_HOME_DIR=/Library/Frameworks/R.framework/Versions/4.3-arm64/Resources
-	// macOS non-orthogonal: R_HOME_DIR=/Library/Frameworks/R.framework/Resources
-	const R_HOME_DIR = removeSurroundingQuotes(extractValue(targetLine, 'R_HOME_DIR'));
-	const homepath = R_HOME_DIR;
-	if (homepath === '') {
-		LOGGER.info(`Can\'t determine R_HOME_DIR from the binary: ${binpath}`);
-		return undefined;
+}
+
+function hasRBaseLibrary(homepath: string): boolean {
+	return fs.existsSync(path.join(homepath, 'library', 'utils', 'DESCRIPTION'));
+}
+
+function binpathIsUnder(binpath: string, homepath: string): boolean {
+	try {
+		const realBin = fs.realpathSync(binpath);
+		const realHome = fs.realpathSync(homepath);
+		return realBin.startsWith(realHome + path.sep);
+	} catch {
+		return false;
 	}
-	return homepath;
 }
 
 function getRHomePathLinux(binpath: string): string | undefined {

--- a/extensions/positron-r/src/test/r-installation.test.ts
+++ b/extensions/positron-r/src/test/r-installation.test.ts
@@ -1,0 +1,135 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import './mocha-setup';
+
+import * as assert from 'assert';
+import Fs = require('fs');
+import * as Sinon from 'sinon';
+import { getRHomePath } from '../r-installation';
+
+// Build the contents of an R wrapper script with a given R_HOME_DIR value.
+// The "Shell wrapper for R executable" header is what getRHomePathDarwin
+// uses to recognize the file as a valid R wrapper.
+function rWrapperScript(rHomeDir: string): string {
+	return [
+		'#!/bin/sh',
+		'# Shell wrapper for R executable.',
+		'',
+		`R_HOME_DIR=${rHomeDir}`,
+		'export R_HOME_DIR',
+	].join('\n');
+}
+
+suite('r-installation: getRHomePathDarwin', () => {
+
+	let originalPlatform: PropertyDescriptor | undefined;
+	let readFileSyncStub: Sinon.SinonStub;
+	let existsSyncStub: Sinon.SinonStub;
+	let realpathSyncStub: Sinon.SinonStub;
+
+	suiteSetup(function () {
+		originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+		Object.defineProperty(process, 'platform', { value: 'darwin' });
+	});
+
+	suiteTeardown(function () {
+		if (originalPlatform) {
+			Object.defineProperty(process, 'platform', originalPlatform);
+		}
+	});
+
+	teardown(() => {
+		readFileSyncStub?.restore();
+		existsSyncStub?.restore();
+		realpathSyncStub?.restore();
+	});
+
+	test('returns parsed R_HOME_DIR when it validates and binpath lives under it', () => {
+		const binpath = '/Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/bin/R';
+		const parsedHome = '/Library/Frameworks/R.framework/Versions/4.5-arm64/Resources';
+
+		readFileSyncStub = Sinon.stub(Fs, 'readFileSync').returns(rWrapperScript(parsedHome));
+		existsSyncStub = Sinon.stub(Fs, 'existsSync').callsFake((p: Fs.PathLike) =>
+			String(p) === `${parsedHome}/library/utils/DESCRIPTION`
+		);
+		// Identity realpath: no symlinks in this scenario.
+		realpathSyncStub = Sinon.stub(Fs, 'realpathSync').callsFake((p: Fs.PathLike) => String(p));
+
+		const result = getRHomePath(binpath);
+
+		assert.strictEqual(result, parsedHome);
+	});
+
+	test('falls back to dirname(dirname(realpath(binpath))) when parsed R_HOME_DIR is invalid', () => {
+		const binpath = '/Users/jane/portable-r/4.5.3-arm64/Resources/bin/R';
+		const staleHome = '/build/tmp/R-4.5.3/Resources'; // Baked at build time, doesn't exist on this machine.
+		const derivedHome = '/Users/jane/portable-r/4.5.3-arm64/Resources';
+
+		readFileSyncStub = Sinon.stub(Fs, 'readFileSync').returns(rWrapperScript(staleHome));
+		// Identity realpath: no symlinks. Used by both binpathIsUnder and derivedRHomePathDarwin.
+		realpathSyncStub = Sinon.stub(Fs, 'realpathSync').callsFake((p: Fs.PathLike) => String(p));
+		existsSyncStub = Sinon.stub(Fs, 'existsSync').callsFake((p: Fs.PathLike) =>
+			String(p) === `${derivedHome}/library/utils/DESCRIPTION`
+		);
+
+		const result = getRHomePath(binpath);
+
+		assert.strictEqual(result, derivedHome);
+	});
+
+	test('falls back to derived path when parsed R_HOME_DIR validates but binpath lives elsewhere', () => {
+		// Conflation case: portable R-4.5.3's wrapper has R_HOME_DIR baked to
+		// /Library/.../4.5-arm64/Resources, and the user *also* has CRAN R 4.5.1
+		// installed at that exact path. hasRBaseLibrary(parsed) returns true, but
+		// binpath is in /Users/.../portable-r/... — handing back parsed would
+		// register the portable with CRAN's metadata. Verify we fall through.
+		const binpath = '/Users/jane/portable-r/4.5.3-arm64/Resources/bin/R';
+		const parsedHome = '/Library/Frameworks/R.framework/Versions/4.5-arm64/Resources';
+		const derivedHome = '/Users/jane/portable-r/4.5.3-arm64/Resources';
+
+		readFileSyncStub = Sinon.stub(Fs, 'readFileSync').returns(rWrapperScript(parsedHome));
+		realpathSyncStub = Sinon.stub(Fs, 'realpathSync').callsFake((p: Fs.PathLike) => String(p));
+		existsSyncStub = Sinon.stub(Fs, 'existsSync').callsFake((p: Fs.PathLike) => {
+			const s = String(p);
+			return s === `${parsedHome}/library/utils/DESCRIPTION` ||
+				s === `${derivedHome}/library/utils/DESCRIPTION`;
+		});
+
+		const result = getRHomePath(binpath);
+
+		assert.strictEqual(result, derivedHome);
+	});
+
+	test('returns undefined when neither parsed R_HOME_DIR nor fallback validates', () => {
+		const binpath = '/some/broken/path/Resources/bin/R';
+		const staleHome = '/build/tmp/R/Resources';
+
+		readFileSyncStub = Sinon.stub(Fs, 'readFileSync').returns(rWrapperScript(staleHome));
+		realpathSyncStub = Sinon.stub(Fs, 'realpathSync').returns(binpath);
+		existsSyncStub = Sinon.stub(Fs, 'existsSync').returns(false); // Nothing validates.
+
+		const result = getRHomePath(binpath);
+
+		assert.strictEqual(result, undefined);
+	});
+
+	test('returns undefined when the binary is not an R wrapper script', () => {
+		const binpath = '/usr/bin/python';
+
+		// Script lacks the "Shell wrapper for R executable" header.
+		readFileSyncStub = Sinon.stub(Fs, 'readFileSync').returns('#!/bin/sh\necho hello\n');
+		existsSyncStub = Sinon.stub(Fs, 'existsSync').returns(true); // Even if DESCRIPTION existed, we shouldn't get there.
+		realpathSyncStub = Sinon.stub(Fs, 'realpathSync');
+
+		const result = getRHomePath(binpath);
+
+		assert.strictEqual(result, undefined);
+		assert.strictEqual(existsSyncStub.callCount, 0,
+			'existsSync should not be called when the wrapper header is missing');
+		assert.strictEqual(realpathSyncStub.callCount, 0,
+			'realpath should not be called when the wrapper header is missing');
+	});
+});


### PR DESCRIPTION
The portable Mac R builds from [rstudio/r-builds#284](https://github.com/rstudio/r-builds/pull/284) that we just merged let you extract a tarball anywhere and have R work. Historically, Mac R builds have not been relocatable so Positron did not support this.

On Mac, the R wrapper script bakes in an absolute `R_HOME_DIR` line at build time. Positron read that line and used it as-is, so portable installs ended up pointing at a path that didn't exist on the user's machine. If the user happened to have a CRAN R at that same path, Positron silently registered the portable with the CRAN install's metadata instead.

The fix adds a path-derived fallback to `getRHomePathDarwin`: if the parsed `R_HOME_DIR` doesn't validate, or the binary doesn't actually live under it, fall back to `dirname(dirname(realpath(binpath)))`. This implements similar relative path discovery used by Windows since R is already relocatable on Windows. System R installs still take the parsed path; portable builds get rescued by the fallback.

### Test plan

Download a Mac R tarball and extract it:

```bash
R_VERSION=4.4.3
curl -O https://cdn.posit.co/r/macos/R-${R_VERSION}-macos-arm64.tar.gz
mkdir -p ~/R
tar xzf R-${R_VERSION}-macos-arm64.tar.gz -C ~/R
~/R/R-${R_VERSION}/bin/R --version
```

Point Positron at it via user settings (adjust the path if you extracted elsewhere):

```json
"positron.r.interpreters.override": [
  "/Users/<you>/R/R-4.4.3/bin/R"
]
```

**On current `main`** the portable install is rejected:

```
2026-05-01 09:39:14.056 [info] R installation paths from 'positron.r.interpreters.override' to exclusively include:
[
  "/Users/jacobwoliver/R/R-4.4.3/bin/R"
]
2026-05-01 09:39:14.056 [info] Candidate R binary at /Users/jacobwoliver/R/R-4.4.3/bin/R
2026-05-01 09:39:14.056 [info] Can't find DESCRIPTION for the utils package at /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/utils/DESCRIPTION
2026-05-01 09:39:14.056 [info] Filtering out /Users/jacobwoliver/R/R-4.4.3/bin/R, reason: Invalid installation.
2026-05-01 09:39:14.056 [warning] All discovered R installations are unusable by Positron.
2026-05-01 09:39:14.056 [warning] Learn more about R discovery at https://positron.posit.co/r-installations
```

**On this branch** it registers correctly with the right version and homepath:

```
2026-05-01 09:36:49.258 [info] Candidate R binary at /Users/jacobwoliver/R/R-4.4.3/bin/R
2026-05-01 09:36:49.258 [info] R installation discovered: {
  "usable": true,
  "supported": true,
  "reasonDiscovered": [
    "Found in a location specified via user settings"
  ],
  "reasonRejected": null,
  "binpath": "/Users/jacobwoliver/R/R-4.4.3/bin/R",
  "homepath": "/Users/jacobwoliver/R/R-4.4.3",
  "version": "4.4.3",
  "arch": "arm64",
  "current": false,
  "orthogonal": true,
  "default": false
}
```