### PR TITLE
Make quick picks block their parent Positron modal

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -114,6 +114,11 @@ export class QuickInputController extends Disposable {
 			}
 		}));
 		this.viewState = this.loadViewState();
+
+		// --- Start Positron ---
+		// When the quick pick hides, restore interaction on the Positron modal it was reparented into (if any).
+		this._register(this.onHide(() => this.clearPositronModalInert()));
+		// --- End Positron ---
 	}
 
 	private registerKeyModsListeners(window: Window, disposables: DisposableStore): void {
@@ -129,12 +134,18 @@ export class QuickInputController extends Disposable {
 
 	// --- Start Positron ---
 	/**
-	 * Special handling for Positron modals because they create an overlay to prevent interaction with anything
-	 * below. This reparents the quick input to the modal if needed. Unnecessarily reparenting causes
-	 * focus problems with the quick input.
-	 *
-	 * TODO: The quick pick still allows interaction with the modal. It should probably prevent modal
-	 * interaction while the quick pick is open.
+	 * Elements inside the active Positron modal that were marked `inert` while
+	 * the quick pick was reparented into the modal. Tracked so we only clear
+	 * inert on elements we set it on, leaving any pre-existing inert intact.
+	 */
+	private positronModalInertElements: HTMLElement[] = [];
+
+	/**
+	 * Special handling for Positron modals. Reparents the quick input into the modal so it
+	 * renders above the dialog, and marks the modal's other children `inert` so the dialog
+	 * can't be interacted with while the quick pick is open (matching the desktop modality
+	 * users get from a native OS file picker). Unnecessarily reparenting causes focus problems
+	 * with the quick input, so the reparent itself is gated on the parent already being correct.
 	 */
 	private handlePositronModal() {
 		const modal = this.layoutService.activeContainer.getElementsByClassName('positron-modal-dialog-box');
@@ -153,6 +164,10 @@ export class QuickInputController extends Disposable {
 					}
 				}).observe(modalContainer, { childList: true });
 			}
+			// Always (re-)apply inert: the same modal may open a second quick pick after
+			// the first one hid and cleared inert, and the early-out above would skip the
+			// reparent in that case.
+			this.applyPositronModalInert(modalContainer);
 		} else {
 			if (this.ui) {
 				// restore parent
@@ -163,6 +178,23 @@ export class QuickInputController extends Disposable {
 				}
 			}
 		}
+	}
+
+	private applyPositronModalInert(modalContainer: HTMLElement) {
+		this.clearPositronModalInert();
+		for (const child of Array.from(modalContainer.children)) {
+			if (child !== this.ui?.container && dom.isHTMLElement(child) && !child.inert) {
+				child.inert = true;
+				this.positronModalInertElements.push(child);
+			}
+		}
+	}
+
+	private clearPositronModalInert() {
+		for (const el of this.positronModalInertElements) {
+			el.inert = false;
+		}
+		this.positronModalInertElements = [];
 	}
 	// --- End Positron ---
 

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -147,7 +147,7 @@ export class QuickInputController extends Disposable {
 	 * users get from a native OS file picker). Unnecessarily reparenting causes focus problems
 	 * with the quick input, so the reparent itself is gated on the parent already being correct.
 	 */
-	private handlePositronModal() {
+	private handlePositronModal(applyInert = false) {
 		const modal = this.layoutService.activeContainer.getElementsByClassName('positron-modal-dialog-box');
 		if (modal.length && dom.isHTMLElement(modal.item(0)) && this.ui) {
 			const modalContainer = modal.item(0) as HTMLElement;
@@ -164,10 +164,9 @@ export class QuickInputController extends Disposable {
 					}
 				}).observe(modalContainer, { childList: true });
 			}
