### PR TITLE
e2e: fix R SQLite schema node failure on Windows

### DIFF
--- a/test/e2e/pages/connections.ts
+++ b/test/e2e/pages/connections.ts
@@ -31,7 +31,7 @@ export class Connections {
 		this.currentConnectionName = code.driver.currentPage.locator('.connections-instance-details .connection-name');
 	}
 
-	async openConnectionsNodes(nodes: string[]) {
+	async openConnectionsNodes(nodes: (string | RegExp)[]) {
 		for (const node of nodes) {
 			await this.code.driver.currentPage.locator(CONNECTIONS_ITEM).filter({ hasText: node }).locator('.codicon-chevron-right').click();
 			await expect(this.code.driver.currentPage.locator(CONNECTIONS_ITEM).filter({ hasText: node }).locator('.codicon-chevron-down')).toBeVisible();

--- a/test/e2e/tests/connections/connections-sqlite.test.ts
+++ b/test/e2e/tests/connections/connections-sqlite.test.ts
@@ -71,7 +71,7 @@ test.describe('SQLite DB Connection', {
 		});
 
 		await test.step('Verify connection nodes', async () => {
-			await app.workbench.connections.openConnectionsNodes(['SQLiteConnection', 'Default']);
+			await app.workbench.connections.openConnectionsNodes(['SQLiteConnection', /^main$|^Default$/]);
 			await app.workbench.connections.openConnectionsNodes(tables);
 		});
 
@@ -80,7 +80,7 @@ test.describe('SQLite DB Connection', {
 			await app.workbench.connections.connectIcon.click();
 			await app.workbench.connections.resumeConnectionButton.click();
 
-			await app.workbench.connections.openConnectionsNodes(['SQLiteConnection', 'Default']);
+			await app.workbench.connections.openConnectionsNodes(['SQLiteConnection', /^main$|^Default$/]);
 			await app.workbench.connections.openConnectionsNodes(tables);
 		});
 
@@ -99,7 +99,7 @@ test.describe('SQLite DB Connection', {
 		await test.step('Open connections pane', async () => {
 			await app.workbench.connections.openConnectionPane();
 			await app.workbench.connections.viewConnection('SQLiteConnection');
-			await app.workbench.connections.openConnectionsNodes(['SQLiteConnection', 'Default']);
+			await app.workbench.connections.openConnectionsNodes(['SQLiteConnection', /^main$|^Default$/]);
 
 			// mtcars node should not exist
 			await expect(


### PR DESCRIPTION
### Summary
Fix failing R SQLite connection tests caused by the default schema node being labeled `'main'` in some environments and `'Default'` in others. [See failures here](https://connect.posit.it/e2e-test-insights/?time=seven_days&branch=main&tab=test_health&date=2&search=connections-sqlite&env_os=win).

### QA Notes
@:win