### PR TITLE
Fix EXTENSIONS_GALLERY override

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryManifestService.ts
@@ -43,6 +43,25 @@ export const POSITRON_GALLERY_PRESETS: Record<string, ExtensionGalleryConfig> = 
 	},
 };
 
+/**
+ * Resolves the gallery config to use, applying the Positron precedence:
+ * a successfully-parsed EXTENSIONS_GALLERY env var wins over the
+ * `positron.extensions.gallerySource` setting, which wins over the default
+ * product gallery. An env var that failed to parse should be passed as
+ * undefined so the caller falls through to the preset.
+ */
+export function resolvePositronGalleryConfig(
+	envGallery: ExtensionGalleryConfig | undefined,
+	gallerySource: string | undefined,
+	productGallery: ExtensionGalleryConfig | undefined,
+): ExtensionGalleryConfig | undefined {
+	if (envGallery) {
+		return envGallery;
+	}
+	const preset = gallerySource ? POSITRON_GALLERY_PRESETS[gallerySource] : undefined;
+	return preset ?? productGallery;
+}
+
 // --- End Positron ---
 
 export class ExtensionGalleryManifestService extends Disposable implements IExtensionGalleryManifestService {

--- a/src/vs/platform/extensionManagement/common/extensionsGalleryEnv.ts
+++ b/src/vs/platform/extensionManagement/common/extensionsGalleryEnv.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Type-only import: erased at runtime so this module stays a leaf and can be
+// safely imported from product.ts (which loads before the extension management
+// Registry contributions are wired up). See extensionManagement.ts:719 — that
+// file runs Registry side-effects at module load, so any runtime import chain
+// from product.ts into it would crash startup.
+import type { IProductConfiguration } from '../../../base/common/product.js';
+
+/**
+ * Parses the EXTENSIONS_GALLERY env var into an extensions-gallery config.
+ * Returns undefined if the value is not valid JSON, so a malformed env var is
+ * ignored rather than crashing startup. The caller should fall back to the
+ * default product gallery when undefined is returned.
+ *
+ * Pass `warn` to route the failure message somewhere persistent (e.g. an
+ * ILogService). The default writes to console.warn — appropriate for product.ts
+ * at module-load time when no logger is wired up yet, but invisible in the log
+ * file. Workbench-stage callers should pass `msg => logService.warn(msg)`.
+ *
+ * The generic parameter lets downstream forks specialize the return type with
+ * a wider gallery shape (e.g. one that includes itemUrl/publisherUrl) without
+ * this leaf module needing to know about those fields.
+ */
+export function parseExtensionsGalleryEnv<T = NonNullable<IProductConfiguration['extensionsGallery']>>(
+	envValue: string,
+	warn: (message: string) => void = msg => console.warn(msg),
+): T | undefined {
+	try {
+		return JSON.parse(envValue) as T;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		warn(`Ignoring EXTENSIONS_GALLERY env var: not valid JSON (${message}).`);
+		return undefined;
+	}
+}

--- a/src/vs/platform/extensionManagement/test/common/positronGalleryManifestService.vitest.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronGalleryManifestService.vitest.ts
@@ -5,7 +5,8 @@
 
 /// <reference types="vitest/globals" />
 
-import { ExtensionGalleryManifestService, ExtensionGalleryConfig, POSITRON_GALLERY_PRESETS } from '../../common/extensionGalleryManifestService.js';
+import { ExtensionGalleryManifestService, ExtensionGalleryConfig, POSITRON_GALLERY_PRESETS, resolvePositronGalleryConfig } from '../../common/extensionGalleryManifestService.js';
+import { parseExtensionsGalleryEnv } from '../../common/extensionsGalleryEnv.js';
 import { ExtensionGalleryResourceType, getExtensionGalleryManifestResourceUri } from '../../common/extensionGalleryManifest.js';
 import { IProductService } from '../../../product/common/productService.js';
 
@@ -146,5 +147,118 @@ describe('ExtensionGalleryManifestService', () => {
 	it('should report Unavailable status when gallery is not configured', () => {
 		const service = new ExtensionGalleryManifestService(createProductService());
 		expect(service.extensionGalleryManifestStatus).toBe('unavailable');
+	});
+});
+
+describe('resolvePositronGalleryConfig', () => {
+
+	const productGallery: ExtensionGalleryConfig = {
+		serviceUrl: 'https://product.example.com/gallery',
+		itemUrl: 'https://product.example.com/item',
+		resourceUrlTemplate: '',
+		controlUrl: '',
+		extensionUrlTemplate: '',
+		nlsBaseUrl: '',
+		publisherUrl: '',
+	};
+
+	it('returns the parsed env gallery, ignoring gallerySource', () => {
+		const envGallery: ExtensionGalleryConfig = {
+			...productGallery,
+			serviceUrl: 'https://override.example.com/gallery',
+		};
+		const result = resolvePositronGalleryConfig(envGallery, 'open-vsx', productGallery);
+		expect(result).toBe(envGallery);
+		expect(result?.serviceUrl).toBe('https://override.example.com/gallery');
+		expect(result?.serviceUrl).not.toBe(POSITRON_GALLERY_PRESETS['open-vsx'].serviceUrl);
+	});
+
+	it('returns the parsed env gallery even with no gallerySource', () => {
+		const envGallery: ExtensionGalleryConfig = {
+			...productGallery,
+			serviceUrl: 'https://override.example.com/gallery',
+		};
+		const result = resolvePositronGalleryConfig(envGallery, undefined, productGallery);
+		expect(result).toBe(envGallery);
+	});
+
+	it('falls through to the gallerySource preset when env is undefined (parse failed or env unset)', () => {
+		// Passing undefined is how the caller signals "env was not usable" — either
+		// it wasn't set, or it was set but parseExtensionsGalleryEnv returned undefined
+		// because the value was not valid JSON. In both cases the preset wins.
+		expect(resolvePositronGalleryConfig(undefined, 'open-vsx', productGallery)).toBe(POSITRON_GALLERY_PRESETS['open-vsx']);
+		expect(resolvePositronGalleryConfig(undefined, 'posit-p3m', productGallery)).toBe(POSITRON_GALLERY_PRESETS['posit-p3m']);
+	});
+
+	it('returns the product gallery when env is undefined and gallerySource is unset or unknown', () => {
+		expect(resolvePositronGalleryConfig(undefined, undefined, productGallery)).toBe(productGallery);
+		expect(resolvePositronGalleryConfig(undefined, '', productGallery)).toBe(productGallery);
+		expect(resolvePositronGalleryConfig(undefined, 'not-a-preset', productGallery)).toBe(productGallery);
+	});
+
+	it('returns undefined when env is undefined and the product gallery is unset', () => {
+		expect(resolvePositronGalleryConfig(undefined, undefined, undefined)).toBeUndefined();
+	});
+});
+
+describe('parseExtensionsGalleryEnv', () => {
+
+	// Invalid JSON is ignored (returns undefined, logs a warning) so a
+	// malformed EXTENSIONS_GALLERY env var doesn't crash startup. product.ts
+	// then falls back to the default product gallery.
+
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+	});
+
+	it('parses a properly-quoted JSON value into an ExtensionGalleryConfig', () => {
+		const valid = JSON.stringify({
+			serviceUrl: 'https://open-vsx.org/vscode/gallery',
+			itemUrl: 'https://open-vsx.org/vscode/item',
+			resourceUrlTemplate: '',
+			controlUrl: '',
+			extensionUrlTemplate: '',
+			nlsBaseUrl: '',
+			publisherUrl: '',
+		});
+		const parsed = parseExtensionsGalleryEnv<ExtensionGalleryConfig>(valid);
+		expect(parsed?.serviceUrl).toBe('https://open-vsx.org/vscode/gallery');
+		expect(parsed?.itemUrl).toBe('https://open-vsx.org/vscode/item');
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it('returns undefined and warns on object literal with unquoted keys / single-quoted strings', () => {
+		// This is the kind of value that was previously in .vscode/launch.json:
+		// JS object literal syntax, not JSON.
+		const malformed = `{serviceUrl: 'https://open-vsx.org/vscode/gallery'}`;
+		expect(parseExtensionsGalleryEnv(malformed)).toBeUndefined();
+		expect(warnSpy).toHaveBeenCalledOnce();
+	});
+
+	it('returns undefined and warns on truncated JSON', () => {
+		const truncated = '{"serviceUrl": "https://open-vsx';
+		expect(parseExtensionsGalleryEnv(truncated)).toBeUndefined();
+		expect(warnSpy).toHaveBeenCalledOnce();
+	});
+
+	it('returns undefined and warns on the empty string', () => {
+		// product.ts guards on truthiness before calling this, so '' is unreachable
+		// in practice. The helper still handles it defensively.
+		expect(parseExtensionsGalleryEnv('')).toBeUndefined();
+		expect(warnSpy).toHaveBeenCalledOnce();
+	});
+
+	it('routes the failure message through the optional warn callback instead of console.warn', () => {
+		// Workbench-stage callers pass `msg => logService.warn(msg)` so the warning
+		// persists to the log file. Verify the callback receives the message and
+		// console.warn is left untouched.
+		const customWarn = vi.fn();
+		const result = parseExtensionsGalleryEnv('not json', customWarn);
+		expect(result).toBeUndefined();
+		expect(customWarn).toHaveBeenCalledOnce();
+		expect(customWarn.mock.calls[0][0]).toMatch(/Ignoring EXTENSIONS_GALLERY env var: not valid JSON/);
+		expect(warnSpy).not.toHaveBeenCalled();
 	});
 });

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -6,6 +6,13 @@
 import { env } from '../../../base/common/process.js';
 import { IProductConfiguration } from '../../../base/common/product.js';
 import { ISandboxConfiguration } from '../../../base/parts/sandbox/common/sandboxTypes.js';
+// --- Start PWB ---
+// Import from extensionsGalleryEnv.js (leaf module) rather than
+// extensionGalleryManifestService.js: the latter transitively pulls in
+// extensionManagement.ts, which runs Registry contributions at module load
+// before the Registry is ready, crashing startup with a ReferenceError.
+import { parseExtensionsGalleryEnv } from '../../extensionManagement/common/extensionsGalleryEnv.js';
+// --- End PWB ---
 
 /**
  * @deprecated It is preferred that you use `IProductService` if you can. This
@@ -50,13 +57,14 @@ else if (globalThis._VSCODE_PRODUCT_JSON && globalThis._VSCODE_PACKAGE_JSON) {
 		});
 	}
 
-	// --- Start PWB: Custom extensions gallery
+	// --- Start PWB: Custom extensions gallery ---
 	if (env['EXTENSIONS_GALLERY']) {
-		Object.assign(product, {
-			extensionsGallery: JSON.parse(env['EXTENSIONS_GALLERY'])
-		});
+		const extensionsGallery = parseExtensionsGalleryEnv(env['EXTENSIONS_GALLERY']);
+		if (extensionsGallery) {
+			Object.assign(product, { extensionsGallery });
+		}
 	}
-	// --- End PWB: Custom extensions gallery
+	// --- End PWB: Custom extensions gallery ---
 }
 
 // Web environment or unknown

--- a/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
+++ b/src/vs/workbench/services/extensionManagement/electron-browser/extensionGalleryManifestService.ts
@@ -27,10 +27,12 @@ import { IHostService } from '../../host/browser/host.js';
 import { IDefaultAccount } from '../../../../base/common/defaultAccount.js';
 
 // --- Start Positron ---
+import { env } from '../../../../base/common/process.js';
 // eslint-disable-next-line no-duplicate-imports
 import { PositronGallerySourceConfigKey } from '../../../../platform/extensionManagement/common/extensionGalleryManifest.js';
 // eslint-disable-next-line no-duplicate-imports
-import { ExtensionGalleryConfig, POSITRON_GALLERY_PRESETS } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
+import { ExtensionGalleryConfig, resolvePositronGalleryConfig } from '../../../../platform/extensionManagement/common/extensionGalleryManifestService.js';
+import { parseExtensionsGalleryEnv } from '../../../../platform/extensionManagement/common/extensionsGalleryEnv.js';
 // --- End Positron ---
 
 export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryManifestService implements IExtensionGalleryManifestService {
@@ -83,12 +85,15 @@ export class WorkbenchExtensionGalleryManifestService extends ExtensionGalleryMa
 
 	// --- Start Positron ---
 	protected override getGalleryConfig(): ExtensionGalleryConfig | undefined {
-		const source = this.configurationService.getValue<string>(PositronGallerySourceConfigKey);
-		const preset = POSITRON_GALLERY_PRESETS[source];
-		if (preset) {
-			return preset;
-		}
-		return super.getGalleryConfig();
+		const envValue = env['EXTENSIONS_GALLERY'];
+		const envGallery = envValue
+			? parseExtensionsGalleryEnv<ExtensionGalleryConfig>(envValue, msg => this.logService.warn(msg))
+			: undefined;
+		return resolvePositronGalleryConfig(
+			envGallery,
+			this.configurationService.getValue<string>(PositronGallerySourceConfigKey),
+			super.getGalleryConfig(),
+		);
 	}
 	// --- End Positron ---
 


### PR DESCRIPTION
Fixes #13415 

Built on changes from https://github.com/rstudio/vscode-server/pull/360 

The environment variable was being overridden when checking the preferences. This sets the environment variable as the highest priority.

Testing also revealed that setting a bad value will stop Positron from starting so the error is now handled.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix `EXTENSIONS_GALLERY` not applying URL override


### QA Notes