### PR TITLE
Dispose session listeners in extHostLanguageRuntime

### DIFF
--- a/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
+++ b/src/vs/workbench/api/common/positron/extHostLanguageRuntime.ts
@@ -270,6 +270,12 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 	// A list of active sessions owned by this extension host
 	private readonly _runtimeSessions = new Array<positron.LanguageRuntimeSession>();
 
+	// Per-session disposable stores, parallel to `_runtimeSessions`. Holds the
+	// event subscriptions created by `attachToSession` (and other per-session
+	// subscriptions like the one in `handleCommOpen`) so they can be released
+	// when `$disposeLanguageRuntime` is called.
+	private readonly _sessionDisposables = new Array<DisposableStore>();
+
 	// A list of runtime proxies to sessions owned by other extension hosts; map of
 	// session ID to proxy
 	private readonly _runtimeProxies = new Map<string, ExtHostRuntimeSessionProxy>();
@@ -575,9 +581,10 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 	 */
 	private attachToSession(session: positron.LanguageRuntimeSession): number {
 		const sessionId = session.metadata.sessionId;
+		const disposables = new DisposableStore();
 
 		// Wire event handlers for state changes and messages
-		session.onDidChangeRuntimeState(state => {
+		disposables.add(session.onDidChangeRuntimeState(state => {
 			const tick = this._eventClocks[handle] = this._eventClocks[handle] + 1;
 			this._proxy.$emitLanguageRuntimeState(sessionId, tick, state);
 
@@ -601,9 +608,9 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 					}
 				});
 			}
-		});
+		}));
 
-		session.onDidReceiveRuntimeMessage(message => {
+		disposables.add(session.onDidReceiveRuntimeMessage(message => {
 			const tick = this._eventClocks[handle] = this._eventClocks[handle] + 1;
 			// Amend the message with the event clock for ordering
 			const runtimeMessage: ILanguageRuntimeMessage = {
@@ -644,10 +651,10 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 					this._proxy.$emitLanguageRuntimeMessage(sessionId, false, new SerializableObjectWithBuffers(runtimeMessage));
 					break;
 			}
-		});
+		}));
 
 		// Hook up the session end (exit) handler
-		session.onDidEndSession(exit => {
+		disposables.add(session.onDidEndSession(exit => {
 			// Notify the main thread that the session has ended
 			this._proxy.$emitLanguageRuntimeExit(session.metadata.sessionId, exit);
 
@@ -658,16 +665,17 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 			// that would invalidate the handles of all subsequent sessions
 			// since we store them in an array. The session remains in an inert
 			// state.
-		});
+		}));
 
 		// Hook up the resource usage update handler
-		session.onDidUpdateResourceUsage(usage => {
+		disposables.add(session.onDidUpdateResourceUsage(usage => {
 			this._proxy.$emitLanguageRuntimeResourceUsage(session.metadata.sessionId, usage);
-		});
+		}));
 
 		// Register the runtime
 		const handle = this._runtimeSessions.length;
 		this._runtimeSessions.push(session);
+		this._sessionDisposables.push(disposables);
 
 		this._eventClocks.push(0);
 
@@ -813,6 +821,9 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 		if (handle >= this._runtimeSessions.length) {
 			throw new Error(`Cannot cleanup runtime: session handle '${handle}' not found or no longer valid.`);
 		}
+		// Release the event subscriptions wired in `attachToSession`. The
+		// array slot is kept so subsequent session handles remain valid.
+		this._sessionDisposables[handle].dispose();
 		// Dispose session to cleanup kernel, LSP, etc.
 		await this._runtimeSessions[handle].dispose();
 	}
@@ -1588,14 +1599,14 @@ export class ExtHostLanguageRuntime implements extHostProtocol.ExtHostLanguageRu
 			});
 
 		// Dispose the client instance when the runtime exits
-		this._runtimeSessions[handle].onDidChangeRuntimeState(state => {
+		this._sessionDisposables[handle].add(this._runtimeSessions[handle].onDidChangeRuntimeState(state => {
 			if (state === RuntimeState.Exited) {
 				// Mark the client instance as already closed so disposal
 				// doesn't try to close it
 				clientInstance.setClientState(RuntimeClientState.Closed);
 				clientInstance.dispose();
 			}
-		});
+		}));
 
 		// See if one of the registered client handlers wants to handle this
 		let handled = false;

