### PR TITLE
e2e: compare scroll anchor (not raw scrollTop) in notebook reload test

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -1684,6 +1684,29 @@ export class PositronNotebooks extends Notebooks {
 	async getScrollTop(): Promise<number> {
 		return this.cellsContainer.evaluate(el => el.scrollTop);
 	}
+
+	/**
+	 * Capture the scroll anchor: the first cell at least partially visible in
+	 * the viewport, plus its top offset relative to the cells container.
+	 *
+	 * This is what the scroll restoration implementation preserves across
+	 * reloads. Compare anchors (not raw scrollTop): cells above the anchor can
+	 * re-render with slightly different heights between sessions, shifting
+	 * scrollTop while leaving the user-visible position unchanged.
+	 */
+	async getScrollAnchor(): Promise<{ cellIndex: number; offsetFromTop: number } | null> {
+		return this.cellsContainer.evaluate(c => {
+			const containerRect = c.getBoundingClientRect();
+			const cells = c.querySelectorAll('[data-testid="notebook-cell"]');
+			for (let i = 0; i < cells.length; i++) {
+				const r = cells[i].getBoundingClientRect();
+				if (r.bottom > containerRect.top) {
+					return { cellIndex: i, offsetFromTop: r.top - containerRect.top };
+				}
+			}
+			return null;
+		});
+	}
 	// #endregion
 }
 

--- a/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
@@ -61,9 +61,12 @@ test.describe('Positron Notebooks: Scroll Position', {
 		const middleCellIndex = Math.floor(await notebooksPositron.cell.count() / 2);
 		await notebooksPositron.cell.nth(middleCellIndex).scrollIntoViewIfNeeded();
 
-		// Capture the scroll position
-		const scrollTopBefore = await notebooksPositron.getScrollTop();
-		expect(scrollTopBefore).toBeGreaterThan(0);
+		// Capture the scroll anchor (first visible cell + offset within viewport).
+		// Cells above can re-render with slightly different heights after reload,
+		// shifting scrollTop without changing what the user sees -- so compare the
+		// anchor that restoration actually preserves, not the raw scrollTop.
+		const anchorBefore = await notebooksPositron.getScrollAnchor();
+		expect(anchorBefore).not.toBeNull();
 
 		// Reload the window
 		await hotKeys.reloadWindow(true);
@@ -71,13 +74,13 @@ test.describe('Positron Notebooks: Scroll Position', {
 		// Wait for the notebook to be visible again after reload
 		await notebooksPositron.expectToBeVisible();
 
-		// Verify the scroll position is restored.
+		// Verify the same cell is first-visible at the same offset.
 		await expect.poll(async () => {
-			const scrollTop = await notebooksPositron.getScrollTop();
-			return Math.abs(scrollTop - scrollTopBefore);
-			// Allow a small delta here. For unknown reasons, we can't yet match it
-			// excactly after a window reload. Should not significantly affect the
-			// user experience.
+			const anchorAfter = await notebooksPositron.getScrollAnchor();
+			if (!anchorAfter || anchorAfter.cellIndex !== anchorBefore!.cellIndex) {
+				return Number.POSITIVE_INFINITY;
+			}
+			return Math.abs(anchorAfter.offsetFromTop - anchorBefore!.offsetFromTop);
 		}, { timeout: 5000 }).toBeLessThanOrEqual(50);
 	});
 });


### PR DESCRIPTION
The reload variant of the notebook scroll-position e2e test was failing on `win/electron` with deltas of 59-179 px because it compared raw `scrollTop` before and after window reload. The restoration implementation preserves an *anchor* (`cellIndex` + `offsetFromCell`), not an absolute `scrollTop` — cells above the anchor can re-render with slightly different heights between sessions, shifting `scrollTop` by tens of px while leaving the user-visible position unchanged. Trace logs from a failing run confirmed the restoration loop hit its target within 0.4 px; the test was measuring the wrong thing.

Adds `notebooksPositron.getScrollAnchor()` returning `{cellIndex, offsetFromTop}` for the first cell at least partially visible, and updates the reload test to compare anchors across the reload. Cell index must match exactly; `offsetFromTop` tolerance is left at `<= 50` for now and a follow-up will tighten it to `<= 1` (matching the tab-switch test in the same file) once a few days of green Windows runs confirm stability.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:win @:web @:positron-notebooks

Test-only change. The reload test in `test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts` should pass consistently on `e2e / windows`; the existing tab-switch test in the same file should be unaffected.