### PR TITLE
assistant: handle extension activation and model resolution errors

### DIFF
--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -1124,7 +1124,19 @@ export class LanguageModelsService implements ILanguageModelsService {
 		}
 
 		// Activate extensions before requesting to resolve the models
-		await this._extensionService.activateByEvent(`onLanguageModelChatProvider:${vendorId}`);
+		// --- Start Positron ---
+		// Guard against unhandled errors from extension activation. Without
+		// this, a single extension throwing during activation (e.g. the
+		// GitHub Copilot extension when stale auth tokens are present)
+		// rejects the Promise.all in selectLanguageModels and causes
+		// vscode.lm.selectChatModels() to return zero models for every
+		// vendor. See https://github.com/posit-dev/positron/issues/11452.
+		try {
+			await this._extensionService.activateByEvent(`onLanguageModelChatProvider:${vendorId}`);
+		} catch (error) {
+			this._logService.error(`[LM] Failed to activate provider extension for vendor ${vendorId}`, error);
+		}
+		// --- End Positron ---
 
 		const provider = this._providers.get(vendorId);
 		if (!provider) {
@@ -1261,8 +1273,17 @@ export class LanguageModelsService implements ILanguageModelsService {
 			const allVendors = Array.from(this._vendors.keys()).filter(vendor =>
 				this._positronAssistantConfigurationService.isProviderEnabled(vendor)
 			);
+			// Use allSettled so a single vendor cannot prevent
+			// other vendors' models from being returned. See
+			// https://github.com/posit-dev/positron/issues/11452.
+			const results = await Promise.allSettled(allVendors.map(vendor => this._resolveAllLanguageModels(vendor, true)));
+			for (let i = 0; i < results.length; i++) {
+				const r = results[i];
+				if (r.status === 'rejected') {
+					this._logService.error(`[LM] Failed to resolve language models for vendor ${allVendors[i]}`, r.reason);
+				}
+			}
 			// --- End Positron ---
-			await Promise.all(allVendors.map(vendor => this._resolveAllLanguageModels(vendor, true)));
 		}
 
 		const result: string[] = [];


### PR DESCRIPTION
Fixes #11452

When `vscode.lm.selectChatModels()` was called, an uncaught error from any single chat-model provider extension's activation (e.g. the GitHub Copilot extension throwing due to stale auth tokens from before the 2026.01 auth migration) would reject the `Promise.all` in `selectLanguageModels`, causing zero models to be returned for every vendor — even ones that activated successfully.

This wraps `activateByEvent` in `_resolveAllLanguageModels` with a try/catch so we don't run into the uncaught error, and switches the `Promise.all` over vendors in `selectLanguageModels` to `Promise.allSettled` for a bit more assurance.

Before this fix, no models would appear from any provider; after the fix, the Copilot failure is logged but other providers' models continue to surface.

The exact repro requires stale GitHub Copilot auth tokens, and I do not currently have this state, so this fix is considered speculative.

### Release Notes

#### Bug Fixes
- Assistant: fix `vscode.lm.selectChatModels()` returning no models when another chat-model provider extension throws during activation (#11452)

### Validation Steps

@:assistant

1. Sign in to a non-Copilot model provider (e.g. Anthropic) in Positron Assistant / Databot.
2. Confirm models are listed and selectable.