-			// Always (re-)apply inert: the same modal may open a second quick pick after
-			// the first one hid and cleared inert, and the early-out above would skip the
-			// reparent in that case.
-			this.applyPositronModalInert(modalContainer);
+			if (applyInert) {
+				this.applyPositronModalInert(modalContainer);
+			}
 		} else {
 			if (this.ui) {
 				// restore parent
@@ -786,6 +785,9 @@ export class QuickInputController extends Disposable {
 		backButton.tooltip = backKeybindingLabel ? localize('quickInput.backWithKeybinding', "Back ({0})", backKeybindingLabel) : localize('quickInput.back', "Back");
 
 		ui.container.style.display = '';
+		// --- Start Positron ---
+		this.handlePositronModal(true);
+		// --- End Positron ---
 		this.updateLayout();
 		this.dndController?.setEnabled(!controller.anchor);
 		this.dndController?.layoutContainer();
@@ -929,6 +931,13 @@ export class QuickInputController extends Disposable {
 	async cancel(reason?: QuickInputHideReason) {
 		this.hide(reason);
 	}
+
+	// --- Start Positron ---
+	override dispose(): void {
+		this.clearPositronModalInert();
+		super.dispose();
+	}
+	// --- End Positron ---
 
 	layout(dimension: dom.IDimension, titleBarOffset: number): void {
 		this.dimension = dimension;

--- a/src/vs/platform/quickinput/test/browser/quickinput.test.ts
+++ b/src/vs/platform/quickinput/test/browser/quickinput.test.ts
@@ -118,6 +118,27 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 		controller.layout({ height: 20, width: 40 }, 0);
 	});
 
+	// --- Start Positron ---
+	test('modal inert is applied only while quick input is visible', () => {
+		const modalContainer = document.createElement('div');
+		modalContainer.className = 'positron-modal-dialog-box';
+		const modalContent = document.createElement('button');
+		modalContainer.appendChild(modalContent);
+		controller.container.appendChild(modalContainer);
+		store.add(toDisposable(() => modalContainer.remove()));
+
+		const quickpick = store.add(controller.createQuickPick());
+
+		assert.strictEqual(modalContent.inert, false);
+
+		quickpick.show();
+		assert.strictEqual(modalContent.inert, true);
+
+		quickpick.hide();
+		assert.strictEqual(modalContent.inert, false);
+	});
+	// --- End Positron ---
+
 	test('pick - basecase', async () => {
 		const item = { label: 'foo' };
 


### PR DESCRIPTION
Fixes #13359

This PR changes the behavior when a quick pick is opened from a Positron modal (e.g., the file picker invoked from the New Folder from Template flow), to now _block_ interaction with the modal underneath until the quick pick is dismissed. This is implemented by marking the modal's other children `inert` while the quick pick is reparented in, and clearing `inert` when the quick pick hides.

We only observe this problem in a web build because on desktop, `IFileDialogService.showOpenDialog` returns a native OS file picker. This is a modal at the OS level and the user cannot click into the parent Positron modal while it's up. In web (Workbench, JupyterLab, etc), there is no native picker, so the call falls back to `SimpleFileDialog`, a workbench quick pick. Quick picks are floating UI and do not draw a backdrop, so clicks fell through to the wizard underneath, producing the overlap shown in the issue.

I am proposing the particular fix here because `quickInputController.ts` already has a Positron-specific patch (`handlePositronModal`) that reparents the quick pick into the active `.positron-modal-dialog-box` and auto-hides it if the modal closes. That patch had an explicit TODO:

> The quick pick still allows interaction with the modal. It should probably prevent modal interaction while the quick pick is open.

Finishing that TODO in the same place fixes every Positron modal + quick pick combo at once (new folder from template, save plot, new folder from git, and any future caller) rather than patching each modal individually. Using the HTML `inert` attribute gives the exact same desktop semantics as desktop (subtree visible, not clickable, not focusable) without any CSS or z-index work.

I do want to highlight that `SimpleFileDialog` itself has no visible "cancel" affordance so users might still get confused here. With this proposed change, users can't click out of it on web anymore so the bad UI mixup is gone, but the only dismissal paths are still just <kbd>Escape</kbd> or selecting a folder and pressing Enter / OK. If you click <kbd>Escape</kbd>, it dismisses _both_ the file picker _and_ the New Folder Template dialog, which is not great. If we find that users get confused about this, we might need to do something about how `SimpleFileDialog` dismisses but I'd advocate for waiting to see on that.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Prevent the file picker from overlapping other panes when advancing in the New Folder from Template flow on web (#13359)

### Validation Steps

@:new-folder-flow @:modal @:web

1. Open Positron in a web build (regular Positron Server dev build is OK)
2. File > New Folder from Template > select Jupyter Notebook or any other option
3. Click Browse to pick a folder location, but do not click OK
4. Click "Next" in the wizard
5. Verify: the "Next" click is rejected (wizard does not advance) until the file picker is dismissed via <kbd>Escape</kbd> or OK.
6. Smoke-check the same flow on the desktop build to confirm no regression (native picker behavior unchanged)
