### PR TITLE
e2e: skip help iframe tests broken by upstream merge

### DIFF
--- a/test/e2e/tests/console/console-ansi.test.ts
+++ b/test/e2e/tests/console/console-ansi.test.ts
@@ -37,7 +37,10 @@ test.describe('Console ANSI styling', { tag: [tags.CONSOLE, tags.WIN, tags.WEB] 
 		}).toPass({ timeout: 60000 });
 	});
 
-	test("R - Can produce clickable help links", {
+	test.skip("R - Can produce clickable help links", {
+		annotation: {
+			type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
+		},
 		tag: [tags.ARK]
 	}, async function ({ app, r }) {
 		const inputCode = `cli::cli_inform("{.fun base::mean}")`;

--- a/test/e2e/tests/console/console-r-hyperlinks.test.ts
+++ b/test/e2e/tests/console/console-r-hyperlinks.test.ts
@@ -14,7 +14,11 @@ test.describe('Console Pane: R Hyperlinks', {
 	tag: [tags.WEB, tags.CONSOLE, tags.WIN, tags.ARK]
 }, () => {
 
-	test('R - Verify console link to help', async function ({ app, r }) {
+	test.skip('R - Verify console link to help', {
+		annotation: {
+			type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
+		}
+	}, async function ({ app, r }) {
 		const { console, help } = app.workbench;
 
 		await console.pasteCodeToConsole("txt_formatted <- \"Help for a function: `\u001b]8;;x-r-help:utils::available.packages\\autils::available.packages\u001b]8;;\u0007()`\"", true);
@@ -26,7 +30,11 @@ test.describe('Console Pane: R Hyperlinks', {
 	});
 
 
-	test('R - Verify help with custom link text', async function ({ app, r }) {
+	test.skip('R - Verify help with custom link text', {
+		annotation: {
+			type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
+		}
+	}, async function ({ app, r }) {
 		const { console, help } = app.workbench;
 
 		await console.pasteCodeToConsole('library(cli)', true);
@@ -38,7 +46,11 @@ test.describe('Console Pane: R Hyperlinks', {
 		await expect((await help.getHelpFrame(0)).getByText('Collect Information About the Current R Session')).toBeVisible({ timeout: 30000 });
 	});
 
-	test('R - Verify help for a topic that is not a function', async function ({ app, r }) {
+	test.skip('R - Verify help for a topic that is not a function', {
+		annotation: {
+			type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
+		}
+	}, async function ({ app, r }) {
 		const { console, help } = app.workbench;
 
 		await console.pasteCodeToConsole('library(cli)', true);
@@ -50,7 +62,11 @@ test.describe('Console Pane: R Hyperlinks', {
 		await expect((await help.getHelpFrame(0)).getByText('Batch Execution of R')).toBeVisible({ timeout: 30000 });
 	});
 
-	test('R - Verify help for a vignette', async function ({ app, r }) {
+	test.skip('R - Verify help for a vignette', {
+		annotation: {
+			type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
+		}
+	}, async function ({ app, r }) {
 		const { console, help } = app.workbench;
 
 		await console.pasteCodeToConsole('library(cli)', true);

--- a/test/e2e/tests/help/f1.test.ts
+++ b/test/e2e/tests/help/f1.test.ts
@@ -22,7 +22,11 @@ test.describe('F1 Help', {
 		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 	});
 
-	test('R - Verify basic F1 console help functionality', async function ({ app, page, r }) {
+	test.skip('R - Verify basic F1 console help functionality', {
+		annotation: {
+			type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
+		}
+	}, async function ({ app, page, r }) {
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'nyc-flights-data-r', 'flights-data-frame.r'));
 		await app.workbench.quickaccess.runCommand('r.sourceCurrentFile');
 
@@ -40,7 +44,11 @@ test.describe('F1 Help', {
 
 	});
 
-	test('R - Verify basic F1 editor help functionality', async function ({ app, page, r }) {
+	test.skip('R - Verify basic F1 editor help functionality', {
+		annotation: {
+			type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
+		}
+	}, async function ({ app, page, r }) {
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'generate-data-frames-r', 'generate-data-frames.r'));
 
 		await app.code.driver.currentPage.locator('span').filter({ hasText: 'colnames(df) <- paste0(\'col\', 1:num_cols)' }).locator('span').first().dblclick();
@@ -53,7 +61,12 @@ test.describe('F1 Help', {
 
 	});
 
-	test('R - Verify basic F1 notebook help functionality', { tag: tags.NOTEBOOKS }, async function ({ app, page, r }) {
+	test.skip('R - Verify basic F1 notebook help functionality', {
+		annotation: {
+			type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
+		},
+		tag: tags.NOTEBOOKS
+	}, async function ({ app, page, r }) {
 		await app.workbench.quickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'large_r_notebook', 'spotify.ipynb'));
 
 		await app.workbench.layouts.enterLayout('notebook');
@@ -76,7 +89,11 @@ test.describe('F1 Help', {
 
 	});
 
-	test('Python - Verify basic F1 console help functionality', async function ({ app, page, python }) {
+	test.skip('Python - Verify basic F1 console help functionality', {
+		annotation: {
+			type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
+		}
+	}, async function ({ app, page, python }) {
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'nyc-flights-data-py', 'flights-data-frame.py'));
 		await app.workbench.quickaccess.runCommand('python.execInConsole');
 
@@ -94,7 +111,11 @@ test.describe('F1 Help', {
 
 	});
 
-	test('Python - Verify basic F1 editor help functionality', async function ({ app, page, python }) {
+	test.skip('Python - Verify basic F1 editor help functionality', {
+		annotation: {
+			type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
+		}
+	}, async function ({ app, page, python }) {
 		const fileName = 'generate-data-frames.py';
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'generate-data-frames-py', fileName));
 
@@ -114,7 +135,12 @@ test.describe('F1 Help', {
 
 	});
 
-	test('Python - Verify basic F1 notebook help functionality', { tag: tags.NOTEBOOKS }, async function ({ app, page, python }) {
+	test.skip('Python - Verify basic F1 notebook help functionality', {
+		annotation: {
+			type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
+		},
+		tag: tags.NOTEBOOKS
+	}, async function ({ app, page, python }) {
 		await app.workbench.quickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'large_py_notebook', 'spotify.ipynb'));
 
 		// Position the mouse over the notebook for scrolling

--- a/test/e2e/tests/help/help.test.ts
+++ b/test/e2e/tests/help/help.test.ts
@@ -17,7 +17,12 @@ test.describe('Help', { tag: [tags.HELP, tags.WEB] }, () => {
 		await settings.set({ 'workbench.reduceMotion': 'on' }, { reload: 'web' });
 	});
 
-	test('Python - Verify Help landing page', { tag: [tags.WIN] }, async function ({ app }) {
+	test.skip('Python - Verify Help landing page', {
+		annotation: {
+			type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
+		},
+		tag: [tags.WIN]
+	}, async function ({ app }) {
 
 		await app.workbench.layouts.enterLayout('fullSizedAuxBar');
 		await app.workbench.help.openHelpPanel();
@@ -34,7 +39,12 @@ test.describe('Help', { tag: [tags.HELP, tags.WEB] }, () => {
 		await app.workbench.layouts.enterLayout('stacked');
 	});
 
-	test('Python - Verify basic help functionality', { tag: [tags.WIN] }, async function ({ app, python }) {
+	test.skip('Python - Verify basic help functionality', {
+		annotation: {
+			type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
+		},
+		tag: [tags.WIN]
+	}, async function ({ app, python }) {
 		await app.workbench.console.executeCode('Python', `?load`);
 
 		await expect(async () => {
@@ -44,7 +54,12 @@ test.describe('Help', { tag: [tags.HELP, tags.WEB] }, () => {
 
 	});
 
-	test('R - Verify basic help functionality', { tag: [tags.WIN] }, async function ({ app, r }) {
+	test.skip('R - Verify basic help functionality', {
+		annotation: {
+			type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
+		},
+		tag: [tags.WIN]
+	}, async function ({ app, r }) {
 		await app.workbench.console.executeCode('R', `?load()`);
 
 		await expect(async () => {


### PR DESCRIPTION
Skip 14 e2e tests that exercise content rendering in the Help iframe. The Help iframe stops loading content on desktop release builds following the CodeOSS 1.111.0 upstream merge (#12996). Tracked in #13332.


Each skipped test carries:

```ts
annotation: {
    type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13332'
}
```

Tests left enabled in the affected files (these don't exercise the broken iframe-content path): the help-panel resize test, and the runnable / file / not-runnable code-link tests in `console-r-hyperlinks.test.ts`.

### QA Notes

Test-only change — pure skip annotations. Once #13332 is fixed, revert this PR (or remove the `.skip` and `annotation` blocks) to re-enable the tests.