### PR TITLE
Fix font icon size and position

### DIFF
--- a/product.json
+++ b/product.json
@@ -242,8 +242,8 @@
 		},
 		{
 			"name": "quarto.quarto",
-			"version": "1.131.0",
-			"sha256": "1fcae21883e96367a6e65a76d84cf8900138c4536774f9a5387f711538389a0c",
+			"version": "1.132.0",
+			"sha256": "fe54121a32cae2b1bd9e6b8560fcfcbacc23515587abb09dd735110d3246245b",
 			"repo": "https://github.com/quarto-dev/quarto/tree/main/apps/vscode",
 			"metadata": {
 				"id": "a1be81fc-0f3a-4f2e-92ee-3fdc7ab96c73",

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.css
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.css
@@ -6,4 +6,5 @@
 .top-action-bar-session-manager-face {
 	display: flex;
 	align-items: center;
+	gap: 6px;
 }

--- a/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.css
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/components/topActionBarSessionManager.css
@@ -6,5 +6,5 @@
 .top-action-bar-session-manager-face {
 	display: flex;
 	align-items: center;
-	gap: 6px;
+	gap: 4px;
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
@@ -30,7 +30,7 @@
 .tab-button .tab-header {
 	display: flex;
 	align-items: center;
-	gap: 6px;
+	gap: 4px;
 	height: 22px;
 	width: 100%;
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleTab.css
@@ -30,6 +30,7 @@
 .tab-button .tab-header {
 	display: flex;
 	align-items: center;
+	gap: 6px;
 	height: 22px;
 	width: 100%;
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeIcon.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeIcon.css
@@ -7,25 +7,30 @@
 	display: inline-flex;
 	align-items: center;
 	flex-shrink: 0;
-	width: 20px;
-	height: 20px;
+	line-height: 22px;
+	padding-left: 6px;
 }
 
 /**
  * File icon themes scope all their CSS to `.show-file-icons`.
- * Without this class nothing renders. Each surface using RuntimeIcon
- * has to add the class to its container.
+ * Without this class nothing renders. Each surface using
+ * RuntimeIcon has to add the class to its container.
  *
- * The sizing strategy used here matches IconLabel (see iconLabel.css)
- * so Seti font glyphs and language-contributed SVGs end up the same
- * visual size.
+ * Mirror IconLabel (iconLabel.css) so the icon renderes
+ * identically to the file explorer, breadcrumbs, and editor tabs
+ * across all themes.
  */
 .show-file-icons .runtime-session-icon::before {
-	display: inline-block;
-	font-size: 20px !important; /* override the show-file-icons default font size */
-	line-height: 20px;
 	background-size: 16px;
 	background-position: left center;
 	background-repeat: no-repeat;
+	padding-right: 6px;
+	width: 16px;
+	height: 22px;
+	line-height: inherit !important;
+	display: inline-block;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	vertical-align: top;
 	flex-shrink: 0;
 }

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeIcon.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeIcon.css
@@ -32,3 +32,29 @@
 	vertical-align: top;
 	flex-shrink: 0;
 }
+
+/**
+ * Seti glyphs draw offset-right within the em quad, leaving visible empty
+ * space on the left of the icon between the parent's padding edge and the
+ * painted glyph. To compensate, we pull the entire icon left via margin-left,
+ * which visually centers Seti icons within the padded area of the console tab
+ * list and session picker.
+ */
+.runtime-session-icon.seti-icon-theme-active {
+	margin-left: -5px;
+}
+
+/**
+ * Seti renders its language glyphs offset-right within the em quad. Seti has no
+ * `.qmd` rule, so `.qmd` files fall through to the Quarto extension's SVG
+ * (centered SVG), which does not look vertically aligned with other Seti glyphs
+ * in the console tab list and session picker. To fix this we shift the  SVG right
+ * to match Seti's visual center.
+ *
+ * Scoped to `.qmd` only (not `.quarto-lang-file-icon`) because Seti DOES map
+ * `.rmd` to an R glyph. Those files render via Seti's font and are already
+ * right-aligned, so applying the shim would over-shift them.
+ */
+.runtime-session-icon.seti-icon-theme-active.qmd-ext-file-icon::before {
+	transform: translateX(2px);
+}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeIcon.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeIcon.css
@@ -8,7 +8,6 @@
 	align-items: center;
 	flex-shrink: 0;
 	line-height: 22px;
-	padding-left: 6px;
 }
 
 /**
@@ -24,7 +23,6 @@
 	background-size: 16px;
 	background-position: left center;
 	background-repeat: no-repeat;
-	padding-right: 6px;
 	width: 16px;
 	height: 22px;
 	line-height: inherit !important;

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeIcon.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeIcon.tsx
@@ -6,12 +6,27 @@
 // CSS.
 import './runtimeIcon.css';
 
+// React.
+import { useEffect, useState } from 'react';
+
 // Other dependencies.
 import { LanguageRuntimeSessionMode } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { getSessionIconClasses } from '../../common/sessionDisplayUtils.js';
 import { URI } from '../../../../../base/common/uri.js';
+import { IWorkbenchFileIconTheme } from '../../../../services/themes/common/workbenchThemeService.js';
+
+/**
+ * Seti is the default file icon theme. Its font glyphs are drawn offset-right
+ * within the em quad, so language-contributed SVGs (rendered via background-image
+ * with `left center`) visually misalign with adjacent Seti glyphs. To compensate,
+ * we add a class when Seti is active which compensates for this.
+ *
+ * To know when to apply the shim CSS we need to know the active file icon theme.
+ * Compare against `settingsId` (the value users set in `workbench.iconTheme`).
+ */
+const SETI_ICON_THEME_SETTINGS_ID = 'vs-seti';
 
 export interface RuntimeIconProps {
 	sessionMode: LanguageRuntimeSessionMode;
@@ -22,10 +37,31 @@ export interface RuntimeIconProps {
 
 export const RuntimeIcon = ({ sessionMode, notebookUri, languageId, 'data-testid': dataTestId }: RuntimeIconProps) => {
 	const services = usePositronReactServicesContext();
+
+	const [iconThemeSettingsId, setIconThemeSettingsId] = useState(
+		() => (services.themeService.getFileIconTheme() as IWorkbenchFileIconTheme).settingsId,
+	);
+
+	useEffect(() => {
+		const disposable = services.themeService.onDidFileIconThemeChange((theme) => {
+			setIconThemeSettingsId((theme as IWorkbenchFileIconTheme).settingsId);
+		});
+		return () => disposable.dispose();
+	}, [services.themeService]);
+
 	const iconClasses = getSessionIconClasses(
 		{ sessionMode, notebookUri, languageId },
 		services.modelService,
 		services.languageService,
 	);
-	return <span className={positronClassNames('runtime-session-icon', ...iconClasses)} data-testid={dataTestId}></span>;
+	return (
+		<span
+			className={positronClassNames(
+				'runtime-session-icon',
+				...iconClasses,
+				{ 'seti-icon-theme-active': iconThemeSettingsId === SETI_ICON_THEME_SETTINGS_ID },
+			)}
+			data-testid={dataTestId}
+		></span>
+	);
 };


### PR DESCRIPTION
I was changing my Positron file icon theme and noticed the file icons in the console tab list and interpreter picker weren't scaling correctly. Missed this during my testing with the default Seti theme in https://github.com/posit-dev/positron/pull/13162.

With Seti (the default file icon theme), the rendering looked roughly correct, but with other themes the icon was visibly larger than the same icon in the file explorer, breadcrumbs, and editor tabs. This PR updates the CSS to fix that problem.

This also removes the special handling we were doing to get the Quarto extension icon to look centered for other themes and instead adds CSS to compensate for there not being a Quarto icon in the Seti file icon theme (since we centered the Quarto SVG). I think the Quarto SVG from the extension was originally right aligned so it would match the Seti icon theme which right aligns all of its icons but this causes the quarto icon to look misaligned when the file icon them was anything besides the default. 

The ideal fix would be to introduce the quarto icon them to Seti so we don't fallback to the language pack theme but until that happens we can specifically solve for the Seti theme while supporting all other file icon themes out of the box.

### Screenshots

**BEFORE - Seti File Icon Theme**

<img width="1322" height="659" alt="Screenshot 2026-05-05 at 6 12 54 PM" src="https://github.com/user-attachments/assets/06875e66-afa1-4bed-8d6e-554d8a0ed662" />

**BEFORE - Other File Icon Theme**

<img width="1322" height="659" alt="Screenshot 2026-05-05 at 6 13 08 PM" src="https://github.com/user-attachments/assets/fc16540a-0761-4bf3-bdfb-5d62392bf86a" />

**AFTER - Seti File Icon Theme**

<img width="1322" height="659" alt="Screenshot 2026-05-05 at 6 00 46 PM" src="https://github.com/user-attachments/assets/0650a602-a0fb-4a0f-8086-329b388436dc" />

**AFTER - Other File Icon Theme**

<img width="1322" height="659" alt="Screenshot 2026-05-05 at 6 01 57 PM" src="https://github.com/user-attachments/assets/0433af03-571f-476e-9ab9-d00f5b115dff" />


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix file icon size and alignment in the console tab list and session picker so icons render consistently across file icon themes

### QA Notes

@:console @:top-action-bar @:sessions

1. Install a file icon theme that defines its own font size, I used Monokai Pro 
2. Activate it via `Preferences: File Icon Theme`
3. Confirm the language icon renders at the same size in all of these locations:
   - Console tab list (left sidebar of the Console pane)
   - Top action bar session manager (interpreter dropdown at the top of the workbench)
   - File explorer entry for a file of the same language
   - Breadcrumb of an open file
   - Editor tab of an open file
4. Confirm the icon is vertically centered with the session status indicator and the session name in the console tab and top action bar
5. Switch back to the default Seti theme and confirm no visual regression