--- a/src/vs/workbench/api/test/common/positron/extHostLanguageRuntime.vitest.ts
+++ b/src/vs/workbench/api/test/common/positron/extHostLanguageRuntime.vitest.ts
@@ -1,0 +1,180 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import type * as positron from 'positron';
+import { Emitter } from '../../../../../base/common/event.js';
+import { mock } from '../../../../../base/test/common/mock.js';
+import { ExtensionIdentifier, IExtensionDescription } from '../../../../../platform/extensions/common/extensions.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ILanguageRuntimeMetadata, LanguageRuntimeMessageType, LanguageRuntimeSessionMode, RuntimeExitReason, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { IRuntimeSessionMetadata } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { IMainPositronContext, MainThreadLanguageRuntimeShape } from '../../../common/positron/extHost.positron.protocol.js';
+import { ExtHostLanguageRuntime } from '../../../common/positron/extHostLanguageRuntime.js';
+import { SingleProxyRPCProtocol } from '../testRPCProtocol.js';
+
+/** The internal and positron-API enums share string values — the bridge is structural. */
+const positronSessionMode = LanguageRuntimeSessionMode.Console as unknown as positron.LanguageRuntimeSessionMode;
+const positronMessageType = {
+	Output: LanguageRuntimeMessageType.Output as unknown as positron.LanguageRuntimeMessageType,
+	CommOpen: LanguageRuntimeMessageType.CommOpen as unknown as positron.LanguageRuntimeMessageType,
+};
+
+class TestSession extends mock<positron.LanguageRuntimeSession>() {
+	readonly stateEmitter = new Emitter<RuntimeState>();
+	readonly messageEmitter = new Emitter<positron.LanguageRuntimeMessage>();
+	readonly endEmitter = new Emitter<positron.LanguageRuntimeExit>();
+	readonly usageEmitter = new Emitter<positron.RuntimeResourceUsage>();
+
+	override readonly onDidChangeRuntimeState = this.stateEmitter.event;
+	override readonly onDidReceiveRuntimeMessage = this.messageEmitter.event;
+	override readonly onDidEndSession = this.endEmitter.event;
+	override readonly onDidUpdateResourceUsage = this.usageEmitter.event;
+
+	override readonly metadata = stubInterface<positron.RuntimeSessionMetadata>({
+		sessionId: 'test-session',
+		sessionMode: positronSessionMode,
+	});
+
+	override updateSessionName(_name: string): void { }
+	override async getDynState(): Promise<positron.LanguageRuntimeDynState> {
+		return { inputPrompt: '>', continuationPrompt: '+', sessionName: 'test' };
+	}
+	// eslint-disable-next-line local/code-must-use-super-dispose -- mock<T>() has no real super.dispose()
+	override dispose(): void { }
+}
+
+class TestManager extends mock<positron.LanguageRuntimeManager>() {
+	constructor(private readonly _session: positron.LanguageRuntimeSession) { super(); }
+	override async createSession(): Promise<positron.LanguageRuntimeSession> {
+		return this._session;
+	}
+}
+
+class TestProxy extends mock<MainThreadLanguageRuntimeShape>() {
+	override $emitLanguageRuntimeState = vi.fn();
+	override $emitLanguageRuntimeMessage = vi.fn();
+	override $emitLanguageRuntimeExit = vi.fn();
+	override $emitLanguageRuntimeResourceUsage = vi.fn();
+}
+
+const extensionId = 'test.ext';
+const runtimeMetadata = stubInterface<ILanguageRuntimeMetadata>({
+	languageId: 'r',
+	extensionId: new ExtensionIdentifier(extensionId),
+	runtimeId: 'r-1',
+});
+const sessionMetadata: IRuntimeSessionMetadata = {
+	sessionId: 'test-session',
+	sessionMode: LanguageRuntimeSessionMode.Console,
+	notebookUri: undefined,
+	createdTimestamp: 0,
+	startReason: 'test',
+};
+const extension = stubInterface<IExtensionDescription>({
+	id: extensionId,
+	identifier: new ExtensionIdentifier(extensionId),
+});
+
+function buildMessage(type: positron.LanguageRuntimeMessageType, overrides: Partial<positron.LanguageRuntimeMessage> = {}): positron.LanguageRuntimeMessage {
+	return { id: 'msg', parent_id: '', when: '', type, ...overrides };
+}
+
+function buildExit(): positron.LanguageRuntimeExit {
+	return {
+		runtime_name: 'R',
+		session_name: 'test',
+		exit_code: 0,
+		reason: RuntimeExitReason.Shutdown as unknown as positron.RuntimeExitReason,
+		message: '',
+	};
+}
+
+function buildResourceUsage(): positron.RuntimeResourceUsage {
+	return { cpu_percent: 0, memory_bytes: 0, thread_count: 0, sampling_period_ms: 0 };
+}
+
+async function createAttachedSession(runtime: ExtHostLanguageRuntime): Promise<{ session: TestSession; handle: number }> {
+	const session = new TestSession();
+	const manager = new TestManager(session);
+	runtime.registerLanguageRuntimeManager(extension, 'r', manager);
+	const init = await runtime.$createLanguageRuntimeSession(runtimeMetadata, sessionMetadata, 'test');
+	return { session, handle: init.handle };
+}
+
+describe('ExtHostLanguageRuntime', () => {
+	let proxy: TestProxy;
+	let runtime: ExtHostLanguageRuntime;
+
+	beforeEach(() => {
+		proxy = new TestProxy();
+		const rpc = SingleProxyRPCProtocol(proxy) as unknown as IMainPositronContext;
+		runtime = new ExtHostLanguageRuntime(rpc, new NullLogService());
+	});
+
+	describe('$disposeLanguageRuntime', () => {
+		it('disposes the four session listeners wired by attachToSession', async () => {
+			const { session, handle } = await createAttachedSession(runtime);
+
+			session.stateEmitter.fire(RuntimeState.Ready);
+			session.messageEmitter.fire(buildMessage(positronMessageType.Output));
+			session.endEmitter.fire(buildExit());
+			session.usageEmitter.fire(buildResourceUsage());
+
+			expect(proxy.$emitLanguageRuntimeState).toHaveBeenCalledTimes(1);
+			expect(proxy.$emitLanguageRuntimeMessage).toHaveBeenCalledTimes(1);
+			expect(proxy.$emitLanguageRuntimeExit).toHaveBeenCalledTimes(1);
+			expect(proxy.$emitLanguageRuntimeResourceUsage).toHaveBeenCalledTimes(1);
+
+			await runtime.$disposeLanguageRuntime(handle);
+
+			expect(session.stateEmitter.hasListeners()).toBe(false);
+			expect(session.messageEmitter.hasListeners()).toBe(false);
+			expect(session.endEmitter.hasListeners()).toBe(false);
+			expect(session.usageEmitter.hasListeners()).toBe(false);
+
+			// Further emissions must not reach the proxy.
+			session.stateEmitter.fire(RuntimeState.Exited);
+			session.messageEmitter.fire(buildMessage(positronMessageType.Output, { id: 'msg2' }));
+			session.endEmitter.fire(buildExit());
+			session.usageEmitter.fire(buildResourceUsage());
+
+			expect(proxy.$emitLanguageRuntimeState).toHaveBeenCalledTimes(1);
+			expect(proxy.$emitLanguageRuntimeMessage).toHaveBeenCalledTimes(1);
+			expect(proxy.$emitLanguageRuntimeExit).toHaveBeenCalledTimes(1);
+			expect(proxy.$emitLanguageRuntimeResourceUsage).toHaveBeenCalledTimes(1);
+		});
+
+		it('disposes per-comm state listeners registered by handleCommOpen', async () => {
+			const { session, handle } = await createAttachedSession(runtime);
+
+			// CommOpen via the wire causes handleCommOpen to register an extra
+			// listener on the state emitter.
+			session.messageEmitter.fire(buildMessage(positronMessageType.CommOpen, {
+				id: 'comm-msg-1',
+			}));
+			session.messageEmitter.fire(buildMessage(positronMessageType.CommOpen, {
+				id: 'comm-msg-2',
+			}));
+
+			await runtime.$disposeLanguageRuntime(handle);
+
+			expect(session.stateEmitter.hasListeners()).toBe(false);
+		});
+
+		it('keeps the array slot so later session handles stay valid', async () => {
+			const { handle: firstHandle } = await createAttachedSession(runtime);
+			await runtime.$disposeLanguageRuntime(firstHandle);
+
+			const { handle: secondHandle } = await createAttachedSession(runtime);
+
+			expect(secondHandle).toBe(firstHandle + 1);
+			// Re-disposing must still find the (released) slot rather than throwing.
+			await expect(runtime.$disposeLanguageRuntime(secondHandle)).resolves.toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
The four event subscriptions wired in `attachToSession` (and the per-comm state listener in handleCommOpen) were never tracked, so they stayed attached to each session's emitters for the lifetime of the extension host. Track them in a parallel DisposableStore indexed by handle and release it in $disposeLanguageRuntime. The array slot is preserved so existing session handles remain valid.

I chose to use an `Array<DisposableStore>` to mirror the way we store sessions.

See #12901

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

I added a unit test to demonstrate this works. If you comment out this line in `$disposeLanguageRuntime`:

```
this._sessionDisposables[handle].dispose();
```

And run the tests, you'll see the tests fail with some emitters still sticking around.