### PR TITLE
Plots: consolidate "Open somewhere else" actions into a single dropdown

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -508,6 +508,13 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 			run: () => openGalleryInNewWindowHandler()
 		});
 
+		if (!actions.some(action => !(action instanceof Separator) && action.checked)) {
+			const fallback = actions.find(action => !(action instanceof Separator));
+			if (fallback) {
+				fallback.checked = true;
+			}
+		}
+
 		return actions;
 	};
 

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -47,7 +47,6 @@ const showNextPlot = localize('positronShowNextPlot', "Show next plot");
 const savePlot = localize('positronSavePlot', "Save plot");
 const copyPlotToClipboard = localize('positronCopyPlotToClipboard', "Copy plot to clipboard");
 const openPlotInNewWindow = localize('positronOpenPlotInNewWindow', "Open plot in new window");
-const openInEditorTab = localize('positronOpenPlotInEditorTab', "Open in editor tab");
 const openPlotsGalleryInNewWindow = localize('positronOpenPlotsGalleryInNewWindow', "Open plots gallery in new window");
 const clearAllPlots = localize('positronClearAllPlots', "Clear all plots");
 // dark filter localized strings
@@ -139,15 +138,25 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		plotClientForPolicy?.sizingPolicy.getName(plotClientForPolicy) ?? ''
 	);
 
-	// State for open in editor default action.
-	const [defaultEditorAction, setDefaultEditorAction] = useState<number>(
-		services.positronPlotsService.getPreferredEditorGroup()
-	);
+	// State for the "Open in..." dropdown's default action — the entry the user
+	// picked most recently, which the split-button primary click will repeat.
+	// Either an editor target number, 'gallery', or 'popout' (HTML plots).
+	// Seed from the service so the choice survives the action bar being remounted
+	// (e.g. when the gallery is closed and the plots view comes back).
+	const [defaultOpenAction, setDefaultOpenAction] = useState<number | 'gallery' | 'popout'>(() => {
+		if (services.positronPlotsService.getPreferPopout()) {
+			return 'popout';
+		}
+		if (services.positronPlotsService.getPreferGallery()) {
+			return 'gallery';
+		}
+		return services.positronPlotsService.getPreferredEditorGroup();
+	});
 
 	// Handler to open plot in editor and update default action.
 	const openEditorPlotHandler = useCallback((groupType: number) => {
 		services.commandService.executeCommand(PlotsEditorAction.ID, groupType);
-		setDefaultEditorAction(groupType);
+		setDefaultOpenAction(groupType);
 	}, [services.commandService]);
 
 	// Only show the sizing policy controls when Positron is in control of the
@@ -211,10 +220,14 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 
 	const popoutPlotHandler = () => {
 		services.commandService.executeCommand(PlotsPopoutAction.ID);
+		setDefaultOpenAction('popout');
+		services.positronPlotsService.setPreferPopout(true);
 	};
 
 	const openGalleryInNewWindowHandler = () => {
 		services.commandService.executeCommand(PlotsGalleryInNewWindowAction.ID);
+		setDefaultOpenAction('gallery');
+		services.positronPlotsService.setPreferGallery(true);
 	};
 
 	// Track dark filter mode changes.
@@ -454,26 +467,62 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		});
 	});
 
-	// Open in editor actions builder.
+	// Open in editor actions builder. The three "open in..." options only show when
+	// there is a plot; the gallery option is always available at the bottom.
 	const openInEditorActions = (): IAction[] => {
-		return openInEditorCommands.map(command => ({
-			id: `${PlotsEditorAction.ID}.${command.editorTarget}`,
-			label: command.label,
+		const actions: IAction[] = [];
+
+		if (showOpenInEditorButton) {
+			openInEditorCommands.forEach(command => actions.push({
+				id: `${PlotsEditorAction.ID}.${command.editorTarget}`,
+				label: command.label,
+				tooltip: '',
+				class: undefined,
+				checked: defaultOpenAction === command.editorTarget,
+				enabled: true,
+				run: () => openEditorPlotHandler(command.editorTarget)
+			}));
+		} else if (enablePopoutPlot) {
+			actions.push({
+				id: PlotsPopoutAction.ID,
+				label: openPlotInNewWindow,
+				tooltip: '',
+				class: undefined,
+				checked: defaultOpenAction === 'popout',
+				enabled: true,
+				run: () => popoutPlotHandler()
+			});
+		}
+
+		if (actions.length > 0) {
+			actions.push(new Separator());
+		}
+
+		actions.push({
+			id: PlotsGalleryInNewWindowAction.ID,
+			label: openPlotsGalleryInNewWindow,
 			tooltip: '',
 			class: undefined,
-			checked: defaultEditorAction === command.editorTarget,
+			checked: defaultOpenAction === 'gallery',
 			enabled: true,
-			run: () => openEditorPlotHandler(command.editorTarget)
-		}));
+			run: () => openGalleryInNewWindowHandler()
+		});
+
+		return actions;
 	};
 
 	// A function that converts the open in editor IAction[] to CustomContextMenuItem[] for the overflow menu.
