### PR TITLE
Refactor/unify notebook command namespace

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/actions.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/actions.ts
@@ -71,7 +71,7 @@ function findEditorActionImplementation(handler: (controller: PositronNotebookFi
 
 // Start/reveal the find widget
 registerPositronNotebookFindAction({
-	id: 'positron.notebook.find.start',
+	id: 'positronNotebook.find.start',
 	title: localize2('positron.notebook.find.start.title', 'Find'),
 	keybinding: [{
 		when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
@@ -83,7 +83,7 @@ registerPositronNotebookFindAction({
 
 // Hide the find widget
 registerPositronNotebookFindAction({
-	id: 'positron.notebook.find.hide',
+	id: 'positronNotebook.find.hide',
 	title: localize2('positron.notebook.find.hide.title', 'Hide Find'),
 	keybinding: [{
 		when: ContextKeyExpr.and(
@@ -98,7 +98,7 @@ registerPositronNotebookFindAction({
 
 // Find the next match
 registerPositronNotebookFindAction({
-	id: 'positron.notebook.find.next',
+	id: 'positronNotebook.find.next',
 	title: localize2('positron.notebook.find.next.title', 'Find Next'),
 	keybinding: [{
 		// From cell editor
@@ -120,7 +120,7 @@ registerPositronNotebookFindAction({
 
 // Find the previous match from command mode
 registerPositronNotebookFindAction({
-	id: 'positron.notebook.find.previous',
+	id: 'positronNotebook.find.previous',
 	title: localize2('positron.notebook.find.previous.title', 'Find Previous'),
 	keybinding: [{
 		// From cell editor
@@ -146,7 +146,7 @@ PreviousMatchFindAction.addImplementation(0, findEditorActionImplementation((con
 
 // Open find widget with replace expanded
 registerPositronNotebookFindAction({
-	id: 'positron.notebook.find.replaceStart',
+	id: 'positronNotebook.find.replaceStart',
 	title: localize2('positron.notebook.find.replaceStart.title', 'Find and Replace'),
 	keybinding: [{
 		when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
@@ -159,7 +159,7 @@ registerPositronNotebookFindAction({
 
 // Replace the current match
 registerPositronNotebookFindAction({
-	id: 'positron.notebook.find.replace',
+	id: 'positronNotebook.find.replace',
 	title: localize2('positron.notebook.find.replace.title', 'Replace'),
 	keybinding: [{
 		when: ContextKeyExpr.and(
@@ -182,7 +182,7 @@ registerPositronNotebookFindAction({
 
 // Replace all matches
 registerPositronNotebookFindAction({
-	id: 'positron.notebook.find.replaceAll',
+	id: 'positronNotebook.find.replaceAll',
 	title: localize2('positron.notebook.find.replaceAll.title', 'Replace All'),
 	keybinding: [{
 		when: ContextKeyExpr.and(

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -15,10 +15,18 @@ import { usePositronReactServicesContext } from '../../../../../base/browser/pos
 import { usePositronConfiguration, usePositronContextKey } from '../../../../../base/browser/positronReactHooks.js';
 import { IAction } from '../../../../../base/common/actions.js';
 import { removeAnsiEscapeCodes } from '../../../../../base/common/strings.js';
+import { encodeBase64, VSBuffer } from '../../../../../base/common/buffer.js';
 import { CHAT_OPEN_ACTION_ID, ACTION_ID_NEW_CHAT } from '../../../chat/browser/actions/chatActions.js';
 import { ChatModeKind } from '../../../chat/common/constants.js';
 import { POSITRON_NOTEBOOK_ENABLED_KEY } from '../../common/positronNotebookConfig.js';
 import { SplitButton } from '../utilityComponents/SplitButton.js';
+
+const fixPrompt = localize('positronNotebookAssistantFixPrompt', "Fix this notebook cell error.");
+const explainPrompt = localize('positronNotebookAssistantExplainPrompt', "Explain this notebook cell error.");
+
+const NEW_CHAT_COMMAND = 'posit-assistant.newChat';
+const ATTACHMENT_NAME = 'notebook-cell-error.txt';
+const SIDEBAR_VIEW_SETTING = 'assistant.sidebarView';
 
 /**
  * Props for the NotebookCellQuickFix component.
@@ -30,73 +38,79 @@ interface NotebookCellQuickFixProps {
 
 /**
  * Quick fix component for notebook cell errors.
- * Displays "Fix" and "Explain" split buttons that send the error content to the assistant chat.
- * Primary click starts a fresh chat session in agent mode (with tool access to modify notebooks),
- * dropdown opens in the existing chat panel to retain conversation context.
- *
- * @param props Component props containing the error content
- * @returns The rendered component, or null if assistant is not enabled
+ * Displays "Fix" and "Explain" split buttons that send the error content to the assistant.
+ * Uses posit-assistant.newChat when available, falling back to the built-in quick chat.
+ * Primary click starts a fresh conversation; dropdown continues in the current conversation.
  */
 export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 	const services = usePositronReactServicesContext();
-	const { commandService, contextMenuService } = services;
+	const { commandService, contextMenuService, notificationService } = services;
 
 	// Configuration hooks to conditionally show the quick-fix buttons
 	const enableAssistant = usePositronConfiguration<boolean>('positron.assistant.enable');
 	const enableNotebookMode = usePositronConfiguration<boolean>(POSITRON_NOTEBOOK_ENABLED_KEY);
 	const hasChatModels = usePositronContextKey<boolean>('positron-assistant.hasChatModels');
+	const sidebarViewEnabled = usePositronConfiguration<boolean>(SIDEBAR_VIEW_SETTING);
 
 	// Only show buttons if assistant is enabled, notebook mode is enabled, and chat models are available
 	const showQuickFix = enableAssistant && enableNotebookMode && hasChatModels;
 
-	/**
-	 * Builds a query string for asking the assistant to fix the erroring cell.
-	 * The assistant already has notebook context including the selected cell,
-	 * so we only need to include the error output.
-	 */
-	const buildFixQuery = useCallback((): string => {
-		const cleanError = removeAnsiEscapeCodes(props.errorContent).trim();
-		return cleanError
-			? `Fix this cell that produced an error:\n\`\`\`\n${cleanError}\n\`\`\``
-			: 'Fix this cell that produced an error.';
-	}, [props.errorContent]);
+	const cleanError = useMemo(
+		() => removeAnsiEscapeCodes(props.errorContent).trim(),
+		[props.errorContent]
+	);
 
-	/**
-	 * Builds a query string for asking the assistant to explain the error.
-	 * The assistant already has notebook context including the selected cell,
-	 * so we only need to include the error output.
-	 */
-	const buildExplainQuery = useCallback((): string => {
-		const cleanError = removeAnsiEscapeCodes(props.errorContent).trim();
-		return cleanError
-			? `Explain why this cell produced an error:\n\`\`\`\n${cleanError}\n\`\`\``
-			: 'Explain why this cell produced an error.';
-	}, [props.errorContent]);
+	const attachment = useMemo(() => {
+		if (!cleanError) {
+			return undefined;
+		}
+		const base64 = encodeBase64(VSBuffer.fromString(cleanError));
+		return { uri: `data:text/plain;base64,${base64}`, name: ATTACHMENT_NAME };
+	}, [cleanError]);
 
-	/**
-	 * Handler for the "Fix" button primary click.
-	 * Starts a fresh chat session and opens the chat panel in agent mode with a fix prompt and error output.
-	 * Agent mode has tool access to modify notebooks.
-	 */
-	const pressedFixHandler = async () => {
-		await commandService.executeCommand(ACTION_ID_NEW_CHAT);
-		await commandService.executeCommand(CHAT_OPEN_ACTION_ID, {
-			query: buildFixQuery(),
+	const runNewChat = useCallback(async (prompt: string, target: 'new' | 'auto') => {
+		try {
+			await commandService.executeCommand(NEW_CHAT_COMMAND, {
+				prompt,
+				target,
+				behavior: 'submit',
+				...(attachment && { files: [attachment] }),
+			});
+		} catch {
+			notificationService.error(
+				localize(
+					'positronNotebookAssistantUnavailable',
+					"Posit Assistant is not available. Install the Posit Assistant extension to use Fix and Explain."
+				)
+			);
+		}
+	}, [commandService, notificationService, attachment]);
+
+	const runQuickChat = useCallback((prompt: string, isNew: boolean) => {
+		const query = cleanError
+			? `${prompt}\n\`\`\`\n${cleanError}\n\`\`\``
+			: prompt;
+		if (isNew) {
+			commandService.executeCommand(ACTION_ID_NEW_CHAT);
+		}
+		commandService.executeCommand(CHAT_OPEN_ACTION_ID, {
+			query,
 			mode: ChatModeKind.Agent
 		});
+	}, [commandService, cleanError]);
+
+	const pressedFixHandler = () => {
+		if (sidebarViewEnabled) {
+			return runNewChat(fixPrompt, 'new');
+		}
+		return runQuickChat(fixPrompt, true);
 	};
 
-	/**
-	 * Handler for the "Explain" button primary click.
-	 * Starts a fresh chat session and opens the chat panel in agent mode with an explain prompt and error output.
-	 * Agent mode has tool access to modify notebooks.
-	 */
-	const pressedExplainHandler = async () => {
-		await commandService.executeCommand(ACTION_ID_NEW_CHAT);
-		await commandService.executeCommand(CHAT_OPEN_ACTION_ID, {
-			query: buildExplainQuery(),
-			mode: ChatModeKind.Agent
-		});
+	const pressedExplainHandler = () => {
+		if (sidebarViewEnabled) {
+			return runNewChat(explainPrompt, 'new');
+		}
+		return runQuickChat(explainPrompt, true);
 	};
 
 	// Memoize dropdown actions for Fix button
@@ -107,14 +121,14 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 			tooltip: localize('positronNotebookAssistantFixInCurrentChatTooltip', "Opens in the current chat session to retain conversation context"),
 			class: undefined,
 			enabled: true,
-			run: async () => {
-				await commandService.executeCommand(CHAT_OPEN_ACTION_ID, {
-					query: buildFixQuery(),
-					mode: ChatModeKind.Agent
-				});
+			run: () => {
+				if (sidebarViewEnabled) {
+					return runNewChat(fixPrompt, 'auto');
+				}
+				return runQuickChat(fixPrompt, false);
 			}
 		}
-	], [commandService, buildFixQuery]);
+	], [sidebarViewEnabled, runNewChat, runQuickChat]);
 
 	// Memoize dropdown actions for Explain button
 	const explainDropdownActions = useMemo((): IAction[] => [
@@ -124,14 +138,14 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 			tooltip: localize('positronNotebookAssistantExplainInCurrentChatTooltip', "Opens in the current chat session to retain conversation context"),
 			class: undefined,
 			enabled: true,
-			run: async () => {
-				await commandService.executeCommand(CHAT_OPEN_ACTION_ID, {
-					query: buildExplainQuery(),
-					mode: ChatModeKind.Agent
-				});
+			run: () => {
+				if (sidebarViewEnabled) {
+					return runNewChat(explainPrompt, 'auto');
+				}
+				return runQuickChat(explainPrompt, false);
 			}
 		}
-	], [commandService, buildExplainQuery]);
+	], [sidebarViewEnabled, runNewChat, runQuickChat]);
 
 	// Don't render if assistant features are not enabled
 	if (!showQuickFix) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -191,7 +191,7 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 
 				return [
 					{
-						id: 'positron.notebook.copyOutputText',
+						id: 'positronNotebook.copyOutputText',
 						label: copyOutputTextLabel,
 						tooltip: '',
 						class: undefined,

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookMarkdownCell.tsx
@@ -69,7 +69,7 @@ export function NotebookMarkdownCell({ cell }: { cell: PositronNotebookMarkdownC
 			const getClipboardActions = (): IAction[] => {
 				const actions: IAction[] = [];
 				actions.push({
-					id: 'positron.notebook.copy',
+					id: 'positronNotebook.copy',
 					label: copyLabel,
 					tooltip: '',
 					class: undefined,
@@ -81,7 +81,7 @@ export function NotebookMarkdownCell({ cell }: { cell: PositronNotebookMarkdownC
 					}
 				});
 				actions.push({
-					id: 'positron.notebook.selectAll',
+					id: 'positronNotebook.selectAll',
 					label: selectAllLabel,
 					tooltip: '',
 					class: undefined,

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookPrompt.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookPrompt.ts
@@ -131,7 +131,7 @@ export class PositronNotebookPromptContribution extends Disposable implements IW
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: 'positron.notebook.resetPrompt',
+			id: 'positronNotebook.resetPrompt',
 			title: localize2('positron.notebook.resetPrompt', 'Reset Positron Notebook Prompt'),
 			category: Categories.Developer,
 			f1: true,


### PR DESCRIPTION
### Summary

Renames 11 notebook command IDs from the `positron.notebook.*` namespace to `positronNotebook.*`, consolidating all Positron notebook commands under a single camelCase namespace.

This is a prerequisite for clean filtering in the Keyboard Shortcuts editor (see #13510). Command IDs contain dots (`positronNotebook.cell.edit`) while context key names do not (`positronNotebookEditorFocused`), so searching `positronNotebook.` precisely matches commands without false-positiving on when-clause negations like `!positronNotebookCellEditorFocused`.

**Commands renamed:**
| Before | After |
|---|---|
| `positron.notebook.find.start` | `positronNotebook.find.start` |
| `positron.notebook.find.hide` | `positronNotebook.find.hide` |
| `positron.notebook.find.next` | `positronNotebook.find.next` |
| `positron.notebook.find.previous` | `positronNotebook.find.previous` |
| `positron.notebook.find.replace` | `positronNotebook.find.replace` |
| `positron.notebook.find.replaceAll` | `positronNotebook.find.replaceAll` |
| `positron.notebook.find.replaceStart` | `positronNotebook.find.replaceStart` |
| `positron.notebook.copy` | `positronNotebook.copy` |
| `positron.notebook.copyOutputText` | `positronNotebook.copyOutputText` |
| `positron.notebook.selectAll` | `positronNotebook.selectAll` |
| `positron.notebook.resetPrompt` | `positronNotebook.resetPrompt` |

### Why only command IDs?

The codebase has several types of dot-delimited string identifiers that look similar but serve different purposes:

| Type | Example | Purpose | Renamed? |
|---|---|---|---|
| **Command IDs** | `positronNotebook.cell.edit` | User-facing: Command Palette, Keyboard Shortcuts editor, `keybindings.json` | Yes |
| **Setting keys** | `positron.notebook.enabled` | User-facing: Settings editor, `settings.json`. Renaming breaks existing user config. | No |
| **Configuration section IDs** | `positron.ghostCell` | Internal: groups settings visually in the Settings editor | No |
| **Contribution IDs** | `positron.notebook.contrib.findController` | Internal: registers feature controllers within an editor instance | No |
| **`localize()` IDs** | `'positron.notebook.prompt'` | Internal: lookup keys for the localization/translation system | No |
| **Storage keys** | `positron.notebook.promptDismissed` | Internal: persists state across sessions. Renaming resets user state. | No |

Only **command IDs** appear in the Keyboard Shortcuts editor search results, making them the only type that needed renaming for the filtering fix.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:positron-notebooks

1. Open a notebook, click into a cell, press Cmd+F -- find widget should appear
2. Use find next/previous, replace, replace all -- all should work
3. Select all cells (Cmd+A in command mode) -- should work
4. Right-click a markdown cell -- Copy should work
5. Right-click a code cell output -- "Copy Output" should work