### PR TITLE
Fix InstantiationService disposal in cached notebook cells

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1947,9 +1947,21 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		editorContainer: HTMLElement
 	) {
 		this.detachView();
-		this._scopedContextKeyService = scopedContextKeyService;
-		this._scopedInstantiationService.value = this._instantiationService.createChild(
-			new ServiceCollection([IContextKeyService, scopedContextKeyService]));
+		// Each cell's Monaco editor creates a child dependency-injection
+		// container under this one. That child overrides the context-key
+		// service with one scoped to the cell's DOM. Disposing this container
+		// also disposes every child container under it. The render cache keeps
+		// cell React trees alive across tab switches, and those cells still
+		// reference their child containers. If we rebuild this container on
+		// every attachView, those children get disposed. The next keystroke
+		// in a cached cell would then throw "InstantiationService has been
+		// disposed". Reuse the existing container when the context-key service
+		// hasn't changed.
+		if (this._scopedContextKeyService !== scopedContextKeyService || !this._scopedInstantiationService.value) {
+			this._scopedContextKeyService = scopedContextKeyService;
+			this._scopedInstantiationService.value = this._instantiationService.createChild(
+				new ServiceCollection([IContextKeyService, scopedContextKeyService]));
+		}
 		// Set container last -- contributions react to this observable, and they
 		// may need scopedContextKeyService to already be available.
 		this.container.set(container, undefined);

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookInstance.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookInstance.vitest.ts
@@ -5,8 +5,11 @@
 
 /// <reference types="vitest/globals" />
 
+import { URI } from '../../../../../base/common/uri.js';
+import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+import { MockScopableContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
-import { createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
+import { createTestPositronNotebookInstance, TestPositronNotebookInstance } from './testPositronNotebookInstance.js';
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
 import { CellSelectionStatus } from '../../browser/PositronNotebookCells/IPositronNotebookCell.js';
 import { CellSelectionType, getSelectedCells, SelectionState } from '../../browser/selectionMachine.js';
@@ -267,6 +270,66 @@ describe('PositronNotebookInstance', () => {
 
 			notebook.moveCellsDown();
 			expect(getCellValues(notebook)).toEqual(['A', 'D', 'E', 'B', 'C']);
+		});
+	});
+
+	describe('attachView', () => {
+		function createInstance(): TestPositronNotebookInstance {
+			const id = `attach-${Math.random().toString(36).slice(2)}`;
+			const notebook = ctx.disposables.add(ctx.instantiationService.createInstance(
+				TestPositronNotebookInstance,
+				id,
+				URI.parse(`test:///${id}.ipynb`),
+				'jupyter-notebook',
+				undefined,
+			));
+			notebook.instantiationService = ctx.instantiationService;
+			return notebook;
+		}
+
+		function makeContainersAndContextKeyService() {
+			const editorContainer = document.createElement('div');
+			const notebookContainer = document.createElement('div');
+			const overlayContainer = document.createElement('div');
+			const contextKeyService = ctx.instantiationService
+				.invokeFunction(accessor => accessor.get(IContextKeyService))
+				.createScoped(editorContainer);
+			return { editorContainer, notebookContainer, overlayContainer, contextKeyService };
+		}
+
+		it('re-attaching with the same scopedContextKeyService preserves the scoped instantiation service', () => {
+			// Each cell's Monaco editor creates a child dependency-injection
+			// container under `scopedInstantiationService`. Disposing this
+			// container also disposes its children. If attachView rebuilt it
+			// on every call, every cached cell's child container would be
+			// disposed and the next keystroke would throw
+			// "InstantiationService has been disposed". Re-attaching with
+			// the same context-key service must reuse the existing container.
+			const notebook = createInstance();
+			const c = makeContainersAndContextKeyService();
+			notebook.attachView(c.editorContainer, c.contextKeyService, c.notebookContainer, c.overlayContainer);
+			const isBefore = notebook.scopedInstantiationService;
+
+			notebook.attachView(c.editorContainer, c.contextKeyService, c.notebookContainer, c.overlayContainer);
+
+			expect(notebook.scopedInstantiationService).toBe(isBefore);
+		});
+
+		it('re-attaching with a different scopedContextKeyService rebuilds the scoped instantiation service', () => {
+			// When a notebook moves to a different editor group, it gets a
+			// different context-key service. The scoped container has to be
+			// rebuilt so new cells bind their context keys to the new one.
+			const notebook = createInstance();
+			const editorContainer = document.createElement('div');
+			const notebookContainer = document.createElement('div');
+			const overlayContainer = document.createElement('div');
+
+			notebook.attachView(editorContainer, new MockScopableContextKeyService(), notebookContainer, overlayContainer);
+			const isBefore = notebook.scopedInstantiationService;
+
+			notebook.attachView(editorContainer, new MockScopableContextKeyService(), notebookContainer, overlayContainer);
+
+			expect(notebook.scopedInstantiationService).not.toBe(isBefore);
 		});
 	});
 });


### PR DESCRIPTION
Fixes #13420

Switching tabs in a Positron notebook would break cell editing. Typing or backspacing produced an "InstantiationService has been disposed" notification. The render cache keeps cells alive across tab switches, but `attachView` was rebuilding the dependency-injection container those cells depended on. This left the cached cells holding a disposed reference. The fix reuses the existing container when its context-key service hasn't changed.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix "InstantiationService has been disposed" error when editing cells in a Positron notebook after switching tabs (#13420)

### QA Notes

@:positron-notebooks

1. Open a Positron notebook (Python or R kernel) and run a few cells.
2. Open a second file in the same editor group (another notebook, a Python file, etc.).
3. Switch back to the notebook tab.
4. Click into a cell and try to backspace, delete, or type.
5. Verify no "InstantiationService has been disposed" notification appears and editing commands work normally.
6. Repeat the tab switch a few times to confirm the error doesn't show up after multiple round-trips.
