### PR TITLE
Add help button to the packages pane

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -118,10 +118,14 @@
 	border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
 	border-radius: 3px;
 	color: inherit;
-	opacity: 0.5;
+	opacity: 0.7;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
+}
+
+.packages-list-item .packages-list-item-help .codicon {
+	font-size: 13px;
 }
 
 .packages-list-item:hover .packages-list-item-help {

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -45,8 +45,9 @@
 
 .packages-list-item {
 	height: 100%;
-	padding-left: 8px;
-	padding-right: 8px;
+	padding-left: 12px;
+	padding-right: 12px;
+	box-sizing: border-box;
 	display: flex;
 	align-items: center;
 	cursor: pointer;
@@ -104,6 +105,32 @@
 	margin-left: 0.5em;
 	color: var(--vscode-notificationsInfoIcon-foreground);
 	font-size: 0.9em;
+}
+
+.packages-list-item .packages-list-item-help {
+	flex: 0 0 auto;
+	margin-left: auto;
+	box-sizing: border-box;
+	width: 27px;
+	height: 17px;
+	padding: 0;
+	background: transparent;
+	border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+	border-radius: 3px;
+	color: inherit;
+	opacity: 0.5;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.packages-list-item:hover .packages-list-item-help {
+	opacity: 0.85;
+}
+
+.packages-list-item .packages-list-item-help:hover {
+	background: var(--vscode-toolbar-hoverBackground);
+	opacity: 1;
 }
 
 .positron-packages-list .positron-list-empty {

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -259,10 +259,14 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 		}
 		const languageId = session.runtimeMetadata.languageId;
 
-		// R users would prefer we use the `??` operator, whereas the PositronHelpService uses `?`
+		// R: open the package's help index directly. The help comm only knows
+		// how to look up help *topics*, so bare "dplyr" usually finds nothing.
+		// `help(package = ...)` is the canonical entry point for package-level
+		// help; printing the result triggers ark's browseURL hook, which
+		// surfaces the page in the help pane.
 		if (languageId === 'r') {
 			session.execute(
-				`??${packageName}`,
+				`help(package = "${packageName}", help_type = "html")`,
 				generateUuid(),
 				RuntimeCodeExecutionMode.Interactive,
 				RuntimeErrorBehavior.Stop,

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -387,9 +387,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 							tooltip={localize('positronPackages.showHelpTooltip', "Show help for {0}", name)}
 							onPressed={() => { void showHelpForPackage(name); }}
 						>
-							<svg fill='currentColor' height='11' viewBox='0 0 16 16' width='11'>
-								<path d='M2 2.5A.5.5 0 012.5 2H5c1.1 0 2.1.4 2.9 1.1.7-.7 1.8-1.1 2.9-1.1h2.5a.5.5 0 01.5.5v10a.5.5 0 01-.5.5H11c-1 0-1.9.4-2.5 1.1-.6-.7-1.5-1.1-2.5-1.1H2.5a.5.5 0 01-.5-.5v-10zM7.5 4.1C6.9 3.4 6 3 5 3H3v9h3c.7 0 1.4.2 2 .5.6-.3 1.2-.5 2-.5h2V3h-2c-1 0-1.9.4-2.5 1.1z' />
-							</svg>
+							<span className='codicon codicon-book' />
 						</Button>
 					)}
 				</div>

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -8,6 +8,7 @@ import './listPackages.css';
 
 // React.
 import React, {
+	useCallback,
 	useEffect,
 	useMemo,
 	useRef,
@@ -29,6 +30,7 @@ import { usePositronReactServicesContext } from '../../../../../base/browser/pos
 import { showCustomContextMenu, CustomContextMenuSubmenu, CustomContextMenuEntry } from '../../../../browser/positronComponents/customContextMenu/customContextMenu.js';
 import { CustomContextMenuItem } from '../../../../browser/positronComponents/customContextMenu/customContextMenuItem.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
+import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 import { applyFilterToQuery, applySortToQuery, PackagesFilter, PackagesSortOrder, parseQuery } from './packagesQuery.js';
 import { PositronList } from '../../../../browser/positronList/positronList.js';
 import { ListEntry, PositronListInstance, PositronListItemContext } from '../../../../browser/positronList/classes/positronListInstance.js';
@@ -246,6 +248,21 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 		}
 	}, [listInstance, filteredPackages]);
 
