### PR TITLE
Skip Microsoft repo cleanup in postrm

### DIFF
--- a/resources/linux/debian/postrm.template
+++ b/resources/linux/debian/postrm.template
@@ -15,6 +15,12 @@ if hash update-mime-database 2>/dev/null; then
 	update-mime-database /usr/share/mime
 fi
 
+# --- Start Positron ---
+# Skip the rest of this file; it attempts to register Microsoft repositories
+# which aren't needed for Positron.
+exit 0
+# --- End Positron ---
+
 RET=true
 if [ -e '/usr/share/debconf/confmodule' ]; then
 	. /usr/share/debconf/confmodule


### PR DESCRIPTION
Fixes #13134

The Debian `postrm` maintainer script inherited from upstream VS Code removes `/etc/apt/sources.list.d/vscode.sources` and `/usr/share/keyrings/microsoft.gpg` when its package is uninstalled or upgraded. Positron does not install these files (its `postinst` already exits early before registering the Microsoft repository), but `postrm` had no matching guard, so a Positron uninstall or upgrade silently deleted a coexisting VS Code installation's APT sources.

This PR dds the same early `exit 0` guard to `postrm.template` that `postinst.template` already uses, between `# --- Start Positron ---` markers, so the Microsoft repository cleanup block never runs. I left the upstream code below the guard intact to minimize future merge conflicts.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Stop the Positron `.deb` uninstaller from removing Visual Studio Code's APT sources and signing key (#13134).

### Validation Steps

This change cannot be exercised by the e2e suite; it requires installing and removing the built `.deb` on a Debian-derivative system.

On a fresh Ubuntu/Debian/Mint VM or container:

1. Install VS Code from Microsoft's `.deb`. Confirm both files exist:
   ```
   ls /etc/apt/sources.list.d/vscode.sources /usr/share/keyrings/microsoft.gpg
   ```
2. Install the Positron `.deb` from this branch (I will link a GH action run). Re-run the `ls` above; both VS Code files should still be present.
3. `sudo apt remove positron`. Re-run the `ls`; both files should still exist.
4. `sudo apt purge positron`. Re-run the `ls`; both files should still exist.
5. `sudo apt update` should still resolve the VS Code repository without errors.
