### PR TITLE
Add output-focused state for context-dependent Cmd+C in notebooks

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
@@ -66,6 +66,13 @@ export const POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS = new RawContextKey<boolean
 export const POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING = new RawContextKey<boolean>('positronNotebookCellOutputScrolling', false, localize('positronNotebookCellOutputScrolling', "Whether the cell's output is in scrolling mode"));
 
 /**
+ * Context key set to true when a cell's output section has DOM focus.
+ * Used to gate keyboard shortcuts (e.g. Cmd+C to copy image) so they only
+ * fire when the user has explicitly focused the output area.
+ */
+export const POSITRON_NOTEBOOK_OUTPUT_FOCUSED = new RawContextKey<boolean>('positronNotebookOutputFocused', false, localize('positronNotebookOutputFocused', "Whether a cell's output area has focus"));
+
+/**
  * Interaction-driven context key set to true when the user right-clicks on an
  * image in the output area, or opens the ellipsis menu for a cell with image
  * output. This key tracks the current menu interaction and is NOT part of the

--- a/src/vs/workbench/contrib/positronNotebook/browser/copyImageUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/copyImageUtils.ts
@@ -4,6 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { VSBuffer, encodeBase64 } from '../../../../base/common/buffer.js';
+import { localize } from '../../../../nls.js';
+import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
 
 /**
  * Shape of the arg passed to `positronNotebook.cell.copyOutputImage` to target
@@ -15,6 +19,23 @@ export interface CopyImageMenuArg {
 
 export function isCopyImageMenuArg(arg: unknown): arg is CopyImageMenuArg {
 	return typeof arg === 'object' && arg !== null && typeof (arg as CopyImageMenuArg).imageDataUrl === 'string';
+}
+
+/**
+ * Copy an image data URL to the clipboard, logging and notifying the user on failure.
+ */
+export async function copyImageToClipboard(
+	dataUrl: string,
+	clipboardService: IClipboardService,
+	logService: ILogService,
+	notificationService: INotificationService,
+): Promise<void> {
+	try {
+		await clipboardService.writeImage(toBase64DataUrl(dataUrl));
+	} catch (err) {
+		logService.error('Failed to copy image to clipboard:', err);
+		notificationService.error(localize('copyImageFailed', "Failed to copy image to clipboard"));
+	}
 }
 
 /**

--- a/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
@@ -5,6 +5,7 @@
 
 import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { localize } from '../../../../nls.js';
+import { removeAnsiEscapeCodes } from '../../../../base/common/strings.js';
 import { NotebookCellOutputTextModel } from '../../notebook/common/model/notebookCellOutputTextModel.js';
 import { NotebookCellTextModel } from '../../notebook/common/model/notebookCellTextModel.js';
 import { ICellOutput, IOutputItemDto } from '../../notebook/common/notebookCommon.js';
@@ -98,6 +99,13 @@ const textOutputTypes: ParsedTextOutput['type'][] = ['stdout', 'text', 'stderr',
 
 export function isParsedTextOutput(output: ParsedOutput): output is ParsedTextOutput {
 	return (textOutputTypes as string[]).includes(output.type);
+}
+
+export function getPlainTextOutputContent(outputs: ReadonlyArray<{ parsed: ParsedOutput }>): string {
+	return outputs
+		.filter(o => isParsedTextOutput(o.parsed))
+		.map(o => removeAnsiEscapeCodes((o.parsed as ParsedTextOutput).content))
+		.join('\n');
 }
 
 /**

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -56,6 +56,15 @@
 	border-color: var(--vscode-focusBorder);
 }
 
+/* === Output Focus: suppress doubled border === */
+/* When the output section itself has focus, its inset box-shadow provides the
+focus indicator. Revert the selection border to avoid a doubled ring. */
+
+.positron-notebook-code-cell.selected .positron-notebook-cell-outputs:focus,
+.positron-notebook-code-cell.editing .positron-notebook-cell-outputs:focus {
+	border-color: var(--vscode-positronNotebook-border-color);
+}
+
 /* === Selection States: Hover (when not selected/editing) === */
 /* Use .sortable-cell:hover so hovering the drag handle also triggers the cell outline */
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -26,6 +26,7 @@ import { usePositronReactServicesContext } from '../../../../../base/browser/pos
 import { NotebookErrorBoundary } from '../NotebookErrorBoundary.js';
 import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED } from '../../../../../editor/contrib/find/browser/findModel.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+import { getWindow } from '../../../../../base/browser/dom.js';
 
 /**
  * Wraps children in a {@link CellProvider} when the cell is a code cell, so descendants
@@ -96,7 +97,9 @@ export function NotebookCellWrapper({ cell, children }: {
 			//    (markdown cells should still get container focus since their editor unmounts)
 			!wasEditingCodeCell &&
 			// 3. The find widget is focused (to keep focus in the find input)
-			!findWidgetFocused) {
+			!findWidgetFocused &&
+			// 4. Focus is already inside this cell (e.g. on the output section)
+			!cellElement.contains(getWindow(cellElement).document.activeElement)) {
 			cellElement.focus();
 		}
 	}, [isActiveCell, selectionStatus, cellElement, cell, notebookInstance]);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -28,6 +28,23 @@ import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED } from '../..
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 import { getWindow } from '../../../../../base/browser/dom.js';
 
+const OUTPUT_SECTION_CLASS = 'positron-notebook-cell-outputs';
+
+function isActiveElementInOutputSection(cellElement: HTMLElement): boolean {
+	const activeElement = getWindow(cellElement).document.activeElement;
+	if (!activeElement || !cellElement.contains(activeElement)) {
+		return false;
+	}
+	let el: Element | null = activeElement;
+	while (el && el !== cellElement) {
+		if (el.classList.contains(OUTPUT_SECTION_CLASS)) {
+			return true;
+		}
+		el = el.parentElement;
+	}
+	return false;
+}
+
 /**
  * Wraps children in a {@link CellProvider} when the cell is a code cell, so descendants
  * can resolve it via {@link useCell}. Markdown and raw cells render without the provider.
@@ -98,8 +115,8 @@ export function NotebookCellWrapper({ cell, children }: {
 			!wasEditingCodeCell &&
 			// 3. The find widget is focused (to keep focus in the find input)
 			!findWidgetFocused &&
-			// 4. Focus is already inside this cell (e.g. on the output section)
-			!cellElement.contains(getWindow(cellElement).document.activeElement)) {
+			// 4. Focus is on the output section (which is deliberately focusable for Cmd+C)
+			!isActiveElementInOutputSection(cellElement)) {
 			cellElement.focus();
 		}
 	}, [isActiveCell, selectionStatus, cellElement, cell, notebookInstance]);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.css
@@ -44,6 +44,11 @@
 	.positron-notebook-cell-outputs {
 		overflow: hidden;
 		position: relative;
+
+		&:focus {
+			outline: none;
+			box-shadow: inset 0 0 0 1px var(--vscode-focusBorder);
+		}
 	}
 
 	.positron-notebook-code-cell-outputs-inner {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -250,6 +250,7 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 				aria-label={localize('positron.notebook.cellOutput', 'Cell output')}
 				className='positron-notebook-code-cell-outputs positron-notebook-cell-outputs'
 				data-testid='cell-output'
+				role='region'
 				tabIndex={0}
 				onBlur={handleOutputBlur}
 				onContextMenu={handleContextMenu}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -10,13 +10,12 @@ import './NotebookCodeCell.css';
 import React, { useCallback, useEffect, useMemo } from 'react';
 
 // Other dependencies.
-import { NotebookCellOutputs, ParsedTextOutput } from '../PositronNotebookCells/IPositronNotebookCell.js';
-import { isParsedTextOutput } from '../getOutputContents.js';
+import { NotebookCellOutputs } from '../PositronNotebookCells/IPositronNotebookCell.js';
+import { getPlainTextOutputContent, isParsedTextOutput } from '../getOutputContents.js';
 import { useObservedValue, useDebouncedObservedValue } from '../useObservedValue.js';
 import { CellEditorMonacoWidget } from './CellEditorMonacoWidget.js';
 import { localize } from '../../../../../nls.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
-import { removeAnsiEscapeCodes } from '../../../../../base/common/strings.js';
 import { CellTextOutput } from './CellTextOutput.js';
 import { NotebookCellWrapper } from './NotebookCellWrapper.js';
 import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
@@ -36,13 +35,14 @@ import { DataExplorerCellOutput } from './DataExplorerCellOutput.js';
 import { JsonOutput } from './JsonOutput.js';
 import { NotebookErrorBoundary } from '../NotebookErrorBoundary.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
-import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED } from '../ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_OUTPUT_FOCUSED, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED } from '../ContextKeysManager.js';
 import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.js';
 import { useScrollingIndicator } from './useScrollingIndicator.js';
 import { CellOutputActionBar } from './CellOutputActionBar.js';
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 import { HorizontalSplitter, HorizontalSplitterResizeParams } from '../../../../../base/browser/ui/positronComponents/splitters/horizontalSplitter.js';
 import { serializeJsonOutput } from '../copyJsonUtils.js';
+import { CellSelectionType } from '../selectionMachine.js';
 
 /** The minimum height (pixels) that scrollable outputs can be resized to. */
 const MINIMUM_SCROLLABLE_OUTPUT_HEIGHT = 50;
