### PR TITLE
Update branding on workspace trust

### DIFF
--- a/src/vs/workbench/contrib/workspace/browser/workspace.contribution.ts
+++ b/src/vs/workbench/contrib/workspace/browser/workspace.contribution.ts
@@ -381,10 +381,16 @@ export class WorkspaceTrustUXHandler extends Disposable implements IWorkbenchCon
 				{ label: trustOption ?? localize({ key: 'trustOption', comment: ['&& denotes a mnemonic'] }, "&&Yes, I trust the authors"), sublabel: isSingleFolderWorkspace ? localize('trustFolderOptionDescription', "Trust folder and enable all features") : localize('trustWorkspaceOptionDescription', "Trust workspace and enable all features") },
 				{ label: dontTrustOption ?? localize({ key: 'dontTrustOption', comment: ['&& denotes a mnemonic'] }, "&&No, I don't trust the authors"), sublabel: isSingleFolderWorkspace ? localize('dontTrustFolderOptionDescription', "Open folder in restricted mode") : localize('dontTrustWorkspaceOptionDescription', "Open workspace in restricted mode") },
 				[
+					// --- Start Positron ---
+					// !isSingleFolderWorkspace ?
+					// 	   localize('workspaceStartupTrustDetails', "{0} provides features that may automatically execute files in this workspace.", this.productService.nameShort) :
+					// 	   localize('folderStartupTrustDetails', "{0} provides features that may automatically execute files in this folder.", this.productService.nameShort),
+					// 	learnMoreString ?? localize('startupTrustRequestLearnMore', "If you don't trust the authors of these files, we recommend to continue in restricted mode as the files may be malicious. See [our docs](https://aka.ms/vscode-workspace-trust) to learn more."),
 					!isSingleFolderWorkspace ?
-						localize('workspaceStartupTrustDetails', "{0} provides features that may automatically execute files in this workspace.", this.productService.nameShort) :
-						localize('folderStartupTrustDetails', "{0} provides features that may automatically execute files in this folder.", this.productService.nameShort),
-					learnMoreString ?? localize('startupTrustRequestLearnMore', "If you don't trust the authors of these files, we recommend to continue in restricted mode as the files may be malicious. See [our docs](https://aka.ms/vscode-workspace-trust) to learn more."),
+						localize('positron.workspaceStartupTrustDetails', "{0} provides features that can automatically start Python or R sessions in this workspace, which could execute files.", this.productService.nameShort) :
+						localize('positron.folderStartupTrustDetails', "{0} provides features that can automatically start Python or R sessions in this folder, which could execute files.", this.productService.nameShort),
+					learnMoreString ?? localize('positron.startupTrustRequestLearnMore', "If you don't trust the authors of these files, we recommend to continue in restricted mode as the files may be malicious. See [the VS Code documentation](https://aka.ms/vscode-workspace-trust) to learn more."),
+					// --- End Positron ---
 					!isEmptyWindow ?
 						`\`${this.labelService.getWorkspaceLabel(workspaceIdentifier, { verbose: Verbosity.LONG })}\`` : '',
 				],

