### PR TITLE
Add application/json MIME type rendering in notebook outputs

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
@@ -60,7 +60,7 @@ export const POSITRON_NOTEBOOK_CELL_CAN_MOVE_DOWN = new RawContextKey<boolean>('
 // Output-related context keys
 export const POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS = new RawContextKey<boolean>('positronNotebookCellHasOutputs', false);
 export const POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT = new RawContextKey<number>('positronNotebookCellImageOutputCount', 0);
-export const POSITRON_NOTEBOOK_CELL_HAS_JSON_OUTPUT = new RawContextKey<boolean>('positronNotebookCellHasJsonOutput', false);
+export const POSITRON_NOTEBOOK_CELL_JSON_OUTPUT_COUNT = new RawContextKey<number>('positronNotebookCellJsonOutputCount', 0);
 export const POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED = new RawContextKey<boolean>('positronNotebookCellOutputIsCollapsed', false);
 export const POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS = new RawContextKey<boolean>('positronNotebookCellOutputOverflows', false, localize('positronNotebookCellOutputOverflows', "Whether the cell's text output exceeds the line limit"));
 export const POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING = new RawContextKey<boolean>('positronNotebookCellOutputScrolling', false, localize('positronNotebookCellOutputScrolling', "Whether the cell's output is in scrolling mode"));
@@ -90,7 +90,7 @@ export const POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS = {
 	canMoveDown: POSITRON_NOTEBOOK_CELL_CAN_MOVE_DOWN,
 	hasOutputs: POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
 	imageOutputCount: POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT,
-	hasJsonOutput: POSITRON_NOTEBOOK_CELL_HAS_JSON_OUTPUT,
+	jsonOutputCount: POSITRON_NOTEBOOK_CELL_JSON_OUTPUT_COUNT,
 	outputIsCollapsed: POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED,
 	outputOverflows: POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
 	outputScrolling: POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING,
@@ -122,7 +122,7 @@ export function bindCellContextKeys(service: IScopedContextKeyService): IPositro
 		canMoveDown: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.canMoveDown.bindTo(service),
 		hasOutputs: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.hasOutputs.bindTo(service),
 		imageOutputCount: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.imageOutputCount.bindTo(service),
-		hasJsonOutput: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.hasJsonOutput.bindTo(service),
+		jsonOutputCount: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.jsonOutputCount.bindTo(service),
 		outputIsCollapsed: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputIsCollapsed.bindTo(service),
 		outputOverflows: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputOverflows.bindTo(service),
 		outputScrolling: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputScrolling.bindTo(service),

--- a/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
@@ -72,6 +72,7 @@ export const POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING = new RawContextKey<boolean
  * cell context key set or bindCellContextKeys.
  */
 export const POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED = new RawContextKey<boolean>('positronNotebookOutputImageTargeted', false);
+export const POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED = new RawContextKey<boolean>('positronNotebookOutputJsonTargeted', false);
 
 // All cell context keys in one place so we can easily operate on them all at once
 export const POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS = {

--- a/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
@@ -60,6 +60,7 @@ export const POSITRON_NOTEBOOK_CELL_CAN_MOVE_DOWN = new RawContextKey<boolean>('
 // Output-related context keys
 export const POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS = new RawContextKey<boolean>('positronNotebookCellHasOutputs', false);
 export const POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT = new RawContextKey<number>('positronNotebookCellImageOutputCount', 0);
+export const POSITRON_NOTEBOOK_CELL_HAS_JSON_OUTPUT = new RawContextKey<boolean>('positronNotebookCellHasJsonOutput', false);
 export const POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED = new RawContextKey<boolean>('positronNotebookCellOutputIsCollapsed', false);
 export const POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS = new RawContextKey<boolean>('positronNotebookCellOutputOverflows', false, localize('positronNotebookCellOutputOverflows', "Whether the cell's text output exceeds the line limit"));
 export const POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING = new RawContextKey<boolean>('positronNotebookCellOutputScrolling', false, localize('positronNotebookCellOutputScrolling', "Whether the cell's output is in scrolling mode"));
@@ -89,6 +90,7 @@ export const POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS = {
 	canMoveDown: POSITRON_NOTEBOOK_CELL_CAN_MOVE_DOWN,
 	hasOutputs: POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
 	imageOutputCount: POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT,
+	hasJsonOutput: POSITRON_NOTEBOOK_CELL_HAS_JSON_OUTPUT,
 	outputIsCollapsed: POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED,
 	outputOverflows: POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
 	outputScrolling: POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING,
@@ -120,6 +122,7 @@ export function bindCellContextKeys(service: IScopedContextKeyService): IPositro
 		canMoveDown: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.canMoveDown.bindTo(service),
 		hasOutputs: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.hasOutputs.bindTo(service),
 		imageOutputCount: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.imageOutputCount.bindTo(service),
+		hasJsonOutput: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.hasJsonOutput.bindTo(service),
 		outputIsCollapsed: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputIsCollapsed.bindTo(service),
 		outputOverflows: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputOverflows.bindTo(service),
 		outputScrolling: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputScrolling.bindTo(service),

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -403,6 +403,10 @@ export type ParsedOutput = ParsedTextOutput |
 	content: string;
 } |
 {
+	type: 'json';
+	data: unknown;
+} |
+{
 	type: 'unknown';
 	content: string;
 } |

--- a/src/vs/workbench/contrib/positronNotebook/browser/copyJsonUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/copyJsonUtils.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Shape of the arg passed to `positronNotebook.cell.copyOutputJson` to target
+ * a specific JSON output.
+ */
+export interface CopyJsonMenuArg {
+	jsonText: string;
+}
+
+export function isCopyJsonMenuArg(arg: unknown): arg is CopyJsonMenuArg {
+	return typeof arg === 'object' && arg !== null && typeof (arg as CopyJsonMenuArg).jsonText === 'string';
+}
+
+export function serializeJsonOutput(data: unknown): string {
+	return JSON.stringify(data, null, 2) ?? String(data);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/copyJsonUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/copyJsonUtils.ts
@@ -16,5 +16,5 @@ export function isCopyJsonMenuArg(arg: unknown): arg is CopyJsonMenuArg {
 }
 
 export function serializeJsonOutput(data: unknown): string {
-	return JSON.stringify(data, null, 2) ?? String(data);
+	return JSON.stringify(data, null, 2);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
@@ -109,6 +109,16 @@ export function parseOutputData(outputItem: IOutputItemDto): ParsedOutput {
 	const { data, mime } = outputItem;
 	const message = data.toString();
 
+	if (mime === 'application/json') {
+		try {
+			const parsed = JSON.parse(message);
+			return { type: 'json', data: parsed };
+		} catch {
+			// Invalid JSON -- fall through to render as plain text
+			return { type: 'text', content: message };
+		}
+	}
+
 	try {
 		const parsedMessage = JSON.parse(message);
 
@@ -155,16 +165,6 @@ export function parseOutputData(outputItem: IOutputItemDto): ParsedOutput {
 			} satisfies ParsedDataExplorerOutput;
 		} catch {
 			// Fall through to unknown if parsing fails
-		}
-	}
-
-	if (mime === 'application/json') {
-		try {
-			const parsed = JSON.parse(message);
-			return { type: 'json', data: parsed };
-		} catch {
-			// Invalid JSON -- fall through to render as plain text
-			return { type: 'text', content: message };
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
@@ -158,6 +158,16 @@ export function parseOutputData(outputItem: IOutputItemDto): ParsedOutput {
 		}
 	}
 
+	if (mime === 'application/json') {
+		try {
+			const parsed = JSON.parse(message);
+			return { type: 'json', data: parsed };
+		} catch {
+			// Invalid JSON -- fall through to render as plain text
+			return { type: 'text', content: message };
+		}
+	}
+
 	if (mime === 'text/html') {
 		return { type: 'html', content: message };
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -103,6 +103,27 @@
 	font-style: italic;
 }
 
+.json-expand-value {
+	border: none;
+	background: none;
+	font: inherit;
+	font-size: 11px;
+	color: var(--vscode-textLink-foreground);
+	cursor: pointer;
+	padding: 0 4px;
+	margin-left: 4px;
+	border-radius: 3px;
+}
+
+.json-expand-value:hover {
+	background: var(--vscode-toolbar-hoverBackground);
+}
+
+.json-expand-value:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
+}
+
 /* Token colors */
 .json-key {
 	color: var(--vscode-debugTokenExpression-name);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -102,7 +102,7 @@
 }
 
 .json-bracket-close {
-	padding-left: 16px;
+	padding-left: 6px;
 	min-height: 18px;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -56,6 +56,7 @@
 	gap: 2px;
 	padding: 1px 0;
 	cursor: pointer;
+	user-select: none;
 	border-radius: 3px;
 	border: none;
 	background: none;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -66,8 +66,17 @@
 	text-align: left;
 }
 
+.json-collapsible-header span {
+	cursor: pointer;
+}
+
 .json-collapsible-header:hover {
 	background: var(--vscode-list-hoverBackground);
+}
+
+.json-collapsible-header:focus-visible {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: -1px;
 }
 
 .json-chevron {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.json-output {
+	margin: 0;
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+.json-output .json-key {
+	color: var(--vscode-debugTokenExpression-name);
+}
+
+.json-output .json-string {
+	color: var(--vscode-debugTokenExpression-string);
+}
+
+.json-output .json-number {
+	color: var(--vscode-debugTokenExpression-number);
+}
+
+.json-output .json-boolean {
+	color: var(--vscode-debugTokenExpression-boolean);
+}
+
+.json-output .json-null {
+	color: var(--vscode-debugTokenExpression-value);
+}
+
+.json-output .json-punct {
+	color: var(--vscode-foreground);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -52,7 +52,8 @@
 
 .json-leaf {
 	display: flex;
-	align-items: center;
+	flex-wrap: wrap;
+	align-items: baseline;
 	padding-left: var(--_json-chevron-size);
 	min-height: var(--_json-row-height);
 }
@@ -112,38 +113,30 @@
 	min-height: var(--_json-row-height);
 }
 
-/* Inline toggle for long strings */
-.json-inline-toggle {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	flex-shrink: 0;
-	width: var(--_json-chevron-size);
-	height: var(--_json-chevron-size);
+/* Inline expand/collapse for long strings */
+.json-expand-value {
 	border: none;
 	background: none;
-	padding: 0;
+	font: inherit;
+	font-size: 11px;
+	color: var(--vscode-textLink-foreground);
 	cursor: pointer;
-	color: var(--vscode-foreground);
-	opacity: 0.7;
+	padding: 0 2px;
+	margin-left: 4px;
 	border-radius: 3px;
+	white-space: nowrap;
 }
 
-.json-inline-toggle:hover {
-	opacity: 1;
-	background: var(--vscode-toolbar-hoverBackground);
+.json-expand-value:hover {
+	text-decoration: underline;
 }
 
-.json-inline-toggle:focus-visible {
+.json-expand-value:focus-visible {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }
 
-.json-inline-toggle span {
-	cursor: pointer;
-}
-
-/* Secondary annotation text (item counts, char counts) */
+/* Secondary annotation text (item counts) */
 .json-secondary {
 	color: var(--vscode-descriptionForeground);
 	font-style: italic;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -75,7 +75,7 @@
 
 .json-children {
 	border-left: 1px solid var(--vscode-editorIndentGuide-background);
-	padding-left: var(--_json-indent);
+	padding-left: calc(var(--_json-indent) - 1px);
 }
 
 .json-bracket-close {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -147,6 +147,7 @@
 
 .json-string {
 	color: var(--vscode-debugTokenExpression-string);
+	overflow-wrap: anywhere;
 }
 
 .json-number {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -4,6 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 .json-output {
+	--_json-chevron-size: 16px;
+	--_json-indent: 16px;
+	--_json-row-height: 18px;
+	--_json-guide-offset: 7px;
+
 	position: relative;
 	font-family: var(--vscode-positronNotebook-text-output-font-family, var(--monaco-monospace-font));
 	font-size: 12px;
@@ -48,8 +53,8 @@
 .json-leaf {
 	display: flex;
 	align-items: center;
-	padding-left: 16px;
-	min-height: 18px;
+	padding-left: var(--_json-chevron-size);
+	min-height: var(--_json-row-height);
 }
 
 .json-collapsible-header {
@@ -57,7 +62,7 @@
 	align-items: center;
 	gap: 0;
 	padding: 0;
-	min-height: 18px;
+	min-height: var(--_json-row-height);
 	cursor: pointer;
 	user-select: none;
 	border-radius: 3px;
@@ -87,8 +92,8 @@
 	align-items: center;
 	justify-content: center;
 	flex-shrink: 0;
-	width: 16px;
-	height: 16px;
+	width: var(--_json-chevron-size);
+	height: var(--_json-chevron-size);
 	font-size: 12px;
 	color: var(--vscode-foreground);
 	opacity: 0.7;
@@ -96,14 +101,15 @@
 }
 
 .json-children {
-	padding-left: 16px;
+	padding-left: var(--_json-indent);
 	border-left: 1px solid var(--vscode-editorIndentGuide-background);
-	margin-left: 7px;
+	margin-left: var(--_json-guide-offset);
 }
 
 .json-bracket-close {
-	padding-left: 6px;
-	min-height: 18px;
+	/* Align with content after the chevron: guide-offset minus the border (1px) */
+	padding-left: calc(var(--_json-guide-offset) - 1px);
+	min-height: var(--_json-row-height);
 }
 
 /* Inline toggle for long strings */
@@ -112,8 +118,8 @@
 	align-items: center;
 	justify-content: center;
 	flex-shrink: 0;
-	width: 16px;
-	height: 16px;
+	width: var(--_json-chevron-size);
+	height: var(--_json-chevron-size);
 	border: none;
 	background: none;
 	padding: 0;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -7,7 +7,7 @@
 	position: relative;
 	font-family: var(--vscode-positronNotebook-text-output-font-family, var(--monaco-monospace-font));
 	font-size: 12px;
-	line-height: 1.5;
+	line-height: 1.4;
 }
 
 .json-output-header {
@@ -42,19 +42,22 @@
 
 /* Tree layout */
 .json-tree {
-	padding: 2px 0;
+	padding: 1px 0;
 }
 
 .json-leaf {
-	padding: 1px 0;
+	display: flex;
+	align-items: baseline;
 	padding-left: 16px;
+	min-height: 18px;
 }
 
 .json-collapsible-header {
 	display: flex;
-	align-items: center;
-	gap: 2px;
-	padding: 1px 0;
+	align-items: baseline;
+	gap: 0;
+	padding: 0;
+	min-height: 18px;
 	cursor: pointer;
 	user-select: none;
 	border-radius: 3px;
@@ -95,33 +98,47 @@
 }
 
 .json-bracket-close {
-	padding: 1px 0;
+	padding-left: 0;
+	min-height: 18px;
 }
 
-.json-collapsed-preview {
-	color: var(--vscode-descriptionForeground);
-	font-style: italic;
-}
-
-.json-expand-value {
+/* Inline toggle for long strings */
+.json-inline-toggle {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	width: 16px;
+	height: 16px;
 	border: none;
 	background: none;
-	font: inherit;
-	font-size: 11px;
-	color: var(--vscode-textLink-foreground);
+	padding: 0;
 	cursor: pointer;
-	padding: 0 4px;
-	margin-left: 4px;
+	color: var(--vscode-foreground);
+	opacity: 0.7;
 	border-radius: 3px;
 }
 
-.json-expand-value:hover {
+.json-inline-toggle:hover {
+	opacity: 1;
 	background: var(--vscode-toolbar-hoverBackground);
 }
 
-.json-expand-value:focus-visible {
+.json-inline-toggle:focus-visible {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
+}
+
+.json-inline-toggle span {
+	cursor: pointer;
+}
+
+/* Secondary annotation text (item counts, char counts) */
+.json-secondary {
+	color: var(--vscode-descriptionForeground);
+	font-style: italic;
+	margin-left: 6px;
+	font-size: 11px;
 }
 
 /* Token colors */

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -57,8 +57,7 @@
 	display: flex;
 	align-items: center;
 	gap: 0;
-	padding: 1px 4px;
-	margin: 0 -4px;
+	padding: 1px 4px 1px 0;
 	min-height: var(--_json-row-height);
 	cursor: pointer;
 	user-select: none;
@@ -67,7 +66,7 @@
 	background: none;
 	font: inherit;
 	color: inherit;
-	width: calc(100% + 8px);
+	width: 100%;
 	text-align: left;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -102,7 +102,7 @@
 }
 
 .json-bracket-close {
-	padding-left: 0;
+	padding-left: 16px;
 	min-height: 18px;
 }
 
@@ -148,6 +148,7 @@
 /* Token colors */
 .json-key {
 	color: var(--vscode-debugTokenExpression-name);
+	margin-right: 4px;
 }
 
 .json-string {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -5,9 +5,7 @@
 
 .json-output {
 	--_json-chevron-size: 16px;
-	--_json-indent: 16px;
 	--_json-row-height: 18px;
-	--_json-guide-offset: 7px;
 
 	position: relative;
 	font-family: var(--vscode-positronNotebook-text-output-font-family, var(--monaco-monospace-font));
@@ -99,9 +97,9 @@
 }
 
 .json-children {
-	padding-left: var(--_json-indent);
+	margin-left: calc(var(--_json-chevron-size) / 2);
 	border-left: 1px solid var(--vscode-editorIndentGuide-background);
-	margin-left: var(--_json-guide-offset);
+	padding-left: calc(var(--_json-chevron-size) / 2 - 1px);
 }
 
 .json-bracket-close {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .json-output {
-	--_json-chevron-size: 16px;
+	--_json-indent: 16px;
 	--_json-row-height: 18px;
 
 	position: relative;
@@ -43,13 +43,13 @@
 	background: var(--vscode-toolbar-activeBackground);
 }
 
-/* Tree layout */
+/* Tree layout: initial padding provides gutter space for root-level chevrons */
 .json-tree {
 	padding: 1px 0;
+	padding-left: var(--_json-indent);
 }
 
 .json-leaf {
-	padding-left: var(--_json-chevron-size);
 	min-height: var(--_json-row-height);
 }
 
@@ -57,7 +57,7 @@
 	display: flex;
 	align-items: center;
 	gap: 0;
-	padding-left: var(--_json-chevron-size);
+	padding: 0;
 	min-height: var(--_json-row-height);
 	cursor: pointer;
 	user-select: none;
@@ -83,27 +83,26 @@
 	outline-offset: -1px;
 }
 
+/* Chevron sits in the gutter via negative margin */
 .json-chevron {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 	flex-shrink: 0;
-	width: var(--_json-chevron-size);
-	height: var(--_json-chevron-size);
-	margin-left: calc(-1 * var(--_json-chevron-size));
+	width: var(--_json-indent);
+	height: var(--_json-indent);
+	margin-left: calc(-1 * var(--_json-indent));
 	font-size: 12px;
 	color: var(--vscode-foreground);
 	opacity: 0.7;
 }
 
 .json-children {
-	margin-left: calc(var(--_json-chevron-size) / 2);
 	border-left: 1px solid var(--vscode-editorIndentGuide-background);
-	padding-left: calc(var(--_json-chevron-size) / 2 - 1px);
+	padding-left: var(--_json-indent);
 }
 
 .json-bracket-close {
-	padding-left: var(--_json-chevron-size);
 	min-height: var(--_json-row-height);
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -59,7 +59,7 @@
 	display: flex;
 	align-items: center;
 	gap: 0;
-	padding: 0;
+	padding-left: var(--_json-chevron-size);
 	min-height: var(--_json-row-height);
 	cursor: pointer;
 	user-select: none;
@@ -92,10 +92,10 @@
 	flex-shrink: 0;
 	width: var(--_json-chevron-size);
 	height: var(--_json-chevron-size);
+	margin-left: calc(-1 * var(--_json-chevron-size));
 	font-size: 12px;
 	color: var(--vscode-foreground);
 	opacity: 0.7;
-	transform: translateX(-1px);
 }
 
 .json-children {
@@ -105,8 +105,7 @@
 }
 
 .json-bracket-close {
-	/* Align with content after the chevron: guide-offset minus the border (1px) */
-	padding-left: calc(var(--_json-guide-offset) - 1px);
+	padding-left: var(--_json-chevron-size);
 	min-height: var(--_json-row-height);
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -7,41 +7,11 @@
 	--_json-indent: 16px;
 	--_json-row-height: 18px;
 
-	position: relative;
 	font-family: var(--vscode-positronNotebook-text-output-font-family, var(--monaco-monospace-font));
 	font-size: 12px;
 	line-height: 1.4;
 }
 
-.json-output-header {
-	position: absolute;
-	top: 0;
-	right: 0;
-	opacity: 0;
-	transition: opacity 150ms ease;
-}
-
-.json-output:hover .json-output-header {
-	opacity: 1;
-}
-
-.json-copy-button {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 22px;
-	height: 22px;
-	border: none;
-	border-radius: 4px;
-	background: var(--vscode-toolbar-hoverBackground);
-	color: var(--vscode-foreground);
-	cursor: pointer;
-	padding: 0;
-}
-
-.json-copy-button:hover {
-	background: var(--vscode-toolbar-activeBackground);
-}
 
 /* Tree layout: initial padding provides gutter space for root-level chevrons */
 .json-tree {
@@ -57,12 +27,11 @@
 	display: flex;
 	align-items: center;
 	gap: 0;
-	padding: 2px 0;
-	margin: -2px 0;
+	padding: 0;
+	margin: 0;
 	min-height: var(--_json-row-height);
 	cursor: pointer;
 	user-select: none;
-	border-radius: 3px;
 	border: none;
 	background: none;
 	font: inherit;
@@ -75,11 +44,17 @@
 	cursor: pointer;
 }
 
-.json-collapsible-header:hover {
+.json-collapsible-content {
+	padding: 2px 4px;
+	margin: -2px 0;
+	border-radius: 3px;
+}
+
+.json-collapsible-header:hover .json-collapsible-content {
 	background: var(--vscode-list-hoverBackground);
 }
 
-.json-collapsible-header:focus-visible {
+.json-collapsible-header:focus-visible .json-collapsible-content {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -51,9 +51,6 @@
 }
 
 .json-leaf {
-	display: flex;
-	flex-wrap: wrap;
-	align-items: baseline;
 	padding-left: var(--_json-chevron-size);
 	min-height: var(--_json-row-height);
 }
@@ -119,16 +116,18 @@
 	background: none;
 	font: inherit;
 	font-size: 11px;
-	color: var(--vscode-textLink-foreground);
+	color: var(--vscode-descriptionForeground);
 	cursor: pointer;
 	padding: 0 2px;
 	margin-left: 4px;
 	border-radius: 3px;
 	white-space: nowrap;
+	opacity: 0.7;
 }
 
 .json-expand-value:hover {
-	text-decoration: underline;
+	opacity: 1;
+	color: var(--vscode-textLink-foreground);
 }
 
 .json-expand-value:focus-visible {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -4,31 +4,118 @@
  *--------------------------------------------------------------------------------------------*/
 
 .json-output {
-	margin: 0;
-	white-space: pre-wrap;
-	word-break: break-word;
+	position: relative;
+	font-family: var(--vscode-positronNotebook-text-output-font-family, var(--monaco-monospace-font));
+	font-size: 12px;
+	line-height: 1.5;
 }
 
-.json-output .json-key {
+.json-output-header {
+	position: absolute;
+	top: 0;
+	right: 0;
+	opacity: 0;
+	transition: opacity 150ms ease;
+}
+
+.json-output:hover .json-output-header {
+	opacity: 1;
+}
+
+.json-copy-button {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	border: none;
+	border-radius: 4px;
+	background: var(--vscode-toolbar-hoverBackground);
+	color: var(--vscode-foreground);
+	cursor: pointer;
+	padding: 0;
+}
+
+.json-copy-button:hover {
+	background: var(--vscode-toolbar-activeBackground);
+}
+
+/* Tree layout */
+.json-tree {
+	padding: 2px 0;
+}
+
+.json-leaf {
+	padding: 1px 0;
+	padding-left: 16px;
+}
+
+.json-collapsible-header {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	padding: 1px 0;
+	cursor: pointer;
+	border-radius: 3px;
+	border: none;
+	background: none;
+	font: inherit;
+	color: inherit;
+	width: 100%;
+	text-align: left;
+}
+
+.json-collapsible-header:hover {
+	background: var(--vscode-list-hoverBackground);
+}
+
+.json-chevron {
+	flex-shrink: 0;
+	width: 16px;
+	font-size: 12px;
+	text-align: center;
+	color: var(--vscode-foreground);
+	opacity: 0.7;
+}
+
+.json-children {
+	padding-left: 16px;
+	border-left: 1px solid var(--vscode-editorIndentGuide-background);
+	margin-left: 7px;
+}
+
+.json-bracket-close {
+	padding: 1px 0;
+}
+
+.json-collapsed-preview {
+	color: var(--vscode-descriptionForeground);
+	font-style: italic;
+}
+
+/* Token colors */
+.json-key {
 	color: var(--vscode-debugTokenExpression-name);
 }
 
-.json-output .json-string {
+.json-string {
 	color: var(--vscode-debugTokenExpression-string);
 }
 
-.json-output .json-number {
+.json-number {
 	color: var(--vscode-debugTokenExpression-number);
 }
 
-.json-output .json-boolean {
+.json-boolean {
 	color: var(--vscode-debugTokenExpression-boolean);
 }
 
-.json-output .json-null {
+.json-null {
 	color: var(--vscode-debugTokenExpression-value);
+	font-style: italic;
 }
 
-.json-output .json-punct {
+.json-punct {
 	color: var(--vscode-foreground);
+	opacity: 0.6;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -47,14 +47,14 @@
 
 .json-leaf {
 	display: flex;
-	align-items: baseline;
+	align-items: center;
 	padding-left: 16px;
 	min-height: 18px;
 }
 
 .json-collapsible-header {
 	display: flex;
-	align-items: baseline;
+	align-items: center;
 	gap: 0;
 	padding: 0;
 	min-height: 18px;
@@ -83,10 +83,13 @@
 }
 
 .json-chevron {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	flex-shrink: 0;
 	width: 16px;
+	height: 16px;
 	font-size: 12px;
-	text-align: center;
 	color: var(--vscode-foreground);
 	opacity: 0.7;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -92,6 +92,7 @@
 	font-size: 12px;
 	color: var(--vscode-foreground);
 	opacity: 0.7;
+	transform: translateX(-1px);
 }
 
 .json-children {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -57,7 +57,8 @@
 	display: flex;
 	align-items: center;
 	gap: 0;
-	padding: 0;
+	padding: 1px 4px;
+	margin: 0 -4px;
 	min-height: var(--_json-row-height);
 	cursor: pointer;
 	user-select: none;
@@ -66,7 +67,7 @@
 	background: none;
 	font: inherit;
 	color: inherit;
-	width: 100%;
+	width: calc(100% + 8px);
 	text-align: left;
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.css
@@ -57,7 +57,8 @@
 	display: flex;
 	align-items: center;
 	gap: 0;
-	padding: 1px 4px 1px 0;
+	padding: 2px 0;
+	margin: -2px 0;
 	min-height: var(--_json-row-height);
 	cursor: pointer;
 	user-select: none;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
@@ -99,12 +99,12 @@ function JsonLeaf({ keyName, valueClass, display }: JsonLeafProps) {
 			<span className={valueClass}>{shown}</span>
 			{isTruncatable && (
 				<button
-					aria-label={expanded ? 'Collapse string' : `Expand string (${contentLength} chars)`}
 					className='json-expand-value'
+					title={expanded ? 'Collapse to truncated preview' : `Expand to see all ${contentLength} characters`}
 					type='button'
 					onClick={() => setExpanded(prev => !prev)}
 				>
-					{expanded ? 'less' : `${contentLength} chars`}
+					{expanded ? 'less' : 'more'}
 				</button>
 			)}
 		</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
@@ -119,7 +119,13 @@ function JsonCollapsible({ keyName, value, type }: JsonCollapsibleProps) {
 
 	return (
 		<div className='json-collapsible'>
-			<button className='json-collapsible-header' type='button' onClick={toggle}>
+			<button
+				aria-expanded={expanded}
+				aria-label={keyName ? `${keyName}: ${count} ${count === 1 ? 'item' : 'items'}` : `${count} ${count === 1 ? 'item' : 'items'}`}
+				className='json-collapsible-header'
+				type='button'
+				onClick={toggle}
+			>
 				<span className={`codicon json-chevron ${expanded ? 'codicon-chevron-down' : 'codicon-chevron-right'}`} />
 				{keyName !== undefined && <span className='json-key'>{keyName}: </span>}
 				{!expanded && (

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
@@ -27,7 +27,7 @@ function highlightJson(data: unknown): React.ReactNode[] {
 	let i = 0;
 
 	// Regex matches JSON tokens: strings, numbers, booleans, null, structural chars
-	const tokenRegex = /("(?:[^"\\]|\\.)*")\s*:|("(?:[^"\\]|\\.)*")|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)|(\btrue\b|\bfalse\b)|(\bnull\b)|([{}[\],])|(\s+)/g;
+	const tokenRegex = /("(?:[^"\\]|\\.)*")\s*:\s*|("(?:[^"\\]|\\.)*")|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)|(\btrue\b|\bfalse\b)|(\bnull\b)|([{}[\],])|(\s+)/g;
 	let match: RegExpExecArray | null;
 
 	while ((match = tokenRegex.exec(json)) !== null) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
@@ -77,6 +77,8 @@ function JsonNode({ value, keyName }: JsonNodeProps) {
 	}
 }
 
+const STRING_TRUNCATE_LENGTH = 120;
+
 interface JsonLeafProps {
 	keyName?: string;
 	valueClass: string;
@@ -84,10 +86,25 @@ interface JsonLeafProps {
 }
 
 function JsonLeaf({ keyName, valueClass, display }: JsonLeafProps) {
+	const [expanded, setExpanded] = useState(false);
+	const isTruncatable = valueClass === 'json-string' && display.length > STRING_TRUNCATE_LENGTH;
+	const shown = isTruncatable && !expanded
+		? display.slice(0, STRING_TRUNCATE_LENGTH - 1) + '…"'
+		: display;
+
 	return (
 		<div className='json-leaf'>
 			{keyName !== undefined && <span className='json-key'>{keyName}: </span>}
-			<span className={valueClass}>{display}</span>
+			<span className={valueClass}>{shown}</span>
+			{isTruncatable && (
+				<button
+					className='json-expand-value'
+					type='button'
+					onClick={() => setExpanded(prev => !prev)}
+				>
+					{expanded ? 'less' : `${display.length - 2} chars`}
+				</button>
+			)}
 		</div>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
@@ -67,7 +67,7 @@ function JsonNode({ value, keyName }: JsonNodeProps) {
 		case 'object':
 			return <JsonCollapsible keyName={keyName} type='object' value={value as Record<string, unknown>} />;
 		case 'string':
-			return <JsonLeaf display={JSON.stringify(value)} keyName={keyName} valueClass='json-string' />;
+			return <JsonLeaf display={JSON.stringify(value) ?? '""'} keyName={keyName} valueClass='json-string' />;
 		case 'number':
 			return <JsonLeaf display={String(value)} keyName={keyName} valueClass='json-number' />;
 		case 'boolean':
@@ -99,6 +99,8 @@ function JsonLeaf({ keyName, valueClass, display }: JsonLeafProps) {
 			<span className={valueClass}>{shown}</span>
 			{isTruncatable && (
 				<button
+					aria-expanded={expanded}
+					aria-label={expanded ? 'Collapse to truncated preview' : `Expand to see all ${contentLength} characters`}
 					className='json-expand-value'
 					title={expanded ? 'Collapse to truncated preview' : `Expand to see all ${contentLength} characters`}
 					type='button'

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
@@ -4,44 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 // React.
-import React, { useCallback, useState } from 'react';
+import React, { useState } from 'react';
 
 // CSS.
 import './JsonOutput.css';
-
-// Other dependencies.
-import { localize } from '../../../../../nls.js';
-import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 
 interface JsonOutputProps {
 	data: unknown;
 }
 
-const copyJsonLabel = localize('positron.notebook.copyJson', "Copy JSON");
-
 export const JsonOutput = React.memo(function JsonOutput({ data }: JsonOutputProps) {
-	const services = usePositronReactServicesContext();
-	const [copied, setCopied] = useState(false);
-
-	const handleCopy = useCallback(() => {
-		const text = JSON.stringify(data, null, 2) ?? String(data);
-		services.clipboardService.writeText(text);
-		setCopied(true);
-		setTimeout(() => setCopied(false), 1500);
-	}, [data, services.clipboardService]);
-
 	return (
 		<div className='json-output'>
-			<div className='json-output-header'>
-				<button
-					aria-label={copyJsonLabel}
-					className='json-copy-button'
-					title={copyJsonLabel}
-					onClick={handleCopy}
-				>
-					<span className={`codicon ${copied ? 'codicon-check' : 'codicon-copy'}`} />
-				</button>
-			</div>
 			<div className='json-tree'>
 				<JsonNode value={data} />
 			</div>
@@ -148,14 +122,16 @@ function JsonCollapsible({ keyName, value, type }: JsonCollapsibleProps) {
 				onClick={toggle}
 			>
 				<span className={`codicon json-chevron ${expanded ? 'codicon-chevron-down' : 'codicon-chevron-right'}`} />
-				{keyName !== undefined && <span className='json-key'>{keyName}: </span>}
-				{!expanded && (
-					<>
-						<span className='json-punct'>{brackets[0]}...{brackets[1]}</span>
-						<span className='json-secondary'>{count} {count === 1 ? 'item' : 'items'}</span>
-					</>
-				)}
-				{expanded && <span className='json-punct'>{brackets[0]}</span>}
+				<span className='json-collapsible-content'>
+					{keyName !== undefined && <span className='json-key'>{keyName}: </span>}
+					{!expanded && (
+						<>
+							<span className='json-punct'>{brackets[0]}...{brackets[1]}</span>
+							<span className='json-secondary'>{count} {count === 1 ? 'item' : 'items'}</span>
+						</>
+					)}
+					{expanded && <span className='json-punct'>{brackets[0]}</span>}
+				</span>
 			</button>
 			{expanded && (
 				<>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
@@ -24,7 +24,7 @@ export const JsonOutput = React.memo(function JsonOutput({ data }: JsonOutputPro
 	const [copied, setCopied] = useState(false);
 
 	const handleCopy = useCallback(() => {
-		const text = JSON.stringify(data, null, 2);
+		const text = JSON.stringify(data, null, 2) ?? String(data);
 		services.clipboardService.writeText(text);
 		setCopied(true);
 		setTimeout(() => setCopied(false), 1500);
@@ -67,7 +67,7 @@ function JsonNode({ value, keyName }: JsonNodeProps) {
 		case 'object':
 			return <JsonCollapsible keyName={keyName} type='object' value={value as Record<string, unknown>} />;
 		case 'string':
-			return <JsonLeaf display={`"${value}"`} keyName={keyName} valueClass='json-string' />;
+			return <JsonLeaf display={JSON.stringify(value)} keyName={keyName} valueClass='json-string' />;
 		case 'number':
 			return <JsonLeaf display={String(value)} keyName={keyName} valueClass='json-number' />;
 		case 'boolean':
@@ -87,9 +87,10 @@ interface JsonLeafProps {
 
 function JsonLeaf({ keyName, valueClass, display }: JsonLeafProps) {
 	const [expanded, setExpanded] = useState(false);
-	const isTruncatable = valueClass === 'json-string' && display.length > STRING_TRUNCATE_LENGTH;
+	const contentLength = display.length - 2; // exclude wrapper quotes
+	const isTruncatable = valueClass === 'json-string' && contentLength > STRING_TRUNCATE_LENGTH;
 	const shown = isTruncatable && !expanded
-		? display.slice(0, STRING_TRUNCATE_LENGTH - 1) + '..."'
+		? display.slice(0, STRING_TRUNCATE_LENGTH + 1) + '..."'
 		: display;
 
 	return (
@@ -97,7 +98,7 @@ function JsonLeaf({ keyName, valueClass, display }: JsonLeafProps) {
 			{isTruncatable && (
 				<button
 					aria-expanded={expanded}
-					aria-label={expanded ? 'Collapse string' : `Expand string (${display.length - 2} chars)`}
+					aria-label={expanded ? 'Collapse string' : `Expand string (${contentLength} chars)`}
 					className='json-inline-toggle'
 					type='button'
 					onClick={() => setExpanded(prev => !prev)}
@@ -108,7 +109,7 @@ function JsonLeaf({ keyName, valueClass, display }: JsonLeafProps) {
 			{keyName !== undefined && <span className='json-key'>{keyName}: </span>}
 			<span className={valueClass}>{shown}</span>
 			{isTruncatable && !expanded && (
-				<span className='json-secondary'>{display.length - 2} chars</span>
+				<span className='json-secondary'>{contentLength} chars</span>
 			)}
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
@@ -89,21 +89,26 @@ function JsonLeaf({ keyName, valueClass, display }: JsonLeafProps) {
 	const [expanded, setExpanded] = useState(false);
 	const isTruncatable = valueClass === 'json-string' && display.length > STRING_TRUNCATE_LENGTH;
 	const shown = isTruncatable && !expanded
-		? display.slice(0, STRING_TRUNCATE_LENGTH - 1) + '…"'
+		? display.slice(0, STRING_TRUNCATE_LENGTH - 1) + '..."'
 		: display;
 
 	return (
 		<div className='json-leaf'>
-			{keyName !== undefined && <span className='json-key'>{keyName}: </span>}
-			<span className={valueClass}>{shown}</span>
 			{isTruncatable && (
 				<button
-					className='json-expand-value'
+					aria-expanded={expanded}
+					aria-label={expanded ? 'Collapse string' : `Expand string (${display.length - 2} chars)`}
+					className='json-inline-toggle'
 					type='button'
 					onClick={() => setExpanded(prev => !prev)}
 				>
-					{expanded ? 'less' : `${display.length - 2} chars`}
+					<span className={`codicon ${expanded ? 'codicon-chevron-down' : 'codicon-chevron-right'}`} />
 				</button>
+			)}
+			{keyName !== undefined && <span className='json-key'>{keyName}: </span>}
+			<span className={valueClass}>{shown}</span>
+			{isTruncatable && !expanded && (
+				<span className='json-secondary'>{display.length - 2} chars</span>
 			)}
 		</div>
 	);
@@ -146,9 +151,10 @@ function JsonCollapsible({ keyName, value, type }: JsonCollapsibleProps) {
 				<span className={`codicon json-chevron ${expanded ? 'codicon-chevron-down' : 'codicon-chevron-right'}`} />
 				{keyName !== undefined && <span className='json-key'>{keyName}: </span>}
 				{!expanded && (
-					<span className='json-collapsed-preview'>
-						{brackets[0]} {count} {count === 1 ? 'item' : 'items'} {brackets[1]}
-					</span>
+					<>
+						<span className='json-punct'>{brackets[0]}...{brackets[1]}</span>
+						<span className='json-secondary'>{count} {count === 1 ? 'item' : 'items'}</span>
+					</>
 				)}
 				{expanded && <span className='json-punct'>{brackets[0]}</span>}
 			</button>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
@@ -4,61 +4,141 @@
  *--------------------------------------------------------------------------------------------*/
 
 // React.
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 // CSS.
 import './JsonOutput.css';
+
+// Other dependencies.
+import { localize } from '../../../../../nls.js';
+import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 
 interface JsonOutputProps {
 	data: unknown;
 }
 
-/**
- * Renders a JSON value with syntax highlighting.
- * Returns an array of React elements representing the highlighted tokens.
- */
-function highlightJson(data: unknown): React.ReactNode[] {
-	const json = JSON.stringify(data, null, 2);
-	if (json === undefined) {
-		return [<span key={0} className='json-null'>undefined</span>];
-	}
-
-	const nodes: React.ReactNode[] = [];
-	let i = 0;
-
-	// Regex matches JSON tokens: strings, numbers, booleans, null, structural chars
-	const tokenRegex = /("(?:[^"\\]|\\.)*")\s*:\s*|("(?:[^"\\]|\\.)*")|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)|(\btrue\b|\bfalse\b)|(\bnull\b)|([{}[\],])|(\s+)/g;
-	let match: RegExpExecArray | null;
-
-	while ((match = tokenRegex.exec(json)) !== null) {
-		const [, key, str, num, bool, nul, punct, ws] = match;
-
-		if (key) {
-			// Object key (string followed by colon)
-			nodes.push(<span key={i++} className='json-key'>{key}</span>);
-			nodes.push(<span key={i++} className='json-punct'>: </span>);
-		} else if (str) {
-			nodes.push(<span key={i++} className='json-string'>{str}</span>);
-		} else if (num) {
-			nodes.push(<span key={i++} className='json-number'>{num}</span>);
-		} else if (bool) {
-			nodes.push(<span key={i++} className='json-boolean'>{bool}</span>);
-		} else if (nul) {
-			nodes.push(<span key={i++} className='json-null'>{nul}</span>);
-		} else if (punct) {
-			nodes.push(<span key={i++} className='json-punct'>{punct}</span>);
-		} else if (ws) {
-			nodes.push(<span key={i++}>{ws}</span>);
-		}
-	}
-
-	return nodes;
-}
+const copyJsonLabel = localize('positron.notebook.copyJson', "Copy JSON");
 
 export const JsonOutput = React.memo(function JsonOutput({ data }: JsonOutputProps) {
+	const services = usePositronReactServicesContext();
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = useCallback(() => {
+		const text = JSON.stringify(data, null, 2);
+		services.clipboardService.writeText(text);
+		setCopied(true);
+		setTimeout(() => setCopied(false), 1500);
+	}, [data, services.clipboardService]);
+
 	return (
-		<pre className='json-output'>
-			<code>{highlightJson(data)}</code>
-		</pre>
+		<div className='json-output'>
+			<div className='json-output-header'>
+				<button
+					aria-label={copyJsonLabel}
+					className='json-copy-button'
+					title={copyJsonLabel}
+					onClick={handleCopy}
+				>
+					<span className={`codicon ${copied ? 'codicon-check' : 'codicon-copy'}`} />
+				</button>
+			</div>
+			<div className='json-tree'>
+				<JsonNode value={data} />
+			</div>
+		</div>
 	);
 });
+
+interface JsonNodeProps {
+	value: unknown;
+	keyName?: string;
+}
+
+function JsonNode({ value, keyName }: JsonNodeProps) {
+	if (value === null) {
+		return <JsonLeaf display='null' keyName={keyName} valueClass='json-null' />;
+	}
+
+	if (Array.isArray(value)) {
+		return <JsonCollapsible keyName={keyName} type='array' value={value} />;
+	}
+
+	switch (typeof value) {
+		case 'object':
+			return <JsonCollapsible keyName={keyName} type='object' value={value as Record<string, unknown>} />;
+		case 'string':
+			return <JsonLeaf display={`"${value}"`} keyName={keyName} valueClass='json-string' />;
+		case 'number':
+			return <JsonLeaf display={String(value)} keyName={keyName} valueClass='json-number' />;
+		case 'boolean':
+			return <JsonLeaf display={String(value)} keyName={keyName} valueClass='json-boolean' />;
+		default:
+			return <JsonLeaf display={String(value)} keyName={keyName} valueClass='json-null' />;
+	}
+}
+
+interface JsonLeafProps {
+	keyName?: string;
+	valueClass: string;
+	display: string;
+}
+
+function JsonLeaf({ keyName, valueClass, display }: JsonLeafProps) {
+	return (
+		<div className='json-leaf'>
+			{keyName !== undefined && <span className='json-key'>{keyName}: </span>}
+			<span className={valueClass}>{display}</span>
+		</div>
+	);
+}
+
+interface JsonCollapsibleProps {
+	keyName?: string;
+	value: unknown[] | Record<string, unknown>;
+	type: 'array' | 'object';
+}
+
+function JsonCollapsible({ keyName, value, type }: JsonCollapsibleProps) {
+	const [expanded, setExpanded] = useState(true);
+	const entries = type === 'array'
+		? (value as unknown[]).map((v, i) => [String(i), v] as const)
+		: Object.entries(value as Record<string, unknown>);
+	const count = entries.length;
+	const brackets = type === 'array' ? ['[', ']'] : ['{', '}'];
+
+	if (count === 0) {
+		return (
+			<div className='json-leaf'>
+				{keyName !== undefined && <span className='json-key'>{keyName}: </span>}
+				<span className='json-punct'>{brackets[0]}{brackets[1]}</span>
+			</div>
+		);
+	}
+
+	const toggle = () => setExpanded(prev => !prev);
+
+	return (
+		<div className='json-collapsible'>
+			<button className='json-collapsible-header' type='button' onClick={toggle}>
+				<span className={`codicon json-chevron ${expanded ? 'codicon-chevron-down' : 'codicon-chevron-right'}`} />
+				{keyName !== undefined && <span className='json-key'>{keyName}: </span>}
+				{!expanded && (
+					<span className='json-collapsed-preview'>
+						{brackets[0]} {count} {count === 1 ? 'item' : 'items'} {brackets[1]}
+					</span>
+				)}
+				{expanded && <span className='json-punct'>{brackets[0]}</span>}
+			</button>
+			{expanded && (
+				<div className='json-children'>
+					{entries.map(([k, v]) => (
+						<JsonNode key={k} keyName={type === 'object' ? k : undefined} value={v} />
+					))}
+					<div className='json-bracket-close'>
+						<span className='json-punct'>{brackets[1]}</span>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
@@ -42,7 +42,7 @@ function JsonNode({ value, keyName }: JsonNodeProps) {
 		case 'object':
 			return <JsonCollapsible keyName={keyName} type='object' value={value as Record<string, unknown>} />;
 		case 'string':
-			return <JsonLeaf display={JSON.stringify(value) ?? '""'} keyName={keyName} valueClass='json-string' />;
+			return <JsonLeaf display={JSON.stringify(value)} keyName={keyName} valueClass='json-string' />;
 		case 'number':
 			return <JsonLeaf display={String(value)} keyName={keyName} valueClass='json-number' />;
 		case 'boolean':

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
@@ -11,11 +11,12 @@ import './JsonOutput.css';
 
 interface JsonOutputProps {
 	data: unknown;
+	outputId?: string;
 }
 
-export const JsonOutput = React.memo(function JsonOutput({ data }: JsonOutputProps) {
+export const JsonOutput = React.memo(function JsonOutput({ data, outputId }: JsonOutputProps) {
 	return (
-		<div className='json-output'>
+		<div className='json-output' data-positron-json-output-id={outputId}>
 			<div className='json-tree'>
 				<JsonNode value={data} />
 			</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// React.
+import React from 'react';
+
+// CSS.
+import './JsonOutput.css';
+
+interface JsonOutputProps {
+	data: unknown;
+}
+
+/**
+ * Renders a JSON value with syntax highlighting.
+ * Returns an array of React elements representing the highlighted tokens.
+ */
+function highlightJson(data: unknown): React.ReactNode[] {
+	const json = JSON.stringify(data, null, 2);
+	if (json === undefined) {
+		return [<span key={0} className='json-null'>undefined</span>];
+	}
+
+	const nodes: React.ReactNode[] = [];
+	let i = 0;
+
+	// Regex matches JSON tokens: strings, numbers, booleans, null, structural chars
+	const tokenRegex = /("(?:[^"\\]|\\.)*")\s*:|("(?:[^"\\]|\\.)*")|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)|(\btrue\b|\bfalse\b)|(\bnull\b)|([{}[\],])|(\s+)/g;
+	let match: RegExpExecArray | null;
+
+	while ((match = tokenRegex.exec(json)) !== null) {
+		const [, key, str, num, bool, nul, punct, ws] = match;
+
+		if (key) {
+			// Object key (string followed by colon)
+			nodes.push(<span key={i++} className='json-key'>{key}</span>);
+			nodes.push(<span key={i++} className='json-punct'>: </span>);
+		} else if (str) {
+			nodes.push(<span key={i++} className='json-string'>{str}</span>);
+		} else if (num) {
+			nodes.push(<span key={i++} className='json-number'>{num}</span>);
+		} else if (bool) {
+			nodes.push(<span key={i++} className='json-boolean'>{bool}</span>);
+		} else if (nul) {
+			nodes.push(<span key={i++} className='json-null'>{nul}</span>);
+		} else if (punct) {
+			nodes.push(<span key={i++} className='json-punct'>{punct}</span>);
+		} else if (ws) {
+			nodes.push(<span key={i++}>{ws}</span>);
+		}
+	}
+
+	return nodes;
+}
+
+export const JsonOutput = React.memo(function JsonOutput({ data }: JsonOutputProps) {
+	return (
+		<pre className='json-output'>
+			<code>{highlightJson(data)}</code>
+		</pre>
+	);
+});

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
@@ -159,14 +159,16 @@ function JsonCollapsible({ keyName, value, type }: JsonCollapsibleProps) {
 				{expanded && <span className='json-punct'>{brackets[0]}</span>}
 			</button>
 			{expanded && (
-				<div className='json-children'>
-					{entries.map(([k, v]) => (
-						<JsonNode key={k} keyName={type === 'object' ? k : undefined} value={v} />
-					))}
+				<>
+					<div className='json-children'>
+						{entries.map(([k, v]) => (
+							<JsonNode key={k} keyName={type === 'object' ? k : undefined} value={v} />
+						))}
+					</div>
 					<div className='json-bracket-close'>
 						<span className='json-punct'>{brackets[1]}</span>
 					</div>
-				</div>
+				</>
 			)}
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/JsonOutput.tsx
@@ -95,21 +95,17 @@ function JsonLeaf({ keyName, valueClass, display }: JsonLeafProps) {
 
 	return (
 		<div className='json-leaf'>
+			{keyName !== undefined && <span className='json-key'>{keyName}: </span>}
+			<span className={valueClass}>{shown}</span>
 			{isTruncatable && (
 				<button
-					aria-expanded={expanded}
 					aria-label={expanded ? 'Collapse string' : `Expand string (${contentLength} chars)`}
-					className='json-inline-toggle'
+					className='json-expand-value'
 					type='button'
 					onClick={() => setExpanded(prev => !prev)}
 				>
-					<span className={`codicon ${expanded ? 'codicon-chevron-down' : 'codicon-chevron-right'}`} />
+					{expanded ? 'less' : `${contentLength} chars`}
 				</button>
-			)}
-			{keyName !== undefined && <span className='json-key'>{keyName}: </span>}
-			<span className={valueClass}>{shown}</span>
-			{isTruncatable && !expanded && (
-				<span className='json-secondary'>{contentLength} chars</span>
 			)}
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -35,12 +35,13 @@ import { DataExplorerCellOutput } from './DataExplorerCellOutput.js';
 import { JsonOutput } from './JsonOutput.js';
 import { NotebookErrorBoundary } from '../NotebookErrorBoundary.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
-import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS } from '../ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED } from '../ContextKeysManager.js';
 import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.js';
 import { useScrollingIndicator } from './useScrollingIndicator.js';
 import { CellOutputActionBar } from './CellOutputActionBar.js';
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 import { HorizontalSplitter, HorizontalSplitterResizeParams } from '../../../../../base/browser/ui/positronComponents/splitters/horizontalSplitter.js';
+import { serializeJsonOutput } from '../copyJsonUtils.js';
 
 /** The minimum height (pixels) that scrollable outputs can be resized to. */
 const MINIMUM_SCROLLABLE_OUTPUT_HEIGHT = 50;
@@ -65,6 +66,10 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 	);
 	const outputImageTargeted = useMemo(
 		() => contextKeyService ? POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED.bindTo(contextKeyService) : undefined,
+		[contextKeyService]
+	);
+	const outputJsonTargeted = useMemo(
+		() => contextKeyService ? POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED.bindTo(contextKeyService) : undefined,
 		[contextKeyService]
 	);
 	const notebookOptions = useNotebookOptions();
@@ -153,10 +158,24 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 			: undefined;
 		const imageDataUrl = src?.startsWith('data:') ? src : undefined;
 
-		// Set context key so the "Copy Image" menu item shows only when an image is targeted
-		outputImageTargeted?.set(!!imageDataUrl);
+		const targetElement = isHTMLElement(event.target) ? event.target : undefined;
+		const jsonOutputElement = targetElement?.closest<HTMLElement>('[data-positron-json-output-id]');
+		const jsonOutputId = jsonOutputElement?.dataset.positronJsonOutputId;
+		const jsonOutput = jsonOutputId
+			? outputs.find(o => o.outputId === jsonOutputId && o.parsed.type === 'json')
+			: undefined;
+		const jsonText = jsonOutput?.parsed.type === 'json'
+			? serializeJsonOutput(jsonOutput.parsed.data)
+			: undefined;
 
-		const onHide = () => outputImageTargeted?.set(false);
+		// Set context keys so targeted copy menu items show only for the right output type.
+		outputImageTargeted?.set(!!imageDataUrl);
+		outputJsonTargeted?.set(!!jsonText);
+
+		const onHide = () => {
+			outputImageTargeted?.set(false);
+			outputJsonTargeted?.set(false);
+		};
 
 		// Delay to next tick so the browser selection is up to date
 		// (right-click may highlight a word after the contextmenu event fires)
@@ -194,8 +213,14 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 				];
 			};
 
-			const menuActionOptions = imageDataUrl
-				? { arg: { imageDataUrl }, shouldForwardArgs: true }
+			let menuArg: { imageDataUrl: string } | { jsonText: string } | undefined;
+			if (imageDataUrl) {
+				menuArg = { imageDataUrl };
+			} else if (jsonText) {
+				menuArg = { jsonText };
+			}
+			const menuActionOptions = menuArg
+				? { arg: menuArg, shouldForwardArgs: true }
 				: undefined;
 
 			showContextMenu({ x, y }, getClipboardActions, onHide, menuActionOptions);
@@ -324,7 +349,7 @@ const CellOutput = React.memo(function CellOutput(output: CellOutputProps) {
 		case 'markdown':
 			return <Markdown content={parsed.content} />;
 		case 'json':
-			return <JsonOutput data={parsed.data} />;
+			return <JsonOutput data={parsed.data} outputId={output.outputId} />;
 		case 'dataExplorer':
 			return <DataExplorerCellOutput outputs={outputs} parsed={parsed} />;
 		case 'unknown':
@@ -351,4 +376,3 @@ const CollapsedOutputLabel = ({ onExpand }: { onExpand: () => void }) => {
 		{outputCollapsedLabel}
 	</Button>;
 };
-

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -32,6 +32,7 @@ import { Markdown } from './Markdown.js';
 import { useCellContextMenu } from './useCellContextMenu.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
 import { DataExplorerCellOutput } from './DataExplorerCellOutput.js';
+import { JsonOutput } from './JsonOutput.js';
 import { NotebookErrorBoundary } from '../NotebookErrorBoundary.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS } from '../ContextKeysManager.js';
@@ -322,6 +323,8 @@ const CellOutput = React.memo(function CellOutput(output: CellOutputProps) {
 			return renderHtml(parsed.content);
 		case 'markdown':
 			return <Markdown content={parsed.content} />;
+		case 'json':
+			return <JsonOutput data={parsed.data} />;
 		case 'dataExplorer':
 			return <DataExplorerCellOutput outputs={outputs} parsed={parsed} />;
 		case 'unknown':

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/actionBar/CellActionButton.tsx
@@ -34,6 +34,7 @@ interface CellActionButtonProps {
  */
 const SHOW_SUCCESS_FEEDBACK = new Set([
 	PositronNotebookActionId.CopyOutputImage,
+	PositronNotebookActionId.CopyOutputJson,
 ]);
 
 /** Duration to show the success feedback (in milliseconds). */

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
@@ -89,7 +89,7 @@ export function useCellContextKeys(
 			keys.canMoveDown.set(cell.index < cells.length - 1 && cells.length > 1);
 			keys.hasOutputs.set(outputs.length > 0);
 			keys.imageOutputCount.set(outputs.filter(o => o.parsed.type === 'image').length);
-			keys.hasJsonOutput.set(outputs.some(o => o.parsed.type === 'json'));
+			keys.jsonOutputCount.set(outputs.filter(o => o.parsed.type === 'json').length);
 			keys.outputIsCollapsed.set(outputIsCollapsed);
 			keys.outputScrolling.set(outputScrolling ?? globalOutputScrolling);
 		}));

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextKeys.ts
@@ -89,6 +89,7 @@ export function useCellContextKeys(
 			keys.canMoveDown.set(cell.index < cells.length - 1 && cells.length > 1);
 			keys.hasOutputs.set(outputs.length > 0);
 			keys.imageOutputCount.set(outputs.filter(o => o.parsed.type === 'image').length);
+			keys.hasJsonOutput.set(outputs.some(o => o.parsed.type === 'json'));
 			keys.outputIsCollapsed.set(outputIsCollapsed);
 			keys.outputScrolling.set(outputScrolling ?? globalOutputScrolling);
 		}));

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -53,7 +53,7 @@ import { IPYNB_VIEW_TYPE } from '../../notebook/browser/notebookBrowser.js';
 import { IPositronNotebookEditorOptions } from './positronNotebookEditorTypes.js';
 import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID, PositronNotebookActionId, PositronNotebookCellActionBarLeftGroup, PositronNotebookCellOutputActionGroup, usingPositronNotebooks } from '../common/positronNotebookCommon.js';
 import { getActiveCell, getSelectedCells, SelectionState } from './selectionMachine.js';
-import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_HAS_JSON_OUTPUT, POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING, POSITRON_NOTEBOOK_EXPERIMENTAL, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from './ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_JSON_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING, POSITRON_NOTEBOOK_EXPERIMENTAL, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from './ContextKeysManager.js';
 import './contrib/undoRedo/positronNotebookUndoRedo.js';
 import { registerAction2, MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { ExecuteSelectionInConsoleAction } from './ExecuteSelectionInConsoleAction.js';
@@ -1831,7 +1831,7 @@ registerAction2(class extends NotebookAction2 {
 					group: PositronNotebookCellOutputActionGroup.Copy,
 					order: 2,
 					when: ContextKeyExpr.and(
-						POSITRON_NOTEBOOK_CELL_HAS_JSON_OUTPUT,
+						ContextKeyExpr.equals(POSITRON_NOTEBOOK_CELL_JSON_OUTPUT_COUNT.key, 1),
 						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated()
 					)
 				},

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -53,7 +53,7 @@ import { IPYNB_VIEW_TYPE } from '../../notebook/browser/notebookBrowser.js';
 import { IPositronNotebookEditorOptions } from './positronNotebookEditorTypes.js';
 import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID, PositronNotebookActionId, PositronNotebookCellActionBarLeftGroup, PositronNotebookCellOutputActionGroup, usingPositronNotebooks } from '../common/positronNotebookCommon.js';
 import { getActiveCell, getSelectedCells, SelectionState } from './selectionMachine.js';
-import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING, POSITRON_NOTEBOOK_EXPERIMENTAL, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from './ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_HAS_JSON_OUTPUT, POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING, POSITRON_NOTEBOOK_EXPERIMENTAL, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from './ContextKeysManager.js';
 import './contrib/undoRedo/positronNotebookUndoRedo.js';
 import { registerAction2, MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { ExecuteSelectionInConsoleAction } from './ExecuteSelectionInConsoleAction.js';
@@ -1815,6 +1815,45 @@ registerAction2(class extends NotebookAction2 {
 			logService.error('Failed to copy image to clipboard:', err);
 			notificationService.error(localize('copyImageFailed', "Failed to copy image to clipboard"));
 		}
+	}
+});
+
+// Copy JSON output to clipboard
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: PositronNotebookActionId.CopyOutputJson,
+			title: localize2('positronNotebook.cell.copyOutputJson', "Copy JSON"),
+			icon: ThemeIcon.fromId('copy'),
+			menu: [
+				{
+					id: MenuId.PositronNotebookCellOutputActionBar,
+					group: PositronNotebookCellOutputActionGroup.Copy,
+					order: 2,
+					when: ContextKeyExpr.and(
+						POSITRON_NOTEBOOK_CELL_HAS_JSON_OUTPUT,
+						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated()
+					)
+				},
+			],
+		});
+	}
+
+	override async runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor): Promise<void> {
+		const clipboardService = accessor.get(IClipboardService);
+
+		const state = notebook.selectionStateMachine.state.get();
+		const cell = getActiveCell(state);
+		if (!cell?.isCodeCell()) {
+			return;
+		}
+		const jsonOutput = cell.outputs.get().find(o => o.parsed.type === 'json');
+		if (jsonOutput?.parsed.type !== 'json') {
+			return;
+		}
+
+		const text = JSON.stringify(jsonOutput.parsed.data, null, 2);
+		await clipboardService.writeText(text);
 	}
 });
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -15,6 +15,7 @@ import './SelectPositronNotebookKernelAction.js';
 import './contrib/visualize/VisualizeAction.js';
 
 import { isCopyImageMenuArg, toBase64DataUrl } from './copyImageUtils.js';
+import { isCopyJsonMenuArg, serializeJsonOutput } from './copyJsonUtils.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -53,7 +54,7 @@ import { IPYNB_VIEW_TYPE } from '../../notebook/browser/notebookBrowser.js';
 import { IPositronNotebookEditorOptions } from './positronNotebookEditorTypes.js';
 import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID, PositronNotebookActionId, PositronNotebookCellActionBarLeftGroup, PositronNotebookCellOutputActionGroup, usingPositronNotebooks } from '../common/positronNotebookCommon.js';
 import { getActiveCell, getSelectedCells, SelectionState } from './selectionMachine.js';
-import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_JSON_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING, POSITRON_NOTEBOOK_EXPERIMENTAL, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from './ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_JSON_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING, POSITRON_NOTEBOOK_EXPERIMENTAL, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED } from './ContextKeysManager.js';
 import './contrib/undoRedo/positronNotebookUndoRedo.js';
 import { registerAction2, MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { ExecuteSelectionInConsoleAction } from './ExecuteSelectionInConsoleAction.js';
@@ -1835,24 +1836,37 @@ registerAction2(class extends NotebookAction2 {
 						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated()
 					)
 				},
+				{
+					id: MenuId.PositronNotebookCellOutputActionContext,
+					group: PositronNotebookCellOutputActionGroup.Copy,
+					order: 2,
+					when: ContextKeyExpr.and(
+						POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED,
+						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated()
+					)
+				},
 			],
 		});
 	}
 
-	override async runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor): Promise<void> {
+	override async runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
 		const clipboardService = accessor.get(IClipboardService);
 
-		const state = notebook.selectionStateMachine.state.get();
-		const cell = getActiveCell(state);
-		if (!cell?.isCodeCell()) {
-			return;
-		}
-		const jsonOutput = cell.outputs.get().find(o => o.parsed.type === 'json');
-		if (jsonOutput?.parsed.type !== 'json') {
-			return;
-		}
+		const menuArg = args.find(isCopyJsonMenuArg);
+		let text = menuArg?.jsonText;
 
-		const text = JSON.stringify(jsonOutput.parsed.data, null, 2);
+		if (!text) {
+			const state = notebook.selectionStateMachine.state.get();
+			const cell = getActiveCell(state);
+			if (!cell?.isCodeCell()) {
+				return;
+			}
+			const jsonOutput = cell.outputs.get().find(o => o.parsed.type === 'json');
+			if (jsonOutput?.parsed.type !== 'json') {
+				return;
+			}
+			text = serializeJsonOutput(jsonOutput.parsed.data);
+		}
 		await clipboardService.writeText(text);
 	}
 });

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
@@ -42,6 +42,7 @@ export enum PositronNotebookCellOutputActionGroup {
  */
 export enum PositronNotebookActionId {
 	CopyOutputImage = 'positronNotebook.cell.copyOutputImage',
+	CopyOutputJson = 'positronNotebook.cell.copyOutputJson',
 }
 
 /**

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/copyJsonUtils.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/copyJsonUtils.vitest.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { isCopyJsonMenuArg, serializeJsonOutput } from '../../browser/copyJsonUtils.js';
+
+describe('copyJsonUtils', () => {
+	createTestContainer().build();
+
+	describe('serializeJsonOutput', () => {
+		it('pretty-prints JSON data with two-space indentation', () => {
+			const result = serializeJsonOutput({ name: 'test', values: [1, true, null] });
+
+			expect(result).toBe('{\n  "name": "test",\n  "values": [\n    1,\n    true,\n    null\n  ]\n}');
+		});
+
+		it('serializes primitive JSON values', () => {
+			expect(serializeJsonOutput(null)).toBe('null');
+			expect(serializeJsonOutput(true)).toBe('true');
+			expect(serializeJsonOutput('text')).toBe('"text"');
+		});
+	});
+
+	describe('isCopyJsonMenuArg', () => {
+		it('returns true for valid arg', () => {
+			expect(isCopyJsonMenuArg({ jsonText: '{"x":1}' })).toBe(true);
+		});
+
+		it('returns false for null', () => {
+			expect(isCopyJsonMenuArg(null)).toBe(false);
+		});
+
+		it('returns false for missing jsonText', () => {
+			expect(isCopyJsonMenuArg({ other: 'value' })).toBe(false);
+		});
+
+		it('returns false for non-string jsonText', () => {
+			expect(isCopyJsonMenuArg({ jsonText: 123 })).toBe(false);
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { JsonOutput } from '../../browser/notebookCells/JsonOutput.js';
+
+describe('JsonOutput', () => {
+	it('renders object with syntax-highlighted tokens', () => {
+		render(<JsonOutput data={{ name: 'test', count: 42, active: true, value: null }} />);
+
+		const pre = screen.getByText((_content, element) =>
+			element?.tagName === 'PRE' && element.classList.contains('json-output')
+		);
+		expect(pre).toBeInTheDocument();
+
+		// Keys
+		expect(screen.getByText('"name"', { selector: '.json-key' })).toBeInTheDocument();
+		expect(screen.getByText('"count"', { selector: '.json-key' })).toBeInTheDocument();
+		expect(screen.getByText('"active"', { selector: '.json-key' })).toBeInTheDocument();
+		expect(screen.getByText('"value"', { selector: '.json-key' })).toBeInTheDocument();
+
+		// Values
+		expect(screen.getByText('"test"', { selector: '.json-string' })).toBeInTheDocument();
+		expect(screen.getByText('42', { selector: '.json-number' })).toBeInTheDocument();
+		expect(screen.getByText('true', { selector: '.json-boolean' })).toBeInTheDocument();
+		expect(screen.getByText('null', { selector: '.json-null' })).toBeInTheDocument();
+	});
+
+	it('renders arrays', () => {
+		render(<JsonOutput data={[1, 'two', false]} />);
+
+		expect(screen.getByText('1', { selector: '.json-number' })).toBeInTheDocument();
+		expect(screen.getByText('"two"', { selector: '.json-string' })).toBeInTheDocument();
+		expect(screen.getByText('false', { selector: '.json-boolean' })).toBeInTheDocument();
+	});
+
+	it('renders nested structures', () => {
+		render(<JsonOutput data={{ nested: { deep: 'value' } }} />);
+
+		expect(screen.getByText('"nested"', { selector: '.json-key' })).toBeInTheDocument();
+		expect(screen.getByText('"deep"', { selector: '.json-key' })).toBeInTheDocument();
+		expect(screen.getByText('"value"', { selector: '.json-string' })).toBeInTheDocument();
+	});
+
+	it('renders primitive values at top level', () => {
+		render(<JsonOutput data='just a string' />);
+
+		expect(screen.getByText('"just a string"', { selector: '.json-string' })).toBeInTheDocument();
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
@@ -104,12 +104,13 @@ describe('JsonOutput', () => {
 		// Should be truncated -- full string not present
 		expect(screen.queryByText(`"${longStr}"`, { selector: '.json-string' })).not.toBeInTheDocument();
 
-		// Expand button shows char count
-		const expandBtn = screen.getByRole('button', { name: /200 chars/ });
-		expect(expandBtn).toBeInTheDocument();
+		// Secondary annotation shows char count
+		expect(screen.getByText('200 chars', { selector: '.json-secondary' })).toBeInTheDocument();
 
-		// Click to expand
+		// Inline toggle expands
+		const expandBtn = screen.getByRole('button', { name: /expand string/i });
 		await user.click(expandBtn);
 		expect(screen.getByText(`"${longStr}"`, { selector: '.json-string' })).toBeInTheDocument();
+		expect(screen.queryByText('200 chars', { selector: '.json-secondary' })).not.toBeInTheDocument();
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
@@ -104,13 +104,13 @@ describe('JsonOutput', () => {
 		// Should be truncated -- full string not present
 		expect(screen.queryByText(`"${longStr}"`, { selector: '.json-string' })).not.toBeInTheDocument();
 
-		// Secondary annotation shows char count
-		expect(screen.getByText('200 chars', { selector: '.json-secondary' })).toBeInTheDocument();
-
-		// Inline toggle expands
+		// Expand button at end of truncated string shows char count
 		const expandBtn = screen.getByRole('button', { name: /expand string/i });
+		expect(expandBtn).toHaveTextContent('200 chars');
+
+		// Click to expand
 		await user.click(expandBtn);
 		expect(screen.getByText(`"${longStr}"`, { selector: '.json-string' })).toBeInTheDocument();
-		expect(screen.queryByText('200 chars', { selector: '.json-secondary' })).not.toBeInTheDocument();
+		expect(expandBtn).toHaveTextContent('less');
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
@@ -104,13 +104,14 @@ describe('JsonOutput', () => {
 		// Should be truncated -- full string not present
 		expect(screen.queryByText(`"${longStr}"`, { selector: '.json-string' })).not.toBeInTheDocument();
 
-		// Expand button at end of truncated string shows char count
-		const expandBtn = screen.getByRole('button', { name: /expand string/i });
-		expect(expandBtn).toHaveTextContent('200 chars');
+		// "more" button with tooltip showing char count
+		const expandBtn = screen.getByRole('button', { name: 'more' });
+		expect(expandBtn).toHaveAttribute('title', 'Expand to see all 200 characters');
 
 		// Click to expand
 		await user.click(expandBtn);
 		expect(screen.getByText(`"${longStr}"`, { selector: '.json-string' })).toBeInTheDocument();
 		expect(expandBtn).toHaveTextContent('less');
+		expect(expandBtn).toHaveAttribute('title', 'Collapse to truncated preview');
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
@@ -95,4 +95,21 @@ describe('JsonOutput', () => {
 
 		expect(screen.getByText('"just a string"', { selector: '.json-string' })).toBeInTheDocument();
 	});
+
+	it('truncates long strings and expands on click', async () => {
+		const user = userEvent.setup();
+		const longStr = 'x'.repeat(200);
+		rtl.render(<JsonOutput data={{ msg: longStr }} />);
+
+		// Should be truncated -- full string not present
+		expect(screen.queryByText(`"${longStr}"`, { selector: '.json-string' })).not.toBeInTheDocument();
+
+		// Expand button shows char count
+		const expandBtn = screen.getByRole('button', { name: /200 chars/ });
+		expect(expandBtn).toBeInTheDocument();
+
+		// Click to expand
+		await user.click(expandBtn);
+		expect(screen.getByText(`"${longStr}"`, { selector: '.json-string' })).toBeInTheDocument();
+	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
@@ -6,18 +6,14 @@
 /// <reference types="vitest/globals" />
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { JsonOutput } from '../../browser/notebookCells/JsonOutput.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
-import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
-
 describe('JsonOutput', () => {
-	const mockWriteText = vi.fn();
 	const ctx = createTestContainer()
 		.withReactServices()
-		.stub(IClipboardService, { writeText: mockWriteText })
 		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
@@ -72,16 +68,6 @@ describe('JsonOutput', () => {
 		expect(screen.getByText('1', { selector: '.json-number' })).toBeInTheDocument();
 	});
 
-	it('copies JSON to clipboard', async () => {
-		const user = userEvent.setup();
-
-		rtl.render(<JsonOutput data={{ x: 1 }} />);
-
-		const copyButton = screen.getByRole('button', { name: /copy json/i });
-		await user.click(copyButton);
-
-		expect(mockWriteText).toHaveBeenCalledWith(JSON.stringify({ x: 1 }, null, 2));
-	});
 
 	it('renders empty objects compactly', () => {
 		rtl.render(<JsonOutput data={{ empty: {} }} />);

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
@@ -82,6 +82,13 @@ describe('JsonOutput', () => {
 		expect(screen.getByText('"just a string"', { selector: '.json-string' })).toBeInTheDocument();
 	});
 
+	it('marks the root element with the output id', () => {
+		rtl.render(<JsonOutput data={{ value: 1 }} outputId='output-123' />);
+
+		const output = screen.getByText('value:', { selector: '.json-key' }).closest('.json-output');
+		expect(output).toHaveAttribute('data-positron-json-output-id', 'output-123');
+	});
+
 	it('truncates long strings and expands on click', async () => {
 		const user = userEvent.setup();
 		const longStr = 'x'.repeat(200);

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
@@ -7,48 +7,91 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { JsonOutput } from '../../browser/notebookCells/JsonOutput.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 
 describe('JsonOutput', () => {
-	it('renders object with syntax-highlighted tokens', () => {
-		render(<JsonOutput data={{ name: 'test', count: 42, active: true, value: null }} />);
+	const mockWriteText = vi.fn();
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(IClipboardService, { writeText: mockWriteText })
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
-		const pre = screen.getByText((_content, element) =>
-			element?.tagName === 'PRE' && element.classList.contains('json-output')
-		);
-		expect(pre).toBeInTheDocument();
+	it('renders object keys and string values', () => {
+		rtl.render(<JsonOutput data={{ name: 'test', count: 42 }} />);
 
-		// Keys
-		expect(screen.getByText('"name"', { selector: '.json-key' })).toBeInTheDocument();
-		expect(screen.getByText('"count"', { selector: '.json-key' })).toBeInTheDocument();
-		expect(screen.getByText('"active"', { selector: '.json-key' })).toBeInTheDocument();
-		expect(screen.getByText('"value"', { selector: '.json-key' })).toBeInTheDocument();
-
-		// Values
+		expect(screen.getByText('name:', { selector: '.json-key' })).toBeInTheDocument();
 		expect(screen.getByText('"test"', { selector: '.json-string' })).toBeInTheDocument();
 		expect(screen.getByText('42', { selector: '.json-number' })).toBeInTheDocument();
+	});
+
+	it('renders booleans and null', () => {
+		rtl.render(<JsonOutput data={{ active: true, value: null }} />);
+
 		expect(screen.getByText('true', { selector: '.json-boolean' })).toBeInTheDocument();
 		expect(screen.getByText('null', { selector: '.json-null' })).toBeInTheDocument();
 	});
 
-	it('renders arrays', () => {
-		render(<JsonOutput data={[1, 'two', false]} />);
+	it('renders arrays without key names on items', () => {
+		rtl.render(<JsonOutput data={[1, 'two', false]} />);
 
 		expect(screen.getByText('1', { selector: '.json-number' })).toBeInTheDocument();
 		expect(screen.getByText('"two"', { selector: '.json-string' })).toBeInTheDocument();
 		expect(screen.getByText('false', { selector: '.json-boolean' })).toBeInTheDocument();
 	});
 
-	it('renders nested structures', () => {
-		render(<JsonOutput data={{ nested: { deep: 'value' } }} />);
+	it('renders nested structures with collapsible nodes', () => {
+		rtl.render(<JsonOutput data={{ nested: { deep: 'value' } }} />);
 
-		expect(screen.getByText('"nested"', { selector: '.json-key' })).toBeInTheDocument();
-		expect(screen.getByText('"deep"', { selector: '.json-key' })).toBeInTheDocument();
+		expect(screen.getByText('nested:', { selector: '.json-key' })).toBeInTheDocument();
+		expect(screen.getByText('deep:', { selector: '.json-key' })).toBeInTheDocument();
 		expect(screen.getByText('"value"', { selector: '.json-string' })).toBeInTheDocument();
 	});
 
+	it('collapses and expands on click', async () => {
+		const user = userEvent.setup();
+		rtl.render(<JsonOutput data={{ items: [1, 2, 3] }} />);
+
+		// Items should be visible initially
+		expect(screen.getByText('1', { selector: '.json-number' })).toBeInTheDocument();
+
+		// Click the collapsible header for the 'items' array
+		const header = screen.getByText('items:', { selector: '.json-key' }).closest('.json-collapsible-header')!;
+		await user.click(header);
+
+		// Items should be hidden, preview shown
+		expect(screen.queryByText('1', { selector: '.json-number' })).not.toBeInTheDocument();
+		expect(screen.getByText(/3 items/)).toBeInTheDocument();
+
+		// Click again to expand
+		await user.click(header);
+		expect(screen.getByText('1', { selector: '.json-number' })).toBeInTheDocument();
+	});
+
+	it('copies JSON to clipboard', async () => {
+		const user = userEvent.setup();
+
+		rtl.render(<JsonOutput data={{ x: 1 }} />);
+
+		const copyButton = screen.getByRole('button', { name: /copy json/i });
+		await user.click(copyButton);
+
+		expect(mockWriteText).toHaveBeenCalledWith(JSON.stringify({ x: 1 }, null, 2));
+	});
+
+	it('renders empty objects compactly', () => {
+		rtl.render(<JsonOutput data={{ empty: {} }} />);
+
+		expect(screen.getByText('empty:', { selector: '.json-key' })).toBeInTheDocument();
+		expect(screen.getByText('{}', { selector: '.json-punct' })).toBeInTheDocument();
+	});
+
 	it('renders primitive values at top level', () => {
-		render(<JsonOutput data='just a string' />);
+		rtl.render(<JsonOutput data='just a string' />);
 
 		expect(screen.getByText('"just a string"', { selector: '.json-string' })).toBeInTheDocument();
 	});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jsonOutput.vitest.tsx
@@ -104,14 +104,14 @@ describe('JsonOutput', () => {
 		// Should be truncated -- full string not present
 		expect(screen.queryByText(`"${longStr}"`, { selector: '.json-string' })).not.toBeInTheDocument();
 
-		// "more" button with tooltip showing char count
-		const expandBtn = screen.getByRole('button', { name: 'more' });
-		expect(expandBtn).toHaveAttribute('title', 'Expand to see all 200 characters');
+		// "more" button with descriptive aria-label
+		const expandBtn = screen.getByRole('button', { name: /expand to see all 200 characters/i });
+		expect(expandBtn).toHaveTextContent('more');
 
 		// Click to expand
 		await user.click(expandBtn);
 		expect(screen.getByText(`"${longStr}"`, { selector: '.json-string' })).toBeInTheDocument();
 		expect(expandBtn).toHaveTextContent('less');
-		expect(expandBtn).toHaveAttribute('title', 'Collapse to truncated preview');
+		expect(expandBtn).toHaveAttribute('aria-expanded', 'true');
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputUtils.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputUtils.vitest.ts
@@ -59,6 +59,38 @@ describe('Notebook Output Utils', () => {
 			const result = parseOutputData(makeOutputItem('application/vnd.code.notebook.stdout', 'hello'));
 			expect(result.type).toBe('stdout');
 		});
+
+		it('parses application/json with a runtime error shape as JSON', () => {
+			const payload = { name: 'Runtime Error', message: 'queued' };
+			const result = parseOutputData(makeOutputItem('application/json', JSON.stringify(payload)));
+
+			expect(result.type).toBe('json');
+			if (result.type === 'json') {
+				expect(result.data).toEqual(payload);
+			}
+		});
+
+		it('parses application/json with a keyboard interrupt shape as JSON', () => {
+			const payload = { name: 'KeyboardInterrupt', traceback: ['interrupted'] };
+			const result = parseOutputData(makeOutputItem('application/json', JSON.stringify(payload)));
+
+			expect(result.type).toBe('json');
+			if (result.type === 'json') {
+				expect(result.data).toEqual(payload);
+			}
+		});
+
+		it('parses notebook error MIME as error output', () => {
+			const result = parseOutputData(makeOutputItem(
+				'application/vnd.code.notebook.error',
+				JSON.stringify({ name: 'Error', message: 'failed', stack: 'stack trace' })
+			));
+
+			expect(result.type).toBe('error');
+			if (result.type === 'error') {
+				expect(result.content).toBe('stack trace');
+			}
+		});
 	});
 
 	it('pickPreferredOutputItem: prefers image/svg+xml over text/plain', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputUtils.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputUtils.vitest.ts
@@ -60,26 +60,6 @@ describe('Notebook Output Utils', () => {
 			expect(result.type).toBe('stdout');
 		});
 
-		it('parses application/json with a runtime error shape as JSON', () => {
-			const payload = { name: 'Runtime Error', message: 'queued' };
-			const result = parseOutputData(makeOutputItem('application/json', JSON.stringify(payload)));
-
-			expect(result.type).toBe('json');
-			if (result.type === 'json') {
-				expect(result.data).toEqual(payload);
-			}
-		});
-
-		it('parses application/json with a keyboard interrupt shape as JSON', () => {
-			const payload = { name: 'KeyboardInterrupt', traceback: ['interrupted'] };
-			const result = parseOutputData(makeOutputItem('application/json', JSON.stringify(payload)));
-
-			expect(result.type).toBe('json');
-			if (result.type === 'json') {
-				expect(result.data).toEqual(payload);
-			}
-		});
-
 		it('parses notebook error MIME as error output', () => {
 			const result = parseOutputData(makeOutputItem(
 				'application/vnd.code.notebook.error',

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.vitest.ts
@@ -8,7 +8,7 @@
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { CellEditType, CellKind } from '../../../notebook/common/notebookCommon.js';
-import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from '../../browser/ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED } from '../../browser/ContextKeysManager.js';
 import { createTestPositronNotebookInstance, TestCellInput } from './testPositronNotebookInstance.js';
 
 function pngOutputItem() {
@@ -180,6 +180,36 @@ describe('Positron Notebook Cell Outputs', () => {
 			expect(
 				cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED.key),
 				'outputImageTargeted should be false after being cleared'
+			).toBe(false);
+		});
+
+		it('outputJsonTargeted context key defaults to false and can be set', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]],
+				ctx
+			);
+
+			const cellElement = document.createElement('div');
+			const cellContextKeyService = notebook.scopedContextKeyService.createScoped(cellElement);
+			ctx.disposables.add(cellContextKeyService);
+
+			expect(
+				cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED.key),
+				'outputJsonTargeted should not be set by default'
+			).toBe(undefined);
+
+			const outputJsonTargeted = POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED.bindTo(cellContextKeyService);
+			outputJsonTargeted.set(true);
+
+			expect(
+				cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED.key),
+				'outputJsonTargeted should be true after being set'
+			).toBe(true);
+
+			outputJsonTargeted.set(false);
+			expect(
+				cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED.key),
+				'outputJsonTargeted should be false after being cleared'
 			).toBe(false);
 		});
 	});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.vitest.ts
@@ -24,6 +24,14 @@ function svgOutputItem() {
 	return { mime: 'image/svg+xml', data: VSBuffer.fromString('<svg><circle r="10"/></svg>') };
 }
 
+function jsonOutputItem(data: unknown) {
+	return { mime: 'application/json', data: VSBuffer.fromString(JSON.stringify(data)) };
+}
+
+function invalidJsonOutputItem() {
+	return { mime: 'application/json', data: VSBuffer.fromString('{not valid json') };
+}
+
 describe('Positron Notebook Cell Outputs', () => {
 	const ctx = createTestContainer().withNotebookEditorServices().build();
 
@@ -173,6 +181,51 @@ describe('Positron Notebook Cell Outputs', () => {
 				cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED.key),
 				'outputImageTargeted should be false after being cleared'
 			).toBe(false);
+		});
+	});
+
+	describe('JSON output', () => {
+		it('cell with application/json output has parsed type "json"', () => {
+			const cellWithJsonOutput: TestCellInput = {
+				source: 'JSON({"x": 1})',
+				language: 'python',
+				mime: undefined,
+				cellKind: CellKind.Code,
+				outputs: [{
+					outputId: 'output-1',
+					outputs: [jsonOutputItem({ x: 1, y: [2, 3], nested: { flag: true } })],
+				}],
+			};
+			const notebook = createTestPositronNotebookInstance([cellWithJsonOutput], ctx);
+			const cell = notebook.cells.get()[0];
+
+			expect(cell.isCodeCell()).toBe(true);
+			const outputs = cell.outputs.get();
+			expect(outputs.length).toBe(1);
+			expect(outputs[0].parsed.type).toBe('json');
+			if (outputs[0].parsed.type === 'json') {
+				expect(outputs[0].parsed.data).toEqual({ x: 1, y: [2, 3], nested: { flag: true } });
+			}
+		});
+
+		it('invalid JSON falls back to text output', () => {
+			const cellWithInvalidJson: TestCellInput = {
+				source: 'display_json()',
+				language: 'python',
+				mime: undefined,
+				cellKind: CellKind.Code,
+				outputs: [{
+					outputId: 'output-1',
+					outputs: [invalidJsonOutputItem()],
+				}],
+			};
+			const notebook = createTestPositronNotebookInstance([cellWithInvalidJson], ctx);
+			const cell = notebook.cells.get()[0];
+
+			expect(cell.isCodeCell()).toBe(true);
+			const outputs = cell.outputs.get();
+			expect(outputs.length).toBe(1);
+			expect(outputs[0].parsed.type).toBe('text');
 		});
 	});
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.vitest.ts
@@ -8,7 +8,7 @@
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { CellEditType, CellKind } from '../../../notebook/common/notebookCommon.js';
-import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED } from '../../browser/ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from '../../browser/ContextKeysManager.js';
 import { createTestPositronNotebookInstance, TestCellInput } from './testPositronNotebookInstance.js';
 
 function pngOutputItem() {
@@ -183,35 +183,6 @@ describe('Positron Notebook Cell Outputs', () => {
 			).toBe(false);
 		});
 
-		it('outputJsonTargeted context key defaults to false and can be set', () => {
-			const notebook = createTestPositronNotebookInstance(
-				[['print("hello")', 'python', CellKind.Code]],
-				ctx
-			);
-
-			const cellElement = document.createElement('div');
-			const cellContextKeyService = notebook.scopedContextKeyService.createScoped(cellElement);
-			ctx.disposables.add(cellContextKeyService);
-
-			expect(
-				cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED.key),
-				'outputJsonTargeted should not be set by default'
-			).toBe(undefined);
-
-			const outputJsonTargeted = POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED.bindTo(cellContextKeyService);
-			outputJsonTargeted.set(true);
-
-			expect(
-				cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED.key),
-				'outputJsonTargeted should be true after being set'
-			).toBe(true);
-
-			outputJsonTargeted.set(false);
-			expect(
-				cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED.key),
-				'outputJsonTargeted should be false after being cleared'
-			).toBe(false);
-		});
 	});
 
 	describe('JSON output', () => {

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookCellExecution.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookCellExecution.ts
@@ -365,6 +365,7 @@ function toOutputItems(data: ILanguageRuntimeMessageOutputData): IOutputItemDto[
 				outputItems.push({ data: decodeBase64(String(value)), mime });
 				break;
 			// This list is a subset of src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.JUPYTER_RENDERER_MIMETYPES
+			case 'application/json':
 			case 'application/geo+json':
 			case 'application/vdom.v1+json':
 			case 'application/vnd.dataresource+json':


### PR DESCRIPTION
Closes #10604

### Summary

Adds `application/json` MIME type support to the Positron Notebook Editor. JSON outputs are rendered as an interactive collapsible tree view with syntax-colored tokens, expandable/collapsible nodes, long-string truncation, and a "Copy JSON" action available from both the output action bar and the context menu.

### Demo

https://github.com/user-attachments/assets/b6c43dc7-dc90-4950-be73-30ff9249c6a3


### Release Notes

#### New Features

- Render `application/json` notebook outputs as a collapsible tree view with syntax highlighting (#10604)
- Added "Copy JSON" action to copy formatted JSON output to clipboard

#### Bug Fixes

- N/A

### QA Notes

@:positron-notebooks

1. Open a Python notebook and run a cell that produces JSON output:

```python
from IPython.display import JSON
JSON({"name": "example", "values": [1, 2, 3], "nested": {"flag": True, "items": ["a", "b"]}})
```

2. Verify the output renders as a collapsible tree (not raw text)
3. Click chevrons to collapse/expand nodes
4. Verify long strings (>120 chars) show a "more"/"less" toggle
5. Right-click the output and verify "Copy JSON" appears in the context menu
6. Click "Copy JSON" and paste -- verify it is pretty-printed with 2-space indentation
7. Verify the "Copy JSON" button also appears in the output action bar (top-right of the output area)
8. Run a cell that produces invalid JSON via `application/json` and verify it falls back to plain text rendering