@@ -73,6 +73,20 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 		() => contextKeyService ? POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED.bindTo(contextKeyService) : undefined,
 		[contextKeyService]
 	);
+	const outputFocusedKey = useMemo(
+		() => contextKeyService ? POSITRON_NOTEBOOK_OUTPUT_FOCUSED.bindTo(contextKeyService) : undefined,
+		[contextKeyService]
+	);
+	const { selectionStateMachine } = useNotebookInstance();
+	const handleOutputFocus = useCallback(() => {
+		outputFocusedKey?.set(true);
+		selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
+	}, [outputFocusedKey, selectionStateMachine, cell]);
+	const handleOutputBlur = useCallback((e: React.FocusEvent) => {
+		if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+			outputFocusedKey?.set(false);
+		}
+	}, [outputFocusedKey]);
 	const notebookOptions = useNotebookOptions();
 	const layout = notebookOptions.getLayoutConfiguration();
 	const outputsInnerRef = React.useRef<HTMLDivElement>(null);
@@ -202,11 +216,7 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 								getActiveWindow().document.execCommand('copy');
 							} else {
 								// Fall back to copying all text output from the cell
-								const textContent = outputs
-									.filter(o => isParsedTextOutput(o.parsed))
-									.map(o => removeAnsiEscapeCodes((o.parsed as ParsedTextOutput).content))
-									.join('\n');
-								services.clipboardService.writeText(textContent);
+								services.clipboardService.writeText(getPlainTextOutputContent(outputs));
 							}
 						}
 					},
