### PR TITLE
Fix Vitest Config

### DIFF
--- a/.claude/skills/author-vitest-tests/SKILL.md
+++ b/.claude/skills/author-vitest-tests/SKILL.md
@@ -147,13 +147,15 @@ For each approved item:
 
 2. **Run the test:** `npx vitest run <path-to-test-file>`. Iterate on missing stubs per the "start low, let errors guide you up" pattern in the rules file's Builder section.
 
-3. **Check coverage** for React component tests: `npx vitest run --coverage --coverage.include='**/sourceFile.tsx' <path-to-test-file>`
+3. **Type-check the file:** `npm run test:positron:check-ts 2>&1 | grep '<test-file-name>.vitest.ts'`. This surfaces strict TypeScript errors (overload compatibility, missing properties on stubs, etc.) that `npx vitest run` does NOT catch — the output matches what the VS Code Problems pane shows. The file must be clean before considering it done.
 
-4. **For React tests**, run `npx eslint <file>` before considering it done -- `eslint-plugin-testing-library` enforces most of the RTL conventions.
+4. **Check coverage** for React component tests: `npx vitest run --coverage --coverage.include='**/sourceFile.tsx' <path-to-test-file>`
 
-5. Move to the next file. Do NOT ask the dev after each file.
+5. **For React tests**, run `npx eslint <file>` before considering it done -- `eslint-plugin-testing-library` enforces most of the RTL conventions.
 
-6. After all tests pass, run the full Vitest suite: `npm run test:positron`
+6. Move to the next file. Do NOT ask the dev after each file.
+
+7. After all tests pass, run the full Vitest suite: `npm run test:positron`
 
 ### Builder enforcement
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Positron is a next-generation data science IDE built on VS Code with first-class
 
 ## Build System
 
-**NEVER run direct TypeScript compilation** (`npx tsc`, `tsc --noEmit`, etc.). This project is too large and it will fail or hang. The background daemons handle all compilation. If you need to verify code compiles:
+**NEVER run direct TypeScript compilation on the main project** (`npx tsc`, `tsc --noEmit`, etc. against `src/tsconfig.json`). This project is too large and it will fail or hang. The background daemons handle all compilation. If you need to verify code compiles:
 
 1. Check daemon status first: `npm run build-ps`
 2. Start missing daemons in the background if needed: `npm run build-start`
@@ -16,6 +16,8 @@ Positron is a next-generation data science IDE built on VS Code with first-class
 Edge cases:
 
 - Restart build daemons to fix missing package errors after `npm install`: `npm run build-stop && npm run build-start && npm run build-check`
+
+**Exception for vitest test files:** `npm run build-check` excludes `*.vitest.ts` files, so it won't surface type errors in tests. To check those, run `npm run test:positron:check-ts` (wraps `tsc --noEmit -p ./vitest.tsconfig.json --skipLibCheck`). It is scoped to vitest files + their ambient declarations and completes in seconds. The output matches what the VS Code Problems pane shows for `.vitest.{ts,tsx}` files. Filter to a specific file with: `npm run test:positron:check-ts 2>&1 | grep '<file>.vitest.ts'`.
 
 ## Upstream Compatibility
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test-extension": "vscode-test",
     "test-build-scripts": "cd build && npm run test",
     "test:positron": "vitest --run",
+    "test:positron:check-ts": "tsc --noEmit -p ./vitest.tsconfig.json --skipLibCheck",
     "test:core": "./scripts/test.sh",
     "test:ext-host": "./scripts/test-integration.sh",
     "check-cyclic-dependencies": "node build/lib/checkCyclicDependencies.ts out",

--- a/vitest.tsconfig.json
+++ b/vitest.tsconfig.json
@@ -21,6 +21,15 @@
 	"include": [
 		"src/vs/**/*.vitest.ts",
 		"src/vs/**/*.vitest.tsx",
-		"src/vs/test/vitest/**"
-	]
+		"src/vs/test/vitest/**/*",
+		// Add files from the base tsconfig that we need for Vitest tests
+		"src/typings",
+		"src/positron-dts/positron.d.ts",
+		"src/positron-dts/ui-comm.d.ts",
+		"src/vscode-dts/vscode.proposed.*.d.ts",
+		"src/vscode-dts/vscode.d.ts"
+	],
+	// Reset the exclude list so we aren't inheriting it from base tsconfig
+	// which excludes vitest files that we DO want to include here.
+	"exclude": []
 }


### PR DESCRIPTION
I noticed a large number of TypeScript errors in the "Problems" pane in VS Code for our newer `.vitest.ts` files. These tests were mostly generated via our new test writing skill. It turns out our skill doesn't have a way to catch strict type errors (overload mismatches, missing properties on stubs, etc.), so these were slipping through!

Normally type errors get caught by `npm run build-check` which runs the project's main TS check, but we exclude `.vitest.ts` files entirely (the parent `src/tsconfig.json` puts them in `exclude`). We also explicitly tell Claude not to run the typescript compilation commands so it was never checking the compilation status of the vitest files.

I've updated the skill + our vitest config file to make sure that we have a way to see these type errors via CLI commands.

This will allow us to fix all the type errors in follow-up PRs.

### Testing

You can run `tsc --noEmit -p ./vitest.tsconfig.json` on `main` and see that the typescript errors aren't being shown.
If you run `tsc --noEmit -p ./vitest.tsconfig.json` on this branch, you'll see the typescript errors come through!

I was testing against `selectionKeybindings.vitest.ts` file which has a bunch of TS errors.