### PR TITLE
Rebrand upstream experimental themes for Positron

### DIFF
--- a/extensions/theme-defaults/package.json
+++ b/extensions/theme-defaults/package.json
@@ -50,6 +50,18 @@
         "path": "./themes/positron_light.json"
       },
       {
+        "id": "Experimental Positron Dark",
+        "label": "%positronExperimentalDarkThemeLabel%",
+        "uiTheme": "vs-dark",
+        "path": "./themes/positron_experimental_dark.json"
+      },
+      {
+        "id": "Experimental Positron Light",
+        "label": "%positronExperimentalLightThemeLabel%",
+        "uiTheme": "vs",
+        "path": "./themes/positron_experimental_light.json"
+      },
+      {
         "id": "Visual Studio Dark",
         "label": "%darkColorThemeLabel%",
         "uiTheme": "vs-dark",

--- a/extensions/theme-defaults/package.nls.json
+++ b/extensions/theme-defaults/package.nls.json
@@ -10,6 +10,8 @@
 	"hcColorThemeLabel": "Dark High Contrast",
 	"lightHcColorThemeLabel": "Light High Contrast",
 	"minimalIconThemeLabel": "Minimal (Visual Studio Code)",
-	"positronDarkThemeLabel": "Positron Dark",
-	"positronLightThemeLabel": "Positron Light"
+	"positronDarkThemeLabel": "Dark",
+	"positronLightThemeLabel": "Light",
+	"positronExperimentalDarkThemeLabel": "Dark Experimental",
+	"positronExperimentalLightThemeLabel": "Light Experimental"
 }

--- a/extensions/theme-defaults/themes/positron_experimental_dark.json
+++ b/extensions/theme-defaults/themes/positron_experimental_dark.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "Dark Experimental",
+	"include": "../../theme-2026/themes/2026-dark.json"
+}

--- a/extensions/theme-defaults/themes/positron_experimental_light.json
+++ b/extensions/theme-defaults/themes/positron_experimental_light.json
@@ -1,0 +1,5 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "Light Experimental",
+	"include": "../../theme-2026/themes/2026-light.json"
+}

