### PR TITLE
Restore PWB 2026.04 session compatibility

### DIFF
--- a/.github/workflows/test-e2e-workbench-ubuntu.yml
+++ b/.github/workflows/test-e2e-workbench-ubuntu.yml
@@ -28,6 +28,11 @@ on:
         description: "Whether to allow tests marked with :soft-fail to fail without failing the job."
         type: boolean
         default: false
+      install_mode:
+        required: false
+        description: "Workbench install mode: 'ci' for latest daily, 'ci-stable' for the last stable release."
+        type: string
+        default: "ci"
 
 permissions:
   id-token: write
@@ -121,7 +126,7 @@ jobs:
       - name: Setup Workbench Docker Environment
         uses: ./.github/actions/setup-workbench-docker
         with:
-          install-mode: ci
+          install-mode: ${{ inputs.install_mode }}
           wb-password: ${{ secrets.WB_PASSWORD }}
           github-token: ${{ steps.access-token.outputs.token }}
           run-id: ${{ github.run_id }}

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -29,6 +29,7 @@ jobs:
       debian_web_tag_found: ${{ steps.pr-tags.outputs.debian_web_tag_found }}
       pyrefly_tag_found: ${{ steps.pr-tags.outputs.pyrefly_tag_found }}
       workbench_tag_found: ${{ steps.pr-tags.outputs.workbench_tag_found }}
+      workbench_stable_tag_found: ${{ steps.pr-tags.outputs.workbench_stable_tag_found }}
       jupyter_tag_found: ${{ steps.pr-tags.outputs.jupyter_tag_found }}
 
     steps:
@@ -208,7 +209,7 @@ jobs:
 
   build-workbench:
     needs: pr-tags
-    if: ${{ needs.pr-tags.outputs.workbench_tag_found == 'true' }}
+    if: ${{ needs.pr-tags.outputs.workbench_tag_found == 'true' || needs.pr-tags.outputs.workbench_stable_tag_found == 'true' }}
     name: build
     uses: ./.github/workflows/build-workbench-linux.yml
     secrets: inherit
@@ -224,6 +225,20 @@ jobs:
       install_license: false
       upload_logs: false
       allow_soft_fail: false
+    secrets: inherit
+
+  e2e-workbench-stable:
+    needs: [pr-tags, build-workbench]
+    if: ${{ needs.pr-tags.outputs.workbench_stable_tag_found == 'true' }}
+    name: e2e
+    uses: ./.github/workflows/test-e2e-workbench-ubuntu.yml
+    with:
+      grep: "@:workbench"
+      display_name: "workbench-stable"
+      install_license: false
+      upload_logs: false
+      allow_soft_fail: false
+      install_mode: "ci-stable"
     secrets: inherit
 
   build-jupyter:

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -75,9 +75,13 @@ if echo "$PR_BODY" | grep -q "@:pyrefly"; then
 	echo "Found pyrefly tag in PR body. Setting to run pyrefly tests."
 	echo "pyrefly_tag_found=true" >> "$GITHUB_OUTPUT"
 fi
-if echo "$PR_BODY" | grep -q "@:workbench"; then
+if echo "$PR_BODY" | grep -qE "@:workbench( |\$|,)"; then
 	echo "Found workbench tag in PR body. Setting to run workbench tests."
 	echo "workbench_tag_found=true" >> "$GITHUB_OUTPUT"
+fi
+if echo "$PR_BODY" | grep -q "@:workbench-stable"; then
+	echo "Found workbench-stable tag in PR body. Setting to run workbench tests against the last stable Workbench."
+	echo "workbench_stable_tag_found=true" >> "$GITHUB_OUTPUT"
 fi
 if echo "$PR_BODY" | grep -q "@:jupyter"; then
 	echo "Found jupyter tag in PR body. Setting to run jupyter tests."

