### PR TITLE
Positron Notebook Editor: Add a keyboard shortcuts help panel 

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
@@ -61,7 +61,7 @@ registerAction2(class NotebookShowKeyboardShortcutsAction extends Action2 {
 				renderer={renderer}
 				resolvedBindings={resolvedBindings}
 				onOpenAllShortcuts={() => {
-					commandService.executeCommand('workbench.action.openGlobalKeybindings', 'positronNotebook');
+					commandService.executeCommand('workbench.action.openGlobalKeybindings', 'positronNotebook.');
 				}}
 			/>
 		);

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
@@ -15,7 +15,7 @@ import { KeyCode, KeyMod } from '../../../../../../base/common/keyCodes.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
-import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../ContextKeysManager.js';
+import { NotebookContextKeys } from '../../../common/notebookContextKeys.js';
 import { NotebookHelpPanel, resolveShortcutBindings } from './NotebookHelpPanel.js';
 
 const NOTEBOOK_HELP_ACTION_ID = 'positronNotebook.showKeyboardShortcuts';
@@ -32,7 +32,7 @@ registerAction2(class NotebookShowKeyboardShortcutsAction extends Action2 {
 			keybinding: {
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyH,
-				when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+				when: NotebookContextKeys.editorFocused,
 			},
 			menu: {
 				id: MenuId.EditorActionsLeft,

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
@@ -9,6 +9,7 @@ import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/con
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
 import { ILayoutService } from '../../../../../../platform/layout/browser/layoutService.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
 import { KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { KeyCode, KeyMod } from '../../../../../../base/common/keyCodes.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
@@ -45,6 +46,7 @@ registerAction2(class NotebookShowKeyboardShortcutsAction extends Action2 {
 	override run(accessor: ServicesAccessor): void {
 		const keybindingService = accessor.get(IKeybindingService);
 		const layoutService = accessor.get(ILayoutService);
+		const commandService = accessor.get(ICommandService);
 
 		// Resolve keybindings while the notebook editor still has focus,
 		// before the modal steals it and changes the active context.
@@ -58,6 +60,9 @@ registerAction2(class NotebookShowKeyboardShortcutsAction extends Action2 {
 			<NotebookHelpPanel
 				renderer={renderer}
 				resolvedBindings={resolvedBindings}
+				onOpenAllShortcuts={() => {
+					commandService.executeCommand('workbench.action.openGlobalKeybindings', 'positronNotebook');
+				}}
 			/>
 		);
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
@@ -9,9 +9,12 @@ import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/con
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
 import { ILayoutService } from '../../../../../../platform/layout/browser/layoutService.js';
+import { KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { KeyCode, KeyMod } from '../../../../../../base/common/keyCodes.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
 import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
+import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../ContextKeysManager.js';
 import { NotebookHelpPanel, resolveShortcutBindings } from './NotebookHelpPanel.js';
 
 const NOTEBOOK_HELP_ACTION_ID = 'positronNotebook.showKeyboardShortcuts';
@@ -25,6 +28,11 @@ registerAction2(class NotebookShowKeyboardShortcutsAction extends Action2 {
 			icon: Codicon.keyboard,
 			f1: true,
 			category: localize2('positronNotebook.category', 'Notebook'),
+			keybinding: {
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyH,
+				when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+			},
 			menu: {
 				id: MenuId.EditorActionsLeft,
 				group: 'navigation',

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
@@ -61,7 +61,7 @@ registerAction2(class NotebookShowKeyboardShortcutsAction extends Action2 {
 				renderer={renderer}
 				resolvedBindings={resolvedBindings}
 				onOpenAllShortcuts={() => {
-					commandService.executeCommand('workbench.action.openGlobalKeybindings', 'positronNotebook');
+					commandService.executeCommand('workbench.action.openGlobalKeybindings', 'positron notebook');
 				}}
 			/>
 		);

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize2 } from '../../../../../../nls.js';
+import { Action2, MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
+import { ILayoutService } from '../../../../../../platform/layout/browser/layoutService.js';
+import { Codicon } from '../../../../../../base/common/codicons.js';
+import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
+import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
+import { NotebookHelpPanel, resolveShortcutBindings } from './NotebookHelpPanel.js';
+
+const NOTEBOOK_HELP_ACTION_ID = 'positronNotebook.showKeyboardShortcuts';
+
+registerAction2(class NotebookShowKeyboardShortcutsAction extends Action2 {
+	constructor() {
+		super({
+			id: NOTEBOOK_HELP_ACTION_ID,
+			title: localize2('positron.notebookHelp.action', 'Keyboard Shortcuts'),
+			tooltip: localize2('positron.notebookHelp.tooltip', 'Show Notebook Keyboard Shortcuts'),
+			icon: Codicon.keyboard,
+			f1: true,
+			category: localize2('positronNotebook.category', 'Notebook'),
+			menu: {
+				id: MenuId.EditorActionsLeft,
+				group: 'navigation',
+				order: 55,
+				when: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID)
+			}
+		});
+	}
+
+	override run(accessor: ServicesAccessor): void {
+		const keybindingService = accessor.get(IKeybindingService);
+		const layoutService = accessor.get(ILayoutService);
+
+		// Resolve keybindings while the notebook editor still has focus,
+		// before the modal steals it and changes the active context.
+		const resolvedBindings = resolveShortcutBindings(keybindingService);
+
+		const renderer = new PositronModalReactRenderer({
+			container: layoutService.activeContainer,
+		});
+
+		renderer.render(
+			<NotebookHelpPanel
+				renderer={renderer}
+				resolvedBindings={resolvedBindings}
+			/>
+		);
+	}
+});

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
@@ -61,7 +61,7 @@ registerAction2(class NotebookShowKeyboardShortcutsAction extends Action2 {
 				renderer={renderer}
 				resolvedBindings={resolvedBindings}
 				onOpenAllShortcuts={() => {
-					commandService.executeCommand('workbench.action.openGlobalKeybindings', 'positron notebook');
+					commandService.executeCommand('workbench.action.openGlobalKeybindings', 'positronNotebook');
 				}}
 			/>
 		);

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.css
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.notebook-help-panel {
+	padding: 0 8px;
+	font-size: 13px;
+	color: var(--vscode-foreground);
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+}
+
+.notebook-help-panel h2 {
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	color: var(--vscode-descriptionForeground);
+	margin: 0 0 8px 0;
+	padding-bottom: 4px;
+	border-bottom: 1px solid var(--vscode-widget-border);
+}
+
+.notebook-help-panel .shortcut-grid {
+	display: grid;
+	grid-template-columns: 1fr 140px;
+	gap: 6px 16px;
+	align-items: center;
+}
+
+.notebook-help-panel .shortcut-row {
+	display: grid;
+	grid-template-columns: subgrid;
+	grid-column: 1 / -1;
+	align-items: center;
+}
+
+.notebook-help-panel .shortcut-label {
+	color: var(--vscode-foreground);
+}
+
+.notebook-help-panel .shortcut-keys {
+	white-space: nowrap;
+}
+
+.notebook-help-panel .shortcut-keys .monaco-keybinding-key {
+	color: var(--vscode-keybindingLabel-foreground);
+	background-color: var(--vscode-keybindingLabel-background);
+	border-color: var(--vscode-keybindingLabel-border);
+	border-bottom-color: var(--vscode-keybindingLabel-bottomBorder);
+	box-shadow: inset 0 -1px 0 var(--vscode-keybindingLabel-bottomBorder);
+}
+
+.notebook-help-panel .shortcut-unbound {
+	color: var(--vscode-descriptionForeground);
+	font-style: italic;
+	font-size: 11px;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.css
@@ -58,3 +58,23 @@
 	font-style: italic;
 	font-size: 11px;
 }
+
+.notebook-help-panel .notebook-help-all-shortcuts {
+	text-align: center;
+	padding-top: 4px;
+	border-top: 1px solid var(--vscode-widget-border);
+}
+
+.notebook-help-panel .all-shortcuts-link {
+	background: none;
+	border: none;
+	color: var(--vscode-textLink-foreground);
+	font-size: 12px;
+	cursor: pointer;
+	padding: 4px 8px;
+}
+
+.notebook-help-panel .all-shortcuts-link:hover {
+	color: var(--vscode-textLink-activeForeground);
+	text-decoration: underline;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
@@ -55,8 +55,6 @@ const SHORTCUT_SECTIONS: ShortcutSection[] = [
 			{ label: localize('positron.notebookHelp.deleteCell', 'Delete cell'), commandId: 'positronNotebook.cell.delete' },
 			{ label: localize('positron.notebookHelp.moveCellUp', 'Move cell up'), commandId: 'positronNotebook.cell.moveUp' },
 			{ label: localize('positron.notebookHelp.moveCellDown', 'Move cell down'), commandId: 'positronNotebook.cell.moveDown' },
-			{ label: localize('positron.notebookHelp.undo', 'Undo'), commandId: 'undo' },
-			{ label: localize('positron.notebookHelp.redo', 'Redo'), commandId: 'redo' },
 		]
 	},
 	{

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
@@ -1,0 +1,174 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './NotebookHelpPanel.css';
+import '../../../../../../base/browser/ui/keybindingLabel/keybindingLabel.css';
+
+// React.
+import { ReactElement } from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../../nls.js';
+import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
+import { OKModalDialog } from '../../../../../browser/positronComponents/positronModalDialog/positronOKModalDialog.js';
+import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
+import { ResolvedChord, ResolvedKeybinding } from '../../../../../../base/common/keybindings.js';
+import { UILabelProvider } from '../../../../../../base/common/keybindingLabels.js';
+import { OS } from '../../../../../../base/common/platform.js';
+
+interface ShortcutEntry {
+	label: string;
+	commandId: string;
+}
+
+interface ShortcutSection {
+	title: string;
+	shortcuts: ShortcutEntry[];
+}
+
+const SHORTCUT_SECTIONS: ShortcutSection[] = [
+	{
+		title: localize('positron.notebookHelp.section.execution', 'Execution'),
+		shortcuts: [
+			{ label: localize('positron.notebookHelp.runCell', 'Run cell'), commandId: 'positronNotebook.cell.executeOrToggleEditor' },
+			{ label: localize('positron.notebookHelp.runCellAndAdvance', 'Run cell and advance'), commandId: 'positronNotebook.cell.executeAndSelectBelow' },
+			{ label: localize('positron.notebookHelp.runAll', 'Run all cells'), commandId: 'positronNotebook.runAllCells' },
+		]
+	},
+	{
+		title: localize('positron.notebookHelp.section.navigation', 'Navigation'),
+		shortcuts: [
+			{ label: localize('positron.notebookHelp.selectUp', 'Select cell above'), commandId: 'positronNotebook.selectUp' },
+			{ label: localize('positron.notebookHelp.selectDown', 'Select cell below'), commandId: 'positronNotebook.selectDown' },
+			{ label: localize('positron.notebookHelp.enterEditMode', 'Enter edit mode'), commandId: 'positronNotebook.cell.edit' },
+			{ label: localize('positron.notebookHelp.exitEditMode', 'Exit edit mode (command mode)'), commandId: 'positronNotebook.cell.quitEdit' },
+		]
+	},
+	{
+		title: localize('positron.notebookHelp.section.editing', 'Editing'),
+		shortcuts: [
+			{ label: localize('positron.notebookHelp.addCodeAbove', 'Insert code cell above'), commandId: 'positronNotebook.cell.insertCodeCellAboveAndFocusContainer' },
+			{ label: localize('positron.notebookHelp.addCodeBelow', 'Insert code cell below'), commandId: 'positronNotebook.cell.insertCodeCellBelowAndFocusContainer' },
+			{ label: localize('positron.notebookHelp.deleteCell', 'Delete cell'), commandId: 'positronNotebook.cell.delete' },
+			{ label: localize('positron.notebookHelp.moveCellUp', 'Move cell up'), commandId: 'positronNotebook.cell.moveUp' },
+			{ label: localize('positron.notebookHelp.moveCellDown', 'Move cell down'), commandId: 'positronNotebook.cell.moveDown' },
+			{ label: localize('positron.notebookHelp.undo', 'Undo'), commandId: 'undo' },
+			{ label: localize('positron.notebookHelp.redo', 'Redo'), commandId: 'redo' },
+		]
+	},
+	{
+		title: localize('positron.notebookHelp.section.cellType', 'Cell Type'),
+		shortcuts: [
+			{ label: localize('positron.notebookHelp.toCode', 'Convert to code cell'), commandId: 'positronNotebook.cell.changeToCode' },
+			{ label: localize('positron.notebookHelp.toMarkdown', 'Convert to markdown cell'), commandId: 'positronNotebook.cell.changeToMarkdown' },
+		]
+	},
+	{
+		title: localize('positron.notebookHelp.section.other', 'Other'),
+		shortcuts: [
+			{ label: localize('positron.notebookHelp.find', 'Find'), commandId: 'positron.notebook.find.start' },
+			{ label: localize('positron.notebookHelp.save', 'Save notebook'), commandId: 'workbench.action.files.save' },
+			{ label: localize('positron.notebookHelp.commandPalette', 'Command palette'), commandId: 'workbench.action.showCommands' },
+		]
+	}
+];
+
+export type ResolvedBindingsMap = ReadonlyMap<string, ResolvedKeybinding>;
+
+/**
+ * Resolve keybindings for all shortcuts while the notebook editor context is
+ * still active. Call this before opening the modal so focus changes don't
+ * affect lookup results.
+ */
+export function resolveShortcutBindings(keybindingService: IKeybindingService): ResolvedBindingsMap {
+	const map = new Map<string, ResolvedKeybinding>();
+	for (const section of SHORTCUT_SECTIONS) {
+		for (const shortcut of section.shortcuts) {
+			const binding = keybindingService.lookupKeybinding(shortcut.commandId);
+			if (binding) {
+				map.set(shortcut.commandId, binding);
+			}
+		}
+	}
+	return map;
+}
+
+interface NotebookHelpPanelProps {
+	renderer: PositronModalReactRenderer;
+	resolvedBindings: ResolvedBindingsMap;
+}
+
+function getChordKeys(chord: ResolvedChord): string[] {
+	const modifierLabels = UILabelProvider.modifierLabels[OS];
+	const keys: string[] = [];
+	if (chord.ctrlKey) { keys.push(modifierLabels.ctrlKey); }
+	if (chord.shiftKey) { keys.push(modifierLabels.shiftKey); }
+	if (chord.altKey) { keys.push(modifierLabels.altKey); }
+	if (chord.metaKey) { keys.push(modifierLabels.metaKey); }
+	if (chord.keyLabel) { keys.push(chord.keyLabel); }
+	return keys;
+}
+
+function renderKeybinding(keybinding: ResolvedKeybinding): ReactElement {
+	const chords = keybinding.getChords();
+	const separator = UILabelProvider.modifierLabels[OS].separator;
+	const elements: ReactElement[] = [];
+	chords.forEach((chord, chordIdx) => {
+		if (chordIdx > 0) {
+			elements.push(<span key={`csep-${chordIdx}`} className='monaco-keybinding-key-chord-separator'> </span>);
+		}
+		const keys = getChordKeys(chord);
+		keys.forEach((key, keyIdx) => {
+			if (keyIdx > 0 && separator) {
+				elements.push(<span key={`sep-${chordIdx}-${keyIdx}`} className='monaco-keybinding-key-separator'>{separator}</span>);
+			}
+			elements.push(<span key={`${chordIdx}-${keyIdx}`} className='monaco-keybinding-key'>{key}</span>);
+		});
+	});
+	const ariaLabel = keybinding.getAriaLabel() || undefined;
+	return <span aria-label={ariaLabel} className='monaco-keybinding'>{elements}</span>;
+}
+
+function KeybindingDisplay({ commandId, resolvedBindings }: { commandId: string; resolvedBindings: ResolvedBindingsMap }): ReactElement {
+	const keybinding = resolvedBindings.get(commandId);
+	if (!keybinding) {
+		return <span className='shortcut-unbound'>{localize('positron.notebookHelp.unbound', 'not bound')}</span>;
+	}
+	return renderKeybinding(keybinding);
+}
+
+export function NotebookHelpPanel({ renderer, resolvedBindings }: NotebookHelpPanelProps): ReactElement {
+	return (
+		<OKModalDialog
+			closeOnClickOutside={true}
+			height={620}
+			okButtonTitle={localize('positron.notebookHelp.close', 'Close')}
+			renderer={renderer}
+			title={localize('positron.notebookHelp.title', 'Notebook Keyboard Shortcuts')}
+			width={500}
+			onAccept={() => renderer.dispose()}
+			onCancel={() => renderer.dispose()}
+		>
+			<div className='notebook-help-panel'>
+				{SHORTCUT_SECTIONS.map(section => (
+					<div key={section.title}>
+						<h2>{section.title}</h2>
+						<div className='shortcut-grid'>
+							{section.shortcuts.map(shortcut => (
+								<div key={shortcut.commandId} className='shortcut-row'>
+									<span className='shortcut-label'>{shortcut.label}</span>
+									<span className='shortcut-keys'>
+										<KeybindingDisplay commandId={shortcut.commandId} resolvedBindings={resolvedBindings} />
+									</span>
+								</div>
+							))}
+						</div>
+					</div>
+				))}
+			</div>
+		</OKModalDialog>
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
@@ -67,7 +67,7 @@ const SHORTCUT_SECTIONS: ShortcutSection[] = [
 	{
 		title: localize('positron.notebookHelp.section.other', 'Other'),
 		shortcuts: [
-			{ label: localize('positron.notebookHelp.find', 'Find'), commandId: 'positron.notebook.find.start' },
+			{ label: localize('positron.notebookHelp.find', 'Find'), commandId: 'positronNotebook.find.start' },
 			{ label: localize('positron.notebookHelp.save', 'Save notebook'), commandId: 'workbench.action.files.save' },
 			{ label: localize('positron.notebookHelp.commandPalette', 'Command palette'), commandId: 'workbench.action.showCommands' },
 		]

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
@@ -97,6 +97,7 @@ export function resolveShortcutBindings(keybindingService: IKeybindingService): 
 interface NotebookHelpPanelProps {
 	renderer: PositronModalReactRenderer;
 	resolvedBindings: ResolvedBindingsMap;
+	onOpenAllShortcuts: () => void;
 }
 
 function getChordKeys(chord: ResolvedChord): string[] {
@@ -138,7 +139,7 @@ function KeybindingDisplay({ commandId, resolvedBindings }: { commandId: string;
 	return renderKeybinding(keybinding);
 }
 
-export function NotebookHelpPanel({ renderer, resolvedBindings }: NotebookHelpPanelProps): ReactElement {
+export function NotebookHelpPanel({ renderer, resolvedBindings, onOpenAllShortcuts }: NotebookHelpPanelProps): ReactElement {
 	return (
 		<OKModalDialog
 			closeOnClickOutside={true}
@@ -166,6 +167,11 @@ export function NotebookHelpPanel({ renderer, resolvedBindings }: NotebookHelpPa
 						</div>
 					</div>
 				))}
+				<div className='notebook-help-all-shortcuts'>
+					<button className='all-shortcuts-link' onClick={() => { renderer.dispose(); onOpenAllShortcuts(); }}>
+						{localize('positron.notebookHelp.allShortcuts', 'View All Notebook Keyboard Shortcuts...')}
+					</button>
+				</div>
 			</div>
 		</OKModalDialog>
 	);

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -13,6 +13,7 @@ import './contrib/outline/positronNotebookOutline.contribution.js';
 import './notebookCells/InlineDataExplorerActions.js';
 import './SelectPositronNotebookKernelAction.js';
 import './contrib/visualize/VisualizeAction.js';
+import './contrib/help/NotebookHelpAction.js';
 
 import { copyImageToClipboard, isCopyImageMenuArg } from './copyImageUtils.js';
 import { isCopyJsonMenuArg, serializeJsonOutput } from './copyJsonUtils.js';


### PR DESCRIPTION
Fixes #13510

### Summary

Add a new button in the positron notebook editor's action bar to show keyboard shortcuts. This currently opens up a modal that lists out the common keyboard shortcuts a user might use for notebooks. The keyboard shortcuts are dynamic so if the user has changed them the help panel will show the updated one. The action is also available via the command palette as "Notebook: Keyboard Shortcuts".


### Demo

https://github.com/user-attachments/assets/fe6c850e-2690-4127-bb59-8513d7f7a3e8


### Release Notes

#### New Features

- Added a keyboard shortcuts help panel for Positron notebooks, accessible via a toolbar button or the command palette (#13510)

#### Bug Fixes

- N/A

### Validation Steps

@:positron-notebooks

1. Open a `.ipynb` file in Positron (ensure Positron notebooks are enabled)
2. Verify a keyboard icon appears in the left side of the editor toolbar
3. Click it -- a modal should appear showing shortcuts grouped by category with keybinding badges
4. Verify keybindings match your current configuration (e.g., if you've rebound a shortcut, it should reflect that)
5. Click "Close" or click outside the modal to dismiss it
6. Open the command palette and search "Keyboard Shortcuts" -- the "Notebook: Keyboard Shortcuts" command should appear and work the same way
