### PR TITLE
ci: remove old slack-workflow-status calls for test results

### DIFF
--- a/.github/actions/notify-e2e-insights/action.yml
+++ b/.github/actions/notify-e2e-insights/action.yml
@@ -28,6 +28,9 @@ inputs:
   source_repo:
     description: 'GitHub owner/repo where this workflow runs (auto-detected, only override if needed)'
     required: false
+  notify_on:
+    description: 'Override the dashboard repo config notify_on rule: always | failures_only | flaky_or_failures'
+    required: false
 
 runs:
   using: 'composite'
@@ -43,6 +46,7 @@ runs:
         FILTER_JOBS: ${{ inputs.filter_jobs }}
         HIDE_SKIPPED: ${{ inputs.hide_skipped }}
         SOURCE_REPO: ${{ inputs.source_repo || github.repository }}
+        NOTIFY_ON: ${{ inputs.notify_on }}
         RUN_ID: ${{ github.run_id }}
         BRANCH: ${{ github.ref_name }}
         ACTOR: ${{ github.actor }}
@@ -62,6 +66,7 @@ runs:
           --argjson hide_skipped "${HIDE_SKIPPED:-false}" \
           --arg owner_repo "$SOURCE_REPO" \
           --arg commit_message "$COMMIT_FIRST_LINE" \
+          --arg notify_on "$NOTIFY_ON" \
           '{
             workflow_run_id: $run_id,
             repo_id: $repo_id,
@@ -73,6 +78,7 @@ runs:
           + if $hide_skipped then {hide_skipped: true} else {} end
           + if $owner_repo != "" then {owner_repo: $owner_repo} else {} end
           + if $commit_message != "" then {commit_message: $commit_message} else {} end
+          + if $notify_on != "" then {notify_on: $notify_on} else {} end
           ')
 
         response=$(curl -s -w "\n%{http_code}" -X POST \

--- a/.github/workflows/test-cross-browser.yml
+++ b/.github/workflows/test-cross-browser.yml
@@ -25,15 +25,6 @@ on:
         description: "Override default grep pattern. Leave empty to use config default (@:cross-browser)"
         default: ""
         type: string
-      notify_on:
-        description: "Slack notification on:"
-        required: true
-        default: "always"
-        type: choice
-        options:
-        - failure
-        - always
-        - never
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -91,24 +82,7 @@ jobs:
     needs:
       [e2e-firefox, e2e-webkit, e2e-edge]
     runs-on: ubuntu-latest
-    env:
-      notify_on: ${{ github.event_name == 'schedule' && 'always' || inputs.notify_on || 'always' }}
     steps:
-      - run: |
-          echo "Will notify on: ${{ env.notify_on }}"
-      - name: Set short SHA
-        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
-      - name: Notify Slack
-        uses: midleman/slack-workflow-status@v3.1.3
-        with:
-          gh_repo_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_token: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
-          slack_channel: "#positron-test-results"
-          notify_on: ${{ env.notify_on }}
-          filter_jobs: "(e2e / ([^0-9]*))$"
-          include_job_durations: false
-          custom_title: "E2E Cross Browser Tests — `main` (commit <https://github.com/posit-dev/positron/commit/${{ github.sha }}|${{ env.SHORT_SHA }}>)"
-
       - name: Checkout
         if: always()
         uses: actions/checkout@v6

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -79,15 +79,6 @@ on:
         required: false
         default: "latest"
         type: string
-      notify_on:
-        description: "Slack notification on:"
-        required: false
-        default: "failure"
-        type: choice
-        options:
-          - failure
-          - always
-          - never
       grep:
         description: "Grep pattern:"
         required: false
@@ -350,21 +341,7 @@ jobs:
     needs:
       [validate-commit, e2e-electron, e2e-windows, e2e-chromium, e2e-rhel, e2e-chromium-rhel, e2e-suse, e2e-chromium-suse, e2e-sles, e2e-chromium-sles, e2e-debian, e2e-chromium-debian, unit-tests, ext-host-tests]
     runs-on: ubuntu-latest
-    env:
-      notify_on: ${{ github.event_name == 'schedule' && 'always' || inputs.notify_on || 'failure' }}
     steps:
-      - run: |
-          echo "Will notify on: ${{ env.notify_on }}"
-      - name: Notify Slack
-        uses: midleman/slack-workflow-status@v3.1.3
-        with:
-          gh_repo_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_token: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
-          slack_channel: "#positron-test-results"
-          filter_jobs: "(e2e / ([^0-9]*)|unit|ext-host)$"
-          include_job_durations: false
-          notify_on: ${{ env.notify_on }}
-
       - name: Checkout
         if: always()
         uses: actions/checkout@v6

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -79,6 +79,16 @@ on:
         required: false
         default: "latest"
         type: string
+      notify_on:
+        description: "Slack notification on:"
+        required: false
+        default: "failures_only"
+        type: choice
+        options:
+          - failures_only
+          - always
+          - flaky_or_failures
+          - never
       grep:
         description: "Grep pattern:"
         required: false
@@ -349,7 +359,7 @@ jobs:
           sparse-checkout: .github/actions/notify-e2e-insights
 
       - name: Notify E2E Test Insights
-        if: always()
+        if: always() && inputs.notify_on != 'never'
         uses: ./.github/actions/notify-e2e-insights
         with:
           webhook_secret: ${{ secrets.E2E_INSIGHTS_WEBHOOK_SECRET }}
@@ -357,3 +367,4 @@ jobs:
           repo_id: "positron"
           title: "E2E Full Suite Tests"
           filter_jobs: "(e2e / ([^0-9]*)|unit|ext-host)$"
+          notify_on: ${{ inputs.notify_on }}

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -91,16 +91,6 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - name: Notify Slack
-        uses: midleman/slack-workflow-status@v3.1.3
-        with:
-          gh_repo_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_token: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
-          slack_channel: "#positron-test-results"
-          filter_jobs: "(e2e / ([^0-9]*)|unit|ext-host)$"
-          include_job_durations: false
-          notify_on: "failure"
-
       - name: Checkout
         if: always()
         uses: actions/checkout@v6


### PR DESCRIPTION
### Summary
The e2e-test-insights notify action now handles Slack alerts for `#positron-test-results`, so the parallel `midleman/slack-workflow-status` steps are redundant.

### QA Notes
After merge, watch the next merge / full-suite / cross-browser run and confirm `#positron-test-results` still gets notifications via the e2e-test-insights path.