### PR TITLE
Add `params` to Quarto/R Markdown notebook environments

### DIFF
--- a/extensions/positron-r/package-lock.json
+++ b/extensions/positron-r/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "fs-extra": "^10.0.1",
+        "js-yaml": "^4.1.0",
         "p-queue": "^6.6.2",
         "split2": "^4.2.0",
         "vscode-languageclient": "^9.0.1",
@@ -21,6 +22,7 @@
         "@types/decompress": "^4.2.7",
         "@types/fs-extra": "^9.0.13",
         "@types/glob": "^7.2.0",
+        "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^9.1.0",
         "@types/node": "18.x",
         "@types/split2": "^4.2.2",
@@ -561,6 +563,13 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.10",
@@ -1356,7 +1365,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
@@ -3492,7 +3500,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -1058,6 +1058,7 @@
     "@types/decompress": "^4.2.7",
     "@types/fs-extra": "^9.0.13",
     "@types/glob": "^7.2.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^9.1.0",
     "@types/node": "18.x",
     "@types/split2": "^4.2.2",
@@ -1075,6 +1076,7 @@
   },
   "dependencies": {
     "fs-extra": "^10.0.1",
+    "js-yaml": "^4.1.0",
     "p-queue": "^6.6.2",
     "split2": "^4.2.0",
     "vscode-languageclient": "^9.0.1",

--- a/extensions/positron-r/src/params.ts
+++ b/extensions/positron-r/src/params.ts
@@ -1,0 +1,331 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+import * as yaml from 'js-yaml';
+
+import { LOGGER } from './extension.js';
+import { RSession } from './session.js';
+
+/**
+ * Marker produced when js-yaml encounters an `!r` or `!expr` tag.
+ * The wrapped string is interpolated verbatim into the generated R code.
+ */
+interface RExprMarker {
+	readonly __rExpr: true;
+	readonly code: string;
+}
+
+function isExprMarker(val: unknown): val is RExprMarker {
+	return !!val && typeof val === 'object' && (val as RExprMarker).__rExpr === true;
+}
+
+const exprConstruct = (data: unknown): RExprMarker => ({
+	__rExpr: true,
+	code: typeof data === 'string' ? data : '',
+});
+
+const RTagType = new yaml.Type('!r', {
+	kind: 'scalar',
+	resolve: () => true,
+	construct: exprConstruct,
+});
+
+const ExprTagType = new yaml.Type('!expr', {
+	kind: 'scalar',
+	resolve: () => true,
+	construct: exprConstruct,
+});
+
+const PARAMS_SCHEMA = yaml.DEFAULT_SCHEMA.extend([RTagType, ExprTagType]);
+
+/**
+ * Extract the YAML front matter from a document body, or undefined if there
+ * isn't one. The front matter must start at the very beginning of the file
+ * (after an optional BOM) and is delimited by `---` lines.
+ */
+export function extractFrontMatter(text: string): string | undefined {
+	// Strip a UTF-8 BOM if present.
+	const body = text.charCodeAt(0) === 0xFEFF ? text.slice(1) : text;
+	if (!body.startsWith('---')) {
+		return undefined;
+	}
+	// Match `---\n...\n---` or `---\n...\n...` (YAML allows `...` as a closing
+	// document marker).
+	const m = body.match(/^---\r?\n([\s\S]*?)\r?\n(?:---|\.\.\.)(?:\r?\n|$)/);
+	return m?.[1];
+}
+
+const R_RESERVED = new Set([
+	'if', 'else', 'repeat', 'while', 'function', 'for', 'in', 'next', 'break',
+	'TRUE', 'FALSE', 'NULL', 'Inf', 'NaN', 'NA', 'NA_integer_', 'NA_real_',
+	'NA_complex_', 'NA_character_',
+]);
+
+function escapeRName(name: string): string {
+	if (/^[A-Za-z.][A-Za-z0-9._]*$/.test(name) && !R_RESERVED.has(name)) {
+		return name;
+	}
+	return '`' + name.replace(/\\/g, '\\\\').replace(/`/g, '\\`') + '`';
+}
+
+function formatNumber(n: number): string {
+	if (Number.isNaN(n)) { return 'NaN'; }
+	if (!Number.isFinite(n)) { return n > 0 ? 'Inf' : '-Inf'; }
+	return String(n);
+}
+
+function formatDate(d: Date): string {
+	const iso = d.toISOString();
+	// js-yaml parses both date-only (`2024-01-01`) and full-timestamp scalars
+	// into Date objects, with no way to recover the original form. Treat UTC
+	// midnight as a date scalar, anything else as a timestamp -- the common
+	// YAML use case is date-only and we want as.Date() there.
+	if (iso.endsWith('T00:00:00.000Z')) {
+		return `as.Date("${iso.slice(0, 10)}")`;
+	}
+	return `as.POSIXct("${iso.replace('T', ' ').replace(/\.\d{3}Z$/, '')}", tz = "UTC")`;
+}
+
+/**
+ * Render a JS value (as parsed by js-yaml with the params schema) as an R
+ * expression. Strings, numbers, booleans, null, dates, expression markers,
+ * arrays, and plain objects are supported. Arrays of homogeneous primitives
+ * become `c(...)`; anything else becomes `list(...)`.
+ */
+export function toRLiteral(val: unknown): string {
+	if (val === null || val === undefined) {
+		return 'NULL';
+	}
+	if (isExprMarker(val)) {
+		return `(${val.code})`;
+	}
+	if (typeof val === 'boolean') {
+		return val ? 'TRUE' : 'FALSE';
+	}
+	if (typeof val === 'number') {
+		return formatNumber(val);
+	}
+	if (typeof val === 'string') {
+		return JSON.stringify(val);
+	}
+	if (val instanceof Date) {
+		return formatDate(val);
+	}
+	if (Array.isArray(val)) {
+		if (val.length === 0) {
+			return 'list()';
+		}
+		const first = val[0];
+		const firstType = first === null ? null : typeof first;
+		const homogeneousScalar =
+			firstType !== null &&
+			(firstType === 'boolean' || firstType === 'number' || firstType === 'string') &&
+			val.every(v => typeof v === firstType);
+		const rendered = val.map(toRLiteral).join(', ');
+		return homogeneousScalar ? `c(${rendered})` : `list(${rendered})`;
+	}
+	if (typeof val === 'object') {
+		const entries = Object.entries(val as Record<string, unknown>);
+		if (entries.length === 0) {
+			return 'list()';
+		}
+		return `list(${entries.map(([k, v]) => `${escapeRName(k)} = ${toRLiteral(v)}`).join(', ')})`;
+	}
+	return 'NULL';
+}
+
+/**
+ * If a top-level params entry is an object with a `value` field (the
+ * structured form used to attach `label`/`input`/`choices`), unwrap to the
+ * value. Otherwise return the raw value unchanged.
+ */
+function unwrapTopLevelParam(raw: unknown): unknown {
+	if (
+		raw &&
+		typeof raw === 'object' &&
+		!Array.isArray(raw) &&
+		!(raw instanceof Date) &&
+		!isExprMarker(raw)
+	) {
+		const obj = raw as Record<string, unknown>;
+		if (Object.prototype.hasOwnProperty.call(obj, 'value')) {
+			return obj.value;
+		}
+	}
+	return raw;
+}
+
+/**
+ * Build the R code that assigns `params` in the global environment based on
+ * the `params:` block in a YAML front matter. Returns undefined if the front
+ * matter is absent, malformed, or has no `params:` key.
+ */
+export function buildParamsRCode(frontMatterYaml: string | undefined): string | undefined {
+	if (!frontMatterYaml) {
+		return undefined;
+	}
+	let parsed: unknown;
+	try {
+		parsed = yaml.load(frontMatterYaml, { schema: PARAMS_SCHEMA });
+	} catch (err) {
+		LOGGER.debug(`Skipping params: malformed YAML front matter (${err})`);
+		return undefined;
+	}
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+		return undefined;
+	}
+	const params = (parsed as Record<string, unknown>).params;
+	if (params === undefined || params === null) {
+		return undefined;
+	}
+	if (typeof params !== 'object' || Array.isArray(params)) {
+		// `params:` must be a map. Anything else is malformed; skip silently.
+		return undefined;
+	}
+	const entries = Object.entries(params as Record<string, unknown>);
+	const rendered = entries
+		.map(([k, v]) => `${escapeRName(k)} = ${toRLiteral(unwrapTopLevelParam(v))}`)
+		.join(', ');
+	return `assign("params", list(${rendered}), envir = globalenv())`;
+}
+
+/**
+ * Format an error for logging. Errors thrown by `evaluateCode` are typically
+ * `RuntimeMethodError`-shaped objects (`{ message, code, name, data }`),
+ * which stringify to `[object Object]` by default; this prefers `.message`
+ * and falls back to JSON.
+ */
+function formatError(err: unknown): string {
+	if (err instanceof Error) {
+		return err.message;
+	}
+	if (err && typeof err === 'object') {
+		const e = err as { message?: unknown; code?: unknown };
+		if (typeof e.message === 'string') {
+			return typeof e.code === 'number'
+				? `${e.message} (code ${e.code})`
+				: e.message;
+		}
+		try {
+			return JSON.stringify(err);
+		} catch {
+			// fall through
+		}
+	}
+	return String(err);
+}
+
+/**
+ * Determines whether a session should have `params` bound from the YAML
+ * front matter of its associated document.
+ */
+function isQuartoOrRmdNotebookSession(session: RSession): boolean {
+	if (session.metadata.sessionMode !== positron.LanguageRuntimeSessionMode.Notebook) {
+		return false;
+	}
+	const uri = session.metadata.notebookUri;
+	if (!uri) {
+		return false;
+	}
+	const path = uri.path.toLowerCase();
+	return path.endsWith('.qmd') || path.endsWith('.rmd');
+}
+
+/**
+ * Per-session binder that mirrors a Quarto/RMarkdown document's `params:`
+ * block into a `params` list in the R global environment. Refreshes on the
+ * first `Ready` state and on subsequent saves of the bound document.
+ */
+export class ParamsBinder implements vscode.Disposable {
+	private readonly _disposables: vscode.Disposable[] = [];
+
+	/**
+	 * The most recently observed front matter text; used to skip re-evaluation
+	 * when a save doesn't touch the YAML header. Cleared on `Ready` so that a
+	 * kernel restart forces a fresh sync against the same document.
+	 */
+	private _lastFrontMatter: string | undefined;
+
+	private _disposed = false;
+
+	constructor(private readonly _session: RSession) { }
+
+	start(): void {
+		if (!isQuartoOrRmdNotebookSession(this._session)) {
+			return;
+		}
+
+		this._disposables.push(
+			this._session.onDidChangeRuntimeState(state => {
+				if (state === positron.RuntimeState.Ready) {
+					this._lastFrontMatter = undefined;
+					void this.sync();
+				}
+			})
+		);
+
+		this._disposables.push(
+			vscode.workspace.onDidSaveTextDocument(doc => {
+				if (doc.uri.toString() === this._session.metadata.notebookUri?.toString()) {
+					void this.sync(doc.getText());
+				}
+			})
+		);
+	}
+
+	private async sync(text?: string): Promise<void> {
+		if (this._disposed) {
+			return;
+		}
+
+		const uri = this._session.metadata.notebookUri;
+		if (!uri) {
+			return;
+		}
+
+		try {
+			if (text === undefined) {
+				const doc = await vscode.workspace.openTextDocument(uri);
+				text = doc.getText();
+			}
+		} catch (err) {
+			LOGGER.debug(`params sync: failed to read ${uri.toString()}: ${formatError(err)}`);
+			return;
+		}
+
+		const fm = extractFrontMatter(text);
+		if (fm === this._lastFrontMatter) {
+			return;
+		}
+		this._lastFrontMatter = fm;
+
+		const code = buildParamsRCode(fm);
+		if (!code) {
+			return;
+		}
+
+		LOGGER.info(`Binding params for ${uri.toString()}: ${code}`);
+
+		try {
+			await positron.runtime.evaluateCode(
+				'r',
+				code,
+				undefined,
+				this._session.metadata.sessionId,
+			);
+		} catch (err) {
+			LOGGER.warn(`Failed to bind params for ${uri.toString()}: ${formatError(err)}`);
+		}
+	}
+
+	dispose(): void {
+		this._disposed = true;
+		while (this._disposables.length > 0) {
+			this._disposables.pop()?.dispose();
+		}
+	}
+}

--- a/extensions/positron-r/src/params.ts
+++ b/extensions/positron-r/src/params.ts
@@ -3,12 +3,26 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as path from 'path';
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import * as yaml from 'js-yaml';
 
 import { LOGGER } from './extension.js';
 import { RSession } from './session.js';
+
+/**
+ * Quarto/RMarkdown params binder for R notebook sessions.
+ *
+ * `rmarkdown::render` and `quarto::render` populate a `params` list in the
+ * global environment from a document's YAML front matter. Positron opens
+ * these documents as notebooks and bypasses the render entry point, so this
+ * module mirrors the binding ourselves: parse the front matter, render the
+ * `params:` block as R code, and assign on the kernel's first Ready state
+ * and on every subsequent save of the bound document. Supports primitives,
+ * dates, arrays, the structured `{value, label, input, choices}` form, and
+ * `!r` / `!expr` expression tags.
+ */
 
 /**
  * Marker produced when js-yaml encounters an `!r` or `!expr` tag.
@@ -162,7 +176,9 @@ function unwrapTopLevelParam(raw: unknown): unknown {
 /**
  * Build the R code that assigns `params` in the global environment based on
  * the `params:` block in a YAML front matter. Returns undefined if the front
- * matter is absent, malformed, or has no `params:` key.
+ * matter is absent or has no `params:` key. Throws when the YAML is malformed
+ * and a `params:` section appears to be present -- callers can ignore the
+ * throw if no params binding is expected.
  */
 export function buildParamsRCode(frontMatterYaml: string | undefined): string | undefined {
 	if (!frontMatterYaml) {
@@ -172,7 +188,12 @@ export function buildParamsRCode(frontMatterYaml: string | undefined): string | 
 	try {
 		parsed = yaml.load(frontMatterYaml, { schema: PARAMS_SCHEMA });
 	} catch (err) {
-		LOGGER.debug(`Skipping params: malformed YAML front matter (${err})`);
+		// Only surface parse errors when the document looks like it intends to
+		// define params. Otherwise we'd complain about every malformed header
+		// even when there's no params binding at stake.
+		if (/^\s*params\s*:/m.test(frontMatterYaml)) {
+			throw err;
+		}
 		return undefined;
 	}
 	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
@@ -220,19 +241,28 @@ function formatError(err: unknown): string {
 }
 
 /**
+ * Display name for the document type backing a session, derived from the
+ * notebook URI extension. Returns undefined if the session isn't backed by
+ * a Quarto or R Markdown document.
+ */
+function docFlavor(session: RSession): 'Quarto' | 'R Markdown' | undefined {
+	const path = session.metadata.notebookUri?.path.toLowerCase();
+	if (path?.endsWith('.qmd')) {
+		return 'Quarto';
+	}
+	if (path?.endsWith('.rmd')) {
+		return 'R Markdown';
+	}
+	return undefined;
+}
+
+/**
  * Determines whether a session should have `params` bound from the YAML
  * front matter of its associated document.
  */
 function isQuartoOrRmdNotebookSession(session: RSession): boolean {
-	if (session.metadata.sessionMode !== positron.LanguageRuntimeSessionMode.Notebook) {
-		return false;
-	}
-	const uri = session.metadata.notebookUri;
-	if (!uri) {
-		return false;
-	}
-	const path = uri.path.toLowerCase();
-	return path.endsWith('.qmd') || path.endsWith('.rmd');
+	return session.metadata.sessionMode === positron.LanguageRuntimeSessionMode.Notebook
+		&& docFlavor(session) !== undefined;
 }
 
 /**
@@ -263,7 +293,9 @@ export class ParamsBinder implements vscode.Disposable {
 			this._session.onDidChangeRuntimeState(state => {
 				if (state === positron.RuntimeState.Ready) {
 					this._lastFrontMatter = undefined;
-					void this.sync();
+					// Initial bind: the user didn't trigger this, so failures
+					// stay in the log rather than popping a toast.
+					void this.sync(undefined, false);
 				}
 			})
 		);
@@ -271,13 +303,14 @@ export class ParamsBinder implements vscode.Disposable {
 		this._disposables.push(
 			vscode.workspace.onDidSaveTextDocument(doc => {
 				if (doc.uri.toString() === this._session.metadata.notebookUri?.toString()) {
-					void this.sync(doc.getText());
+					// User-initiated save: surface failures as a toast.
+					void this.sync(doc.getText(), true);
 				}
 			})
 		);
 	}
 
-	private async sync(text?: string): Promise<void> {
+	private async sync(text: string | undefined, notifyOnError: boolean): Promise<void> {
 		if (this._disposed) {
 			return;
 		}
@@ -298,12 +331,27 @@ export class ParamsBinder implements vscode.Disposable {
 		}
 
 		const fm = extractFrontMatter(text);
+		// Front matter unchanged since our last attempt -- skip silently. This
+		// also dedups error toasts: a failed attempt records its front matter
+		// here so the same broken header doesn't surface a second notification.
 		if (fm === this._lastFrontMatter) {
 			return;
 		}
 		this._lastFrontMatter = fm;
 
-		const code = buildParamsRCode(fm);
+		let code: string | undefined;
+		try {
+			code = buildParamsRCode(fm);
+		} catch (err) {
+			// YAML parse errors are noisy and hard to interpret out of context;
+			// log them but don't surface a toast. The user already sees the
+			// problem in their editor.
+			LOGGER.warn(
+				`Failed to parse YAML front matter for ${uri.toString()}: ${formatError(err)}\nFront matter:\n${fm}`,
+			);
+			return;
+		}
+
 		if (!code) {
 			return;
 		}
@@ -318,7 +366,25 @@ export class ParamsBinder implements vscode.Disposable {
 				this._session.metadata.sessionId,
 			);
 		} catch (err) {
-			LOGGER.warn(`Failed to bind params for ${uri.toString()}: ${formatError(err)}`);
+			LOGGER.warn(
+				`Failed to bind params for ${uri.toString()}: ${formatError(err)}\nGenerated code:\n${code}`,
+			);
+			if (notifyOnError) {
+				void this.showEvalErrorNotification();
+			}
+		}
+	}
+
+	private async showEvalErrorNotification(): Promise<void> {
+		const flavor = docFlavor(this._session) ?? 'Quarto';
+		const filename = path.basename(this._session.metadata.notebookUri?.path ?? '');
+		const message = flavor === 'Quarto'
+			? vscode.l10n.t('{0}: An error occurred evaluating the Quarto params in the document header.', filename)
+			: vscode.l10n.t('{0}: An error occurred evaluating the R Markdown params in the document header.', filename);
+		const showLog = vscode.l10n.t('Show Log');
+		const choice = await vscode.window.showErrorMessage(message, showLog);
+		if (choice === showLog) {
+			LOGGER.show();
 		}
 	}
 

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -19,6 +19,7 @@ import { LOGGER, supervisorApi } from './extension.js';
 import { ArkComm } from './ark-comm';
 import { RPackageManager } from './packages';
 import { RMetadataExtra } from './r-installation';
+import { ParamsBinder } from './params';
 
 interface RPackageInstallation {
 	packageName: string;
@@ -171,6 +172,13 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		this.onDidChangeRuntimeState(async (state) => {
 			await this.onStateChange(state);
 		});
+
+		// For notebook sessions bound to a Quarto/RMarkdown document, mirror
+		// the document's `params:` block into a `params` list in the global
+		// environment. The binder no-ops for sessions that don't qualify.
+		const paramsBinder = new ParamsBinder(this);
+		paramsBinder.start();
+		this._disposables.push(paramsBinder);
 	}
 
 	onDidEndSession: vscode.Event<positron.LanguageRuntimeExit>;

--- a/extensions/positron-r/src/test/params.unit.test.ts
+++ b/extensions/positron-r/src/test/params.unit.test.ts
@@ -1,0 +1,189 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { buildParamsRCode, extractFrontMatter, toRLiteral } from '../params';
+
+suite('extractFrontMatter', () => {
+	test('returns the YAML body for a standard --- delimited block', () => {
+		const text = '---\ntitle: Hello\nparams:\n  x: 1\n---\n\n# Body\n';
+		assert.strictEqual(extractFrontMatter(text), 'title: Hello\nparams:\n  x: 1');
+	});
+
+	test('handles CRLF line endings', () => {
+		const text = '---\r\ntitle: Hello\r\n---\r\n\r\nbody';
+		assert.strictEqual(extractFrontMatter(text), 'title: Hello');
+	});
+
+	test('accepts ... as a closing marker', () => {
+		const text = '---\nparams:\n  x: 1\n...\n\nbody';
+		assert.strictEqual(extractFrontMatter(text), 'params:\n  x: 1');
+	});
+
+	test('strips a leading BOM', () => {
+		const text = '\uFEFF---\ntitle: Hello\n---\n';
+		assert.strictEqual(extractFrontMatter(text), 'title: Hello');
+	});
+
+	test('returns undefined when there is no front matter', () => {
+		assert.strictEqual(extractFrontMatter('# Just a body\n'), undefined);
+	});
+
+	test('returns undefined when the closing delimiter is missing', () => {
+		assert.strictEqual(extractFrontMatter('---\ntitle: Hello\n# body\n'), undefined);
+	});
+});
+
+suite('toRLiteral', () => {
+	test('renders primitives', () => {
+		assert.strictEqual(toRLiteral(null), 'NULL');
+		assert.strictEqual(toRLiteral(undefined), 'NULL');
+		assert.strictEqual(toRLiteral(true), 'TRUE');
+		assert.strictEqual(toRLiteral(false), 'FALSE');
+		assert.strictEqual(toRLiteral(42), '42');
+		assert.strictEqual(toRLiteral(3.14), '3.14');
+		assert.strictEqual(toRLiteral('hi'), '"hi"');
+	});
+
+	test('escapes strings', () => {
+		assert.strictEqual(toRLiteral('say "hi"\n'), '"say \\"hi\\"\\n"');
+		assert.strictEqual(toRLiteral('back\\slash'), '"back\\\\slash"');
+	});
+
+	test('renders Inf, -Inf, NaN', () => {
+		assert.strictEqual(toRLiteral(Number.POSITIVE_INFINITY), 'Inf');
+		assert.strictEqual(toRLiteral(Number.NEGATIVE_INFINITY), '-Inf');
+		assert.strictEqual(toRLiteral(Number.NaN), 'NaN');
+	});
+
+	test('renders date-only Date as as.Date', () => {
+		assert.strictEqual(toRLiteral(new Date('2024-01-15T00:00:00.000Z')), 'as.Date("2024-01-15")');
+	});
+
+	test('renders timestamps as as.POSIXct', () => {
+		assert.strictEqual(
+			toRLiteral(new Date('2024-01-15T12:34:56.000Z')),
+			'as.POSIXct("2024-01-15 12:34:56", tz = "UTC")',
+		);
+	});
+
+	test('renders homogeneous primitive arrays as c()', () => {
+		assert.strictEqual(toRLiteral([1, 2, 3]), 'c(1, 2, 3)');
+		assert.strictEqual(toRLiteral(['a', 'b']), 'c("a", "b")');
+		assert.strictEqual(toRLiteral([true, false]), 'c(TRUE, FALSE)');
+	});
+
+	test('renders mixed or non-primitive arrays as list()', () => {
+		assert.strictEqual(toRLiteral([1, 'a']), 'list(1, "a")');
+		assert.strictEqual(toRLiteral([1, null, 2]), 'list(1, NULL, 2)');
+		assert.strictEqual(toRLiteral([]), 'list()');
+		assert.strictEqual(toRLiteral([{ a: 1 }, { a: 2 }]), 'list(list(a = 1), list(a = 2))');
+	});
+
+	test('renders objects as named list()', () => {
+		assert.strictEqual(toRLiteral({ a: 1, b: 'x' }), 'list(a = 1, b = "x")');
+	});
+
+	test('quotes non-syntactic names with backticks', () => {
+		assert.strictEqual(toRLiteral({ '1bad': 1 }), 'list(`1bad` = 1)');
+		assert.strictEqual(toRLiteral({ 'has space': 1 }), 'list(`has space` = 1)');
+		assert.strictEqual(toRLiteral({ 'TRUE': 1 }), 'list(`TRUE` = 1)');
+	});
+});
+
+suite('buildParamsRCode', () => {
+	test('returns undefined for missing front matter', () => {
+		assert.strictEqual(buildParamsRCode(undefined), undefined);
+	});
+
+	test('returns undefined when YAML has no params key', () => {
+		assert.strictEqual(buildParamsRCode('title: Hello'), undefined);
+	});
+
+	test('returns undefined when params is null or empty', () => {
+		assert.strictEqual(buildParamsRCode('params:'), undefined);
+	});
+
+	test('builds a simple params list', () => {
+		const code = buildParamsRCode('params:\n  alpha: 0.1\n  region: east');
+		assert.strictEqual(
+			code,
+			'assign("params", list(alpha = 0.1, region = "east"), envir = globalenv())',
+		);
+	});
+
+	test('unwraps the structured {value, label, ...} form', () => {
+		const yaml = [
+			'params:',
+			'  region:',
+			'    label: "Region:"',
+			'    value: east',
+			'    input: select',
+			'    choices: [east, west]',
+		].join('\n');
+		assert.strictEqual(
+			buildParamsRCode(yaml),
+			'assign("params", list(region = "east"), envir = globalenv())',
+		);
+	});
+
+	test('leaves nested objects without a value key intact', () => {
+		const yaml = [
+			'params:',
+			'  thing:',
+			'    a: 1',
+			'    b: 2',
+		].join('\n');
+		assert.strictEqual(
+			buildParamsRCode(yaml),
+			'assign("params", list(thing = list(a = 1, b = 2)), envir = globalenv())',
+		);
+	});
+
+	test('inlines !r and !expr tagged values as raw R code', () => {
+		const yaml = [
+			'params:',
+			'  today: !r Sys.Date()',
+			'  tomorrow: !expr Sys.Date() + 1',
+		].join('\n');
+		assert.strictEqual(
+			buildParamsRCode(yaml),
+			'assign("params", list(today = (Sys.Date()), tomorrow = (Sys.Date() + 1)), envir = globalenv())',
+		);
+	});
+
+	test('inlines !r in the structured form', () => {
+		const yaml = [
+			'params:',
+			'  today:',
+			'    label: "Date"',
+			'    value: !r Sys.Date()',
+		].join('\n');
+		assert.strictEqual(
+			buildParamsRCode(yaml),
+			'assign("params", list(today = (Sys.Date())), envir = globalenv())',
+		);
+	});
+
+	test('returns undefined for malformed YAML', () => {
+		assert.strictEqual(buildParamsRCode('params:\n  : : :'), undefined);
+	});
+
+	test('renders YAML date scalars as as.Date()', () => {
+		const yaml = 'params:\n  start: 2024-01-15';
+		assert.strictEqual(
+			buildParamsRCode(yaml),
+			'assign("params", list(start = as.Date("2024-01-15")), envir = globalenv())',
+		);
+	});
+
+	test('renders array of strings as c()', () => {
+		const yaml = 'params:\n  regions: [east, west, north]';
+		assert.strictEqual(
+			buildParamsRCode(yaml),
+			'assign("params", list(regions = c("east", "west", "north")), envir = globalenv())',
+		);
+	});
+});

--- a/extensions/positron-r/src/test/params.unit.test.ts
+++ b/extensions/positron-r/src/test/params.unit.test.ts
@@ -186,4 +186,37 @@ suite('buildParamsRCode', () => {
 			'assign("params", list(regions = c("east", "west", "north")), envir = globalenv())',
 		);
 	});
+
+	test('unwraps a full mixed structured-form params block', () => {
+		// Mirrors the example at https://yihui.org/rmarkdown/params-knit
+		const yaml = [
+			'title: My Document',
+			'output: html_document',
+			'params:',
+			'  year:',
+			'    label: "Year"',
+			'    value: 2017',
+			'    input: slider',
+			'    min: 2010',
+			'    max: 2018',
+			'    step: 1',
+			'    sep: ""',
+			'  region:',
+			'    label: "Region:"',
+			'    value: Europe',
+			'    input: select',
+			'    choices: [North America, Europe, Asia, Africa]',
+			'  printcode:',
+			'    label: "Display Code:"',
+			'    value: TRUE',
+			'  data:',
+			'    label: "Input dataset:"',
+			'    value: results.csv',
+			'    input: file',
+		].join('\n');
+		assert.strictEqual(
+			buildParamsRCode(yaml),
+			'assign("params", list(year = 2017, region = "Europe", printcode = TRUE, data = "results.csv"), envir = globalenv())',
+		);
+	});
 });

--- a/extensions/positron-r/src/test/params.unit.test.ts
+++ b/extensions/positron-r/src/test/params.unit.test.ts
@@ -167,8 +167,12 @@ suite('buildParamsRCode', () => {
 		);
 	});
 
-	test('returns undefined for malformed YAML', () => {
-		assert.strictEqual(buildParamsRCode('params:\n  : : :'), undefined);
+	test('throws for malformed YAML when a params section is present', () => {
+		assert.throws(() => buildParamsRCode('params:\n  : : :'));
+	});
+
+	test('returns undefined for malformed YAML when no params section is present', () => {
+		assert.strictEqual(buildParamsRCode('title: Hello\n  : : :'), undefined);
 	});
 
 	test('renders YAML date scalars as as.Date()', () => {

--- a/test/e2e/tests/quarto/quarto-inline-output-params.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-params.test.ts
@@ -6,16 +6,12 @@
 import { join } from 'path';
 import { test, tags } from '../_test.setup';
 
-// The parameters.qmd fixture lives on the `feature/quarto-params` branch of
-// qa-example-content; set `QA_REPO=feature/quarto-params` when running this
-// test until that branch is merged to main.
-
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Quarto - Inline Output: R Params', {
-	tag: [tags.WEB, tags.WIN, tags.QUARTO]
+	tag: [tags.QUARTO]
 }, () => {
 
 	test.beforeAll(async function ({ settings }) {

--- a/test/e2e/tests/quarto/quarto-inline-output-params.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-params.test.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { test, tags } from '../_test.setup';
+
+// The parameters.qmd fixture lives on the `feature/quarto-params` branch of
+// qa-example-content; set `QA_REPO=feature/quarto-params` when running this
+// test until that branch is merged to main.
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Quarto - Inline Output: R Params', {
+	tag: [tags.WEB, tags.WIN, tags.QUARTO]
+}, () => {
+
+	test.beforeAll(async function ({ settings }) {
+		await settings.set({
+			'positron.quarto.inlineOutput.enabled': true
+		}, { reload: 'web' });
+	});
+
+	test.afterEach(async function ({ hotKeys }) {
+		await hotKeys.closeAllEditors();
+	});
+
+	test('R - Verify YAML params are bound and rendered as inline output', async function ({ app, openFile, r }) {
+		const { editors, inlineQuarto } = app.workbench;
+
+		// Open the parameters Quarto file and wait for the kernel to be ready
+		await openFile(join('workspaces', 'quarto_inline_output', 'parameters.qmd'));
+		await editors.waitForActiveTab('parameters.qmd');
+		await inlineQuarto.expectKernelStatusVisible();
+		await editors.clickTab('parameters.qmd');
+
+		// Cell 1: `!r 6 * 7` -- exercises R expression evaluation in params
+		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 22, outputLine: 24 });
+		await inlineQuarto.expectOutputContainsText('42', { index: 0 });
+
+		// Cell 2: `params$alpha * params$ratio` -- exercises plain scalar params
+		await inlineQuarto.gotoLine(30);
+		await inlineQuarto.runCurrentCell();
+		await inlineQuarto.expectOutputContainsText('0.01', { index: 1 });
+
+		// Cell 3: `params$year` -- exercises the structured params form (with
+		// `label`, `input`, etc.) where the binder must unwrap to `value`
+		await inlineQuarto.gotoLine(38);
+		await inlineQuarto.runCurrentCell();
+		await inlineQuarto.expectOutputContainsText('2026', { index: 2 });
+	});
+});


### PR DESCRIPTION
This change adds basic support for parameterized Quarto documents to Positron when using inline output.

<img width="1379" height="927" alt="image" src="https://github.com/user-attachments/assets/2bbc1322-dbba-4e3f-b09d-7501d70377e8" />

The approach is a little different than RStudio's; since Positron doesn't have to worry about `params` conflicting between documents, it creates the `params` value in the session right after starting the session, and updates it immediately when the YAML changes, using mostly TS parsing to avoid R package dependencies. This results in a good autocomplete experience and immediate feedback when changing the params. 

Some important notes/caveats:

- This only applies to R documents, since Python document "parameters" are just a cell with a tag. The only support I can think of us offering here is automatically running this cell at startup and when the cell changes, which might not be desirable -- unlike R, you can just run the cell yourself and it gets run automatically with e.g. "run cells above". 
- This change does not implement the "Run with Parameters" UI.
- You must use inline output to have `params` populated, since the parameters are stored in the per-document kernel. 
- There is currently an issue in the R kernel which delays the update events for variables assigned or created with `evaluateCode`, so when you change params you will not see the Variables pane update right away. Inspecting the value in the Console (or just running any R code) will trigger an update. 

Fixes https://github.com/posit-dev/positron/issues/4338.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

The change includes unit and E2E tests. I've also added a Quarto document in https://github.com/posit-dev/qa-example-content/pull/129 that contains several examples of different kinds of parameters along with documentation on their expected values.

References for expected behavior and further test examples:

https://quarto.org/docs/computations/parameters.html

https://yihui.org/rmarkdown/params-knit

Test tags: `@:quarto` 