### PR TITLE
Upstream merge from vscode-server

### DIFF
--- a/.claude/skills/positron-pull-vscode-server/SKILL.md
+++ b/.claude/skills/positron-pull-vscode-server/SKILL.md
@@ -5,7 +5,7 @@ description: Use when pulling changes from rstudio/vscode-server into Positron �
 
 # Pull Upstream vscode-server Changes
 
-Ports changes from `rstudio/vscode-server` into Positron as a single "pseudo upstream merge" commit. A full `git merge` is not possible — the two repos are parallel VSCode forks with no shared git ancestry.
+Ports changes from `rstudio/vscode-server` into Positron as a single "upstream merge from vscode-server" commit. A full `git merge` is not possible — the two repos are parallel VSCode forks with no shared git ancestry — so changes are applied manually and bundled into one commit.
 
 ## When to Use This Skill
 
@@ -36,7 +36,7 @@ Find `<baseline-sha>` — it's the `upstream/main` HEAD recorded after the previ
 git rev-parse upstream/main
 ```
 
-If starting fresh with no recorded SHA, look at the `Brings in:` lines of the last pseudo upstream merge commit, find the earliest of those commits on `upstream/main`, and use its parent SHA as the baseline.
+If starting fresh with no recorded SHA, look at the `Brings in:` lines of the last upstream merge commit, find the earliest of those commits on `upstream/main`, and use its parent SHA as the baseline.
 
 The script assumes Positron and vscode-server are on the same Microsoft VSCode baseline. If Microsoft commits appear in the range it exits with an error — sync the Microsoft baseline first.
 
@@ -70,21 +70,25 @@ npm run precommit -- <file1> <file2> ...           # lint and formatting
 
 Fix precommit issues only in lines you touched. Do not fix pre-existing warnings in unrelated parts of the file — those belong in a separate commit.
 
-Bundle everything into one commit:
+Bundle everything into one commit. Keep the message focused on what's being ported and why — do not include QA notes or e2e test tags (those belong in the PR body only):
 ```bash
-git commit -m "pseudo upstream merge from vscode-server
+git commit -m "upstream merge from vscode-server
 
 Brings in:
 - rstudio/vscode-server#N: <description>
 
