### PR TITLE
Fix import on createEnvTriggerUtils

### DIFF
--- a/extensions/positron-python/src/client/pythonEnvironments/creation/provider/autoCreateVenv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/provider/autoCreateVenv.ts
@@ -17,7 +17,7 @@ import { showQuickPickWithBack } from '../../../common/vscodeApis/windowApis';
 import { Commands } from '../../../common/constants';
 import { getPipRequirementsFiles } from './venvUtils';
 import { UV_PROVIDER_ID } from './uvCreationProvider';
-import { hasPyprojectToml } from '../common/createEnvTriggerUtils.js';
+import { hasPyprojectToml } from '../common/createEnvTriggerUtils';
 
 export interface AutoCreateVenvContext {
     hasRequirements: boolean;


### PR DESCRIPTION
Fix an error loading the Python extension in Workbench due to a stray `.js` import:

```
Activating extension 'ms-python.python' failed: Cannot find module '../common/createEnvTriggerUtils.js'.
$onExtensionActivationError	@	workbench.js:238246
```

Appears to have been unintentionally included in https://github.com/posit-dev/positron/commit/213b6f0ab1ded1c409a8522f63f37ed17323a5a0.

Example failure: https://github.com/posit-dev/positron/actions/runs/25519440974/job/74902133031?pr=13224
