### PR TITLE
e2e: fix Posit Assistant tool-confirm selector

### DIFF
--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -51,7 +51,6 @@ const CODE_BLOCK_INSERT_CURSOR_BUTTON = 'button[aria-label="Insert At Cursor"]';
 const CODE_BLOCK_INSERT_FILE_BUTTON = 'button[aria-label="Insert into New File"]';
 
 // Tool confirmation UI
-const TOOL_CONFIRM_TITLE = 'h4.font-semibold';
 const TOOL_ALLOW_BUTTON = 'button.rounded-r-none:has-text("Allow")';
 const TOOL_ALLOW_DROPDOWN_TRIGGER = 'button[aria-label="More allow options"]';
 const TOOL_ALLOW_SESSION_MENU_ITEM = '[role="menuitem"]:has-text("for this session")';
@@ -402,7 +401,7 @@ export class PositAssistant {
 	 * Verifies the tool confirmation dialog is visible.
 	 */
 	async expectToolConfirmVisible(): Promise<void> {
-		await expect(this.frame.locator(TOOL_CONFIRM_TITLE)).toBeVisible();
+		await expect(this.frame.locator('.bg-warning').getByRole('heading', { level: 4 })).toBeVisible();
 	}
 
 	/**

--- a/test/e2e/tests/posit-assistant/posit-assistant.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant.test.ts
@@ -133,9 +133,7 @@ test.describe('Posit Assistant', {
 				await sessions.delete(session.id);
 			});
 
-			test.skip(`${provider} - Create data visualization via Posit Assistant (Python)`, {
-				annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/assistant/issues/1064' }],
-			}, async function ({ app, sessions }) {
+			test(`${provider} - Create data visualization via Posit Assistant (Python)`, async function ({ app, sessions }) {
 				const session = await sessions.start('python', { reuse: false });
 				await app.workbench.plots.clearPlots();
 				await app.workbench.positAssistant.open();


### PR DESCRIPTION
## Summary

- Update `expectToolConfirmVisible` to match the new tool-confirmation markup. The title element moved from `<h4 class="font-semibold">` to `<div role="heading" aria-level={4}>` in [posit-dev/assistant#1218](https://github.com/posit-dev/assistant/pull/1218) (landed May 1), which broke all 5 tests in `posit-assistant.test.ts` on every platform in [yesterday's daily regression run](https://github.com/posit-dev/positron-builds/actions/runs/25307812497).
- Scope the locator to `.bg-warning` (the warning-variant `<Alert>` wrapper) so it survives the heading-tag change without false-positives from other `<h4>`s in the assistant UI (`PopoverInfoCard`, `ModeExitConfirmation`).
- Unskip the Python `Create data visualization` test now that [posit-dev/assistant#1064](https://github.com/posit-dev/assistant/issues/1064) is resolved.

## Test plan
@:posit-assistant