### PR TITLE
Update some templating, skills, etc for new process around PRs

### DIFF
--- a/.claude/skills/positron-pr-helper/SKILL.md
+++ b/.claude/skills/positron-pr-helper/SKILL.md
@@ -49,7 +49,7 @@ I'll dynamically fetch the current e2e test tags from `test/e2e/infra/test-runne
 Based on the PR type and context, I'll create a structured PR body with:
 
 1. **Opening Line**
-   - "Addresses #[issue]." if applicable
+   - "Fixes #[issue]" if applicable, using a GitHub closing keyword (`Fixes`, `Closes`, `Resolves`) so the issue auto-closes when the PR is merged
    - Brief statement of what the PR does otherwise
 
 2. **Description/Summary**
@@ -101,7 +101,7 @@ I use different templates based on PR type:
 
 ### Bug Fix Template
 ```markdown
-Addresses #[issue].
+Fixes #[issue]
 
 [2-3 sentences explaining the fix]
 
@@ -122,7 +122,7 @@ Addresses #[issue].
 
 ### New Feature Template
 ```markdown
-Addresses #[issue].
+Fixes #[issue]
 
 ### Summary
 [1-2 paragraphs explaining the feature]
@@ -148,7 +148,7 @@ Addresses #[issue].
 
 ### Example 1: Bug Fix PR
 ```markdown
-Addresses #8930.
+Fixes #8930
 
 This PR fixes the Data Explorer scrollbars snapping back to 0 on Safari. The issue was caused by incorrect event handling in the virtual scrolling implementation.
 
@@ -169,7 +169,7 @@ Open a large data frame in Data Explorer on Safari and verify scrollbars can be 
 
 ### Example 2: New Feature PR
 ```markdown
-Addresses #8484.
+Fixes #8484
 
 ### Summary
 Adds support for native DuckDB connections in the Connections Pane. Users can now inspect DuckDB databases directly without needing external tools. This implementation uses the native DuckDB Python API for better performance.

--- a/.claude/skills/positron-pr-helper/references/pr-templates.md
+++ b/.claude/skills/positron-pr-helper/references/pr-templates.md
@@ -8,8 +8,10 @@ This document contains templates and examples for different types of PRs in the 
 
 **With Issue:**
 ```
-Addresses #[issue_number].
+Fixes #[issue_number]
 ```
+
+Use a GitHub closing keyword (`Fixes`, `Closes`, `Resolves`) so the issue auto-closes when the PR is merged.
 
 **Without Issue:**
 ```
@@ -18,8 +20,10 @@ Addresses #[issue_number].
 
 **Multiple Issues:**
 ```
-Addresses #[issue1], #[issue2], and #[issue3].
+Fixes #[issue1], fixes #[issue2], and fixes #[issue3]
 ```
+
+Each issue needs its own closing keyword for GitHub to link and close all of them.
 
 ### Description Patterns
 
@@ -46,7 +50,7 @@ Related PRs:
 ### 1. Bug Fix
 
 ```markdown
-Addresses #[issue].
+Fixes #[issue]
 
 This PR fixes [the problem]. The issue was caused by [root cause]. [Implementation approach if non-obvious].
 
@@ -68,7 +72,7 @@ This PR fixes [the problem]. The issue was caused by [root cause]. [Implementati
 ### 2. New Feature
 
 ```markdown
-Addresses #[issue].
+Fixes #[issue]
 
 ### Summary
 
@@ -103,7 +107,7 @@ This PR adds [feature description]. Users can now [what they can do].
 ### 3. UI/UX Change
 
 ```markdown
-Addresses #[issue].
+Fixes #[issue]
 
 This PR [describes the UI change]. The change improves [what it improves].
 
@@ -129,7 +133,7 @@ This PR [describes the UI change]. The change improves [what it improves].
 ### 4. Performance Improvement
 
 ```markdown
-Addresses #[issue].
+Fixes #[issue]
 
 ### Summary
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,10 +10,11 @@ main branch by either pulling or rebasing.
 <!--
   Describe briefly what problem this pull request resolves, or what
   new feature it introduces. Include screenshots of any new or altered
-  UI. Link to any GitHub issues but avoid "magic" keywords that will
-  automatically close the issue. If there are any details about your
-  approach that are unintuitive or you want to draw attention to, please
-  describe them here.
+  UI. Reference the associated issue with a closing keyword such as
+  "Fixes #123" so GitHub automatically closes the issue when this PR
+  is merged. If there are any details about your approach that are
+  unintuitive or you want to draw attention to, please describe them
+  here.
 -->
 
 
@@ -39,7 +40,7 @@ main branch by either pulling or rebasing.
 - N/A
 
 
-### QA Notes
+### Validation Steps
 
 <!--
   Positron team members: please add relevant e2e test tags, so the tests can be
@@ -51,8 +52,8 @@ main branch by either pulling or rebasing.
 
 
 <!--
-  Add additional information for QA on how to validate the change,
-  paying special attention to the level of risk, adjacent areas that
-  could be affected by the change, and any important contextual
-  information not present in the linked issues.
+  Add additional information on how to validate the change, paying
+  special attention to the level of risk, adjacent areas that could
+  be affected by the change, and any important contextual information
+  not present in the linked issues.
 -->


### PR DESCRIPTION
A follow-up to https://github.com/posit-dev/positron-wiki/pull/211 to adjust our various templates and skills for our new process around PR review and issue closing.