### PR TITLE
Fix ext host log overflow in CI

### DIFF
--- a/src/vs/workbench/api/common/extHostLanguageModels.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModels.ts
@@ -128,6 +128,12 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 	private readonly _pendingRequest = new Map<number, { languageModelId: string; res: LanguageModelResponse }>();
 	private readonly _ignoredFileProviders = new Map<number, vscode.LanguageModelIgnoredFileProvider>();
 	private _languageModelProxyProvider: vscode.LanguageModelProxyProvider | undefined;
+	// --- Start Positron ---
+	// Tracks model identifiers currently being re-resolved by
+	// getLanguageModelByIdentifier. Used to break recursion when
+	// selectLanguageModels keeps returning a model id we still can't find.
+	private readonly _modelLookupInFlight = new Set<string>();
+	// --- End Positron ---
 
 	constructor(
 		@IExtHostRpcService extHostRpc: IExtHostRpcService,
@@ -398,6 +404,16 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 
 		let model = this._localModels.get(modelId);
 		if (!model) {
+			// --- Start Positron ---
+			// Break recursion: if a re-resolve is already in flight for this
+			// modelId, don't kick off another one. Without this guard, a stale
+			// id returned by selectLanguageModels (e.g. an orphaned entry in
+			// main thread's _modelCache for a vendor with no provider) drives
+			// an unbounded loop through selectLanguageModels → here → back.
+			if (this._modelLookupInFlight.has(modelId)) {
+				return undefined;
+			}
+			// --- End Positron ---
 			// model gone? is this an error on us? Try to resolve model again
 			this._logService.warn(`[LanguageModelProxy](${extension.identifier.value}) Could not find model '${modelId}' in local cache. Trying to resolve model again.`);
 			const vendor = this.getVendorFromModelIdentifier(modelId);
@@ -405,7 +421,14 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 				this._logService.warn(`[LanguageModelProxy](${extension.identifier.value}) Could not extract vendor from model identifier '${modelId}'.`);
 				return undefined;
 			}
-			await this.selectLanguageModels(extension, { vendor });
+			// --- Start Positron ---
+			this._modelLookupInFlight.add(modelId);
+			try {
+				await this.selectLanguageModels(extension, { vendor });
+			} finally {
+				this._modelLookupInFlight.delete(modelId);
+			}
+			// --- End Positron ---
 			model = this._localModels.get(modelId);
 			if (!model) {
 				this._logService.warn(`[LanguageModelProxy](${extension.identifier.value}) Could not find model '${modelId}' in local cache after re-resolving models.`);

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -1141,6 +1141,16 @@ export class LanguageModelsService implements ILanguageModelsService {
 		const provider = this._providers.get(vendorId);
 		if (!provider) {
 			this._logService.warn(`[LM] No provider registered for vendor ${vendorId}`);
+			// --- Start Positron ---
+			// Clear any stale model cache entries for this vendor. Without
+			// this, models left in _modelCache from a prior registration
+			// continue to be returned from selectLanguageModels, which
+			// triggers an ext-host recursion loop in
+			// getLanguageModelByIdentifier (selectLanguageModels → resolve
+			// → cache returns stale id → getLanguageModelByIdentifier
+			// re-resolves via selectLanguageModels(vendor) → repeat).
+			this._clearModelCache(vendorId);
+			// --- End Positron ---
 			return;
 		}
 


### PR DESCRIPTION
Addresses a timing issue causing ext-host tests to fail frequently. The issue is that there's a small chance of an infinite loop from getLanguageModelByIdentifier -> _resolveAllLanguageModels -> getLanguageModelByIdentifier when a cache isn't cleared correctly.

Specifically _modelCache has stale entries for copilot (e.g., copilot/test-lm left from chat.test.ts's copilot provider), and that provider gets unregistered, the cache is supposed to be cleared by the unregister disposable at languageModels.ts:1339. But if any path leaves cache populated when no provider is registered (a registration race, an exception during dispose, etc.), _modelCache keeps returning the stale ID forever, and the ext-host recursion churns indefinitely.

The fix is to add a reentrancy guard (don't recurse if we're already resolving) and to clear the model cache when we fail to look up a provider. 

Test tags: `@:assistant`