+	// Show the help page for a package using the active session's language. Falls back to a
+	// notification if the help service can't find anything.
+	const showHelpForPackage = useCallback(async (packageName: string) => {
+		const languageId = activeInstance?.session.runtimeMetadata.languageId;
+		if (!languageId) {
+			return;
+		}
+		const found = await services.positronHelpService.showHelpTopic(languageId, packageName);
+		if (!found) {
+			services.notificationService.info(
+				localize('positronPackages.noHelpFound', "No help found for '{0}'.", packageName)
+			);
+		}
+	}, [activeInstance, services]);
+
 	// Replace the item renderer whenever its closed-over deps change so the latest
 	// deduplicatedPackages snapshot is visible to "Copy All" and clicks select via the
 	// instance.
@@ -343,12 +360,24 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 							&#x2191;
 						</div>
 					)}
+					{attached === true && (
+						<Button
+							ariaLabel={localize('positronPackages.showHelpAriaLabel', "Show help for {0}", name)}
+							className='packages-list-item-help'
+							tooltip={localize('positronPackages.showHelpTooltip', "Show help for {0}", name)}
+							onPressed={() => { void showHelpForPackage(name); }}
+						>
+							<svg fill='currentColor' height='11' viewBox='0 0 16 16' width='11'>
+								<path d='M2 2.5A.5.5 0 012.5 2H5c1.1 0 2.1.4 2.9 1.1.7-.7 1.8-1.1 2.9-1.1h2.5a.5.5 0 01.5.5v10a.5.5 0 01-.5.5H11c-1 0-1.9.4-2.5 1.1-.6-.7-1.5-1.1-2.5-1.1H2.5a.5.5 0 01-.5-.5v-10zM7.5 4.1C6.9 3.4 6 3 5 3H3v9h3c.7 0 1.4.2 2 .5.6-.3 1.2-.5 2-.5h2V3h-2c-1 0-1.9.4-2.5 1.1z' />
+							</svg>
+						</Button>
+					)}
 				</div>
 			);
 		};
 
 		listInstance.setItemRenderer(renderItem);
