### PR TITLE
ci: auto-update bootstrap extensions on nightly mismatch

### DIFF
--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -91,14 +91,7 @@ jobs:
           git config user.email "positron-bot[bot]@users.noreply.github.com"
 
       - name: Update extensions
-        env:
-          TEST_RESULT: ${{ needs.extensions-linux.result }}
-        run: |
-          if [ "$TEST_RESULT" = "failure" ]; then
-            ./scripts/update-extensions.sh --all
-          else
-            ./scripts/update-extensions.sh meta.pyrefly
-          fi
+        run: ./scripts/update-extensions.sh meta.pyrefly
 
       - name: Commit and push
         id: push

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -91,7 +91,14 @@ jobs:
           git config user.email "positron-bot[bot]@users.noreply.github.com"
 
       - name: Update extensions
-        run: ./scripts/update-extensions.sh --all
+        env:
+          TEST_RESULT: ${{ needs.extensions-linux.result }}
+        run: |
+          if [ "$TEST_RESULT" = "failure" ]; then
+            ./scripts/update-extensions.sh --all
+          else
+            ./scripts/update-extensions.sh meta.pyrefly
+          fi
 
       - name: Commit and push
         id: push

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -63,7 +63,7 @@ jobs:
 
   auto-update:
     name: 'auto-update-extensions'
-    if: always() && needs.extensions-linux.result == 'failure'
+    if: always() && needs.extensions-linux.result != 'cancelled'
     needs: [extensions-linux]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -157,8 +157,8 @@ jobs:
                }')"
 
   slack-notify:
-    if: failure()
-    needs: [extensions-linux]
+    if: always() && needs.extensions-linux.result == 'failure' && needs.auto-update.result != 'success'
+    needs: [extensions-linux, auto-update]
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -91,7 +91,14 @@ jobs:
           git config user.email "positron-bot[bot]@users.noreply.github.com"
 
       - name: Update extensions
-        run: ./scripts/update-extensions.sh meta.pyrefly
+        env:
+          TEST_RESULT: ${{ needs.extensions-linux.result }}
+        run: |
+          if [ "$TEST_RESULT" = "failure" ]; then
+            ./scripts/update-extensions.sh --all
+          else
+            ./scripts/update-extensions.sh meta.pyrefly
+          fi
 
       - name: Commit and push
         id: push

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -16,6 +16,8 @@ jobs:
     name: 'extensions-linux'
     timeout-minutes: 60
     runs-on: ubuntu-latest-8x
+    outputs:
+      extensions: ${{ steps.parse.outputs.extensions }}
     container:
       image: ghcr.io/posit-dev/positron-ubuntu24-amd64:116
       options: --user 0:0
@@ -49,6 +51,8 @@ jobs:
           identifier: e2e-electron
 
       - name: 🧪 Run Playwright Tests (Electron)
+        id: playwright-test
+        continue-on-error: true
         shell: bash
         env:
           POSITRON_PY_VER_SEL: "3.10.12"
@@ -58,8 +62,125 @@ jobs:
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           EXTENSIONS_FAIL_ON_MISMATCH: true
         run: |
