### PR TITLE
Allow adding help pages even if same `sourceUrl`

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/positronHelpService.ts
@@ -481,11 +481,6 @@ class PositronHelpService extends Disposable implements IPositronHelpService {
 	 * @param helpEntry The help entry to add.
 	 */
 	private addHelpEntry(helpEntry: HelpEntry) {
-		// If the help entry being added matches the current help entry, don't open it again.
-		if (this._helpEntries[this._helpEntryIndex]?.sourceUrl === helpEntry.sourceUrl) {
-			return;
-		}
-
 		// Splice the help entry into the help entries at the current help entry index and trim the
 		// remaining help entries to 10.
 		const deletedHelpEntries = [


### PR DESCRIPTION
The help service will not add a new help page if it has the same URL. I assume this was added for performance or to handle potential edge cases (e.g. infinite reload), but it introduces bugs with the Ark implementation of help. 

The search help pages (e.g. when running ??package from an R console) are all served from the same URL. So if a user entered:

```
??base
??cowsay
```

The help pane would open to the search results for `base` but not `cowsay`. The user can resolve this by manually navigating away from the page and re-executing `??cowsay` as the `sourceUrls` would never match between pages.

This bug came out of #13499 but we chose a different implementation where this fix was no longer needed. I am not sure this is the best approach or if there are other considerations to be made, so I figured I'd open a PR separately. There is no associated ticket.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- R: Subsequent calls with `??` should now work


### Validation Steps

Run two of the commands back to back with different packages:

```
??base
??cowsay
```

Other things to consider are whether history is preserved with the back arrows, etc.

@:help