### PR TITLE
Use platform-specific ark on macOS

### DIFF
--- a/extensions/positron-r/scripts/install-kernel.ts
+++ b/extensions/positron-r/scripts/install-kernel.ts
@@ -203,7 +203,10 @@ function getDownloadTargets(currentPlatform: NodeJS.Platform, currentArch: NodeA
 				{ assetSuffix: 'windows-x64', subdirectory: 'windows-x64', label: 'Windows x64' }
 			];
 		case 'darwin':
-			return [{ assetSuffix: 'darwin-universal', label: 'macOS Universal' }];
+			return [{
+				assetSuffix: currentArch === 'arm64' ? 'darwin-arm64' : 'darwin-x64',
+				label: currentArch === 'arm64' ? 'macOS ARM64' : 'macOS x64'
+			}];
 		case 'linux':
 			return [{
 				assetSuffix: currentArch === 'arm64' ? 'linux-arm64' : 'linux-x64',
@@ -632,7 +635,9 @@ async function main(): Promise<void> {
 	const info = await readSubmoduleBuildInfo();
 	console.log(`Ark submodule: version ${info.version}, distance ${info.distance} (${info.releaseTag})`);
 
-	const targets = getDownloadTargets(platform() as NodeJS.Platform, arch());
+	// Respect npm_config_arch when cross-building (e.g. building x64 on arm64 macOS).
+	const targetArch = (process.env.npm_config_arch as NodeArch | undefined) || arch();
+	const targets = getDownloadTargets(platform() as NodeJS.Platform, targetArch);
 
 	// In CI we require correctness: if the exact prebuild is missing, build
 	// from source. If that also fails, fail hard rather than silently using a


### PR DESCRIPTION
This change switches us from using a universal build of Ark to selecting one appropriate to the machine's architecture. This shaves ~8mb of space from the installer, reduces launch complexity, and prepares us for (eventually) dropping x64 support. 

Includes a submodule bump of Ark, so that we use a version of Ark that has architecture-specific builds.

Respects `npm_config_arch` for cross-compiling. 

Closes https://github.com/posit-dev/ark/issues/1173.
