### PR TITLE
Fix unresponsive column resizer in Variables pane after first pointer move

### DIFF
--- a/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/variablesInstance.tsx
@@ -47,6 +47,92 @@ interface VariablesInstanceProps {
 }
 
 /**
+ * Row data passed to the virtualized row component via react-window's `itemData`.
+ *
+ * The row component (`VariableEntryRow`) is defined at module scope so its reference
+ * is stable across renders. react-window calls `createElement(children, ...)` per cell,
+ * so an inline children function would change component-type identity each render and
+ * remount every row -- which would tear the sash element out of the DOM mid-drag and
+ * break column resizing.
+ */
+interface VariableEntryRowData {
+	readonly entries: VariableEntry[];
+	readonly selectedId: string | undefined;
+	readonly focused: boolean;
+	readonly positronVariablesInstance: IPositronVariablesInstance;
+	readonly detailsColumnWidth: number;
+	readonly nameColumnWidth: number;
+	readonly rightColumnVisible: boolean;
+	readonly clientState: RuntimeClientState;
+	readonly onSelected: (index: number) => void;
+	readonly onDeselected: () => void;
+	readonly onToggleExpandCollapse: (index: number) => void;
+	readonly onBeginResizeNameColumn: () => VerticalSplitterResizeParams;
+	readonly onResizeNameColumn: (newNameColumnWidth: number) => void;
+}
+
+/**
+ * Stable row component for the virtualized variable list.
+ */
+const VariableEntryRow = ({ index, style, data }: ListChildComponentProps<VariableEntryRowData>) => {
+	const entry = data.entries[index];
+	if (isVariableGroup(entry)) {
+		return (
+			<VariableGroup
+				key={entry.id}
+				focused={data.focused}
+				positronVariablesInstance={data.positronVariablesInstance}
+				selected={data.selectedId === entry.id}
+				style={style}
+				variableGroup={entry}
+				onDeselected={data.onDeselected}
+				onSelected={() => data.onSelected(index)}
+				onToggleExpandCollapse={() => data.onToggleExpandCollapse(index)}
+			/>
+		);
+	} else if (isVariableItem(entry)) {
+		return (
+			<VariableItem
+				key={entry.id}
+				detailsColumnWidth={data.detailsColumnWidth}
+				disabled={data.clientState === RuntimeClientState.Closed}
+				focused={data.focused}
+				nameColumnWidth={data.nameColumnWidth}
+				positronVariablesInstance={data.positronVariablesInstance}
+				rightColumnVisible={data.rightColumnVisible}
+				selected={data.selectedId === entry.id}
+				style={style}
+				variableItem={entry}
+				onBeginResizeNameColumn={data.onBeginResizeNameColumn}
+				onDeselected={data.onDeselected}
+				onResizeNameColumn={data.onResizeNameColumn}
+				onSelected={() => data.onSelected(index)}
+				onToggleExpandCollapse={() => data.onToggleExpandCollapse(index)}
+			/>
+		);
+	} else if (isVariableOverflow(entry)) {
+		return (
+			<VariableOverflow
+				key={entry.id}
+				detailsColumnWidth={data.detailsColumnWidth}
+				focused={data.focused}
+				nameColumnWidth={data.nameColumnWidth}
+				selected={data.selectedId === entry.id}
+				style={style}
+				variableOverflow={entry}
+				onBeginResizeNameColumn={data.onBeginResizeNameColumn}
+				onDeselected={data.onDeselected}
+				onResizeNameColumn={data.onResizeNameColumn}
+				onSelected={() => data.onSelected(index)}
+			/>
+		);
+	} else {
+		// It's a bug to get here.
+		return null;
+	}
+};
+
+/**
 * VariablesInstance component.
 * @param props A VariablesInstanceProps that contains the component properties.
 * @returns The rendered component.
@@ -463,69 +549,23 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 		innerRef.current.parentElement?.scrollBy(e.deltaX, e.deltaY);
 	};
 
-	/**
-	 * VariableEntry component.
-	 * @param index The index of the variable entry.
-	 * @param style The style (positioning) at which to render the variable entry.
-	 * @returns The rendered variable entry.
-	 */
-	const VariableEntry = ({ index, style }: ListChildComponentProps<VariableEntry>) => {
-		// Get the entry being rendered.
-		const entry = variableEntries[index];
-		if (isVariableGroup(entry)) {
-			return (
-				<VariableGroup
-					key={entry.id}
-					focused={focused}
-					positronVariablesInstance={props.positronVariablesInstance}
-					selected={selectedId === entry.id}
-					style={style}
-					variableGroup={entry}
-					onDeselected={deselectedHandler}
-					onSelected={() => selectedHandler(index)}
-					onToggleExpandCollapse={() => toggleExpandCollapseHandler(index)}
-				/>
-			);
-		} else if (isVariableItem(entry)) {
-			return (
-				<VariableItem
-					key={entry.id}
-					detailsColumnWidth={detailsColumnWidth}
-					disabled={clientState === RuntimeClientState.Closed}
-					focused={focused}
-					nameColumnWidth={nameColumnWidth}
-					positronVariablesInstance={props.positronVariablesInstance}
-					rightColumnVisible={rightColumnVisible}
-					selected={selectedId === entry.id}
-					style={style}
-					variableItem={entry}
-					onBeginResizeNameColumn={beginResizeNameColumnHandler}
-					onDeselected={deselectedHandler}
-					onResizeNameColumn={resizeNameColumnHandler}
-					onSelected={() => selectedHandler(index)}
-					onToggleExpandCollapse={() => toggleExpandCollapseHandler(index)}
-				/>
-			);
-		} else if (isVariableOverflow(entry)) {
-			return (
-				<VariableOverflow
-					key={entry.id}
-					detailsColumnWidth={detailsColumnWidth}
-					focused={focused}
-					nameColumnWidth={nameColumnWidth}
-					selected={selectedId === entry.id}
-					style={style}
-					variableOverflow={entry}
-					onBeginResizeNameColumn={beginResizeNameColumnHandler}
-					onDeselected={deselectedHandler}
-					onResizeNameColumn={resizeNameColumnHandler}
-					onSelected={() => selectedHandler(index)}
-				/>
-			);
-		} else {
-			// It's a bug to get here.
-			return null;
-		}
+	// Build the row data passed to the stable virtualized row component. Identity changes
+	// each render, but `VariableEntryRow` itself is hoisted at module scope so react-window
+	// re-renders rows with new props instead of unmounting and remounting them.
+	const itemData: VariableEntryRowData = {
+		entries: variableEntries,
+		selectedId,
+		focused,
+		positronVariablesInstance: props.positronVariablesInstance,
+		detailsColumnWidth,
+		nameColumnWidth,
+		rightColumnVisible,
+		clientState,
+		onSelected: selectedHandler,
+		onDeselected: deselectedHandler,
+		onToggleExpandCollapse: toggleExpandCollapseHandler,
+		onBeginResizeNameColumn: beginResizeNameColumnHandler,
+		onResizeNameColumn: resizeNameColumnHandler,
 	};
 
 	// Render.
@@ -548,6 +588,7 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 					height={props.height}
 					innerRef={innerRef}
 					itemCount={variableEntries.length}
+					itemData={itemData}
 					itemKey={index => variableEntries[index].id}
 					itemSize={LINE_HEIGHT}
 					overscanCount={10}
@@ -560,7 +601,7 @@ export const VariablesInstance = (props: VariablesInstanceProps) => {
 						}
 					}}
 				>
