### PR TITLE
Fix Don't Show Again notification collision in e2e Toasts.clickButton

### DIFF
--- a/test/e2e/pages/dialog-toasts.ts
+++ b/test/e2e/pages/dialog-toasts.ts
@@ -78,10 +78,15 @@ export class Toasts {
 			: await this.toastNotification.waitFor({ state: 'detached', timeout });
 	}
 
-	async clickButton(button: string) {
+	async clickButton(button: string, options: { notificationFilter?: string | RegExp } = {}) {
 		await test.step(`Click notification button: ${button}`, async () => {
+			const { notificationFilter } = options;
+
 			// Check if the toast button is immediately accessible
-			const toastButton = this.getOptionButton(button);
+			const scopedToast = notificationFilter
+				? this.toastNotification.filter({ hasText: notificationFilter })
+				: this.toastNotification;
+			const toastButton = scopedToast.getByRole('button', { name: button });
 			if (await toastButton.isVisible()) {
 				await toastButton.click();
 				return;
@@ -90,7 +95,10 @@ export class Toasts {
 			// Open notification center and try clicking there (handles smoke test mode
 			// and cases where the toast is obscured by the editor)
 			await this.openNotificationCenter();
-			const notificationCenterButton = this.notificationsCenter.getByRole('button', { name: button });
+			const scopedCenter = notificationFilter
+				? this.notificationsCenter.locator('.notification-list-item').filter({ hasText: notificationFilter })
+				: this.notificationsCenter;
+			const notificationCenterButton = scopedCenter.getByRole('button', { name: button });
 			if (await notificationCenterButton.isVisible()) {
 				await notificationCenterButton.click();
 				await this.closeNotificationCenter();

--- a/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
+++ b/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
@@ -68,7 +68,7 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS] }, () => {
 
 			// select "Don't Show Again" and verify that the prompt is no longer visible
 			await toasts.expectImportSettingsToastToBeVisible();
-			await toasts.clickButton("Don't Show Again");
+			await toasts.clickButton("Don't Show Again", { notificationFilter: /Import your settings from Visual Studio Code/ });
 			await toasts.expectImportSettingsToastToBeVisible(false);
 
 			// verify that prompt is not shown again


### PR DESCRIPTION
A test on the Windows e2e run was deterministically failing because `Toasts.clickButton` searched the entire `.notifications-center` for a button by name. When the requirements.txt prompt and the VS Code import prompt are both stacked in the notification center (which is reliably the case on the Windows e2e build), `getByRole('button', { name: "Don't Show Again" })` matches buttons in both notifications and Playwright throws a strict-mode violation.

`Toasts.clickButton` now takes an optional `notificationFilter: string | RegExp` that scopes both the toast and notification-center lookups to a single `.notification-list-item`. The failing test passes the filter for the VS Code import prompt.

Run that started this: https://github.com/posit-dev/positron/actions/runs/25568637867

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (test infrastructure only)

### Validation Steps

@:vscode-settings @:win

The `Verify import prompt behavior on "Don't Show Again"` test in `test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts` should pass on the Windows e2e run with no strict-mode violation, even when the requirements.txt notification is also visible.