### PR TITLE
Fix notebook scrolling in web mode

### DIFF
--- a/remote/reh-web/package.json
+++ b/remote/reh-web/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "positron-reh-web",
 	"version": "0.0.0",
-	"product-label": "positron",
 	"private": true,
 	"dependencies": {
 		"@anthropic-ai/sandbox-runtime": "0.0.23",
@@ -68,5 +67,6 @@
 		"react-dom": "umd/react-dom.production.min.js",
 		"react-window": "dist/index-prod.umd.js",
 		"he": "he.js"
-	}
+	},
+	"product-label": "positron"
 }

--- a/remote/reh-web/package.json
+++ b/remote/reh-web/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "positron-reh-web",
 	"version": "0.0.0",
+	"product-label": "positron",
 	"private": true,
 	"dependencies": {
 		"@anthropic-ai/sandbox-runtime": "0.0.23",
@@ -67,6 +68,5 @@
 		"react-dom": "umd/react-dom.production.min.js",
 		"react-window": "dist/index-prod.umd.js",
 		"he": "he.js"
-	},
-	"product-label": "positron"
+	}
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -103,10 +103,15 @@ export function PositronNotebookComponent() {
 		previousCellCount.current = currentCount;
 	}, [notebookCells.length]);
 
-	// In web mode the workbench's monaco-scrollable-element ancestor calls
-	// preventDefault on wheel events during the bubble phase, which blocks
-	// native scrolling on this container. Stop propagation so the event
-	// never reaches that handler.
+	// The workbench's monaco-scrollable-element ancestor calls preventDefault
+	// on wheel events during the bubble phase, which blocks native scrolling
+	// on this container. This manifests in web mode (PWB) where the workbench
+	// ScrollableElement doesn't detect that it has nothing to scroll. Applied
+	// unconditionally because stopPropagation is harmless in Electron (the
+	// ancestor already skips preventDefault when it has no overflow).
+	// Deps: [] is safe because the container div is unconditionally rendered
+	// at a fixed tree position, so the DOM node is stable for the component's
+	// lifetime.
 	React.useEffect(() => {
 		const container = containerRef.current;
 		if (!container) { return; }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -103,15 +103,12 @@ export function PositronNotebookComponent() {
 		previousCellCount.current = currentCount;
 	}, [notebookCells.length]);
 
-	// The workbench's monaco-scrollable-element ancestor calls preventDefault
-	// on wheel events during the bubble phase, which blocks native scrolling
-	// on this container. This manifests in web mode (PWB) where the workbench
-	// ScrollableElement doesn't detect that it has nothing to scroll. Applied
-	// unconditionally because stopPropagation is harmless in Electron (the
-	// ancestor already skips preventDefault when it has no overflow).
-	// Deps: [] is safe because the container div is unconditionally rendered
-	// at a fixed tree position, so the DOM node is stable for the component's
-	// lifetime.
+	// In web mode, BrowserWindow (window.ts) registers an unconditional
+	// preventDefault() on wheel events on the mainContainer (.monaco-workbench)
+	// to block macOS back/forward gestures. Because it's non-passive and fires
+	// during bubble, it cancels native scrolling for ALL descendants that rely
+	// on overflow:auto. stopPropagation() here prevents the event from reaching
+	// that listener. Harmless in Electron where NativeWindow has no such handler.
 	React.useEffect(() => {
 		const container = containerRef.current;
 		if (!container) { return; }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -103,6 +103,18 @@ export function PositronNotebookComponent() {
 		previousCellCount.current = currentCount;
 	}, [notebookCells.length]);
 
+	// In web mode the workbench's monaco-scrollable-element ancestor calls
+	// preventDefault on wheel events during the bubble phase, which blocks
+	// native scrolling on this container. Stop propagation so the event
+	// never reaches that handler.
+	React.useEffect(() => {
+		const container = containerRef.current;
+		if (!container) { return; }
+		const handler = (e: WheelEvent) => { e.stopPropagation(); };
+		container.addEventListener('wheel', handler);
+		return () => container.removeEventListener('wheel', handler);
+	}, []);
+
 	// Observe scroll events and fire to notebook instance, also track scroll position
 	useScrollObserver(containerRef as React.RefObject<HTMLElement>, React.useCallback(() => {
 		notebookInstance.fireScrollEvent();


### PR DESCRIPTION
In web-hosted Positron the workbench's `monaco-scrollable-element` ancestor calls `preventDefault()` on wheel events during the bubble phase, which blocks native scrolling on the notebook cells container. In Electron this doesn't manifest because the workbench's `ScrollableElement` short-circuits when it detects it has nothing to scroll.

This PR fixes this by adding a `stopPropagation()` on wheel events at the cells container boundary so they never reach the workbench handler, restoring native `overflow: auto` scrolling in web mode. Applied unconditionally since it's harmless in Electron (the ancestor already skips `preventDefault` when it has no overflow).

## References

**Root cause:**
- `src/vs/workbench/browser/window.ts:271` -- the `BrowserWindow` wheel listener that calls `preventDefault()` on all wheel events on `mainContainer`. Only exists in web build.
- `src/vs/workbench/electron-browser/window.ts:84` -- `NativeWindow` (Electron equivalent) has no wheel handler, which is why this only affects web mode.

**Why CSS alone can't fix it:**
- `src/vs/workbench/browser/media/style.css:70-73` -- `.monaco-workbench.web` already has `overscroll-behavior: none`, but that only prevents scroll-chaining, not `preventDefault()` canceling native scroll.

**The fix (stopPropagation pattern):**
- `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx:106-119` -- the fix itself
- `src/vs/workbench/contrib/positronConnections/browser/components/newConnectionModalDialog/createConnectionState.tsx:190-196` -- same pattern already in use for the same reason, with a comment linking to the root cause

**Scroll mechanics for context:**
- `src/vs/base/browser/ui/scrollbar/scrollableElement.ts:424` -- ScrollableElement registers with `{ passive: false }` (same mechanism the workbench listener uses to block scrolling)
- `src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css:101` -- the cells container uses native `overflow: auto`

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix Positron notebook scrolling broken in web mode (PWB)

### Validation Steps

@:positron-notebooks @:web

1. Open Positron in web mode (PWB)
2. Open or create a notebook with enough cells to overflow the viewport
3. Scroll with the mouse wheel/trackpad -- cells container should scroll normally
4. Verify scrolling still works in Electron mode (no regression)