### PR TITLE
Move save icon from global toolbar to editor action bar

### DIFF
--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
@@ -25,14 +25,13 @@ import { TopActionBarCommandCenter } from './components/topActionBarCommandCente
 import { PositronTopActionBarContextProvider } from './positronTopActionBarContext.js';
 import { TopActionBarCustomFolderMenu } from './components/topActionBarCustomFolderMenu.js';
 import { TopActionBarSessionManager } from './components/topActionBarSessionManager.js';
-import { SAVE_ALL_COMMAND_ID, SAVE_FILE_COMMAND_ID } from '../../../contrib/files/browser/fileConstants.js';
+import { SAVE_ALL_COMMAND_ID } from '../../../contrib/files/browser/fileConstants.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 
 // Constants.
 const kHorizontalPadding = 4;
 const kCenterUIBreak = 600;
 const kFulllCenterUIBreak = 765;
-const SAVE = SAVE_FILE_COMMAND_ID;
 const SAVE_ALL = SAVE_ALL_COMMAND_ID;
 const NAV_BACK = NavigateBackwardsAction.ID;
 const NAV_FORWARD = NavigateForwardAction.ID;
@@ -103,11 +102,6 @@ export const PositronTopActionBar = (props: PositronTopActionBarProps) => {
 							<ActionBarSeparator />
 							<TopActionBarOpenMenu />
 							<ActionBarSeparator />
-							<ActionBarCommandButton
-								ariaLabel={CommandCenter.title(SAVE)}
-								commandId={SAVE}
-								icon={ThemeIcon.fromId('positron-save')}
-							/>
 							<ActionBarCommandButton
 								ariaLabel={CommandCenter.title(SAVE_ALL)}
 								commandId={SAVE_ALL}

--- a/src/vs/workbench/contrib/positronEditorActions/browser/positronEditorActions.contribution.ts
+++ b/src/vs/workbench/contrib/positronEditorActions/browser/positronEditorActions.contribution.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ThemeIcon } from '../../../../base/common/themables.js';
+import { MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
+import { ActiveEditorDirtyContext, ResourceContextKey } from '../../../common/contextkeys.js';
+import { SAVE_FILE_COMMAND_ID, SAVE_FILE_LABEL } from '../../files/browser/fileConstants.js';
+
+// Adds the Save File button to the editor action bar so it sits with the
+// editor it acts on. Always rendered for file-backed editors (text editors,
+// Quarto, Positron notebooks); precondition disables it when the active editor
+// is clean.
+//
+// Group `1_save` (not `navigation`): the menu service special-cases
+// `navigation` to render first regardless of group-name order, so Save in
+// `navigation` would sit to the left of editor-specific actions like Quarto's
+// `0_preview` Render buttons or the notebook's `navigation` Run / Clear / Add
+// cluster. `1_save` sorts lexically after those, placing Save just to the
+// right of them with a group separator between.
+MenuRegistry.appendMenuItem(MenuId.EditorActionsLeft, {
+	command: {
+		id: SAVE_FILE_COMMAND_ID,
+		title: SAVE_FILE_LABEL,
+		icon: ThemeIcon.fromId('positron-save'),
+		precondition: ActiveEditorDirtyContext,
+	},
+	group: '1_save',
+	order: 10,
+	when: ResourceContextKey.IsFileSystemResource,
+});
+
+

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -327,6 +327,7 @@ import './contrib/positronOutputWebview/browser/notebookOutputWebview.contributi
 import './contrib/positronNotebook/browser/positronNotebook.contribution.js';
 import './contrib/positronWelcome/browser/positronWelcome.contribution.js';
 import './contrib/positronTelemetry/browser/positronTelemetry.contribution.js';
+import './contrib/positronEditorActions/browser/positronEditorActions.contribution.js';
 // --- End Positron ---
 
 // Terminal

--- a/test/e2e/pages/editorActionBar.ts
+++ b/test/e2e/pages/editorActionBar.ts
@@ -17,7 +17,8 @@ type EditorActionBarButton =
 	| 'Open as Plain Text File'
 	| 'Deploy with Posit Publisher'
 	| 'Convert to Code'
-	| 'Clear Column Sorting';
+	| 'Clear Column Sorting'
+	| 'Save';
 
 
 export class EditorActionBar {
@@ -206,6 +207,36 @@ export class EditorActionBar {
 			isVisible
 				? await expect(this.actionBar).toBeVisible()
 				: await expect(this.actionBar).not.toBeVisible();
+		});
+	}
+
+	/**
+	 * Verify: a specific button on the editor action bar is visible (or not).
+	 *
+	 * @param button the button to verify
+	 * @param isVisible whether the button is expected to be visible
+	 */
+	async verifyButtonVisible(button: EditorActionBarButton, isVisible: boolean) {
+		await test.step(`Verify "${button}" button is ${isVisible ? 'visible' : 'not visible'}`, async () => {
+			const buttonLocator = this.actionBar.getByLabel(button, { exact: true });
+			isVisible
+				? await expect(buttonLocator).toBeVisible()
+				: await expect(buttonLocator).not.toBeVisible();
+		});
+	}
+
+	/**
+	 * Verify: a specific button on the editor action bar is enabled (or disabled).
+	 *
+	 * @param button the button to verify
+	 * @param isEnabled whether the button is expected to be enabled
+	 */
+	async verifyButtonEnabled(button: EditorActionBarButton, isEnabled: boolean) {
+		await test.step(`Verify "${button}" button is ${isEnabled ? 'enabled' : 'disabled'}`, async () => {
+			const buttonLocator = this.actionBar.getByLabel(button, { exact: true });
+			isEnabled
+				? await expect(buttonLocator).toBeEnabled()
+				: await expect(buttonLocator).toBeDisabled();
 		});
 	}
 }