@@ -240,7 +250,10 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 				aria-label={localize('positron.notebook.cellOutput', 'Cell output')}
 				className='positron-notebook-code-cell-outputs positron-notebook-cell-outputs'
 				data-testid='cell-output'
+				tabIndex={0}
+				onBlur={handleOutputBlur}
 				onContextMenu={handleContextMenu}
+				onFocus={handleOutputFocus}
 			>
 				<div ref={outputsInnerRef} className={positronClassNames(
 					'positron-notebook-code-cell-outputs-inner',

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -16,6 +16,8 @@ import './contrib/visualize/VisualizeAction.js';
 
 import { isCopyImageMenuArg, toBase64DataUrl } from './copyImageUtils.js';
 import { isCopyJsonMenuArg, serializeJsonOutput } from './copyJsonUtils.js';
+import { getPlainTextOutputContent, isParsedTextOutput } from './getOutputContents.js';
+import { getActiveWindow, isEditableElement, isHTMLElement } from '../../../../base/browser/dom.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -54,7 +56,7 @@ import { IPYNB_VIEW_TYPE } from '../../notebook/browser/notebookBrowser.js';
 import { IPositronNotebookEditorOptions } from './positronNotebookEditorTypes.js';
 import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID, PositronNotebookActionId, PositronNotebookCellActionBarLeftGroup, PositronNotebookCellOutputActionGroup, usingPositronNotebooks } from '../common/positronNotebookCommon.js';
 import { getActiveCell, getSelectedCells, SelectionState } from './selectionMachine.js';
-import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_JSON_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING, POSITRON_NOTEBOOK_EXPERIMENTAL, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED } from './ContextKeysManager.js';
+import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_JSON_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING, POSITRON_NOTEBOOK_EXPERIMENTAL, POSITRON_NOTEBOOK_OUTPUT_FOCUSED, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED } from './ContextKeysManager.js';
 import './contrib/undoRedo/positronNotebookUndoRedo.js';
 import { registerAction2, MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { ExecuteSelectionInConsoleAction } from './ExecuteSelectionInConsoleAction.js';
@@ -1759,13 +1761,88 @@ registerAction2(class extends NotebookAction2 {
 	}
 });
 
