### PR TITLE
Fix Save As for Altair plots in Positron notebooks

### DIFF
--- a/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/downloadUtils.ts
@@ -13,8 +13,8 @@ export function msgIsDownloadMessage(msg: any): msg is IClickedDataUrlMessage {
 	return msg.type === 'clicked-data-url';
 }
 
-// Let typescript know that the vscode object is available
-declare const vscode: {
+// Let typescript know that the acquireVsCodeApi function is available in webviews
+declare function acquireVsCodeApi(): {
 	postMessage(message: IClickedDataUrlMessage): void;
 };
 
@@ -24,6 +24,7 @@ declare const vscode: {
 // notebook webviews. The implementation here is a bit simpler because there's contexts that don't
 // apply to the positron webviews that are handled in the notebook webviews.
 function handleWebviewClicks() {
+	const vscode = acquireVsCodeApi();
 
 	// eslint-disable-next-line no-restricted-syntax
 	document.addEventListener('click', (event) => {

--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -24,6 +24,7 @@ import { INotebookRendererMessagingService } from '../../notebook/common/noteboo
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { webviewMessageCodeString } from '../../positronWebviewPreloads/browser/notebookOutputUtils.js';
+import { handleWebviewLinkClicksInjection } from './downloadUtils.js';
 
 /**
  * Processed bundle of information about a message and how to render it for a webview.
@@ -388,7 +389,7 @@ export class PositronNotebookOutputWebviewService implements IPositronNotebookOu
 		const headContent = [
 			needsBase ? `<base href="${asWebviewUri(baseUri).toString(true)}/">` : '',
 			PositronNotebookOutputWebviewService.CssAddons,
-			`<script>${webviewMessageCodeString}</script>`,
+			`<script>${webviewMessageCodeString}\n${handleWebviewLinkClicksInjection}</script>`,
 		].filter(Boolean).join('\n');
 
 		if (/<head[\s>]/i.test(html)) {
@@ -421,6 +422,7 @@ ${headContent}
 			origin: DOM.getActiveWindow().origin,
 			contentOptions: {
 				allowScripts: true,
+				allowMultipleAPIAcquire: true,
 				localResourceRoots: baseUri ? [baseUri] : [],
 			},
 			extension: undefined,


### PR DESCRIPTION
## Summary

- Altair plots in Positron notebooks use the `createRawHtmlOutputWebview` path (since their `text/html` output contains `<script>` tags), which was missing blob URL click interception -- so Vega's "Save as SVG/PNG" action silently failed
- Wires up the existing but unused `handleWebviewLinkClicksInjection` (from `downloadUtils.ts`) into the raw HTML webview, and enables `allowMultipleAPIAcquire` so the download handler can acquire its own VS Code API instance



https://github.com/user-attachments/assets/c72971e6-4cbd-498f-bc49-3c772f7a46cd


### Root cause

When Altair's "Save as SVG/PNG" runs, Vega-Embed creates a blob URL, attaches it to a temporary `<a download="...">` element, and clicks it. In the Plots pane, the full `webviewPreloads.ts` script intercepts this click and routes it through a file save dialog. In notebooks, the raw HTML webview path only injected a sizing script -- no click interception -- so the download attempt was silently swallowed.

## QA Notes

@:positron-notebook @:plots

1. Open a Python notebook
2. Run a cell that creates an Altair chart (e.g. `alt.Chart(...).mark_bar().encode(...)`)
3. Hover over the rendered chart, click the "..." menu in the top-right of the Vega-Embed toolbar
4. Click "Save as SVG" or "Save as PNG"
5. Verify that a file save dialog appears and the file is saved successfully

Also verify that the same flow still works in the Plots pane (run the same Altair code in the console).