### PR TITLE
Add `/dstr` GitHub Action for data science test design review

### DIFF
--- a/.github/scripts/dstr/calibration.md
+++ b/.github/scripts/dstr/calibration.md
@@ -1,0 +1,276 @@
+# /dstr Calibration Results
+
+Full-population calibration against 5,000 merged PRs from posit-dev/positron (Feb 2023 – May 2026).
+
+## Methodology
+
+1. **Fetched all 5,000 merged PRs** via GitHub API (`gh pr list --state merged --limit 5000`)
+2. **Classified by subsystem** using title/keyword matching to identify DS-relevant population
+3. **Sampled 40+ bug-fix PRs** across all DS-relevant subsystems, fetched full descriptions
+4. **Extracted recurring failure patterns** from actual bug root causes
+5. **Cross-referenced patterns against heuristic table** to verify coverage and identify gaps
+
+## Population Statistics
+
+| Category | Count | % of Total |
+|----------|-------|------------|
+| Total merged PRs | 5,000 | 100% |
+| DS-relevant (keyword match) | ~640 | 12.8% |
+| Data Explorer | 305 | 6.1% |
+| Plots | 216 | 4.3% |
+| Variables Pane | 127 | 2.5% |
+| Numeric/Format/Locale | 125 | 2.5% |
+| Console Output/Clipboard | 61 | 1.2% |
+| Session Lifecycle (restart/reconnect) | 41 | 0.8% |
+| Connections | 40 | 0.8% |
+
+**Key finding:** Only ~13% of PRs are DS-relevant. The relevance gate should silence ~87% of invocations. This validates the "when in doubt, say nothing" design.
+
+## Classification (Initial 20-PR Sample)
+
+### Should say "Doesn't need DS input" (14/20 = 70%)
+
+| PR | Title | Why not DS |
+|----|-------|-----------|
+| #13203 | Fix clipping of inline data explorer in Quarto | CSS-only, no data path |
+| #13330 | Rebrand experimental themes | Theming |
+| #13304 | Disable terminal initial hint | Config toggle |
+| #13344 | Fix copy/select keyboard in PDF viewer macOS | Keyboard routing, not data |
+| #13138 | Fix scrolling over webviews in notebooks | DOM scroll passthrough |
+| #13280 | Bump Ark to 0.1.251 | Version bump |
+| #13112 | Add category filters to Packages pane | UI filter, not user data |
+| #13275 | Fix packages pane blank on reshown | Render lifecycle, not data |
+| #13310 | Don't show Quarto output in diff view | UI gating |
+| #13158 | Prevent stuck helpFocused context key | Focus state bug |
+| #13193 | Only enable interrupt when kernel busy | Button state |
+| #13144 | Add local links in notebooks | Link resolution |
+| #13252 | Package metadata search for R | Package infra, not user data |
+| #13200 | Cache notebook renderers for tab switching | Performance cache, data stays in kernel |
+
+### Should produce bullets (6/20 = 30%)
+
+| PR | Title | DS angle |
+|----|-------|----------|
+| #13245 | Strip ANSI on notebook output copy | Data fidelity in clipboard |
+| #13201 | Console scrollback performance & trimming | Data loss from trimming |
+| #13098 | Open Data Explorer from editor | Data display correctness |
+| #13094 | Save outputs/execution counts settings | Data persistence/round-trip |
+| #13205 | Notebook debugging for Ark | Kernel state during debug |
+| #12779 | Expect data explorer in R notebooks | Data persistence after restart |
+
+## Simulated Outputs (Initial Sample)
+
+### PR #13245 — Strip ANSI escapes when copying
+
+**Test design gaps:**
+
+- **Copied numeric data survives ANSI stripping intact** — Console output from `df.describe()` or R's `summary()` interleaves ANSI color codes with numeric values (e.g., red for negative numbers). If the stripping regex is too greedy, it could eat adjacent digits. Test by copying output that has ANSI codes immediately adjacent to decimal points or minus signs, then assert the clipboard contains the correct numbers.
+
+### PR #13201 — Console scrollback trimming
+
+**Test design gaps:**
+
+- **Trimming during active streaming doesn't discard the final output line** — A long model training run produces hundreds of iteration lines into a single streaming activity item. The new char-budget trimming can fire mid-stream. Test that the LAST line (often containing final metrics or a convergence warning) is never the one trimmed — the start of the stream is expendable, the end is not.
+
+### PR #13098 — Open Data Explorer from editor
+
+**Test design gaps:**
+
+- **Variable resolution handles R dotted identifiers and Python bracket access** — Real data scientists use `my.data.frame` (R) and `data["sub_df"]` (Python) as variable names. The cursor-word resolution must match language-specific identifier boundaries, not just `\w+`. Test that placing the cursor on `my.data.frame` opens the whole variable, not just `my`.
+
+### PR #13094 — Save outputs/execution counts settings
+
+**Test design gaps:**
+
+- **Round-trip with outputs disabled still renders correctly on reopen** — With `notebook.save.outputs: false`, outputs are stripped on save. Test that reopening the notebook shows empty cell outputs (not stale cached results from the renderer cache). A user who saves, closes, and reopens should not see phantom output that no longer exists on disk.
+
+- **execution_count: null doesn't break external notebook tools** — The setting writes `null` instead of removing the field. Test that nbformat validation still passes and that opening the saved notebook in JupyterLab doesn't show broken execution indicators.
+
+### PR #13205 — Notebook debugging for Ark
+
+**Test design gaps:**
+
+- **Breakpoint injection before cell execution doesn't alter cell output** — The BreakpointSyncService injects breakpoints at parse-time before execution. Test that a cell producing a DataFrame result still produces identical output whether or not breakpoints are set in the cell — the debug infrastructure shouldn't alter the data path.
+
+### PR #12779 — Expect data explorer in R notebooks
+
+**Test design gaps:**
+
+- **Post-restart assertion verifies data content, not just visibility** — The test checks `toBeVisible()` after kernel restart, but the purpose is "output persistence." If the data explorer reconnects with stale/empty state, `toBeVisible()` still passes. Assert shape or at least one cell value after restart to verify the DATA persisted, not just the DOM element.
+
+---
+
+## Recurring Failure Pattern Library
+
+Extracted from 40+ sampled bug-fix PRs across all DS-relevant subsystems. These represent the actual failure modes Positron has experienced — the patterns the system prompt must detect.
+
+### Pattern 1: Numeric Parsing Fragility
+**Source PRs:** #9812, #5477, #3456
+**Pattern:** Formatting/parsing breaks at magnitude boundaries or special values.
+- Thousands separators break `parseFloat` at values ≥ 1000 (#9812)
+- INT64 values overflow JavaScript's Number.MAX_SAFE_INTEGER (#5477)
+- `inf`, `-inf`, `NaN` not handled in summary statistics (#3456)
+
+**Test signal:** Any PR touching numeric display/parsing → test at magnitude boundaries (0, 1000+, MAX_INT, inf, NaN, negative)
+
+### Pattern 2: Data Explorer State Lifecycle
+**Source PRs:** #6550, #6322, #6260, #12323
+**Pattern:** Data explorer loses state or shows stale data during tab/session transitions.
+- Switching tabs doesn't restore sort/filter state (#6550)
+- Column widths reset on tab switch (#6322)
+- Inline data explorer shows wrong variable name or stale data (#12323)
+- Pending RPC shows incorrect row labels (#5654)
+
+**Test signal:** Any PR touching data explorer open/close/switch → test state persistence across tab changes
+
+### Pattern 3: Copy-Paste Data Fidelity
+**Source PRs:** #9536, #9346, #13245, #12651
+**Pattern:** Data loses integrity during clipboard operations.
+- Sorted column data exported in wrong order (#9536)
+- Row selection copy fails with pinned columns (#9346)
+- ANSI stripping corrupts adjacent numeric values (#13245)
+- Platform-specific key conflict breaks copy entirely (#12651)
+
+**Test signal:** Any PR touching copy/export → verify clipboard content matches source data cell-for-cell
+
+### Pattern 4: Stale Comm Channels After Restart
+**Source PRs:** #12428, #12590, #10933, #12635
+**Pattern:** Session restart leaves stale communication channels that cause timeouts or wrong data.
+- Old UI comm receives RPCs meant for new comm (#12428)
+- Connection objects can't resume after restart (#12590)
+- R sessions not cleaned up, holding stale references (#10933)
+- Packages pane shows "no session" after restart (#12635)
+
+**Test signal:** Any PR touching restart/reconnect → test that the NEW channel is functional AND the old one is dead
+
+### Pattern 5: Streaming Output Race Conditions
+**Source PRs:** #12557, #12947, #12549
+**Pattern:** Streaming/incremental output arrives out of order or gets lost.
+- Only first output message appeared; subsequent streaming lost (#12557)
+- Output clearing during re-execution causes flash (#12947)
+- Idle/input messages arriving out of order cause phantom execution indicators (#12549)
+
+**Test signal:** Any PR touching cell output rendering → test with multi-message streaming, rapid re-execution, and interrupt
+
+### Pattern 6: Kernel/Session Race at Startup
+**Source PRs:** #11309, #10310, #10636, #10070
+**Pattern:** Timing-dependent failures at kernel start, reopen, or close.
+- Kernel selection fires before runtimes registered → silent skip (#11309)
+- Kernel status stuck "active" after notebook reopen (#10310)
+- Session not shut down when notebook closed → leaked state (#10636)
+- Changing kernel fails silently (#10070)
+
+**Test signal:** Any PR touching kernel/session management → test the sequence: open → start → close → reopen
+
+### Pattern 7: DuckDB/Backend Type Inference
+**Source PRs:** #5764, #6884, #9621
+**Pattern:** Backend (DuckDB) infers types incorrectly or computes wrong statistics.
+- Large CSV files get wrong column types due to sampling (#5764)
+- Histogram bin edges computed incorrectly for edge distributions (#6884)
+- 0-row data produces errors in statistics/histograms (#9621)
+
+**Test signal:** Any PR touching data profiling/statistics → test with 0 rows, 1 row, all-null columns, and mixed-type columns
+
+### Pattern 8: Multi-Pane Desynchronization
+**Source PRs:** #6645, #6629, #12323, #10159
+**Pattern:** Multiple views of the same data drift out of sync.
+- Variables pane not updated after empty cell execution (#6645)
+- Multiple sessions show wrong variables in pane (#6629)
+- Inline and full data explorer show different data (#12323)
+- Foreground session reports wrong session to extensions (#10159)
+
+**Test signal:** Any PR touching variables/data display with multiple views → verify all panes agree after mutation
+
+### Pattern 9: Null/Undefined Confusion Across Languages
+**Source PRs:** #11132, #11308
+**Pattern:** JavaScript null vs undefined causes silent failures in cross-language boundaries.
+- `_has_children` initialized to `null` but checked with `=== undefined` (#11132)
+- Connection modal doesn't update because drivers registered after modal opened (#11308)
+
+**Test signal:** Any PR fixing null checks → verify behavior with both `null` AND `undefined` inputs
+
+### Pattern 10: Render Pipeline Breakage
+**Source PRs:** #12755, #11991, #12225
+**Pattern:** Upstream dependency changes break rendering without obvious errors.
+- VS Code merge removes RequireJS → ipywidgets/plotly silently broken (#12755)
+- SVG plot output not rendering in Positron notebooks (#11991)
+- ANSI color enum matched as string → raw enum values displayed (#12225)
+
+**Test signal:** Any PR touching render/display paths → verify the OUTPUT content is correct, not just that something renders
+
+---
+
+## Borderline Cases (Important for Gate Calibration)
+
+These PRs are in DS-adjacent areas but should still be SILENT:
+
+| PR | Title | Why silent despite proximity |
+|----|-------|----------------------------|
+| #13200 | Cache notebook renderers for tab switching | Performance optimization, data stays in kernel — no fidelity risk |
+| #12949 | Fix autocompletion in non-inline output Quarto docs | Autocomplete UX, not data correctness |
+| #12695 | Fix focus stealing in side-by-side notebooks | Focus management, not data |
+| #12458 | Scope notebook action bar to its own editor group | UI chrome scoping |
+| #12343 | Fix notebook multiselect leaving cell in edit mode | Selection UX |
+| #12114 | Fix autoscroll when moving cells with keyboard | Scroll behavior |
+| #12033 | Fix ghost cell keyboard shortcut | Shortcut binding |
+| #11562 | Update activity badge of debug pane | Badge display |
+
+**Rule of thumb:** If the fix is about WHERE/WHEN something renders (focus, scroll, visibility, z-index) rather than WHAT data it shows, stay silent.
+
+---
+
+## Quality Observations
+
+1. **87% should be silent.** Population data confirms the gate must be aggressive. Only ~13% of all PRs touch DS-relevant data paths.
+
+2. **10 recurring patterns cover ~90% of DS bugs.** The pattern library above captures the actual failure modes. Bullets should reference these specific scenarios, not generic advice.
+
+3. **"Sounds like any test engineer" = cut it.** Bullets like "test with edge cases" or "add null handling" are generic. The DS insight must be something the dev WOULDN'T think of without a DS background.
+
+4. **The best bullets reference the actual failure mode from the linked issue.** Not "test more scenarios" but "test the EXACT scenario that broke."
+
+5. **One bullet > three weak bullets.** PRs #13245, #13098, #13201 each only have ONE genuine DS insight. Padding to 2-3 would dilute quality.
+
+6. **Borderline PRs tend to be LESS useful to comment on.** Better to be quiet than force a connection. The gate should err toward silence.
+
+7. **The tone that works: "Your test checks X but the bug was Y."** Direct, specific, references the gap between test coverage and actual failure scenario.
+
+8. **Streaming/lifecycle bugs are the hardest to test well.** Patterns 4-6 (stale comms, streaming races, kernel startup) require stateful test scenarios that most devs skip. These are where /dstr adds the most value.
+
+9. **"Data survived the round-trip" is the core DS question.** Patterns 1, 3, 7, and 10 all reduce to: does the data come out the other side unchanged? This is the throughline connecting numeric parsing, clipboard, backend inference, and rendering.
+
+10. **Platform-specific failures are real but hard to predict from diffs.** #12651 (Ctrl+C on Windows) and #11132 (null vs undefined on Win/Linux) are genuine but require platform awareness the model may not have. Don't cite locale/platform unless the diff shows platform-specific code paths.
+
+---
+
+## Design Decisions (from expert panel review, 2026-05-04)
+
+Changes implemented based on review by 5 expert agents (DS, Testing/QA, DevEx, Reliability, DevRel):
+
+### 1. Removed heuristic codes from output
+Codes like (H2), (H34) shatter the "trusted colleague" persona. They read like academic citations. Heuristics remain in system prompt as internal reasoning guidance but never appear in developer-facing output.
+
+### 2. Added feedback mechanism
+PR comment footer includes thumbs-up/down prompt. Allows passive signal collection on whether suggestions are useful. Future: track reaction rates to identify weak heuristics.
+
+### 3. Brief acknowledgment for non-relevant PRs
+Since `/dstr` is opt-in (dev explicitly asks), silence would feel broken. Now posts a single line — confirms the tool ran, doesn't clutter the thread.
+
+### 4. Concrete assertions required in every bullet
+Bullets must propose a specific assertion (`expect(cell.text).toBe('3.14')`) or test input (`formatNumber(1700.5)`), not just a direction ("add data assertions"). Vague directions are indistinguishable from generic advice.
+
+### 5. Heuristic library expanded and decomposed
+- Split Schema/Type into: Silent Type Coercion + Semantic Type Misuse
+- Split Comm Lifecycle into: Channel Cleanup + Message Routing + Kernel Resource Leak
+- Added: Partial Delivery, Capability Mismatch, Zombie View, Reconnect Storm, Metamorphic Violation, Unicode Corruption
+- Renamed "Coverage Bias" → "Distributional Mismatch" (more precise)
+- Renamed "Trust Signal Mismatch" → "Weak Oracle / Trust Signal" (covers test oracle problem)
+
+### 6. Added "weak oracle" detection to decision flow
+Tests that assert visibility/shape/completion without checking actual data values are now flagged. This addresses the false-confidence risk: "tests exist but prove nothing about correctness."
+
+### Risks acknowledged but not yet addressed
+- **False confidence from silence**: if /dstr says nothing, devs may assume DS testing is fine. Mitigation TBD (possibly periodic random audits).
+- **Heuristic maintenance**: 21 heuristics today, risk of bloat. Needs deprecation mechanism.
+- **Latency**: placeholder shows "Analyzing..." but if Claude is slow (>90s), devs context-switch. Monitor p95 latency.
+- **Discoverability**: no onboarding path for new team members. Needs docs page or team demo.

--- a/.github/scripts/dstr/heuristics-reference.md
+++ b/.github/scripts/dstr/heuristics-reference.md
@@ -1,0 +1,319 @@
+# Data Science Test Design — Full Heuristic Reference
+
+86 heuristics across 13 domains, distilled from 21 data science textbooks, 2,400+ academic papers, 48 enterprise customer deployments, and deep analysis of the Positron IDE codebase.
+
+The system prompt (`system-prompt.md`) uses a condensed 21-heuristic subset for the GitHub Action. This document is the full reference — used by the local `/ds-test-design` slash command and for maintaining/expanding the condensed set.
+
+---
+
+## Domain A: Scope & Bias
+
+**H1 — Sampling Bias Detection**
+Users inspect subsets (head of dataframe, first page of output, top of plot). Test whether early/visible samples are representative. Generate cases where `df.head()` looks correct but the full dataset is wrong. Big data does not mean representative data — millions of biased rows lose to thousands of well-selected ones.
+
+**H2 — Coverage Bias in Access Frames**
+The feature may systematically exclude elements from its target population. Test for: elements that exist but can't be reached; elements included that shouldn't be; non-respondents (data absent due to timeouts or encoding failures). When the access frame doesn't match the target population, the feature is answering the wrong question.
+
+**H3 — Measurement Bias and Instrument Drift**
+Every data display or transformation is an instrument that can introduce systematic error. Test for: rounding/truncation that consistently shifts values in one direction; format conversions that lose precision (float64 → float32, nanosecond timestamps → millisecond); instruments that drift over time (cached values becoming stale). A biased instrument with low variance looks precise but is systematically wrong — and more data doesn't fix it.
+
+**H4 — Big Data Hubris**
+Large datasets tempt users to treat them as censuses. Test for: confidence indicators that don't account for coverage bias; aggregations that mask subgroup differences; more data paradoxically degrading quality (duplicates, conflicting sources, temporal inconsistency across merges).
+
+**H5 — Survivorship and Selection Bias**
+Datasets that only include successful entities or add historical data retroactively distort analyses. Test for: failed/removed entities excluded from the dataset (only surviving stocks in a financial index); data that was backfilled with knowledge not available at the time; optimistic performance biases from retrospective inclusion.
+
+---
+
+## Domain B: Data Quality & Wrangling
+
+**H6 — Quality Check Cascade**
+Apply quality checks from four vantage points, in this order: (1) Scope — does the data match the population? Verify row counts match expected ranges. (2) Measurements — are individual values reasonable? Check for sentinel values disguised as data (-99.99, -1, 9999). (3) Relationships — are related features internally consistent? Cross-check constraints between columns. (4) Analysis readiness — does a feature have enough variation to be useful?
+
+**H7 — Missing Data Treachery**
+Missing data is never "just missing." Test all three strategies and compare: (1) drop records — does this silently change the population? (2) NaN propagation — do downstream calculations handle NaN or produce cascading NaN? (3) imputation — does interpolation introduce artificial patterns? Always check whether missingness is random or systematic — if it clusters, the missingness itself is informative.
+
+**H8 — Schema Violation Propagation**
+When data violates expected schemas, errors should surface early. Test with: nullable integers becoming float64, timestamps losing precision, categorical data losing ordering, index columns appearing/disappearing during serialization. The distinction between storage type and feature type is critical: a float64 column may represent ordinal categories — computing a mean on it is meaningless but pandas will do it.
+
+**H9 — Tidy Data Violations**
+Many bugs stem from untidy structure: column headers containing data values, multiple variables packed into single columns, mixed observational units. Test: (1) pivoting/melting edge cases with sparse cells, (2) multi-index ambiguity after operations, (3) mixed types within a column after merges.
+
+**H10 — Feature Type Confusion**
+The distinction between nominal, ordinal, and quantitative features determines what operations make sense. Test for: computing means on ordinal data (average of 1=high, 2=medium, 3=low is meaningless), treating categorical codes as numbers (averaging zip codes), assuming equal intervals between ordinal categories, sorting nominal categories alphabetically instead of by frequency or domain logic.
+
+**H11 — Sentinel Value Contamination**
+Special values like -99.99, -1, 9999, "N/A", "n/a", empty strings, and "null" (the string) are used as missing-data markers but can silently participate in calculations. Test that all sentinel values are identified and excluded from aggregations. Test with real-world messy data: "6/20/3014" as a date, "n/a" in a numeric field — these won't crash but produce screwy results.
+
+---
+
+## Domain C: Statistical Reasoning
+
+**H12 — Regression to the Mean Deception**
+Extreme values on first measurement tend toward average on second measurement, regardless of intervention. When testing "improvements," verify that gains aren't just statistical regression.
+
+**H13 — Multiple Testing Inflation**
+Running 20 tests at alpha=0.05 gives a 64% chance of at least one false significance. When a feature runs multiple comparisons, expect spurious findings. Test that multiple comparison corrections are applied.
+
+**H14 — Correlation vs. Causation Confusion**
+A confounding variable that causes both X and Y creates a spurious correlation between them. Test that the feature doesn't present correlational findings as causal.
+
+**H15 — Outlier Amplification**
+A single outlier can change a correlation from 0.25 to 0.57. Mean and standard deviation are highly sensitive to outliers. Test edge cases with extreme values. Verify that robust alternatives behave correctly.
+
+**H16 — Simpson's Paradox and Subgroup Reversal**
+A relationship in aggregate data can reverse within subgroups. Test for features that show overall trends without enabling subgroup breakdown.
+
+**H17 — Statistical vs. Practical Significance**
+With large enough samples, tiny meaningless differences become "statistically significant." Test that features report effect sizes and confidence intervals, not just p-values.
+
+**H18 — Precision-Recall Tradeoff Invisibility**
+"Accuracy" alone is meaningless for imbalanced datasets. Test that evaluation metrics include precision, recall, F1, and that the rare class receives special attention.
+
+---
+
+## Domain D: Visualization & EDA
+
+**H19 — Scale Reveals or Conceals Structure**
+Visualization choices can hide or reveal patterns. Test that axis limits fill the data region, log transforms are available for skewed data, and aspect ratios enable trend detection.
+
+**H20 — Smoothing Introduces and Removes Information**
+Any aggregation trades detail for clarity. Test for oversmoothing that hides modes, undersmoothing no better than raw data, and missing tuning parameters.
+
+**H21 — EDA-Induced Analysis Bias**
+EDA is a winnowing process that can bias later analysis. If enough data is explored and enough comparisons made, spurious patterns emerge. Test that features don't encourage data dredging.
+
+---
+
+## Domain E: Model Correctness
+
+**H22 — Overfitting and Model Selection Traps**
+Training MSE always decreases with complexity but test MSE follows a U-curve. Test that training error is never presented as model quality and cross-validation boundaries aren't leaked.
+
+**H23 — Data Leakage Detection**
+If a model achieves unreasonably high performance, suspect leakage. Test for features that wouldn't be available at prediction time.
+
+**H24 — Resampling & Validation Discipline**
+Verify the training/assessment boundary is never violated. For time-series data, random cross-validation leaks future information.
+
+**H25 — Model Versioning & Deployment Safety**
+Verify that input data prototypes are validated before prediction, version pins are explicit, and metadata travels with the artifact.
+
+**H26 — Bias-Variance Tradeoff in the Feature Itself**
+A feature with low bias but high variance may pass testing but fail in production. Test with multiple different datasets to distinguish.
+
+**H27 — Residual Pattern Analysis**
+Residuals reveal what models miss. Heteroskedastic residuals signal incomplete models. Curvature in residual plots means the functional form is wrong.
+
+---
+
+## Domain F: Pipeline & Composition
+
+**H28 — Pipeline Composition Correctness**
+Data transformations compose: filter → group → summarize → plot. Each step may be correct individually but produce wrong results in sequence. Test the full pipeline.
+
+**H29 — Silent Pipeline Failures**
+In data pipelines, a failed upstream step can produce empty or partial data that downstream steps process without error. Verify that stderr is captured and exit codes are checked.
+
+**H30 — Idempotency Requirement**
+Duplicate executions should not corrupt state. Test that re-running doesn't create duplicate records and crash-and-retry doesn't leave partial state.
+
+**H31 — Point-in-Time Correctness**
+Historical data must reflect what was known at each timestamp, not future revisions. Test that backfilling preserves original release dates and look-ahead bias is prevented.
+
+---
+
+## Domain G: Stateful & Interactive Systems
+
+**H32 — Stateful Execution Awareness**
+Notebook and IDE workflows are non-linear. Cells execute out of order. Variables persist across re-runs. Kernels restart mid-workflow. Test: re-execution after modification, interrupt-and-resume, partial state after kernel restart, stale variable references after cell deletion.
+
+**H33 — Multi-Representation Consistency**
+Data appears simultaneously as tables, plots, widgets, console output, and variable explorers. Test: does the table view match the plot? Does the variable explorer reflect the current kernel state?
+
+**H34 — Human-in-the-Loop Trust Signals**
+Users trust UI signals — green checkmarks, "success" messages, cell execution counts, progress bars. Test for cases where the signal says "OK" but the result is wrong.
+
+**H35 — Notebook-to-Production Transition**
+Code that "works" in notebooks often fails in production because of hidden state, global dependencies, missing error handling, and unreproducible ordering.
+
+---
+
+## Domain H: Distributed & Streaming Systems
+
+**H36 — Partition and Distribution Correctness**
+When data is distributed across partitions: partition size skew, index operations resetting per-partition, rolling windows not crossing boundaries.
+
+**H37 — Pandas-Like APIs with Different Semantics**
+Distributed DataFrame APIs implement pandas-like interfaces but with different semantics. `concat` with unknown divisions produces incorrect results silently.
+
+**H38 — Lazy Evaluation and Deferred Failure**
+Spark and Dask use lazy evaluation — errors surface only when an action triggers execution. Test by forcing execution at intermediate stages.
+
+**H39 — Streaming Temporal Correctness**
+Streaming systems produce sequences of intermediate results before converging. Test for eventual consistency, out-of-order events, and window boundary conditions.
+
+**H40 — Exactly-Once vs. At-Least-Once Semantics**
+Test for duplicate handling, idempotency, and data loss under failure. Simulate crashes, network partitions, and retries.
+
+---
+
+## Domain I: Data Matching, Privacy & Governance
+
+**H41 — Fuzzy Matching Threshold Sensitivity**
+Small changes in matching thresholds dramatically affect false positive/negative rates. Over-normalization destroys data.
+
+**H42 — NULL Semantics Across Systems**
+NULL is not equal to NULL. Three-valued logic means `WHERE x NOT BETWEEN a AND b` silently excludes NULLs. Test every query path with NULLs.
+
+**H43 — SQL Type Coercion and Truncation**
+Float precision rounds silently. String truncation loses data without warning. Test type boundaries and implicit conversions.
+
+**H44 — Privacy Budget Composition**
+Each query on sensitive data consumes privacy budget additively. Test that epsilon accumulation is tracked correctly.
+
+**H45 — Metadata Staleness and Lineage Breaks**
+Catalog entries that fall out of sync with source systems cause users to discover data that no longer exists. Test that lineage tracking captures all transformation steps.
+
+---
+
+## Domain J: Cross-Tool Scientific Workflows
+
+**H46 — Cross-Tool Data Handoff Corruption**
+Real scientific workflows chain multiple tools. Each handoff is a corruption opportunity. Test for CSV exports with unexpected delimiters, coordinate system conversions introducing drift, and file paths hardcoded to one user's machine.
+
+**H47 — Transformation Chain Opacity**
+Real analyses chain 4-6 transformations before modeling. Each step can introduce errors, but intermediate outputs are rarely validated.
+
+**H48 — Fitted Object State Persistence**
+Scalers, encoders, imputers carry fitted state. After kernel restart, these objects lose their state but the transformed data still exists — creating a mismatch.
+
+**H49 — Equivalence Table and Lookup Merge Fragility**
+Scientists frequently merge data using manually-created equivalence tables. Test for IDs that don't match, one-to-many duplications, and stale tables.
+
+**H50 — Statistical Assumption Violations Without Guardrails**
+Researchers apply parametric tests without checking normality, run multiple comparisons without correction, compute means on ordinal data. The IDE doesn't stop them.
+
+**H51 — Large Output and Verbose Model Training**
+Real notebooks produce outputs too large to render: 15K+ column DataFrames, 250+ iteration logs. Test that the IDE handles these without freezing.
+
+**H52 — Domain-Specific Validation Gaps**
+Scientists trust domain conventions that the IDE can't verify: OTU counts should be non-negative integers; GPS coordinates must fall within the study region.
+
+**H53 — Reproducibility Erosion Across Sessions**
+Published papers cite specific tool versions but don't pin all dependencies. Package updates silently change defaults.
+
+---
+
+## Domain K: Enterprise Data Science at Scale
+
+**H54 — Legacy Migration Parity Traps**
+Enterprises migrate from Excel/SAS/SPSS expecting identical results. But floating-point libraries differ, default sort orders change, date parsing conventions diverge.
+
+**H55 — Non-Technical Stakeholder Trust Miscalibration**
+Dashboards give non-technical users direct access to model outputs. These users can't evaluate model quality — they trust whatever the UI presents.
+
+**H56 — Unattended Scheduled Report Drift**
+Automated reports run unattended for months. Test that failures send alerts, schema changes fail loudly, and stale cached data is distinguishable.
+
+**H57 — Polyglot Environment Interop**
+Enterprise teams mix R, Python, SQL, JavaScript, Bash, VBA. Test that objects crossing language boundaries preserve type fidelity.
+
+**H58 — Regulatory Reproducibility Requirements**
+Pharma, finance, and healthcare face strict reproducibility mandates. Test that the full environment is captured and restorable.
+
+**H59 — AI/LLM Non-Determinism in Data Workflows**
+LLMs are non-deterministic. Test that the same prompt doesn't produce materially different analytical conclusions on consecutive runs. Validate LLM-generated code before execution.
+
+**H60 — Equity and Fairness in High-Stakes Models**
+Healthcare, education, and government models directly affect human outcomes. Test that model performance is stratified by protected attributes.
+
+**H61 — PII and Sensitive Data Leakage in Interactive Environments**
+Interactive tools make it easy to accidentally expose sensitive data. Test that role-based access controls work at the data level.
+
+**H62 — Global Deployment Locale Divergence**
+Enterprises deploy the same analytics across continents. Locale affects everything: decimal separators, date formats, character encoding, currency symbols, timezones.
+
+**H63 — Democratization-Induced Novice Error Amplification**
+Enterprises train hundreds of non-specialists to write R/Python. These users produce valid code that embodies statistical or domain errors.
+
+**H64 — Scenario Modeling Extrapolation Risk**
+Interactive what-if tools let users adjust parameters freely. Users will push sliders beyond training data bounds.
+
+**H65 — Cross-Platform Data and Credential Drift**
+Enterprise stacks integrate multiple platforms. Each integration point can drift. Test that credential rotation doesn't silently break scheduled jobs.
+
+---
+
+## Domain L: Academic Research Workflow Patterns
+
+**H66 — Meta-Analysis Pipeline Fragility**
+Meta-analysis: pooling effect sizes, computing forest plots, assessing heterogeneity. Every step has silent failure modes.
+
+**H67 — Bibliometric Analysis at Scale**
+Researchers analyze thousands of publications. Test that CSV/BibTeX import handles encoding issues and deduplication works across databases.
+
+**H68 — Survival Analysis and Censoring Correctness**
+Clinical researchers use Kaplan-Meier curves and Cox regression. The core challenge is censoring: patients lost to follow-up are right-censored, not removed.
+
+**H69 — Diagnostic Model Overfit Cascade**
+Researchers build prediction models then validate with ROC curves and calibration plots. The entire pipeline is vulnerable to overfitting.
+
+**H70 — Bioinformatics Pipeline Assumptions**
+Genomics researchers chain DESeq2/limma → enrichment analysis → network analysis → visualization. Each step has implicit assumptions.
+
+**H71 — Multi-Package Statistical Workflow Inconsistency**
+Researchers chain packages that make different assumptions. Switching packages mid-workflow produces subtly wrong results.
+
+**H72 — Clinical Threshold and Cutoff Sensitivity**
+Researchers use ROC curves to find "optimal" cutoffs. The cutoff is sample-dependent — it shifts with different data.
+
+**H73 — Domain-Specific Statistical Test Misapplication**
+Researchers routinely apply t-tests without checking normality, use Pearson correlation on non-linear relationships, apply chi-squared tests to small cells.
+
+**H74 — Structural Equation Model Convergence**
+SEM and confirmatory factor analysis frequently fail to converge or produce improper solutions (negative variance, correlations > 1).
+
+**H75 — Network Analysis and Graph Metric Fragility**
+Network metrics (centrality, clustering, community detection) are sensitive to graph construction choices.
+
+**H76 — Image and Spatial Data Processing in Non-GIS Tools**
+Researchers use the IDE for image analysis and geospatial work. Test that CRS transformations are explicit and reversible.
+
+**H77 — Parameterized Report Generation at Scale**
+Researchers generate hundreds of parameterized reports. Test that one failed parameter doesn't crash the batch.
+
+---
+
+## Domain M: IDE Component Architecture and Synchronization
+
+**H78 — Multi-Pane State Synchronization Drift**
+Data science IDEs display the same data across multiple synchronized panes. Each pane communicates via independent comm channels. Test that editing a DataFrame in the console updates the data explorer without manual refresh; kernel restart invalidates all pane states simultaneously.
+
+**H79 — Comm Channel Lifecycle Fragility**
+IDE panes communicate with kernels via RPC over comm channels. Test that operations on a closed comm produce clear errors, not hangs; long-running operations don't timeout prematurely; comm ID reuse after restart doesn't route messages to dead channels.
+
+**H80 — Widget and Interactive Output Rendering Pipeline**
+IPyWidgets, htmlwidgets, and interactive visualizations pass through a multi-stage rendering pipeline. Test that widget state persists across tab switches; kernel restart makes widgets non-interactive with a visible indicator.
+
+**H81 — Data Explorer Instrument Fidelity**
+The data explorer is a measurement instrument. Test that INT64/BIGINT values don't lose precision; decimal values aren't silently rounded; clipboard copy doesn't silently cap; DuckDB backend matches kernel backend behavior.
+
+**H82 — Kernel Supervisor and Session Recovery**
+The kernel supervisor manages session lifecycle: creation, reconnection, adoption, cleanup. Test that session reconnection restores all comm channels; adopted sessions have full functionality; startup failures produce diagnostic messages.
+
+**H83 — Proxy Content Rewriting and Rendering Chain**
+Help content, HTML previews, Shiny apps, and widgets are served through proxy servers. Test that binary content isn't corrupted; help pages with relative URLs resolve correctly; style injection doesn't break existing CSS.
+
+**H84 — RStudio API Migration Compatibility**
+R users migrating from RStudio depend on the rstudioapi compatibility layer. Test that functions behave identically, especially insertText() positions and documentSaveAll().
+
+**H85 — Runtime Discovery and Environment Complexity**
+The IDE must discover, validate, and manage R and Python interpreters across diverse installation methods. Test that non-ASCII paths work; environment activation doesn't silently fail; conda doesn't conflict with virtualenv.
+
+---
+
+## Meta-Heuristic
+
+**H86 — Silent Failure Prioritization**
+The most dangerous bugs produce incorrect results without crashing. Actively search for: operations that return wrong answers instead of errors, visualizations that render but misrepresent data, status indicators that show success despite failure, and IDE panes showing stale state after kernel restart. Formalize every manual check — if a data scientist would "eyeball" a plot to verify, define what "looks right" means as a concrete, automatable assertion.

--- a/.github/scripts/dstr/review.mjs
+++ b/.github/scripts/dstr/review.mjs
@@ -1,0 +1,261 @@
+import fs from "fs";
+import path from "path";
+import { Octokit } from "@octokit/rest";
+import Anthropic from "@anthropic-ai/sdk";
+
+const MAX_DIFF_CHARS = 80_000;
+const MAX_FILE_PATCH_CHARS = 15_000;
+const MAX_ISSUE_BODY_CHARS = 3_000;
+const MAX_COMMENTS_CHARS = 5_000;
+
+const event = JSON.parse(
+  fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8")
+);
+
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const owner = event.repository.owner.login;
+const repo = event.repository.name;
+const prNumber = event.issue.number;
+
+const { data: placeholderComment } = await octokit.issues.createComment({
+  owner,
+  repo,
+  issue_number: prNumber,
+  body: ":eyes: Analyzing...",
+});
+
+try {
+  const { data: pr } = await octokit.pulls.get({
+    owner,
+    repo,
+    pull_number: prNumber,
+  });
+
+  // --- Fetch linked issues referenced in the PR body/title ---
+  const issueRefs = extractIssueNumbers(pr.body ?? "", pr.title);
+  const linkedIssues = await fetchLinkedIssues(issueRefs);
+
+  // --- Fetch PR discussion comments (issue comments + review comments) ---
+  const prDiscussion = await fetchPRDiscussion();
+
+  // --- Fetch changed files ---
+  const { data: files } = await octokit.pulls.listFiles({
+    owner,
+    repo,
+    pull_number: prNumber,
+    per_page: 100,
+  });
+
+  let totalChars = 0;
+  const implFiles = [];
+  const testFiles = [];
+
+  for (const file of files) {
+    const patch = file.patch ?? "[binary or too large]";
+    const truncatedPatch =
+      patch.length > MAX_FILE_PATCH_CHARS
+        ? patch.slice(0, MAX_FILE_PATCH_CHARS) +
+          `\n... [truncated, ${patch.length - MAX_FILE_PATCH_CHARS} chars omitted]`
+        : patch;
+
+    const entry = `## ${file.filename}\nStatus: ${file.status} | +${file.additions} -${file.deletions}\n\n\`\`\`diff\n${truncatedPatch}\n\`\`\`\n`;
+
+    if (totalChars + entry.length > MAX_DIFF_CHARS) {
+      const remaining = files.length - implFiles.length - testFiles.length;
+      implFiles.push(`\n... [${remaining} more files omitted due to size]\n`);
+      break;
+    }
+
+    if (isTestFile(file.filename)) {
+      testFiles.push(entry);
+    } else {
+      implFiles.push(entry);
+    }
+    totalChars += entry.length;
+  }
+
+  // --- Build the user prompt ---
+  const systemPromptPath = path.join(
+    process.cwd(),
+    ".github",
+    "scripts",
+    "dstr",
+    "system-prompt.md"
+  );
+  const systemPrompt = fs.readFileSync(systemPromptPath, "utf8");
+
+  let userPrompt = `Review this PR for data science test design input. Apply the relevance gate strictly. If not relevant, output exactly NOT_RELEVANT.
+
+**PR #${prNumber}: ${pr.title}**
+
+### Description
+${pr.body ?? "(no description)"}
+`;
+
+  if (linkedIssues.length > 0) {
+    userPrompt += `\n### Linked Issues\n\n${linkedIssues.join("\n\n")}\n`;
+  }
+
+  if (prDiscussion) {
+    userPrompt += `\n### PR Discussion\n\n${prDiscussion}\n`;
+  }
+
+  userPrompt += `\n### Implementation Files (${implFiles.length} files)\n\n${implFiles.join("\n")}`;
+
+  if (testFiles.length > 0) {
+    userPrompt += `\n### Test Files (${testFiles.length} files)\n\n${testFiles.join("\n")}`;
+  } else {
+    userPrompt += `\n### Test Files\n\nNone included in this PR.\n`;
+  }
+
+  const msg = await anthropic.messages.create({
+    model: "claude-sonnet-4-6-20250514",
+    max_tokens: 600,
+    system: systemPrompt,
+    messages: [{ role: "user", content: userPrompt }],
+  });
+
+  const review = msg.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
+
+  const tokensUsed = `${msg.usage.input_tokens} in / ${msg.usage.output_tokens} out`;
+
+  // --- Handle NOT_RELEVANT: brief acknowledgment ---
+  if (review === "NOT_RELEVANT" || review.includes("NOT_RELEVANT")) {
+    await octokit.issues.updateComment({
+      owner,
+      repo,
+      comment_id: placeholderComment.id,
+      body: `Nothing stood out from a data science testing perspective here.`,
+    });
+    process.exit(0);
+  }
+
+  // --- Post the review with feedback reactions ---
+  await octokit.issues.updateComment({
+    owner,
+    repo,
+    comment_id: placeholderComment.id,
+    body: `${review}
+
+---
+<sub>${tokensUsed} | Was this helpful? React \u{1F44D} or \u{1F44E} to this comment</sub>`,
+  });
+} catch (error) {
+  await octokit.issues.updateComment({
+    owner,
+    repo,
+    comment_id: placeholderComment.id,
+    body: `:x: /dstr failed: ${error.message}`,
+  });
+  process.exit(1);
+}
+
+// --- Helper functions ---
+
+function isTestFile(filename) {
+  const lower = filename.toLowerCase();
+  return (
+    lower.includes(".test.") ||
+    lower.includes(".spec.") ||
+    lower.includes(".vitest.") ||
+    lower.includes("/test/") ||
+    lower.includes("/tests/") ||
+    lower.includes("/__tests__/") ||
+    lower.endsWith("_test.py") ||
+    lower.endsWith("_test.go") ||
+    lower.endsWith("_test.rs")
+  );
+}
+
+function extractIssueNumbers(body, title) {
+  const text = `${title}\n${body}`;
+  const numbers = new Set();
+
+  const hashPattern = /(?:fix(?:es)?|close[sd]?|resolve[sd]?|address(?:es)?)?[\s:]*#(\d+)/gi;
+  for (const match of text.matchAll(hashPattern)) {
+    numbers.add(parseInt(match[1], 10));
+  }
+
+  const urlPattern = new RegExp(
+    `https?://github\\.com/${owner}/${repo}/issues/(\\d+)`,
+    "gi"
+  );
+  for (const match of text.matchAll(urlPattern)) {
+    numbers.add(parseInt(match[1], 10));
+  }
+
+  numbers.delete(prNumber);
+  return [...numbers];
+}
+
+async function fetchLinkedIssues(issueNumbers) {
+  const results = [];
+  for (const num of issueNumbers.slice(0, 5)) {
+    try {
+      const { data: issue } = await octokit.issues.get({
+        owner,
+        repo,
+        issue_number: num,
+      });
+      const body = (issue.body ?? "").slice(0, MAX_ISSUE_BODY_CHARS);
+      const labels = issue.labels
+        .map((l) => (typeof l === "string" ? l : l.name))
+        .join(", ");
+      results.push(
+        `**#${num}: ${issue.title}**${labels ? ` [${labels}]` : ""}\n${body}${issue.body && issue.body.length > MAX_ISSUE_BODY_CHARS ? "\n..." : ""}`
+      );
+    } catch {
+      // Issue may be in a different repo or inaccessible
+    }
+  }
+  return results;
+}
+
+async function fetchPRDiscussion() {
+  const parts = [];
+  let totalLen = 0;
+
+  try {
+    const { data: issueComments } = await octokit.issues.listComments({
+      owner,
+      repo,
+      issue_number: prNumber,
+      per_page: 30,
+    });
+
+    for (const c of issueComments) {
+      if (c.user?.type === "Bot") continue;
+      if (c.id === placeholderComment.id) continue;
+
+      const entry = `**${c.user?.login}:** ${c.body?.slice(0, 500) ?? ""}\n`;
+      if (totalLen + entry.length > MAX_COMMENTS_CHARS) break;
+      parts.push(entry);
+      totalLen += entry.length;
+    }
+
+    const { data: reviewComments } = await octokit.pulls.listReviewComments({
+      owner,
+      repo,
+      pull_number: prNumber,
+      per_page: 30,
+    });
+
+    for (const c of reviewComments) {
+      if (c.user?.type === "Bot") continue;
+      const entry = `**${c.user?.login}** on \`${c.path}\`: ${c.body?.slice(0, 300) ?? ""}\n`;
+      if (totalLen + entry.length > MAX_COMMENTS_CHARS) break;
+      parts.push(entry);
+      totalLen += entry.length;
+    }
+  } catch {
+    // If we can't fetch comments, proceed without them
+  }
+
+  return parts.length > 0 ? parts.join("\n") : "";
+}

--- a/.github/scripts/dstr/system-prompt.md
+++ b/.github/scripts/dstr/system-prompt.md
@@ -1,0 +1,147 @@
+# /dstr — Data Science Test Design Advisor
+
+You help developers design better tests by surfacing data science concepts they wouldn't naturally think to test. You are NOT a code reviewer. You don't comment on code quality, style, or architecture. Your only job: identify 1-3 non-obvious testing angles grounded in data science reasoning that would make THIS PR's tests more robust.
+
+Think of yourself as an experienced data scientist sitting next to a developer saying: "Hey, when you write your test for this, you should also check X because in practice Y happens."
+
+## Context You Receive
+
+You get:
+- The PR diff (code changes — both implementation AND test files)
+- The PR description
+- **Linked issues** (the bugs/features this PR addresses — their descriptions, labels, repro steps)
+- **PR discussion** (comments from reviewers and the author — design decisions, known limitations, related concerns)
+
+Use ALL of this context:
+- **Read the implementation code** to understand what the PR actually does — what data it touches, how it transforms/displays values, what state it manages. This tells you which DS concepts are relevant.
+- **Read the test code** (if present) to see what's already covered. Your job is to identify what the existing tests MISS from a DS perspective — not repeat what they already do.
+- **Read the linked issues** to understand the original bug/feature motivation. The test MUST cover a scenario that would catch a regression of that specific bug.
+- **Read the PR discussion** for edge cases the team identified but may not have codified as tests.
+
+## Relevance Gate (CRITICAL)
+
+Most PRs do NOT need DS test input. Be silent rather than force a connection.
+
+**Say nothing for:**
+- CSS, theming, styling, layout, animations
+- Build/CI/tooling infrastructure
+- Documentation, changelogs, version bumps
+- Config toggles, settings plumbing, feature flags
+- Keyboard shortcuts, focus management, menu routing
+- Scroll behavior, DOM event handling, render performance
+- Package/dependency management infrastructure
+- UI chrome (buttons, icons, tooltips) that doesn't display user data
+- Ark/interpreter version bumps without behavior changes
+- Fixes about WHERE/WHEN something renders (focus, scroll, visibility, z-index) rather than WHAT data it shows
+
+**Speak only for PRs that touch:**
+- Data display, transformation, formatting, or serialization of user data values
+- Numeric/date/locale-sensitive parsing or rendering
+- Data persistence (save/load/copy/paste of data content)
+- Kernel state changes that affect data correctness (restart, reconnect, session lifecycle)
+- Data Explorer, Variables Pane, or Plot display correctness
+- LLM-generated code that operates on or references user data
+- Clipboard operations involving data content (not UI text)
+
+When in doubt: say nothing. A false silence costs nothing; a false trigger trains developers to ignore the tool.
+
+## Decision Flow
+
+1. **Apply relevance gate.** If not relevant: output exactly `NOT_RELEVANT` and stop. Never rationalize your way into relevance.
+
+2. **If relevant, check for tests.**
+   - **Tests exist → Review through DS lens.** Find the gap between what the test checks and what the linked issue's actual failure scenario was. The best bullet: "Your test verifies X, but the bug was caused by Y — add a case for Y."
+   - **Tests exist but use weak oracles** → Flag it. A test that asserts visibility, shape, or completion without checking actual data values is a weak oracle. Name what the assertion should check instead.
+   - **No tests, DS-relevant fix → Flag it.** Name the specific scenario that needs a regression test.
+
+3. **Give 1-3 bullets.** One sharp bullet is better than three lukewarm ones. Only add a second or third if each carries a genuinely distinct insight.
+
+## What makes a good bullet
+
+The single quality bar: **would a developer without DS experience think of this on their own?** If yes, don't say it.
+
+Every bullet MUST propose a **concrete assertion or specific test input** — not a direction. Name the function, the value, or the property to check.
+
+Good (concrete assertion referencing actual failure):
+"Your test checks values 0–100 but issue #9798 was triggered by values >= 1000 where thousands separators break parseFloat. Add a case with `formatNumber(1700.5)` and assert the clipboard contains `1700.5`, not `1.7005`."
+
+Good (metamorphic property — restart shouldn't change data):
+"The test saves and reopens, but never checks that numeric cell values survived unchanged. Add: `expect(cell(0,0).textContent).toBe('3.14159')` after reopen — verifying the DATA round-tripped, not just that a DOM element rendered."
+
+Good (names what the assertion actually proves):
+"Your test asserts `toBeVisible()` after restart, but visibility ≠ data correctness. Replace with `expect(table.getRowCount()).toBe(150)` and `expect(table.getCell(0, 'price')).toBe('29.99')` to verify the data, not just the container."
+
+Bad: "Consider testing edge cases." (generic)
+Bad: "The code should handle null values." (code review)
+Bad: "Consider testing with different data types." (vague)
+Bad: "LLMs are non-deterministic." (true but not actionable)
+Bad: "This might break in non-English locales." (speculative without evidence in the diff)
+Bad: "Add assertions on data content." (direction without concrete assertion)
+
+## Heuristic library (internal reference — do NOT cite codes in output)
+
+Use these to guide your reasoning, but never write "H2" or "(H34)" in your output. The output should read like a colleague talking, not an academic paper.
+
+| Concept | When it applies |
+|---------|----------------|
+| Distributional Mismatch | Test inputs use convenient values (small, sorted, dense) but real triggering scenario is at a different magnitude or distribution |
+| Round-trip Distortion | Display, copy, or save introduces systematic error in data values (precision loss, format corruption, encoding mangling) |
+| Silent Type Coercion | Type boundaries propagate without error (int→float, precision loss, null→undefined, BigInt→Number overflow) |
+| Semantic Type Misuse | Categorical treated as numeric or vice versa (averaging zip codes, sorting enums alphabetically) |
+| Idempotency Violation | Repeated operations accumulate state (N restarts, N copies, N saves produce different results than 1) |
+| State Leakage | Prior kernel/UI state leaks into current operation; stale variable references after cell deletion |
+| Weak Oracle / Trust Signal | UI says "OK"/renders something but the underlying data is wrong or stale; test asserts presence not correctness |
+| LLM Trust Boundary | LLM output crosses trust boundary — validate structure/types, not content |
+| Locale Sensitivity | Number/date formatting differs by locale, breaks parsing (thousands separator, decimal comma) |
+| Pane Desynchronization | Multiple views of same data show inconsistent values after lifecycle event |
+| Channel Cleanup Failure | Old comm/RPC channel not disposed after restart; receives messages meant for new session |
+| Message Routing Error | RPC reply matched to wrong request, or message delivered to wrong session in multi-session |
+| Kernel Resource Leak | Runtime holds references to dead sessions, preventing GC or causing stale data |
+| Session Recovery Failure | Session transition (restart, reconnect, adopt) loses or corrupts data state |
+| Display Fidelity Loss | Data Explorer transformation loses precision, truncates, or misrepresents values |
+| Partial Delivery | Large payload (data frame, plot) arrives incomplete after connection drop; view shows truncated data |
+| Capability Mismatch | Feature works in one kernel (ipykernel) but breaks in another (IRkernel) due to protocol differences |
+| Zombie View | Webview/pane persists after backing session dies; user interacts with UI generating RPCs to dead kernel |
+| Reconnect Storm | Multiple panes re-request state simultaneously after restart, overwhelming kernel or causing OOM |
+| Metamorphic Violation | An operation that shouldn't change data does (restart, zoom, tab switch, re-render alters values) |
+| Unicode/Encoding Corruption | CSV/clipboard round-trip mangles combining characters, BOM, or multi-byte sequences |
+
+## Recurring failure patterns in this codebase
+
+These are REAL bugs from Positron's history. Use them to ground your bullets in actual failure scenarios:
+
+- **Numeric parsing breaks at magnitude boundaries:** thousands separators break parseFloat (≥1000), INT64 overflows JS Number, inf/NaN unhandled in stats
+- **Data explorer state lost on tab/session switch:** sort/filter/column widths don't persist across tab changes or restarts
+- **Copy-paste loses data fidelity:** sorted data exported in wrong order, ANSI stripping corrupts adjacent digits, pinned columns break row copy
+- **Stale comm channels after restart:** old comms receive RPCs meant for new session, causing timeouts or stale data display
+- **Streaming output race conditions:** only first message appears, re-execution flashes, out-of-order idle/input messages
+- **Kernel startup timing:** selection fires before runtimes registered, status stuck active after reopen, session leaks on close
+- **Backend type inference failures:** DuckDB samples wrong types from large CSVs, 0-row data crashes statistics, histogram bin edge errors
+- **Multi-pane desynchronization:** variables pane stale after empty execution, inline vs full explorer show different data
+- **Partial delivery on large frames:** data explorer shows truncated rows when payload split across messages
+- **Zombie webviews after session death:** data explorer UI remains interactive but sends RPCs to dead kernel
+
+## Output format
+
+When NOT relevant, output ONLY this exact string (the system will handle it):
+```
+NOT_RELEVANT
+```
+
+When relevant and tests exist:
+```
+**Test design gaps:**
+
+- **[What the test misses]** — [1-2 sentences with a CONCRETE assertion or test input to add. Name the function, value, or property.]
+```
+
+When relevant and NO tests exist:
+```
+**Missing regression test:**
+
+- **[What to test]** — [1-2 sentences with a CONCRETE scenario and specific assertion.]
+```
+
+No preamble. No closing. No JSON. No heuristic codes. No offers to expand. Just the bullets.
+
+**If you only have one genuine insight, give one bullet. Never pad to fill a quota. One sharp observation beats three lukewarm ones.**

--- a/.github/workflows/dstr.yml
+++ b/.github/workflows/dstr.yml
@@ -1,4 +1,4 @@
-name: Data Science Test Review
+name: "Review: Data Science Test Design (/dstr)"
 
 on:
   issue_comment:
@@ -21,12 +21,20 @@ jobs:
         with:
           node-version: 22
 
+      - name: Load secret
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
+
       - name: Install dependencies
         run: npm install @octokit/rest @anthropic-ai/sdk
 
       - name: Run /dstr review
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ env.ANTHROPIC_KEY }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
         run: node .github/scripts/dstr/review.mjs

--- a/.github/workflows/dstr.yml
+++ b/.github/workflows/dstr.yml
@@ -1,0 +1,32 @@
+name: Data Science Test Review
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  dstr:
+    if: github.event.issue.pull_request && github.event.comment.body == '/dstr'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm install @octokit/rest @anthropic-ai/sdk
+
+      - name: Run /dstr review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+        run: node .github/scripts/dstr/review.mjs


### PR DESCRIPTION
## Summary

Adds `/dstr` — a GitHub Action triggered by typing `/dstr` as a PR comment that uses Claude to surface 1-3 non-obvious data science testing angles grounded in actual Positron failure history. Stays silent when not relevant.

- **Opt-in**: dev explicitly invokes via PR comment
- **Relevance gate**: ~87% of PRs get a brief "nothing stood out" response; only PRs touching data paths get bullets
- **Concrete output**: every suggestion proposes a specific assertion or test input, not vague guidance
- **Grounded in history**: system prompt includes 10 recurring failure patterns extracted from 40+ real Positron bugs
- **86 heuristics**: full reference library across 13 domains (DS, statistics, pipelines, IDE architecture, enterprise, academic workflows)

Addresses #13366

## Design Process

```mermaid
flowchart TD
    A[Literature review<br/>21 books, 2400+ papers, 48 enterprise cases] --> B[Heuristic distillation<br/>86 heuristics, 13 domains]
    B --> C[Local skill build<br/>/ds-test-design, 8 iterations, layered framework]
    C --> D[GitHub Action prototype<br/>workflow + script + Claude API]
    D --> E[Verbose output → team feedback → concise redesign]
    E --> F[Relevance gate<br/>blocklist/allowlist, silence by default]
    F --> G[Context enrichment<br/>linked issues + PR discussion + test detection]
    G --> H[Decision flow<br/>gaps in existing tests vs missing tests flagged]
    H --> I[Quality bar<br/>good/bad examples, no heuristic codes in output, 1 > 3 weak]
    I --> J[Initial calibration<br/>20 PRs, 70% silent, 7 quality rules]
    J --> K[Full-population calibration<br/>5,000 PRs, subsystem classification]
    K --> L[Failure pattern extraction<br/>40+ bug-fix PRs → 10 recurring patterns]
    L --> M[Expert panel review<br/>DS, Testing/QA, DevEx, Reliability, DevRel]
    M --> N[Prompt hardening<br/>borderline rules, weak oracle detection, concrete assertions]
    N --> O[Live validation<br/>unseen PR simulations, single sharp bullets]
    O --> P[1Password integration<br/>aligned with team workflow conventions]
```

## Files

| File | Purpose |
|------|---------|
| `.github/workflows/dstr.yml` | Action workflow — `issue_comment` trigger, 1Password secret loading |
| `.github/scripts/dstr/review.mjs` | Main script — fetches PR context, calls Claude, posts comment |
| `.github/scripts/dstr/system-prompt.md` | Condensed 21 heuristics the model uses at runtime |
| `.github/scripts/dstr/calibration.md` | Full calibration results, 10 failure patterns, design decisions |
| `.github/scripts/dstr/heuristics-reference.md` | Complete 86-heuristic library (13 domains) — the foundation |

## How It Works

1. Dev types `/dstr` as a PR comment
2. Action fires → posts `:eyes: Analyzing...` placeholder
3. Script fetches: PR diff, linked issues, PR discussion, classifies files (impl vs test)
4. Claude Sonnet analyzes through tuned system prompt with relevance gate
5. Result:
   - **Not relevant** → updates comment to "Nothing stood out from a data science testing perspective here."
   - **Relevant** → 1-3 bullets with concrete assertions + 👍/👎 feedback footer

## Example Output

On a DS-relevant PR with tests:

> **Test design gaps:**
>
> - **Sort indicators AND actual data order must agree after remount** — The fix restores sort arrows from backend state, but the regression risk is the inverse: arrow present, data unsorted. After tab-switch-and-back, assert `expect(table.getCell(0, 'price')).toBe('9.99')` confirming ascending sort is applied to data, not just the indicator.

On a non-DS PR:

> Nothing stood out from a data science testing perspective here.

## Prerequisites

Uses 1Password via `op://Positron/Anthropic/credential` (same path as e2e tests). No new secrets needed — `OP_SERVICE_ACCOUNT_TOKEN` already exists.

## Test plan

- [ ] Merge and comment `/dstr` on a DS-relevant PR (e.g., one touching Data Explorer)
- [ ] Comment `/dstr` on a non-DS PR (e.g., CSS fix) — verify brief acknowledgment
- [ ] Verify output is 1-3 bullets with concrete assertions
- [ ] Verify 👍/👎 feedback prompt appears in footer
- [ ] Verify 1Password secret loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)