-// Copy output image to clipboard
-registerAction2(class extends NotebookAction2 {
+// Copy output (unified Cmd+C when output is focused)
+export class CopyOutputAction extends NotebookAction2 {
+	constructor() {
+		super({
+			id: PositronNotebookActionId.CopyOutput,
+			title: localize2('positronNotebook.cell.copyOutput', "Copy Output"),
+			grabFocusOnRun: false,
+			keybinding: {
+				primary: KeyMod.CtrlCmd | KeyCode.KeyC,
+				when: ContextKeyExpr.and(
+					POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+					POSITRON_NOTEBOOK_OUTPUT_FOCUSED,
+					POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
+					POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated(),
+				),
+				weight: KeybindingWeight.EditorContrib,
+			},
+		});
+	}
+
+	override async runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor): Promise<void> {
+		const clipboardService = accessor.get(IClipboardService);
+		const logService = accessor.get(ILogService);
+		const notificationService = accessor.get(INotificationService);
+
+		const state = notebook.selectionStateMachine.state.get();
+		const cell = getActiveCell(state);
+		if (!cell?.isCodeCell()) {
+			return;
+		}
+
+		const outputs = cell.outputs.get();
+
+		const win = getActiveWindow();
+		const focusedElement = win.document.activeElement;
+
+		// Editable controls: execute native copy and bail out
+		if (focusedElement && (isEditableElement(focusedElement) ||
+			(isHTMLElement(focusedElement) && focusedElement.isContentEditable))) {
+			win.document.execCommand('copy');
+			return;
+		}
+
+		// Priority 1: If there's a text selection entirely within the output, copy it
+		const selection = win.document.getSelection();
+		if (selection && selection.type === 'Range' && focusedElement &&
+			selection.anchorNode && selection.focusNode &&
+			focusedElement.contains(selection.anchorNode) &&
+			focusedElement.contains(selection.focusNode)) {
+			win.document.execCommand('copy');
+			return;
+		}
+
+		// Priority 2: If the cell has exactly one image output, copy the image
+		const imageOutputs = outputs.filter(o => o.parsed.type === 'image');
+		if (imageOutputs.length === 1 && imageOutputs[0].parsed.type === 'image') {
+			try {
+				await clipboardService.writeImage(toBase64DataUrl(imageOutputs[0].parsed.dataUrl));
+			} catch (err) {
+				logService.error('Failed to copy image to clipboard:', err);
+				notificationService.error(localize('copyImageFailed', "Failed to copy image to clipboard"));
+			}
+			return;
+		}
+
+		// Priority 3: Copy all text output content
+		if (outputs.some(o => isParsedTextOutput(o.parsed))) {
+			await clipboardService.writeText(getPlainTextOutputContent(outputs));
+			return;
+		}
+	}
+}
+registerAction2(CopyOutputAction);
+
+// Copy output image to clipboard (menu-driven, e.g. right-click on specific image)
+export class CopyOutputImageAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: PositronNotebookActionId.CopyOutputImage,
 			title: localize2('positronNotebook.cell.copyOutputImage', "Copy Image"),
 			icon: ThemeIcon.fromId('copy'),
+			grabFocusOnRun: false,
 			menu: [
 				{
 					id: MenuId.PositronNotebookCellOutputActionBar,
@@ -1789,8 +1866,6 @@ registerAction2(class extends NotebookAction2 {
 					)
 				},
 			],
-			// Keybinding deferred to #12434 (output-focused state for
-			// context-dependent Cmd+C)
 		});
 	}
 
@@ -1827,7 +1902,8 @@ registerAction2(class extends NotebookAction2 {
 			notificationService.error(localize('copyImageFailed', "Failed to copy image to clipboard"));
 		}
 	}
