### PR TITLE
Fix release notes command in Workbench

### DIFF
--- a/src/vs/workbench/contrib/update/browser/update.contribution.ts
+++ b/src/vs/workbench/contrib/update/browser/update.contribution.ts
@@ -30,8 +30,11 @@ import { IRuntimeSessionService } from '../../../services/runtimeSession/common/
 import { IsDevelopmentContext } from '../../../../platform/contextkey/common/contextkeys.js';
 // eslint-disable-next-line no-duplicate-imports
 import { storeLastUpdateVersion } from './update.js';
+// eslint-disable-next-line no-duplicate-imports
+import { isWeb } from '../../../../base/common/platform.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
+import { IPositronDocsService } from '../../../services/positronDocs/browser/positronDocsService.js';
 // --- End Positron ---
 
 const workbench = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
@@ -70,6 +73,16 @@ export class ShowReleaseNotesAction extends Action2 {
 		const productService = accessor.get(IProductService);
 		// --- Start Positron ---
 		// const openerService = accessor.get(IOpenerService);
+		// In a web context (e.g. Posit Workbench), the local update service
+		// cannot serve release notes, so open the docs URL externally instead.
+		// IPositronDocsService honors POSITRON_DOCS_URL and otherwise falls
+		// back to the public Positron docs site.
+		if (isWeb) {
+			const openerService = accessor.get(IOpenerService);
+			const docsService = accessor.get(IPositronDocsService);
+			await openerService.open(URI.parse(docsService.getUrl('release-notes')));
+			return;
+		}
 
 		try {
 			await showReleaseNotesInEditor(instantiationService, productService.positronVersion, false);

--- a/src/vs/workbench/services/positronDocs/test/browser/positronDocsService.vitest.ts
+++ b/src/vs/workbench/services/positronDocs/test/browser/positronDocsService.vitest.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { IBrowserWorkbenchEnvironmentService } from '../../../environment/browser/environmentService.js';
+import { PositronDocsService } from '../../browser/positronDocsService.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+
+function makeSvc(positronDocsUrl?: string): PositronDocsService {
+	const env = stubInterface<IBrowserWorkbenchEnvironmentService>({ positronDocsUrl });
+	return new PositronDocsService(env);
+}
+
+describe('PositronDocsService', () => {
+
+	it('uses POSITRON_DOCS_URL when the environment provides one', () => {
+		expect(makeSvc('https://workbench.example.com/docs/').baseUrl)
+			.toBe('https://workbench.example.com/docs/');
+	});
+
+	// Either side may or may not carry a slash; the join should always
+	// produce exactly one separator.
+	it.each([
+		['https://docs.example.com/', 'release-notes', 'https://docs.example.com/release-notes'],
+		['https://docs.example.com', 'release-notes', 'https://docs.example.com/release-notes'],
+		['https://docs.example.com/', '/release-notes', 'https://docs.example.com/release-notes'],
+		['https://docs.example.com', '/release-notes', 'https://docs.example.com/release-notes'],
+	])('getUrl normalizes slashes: %s + %s', (base, path, expected) => {
+		expect(makeSvc(base).getUrl(path)).toBe(expected);
+	});
+});


### PR DESCRIPTION
Fixes #13427

In a web context such as Posit Workbench, _Positron: Show Release Notes_ just rendered the placeholder string "No release notes available". This change routes the command through `IPositronDocsService` instead, so it opens the configured docs URL externally. When `POSITRON_DOCS_URL` is set (like on Workbench), it opens the locally-hosted docs; otherwise it falls back to the public <https://positron.posit.co/release-notes>. This will be nice for Positron on JupyterHub, I think! The desktop in-app webview rendering is unchanged.

Related to #12334 where we started that docs service.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Workbench: open release notes via `POSITRON_DOCS_URL` so they are reachable from Workbench sessions (#13427)

### Validation Steps

@:help @:web

I did add some very minimal unit tests for `IPositronDocsService` itself here (no tests added when it shipped in #12334). I don't think E2E tests are a great fit for this, although we could consider adding some Positron-on-Workbench tests for the doc bundling in general.

To verify this manually in a web server dev build, you need to do something like:

1. Edit `.vscode/tasks.json` and add an `options.env` block to the "Run code server" task with a placeholder URL:

   ```json
   "options": {
       "env": {
           "POSITRON_DOCS_URL": "https://http.cat/"
       }
   },
   ```

2. Edit `src/vs/platform/product/common/product.ts` and add `releaseNotesUrl: 'https://cdn.posit.co/positron'` to the dev fallback (Web environment or unknown branch). The command is gated on `product.releaseNotesUrl`, and dev web builds do not load `product.json`.

3. Launch "Positron Server" from the debug panel.

4. Open the Command Palette and run *Positron: Show Release Notes*. With the env var set, it opens the configured URL (the external-site prompt expected in dev, but it won't do that on Workbench when docs are same origin).

<img width="543" height="201" alt="Screenshot 2026-05-14 at 4 25 18 PM" src="https://github.com/user-attachments/assets/7f1fa75f-455a-4083-b0e0-416710239c08" />

5. Remove the env var and reload. The command should now open `https://positron.posit.co/release-notes` via the docs service default.

6. Don't forget to revert the `tasks.json` and `product.ts` edits before merging! 😅 
