### PR TITLE
Add "Change Notebook Session..." option to interpreter picker

### DIFF
--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -19,8 +19,7 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../editor/common/services/model.js';
 import { getSessionDisplayName, getSessionIconClasses, isQuartoSession } from '../../positronConsole/common/sessionDisplayUtils.js';
-import { SELECT_KERNEL_ID_POSITRON } from '../../positronNotebook/browser/SelectPositronNotebookKernelAction.js';
-import { POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../../positronNotebook/common/positronNotebookCommon.js';
+import { POSITRON_NOTEBOOK_EDITOR_INPUT_ID, SELECT_KERNEL_ID_POSITRON } from '../../positronNotebook/common/positronNotebookCommon.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
 import { DisposableStore, dispose } from '../../../../base/common/lifecycle.js';

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -200,7 +200,7 @@ export const selectLanguageRuntimeSession = async (
 		}
 	};
 
-	const foregroundSessionId = runtimeSessionService.foregroundSession?.sessionId;
+	const currentForegroundSession = runtimeSessionService.foregroundSession;
 	const sessionItems: IQuickPickItem[] = [];
 
 	// Create quick pick items for active console sessions sorted by creation time, oldest to newest.
@@ -212,11 +212,11 @@ export const selectLanguageRuntimeSession = async (
 			id: session.sessionId,
 			label: session.dynState.sessionName,
 			detail: session.runtimeMetadata.runtimePath,
-			description: session.sessionId === foregroundSessionId
+			description: session.sessionId === currentForegroundSession?.sessionId
 				? localize('positron.languageRuntime.currentlySelected', 'Currently Selected')
 				: undefined,
 			iconClasses: iconClassesForSession(session),
-			picked: session.sessionId === foregroundSessionId,
+			picked: session.sessionId === currentForegroundSession?.sessionId
 		}));
 
 	const quickPickItems: QuickPickItem[] = [
@@ -241,11 +241,11 @@ export const selectLanguageRuntimeSession = async (
 				id: session.sessionId,
 				label: getSessionDisplayNameWithRuntime(session),
 				detail: session.runtimeMetadata.runtimePath,
-				description: session.sessionId === foregroundSessionId
+				description: session.sessionId === currentForegroundSession?.sessionId
 					? localize('positron.languageRuntime.currentlySelected', 'Currently Selected')
 					: undefined,
 				iconClasses: iconClassesForSession(session),
-				picked: session.sessionId === foregroundSessionId,
+				picked: session.sessionId === currentForegroundSession?.sessionId,
 			}));
 
 		if (notebookItems.length > 0) {
@@ -263,11 +263,11 @@ export const selectLanguageRuntimeSession = async (
 				id: session.sessionId,
 				label: getSessionDisplayNameWithRuntime(session),
 				detail: session.runtimeMetadata.runtimePath,
-				description: session.sessionId === foregroundSessionId
+				description: session.sessionId === currentForegroundSession?.sessionId
 					? localize('positron.languageRuntime.currentlySelected', 'Currently Selected')
 					: undefined,
 				iconClasses: iconClassesForSession(session),
-				picked: session.sessionId === foregroundSessionId,
+				picked: session.sessionId === currentForegroundSession?.sessionId,
 			}));
 
 		if (quartoItems.length > 0) {
@@ -280,14 +280,13 @@ export const selectLanguageRuntimeSession = async (
 		}
 	}
 
-	const foregroundForChange = runtimeSessionService.foregroundSession;
 	const showChangeNotebookSession =
 		includeNotebookSessions
-		&& foregroundForChange?.metadata.sessionMode === LanguageRuntimeSessionMode.Notebook
-		&& foregroundForChange.metadata.notebookUri !== undefined
+		&& currentForegroundSession?.metadata.sessionMode === LanguageRuntimeSessionMode.Notebook
+		&& currentForegroundSession.metadata.notebookUri !== undefined
 		&& editorService.activeEditor?.typeId === POSITRON_NOTEBOOK_EDITOR_INPUT_ID
 		&& !isQuartoSession({
-			notebookUri: foregroundForChange.metadata.notebookUri,
+			notebookUri: currentForegroundSession.metadata.notebookUri,
 			modelService,
 		});
 

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -20,6 +20,7 @@ import { ILanguageService } from '../../../../editor/common/languages/language.j
 import { IModelService } from '../../../../editor/common/services/model.js';
 import { getSessionDisplayName, getSessionIconClasses, isQuartoSession } from '../../positronConsole/common/sessionDisplayUtils.js';
 import { SELECT_KERNEL_ID_POSITRON } from '../../positronNotebook/browser/SelectPositronNotebookKernelAction.js';
