### PR TITLE
e2e: skip assistant tests broken by sidebarView routing

### DIFF
--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -203,7 +203,7 @@ test.describe('Positron Assistant Model Picker Default Indicator', { tag: [tags.
 	 * 1. The model picker shows "(default)" suffix next to the model name
 	 * 2. The default model appears first in the vendor group
 	 */
-	test('Verify default model indicator and ordering for single provider', async function ({ settings, assistant }) {
+	test.skip('Verify default model indicator and ordering for single provider', async function ({ settings, assistant }) {
 		// Configure the Echo Language Model v2 as the default for the echo provider
 		await settings.set({
 			'positron.assistant.models.preference.echo': 'Echo Language Model v2'

--- a/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
@@ -70,7 +70,7 @@ test.describe('Notebook Assistant: Interaction Flow', {
 		await assistant.logoutModelProvider('echo');
 	});
 
-	test('Fix error button opens chat and sends error context', async function ({ app }) {
+	test.skip('Fix error button opens chat and sends error context', async function ({ app }) {
 		const { notebooksPositron, assistant } = app.workbench;
 
 		// Create notebook
@@ -99,7 +99,7 @@ test.describe('Notebook Assistant: Interaction Flow', {
 		expect(responseText).toContain('undefined_var');
 	});
 
-	test('Explain error button opens chat and sends error context', async function ({ app }) {
+	test.skip('Explain error button opens chat and sends error context', async function ({ app }) {
 		const { notebooksPositron, assistant } = app.workbench;
 
 		// Create notebook


### PR DESCRIPTION
### Summary
Skips 2 e2e tests that are failing because #13525 rerouted Fix/Explain notebook button actions through `posit-assistant.newChat` when `assistant.sidebarView` is enabled (the default in CI fixtures). The tests' POM methods use built-in chat selectors that never match the Posit Assistant UI.

- `test.skip` Fix error button opens chat and sends error context
- `test.skip` Explain error button opens chat and sends error context
- `test.skip` Verify default model indicator and ordering for single provider
   - Also skipping this one. I think @jonvanausdeln is going to be deleting it, but I wasn't entirely sure of his plans.

### QA Notes
n/a