### PR TITLE
fix: enable icons on secondary sidebar

### DIFF
--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
@@ -205,10 +205,7 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 			pinnedViewContainersKey: AuxiliaryBarPart.pinnedViewsKey,
 			placeholderViewContainersKey: AuxiliaryBarPart.placeholdeViewContainersKey,
 			viewContainersWorkspaceStateKey: AuxiliaryBarPart.viewContainersWorkspaceStateKey,
-			// --- Start Positron ---
-			// Do not use icons.
-			icon: false,
-			// --- End Positron ---
+			icon: !this.configuration.showLabels,
 			orientation: ActionsOrientation.HORIZONTAL,
 			recomputeSizes: true,
 			activityHoverOptions: {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Reference the associated issue with a closing keyword such as
  "Fixes #123" so GitHub automatically closes the issue when this PR
  is merged. If there are any details about your approach that are
  unintuitive or you want to draw attention to, please describe them
  here.
-->

Setting `workbench.secondarySideBar.showLabel` to `false` should cause Positron's side bar items to be shown as icons but has no effect. The cause is a hardcoded setting.

This PR removes the hardcoded config and let it follow the option as intended.

Fixes #7644 

Screenshots after succesfull build:
<img width="1607" height="402" alt="labelFix" src="https://github.com/user-attachments/assets/00f0a89e-1c45-4c19-b7e2-1c6ef1926007" />


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
