### PR TITLE
Fix top action bar visibility setting

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -759,6 +759,12 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				this.setStatusBarHidden(change.value as boolean);
 			}
 
+			// --- Start Positron ---
+			if (change.key === LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN) {
+				this.setPositronTopActionBarHidden(change.value as boolean);
+			}
+			// --- End Positron ---
+
 			if (change.key === LayoutStateKeys.SIDEBAR_POSITON) {
 				this.setSideBarPosition(change.value as Position);
 			}
@@ -3220,6 +3226,12 @@ class LayoutStateModel extends Disposable {
 			this.setRuntimeValueAndFire(LayoutStateKeys.STATUSBAR_HIDDEN, !this.configurationService.getValue(LegacyWorkbenchLayoutSettings.STATUSBAR_VISIBLE));
 		}
 
+		// --- Start Positron ---
+		if (configurationChangeEvent.affectsConfiguration(LayoutSettings.TOP_ACTION_BAR_VISIBLE)) {
+			this.setRuntimeValueAndFire(LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN, !this.configurationService.getValue(LayoutSettings.TOP_ACTION_BAR_VISIBLE));
+		}
+		// --- End Positron ---
+
 		if (configurationChangeEvent.affectsConfiguration(LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION)) {
 			this.setRuntimeValueAndFire(LayoutStateKeys.SIDEBAR_POSITON, positionFromString(this.configurationService.getValue(LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION) ?? 'left'));
 		}
@@ -3258,6 +3270,9 @@ class LayoutStateModel extends Disposable {
 		// Apply legacy settings
 		this.stateCache.set(LayoutStateKeys.ACTIVITYBAR_HIDDEN.name, this.isActivityBarHidden());
 		this.stateCache.set(LayoutStateKeys.STATUSBAR_HIDDEN.name, !this.configurationService.getValue(LegacyWorkbenchLayoutSettings.STATUSBAR_VISIBLE));
+		// --- Start Positron ---
+		this.stateCache.set(LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN.name, !this.configurationService.getValue(LayoutSettings.TOP_ACTION_BAR_VISIBLE));
+		// --- End Positron ---
 		this.stateCache.set(LayoutStateKeys.SIDEBAR_POSITON.name, positionFromString(this.configurationService.getValue(LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION) ?? 'left'));
 
 		// Set dynamic defaults: part sizing and side bar visibility


### PR DESCRIPTION
Fixes #13113.

This wires the Top Bar visibility setting into the layout layer. The setting was registered and the toggle command updated `workbench.topActionBar.visible`, but that configuration value was not connected to actual workbench part visibility. As a result, the top action bar stayed visible and continued to occupy its grid row.

The fix connects `LayoutSettings.TOP_ACTION_BAR_VISIBLE` and `LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN` to the existing workbench layout visibility mechanism. Layout state changes now call `setPositronTopActionBarHidden`, which updates runtime state and calls `workbenchGrid.setViewVisible` for `Parts.POSITRON_TOP_ACTION_BAR_PART`.


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed `workbench.topActionBar.visible` and the Top Bar visibility toggle so the Top Bar is hidden through the workbench layout grid.


### Validation Steps

E2E tags: @:top-action-bar @:layouts

- Ran `npm install` with Node 22.22.0.
- Ran `npm run build-start && npm run build-check`:
  - `watch-client` completed with 0 errors.
  - `watch-client-transpile` completed with 0 errors.
  - `watch-extensions` completed successfully.
  - `watch-e2e` reported missing test-only dependencies (`ncp`, `@anthropic-ai/sdk`, `resemblejs`) unrelated to this layout change.
- Built the production Linux app with `npm run gulp vscode-linux-x64`.
- Verified the built app contains the layout bridge in `workbench.desktop.main.js`.
- Manually verified that setting `workbench.topActionBar.visible` to `false` hides the Top Bar without leaving a blank gap.

<img width="2295" height="2110" alt="image" src="https://github.com/user-attachments/assets/f90dff0e-a361-43ed-8414-50f61f008877" />