--- a/src/vs/workbench/services/themes/browser/positronColorThemeFilter.ts
+++ b/src/vs/workbench/services/themes/browser/positronColorThemeFilter.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Positron ships with a subset of the upstream Visual Studio Code color themes.
+// This filter is applied at picker-display time only; hidden themes remain
+// registered and continue to resolve from settings.json by ID.
+export function isColorThemeVisibleInPicker(themeId: string, currentThemeId: string): boolean {
+	if (themeId === currentThemeId) {
+		return true;
+	}
+	switch (themeId) {
+		case 'vs vscode-theme-defaults-themes-light_modern-json':
+		case 'vs vscode-theme-defaults-themes-light_plus-json':
+		case 'vs vscode-theme-defaults-themes-light_vs-json':
+		case 'vs vscode-theme-quietlight-themes-quietlight-color-theme-json':
+		case 'vs vscode-theme-solarized-light-themes-solarized-light-color-theme-json':
+		case 'vs-dark vscode-theme-abyss-themes-abyss-color-theme-json':
+		case 'vs-dark vscode-theme-defaults-themes-dark_modern-json':
+		case 'vs-dark vscode-theme-defaults-themes-dark_plus-json':
+		case 'vs-dark vscode-theme-defaults-themes-dark_vs-json':
+		case 'vs-dark vscode-theme-kimbie-dark-themes-kimbie-dark-color-theme-json':
+		case 'vs-dark vscode-theme-monokai-dimmed-themes-dimmed-monokai-color-theme-json':
+		case 'vs-dark vscode-theme-monokai-themes-monokai-color-theme-json':
+		case 'vs-dark vscode-theme-red-themes-Red-color-theme-json':
+		case 'vs-dark vscode-theme-solarized-dark-themes-solarized-dark-color-theme-json':
+		case 'vs vscode-theme-2026-themes-2026-light-json':
+		case 'vs-dark vscode-theme-2026-themes-2026-dark-json':
+			return false;
+		default:
+			return true;
+	}
+}

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -373,7 +373,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 	public async getColorThemes(): Promise<IWorkbenchColorTheme[]> {
 		// --- Start Positron ---
 		// Positron ships with a subset of the themes that are available by default;
-		// see positronColorThemeFilter.ts for the blacklist and bypass rules.
+		// see positronColorThemeFilter.ts for the filter and bypass rules.
 		const themes = this.colorThemeRegistry.getThemes();
 		const currentThemeId = this.getColorTheme().id;
 		return themes.filter(theme => isColorThemeVisibleInPicker(theme.id, currentThemeId));

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -43,6 +43,9 @@ import { getColorRegistry } from '../../../../platform/theme/common/colorRegistr
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { mainWindow } from '../../../../base/browser/window.js';
 import { generateColorThemeCSS } from './colorThemeCss.js';
+// --- Start Positron ---
+import { isColorThemeVisibleInPicker } from './positronColorThemeFilter.js';
+// --- End Positron ---
 
 // implementation
 
@@ -369,48 +372,11 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 
 	public async getColorThemes(): Promise<IWorkbenchColorTheme[]> {
 		// --- Start Positron ---
-
-		// Get the themes and the current theme.
+		// Positron ships with a subset of the themes that are available by default;
+		// see positronColorThemeFilter.ts for the blacklist and bypass rules.
 		const themes = this.colorThemeRegistry.getThemes();
-		const currentTheme = this.getColorTheme();
-
-		// Positron ships with a subset of the themes that are available by default.
-		return themes.filter(theme => {
-			// Always include the current theme.
-			if (theme.id === currentTheme.id) {
-				return true;
-			}
-
-			// Filter themes.
-			switch (theme.id) {
-				// Exclude older Visual Studio Code themes.
-				case 'vs vscode-theme-defaults-themes-light_modern-json':
-				case 'vs vscode-theme-defaults-themes-light_plus-json':
-				case 'vs vscode-theme-defaults-themes-light_vs-json':
-				case 'vs vscode-theme-quietlight-themes-quietlight-color-theme-json':
-				case 'vs vscode-theme-solarized-light-themes-solarized-light-color-theme-json':
-				case 'vs-dark vscode-theme-abyss-themes-abyss-color-theme-json':
-				case 'vs-dark vscode-theme-defaults-themes-dark_modern-json':
-				case 'vs-dark vscode-theme-defaults-themes-dark_plus-json':
-				case 'vs-dark vscode-theme-defaults-themes-dark_vs-json':
-				case 'vs-dark vscode-theme-kimbie-dark-themes-kimbie-dark-color-theme-json':
-				case 'vs-dark vscode-theme-monokai-dimmed-themes-dimmed-monokai-color-theme-json':
-				case 'vs-dark vscode-theme-monokai-themes-monokai-color-theme-json':
-				case 'vs-dark vscode-theme-red-themes-Red-color-theme-json':
-				case 'vs-dark vscode-theme-solarized-dark-themes-solarized-dark-color-theme-json':
-				// Hide the upstream theme-2026 entries; surfaced as Positron-branded
-				// wrappers via theme-defaults/themes/positron_experimental_*.json.
-				case 'vs vscode-theme-2026-themes-2026-light-json':
-				case 'vs-dark vscode-theme-2026-themes-2026-dark-json':
-					return false;
-
-				// Include user-defined themes as well as any new themes that have been added to
-				// Visual Studio Code.
-				default:
-					return true;
-			}
-		});
-
+		const currentThemeId = this.getColorTheme().id;
+		return themes.filter(theme => isColorThemeVisibleInPicker(theme.id, currentThemeId));
 		// --- End Positron ---
 	}
 

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -398,6 +398,10 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 				case 'vs-dark vscode-theme-monokai-themes-monokai-color-theme-json':
 				case 'vs-dark vscode-theme-red-themes-Red-color-theme-json':
 				case 'vs-dark vscode-theme-solarized-dark-themes-solarized-dark-color-theme-json':
+				// Hide the upstream theme-2026 entries; surfaced as Positron-branded
+				// wrappers via theme-defaults/themes/positron_experimental_*.json.
+				case 'vs vscode-theme-2026-themes-2026-light-json':
+				case 'vs-dark vscode-theme-2026-themes-2026-dark-json':
 					return false;
 
 				// Include user-defined themes as well as any new themes that have been added to

--- a/src/vs/workbench/services/themes/test/browser/positronColorThemeFilter.vitest.ts
+++ b/src/vs/workbench/services/themes/test/browser/positronColorThemeFilter.vitest.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { isColorThemeVisibleInPicker } from '../../browser/positronColorThemeFilter.js';
+
+const upstreamExperimentalDark = 'vs-dark vscode-theme-2026-themes-2026-dark-json';
+const upstreamVisualStudioLight = 'vs vscode-theme-defaults-themes-light_vs-json';
+const positronExperimentalDark = 'vs-dark vscode-theme-defaults-themes-positron_experimental_dark-json';
+const positronDark = 'vs-dark vscode-theme-defaults-themes-positron_dark-json';
+const userInstalled = 'vs-dark some-publisher.cool-theme-themes-cool-json';
+
+describe('isColorThemeVisibleInPicker', () => {
+	it('hides upstream theme-2026 entries', () => {
+		expect(isColorThemeVisibleInPicker(upstreamExperimentalDark, positronDark)).toBe(false);
+	});
+
+	it('hides legacy upstream entries Positron has always suppressed', () => {
+		expect(isColorThemeVisibleInPicker(upstreamVisualStudioLight, positronDark)).toBe(false);
+	});
+
+	it('keeps Positron-branded experimental themes', () => {
+		expect(isColorThemeVisibleInPicker(positronExperimentalDark, positronDark)).toBe(true);
+	});
+
+	it('keeps unknown user-installed themes by default', () => {
+		expect(isColorThemeVisibleInPicker(userInstalled, positronDark)).toBe(true);
+	});
+
+	it('always keeps the user\'s current theme, even when blacklisted', () => {
+		// Protects users who selected an upstream theme before our filter shipped.
+		expect(isColorThemeVisibleInPicker(upstreamExperimentalDark, upstreamExperimentalDark)).toBe(true);
+	});
+});


### PR DESCRIPTION
Addresses #13230

The upstream `theme-2026` extension contributes Experimental Light/Dark themes. They lack Positron-specific color overrides, but they do seem to be mostly working well and we know from recent calls with customers that folks are using these and want access to them. This PR does _not_ tune these new theme colors now, but it does hide those entries from the theme picker and surface equivalents under Positron branding.

Two new wrapper themes are added in `theme-defaults/themes/` (`positron_experimental_dark.json`, `positron_experimental_light.json`) that `include` the upstream 2026 theme files, with matching entries and labels added to `theme-defaults/package.json` and `package.nls.json`. The upstream `theme-2026` entries are hidden via the existing Positron-fenced filter in `workbenchThemeService.ts`. This is the same mechanism that already hides Light (Visual Studio), Monokai, Solarized, etc. I think this is the right call for upstream merge management.

The existing default Positron themes are also relabeled from "Positron Dark" / "Positron Light" to just "Dark" / "Light" so the entries read as a set: Dark, Light, Dark Experimental, Light Experimental, Dark High Contrast, Light High Contrast:

<img width="625" height="233" alt="Screenshot 2026-05-01 at 10 48 55 AM" src="https://github.com/user-attachments/assets/02023b3e-2bb3-43a3-82c6-2b9e60c7eecc" />

Anyone who already has one of these themes selected keeps it because the filter has a current-theme bypass. The session window default still resolves because the upstream themes remain registered, just hidden from the picker.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Replace upstream "Experimental" color themes with Positron-branded variants in the theme picker (#13230)

### QA Notes

1. Open the command palette and run _Preferences: Color Theme_.
2. Confirm "VS Code Light" and "VS Code Dark" no longer appear.
3. Confirm "Dark Experimental" and "Light Experimental" appear in their place.
4. Select each and confirm the rendered colors match the prior upstream `theme-2026` versions.
5. Confirm the existing Positron default themes now appear as "Dark" / "Light" (formerly "Positron Dark" / "Positron Light").
6. (Optional) Set `workbench.colorTheme` to `"Experimental Dark"` directly in settings.json. The theme should still load (the filter only affects the picker, not registration).
