### PR TITLE
Fix macOS Intel compatibility: respect npm_config_arch

### DIFF
--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -351,14 +351,16 @@ const baseHeaders = {
 // --- Start Positron ---
 
 function getPlatformDownloads(): string[] {
-	switch (os.arch()) {
+	// Respect npm_config_arch when cross-building (e.g. building x64 on arm64 macOS).
+	const targetArch = process.env['npm_config_arch'] || os.arch();
+	switch (targetArch) {
 		case 'arm64':
 			return [`${process.platform}-arm64`];
 		case 'x64':
 		case 'x86_64':
 			return [`${process.platform}-x64`];
 		default:
-			throw new Error(`Unsupported architecture: ${os.arch()}`);
+			throw new Error(`Unsupported architecture: ${targetArch}`);
 	}
 }
 

--- a/extensions/positron-python/scripts/install-pet.ts
+++ b/extensions/positron-python/scripts/install-pet.ts
@@ -147,6 +147,8 @@ async function downloadAndReplacePet(version: string, githubPat: string | undefi
             if (!release) {
                 throw new Error(`Could not find Python Environment Tool ${version} in the releases.`);
             }
+            // Respect npm_config_arch when cross-building (e.g. building x64 on arm64).
+            const targetArch = process.env['npm_config_arch'] || arch();
             let os: string;
             switch (platform()) {
                 case 'win32':
@@ -156,7 +158,7 @@ async function downloadAndReplacePet(version: string, githubPat: string | undefi
                     os = 'darwin-universal';
                     break;
                 case 'linux':
-                    os = arch() === 'arm64' ? 'linux-arm64' : 'linux-x64';
+                    os = targetArch === 'arm64' ? 'linux-arm64' : 'linux-x64';
                     break;
                 default: {
                     throw new Error(`Unsupported platform ${platform()}.`);

--- a/extensions/positron-r/scripts/install-kernel.ts
+++ b/extensions/positron-r/scripts/install-kernel.ts
@@ -239,7 +239,8 @@ async function downloadAndReplaceArk(version: string,
 		}
 
 		const currentPlatform = platform() as NodeJS.Platform;
-		const currentArch = arch();
+		// Respect npm_config_arch when cross-building (e.g. building x64 on arm64 macOS).
+		const currentArch = (process.env['npm_config_arch'] as NodeArch | undefined) || arch();
 		const targets = getDownloadTargets(currentPlatform, currentArch);
 		const arkDir = path.join('resources', 'ark');
 		await fs.promises.mkdir(arkDir, { recursive: true });
@@ -368,9 +369,11 @@ async function downloadFromGitHubRepository(
 		// Copy the binary to the resources directory (root) so packaging picks it up
 		await fs.promises.copyFile(binaryPath, path.join(arkDir, kernelName));
 
-		// On Windows, also place the binary inside the architecture-specific subdirectory
+		// On Windows, also place the binary inside the architecture-specific subdirectory.
+		// Respect npm_config_arch when cross-building (e.g. building x64 on arm64).
 		if (platform() === 'win32') {
-			const windowsSubdir = process.arch === 'arm64' ? 'windows-arm64' : 'windows-x64';
+			const targetArch = process.env['npm_config_arch'] || process.arch;
+			const windowsSubdir = targetArch === 'arm64' ? 'windows-arm64' : 'windows-x64';
 			const targetDir = path.join(arkDir, windowsSubdir);
 			await fs.promises.mkdir(targetDir, { recursive: true });
 			await fs.promises.copyFile(binaryPath, path.join(targetDir, kernelName));

--- a/extensions/positron-supervisor/scripts/install-kallichore-server.ts
+++ b/extensions/positron-supervisor/scripts/install-kallichore-server.ts
@@ -146,7 +146,8 @@ async function downloadAndReplaceKallichore(version: string,
 			}
 
 			const currentPlatform = platform();
-			const currentArch = arch();
+			// Respect npm_config_arch when cross-building (e.g. building x64 on arm64 macOS).
+			const currentArch = process.env['npm_config_arch'] || arch();
 			let os: string;
 			switch (currentPlatform) {
 				case 'win32': os = (currentArch === 'arm64' ? 'windows-arm64' : 'windows-x64'); break;


### PR DESCRIPTION
When building for macOS Intel processors, we set `npm_config_arch` to the intended architecture; since all our build infrastructure is on Apple Silicon, `arch()` is always `arm64`, and we rely `npm_config_arch` to select binaries that are architecture-dependent.

There are a few places where we were still relying on `arch()`. This was never a problem before because we selected (or created) universal binaries, but now that we don't have a universal build it is vital to respect `npm_config_arch` when selecting binaries.

Closes https://github.com/posit-dev/positron/issues/13372
Closes https://github.com/posit-dev/positron/issues/13369