### PR TITLE
upstream merge from vscode-server

### DIFF
--- a/product.json
+++ b/product.json
@@ -94,10 +94,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "2026.5.4",
+			"version": "2026.5.8",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web-pwb",
-			"sha256": "af0786f6732b28c929892c2fbefde5ddf65bb68bb7742c7e1047438068365dc2",
+			"sha256": "81abe1e8b5d9bf6a227fa54eee90b791593f5cd271bb0b9cc487f67ee468be9a",
 			"metadata": {
 				"publisherDisplayName": "Posit PBC"
 			}

--- a/src/vs/platform/extensionManagement/common/extensionsGalleryEnv.ts
+++ b/src/vs/platform/extensionManagement/common/extensionsGalleryEnv.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Type-only import: erased at runtime so this module stays a leaf and can be
+// safely imported from product.ts (which loads before the extension management
+// Registry contributions are wired up). See extensionManagement.ts:719 -- that
+// file runs Registry side-effects at module load, so any runtime import chain
+// from product.ts into it would crash startup.
+import type { IProductConfiguration } from '../../../base/common/product.js';
+
+/**
+ * Parses the EXTENSIONS_GALLERY env var into an extensions-gallery config.
+ * Returns undefined if the value is not valid JSON, so a malformed env var is
+ * ignored rather than crashing startup. The caller should fall back to the
+ * default product gallery when undefined is returned.
+ *
+ * Pass `warn` to route the failure message somewhere persistent (e.g. an
+ * ILogService). The default writes to console.warn -- appropriate for product.ts
+ * at module-load time when no logger is wired up yet, but invisible in the log
+ * file. Workbench-stage callers should pass `msg => logService.warn(msg)`.
+ *
+ * The generic parameter lets downstream forks specialize the return type with
+ * a wider gallery shape (e.g. one that includes itemUrl/publisherUrl) without
+ * this leaf module needing to know about those fields.
+ */
+export function parseExtensionsGalleryEnv<T = NonNullable<IProductConfiguration['extensionsGallery']>>(
+	envValue: string,
+	warn: (message: string) => void = msg => console.warn(msg),
+): T | undefined {
+	try {
+		return JSON.parse(envValue) as T;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		warn(`Ignoring EXTENSIONS_GALLERY env var: not valid JSON (${message}).`);
+		return undefined;
+	}
+}

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -6,6 +6,13 @@
 import { env } from '../../../base/common/process.js';
 import { IProductConfiguration } from '../../../base/common/product.js';
 import { ISandboxConfiguration } from '../../../base/parts/sandbox/common/sandboxTypes.js';
+// --- Start PWB ---
+// Import from extensionsGalleryEnv.js (leaf module) rather than
+// extensionGalleryManifestService.js: the latter transitively pulls in
+// extensionManagement.ts, which runs Registry contributions at module load
+// before the Registry is ready, crashing startup with a ReferenceError.
+import { parseExtensionsGalleryEnv } from '../../extensionManagement/common/extensionsGalleryEnv.js';
+// --- End PWB ---
 
 /**
  * @deprecated It is preferred that you use `IProductService` if you can. This
@@ -50,13 +57,14 @@ else if (globalThis._VSCODE_PRODUCT_JSON && globalThis._VSCODE_PACKAGE_JSON) {
 		});
 	}
 
-	// --- Start PWB: Custom extensions gallery
+	// --- Start PWB: Custom extensions gallery ---
 	if (env['EXTENSIONS_GALLERY']) {
-		Object.assign(product, {
-			extensionsGallery: JSON.parse(env['EXTENSIONS_GALLERY'])
-		});
+		const extensionsGallery = parseExtensionsGalleryEnv(env['EXTENSIONS_GALLERY']);
+		if (extensionsGallery) {
+			Object.assign(product, { extensionsGallery });
+		}
 	}
-	// --- End PWB: Custom extensions gallery
+	// --- End PWB: Custom extensions gallery ---
 }
 
 // Web environment or unknown


### PR DESCRIPTION
Brings in:
- rstudio/vscode-server#347: Session-less static file serving via consistent URLs
- rstudio/vscode-server#357: Buffer reconnection socket until extension host is ready (fixes R console stuck on "loading...")
- rstudio/vscode-server#358: Bump `rstudio.rstudio-workbench` to 2026.5.7
- rstudio/vscode-server#359: Account for workbench deployment prefix in static URLs
- rstudio/vscode-server#360: Handle malformed `EXTENSIONS_GALLERY` env var via a new leaf module
- rstudio/vscode-server#361: Bump `rstudio.rstudio-workbench` to 2026.5.8

This is a catch-up port for `release/2026.05` covering everything that landed on `main` from vscode-server since the previous release-branch pull (#13154). It mirrors the work already merged to `main` in #13224 (#347) and #13497 (#357/#358/#359), plus the two newest upstream commits (#360, #361).

### Notes

- **#347** introduces session-less static URLs and an `isWorkbench` helper. The helper is also used to short-circuit client-side idle reporting on Workbench (`positronIdleReporter`).
- **#357** adds socket buffering on reconnect so the extension host can finish signalling `VSCODE_EXTHOST_IPC_READY` before traffic resumes. The upstream `setRecordInflateBytes(false)` call was dropped from the port because that API does not exist on this release branch's VS Code base (1.109.2).
- **#359** only affects Workbench installations mounted under a sub-path; desktop and standalone server are unaffected.
- **#360** introduces `extensionsGalleryEnv.ts` as a leaf module so `product.ts` can parse the env var without pulling in `extensionGalleryManifestService.js` (whose Registry contributions run at module load).
- Also adds the `positron-pull-vscode-server` skill to `.claude/skills/` so this workflow is available on the release branch.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:workbench @:web @:jupyter @:extensions

For #357 (the headline fix): under Workbench, start a Positron session, then trigger a reconnect (e.g. drop the WebSocket) and confirm the R console does not get stuck on "loading...".

For #360: set `EXTENSIONS_GALLERY` to an invalid JSON value (e.g. `EXTENSIONS_GALLERY=not-json`) and confirm Positron starts up with a warning logged, rather than crashing.

No manual testing needed for the workbench extension version bumps (#358, #361).