### PR TITLE
Look for auto-closing pairs in insertions sourced as 'suggest'

### DIFF
--- a/src/vs/editor/common/cursor/cursor.ts
+++ b/src/vs/editor/common/cursor/cursor.ts
@@ -466,9 +466,15 @@ export class CursorsController extends Disposable {
 
 	public executeEdits(eventsCollector: ViewModelEventsCollector, source: string | null | undefined, edits: IIdentifiedSingleEditOperation[], cursorStateComputer: ICursorStateComputer, reason: TextModelEditSource): void {
 		let autoClosingIndices: [number, number][] | null = null;
-		if (source === 'snippet') {
+		// --- Start Positron ---
+		// `|| source === 'suggest'`: completion-driven snippet inserts arrive
+		// tagged 'suggest' (since upstream 1.102) and also need auto-closing
+		// pair detection. See https://github.com/posit-dev/positron/issues/9044.
+		if (source === 'snippet' || source === 'suggest') {
+			// if (source === 'snippet') {
 			autoClosingIndices = this._findAutoClosingPairs(edits);
 		}
+		// --- End Positron ---
 
 		if (autoClosingIndices) {
 			edits[0]._isTracked = true;

--- a/src/vs/editor/test/browser/controller/cursor.test.ts
+++ b/src/vs/editor/test/browser/controller/cursor.test.ts
@@ -5759,6 +5759,26 @@ suite('Editor Controller', () => {
 		});
 	});
 
+	// --- Start Positron ---
+	test('positron #9044 - completion-inserted `()` is tracked as auto-closed pair', () => {
+		usingCursor({
+			text: [''],
+			languageId: autoClosingLanguageId
+		}, (editor, model, viewModel) => {
+			viewModel.setSelections('test', [new Selection(1, 1, 1, 1)]);
+
+			editor.executeEdits(EditSources.suggest({ providerId: undefined }), [{
+				range: new Range(1, 1, 1, 1),
+				text: 'foo()'
+			}], [new Selection(1, 5, 1, 5)]);
+			assert.strictEqual(model.getLineContent(1), 'foo()');
+
+			editor.runCommand(CoreEditingCommands.DeleteLeft, null);
+			assert.strictEqual(model.getLineContent(1), 'foo');
+		});
+	});
+	// --- End Positron ---
+
 	test('issue #78833 - Add config to use old brackets/quotes overtyping', () => {
 		usingCursor({
 			text: [


### PR DESCRIPTION
Completions from an LSP will have 'suggest' as their source. This happened in the 1.102 merge (9ff942f0fb on 2025-07-21, which pulled in https://github.com/microsoft/vscode/pull/252666), which correlates with @DavisVaughan noticing a regression with R function completions in August 2025. Prior to that, such completions weren't equipped with a "reason", which resulted in them eventually showing up with 'snippet' as their fallback source.

Fixes #9044

Here's a demo of behaviour with this PR:


https://github.com/user-attachments/assets/92a91eba-3457-45c5-9e0a-8270f462d017

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- `()` inserted as part of a function completion, such as in `.libPaths()`, are once again treated as an auto-closing pair, i.e. backspace removes `()`, not just `(`.

### Validation Steps

Accept completion for a function, such as for `.ps.ark.version()`. Your cursor will sit inside the parentheses. Hit backspace. You should end up with `.ps.ark.version`, not `.ps.ark.version)`.
