### PR TITLE
Fix "copy" and "select all" keyboard shortcuts in PDF viewer on macOS

### DIFF
--- a/extensions/positron-pdf-server/keyboard-forwarder.js
+++ b/extensions/positron-pdf-server/keyboard-forwarder.js
@@ -15,13 +15,14 @@
 (function () {
 	'use strict';
 
+	const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+
 	/**
 	 * Check if the keyboard event matches a shortcut that should be forwarded to VS Code.
 	 * @param {KeyboardEvent} e
 	 * @returns {boolean}
 	 */
 	function shouldForwardToVSCode(e) {
-		const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
 		const cmdOrCtrl = isMac ? e.metaKey : e.ctrlKey;
 
 		// Command Palette: Cmd/Ctrl+Shift+P
@@ -115,6 +116,25 @@
 	 * @param {KeyboardEvent} e
 	 */
 	function handleKeyDown(e) {
+		// On macOS, Electron's menu accelerators for Cmd+C (role: 'copy') and
+		// Cmd+A (sendActionToFirstResponder('selectAll:')) consume the
+		// OS-level commands before Chromium can synthesize the corresponding
+		// events inside this nested cross-origin iframe, so PDF.js's
+		// text-layer listeners never fire on their own. execCommand triggers
+		// the events synchronously here, sidestepping the menu accelerator
+		// path. Other platforms route the keystrokes through Chromium
+		// normally and don't need this workaround.
+		if (isMac && e.metaKey && !e.shiftKey && !e.altKey) {
+			if (e.code === 'KeyC') {
+				document.execCommand('copy');
+				return;
+			}
+			if (e.code === 'KeyA') {
+				document.execCommand('selectAll');
+				return;
+			}
+		}
+
 		if (shouldForwardToVSCode(e)) {
 			// Prevent PDF.js from handling this shortcut
 			e.preventDefault();


### PR DESCRIPTION
Closes #13234

When the PDF viewer was focused, pressing <kbd>Cmd+C</kbd> did not copy selected text as reported in the issue, and additionally <kbd>Cmd+A</kbd> did not select all visible text. Turns out this is a macOS-specific bug; Electron's menu accelerators consume the OS-level commands before Chromium can synthesize the corresponding `copy` / `selectall` events inside our nested cross-origin PDF iframe, so PDF.js's text-layer listeners never fire on their own.

The fix manually triggers the events from inside the PDF iframe via `document.execCommand('copy')` and `document.execCommand('selectAll')` when <kbd>Cmd+C</kbd> or <kbd>Cmd+A</kbd> is pressed, sidestepping the menu accelerator path. The workaround is gated to macOS since Linux/Windows route these keystrokes through Chromium normally.

I looked at all the edit menu accelerators with similar interception. For a read-only PDF viewer, only copy and select-all matter IMO:

| Shortcut | Mechanism | Applies to PDF viewer? |
|---|---|---|
| Cmd+C (copy) | `role: 'copy'` | Yes, fixed |
| Cmd+A (select all) | `sendActionToFirstResponder('selectAll:')` | Yes, fixed |
| Cmd+X (cut) | `role: 'cut'` | No, PDF is read-only; native inputs handle their own |
| Cmd+V (paste) | `role: 'paste'` | No, PDF is read-only; native inputs handle their own |
| Cmd+Z (undo) | `sendActionToFirstResponder('undo:')` | No, no undo state in a PDF |
| Cmd+Shift+Z (redo) | `sendActionToFirstResponder('redo:')` | No |

Related to #12501 (initial keyboard forwarding) and #13046 (`allow-modals` for print).

#### Testing situation

Existing PDF e2e tests in `test/e2e/tests/pdf/pdf.test.ts` cover open/close and print but not copy or select-all. macOS also isn't in the active e2e CI rotation so this regression wouldn't have been caught by CI even if a copy test existed. Adding a copy/select-all test might be a reasonable follow-up but I don't know if the lift is worth it given that the existing tests _do_ cover some of the nested iframe challenges.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed <kbd>Cmd+C</kbd> and <kbd>Cmd+A</kbd> not working when the PDF viewer has focus on macOS (#13234)

### QA Notes

@:pdf @:viewer

1. On macOS, open any PDF file in Positron
2. Click into the PDF viewer to give it focus
3. Select some text by dragging, then press Cmd+C
4. Paste somewhere outside Positron and verify the selected text is on the clipboard
5. Press Cmd+A and verify all visible page text is highlighted
6. Sanity check that existing forwarded shortcuts still work: Cmd+Shift+P opens Command Palette, Cmd+B toggles sidebar, Cmd+W closes the PDF tab
7. Sanity check that PDF.js shortcuts still work: Cmd+F opens the find bar, Cmd+P opens print dialog
