### PR TITLE
Add JupyterLab keyboard shortcuts to Positron notebook editor

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -359,6 +359,14 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	moveCells(cells: IPositronNotebookCell[], targetIndex: number): void;
 
 	/**
+	 * Changes the active cell to a markdown heading of the given level.
+	 * Converts to markdown if needed, then sets the heading prefix.
+	 *
+	 * @param level Heading level 1-6
+	 */
+	changeToHeading(level: number): void;
+
+	/**
 	 * Splits the currently editing cell at the cursor position(s).
 	 * Supports multi-cursor: each cursor creates an additional split point.
 	 */

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -367,6 +367,16 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	changeToHeading(level: number): void;
 
 	/**
+	 * Interrupts all currently executing cells in the notebook.
+	 */
+	interruptKernel(): void;
+
+	/**
+	 * Selects all cells in the notebook.
+	 */
+	selectAllCells(): void;
+
+	/**
 	 * Splits the currently editing cell at the cursor position(s).
 	 * Supports multi-cursor: each cursor creates an additional split point.
 	 */

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -373,6 +373,12 @@ export interface IPositronNotebookCodeCell extends IPositronNotebookCell {
 	showFullOutput(): void;
 
 	/**
+	 * Toggle output scrolling, resolving the effective state from the per-cell
+	 * override or the global setting.
+	 */
+	toggleOutputScroll(): void;
+
+	/**
 	 * Reset per-cell output truncation to follow the global setting.
 	 */
 	resetOutputScrolling(): void;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCodeCell.ts
@@ -119,6 +119,12 @@ export class PositronNotebookCodeCell extends PositronNotebookCellGeneral implem
 		this._outputScrolling.set(true, undefined);
 	}
 
+	toggleOutputScroll(): void {
+		const effective = this._outputScrolling.get()
+			?? this.instance.notebookOptions.getLayoutConfiguration().outputScrolling;
+		this._outputScrolling.set(!effective, undefined);
+	}
+
 	resetOutputScrolling(): void {
 		this._outputScrolling.set(undefined, undefined);
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1519,6 +1519,36 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		}], true, undefined, () => endSelections, undefined, computeUndoRedo);
 	}
 
+	interruptKernel(): void {
+		this._assertTextModel();
+		const cells = this.cells.get();
+		const executingCells = cells.filter(cell =>
+			this.notebookExecutionStateService.getCellExecution(cell.uri)
+		);
+		if (executingCells.length > 0) {
+			this.notebookExecutionService.cancelNotebookCells(
+				this.textModel,
+				executingCells.map(c => c.model as NotebookCellTextModel)
+			);
+		}
+	}
+
+	selectAllCells(): void {
+		const cells = this.cells.get();
+		if (cells.length === 0) {
+			return;
+		}
+		if (cells.length === 1) {
+			this.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			return;
+		}
+		// Select the first cell normally, then add all remaining cells
+		this.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+		for (let i = 1; i < cells.length; i++) {
+			this.selectionStateMachine.selectCell(cells[i], CellSelectionType.Add);
+		}
+	}
+
 	/**
 	 * Splits the currently editing cell at the cursor position(s).
 	 * Supports multi-cursor: each cursor creates an additional split point.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1473,15 +1473,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			return;
 		}
 
-		// Capture index before any mutations
 		const cellIndex = cell.index;
-
-		// Convert to markdown first if needed
-		if (cell.kind !== CellKind.Markup) {
-			this.changeCellType(CellKind.Markup);
-		}
-
-		// Re-read cell model at the same index (changeCellType replaces the cell)
 		const cellModel = this.textModel.cells[cellIndex];
 		if (!cellModel) {
 			return;
@@ -1491,10 +1483,9 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		const lines = content.split(/\r?\n/);
 		const firstLine = lines[0] ?? '';
 
-		// Strip existing heading prefix
+		// Strip existing heading prefix and apply new one
 		const stripped = firstLine.replace(/^#{1,6}\s*/, '');
-		const prefix = '#'.repeat(level) + ' ';
-		lines[0] = prefix + stripped;
+		lines[0] = '#'.repeat(level) + ' ' + stripped;
 
 		const newContent = lines.join('\n');
 		const computeUndoRedo = !this.isReadOnly || this.textModel.viewType === 'interactive';
@@ -1504,16 +1495,17 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			selections: [{ start: cellIndex, end: cellIndex + 1 }]
 		};
 
+		// Single atomic edit: converts to markdown (if needed) and sets heading in one operation
 		this.textModel.applyEdits([{
 			editType: CellEditType.Replace,
 			index: cellIndex,
 			count: 1,
 			cells: [{
 				cellKind: CellKind.Markup,
-				language: cellModel.language,
+				language: 'markdown',
 				mime: cellModel.mime,
 				source: newContent,
-				outputs: [],
+				outputs: cellModel.outputs,
 				metadata: cellModel.metadata,
 			}]
 		}], true, undefined, () => endSelections, undefined, computeUndoRedo);

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1466,6 +1466,59 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		}
 	}
 