-### QA Notes
-
-<steps or 'No manual testing needed.'>"
+<optional: 1-2 short paragraphs of context, e.g. who/what is affected>"
 ```
 
-### Step 5: Create PR
+### Step 5: Offer to create PR
 
-Use the `positron-pr-helper` skill to create the PR. Always include `@:workbench @:web` in the QA tags.
+After the commit lands and verification passes, ask the user whether to create a PR using the `positron-pr-helper` skill — do not push or open the PR until they confirm.
+
+If they say yes, invoke `positron-pr-helper`. Always include `@:workbench @:web @:jupyter` in the QA tags. Then look at the ported diffs and add any other tags that match the affected areas — `positron-pr-helper` fetches the current list from `test/e2e/infra/test-runner/test-tags.ts` (or run `.claude/skills/positron-pr-helper/scripts/fetch-test-tags.sh list` directly). Pick tags conservatively — only add ones that genuinely match what changed. The mandatory three (`@:workbench @:web @:jupyter`) already cover the PWB surface area; additional tags are for routing extra coverage at the specific subsystem that was touched.
+
+### Step 6: Ask for skill feedback
+
+After the PR is open (or after the user declines to create one), ask the user how the skill worked for them and whether anything about the workflow should be changed. If they suggest changes, edit `SKILL.md` directly so future runs incorporate the feedback.
 
 ## Common Mistakes
 

--- a/.claude/skills/positron-pull-vscode-server/scripts/enumerate-upstream.sh
+++ b/.claude/skills/positron-pull-vscode-server/scripts/enumerate-upstream.sh
@@ -4,7 +4,7 @@
 # Usage: ./enumerate-upstream.sh <baseline-sha>
 #
 # <baseline-sha> is the upstream/main commit that corresponds to the last
-# "pseudo upstream merge from vscode-server" commit in Positron's history.
+# "upstream merge from vscode-server" commit in Positron's history.
 #
 # Assumes Positron and vscode-server are on the same Microsoft VSCode baseline.
 # If Microsoft commits appear in the range, the script exits with an error —
@@ -15,8 +15,8 @@ set -euo pipefail
 if [ -z "${1:-}" ]; then
 	echo "Usage: $0 <baseline-sha>"
 	echo ""
-	echo "Recent pseudo upstream merges in Positron:"
-	git log --oneline --grep="pseudo upstream merge from vscode-server" -5
+	echo "Recent upstream merges from vscode-server in Positron:"
+	git log --oneline --grep="upstream merge from vscode-server" -5
 	exit 1
 fi
 

--- a/product.json
+++ b/product.json
@@ -94,10 +94,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "2026.5.4",
+			"version": "2026.5.7",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web-pwb",
-			"sha256": "af0786f6732b28c929892c2fbefde5ddf65bb68bb7742c7e1047438068365dc2",
+			"sha256": "063ee8c0cd480f74723f4d32d9a92fe34f8f5d74dd416d6b466bac467f5a8161",
 			"metadata": {
 				"publisherDisplayName": "Posit PBC"
 			}

--- a/src/vs/server/node/extensionHostConnection.ts
+++ b/src/vs/server/node/extensionHostConnection.ts
@@ -117,6 +117,9 @@ export class ExtensionHostConnection extends Disposable {
 	private _remoteAddress: string;
 	private _extensionHostProcess: cp.ChildProcess | null;
 	private _connectionData: ConnectionData | null;
+	// --- Start PWB: Track whether extension host has sent VSCODE_EXTHOST_IPC_READY ---
+	private _extHostIsReady: boolean;
+	// --- End PWB ---
 
 	constructor(
 		private readonly _reconnectionToken: string,
@@ -141,6 +144,9 @@ export class ExtensionHostConnection extends Disposable {
 		if (!this._canSendSocket && socket instanceof WebSocketNodeSocket) {
 			socket.setRecordInflateBytes(false);
 		}
+		// --- Start PWB: Track whether extension host has sent VSCODE_EXTHOST_IPC_READY ---
+		this._extHostIsReady = false;
+		// --- End PWB ---
 
 		this._log(`New connection established.`);
 	}
@@ -256,6 +262,15 @@ export class ExtensionHostConnection extends Disposable {
 			return;
 		}
 
+		// --- Start PWB: Buffer socket until extension host is ready to avoid silent drop ---
+		if (!this._extHostIsReady) {
+			// Process started but hasn't signalled ready yet; the ready handler
+			// in start() will pick up _connectionData and send it.
+			this._connectionData = connectionData;
+			return;
+		}
+		// --- End PWB ---
+
 		this._sendSocketToExtensionHost(this._extensionHostProcess, connectionData);
 	}
 
@@ -365,12 +380,18 @@ export class ExtensionHostConnection extends Disposable {
 			if (extHostNamedPipeServer) {
 				extHostNamedPipeServer.on('connection', (socket) => {
 					extHostNamedPipeServer.close();
+					// --- Start PWB: Mark host ready when pipe connection is established ---
+					this._extHostIsReady = true;
+					// --- End PWB ---
 					this._pipeSockets(socket, this._connectionData!);
 				});
 			} else {
 				const messageListener = (msg: IExtHostReadyMessage) => {
 					if (msg.type === 'VSCODE_EXTHOST_IPC_READY') {
 						this._extensionHostProcess!.removeListener('message', messageListener);
+						// --- Start PWB: Mark host ready before sending buffered socket ---
+						this._extHostIsReady = true;
+						// --- End PWB ---
 						this._sendSocketToExtensionHost(this._extensionHostProcess!, this._connectionData!);
 						this._connectionData = null;
 					}

--- a/src/vs/server/node/pwbConstants.ts
+++ b/src/vs/server/node/pwbConstants.ts
@@ -47,3 +47,22 @@ function resolveProductLabel(): string {
 
 export const VSCODE_STATIC_PREFIX = `/${resolveProductLabel()}-static`;
 // --- End PWB ---
+
+// --- Start PWB: Workbench deployment path prefix ---
+// Deployment path prefix for Workbench installations mounted under a sub-path (e.g. behind a
+// front-end reverse proxy that only routes /rstudio/* to Workbench). rserver passes the session
+// URL via RS_SESSION_URL, which looks like "/rstudio/s/<session-id>/" or "/s/<session-id>/" --
+// the part before "/s/" is the deployment prefix, and we prepend it to the absolute-from-root
+// URLs we emit so the front proxy will actually route them to Workbench. Empty string when
+// Workbench is mounted at the origin root or when running outside Workbench.
+function resolveDeploymentPrefix(): string {
+	const sessionUrl = process.env['RS_SESSION_URL'];
+	if (!sessionUrl) {
+		return '';
+	}
+	const idx = sessionUrl.indexOf('/s/');
+	return idx > 0 ? sessionUrl.substring(0, idx) : '';
+}
+
+export const WORKBENCH_DEPLOYMENT_PREFIX = resolveDeploymentPrefix();
+// --- End PWB ---

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -32,9 +32,9 @@ import { ICSSDevelopmentService } from '../../platform/cssDev/node/cssDevService
 // --- Start PWB: Server proxy support ---
 // eslint-disable-next-line local/code-import-patterns
 import httpProxy from 'http-proxy';
-import { kProxyRegex, VSCODE_STATIC_PREFIX } from './pwbConstants.js';
 // eslint-disable-next-line no-duplicate-imports
 import { existsSync } from 'fs';
+import { kProxyRegex, VSCODE_STATIC_PREFIX, WORKBENCH_DEPLOYMENT_PREFIX } from './pwbConstants.js';
 // --- End PWB ---
 
 const textMimeType: { [ext: string]: string | undefined } = {
@@ -448,8 +448,10 @@ export class WebClientServer {
 		// --- End PWB ---
 		// --- Start PWB: session-less static route for cacheable assets (workbench.js/.css, NLS, icons, rsLoginCheck) ---
 		// Absolute-from-root so it bypasses the /s/<sid>/ session prefix; `<quality>-<commit>` is the cache-version key.
+		// WORKBENCH_DEPLOYMENT_PREFIX (e.g. "/rstudio") is prepended for installations mounted under a sub-path,
+		// where the front-end reverse proxy only routes that prefix back to Workbench. Empty when mounted at root.
 		// Only used when running under Workbench -- standalone/dev falls back to session-scoped relative URLs below.
-		const sessionlessStaticRoute = posix.join(VSCODE_STATIC_PREFIX, this._productPath, STATIC_PATH);
+		const sessionlessStaticRoute = posix.join(WORKBENCH_DEPLOYMENT_PREFIX, VSCODE_STATIC_PREFIX, this._productPath, STATIC_PATH);
 		// --- End PWB ---
 
 		const resolveWorkspaceURI = (defaultLocation?: string) => defaultLocation && URI.file(resolve(defaultLocation)).with({ scheme: Schemas.vscodeRemote, authority: remoteAuthority });


### PR DESCRIPTION
### Upstream merge

Brings in:
- rstudio/vscode-server#357: Buffer reconnection socket until extension host is ready
- rstudio/vscode-server#358: Bump rstudio.rstudio-workbench to 2026.5.7
- rstudio/vscode-server#359: Account for workbench deployment prefix in static URLs

The reconnection fix targets Workbench's reh-web-pwb mode where the extension host is forked separately from the main process. On reconnect before the host signals `VSCODE_EXTHOST_IPC_READY`, the socket is now buffered and replayed when the host becomes ready, instead of being silently dropped. This unblocks the R console "loading..." hang seen after reconnects in Workbench sessions.

The deployment prefix change only affects Workbench installations mounted under a sub-path (e.g. `/rstudio/*`). Positron desktop and standalone server are unaffected.

### Skill updates

Includes some updates to the merge skill based on this implementation.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### QA Notes

@:workbench @:web @:jupyter

These changes affect Positron Server (reh-web-pwb) running under Workbench. Positron desktop is unaffected. No manual testing needed for the version bump or the deployment-prefix change. For the reconnection fix, repro on the desktop is not practical -- it requires a reh-web-pwb session where the WebSocket reconnects before the extension host has finished starting.