### PR TITLE
Add text/latex MIME type rendering in notebook outputs

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -403,6 +403,10 @@ export type ParsedOutput = ParsedTextOutput |
 	content: string;
 } |
 {
+	type: 'latex';
+	content: string;
+} |
+{
 	type: 'json';
 	data: unknown;
 } |

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/notebookOutputUtils.ts
@@ -24,6 +24,8 @@ function getMimeTypePriority(mime: string): number | null {
 	switch (mime) {
 		case 'text/html':
 			return 2;
+		case 'text/latex':
+			return 2.3;
 		case 'text/markdown':
 			return 2.5;
 		case 'image/png':

--- a/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
@@ -176,6 +176,10 @@ export function parseOutputData(outputItem: IOutputItemDto): ParsedOutput {
 		return { type: 'markdown', content: message };
 	}
 
+	if (mime === 'text/latex') {
+		return { type: 'latex', content: message };
+	}
+
 	if (mime === 'image/png') {
 		return {
 			type: 'image',

--- a/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/markdownRenderer.tsx
@@ -16,10 +16,10 @@ import { MarkedKatexSupport } from '../../markdown/browser/markedKatexSupport.js
 import { getWindow } from '../../../../base/browser/dom.js';
 import { escape } from '../../../../base/common/strings.js';
 import { DeferredImage } from './notebookCells/DeferredImage.js';
+import { KatexMath } from './notebookCells/KatexMath.js';
 import { NotebookLink } from './notebookCells/NotebookLink.js';
 import { safeSetInnerHtml } from '../../../../base/browser/domSanitize.js';
 import { allowedMarkdownHtmlTags, allowedMarkdownHtmlAttributes } from '../../../../base/browser/markdownRenderer.js';
-import { importAMDNodeModule } from '../../../../amdX.js';
 import { convertDomChildrenToReact } from './domToReact.js';
 import { MarkedKatexExtension } from '../../markdown/common/markedKatexExtension.js';
 import { MarkedSuperSubExtension } from '../../markdown/common/markedSuperSubExtension.js';
@@ -76,68 +76,6 @@ function decodeHtmlEntities(text: string): string {
  */
 type ExtendedToken = marked.MarkedToken | MarkedKatexExtension.KatexToken | MarkedSuperSubExtension.SuperSubToken | MarkedFootnoteExtension.FootnoteToken;
 
-/**
- * Component that renders LaTeX expressions.
- *
- * Since rendering LaTeX to HTML requires KaTeX which produces
- * HTML/MathML/SVG, we need to use safeSetInnerHtml to render it
- * which will parse the HTML string into the DOM.
- *
- * @param latex The raw LaTeX string to render
- * @param displayMode Whether to render in display mode block or inline mode (default)
- * @returns React element containing the rendered math
- */
-function KatexMath({ latex, displayMode }: { latex: string; displayMode?: boolean }) {
-	const containerRef = React.useRef<HTMLSpanElement | HTMLDivElement>(null);
-
-	React.useEffect(() => {
-		const container = containerRef.current;
-		if (!container) {
-			return;
-		}
-
-		let cancelled = false;
-
-		// Load KaTeX dynamically using AMD module loader
-		importAMDNodeModule<typeof import('katex').default>('katex', 'dist/katex.min.js').then(katex => {
-			if (cancelled) {
-				return;
-			}
-
-			try {
-				// convert the raw latex into HTML/MathML/SVG
-				const html = katex.renderToString(latex, {
-					throwOnError: false,
-					displayMode: displayMode || false
-				});
-				const sanitizerConfig = MarkedKatexSupport.getSanitizerOptions({
-					allowedTags: allowedMarkdownHtmlTags,
-					allowedAttributes: allowedMarkdownHtmlAttributes,
-				});
-				// Parse the HTML into the container element safely
-				safeSetInnerHtml(container, html, sanitizerConfig);
-			} catch (e) {
-				container.textContent = latex; // Fallback to raw LaTeX on error
-			}
-		}).catch((err) => {
-			if (!cancelled) {
-				if (container) {
-					container.textContent = latex; // Fallback to raw LaTeX on error
-				}
-			}
-		});
-
-		return () => {
-			cancelled = true;
-		};
-	}, [latex, displayMode]);
-
-	// KaTeX will populate this container with its rendered output
-	if (displayMode) {
-		return <div ref={containerRef as React.RefObject<HTMLDivElement>} className='katex-block' />;
-	}
-	return <span ref={containerRef as React.RefObject<HTMLSpanElement>} className='katex-inline' />;
-}
 
 /**
  * Component that renders syntax-highlighted code blocks.

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/KatexMath.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/KatexMath.tsx
@@ -12,44 +12,59 @@ import { safeSetInnerHtml } from '../../../../../base/browser/domSanitize.js';
 import { allowedMarkdownHtmlTags, allowedMarkdownHtmlAttributes } from '../../../../../base/browser/markdownRenderer.js';
 import { MarkedKatexSupport } from '../../../markdown/browser/markedKatexSupport.js';
 
+type KatexModule = typeof import('katex').default;
+
+let cachedKatex: KatexModule | undefined;
+let katexPromise: Promise<KatexModule> | undefined;
+
+function getKatex(): Promise<KatexModule> {
+	if (!katexPromise) {
+		katexPromise = importAMDNodeModule<KatexModule>('katex', 'dist/katex.min.js')
+			.then(k => { cachedKatex = k; return k; });
+	}
+	return katexPromise;
+}
+
+function renderLatex(container: HTMLElement, katex: KatexModule, latex: string, displayMode?: boolean): void {
+	try {
+		const html = katex.renderToString(latex, {
+			throwOnError: false,
+			displayMode: displayMode || false
+		});
+		const sanitizerConfig = MarkedKatexSupport.getSanitizerOptions({
+			allowedTags: allowedMarkdownHtmlTags,
+			allowedAttributes: allowedMarkdownHtmlAttributes,
+		});
+		safeSetInnerHtml(container, html, sanitizerConfig);
+	} catch {
+		container.textContent = latex;
+	}
+}
+
 /**
  * Component that renders LaTeX expressions using KaTeX.
  *
- * Loads KaTeX dynamically, renders the LaTeX string to HTML/MathML/SVG,
- * then sanitizes and injects it into the container element.
- * Falls back to displaying the raw LaTeX text on error.
- *
- * @param latex The raw LaTeX string to render
- * @param displayMode Whether to render in display mode (block) or inline mode (default)
+ * Uses a module-level cache so that after the initial async load, all
+ * subsequent renders are synchronous (no empty-frame flicker).
  */
 export function KatexMath({ latex, displayMode }: { latex: string; displayMode?: boolean }) {
 	const containerRef = React.useRef<HTMLSpanElement | HTMLDivElement>(null);
 
-	React.useEffect(() => {
+	React.useLayoutEffect(() => {
 		const container = containerRef.current;
 		if (!container) {
 			return;
 		}
 
+		if (cachedKatex) {
+			renderLatex(container, cachedKatex, latex, displayMode);
+			return;
+		}
+
 		let cancelled = false;
-
-		importAMDNodeModule<typeof import('katex').default>('katex', 'dist/katex.min.js').then(katex => {
-			if (cancelled) {
-				return;
-			}
-
-			try {
-				const html = katex.renderToString(latex, {
-					throwOnError: false,
-					displayMode: displayMode || false
-				});
-				const sanitizerConfig = MarkedKatexSupport.getSanitizerOptions({
-					allowedTags: allowedMarkdownHtmlTags,
-					allowedAttributes: allowedMarkdownHtmlAttributes,
-				});
-				safeSetInnerHtml(container, html, sanitizerConfig);
-			} catch {
-				container.textContent = latex;
+		getKatex().then(katex => {
+			if (!cancelled) {
+				renderLatex(container, katex, latex, displayMode);
 			}
 		}).catch(() => {
 			if (!cancelled && container) {
@@ -57,9 +72,7 @@ export function KatexMath({ latex, displayMode }: { latex: string; displayMode?:
 			}
 		});
 
-		return () => {
-			cancelled = true;
-		};
+		return () => { cancelled = true; };
 	}, [latex, displayMode]);
 
 	if (displayMode) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/KatexMath.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/KatexMath.tsx
@@ -11,6 +11,7 @@ import { importAMDNodeModule } from '../../../../../amdX.js';
 import { safeSetInnerHtml } from '../../../../../base/browser/domSanitize.js';
 import { allowedMarkdownHtmlTags, allowedMarkdownHtmlAttributes } from '../../../../../base/browser/markdownRenderer.js';
 import { MarkedKatexSupport } from '../../../markdown/browser/markedKatexSupport.js';
+import { getWindow } from '../../../../../base/browser/dom.js';
 
 type KatexModule = typeof import('katex').default;
 
@@ -55,6 +56,8 @@ export function KatexMath({ latex, displayMode }: { latex: string; displayMode?:
 		if (!container) {
 			return;
 		}
+
+		MarkedKatexSupport.ensureKatexStyles(getWindow(container));
 
 		if (cachedKatex) {
 			renderLatex(container, cachedKatex, latex, displayMode);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/KatexMath.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/KatexMath.tsx
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// React.
+import React from 'react';
+
+// Other dependencies.
+import { importAMDNodeModule } from '../../../../../amdX.js';
+import { safeSetInnerHtml } from '../../../../../base/browser/domSanitize.js';
+import { allowedMarkdownHtmlTags, allowedMarkdownHtmlAttributes } from '../../../../../base/browser/markdownRenderer.js';
+import { MarkedKatexSupport } from '../../../markdown/browser/markedKatexSupport.js';
+
+/**
+ * Component that renders LaTeX expressions using KaTeX.
+ *
+ * Loads KaTeX dynamically, renders the LaTeX string to HTML/MathML/SVG,
+ * then sanitizes and injects it into the container element.
+ * Falls back to displaying the raw LaTeX text on error.
+ *
+ * @param latex The raw LaTeX string to render
+ * @param displayMode Whether to render in display mode (block) or inline mode (default)
+ */
+export function KatexMath({ latex, displayMode }: { latex: string; displayMode?: boolean }) {
+	const containerRef = React.useRef<HTMLSpanElement | HTMLDivElement>(null);
+
+	React.useEffect(() => {
+		const container = containerRef.current;
+		if (!container) {
+			return;
+		}
+
+		let cancelled = false;
+
+		importAMDNodeModule<typeof import('katex').default>('katex', 'dist/katex.min.js').then(katex => {
+			if (cancelled) {
+				return;
+			}
+
+			try {
+				const html = katex.renderToString(latex, {
+					throwOnError: false,
+					displayMode: displayMode || false
+				});
+				const sanitizerConfig = MarkedKatexSupport.getSanitizerOptions({
+					allowedTags: allowedMarkdownHtmlTags,
+					allowedAttributes: allowedMarkdownHtmlAttributes,
+				});
+				safeSetInnerHtml(container, html, sanitizerConfig);
+			} catch {
+				container.textContent = latex;
+			}
+		}).catch(() => {
+			if (!cancelled && container) {
+				container.textContent = latex;
+			}
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [latex, displayMode]);
+
+	if (displayMode) {
+		return <div ref={containerRef as React.RefObject<HTMLDivElement>} className='katex-block' />;
+	}
+	return <span ref={containerRef as React.RefObject<HTMLSpanElement>} className='katex-inline' />;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/LatexOutput.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/LatexOutput.css
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.positron-notebook-latex-output {
+	padding: 4px 0;
+	overflow-x: auto;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/LatexOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/LatexOutput.tsx
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './LatexOutput.css';
+
+// React.
+import React from 'react';
+
+// Other dependencies.
+import { importAMDNodeModule } from '../../../../../amdX.js';
+import { getWindow } from '../../../../../base/browser/dom.js';
+import { safeSetInnerHtml } from '../../../../../base/browser/domSanitize.js';
+import { allowedMarkdownHtmlTags, allowedMarkdownHtmlAttributes } from '../../../../../base/browser/markdownRenderer.js';
+import { MarkedKatexSupport } from '../../../markdown/browser/markedKatexSupport.js';
+import { normalizeLatex } from './normalizeLatex.js';
+
+/**
+ * Renders `text/latex` MIME output using KaTeX.
+ *
+ * Strips math-mode delimiters (since the MIME type already signals the content
+ * is LaTeX) and renders in display mode (block-level math).
+ */
+export function LatexOutput({ content }: { content: string }) {
+	const containerRef = React.useRef<HTMLDivElement>(null);
+
+	React.useEffect(() => {
+		const container = containerRef.current;
+		if (!container) {
+			return;
+		}
+
+		let cancelled = false;
+
+		const latex = normalizeLatex(content);
+
+		MarkedKatexSupport.ensureKatexStyles(getWindow(container));
+
+		importAMDNodeModule<typeof import('katex').default>('katex', 'dist/katex.min.js').then(katex => {
+			if (cancelled) {
+				return;
+			}
+
+			try {
+				const html = katex.renderToString(latex, {
+					throwOnError: false,
+					displayMode: true,
+				});
+				const sanitizerConfig = MarkedKatexSupport.getSanitizerOptions({
+					allowedTags: allowedMarkdownHtmlTags,
+					allowedAttributes: allowedMarkdownHtmlAttributes,
+				});
+				safeSetInnerHtml(container, html, sanitizerConfig);
+			} catch {
+				container.textContent = content;
+			}
+		}).catch(() => {
+			if (!cancelled && container) {
+				container.textContent = content;
+			}
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [content]);
+
+	return <div ref={containerRef} className='positron-notebook-latex-output' />;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/LatexOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/LatexOutput.tsx
@@ -10,8 +10,6 @@ import './LatexOutput.css';
 import React from 'react';
 
 // Other dependencies.
-import { getWindow } from '../../../../../base/browser/dom.js';
-import { MarkedKatexSupport } from '../../../markdown/browser/markedKatexSupport.js';
 import { KatexMath } from './KatexMath.js';
 import { normalizeLatex } from './normalizeLatex.js';
 
@@ -22,18 +20,10 @@ import { normalizeLatex } from './normalizeLatex.js';
  * is LaTeX) and renders in display mode (block-level math).
  */
 export function LatexOutput({ content }: { content: string }) {
-	const containerRef = React.useRef<HTMLDivElement>(null);
-
-	React.useEffect(() => {
-		if (containerRef.current) {
-			MarkedKatexSupport.ensureKatexStyles(getWindow(containerRef.current));
-		}
-	}, []);
-
 	const latex = React.useMemo(() => normalizeLatex(content), [content]);
 
 	return (
-		<div ref={containerRef} className='positron-notebook-latex-output'>
+		<div className='positron-notebook-latex-output'>
 			<KatexMath displayMode latex={latex} />
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/LatexOutput.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/LatexOutput.tsx
@@ -10,11 +10,9 @@ import './LatexOutput.css';
 import React from 'react';
 
 // Other dependencies.
-import { importAMDNodeModule } from '../../../../../amdX.js';
 import { getWindow } from '../../../../../base/browser/dom.js';
-import { safeSetInnerHtml } from '../../../../../base/browser/domSanitize.js';
-import { allowedMarkdownHtmlTags, allowedMarkdownHtmlAttributes } from '../../../../../base/browser/markdownRenderer.js';
 import { MarkedKatexSupport } from '../../../markdown/browser/markedKatexSupport.js';
+import { KatexMath } from './KatexMath.js';
 import { normalizeLatex } from './normalizeLatex.js';
 
 /**
@@ -27,45 +25,16 @@ export function LatexOutput({ content }: { content: string }) {
 	const containerRef = React.useRef<HTMLDivElement>(null);
 
 	React.useEffect(() => {
-		const container = containerRef.current;
-		if (!container) {
-			return;
+		if (containerRef.current) {
+			MarkedKatexSupport.ensureKatexStyles(getWindow(containerRef.current));
 		}
+	}, []);
 
-		let cancelled = false;
+	const latex = React.useMemo(() => normalizeLatex(content), [content]);
 
-		const latex = normalizeLatex(content);
-
-		MarkedKatexSupport.ensureKatexStyles(getWindow(container));
-
-		importAMDNodeModule<typeof import('katex').default>('katex', 'dist/katex.min.js').then(katex => {
-			if (cancelled) {
-				return;
-			}
-
-			try {
-				const html = katex.renderToString(latex, {
-					throwOnError: false,
-					displayMode: true,
-				});
-				const sanitizerConfig = MarkedKatexSupport.getSanitizerOptions({
-					allowedTags: allowedMarkdownHtmlTags,
-					allowedAttributes: allowedMarkdownHtmlAttributes,
-				});
-				safeSetInnerHtml(container, html, sanitizerConfig);
-			} catch {
-				container.textContent = content;
-			}
-		}).catch(() => {
-			if (!cancelled && container) {
-				container.textContent = content;
-			}
-		});
-
-		return () => {
-			cancelled = true;
-		};
-	}, [content]);
-
-	return <div ref={containerRef} className='positron-notebook-latex-output' />;
+	return (
+		<div ref={containerRef} className='positron-notebook-latex-output'>
+			<KatexMath displayMode latex={latex} />
+		</div>
+	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -29,6 +29,7 @@ import { getActiveWindow, isHTMLElement } from '../../../../../base/browser/dom.
 import { IAction, Separator } from '../../../../../base/common/actions.js';
 import { renderHtml } from '../../../../../base/browser/positron/renderHtml.js';
 import { Markdown } from './Markdown.js';
+import { LatexOutput } from './LatexOutput.js';
 import { useCellContextMenu } from './useCellContextMenu.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
 import { DataExplorerCellOutput } from './DataExplorerCellOutput.js';
@@ -348,6 +349,8 @@ const CellOutput = React.memo(function CellOutput(output: CellOutputProps) {
 			return renderHtml(parsed.content);
 		case 'markdown':
 			return <Markdown content={parsed.content} />;
+		case 'latex':
+			return <LatexOutput content={parsed.content} />;
 		case 'json':
 			return <JsonOutput data={parsed.data} outputId={output.outputId} />;
 		case 'dataExplorer':

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/normalizeLatex.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/normalizeLatex.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Normalizes LaTeX content from `text/latex` MIME outputs for direct KaTeX rendering.
+ *
+ * Content from `text/latex` MIME may arrive with various delimiter styles depending on source:
+ * - IPython.display.Math: wraps in `$...$` or `\(...\)`
+ * - IPython.display.Latex: raw LaTeX environments like `\begin{align}...`
+ * - Raw mimebundles: arbitrary combinations including `$...$` fragments
+ *
+ * Since the MIME type already signals the content is LaTeX, all `$` delimiter pairs are
+ * redundant. KaTeX cannot parse `$` in math mode, so we strip them.
+ */
+export function normalizeLatex(content: string): string {
+	const trimmed = content.trim();
+
+	// Strip outer \[...\] (display math)
+	if (trimmed.startsWith('\\[') && trimmed.endsWith('\\]')) {
+		return trimmed.slice(2, -2).trim();
+	}
+
+	// Strip outer \(...\) (inline math)
+	if (trimmed.startsWith('\\(') && trimmed.endsWith('\\)')) {
+		return trimmed.slice(2, -2).trim();
+	}
+
+	// Strip all $ delimiters (both $...$ and $$...$$) since the MIME type
+	// already establishes math context. KaTeX errors on literal $ in math mode.
+	return trimmed.replace(/\${1,2}/g, '').trim();
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/normalizeLatex.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/normalizeLatex.ts
@@ -27,7 +27,8 @@ export function normalizeLatex(content: string): string {
 		return trimmed.slice(2, -2).trim();
 	}
 
-	// Strip all $ delimiters (both $...$ and $$...$$) since the MIME type
+	// Strip unescaped $ delimiters (both $...$ and $$...$$) since the MIME type
 	// already establishes math context. KaTeX errors on literal $ in math mode.
-	return trimmed.replace(/\${1,2}/g, '').trim();
+	// Preserve escaped \$ which represents a literal dollar sign in LaTeX.
+	return trimmed.replace(/(?<!\\)\${1,2}/g, '').trim();
 }

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/normalizeLatex.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/normalizeLatex.vitest.ts
@@ -43,6 +43,14 @@ describe('normalizeLatex', () => {
 			.toBe('\\displaystyle \\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}');
 	});
 
+	it('preserves escaped \\$ (literal dollar signs)', () => {
+		expect(normalizeLatex('\\$5 + \\$10 = \\$15')).toBe('\\$5 + \\$10 = \\$15');
+	});
+
+	it('strips unescaped $ but preserves escaped \\$ in mixed content', () => {
+		expect(normalizeLatex('$\\text{costs \\$5}$')).toBe('\\text{costs \\$5}');
+	});
+
 	it('handles empty content', () => {
 		expect(normalizeLatex('')).toBe('');
 	});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/normalizeLatex.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/normalizeLatex.vitest.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { normalizeLatex } from '../../browser/notebookCells/normalizeLatex.js';
+
+describe('normalizeLatex', () => {
+	it('strips outer $...$ delimiters', () => {
+		expect(normalizeLatex('$E = mc^2$')).toBe('E = mc^2');
+	});
+
+	it('strips outer $$...$$ delimiters', () => {
+		expect(normalizeLatex('$$\\int_0^1 x\\,dx$$')).toBe('\\int_0^1 x\\,dx');
+	});
+
+	it('strips outer \\(...\\) delimiters', () => {
+		expect(normalizeLatex('\\(E = mc^2\\)')).toBe('E = mc^2');
+	});
+
+	it('strips outer \\[...\\] delimiters', () => {
+		expect(normalizeLatex('\\[\\sum_{i=1}^n i\\]')).toBe('\\sum_{i=1}^n i');
+	});
+
+	it('trims whitespace around content', () => {
+		expect(normalizeLatex('  $$ x^2 $$  ')).toBe('x^2');
+	});
+
+	it('preserves raw LaTeX environments without delimiters', () => {
+		const env = '\\begin{align}\na &= b \\\\\nc &= d\n\\end{align}';
+		expect(normalizeLatex(env)).toBe(env.trim());
+	});
+
+	it('strips embedded $ delimiters from mimebundle content', () => {
+		expect(normalizeLatex('$E = mc^2$ \\quad \\Rightarrow \\quad m = \\frac{E}{c^2}'))
+			.toBe('E = mc^2 \\quad \\Rightarrow \\quad m = \\frac{E}{c^2}');
+	});
+
+	it('handles IPython.display.Math output (\\displaystyle with single $)', () => {
+		expect(normalizeLatex('$\\displaystyle \\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}$'))
+			.toBe('\\displaystyle \\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}');
+	});
+
+	it('handles empty content', () => {
+		expect(normalizeLatex('')).toBe('');
+	});
+
+	it('handles whitespace-only content', () => {
+		expect(normalizeLatex('   ')).toBe('');
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/latexOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/latexOutput.vitest.tsx
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen } from '@testing-library/react';
+import { setupRTLRenderer } from '../../../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../../../test/vitest/positronTestContainer.js';
+import { LatexOutput } from '../../../browser/notebookCells/LatexOutput.js';
+
+vi.mock('../../../../../../amdX.js', () => ({
+	importAMDNodeModule: vi.fn().mockResolvedValue({
+		renderToString: (latex: string, opts: { displayMode: boolean; throwOnError: boolean }) => {
+			return `<span class="katex">${latex}</span>`;
+		}
+	}),
+	resolveAmdNodeModulePath: vi.fn().mockReturnValue(''),
+}));
+
+vi.mock('../../../../markdown/browser/markedKatexSupport.js', () => ({
+	MarkedKatexSupport: {
+		ensureKatexStyles: vi.fn(),
+		getSanitizerOptions: () => ({
+			allowedTags: { override: [] },
+			allowedAttributes: { override: [] },
+		}),
+	}
+}));
+
+describe('LatexOutput', () => {
+	const ctx = createTestContainer()
+		.withReactServices()
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	it('renders a container with the latex-output class', () => {
+		const { container } = rtl.render(<LatexOutput content='E = mc^2' />);
+		// eslint-disable-next-line no-restricted-syntax
+		expect(container.querySelector('.positron-notebook-latex-output')).toBeInTheDocument();
+	});
+
+	it('renders KaTeX content after async load', async () => {
+		rtl.render(<LatexOutput content='$E = mc^2$' />);
+		const output = await screen.findByText('E = mc^2');
+		expect(output).toBeInTheDocument();
+	});
+
+	it('renders raw LaTeX environments', async () => {
+		const latex = '\\begin{align} a &= b \\end{align}';
+		rtl.render(<LatexOutput content={latex} />);
+		const output = await screen.findByText(latex);
+		expect(output).toBeInTheDocument();
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputUtils.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputUtils.vitest.ts
@@ -71,6 +71,17 @@ describe('Notebook Output Utils', () => {
 				expect(result.content).toBe('stack trace');
 			}
 		});
+
+		it('parses text/latex as latex output', () => {
+			const latex = '\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}';
+			const result = parseOutputData(makeOutputItem('text/latex', latex));
+			expect(result).toEqual({ type: 'latex', content: latex });
+		});
+
+		it('parses text/markdown as markdown output', () => {
+			const result = parseOutputData(makeOutputItem('text/markdown', '# Hello'));
+			expect(result).toEqual({ type: 'markdown', content: '# Hello' });
+		});
 	});
 
 	it('pickPreferredOutputItem: prefers image/svg+xml over text/plain', () => {
@@ -81,6 +92,26 @@ describe('Notebook Output Utils', () => {
 
 		const preferred = pickPreferredOutputItem(items);
 		expect(preferred?.mime).toBe('image/svg+xml');
+	});
+
+	it('pickPreferredOutputItem: prefers text/latex over text/plain', () => {
+		const items = [
+			makeOutputItem('text/plain', 'E = mc^2'),
+			makeOutputItem('text/latex', '$E = mc^2$'),
+		];
+
+		const preferred = pickPreferredOutputItem(items);
+		expect(preferred?.mime).toBe('text/latex');
+	});
+
+	it('pickPreferredOutputItem: prefers text/latex over text/markdown', () => {
+		const items = [
+			makeOutputItem('text/markdown', '# Math'),
+			makeOutputItem('text/latex', '$E = mc^2$'),
+		];
+
+		const preferred = pickPreferredOutputItem(items);
+		expect(preferred?.mime).toBe('text/latex');
 	});
 
 	describe('parseOutputData: data explorer MIME type', () => {


### PR DESCRIPTION
## Summary

Closes #12687

Adds rendering support for the `text/latex` MIME type in Positron notebook cell outputs, enabling display of mathematical notation from `IPython.display.Math`, `IPython.display.Latex`, and raw mimebundles.

- Parses `text/latex` MIME outputs and routes them through a dedicated `LatexOutput` component
- Renders LaTeX using the existing KaTeX infrastructure (shared `KatexMath` component extracted from the markdown renderer)
- Normalizes delimiter styles (`$`, `$$`, `\(...\)`, `\[...\]`) since the MIME type already signals math context
- Prioritizes `text/latex` above `text/markdown` but below `text/html` in output selection

## Screenshots

### Before

<img width="631" height="552" alt="image" src="https://github.com/user-attachments/assets/63cf3387-19fb-4aa0-b081-4b7184be06bc" />

### After

<img width="841" height="787" alt="image" src="https://github.com/user-attachments/assets/9077d632-2f00-4534-b97e-6b39e70b43db" />

## Test plan

- [x] Unit tests for `normalizeLatex` covering all delimiter styles, escaped `\$`, and raw environments
- [x] Component tests for `LatexOutput` verifying container rendering and KaTeX integration
- [x] Integration tests for `parseOutputData` and `pickPreferredOutputItem` with `text/latex`
- [x] Existing markdown renderer tests still pass (shared `KatexMath` extraction)
- [ ] Manual: run the Python cell from the issue (`IPython.display.Math`, `Latex`, raw mimebundle) and verify rendered output