+	changeToHeading(level: number): void {
+		this._assertTextModel();
+		const cell = getActiveCell(this.selectionStateMachine.state.get());
+		if (!cell) {
+			return;
+		}
+
+		// Capture index before any mutations
+		const cellIndex = cell.index;
+
+		// Convert to markdown first if needed
+		if (cell.kind !== CellKind.Markup) {
+			this.changeCellType(CellKind.Markup);
+		}
+
+		// Re-read cell model at the same index (changeCellType replaces the cell)
+		const cellModel = this.textModel.cells[cellIndex];
+		if (!cellModel) {
+			return;
+		}
+
+		const content = cellModel.getValue();
+		const lines = content.split(/\r?\n/);
+		const firstLine = lines[0] ?? '';
+
+		// Strip existing heading prefix
+		const stripped = firstLine.replace(/^#{1,6}\s*/, '');
+		const prefix = '#'.repeat(level) + ' ';
+		lines[0] = prefix + stripped;
+
+		const newContent = lines.join('\n');
+		const computeUndoRedo = !this.isReadOnly || this.textModel.viewType === 'interactive';
+		const endSelections: ISelectionState = {
+			kind: SelectionStateType.Index,
+			focus: { start: cellIndex, end: cellIndex + 1 },
+			selections: [{ start: cellIndex, end: cellIndex + 1 }]
+		};
+
+		this.textModel.applyEdits([{
+			editType: CellEditType.Replace,
+			index: cellIndex,
+			count: 1,
+			cells: [{
+				cellKind: CellKind.Markup,
+				language: cellModel.language,
+				mime: cellModel.mime,
+				source: newContent,
+				outputs: [],
+				metadata: cellModel.metadata,
+			}]
+		}], true, undefined, () => endSelections, undefined, computeUndoRedo);
+	}
+
 	/**
 	 * Splits the currently editing cell at the cursor position(s).
 	 * Supports multi-cursor: each cursor creates an additional split point.

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -752,6 +752,65 @@ registerAction2(class extends NotebookAction2 {
 	}
 });
 
+// I+I: Interrupt kernel in command mode (Jupyter-style)
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.interruptKernel',
+			title: localize2('positronNotebook.interruptKernel', "Interrupt Kernel"),
+			keybinding: {
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyChord(KeyCode.KeyI, KeyCode.KeyI)
+			}
+		});
+	}
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		notebook.interruptKernel();
+	}
+});
+
+// o: Toggle output of selected cell in command mode (Jupyter-style)
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.toggleOutput',
+			title: localize2('positronNotebook.cell.toggleOutput', "Toggle Cell Output"),
+			keybinding: {
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyCode.KeyO
+			}
+		});
+	}
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		const state = notebook.selectionStateMachine.state.get();
+		const cell = getActiveCell(state);
+		if (cell?.isCodeCell()) {
+			cell.toggleOutputCollapse();
+		}
+	}
+});
+
+// Cmd+A / Ctrl+A: Select all cells in command mode (Jupyter-style)
+export class SelectAllCellsAction extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.selectAllCells',
+			title: localize2('positronNotebook.selectAllCells', "Select All Cells"),
+			keybinding: {
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyMod.CtrlCmd | KeyCode.KeyA
+			}
+		});
+	}
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		notebook.selectAllCells();
+	}
+}
+registerAction2(SelectAllCellsAction);
+
 //#endregion Notebook Commands
 
 //#region Cell Commands

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1566,7 +1566,9 @@ export class MoveCellUpAction extends NotebookAction2 {
 				when: NotebookContextKeys.editorFocused,
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.Alt | KeyCode.UpArrow,
-				secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.UpArrow]
+				// WinCtrl is literal Ctrl on macOS (Cmd on Win/Linux), so both Cmd+Shift
+				// and Ctrl+Shift move cells on macOS, matching JupyterLab's Ctrl+Shift.
+				secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.UpArrow, KeyMod.WinCtrl | KeyMod.Shift | KeyCode.UpArrow]
 			}
 		});
 	}
@@ -1594,7 +1596,9 @@ export class MoveCellDownAction extends NotebookAction2 {
 				when: NotebookContextKeys.editorFocused,
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.Alt | KeyCode.DownArrow,
-				secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.DownArrow]
+				// WinCtrl is literal Ctrl on macOS (Cmd on Win/Linux), so both Cmd+Shift
+				// and Ctrl+Shift move cells on macOS, matching JupyterLab's Ctrl+Shift.
+				secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.DownArrow, KeyMod.WinCtrl | KeyMod.Shift | KeyCode.DownArrow]
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -628,6 +628,130 @@ KeybindingsRegistry.registerKeybindingRule({
 	primary: KeyMod.Shift | KeyCode.KeyZ
 });
 
+// Shift+L: Toggle line numbers in command mode (Jupyter-style)
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.toggleLineNumbers',
+			title: localize2('positronNotebook.toggleLineNumbers', "Toggle Line Numbers"),
+			keybinding: {
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyMod.Shift | KeyCode.KeyL
+			},
+			grabFocusOnRun: false
+		});
+	}
+	override runNotebookAction(_notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+		const configurationService = accessor.get(IConfigurationService);
+		const current = configurationService.getValue<'on' | 'off'>('notebook.lineNumbers') === 'on';
+		configurationService.updateValue('notebook.lineNumbers', current ? 'off' : 'on');
+	}
+});
+
+// 1-6: Change cell to heading level (Jupyter-style)
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.changeToHeading1',
+			title: localize2('positronNotebook.cell.changeToHeading1', "Change Cell to Heading 1"),
+			keybinding: {
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyCode.Digit1
+			}
+		});
+	}
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		notebook.changeToHeading(1);
+	}
+});
+
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.changeToHeading2',
+			title: localize2('positronNotebook.cell.changeToHeading2', "Change Cell to Heading 2"),
+			keybinding: {
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyCode.Digit2
+			}
+		});
+	}
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		notebook.changeToHeading(2);
+	}
+});
+
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.changeToHeading3',
+			title: localize2('positronNotebook.cell.changeToHeading3', "Change Cell to Heading 3"),
+			keybinding: {
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyCode.Digit3
+			}
+		});
+	}
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		notebook.changeToHeading(3);
+	}
+});
+
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.changeToHeading4',
+			title: localize2('positronNotebook.cell.changeToHeading4', "Change Cell to Heading 4"),
+			keybinding: {
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyCode.Digit4
+			}
+		});
+	}
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		notebook.changeToHeading(4);
+	}
+});
+
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.changeToHeading5',
+			title: localize2('positronNotebook.cell.changeToHeading5', "Change Cell to Heading 5"),
+			keybinding: {
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyCode.Digit5
+			}
+		});
+	}
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		notebook.changeToHeading(5);
+	}
+});
+
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.changeToHeading6',
+			title: localize2('positronNotebook.cell.changeToHeading6', "Change Cell to Heading 6"),
+			keybinding: {
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyCode.Digit6
+			}
+		});
+	}
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		notebook.changeToHeading(6);
+	}
+});
+
 //#endregion Notebook Commands
 
 //#region Cell Commands
@@ -1351,7 +1475,8 @@ export class MoveCellUpAction extends NotebookAction2 {
 			keybinding: {
 				when: NotebookContextKeys.editorFocused,
 				weight: KeybindingWeight.EditorContrib,
-				primary: KeyMod.Alt | KeyCode.UpArrow
+				primary: KeyMod.Alt | KeyCode.UpArrow,
+				secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.UpArrow]
 			}
 		});
 	}
@@ -1378,7 +1503,8 @@ export class MoveCellDownAction extends NotebookAction2 {
 			keybinding: {
 				when: NotebookContextKeys.editorFocused,
 				weight: KeybindingWeight.EditorContrib,
-				primary: KeyMod.Alt | KeyCode.DownArrow
+				primary: KeyMod.Alt | KeyCode.DownArrow,
+				secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.DownArrow]
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -756,7 +756,7 @@ registerAction2(class extends NotebookAction2 {
 });
 
 // I+I: Interrupt kernel in command mode (Jupyter-style)
-registerAction2(class extends NotebookAction2 {
+export class InterruptKernelAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.interruptKernel',
@@ -771,10 +771,11 @@ registerAction2(class extends NotebookAction2 {
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
 		notebook.interruptKernel();
 	}
-});
+}
+registerAction2(InterruptKernelAction);
 
 // o: Toggle output of selected cell in command mode (Jupyter-style)
-registerAction2(class extends NotebookAction2 {
+export class ToggleOutputAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.toggleOutput',
@@ -793,7 +794,8 @@ registerAction2(class extends NotebookAction2 {
 			cell.toggleOutputCollapse();
 		}
 	}
-});
+}
+registerAction2(ToggleOutputAction);
 
 // Cmd+A / Ctrl+A: Select all cells in command mode (Jupyter-style)
 export class SelectAllCellsAction extends NotebookAction2 {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -797,6 +797,30 @@ export class ToggleOutputAction extends NotebookAction2 {
 }
 registerAction2(ToggleOutputAction);
 
+// Shift+O: Toggle cell output scrolling in command mode (Jupyter-style)
+export class ToggleOutputScrollAction extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.toggleOutputScroll',
+			title: localize2('positronNotebook.cell.toggleOutputScroll', "Toggle Cell Output Scrolling"),
+			keybinding: {
+				when: POSITRON_NOTEBOOK_COMMAND_MODE,
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyMod.Shift | KeyCode.KeyO
+			}
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		const state = notebook.selectionStateMachine.state.get();
+		const cell = getActiveCell(state);
+		if (cell?.isCodeCell()) {
+			cell.toggleOutputScroll();
+		}
+	}
+}
+registerAction2(ToggleOutputScrollAction);
+
 // Cmd+A / Ctrl+A: Select all cells in command mode (Jupyter-style)
 export class SelectAllCellsAction extends NotebookAction2 {
 	constructor() {
@@ -2192,7 +2216,7 @@ export class RunAllCellsAction extends NotebookAction2 {
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
 		return notebook.runAllCells();
 	}
-});
+}
 
 // Stop All Cells - cancels execution of every running cell.
 registerAction2(class extends NotebookAction2 {
@@ -2232,7 +2256,7 @@ registerAction2(class extends NotebookAction2 {
 		// routes to cancelNotebookCells instead of executeNotebookCells.
 		return notebook.runAllCells();
 	}
-}
+});
 registerAction2(RunAllCellsAction);
 
 // Clear All Outputs - Clears outputs from all cells

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -513,7 +513,7 @@ export class AddSelectionUpAction extends NotebookAction2 {
 registerAction2(AddSelectionUpAction);
 
 // Enter key: Enter edit mode when cell is selected but NOT editing
-registerAction2(class extends NotebookAction2 {
+export class EnterEditModeAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.edit',
@@ -532,7 +532,8 @@ registerAction2(class extends NotebookAction2 {
 			console.error('Error entering editor:', err);
 		});
 	}
-});
+}
+registerAction2(EnterEditModeAction);
 
 /**
  * Escape key: Exit edit mode when cell editor is focused.
@@ -544,7 +545,7 @@ registerAction2(class extends NotebookAction2 {
  * cell action bars. We should keep both commands in sync
  * to ensure consistent behavior.
  */
-registerAction2(class extends NotebookAction2 {
+export class ExitEditModeAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.quitEdit',
@@ -580,7 +581,8 @@ registerAction2(class extends NotebookAction2 {
 			}
 		}
 	}
-});
+}
+registerAction2(ExitEditModeAction);
 
 /**
  * Escape key: Reduce multi-selection to just the active cell when in command mode.
@@ -629,7 +631,7 @@ KeybindingsRegistry.registerKeybindingRule({
 });
 
 // Shift+L: Toggle line numbers in command mode (Jupyter-style)
-registerAction2(class extends NotebookAction2 {
+export class ToggleLineNumbersAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.toggleLineNumbers',
@@ -647,7 +649,8 @@ registerAction2(class extends NotebookAction2 {
 		const current = configurationService.getValue<'on' | 'off'>('notebook.lineNumbers') === 'on';
 		configurationService.updateValue('notebook.lineNumbers', current ? 'off' : 'on');
 	}
-});
+}
+registerAction2(ToggleLineNumbersAction);
 
 // 1-6: Change cell to heading level (Jupyter-style)
 registerAction2(class extends NotebookAction2 {
@@ -1268,7 +1271,7 @@ registerAction2(ViewMarkdownAction);
 // TODO: Improve the context key support so we don't need to have a single command per
 // the keyboard shortcut and can reuse the action bar commands. Cell agnostic
 // "Execute in place" command.
-registerAction2(class extends NotebookAction2 {
+export class ExecuteOrToggleEditorAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.executeOrToggleEditor',
@@ -1294,7 +1297,8 @@ registerAction2(class extends NotebookAction2 {
 			}
 		}
 	}
-});
+}
+registerAction2(ExecuteOrToggleEditorAction);
 
 
 /**
@@ -1330,7 +1334,7 @@ function executeActiveCell(notebook: IPositronNotebookInstance): IPositronNotebo
 }
 
 // Execute cell and select below
-registerAction2(class extends NotebookAction2 {
+export class ExecuteAndSelectBelowAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.executeAndSelectBelow',
@@ -1373,7 +1377,8 @@ registerAction2(class extends NotebookAction2 {
 			notebook.selectionStateMachine.moveSelectionDown(false);
 		}
 	}
-});
+}
+registerAction2(ExecuteAndSelectBelowAction);
 
 // Execute cell, insert a new cell below, and focus it (Alt+Enter, Jupyter-style)
 export class ExecuteAndInsertBelowAction extends NotebookAction2 {
@@ -2150,7 +2155,7 @@ registerAction2(class extends NotebookAction2 {
 // Register notebook-level actions that appear in the editor action bar
 
 // Run All Cells - Executes all code cells in the notebook
-registerAction2(class extends NotebookAction2 {
+export class RunAllCellsAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.runAllCells',
@@ -2225,10 +2230,11 @@ registerAction2(class extends NotebookAction2 {
 		// routes to cancelNotebookCells instead of executeNotebookCells.
 		return notebook.runAllCells();
 	}
-});
+}
+registerAction2(RunAllCellsAction);
 
 // Clear All Outputs - Clears outputs from all cells
-registerAction2(class extends NotebookAction2 {
+export class ClearAllOutputsAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.clearAllOutputs',
@@ -2257,7 +2263,8 @@ registerAction2(class extends NotebookAction2 {
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
 		notebook.clearAllCellOutputs();
 	}
-});
+}
+registerAction2(ClearAllOutputsAction);
 
 // Show Console - Opens or focuses the notebook console
 registerAction2(class extends NotebookAction2 {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
@@ -12,7 +12,7 @@ import { ServicesAccessor } from '../../../../../platform/instantiation/common/i
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
-import { POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../browser/ContextKeysManager.js';
+import { NotebookContextKeys } from '../../common/notebookContextKeys.js';
 import { IPositronNotebookInstance } from '../../browser/IPositronNotebookInstance.js';
 import { IPositronNotebookCell } from '../../browser/PositronNotebookCells/IPositronNotebookCell.js';
 import {
@@ -30,6 +30,7 @@ import {
 	SelectAllCellsAction,
 	ToggleLineNumbersAction,
 	ToggleOutputAction,
+	ToggleOutputScrollAction,
 } from '../../browser/positronNotebook.contribution.js';
 import { CellSelectionType, getSelectedCells, SelectionState, SelectionStateMachine } from '../../browser/selectionMachine.js';
 import { createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
@@ -96,7 +97,7 @@ describe('Positron Notebook keyboard shortcuts', () => {
 		it('declares Cmd+Enter scoped to notebook editor focused', () => {
 			const action = new ExecuteOrToggleEditorAction();
 			expect(action.desc.keybinding?.primary).toBe(KeyMod.CtrlCmd | KeyCode.Enter);
-			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_EDITOR_FOCUSED);
+			expect(action.desc.keybinding?.when).toBe(NotebookContextKeys.editorFocused);
 		});
 
 		it('calls run() on active code cell', () => {
@@ -140,7 +141,7 @@ describe('Positron Notebook keyboard shortcuts', () => {
 		it('declares Shift+Enter scoped to notebook editor focused', () => {
 			const action = new ExecuteAndSelectBelowAction();
 			expect(action.desc.keybinding?.primary).toBe(KeyMod.Shift | KeyCode.Enter);
-			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_EDITOR_FOCUSED);
+			expect(action.desc.keybinding?.when).toBe(NotebookContextKeys.editorFocused);
 		});
 
 		it('runs cell and moves selection down', async () => {
@@ -185,7 +186,7 @@ describe('Positron Notebook keyboard shortcuts', () => {
 		it('declares Alt+Enter scoped to notebook editor focused', () => {
 			const action = new ExecuteAndInsertBelowAction();
 			expect(action.desc.keybinding?.primary).toBe(KeyMod.Alt | KeyCode.Enter);
-			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_EDITOR_FOCUSED);
+			expect(action.desc.keybinding?.when).toBe(NotebookContextKeys.editorFocused);
 		});
 
 		it('runs cell and inserts a new cell below', async () => {
@@ -251,7 +252,8 @@ describe('Positron Notebook keyboard shortcuts', () => {
 		it('declares Escape scoped to cell editor focused', () => {
 			const action = new ExitEditModeAction();
 			expect(action.desc.keybinding?.primary).toBe(KeyCode.Escape);
-			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED);
+			// `when` is a composite ContextKeyExpr.and(...), so check it includes the cell-editor key.
+			expect(action.desc.keybinding?.when?.keys()).toContain(NotebookContextKeys.cellEditorFocused.key);
 		});
 
 		it('calls exitEditor when in editing state for code cell', () => {
@@ -281,7 +283,7 @@ describe('Positron Notebook keyboard shortcuts', () => {
 			const action = new MoveCellUpAction();
 			expect(action.desc.keybinding?.primary).toBe(KeyMod.Alt | KeyCode.UpArrow);
 			expect(action.desc.keybinding?.secondary).toEqual([KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.UpArrow]);
-			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_EDITOR_FOCUSED);
+			expect(action.desc.keybinding?.when).toBe(NotebookContextKeys.editorFocused);
 		});
 	});
 
@@ -290,7 +292,7 @@ describe('Positron Notebook keyboard shortcuts', () => {
 			const action = new MoveCellDownAction();
 			expect(action.desc.keybinding?.primary).toBe(KeyMod.Alt | KeyCode.DownArrow);
 			expect(action.desc.keybinding?.secondary).toEqual([KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.DownArrow]);
-			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_EDITOR_FOCUSED);
+			expect(action.desc.keybinding?.when).toBe(NotebookContextKeys.editorFocused);
 		});
 	});
 
@@ -440,6 +442,37 @@ describe('Positron Notebook keyboard shortcuts', () => {
 				expect(cell.outputIsCollapsed.get()).toBe(true);
 				cell.toggleOutputCollapse();
 				expect(cell.outputIsCollapsed.get()).toBe(false);
+			}
+		});
+	});
+
+	describe('Shift+O (Toggle Cell Output Scrolling)', () => {
+		it('declares Shift+O scoped to command mode', () => {
+			const action = new ToggleOutputScrollAction();
+			expect(action.desc.keybinding?.primary).toBe(KeyMod.Shift | KeyCode.KeyO);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_COMMAND_MODE);
+		});
+
+		it('toggles output scrolling on a code cell', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]],
+				ctx,
+			);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			const cell = cells[0];
+
+			expect(cell.isCodeCell()).toBe(true);
+			if (cell.isCodeCell()) {
+				// Starts as undefined (follows the global notebook.outputScrolling setting).
+				expect(cell.outputScrolling.get()).toBe(undefined);
+				// First toggle resolves the effective state and sets the explicit opposite.
+				cell.toggleOutputScroll();
+				const first = cell.outputScrolling.get();
+				expect(typeof first).toBe('boolean');
+				// Subsequent toggles flip the explicit value.
+				cell.toggleOutputScroll();
+				expect(cell.outputScrolling.get()).toBe(!first);
 			}
 		});
 	});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
@@ -1,0 +1,131 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { CellKind } from '../../../notebook/common/notebookCommon.js';
+import {
+	MoveCellDownAction,
+	MoveCellUpAction,
+	POSITRON_NOTEBOOK_COMMAND_MODE,
+} from '../../browser/positronNotebook.contribution.js';
+import { createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
+import { CellSelectionType } from '../../browser/selectionMachine.js';
+import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../browser/ContextKeysManager.js';
+
+describe('JupyterLab keyboard shortcuts', () => {
+	const ctx = createTestContainer().withNotebookEditorServices().build();
+
+	describe('Ctrl+Shift+Up/Down move cell keybindings', () => {
+		it('MoveCellUpAction declares Ctrl+Shift+Up as secondary binding', () => {
+			const action = new MoveCellUpAction();
+			expect(action.desc.keybinding?.primary).toBe(KeyMod.Alt | KeyCode.UpArrow);
+			expect(action.desc.keybinding?.secondary).toEqual([KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.UpArrow]);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_EDITOR_FOCUSED);
+		});
+
+		it('MoveCellDownAction declares Ctrl+Shift+Down as secondary binding', () => {
+			const action = new MoveCellDownAction();
+			expect(action.desc.keybinding?.primary).toBe(KeyMod.Alt | KeyCode.DownArrow);
+			expect(action.desc.keybinding?.secondary).toEqual([KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.DownArrow]);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_EDITOR_FOCUSED);
+		});
+	});
+
+	describe('changeToHeading (1-6 keys)', () => {
+		it('converts code cell to markdown with heading prefix', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['some content', 'python', CellKind.Code]],
+				ctx,
+			);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+
+			notebook.changeToHeading(1);
+
+			const after = notebook.cells.get();
+			expect(after[0].kind).toBe(CellKind.Markup);
+			expect(after[0].getContent()).toBe('# some content');
+		});
+
+		it('replaces existing heading prefix when changing levels', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['## existing heading', 'markdown', CellKind.Markup]],
+				ctx,
+			);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+
+			notebook.changeToHeading(3);
+
+			const after = notebook.cells.get();
+			expect(after[0].getContent()).toBe('### existing heading');
+		});
+
+		it('handles empty cell content', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['', 'markdown', CellKind.Markup]],
+				ctx,
+			);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+
+			notebook.changeToHeading(2);
+
+			const after = notebook.cells.get();
+			expect(after[0].getContent()).toBe('## ');
+		});
+
+		it('preserves lines after the first when setting heading', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['first line\nsecond line\nthird line', 'markdown', CellKind.Markup]],
+				ctx,
+			);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+
+			notebook.changeToHeading(1);
+
+			const after = notebook.cells.get();
+			expect(after[0].getContent()).toBe('# first line\nsecond line\nthird line');
+		});
+
+		it('supports all heading levels 1-6', () => {
+			for (let level = 1; level <= 6; level++) {
+				const notebook = createTestPositronNotebookInstance(
+					[['text', 'markdown', CellKind.Markup]],
+					ctx,
+				);
+				const cells = notebook.cells.get();
+				notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+
+				notebook.changeToHeading(level);
+
+				const after = notebook.cells.get();
+				const expectedPrefix = '#'.repeat(level) + ' ';
+				expect(after[0].getContent()).toBe(expectedPrefix + 'text');
+			}
+		});
+
+		it('keybinding for heading 1 is Digit1 scoped to command mode', () => {
+			// We can't import anonymous classes, but we can check the registration
+			// exists by verifying the changeToHeading method is callable
+			const notebook = createTestPositronNotebookInstance(
+				[['test', 'python', CellKind.Code]],
+				ctx,
+			);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+
+			notebook.changeToHeading(6);
+
+			const after = notebook.cells.get();
+			expect(after[0].kind).toBe(CellKind.Markup);
+			expect(after[0].getContent()).toBe('###### test');
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
@@ -5,16 +5,17 @@
 
 /// <reference types="vitest/globals" />
 
-import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { KeyChord, KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
 import {
 	MoveCellDownAction,
 	MoveCellUpAction,
 	POSITRON_NOTEBOOK_COMMAND_MODE,
+	SelectAllCellsAction,
 } from '../../browser/positronNotebook.contribution.js';
 import { createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
-import { CellSelectionType } from '../../browser/selectionMachine.js';
+import { CellSelectionType, getSelectedCells, SelectionState } from '../../browser/selectionMachine.js';
 import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../browser/ContextKeysManager.js';
 
 describe('JupyterLab keyboard shortcuts', () => {
@@ -126,6 +127,86 @@ describe('JupyterLab keyboard shortcuts', () => {
 			const after = notebook.cells.get();
 			expect(after[0].kind).toBe(CellKind.Markup);
 			expect(after[0].getContent()).toBe('###### test');
+		});
+	});
+
+	describe('selectAllCells (Cmd+A)', () => {
+		it('SelectAllCellsAction declares Cmd+A scoped to command mode', () => {
+			const action = new SelectAllCellsAction();
+			expect(action.desc.keybinding?.primary).toBe(KeyMod.CtrlCmd | KeyCode.KeyA);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_COMMAND_MODE);
+		});
+
+		it('selects all cells in a multi-cell notebook', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[
+					['cell1', 'python', CellKind.Code],
+					['cell2', 'python', CellKind.Code],
+					['cell3', 'python', CellKind.Code],
+				],
+				ctx,
+			);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+
+			notebook.selectAllCells();
+
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.MultiSelection);
+			if (state.type === SelectionState.MultiSelection) {
+				expect(getSelectedCells(state)).toHaveLength(3);
+			}
+		});
+
+		it('handles single-cell notebook', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['only cell', 'python', CellKind.Code]],
+				ctx,
+			);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+
+			notebook.selectAllCells();
+
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+		});
+	});
+
+	describe('toggleOutput (o key)', () => {
+		it('toggles output collapse on a code cell', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]],
+				ctx,
+			);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			const cell = cells[0];
+
+			expect(cell.isCodeCell()).toBe(true);
+			if (cell.isCodeCell()) {
+				cell.toggleOutputCollapse();
+				expect(cell.outputIsCollapsed.get()).toBe(true);
+				cell.toggleOutputCollapse();
+				expect(cell.outputIsCollapsed.get()).toBe(false);
+			}
+		});
+	});
+
+	describe('interruptKernel (I+I)', () => {
+		it('interruptKernel is callable on notebook instance', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]],
+				ctx,
+			);
+			// Verify interruptKernel doesn't throw when no cells are executing
+			expect(() => notebook.interruptKernel()).not.toThrow();
+		});
+
+		it('I+I keybinding uses KeyChord', () => {
+			// Verify the keychord constant matches what we'd expect
+			const chord = KeyChord(KeyCode.KeyI, KeyCode.KeyI);
+			expect(chord).toBeGreaterThan(0);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
@@ -6,30 +6,285 @@
 /// <reference types="vitest/globals" />
 
 import { KeyChord, KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
+import { POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../browser/ContextKeysManager.js';
+import { IPositronNotebookInstance } from '../../browser/IPositronNotebookInstance.js';
+import { IPositronNotebookCell } from '../../browser/PositronNotebookCells/IPositronNotebookCell.js';
 import {
+	ClearAllOutputsAction,
+	EnterEditModeAction,
+	ExecuteAndInsertBelowAction,
+	ExecuteAndSelectBelowAction,
+	ExecuteOrToggleEditorAction,
+	ExitEditModeAction,
 	MoveCellDownAction,
 	MoveCellUpAction,
 	POSITRON_NOTEBOOK_COMMAND_MODE,
+	RunAllCellsAction,
 	SelectAllCellsAction,
+	ToggleLineNumbersAction,
 } from '../../browser/positronNotebook.contribution.js';
+import { CellSelectionType, getSelectedCells, SelectionState, SelectionStateMachine } from '../../browser/selectionMachine.js';
 import { createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
-import { CellSelectionType, getSelectedCells, SelectionState } from '../../browser/selectionMachine.js';
-import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../browser/ContextKeysManager.js';
 
-describe('JupyterLab keyboard shortcuts', () => {
+/**
+ * Tests for all Positron Notebook keyboard shortcuts.
+ *
+ * Each shortcut is tested for:
+ * 1. Keybinding metadata (correct key, correct `when` context)
+ * 2. Action behavior (invoking produces the right state change)
+ */
+describe('Positron Notebook keyboard shortcuts', () => {
 	const ctx = createTestContainer().withNotebookEditorServices().build();
 
-	describe('Ctrl+Shift+Up/Down move cell keybindings', () => {
-		it('MoveCellUpAction declares Ctrl+Shift+Up as secondary binding', () => {
+	// Testable subclasses that expose the protected `runNotebookAction`.
+	class TestableExecuteOrToggleEditor extends ExecuteOrToggleEditorAction {
+		testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+	class TestableExecuteAndSelectBelow extends ExecuteAndSelectBelowAction {
+		testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+	class TestableExecuteAndInsertBelow extends ExecuteAndInsertBelowAction {
+		testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+	class TestableEnterEditMode extends EnterEditModeAction {
+		testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+	class TestableExitEditMode extends ExitEditModeAction {
+		testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+	class TestableToggleLineNumbers extends ToggleLineNumbersAction {
+		testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+	class TestableRunAllCells extends RunAllCellsAction {
+		testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+	class TestableClearAllOutputs extends ClearAllOutputsAction {
+		testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+
+	const unusedAccessor: ServicesAccessor = {
+		get() { throw new Error('ServicesAccessor must not be used'); },
+	};
+
+	//#region Execution shortcuts
+
+	describe('Ctrl+Enter (Execute Cell or Toggle Editor)', () => {
+		it('declares Cmd+Enter scoped to notebook editor focused', () => {
+			const action = new ExecuteOrToggleEditorAction();
+			expect(action.desc.keybinding?.primary).toBe(KeyMod.CtrlCmd | KeyCode.Enter);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_EDITOR_FOCUSED);
+		});
+
+		it('calls run() on active code cell', () => {
+			const run = vi.fn();
+			const cell = stubInterface<IPositronNotebookCell>({
+				isMarkdownCell: () => false,
+				isCodeCell: () => true,
+				run,
+			});
+			const notebook = stubInterface<IPositronNotebookInstance>({
+				selectionStateMachine: {
+					state: observableValue('state', { type: SelectionState.SingleSelection, active: cell }),
+				} as unknown as SelectionStateMachine,
+			});
+
+			new TestableExecuteOrToggleEditor().testRun(notebook, unusedAccessor);
+
+			expect(run).toHaveBeenCalledOnce();
+		});
+
+		it('calls toggleEditor() on active markdown cell', () => {
+			const toggleEditor = vi.fn();
+			const cell = stubInterface<IPositronNotebookCell>({
+				isMarkdownCell: () => true,
+				isCodeCell: () => false,
+				toggleEditor,
+			});
+			const notebook = stubInterface<IPositronNotebookInstance>({
+				selectionStateMachine: {
+					state: observableValue('state', { type: SelectionState.SingleSelection, active: cell }),
+				} as unknown as SelectionStateMachine,
+			});
+
+			new TestableExecuteOrToggleEditor().testRun(notebook, unusedAccessor);
+
+			expect(toggleEditor).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe('Shift+Enter (Execute Cell and Select Below)', () => {
+		it('declares Shift+Enter scoped to notebook editor focused', () => {
+			const action = new ExecuteAndSelectBelowAction();
+			expect(action.desc.keybinding?.primary).toBe(KeyMod.Shift | KeyCode.Enter);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_EDITOR_FOCUSED);
+		});
+
+		it('runs cell and moves selection down', async () => {
+			const notebook = createTestPositronNotebookInstance(
+				[
+					['cell1', 'python', CellKind.Code],
+					['cell2', 'python', CellKind.Code],
+				],
+				ctx,
+			);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			// Spy to prevent actual execution reaching the test execution service
+			const runSpy = vi.spyOn(cells[0], 'run').mockImplementation(() => { });
+
+			await new TestableExecuteAndSelectBelow().testRun(notebook, unusedAccessor);
+
+			expect(runSpy).toHaveBeenCalledOnce();
+			const state = notebook.selectionStateMachine.state.get();
+			expect(state.type).toBe(SelectionState.SingleSelection);
+			if (state.type === SelectionState.SingleSelection) {
+				expect(state.active.getContent()).toBe('cell2');
+			}
+		});
+
+		it('inserts new cell when on last cell', async () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['only', 'python', CellKind.Code]],
+				ctx,
+			);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			vi.spyOn(cells[0], 'run').mockImplementation(() => { });
+
+			await new TestableExecuteAndSelectBelow().testRun(notebook, unusedAccessor);
+
+			expect(notebook.cells.get()).toHaveLength(2);
+		});
+	});
+
+	describe('Alt+Enter (Execute Cell and Insert Below)', () => {
+		it('declares Alt+Enter scoped to notebook editor focused', () => {
+			const action = new ExecuteAndInsertBelowAction();
+			expect(action.desc.keybinding?.primary).toBe(KeyMod.Alt | KeyCode.Enter);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_EDITOR_FOCUSED);
+		});
+
+		it('runs cell and inserts a new cell below', async () => {
+			const notebook = createTestPositronNotebookInstance(
+				[
+					['cell1', 'python', CellKind.Code],
+					['cell2', 'python', CellKind.Code],
+				],
+				ctx,
+			);
+			const cells = notebook.cells.get();
+			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			const runSpy = vi.spyOn(cells[0], 'run').mockImplementation(() => { });
+
+			await new TestableExecuteAndInsertBelow().testRun(notebook, unusedAccessor);
+
+			expect(runSpy).toHaveBeenCalledOnce();
+			expect(notebook.cells.get()).toHaveLength(3);
+		});
+	});
+
+	describe('Ctrl+Shift+Enter (Run All Cells)', () => {
+		it('declares Ctrl+Shift+Enter', () => {
+			const action = new RunAllCellsAction();
+			expect(action.desc.keybinding?.primary).toBe(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter);
+		});
+
+		it('calls runAllCells() on the notebook', () => {
+			const runAllCells = vi.fn();
+			const notebook = stubInterface<IPositronNotebookInstance>({ runAllCells });
+
+			new TestableRunAllCells().testRun(notebook, unusedAccessor);
+
+			expect(runAllCells).toHaveBeenCalledOnce();
+		});
+	});
+
+	//#endregion
+
+	//#region Mode switching
+
+	describe('Enter (Enter Edit Mode)', () => {
+		it('declares Enter scoped to command mode', () => {
+			const action = new EnterEditModeAction();
+			expect(action.desc.keybinding?.primary).toBe(KeyCode.Enter);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_COMMAND_MODE);
+		});
+
+		it('calls enterEditor on the selection state machine', () => {
+			const enterEditor = vi.fn().mockResolvedValue(undefined);
+			const notebook = stubInterface<IPositronNotebookInstance>({
+				getFocusedCell: () => undefined,
+				selectionStateMachine: { enterEditor } as unknown as SelectionStateMachine,
+			});
+
+			new TestableEnterEditMode().testRun(notebook, unusedAccessor);
+
+			expect(enterEditor).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe('Escape (Exit Edit Mode)', () => {
+		it('declares Escape scoped to cell editor focused', () => {
+			const action = new ExitEditModeAction();
+			expect(action.desc.keybinding?.primary).toBe(KeyCode.Escape);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED);
+		});
+
+		it('calls exitEditor when in editing state for code cell', () => {
+			const cell = stubInterface<IPositronNotebookCell>({
+				isMarkdownCell: () => false,
+			});
+			const exitEditor = vi.fn();
+			const notebook = stubInterface<IPositronNotebookInstance>({
+				selectionStateMachine: {
+					state: observableValue('state', { type: SelectionState.EditingSelection, active: cell }),
+					exitEditor,
+				} as unknown as SelectionStateMachine,
+			});
+
+			new TestableExitEditMode().testRun(notebook, unusedAccessor);
+
+			expect(exitEditor).toHaveBeenCalledOnce();
+		});
+	});
+
+	//#endregion
+
+	//#region Cell movement
+
+	describe('Alt+Up / Ctrl+Shift+Up (Move Cell Up)', () => {
+		it('declares Alt+Up primary and Ctrl+Shift+Up secondary', () => {
 			const action = new MoveCellUpAction();
 			expect(action.desc.keybinding?.primary).toBe(KeyMod.Alt | KeyCode.UpArrow);
 			expect(action.desc.keybinding?.secondary).toEqual([KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.UpArrow]);
 			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_EDITOR_FOCUSED);
 		});
+	});
 
-		it('MoveCellDownAction declares Ctrl+Shift+Down as secondary binding', () => {
+	describe('Alt+Down / Ctrl+Shift+Down (Move Cell Down)', () => {
+		it('declares Alt+Down primary and Ctrl+Shift+Down secondary', () => {
 			const action = new MoveCellDownAction();
 			expect(action.desc.keybinding?.primary).toBe(KeyMod.Alt | KeyCode.DownArrow);
 			expect(action.desc.keybinding?.secondary).toEqual([KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.DownArrow]);
@@ -37,7 +292,11 @@ describe('JupyterLab keyboard shortcuts', () => {
 		});
 	});
 
-	describe('changeToHeading (1-6 keys)', () => {
+	//#endregion
+
+	//#region Heading levels
+
+	describe('1-6 (Change to Heading Level)', () => {
 		it('converts code cell to markdown with heading prefix', () => {
 			const notebook = createTestPositronNotebookInstance(
 				[['some content', 'python', CellKind.Code]],
@@ -81,7 +340,7 @@ describe('JupyterLab keyboard shortcuts', () => {
 			expect(after[0].getContent()).toBe('## ');
 		});
 
-		it('preserves lines after the first when setting heading', () => {
+		it('preserves lines after the first', () => {
 			const notebook = createTestPositronNotebookInstance(
 				[['first line\nsecond line\nthird line', 'markdown', CellKind.Markup]],
 				ctx,
@@ -107,31 +366,86 @@ describe('JupyterLab keyboard shortcuts', () => {
 				notebook.changeToHeading(level);
 
 				const after = notebook.cells.get();
-				const expectedPrefix = '#'.repeat(level) + ' ';
-				expect(after[0].getContent()).toBe(expectedPrefix + 'text');
+				expect(after[0].getContent()).toBe('#'.repeat(level) + ' text');
 			}
 		});
+	});
 
-		it('keybinding for heading 1 is Digit1 scoped to command mode', () => {
-			// We can't import anonymous classes, but we can check the registration
-			// exists by verifying the changeToHeading method is callable
+	//#endregion
+
+	//#region Toggle line numbers
+
+	describe('Shift+L (Toggle Line Numbers)', () => {
+		it('declares Shift+L scoped to command mode', () => {
+			const action = new ToggleLineNumbersAction();
+			expect(action.desc.keybinding?.primary).toBe(KeyMod.Shift | KeyCode.KeyL);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_COMMAND_MODE);
+		});
+
+		it('toggles notebook.lineNumbers from off to on', () => {
+			const updateValue = vi.fn();
 			const notebook = createTestPositronNotebookInstance(
-				[['test', 'python', CellKind.Code]],
+				[['cell', 'python', CellKind.Code]],
+				ctx,
+			);
+			const configService = ctx.instantiationService.get(IConfigurationService);
+			vi.spyOn(configService, 'getValue').mockReturnValue('off');
+			vi.spyOn(configService, 'updateValue').mockImplementation(updateValue);
+			const accessor: ServicesAccessor = { get: () => configService };
+
+			new TestableToggleLineNumbers().testRun(notebook, accessor);
+
+			expect(updateValue).toHaveBeenCalledWith('notebook.lineNumbers', 'on');
+		});
+
+		it('toggles notebook.lineNumbers from on to off', () => {
+			const updateValue = vi.fn();
+			const notebook = createTestPositronNotebookInstance(
+				[['cell', 'python', CellKind.Code]],
+				ctx,
+			);
+			const configService = ctx.instantiationService.get(IConfigurationService);
+			vi.spyOn(configService, 'getValue').mockReturnValue('on');
+			vi.spyOn(configService, 'updateValue').mockImplementation(updateValue);
+			const accessor: ServicesAccessor = { get: () => configService };
+
+			new TestableToggleLineNumbers().testRun(notebook, accessor);
+
+			expect(updateValue).toHaveBeenCalledWith('notebook.lineNumbers', 'off');
+		});
+	});
+
+	//#endregion
+
+	//#region Output toggle
+
+	describe('O (Toggle Cell Output)', () => {
+		it('toggles output collapse on a code cell', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]],
 				ctx,
 			);
 			const cells = notebook.cells.get();
 			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
+			const cell = cells[0];
 
-			notebook.changeToHeading(6);
-
-			const after = notebook.cells.get();
-			expect(after[0].kind).toBe(CellKind.Markup);
-			expect(after[0].getContent()).toBe('###### test');
+			expect(cell.isCodeCell()).toBe(true);
+			if (cell.isCodeCell()) {
+				expect(cell.outputIsCollapsed.get()).toBe(false);
+				cell.toggleOutputCollapse();
+				expect(cell.outputIsCollapsed.get()).toBe(true);
+				cell.toggleOutputCollapse();
+				expect(cell.outputIsCollapsed.get()).toBe(false);
+			}
 		});
 	});
 
-	describe('selectAllCells (Cmd+A)', () => {
-		it('SelectAllCellsAction declares Cmd+A scoped to command mode', () => {
+	//#endregion
+
+	//#region Select all
+
+	describe('Cmd+A (Select All Cells)', () => {
+		it('declares Cmd+A scoped to command mode', () => {
 			const action = new SelectAllCellsAction();
 			expect(action.desc.keybinding?.primary).toBe(KeyMod.CtrlCmd | KeyCode.KeyA);
 			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_COMMAND_MODE);
@@ -173,40 +487,44 @@ describe('JupyterLab keyboard shortcuts', () => {
 		});
 	});
 
-	describe('toggleOutput (o key)', () => {
-		it('toggles output collapse on a code cell', () => {
-			const notebook = createTestPositronNotebookInstance(
-				[['print("hello")', 'python', CellKind.Code]],
-				ctx,
-			);
-			const cells = notebook.cells.get();
-			notebook.selectionStateMachine.selectCell(cells[0], CellSelectionType.Normal);
-			const cell = cells[0];
+	//#endregion
 
-			expect(cell.isCodeCell()).toBe(true);
-			if (cell.isCodeCell()) {
-				cell.toggleOutputCollapse();
-				expect(cell.outputIsCollapsed.get()).toBe(true);
-				cell.toggleOutputCollapse();
-				expect(cell.outputIsCollapsed.get()).toBe(false);
-			}
-		});
-	});
+	//#region Interrupt kernel
 
-	describe('interruptKernel (I+I)', () => {
-		it('interruptKernel is callable on notebook instance', () => {
-			const notebook = createTestPositronNotebookInstance(
-				[['print("hello")', 'python', CellKind.Code]],
-				ctx,
-			);
-			// Verify interruptKernel doesn't throw when no cells are executing
-			expect(() => notebook.interruptKernel()).not.toThrow();
-		});
-
-		it('I+I keybinding uses KeyChord', () => {
-			// Verify the keychord constant matches what we'd expect
+	describe('I+I (Interrupt Kernel)', () => {
+		it('uses KeyChord for I,I binding', () => {
 			const chord = KeyChord(KeyCode.KeyI, KeyCode.KeyI);
 			expect(chord).toBeGreaterThan(0);
 		});
+
+		it('does not throw when no cells are executing', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[['print("hello")', 'python', CellKind.Code]],
+				ctx,
+			);
+			expect(() => notebook.interruptKernel()).not.toThrow();
+		});
 	});
+
+	//#endregion
+
+	//#region Clear all outputs
+
+	describe('Ctrl+K, K (Clear All Outputs)', () => {
+		it('declares Ctrl+K,K chord keybinding', () => {
+			const action = new ClearAllOutputsAction();
+			expect(action.desc.keybinding?.primary).toBe(KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyK));
+		});
+
+		it('calls clearAllCellOutputs() on the notebook', () => {
+			const clearAllCellOutputs = vi.fn();
+			const notebook = stubInterface<IPositronNotebookInstance>({ clearAllCellOutputs });
+
+			new TestableClearAllOutputs().testRun(notebook, unusedAccessor);
+
+			expect(clearAllCellOutputs).toHaveBeenCalledOnce();
+		});
+	});
+
+	//#endregion
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
@@ -282,7 +282,7 @@ describe('Positron Notebook keyboard shortcuts', () => {
 		it('declares Alt+Up primary and Ctrl+Shift+Up secondary', () => {
 			const action = new MoveCellUpAction();
 			expect(action.desc.keybinding?.primary).toBe(KeyMod.Alt | KeyCode.UpArrow);
-			expect(action.desc.keybinding?.secondary).toEqual([KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.UpArrow]);
+			expect(action.desc.keybinding?.secondary).toEqual([KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.UpArrow, KeyMod.WinCtrl | KeyMod.Shift | KeyCode.UpArrow]);
 			expect(action.desc.keybinding?.when).toBe(NotebookContextKeys.editorFocused);
 		});
 	});
@@ -291,7 +291,7 @@ describe('Positron Notebook keyboard shortcuts', () => {
 		it('declares Alt+Down primary and Ctrl+Shift+Down secondary', () => {
 			const action = new MoveCellDownAction();
 			expect(action.desc.keybinding?.primary).toBe(KeyMod.Alt | KeyCode.DownArrow);
-			expect(action.desc.keybinding?.secondary).toEqual([KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.DownArrow]);
+			expect(action.desc.keybinding?.secondary).toEqual([KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.DownArrow, KeyMod.WinCtrl | KeyMod.Shift | KeyCode.DownArrow]);
 			expect(action.desc.keybinding?.when).toBe(NotebookContextKeys.editorFocused);
 		});
 	});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts
@@ -22,12 +22,14 @@ import {
 	ExecuteAndSelectBelowAction,
 	ExecuteOrToggleEditorAction,
 	ExitEditModeAction,
+	InterruptKernelAction,
 	MoveCellDownAction,
 	MoveCellUpAction,
 	POSITRON_NOTEBOOK_COMMAND_MODE,
 	RunAllCellsAction,
 	SelectAllCellsAction,
 	ToggleLineNumbersAction,
+	ToggleOutputAction,
 } from '../../browser/positronNotebook.contribution.js';
 import { CellSelectionType, getSelectedCells, SelectionState, SelectionStateMachine } from '../../browser/selectionMachine.js';
 import { createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
@@ -383,35 +385,31 @@ describe('Positron Notebook keyboard shortcuts', () => {
 		});
 
 		it('toggles notebook.lineNumbers from off to on', () => {
-			const updateValue = vi.fn();
 			const notebook = createTestPositronNotebookInstance(
 				[['cell', 'python', CellKind.Code]],
 				ctx,
 			);
 			const configService = ctx.instantiationService.get(IConfigurationService);
 			vi.spyOn(configService, 'getValue').mockReturnValue('off');
-			vi.spyOn(configService, 'updateValue').mockImplementation(updateValue);
-			const accessor: ServicesAccessor = { get: () => configService };
+			const updateSpy = vi.spyOn(configService, 'updateValue').mockResolvedValue(undefined);
 
-			new TestableToggleLineNumbers().testRun(notebook, accessor);
+			new TestableToggleLineNumbers().testRun(notebook, ctx.instantiationService);
 
-			expect(updateValue).toHaveBeenCalledWith('notebook.lineNumbers', 'on');
+			expect(updateSpy).toHaveBeenCalledWith('notebook.lineNumbers', 'on');
 		});
 
 		it('toggles notebook.lineNumbers from on to off', () => {
-			const updateValue = vi.fn();
 			const notebook = createTestPositronNotebookInstance(
 				[['cell', 'python', CellKind.Code]],
 				ctx,
 			);
 			const configService = ctx.instantiationService.get(IConfigurationService);
 			vi.spyOn(configService, 'getValue').mockReturnValue('on');
-			vi.spyOn(configService, 'updateValue').mockImplementation(updateValue);
-			const accessor: ServicesAccessor = { get: () => configService };
+			const updateSpy = vi.spyOn(configService, 'updateValue').mockResolvedValue(undefined);
 
-			new TestableToggleLineNumbers().testRun(notebook, accessor);
+			new TestableToggleLineNumbers().testRun(notebook, ctx.instantiationService);
 
-			expect(updateValue).toHaveBeenCalledWith('notebook.lineNumbers', 'off');
+			expect(updateSpy).toHaveBeenCalledWith('notebook.lineNumbers', 'off');
 		});
 	});
 
@@ -420,6 +418,12 @@ describe('Positron Notebook keyboard shortcuts', () => {
 	//#region Output toggle
 
 	describe('O (Toggle Cell Output)', () => {
+		it('declares O scoped to command mode', () => {
+			const action = new ToggleOutputAction();
+			expect(action.desc.keybinding?.primary).toBe(KeyCode.KeyO);
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_COMMAND_MODE);
+		});
+
 		it('toggles output collapse on a code cell', () => {
 			const notebook = createTestPositronNotebookInstance(
 				[['print("hello")', 'python', CellKind.Code]],
@@ -492,9 +496,23 @@ describe('Positron Notebook keyboard shortcuts', () => {
 	//#region Interrupt kernel
 
 	describe('I+I (Interrupt Kernel)', () => {
-		it('uses KeyChord for I,I binding', () => {
-			const chord = KeyChord(KeyCode.KeyI, KeyCode.KeyI);
-			expect(chord).toBeGreaterThan(0);
+		it('declares I,I chord scoped to command mode', () => {
+			const action = new InterruptKernelAction();
+			expect(action.desc.keybinding?.primary).toBe(KeyChord(KeyCode.KeyI, KeyCode.KeyI));
+			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_COMMAND_MODE);
+		});
+
+		it('calls interruptKernel() on the notebook', () => {
+			const interruptKernel = vi.fn();
+			const notebook = stubInterface<IPositronNotebookInstance>({ interruptKernel });
+
+			new (class extends InterruptKernelAction {
+				testRun(nb: IPositronNotebookInstance, accessor: ServicesAccessor) {
+					return this.runNotebookAction(nb, accessor);
+				}
+			})().testRun(notebook, unusedAccessor);
+
+			expect(interruptKernel).toHaveBeenCalledOnce();
 		});
 
 		it('does not throw when no cells are executing', () => {


### PR DESCRIPTION
## Summary

Closes #12727

Adds commonly expected JupyterLab keyboard shortcuts to the Positron Notebook Editor:

- **1-6**: Change cell to heading level 1-6 (command mode)
- **Shift+L**: Toggle line numbers (command mode)
- **Ctrl+Shift+Up/Down**: Move cell up/down (secondary binding, command mode)
- **I,I** (chord): Interrupt kernel (command mode)
- **O**: Toggle cell output collapse (command mode)
- **Shift+O**: Toggle cell output scrolling (command mode)
- **Cmd/Ctrl+A**: Select all cells (command mode)

Also adds `changeToHeading()`, `interruptKernel()`, and `selectAllCells()` methods to `PositronNotebookInstance`.

Shift+O completes the output-scrolling toggle from #10063 (the O shortcut covers the toggle-display half).

Shortcuts that already existed and required no changes: Ctrl+Enter (run cell), Shift+Enter (run + select below), Alt+Enter (run + insert below), Ctrl+Shift+- (split cell).

## Test plan

- [ ] Verify 1-6 changes cell to appropriate heading level (converts code cells to markdown first)
- [ ] Verify Shift+L toggles line numbers on/off
- [ ] Verify Ctrl+Shift+Up/Down moves cells (same as Alt+Up/Down)
- [ ] Verify I,I interrupts a running kernel
- [ ] Verify O toggles output collapse on code cells
- [ ] Verify Shift+O toggles output scrolling on code cells
- [ ] Verify Cmd+A selects all cells in command mode
- [ ] Verify none of these shortcuts fire in edit mode (cursor in cell editor)
- [ ] Run `npx vitest run src/vs/workbench/contrib/positronNotebook/test/browser/jupyterLabShortcuts.vitest.ts` (36 tests)
