### PR TITLE
fix: ignore .git/ objects in uncached artifacts CI check

### DIFF
--- a/.github/cache-scripts/check-uncached-artifacts.sh
+++ b/.github/cache-scripts/check-uncached-artifacts.sh
@@ -109,6 +109,8 @@ IGNORE_PATTERNS+=(
 	".pyc"
 	"__pycache__"
 	".cpython-"
+	# Git internal objects created by git operations during CI (not source files)
+	".git/"
 )
 
 # ============================================================================


### PR DESCRIPTION
### Summary
Suppresses a spurious CI warning about `.git/` objects created during npm install.

- Git creates loose objects in `.git/objects/` during normal CI operations
- These aren't source files and don't need caching
- First seen in https://github.com/posit-dev/positron/actions/runs/25569250457
<img width="1003" height="218" alt="Screenshot 2026-05-13 at 2 19 07 PM" src="https://github.com/user-attachments/assets/93cee740-d1eb-4668-bd07-84d6f17a7541" />


### QA Notes
No functional change.