### PR TITLE
ci: add e2e-failure-analyzer action and manual-replay workflow

### DIFF
--- a/.claude/skills/e2e-failure-analyzer/SKILL.md
+++ b/.claude/skills/e2e-failure-analyzer/SKILL.md
@@ -99,12 +99,13 @@ Output JSON contains:
 - `testDetails` - array of per-test objects, each containing:
   - `testId`, `title`, `file`, `status`, `blob`, `attemptCount`
   - `attempts` - array of per-attempt objects with:
-    - `trace` - parsed trace data: `timeline` (human-readable string), `errors` (array), `lastScreenshotSha1`
-    - `screenshotPath` - path to extracted last screenshot JPEG (view with Read tool)
+    - `trace` - parsed trace data: `timeline` (human-readable string), `errors` (array), `screenshotShas` (array of `{sha1, timestamp}` in chronological order), `lastScreenshotSha1` (legacy: same as last entry of `screenshotShas`)
+    - `screenshotPaths` - chronological array of paths to extracted screenshot JPEGs (view with Read tool); the last entry is the failure-state frame, earlier entries show the moments before it
+    - `screenshotPath` - legacy alias pointing to the last entry of `screenshotPaths`
     - `errorContextPath` - path to extracted page snapshot markdown (view with Read tool if needed)
   - `logHashes` - array of `{resourceHash, blob}` for logs (extract manually if needed)
 
-**IMPORTANT: View screenshots** using the `screenshotPath` fields with the Read tool. You MUST Read **all** screenshots in a **single message** with multiple parallel Read tool calls -- this results in only one approval prompt instead of one per screenshot. View all attempts; comparing across retries reveals whether a failure is consistent or intermittent. Screenshots are the most revealing evidence for diagnosing failures.
+**IMPORTANT: View screenshots** using the `screenshotPaths` arrays with the Read tool. You MUST Read **all** screenshots in a **single message** with multiple parallel Read tool calls -- this results in only one approval prompt instead of one per screenshot. View all attempts and all frames per attempt; comparing across retries reveals whether a failure is consistent or intermittent, and comparing the trailing frames *within* an attempt often shows where the test went wrong before the visible error. Screenshots are the most revealing evidence for diagnosing failures. Default frame count per attempt is 3 (configurable via `--screenshots N` on `e2e-process-project.js`).
 
 **View error context** with the Read tool using `errorContextPath` paths if the screenshot and trace timeline are insufficient for diagnosis.
 

--- a/.claude/skills/e2e-failure-analyzer/scripts/e2e-process-project.js
+++ b/.claude/skills/e2e-failure-analyzer/scripts/e2e-process-project.js
@@ -16,7 +16,8 @@
 //
 // Options:
 //   --output-dir <dir>   Where to save screenshots and error-context (default: /tmp/e2e-analysis-<random>)
-//   --last <N>           Number of trace actions to show (default: 30)
+//   --last <N>           Number of trace actions to show (default: 500)
+//   --screenshots <N>    Number of trailing screencast frames to extract per attempt (default: 3)
 //   --cleanup            Remove blob-reports, blob-merged, and report JSON after processing
 //
 // Output: JSON to stdout with failures, test details, trace timelines, and paths
@@ -35,7 +36,8 @@ const cliArgs = process.argv.slice(2);
 let blobDir = null;
 let reportPath = null;
 let outputDir = null;
-let lastN = 30;
+let lastN = 500;
+let screenshotsN = 3;
 let doDownload = false;
 let runId = null;
 let repo = null;
