### PR TITLE
e2e: fix notebook scroll-restore flake on rhel-chromium

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
@@ -74,6 +74,11 @@ test.describe('Positron Notebooks: Scroll Position', {
 		// Wait for the notebook to be visible again after reload
 		await notebooksPositron.expectToBeVisible();
 
+		// Wait for cells to actually render -- expectToBeVisible() only waits for
+		// the container, not its children. On slower CI envs the tab restore can
+		// take longer than the scroll-comparison timeout below.
+		await expect.poll(() => notebooksPositron.cell.count(), { timeout: 30000 }).toBeGreaterThan(0);
+
 		// Verify the same cell is first-visible at the same offset.
 		await expect.poll(async () => {
 			const anchorAfter = await notebooksPositron.getScrollAnchor();


### PR DESCRIPTION
The "Scroll position is restored after window reload" test (added in 8ece5c1f30) hard-failed both retries on chromium-rhel in run [25364119954](https://github.com/posit-dev/positron/actions/runs/25364119954) while passing on chromium-sles.

Root cause: after `hotKeys.reloadWindow(true)`, the test calls `notebooksPositron.expectToBeVisible()`, which only waits for the `.positron-notebook` container — not for cell children to populate. The 5s anchor-comparison poll then maps `null` (zero cells) to `Number.POSITIVE_INFINITY`, so the assertion shows `Received: Infinity` for the entire window when cells just hadn't rendered yet on slower CI envs.

Fix: wait for cells to actually render (30s) before the existing 5s scroll-comparison poll. This separates "did the notebook restore" from "did scroll position match", and a true scroll-restoration regression now reports a real number rather than `Infinity`.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (test-only change)

### Validation Steps

@:positron-notebooks @:web

Run the affected test on a slower CI worker (chromium-rhel) to confirm it no longer flakes:

```
npx playwright test test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts --project e2e-electron
```

Both cases should pass; the reload case in particular should no longer report `Received: Infinity` on cold-start envs.