-	const openInEditorOverflowEntries = () => openInEditorActions().map(action => new CustomContextMenuItem({
-		label: action.label,
-		checked: action.checked,
-		disabled: !action.enabled,
-		onSelected: () => action.run()
-	}));
+	const openInEditorOverflowEntries = () => openInEditorActions().map(action => {
+		if (action instanceof Separator) {
+			return new CustomContextMenuSeparator();
+		}
+		return new CustomContextMenuItem({
+			label: action.label,
+			checked: action.checked,
+			disabled: !action.enabled,
+			onSelected: () => action.run()
+		});
+	});
 
 	// Plot code actions builder.
 	const plotCodeActions = (): IAction[] => {
@@ -576,7 +625,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	// Next plot button.
 	leftActions.push({
 		fixedWidth: DEFAULT_ACTION_BAR_BUTTON_WIDTH,
-		separator: enableSizingPolicy || enableSavingPlots || enableZoomPlot || enablePopoutPlot,
+		separator: enableSizingPolicy || enableSavingPlots || enableZoomPlot,
 		component: (
 			<ActionBarButton
 				ariaLabel={showNextPlot}
@@ -608,7 +657,7 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 	if (enableCopyPlot) {
 		leftActions.push({
 			fixedWidth: DEFAULT_ACTION_BAR_BUTTON_WIDTH,
-			separator: false,
+			separator: enableZoomPlot,
 			component: (
 				<ActionBarButton
 					ariaLabel={copyPlotToClipboard}
@@ -672,47 +721,23 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		});
 	}
 
-	// Popout plot button.
-	if (enablePopoutPlot) {
-		leftActions.push({
-			fixedWidth: DEFAULT_ACTION_BAR_BUTTON_WIDTH,
-			separator: false,
-			component: (
-				<ActionBarButton
-					ariaLabel={openPlotInNewWindow}
-					icon={ThemeIcon.fromId('positron-open-in-new-window')}
-					tooltip={openPlotInNewWindow}
-					onPressed={popoutPlotHandler}
-				/>
-			),
-			overflowContextMenuItem: {
-				icon: 'positron-open-in-new-window',
-				label: openPlotInNewWindow,
-				onSelected: popoutPlotHandler
-			}
-		});
-	}
-
-	// Open in editor menu button.
-	if (showOpenInEditorButton) {
+	// Dark filter menu button.
+	if (enableDarkFilter) {
 		leftActions.push({
 			fixedWidth: DEFAULT_ACTION_BAR_DROPDOWN_BUTTON_WIDTH,
 			separator: false,
 			component: (
 				<ActionBarMenuButton
-					actions={openInEditorActions}
-					ariaLabel={openInEditorTab}
-					dropdownAriaLabel={openInEditorDropdownLabel}
-					dropdownIndicator='enabled-split'
-					dropdownTooltip={openInEditorDropdownLabel}
-					icon={ThemeIcon.fromId('go-to-file')}
-					tooltip={openInEditorTab}
+					actions={darkFilterActions}
+					ariaLabel={darkFilterTooltip}
+					icon={ThemeIcon.fromId(iconForDarkFilter(darkFilterMode))}
+					tooltip={darkFilterTooltip}
 				/>
 			),
 			overflowContextMenuSubmenu: {
-				icon: 'go-to-file',
-				label: openInEditorLabel,
-				entries: openInEditorOverflowEntries
+				icon: iconForDarkFilter(darkFilterMode),
+				label: darkFilterLabel,
+				entries: darkFilterOverflowEntries
 			}
 		});
 	}
@@ -739,49 +764,30 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 
 	// Build right actions array.
 	const rightActions: DynamicActionBarAction[] = [];
-	// Dark filter menu button.
-	if (enableDarkFilter) {
+
+	// Open in... menu button. Always visible in the main window. Its menu
+	// contents adapt to the current plot type, and the gallery option is
+	// always present at the bottom.
+	if (props.displayLocation === PlotsDisplayLocation.MainWindow) {
 		rightActions.push({
 			fixedWidth: DEFAULT_ACTION_BAR_DROPDOWN_BUTTON_WIDTH,
 			separator: true,
 			component: (
 				<ActionBarMenuButton
-					actions={darkFilterActions}
+					actions={openInEditorActions}
 					align='right'
-					ariaLabel={darkFilterTooltip}
-					icon={ThemeIcon.fromId(iconForDarkFilter(darkFilterMode))}
-					tooltip={darkFilterTooltip}
+					ariaLabel={openInEditorDropdownLabel}
+					dropdownAriaLabel={openInEditorDropdownLabel}
+					dropdownIndicator='enabled-split'
+					dropdownTooltip={openInEditorDropdownLabel}
+					icon={ThemeIcon.fromId('positron-open-in-new-window')}
+					tooltip={openInEditorDropdownLabel}
 				/>
 			),
 			overflowContextMenuSubmenu: {
-				icon: iconForDarkFilter(darkFilterMode),
-				label: darkFilterLabel,
-				// pass in the helper function that returns the CustomContextMenuItem[] for the submenu entries
-				entries: darkFilterOverflowEntries
-			}
-		});
-	}
-
-	// Gallery in new window button.
-	if (props.displayLocation === PlotsDisplayLocation.MainWindow) {
-		// Add separator if dark filter wasn't added (it has separator: true).
-		const needsSeparator = !enableDarkFilter;
-		rightActions.push({
-			fixedWidth: DEFAULT_ACTION_BAR_BUTTON_WIDTH,
-			separator: needsSeparator,
-			component: (
-				<ActionBarButton
-					align='right'
-					ariaLabel={openPlotsGalleryInNewWindow}
-					icon={ThemeIcon.fromId('window')}
-					tooltip={openPlotsGalleryInNewWindow}
-					onPressed={openGalleryInNewWindowHandler}
-				/>
-			),
-			overflowContextMenuItem: {
-				icon: 'window',
-				label: openPlotsGalleryInNewWindow,
-				onSelected: openGalleryInNewWindowHandler
+				icon: 'positron-open-in-new-window',
+				label: openInEditorLabel,
+				entries: openInEditorOverflowEntries
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -16,7 +16,7 @@ import { PositronActionBarContextProvider } from '../../../../../platform/positr
 import { usePositronPlotsContext } from '../positronPlotsContext.js';
 import { PlotClientInstance } from '../../../../services/languageRuntime/common/languageRuntimePlotClient.js';
 import { StaticPlotClient } from '../../../../services/positronPlots/common/staticPlotClient.js';
-import { DarkFilter, PlotsDisplayLocation, ZoomLevel } from '../../../../services/positronPlots/common/positronPlots.js';
+import { DarkFilter, PlotOpenTarget, PlotsDisplayLocation, ZoomLevel } from '../../../../services/positronPlots/common/positronPlots.js';
 import { DisposableStore, IDisposable } from '../../../../../base/common/lifecycle.js';
 import { IAction, Separator } from '../../../../../base/common/actions.js';
 import { PlotSizingPolicyCustom } from '../../../../services/positronPlots/common/sizingPolicyCustom.js';
@@ -84,20 +84,24 @@ const openSourceFile = localize('positronPlots.openSourceFile', "Open Source Fil
 // Open in editor command interface and data.
 interface OpenInEditorCommand {
 	editorTarget: AUX_WINDOW_GROUP_TYPE | ACTIVE_GROUP_TYPE | SIDE_GROUP_TYPE;
+	openTarget: PlotOpenTarget;
 	label: string;
 }
 
 const openInEditorCommands: Array<OpenInEditorCommand> = [
 	{
 		editorTarget: AUX_WINDOW_GROUP,
+		openTarget: PlotOpenTarget.EditorNewWindow,
 		label: localize('positron-editor-new-window', "Open in New Window")
 	},
 	{
 		editorTarget: ACTIVE_GROUP,
+		openTarget: PlotOpenTarget.EditorTab,
 		label: localize('positron-editor-new-tab', "Open in Editor Tab")
 	},
 	{
 		editorTarget: SIDE_GROUP,
+		openTarget: PlotOpenTarget.EditorTabToSide,
 		label: localize('positron-editor-new-tab-right', "Open in Editor Tab to the Side")
 	},
 ];
@@ -138,25 +142,52 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		plotClientForPolicy?.sizingPolicy.getName(plotClientForPolicy) ?? ''
 	);
 
-	// State for the "Open in..." dropdown's default action — the entry the user
-	// picked most recently, which the split-button primary click will repeat.
-	// Either an editor target number, 'gallery', or 'popout' (HTML plots).
-	// Seed from the service so the choice survives the action bar being remounted
-	// (e.g. when the gallery is closed and the plots view comes back).
-	const [defaultOpenAction, setDefaultOpenAction] = useState<number | 'gallery' | 'popout'>(() => {
-		if (services.positronPlotsService.getPreferPopout()) {
-			return 'popout';
-		}
-		if (services.positronPlotsService.getPreferGallery()) {
-			return 'gallery';
-		}
-		return services.positronPlotsService.getPreferredEditorGroup();
-	});
+	// State for the remembered "Open in..." target. This is the user's explicit
+	// menu selection, persisted in the service so it survives remounts.
+	const [rememberedOpenTarget, setRememberedOpenTarget] = useState<PlotOpenTarget>(() =>
+		services.positronPlotsService.getDefaultOpenTarget()
+	);
 
-	// Handler to open plot in editor and update default action.
-	const openEditorPlotHandler = useCallback((groupType: number) => {
-		services.commandService.executeCommand(PlotsEditorAction.ID, groupType);
-		setDefaultOpenAction(groupType);
+	const getFallbackOpenTarget = (availableTargets: readonly PlotOpenTarget[]): PlotOpenTarget => {
+		const preferredEditorGroup = services.positronPlotsService.getPreferredEditorGroup();
+		const preferredEditorCommand = openInEditorCommands.find(command =>
+			command.editorTarget === preferredEditorGroup
+			&& availableTargets.includes(command.openTarget)
+		);
+		if (preferredEditorCommand) {
+			return preferredEditorCommand.openTarget;
+		}
+
+		const firstAvailableEditorCommand = openInEditorCommands.find(command =>
+			availableTargets.includes(command.openTarget)
+		);
+		if (firstAvailableEditorCommand) {
+			return firstAvailableEditorCommand.openTarget;
+		}
+
+		if (availableTargets.includes(PlotOpenTarget.Popout)) {
+			return PlotOpenTarget.Popout;
+		}
+
+		if (availableTargets.includes(PlotOpenTarget.Gallery)) {
+			return PlotOpenTarget.Gallery;
+		}
+
+		return availableTargets[0] ?? PlotOpenTarget.Gallery;
+	};
+
+	const resolveOpenTarget = (target: PlotOpenTarget, availableTargets: readonly PlotOpenTarget[]): PlotOpenTarget => {
+		if (availableTargets.includes(target)) {
+			return target;
+		}
+
+		return getFallbackOpenTarget(availableTargets);
+	};
+
+	// Handler to open plot in editor and update the remembered target.
+	const openEditorPlotHandler = useCallback(async (command: OpenInEditorCommand) => {
+		await services.commandService.executeCommand(PlotsEditorAction.ID, command.editorTarget);
+		setRememberedOpenTarget(command.openTarget);
 	}, [services.commandService]);
 
 	// Only show the sizing policy controls when Positron is in control of the
@@ -218,16 +249,16 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		services.commandService.executeCommand(PlotsCopyAction.ID, PlotActionTarget.VIEW);
 	};
 
-	const popoutPlotHandler = () => {
-		services.commandService.executeCommand(PlotsPopoutAction.ID);
-		setDefaultOpenAction('popout');
-		services.positronPlotsService.setPreferPopout(true);
+	const popoutPlotHandler = async () => {
+		await services.commandService.executeCommand(PlotsPopoutAction.ID);
+		setRememberedOpenTarget(PlotOpenTarget.Popout);
+		services.positronPlotsService.setDefaultOpenTarget(PlotOpenTarget.Popout);
 	};
 
-	const openGalleryInNewWindowHandler = () => {
-		services.commandService.executeCommand(PlotsGalleryInNewWindowAction.ID);
-		setDefaultOpenAction('gallery');
-		services.positronPlotsService.setPreferGallery(true);
+	const openGalleryInNewWindowHandler = async () => {
+		await services.commandService.executeCommand(PlotsGalleryInNewWindowAction.ID);
+		setRememberedOpenTarget(PlotOpenTarget.Gallery);
+		services.positronPlotsService.setDefaultOpenTarget(PlotOpenTarget.Gallery);
 	};
 
 	// Track dark filter mode changes.
@@ -467,53 +498,59 @@ export const ActionBars = (props: PropsWithChildren<ActionBarsProps>) => {
 		});
 	});
 
-	// Open in editor actions builder. The three "open in..." options only show when
-	// there is a plot; the gallery option is always available at the bottom.
+	// Open in actions builder. The editor targets and popout target are shown
+	// only when available for the selected plot; gallery is always available.
 	const openInEditorActions = (): IAction[] => {
-		const actions: IAction[] = [];
-
+		const availableOpenTargets: Array<{
+			target: PlotOpenTarget;
+			id: string;
+			label: string;
+			run: () => Promise<void>;
+		}> = [];
 		if (showOpenInEditorButton) {
-			openInEditorCommands.forEach(command => actions.push({
+			openInEditorCommands.forEach(command => availableOpenTargets.push({
+				target: command.openTarget,
 				id: `${PlotsEditorAction.ID}.${command.editorTarget}`,
 				label: command.label,
-				tooltip: '',
-				class: undefined,
-				checked: defaultOpenAction === command.editorTarget,
-				enabled: true,
-				run: () => openEditorPlotHandler(command.editorTarget)
+				run: () => openEditorPlotHandler(command)
 			}));
 		} else if (enablePopoutPlot) {
-			actions.push({
+			availableOpenTargets.push({
+				target: PlotOpenTarget.Popout,
 				id: PlotsPopoutAction.ID,
 				label: openPlotInNewWindow,
-				tooltip: '',
-				class: undefined,
-				checked: defaultOpenAction === 'popout',
-				enabled: true,
 				run: () => popoutPlotHandler()
 			});
 		}
 
-		if (actions.length > 0) {
-			actions.push(new Separator());
-		}
-
-		actions.push({
+		availableOpenTargets.push({
+			target: PlotOpenTarget.Gallery,
 			id: PlotsGalleryInNewWindowAction.ID,
 			label: openPlotsGalleryInNewWindow,
-			tooltip: '',
-			class: undefined,
-			checked: defaultOpenAction === 'gallery',
-			enabled: true,
 			run: () => openGalleryInNewWindowHandler()
 		});
 
-		if (!actions.some(action => !(action instanceof Separator) && action.checked)) {
-			const fallback = actions.find(action => !(action instanceof Separator));
-			if (fallback) {
-				fallback.checked = true;
+		const resolvedOpenTarget = resolveOpenTarget(
+			rememberedOpenTarget,
+			availableOpenTargets.map(action => action.target)
+		);
+
+		const actions: IAction[] = [];
+		availableOpenTargets.forEach((action, index) => {
+			if (action.target === PlotOpenTarget.Gallery && index > 0) {
+				actions.push(new Separator());
 			}
-		}
+
+			actions.push({
+				id: action.id,
+				label: action.label,
+				tooltip: '',
+				class: undefined,
+				checked: action.target === resolvedOpenTarget,
+				enabled: true,
+				run: action.run
+			});
+		});
 
 		return actions;
 	};

--- a/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronPlots/browser/components/actionBars.tsx
@@ -46,8 +46,8 @@ const showPreviousPlot = localize('positronShowPreviousPlot', "Show previous plo
 const showNextPlot = localize('positronShowNextPlot', "Show next plot");
 const savePlot = localize('positronSavePlot', "Save plot");
 const copyPlotToClipboard = localize('positronCopyPlotToClipboard', "Copy plot to clipboard");
-const openPlotInNewWindow = localize('positronOpenPlotInNewWindow', "Open plot in new window");
-const openPlotsGalleryInNewWindow = localize('positronOpenPlotsGalleryInNewWindow', "Open plots gallery in new window");
+const openPlotInNewWindow = localize('positronOpenPlotInNewWindow', "Open Plot in New Window");
+const openPlotsGalleryInNewWindow = localize('positronOpenPlotsGalleryInNewWindow', "Open Plots Gallery in New Window");
 const clearAllPlots = localize('positronClearAllPlots', "Clear all plots");
 // dark filter localized strings
 const darkFilterLabel = localize('positron.darkFilter', "Dark Filter");
@@ -90,15 +90,15 @@ interface OpenInEditorCommand {
 const openInEditorCommands: Array<OpenInEditorCommand> = [
 	{
 		editorTarget: AUX_WINDOW_GROUP,
-		label: localize('positron-editor-new-window', "Open in new window")
+		label: localize('positron-editor-new-window', "Open in New Window")
 	},
 	{
 		editorTarget: ACTIVE_GROUP,
-		label: localize('positron-editor-new-tab', "Open in editor tab")
+		label: localize('positron-editor-new-tab', "Open in Editor Tab")
 	},
 	{
 		editorTarget: SIDE_GROUP,
-		label: localize('positron-editor-new-tab-right', "Open in editor tab to the Side")
+		label: localize('positron-editor-new-tab-right', "Open in Editor Tab to the Side")
 	},
 ];
 

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -1516,11 +1516,36 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 		}
 
 		this._storageService.store('positronPlots.defaultEditorAction', selectedEditorGroup, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		// Opening in an editor target supersedes any previous gallery/popout preference.
+		this.setPreferGallery(false);
+		this.setPreferPopout(false);
 	}
 
 	public getPreferredEditorGroup(): number {
 		const preferredEditorGroup = this._storageService.getNumber('positronPlots.defaultEditorAction', StorageScope.WORKSPACE, ACTIVE_GROUP);
 		return preferredEditorGroup;
+	}
+
+	public getPreferGallery(): boolean {
+		return this._storageService.getBoolean('positronPlots.preferGallery', StorageScope.WORKSPACE, false);
+	}
+
+	public setPreferGallery(prefer: boolean): void {
+		this._storageService.store('positronPlots.preferGallery', prefer, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		if (prefer) {
+			this._storageService.store('positronPlots.preferPopout', false, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		}
+	}
+
+	public getPreferPopout(): boolean {
+		return this._storageService.getBoolean('positronPlots.preferPopout', StorageScope.WORKSPACE, false);
+	}
+
+	public setPreferPopout(prefer: boolean): void {
+		this._storageService.store('positronPlots.preferPopout', prefer, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		if (prefer) {
+			this._storageService.store('positronPlots.preferGallery', false, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		}
 	}
 
 	public getEditorInstance(id: string) {

--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -10,7 +10,7 @@ import { ILanguageRuntimeMessageOutput, LanguageRuntimeSessionMode, RuntimeOutpu
 import { ILanguageRuntimeSession, IRuntimeClientInstance, IRuntimeSessionService, RuntimeClientType } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { HTMLFileSystemProvider } from '../../../../platform/files/browser/htmlFileSystemProvider.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
-import { createSuggestedFileNameForPlot, DarkFilter, HistoryPolicy, IPositronPlotClient, IPositronPlotsService, PlotRenderFormat, PlotRenderSettings, PlotsDisplayLocation, POSITRON_PLOTS_LOCATION_CONTEXT, POSITRON_PLOTS_VIEW_ID, ZoomLevel } from '../../../services/positronPlots/common/positronPlots.js';
+import { createSuggestedFileNameForPlot, DarkFilter, HistoryPolicy, IPositronPlotClient, IPositronPlotsService, PlotOpenTarget, PlotRenderFormat, PlotRenderSettings, PlotsDisplayLocation, POSITRON_PLOTS_LOCATION_CONTEXT, POSITRON_PLOTS_VIEW_ID, ZoomLevel } from '../../../services/positronPlots/common/positronPlots.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { StaticPlotClient } from '../../../services/positronPlots/common/staticPlotClient.js';
 import { IStorageService, StorageTarget, StorageScope } from '../../../../platform/storage/common/storage.js';
@@ -43,7 +43,7 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { WebviewPlotClient } from './webviewPlotClient.js';
-import { ACTIVE_GROUP, AUX_WINDOW_GROUP, IEditorService } from '../../../services/editor/common/editorService.js';
+import { ACTIVE_GROUP, AUX_WINDOW_GROUP, IEditorService, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
 import { URI } from '../../../../base/common/uri.js';
 import { PositronPlotCommProxy } from '../../../services/languageRuntime/common/positronPlotCommProxy.js';
 import { PlotResult } from '../../../services/languageRuntime/common/positronPlotComm.js';
@@ -83,6 +83,12 @@ const DefaultSizingPolicyConfigKey = 'plots.defaultSizingPolicy';
 
 /** The config key used to store the history policy setting */
 const HistoryPolicyConfigKey = 'plots.historyPolicy';
+
+/** The key used to store the default "Open in..." target. */
+const DefaultOpenTargetStorageKey = 'positronPlots.defaultOpenTarget';
+
+/** Legacy keys used for one-way migration to DefaultOpenTargetStorageKey. */
+const LegacyDefaultEditorActionStorageKey = 'positronPlots.defaultEditorAction';
 
 interface DataUri {
 	mime: string;
@@ -1515,36 +1521,56 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 			throw new Error('Failed to open editor');
 		}
 
-		this._storageService.store('positronPlots.defaultEditorAction', selectedEditorGroup, StorageScope.WORKSPACE, StorageTarget.MACHINE);
-		// Opening in an editor target supersedes any previous gallery/popout preference.
-		this.setPreferGallery(false);
-		this.setPreferPopout(false);
+		this.setDefaultOpenTarget(this.editorGroupToOpenTarget(selectedEditorGroup));
 	}
 
 	public getPreferredEditorGroup(): number {
-		const preferredEditorGroup = this._storageService.getNumber('positronPlots.defaultEditorAction', StorageScope.WORKSPACE, ACTIVE_GROUP);
-		return preferredEditorGroup;
+		return this.openTargetToEditorGroup(this.getDefaultOpenTarget()) ?? ACTIVE_GROUP;
 	}
 
-	public getPreferGallery(): boolean {
-		return this._storageService.getBoolean('positronPlots.preferGallery', StorageScope.WORKSPACE, false);
+	public getDefaultOpenTarget(): PlotOpenTarget {
+		const target = this._storageService.get(DefaultOpenTargetStorageKey, StorageScope.WORKSPACE);
+		switch (target) {
+			case PlotOpenTarget.EditorNewWindow:
+			case PlotOpenTarget.EditorTab:
+			case PlotOpenTarget.EditorTabToSide:
+			case PlotOpenTarget.Gallery:
+			case PlotOpenTarget.Popout:
+				return target;
+		}
+
+		// Migrate old persisted values from older builds on first read.
+		const legacyEditorGroup = this._storageService.getNumber(LegacyDefaultEditorActionStorageKey, StorageScope.WORKSPACE, ACTIVE_GROUP);
+		return this.editorGroupToOpenTarget(legacyEditorGroup);
 	}
 
-	public setPreferGallery(prefer: boolean): void {
-		this._storageService.store('positronPlots.preferGallery', prefer, StorageScope.WORKSPACE, StorageTarget.MACHINE);
-		if (prefer) {
-			this._storageService.store('positronPlots.preferPopout', false, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+	public setDefaultOpenTarget(target: PlotOpenTarget): void {
+		this._storageService.store(DefaultOpenTargetStorageKey, target, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+	}
+
+	private editorGroupToOpenTarget(groupType: number): PlotOpenTarget {
+		switch (groupType) {
+			case AUX_WINDOW_GROUP:
+				return PlotOpenTarget.EditorNewWindow;
+			case SIDE_GROUP:
+				return PlotOpenTarget.EditorTabToSide;
+			case ACTIVE_GROUP:
+			default:
+				return PlotOpenTarget.EditorTab;
 		}
 	}
 
-	public getPreferPopout(): boolean {
-		return this._storageService.getBoolean('positronPlots.preferPopout', StorageScope.WORKSPACE, false);
-	}
-
-	public setPreferPopout(prefer: boolean): void {
-		this._storageService.store('positronPlots.preferPopout', prefer, StorageScope.WORKSPACE, StorageTarget.MACHINE);
-		if (prefer) {
-			this._storageService.store('positronPlots.preferGallery', false, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+	private openTargetToEditorGroup(target: PlotOpenTarget): number | undefined {
+		switch (target) {
+			case PlotOpenTarget.EditorNewWindow:
+				return AUX_WINDOW_GROUP;
+			case PlotOpenTarget.EditorTab:
+				return ACTIVE_GROUP;
+			case PlotOpenTarget.EditorTabToSide:
+				return SIDE_GROUP;
+			case PlotOpenTarget.Gallery:
+			case PlotOpenTarget.Popout:
+				return undefined;
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronPlots/test/electron-browser/positronPlotsService.vitest.ts
+++ b/src/vs/workbench/contrib/positronPlots/test/electron-browser/positronPlotsService.vitest.ts
@@ -9,7 +9,9 @@ import { raceTimeout } from '../../../../../base/common/async.js';
 import { PositronTestServiceAccessor } from '../../../../test/browser/positronWorkbenchTestServices.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { IPositronPlotMetadata, PlotClientInstance } from '../../../../services/languageRuntime/common/languageRuntimePlotClient.js';
-import { HistoryPolicy, IPositronPlotClient, IPositronPlotsService, PlotsDisplayLocation } from '../../../../services/positronPlots/common/positronPlots.js';
+import { HistoryPolicy, IPositronPlotClient, IPositronPlotsService, PlotOpenTarget, PlotsDisplayLocation } from '../../../../services/positronPlots/common/positronPlots.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { ACTIVE_GROUP, AUX_WINDOW_GROUP, SIDE_GROUP } from '../../../../services/editor/common/editorService.js';
 import { RuntimeClientType } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { TestLanguageRuntimeSession } from '../../../../services/runtimeSession/test/common/testLanguageRuntimeSession.js';
 import { startTestLanguageRuntimeSession } from '../../../../services/runtimeSession/test/common/testRuntimeSessionService.js';
@@ -231,6 +233,53 @@ describe('Positron - Plots Service', () => {
 
 	it('selection: expect error removing plot when no plot selected', () => {
 		expect(() => plotsService.removeSelectedPlot()).toThrow('No plot is selected');
+	});
+
+	describe('default open target', () => {
+		const NEW_KEY = 'positronPlots.defaultOpenTarget';
+		const LEGACY_KEY = 'positronPlots.defaultEditorAction';
+
+		let storageService: IStorageService;
+
+		beforeEach(() => {
+			storageService = ctx.instantiationService.invokeFunction(accessor => accessor.get(IStorageService));
+			// Reset both storage keys so each scenario starts from a known state.
+			storageService.remove(NEW_KEY, StorageScope.WORKSPACE);
+			storageService.remove(LEGACY_KEY, StorageScope.WORKSPACE);
+		});
+
+		it('migrates legacy editor-group values when the new key is unset', () => {
+			const cases: Array<[number, PlotOpenTarget]> = [
+				[ACTIVE_GROUP, PlotOpenTarget.EditorTab],
+				[AUX_WINDOW_GROUP, PlotOpenTarget.EditorNewWindow],
+				[SIDE_GROUP, PlotOpenTarget.EditorTabToSide],
+			];
+			for (const [legacyGroup, expected] of cases) {
+				storageService.remove(NEW_KEY, StorageScope.WORKSPACE);
+				storageService.store(LEGACY_KEY, legacyGroup, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+				expect(plotsService.getDefaultOpenTarget()).toBe(expected);
+			}
+		});
+
+		it('prefers the new key over the legacy key when both are present', () => {
+			storageService.store(LEGACY_KEY, AUX_WINDOW_GROUP, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+			plotsService.setDefaultOpenTarget(PlotOpenTarget.Gallery);
+			expect(plotsService.getDefaultOpenTarget()).toBe(PlotOpenTarget.Gallery);
+		});
+
+		it('derives getPreferredEditorGroup from the remembered target', () => {
+			const cases: Array<[PlotOpenTarget, number]> = [
+				[PlotOpenTarget.EditorNewWindow, AUX_WINDOW_GROUP],
+				[PlotOpenTarget.EditorTab, ACTIVE_GROUP],
+				[PlotOpenTarget.EditorTabToSide, SIDE_GROUP],
+				[PlotOpenTarget.Gallery, ACTIVE_GROUP],
+				[PlotOpenTarget.Popout, ACTIVE_GROUP],
+			];
+			for (const [target, expectedGroup] of cases) {
+				plotsService.setDefaultOpenTarget(target);
+				expect(plotsService.getPreferredEditorGroup()).toBe(expectedGroup);
+			}
+		});
 	});
 
 	it('selection: select previous/next plot', async () => {

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -340,6 +340,30 @@ export interface IPositronPlotsService {
 	getPreferredEditorGroup(): number;
 
 	/**
+	 * Whether the gallery was the most recent "Open in..." choice. When true,
+	 * the plots action bar's split-button primary click should open the gallery
+	 * rather than repeat the preferred editor group.
+	 */
+	getPreferGallery(): boolean;
+
+	/**
+	 * Records whether the gallery was the most recent "Open in..." choice.
+	 */
+	setPreferGallery(prefer: boolean): void;
+
+	/**
+	 * Whether popping out an HTML plot was the most recent "Open in..." choice.
+	 * The popout option only appears for HTML plots, so this preference scopes
+	 * to that case.
+	 */
+	getPreferPopout(): boolean;
+
+	/**
+	 * Records whether popping out an HTML plot was the most recent "Open in..." choice.
+	 */
+	setPreferPopout(prefer: boolean): void;
+
+	/**
 	 * Gets the plot client that is connected to an editor for the specified id.
 	 *
 	 * @param id The id of the plot client to get.

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -113,6 +113,22 @@ export enum PlotsDisplayLocation {
 }
 
 /**
+ * The remembered target for the plots action bar "Open in..." split-button.
+ */
+export enum PlotOpenTarget {
+	/** Open in a new auxiliary window editor group. */
+	EditorNewWindow = 'editorNewWindow',
+	/** Open in the active editor group. */
+	EditorTab = 'editorTab',
+	/** Open in the side editor group. */
+	EditorTabToSide = 'editorTabToSide',
+	/** Open the plots gallery in a new window. */
+	Gallery = 'gallery',
+	/** Pop out an HTML plot in a new window. */
+	Popout = 'popout'
+}
+
+/**
  * Creates a suggested file name for a plot.
  * @param storageService The storage service to use.
  * @returns A suggested file name for the plot.
@@ -340,28 +356,14 @@ export interface IPositronPlotsService {
 	getPreferredEditorGroup(): number;
 
 	/**
-	 * Whether the gallery was the most recent "Open in..." choice. When true,
-	 * the plots action bar's split-button primary click should open the gallery
-	 * rather than repeat the preferred editor group.
+	 * Gets the remembered "Open in..." target for the plots action bar split-button.
 	 */
-	getPreferGallery(): boolean;
+	getDefaultOpenTarget(): PlotOpenTarget;
 
 	/**
-	 * Records whether the gallery was the most recent "Open in..." choice.
+	 * Records the remembered "Open in..." target for the plots action bar split-button.
 	 */
-	setPreferGallery(prefer: boolean): void;
-
-	/**
-	 * Whether popping out an HTML plot was the most recent "Open in..." choice.
-	 * The popout option only appears for HTML plots, so this preference scopes
-	 * to that case.
-	 */
-	getPreferPopout(): boolean;
-
-	/**
-	 * Records whether popping out an HTML plot was the most recent "Open in..." choice.
-	 */
-	setPreferPopout(prefer: boolean): void;
+	setDefaultOpenTarget(target: PlotOpenTarget): void;
 
 	/**
 	 * Gets the plot client that is connected to an editor for the specified id.

--- a/src/vs/workbench/services/positronPlots/common/positronPlots.ts
+++ b/src/vs/workbench/services/positronPlots/common/positronPlots.ts
@@ -357,11 +357,16 @@ export interface IPositronPlotsService {
 
 	/**
 	 * Gets the remembered "Open in..." target for the plots action bar split-button.
+	 *
+	 * When the dedicated storage key is unset, falls back to migrating the legacy
+	 * `positronPlots.defaultEditorAction` editor-group number (used by older builds)
+	 * into the corresponding {@link PlotOpenTarget}.
 	 */
 	getDefaultOpenTarget(): PlotOpenTarget;
 
 	/**
 	 * Records the remembered "Open in..." target for the plots action bar split-button.
+	 * Supersedes any value carried over from the legacy editor-group key.
 	 */
 	setDefaultOpenTarget(target: PlotOpenTarget): void;
 

--- a/src/vs/workbench/services/positronPlots/test/common/testPositronPlotsService.ts
+++ b/src/vs/workbench/services/positronPlots/test/common/testPositronPlotsService.ts
@@ -486,6 +486,31 @@ export class TestPositronPlotsService extends Disposable implements IPositronPlo
 		return 0; // Default to active group for test implementation
 	}
 
+	private _preferGallery = false;
+	private _preferPopout = false;
+
+	getPreferGallery(): boolean {
+		return this._preferGallery;
+	}
+
+	setPreferGallery(prefer: boolean): void {
+		this._preferGallery = prefer;
+		if (prefer) {
+			this._preferPopout = false;
+		}
+	}
+
+	getPreferPopout(): boolean {
+		return this._preferPopout;
+	}
+
+	setPreferPopout(prefer: boolean): void {
+		this._preferPopout = prefer;
+		if (prefer) {
+			this._preferGallery = false;
+		}
+	}
+
 	/**
 	 * Gets the plot client that is connected to an editor for the specified id.
 	 *

--- a/src/vs/workbench/services/positronPlots/test/common/testPositronPlotsService.ts
+++ b/src/vs/workbench/services/positronPlots/test/common/testPositronPlotsService.ts
@@ -5,9 +5,10 @@
 
 import { Emitter } from '../../../../../base/common/event.js';
 import { Disposable, DisposableMap } from '../../../../../base/common/lifecycle.js';
-import { IPositronPlotsService, IPositronPlotClient, HistoryPolicy, DarkFilter, PlotRenderSettings, PlotsDisplayLocation } from '../../common/positronPlots.js';
+import { IPositronPlotsService, IPositronPlotClient, HistoryPolicy, DarkFilter, PlotOpenTarget, PlotRenderSettings, PlotsDisplayLocation } from '../../common/positronPlots.js';
 import { IPositronPlotSizingPolicy } from '../../common/sizingPolicy.js';
 import { IPositronPlotMetadata } from '../../../languageRuntime/common/languageRuntimePlotClient.js';
+import { ACTIVE_GROUP, AUX_WINDOW_GROUP, SIDE_GROUP } from '../../../editor/common/editorService.js';
 
 /**
  * TestPositronPlotsService class.
@@ -483,32 +484,27 @@ export class TestPositronPlotsService extends Disposable implements IPositronPlo
 	 * Gets the preferred editor group for opening the plot in an editor tab.
 	 */
 	getPreferredEditorGroup(): number {
-		return 0; // Default to active group for test implementation
-	}
-
-	private _preferGallery = false;
-	private _preferPopout = false;
-
-	getPreferGallery(): boolean {
-		return this._preferGallery;
-	}
-
-	setPreferGallery(prefer: boolean): void {
-		this._preferGallery = prefer;
-		if (prefer) {
-			this._preferPopout = false;
+		switch (this._defaultOpenTarget) {
+			case PlotOpenTarget.EditorNewWindow:
+				return AUX_WINDOW_GROUP;
+			case PlotOpenTarget.EditorTabToSide:
+				return SIDE_GROUP;
+			case PlotOpenTarget.EditorTab:
+			case PlotOpenTarget.Gallery:
+			case PlotOpenTarget.Popout:
+			default:
+				return ACTIVE_GROUP;
 		}
 	}
 
-	getPreferPopout(): boolean {
-		return this._preferPopout;
+	private _defaultOpenTarget = PlotOpenTarget.EditorTab;
+
+	getDefaultOpenTarget(): PlotOpenTarget {
+		return this._defaultOpenTarget;
 	}
 
-	setPreferPopout(prefer: boolean): void {
-		this._preferPopout = prefer;
-		if (prefer) {
-			this._preferGallery = false;
-		}
+	setDefaultOpenTarget(target: PlotOpenTarget): void {
+		this._defaultOpenTarget = target;
 	}
 
 	/**

--- a/test/e2e/pages/plots.ts
+++ b/test/e2e/pages/plots.ts
@@ -206,9 +206,9 @@ export class Plots {
 
 	async openPlotIn(plotLocation: PlotLocations) {
 		const menuItemRegex = {
-			'editor': /Open in editor tab$/,
-			'new window': /Open in new window$/,
-			'editor tab to the side': /Open in editor tab to the Side$/
+			'editor': /Open in Editor Tab$/,
+			'new window': /Open in New Window$/,
+			'editor tab to the side': /Open in Editor Tab to the Side$/
 		};
 		await test.step(`Open plot in: ${plotLocation}`, async () => {
 			// The "Open in Editor" button may be visible in the action bar or overflowed into the overflow menu.
@@ -253,9 +253,9 @@ export class Plots {
 
 	async verifyOpenPlotDropdownCheckedOption(expectedOption: PlotLocations) {
 		const menuItemLabels: Record<PlotLocations, string> = {
-			'editor': 'Open in editor tab',
-			'new window': 'Open in new window',
-			'editor tab to the side': 'Open in editor tab to the Side'
+			'editor': 'Open in Editor Tab',
+			'new window': 'Open in New Window',
+			'editor tab to the side': 'Open in Editor Tab to the Side'
 		};
 		await test.step(`Verify dropdown checked option is: ${expectedOption}`, async () => {
 			const openInEditorButton = this.code.driver.currentPage.locator(OPEN_IN_EDITOR_DROPDOWN_BUTTON);

--- a/test/e2e/pages/plots.ts
+++ b/test/e2e/pages/plots.ts
@@ -19,9 +19,7 @@ const PLOT_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .pos
 const SAVE_PLOT_FROM_PLOTS_PANE_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Save plot"]';
 const COPY_PLOT_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Copy plot to clipboard"]';
 const ZOOM_PLOT_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Fit"]';
-const OPEN_IN_EDITOR_DROPDOWN_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Select where to open plot"]';
-// The primary (non-caret) half of the split-button. Clicking it repeats the
-// most recent menu selection rather than opening the dropdown.
+const OPEN_IN_EDITOR_DROPDOWN_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .action-bar-button-drop-down-button[aria-label="Select where to open plot"]';
 const OPEN_IN_EDITOR_PRIMARY_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .action-bar-button-action-button[aria-label="Select where to open plot"]';
 const OVERFLOW_MENU_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="overflow"]';
 const SESSION_NAME_BUTTON = '.plot-session-name';

--- a/test/e2e/pages/plots.ts
+++ b/test/e2e/pages/plots.ts
@@ -19,8 +19,10 @@ const PLOT_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .pos
 const SAVE_PLOT_FROM_PLOTS_PANE_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Save plot"]';
 const COPY_PLOT_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Copy plot to clipboard"]';
 const ZOOM_PLOT_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Fit"]';
-const OPEN_IN_EDITOR_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Open in editor tab"]';
 const OPEN_IN_EDITOR_DROPDOWN_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="Select where to open plot"]';
+// The primary (non-caret) half of the split-button. Clicking it repeats the
+// most recent menu selection rather than opening the dropdown.
+const OPEN_IN_EDITOR_PRIMARY_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .action-bar-button-action-button[aria-label="Select where to open plot"]';
 const OVERFLOW_MENU_BUTTON = '.positron-plots-container .positron-dynamic-action-bar .positron-button[aria-label="overflow"]';
 const SESSION_NAME_BUTTON = '.plot-session-name';
 const ORIGIN_FILE_BUTTON = '.plot-origin-file';
@@ -193,10 +195,6 @@ export class Plots {
 		}
 	}
 
-	async clickGoToFileButton() {
-		await this.code.driver.currentPage.locator('.codicon-go-to-file').click();
-	}
-
 	async setThePlotZoom(zoomLevel: ZoomLevels) {
 		await test.step(`Set plot zoom to: ${zoomLevel}`, async () => {
 			await this.contextMenu.triggerAndClick({
@@ -247,9 +245,9 @@ export class Plots {
 	}
 
 	async clickOpenInEditorButton() {
-		await test.step('Click the main Open in Editor button', async () => {
-			const openInEditorButton = this.code.driver.currentPage.locator(OPEN_IN_EDITOR_BUTTON);
-			await openInEditorButton.click();
+		await test.step('Click the primary half of the Open-in split button', async () => {
+			const primaryButton = this.code.driver.currentPage.locator(OPEN_IN_EDITOR_PRIMARY_BUTTON);
+			await primaryButton.click();
 		});
 	}
 


### PR DESCRIPTION
Addresses #13068, only the part about the Plots action bar (not the Viewer action bar, which can come in a separate PR)

This PR reworks the plots pane action bar to consolidate the three "Open somewhere else" affordances we had (popout for HTML plots, the editor target dropdown for regular plots, and "Open plots gallery in new window") into a single split button dropdown on the right side, with the same Positron custom icon that we use on the editor. The dropdown's contents adapt to the current plot type, and "Open Plots Gallery in New Window" is always present as the last entry below a separator (hopefully to indicate that it's a different kind of action):

<img width="340" height="179" alt="Screenshot 2026-05-17 at 4 00 35 PM" src="https://github.com/user-attachments/assets/9d76fce6-b789-4c29-9f54-acbdd30a22ed" />

Other action bar changes here:

- Dark filter moved from the right side to the left, because I think we should not prioritize it so much compared to the "Open somewhere else" actions and it makes the more-used behavior persist more at smaller widths:

<img width="768" height="418" alt="plots-action-bar" src="https://github.com/user-attachments/assets/2f86e469-610f-471d-b89f-7ebfb1ab30e4" />

- Separator added between "Copy plot to clipboard" and the Zoom dropdown, to highlight that these all work similarly to each other (same kind of buttons with similar UX):

<img width="554" height="458" alt="Screenshot_2026-05-17_at_3_53_36 PM" src="https://github.com/user-attachments/assets/325fef58-bebd-431c-8ace-057711b4bf90" />

- The new split button's primary (icon) click repeats the user's most recent choice. The choice is persisted to the storage service via the plots service, so it survives closing the gallery, switching plots, or reloading the window.

- When no prior choice applies to the current plot type, the menu visually checks the fallback action so the user can see what the primary click will do.

- I updated the user-facing strings to be consistent with the project style (title case).

I'll highlight that _before_ this change, an HTML plot open in the auxiliary window plots gallery WOULD have a button to open it in a new window (i.e. a browser) but now it does not. Static plots never had that ability in the auxiliary window. I think the consistency here is good.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Consolidate the plots pane's "Open in..." actions into a single dropdown with consistent placement and iconography (#13068)

### Validation Steps

@:plots @:web @:win

1. Generate a regular plot (matplotlib / ggplot). Confirm the action bar shows a single "Open in..." split-button on the right, plus Clear all.
2. Open the dropdown. Confirm it lists "Open in New Window", "Open in Editor Tab", "Open in Editor Tab to the Side", a separator, then "Open Plots Gallery in New Window".
3. Click one of the editor-target options. Reopen the dropdown and confirm that option is checked.
4. Click the split-button's icon area (not the caret). Confirm it repeats the most recent choice.
5. Click "Open Plots Gallery in New Window". Close the gallery. Reopen the dropdown and confirm gallery is checked; primary click reopens the gallery.
6. Reload the window with the gallery preference set. Confirm the gallery remains the checked / default-click option.
7. Generate an HTML plot (e.g. plotly, htmlwidgets, shiny). Open the dropdown. Confirm it lists "Open Plot in New Window", a separator, then "Open Plots Gallery in New Window".
8. Click "Open Plot in New Window". Reopen the dropdown and confirm popout is checked.
9. With no plots in the pane, confirm the "Open in..." button is still visible and the dropdown shows just "Open Plots Gallery in New Window" (checked).
10. Confirm the Dark filter dropdown is now on the left side (after the sizing dropdown).
11. Confirm there is a visual separator between "Copy plot to clipboard" and the Zoom dropdown.