-					{VariableEntry}
+					{VariableEntryRow}
 				</List>
 			}
 		</div>


### PR DESCRIPTION
## Summary

Fixes the column resizer in the Variables pane, which would move a few pixels and then stop tracking the pointer.

## Root cause

The `VerticalSplitter` is rendered inside each row of the virtualized variable list. The list uses `react-window`'s `FixedSizeList`, which calls `React.createElement(children, ...)` for every visible cell. The `children` was an inline `VariableEntry` function defined inside `VariablesInstance`'s render body, so its reference changed on every render. React's reconciler treats a different component-type reference as a different type and **unmounts/remounts every row**.

The drag flow then broke like this:

1. `pointerdown` on the sash sets up pointer capture and native `pointermove` / `lostpointercapture` listeners.
2. The first `pointermove` calls `onResize` -> `setNameColumnWidth(...)` in `VariablesInstance`.
3. `VariablesInstance` re-renders -> a new `VariableEntry` function reference -> `react-window` remounts every row -> the original sash element is detached from the DOM.
4. The browser fires `lostpointercapture` on the dead element, the cleanup handler runs, and the drag ends.

This structural problem has been latent in the file since it was created, but it had been masked by an incidental safeguard in `VerticalSplitter`: it used to attach pointer capture and the native listeners to `document.body`, which never gets unmounted. PR #13093 cleanly refactored the splitter to attach to the sash element directly (removing some `@ts-ignore`s in the process) and inadvertently re-exposed the underlying issue.

## Fix

Hoist the row component out of `VariablesInstance` so its reference is stable across renders.

- New module-scope `VariableEntryRow` component.
- New `VariableEntryRowData` interface threaded through `react-window`'s `itemData` prop.
- `VariablesInstance` now builds an `itemData` object each render and passes `<List itemData={itemData}>{VariableEntryRow}</List>`.

`react-window` now sees the same `children` component type across renders and re-renders rows in place with new props instead of unmounting and remounting them. The sash element stays in the DOM for the duration of the drag, pointer capture survives, and resize tracks the cursor end-to-end. As a side benefit, this also removes per-keystroke remount churn for every visible row.

The splitter's pointer-capture target is unchanged in this PR. Restoring the `document.body` capture from before #13093 would be a defense-in-depth improvement for other splitter consumers, but is out of scope here.

## Demo

https://github.com/user-attachments/assets/2f00f5d9-e76c-4d1e-992b-cb7c67c2469b

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #13456 Fix unresponsive column resizer in Variables pane

### Validation Steps

- [ ] Open the Variables pane and drag the column splitter -- it tracks the cursor smoothly across the full range.
- [ ] Splitter respects the minimum (100px) and maximum (2/3 of pane width) name-column widths.
- [ ] Right column visibility toggles correctly as the details column passes the 250px threshold.
- [ ] Selection, expand/collapse, and keyboard navigation in the Variables pane still work.
- [ ] Drag still works after expanding/collapsing variable groups.

### Tests

@:variables