-});
+}
+registerAction2(CopyOutputImageAction);
 
 // Copy JSON output to clipboard
 registerAction2(class extends NotebookAction2 {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1826,7 +1826,14 @@ export class CopyOutputAction extends NotebookAction2 {
 			return;
 		}
 
-		// Priority 3: Copy all text output content
+		// Priority 3: If the cell has exactly one JSON output, copy as formatted JSON
+		const jsonOutputs = outputs.filter(o => o.parsed.type === 'json');
+		if (jsonOutputs.length === 1 && jsonOutputs[0].parsed.type === 'json') {
+			await clipboardService.writeText(serializeJsonOutput(jsonOutputs[0].parsed.data));
+			return;
+		}
+
+		// Priority 4: Copy all text output content
 		if (outputs.some(o => isParsedTextOutput(o.parsed))) {
 			await clipboardService.writeText(getPlainTextOutputContent(outputs));
 			return;

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -14,7 +14,7 @@ import './notebookCells/InlineDataExplorerActions.js';
 import './SelectPositronNotebookKernelAction.js';
 import './contrib/visualize/VisualizeAction.js';
 
-import { isCopyImageMenuArg, toBase64DataUrl } from './copyImageUtils.js';
+import { copyImageToClipboard, isCopyImageMenuArg } from './copyImageUtils.js';
 import { isCopyJsonMenuArg, serializeJsonOutput } from './copyJsonUtils.js';
 import { getPlainTextOutputContent, isParsedTextOutput } from './getOutputContents.js';
 import { getActiveWindow, isEditableElement, isHTMLElement } from '../../../../base/browser/dom.js';
@@ -1817,25 +1817,30 @@ export class CopyOutputAction extends NotebookAction2 {
 		// Priority 2: If the cell has exactly one image output, copy the image
 		const imageOutputs = outputs.filter(o => o.parsed.type === 'image');
 		if (imageOutputs.length === 1 && imageOutputs[0].parsed.type === 'image') {
-			try {
-				await clipboardService.writeImage(toBase64DataUrl(imageOutputs[0].parsed.dataUrl));
-			} catch (err) {
-				logService.error('Failed to copy image to clipboard:', err);
-				notificationService.error(localize('copyImageFailed', "Failed to copy image to clipboard"));
-			}
+			await copyImageToClipboard(imageOutputs[0].parsed.dataUrl, clipboardService, logService, notificationService);
 			return;
 		}
 
 		// Priority 3: If the cell has exactly one JSON output, copy as formatted JSON
 		const jsonOutputs = outputs.filter(o => o.parsed.type === 'json');
 		if (jsonOutputs.length === 1 && jsonOutputs[0].parsed.type === 'json') {
-			await clipboardService.writeText(serializeJsonOutput(jsonOutputs[0].parsed.data));
+			try {
+				await clipboardService.writeText(serializeJsonOutput(jsonOutputs[0].parsed.data));
+			} catch (err) {
+				logService.error('Failed to copy output to clipboard:', err);
+				notificationService.error(localize('copyOutputFailed', "Failed to copy output to clipboard"));
+			}
 			return;
 		}
 
 		// Priority 4: Copy all text output content
 		if (outputs.some(o => isParsedTextOutput(o.parsed))) {
-			await clipboardService.writeText(getPlainTextOutputContent(outputs));
+			try {
+				await clipboardService.writeText(getPlainTextOutputContent(outputs));
+			} catch (err) {
+				logService.error('Failed to copy output to clipboard:', err);
+				notificationService.error(localize('copyOutputFailed', "Failed to copy output to clipboard"));
+			}
 			return;
 		}
 	}
@@ -1843,7 +1848,7 @@ export class CopyOutputAction extends NotebookAction2 {
 registerAction2(CopyOutputAction);
 
 // Copy output image to clipboard (menu-driven, e.g. right-click on specific image)
-export class CopyOutputImageAction extends NotebookAction2 {
+class CopyOutputImageAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: PositronNotebookActionId.CopyOutputImage,
@@ -1902,12 +1907,7 @@ export class CopyOutputImageAction extends NotebookAction2 {
 			return;
 		}
 
-		try {
-			await clipboardService.writeImage(toBase64DataUrl(dataUrl));
-		} catch (err) {
-			logService.error('Failed to copy image to clipboard:', err);
-			notificationService.error(localize('copyImageFailed', "Failed to copy image to clipboard"));
-		}
+		await copyImageToClipboard(dataUrl, clipboardService, logService, notificationService);
 	}
 }
 registerAction2(CopyOutputImageAction);

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
@@ -41,6 +41,7 @@ export enum PositronNotebookCellOutputActionGroup {
  * Not exhaustive; add here when Action IDs are referenced in more than one place.
  */
 export enum PositronNotebookActionId {
+	CopyOutput = 'positronNotebook.cell.copyOutput',
 	CopyOutputImage = 'positronNotebook.cell.copyOutputImage',
 	CopyOutputJson = 'positronNotebook.cell.copyOutputJson',
 }

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputFocus.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputFocus.vitest.tsx
@@ -1,0 +1,284 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { VSBuffer } from '../../../../../base/common/buffer.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
+import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ISize } from '../../../../../base/browser/positronReactRenderer.js';
+import { IScopedContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_OUTPUT_FOCUSED } from '../../browser/ContextKeysManager.js';
+import { NotebookInstanceProvider } from '../../browser/NotebookInstanceProvider.js';
+import { EnvironentProvider } from '../../browser/EnvironmentProvider.js';
+import { NotebookCodeCell } from '../../browser/notebookCells/NotebookCodeCell.js';
+import { CellKind } from '../../../notebook/common/notebookCommon.js';
+import { CopyOutputAction } from '../../browser/positronNotebook.contribution.js';
+import { createTestPositronNotebookInstance, TestCellInput } from './testPositronNotebookInstance.js';
+import { CellSelectionType } from '../../browser/selectionMachine.js';
+import { PositronNotebookCodeCell } from '../../browser/PositronNotebookCells/PositronNotebookCodeCell.js';
+
+// Hoisted mock control: lets individual tests provide a real context key service.
+const { mockUseCellScopedContextKeyService } = vi.hoisted(() => ({
+	mockUseCellScopedContextKeyService: vi.fn(() => undefined as IScopedContextKeyService | undefined),
+}));
+
+// Mock heavy transitive deps that are irrelevant to output focus testing.
+vi.mock('../../browser/notebookCells/NotebookCellActionBar.js', () => ({
+	NotebookCellActionBar: () => null,
+}));
+vi.mock('../../browser/notebookCells/useCellContextKeys.js', () => ({
+	useCellContextKeys: () => undefined,
+}));
+vi.mock('../../browser/notebookCells/CellContextKeyServiceProvider.js', () => ({
+	CellScopedContextKeyServiceProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+	useCellScopedContextKeyService: () => mockUseCellScopedContextKeyService(),
+}));
+vi.mock('../../browser/notebookCells/CellEditorMonacoWidget.js', () => ({
+	CellEditorMonacoWidget: () => <div data-testid='mock-editor' />,
+}));
+vi.mock('../../browser/notebookCells/CellLeftActionMenu.js', () => ({
+	CellLeftActionMenu: () => null,
+}));
+vi.mock('../../browser/notebookCells/CodeCellStatusFooter.js', () => ({
+	CodeCellStatusFooter: () => null,
+}));
+
+function pngOutputItem() {
+	return { mime: 'image/png', data: VSBuffer.fromString('iVBORw0KGgo=') };
+}
+
+describe('Notebook output focus state', () => {
+	const ctx = createTestContainer()
+		.withNotebookEditorServices()
+		.withReactServices()
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	function renderCellWithOutput(cellInputs?: TestCellInput[]) {
+		const defaultInput: TestCellInput[] = cellInputs ?? [{
+			source: 'plot()',
+			language: 'python',
+			mime: undefined,
+			cellKind: CellKind.Code,
+			outputs: [{ outputId: 'output-1', outputs: [pngOutputItem()] }],
+		}];
+		const notebook = createTestPositronNotebookInstance(defaultInput, ctx);
+		const cells = notebook.cells.get();
+		notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+
+		const environmentBundle = {
+			size: observableValue<ISize>('test-size', { width: 800, height: 600 }),
+			scopedContextKeyProviderCallback: () => stubInterface<IScopedContextKeyService>({}),
+		};
+
+		rtl.render(
+			<NotebookInstanceProvider instance={notebook}>
+				<EnvironentProvider environmentBundle={environmentBundle}>
+					{cells.map(cell =>
+						<NotebookCodeCell key={cell.handle} cell={cell as unknown as PositronNotebookCodeCell} />
+					)}
+				</EnvironentProvider>
+			</NotebookInstanceProvider>
+		);
+
+		return { cells, notebook };
+	}
+
+	describe('POSITRON_NOTEBOOK_OUTPUT_FOCUSED context key', () => {
+		it('is defined with key positronNotebookOutputFocused', () => {
+			expect(POSITRON_NOTEBOOK_OUTPUT_FOCUSED).toBeDefined();
+			expect(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key).toBe('positronNotebookOutputFocused');
+		});
+
+		it('can be bound and set on a scoped context key service', () => {
+			const { notebook } = renderCellWithOutput();
+
+			const cellElement = document.createElement('div');
+			const cellContextKeyService = notebook.scopedContextKeyService.createScoped(cellElement);
+			ctx.disposables.add(cellContextKeyService);
+
+			expect(cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(undefined);
+
+			const outputFocused = POSITRON_NOTEBOOK_OUTPUT_FOCUSED.bindTo(cellContextKeyService);
+			outputFocused.set(true);
+			expect(cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(true);
+
+			outputFocused.set(false);
+			expect(cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(false);
+		});
+	});
+
+	describe('Output section DOM', () => {
+		it('output section has tabIndex={0} making it focusable via Tab/click', () => {
+			renderCellWithOutput();
+
+			const outputSection = screen.getByTestId('cell-output');
+			expect(outputSection).toHaveAttribute('tabindex', '0');
+		});
+
+		it('output section can receive focus', () => {
+			renderCellWithOutput();
+
+			const outputSection = screen.getByTestId('cell-output');
+			outputSection.focus();
+			expect(outputSection).toHaveFocus();
+		});
+
+		it('output section has accessible label', () => {
+			renderCellWithOutput();
+
+			const outputSection = screen.getByTestId('cell-output');
+			expect(outputSection).toHaveAttribute('aria-label', 'Cell output');
+		});
+	});
+
+	describe('Output focus sets context key', () => {
+		const contextKeyService = new MockContextKeyService();
+
+		beforeEach(() => {
+			mockUseCellScopedContextKeyService.mockReturnValue(contextKeyService);
+		});
+
+		afterEach(() => {
+			mockUseCellScopedContextKeyService.mockReturnValue(undefined);
+		});
+
+		it('sets positronNotebookOutputFocused to true when output section receives focus', () => {
+			renderCellWithOutput();
+
+			const outputSection = screen.getByTestId('cell-output');
+			outputSection.focus();
+
+			expect(contextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(true);
+		});
+
+		it('sets positronNotebookOutputFocused to false when output section loses focus', () => {
+			renderCellWithOutput();
+
+			const outputSection = screen.getByTestId('cell-output');
+			outputSection.focus();
+			expect(contextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(true);
+
+			outputSection.blur();
+			expect(contextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(false);
+		});
+
+		it('keeps positronNotebookOutputFocused true when focus moves to a child element', () => {
+			renderCellWithOutput();
+
+			const outputSection = screen.getByTestId('cell-output');
+			outputSection.focus();
+			expect(contextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(true);
+
+			// Directly fire blur with relatedTarget inside the output section to
+			// isolate the guard logic (avoid relying on re-focus bubbling).
+			const child = document.createElement('button');
+			outputSection.appendChild(child);
+			fireEvent.blur(outputSection, { relatedTarget: child });
+
+			expect(contextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(true);
+		});
+	});
+
+	describe('Focus preservation across cells', () => {
+		it('focusing second cell output makes it active without losing focus', () => {
+			const { cells: notebookCells } = renderCellWithOutput([
+				{
+					source: 'plot1()',
+					language: 'python',
+					mime: undefined,
+					cellKind: CellKind.Code,
+					outputs: [{ outputId: 'output-1', outputs: [pngOutputItem()] }],
+				},
+				{
+					source: 'plot2()',
+					language: 'python',
+					mime: undefined,
+					cellKind: CellKind.Code,
+					outputs: [{ outputId: 'output-2', outputs: [pngOutputItem()] }],
+				},
+			]);
+
+			const outputSections = screen.getAllByTestId('cell-output');
+			outputSections[1].focus();
+
+			expect(outputSections[1]).toHaveFocus();
+			expect(notebookCells[1].isActive.get()).toBe(true);
+		});
+	});
+
+	describe('CopyOutputAction keybinding', () => {
+		it('declares Cmd+C keybinding when output is focused and cell has outputs', () => {
+			const action = new CopyOutputAction();
+
+			const keybinding = action.desc.keybinding;
+			if (!keybinding || Array.isArray(keybinding)) {
+				throw new Error('Expected CopyOutputAction to declare a single keybinding');
+			}
+
+			expect(keybinding.primary).toBe(KeyMod.CtrlCmd | KeyCode.KeyC);
+
+			const whenClause = keybinding.when;
+			expect(whenClause).toBeDefined();
+			expect(whenClause?.serialize()).toContain(POSITRON_NOTEBOOK_EDITOR_FOCUSED.key);
+			expect(whenClause?.serialize()).toContain(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key);
+			expect(whenClause?.serialize()).toContain(POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS.key);
+			expect(whenClause?.serialize()).toContain(`!${POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.key}`);
+		});
+
+		it('has the correct action ID', () => {
+			const action = new CopyOutputAction();
+			expect(action.desc.id).toBe('positronNotebook.cell.copyOutput');
+		});
+	});
+
+	describe('CopyOutputAction behavior', () => {
+		it('writes empty string to clipboard when text outputs have empty content', async () => {
+			const notebook = createTestPositronNotebookInstance([{
+				source: 'print("")',
+				language: 'python',
+				mime: undefined,
+				cellKind: CellKind.Code,
+				outputs: [{
+					outputId: 'empty-output',
+					outputs: [{ mime: 'application/vnd.code.notebook.stdout', data: VSBuffer.fromString('') }],
+				}],
+			}], ctx);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+
+			const writeText = vi.fn();
+			const accessor = stubInterface<ServicesAccessor>({
+				get: (id: unknown) => {
+					if (id === IClipboardService) {
+						return { writeText };
+					}
+					return {};
+				},
+			});
+
+			// Focus a non-editable element so editable/selection guards don't trigger
+			const outputDiv = document.createElement('div');
+			document.body.appendChild(outputDiv);
+			outputDiv.tabIndex = 0;
+			outputDiv.focus();
+
+			const action = new CopyOutputAction();
+			await action.runNotebookAction(notebook, accessor);
+
+			expect(writeText).toHaveBeenCalledWith('');
+			document.body.removeChild(outputDiv);
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputFocus.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputFocus.vitest.tsx
@@ -244,17 +244,8 @@ describe('Notebook output focus state', () => {
 	});
 
 	describe('CopyOutputAction behavior', () => {
-		it('writes empty string to clipboard when text outputs have empty content', async () => {
-			const notebook = createTestPositronNotebookInstance([{
-				source: 'print("")',
-				language: 'python',
-				mime: undefined,
-				cellKind: CellKind.Code,
-				outputs: [{
-					outputId: 'empty-output',
-					outputs: [{ mime: 'application/vnd.code.notebook.stdout', data: VSBuffer.fromString('') }],
-				}],
-			}], ctx);
+		function setupCopyAction(cellInputs: TestCellInput[]) {
+			const notebook = createTestPositronNotebookInstance(cellInputs, ctx);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
 
@@ -274,11 +265,46 @@ describe('Notebook output focus state', () => {
 			outputDiv.tabIndex = 0;
 			outputDiv.focus();
 
+			return { notebook, accessor, writeText, cleanup: () => document.body.removeChild(outputDiv) };
+		}
+
+		it('writes empty string to clipboard when text outputs have empty content', async () => {
+			const { notebook, accessor, writeText, cleanup } = setupCopyAction([{
+				source: 'print("")',
+				language: 'python',
+				mime: undefined,
+				cellKind: CellKind.Code,
+				outputs: [{
+					outputId: 'empty-output',
+					outputs: [{ mime: 'application/vnd.code.notebook.stdout', data: VSBuffer.fromString('') }],
+				}],
+			}]);
+
 			const action = new CopyOutputAction();
 			await action.runNotebookAction(notebook, accessor);
 
 			expect(writeText).toHaveBeenCalledWith('');
-			document.body.removeChild(outputDiv);
+			cleanup();
+		});
+
+		it('copies formatted JSON when cell has a single JSON output', async () => {
+			const jsonData = { key: 'value', nested: { n: 42 } };
+			const { notebook, accessor, writeText, cleanup } = setupCopyAction([{
+				source: 'data',
+				language: 'python',
+				mime: undefined,
+				cellKind: CellKind.Code,
+				outputs: [{
+					outputId: 'json-output',
+					outputs: [{ mime: 'application/json', data: VSBuffer.fromString(JSON.stringify(jsonData)) }],
+				}],
+			}]);
+
+			const action = new CopyOutputAction();
+			await action.runNotebookAction(notebook, accessor);
+
+			expect(writeText).toHaveBeenCalledWith(JSON.stringify(jsonData, null, 2));
+			cleanup();
 		});
 	});
 });


### PR DESCRIPTION
Fixes #12434

### Summary

Adds an output-focused state to Positron notebooks so that Cmd+C can contextually copy an image when the output area has focus, without interfering with the default copy-source behavior in command mode.

### Demo

https://github.com/user-attachments/assets/17c0111c-4b5d-4e75-88f9-0ca9d51dd2cc




Key changes:
- New `positronNotebookOutputFocused` context key tracks when the output section has DOM focus
- Output section is now focusable (`tabIndex={0}`) with a visible focus indicator
- Cmd+C keybinding on `CopyOutputImageAction` fires only when output is focused, the cell has exactly one image output, and output is not collapsed
- Cell wrapper auto-focus guard prevents stealing focus from the output section when a cell becomes active
- `grabFocusOnRun: false` on the copy action prevents focus from jumping away after the copy



### Release Notes

#### New Features
- Notebook cell outputs can now be focused via Tab or click, enabling context-dependent Cmd+C to copy a plot image to clipboard when the output area is active (#12434)

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks

1. Open a Python notebook and run a cell that produces a plot image:
   ```python
   import matplotlib.pyplot as plt
   plt.plot([1, 2, 3], [1, 4, 9])
   plt.show()
   ```
2. Click on the output area (or Tab into it) -- verify a subtle focus border appears
3. Press Cmd+C -- the image should be copied to clipboard (paste into Preview or another app to confirm)
4. Click back on the cell container (outside the output) and press Cmd+C -- normal text copy behavior should apply
5. Collapse the cell output and verify Cmd+C does NOT attempt to copy the image
6. With two cells that each have image output, click the second cell's output -- verify the second cell becomes active and focus stays on its output (not stolen by the cell wrapper)