--- a/src/vs/server/node/pwbConstants.ts
+++ b/src/vs/server/node/pwbConstants.ts
@@ -66,3 +66,20 @@ function resolveDeploymentPrefix(): string {
 
 export const WORKBENCH_DEPLOYMENT_PREFIX = resolveDeploymentPrefix();
 // --- End PWB ---
+
+// --- Start PWB: Workbench 2026.05+ ships the nginx route for /<product-label>-static/...; ---
+// older Workbenches must use session-scoped URLs.
+function hasStaticRoute(): boolean {
+	const v = process.env['RSTUDIO_VERSION'];
+	if (!v) {
+		return false;
+	}
+	const [year, month] = v.split(/[-+]/)[0].split('.').map(Number);
+	if (!Number.isFinite(year) || !Number.isFinite(month)) {
+		return false;
+	}
+	return year > 2026 || (year === 2026 && month >= 5);
+}
+
+export const HAS_STATIC_ROUTE = hasStaticRoute();
+// --- End PWB ---

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -34,7 +34,7 @@ import { ICSSDevelopmentService } from '../../platform/cssDev/node/cssDevService
 import httpProxy from 'http-proxy';
 // eslint-disable-next-line no-duplicate-imports
 import { existsSync } from 'fs';
-import { kProxyRegex, VSCODE_STATIC_PREFIX, WORKBENCH_DEPLOYMENT_PREFIX } from './pwbConstants.js';
+import { kProxyRegex, VSCODE_STATIC_PREFIX, WORKBENCH_DEPLOYMENT_PREFIX, HAS_STATIC_ROUTE } from './pwbConstants.js';
 // --- End PWB ---
 
 const textMimeType: { [ext: string]: string | undefined } = {
@@ -189,7 +189,7 @@ export class WebClientServer {
 			// URL shape: /<product-label>-static/<quality>-<commit>/static/<path>  →  serve APP_ROOT/<path>
 			// Only active when running under Workbench; standalone/dev code-server keeps the
 			// session-scoped /static/ route below.
-			if (isWorkbench && pathname.startsWith(VSCODE_STATIC_PREFIX) && pathname.charCodeAt(VSCODE_STATIC_PREFIX.length) === CharCode.Slash) {
+			if (isWorkbench && HAS_STATIC_ROUTE && pathname.startsWith(VSCODE_STATIC_PREFIX) && pathname.charCodeAt(VSCODE_STATIC_PREFIX.length) === CharCode.Slash) {
 				const afterPrefix = pathname.substring(VSCODE_STATIC_PREFIX.length + 1); // strip "/<product-label>-static/"
 				const versionSlash = afterPrefix.indexOf('/');
 				if (versionSlash === -1) {
@@ -469,8 +469,9 @@ export class WebClientServer {
 		const vscodeBase = relativePath(req.url!);
 		// When under Workbench, session-less URLs are absolute-from-root; otherwise keep the
 		// session-scoped relative form that works behind the default reverse proxy.
-		const effectiveVsBase = isWorkbench ? '' : vscodeBase;
-		const effectiveStaticRoute = isWorkbench ? sessionlessStaticRoute : staticRoute;
+		const useStaticRoute = isWorkbench && HAS_STATIC_ROUTE;
+		const effectiveVsBase = useStaticRoute ? '' : vscodeBase;
+		const effectiveStaticRoute = useStaticRoute ? sessionlessStaticRoute : staticRoute;
 		// --- End PWB ---
 
 		const productConfiguration: Partial<Mutable<IProductConfiguration>> = {

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -89,6 +89,7 @@ export enum TestTags {
 	WEB_ONLY = '@:web-only',
 	WIN = '@:win',
 	WORKBENCH = '@:workbench',
+	WORKBENCH_STABLE = '@:workbench-stable',
 	REMOTE_SSH = '@:remote-ssh',
 
 	// soft fail tag for tests that shouldn't fail merge to main


### PR DESCRIPTION
Fixes #13585

Positron 2026.06 dailies emit session-less static URLs (`/<product-label>-static/...`) under Workbench unconditionally, but the nginx route that serves them only ships in Workbench 2026.05+. On 2026.04, workbench.js 404s and sessions never finish loading -- all `workbench (ubuntu-stable)` e2e tests fail with click timeouts.

Gate the session-less URL scheme on `RSTUDIO_VERSION` (set by rserver on every session spawn): use session-scoped URLs on older Workbenches, keep the nginx-accelerated path on 2026.05+.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Restore Positron session compatibility with Posit Workbench 2026.04 (#13585)

### QA Notes

@:workbench @:workbench-stable

The new `@:workbench-stable` tag exercises this PR's branch build against the last stable Workbench release (currently 2026.04) -- the same configuration that reproduces #13585. The `e2e-workbench-stable` job going green confirms the fix.