### PR TITLE
e2e: stabilize sessions.deleteAll() on Posit Workbench

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -272,6 +272,16 @@ export class Sessions {
 			if (this.code.driver.currentPage.url().includes('8080')) {
 				try { await this.page.getByRole('button', { name: 'Delete Session' }).click({ timeout: 1000 }); } catch (error) { }
 			} else {
+				// Workaround: On Posit Workbench, Positron is sometimes launched without
+				// a folder attached and auto-prompts an "Open Folder" quickpick. The
+				// picker intercepts pointer events and prevents the "There is no session
+				// running." message from rendering, so dismiss it before asserting.
+				// See https://github.com/posit-dev/positron-builds/actions/runs/25307812497
+				const openFolderPicker = this.page.locator('.quick-input-title', { hasText: 'Open Folder' });
+				if (await openFolderPicker.isVisible().catch(() => false)) {
+					await this.page.keyboard.press('Escape');
+					await expect(openFolderPicker).not.toBeVisible();
+				}
 				await expect(this.page.getByText('There is no session running.')).toBeVisible();
 			}
 		});

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -275,14 +275,18 @@ export class Sessions {
 				// Workaround: On Posit Workbench, Positron is sometimes launched without
 				// a folder attached and auto-prompts an "Open Folder" quickpick. The
 				// picker intercepts pointer events and prevents the "There is no session
-				// running." message from rendering, so dismiss it before asserting.
+				// running." message from rendering. Retry-dismiss-and-assert so we cover
+				// the race where the picker appears just after a check returns false or
+				// re-pops after Escape.
 				// See https://github.com/posit-dev/positron-builds/actions/runs/25307812497
 				const openFolderPicker = this.page.locator('.quick-input-title', { hasText: 'Open Folder' });
-				if (await openFolderPicker.isVisible().catch(() => false)) {
-					await this.page.keyboard.press('Escape');
-					await expect(openFolderPicker).not.toBeVisible();
-				}
-				await expect(this.page.getByText('There is no session running.')).toBeVisible();
+				const noSessionMessage = this.page.getByText('There is no session running.');
+				await expect(async () => {
+					if (await openFolderPicker.isVisible().catch(() => false)) {
+						await this.page.keyboard.press('Escape');
+					}
+					await expect(noSessionMessage).toBeVisible({ timeout: 1000 });
+				}).toPass({ timeout: 15000 });
 			}
 		});
 	}

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -272,19 +272,23 @@ export class Sessions {
 			if (this.code.driver.currentPage.url().includes('8080')) {
 				try { await this.page.getByRole('button', { name: 'Delete Session' }).click({ timeout: 1000 }); } catch (error) { }
 			} else {
-				// Workaround: On Posit Workbench, Positron is sometimes launched without
-				// a folder attached and auto-prompts an "Open Folder" quickpick. The
-				// picker intercepts pointer events and prevents the "There is no session
-				// running." message from rendering. Retry-dismiss-and-assert so we cover
-				// the race where the picker appears just after a check returns false or
+				// Two Workbench-specific races can hide the empty-state message:
+				// (1) Positron is launched without a folder and auto-prompts an "Open
+				//     Folder" quickpick that intercepts pointer events.
+				// (2) The bottom panel's active tab is Terminal (not Console) on
+				//     startup, so the Console pane (and the "There is no session
+				//     running." text) is not rendered.
+				// Focus the Console first, then retry-dismiss-and-assert to cover the
+				// race where the picker appears just after a check returns false or
 				// re-pops after Escape.
-				// See https://github.com/posit-dev/positron-builds/actions/runs/25307812497
+				// See https://github.com/posit-dev/positron/actions/runs/25334724797
 				const openFolderPicker = this.page.locator('.quick-input-title', { hasText: 'Open Folder' });
 				const noSessionMessage = this.page.getByText('There is no session running.');
 				await expect(async () => {
 					if (await openFolderPicker.isVisible().catch(() => false)) {
 						await this.page.keyboard.press('Escape');
 					}
+					await this.console.focus();
 					await expect(noSessionMessage).toBeVisible({ timeout: 1000 });
 				}).toPass({ timeout: 15000 });
 			}


### PR DESCRIPTION
On Posit Workbench, `sessions.deleteAll()` (called in fixture setup for many Workbench-tagged specs) was producing the lion's share of e2e test failures and flakes. The 2026-05-04 daily release run had 1 hard failure + 7 collateral flakes all sharing the same root assertion (`expect(getByText('There is no session running.')).toBeVisible()` at `sessions.ts`).

Pulling the Playwright traces and page snapshots revealed two distinct Workbench-only races that hide the empty-state Console message:

1. **Open Folder picker auto-prompts.** Positron is sometimes launched with the workspace folder URL parameter set but the workspace not yet attached, so it opens an "Open Folder" quickpick over `/home/user1/qa-example-content/`. The picker intercepts pointer events and the Console pane never settles into an empty state.
2. **Terminal is the active panel tab on startup.** The Console pane (where "There is no session running." renders) is mounted but hidden behind the Terminal tab. `getByText` matches visible text only, so the assertion finds nothing.

This PR fixes both in the `else` branch of `deleteAll()`:

- Wraps the assertion in `expect.toPass({ timeout: 15s })` so each iteration:
  - escapes the "Open Folder" quickpick if it is visible,
  - calls `console.focus()` to bring the Console pane forward,
  - re-asserts the empty-state message with a 1s inner timeout.
- The 8080 (server) workaround is untouched.

### Failure-rate impact

Comparing the original failing run (before) to the latest CI run on this PR (after):

| | Before | After |
|---|---|---|
| Hard failures | 1 | 0 |
| Flakes | 7 | 1 |
| Cause | Open Folder picker / Console-hidden races in `deleteAll()` | Unrelated runtime-list iteration race in `Sessions.start()` test body |

The single remaining flake (`tests/data-explorer/data-explorer-python-pandas.test.ts:23`) is a pre-existing race in `sessions.ts:1175-1180` where `.locator(...).all()` snapshots the runtime quickpick list, then `.nth(i).textContent()` re-resolves by index. On a fresh Workbench launch the list is still settling and a row gets replaced mid-iteration, hanging on `textContent()`. It was previously masked by the `deleteAll()` failures and should be fixed in a follow-up.

### Evidence

- Original failing run: https://github.com/posit-dev/positron-builds/actions/runs/25307812497 (workbench-ubuntu-stable, job 74200388192)
- Latest passing run with single unrelated flake: https://github.com/posit-dev/positron/actions/runs/25341172193 (job 74301315656)
- Smoking-gun page snapshots: layouts test from the original run shows the Open Folder picker over `/home/user1/qa-example-content/`; data-explorer screenshots from intermediate runs show Terminal active with Console hidden.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (test-only change)

### QA Notes

@:workbench @:sessions

Test-infrastructure-only change; no product behavior is affected. CI should run the `@:workbench` and `@:sessions` test groups to confirm:

1. Workbench specs previously failing in the daily release run (`tests/quarto/quarto-r.test.ts`, `tests/extensions/bootstrap-extensions.test.ts`, `tests/apps/python-apps.test.ts`, `tests/plots/plots.test.ts`, `tests/connections/connections-postgres.test.ts`, `tests/layouts/layouts.test.ts`) pass without the picker / panel-focus races.
2. Session-management specs (`tests/sessions/*`) still pass. The new conditional and `console.focus()` are inside the `expect.toPass()` retry, so they are harmless when the picker isn't up and the Console is already focused (the standard electron path).
3. Electron-only tests should be unchanged.