### PR TITLE
Fix console resize jumpiness

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.css
@@ -1,15 +1,50 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/*
+ * Console body layout: CSS-driven height cascade with ResizeObserver for bottom anchoring.
+ *
+ * Sizing chain (VS Code grid sets the pixel height at the top, every level below fills its parent
+ * through layout):
+ *
+ *   <part element>                       ← VS Code grid sets pixel height
+ *     .positron-console                  ← height: 100% (positronConsole.css)
+ *       .console-core                    ← height: 100% (this file)
+ *         .console-pane                  ← height: 100%, flex column (this file)
+ *           ActionBar                    ← fixed height
+ *           .console-instances-container ← flex: 1 (this file)
+ *             .console-instance          ← top: 0; bottom: 0 (consoleInstance.css)
+ *
+ * Maintaining height in React props (style={{ height: props.height }}) lags the actual DOM resize
+ * by a frame: VS Code's grid mutates the parent synchronously, but a prop-driven height has to
+ * flow through onSizeChanged → setState → re-render before reaching our element. During that
+ * window the parent and child have different sizes and the visible content shifts by 1-10px every
+ * tick. The CSS cascade above eliminates that window — parent resizes reach .console-instance in a
+ * single layout pass with no React in the chain.
+ *
+ * Keeping the user anchored to the bottom of content during a shrink is handled by a
+ * ResizeObserver in consoleInstance.tsx — the browser auto-clamps scrollTop on grow but
+ * not on shrink, so that case needs a JS reaction that fires before paint.
+ */
 .positron-console .console-core {
 	display: flex;
-	flex-direction: row;
 	width: 100%;
+	height: 100%;
+	min-height: 0;
+	flex-direction: row;
+}
+
+.positron-console .console-core .console-pane {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
 }
 
 .positron-console .console-core .console-instances-container {
+	flex: 1;
+	min-height: 0;
 	position: relative;
 }
 

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.tsx
@@ -132,7 +132,7 @@ export const ConsoleCore = (props: ConsoleCoreProps) => {
 	// Render.
 	return (
 		<div className={positronClassNames('console-core')}>
-			<div style={{ height: props.height, width: consolePaneWidth }}>
+			<div className='console-pane' style={{ width: consolePaneWidth }}>
 				<ActionBar {...props} showDeleteButton={positronConsoleContext.consoleSessionListCollapsed} />
 				{/* #6845 - Only render console instances when the console pane width is greater than 0. */}
 				{consolePaneWidth > 0 &&

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.css
@@ -5,6 +5,7 @@
 
 .console-core .console-instance {
 	top: 0;
+	bottom: 0;
 	cursor: default;
 	padding-left: 10px;
 	position: absolute;

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -39,6 +39,13 @@ interface ConsoleInstanceProps {
 	readonly reactComponentContainer: IReactComponentContainer;
 }
 
+// Snapshot of the scroll container's size at a point in time. Used to detect phantom
+// scroll events from layout changes (see scrollHandler).
+interface ObservedSize {
+	readonly scrollHeight: number;
+	readonly clientHeight: number;
+}
+
 /**
  * ConsoleInstance component.
  * @param props A ConsoleInstanceProps that contains the component properties.
@@ -52,6 +59,11 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	// Reference hooks.
 	const consoleInstanceRef = useRef<HTMLDivElement>(undefined!);
 	const consoleInstanceContainerRef = useRef<HTMLDivElement>(undefined!);
+
+	// Tracks scroll / client height as observed by the most recent real scroll event. Used in
+	// scrollHandler to detect phantom scroll events from layout changes (where the user did not
+	// scroll, but the container resized between the scroll write and the scroll event firing).
+	const lastObservedSizeRef = useRef<ObservedSize | null>(null);
 
 	// State hooks.
 	const [fontInfo, setFontInfo] = useState(FontConfigurationManager.getFontInfo(services.configurationService, 'console'));
@@ -90,6 +102,38 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	useEffect(() => {
 		props.positronConsoleInstance.layoutFindWidget(props.width);
 	}, [props.positronConsoleInstance, props.width]);
+
+	// Anchor to bottom on shrink. The browser auto-clamps scrollTop on grow but not on shrink, so
+	// we need to set it ourselves. ResizeObserver fires between layout and paint, keeping the
+	// correction in the same frame as the size change — a useLayoutEffect would run a frame later
+	// because it waits for VS Code's onSizeChanged → React state → re-render. See consoleCore.css
+	// for the overall layout scheme.
+	useEffect(() => {
+		// Get the console instance element. If it doesn't exist, do nothing.
+		const consoleInstanceElement = consoleInstanceRef.current;
+		if (!consoleInstanceElement) {
+			return;
+		}
+
+		// Get the window element for the console instance element and create a ResizeObserver for
+		// it that will scroll to the bottom if the view is not scroll locked.
+		const window = DOM.getWindow(consoleInstanceElement);
+		const resizeObserver = new window.ResizeObserver(() => {
+			if (!props.positronConsoleInstance.scrollLocked) {
+				setIgnoreNextScrollEvent(true);
+				consoleInstanceElement.scrollTo(
+					consoleInstanceElement.scrollLeft,
+					consoleInstanceElement.scrollHeight
+				);
+			}
+		});
+
+		// Observe the console instance element for size changes.
+		resizeObserver.observe(consoleInstanceElement);
+
+		// Disconnect the observer on cleanup.
+		return () => resizeObserver.disconnect();
+	}, [props.positronConsoleInstance, setIgnoreNextScrollEvent]);
 
 	// Determines whether the console is scrollable.
 	const scrollable = () => consoleInstanceRef.current.scrollHeight > consoleInstanceRef.current.clientHeight;
@@ -284,12 +328,6 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			}
 		}));
 
-		disposableStore.add(props.reactComponentContainer.onSizeChanged(_ => {
-			if (!props.positronConsoleInstance.scrollLocked) {
-				scrollToBottom();
-			}
-		}));
-
 		// Add the onDidSelectPlot event handler.
 		disposableStore.add(props.positronConsoleInstance.onDidSelectPlot(plotId => {
 			// Ensure that the Plots pane is visible in the main window.
@@ -324,6 +362,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 		// Add the onDidRequestRevealExecution event handler.
 		disposableStore.add(props.positronConsoleInstance.onDidRequestRevealExecution((executionId) => {
 			// Find the element with the matching data-execution-id attribute.
+			// eslint-disable-next-line no-restricted-syntax
 			const element = consoleInstanceRef.current.querySelector(
 				`[data-execution-id="${executionId}"]`
 			);
@@ -332,6 +371,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			}
 
 			// Find the activity-input element within this activity.
+			// eslint-disable-next-line no-restricted-syntax
 			const activityInput = element.querySelector('.activity-input');
 			if (!activityInput) {
 				return;
@@ -355,10 +395,15 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 
 	useLayoutEffect(() => {
 		// If the view is not scroll locked, scroll to the bottom to reveal the most recent items.
+		// Set ignoreNextScrollEvent so the scroll event from our scrollTo write is not interpreted
+		// as the user scrolling away from the bottom — the scroll handler runs later and may see a
+		// different clientHeight than we used, producing a non-zero scrollPosition that would
+		// incorrectly flip scrollLocked = true.
 		if (!props.positronConsoleInstance.scrollLocked) {
+			setIgnoreNextScrollEvent(true);
 			scrollVertically(consoleInstanceRef.current.scrollHeight);
 		}
-	}, [marker, props.positronConsoleInstance.scrollLocked]);
+	}, [marker, props.positronConsoleInstance.scrollLocked, setIgnoreNextScrollEvent]);
 
 	/**
 	 * onClick event handler.
@@ -565,15 +610,45 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	 * @param e A UIEvent<HTMLDivElement> that describes a user interaction with the mouse.
 	 */
 	const scrollHandler = (e: UIEvent<HTMLDivElement>) => {
-		// If we are ignoring the next scroll event
+		// Get the console instance element. If it doesn't exist, do nothing.
+		const consoleInstanceElement = consoleInstanceRef.current;
+		if (!consoleInstanceElement) {
+			return;
+		}
+
+		// Get the current size of the console instance element.
+		const currentSize: ObservedSize = {
+			scrollHeight: consoleInstanceElement.scrollHeight,
+			clientHeight: consoleInstanceElement.clientHeight,
+		};
+
+		// Skip if this scroll event was triggered by our own scrollTo (e.g. from the
+		// ResizeObserver or scrollToBottom). Otherwise the lock-update logic below would
+		// interpret it as the user scrolling away from the bottom and incorrectly set
+		// scrollLocked = true.
 		if (ignoreNextScrollEventRef.current) {
 			setIgnoreNextScrollEvent(false);
+			lastObservedSizeRef.current = currentSize;
 		} else {
+			// Phantom scroll events from cascading layout changes: a ResizeObserver-driven
+			// scrollTo runs once, but its scroll event fires later — by then the container may
+			// have shrunk further, leaving scrollTop short of the new max. If the size changed
+			// since the last real scroll, treat this as a phantom and skip the scroll lock update.
+			const sizeChanged = lastObservedSizeRef.current !== null &&
+				(
+					currentSize.scrollHeight !== lastObservedSizeRef.current.scrollHeight ||
+					currentSize.clientHeight !== lastObservedSizeRef.current.clientHeight
+				);
+			lastObservedSizeRef.current = currentSize;
+			if (sizeChanged) {
+				return;
+			}
+
 			// Calculate the scroll position.
 			const scrollPosition = Math.abs(
-				consoleInstanceRef.current.scrollHeight -
-				consoleInstanceRef.current.clientHeight -
-				consoleInstanceRef.current.scrollTop
+				consoleInstanceElement.scrollHeight -
+				consoleInstanceElement.clientHeight -
+				consoleInstanceElement.scrollTop
 			);
 
 			// Update scroll lock state
@@ -581,7 +656,7 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 
 			// This used to be saved in an event handler when visibility changed
 			// to `false` but the `scrollTop` already became 0 at that point.
-			props.positronConsoleInstance.lastScrollTop = consoleInstanceRef.current.scrollTop;
+			props.positronConsoleInstance.lastScrollTop = consoleInstanceElement.scrollTop;
 		}
 	};
 
@@ -630,7 +705,6 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			role='tabpanel'
 			style={{
 				width: adjustedWidth,
-				height: props.height,
 				whiteSpace: wordWrap ? 'pre-wrap' : 'pre',
 				zIndex: props.active ? 'auto' : -1
 			}}


### PR DESCRIPTION
# Fix console resize jumpiness

The console panel had visible jumpiness when resizing its height — content would shift up (or down on shrink) for a frame before snapping back. This PR reworks the height cascade and scroll-anchoring to eliminate the timing races behind it.

## Root causes

Three independent bugs were stacking:

1. **React-prop-driven height cascade lagged the DOM resize.** The console's height was set via `style={{ height: props.height }}` at multiple levels of the tree. VS Code's grid mutated the parent DOM size synchronously, but the height had to flow through `onSizeChanged → setState → re-render` before reaching the console body. During that window the parent and child had different sizes, visibly shifting content during resize bursts.

2. **Browser asymmetric `scrollTop` clamping.** On grow, the browser auto-clamps `scrollTop` so the bottom of content stays anchored. On shrink, it preserves `scrollTop` — so a user at the bottom is suddenly N pixels above it, with N equal to how much the viewport shrank.

3. **Phantom scroll events flipping `scrollLocked`.** Programmatic scrolls (marker layout effect, `scrollToBottom`, etc.) fire scroll events that run *later* than the scroll write. By then the container may have shrunk further on the same drag, causing the scroll handler to compute `scrollPosition > 0` and incorrectly flip `scrollLocked = true`. Once locked, all subsequent ticks skipped the bottom-anchor.

## Fixes

### 1. CSS-driven height cascade

Replace the `style={{ height: props.height }}` chain with `height: 100%` CSS from `.console-core` down to `.console-instance` (which fills its parent via `top: 0; bottom: 0`). VS Code's grid sets pixel height on the part element and the browser cascades it to `.console-instance` in a single layout pass — no React in the loop.

Diagram lives in [`consoleCore.css`](src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.css).

### 2. `ResizeObserver` bottom-anchor

A `ResizeObserver` on the scroll container calls `scrollTo(scrollLeft, scrollHeight)` when the size changes (and the view isn't scroll-locked). The observer callback fires *between layout and paint*, putting the correction in the same frame as the size change — no visible misalignment.

This handles the asymmetric-clamping problem: on shrink, where the browser doesn't auto-clamp, we manually scroll to the new max.

### 3. Phantom-scroll suppression (two layers)

- **`ignoreNextScrollEvent`** — set before each programmatic `scrollTo` (marker layout effect, `ResizeObserver`, `scrollToBottom`). Catches the immediate scroll event from the write.
- **`lastObservedSizeRef` size tracking** — in the scroll handler, if the container size has changed since the last *real* scroll event, treat the current event as phantom and skip the lock update. Catches scroll events that fire *after* additional layout changes (where `ignoreNextScrollEvent` has already been consumed).

## Files changed

- [`consoleCore.css`](src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.css) — height cascade, architectural comment with the sizing chain
- [`consoleCore.tsx`](src/vs/workbench/contrib/positronConsole/browser/components/consoleCore.tsx) — outer wrapper as `.console-pane` flex column
- [`consoleInstance.css`](src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.css) — `.console-instance` fills parent via `top/bottom: 0`
- [`consoleInstance.tsx`](src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx) — `ResizeObserver`, size tracking in `scrollHandler`, `ignoreNextScrollEvent` in marker layout effect

## Test plan

- [ ] Resize console taller via the sash drag — content stays anchored to bottom
- [ ] Resize console shorter via the sash drag — content stays anchored to bottom
- [ ] Reload window with restored content, then shrink — content stays anchored
- [ ] Empty console, fill it, then shrink — still works
- [ ] Scroll up to view history — `scrollLocked` stays true, new content does not auto-scroll
- [ ] Scroll back to bottom — `scrollLocked` goes false, new content auto-scrolls
- [ ] Execute commands — output appears at bottom as expected

Screen recording:

https://github.com/user-attachments/assets/3baa025b-adab-408d-bf5c-44b47e52f42f

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #13395 Fix console resize jumpiness.

### Validation Steps

Test:
@:console