--- a/test/e2e/pages/topActionBar.ts
+++ b/test/e2e/pages/topActionBar.ts
@@ -8,7 +8,6 @@ import { Locator } from '@playwright/test';
 import { Code } from '../infra/code';
 
 const POSITRON_TOP_ACTION_BAR = 'div[id="workbench.parts.positron-top-action-bar"]';
-const POSITRON_TOP_ACTION_SAVE_BUTTON = 'div[id="workbench.parts.positron-top-action-bar"] .action-bar-region-left .action-bar-button[aria-label="Save"]';
 const POSITRON_TOP_ACTION_SAVE_ALL_BUTTON = 'div[id="workbench.parts.positron-top-action-bar"] .action-bar-region-left .action-bar-button[aria-label="Save All"]';
 
 /*
@@ -16,12 +15,10 @@ const POSITRON_TOP_ACTION_SAVE_ALL_BUTTON = 'div[id="workbench.parts.positron-to
  */
 export class TopActionBar {
 	topActionBar: Locator;
-	saveButton: Locator;
 	saveAllButton: Locator;
 
 	constructor(private code: Code) {
 		this.topActionBar = this.code.driver.currentPage.locator(POSITRON_TOP_ACTION_BAR);
-		this.saveButton = this.code.driver.currentPage.locator(POSITRON_TOP_ACTION_SAVE_BUTTON);
 		this.saveAllButton = this.code.driver.currentPage.locator(POSITRON_TOP_ACTION_SAVE_ALL_BUTTON);
 	}
 }

