### PR TITLE
E2E test: fix remote ssh test

### DIFF
--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -107,7 +107,7 @@ test.describe('Remote SSH', {
 			await sshWin.keyboard.type('root');
 			await sshWin.keyboard.press('Enter');
 
-			const alertLocator = sshWin.locator('span', { hasText: 'Setting up SSH Host remote' });
+			const alertLocator = sshWin.locator('.statusbar-item-label', { hasText: 'Opening Remote' });
 			await expect(alertLocator).toBeVisible({ timeout: 10_000 });
 			await expect(alertLocator).not.toBeVisible({ timeout: 60_000 });
 


### PR DESCRIPTION
When running a test, remote ssh no longer shows a small dialog with "Setting up SSH Host remote". This is only the case during a test, though. It still does appear when using manually. Must be related to upstream merge.

### QA Notes