--- a/src/vs/workbench/contrib/workspace/browser/workspaceTrustEditor.ts
+++ b/src/vs/workbench/contrib/workspace/browser/workspaceTrustEditor.ts
@@ -985,11 +985,19 @@ export class WorkspaceTrustEditor extends EditorPane {
 		this.renderLimitationsHeaderElement(this.trustedContainer, trustedTitle, trustedSubTitle);
 		const trustedContainerItems = this.workspaceService.getWorkbenchState() === WorkbenchState.EMPTY ?
 			[
+				// --- Start Positron ---
+				localize('positron.trustedSessions', "Python and R sessions are allowed to start"),
+				localize('positron.trustedAssistant', "Posit Assistant can be enabled"),
+				// --- End Positron ---
 				localize('trustedTasks', "Tasks are allowed to run"),
 				localize('trustedDebugging', "Debugging is enabled"),
 				localize('trustedExtensions', "All enabled extensions are activated")
 			] :
 			[
+				// --- Start Positron ---
+				localize('positron.trustedSessions', "Python and R sessions are allowed to start"),
+				localize('positron.trustedAssistant', "Posit Assistant can be enabled"),
+				// --- End Positron ---
 				localize('trustedTasks', "Tasks are allowed to run"),
 				localize('trustedDebugging', "Debugging is enabled"),
 				localize('trustedSettings', "All workspace settings are applied"),
@@ -1003,11 +1011,19 @@ export class WorkspaceTrustEditor extends EditorPane {
 		this.renderLimitationsHeaderElement(this.untrustedContainer, untrustedTitle, untrustedSubTitle);
 		const untrustedContainerItems = this.workspaceService.getWorkbenchState() === WorkbenchState.EMPTY ?
 			[
+				// --- Start Positron ---
+				localize('positron.untrustedSessions', "Python and R sessions will not start"),
+				localize('positron.untrustedAssistant', "Posit Assistant cannot be enabled"),
+				// --- End Positron ---
 				localize('untrustedTasks', "Tasks are not allowed to run"),
 				localize('untrustedDebugging', "Debugging is disabled"),
 				fixBadLocalizedLinks(localize({ key: 'untrustedExtensions', comment: ['Please ensure the markdown link syntax is not broken up with whitespace [text block](link block)'] }, "[{0} extensions]({1}) are disabled or have limited functionality", numExtensions, `command:${LIST_WORKSPACE_UNSUPPORTED_EXTENSIONS_COMMAND_ID}`))
 			] :
 			[
+				// --- Start Positron ---
+				localize('positron.untrustedSessions', "Python and R sessions will not start"),
+				localize('positron.untrustedAssistant', "Posit Assistant cannot be enabled"),
+				// --- End Positron ---
 				localize('untrustedTasks', "Tasks are not allowed to run"),
 				localize('untrustedDebugging', "Debugging is disabled"),
 				fixBadLocalizedLinks(numSettings ? localize({ key: 'untrustedSettings', comment: ['Please ensure the markdown link syntax is not broken up with whitespace [text block](link block)'] }, "[{0} workspace settings]({1}) are not applied", numSettings, 'command:settings.filterUntrusted') : localize('no untrustedSettings', "Workspace settings requiring trust are not applied")),


### PR DESCRIPTION
Fixes #13550

This PR clarifies the workspace trust UI to reflect Positron-specific implications. The trust editor now looks like this:

<img width="900" height="648" alt="Screenshot 2026-05-15 at 9 21 58 AM" src="https://github.com/user-attachments/assets/f0d2843e-d4a6-4fc9-b1f0-5ac1847a5897" />

The original proposed wording in #13550 sounded a bit too much like we were saying AI IS GOING TO START AUTOMATICALLY so I made some changes to the proposed wording. Thoughts?

The startup trust dialog now looks like this:

<img width="573" height="442" alt="Screenshot 2026-05-15 at 9 20 40 AM" src="https://github.com/user-attachments/assets/b1955996-8365-4738-9f43-32361dac83b6" />

Do we think this is likely to be clear to our users?

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Clarify in the workspace trust editor and startup dialog that workspace trust gates Python and R sessions and Posit Assistant (#13550)

### Validation Steps

1. Open a folder that has not previously been marked trusted. If you've already trusted or dismissed this folder, either pick a fresh folder or set `security.workspace.trust.startupPrompt` to `always` to re-trigger the dialog.
2. Confirm the startup trust dialog detail reads: "Positron provides features that can automatically start Python or R sessions in this folder, which could execute files." with a "[the VS Code documentation]" learn-more link.
3. Open the workspace trust editor via the command palette: `Manage Workspace Trust`.
4. Confirm the Trusted features list shows, at the top: "Python and R sessions are allowed to start" and "Posit Assistant can be enabled".
5. Confirm the Restricted Mode list shows, at the top: "Python and R sessions will not start" and "Posit Assistant cannot be enabled".