-          echo "Running: npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project e2e-electron --reporter=null"
-          npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project e2e-electron --reporter=null
+          {
+            echo "Running: npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project e2e-electron --reporter=null"
+            npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project e2e-electron --reporter=null
+          } 2>&1 | tee /tmp/playwright-output.txt
+
+      - name: Parse mismatched extensions
+        id: parse
+        if: steps.playwright-test.outcome == 'failure'
+        shell: bash
+        run: |
+          LINE=$(grep 'update-extensions.sh' /tmp/playwright-output.txt | head -1 | xargs || true)
+          EXTENSIONS="${LINE#./scripts/update-extensions.sh }"
+          echo "extensions=$EXTENSIONS" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if tests failed
+        if: steps.playwright-test.outcome == 'failure'
+        shell: bash
+        run: exit 1
+
+  auto-update:
+    name: 'auto-update-extensions'
+    if: needs.extensions-linux.result == 'failure' && needs.extensions-linux.outputs.extensions != ''
+    needs: [extensions-linux]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate POSITRON_BOT token
+        id: bot-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.POSITRON_BOT_APP_ID }}
+          private-key: ${{ secrets.POSITRON_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.bot-token.outputs.token }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "positron-bot[bot]"
+          git config user.email "positron-bot[bot]@users.noreply.github.com"
+
+      - name: Update extensions
+        env:
+          EXTENSIONS: ${{ needs.extensions-linux.outputs.extensions }}
+        run: ./scripts/update-extensions.sh $EXTENSIONS
+
+      - name: Commit and push
+        id: push
+        run: |
+          BRANCH="automated/update-extensions-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
+          git add product.json
+          if git diff --staged --quiet; then
+            echo "No changes to product.json — skipping PR"
+            exit 0
+          fi
+          git commit -m "chore: update bootstrap extensions"
+          git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        id: create-pr
+        if: steps.push.outputs.branch != ''
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+          EXTENSIONS: ${{ needs.extensions-linux.outputs.extensions }}
+          BRANCH: ${{ steps.push.outputs.branch }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          EXT_BULLETS=$(echo "$EXTENSIONS" | tr ' ' '\n' | sed 's/^/- /')
+          cat > /tmp/pr-body.md << EOF
+          ### Summary
+          Update bootstrap extensions detected as out-of-date by the nightly check.
+
+          ${EXT_BULLETS}
+
+          ### QA Notes
+          Triggered by [nightly extensions check](${RUN_URL}).
+          EOF
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: update bootstrap extensions" \
+            --body-file /tmp/pr-body.md)
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Post PR to Slack
+        if: steps.create-pr.outputs.pr_url != ''
+        env:
+          # Ensure SLACK_TOKEN_TEST_STATUS has access to #positron-qa, or swap for a token that does
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
+          PR_URL: ${{ steps.create-pr.outputs.pr_url }}
+          EXTENSIONS: ${{ needs.extensions-linux.outputs.extensions }}
+        run: |
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg channel "#positron-qa" \
+              --arg pr_url "$PR_URL" \
+              --arg ext "$EXTENSIONS" \
+              '{
+                channel: $channel,
+                text: ("Bootstrap extensions update ready for review: " + $pr_url),
+                blocks: [
+                  {
+                    type: "section",
+                    text: {
+                      type: "mrkdwn",
+                      text: (":package: *Bootstrap extensions update ready for review*\n<" + $pr_url + "|View PR>\n`" + $ext + "`")
+                    }
+                  }
+                ]
+              }')"
 
   slack-notify:
     if: failure()

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -70,7 +70,7 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      pr_url: ${{ steps.create-pr.outputs.pr_url }}
+      pr_url: ${{ steps.create-pr.outputs.pr_url || steps.push.outputs.existing_pr }}
     steps:
       - name: Generate POSITRON_BOT token
         id: bot-token

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -16,8 +16,6 @@ jobs:
     name: 'extensions-linux'
     timeout-minutes: 60
     runs-on: ubuntu-latest-8x
-    outputs:
-      extensions: ${{ steps.parse.outputs.extensions }}
     container:
       image: ghcr.io/posit-dev/positron-ubuntu24-amd64:116
       options: --user 0:0
@@ -51,8 +49,6 @@ jobs:
           identifier: e2e-electron
 
       - name: 🧪 Run Playwright Tests (Electron)
-        id: playwright-test
-        continue-on-error: true
         shell: bash
         env:
           POSITRON_PY_VER_SEL: "3.10.12"
@@ -62,28 +58,12 @@ jobs:
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           EXTENSIONS_FAIL_ON_MISMATCH: true
         run: |
-          {
-            echo "Running: npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project e2e-electron --reporter=null"
-            npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project e2e-electron --reporter=null
-          } 2>&1 | tee /tmp/playwright-output.txt
-
-      - name: Parse mismatched extensions
-        id: parse
-        if: steps.playwright-test.outcome == 'failure'
-        shell: bash
-        run: |
-          LINE=$(grep 'update-extensions.sh' /tmp/playwright-output.txt | head -1 | xargs || true)
-          EXTENSIONS="${LINE#./scripts/update-extensions.sh }"
-          echo "extensions=$EXTENSIONS" >> "$GITHUB_OUTPUT"
-
-      - name: Fail if tests failed
-        if: steps.playwright-test.outcome == 'failure'
-        shell: bash
-        run: exit 1
+          echo "Running: npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project e2e-electron --reporter=null"
+          npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project e2e-electron --reporter=null
 
   auto-update:
     name: 'auto-update-extensions'
-    if: needs.extensions-linux.result == 'failure' && needs.extensions-linux.outputs.extensions != ''
+    if: needs.extensions-linux.result == 'failure'
     needs: [extensions-linux]
     runs-on: ubuntu-latest
     permissions:
@@ -109,9 +89,7 @@ jobs:
           git config user.email "positron-bot[bot]@users.noreply.github.com"
 
       - name: Update extensions
-        env:
-          EXTENSIONS: ${{ needs.extensions-linux.outputs.extensions }}
-        run: ./scripts/update-extensions.sh $EXTENSIONS
+        run: ./scripts/update-extensions.sh --all
 
       - name: Commit and push
         id: push
@@ -132,26 +110,29 @@ jobs:
         if: steps.push.outputs.branch != ''
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
-          EXTENSIONS: ${{ needs.extensions-linux.outputs.extensions }}
           BRANCH: ${{ steps.push.outputs.branch }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          EXT_BULLETS=$(echo "$EXTENSIONS" | tr ' ' '\n' | sed 's/^/- /')
-          cat > /tmp/pr-body.md << EOF
-          ### Summary
+          UPDATED=$(jq -rn \
+            --argjson old "$(git show HEAD~1:product.json)" \
+            --argjson new "$(cat product.json)" \
+            '($old.bootstrapExtensions | map({(.name): .version}) | add) as $ov |
+             ($new.bootstrapExtensions | map({(.name): .version}) | add) as $nv |
+             [$nv | to_entries[] | select(.value != $ov[.key]) | .key] | join(" ")')
+          EXT_BULLETS=$(echo "$UPDATED" | tr ' ' '\n' | sed 's/^/- /')
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: update bootstrap extensions" \
+            --body "### Summary
           Update bootstrap extensions detected as out-of-date by the nightly check.
 
           ${EXT_BULLETS}
 
           ### QA Notes
-          Triggered by [nightly extensions check](${RUN_URL}).
-          EOF
-          PR_URL=$(gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "chore: update bootstrap extensions" \
-            --body-file /tmp/pr-body.md)
+          Triggered by [nightly extensions check](${RUN_URL}).")
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "updated=$UPDATED" >> "$GITHUB_OUTPUT"
 
       - name: Post PR to Slack
         if: steps.create-pr.outputs.pr_url != ''
@@ -159,7 +140,7 @@ jobs:
           # Ensure SLACK_TOKEN_TEST_STATUS has access to #positron-qa, or swap for a token that does
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}
-          EXTENSIONS: ${{ needs.extensions-linux.outputs.extensions }}
+          UPDATED: ${{ steps.create-pr.outputs.updated }}
         run: |
           curl -s -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_TOKEN" \
@@ -167,7 +148,7 @@ jobs:
             -d "$(jq -n \
               --arg channel "#positron-qa" \
               --arg pr_url "$PR_URL" \
-              --arg ext "$EXTENSIONS" \
+              --arg ext "$UPDATED" \
               '{
                 channel: $channel,
                 text: ("PR to update bootstrap extensions: " + $pr_url + "\n" + $ext)

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -69,6 +69,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      pr_url: ${{ steps.create-pr.outputs.pr_url }}
     steps:
       - name: Generate POSITRON_BOT token
         id: bot-token
@@ -93,7 +95,19 @@ jobs:
 
       - name: Commit and push
         id: push
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
         run: |
+          # Skip if an open auto-update PR already exists to avoid duplicates
+          EXISTING=$(gh pr list --base main --state open \
+            --json headRefName,url \
+            --jq '.[] | select(.headRefName | startswith("automated/update-extensions")) | .url' \
+            | head -1 || true)
+          if [ -n "$EXISTING" ]; then
+            echo "Open auto-update PR already exists: $EXISTING — skipping"
+            echo "existing_pr=$EXISTING" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           BRANCH="automated/update-extensions-$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH"
           git add product.json
@@ -120,7 +134,15 @@ jobs:
              ($new.bootstrapExtensions | map({(.name): .version}) | add) as $nv |
              [$nv | to_entries[] | select(.value != $ov[.key]) | .key] | join(" ")')
           EXT_BULLETS=$(echo "$UPDATED" | tr ' ' '\n' | sed 's/^/- /')
-          TITLE="chore: update bootstrap extensions ($(echo "$UPDATED" | tr ' ' ','))"
+          # Truncate title if more than 3 extensions to stay within GitHub's limit
+          EXT_ARRAY=($UPDATED)
+          COUNT=${#EXT_ARRAY[@]}
+          if [ "$COUNT" -le 3 ]; then
+            TITLE="chore: update bootstrap extensions ($(echo "$UPDATED" | tr ' ' ','))"
+          else
+            FIRST3="${EXT_ARRAY[0]},${EXT_ARRAY[1]},${EXT_ARRAY[2]}"
+            TITLE="chore: update bootstrap extensions ($FIRST3 +$((COUNT - 3)) more)"
+          fi
           PR_URL=$(gh pr create \
             --base main \
             --head "$BRANCH" \
@@ -136,11 +158,11 @@ jobs:
           echo "updated=$UPDATED" >> "$GITHUB_OUTPUT"
 
       - name: Post PR to Slack
-        if: steps.create-pr.outputs.pr_url != ''
+        if: steps.push.outputs.existing_pr != '' || steps.create-pr.outputs.pr_url != ''
         env:
           # Ensure SLACK_TOKEN_TEST_STATUS has access to #positron-qa, or swap for a token that does
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
-          PR_URL: ${{ steps.create-pr.outputs.pr_url }}
+          PR_URL: ${{ steps.create-pr.outputs.pr_url || steps.push.outputs.existing_pr }}
           UPDATED: ${{ steps.create-pr.outputs.updated }}
         run: |
           curl -s -X POST https://slack.com/api/chat.postMessage \
@@ -151,14 +173,14 @@ jobs:
               --arg pr_url "$PR_URL" \
               --arg ext "$UPDATED" \
               '($pr_url | split("/") | last) as $pr_num |
-               ($ext | split(" ") | map("• " + .) | join("\n")) as $bullets |
+               (if $ext != "" then ($ext | split(" ") | map("• " + .) | join("\n")) else "" end) as $bullets |
                {
                  channel: $channel,
-                 text: (":pullrequest: bootstrap extensions update | <" + $pr_url + "|PR #" + $pr_num + ">\n\n" + $bullets)
+                 text: (":pullrequest: bootstrap extensions update | <" + $pr_url + "|PR #" + $pr_num + ">" + (if $bullets != "" then "\n\n" + $bullets else "" end))
                }')"
 
   slack-notify:
-    if: always() && needs.extensions-linux.result == 'failure' && needs.auto-update.result != 'success'
+    if: always() && needs.extensions-linux.result == 'failure' && needs.auto-update.outputs.pr_url == ''
     needs: [extensions-linux, auto-update]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -167,9 +167,10 @@ jobs:
             -d "$(jq -n \
               --arg channel "#positron-qa" \
               --arg pr_url "$PR_URL" \
+              --arg ext "$EXTENSIONS" \
               '{
                 channel: $channel,
-                text: ("PR to update bootstrap extensions: " + $pr_url)
+                text: ("PR to update bootstrap extensions: " + $pr_url + "\n" + $ext)
               }')"
 
   slack-notify:

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -149,10 +149,12 @@ jobs:
               --arg channel "#positron-qa" \
               --arg pr_url "$PR_URL" \
               --arg ext "$UPDATED" \
-              '{
-                channel: $channel,
-                text: ("PR to update bootstrap extensions: " + $pr_url + "\n" + $ext)
-              }')"
+              '($pr_url | split("/") | last) as $pr_num |
+               ($ext | split(" ") | map("• " + .) | join("\n")) as $bullets |
+               {
+                 channel: $channel,
+                 text: (":pullrequest: bootstrap extensions update | <" + $pr_url + "|PR #" + $pr_num + ">\n\n" + $bullets)
+               }')"
 
   slack-notify:
     if: failure()

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -63,7 +63,7 @@ jobs:
 
   auto-update:
     name: 'auto-update-extensions'
-    if: needs.extensions-linux.result == 'failure'
+    if: always() && needs.extensions-linux.result == 'failure'
     needs: [extensions-linux]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -176,7 +176,7 @@ jobs:
                (if $ext != "" then ($ext | split(" ") | map("• " + .) | join("\n")) else "" end) as $bullets |
                {
                  channel: $channel,
-                 text: (":pullrequest: bootstrap extensions update | <" + $pr_url + "|PR #" + $pr_num + ">" + (if $bullets != "" then "\n\n" + $bullets else "" end))
+                 text: ("bootstrap extensions update | <" + $pr_url + "|PR #" + $pr_num + ">" + (if $bullets != "" then "\n\n" + $bullets else "" end))
                }')"
 
   slack-notify:

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -120,10 +120,11 @@ jobs:
              ($new.bootstrapExtensions | map({(.name): .version}) | add) as $nv |
              [$nv | to_entries[] | select(.value != $ov[.key]) | .key] | join(" ")')
           EXT_BULLETS=$(echo "$UPDATED" | tr ' ' '\n' | sed 's/^/- /')
+          TITLE="chore: update bootstrap extensions ($(echo "$UPDATED" | tr ' ' ','))"
           PR_URL=$(gh pr create \
             --base main \
             --head "$BRANCH" \
-            --title "chore: update bootstrap extensions" \
+            --title "$TITLE" \
             --body "### Summary
           Update bootstrap extensions detected as out-of-date by the nightly check.
 

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -167,19 +167,9 @@ jobs:
             -d "$(jq -n \
               --arg channel "#positron-qa" \
               --arg pr_url "$PR_URL" \
-              --arg ext "$EXTENSIONS" \
               '{
                 channel: $channel,
-                text: ("Bootstrap extensions update ready for review: " + $pr_url),
-                blocks: [
-                  {
-                    type: "section",
-                    text: {
-                      type: "mrkdwn",
-                      text: (":package: *Bootstrap extensions update ready for review*\n<" + $pr_url + "|View PR>\n`" + $ext + "`")
-                    }
-                  }
-                ]
+                text: ("PR to update bootstrap extensions: " + $pr_url)
               }')"
 
   slack-notify:

--- a/product.json
+++ b/product.json
@@ -106,7 +106,7 @@
 	"bootstrapExtensions": [
 		{
 			"name": "charliermarsh.ruff",
-			"version": "2026.40.0",
+			"version": "2026.42.0",
 			"repo": "https://github.com/astral-sh/ruff-vscode",
 			"metadata": {
 				"publisherId": {

--- a/product.json
+++ b/product.json
@@ -106,7 +106,7 @@
 	"bootstrapExtensions": [
 		{
 			"name": "charliermarsh.ruff",
-			"version": "2026.42.0",
+			"version": "2026.41.0",
 			"repo": "https://github.com/astral-sh/ruff-vscode",
 			"metadata": {
 				"publisherId": {

--- a/product.json
+++ b/product.json
@@ -106,7 +106,7 @@
 	"bootstrapExtensions": [
 		{
 			"name": "charliermarsh.ruff",
-			"version": "2026.41.0",
+			"version": "2026.40.0",
 			"repo": "https://github.com/astral-sh/ruff-vscode",
 			"metadata": {
 				"publisherId": {


### PR DESCRIPTION
### Summary
Extends the nightly extensions check to self-heal when mismatches are detected.
- Runs `update-extensions.sh --all` in a follow-up job, commits `product.json`, and opens a PR as Positron Bot
- Skips PR creation if one is already open
- Posts to `#positron-qa` with the PR link and updated extension list
- Only falls back to `#positron-test-results` when no PR was opened (e.g. unrelated test failure)

### QA Notes
n/a