-	}, [listInstance, deduplicatedPackages, services]);
+	}, [listInstance, deduplicatedPackages, services, showHelpForPackage]);
 
 	// Enter on the focused row sets selection to that row.
 	useEffect(() => {

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -25,6 +25,8 @@ import { Separator } from '../../../../../base/common/actions.js';
 import { localize } from '../../../../../nls.js';
 import { usePositronPackagesContext } from '../positronPackagesContext.js';
 import { ILanguageRuntimePackage } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { RuntimeCodeExecutionMode, RuntimeErrorBehavior } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { generateUuid } from '../../../../../base/common/uuid.js';
 import { ProgressBar } from '../../../../../base/browser/ui/progressbar/progressbar.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { showCustomContextMenu, CustomContextMenuSubmenu, CustomContextMenuEntry } from '../../../../browser/positronComponents/customContextMenu/customContextMenu.js';
@@ -251,10 +253,24 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	// Show the help page for a package using the active session's language. Falls back to a
 	// notification if the help service can't find anything.
 	const showHelpForPackage = useCallback(async (packageName: string) => {
-		const languageId = activeInstance?.session.runtimeMetadata.languageId;
-		if (!languageId) {
+		const session = activeInstance?.session;
+		if (!session) {
 			return;
 		}
+		const languageId = session.runtimeMetadata.languageId;
+
+		// R users would prefer we use the `??` operator, whereas the PositronHelpService uses `?`
+		if (languageId === 'r') {
+			session.execute(
+				`??${packageName}`,
+				generateUuid(),
+				RuntimeCodeExecutionMode.Interactive,
+				RuntimeErrorBehavior.Stop,
+			);
+			return;
+		}
+
+		// Default behavior
 		const found = await services.positronHelpService.showHelpTopic(languageId, packageName);
 		if (!found) {
 			services.notificationService.info(

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -154,7 +154,7 @@ export class Workbench {
 		this.inlineDataExplorer = new InlineDataExplorer(code.driver.currentPage);
 		this.inlineQuarto = new InlineQuarto(code, this.quickaccess, this.hotKeys);
 		this.publisher = new Publisher(this.quickInput);
-		this.packages = new Packages(code, this.contextMenu, this.quickInput, this.toasts);
+		this.packages = new Packages(code, this.contextMenu, this.quickInput, this.toasts, this.help);
 	}
 }
 

--- a/test/e2e/pages/packages.ts
+++ b/test/e2e/pages/packages.ts
@@ -16,6 +16,7 @@ export class Packages {
 
 	packagesButton: Locator;
 	packagesContainer: Locator;
+	refreshPackagesButton: Locator;
 	packagesViewMoreActionsButton: Locator;
 	filterButton: Locator;
 	filterOptionsMenu: Locator;
@@ -24,6 +25,10 @@ export class Packages {
 	constructor(private code: Code, private contextMenu: ContextMenu, private quickInput: QuickInput, private toasts: Toasts) {
 		this.packagesButton = this.code.driver.currentPage.locator('a.action-label.codicon-package');
 		this.packagesContainer = this.code.driver.currentPage.locator('.positron-packages-list');
+
+		this.refreshPackagesButton = this.code.driver.currentPage
+			.getByRole('toolbar', { name: 'Packages actions' })
+			.getByLabel('Refresh Packages');
 		// More Actions button (overflow menu) in the packages view title bar
 		this.packagesViewMoreActionsButton = code.driver.currentPage
 			.getByRole('toolbar', { name: 'Packages actions' })
@@ -157,6 +162,43 @@ export class Packages {
 		});
 		await expect(item).toBeVisible();
 		await item.hover();
+	}
+
+	/**
+	 * Clicks the help button on a package row to open its help topic in the Help pane.
+	 * The packages list is virtualized -- scrolls the list down until the row for
+	 * the requested package is rendered, then clicks its help button.
+	 * @param packageName The name of the package whose help button should be clicked
+	 */
+	async clickHelpButton(packageName: string): Promise<void> {
+		await this.clickPackagesButton();
+		await expect(this.packagesContainer).toBeVisible();
+
+		const helpButton = this.code.driver.currentPage.getByRole('button', { name: `Show help for ${packageName}` });
+
+		if (!(await helpButton.isVisible())) {
+			const box = await this.packagesContainer.boundingBox();
+			if (!box) {
+				throw new Error('Packages container has no bounding box');
+			}
+			await this.code.driver.currentPage.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+
+			const maxScrollAttempts = 100;
+			for (let i = 0; i < maxScrollAttempts; i++) {
+				await this.code.driver.currentPage.mouse.wheel(0, 250);
+				await this.code.driver.currentPage.waitForTimeout(100);
+				if (await helpButton.isVisible()) {
+					break;
+				}
+			}
+		}
+
+		await helpButton.click();
+	}
+
+	async clickRefreshPackagesButton(): Promise<void> {
+		await this.clickPackagesButton();
+		await this.refreshPackagesButton.click();
 	}
 
 	/**

--- a/test/e2e/pages/packages.ts
+++ b/test/e2e/pages/packages.ts
@@ -6,6 +6,7 @@
 import { expect, Locator } from '@playwright/test';
 import { Code } from '../infra/code';
 import { ContextMenu } from './dialog-contextMenu';
+import { Help } from './help';
 import { QuickInput } from './quickInput';
 import { Toasts } from './dialog-toasts';
 
@@ -22,7 +23,7 @@ export class Packages {
 	filterOptionsMenu: Locator;
 	filterOptionsSubmenu: Locator;
 
-	constructor(private code: Code, private contextMenu: ContextMenu, private quickInput: QuickInput, private toasts: Toasts) {
+	constructor(private code: Code, private contextMenu: ContextMenu, private quickInput: QuickInput, private toasts: Toasts, private help: Help) {
 		this.packagesButton = this.code.driver.currentPage.locator('a.action-label.codicon-package');
 		this.packagesContainer = this.code.driver.currentPage.locator('.positron-packages-list');
 
@@ -162,6 +163,19 @@ export class Packages {
 		});
 		await expect(item).toBeVisible();
 		await item.hover();
+	}
+
+	/**
+	 * Waits for the Help pane to render content for a package, retrying past the
+	 * help-frame load delay.
+	 * @param expectedText Substring that must appear in the help frame body
+	 * @param helpFrameIndex Index of the help webview to check (0 for the first opened, etc.)
+	 */
+	async expectHelpPaneToContainText(expectedText: string, helpFrameIndex: number): Promise<void> {
+		await expect(async () => {
+			const helpFrame = await this.help.getHelpFrame(helpFrameIndex);
+			await expect(helpFrame.locator('body')).toContainText(expectedText);
+		}).toPass();
 	}
 
 	/**

--- a/test/e2e/pages/packages.ts
+++ b/test/e2e/pages/packages.ts
@@ -188,26 +188,11 @@ export class Packages {
 		await this.clickPackagesButton();
 		await expect(this.packagesContainer).toBeVisible();
 
-		const helpButton = this.code.driver.currentPage.getByRole('button', { name: `Show help for ${packageName}` });
-
-		if (!(await helpButton.isVisible())) {
-			const box = await this.packagesContainer.boundingBox();
-			if (!box) {
-				throw new Error('Packages container has no bounding box');
-			}
-			await this.code.driver.currentPage.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-
-			const maxScrollAttempts = 100;
-			for (let i = 0; i < maxScrollAttempts; i++) {
-				await this.code.driver.currentPage.mouse.wheel(0, 250);
-				await this.code.driver.currentPage.waitForTimeout(100);
-				if (await helpButton.isVisible()) {
-					break;
-				}
-			}
-		}
+		await this.searchPackages(packageName);
+		const helpButton = this.packagesContainer.getByRole('button', { name: `Show help for ${packageName}` });
 
 		await helpButton.click();
+		await this.clearFilter();
 	}
 
 	async clickRefreshPackagesButton(): Promise<void> {

--- a/test/e2e/tests/environment-pane/environment-pane.test.ts
+++ b/test/e2e/tests/environment-pane/environment-pane.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, tags, expect } from '../_test.setup';
+import { test, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -48,30 +48,22 @@ test.describe('Environment Pane', {
 
 	test.describe('Help button', { tag: [tags.HELP] }, () => {
 		test('R - Opens package help in Help pane', async function ({ app, r: _r }) {
-			const { packages, help } = app.workbench;
+			const { packages } = app.workbench;
 
 			// Base is always attached
 			await packages.clickHelpButton('base');
-
-			await expect(async () => {
-				const helpFrame = await help.getHelpFrame(0);
-				await expect(helpFrame.locator('body')).toContainText('The R Base Package');
-			}).toPass();
+			await packages.expectHelpPaneToContainText('The R Base Package', 0);
 		});
 
 		test('Python - Opens package help in Help pane', async function ({ app, python: _python, executeCode }) {
-			const { packages, help } = app.workbench;
+			const { packages } = app.workbench;
 
 			// `attached` is true only when the user has bound the module in the REPL and refreshed
 			await executeCode('Python', 'import numpy');
 			await packages.clickRefreshPackagesButton();
 
 			await packages.clickHelpButton('numpy');
-
-			await expect(async () => {
-				const helpFrame = await help.getHelpFrame(1);
-				await expect(helpFrame.locator('body')).toContainText('NumPy');
-			}).toPass();
+			await packages.expectHelpPaneToContainText('NumPy', 1);
 		});
 	});
 });

--- a/test/e2e/tests/environment-pane/environment-pane.test.ts
+++ b/test/e2e/tests/environment-pane/environment-pane.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, tags } from '../_test.setup';
+import { test, tags, expect } from '../_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -44,5 +44,34 @@ test.describe('Environment Pane', {
 		await packages.installPackage('cowsay');
 		await packages.searchPackages('cowsay');
 		await packages.expectPackageInList('cowsay');
+	});
+
+	test.describe('Help button', { tag: [tags.HELP] }, () => {
+		test('R - Opens package help in Help pane', async function ({ app, r: _r }) {
+			const { packages, help } = app.workbench;
+
+			// Base is always attached
+			await packages.clickHelpButton('base');
+
+			await expect(async () => {
+				const helpFrame = await help.getHelpFrame(0);
+				await expect(helpFrame.locator('body')).toContainText('The R Base Package');
+			}).toPass();
+		});
+
+		test('Python - Opens package help in Help pane', async function ({ app, python: _python, executeCode }) {
+			const { packages, help } = app.workbench;
+
+			// `attached` is true only when the user has bound the module in the REPL and refreshed
+			await executeCode('Python', 'import numpy');
+			await packages.clickRefreshPackagesButton();
+
+			await packages.clickHelpButton('numpy');
+
+			await expect(async () => {
+				const helpFrame = await help.getHelpFrame(1);
+				await expect(helpFrame.locator('body')).toContainText('NumPy');
+			}).toPass();
+		});
 	});
 });


### PR DESCRIPTION
See #12773 

This adds a help button next to each item in the packages pane. Currently, it only supports attached packages. In the case of the packages pane, these are items with a green dot next to them.

<img width="1840" height="1196" alt="Screenshot 2026-05-11 at 11 20 10 AM" src="https://github.com/user-attachments/assets/ddab36ce-3fd1-4fd3-94fd-cf66e5988471" />


### Release Notes

#### New Features

- Add help button to attached packages in the Packages pane

#### Bug Fixes

- N/A


### Validation Steps

First, you must attach a package to the runtime using your usual `import cowsay` or `library(cowsay)`
You'll then need to refresh the packages list.
Finally, the button should appear.

@:help @:packages-pane