### PR TITLE
e2e: skip flaky save button assertion in editor action bar test

### DIFF
--- a/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
@@ -53,7 +53,7 @@ test.describe('Editor Action Bar: Document Files', {
 	}, async function ({ app, page, openFile }) {
 		await openFile('workspaces/quarto_basic/quarto_basic.qmd');
 		await verifyPreviewRendersHtml('Diamond sizes');
-		await verifySaveButton(app, page);
+		// await verifySaveButton(app, page); // Skipped due to https://github.com/posit-dev/positron/issues/13530
 		await verifyOpenChanges(page);
 		await verifySplitEditor('quarto_basic.qmd');
 		await verifyOpenInNewWindow(app, 'Diamond sizes');

--- a/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
@@ -98,25 +98,25 @@ async function bindPlatformHotkey(page: Page, key: string) {
 	await page.keyboard.press(process.platform === 'darwin' ? `Meta+${key}` : `Control+${key}`);
 }
 
-async function verifySaveButton(app: Application, page: Page) {
-	await test.step('verify Save button visibility, dirty state, and click', async () => {
-		// Clean editor: button visible but disabled.
-		await editorActionBar.verifyButtonVisible('Save', true);
-		await editorActionBar.verifyButtonEnabled('Save', false);
+// async function verifySaveButton(app: Application, page: Page) {
+// 	await test.step('verify Save button visibility, dirty state, and click', async () => {
+// 		// Clean editor: button visible but disabled.
+// 		await editorActionBar.verifyButtonVisible('Save', true);
+// 		await editorActionBar.verifyButtonEnabled('Save', false);
 
-		// Make a change to dirty the editor; Save becomes enabled.
-		await app.workbench.editor.selectTabAndType('quarto_basic.qmd', 'Y');
-		await editorActionBar.verifyButtonEnabled('Save', true);
+// 		// Make a change to dirty the editor; Save becomes enabled.
+// 		await app.workbench.editor.selectTabAndType('quarto_basic.qmd', 'Y');
+// 		await editorActionBar.verifyButtonEnabled('Save', true);
 
-		// Click Save; editor should be clean again, so Save disables.
-		await editorActionBar.clickButton('Save');
-		await editorActionBar.verifyButtonEnabled('Save', false);
+// 		// Click Save; editor should be clean again, so Save disables.
+// 		await editorActionBar.clickButton('Save');
+// 		await editorActionBar.verifyButtonEnabled('Save', false);
 
-		// Restore the file so subsequent steps see the original content.
-		await bindPlatformHotkey(page, 'Z');
-		await bindPlatformHotkey(page, 'S');
-	});
-}
+// 		// Restore the file so subsequent steps see the original content.
+// 		await bindPlatformHotkey(page, 'Z');
+// 		await bindPlatformHotkey(page, 'S');
+// 	});
+// }
 
 async function verifyOpenChanges(page: Page) {
 	await test.step('verify "open changes" shows diff', async () => {


### PR DESCRIPTION
### Summary
Temporarily skips the save button assertion in the editor action bar Quarto e2e test while the underlying bug is fixed.

- `verifySaveButton` commented out in `editor-action-bar-document-files.test.ts`
- Tracks back to #13530 (save button stays disabled after editing, web/Chromium only)

### QA Notes
Re-enable once #13530 is resolved.