### PR TITLE
Don't hang Runtime Startup Diagnostics on unresponsive extension host

### DIFF
--- a/src/vs/workbench/contrib/positronStartupDiagnostics/browser/positronStartupDiagnostics.contribution.ts
+++ b/src/vs/workbench/contrib/positronStartupDiagnostics/browser/positronStartupDiagnostics.contribution.ts
@@ -8,11 +8,12 @@ import { Registry } from '../../../../platform/registry/common/platform.js';
 import { EditorExtensions, IEditorSerializer, IEditorFactoryRegistry } from '../../../common/editor.js';
 import { registerAction2, Action2 } from '../../../../platform/actions/common/actions.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
-import { localize2 } from '../../../../nls.js';
-import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { localize, localize2 } from '../../../../nls.js';
+import { ServicesAccessor, IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { PositronStartupDiagnosticsContrib, PositronStartupDiagnosticsInput } from './positronStartupDiagnosticsEditor.js';
-import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { PositronStartupDiagnosticsContrib, PositronStartupDiagnosticsInput, EXTENSION_HOST_TIMEOUT_CONFIG_KEY, EXTENSION_HOST_TIMEOUT_DEFAULT_MS } from './positronStartupDiagnosticsEditor.js';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { positronConfigurationNodeBase } from '../../../services/languageRuntime/common/languageRuntime.js';
 
 // Register the contribution (lazy loading)
 registerWorkbenchContribution2(
@@ -20,6 +21,23 @@ registerWorkbenchContribution2(
 	PositronStartupDiagnosticsContrib,
 	WorkbenchPhase.BlockRestore
 );
+
+// Register timeout used by the diagnostics report
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	...positronConfigurationNodeBase,
+	properties: {
+		[EXTENSION_HOST_TIMEOUT_CONFIG_KEY]: {
+			type: 'number',
+			default: EXTENSION_HOST_TIMEOUT_DEFAULT_MS,
+			minimum: 1000,
+			maximum: 60000,
+			description: localize(
+				'positron.startupDiagnostics.timeout',
+				"Time in milliseconds the Runtime Startup Diagnostics report will wait for a response from the extension host before continuing without that data. Increase this on slower systems."
+			)
+		}
+	}
+});
 
 // Register editor serializer
 Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEditorSerializer(

--- a/src/vs/workbench/contrib/positronStartupDiagnostics/browser/positronStartupDiagnosticsEditor.ts
+++ b/src/vs/workbench/contrib/positronStartupDiagnostics/browser/positronStartupDiagnosticsEditor.ts
@@ -405,7 +405,7 @@ class PositronStartupDiagnosticsContentProvider implements ITextModelContentProv
 		const timeoutMs = this._configurationService.getValue<number>(EXTENSION_HOST_TIMEOUT_CONFIG_KEY);
 		const results = await Promise.all(sessions.map(async session => {
 			if (!session.getLaunchInfo) {
-				return { session, skipped: true } as const;
+				return undefined;
 			}
 
 			let timedOut: boolean = false;
@@ -415,15 +415,15 @@ class PositronStartupDiagnosticsContentProvider implements ITextModelContentProv
 					timeoutMs,
 					() => { timedOut = true; }
 				);
-				return { session, launchInfo, timedOut } as const;
+				return { session, launchInfo, timedOut };
 			} catch {
 				// Session may not support launch info; skip it.
-				return { session, skipped: true } as const;
+				return undefined;
 			}
 		}));
 
 		for (const result of results) {
-			if (result.skipped) {
+			if (!result) {
 				continue;
 			}
 			const { session, launchInfo, timedOut } = result;

--- a/src/vs/workbench/contrib/positronStartupDiagnostics/browser/positronStartupDiagnosticsEditor.ts
+++ b/src/vs/workbench/contrib/positronStartupDiagnostics/browser/positronStartupDiagnosticsEditor.ts
@@ -181,8 +181,6 @@ class PositronStartupDiagnosticsContentProvider implements ITextModelContentProv
 				md.blank();
 				this._addSystemInfo(md);
 				md.blank();
-				this._addExtensionHostStatus(md);
-				md.blank();
 				this._addAffiliatedRuntimes(md);
 				md.blank();
 				this._addActiveRuntimes(md);
@@ -202,6 +200,8 @@ class PositronStartupDiagnosticsContentProvider implements ITextModelContentProv
 				await this._addSessionLaunchInfo(md);
 				md.blank();
 				this._addDiscoveredRuntimes(md);
+				md.blank();
+				this._addExtensionHostStatus(md);
 				md.blank();
 				await this._addOutputChannels(md);
 

--- a/src/vs/workbench/contrib/positronStartupDiagnostics/browser/positronStartupDiagnosticsEditor.ts
+++ b/src/vs/workbench/contrib/positronStartupDiagnostics/browser/positronStartupDiagnosticsEditor.ts
@@ -13,6 +13,9 @@ import { IInstantiationService } from '../../../../platform/instantiation/common
 import { IModelService } from '../../../../editor/common/services/model.js';
 import { ITimerService } from '../../../services/timer/browser/timerService.js';
 import { IDisposable, dispose } from '../../../../base/common/lifecycle.js';
+import { raceTimeout } from '../../../../base/common/async.js';
+import { IExtensionService, IResponsiveStateChangeEvent } from '../../../services/extensions/common/extensions.js';
+import { ExtensionHostKind } from '../../../services/extensions/common/extensionHostKind.js';
 import { ICodeEditorService } from '../../../../editor/browser/services/codeEditorService.js';
 import { writeTransientState } from '../../codeEditor/browser/toggleWordWrap.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
@@ -26,11 +29,21 @@ import { getWorkbenchContribution } from '../../../common/contributions.js';
 import { ICustomEditorLabelService } from '../../../services/editor/common/customEditorLabelService.js';
 import { IRuntimeSessionService } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
-import { ILanguageRuntimeService, ILanguageRuntimeLaunchInfo } from '../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeService } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IOutputService } from '../../../services/output/common/output.js';
 import { IAdminPolicyService } from '../../../../platform/policy/common/adminPolicyService.js';
 import * as perf from '../../../../base/common/performance.js';
+
+/**
+ * Setting that controls how long the Runtime Startup Diagnostics report waits
+ * for a response from the extension host before giving up and rendering the
+ * rest of the report without that data. Configurable for slower systems.
+ */
+export const EXTENSION_HOST_TIMEOUT_CONFIG_KEY = 'startupDiagnostics.timeout';
+
+/** Default value (ms) for {@link EXTENSION_HOST_TIMEOUT_CONFIG_KEY}. */
+export const EXTENSION_HOST_TIMEOUT_DEFAULT_MS = 5000;
 
 export class PositronStartupDiagnosticsContrib implements IDisposable {
 
@@ -42,19 +55,22 @@ export class PositronStartupDiagnosticsContrib implements IDisposable {
 
 	private readonly _inputUri = URI.from({ scheme: 'positron-startup-diagnostics', path: 'Runtime Startup Diagnostics' });
 	private readonly _registration: IDisposable;
+	private readonly _provider: PositronStartupDiagnosticsContentProvider;
 
 	constructor(
 		@IInstantiationService private readonly _instaService: IInstantiationService,
 		@ITextModelService textModelResolverService: ITextModelService
 	) {
+		this._provider = _instaService.createInstance(PositronStartupDiagnosticsContentProvider);
 		this._registration = textModelResolverService.registerTextModelContentProvider(
 			'positron-startup-diagnostics',
-			_instaService.createInstance(PositronStartupDiagnosticsContentProvider)
+			this._provider
 		);
 	}
 
 	dispose(): void {
 		this._registration.dispose();
+		this._provider.dispose();
 	}
 
 	getInputUri(): URI {
@@ -102,10 +118,16 @@ export class PositronStartupDiagnosticsInput extends TextResourceEditorInput {
 	}
 }
 
-class PositronStartupDiagnosticsContentProvider implements ITextModelContentProvider {
+class PositronStartupDiagnosticsContentProvider implements ITextModelContentProvider, IDisposable {
 
 	private _model: ITextModel | undefined;
 	private _modelDisposables: IDisposable[] = [];
+	private _disposables: IDisposable[] = [];
+
+	// Latest known responsive state per extension host kind, populated by
+	// onDidChangeResponsiveChange. A host that has never reported a transition
+	// is omitted from the map (and we surface that as "no transitions reported").
+	private readonly _hostResponsiveState = new Map<ExtensionHostKind, boolean>();
 
 	constructor(
 		@IModelService private readonly _modelService: IModelService,
@@ -120,7 +142,18 @@ class PositronStartupDiagnosticsContentProvider implements ITextModelContentProv
 		@IOutputService private readonly _outputService: IOutputService,
 		@ITextModelService private readonly _textModelService: ITextModelService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-	) { }
+		@IExtensionService private readonly _extensionService: IExtensionService,
+	) {
+		this._disposables.push(this._extensionService.onDidChangeResponsiveChange(
+			(e: IResponsiveStateChangeEvent) => {
+				this._hostResponsiveState.set(e.extensionHostKind, e.isResponsive);
+			}));
+	}
+
+	dispose(): void {
+		dispose(this._disposables);
+		dispose(this._modelDisposables);
+	}
 
 	provideTextContent(resource: URI): Promise<ITextModel> {
 		if (!this._model || this._model.isDisposed()) {
@@ -147,6 +180,8 @@ class PositronStartupDiagnosticsContentProvider implements ITextModelContentProv
 				md.heading(1, 'Positron Runtime Startup Diagnostics');
 				md.blank();
 				this._addSystemInfo(md);
+				md.blank();
+				this._addExtensionHostStatus(md);
 				md.blank();
 				this._addAffiliatedRuntimes(md);
 				md.blank();
@@ -188,6 +223,42 @@ class PositronStartupDiagnosticsContentProvider implements ITextModelContentProv
 			md.li(`Memory(System): ${(metrics.totalmem / (ByteSize.GB)).toFixed(2)} GB (${(metrics.freemem / (ByteSize.GB)).toFixed(2)}GB free)`);
 		}
 		md.li(`Initial Startup: ${metrics.initialStartup}`);
+	}
+
+	private _addExtensionHostStatus(md: MarkdownBuilder): void {
+		md.heading(2, 'Extension Host Status');
+
+		// Registered extension count. Synchronous local data; if the extension
+		// host never finished registering (e.g. it's hung), this will be empty
+		// and is itself a useful diagnostic signal.
+		const registered = this._extensionService.extensions;
+		md.li(`Registered extensions: ${registered.length}`);
+
+		// Determine which extension host kinds are actually in use by looking
+		// at where each registered extension is running. Hosts default to
+		// "Responsive": onDidChangeResponsiveChange only fires on transitions,
+		// so the absence of an event means the host has stayed responsive
+		// since startup.
+		const status = this._extensionService.getExtensionsStatus();
+		const kindsInUse = new Set<ExtensionHostKind>();
+		for (const id of Object.keys(status)) {
+			const loc = status[id].runningLocation;
+			if (loc) {
+				kindsInUse.add(loc.kind);
+			}
+		}
+
+		md.blank();
+		if (kindsInUse.size === 0) {
+			md.li('No extension hosts running');
+		} else {
+			const stateRows: Array<Array<string>> = [];
+			for (const kind of kindsInUse) {
+				const isResponsive = this._hostResponsiveState.get(kind) ?? true;
+				stateRows.push([extensionHostKindLabel(kind), isResponsive ? 'Responsive' : 'Unresponsive']);
+			}
+			md.table(['Extension Host', 'State'], stateRows);
+		}
 	}
 
 	private _addInterpreterSettings(md: MarkdownBuilder): void {
@@ -328,16 +399,39 @@ class PositronStartupDiagnosticsContentProvider implements ITextModelContentProv
 			return;
 		}
 
-		for (const session of sessions) {
+		// Kick off all getLaunchInfo() calls in parallel against a single shared
+		// timeout window. Awaiting them sequentially would multiply the wait by
+		// the number of active sessions when the extension host is unresponsive.
+		const timeoutMs = this._configurationService.getValue<number>(EXTENSION_HOST_TIMEOUT_CONFIG_KEY);
+		const results = await Promise.all(sessions.map(async session => {
 			if (!session.getLaunchInfo) {
-				continue;
+				return { session, skipped: true } as const;
 			}
 
-			let launchInfo: ILanguageRuntimeLaunchInfo | undefined;
+			let timedOut: boolean = false;
 			try {
-				launchInfo = await session.getLaunchInfo();
+				const launchInfo = await raceTimeout(
+					Promise.resolve(session.getLaunchInfo()),
+					timeoutMs,
+					() => { timedOut = true; }
+				);
+				return { session, launchInfo, timedOut } as const;
 			} catch {
 				// Session may not support launch info; skip it.
+				return { session, skipped: true } as const;
+			}
+		}));
+
+		for (const result of results) {
+			if (result.skipped) {
+				continue;
+			}
+			const { session, launchInfo, timedOut } = result;
+
+			if (timedOut) {
+				md.heading(3, session.runtimeMetadata.runtimeName);
+				md.li(`(Could not retrieve launch info: extension host did not respond within ${timeoutMs / 1000}s)`);
+				md.blank();
 				continue;
 			}
 
@@ -601,6 +695,14 @@ class PositronStartupDiagnosticsContentProvider implements ITextModelContentProv
 		// timer service snapshot, which is captured early during startup and
 		// misses marks recorded after that point.
 		return perf.getMarks().filter(m => m.name.startsWith('code/positron/'));
+	}
+}
+
+function extensionHostKindLabel(kind: ExtensionHostKind): string {
+	switch (kind) {
+		case ExtensionHostKind.LocalProcess: return 'Local Process';
+		case ExtensionHostKind.LocalWebWorker: return 'Local Web Worker';
+		case ExtensionHostKind.Remote: return 'Remote';
 	}
 }
 

--- a/src/vs/workbench/contrib/positronStartupDiagnostics/browser/positronStartupDiagnosticsEditor.ts
+++ b/src/vs/workbench/contrib/positronStartupDiagnostics/browser/positronStartupDiagnosticsEditor.ts
@@ -43,7 +43,7 @@ import * as perf from '../../../../base/common/performance.js';
 export const EXTENSION_HOST_TIMEOUT_CONFIG_KEY = 'startupDiagnostics.timeout';
 
 /** Default value (ms) for {@link EXTENSION_HOST_TIMEOUT_CONFIG_KEY}. */
-export const EXTENSION_HOST_TIMEOUT_DEFAULT_MS = 5000;
+export const EXTENSION_HOST_TIMEOUT_DEFAULT_MS = 10000;
 
 export class PositronStartupDiagnosticsContrib implements IDisposable {
 


### PR DESCRIPTION
Fixes #12865

When Positron's extension host stops responding or never comes up to start with, the Runtime Startup Diagnostics report calls `session.getLaunchInfo()` (which proxies through the ext host) and never returns, so the report stays at "Loading..." forever. This defeats the purpose of a diagnostic tool meant to surface startup problems!

This PR has two main changes:

1. **Time out the extension host calls.** `getLaunchInfo()` for every active session is now raced against a single shared timeout window (calls run in parallel so the wait does not multiply by session count). On timeout, the Session Launch Parameters section renders a "(Could not retrieve launch info: extension host did not respond within 5s)" line and the rest of the report (Discovered Runtimes, Output Channels, etc.) continues to build out below it.
2. **Surface extension host status.** A new "Extension Host Status" section sits just below "System Information" and shows the registered extension count and the last-known responsive state of each ext host kind in use. The state subscribes to `IExtensionService.onDidChangeResponsiveChange` and defaults to "Responsive" when no unresponsive transition has been observed.

Here is what the top looks like when the extension host is unresponsive:

````
# Positron Runtime Startup Diagnostics


## System Information

* Positron Dev: 2026.06.0 build 0 (Code OSS 1.111.0)
* Commit: unknown
* OS: darwin(25.4.0)
* CPUs: Apple M4 Pro(14 x 2400)
* Memory(System): 48.00 GB (1.58GB free)
* Initial Startup: true

## Extension Host Status

* Registered extensions: 135

| Extension Host | State        |
| -------------- | ------------ |
| Local Process  | Unresponsive |

## Workspace-Affiliated Runtimes

| Name                        | Language | Version | Source | Has Session | Session ID(s)                   |
| --------------------------- | -------- | ------- | ------ | ----------- | ------------------------------- |
| Zed 2.0.0                   | zed      | 2.0.0   | Test   | No          | -                               |
| Python 3.13.2 (uv: scratch) | python   | 3.13.2  | uv     | No          | -                               |
| R 4.5.2                     | r        | 4.5.2   | System | Yes         | r-20f7fc33, r-notebook-a933a7fc |

````

The timeout is configurable via the new `startupDiagnostics.timeout` setting (number, ms, default 5000, range 1000-60000), for our friends on slower systems. I'm not sure if 5 sec is about right for a default?

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- The command _Developer: Runtime Startup Diagnostics_ no longer hangs when the extension host is unresponsive (#12865)

### QA Notes

@:interpreter

**Happy path** 😃 

1. Start an R or Python session.
2. Open the Runtime Startup Diagnostics report (_Developer: Runtime Startup Diagnostics_).
4. Verify the new "Extension Host Status" section appears just below "System Information" and shows the registered extension count plus a "Local Process: Responsive" row.
5. Verify the rest of the report renders normally and within a few seconds.

**Faking an unresponsive extension host** 😩 

I tried a couple of different options but I think this is probably best:

1. Run Positron Dev and start a session.
2. Choose "Attach to Extension Host" in the floating debugger toolbar.
4. Click the pause/break button in the debugger toolbar. The ext host freezes wherever it currently is.
5. Wait ~10 seconds so VS Code's responsive watchdog has time to fire `isResponsive: false`.
6. Open the Runtime Startup Diagnostics report.
7. Verify:
   - Extension Host Status: `Local Process: Unresponsive`
   - Session Launch Parameters: timeout message after 5s
   - Sections after Session Launch Parameters still render