+import { POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../../positronNotebook/common/positronNotebookCommon.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
 import { DisposableStore, dispose } from '../../../../base/common/lifecycle.js';
@@ -165,6 +166,7 @@ export const selectLanguageRuntimeSession = async (
 	const quickInputService = accessor.get(IQuickInputService);
 	const runtimeSessionService = accessor.get(IRuntimeSessionService);
 	const commandService = accessor.get(ICommandService);
+	const editorService = accessor.get(IEditorService);
 	const modelService = accessor.get(IModelService);
 	const languageService = accessor.get(ILanguageService);
 
@@ -284,6 +286,7 @@ export const selectLanguageRuntimeSession = async (
 		includeNotebookSessions
 		&& foregroundForChange?.metadata.sessionMode === LanguageRuntimeSessionMode.Notebook
 		&& foregroundForChange.metadata.notebookUri !== undefined
+		&& editorService.activeEditor?.typeId === POSITRON_NOTEBOOK_EDITOR_INPUT_ID
 		&& !isQuartoSession({
 			notebookUri: foregroundForChange.metadata.notebookUri,
 			modelService,

--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -19,6 +19,7 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
 import { IModelService } from '../../../../editor/common/services/model.js';
 import { getSessionDisplayName, getSessionIconClasses, isQuartoSession } from '../../positronConsole/common/sessionDisplayUtils.js';
+import { SELECT_KERNEL_ID_POSITRON } from '../../positronNotebook/browser/SelectPositronNotebookKernelAction.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
 import { DisposableStore, dispose } from '../../../../base/common/lifecycle.js';
@@ -148,7 +149,7 @@ async function selectLanguage(accessor: ServicesAccessor) {
  *   false for actions that only operate on console sessions.
  * @returns The runtime session the user selected, or undefined, if the user canceled the operation.
  */
-const selectLanguageRuntimeSession = async (
+export const selectLanguageRuntimeSession = async (
 	accessor: ServicesAccessor,
 	options?: {
 		allowStartSession?: boolean;
@@ -158,6 +159,7 @@ const selectLanguageRuntimeSession = async (
 
 	// Constants
 	const startNewRuntimeId = generateUuid();
+	const changeNotebookSessionId = generateUuid();
 
 	// Access services.
 	const quickInputService = accessor.get(IQuickInputService);
@@ -277,12 +279,31 @@ const selectLanguageRuntimeSession = async (
 		}
 	}
 
-	if (options?.allowStartSession) {
+	const foregroundForChange = runtimeSessionService.foregroundSession;
+	const showChangeNotebookSession =
+		includeNotebookSessions
+		&& foregroundForChange?.metadata.sessionMode === LanguageRuntimeSessionMode.Notebook
+		&& foregroundForChange.metadata.notebookUri !== undefined
+		&& !isQuartoSession({
+			notebookUri: foregroundForChange.metadata.notebookUri,
+			modelService,
+		});
+
+	if (showChangeNotebookSession || options?.allowStartSession) {
 		quickPickItems.push({ type: 'separator' });
+	}
+	if (options?.allowStartSession) {
 		quickPickItems.push({
 			label: localize('positron.languageRuntime.newConsoleSession', 'New Console Session...'),
 			id: startNewRuntimeId,
-			alwaysShow: true
+			alwaysShow: true,
+		});
+	}
+	if (showChangeNotebookSession) {
+		quickPickItems.push({
+			label: localize('positron.languageRuntime.changeNotebookSession', 'Change Notebook Session...'),
+			id: changeNotebookSessionId,
+			alwaysShow: true,
 		});
 	}
 	const result = await quickInputService.pick(quickPickItems, {
@@ -298,6 +319,9 @@ const selectLanguageRuntimeSession = async (
 		if (sessionId) {
 			return runtimeSessionService.activeSessions.find(session => session.sessionId === sessionId);
 		}
+	} else if (result?.id === changeNotebookSessionId) {
+		await commandService.executeCommand(SELECT_KERNEL_ID_POSITRON);
+		return undefined;
 	} else if (result?.id) {
 		const session = runtimeSessionService.activeSessions
 			.find(session => session.sessionId === result.id);

--- a/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
+++ b/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
@@ -6,13 +6,19 @@
 /// <reference types="vitest/globals" />
 
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
-import { IQuickInputService, IQuickPickItem, QuickInputHideReason } from '../../../../../platform/quickinput/common/quickInput.js';
-import { ILanguageRuntimeMetadata, ILanguageRuntimeService, IRuntimePickerContribution, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, RuntimeStartupPhase } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { IQuickInputService, IQuickPickItem, QuickInputHideReason, QuickPickItem } from '../../../../../platform/quickinput/common/quickInput.js';
+import { ILanguageRuntimeMetadata, ILanguageRuntimeService, IRuntimePickerContribution, LanguageRuntimeSessionLocation, LanguageRuntimeSessionMode, LanguageRuntimeStartupBehavior, RuntimeStartupPhase } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IRuntimeStartupService } from '../../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { TestQuickPick } from '../../../../../test/vitest/testQuickPick.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
-import { selectNewLanguageRuntime } from '../../browser/languageRuntimeActions.js';
+import { selectLanguageRuntimeSession, selectNewLanguageRuntime } from '../../browser/languageRuntimeActions.js';
+import { Emitter } from '../../../../../base/common/event.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IModelService } from '../../../../../editor/common/services/model.js';
+import { IRuntimeSessionService, ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { SELECT_KERNEL_ID_POSITRON } from '../../../positronNotebook/browser/SelectPositronNotebookKernelAction.js';
 
 function makeRuntime(overrides: Partial<ILanguageRuntimeMetadata> = {}): ILanguageRuntimeMetadata {
 	const languageId = overrides.languageId ?? 'python';
@@ -59,7 +65,6 @@ describe('selectNewLanguageRuntime', () => {
 	beforeEach(() => {
 		preferredByLanguage = new Map();
 		pick = ctx.disposables.add(new TestQuickPick<IQuickPickItem>());
-		// Default to Complete so contribution-fetching path runs unless a test overrides.
 		ctx.get(ILanguageRuntimeService).setStartupPhase(RuntimeStartupPhase.Complete);
 	});
 
@@ -397,5 +402,121 @@ describe('selectNewLanguageRuntime', () => {
 			pick.cancel(QuickInputHideReason.Gesture);
 			await promise;
 		});
+	});
+});
+
+describe('selectLanguageRuntimeSession - change notebook session', () => {
+	const changeNotebookSessionLabel = 'Change Notebook Session...';
+
+	let pickItems: QuickPickItem[] = [];
+	const pickFn = vi.fn(async (items: QuickPickItem[]): Promise<QuickPickItem | undefined> => {
+		pickItems = items;
+		return undefined; // user cancels by default; specific tests override
+	});
+	const executeCommand = vi.fn(async () => undefined);
+	const onDidChangeForegroundSession = new Emitter<ILanguageRuntimeSession | undefined>();
+
+	let foregroundSession: ILanguageRuntimeSession | undefined;
+
+	const ctx = createTestContainer()
+		.withRuntimeServices()
+		.stub(IRuntimeSessionService, stubInterface<IRuntimeSessionService>({
+			get foregroundSession() { return foregroundSession; },
+			activeSessions: [] as ILanguageRuntimeSession[],
+			onDidChangeForegroundSession: onDidChangeForegroundSession.event,
+		}))
+		.stub(ICommandService, { executeCommand })
+		.stub(IModelService, { getModel: () => null })
+		.stub(IQuickInputService, stubInterface<IQuickInputService>({
+			pick: pickFn,
+		}))
+		.build();
+
+	function makeNotebookSession(uri: URI): ILanguageRuntimeSession {
+		return stubInterface<ILanguageRuntimeSession>({
+			sessionId: 'notebook-session-1',
+			metadata: {
+				sessionId: 'notebook-session-1',
+				sessionMode: LanguageRuntimeSessionMode.Notebook,
+				notebookUri: uri,
+				createdTimestamp: 0,
+				startReason: 'test',
+			},
+		});
+	}
+
+	function makeConsoleSession(): ILanguageRuntimeSession {
+		return stubInterface<ILanguageRuntimeSession>({
+			sessionId: 'console-session-1',
+			metadata: {
+				sessionId: 'console-session-1',
+				sessionMode: LanguageRuntimeSessionMode.Console,
+				notebookUri: undefined,
+				createdTimestamp: 0,
+				startReason: 'test',
+			},
+		});
+	}
+
+	beforeEach(() => {
+		foregroundSession = undefined;
+		pickItems = [];
+	});
+
+	afterAll(() => {
+		onDidChangeForegroundSession.dispose();
+	});
+
+	function openInterpreterPicker(options?: Parameters<typeof selectLanguageRuntimeSession>[1]) {
+		return ctx.instantiationService.invokeFunction(accessor =>
+			selectLanguageRuntimeSession(accessor, options));
+	}
+
+	function hasChangeNotebookItem(): boolean {
+		return pickItems.some(item => item.label === changeNotebookSessionLabel);
+	}
+
+	it('shows the item when foreground is an .ipynb notebook session', async () => {
+		foregroundSession = makeNotebookSession(URI.file('/path/to/notebook.ipynb'));
+		await openInterpreterPicker();
+		expect(hasChangeNotebookItem()).toBe(true);
+	});
+
+	it('hides the item when foreground is a console session', async () => {
+		foregroundSession = makeConsoleSession();
+		await openInterpreterPicker();
+		expect(hasChangeNotebookItem()).toBe(false);
+	});
+
+	it('hides the item when foreground is a Quarto session', async () => {
+		// .qmd extension makes isQuartoDocument(path, ...) return true regardless of model.
+		foregroundSession = makeNotebookSession(URI.file('/path/to/document.qmd'));
+		await openInterpreterPicker();
+		expect(hasChangeNotebookItem()).toBe(false);
+	});
+
+	it('hides the item when there is no foreground session', async () => {
+		foregroundSession = undefined;
+		await openInterpreterPicker();
+		expect(hasChangeNotebookItem()).toBe(false);
+	});
+
+	it('hides the item when caller passes includeNotebookSessions: false', async () => {
+		foregroundSession = makeNotebookSession(URI.file('/path/to/notebook.ipynb'));
+		await openInterpreterPicker({ includeNotebookSessions: false });
+		expect(hasChangeNotebookItem()).toBe(false);
+	});
+
+	it('dispatches SELECT_KERNEL_ID_POSITRON when the item is selected', async () => {
+		foregroundSession = makeNotebookSession(URI.file('/path/to/notebook.ipynb'));
+		// Override pickFn for this test: return the change-notebook item.
+		pickFn.mockImplementationOnce(async (items: QuickPickItem[]) => {
+			pickItems = items;
+			return items.find(item => item.label === changeNotebookSessionLabel);
+		});
+
+		const result = await openInterpreterPicker();
+		expect(executeCommand).toHaveBeenCalledWith(SELECT_KERNEL_ID_POSITRON);
+		expect(result).toBeUndefined();
 	});
 });

--- a/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
+++ b/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
@@ -16,9 +16,12 @@ import { selectLanguageRuntimeSession, selectNewLanguageRuntime } from '../../br
 import { Emitter } from '../../../../../base/common/event.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IEditorService } from '../../../../services/editor/common/editorService.js';
+import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { IModelService } from '../../../../../editor/common/services/model.js';
 import { IRuntimeSessionService, ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { SELECT_KERNEL_ID_POSITRON } from '../../../positronNotebook/browser/SelectPositronNotebookKernelAction.js';
+import { POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../../../positronNotebook/common/positronNotebookCommon.js';
 
 function makeRuntime(overrides: Partial<ILanguageRuntimeMetadata> = {}): ILanguageRuntimeMetadata {
 	const languageId = overrides.languageId ?? 'python';
@@ -417,6 +420,7 @@ describe('selectLanguageRuntimeSession - change notebook session', () => {
 	const onDidChangeForegroundSession = new Emitter<ILanguageRuntimeSession | undefined>();
 
 	let foregroundSession: ILanguageRuntimeSession | undefined;
+	let activeEditor: EditorInput | undefined;
 
 	const ctx = createTestContainer()
 		.withRuntimeServices()
@@ -427,6 +431,9 @@ describe('selectLanguageRuntimeSession - change notebook session', () => {
 		}))
 		.stub(ICommandService, { executeCommand })
 		.stub(IModelService, { getModel: () => null })
+		.stub(IEditorService, stubInterface<IEditorService>({
+			get activeEditor() { return activeEditor; },
+		}))
 		.stub(IQuickInputService, stubInterface<IQuickInputService>({
 			pick: pickFn,
 		}))
@@ -458,9 +465,15 @@ describe('selectLanguageRuntimeSession - change notebook session', () => {
 		});
 	}
 
+	function makeEditorInput(typeId: string, uri: URI): EditorInput {
+		return stubInterface<EditorInput>({ typeId, resource: uri });
+	}
+
 	beforeEach(() => {
 		foregroundSession = undefined;
 		pickItems = [];
+		// Default to the Positron Notebook Editor for tests
+		activeEditor = makeEditorInput(POSITRON_NOTEBOOK_EDITOR_INPUT_ID, URI.file('/path/to/notebook.ipynb'));
 	});
 
 	afterAll(() => {
@@ -504,6 +517,14 @@ describe('selectLanguageRuntimeSession - change notebook session', () => {
 	it('hides the item when caller passes includeNotebookSessions: false', async () => {
 		foregroundSession = makeNotebookSession(URI.file('/path/to/notebook.ipynb'));
 		await openInterpreterPicker({ includeNotebookSessions: false });
+		expect(hasChangeNotebookItem()).toBe(false);
+	});
+
+	it('hides the item when the active editor is a legacy notebook editor', async () => {
+		foregroundSession = makeNotebookSession(URI.file('/path/to/notebook.ipynb'));
+		// 'jupyter-notebook' is the upstream legacy notebook editor input typeId.
+		activeEditor = makeEditorInput('jupyter-notebook', URI.file('/path/to/notebook.ipynb'));
+		await openInterpreterPicker();
 		expect(hasChangeNotebookItem()).toBe(false);
 	});
 

--- a/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
+++ b/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
@@ -13,7 +13,6 @@ import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { TestQuickPick } from '../../../../../test/vitest/testQuickPick.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { selectLanguageRuntimeSession, selectNewLanguageRuntime } from '../../browser/languageRuntimeActions.js';
-import { Emitter } from '../../../../../base/common/event.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IEditorService } from '../../../../services/editor/common/editorService.js';
@@ -60,7 +59,11 @@ describe('selectNewLanguageRuntime', () => {
 			rediscoverAllRuntimes,
 		})
 		.stub(IQuickInputService, stubInterface<IQuickInputService>({
-			createQuickPick: () => pick.asQuickPick(),
+			// Narrow to IQuickInputService['createQuickPick'] because the field is
+			// overloaded ({useSeparators: true} vs default false); our single-shape
+			// stub function only satisfies one overload and TS rejects it without
+			// the cast.
+			createQuickPick: (() => pick.asQuickPick()) as IQuickInputService['createQuickPick'],
 		}))
 		.build();
 
@@ -416,7 +419,6 @@ describe('selectLanguageRuntimeSession - change notebook session', () => {
 		return undefined; // user cancels by default; specific tests override
 	});
 	const executeCommand = vi.fn(async () => undefined);
-	const onDidChangeForegroundSession = new Emitter<ILanguageRuntimeSession | undefined>();
 
 	let foregroundSession: ILanguageRuntimeSession | undefined;
 	let activeEditor: EditorInput | undefined;
@@ -426,7 +428,6 @@ describe('selectLanguageRuntimeSession - change notebook session', () => {
 		.stub(IRuntimeSessionService, stubInterface<IRuntimeSessionService>({
 			get foregroundSession() { return foregroundSession; },
 			activeSessions: [] as ILanguageRuntimeSession[],
-			onDidChangeForegroundSession: onDidChangeForegroundSession.event,
 		}))
 		.stub(ICommandService, { executeCommand })
 		.stub(IModelService, { getModel: () => null })
@@ -434,7 +435,11 @@ describe('selectLanguageRuntimeSession - change notebook session', () => {
 			get activeEditor() { return activeEditor; },
 		}))
 		.stub(IQuickInputService, stubInterface<IQuickInputService>({
-			pick: pickFn,
+			// Narrow to IQuickInputService['pick'] because the field is overloaded
+			// (canPickMany: true returns Promise<T[]>, canPickMany: false returns
+			// Promise<T>); our single-shape stub satisfies only one overload and
+			// TS rejects it without the cast.
+			pick: pickFn as IQuickInputService['pick'],
 		}))
 		.build();
 
@@ -473,10 +478,6 @@ describe('selectLanguageRuntimeSession - change notebook session', () => {
 		pickItems = [];
 		// Default to the Positron Notebook Editor for tests
 		activeEditor = makeEditorInput(POSITRON_NOTEBOOK_EDITOR_INPUT_ID, URI.file('/path/to/notebook.ipynb'));
-	});
-
-	afterAll(() => {
-		onDidChangeForegroundSession.dispose();
 	});
 
 	function openInterpreterPicker(options?: Parameters<typeof selectLanguageRuntimeSession>[1]) {

--- a/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
+++ b/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
@@ -20,8 +20,7 @@ import { IEditorService } from '../../../../services/editor/common/editorService
 import { EditorInput } from '../../../../common/editor/editorInput.js';
 import { IModelService } from '../../../../../editor/common/services/model.js';
 import { IRuntimeSessionService, ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
-import { SELECT_KERNEL_ID_POSITRON } from '../../../positronNotebook/browser/SelectPositronNotebookKernelAction.js';
-import { POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../../../positronNotebook/common/positronNotebookCommon.js';
+import { POSITRON_NOTEBOOK_EDITOR_INPUT_ID, SELECT_KERNEL_ID_POSITRON } from '../../../positronNotebook/common/positronNotebookCommon.js';
 
 function makeRuntime(overrides: Partial<ILanguageRuntimeMetadata> = {}): ILanguageRuntimeMetadata {
 	const languageId = overrides.languageId ?? 'python';

--- a/src/vs/workbench/contrib/positronNotebook/browser/ExecuteSelectionInConsoleAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ExecuteSelectionInConsoleAction.ts
@@ -22,8 +22,6 @@ import { RuntimeCodeExecutionMode } from '../../../services/languageRuntime/comm
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
 import { NOTEBOOK_CELL_TYPE } from '../../notebook/common/notebookContextKeys.js';
 
-export const SELECT_KERNEL_ID_POSITRON = 'positronNotebook.selectKernel';
-
 /**
  * An action that executes the selected text in a notebook cell in the
  * associated console for the notebook.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -30,7 +30,7 @@ import { POSITRON_NOTEBOOK_ASSISTANT_AUTO_FOLLOW_KEY } from '../common/positronN
 import { getAssistantSettings } from '../common/notebookAssistantMetadata.js';
 import { NotebookCellTextModel } from '../../notebook/common/model/notebookCellTextModel.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
-import { SELECT_KERNEL_ID_POSITRON } from './SelectPositronNotebookKernelAction.js';
+import { SELECT_KERNEL_ID_POSITRON } from '../common/positronNotebookCommon.js';
 import { INotebookKernelService } from '../../notebook/common/notebookKernelService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { ILanguageRuntimeService, RuntimeStartupPhase, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';

--- a/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/SelectPositronNotebookKernelAction.ts
@@ -13,8 +13,8 @@ import { IEditorService } from '../../../services/editor/common/editorService.js
 import { getNotebookInstanceFromActiveEditorPane } from './notebookUtils.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { selectNewLanguageRuntime } from '../../languageRuntime/browser/languageRuntimeActions.js';
+import { SELECT_KERNEL_ID_POSITRON } from '../common/positronNotebookCommon.js';
 
-export const SELECT_KERNEL_ID_POSITRON = 'positronNotebook.selectKernel';
 const NOTEBOOK_ACTIONS_CATEGORY_POSITRON = localize2('positronNotebookActions.category', 'Positron Notebook');
 const NOTEBOOK_IS_ACTIVE_EDITOR = ContextKeyExpr.equals('activeEditor', 'workbench.editor.positronNotebook');
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -11,6 +11,7 @@ import './contrib/outline/positronNotebookOutline.contribution.js';
 
 // Self-registering Action2 contributions
 import './notebookCells/InlineDataExplorerActions.js';
+import './SelectPositronNotebookKernelAction.js';
 
 import { isCopyImageMenuArg, toBase64DataUrl } from './copyImageUtils.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
@@ -12,6 +12,8 @@ export const POSITRON_NOTEBOOK_EDITOR_INPUT_ID = 'workbench.input.positronNotebo
 
 export const POSITRON_EXECUTE_CELL_COMMAND_ID = 'positronNotebook.cell.execute';
 
+export const SELECT_KERNEL_ID_POSITRON = 'positronNotebook.selectKernel';
+
 /**
  * Returns whether Positron Notebooks should be used.
  * @param configurationService Configuration service


### PR DESCRIPTION
Fixes #11906

### Summary

Adds a "Change Notebook Session..." entry to the interpreter picker when the foreground session is a notebook session running in the Positron Notebook editor. Selecting it dispatches the existing `positronNotebook.selectKernel` command, which opens the same rich runtime picker as `Change Kernel...` in the kernel-status submenu.

This action DOES NOT show up for Quarto inline output documents or the Legacy Notebook Editor. I didn't apply this change to quarto because I don't know think the term "Change Notebook Session..." makes sense for Quarto. Users don't think of Quarto docs as notebooks. We should consider revisiting this once we have an idea of what we want to show for Quarto. 

The "Change Notebook Session..." option requires all of the following to be shown:
- Caller passes `includeNotebookSessions: true` (default)
- Foreground session is `LanguageRuntimeSessionMode.Notebook`.
- Session has a `notebookUri`.
- Session is not a Quarto session (filtered via `isQuartoSession`).
- Active editor is a Positron notebook editor (`POSITRON_NOTEBOOK_EDITOR_INPUT_ID`)

This PR also moves the `SELECT_KERNEL_ID_POSITRON` constant from `SelectPositronNotebookKernelAction.ts` to `positronNotebookCommon.ts` to break a cyclic dependency that surfaced when `languageRuntimeActions.ts` started importing it.

### Screenshots

Positron Notebook Editor

https://github.com/user-attachments/assets/d6f527d9-6f54-4537-a3a3-87bdf18099f5

All Other File Types

https://github.com/user-attachments/assets/5f3f478a-52ab-4209-9167-e0a5cd47c5a2

### Release Notes

#### New Features

- Add a "Change Notebook Session..." entry to the interpreter picker, allowing users to change the runtime for the active notebook editor (#11906)

#### Bug Fixes

- N/A

### QA Notes

@:interpreter @:positron-notebooks @:sessions

#### Test cases

**Positron Notebook Editor.**
   - Open a `.ipynb` notebook with the Positron Notebook Editor and wait for a session to start.
   - Click the interpreter picker in the top right.
   - Verify "Change Notebook Session..." option appears.
   - Select it and verify a rich runtime picker opens with the current kernel pre-selected.
   - Pick a different runtime and verify the notebook kernel selector updates and the interpreter picker

**Console**
   - Close all notebooks using the Positron Notebook Editor, open the picker -> "Change Notebook Session..." is NOT shown.

**Quarto*
   - Open a `.qmd` Quarto document with inline output enabled and a running Quarto session.
   - Open the picker -> "Change Notebook Session..." is NOT shown.

**Legacy Notebook Editor**
   - Right-click an `.ipynb` -> "Open With..." -> "Legacy Jupyter Notebook".
   - Open the picker -> "Change Notebook Session..." is NOT shown.