### PR TITLE
e2e: fix timeout in notebook eval test

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -756,6 +756,7 @@ export class PositronNotebooks extends Notebooks {
 	 * @param cellIndex - The index of the cell to add code to (default: 0).
 	 * @param options - Options to control behavior:
 	 * delay: Optional delay between keystrokes for typing simulation (default: 0, meaning no delay).
+	 * fast: Use fill() instead of pressSequentially() — skips keystroke simulation for bulk population (default: false).
 	 * run: Whether to run the cell after adding code (default: false).
 	 * waitForSpinner: Whether to wait for the execution spinner to appear and disappear (default: false).
 	 * waitForPopup: Whether to wait for the execution info popup to appear after running (default: false).
@@ -763,9 +764,9 @@ export class PositronNotebooks extends Notebooks {
 	async addCodeToCell(
 		cellIndex: number,
 		code: string,
-		options?: { delay?: number; run?: boolean; waitForSpinner?: boolean; container?: Locator }
+		options?: { delay?: number; fast?: boolean; run?: boolean; waitForSpinner?: boolean; container?: Locator }
 	): Promise<Locator> {
-		const { delay = 0, run = false, waitForSpinner = false, container } = options ?? {};
+		const { delay = 0, fast = false, run = false, waitForSpinner = false, container } = options ?? {};
 		// When a container is provided, scope all cell lookups to it so that cells from
 		// other open notebooks are not counted or accidentally targeted.
 		const scopedCell = container ? container.locator('[data-testid="notebook-cell"]') : this.cell;
@@ -788,7 +789,11 @@ export class PositronNotebooks extends Notebooks {
 			const editor = cell.locator('.monaco-editor :is(.native-edit-context, .inputarea)');
 			await editor.focus();
 
-			await editor.pressSequentially(code, { delay });
+			if (fast) {
+				await this.code.driver.currentPage.keyboard.insertText(code);
+			} else {
+				await editor.pressSequentially(code, { delay });
+			}
 
 			if (run) {
 				await cell.getByRole('button', { name: 'Run Cell', exact: true }).click();

--- a/test/e2e/tests/assistant-eval/notebooks/py-notebook-get-cells.ts
+++ b/test/e2e/tests/assistant-eval/notebooks/py-notebook-get-cells.ts
@@ -41,7 +41,7 @@ export const pyNotebookGetCells: EvalTestCase = {
 		// Create 21 cells (indices 0-20) so it's a "large" notebook
 		for (let i = 0; i < 21; i++) {
 			const code = `x = ${i}; result_${i} = x * 10; result_${i}`;
-			await notebooksPositron.addCodeToCell(i, code);
+			await notebooksPositron.addCodeToCell(i, code, { fast: true });
 		}
 
 		// Select cell 0 so the sliding window is at the beginning


### PR DESCRIPTION
### Summary
Adds a `fast` option to `addCodeToCell` that uses `keyboard.insertText()` instead of `pressSequentially()`, injecting the full text as a single input event rather than one keystroke at a time.
- Speeds up tests that populate many cells sequentially (e.g. the 21-cell loop in `py-notebook-get-cells`)

### QA Notes
@:assistant-eval