### PR TITLE
fix: add fallback to built-in chat when posit-assistant.newChat is unavailable

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
@@ -26,7 +26,6 @@ const explainPrompt = localize('positronNotebookAssistantExplainPrompt', "Explai
 
 const NEW_CHAT_COMMAND = 'posit-assistant.newChat';
 const ATTACHMENT_NAME = 'notebook-cell-error.txt';
-const SIDEBAR_VIEW_SETTING = 'assistant.sidebarView';
 
 /**
  * Props for the NotebookCellQuickFix component.
@@ -44,13 +43,12 @@ interface NotebookCellQuickFixProps {
  */
 export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 	const services = usePositronReactServicesContext();
-	const { commandService, contextMenuService, notificationService } = services;
+	const { commandService, contextMenuService, logService } = services;
 
 	// Configuration hooks to conditionally show the quick-fix buttons
 	const enableAssistant = usePositronConfiguration<boolean>('positron.assistant.enable');
 	const enableNotebookMode = usePositronConfiguration<boolean>(POSITRON_NOTEBOOK_ENABLED_KEY);
 	const hasChatModels = usePositronContextKey<boolean>('positron-assistant.hasChatModels');
-	const sidebarViewEnabled = usePositronConfiguration<boolean>(SIDEBAR_VIEW_SETTING);
 
 	// Only show buttons if assistant is enabled, notebook mode is enabled, and chat models are available
 	const showQuickFix = enableAssistant && enableNotebookMode && hasChatModels;
@@ -68,6 +66,19 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 		return { uri: `data:text/plain;base64,${base64}`, name: ATTACHMENT_NAME };
 	}, [cleanError]);
 
+	const runBuiltInChat = useCallback(async (prompt: string, isNew: boolean) => {
+		const query = cleanError
+			? `${prompt}\n\`\`\`\n${cleanError}\n\`\`\``
+			: prompt;
+		if (isNew) {
+			await commandService.executeCommand(ACTION_ID_NEW_CHAT);
+		}
+		await commandService.executeCommand(CHAT_OPEN_ACTION_ID, {
+			query,
+			mode: ChatModeKind.Agent
+		});
+	}, [commandService, cleanError]);
+
 	const runNewChat = useCallback(async (prompt: string, target: 'new' | 'auto') => {
 		try {
 			await commandService.executeCommand(NEW_CHAT_COMMAND, {
@@ -76,41 +87,18 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 				behavior: 'submit',
 				...(attachment && { files: [attachment] }),
 			});
-		} catch {
-			notificationService.error(
-				localize(
-					'positronNotebookAssistantUnavailable',
-					"Posit Assistant is not available. Install the Posit Assistant extension to use Fix and Explain."
-				)
-			);
+		} catch (err) {
+			logService.warn('[NotebookCellQuickFix] posit-assistant.newChat unavailable, using built-in chat:', err);
+			await runBuiltInChat(prompt, target === 'new');
 		}
-	}, [commandService, notificationService, attachment]);
-
-	const runQuickChat = useCallback((prompt: string, isNew: boolean) => {
-		const query = cleanError
-			? `${prompt}\n\`\`\`\n${cleanError}\n\`\`\``
-			: prompt;
-		if (isNew) {
-			commandService.executeCommand(ACTION_ID_NEW_CHAT);
-		}
-		commandService.executeCommand(CHAT_OPEN_ACTION_ID, {
-			query,
-			mode: ChatModeKind.Agent
-		});
-	}, [commandService, cleanError]);
+	}, [commandService, logService, runBuiltInChat, attachment]);
 
 	const pressedFixHandler = () => {
-		if (sidebarViewEnabled) {
-			return runNewChat(fixPrompt, 'new');
-		}
-		return runQuickChat(fixPrompt, true);
+		return runNewChat(fixPrompt, 'new');
 	};
 
 	const pressedExplainHandler = () => {
-		if (sidebarViewEnabled) {
-			return runNewChat(explainPrompt, 'new');
-		}
-		return runQuickChat(explainPrompt, true);
+		return runNewChat(explainPrompt, 'new');
 	};
 
 	// Memoize dropdown actions for Fix button
@@ -122,13 +110,10 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 			class: undefined,
 			enabled: true,
 			run: () => {
-				if (sidebarViewEnabled) {
-					return runNewChat(fixPrompt, 'auto');
-				}
-				return runQuickChat(fixPrompt, false);
+				return runNewChat(fixPrompt, 'auto');
 			}
 		}
-	], [sidebarViewEnabled, runNewChat, runQuickChat]);
+	], [runNewChat]);
 
 	// Memoize dropdown actions for Explain button
 	const explainDropdownActions = useMemo((): IAction[] => [
@@ -139,13 +124,10 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 			class: undefined,
 			enabled: true,
 			run: () => {
-				if (sidebarViewEnabled) {
-					return runNewChat(explainPrompt, 'auto');
-				}
-				return runQuickChat(explainPrompt, false);
+				return runNewChat(explainPrompt, 'auto');
 			}
 		}
-	], [sidebarViewEnabled, runNewChat, runQuickChat]);
+	], [runNewChat]);
 
 	// Don't render if assistant features are not enabled
 	if (!showQuickFix) {
@@ -199,4 +181,3 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 		</div>
 	);
 };