--- a/test/e2e/tests/editor-action-bar/editor-action-bar-data-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/editor-action-bar-data-files.test.ts
@@ -84,6 +84,10 @@ test.describe('Editor Action Bar: Data Files', {
 			// Ensure the summary panel is visible
 			await dataExplorer.summaryPanel.show();
 
+			// Save button should NOT appear on the Data Explorer's editor
+			// action bar; the data explorer URI is virtual (not file-backed).
+			await editorActionBar.verifyButtonVisible('Save', false);
+
 			// Verify action bar behavior
 			await editorActionBar.selectSummaryOn(app.web, 'Left');
 			await editorActionBar.verifySummaryPosition('Left');

--- a/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
@@ -53,6 +53,7 @@ test.describe('Editor Action Bar: Document Files', {
 	}, async function ({ app, page, openFile }) {
 		await openFile('workspaces/quarto_basic/quarto_basic.qmd');
 		await verifyPreviewRendersHtml('Diamond sizes');
+		await verifySaveButton(page);
 		await verifyOpenChanges(page);
 		await verifySplitEditor('quarto_basic.qmd');
 		await verifyOpenInNewWindow(app, 'Diamond sizes');
@@ -93,12 +94,33 @@ async function verifyOpenViewerRendersHtml(app: Application, title: string) {
 	await editorActionBar.verifyOpenViewerRendersHtml(app.web, title);
 }
 
+async function bindPlatformHotkey(page: Page, key: string) {
+	await page.keyboard.press(process.platform === 'darwin' ? `Meta+${key}` : `Control+${key}`);
+}
+
+async function verifySaveButton(page: Page) {
+	await test.step('verify Save button visibility, dirty state, and click', async () => {
+		// Clean editor: button visible but disabled.
+		await editorActionBar.verifyButtonVisible('Save', true);
+		await editorActionBar.verifyButtonEnabled('Save', false);
+
+		// Make a change to dirty the editor; Save becomes enabled.
+		await page.locator('[id="workbench\\.parts\\.editor"]').getByText('date').click();
+		await page.keyboard.press('Y');
+		await editorActionBar.verifyButtonEnabled('Save', true);
+
+		// Click Save; editor should be clean again, so Save disables.
+		await editorActionBar.clickButton('Save');
+		await editorActionBar.verifyButtonEnabled('Save', false);
+
+		// Restore the file so subsequent steps see the original content.
+		await bindPlatformHotkey(page, 'Z');
+		await bindPlatformHotkey(page, 'S');
+	});
+}
+
 async function verifyOpenChanges(page: Page) {
 	await test.step('verify "open changes" shows diff', async () => {
-		async function bindPlatformHotkey(page: Page, key: string) {
-			await page.keyboard.press(process.platform === 'darwin' ? `Meta+${key}` : `Control+${key}`);
-		}
-
 		// make change & save
 		await page.locator('[id="workbench\\.parts\\.editor"]').getByText('date').click();
 		await page.keyboard.press('X');

--- a/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
@@ -53,7 +53,7 @@ test.describe('Editor Action Bar: Document Files', {
 	}, async function ({ app, page, openFile }) {
 		await openFile('workspaces/quarto_basic/quarto_basic.qmd');
 		await verifyPreviewRendersHtml('Diamond sizes');
-		await verifySaveButton(page);
+		await verifySaveButton(app, page);
 		await verifyOpenChanges(page);
 		await verifySplitEditor('quarto_basic.qmd');
 		await verifyOpenInNewWindow(app, 'Diamond sizes');
@@ -98,15 +98,14 @@ async function bindPlatformHotkey(page: Page, key: string) {
 	await page.keyboard.press(process.platform === 'darwin' ? `Meta+${key}` : `Control+${key}`);
 }
 
-async function verifySaveButton(page: Page) {
+async function verifySaveButton(app: Application, page: Page) {
 	await test.step('verify Save button visibility, dirty state, and click', async () => {
 		// Clean editor: button visible but disabled.
 		await editorActionBar.verifyButtonVisible('Save', true);
 		await editorActionBar.verifyButtonEnabled('Save', false);
 
 		// Make a change to dirty the editor; Save becomes enabled.
-		await page.locator('[id="workbench\\.parts\\.editor"]').getByText('date').click();
-		await page.keyboard.press('Y');
+		await app.workbench.editor.selectTabAndType('quarto_basic.qmd', 'Y');
 		await editorActionBar.verifyButtonEnabled('Save', true);
 
 		// Click Save; editor should be clean again, so Save disables.

--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -155,7 +155,8 @@ test.describe('Remote SSH', {
 			await sshWorkbench.editor.selectTabAndType(fileName, flaskAppCode);
 			await sshWin.keyboard.press('Enter');
 
-			await sshWorkbench.topActionBar.saveButton.click();
+			// Trigger Save (an untitled file, so this opens the Save As dialog).
+			await sshWin.keyboard.press(process.platform === 'darwin' ? 'Meta+S' : 'Control+S');
 
 			await sshWorkbench.quickInput.waitForQuickInputOpened();
 			await sshWin.keyboard.press('Backspace'); // clear any pre-filled text

--- a/test/e2e/tests/top-action-bar/top-action-bar-save.test.ts
+++ b/test/e2e/tests/top-action-bar/top-action-bar-save.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -10,7 +10,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Top Action Bar - Save Actions', {
+test.describe('Top Action Bar - Save All', {
 	tag: [tags.WEB, tags.TOP_ACTION_BAR]
 }, () => {
 
@@ -24,32 +24,23 @@ test.describe('Top Action Bar - Save Actions', {
 		await cleanup.discardAllChanges();
 	});
 
-	test('Verify `Save` and `Save All` are disabled when no unsaved editors are open', async function ({ app }) {
+	test('Verify `Save All` is disabled when no unsaved editors are open', async function ({ app }) {
 		await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors', { keepOpen: false });
-		await expect(app.workbench.topActionBar.saveButton).not.toBeEnabled();
 		await expect(app.workbench.topActionBar.saveAllButton).not.toBeEnabled();
 	});
 
-	test('Verify `Save` enabled and `Save All` disabled when a single unsaved file is open', async function ({ app }) {
+	test('Verify `Save All` is disabled when a single unsaved file is open', async function ({ app }) {
 		const fileName = 'README.md';
 		await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors', { keepOpen: false });
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, fileName));
 		await app.workbench.quickaccess.runCommand('workbench.action.keepEditor', { keepOpen: false });
 		await app.workbench.editor.selectTabAndType(fileName, 'Puppies frolicking in a meadow of wildflowers');
 
-		// The file is now "dirty" and the save buttons should be enabled
-		await expect(app.workbench.topActionBar.saveButton).toBeEnabled();
-		await expect(app.workbench.topActionBar.saveAllButton).toBeEnabled();
-		await app.workbench.topActionBar.saveButton.click();
-
-		// The file is now saved, so the file should no longer be "dirty"
-		// The Save button stays enabled even when the active file is not "dirty"
-		await expect(app.workbench.topActionBar.saveButton).toBeEnabled();
-		// The Save All button is disabled when less than 2 files are "dirty"
+		// The Save All button is disabled when fewer than 2 files are dirty
 		await expect(app.workbench.topActionBar.saveAllButton).not.toBeEnabled();
 	});
 
-	test('Verify `Save` and `Save All` are enabled when multiple unsaved files are open', async function ({ app }) {
+	test('Verify `Save All` is enabled when multiple unsaved files are open and saves them all on click', async function ({ app }) {
 		const fileName1 = 'README.md';
 		const fileName2 = 'DESCRIPTION';
 		const text = 'Kittens playing with yarn';
@@ -63,35 +54,36 @@ test.describe('Top Action Bar - Save Actions', {
 		await app.workbench.editor.selectTabAndType(fileName1, text);
 		await app.workbench.editor.selectTabAndType(fileName2, text);
 
-		// The files are now "dirty" and the save buttons should be enabled
-		await expect(app.workbench.topActionBar.saveButton).toBeEnabled();
+		// The files are now dirty and Save All should be enabled
 		await expect(app.workbench.topActionBar.saveAllButton).toBeEnabled();
 		await app.workbench.topActionBar.saveAllButton.click();
 
-		// The files are now saved, so the files should no longer be "dirty"
+		// The files are now saved, so they should no longer be dirty
 		await app.workbench.editors.waitForTab(fileName1, false);
 		await app.workbench.editors.waitForTab(fileName2, false);
 
-		// The Save button stays enabled even when the active file is not "dirty"
-		await expect(app.workbench.topActionBar.saveButton).toBeEnabled();
-		// The Save All button is disabled when less than 2 files are "dirty"
+		// Save All is disabled when fewer than 2 files are dirty
 		await expect(app.workbench.topActionBar.saveAllButton).not.toBeEnabled();
 	});
 
-	test('Verify `Save` and `Save All` are enabled when an unsaved new file is open', async function ({ app }) {
-		const fileName = 'Untitled-1';
+	test('Verify `Save All` is enabled when an unsaved new file is open alongside another dirty file', async function ({ app }) {
+		const fileName1 = 'README.md';
+		const fileName2 = 'Untitled-1';
 		const text = 'Bunnies hopping through a field of clover';
 
-		// Open a new file and type in some text
+		// Open a real file, dirty it, then open an untitled file and dirty it.
+		// Save All requires 2+ dirty files to enable.
 		await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors', { keepOpen: false });
-		await app.workbench.quickaccess.runCommand('workbench.action.files.newUntitledFile', { keepOpen: false });
-		await app.workbench.editor.selectTabAndType(fileName, text);
+		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, fileName1));
+		await app.workbench.quickaccess.runCommand('workbench.action.keepEditor', { keepOpen: false });
+		await app.workbench.editor.selectTabAndType(fileName1, text);
 
-		// The file is now "dirty" and the save buttons should be enabled
-		await expect(app.workbench.topActionBar.saveButton).toBeEnabled();
+		await app.workbench.quickaccess.runCommand('workbench.action.files.newUntitledFile', { keepOpen: false });
+		await app.workbench.editor.selectTabAndType(fileName2, text);
+
+		// Both files are dirty, so Save All should be enabled.
+		// We don't click it because the untitled file would trigger a native
+		// save dialog we can't automate.
 		await expect(app.workbench.topActionBar.saveAllButton).toBeEnabled();
-		// We won't try to click the Save buttons because a system dialog will pop up and we
-		// can't automate interactions with the native file dialog
 	});
 });
-

--- a/test/e2e/tests/top-action-bar/top-action-bar-save.test.ts
+++ b/test/e2e/tests/top-action-bar/top-action-bar-save.test.ts
@@ -29,14 +29,21 @@ test.describe('Top Action Bar - Save All', {
 		await expect(app.workbench.topActionBar.saveAllButton).not.toBeEnabled();
 	});
 
-	test('Verify `Save All` is disabled when a single unsaved file is open', async function ({ app }) {
+	test('Verify `Save All` is enabled when a single unsaved file is open and disabled after saving', async function ({ app }) {
 		const fileName = 'README.md';
 		await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors', { keepOpen: false });
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, fileName));
 		await app.workbench.quickaccess.runCommand('workbench.action.keepEditor', { keepOpen: false });
 		await app.workbench.editor.selectTabAndType(fileName, 'Puppies frolicking in a meadow of wildflowers');
 
-		// The Save All button is disabled when fewer than 2 files are dirty
+		// The file is now dirty and Save All should be enabled
+		await expect(app.workbench.topActionBar.saveAllButton).toBeEnabled();
+		await app.workbench.topActionBar.saveAllButton.click();
+
+		// The file is now saved, so it should no longer be dirty
+		await app.workbench.editors.waitForTab(fileName, false);
+
+		// Save All is disabled when no files are dirty
 		await expect(app.workbench.topActionBar.saveAllButton).not.toBeEnabled();
 	});
 
@@ -62,7 +69,7 @@ test.describe('Top Action Bar - Save All', {
 		await app.workbench.editors.waitForTab(fileName1, false);
 		await app.workbench.editors.waitForTab(fileName2, false);
 
-		// Save All is disabled when fewer than 2 files are dirty
+		// Save All is disabled when no files are dirty
 		await expect(app.workbench.topActionBar.saveAllButton).not.toBeEnabled();
 	});
 
@@ -72,7 +79,6 @@ test.describe('Top Action Bar - Save All', {
 		const text = 'Bunnies hopping through a field of clover';
 
 		// Open a real file, dirty it, then open an untitled file and dirty it.
-		// Save All requires 2+ dirty files to enable.
 		await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors', { keepOpen: false });
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, fileName1));
 		await app.workbench.quickaccess.runCommand('workbench.action.keepEditor', { keepOpen: false });


### PR DESCRIPTION
Fixes #13131

This PR moves the Save File icon from the global top action bar to the per-editor action bar, where users expect file-level operations. The icon appears for file-backed editors (text files including `.py` / `.R` / `.qmd`, plus Positron notebooks), is disabled when the active editor is clean, and is hidden on virtual editors that don't represent a file (Plots, Data Explorer, Preview, Settings). Save All remains on the global top action bar.

The new Save entry uses group `1_save` rather than `navigation` so it sits to the right of editor-specific actions like Quarto's Render / Render-on-Save and the notebook's Run All / Clear / Add Cell cluster, with a group separator distinguishing it from the language-specific cluster.

Some screenshots for your enjoyment...

Regular script, dirty state:

<img width="1234" height="943" alt="Screenshot 2026-05-04 at 5 39 53 PM" src="https://github.com/user-attachments/assets/e3dc6695-7c9f-4903-897f-546517fe72d2" />

Regular script, clean state:

<img width="1234" height="943" alt="Screenshot 2026-05-04 at 5 40 34 PM" src="https://github.com/user-attachments/assets/1a950f91-5709-4669-945f-d371dbd0cff4" />

Plot in an editor tab (that save icon is the special one for plots, not the new one here):

<img width="1234" height="943" alt="Screenshot 2026-05-04 at 5 41 15 PM" src="https://github.com/user-attachments/assets/69873c69-7257-44e1-b337-7de37c6b2c01" />

New notebook editor:

<img width="1234" height="943" alt="Screenshot 2026-05-04 at 5 41 37 PM" src="https://github.com/user-attachments/assets/5572a843-7a0b-4d43-81ca-a2f2759ff7b2" />

Quarto (dirty state):

<img width="1234" height="943" alt="Screenshot 2026-05-04 at 5 42 24 PM" src="https://github.com/user-attachments/assets/4839854b-99ee-47c5-88d1-165f0e1b7b1c" />

Data Explorer:

<img width="1234" height="943" alt="Screenshot 2026-05-04 at 5 43 12 PM" src="https://github.com/user-attachments/assets/06121427-f057-4449-8b5f-4d2e656d029e" />


### Release Notes

#### New Features
- Moved the Save File icon from the global toolbar to the editor action bar (#13131)

#### Bug Fixes
- N/A

### Validation Steps

@:editor-action-bar @:top-action-bar @:quarto @:data-explorer

Manual verification:
1. Open a `.py` or `.R` file. The Save button appears on the left side of the editor action bar, disabled when the editor is clean.
2. Type a character. Save becomes enabled.
3. Click Save. The file saves; Save returns to disabled.
4. Open a `.qmd` file. Save appears to the right of Render / Render-on-Save.
5. Open an `.ipynb` file in the Positron Notebook editor. Save appears to the right of the Run All / Clear / Add Cell cluster.
6. Open the Plot editor or Data Explorer. Save does **not** appear on the editor action bar.
7. Top action bar: Save button removed; Save All still present.

E2E coverage in this PR:
- `editor-action-bar-document-files.test.ts` (Quarto) exercises the Save button lifecycle (visible, enabled on dirty, disabled after click).
- `editor-action-bar-data-files.test.ts` asserts Save is hidden on Data Explorer.
- `top-action-bar-save.test.ts` was pivoted to cover Save All only (Save was the focus of the original tests but now lives on the editor action bar).
- `remote-ssh.test.ts` swaps the removed top-bar Save click for `Cmd+S`.
