### PR TITLE
Fallback to foreground session when empty notebook file is created

### DIFF
--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
@@ -392,35 +392,16 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 	 * Try to determine the preferred kernel for a notebook.
 	 */
 	private getPreferredKernel(notebook: NotebookTextModel): RuntimeNotebookKernel | undefined {
-		// Get the notebook's language if possible, otherwise fallback to the foureground session lanaguage.
-		const languageId = getNotebookLanguage(notebook) ?? this._runtimeSessionService.foregroundSession?.runtimeMetadata.languageId;
+		const languageId = getNotebookLanguage(notebook);
 		if (!languageId) {
 			this._logService.debug(`Could not determine notebook ${notebook.uri.fsPath} language`);
 			return;
 		}
-
-		// Get the preferred runtime for the notebook's language.
-		let runtime: ILanguageRuntimeMetadata | undefined;
-		try {
-			runtime = this._runtimeStartupService.getPreferredRuntime(languageId);
-			this._logService.debug(`No preferred runtime for language ${languageId}`);
-		} catch (err) {
-			// It may error if there are no registered runtimes for the language, so log and return.
-			this._logService.debug(`Failed to get preferred runtime for language ${languageId}. Reason: ${err.toString()}`);
-			return;
+		const kernel = this.kernelForLanguage(languageId);
+		if (!kernel) {
+			this._logService.warn(`No kernel for preferred runtime for language ${languageId} for notebook ${notebook.uri}`);
 		}
-
-		// Get the preferred runtime's matching kernel.
-		if (runtime) {
-			const kernel = this._kernelsByRuntimeId.get(runtime.runtimeId);
-			if (kernel) {
-				return kernel;
-			} else {
-				this._logService.warn(`No kernel for preferred runtime ${runtime.runtimeId} for notebook ${notebook.uri}`);
-			}
-		}
-
-		return;
+		return kernel;
 	}
 
 	/**
@@ -479,6 +460,26 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 	}
 
 	private async attachNotebookInstance(instance: IPositronNotebookInstance): Promise<void> {
+		// PositronNotebookEditorInput constructs the instance synchronously and
+		// fires onDidAddNotebookInstance before setInput resolves the notebook
+		// text model. Wait until the model is attached to the instance before
+		// applying the foreground-session fallback.
+		const notebook = await this.awaitInstanceModel(instance);
+
+		// If no kernel was resolved when the notebook was added (for example, an empty
+		// .ipynb with no language metadata and no cells), fall back to the foreground
+		// session's language. Doing this after the instance is constructed ensures
+		// the instance's onWillStartSession subscription is in place before the
+		// session start events fire.
+		if (notebook && !this.getSelectedKernel(notebook)) {
+			const fallback = this.kernelForLanguage(
+				this._runtimeSessionService.foregroundSession?.runtimeMetadata.languageId,
+			);
+			if (fallback) {
+				this._notebookKernelService.selectKernelForNotebook(fallback, notebook);
+			}
+		}
+
 		// Get the selected kernel
 		const kernel = instance.kernel.get();
 
@@ -557,6 +558,36 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 			}
 		}
 		return false;
+	}
+
+	private awaitInstanceModel(instance: IPositronNotebookInstance): Promise<NotebookTextModel | undefined> {
+		if (instance.textModel) {
+			return Promise.resolve(instance.textModel);
+		}
+		return new Promise<NotebookTextModel | undefined>(resolve => {
+			// Register the listener with the service so it's cleaned up if the
+			// service is disposed before the model is attached (which happens
+			// in tests that don't drive the full editor lifecycle).
+			const disposable = this._register(instance.onDidChangeModel(() => {
+				if (instance.textModel) {
+					resolve(instance.textModel);
+					disposable.dispose();
+				}
+			}));
+		});
+	}
+
+	private kernelForLanguage(languageId: string | undefined): RuntimeNotebookKernel | undefined {
+		if (!languageId) {
+			return undefined;
+		}
+		try {
+			const runtime = this._runtimeStartupService.getPreferredRuntime(languageId);
+			return runtime ? this._kernelsByRuntimeId.get(runtime.runtimeId) : undefined;
+		} catch (err) {
+			this._logService.debug(`No preferred runtime for language ${languageId}: ${err.toString()}`);
+			return undefined;
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
@@ -392,8 +392,8 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 	 * Try to determine the preferred kernel for a notebook.
 	 */
 	private getPreferredKernel(notebook: NotebookTextModel): RuntimeNotebookKernel | undefined {
-		// Get the notebook's language.
-		const languageId = getNotebookLanguage(notebook);
+		// Get the notebook's language if possible, otherwise fallback to the foureground session lanaguage.
+		const languageId = getNotebookLanguage(notebook) ?? this._runtimeSessionService.foregroundSession?.runtimeMetadata.languageId;
 		if (!languageId) {
 			this._logService.debug(`Could not determine notebook ${notebook.uri.fsPath} language`);
 			return;

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
@@ -564,14 +564,19 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 		if (instance.textModel) {
 			return Promise.resolve(instance.textModel);
 		}
+
 		return new Promise<NotebookTextModel | undefined>(resolve => {
-			// Register the listener with the service so it's cleaned up if the
-			// service is disposed before the model is attached (which happens
-			// in tests that don't drive the full editor lifecycle).
-			const disposable = this._register(instance.onDidChangeModel(() => {
+			const disposables = this._register(new DisposableStore());
+			disposables.add(instance.onDidChangeModel(() => {
 				if (instance.textModel) {
 					resolve(instance.textModel);
-					disposable.dispose();
+					disposables.dispose();
+				}
+			}));
+			disposables.add(this._positronNotebookService.onDidRemoveNotebookInstance(removed => {
+				if (removed === instance) {
+					resolve(undefined);
+					disposables.dispose();
 				}
 			}));
 		});


### PR DESCRIPTION
Fixes #11555

Notebooks created via "Cmd+N" operation now will auto-start a session that is based off the foreground session's language so the notebook kernel selector no longer shows "No Kernel Selected". The behavior for this flow now behave like the "Create: Create New Jupyter Notebook" command.

### Screenshots


https://github.com/user-attachments/assets/31130ff6-0699-4ca0-b1d9-6806f6b4f14e



### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Auto-select the foreground session's kernel when creating an empty notebook via Cmd+N (#11555)


### Validation Steps
@:notebooks
@:positron-notebooks

**Auto Start Session**
1. Start Positron with a Python console session active in the interpreter picker (foreground session).
2. Create a new file (Cmd+N), then save it as `empty.ipynb`.
3. Observe the kernel selector resolves to the Python version that was the foreground session.

**No Session**
1. Start Positron and ensure there are no sessions (interpreter picker shows "Start Session").
2. Create a new file (Cmd+N), then save it as `empty.ipynb`.
3. Observe the kernel selector shows "No Kernel Selected" and does not resolve to anything because there are.

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