@@ -46,6 +48,7 @@ for (let i = 0; i < cliArgs.length; i++) {
 	switch (cliArgs[i]) {
 		case '--output-dir': outputDir = cliArgs[++i]; break;
 		case '--last': lastN = parseInt(cliArgs[++i], 10); break;
+		case '--screenshots': screenshotsN = parseInt(cliArgs[++i], 10); break;
 		case '--download': doDownload = true; break;
 		case '--run-id': runId = cliArgs[++i]; break;
 		case '--repo': repo = cliArgs[++i]; break;
@@ -340,13 +343,17 @@ function parseTrace(tracePath) {
 	}
 
 	const screenshots = events.filter(e => e.type === 'screencast-frame');
-	const lastScreenshot = screenshots.length > 0 ? screenshots[screenshots.length - 1] : null;
+	const trailingScreenshots = screenshots.slice(-screenshotsN);
+	const lastScreenshot = trailingScreenshots.length > 0 ? trailingScreenshots[trailingScreenshots.length - 1] : null;
 
-	if (lastScreenshot) {
+	if (trailingScreenshots.length > 0) {
 		timelineLines.push(`\n=== Screenshots ===`);
 		timelineLines.push(`Total screencast frames: ${screenshots.length}`);
-		timelineLines.push(`Last screenshot sha1: ${lastScreenshot.sha1}`);
-		timelineLines.push(`Last screenshot timestamp: ${lastScreenshot.timestamp}`);
+		timelineLines.push(`Extracting last ${trailingScreenshots.length} frame(s):`);
+		for (let i = 0; i < trailingScreenshots.length; i++) {
+			const s = trailingScreenshots[i];
+			timelineLines.push(`  [${i}] sha1=${s.sha1} timestamp=${s.timestamp}`);
+		}
 	}
 
 	const errorEvents = events.filter(e => e.type === 'after' && e.error);
@@ -362,6 +369,9 @@ function parseTrace(tracePath) {
 	return {
 		timeline: timelineLines.join('\n'),
 		errors,
+		// Last N screencast frames in chronological order; final entry is the failure-state screenshot.
+		screenshotShas: trailingScreenshots.map(s => ({ sha1: s.sha1, timestamp: s.timestamp })),
+		// Kept for backward compat with callers that read just the final frame.
 		lastScreenshotSha1: lastScreenshot?.sha1 || null,
 	};
 }
@@ -416,6 +426,7 @@ for (const testId of failedTestIds) {
 
 		let traceData = null;
 		let screenshotPath = null;
+		const screenshotPaths = [];
 
 		// Extract and parse trace
 		if (traceAtt.resourceHash) {
@@ -437,21 +448,30 @@ for (const testId of failedTestIds) {
 				if (tracePath) {
 					traceData = parseTrace(tracePath);
 
-					// Step 3: extract last screenshot from resource zip
-					// The sha1 field from screencast-frame events is the full filename
-					// including extension (e.g., "page@abc123-timestamp.jpeg")
-					if (traceData.lastScreenshotSha1) {
-						const ssFileName = `${shortId}-attempt${i}.jpeg`;
+					// Step 3: extract trailing N screencast frames in chronological order.
+					// File naming: <shortId>-attempt<i>-frame<j>.jpeg where j=0 is the
+					// earliest of the N extracted, last index is the failure-state frame.
+					// The sha1 field is the full filename incl. extension (page@<hash>-<ts>.jpeg).
+					const frames = traceData.screenshotShas || [];
+					for (let j = 0; j < frames.length; j++) {
+						const sha = frames[j].sha1;
+						if (!sha) { continue; }
+						const ssFileName = `${shortId}-attempt${i}-frame${j}.jpeg`;
 						const ssDestPath = join(resolvedOutputDir, 'screenshots', ssFileName);
-						const ssEntry = `resources/${traceData.lastScreenshotSha1}`;
-						const ssTempDir = join(tmpWorkDir, `ss-${shortId}-${i}`);
+						const ssEntry = `resources/${sha}`;
+						const ssTempDir = join(tmpWorkDir, `ss-${shortId}-${i}-${j}`);
 						const ssExtracted = unzipFile(resourceZipPath, ssEntry, ssTempDir);
 
 						if (ssExtracted) {
 							writeFileSync(ssDestPath, readFileSync(ssExtracted));
-							screenshotPath = ssDestPath;
+							screenshotPaths.push(ssDestPath);
 						}
 					}
+					// Final frame is the most-revealing failure state -- preserve the
+					// legacy single-screenshotPath field for callers that only want it.
+					screenshotPath = screenshotPaths.length > 0
+						? screenshotPaths[screenshotPaths.length - 1]
+						: null;
 				}
 			}
 		}
@@ -479,7 +499,8 @@ for (const testId of failedTestIds) {
 		attempts.push({
 			attemptIndex: i,
 			trace: traceData,
-			screenshotPath,
+			screenshotPath,           // legacy: final frame only
+			screenshotPaths,          // chronological list; last entry is the failure-state
 			errorContextPath,
 		});
 	}

--- a/.claude/skills/e2e-failure-analyzer/scripts/e2e-process-project.js
+++ b/.claude/skills/e2e-failure-analyzer/scripts/e2e-process-project.js
@@ -44,11 +44,21 @@ let repo = null;
 let project = null;
 let doCleanup = false;
 
+/** Parse a non-negative integer CLI flag. Rejects NaN, negatives, and non-integer floats. */
+function parseNonNegInt(name, raw) {
+	const n = Number(raw);
+	if (!Number.isInteger(n) || n < 0) {
+		console.error(`Invalid ${name}: ${raw} (expected non-negative integer)`);
+		process.exit(1);
+	}
+	return n;
+}
+
 for (let i = 0; i < cliArgs.length; i++) {
 	switch (cliArgs[i]) {
 		case '--output-dir': outputDir = cliArgs[++i]; break;
-		case '--last': lastN = parseInt(cliArgs[++i], 10); break;
-		case '--screenshots': screenshotsN = parseInt(cliArgs[++i], 10); break;
+		case '--last': lastN = parseNonNegInt('--last', cliArgs[++i]); break;
+		case '--screenshots': screenshotsN = parseNonNegInt('--screenshots', cliArgs[++i]); break;
 		case '--download': doDownload = true; break;
 		case '--run-id': runId = cliArgs[++i]; break;
 		case '--repo': repo = cliArgs[++i]; break;
@@ -318,10 +328,11 @@ function parseTrace(tracePath) {
 	}
 
 	const actions = events.filter(e => e.type === 'before' || e.type === 'after');
-	const recent = actions.slice(-lastN);
+	// `slice(-0)` returns the whole array, so handle 0 explicitly.
+	const recent = lastN === 0 ? [] : actions.slice(-lastN);
 
 	const timelineLines = [];
-	timelineLines.push(`=== Action Timeline (last ${Math.min(lastN, actions.length)} of ${actions.length} events) ===\n`);
+	timelineLines.push(`=== Action Timeline (last ${recent.length} of ${actions.length} events) ===\n`);
 
 	for (const a of recent) {
 		if (a.type === 'before') {
@@ -343,7 +354,8 @@ function parseTrace(tracePath) {
 	}
 
 	const screenshots = events.filter(e => e.type === 'screencast-frame');
-	const trailingScreenshots = screenshots.slice(-screenshotsN);
+	// `slice(-0)` returns the whole array, so handle 0 explicitly.
+	const trailingScreenshots = screenshotsN === 0 ? [] : screenshots.slice(-screenshotsN);
 	const lastScreenshot = trailingScreenshots.length > 0 ? trailingScreenshots[trailingScreenshots.length - 1] : null;
 
 	if (trailingScreenshots.length > 0) {

--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -32,6 +32,17 @@ runs:
       working-directory: ${{ github.action_path }}
       run: npm ci --no-audit --no-fund
 
+    - name: Install Claude Code CLI
+      # Workaround for an Agent SDK bug that resolves the musl-variant binary
+      # before the glibc one on Linux runners (claude-agent-sdk-typescript#296).
+      # Installing @anthropic-ai/claude-code globally and pointing the SDK at
+      # it via pathToClaudeCodeExecutable bypasses the buggy resolver.
+      shell: bash
+      run: |
+        npm install -g @anthropic-ai/claude-code
+        echo "CLAUDE_CODE_PATH=$(which claude)" >> "$GITHUB_ENV"
+        claude --version
+
     - name: Prepare working directory
       id: prep
       shell: bash

--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -97,6 +97,9 @@ runs:
         RUN_INFO="$WORK_DIR/run-info.json"
         RUN_ID=$(jq -r '.runId' "$RUN_INFO")
         BRANCH=$(jq -r '.run.branch // .run.head_branch // "main"' "$RUN_INFO")
+        # The e2e-test-insights API uses a single "positron" repo ID for both
+        # posit-dev/positron and posit-dev/positron-builds (same tests, same
+        # storage) -- do not parameterize this on the source GH repo.
         node "${{ github.workspace }}/.claude/skills/e2e-failure-analyzer/scripts/e2e-query-history.js" \
           --repo positron \
           --run-id "$RUN_ID" \

--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -1,0 +1,126 @@
+name: "E2E Failure Analyzer"
+description: "Run the e2e-failure-analyzer skill against a finished GH Actions run via the Claude Agent SDK."
+inputs:
+  run-url:
+    description: "Full GitHub Actions run URL to analyze (e.g. https://github.com/posit-dev/positron/actions/runs/123)"
+    required: true
+  anthropic-api-key:
+    description: "Anthropic API key (resolved from 1Password by the caller)"
+    required: true
+  e2e-insights-api-key:
+    description: "e2e-test-insights API key (optional)"
+    required: false
+    default: ""
+  model:
+    description: "Anthropic model identifier"
+    required: false
+    default: "claude-sonnet-4-5"
+  max-turns:
+    description: "Maximum agent turns (cost guard)"
+    required: false
+    default: "40"
+runs:
+  using: composite
+  steps:
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - name: Install action dependencies
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: npm ci --no-audit --no-fund
+
+    - name: Prepare working directory
+      id: prep
+      shell: bash
+      run: |
+        WORK_DIR="${RUNNER_TEMP}/e2e-analyze"
+        rm -rf "$WORK_DIR"
+        mkdir -p "$WORK_DIR"
+        echo "work_dir=$WORK_DIR" >> "$GITHUB_OUTPUT"
+
+    - name: Gather run info
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        node "${{ github.workspace }}/.claude/skills/e2e-failure-analyzer/scripts/e2e-gather-run-info.js" \
+          "${{ inputs.run-url }}" > "${{ steps.prep.outputs.work_dir }}/run-info.json"
+        echo "::group::run-info.json"
+        cat "${{ steps.prep.outputs.work_dir }}/run-info.json"
+        echo "::endgroup::"
+
+    - name: Process each project
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      working-directory: ${{ github.action_path }}
+      run: |
+        WORK_DIR="${{ steps.prep.outputs.work_dir }}"
+        RUN_INFO="$WORK_DIR/run-info.json"
+        REPO=$(jq -r '.repo' "$RUN_INFO")
+        RUN_ID=$(jq -r '.runId' "$RUN_INFO")
+        PROJECTS=$(jq -r '.projects // [] | .[]' "$RUN_INFO")
+
+        if [ -z "$PROJECTS" ]; then
+          echo "No e2e projects found (likely positron-builds run -- Path B not implemented in v1)."
+          exit 0
+        fi
+
+        for PROJECT in $PROJECTS; do
+          OUT="$WORK_DIR/$PROJECT"
+          mkdir -p "$OUT"
+          echo "::group::Process project $PROJECT"
+          # cwd = action dir so npx finds @playwright/test from action's node_modules
+          node "${{ github.workspace }}/.claude/skills/e2e-failure-analyzer/scripts/e2e-process-project.js" \
+            --download \
+            --run-id "$RUN_ID" \
+            --repo "$REPO" \
+            --project "$PROJECT" \
+            --output-dir "$OUT" \
+            --cleanup \
+            > "$OUT/result.json" || {
+              echo "Failed to process project $PROJECT (exit $?). Continuing."
+            }
+          echo "::endgroup::"
+        done
+
+    - name: Query historical test health
+      if: ${{ inputs.e2e-insights-api-key != '' }}
+      shell: bash
+      env:
+        E2E_INSIGHTS_API_KEY: ${{ inputs.e2e-insights-api-key }}
+      run: |
+        WORK_DIR="${{ steps.prep.outputs.work_dir }}"
+        RUN_INFO="$WORK_DIR/run-info.json"
+        RUN_ID=$(jq -r '.runId' "$RUN_INFO")
+        BRANCH=$(jq -r '.run.branch // .run.head_branch // "main"' "$RUN_INFO")
+        node "${{ github.workspace }}/.claude/skills/e2e-failure-analyzer/scripts/e2e-query-history.js" \
+          --repo positron \
+          --run-id "$RUN_ID" \
+          --lookback-days 14 \
+          --branch "$BRANCH" \
+          > "$WORK_DIR/history.json" || {
+            echo "History query failed (exit $?). Continuing without history."
+            echo '{"error":"query failed"}' > "$WORK_DIR/history.json"
+          }
+
+    - name: Analyze with Claude Agent SDK
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        WORK_DIR: ${{ steps.prep.outputs.work_dir }}
+        MODEL: ${{ inputs.model }}
+        MAX_TURNS: ${{ inputs.max-turns }}
+      run: node analyze.mjs
+
+    - name: Upload analyzer artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: e2e-failure-analysis
+        path: ${{ steps.prep.outputs.work_dir }}
+        retention-days: 14

--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -127,6 +127,9 @@ runs:
       env:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         WORK_DIR: ${{ steps.prep.outputs.work_dir }}
+        # Repo workspace -- the agent reads test source from $REPO_ROOT/test/e2e
+        # to understand each failing test's intent (assertions, page-object usage).
+        REPO_ROOT: ${{ github.workspace }}
         MODEL: ${{ inputs.model }}
         MAX_TURNS: ${{ inputs.max-turns }}
       run: node analyze.mjs

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Drives the Claude Agent SDK to synthesize an e2e test failure report from
+// pre-extracted evidence (failures.json, screenshots, traces, error contexts).
+// All data extraction has already happened in earlier action steps -- this
+// script reads the structured outputs and asks the model for analysis.
+
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { readFileSync, existsSync, appendFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WORK_DIR = mustEnv('WORK_DIR');
+const MODEL = process.env.MODEL || 'claude-sonnet-4-5';
+const STEP_SUMMARY = process.env.GITHUB_STEP_SUMMARY;
+const MAX_TURNS = Number(process.env.MAX_TURNS || 40);
+
+function mustEnv(name) {
+	const v = process.env[name];
+	if (!v) {
+		console.error(`Missing required env var: ${name}`);
+		process.exit(2);
+	}
+	return v;
+}
+
+function readJsonIfExists(path) {
+	if (!existsSync(path)) { return null; }
+	try {
+		return JSON.parse(readFileSync(path, 'utf8'));
+	} catch (err) {
+		console.error(`Failed to parse ${path}: ${err.message}`);
+		return null;
+	}
+}
+
+function discoverProjectDirs(workDir) {
+	const out = [];
+	for (const name of readdirSync(workDir)) {
+		const full = join(workDir, name);
+		if (!statSync(full).isDirectory()) { continue; }
+		if (!name.startsWith('e2e-')) { continue; }
+		const result = readJsonIfExists(join(full, 'result.json'));
+		if (result) { out.push({ project: name, dir: full, result }); }
+	}
+	return out;
+}
+
+function renderRunHeader(runInfo) {
+	const r = runInfo?.run || {};
+	const c = runInfo?.commit || {};
+	return [
+		`Run: ${r.html_url || runInfo?.runId || '?'}`,
+		`Workflow: ${r.name || '?'}`,
+		`Branch: ${r.branch || r.head_branch || '?'}`,
+		`Commit: ${(r.head_sha || '').slice(0, 12)} -- ${(c.message || '').split('\n')[0]}`,
+		`Author: ${c.author || '?'}`,
+		`Files changed (${(c.files || []).length}): ${(c.files || []).slice(0, 30).join(', ')}${(c.files || []).length > 30 ? ', ...' : ''}`,
+	].join('\n');
+}
+
+function renderNonE2eFailures(runInfo) {
+	const failed = (runInfo?.failedJobs || []).filter(j => !j.isE2e);
+	if (failed.length === 0) { return '(none)'; }
+	const logs = runInfo?.nonE2eJobLogs || {};
+	return failed.map(j => {
+		const excerpt = logs[j.id] ? `\n  Excerpt:\n${indent(String(logs[j.id]).slice(0, 2000), '    ')}` : '';
+		return `- Job ${j.id}: ${j.name}${excerpt}`;
+	}).join('\n');
+}
+
+function renderProjectFailures(projects) {
+	if (projects.length === 0) { return '(no e2e projects)'; }
+	const out = [];
+	for (const { project, result } of projects) {
+		out.push(`### Project: ${project}`);
+		const finalFailures = result.failures || [];
+		const allAttempts = result.failedTests || [];
+		out.push(`Hard failures (failed all retries): ${finalFailures.length}`);
+		out.push(`Total failed attempts (incl. flaky recoveries): ${allAttempts.length}`);
+
+		const details = result.testDetails || [];
+		for (const t of details) {
+			out.push('');
+			out.push(`- Test: ${t.title}`);
+			out.push(`  File: ${t.file}`);
+			out.push(`  Status: ${t.status} (${t.attemptCount} attempt${t.attemptCount === 1 ? '' : 's'})`);
+			for (let i = 0; i < (t.attempts || []).length; i++) {
+				const a = t.attempts[i];
+				out.push(`  Attempt ${i + 1}:`);
+				if (a.screenshotPath) { out.push(`    screenshot: ${a.screenshotPath}`); }
+				if (a.errorContextPath) { out.push(`    errorContext: ${a.errorContextPath}`); }
+				if (a.trace?.timeline) {
+					const tl = String(a.trace.timeline).split('\n').slice(0, 12).join('\n');
+					out.push(`    trace timeline (first 12 lines):\n${indent(tl, '      ')}`);
+				}
+				if (Array.isArray(a.trace?.errors) && a.trace.errors.length) {
+					out.push(`    trace errors: ${a.trace.errors.slice(0, 3).map(e => String(e).split('\n')[0]).join(' | ')}`);
+				}
+			}
+		}
+	}
+	return out.join('\n');
+}
+
+function indent(text, prefix) {
+	return String(text).split('\n').map(l => prefix + l).join('\n');
+}
+
+function renderHistory(history) {
+	if (!history) { return '(no historical data; e2e-test-insights API unavailable or no key)'; }
+	if (history.error) { return `(history query error: ${history.error})`; }
+	return JSON.stringify(history, null, 2).slice(0, 8000);
+}
+
+const SYSTEM_PROMPT = `You are an e2e test failure triage analyst for the Positron IDE project. You produce concise, evidence-based markdown reports for GitHub Actions step summaries.
+
+For each failure or group of related failures, determine:
+1. Root cause category -- one of: flaky test | infrastructure issue | product regression | test environment issue | timeout | test logic bug
+2. Brief explanation (1-2 sentences) referencing specific evidence from screenshots, trace timelines, or logs
+3. Suggested action for a developer
+
+Process:
+- READ ALL SCREENSHOTS IN PARALLEL with multiple Read tool calls in a single message. Screenshots are the most revealing evidence.
+- View error-context markdown files only when screenshots and trace timelines are insufficient.
+- Multiple tests failing in the same file/suite usually share a root cause -- group them.
+- A test that failed then passed on retry is flaky. One that failed all retries is a hard failure.
+- Tests tagged \`:soft-fail\` are known flaky.
+- If historical data is provided, use it to distinguish regressions from known flakes:
+  - 0% pass rate on one platform but 100% on others = deterministic platform regression, NOT flaky
+  - Always read environment_breakdown, not just aggregate pass_rate
+- Consider the head commit's changed files: do they touch code exercised by the failing test? Mention this in the per-failure analysis when relevant.
+
+Output the FINAL REPORT as your last message. The report MUST be valid GitHub-flavored markdown starting with the heading \`## Summary\`. Do not include images, raw JSON, or commentary outside the report. Do not include any text before \`## Summary\` in the final message.
+
+Report structure:
+
+## Summary
+
+| Test | Platform | Root cause | Severity |
+|------|----------|------------|----------|
+| <test name> | <project / OS> | <category> | hard \\| flaky |
+
+Include non-e2e job failures (unit tests, build failures, etc.) as additional rows with the job name as the test name.
+
+## Detailed Analysis
+
+For each distinct failure (or group), provide:
+- **<test name>** (<platform>) -- <root cause category>
+  - Evidence: <1-2 sentences citing what the screenshot/trace shows>
+  - Commit: <relevant changed files, or "no related changes">
+  - History: <history line per the SKILL.md format, or "no data available">
+  - Action: <what the developer should do>
+
+Constraints:
+- Keep the report focused. For runs with many failures, group related ones.
+- Use Posit / Positron terminology (workbench, console, runtime, plot view, etc.).
+- Do not embed image markdown -- screenshots aren't rendered in step summaries.
+- Do not invent file paths, test names, or error messages -- only cite what's in the input.`;
+
+async function main() {
+	const runInfo = readJsonIfExists(join(WORK_DIR, 'run-info.json'));
+	const history = readJsonIfExists(join(WORK_DIR, 'history.json'));
+	const projects = discoverProjectDirs(WORK_DIR);
+
+	const userPrompt = [
+		'## Run metadata',
+		renderRunHeader(runInfo),
+		'',
+		'## Non-e2e job failures',
+		renderNonE2eFailures(runInfo),
+		'',
+		'## E2E project failures',
+		renderProjectFailures(projects),
+		'',
+		'## Historical test health (e2e-test-insights)',
+		renderHistory(history),
+		'',
+		'---',
+		'Analyze the failures above. Read all referenced screenshots in parallel before writing the report. Output the final markdown report as instructed.',
+	].join('\n');
+
+	console.log(`[analyzer] WORK_DIR=${WORK_DIR}`);
+	console.log(`[analyzer] model=${MODEL} maxTurns=${MAX_TURNS}`);
+	console.log(`[analyzer] projects=${projects.map(p => p.project).join(', ') || '(none)'}`);
+	console.log(`[analyzer] user prompt (${userPrompt.length} chars):\n${userPrompt.slice(0, 4000)}${userPrompt.length > 4000 ? '\n...(truncated)' : ''}`);
+
+	const assistantMessages = [];
+	let turnCount = 0;
+
+	for await (const message of query({
+		prompt: userPrompt,
+		options: {
+			model: MODEL,
+			cwd: WORK_DIR,
+			systemPrompt: SYSTEM_PROMPT,
+			allowedTools: ['Read', 'Glob', 'Grep'],
+			permissionMode: 'bypassPermissions',
+			maxTurns: MAX_TURNS,
+		},
+	})) {
+		if (message.type === 'assistant') {
+			turnCount++;
+			const content = message.message?.content || [];
+			const textBlocks = content.filter(b => b.type === 'text').map(b => b.text);
+			const toolUses = content.filter(b => b.type === 'tool_use').map(b => `${b.name}(${JSON.stringify(b.input).slice(0, 200)})`);
+			if (textBlocks.length) {
+				const joined = textBlocks.join('\n');
+				assistantMessages.push(joined);
+				console.log(`[turn ${turnCount}] assistant text (${joined.length} chars):\n${joined.slice(0, 1000)}${joined.length > 1000 ? '\n...(truncated)' : ''}`);
+			}
+			if (toolUses.length) {
+				console.log(`[turn ${turnCount}] tool calls: ${toolUses.join(' | ')}`);
+			}
+		} else if (message.type === 'result') {
+			console.log(`[analyzer] usage: input=${message.usage?.input_tokens} output=${message.usage?.output_tokens} cost_usd=${message.total_cost_usd}`);
+		}
+	}
+
+	const report = pickReport(assistantMessages);
+	if (!report) {
+		console.error('[analyzer] no markdown report produced');
+		writeStepSummary('## E2E Failure Analysis\n\n_Analyzer produced no report. Check action logs._\n');
+		process.exit(1);
+	}
+
+	writeStepSummary(report);
+	writeFileSync(join(WORK_DIR, 'analysis-report.md'), report);
+	console.log(`[analyzer] wrote ${report.length} chars to step summary`);
+}
+
+function pickReport(messages) {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const m = messages[i];
+		const idx = m.indexOf('## Summary');
+		if (idx >= 0) { return m.slice(idx); }
+	}
+	return messages.length ? messages[messages.length - 1] : null;
+}
+
+function writeStepSummary(markdown) {
+	if (STEP_SUMMARY) {
+		appendFileSync(STEP_SUMMARY, markdown + '\n');
+	} else {
+		console.log('--- BEGIN REPORT ---');
+		console.log(markdown);
+		console.log('--- END REPORT ---');
+	}
+}
+
+main().catch(err => {
+	console.error('[analyzer] fatal:', err);
+	process.exit(1);
+});

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -17,6 +17,9 @@ const WORK_DIR = mustEnv('WORK_DIR');
 const MODEL = process.env.MODEL || 'claude-sonnet-4-5';
 const STEP_SUMMARY = process.env.GITHUB_STEP_SUMMARY;
 const MAX_TURNS = parsePosIntEnv('MAX_TURNS', 40);
+// Repo workspace (sparse-checkout root). Optional: when present, the agent
+// reads failing tests' source from $REPO_ROOT/test/e2e/{tests,pages,fixtures}.
+const REPO_ROOT = process.env.REPO_ROOT || '';
 // Defensive bounds against pathological runs (many failures x long traces).
 // Per-attempt cap is ~50x the old 12-line truncation -- never trips on typical
 // tests, prevents 500-action timelines from ballooning the prompt.
@@ -298,7 +301,8 @@ For each failure or group of related failures, determine:
 Process:
 - READ EVERY SCREENSHOT IN PARALLEL with multiple Read tool calls in a single message. Each attempt may have several screenshots in chronological order; the last is the failure-state, the earlier ones show what the page looked like in the moments leading up to it. Comparing them is often what reveals the real root cause -- the failure message and the final frame can be misleading on their own.
 - READ THE FULL TRACE TIMELINE in the prompt. The action sequence (selector clicks, navigations, waits) often shows where a test actually went wrong even if the final error points elsewhere. Don't stop at the last action.
-- View error-context markdown files when screenshots and trace timelines are insufficient.
+- READ THE FAILING TEST'S SOURCE FILE before drawing conclusions. The test file path is provided in each failure entry. If REPO_ROOT is set in the input header, the absolute path is \`<REPO_ROOT>/test/e2e/<file>\`. Reading the source tells you what the test actually intends to verify, what page objects/helpers it depends on, and the setup steps -- often the difference between "the assertion is the bug" vs "setup failed before reaching the assertion." When the test imports page objects (e.g., \`import { Console } from '../../pages/console'\`), Read those too if the failure involves their behavior. Do this BEFORE writing the analysis, not after.
+- View error-context markdown files when screenshots, trace timelines, and source code are insufficient.
 - Multiple tests failing in the same file/suite usually share a root cause -- group them.
 - The Severity for each test is pre-computed and labeled in the input ("Severity: HARD" or "Severity: FLAKY"). Use that label VERBATIM in your output. Do NOT recompute severity from retry counts, root cause, or history -- the input label is authoritative. A test can have root cause "flaky test" and severity "HARD" simultaneously: that means the test failed all retries on this run AND its history shows it's prone to flaking.
 - Tests tagged \`:soft-fail\` are known flaky.
@@ -340,9 +344,13 @@ async function main() {
 	const projects = discoverProjectDirs(WORK_DIR);
 
 	const historyMap = buildHistoryByKey(history);
+	const repoRootLine = REPO_ROOT
+		? `REPO_ROOT: ${REPO_ROOT} (test source available at $REPO_ROOT/test/e2e/{tests,pages,fixtures})`
+		: 'REPO_ROOT: not set (test source not available; analyze from screenshots/traces only)';
 	const sections = [
 		'## Run metadata',
 		renderRunHeader(runInfo),
+		repoRootLine,
 		'',
 		'## Non-e2e job failures',
 		renderNonE2eFailures(runInfo),
@@ -366,6 +374,7 @@ async function main() {
 	}
 
 	console.log(`[analyzer] WORK_DIR=${WORK_DIR}`);
+	console.log(`[analyzer] REPO_ROOT=${REPO_ROOT || '(unset)'}`);
 	console.log(`[analyzer] model=${MODEL} maxTurns=${MAX_TURNS} claudePath=${CLAUDE_CODE_PATH || '(default)'}`);
 	console.log(`[analyzer] projects=${projects.map(p => p.project).join(', ') || '(none)'}`);
 	console.log(`[analyzer] user prompt (${userPrompt.length} chars):\n${userPrompt.slice(0, 4000)}${userPrompt.length > 4000 ? '\n...(truncated)' : ''}`);

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -101,11 +101,21 @@ function renderProjectFailures(projects, historyMap) {
 			for (let i = 0; i < (t.attempts || []).length; i++) {
 				const a = t.attempts[i];
 				out.push(`  Attempt ${i + 1}:`);
-				if (a.screenshotPath) { out.push(`    screenshot: ${a.screenshotPath}`); }
+				// Prefer the chronological array; fall back to the single legacy path.
+				const shots = Array.isArray(a.screenshotPaths) && a.screenshotPaths.length
+					? a.screenshotPaths
+					: (a.screenshotPath ? [a.screenshotPath] : []);
+				if (shots.length === 1) {
+					out.push(`    screenshot: ${shots[0]}`);
+				} else if (shots.length > 1) {
+					out.push(`    screenshots (chronological, last is failure-state):`);
+					for (let j = 0; j < shots.length; j++) {
+						out.push(`      [${j}] ${shots[j]}`);
+					}
+				}
 				if (a.errorContextPath) { out.push(`    errorContext: ${a.errorContextPath}`); }
 				if (a.trace?.timeline) {
-					const tl = String(a.trace.timeline).split('\n').slice(0, 12).join('\n');
-					out.push(`    trace timeline (first 12 lines):\n${indent(tl, '      ')}`);
+					out.push(`    trace timeline:\n${indent(String(a.trace.timeline), '      ')}`);
 				}
 				if (Array.isArray(a.trace?.errors) && a.trace.errors.length) {
 					out.push(`    trace errors: ${a.trace.errors.slice(0, 3).map(e => String(e).split('\n')[0]).join(' | ')}`);
@@ -191,8 +201,9 @@ For each failure or group of related failures, determine:
 3. Suggested action for a developer
 
 Process:
-- READ ALL SCREENSHOTS IN PARALLEL with multiple Read tool calls in a single message. Screenshots are the most revealing evidence.
-- View error-context markdown files only when screenshots and trace timelines are insufficient.
+- READ EVERY SCREENSHOT IN PARALLEL with multiple Read tool calls in a single message. Each attempt may have several screenshots in chronological order; the last is the failure-state, the earlier ones show what the page looked like in the moments leading up to it. Comparing them is often what reveals the real root cause -- the failure message and the final frame can be misleading on their own.
+- READ THE FULL TRACE TIMELINE in the prompt. The action sequence (selector clicks, navigations, waits) often shows where a test actually went wrong even if the final error points elsewhere. Don't stop at the last action.
+- View error-context markdown files when screenshots and trace timelines are insufficient.
 - Multiple tests failing in the same file/suite usually share a root cause -- group them.
 - A test that failed then passed on retry is flaky. One that failed all retries is a hard failure.
 - Tests tagged \`:soft-fail\` are known flaky.

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -301,7 +301,7 @@ For each failure or group of related failures, determine:
 Process:
 - READ EVERY SCREENSHOT IN PARALLEL with multiple Read tool calls in a single message. Each attempt may have several screenshots in chronological order; the last is the failure-state, the earlier ones show what the page looked like in the moments leading up to it. Comparing them is often what reveals the real root cause -- the failure message and the final frame can be misleading on their own.
 - READ THE FULL TRACE TIMELINE in the prompt. The action sequence (selector clicks, navigations, waits) often shows where a test actually went wrong even if the final error points elsewhere. Don't stop at the last action.
-- READ THE FAILING TEST'S SOURCE FILE before drawing conclusions. The test file path is provided in each failure entry. If REPO_ROOT is set in the input header, the absolute path is \`<REPO_ROOT>/test/e2e/<file>\`. Reading the source tells you what the test actually intends to verify, what page objects/helpers it depends on, and the setup steps -- often the difference between "the assertion is the bug" vs "setup failed before reaching the assertion." When the test imports page objects (e.g., \`import { Console } from '../../pages/console'\`), Read those too if the failure involves their behavior. Do this BEFORE writing the analysis, not after.
+- READ THE FAILING TEST'S SOURCE FILE before drawing conclusions. The test file path is provided in each failure entry. If REPO_ROOT is set in the input header, the absolute path is \`<REPO_ROOT>/test/e2e/<file>\`. Reading the source tells you what the test actually intends to verify, what page objects/helpers it depends on, and the setup steps -- often the difference between "the assertion is the bug" vs "setup failed before reaching the assertion." When the test imports from \`../../pages/\`, \`../../fixtures/\`, or \`../../infra/\`, Read those too if the failure involves their behavior. \`infra/\` is especially useful when the failure happens during workbench startup, session creation, or teardown -- look at \`workbench.ts\`, \`code.ts\`, or the playwright drivers there. Do this BEFORE writing the analysis, not after.
 - View error-context markdown files when screenshots, trace timelines, and source code are insufficient.
 - Multiple tests failing in the same file/suite usually share a root cause -- group them.
 - The Severity for each test is pre-computed and labeled in the input ("Severity: HARD" or "Severity: FLAKY"). Use that label VERBATIM in your output. Do NOT recompute severity from retry counts, root cause, or history -- the input label is authoritative. A test can have root cause "flaky test" and severity "HARD" simultaneously: that means the test failed all retries on this run AND its history shows it's prone to flaking.
@@ -345,7 +345,7 @@ async function main() {
 
 	const historyMap = buildHistoryByKey(history);
 	const repoRootLine = REPO_ROOT
-		? `REPO_ROOT: ${REPO_ROOT} (test source available at $REPO_ROOT/test/e2e/{tests,pages,fixtures})`
+		? `REPO_ROOT: ${REPO_ROOT} (test source available at $REPO_ROOT/test/e2e/{tests,pages,fixtures,infra})`
 		: 'REPO_ROOT: not set (test source not available; analyze from screenshots/traces only)';
 	const sections = [
 		'## Run metadata',

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -76,7 +76,7 @@ function renderNonE2eFailures(runInfo) {
 	}).join('\n');
 }
 
-function renderProjectFailures(projects) {
+function renderProjectFailures(projects, historyMap) {
 	if (projects.length === 0) { return '(no e2e projects)'; }
 	const out = [];
 	for (const { project, result } of projects) {
@@ -92,6 +92,12 @@ function renderProjectFailures(projects) {
 			out.push(`- Test: ${t.title}`);
 			out.push(`  File: ${t.file}`);
 			out.push(`  Status: ${t.status} (${t.attemptCount} attempt${t.attemptCount === 1 ? '' : 's'})`);
+			const hist = findHistoryFor(historyMap, t.title, t.file);
+			if (hist) {
+				out.push(indent(renderHistoryForTest(hist), '  '));
+			} else if (historyMap.size > 0) {
+				out.push(`  History: no entry for this test (${historyMap.size} tests in history blob)`);
+			}
 			for (let i = 0; i < (t.attempts || []).length; i++) {
 				const a = t.attempts[i];
 				out.push(`  Attempt ${i + 1}:`);
@@ -110,14 +116,71 @@ function renderProjectFailures(projects) {
 	return out.join('\n');
 }
 
+// History keys use forward slashes and a "test/e2e/" prefix; failure `file`
+// fields can be Windows-style (backslashes) and relative to test/e2e. Normalize
+// so the lookup map hits.
+function normalizeSpecPath(file) {
+	let p = String(file || '').replace(/\\/g, '/');
+	if (!p.startsWith('test/e2e/')) {
+		p = `test/e2e/${p}`;
+	}
+	return p;
+}
+
+function buildHistoryByKey(history) {
+	const map = new Map();
+	if (history && Array.isArray(history.tests)) {
+		for (const t of history.tests) {
+			if (t.test_key) { map.set(t.test_key, t); }
+		}
+	}
+	return map;
+}
+
+function findHistoryFor(historyMap, title, file) {
+	if (!historyMap || historyMap.size === 0) { return null; }
+	const key = `${title}|||${normalizeSpecPath(file)}`;
+	return historyMap.get(key) || null;
+}
+
+function renderHistoryForTest(entry) {
+	const h = entry.history || {};
+	const lines = [];
+	const passed = h.pass_count ?? 0;
+	const total = h.total_runs ?? 0;
+	const failRate = h.fail_rate != null ? `${(h.fail_rate * 100).toFixed(0)}%` : '?';
+	const passRate = h.pass_rate != null ? `${(h.pass_rate * 100).toFixed(0)}%` : '?';
+	lines.push(`History (last ${entry.lookback_days || '?'} days, branch ${entry.branch || '?'}):`);
+	lines.push(`  passed ${passed}/${total} (${passRate}), failed ${h.fail_count ?? 0} (${failRate}), flaky ${h.flaky_count ?? 0}, last_status=${h.last_status || '?'}`);
+	if (entry.insight) {
+		const ins = entry.insight;
+		lines.push(`  insight: ${ins.type || '?'}${ins.message ? ` -- "${String(ins.message).slice(0, 80)}"` : ''}${ins.occurrences ? `, ${ins.occurrences} occurrences` : ''}${ins.timing_value ? `, ${ins.timing_label || 'first seen'} ${ins.timing_value}` : ''}`);
+	}
+	if (Array.isArray(entry.environment_breakdown) && entry.environment_breakdown.length) {
+		lines.push('  environments:');
+		for (const e of entry.environment_breakdown) {
+			const er = e.pass_rate != null ? `${(e.pass_rate * 100).toFixed(0)}%` : '?';
+			lines.push(`    ${e.os}/${e.browser}: ${e.passed}/${e.total_runs} (${er}, ${e.failed} failed, ${e.flaky} flaky)`);
+		}
+	}
+	if (Array.isArray(entry.failure_patterns) && entry.failure_patterns.length) {
+		const top = entry.failure_patterns[0];
+		const pct = top.percentage != null ? ` (${(top.percentage * 100).toFixed(0)}%)` : '';
+		lines.push(`  top failure pattern${pct}: "${String(top.pattern || '').replace(/\n/g, ' ').slice(0, 140)}"`);
+	}
+	return lines.join('\n');
+}
+
 function indent(text, prefix) {
 	return String(text).split('\n').map(l => prefix + l).join('\n');
 }
 
-function renderHistory(history) {
+function renderHistorySummary(history, historyMap) {
 	if (!history) { return '(no historical data; e2e-test-insights API unavailable or no key)'; }
 	if (history.error) { return `(history query error: ${history.error})`; }
-	return JSON.stringify(history, null, 2).slice(0, 8000);
+	const total = historyMap.size;
+	if (total === 0) { return '(history blob present but empty)'; }
+	return `Per-test history pre-rendered inline with each failure below. (${total} tests in history blob, lookback ${history.lookback_days || '?'} days, branch ${history.branch || '?'}.)`;
 }
 
 const SYSTEM_PROMPT = `You are an e2e test failure triage analyst for the Positron IDE project. You produce concise, evidence-based markdown reports for GitHub Actions step summaries.
@@ -170,6 +233,7 @@ async function main() {
 	const history = readJsonIfExists(join(WORK_DIR, 'history.json'));
 	const projects = discoverProjectDirs(WORK_DIR);
 
+	const historyMap = buildHistoryByKey(history);
 	const userPrompt = [
 		'## Run metadata',
 		renderRunHeader(runInfo),
@@ -177,11 +241,11 @@ async function main() {
 		'## Non-e2e job failures',
 		renderNonE2eFailures(runInfo),
 		'',
-		'## E2E project failures',
-		renderProjectFailures(projects),
-		'',
 		'## Historical test health (e2e-test-insights)',
-		renderHistory(history),
+		renderHistorySummary(history, historyMap),
+		'',
+		'## E2E project failures',
+		renderProjectFailures(projects, historyMap),
 		'',
 		'---',
 		'Analyze the failures above. Read all referenced screenshots in parallel before writing the report. Output the final markdown report as instructed.',

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -167,23 +167,29 @@ function renderProjectFailures(projects, historyMap) {
 
 /**
  * Normalize an e2e spec file path to the canonical "test/e2e/tests/..." form
- * used by the e2e-test-insights API. Handles three input shapes:
+ * used by the e2e-test-insights API. Handles four input shapes:
  *
  *   "../C:\\a\\positron\\test\\e2e\\tests\\foo\\bar.test.ts"  (failures.file: absolute)
  *   "tests\\foo\\bar.test.ts"                                  (testDetails.file: relative)
  *   "test/e2e/tests/foo/bar.test.ts"                           (already canonical)
+ *   "tests/foo/tests/bar.test.ts"                              (nested `tests/` subdir)
  *
- * All three normalize to "test/e2e/tests/foo/bar.test.ts". Used both for
- * matching against history API keys AND for severity lookup -- using the full
- * project-relative suffix (not just basename) avoids false matches when two
- * test files in different directories happen to share a basename and a title.
+ * All normalize to "test/e2e/tests/<rest>". Used for both severity lookup AND
+ * matching against history API keys -- using the full project-relative suffix
+ * (not just basename) avoids false matches when two test files in different
+ * directories happen to share a basename and a title.
+ *
+ * Anchors on the specific "/test/e2e/tests/" substring rather than a generic
+ * "/tests/" so paths with nested `tests/` subdirectories aren't truncated.
  */
 function normalizeSpecPath(file) {
 	const fwd = String(file || '').replace(/\\/g, '/');
-	const idx = fwd.lastIndexOf('/tests/');
-	if (idx >= 0) { return `test/e2e${fwd.slice(idx)}`; }
-	if (fwd.startsWith('tests/')) { return `test/e2e/${fwd}`; }
+	// Prefer the most specific anchor: matches absolute Playwright-normalized
+	// paths regardless of how deep a `tests/` subdir is nested afterwards.
+	const idx = fwd.indexOf('/test/e2e/tests/');
+	if (idx >= 0) { return fwd.slice(idx + 1); }
 	if (fwd.startsWith('test/e2e/')) { return fwd; }
+	if (fwd.startsWith('tests/')) { return `test/e2e/${fwd}`; }
 	return fwd;
 }
 

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -17,6 +17,10 @@ const WORK_DIR = mustEnv('WORK_DIR');
 const MODEL = process.env.MODEL || 'claude-sonnet-4-5';
 const STEP_SUMMARY = process.env.GITHUB_STEP_SUMMARY;
 const MAX_TURNS = Number(process.env.MAX_TURNS || 40);
+// Workaround for claude-agent-sdk-typescript#296 (resolver picks musl over
+// glibc on Linux): action.yml installs @anthropic-ai/claude-code globally
+// and passes the resolved path here.
+const CLAUDE_CODE_PATH = process.env.CLAUDE_CODE_PATH || undefined;
 
 function mustEnv(name) {
 	const v = process.env[name];
@@ -184,7 +188,7 @@ async function main() {
 	].join('\n');
 
 	console.log(`[analyzer] WORK_DIR=${WORK_DIR}`);
-	console.log(`[analyzer] model=${MODEL} maxTurns=${MAX_TURNS}`);
+	console.log(`[analyzer] model=${MODEL} maxTurns=${MAX_TURNS} claudePath=${CLAUDE_CODE_PATH || '(default)'}`);
 	console.log(`[analyzer] projects=${projects.map(p => p.project).join(', ') || '(none)'}`);
 	console.log(`[analyzer] user prompt (${userPrompt.length} chars):\n${userPrompt.slice(0, 4000)}${userPrompt.length > 4000 ? '\n...(truncated)' : ''}`);
 
@@ -200,6 +204,7 @@ async function main() {
 			allowedTools: ['Read', 'Glob', 'Grep'],
 			permissionMode: 'bypassPermissions',
 			maxTurns: MAX_TURNS,
+			...(CLAUDE_CODE_PATH ? { pathToClaudeCodeExecutable: CLAUDE_CODE_PATH } : {}),
 		},
 	})) {
 		if (message.type === 'assistant') {

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -290,15 +290,31 @@ async function main() {
 	}
 
 	const report = pickReport(assistantMessages);
+	const header = renderReportHeader(runInfo);
 	if (!report) {
 		console.error('[analyzer] no markdown report produced');
-		writeStepSummary('## E2E Failure Analysis\n\n_Analyzer produced no report. Check action logs._\n');
+		writeStepSummary(`${header}\n\n## E2E Failure Analysis\n\n_Analyzer produced no report. Check action logs._\n`);
 		process.exit(1);
 	}
 
-	writeStepSummary(report);
-	writeFileSync(join(WORK_DIR, 'analysis-report.md'), report);
-	console.log(`[analyzer] wrote ${report.length} chars to step summary`);
+	const fullReport = `${header}\n\n${report}`;
+	writeStepSummary(fullReport);
+	writeFileSync(join(WORK_DIR, 'analysis-report.md'), fullReport);
+	console.log(`[analyzer] wrote ${fullReport.length} chars to step summary`);
+}
+
+function renderReportHeader(runInfo) {
+	const r = runInfo?.run || {};
+	const c = runInfo?.commit || {};
+	const url = r.html_url || '';
+	const runId = runInfo?.runId || '';
+	const branch = r.branch || r.head_branch || '?';
+	const workflow = r.name || 'workflow';
+	const sha = (r.head_sha || '').slice(0, 8);
+	const subject = (c.message || '').split('\n')[0];
+	const linkText = url ? `[${workflow} run #${runId}](${url})` : `${workflow} run #${runId}`;
+	const commitSegment = sha ? ` -- commit \`${sha}\`${subject ? ` "${subject}"` : ''}` : '';
+	return `> Analyzed ${linkText} on \`${branch}\`${commitSegment}`;
 }
 
 function pickReport(messages) {

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -16,15 +16,15 @@ import { join } from 'node:path';
 const WORK_DIR = mustEnv('WORK_DIR');
 const MODEL = process.env.MODEL || 'claude-sonnet-4-5';
 const STEP_SUMMARY = process.env.GITHUB_STEP_SUMMARY;
-const MAX_TURNS = Number(process.env.MAX_TURNS || 40);
+const MAX_TURNS = parsePosIntEnv('MAX_TURNS', 40);
 // Defensive bounds against pathological runs (many failures x long traces).
 // Per-attempt cap is ~50x the old 12-line truncation -- never trips on typical
 // tests, prevents 500-action timelines from ballooning the prompt.
-const MAX_TIMELINE_CHARS = Number(process.env.MAX_TIMELINE_CHARS || 30000);
+const MAX_TIMELINE_CHARS = parsePosIntEnv('MAX_TIMELINE_CHARS', 30000);
 // Aggregate soft cap. Sonnet 4.5 has ~600KB of input context; we warn well
 // before that. Exceeding it doesn't fail -- the model handles oversized
 // prompts by failing the request, which we'd see in the action logs anyway.
-const PROMPT_WARN_CHARS = Number(process.env.PROMPT_WARN_CHARS || 400000);
+const PROMPT_WARN_CHARS = parsePosIntEnv('PROMPT_WARN_CHARS', 400000);
 // Workaround for claude-agent-sdk-typescript#296 (resolver picks musl over
 // glibc on Linux): action.yml installs @anthropic-ai/claude-code globally
 // and passes the resolved path here.
@@ -37,6 +37,23 @@ function mustEnv(name) {
 		process.exit(2);
 	}
 	return v;
+}
+
+/**
+ * Parse a positive-integer env var. Falls back to `fallback` (with a logged
+ * warning) for unset, empty, NaN, non-integer, or non-positive values. We
+ * silently accept the fallback rather than crashing because misconfiguring a
+ * defensive bound shouldn't kill the analyzer -- but the user should know.
+ */
+function parsePosIntEnv(name, fallback) {
+	const raw = process.env[name];
+	if (raw === undefined || raw === '') { return fallback; }
+	const n = Number(raw);
+	if (!Number.isInteger(n) || n <= 0) {
+		console.warn(`[analyzer] WARN: invalid ${name}=${raw}, falling back to default ${fallback}`);
+		return fallback;
+	}
+	return n;
 }
 
 function readJsonIfExists(path) {
@@ -198,13 +215,38 @@ function indent(text, prefix) {
  * Cap a per-attempt timeline so a single pathological test can't dominate the
  * prompt. Keeps the head AND tail (failures usually hit the tail; the head
  * shows where the test started) and drops the middle with a marker.
+ *
+ * Guarantees `result.length <= MAX_TIMELINE_CHARS`. Falls back to a hard
+ * truncate (with an ellipsis) if the configured cap is too small for a
+ * meaningful head+tail split.
  */
 function capTimeline(text) {
-	if (text.length <= MAX_TIMELINE_CHARS) { return text; }
-	const half = Math.floor(MAX_TIMELINE_CHARS / 2) - 64;
+	const max = MAX_TIMELINE_CHARS;
+	if (text.length <= max) { return text; }
+
+	// Reserve a generous fixed budget for the elision marker. The marker is
+	// `\n\n[... N chars elided to fit prompt budget ...]\n\n` where N's digit
+	// count is bounded by realistic input sizes; 80 chars covers up to ~10^20.
+	const MARKER_RESERVE = 80;
+
+	if (max <= MARKER_RESERVE + 2) {
+		// Cap is so small there's no room for head + tail + marker. Hard truncate.
+		const ellipsis = '...';
+		if (max <= ellipsis.length) { return text.slice(0, max); }
+		return text.slice(0, max - ellipsis.length) + ellipsis;
+	}
+
+	const half = Math.floor((max - MARKER_RESERVE) / 2);
 	const head = text.slice(0, half);
 	const tail = text.slice(-half);
-	return `${head}\n\n[... ${text.length - 2 * half} chars elided to fit prompt budget ...]\n\n${tail}`;
+	const elided = Math.max(0, text.length - 2 * half);
+	const marker = `\n\n[... ${elided} chars elided to fit prompt budget ...]\n\n`;
+
+	let result = head + marker + tail;
+	// Hard guard: if the marker exceeded MARKER_RESERVE (e.g. astronomical input
+	// size with many digits), trim from the tail rather than blowing the budget.
+	if (result.length > max) { result = result.slice(0, max); }
+	return result;
 }
 
 function renderHistorySummary(history, historyMap) {

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -111,11 +111,21 @@ function renderProjectFailures(projects, historyMap) {
 		out.push(`Hard failures (failed all retries): ${finalFailures.length}`);
 		out.push(`Total failed attempts (incl. flaky recoveries): ${allAttempts.length}`);
 
+		// Pre-compute deterministic severity per test: HARD = appears in result.failures
+		// (failed all retries); FLAKY = only appears in failedTests (recovered on retry).
+		// This must be computed here -- the model will misclassify if asked to count attempts.
+		// Match on (title, basename) since failures.file is a playwright-normalized absolute
+		// path while testDetails.file is project-relative -- but the basenames agree.
+		const hardKeys = new Set(finalFailures.map(f => `${f.title}|||${baseName(f.file)}`));
+
 		const details = result.testDetails || [];
 		for (const t of details) {
+			const key = `${t.title}|||${baseName(t.file)}`;
+			const severity = hardKeys.has(key) ? 'HARD' : 'FLAKY';
 			out.push('');
 			out.push(`- Test: ${t.title}`);
 			out.push(`  File: ${t.file}`);
+			out.push(`  Severity: ${severity} (${severity === 'HARD' ? 'failed all retries' : 'passed on retry'})`);
 			out.push(`  Status: ${t.status} (${t.attemptCount} attempt${t.attemptCount === 1 ? '' : 's'})`);
 			const hist = findHistoryFor(historyMap, t.title, t.file);
 			if (hist) {
@@ -211,6 +221,11 @@ function indent(text, prefix) {
 	return String(text).split('\n').map(l => prefix + l).join('\n');
 }
 
+/** Last path segment, normalized across Windows/Unix separators. */
+function baseName(p) {
+	return String(p || '').replace(/\\/g, '/').split('/').pop() || '';
+}
+
 /**
  * Cap a per-attempt timeline so a single pathological test can't dominate the
  * prompt. Keeps the head AND tail (failures usually hit the tail; the head
@@ -269,7 +284,7 @@ Process:
 - READ THE FULL TRACE TIMELINE in the prompt. The action sequence (selector clicks, navigations, waits) often shows where a test actually went wrong even if the final error points elsewhere. Don't stop at the last action.
 - View error-context markdown files when screenshots and trace timelines are insufficient.
 - Multiple tests failing in the same file/suite usually share a root cause -- group them.
-- A test that failed then passed on retry is flaky. One that failed all retries is a hard failure.
+- The Severity for each test is pre-computed and labeled in the input ("Severity: HARD" or "Severity: FLAKY"). Use that label VERBATIM in your output. Do NOT recompute severity from retry counts, root cause, or history -- the input label is authoritative. A test can have root cause "flaky test" and severity "HARD" simultaneously: that means the test failed all retries on this run AND its history shows it's prone to flaking.
 - Tests tagged \`:soft-fail\` are known flaky.
 - If historical data is provided, use it to distinguish regressions from known flakes:
   - 0% pass rate on one platform but 100% on others = deterministic platform regression, NOT flaky
@@ -286,7 +301,7 @@ Report structure:
 |------|----------|------------|----------|
 | <test name> | <project / OS> | <category> | hard \\| flaky |
 
-Order the rows: **all hard failures first, then all flaky failures**. Within each severity group, keep failures from the same test file adjacent. Non-e2e job failures (unit tests, build failures, etc.) are hard failures by definition -- include them as rows in the hard-failure section with the job name as the test name.
+Order the rows: **all hard-severity failures first, then all flaky-severity failures**. The severity is the label from the input ("Severity: HARD" or "Severity: FLAKY"), not the root cause category. Within each severity group, keep failures from the same test file adjacent. Non-e2e job failures (unit tests, build failures, etc.) are hard severity by definition -- include them as rows in the hard-severity section with the job name as the test name.
 
 ## Detailed Analysis
 

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -286,7 +286,7 @@ Report structure:
 |------|----------|------------|----------|
 | <test name> | <project / OS> | <category> | hard \\| flaky |
 
-Include non-e2e job failures (unit tests, build failures, etc.) as additional rows with the job name as the test name.
+Order the rows: **all hard failures first, then all flaky failures**. Within each severity group, keep failures from the same test file adjacent. Non-e2e job failures (unit tests, build failures, etc.) are hard failures by definition -- include them as rows in the hard-failure section with the job name as the test name.
 
 ## Detailed Analysis
 

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -114,13 +114,16 @@ function renderProjectFailures(projects, historyMap) {
 		// Pre-compute deterministic severity per test: HARD = appears in result.failures
 		// (failed all retries); FLAKY = only appears in failedTests (recovered on retry).
 		// This must be computed here -- the model will misclassify if asked to count attempts.
-		// Match on (title, basename) since failures.file is a playwright-normalized absolute
-		// path while testDetails.file is project-relative -- but the basenames agree.
-		const hardKeys = new Set(finalFailures.map(f => `${f.title}|||${baseName(f.file)}`));
+		// Match on (title, normalizedSpecPath). failures.file is a playwright-normalized
+		// absolute path while testDetails.file is project-relative; we strip up to the
+		// `tests/` root so the suffixes can be compared directly. Using the full project-
+		// relative suffix (not just basename) avoids false matches when two test files in
+		// different directories happen to share a basename and a test title.
+		const hardKeys = new Set(finalFailures.map(f => `${f.title}|||${normalizeSpecPath(f.file)}`));
 
 		const details = result.testDetails || [];
 		for (const t of details) {
-			const key = `${t.title}|||${baseName(t.file)}`;
+			const key = `${t.title}|||${normalizeSpecPath(t.file)}`;
 			const severity = hardKeys.has(key) ? 'HARD' : 'FLAKY';
 			out.push('');
 			out.push(`- Test: ${t.title}`);
@@ -162,15 +165,26 @@ function renderProjectFailures(projects, historyMap) {
 	return out.join('\n');
 }
 
-// History keys use forward slashes and a "test/e2e/" prefix; failure `file`
-// fields can be Windows-style (backslashes) and relative to test/e2e. Normalize
-// so the lookup map hits.
+/**
+ * Normalize an e2e spec file path to the canonical "test/e2e/tests/..." form
+ * used by the e2e-test-insights API. Handles three input shapes:
+ *
+ *   "../C:\\a\\positron\\test\\e2e\\tests\\foo\\bar.test.ts"  (failures.file: absolute)
+ *   "tests\\foo\\bar.test.ts"                                  (testDetails.file: relative)
+ *   "test/e2e/tests/foo/bar.test.ts"                           (already canonical)
+ *
+ * All three normalize to "test/e2e/tests/foo/bar.test.ts". Used both for
+ * matching against history API keys AND for severity lookup -- using the full
+ * project-relative suffix (not just basename) avoids false matches when two
+ * test files in different directories happen to share a basename and a title.
+ */
 function normalizeSpecPath(file) {
-	let p = String(file || '').replace(/\\/g, '/');
-	if (!p.startsWith('test/e2e/')) {
-		p = `test/e2e/${p}`;
-	}
-	return p;
+	const fwd = String(file || '').replace(/\\/g, '/');
+	const idx = fwd.lastIndexOf('/tests/');
+	if (idx >= 0) { return `test/e2e${fwd.slice(idx)}`; }
+	if (fwd.startsWith('tests/')) { return `test/e2e/${fwd}`; }
+	if (fwd.startsWith('test/e2e/')) { return fwd; }
+	return fwd;
 }
 
 function buildHistoryByKey(history) {
@@ -221,10 +235,6 @@ function indent(text, prefix) {
 	return String(text).split('\n').map(l => prefix + l).join('\n');
 }
 
-/** Last path segment, normalized across Windows/Unix separators. */
-function baseName(p) {
-	return String(p || '').replace(/\\/g, '/').split('/').pop() || '';
-}
 
 /**
  * Cap a per-attempt timeline so a single pathological test can't dominate the

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -17,6 +17,14 @@ const WORK_DIR = mustEnv('WORK_DIR');
 const MODEL = process.env.MODEL || 'claude-sonnet-4-5';
 const STEP_SUMMARY = process.env.GITHUB_STEP_SUMMARY;
 const MAX_TURNS = Number(process.env.MAX_TURNS || 40);
+// Defensive bounds against pathological runs (many failures x long traces).
+// Per-attempt cap is ~50x the old 12-line truncation -- never trips on typical
+// tests, prevents 500-action timelines from ballooning the prompt.
+const MAX_TIMELINE_CHARS = Number(process.env.MAX_TIMELINE_CHARS || 30000);
+// Aggregate soft cap. Sonnet 4.5 has ~600KB of input context; we warn well
+// before that. Exceeding it doesn't fail -- the model handles oversized
+// prompts by failing the request, which we'd see in the action logs anyway.
+const PROMPT_WARN_CHARS = Number(process.env.PROMPT_WARN_CHARS || 400000);
 // Workaround for claude-agent-sdk-typescript#296 (resolver picks musl over
 // glibc on Linux): action.yml installs @anthropic-ai/claude-code globally
 // and passes the resolved path here.
@@ -115,7 +123,8 @@ function renderProjectFailures(projects, historyMap) {
 				}
 				if (a.errorContextPath) { out.push(`    errorContext: ${a.errorContextPath}`); }
 				if (a.trace?.timeline) {
-					out.push(`    trace timeline:\n${indent(String(a.trace.timeline), '      ')}`);
+					const tl = capTimeline(String(a.trace.timeline));
+					out.push(`    trace timeline:\n${indent(tl, '      ')}`);
 				}
 				if (Array.isArray(a.trace?.errors) && a.trace.errors.length) {
 					out.push(`    trace errors: ${a.trace.errors.slice(0, 3).map(e => String(e).split('\n')[0]).join(' | ')}`);
@@ -185,6 +194,19 @@ function indent(text, prefix) {
 	return String(text).split('\n').map(l => prefix + l).join('\n');
 }
 
+/**
+ * Cap a per-attempt timeline so a single pathological test can't dominate the
+ * prompt. Keeps the head AND tail (failures usually hit the tail; the head
+ * shows where the test started) and drops the middle with a marker.
+ */
+function capTimeline(text) {
+	if (text.length <= MAX_TIMELINE_CHARS) { return text; }
+	const half = Math.floor(MAX_TIMELINE_CHARS / 2) - 64;
+	const head = text.slice(0, half);
+	const tail = text.slice(-half);
+	return `${head}\n\n[... ${text.length - 2 * half} chars elided to fit prompt budget ...]\n\n${tail}`;
+}
+
 function renderHistorySummary(history, historyMap) {
 	if (!history) { return '(no historical data; e2e-test-insights API unavailable or no key)'; }
 	if (history.error) { return `(history query error: ${history.error})`; }
@@ -245,7 +267,7 @@ async function main() {
 	const projects = discoverProjectDirs(WORK_DIR);
 
 	const historyMap = buildHistoryByKey(history);
-	const userPrompt = [
+	const sections = [
 		'## Run metadata',
 		renderRunHeader(runInfo),
 		'',
@@ -260,7 +282,15 @@ async function main() {
 		'',
 		'---',
 		'Analyze the failures above. Read all referenced screenshots in parallel before writing the report. Output the final markdown report as instructed.',
-	].join('\n');
+	];
+	const oversizedBanner = sections.join('\n').length > PROMPT_WARN_CHARS
+		? `\n> WARNING: This run produced an unusually large evidence bundle (>${Math.round(PROMPT_WARN_CHARS / 1000)}KB of context). Be especially focused -- group related failures aggressively, prefer the most-revealing screenshot per attempt over reading every frame, and keep the report concise.\n`
+		: '';
+	const userPrompt = oversizedBanner ? `${oversizedBanner}\n${sections.join('\n')}` : sections.join('\n');
+
+	if (userPrompt.length > PROMPT_WARN_CHARS) {
+		console.warn(`[analyzer] WARN: prompt size ${userPrompt.length} chars exceeds soft threshold ${PROMPT_WARN_CHARS}. Model may struggle or fail.`);
+	}
 
 	console.log(`[analyzer] WORK_DIR=${WORK_DIR}`);
 	console.log(`[analyzer] model=${MODEL} maxTurns=${MAX_TURNS} claudePath=${CLAUDE_CODE_PATH || '(default)'}`);

--- a/.github/actions/e2e-failure-analyzer/package-lock.json
+++ b/.github/actions/e2e-failure-analyzer/package-lock.json
@@ -1,0 +1,1374 @@
+{
+	"name": "e2e-failure-analyzer-action",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "e2e-failure-analyzer-action",
+			"dependencies": {
+				"@anthropic-ai/claude-agent-sdk": "^0.2.128",
+				"@playwright/test": "^1.58.2"
+			}
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk": {
+			"version": "0.2.128",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.128.tgz",
+			"integrity": "sha512-KI7H9bocPahGDrrQGME5Eh5a4RTqGrN1fQ69uLs6Ik4icXBZXouCx4Ecum450jMVy58myeh9ahYYLlpDAbQXPA==",
+			"license": "SEE LICENSE IN README.md",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.81.0",
+				"@modelcontextprotocol/sdk": "^1.29.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.128",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.128",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.128",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.128",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.128",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.128",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.128",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.128"
+			},
+			"peerDependencies": {
+				"zod": "^4.0.0"
+			}
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+			"version": "0.2.128",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.128.tgz",
+			"integrity": "sha512-RAzmB1ls+GWA/YiyfZLWdFYmj3md5emk7mCEeiKSKl2UN4i+tDWy2m/hjIvMFIzBqJJeGmZZSMnf3S0sL/GbhQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+			"version": "0.2.128",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.128.tgz",
+			"integrity": "sha512-dDPJHxUhL2sgIB8Q2AnBi4xsApImeW0zf1nbL7gBNSc9RWhGoGQAbPm0KaQ7/03jdom30z1VT5VMhQ5KeEYOIw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+			"version": "0.2.128",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.128.tgz",
+			"integrity": "sha512-+GbB33eJSlZUWs84nsibY2nyAFQT96WYLGCteVn62Vv6ZK90NrZsm7lwurjw7oYNnvpzXorhZ2/XpQnWvOK6aQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+			"version": "0.2.128",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.128.tgz",
+			"integrity": "sha512-ZCZEg42St0SCMMZFCvEtkF1LBFMYBxJRXzRno+12vOYYhC6R0l8jPjlgA2ZkN2Lb+TCEOO3fjeWJdZLL/NDM4w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+			"version": "0.2.128",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.128.tgz",
+			"integrity": "sha512-aBBXD6OLN/lq9S1p+BNjuEml0lYIoHunFdzFl49B0fsxEAnz1RfJDrpSNpIUAaL5FMZIaFvLqXtbFRy41N2fxg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+			"version": "0.2.128",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.128.tgz",
+			"integrity": "sha512-sUSJEtvEt2iiMvgUuBGmBJjLhwHxDKOxVBSsXZaY46KAv3ZwLtLuc5xv2XFHId1B5+nMh7b7mr+HAiBmbMUODA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+			"version": "0.2.128",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.128.tgz",
+			"integrity": "sha512-9Ao2J5KgfkfKxUZK3dbQEGonPYcbUyn7Cn7ykZuP91FN/5ux3Tz90YRJW6UtZdWHoDkmFF0FS8P/jiZuyWPLfw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+			"version": "0.2.128",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.128.tgz",
+			"integrity": "sha512-7oxPkgjw1vPZbx6+Qwt9mGouqfpRz5jDcuQ37koayzMdTVzmgCsKAqqbJSpOQfkFGv6gTjcrLWBlk3oapZfBYA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.81.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+			"integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@hono/node-server": {
+			"version": "1.19.14",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.14.1"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@hono/node-server": "^1.19.9",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.59.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/body-parser": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "^3.1.2",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.0",
+				"iconv-lite": "^0.7.0",
+				"on-finished": "^2.4.1",
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/content-disposition": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.6.0"
+			}
+		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"license": "MIT"
+		},
+		"node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT"
+		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+			"license": "MIT",
+			"dependencies": {
+				"eventsource-parser": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+			"integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express-rate-limit": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.0.tgz",
+			"integrity": "sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==",
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "10.1.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT"
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/hono": {
+			"version": "4.12.17",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
+			"integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
+		},
+		"node_modules/ip-address": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"license": "MIT"
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"license": "ISC"
+		},
+		"node_modules/jose": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-to-regexp": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.59.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/qs": {
+			"version": "6.15.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
+		},
+		"node_modules/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"license": "ISC"
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3",
+				"side-channel-list": "^1.0.0",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT"
+		},
+		"node_modules/type-is": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^1.0.5",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC"
+		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		}
+	}
+}

--- a/.github/actions/e2e-failure-analyzer/package.json
+++ b/.github/actions/e2e-failure-analyzer/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "e2e-failure-analyzer-action",
+	"private": true,
+	"type": "module",
+	"description": "GH composite action that runs the e2e failure analysis skill via the Claude Agent SDK.",
+	"dependencies": {
+		"@anthropic-ai/claude-agent-sdk": "^0.2.128",
+		"@playwright/test": "^1.58.2"
+	}
+}

--- a/.github/workflows/analyze-e2e-failures.yml
+++ b/.github/workflows/analyze-e2e-failures.yml
@@ -33,8 +33,10 @@ jobs:
           # Need:
           # - .claude/skills/e2e-failure-analyzer/scripts (extraction helpers)
           # - .github/actions/e2e-failure-analyzer (the action itself)
-          # - test/e2e/{tests,pages,fixtures} so the analyzer can read failing
-          #   test source + page objects to understand each test's intent.
+          # - test/e2e/{tests,pages,fixtures,infra} so the analyzer can read
+          #   failing test source, page objects, fixture configs, and the
+          #   workbench/driver helpers that startup-or-teardown failures often
+          #   route through.
           # - test/e2e/{CLAUDE.md,README.md} for repo-specific test conventions.
           sparse-checkout: |
             .claude/skills/e2e-failure-analyzer
@@ -42,6 +44,7 @@ jobs:
             test/e2e/tests
             test/e2e/pages
             test/e2e/fixtures
+            test/e2e/infra
             test/e2e/CLAUDE.md
             test/e2e/README.md
 

--- a/.github/workflows/analyze-e2e-failures.yml
+++ b/.github/workflows/analyze-e2e-failures.yml
@@ -49,7 +49,7 @@ jobs:
           # On push events, fall back to a fixed test run URL so the workflow
           # exercises end-to-end without manual input. Remove this fallback
           # alongside the push trigger before merging.
-          run-url: ${{ inputs.run_url || 'https://github.com/posit-dev/positron-builds/actions/runs/25207054915' }}
+          run-url: ${{ inputs.run_url || 'https://github.com/posit-dev/positron/actions/runs/25216614544' }}
           anthropic-api-key: ${{ env.ANTHROPIC_KEY }}
           e2e-insights-api-key: ${{ secrets.E2E_INSIGHTS_API_KEY }}
           model: ${{ inputs.model || 'claude-sonnet-4-5' }}

--- a/.github/workflows/analyze-e2e-failures.yml
+++ b/.github/workflows/analyze-e2e-failures.yml
@@ -50,7 +50,7 @@ jobs:
           # On push events, fall back to a fixed test run URL so the workflow
           # exercises end-to-end without manual input. Remove this fallback
           # alongside the push trigger before merging.
-          run-url: ${{ inputs.run_url || 'https://github.com/posit-dev/positron/actions/runs/25216614544' }}
+          run-url: ${{ inputs.run_url || 'https://github.com/posit-dev/positron-builds/actions/runs/25423101658' }}
           anthropic-api-key: ${{ env.ANTHROPIC_KEY }}
           e2e-insights-api-key: ${{ env.E2E_INSIGHTS_KEY }}
           model: ${{ inputs.model || 'claude-sonnet-4-5' }}

--- a/.github/workflows/analyze-e2e-failures.yml
+++ b/.github/workflows/analyze-e2e-failures.yml
@@ -42,6 +42,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
+          E2E_INSIGHTS_KEY: "op://Positron/E2E_dashboard_api_key/credential"
 
       - name: Run analyzer
         uses: ./.github/actions/e2e-failure-analyzer
@@ -51,5 +52,5 @@ jobs:
           # alongside the push trigger before merging.
           run-url: ${{ inputs.run_url || 'https://github.com/posit-dev/positron/actions/runs/25216614544' }}
           anthropic-api-key: ${{ env.ANTHROPIC_KEY }}
-          e2e-insights-api-key: ${{ secrets.E2E_INSIGHTS_API_KEY }}
+          e2e-insights-api-key: ${{ env.E2E_INSIGHTS_KEY }}
           model: ${{ inputs.model || 'claude-sonnet-4-5' }}

--- a/.github/workflows/analyze-e2e-failures.yml
+++ b/.github/workflows/analyze-e2e-failures.yml
@@ -12,12 +12,6 @@ on:
         required: false
         default: "claude-sonnet-4-5"
         type: string
-  # TEMPORARY: trigger on push to this branch so we can iterate on the
-  # action itself without needing a workflow_dispatch UI. Remove this
-  # block before merging.
-  push:
-    branches:
-      - jonv/e2e-failure-analyzer-action
 
 jobs:
   analyze:
@@ -60,10 +54,7 @@ jobs:
       - name: Run analyzer
         uses: ./.github/actions/e2e-failure-analyzer
         with:
-          # On push events, fall back to a fixed test run URL so the workflow
-          # exercises end-to-end without manual input. Remove this fallback
-          # alongside the push trigger before merging.
-          run-url: ${{ inputs.run_url || 'https://github.com/posit-dev/positron/actions/runs/25455097929' }}
+          run-url: ${{ inputs.run_url }}
           anthropic-api-key: ${{ env.ANTHROPIC_KEY }}
           e2e-insights-api-key: ${{ env.E2E_INSIGHTS_KEY }}
-          model: ${{ inputs.model || 'claude-sonnet-4-5' }}
+          model: ${{ inputs.model }}

--- a/.github/workflows/analyze-e2e-failures.yml
+++ b/.github/workflows/analyze-e2e-failures.yml
@@ -1,0 +1,46 @@
+name: "Analyze E2E Failures"
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_url:
+        description: "Full GitHub Actions run URL to analyze"
+        required: true
+        type: string
+      model:
+        description: "Anthropic model"
+        required: false
+        default: "claude-sonnet-4-5"
+        type: string
+
+jobs:
+  analyze:
+    name: analyze
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Need .claude/skills/e2e-failure-analyzer/scripts and the action itself.
+          sparse-checkout: |
+            .claude/skills/e2e-failure-analyzer
+            .github/actions/e2e-failure-analyzer
+
+      - name: Load secret
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
+
+      - name: Run analyzer
+        uses: ./.github/actions/e2e-failure-analyzer
+        with:
+          run-url: ${{ inputs.run_url }}
+          anthropic-api-key: ${{ env.ANTHROPIC_KEY }}
+          e2e-insights-api-key: ${{ secrets.E2E_INSIGHTS_API_KEY }}
+          model: ${{ inputs.model }}

--- a/.github/workflows/analyze-e2e-failures.yml
+++ b/.github/workflows/analyze-e2e-failures.yml
@@ -12,6 +12,12 @@ on:
         required: false
         default: "claude-sonnet-4-5"
         type: string
+  # TEMPORARY: trigger on push to this branch so we can iterate on the
+  # action itself without needing a workflow_dispatch UI. Remove this
+  # block before merging.
+  push:
+    branches:
+      - jonv/e2e-failure-analyzer-action
 
 jobs:
   analyze:
@@ -40,7 +46,10 @@ jobs:
       - name: Run analyzer
         uses: ./.github/actions/e2e-failure-analyzer
         with:
-          run-url: ${{ inputs.run_url }}
+          # On push events, fall back to a fixed test run URL so the workflow
+          # exercises end-to-end without manual input. Remove this fallback
+          # alongside the push trigger before merging.
+          run-url: ${{ inputs.run_url || 'https://github.com/posit-dev/positron-builds/actions/runs/25207054915' }}
           anthropic-api-key: ${{ env.ANTHROPIC_KEY }}
           e2e-insights-api-key: ${{ secrets.E2E_INSIGHTS_API_KEY }}
-          model: ${{ inputs.model }}
+          model: ${{ inputs.model || 'claude-sonnet-4-5' }}

--- a/.github/workflows/analyze-e2e-failures.yml
+++ b/.github/workflows/analyze-e2e-failures.yml
@@ -50,7 +50,7 @@ jobs:
           # On push events, fall back to a fixed test run URL so the workflow
           # exercises end-to-end without manual input. Remove this fallback
           # alongside the push trigger before merging.
-          run-url: ${{ inputs.run_url || 'https://github.com/posit-dev/positron-builds/actions/runs/25423101658' }}
+          run-url: ${{ inputs.run_url || 'https://github.com/posit-dev/positron/actions/runs/25455097929' }}
           anthropic-api-key: ${{ env.ANTHROPIC_KEY }}
           e2e-insights-api-key: ${{ env.E2E_INSIGHTS_KEY }}
           model: ${{ inputs.model || 'claude-sonnet-4-5' }}

--- a/.github/workflows/analyze-e2e-failures.yml
+++ b/.github/workflows/analyze-e2e-failures.yml
@@ -30,10 +30,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          # Need .claude/skills/e2e-failure-analyzer/scripts and the action itself.
+          # Need:
+          # - .claude/skills/e2e-failure-analyzer/scripts (extraction helpers)
+          # - .github/actions/e2e-failure-analyzer (the action itself)
+          # - test/e2e/{tests,pages,fixtures} so the analyzer can read failing
+          #   test source + page objects to understand each test's intent.
+          # - test/e2e/{CLAUDE.md,README.md} for repo-specific test conventions.
           sparse-checkout: |
             .claude/skills/e2e-failure-analyzer
             .github/actions/e2e-failure-analyzer
+            test/e2e/tests
+            test/e2e/pages
+            test/e2e/fixtures
+            test/e2e/CLAUDE.md
+            test/e2e/README.md
 
       - name: Load secret
         uses: 1password/load-secrets-action@v4


### PR DESCRIPTION
This is an incremental phase in the analysis tool.   Once this is merged it can be run manually and I will start tweaking it and then move it to part of the fulll workflow, including slack message.

An example run: https://github.com/posit-dev/positron/actions/runs/25501470865

## Summary

Adds a `workflow_dispatch`-triggered workflow that takes a finished GH Actions run URL, gathers blob reports/screenshots/traces, queries historical test health, and uses the Claude Agent SDK to produce a markdown failure report into the run's step summary.

Phase 1: manual replay only against `posit-dev/positron` runs. Future phases will add automated triggers on `test-merge.yml` and Path B support for `posit-dev/positron-builds`.

## What's new

- `.github/actions/e2e-failure-analyzer/` -- composite action that gathers run data, optionally queries the e2e-test-insights API, and invokes the Agent SDK to synthesize a report.
- `.github/workflows/analyze-e2e-failures.yml` -- workflow_dispatch trigger.
- Reuses the existing `.claude/skills/e2e-failure-analyzer/scripts/` for data extraction (single source of truth between interactive skill and CI).

## How to use

Actions tab -> "Analyze E2E Failures" -> "Run workflow" -> paste a failed run URL. Output appears in the run's step summary; full intermediate JSON is uploaded as the `e2e-failure-analysis` artifact.

## Secrets used

Resolved from 1Password via the existing `1password/load-secrets-action@v4`:
- `op://Positron/Anthropic/credential`
- `op://Positron/E2E_dashboard_api_key/credential`

No new GitHub Actions secrets required.

## Test plan

- [x] Tested end-to-end against a real failing positron run (#25455097929).
- [x] Verified screenshot extraction (3 frames per attempt) and full trace timelines.
- [x] Verified history lookup hits with normalized spec paths.
- [x] Verified severity classification (HARD vs FLAKY) is deterministic, not model-inferred.
- [x] Verified test source reads (the agent followed imports into page objects and infra).
- [ ] One human-eyeball pass on the rendered step summary in this PR (no failures here, so the report would be empty/no-op).