### PR TITLE
Do not contribute `python.installPackages` to the command palette

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -1631,6 +1631,12 @@
                 },
                 {
                     "category": "Python",
+                    "command": "python.installPackages",
+                    "title": "Install Python Packages",
+                    "when": "false"
+                },
+                {
+                    "category": "Python",
                     "command": "python.reportIssue",
                     "title": "%python.command.python.reportIssue.title%",
                     "when": "!virtualWorkspace && shellExecutionSupported"


### PR DESCRIPTION
Fixes #13518

The `python.installPackages` command throws an error when invoked from the Command Palette. It expects a "packages" argument that the palette can't supply (well, at least not without further changes), and we didn't really intend it to be used this way. Instead, this command was created to be used programmatically by the Assistant via `PositronInstallPackagesTool`. In this PR we hide it from the palette with a `commandPalette` entry using `"when": "false"`. This follows the existing precedent in the same file for `python.execSelectionInTerminal` and `python.execSelectionInDjangoShell`, and similar approaches we have taken in other forked extensions.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Hide the _Python: Install Python Packages_ entry from the Command Palette, because it cannot be used in that way (#13518)

### Validation Steps

@:interpreter

1. Open the Command Palette (<kbd>Cmd/Ctrl+Shift+P</kbd>)
2. Type "Install Python Packages"
3. Verify the _Python: Install Python Packages_ command no longer appears
4. Confirm Positron Assistant's package-install tool still works (ask the assistant to install a Python package)