-

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/NotebookCellQuickFix.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/NotebookCellQuickFix.vitest.tsx
@@ -18,8 +18,6 @@ import { ICommandService } from '../../../../../../platform/commands/common/comm
 import { IContextMenuService } from '../../../../../../platform/contextview/browser/contextView.js';
 import { setupRTLRenderer } from '../../../../../../test/vitest/reactTestingLibrary.js';
 import { createTestContainer } from '../../../../../../test/vitest/positronTestContainer.js';
-import { CHAT_OPEN_ACTION_ID, ACTION_ID_NEW_CHAT } from '../../../../chat/browser/actions/chatActions.js';
-import { ChatModeKind } from '../../../../chat/common/constants.js';
 import { NotebookCellQuickFix } from '../../../browser/notebookCells/NotebookCellQuickFix.js';
 
 const errorContent = '\x1b[31mNameError: name "x" is not defined\x1b[0m';
@@ -93,25 +91,4 @@ describe('NotebookCellQuickFix', () => {
 		expect(payload.target).toBe('auto');
 	});
 
-	it('falls back to built-in chat when posit-assistant.newChat rejects', async () => {
-		executeCommand.mockImplementation(async (command: string) => {
-			if (command === 'posit-assistant.newChat') {
-				throw new Error('command not found');
-			}
-		});
-
-		const user = userEvent.setup();
-		rtl.render(<NotebookCellQuickFix errorContent={errorContent} />);
-
-		await user.click(screen.getByRole('button', { name: /ask assistant to fix in new chat/i }));
-
-		await waitFor(() => expect(executeCommand).toHaveBeenCalledTimes(3));
-		expect(executeCommand.mock.calls[0][0]).toBe('posit-assistant.newChat');
-		expect(executeCommand.mock.calls[1][0]).toBe(ACTION_ID_NEW_CHAT);
-		expect(executeCommand.mock.calls[2][0]).toBe(CHAT_OPEN_ACTION_ID);
-		expect(executeCommand.mock.calls[2][1]).toEqual({
-			query: 'Fix this notebook cell error.\n```\nNameError: name "x" is not defined\n```',
-			mode: ChatModeKind.Agent
-		});
-	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/NotebookCellQuickFix.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/NotebookCellQuickFix.vitest.tsx
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { IAction } from '../../../../../../base/common/actions.js';
+import { decodeBase64, VSBuffer } from '../../../../../../base/common/buffer.js';
+import { Event } from '../../../../../../base/common/event.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { MockContextKeyService } from '../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ICommandService } from '../../../../../../platform/commands/common/commands.js';
+import { IContextMenuService } from '../../../../../../platform/contextview/browser/contextView.js';
+import { setupRTLRenderer } from '../../../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../../../test/vitest/positronTestContainer.js';
+import { CHAT_OPEN_ACTION_ID, ACTION_ID_NEW_CHAT } from '../../../../chat/browser/actions/chatActions.js';
+import { ChatModeKind } from '../../../../chat/common/constants.js';
+import { NotebookCellQuickFix } from '../../../browser/notebookCells/NotebookCellQuickFix.js';
+
+const errorContent = '\x1b[31mNameError: name "x" is not defined\x1b[0m';
+
+const decodeDataUri = (uri: string): string => {
+	const base64 = uri.slice(uri.indexOf(',') + 1);
+	return VSBuffer.wrap(decodeBase64(base64).buffer).toString();
+};
+
+describe('NotebookCellQuickFix', () => {
+	const executeCommand = vi.fn().mockResolvedValue(undefined);
+	const showContextMenu = vi.fn();
+	let dropdownActions: IAction[] = [];
+
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(ICommandService, { executeCommand })
+		.stub(IContextMenuService, {
+			onDidShowContextMenu: Event.None,
+			onDidHideContextMenu: Event.None,
+			showContextMenu,
+		})
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	beforeEach(() => {
+		executeCommand.mockReset();
+		executeCommand.mockResolvedValue(undefined);
+		showContextMenu.mockReset();
+		showContextMenu.mockImplementation((delegate: { getActions?: () => IAction[] }) => {
+			dropdownActions = delegate.getActions?.() ?? [];
+		});
+		dropdownActions = [];
+
+		const configurationService = ctx.get(IConfigurationService) as TestConfigurationService;
+		const contextKeyService = ctx.get(IContextKeyService) as MockContextKeyService;
+		configurationService.setUserConfiguration('positron.assistant.enable', true);
+		configurationService.setUserConfiguration('positron.notebook.enabled', true);
+		contextKeyService.createKey('positron-assistant.hasChatModels', true);
+	});
+
+	it('dispatches posit-assistant.newChat with error attachment on Fix click', async () => {
+		const user = userEvent.setup();
+		rtl.render(<NotebookCellQuickFix errorContent={errorContent} />);
+
+		await user.click(screen.getByRole('button', { name: /ask assistant to fix in new chat/i }));
+
+		await waitFor(() => expect(executeCommand).toHaveBeenCalledTimes(1));
+		const [command, payload] = executeCommand.mock.calls[0];
+		expect(command).toBe('posit-assistant.newChat');
+		expect(payload.prompt).toMatch(/fix/i);
+		expect(payload.target).toBe('new');
+		expect(payload.behavior).toBe('submit');
+		expect(payload.files).toHaveLength(1);
+		expect(payload.files[0].name).toBe('notebook-cell-error.txt');
+		expect(payload.files[0].uri).toMatch(/^data:text\/plain;base64,/);
+		expect(decodeDataUri(payload.files[0].uri)).toBe('NameError: name "x" is not defined');
+	});
+
+	it('dispatches posit-assistant.newChat with target "auto" for dropdown action', async () => {
+		const user = userEvent.setup();
+		rtl.render(<NotebookCellQuickFix errorContent={errorContent} />);
+
+		await user.click(screen.getByRole('button', { name: /more fix options/i }));
+		expect(dropdownActions).toHaveLength(1);
+		await dropdownActions[0].run();
+
+		await waitFor(() => expect(executeCommand).toHaveBeenCalledTimes(1));
+		const [command, payload] = executeCommand.mock.calls[0];
+		expect(command).toBe('posit-assistant.newChat');
+		expect(payload.target).toBe('auto');
+	});
+
+	it('falls back to built-in chat when posit-assistant.newChat rejects', async () => {
+		executeCommand.mockImplementation(async (command: string) => {
+			if (command === 'posit-assistant.newChat') {
+				throw new Error('command not found');
+			}
+		});
+
+		const user = userEvent.setup();
+		rtl.render(<NotebookCellQuickFix errorContent={errorContent} />);
+
+		await user.click(screen.getByRole('button', { name: /ask assistant to fix in new chat/i }));
+
+		await waitFor(() => expect(executeCommand).toHaveBeenCalledTimes(3));
+		expect(executeCommand.mock.calls[0][0]).toBe('posit-assistant.newChat');
+		expect(executeCommand.mock.calls[1][0]).toBe(ACTION_ID_NEW_CHAT);
+		expect(executeCommand.mock.calls[2][0]).toBe(CHAT_OPEN_ACTION_ID);
+		expect(executeCommand.mock.calls[2][1]).toEqual({
+			query: 'Fix this notebook cell error.\n```\nNameError: name "x" is not defined\n```',
+			mode: ChatModeKind.Agent
+		});
+	});
+});

--- a/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
@@ -70,7 +70,7 @@ test.describe('Notebook Assistant: Interaction Flow', {
 		await assistant.logoutModelProvider('echo');
 	});
 
-	test.skip('Fix error button opens chat and sends error context', async function ({ app }) {
+	test('Fix error button opens chat and sends error context', async function ({ app }) {
 		const { notebooksPositron, assistant } = app.workbench;
 
 		// Create notebook
@@ -99,7 +99,7 @@ test.describe('Notebook Assistant: Interaction Flow', {
 		expect(responseText).toContain('undefined_var');
 	});
 
-	test.skip('Explain error button opens chat and sends error context', async function ({ app }) {
+	test('Explain error button opens chat and sends error context', async function ({ app }) {
 		const { notebooksPositron, assistant } = app.workbench;
 
 		// Create notebook


### PR DESCRIPTION
PR #13525 added support for routing the fix/explain buttons to posit assistant. The problem is it didnt gracefully fail back to posit**ron** assistant if posit assistant wasnt available. 

This PR adds that graceful fallback and then re-enables the skipped tests (#13599) that #13525 broke. It also removes the `assistant.sidebarView` configuration gate that was used to decide between the two before in favor of the graceful degradation approach.

### Design context:

- The try/catch in `runNewChat` is a **stopgap bridge**: always try posit-assistant first, fall back to built-in chat if the extension isn't installed. Once built-in chat is removed, the fallback becomes dead code and can be deleted.
- The `logService.warn` (vs. the old `notificationService.error`) is intentional -- users shouldn't be alarmed during the transition since they still get a working chat experience either way.
- The `hasChatModels` guard hides buttons entirely when no models are available. This is conservative but it's possible we would want to show the buttons when no models are available to get users to the assistant ui which will then guide them through setting up the models. That being said I opted for this conservative approach so thing are clean and we're not guiding people to something that doesnt work immediately. 
- Removing the `sidebarView` gate simplifies the component: the old code branched at 4 callsites based on a setting; now there's one path with a single fallback point.

@:positron-notebooks, @:assistant

## Test plan
- [ ] Trigger a cell error in a notebook with Posit Assistant installed -- Fix/Explain should open posit-assistant with the error attached
- [ ] Trigger a cell error without Posit Assistant available -- should fall back to built-in chat panel
- [ ] Verify dropdown "Fix in current chat" also routes through posit-assistant.newChat (with `target: auto`)
- [ ] Run vitest: `npx vitest run src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/NotebookCellQuickFix.vitest.tsx`

