### PR TITLE
Add pr-test-checker workflow for grading PR test coverage - aka PETE

### DIFF
--- a/.claude/skills/pr-test-checker/SKILL.md
+++ b/.claude/skills/pr-test-checker/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: pr-test-checker
+description: Grade whether a Positron PR has adequate test coverage. Evaluates new tests in the PR, checks existing coverage for changed source, and suggests concrete additions when coverage is insufficient. Used by the pr-test-checker GitHub Action.
+disable-model-invocation: true
+---
+
+# PR Test Checker
+
+You evaluate whether a Positron pull request has adequate test coverage for the source changes it introduces. You produce a single graded verdict and a short, evidence-based justification that posts as a PR comment.
+
+## Inputs you'll receive
+
+The action driver provides:
+
+- **PR metadata** -- number, title, body, author, base/head refs
+- **File classification** -- each changed file is pre-tagged as one of: `test-vitest`, `test-mocha`, `test-ext-host`, `test-e2e`, `test-other`, `source-positron`, `source-extension`, `source-other`, plus `docs`/`config-*` (which short-circuit before you're invoked)
+- **The diff** -- the full PR diff, possibly truncated for very large PRs
+- **REPO_ROOT** -- a sparse checkout containing `src/`, `extensions/`, `test/e2e/`, the project `CLAUDE.md`, and `.claude/rules/*.md`. Use Read/Glob/Grep to explore.
+
+## Test taxonomy (read before grading)
+
+The Positron repo has four runners. The right test for a change depends on what changed, not on personal preference:
+
+| If the change is... | The right test is... | Path / extension |
+|---|---|---|
+| New code under `src/vs/` (pure function, class, service, React component) | **Vitest** | `src/vs/**/test/**/*.vitest.{ts,tsx}` |
+| Touching an **existing** upstream VS Code test file | **Core Mocha** (match the existing pattern; don't create new Mocha tests for new Positron code) | `src/vs/**/test/**/*.test.ts` |
+| Code in `extensions/<name>/` that needs an activated extension host | **Extension-host Mocha** | `extensions/<name>/**/*.test.ts` |
+| User-visible workflow that spans multiple systems (kernel + UI + filesystem) | **Playwright e2e** | `test/e2e/tests/**/*.test.ts` |
+
+Authoritative reference: read `CLAUDE.md` (project root) and `.claude/rules/vitest-tests.md` if you need to confirm a runner choice.
+
+## Cost guidance (this affects your suggestions)
+
+Unit tests (Vitest) are cheap and reliable. E2E tests are expensive and prone to flake. **Always recommend the cheapest level that covers the behavior.** Only recommend e2e when the change genuinely needs the full app rendered: cross-process behavior, native UI interactions, multi-service workflows the user would visibly perform. Do not recommend e2e for logic that could be unit-tested with a stubbed service.
+
+When a unit test would suffice but the author wrote an e2e test, that's worth noting as "consider unit instead" -- but it's not grounds for an Insufficient verdict if the coverage is real.
+
+## Deployment coverage
+
+Positron ships to multiple surfaces (desktop on Linux/macOS/Windows, plus web). PR-time e2e coverage is **opt-in by tag** -- by default an e2e test runs only on Linux/Electron. Windows and web coverage require explicit tags on the test:
+
+| Surface | How it gets PR-time coverage |
+|---|---|
+| Linux/Electron | Every e2e test runs here by default |
+| Windows | E2e test must be tagged `@:win` |
+| Web | E2e test must be tagged `@:web` |
+| macOS | Nightly only (runs in a separate repo); not at PR time |
+
+| Runner | PR-time CI |
+|---|---|
+| Vitest / Mocha / extension-host | Linux only |
+| Playwright e2e | Linux (always) + Windows/web only when tagged |
+
+Most of the team develops on macOS. The two surfaces most at risk of regressing without PR-time coverage are **Windows** and **web**, because their e2e coverage is opt-in. macOS regressions usually surface in nightly rather than at PR review.
+
+### Windows hotspots
+
+When the change touches one of these, check whether the relevant e2e test is tagged `@:win`:
+- File paths (separators, drive letters, long paths, normalization)
+- Line endings (CRLF vs LF in I/O or process pipes)
+- Process spawning (shell quoting, cmd.exe vs POSIX shells)
+- File watchers (different backends, different event ordering)
+- Filesystem semantics (case sensitivity, permissions, locked files, symlinks)
+- Terminal / pty (ConPTY vs xterm)
+- Native UI (focus, drag-and-drop, IME, dialog behavior)
+
+### Web hotspots
+
+When the change touches one of these, check whether the relevant e2e test is tagged `@:web`:
+- Filesystem access (sandboxed in web -- no direct fs)
+- Process / subprocess spawning (no child processes in web)
+- IPC (no Electron IPC; web uses postMessage / BroadcastChannel)
+- Storage (indexedDB / cookies instead of fs)
+- Native UI (no Electron menus, dialogs, or system file pickers)
+- Network (CORS, no raw sockets)
+- Auth flows (typically OAuth-only in web)
+
+To check whether a candidate e2e test has the right tag, Grep its file for `@:win` or `@:web` literally -- the tags appear in test titles or describe blocks.
+
+### Decision rule
+
+When the change touches a Windows or web hotspot AND no e2e test is tagged for that surface, add a "Deployment note" to the verdict body -- even when grading Adequate. Don't auto-upgrade to Insufficient on surface risk alone; unit tests are still the cheaper test for pure logic. But name the gap so the author can decide whether to tag an existing e2e test, add a new one, or do a manual cross-surface check.
+
+## Investigation steps
+
+Do these in order before writing your verdict:
+
+1. **Read the diff** in the input. Identify which files are source vs test, and what each source change actually does (new function, refactor, bug fix, etc.).
+2. **For each source file changed**, check whether the PR also modified or added a test for it:
+   - Vitest sibling at `src/.../<dir>/test/<base>.vitest.ts(x)`
+   - Mocha sibling at `src/.../<dir>/test/<base>.test.ts` (rare for new Positron code)
+   - Extension-host test inside the same `extensions/<name>/` tree
+   - E2E coverage at `test/e2e/tests/`
+3. **If no new test was added for a source file**, use Grep/Glob to find existing tests that import or exercise it. Examples:
+   - `grep -r "from.*<filename>" src/vs/**/test/`
+   - `grep -r "describe.*<ClassOrFunctionName>" src/vs/**/test/`
+   - For e2e coverage of UI features, check `test/e2e/tests/` for tagged tests
+4. **Read the candidate test files** to confirm they actually exercise the changed behavior, not just adjacent code. A test that imports a module but doesn't call the new function is not coverage.
+5. **For pure refactors or renames**, existing passing tests are usually sufficient -- but only if the test surface didn't change. Check.
+
+Cap your investigation at ~10-15 tool calls. If you can't determine coverage in that budget, lean toward Insufficient with a note that you couldn't fully verify.
+
+## Rubric
+
+You must pick exactly one verdict:
+
+| Verdict | When to use |
+|---|---|
+| **Adequate** | The PR adds tests that cover the new/changed behavior at the cheapest viable level. Cite the test file(s) and what behavior they cover. |
+| **Adequate via existing coverage** | The PR doesn't add tests, but existing tests already exercise the changed code paths (pure refactor, rename, behavior-preserving cleanup, or trivially-covered new code). Cite the specific test file(s) and lines/describes you verified. |
+| **Insufficient** | At least one substantive source change has no test coverage -- neither in the PR nor in existing tests. Name the gap and suggest specific additions. |
+| **Not applicable** | The PR is docs-only, config-only, dependency bumps, or otherwise has no testable behavior change. (Most "Not applicable" PRs short-circuit before you're invoked; reaching this verdict from your seat means the heuristic missed.) |
+
+Be conservative on **Adequate via existing coverage** -- only use it when you've actually read the existing test and confirmed it exercises the changed path. "There's probably a test somewhere" is Insufficient.
+
+## Output format
+
+Output **exactly one final assistant message** containing the markdown report below. Do not include any text before the report. Do not output the report and then continue investigating.
+
+```markdown
+## Test coverage check 🧪
+
+**Verdict:** <Adequate | Adequate via existing coverage | Insufficient | Not applicable> -- <one-sentence justification>
+
+### What changed
+- <file>:<line-range> -- <one-line description of the change>
+- ...
+
+### Tests in this PR
+<bulleted list of test files added/modified in the PR, with one-line description of what each covers. Or "None." if the PR didn't touch any test files.>
+
+### Existing coverage
+<For "Adequate via existing coverage" or "Insufficient": list the existing tests you found that cover (or fail to cover) the changes. Cite file paths. For "Adequate": you can omit this section or write a single line confirming the new tests are the primary coverage.>
+
+### Suggested additions
+<For "Insufficient": concrete, file-path-specific suggestions. For each gap:
+- **Add `<test file path>`** (or "Add to `<existing test file>`"): a <Vitest|extension-host|e2e> test for <specific function or behavior>. Justify the runner choice in one phrase ("pure function -- unit suffices" or "spans kernel + console UI -- needs e2e").
+
+For "Adequate" / "Adequate via existing coverage" / "Not applicable": omit this section or write "None.">
+
+### Deployment note (optional)
+<Include this section ONLY when the change touches a Windows or web hotspot AND no e2e test is tagged for that surface (`@:win` for Windows, `@:web` for web). Name the surface and the missing tag. Examples:
+- "Touches Windows path normalization (`foo.ts:23`). No `@:win`-tagged e2e exercises this path, so a Windows-only regression would slip past PR review. Consider tagging an existing e2e test or adding a manual Windows check."
+- "Adds file-picker behavior (`bar.tsx:88`). No `@:web`-tagged e2e covers this; in the web build there are no native dialogs, so this needs a web-aware test or manual check before shipping to web."
+
+Omit entirely if not applicable.>
+
+---
+<sub>Triggered by pr-test-checker on PR open or `/recheck-tests`. Pilot scope. False positives or missed tests? Reply in this thread or rerun with `/recheck-tests`.</sub>
+```
+
+## Constraints
+
+- **Cite real files only.** Never invent a test file path or function name. If you suggest a test location, it must be either an existing file you read, or a plausible new path next to the source file (`src/.../foo.ts` -> `src/.../test/foo.vitest.ts`).
+- **Be specific.** "Add tests for the new method" is useless. "Add a Vitest test for `Foo.bar()` covering the empty-input branch (foo.ts:42)" is actionable.
+- **One verdict per PR.** Don't grade individual files. The verdict reflects the worst-covered substantive change.
+- **No hedging in the verdict line.** Pick one and own it. Caveats go in the body.
+- **Keep the report under ~80 lines.** This is a PR comment, not an essay. Group related changes; don't enumerate every file in a 50-file PR.
+- **Don't suggest e2e tests as a default.** They're expensive and flaky. Reach for them only when a unit test genuinely can't cover the behavior.

--- a/.claude/skills/pr-test-checker/SKILL.md
+++ b/.claude/skills/pr-test-checker/SKILL.md
@@ -119,7 +119,7 @@ Be conservative on **Adequate via existing coverage** -- only use it when you've
 Output **exactly one final assistant message** containing the markdown report below. Do not include any text before the report. Do not output the report and then continue investigating.
 
 ```markdown
-## Test coverage check 🧪
+## PETE's assessment 🧪
 
 **Verdict:** <Adequate | Adequate via existing coverage | Insufficient | Not applicable> -- <one-sentence justification>
 
@@ -147,7 +147,7 @@ For "Adequate" / "Adequate via existing coverage" / "Not applicable": omit this 
 Omit entirely if not applicable.>
 
 ---
-<sub>Triggered by pr-test-checker on PR open or `/recheck-tests`. Pilot scope. False positives or missed tests? Reply in this thread or rerun with `/recheck-tests`.</sub>
+<sub>PETE (Positron Extreme Test Experiment) — LLM-based test-coverage advisor, in pilot. Triggers on PR open and `/recheck-tests`. Wrong verdict? Run `/recheck-tests` or ping @jonvanausdeln.</sub>
 ```
 
 ## Constraints

--- a/.claude/skills/pr-test-checker/scripts/gather-pr-context.mjs
+++ b/.claude/skills/pr-test-checker/scripts/gather-pr-context.mjs
@@ -67,7 +67,7 @@ const CATEGORIES = [
 	{ name: 'test-other', match: p => /\/(test|tests|__tests__)\//.test(p) },
 
 	// Docs / config / lockfiles -- not source, not tests
-	{ name: 'docs', match: p => /\.(md|mdx)$/i.test(p) || /^(LICENSE|NOTICE)(\.txt)?$/i.test(p) || /CHANGELOG\.md$/i.test(p) || /CONTRIBUTING\.md$/i.test(p) || /README/i.test(p) },
+	{ name: 'docs', match: p => /\.(md|mdx)$/i.test(p) || /^(LICENSE|NOTICE)(\.txt)?$/i.test(p) || /CHANGELOG\.md$/i.test(p) || /CONTRIBUTING\.md$/i.test(p) || /(^|\/)README(\.[^\/]+)?$/i.test(p) },
 	{ name: 'lockfile', match: p => /(package-lock\.json|yarn\.lock|pnpm-lock\.yaml)$/i.test(p) },
 	{ name: 'config-repo', match: p => p.startsWith('.github/') || p.startsWith('.vscode/') || /^\.(editorconfig|gitignore|gitattributes)$/.test(p) },
 	{ name: 'config-build', match: p => p.startsWith('build/azure-pipelines/') || p.startsWith('build/checksums/') || p.startsWith('build/lib/i18n/') },

--- a/.claude/skills/pr-test-checker/scripts/gather-pr-context.mjs
+++ b/.claude/skills/pr-test-checker/scripts/gather-pr-context.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Fetch PR metadata, classify each changed file, and emit a context.json the
+// agent driver can consume. Runs the cheap heuristic pre-filter so docs-only
+// and config-only PRs never invoke the LLM.
+//
+// Usage: node gather-pr-context.mjs <pr-number> <output-path>
+// Requires: gh CLI authenticated; env GH_TOKEN or auth cache.
+
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+const [, , prNumberArg, outPath] = process.argv;
+if (!prNumberArg || !outPath) {
+	console.error('Usage: gather-pr-context.mjs <pr-number> <output-path>');
+	process.exit(2);
+}
+const prNumber = Number(prNumberArg);
+if (!Number.isInteger(prNumber) || prNumber <= 0) {
+	console.error(`Invalid PR number: ${prNumberArg}`);
+	process.exit(2);
+}
+
+const REPO = process.env.GITHUB_REPOSITORY || 'posit-dev/positron';
+// Defensive cap on the diff we send to the model. Sonnet handles >100k tokens
+// fine but huge diffs are usually generated/vendored code where deep analysis
+// adds no value. The agent can still Read individual files via tools.
+const MAX_DIFF_CHARS = Number(process.env.MAX_DIFF_CHARS) || 120_000;
+
+function gh(args) {
+	try {
+		return execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
+	} catch (err) {
+		console.error(`gh ${args.join(' ')} failed:`, err.message);
+		process.exit(1);
+	}
+}
+
+// --- Fetch PR metadata and file list ----------------------------------------
+
+const prJson = JSON.parse(gh([
+	'pr', 'view', String(prNumber),
+	'--repo', REPO,
+	'--json', 'number,title,body,author,additions,deletions,files,baseRefName,headRefName,url',
+]));
+
+const diffRaw = gh(['pr', 'diff', String(prNumber), '--repo', REPO]);
+const diffTruncated = diffRaw.length > MAX_DIFF_CHARS;
+const diff = diffTruncated
+	? diffRaw.slice(0, MAX_DIFF_CHARS) + `\n\n[... diff truncated at ${MAX_DIFF_CHARS} chars; ${diffRaw.length - MAX_DIFF_CHARS} chars elided ...]`
+	: diffRaw;
+
+// --- Classify each changed file ---------------------------------------------
+
+// Categories drive the rubric: the agent grades source changes against tests
+// at the appropriate level. Order matters -- the first matching pattern wins.
+const CATEGORIES = [
+	// Tests (any of these counts as "has tests")
+	{ name: 'test-vitest', match: p => /\.vitest\.(ts|tsx)$/.test(p) },
+	{ name: 'test-e2e', match: p => p.startsWith('test/e2e/') },
+	{ name: 'test-ext-host', match: p => p.startsWith('extensions/') && /(\.test|\.integrationTest)\.tsx?$/.test(p) },
+	{ name: 'test-mocha', match: p => p.startsWith('src/') && /(\.test|\.integrationTest)\.tsx?$/.test(p) },
+	{ name: 'test-other', match: p => /\/(test|tests|__tests__)\//.test(p) },
+
+	// Docs / config / lockfiles -- not source, not tests
+	{ name: 'docs', match: p => /\.(md|mdx)$/i.test(p) || /^(LICENSE|NOTICE)(\.txt)?$/i.test(p) || /CHANGELOG\.md$/i.test(p) || /CONTRIBUTING\.md$/i.test(p) || /README/i.test(p) },
+	{ name: 'lockfile', match: p => /(package-lock\.json|yarn\.lock|pnpm-lock\.yaml)$/i.test(p) },
+	{ name: 'config-repo', match: p => p.startsWith('.github/') || p.startsWith('.vscode/') || /^\.(editorconfig|gitignore|gitattributes)$/.test(p) },
+	{ name: 'config-build', match: p => p.startsWith('build/azure-pipelines/') || p.startsWith('build/checksums/') || p.startsWith('build/lib/i18n/') },
+	{ name: 'config-ts', match: p => /tsconfig.*\.json$/.test(p) || /vitest\.(config|workspace)\./.test(p) || /playwright\.config\./.test(p) || /eslint\.config\./.test(p) || /\.eslintrc/.test(p) || /\.prettierrc/.test(p) },
+	{ name: 'config-pkg', match: p => /\/package\.json$/.test(p) || p === 'package.json' },
+	{ name: 'config-release', match: p => p === 'product.json' || p.startsWith('versions/') },
+
+	// Source (everything else falling into known source roots)
+	{ name: 'source-positron', match: p => p.startsWith('src/') },
+	{ name: 'source-extension', match: p => p.startsWith('extensions/') },
+	{ name: 'source-e2e-infra', match: p => p.startsWith('test/e2e/') }, // unreachable -- e2e tests already caught above
+	{ name: 'source-other', match: () => true },
+];
+
+function classify(path) {
+	for (const c of CATEGORIES) {
+		if (c.match(path)) { return c.name; }
+	}
+	return 'source-other';
+}
+
+const files = (prJson.files || []).map(f => ({
+	path: f.path,
+	additions: f.additions ?? 0,
+	deletions: f.deletions ?? 0,
+	category: classify(f.path),
+}));
+
+// --- Decide whether to skip -------------------------------------------------
+
+// Skip categories: every changed file falls into one of these and the PR is
+// chore-shaped (no source touched, no tests touched). Matches the conjunctive
+// rule from positron-pr-test-report.
+const SKIP_CATEGORIES = new Set([
+	'docs', 'lockfile', 'config-repo', 'config-build', 'config-ts',
+	'config-pkg', 'config-release',
+]);
+
+// Title-based skip (release/version/dep bumps). Match positron-pr-test-report.
+const SKIP_TITLE_PREFIXES = ['chore(deps):', 'build:', 'docs:', 'ci:', 'Bump '];
+const titleSkip = SKIP_TITLE_PREFIXES.some(p => prJson.title.startsWith(p));
+
+const allFilesSkippable = files.length > 0 && files.every(f => SKIP_CATEGORIES.has(f.category));
+
+let skip = null;
+if (files.length === 0) {
+	skip = { reason: 'empty-pr', detail: 'No files changed.' };
+} else if (titleSkip) {
+	skip = { reason: 'title-prefix', detail: `Title starts with a chore/release prefix.` };
+} else if (allFilesSkippable) {
+	skip = { reason: 'docs-or-config-only', detail: 'All changed files are docs, config, or lockfiles.' };
+}
+
+// --- Summary counters (for the agent's prompt header) -----------------------
+
+const counts = files.reduce((acc, f) => {
+	acc[f.category] = (acc[f.category] || 0) + 1;
+	return acc;
+}, {});
+
+const testCount = files.filter(f => f.category.startsWith('test-')).length;
+const sourceCount = files.filter(f => f.category.startsWith('source-')).length;
+
+// --- Emit context.json ------------------------------------------------------
+
+const context = {
+	pr: {
+		number: prJson.number,
+		title: prJson.title,
+		body: prJson.body || '',
+		author: prJson.author?.login || '?',
+		url: prJson.url,
+		baseRef: prJson.baseRefName,
+		headRef: prJson.headRefName,
+	},
+	stats: {
+		additions: prJson.additions ?? 0,
+		deletions: prJson.deletions ?? 0,
+		fileCount: files.length,
+		testFileCount: testCount,
+		sourceFileCount: sourceCount,
+		categoryCounts: counts,
+	},
+	files,
+	diff,
+	diffTruncated,
+	skip,
+};
+
+writeFileSync(outPath, JSON.stringify(context, null, 2));
+console.log(`[gather] wrote ${outPath} -- ${files.length} files, ${testCount} test, ${sourceCount} source, skip=${skip?.reason || 'no'}`);

--- a/.github/actions/pr-test-checker/action.yml
+++ b/.github/actions/pr-test-checker/action.yml
@@ -1,0 +1,113 @@
+name: "PR Test Checker"
+description: "Grade a PR's test coverage using the Claude Agent SDK and post the verdict as a PR comment."
+inputs:
+  pr-number:
+    description: "PR number to analyze"
+    required: true
+  anthropic-api-key:
+    description: "Anthropic API key (resolved from 1Password by the caller)"
+    required: true
+  model:
+    description: "Anthropic model identifier"
+    required: false
+    default: "claude-sonnet-4-6"
+  max-turns:
+    description: "Maximum agent turns (cost guard)"
+    required: false
+    default: "25"
+runs:
+  using: composite
+  steps:
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - name: Install action dependencies
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: npm ci --no-audit --no-fund
+
+    - name: Install Claude Code CLI
+      # Same workaround as e2e-failure-analyzer: the Agent SDK's resolver picks
+      # the musl variant over glibc on Linux runners. Installing globally and
+      # passing the resolved path via pathToClaudeCodeExecutable sidesteps it.
+      # See claude-agent-sdk-typescript#296.
+      shell: bash
+      run: |
+        npm install -g @anthropic-ai/claude-code
+        echo "CLAUDE_CODE_PATH=$(which claude)" >> "$GITHUB_ENV"
+        claude --version
+
+    - name: Prepare working directory
+      id: prep
+      shell: bash
+      run: |
+        WORK_DIR="${RUNNER_TEMP}/pr-test-checker"
+        rm -rf "$WORK_DIR"
+        mkdir -p "$WORK_DIR"
+        echo "work_dir=$WORK_DIR" >> "$GITHUB_OUTPUT"
+
+    - name: Gather PR context
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+      run: |
+        node "${{ github.workspace }}/.claude/skills/pr-test-checker/scripts/gather-pr-context.mjs" \
+          "${{ inputs.pr-number }}" \
+          "${{ steps.prep.outputs.work_dir }}/context.json"
+        echo "::group::context.json (summary)"
+        jq '{ pr: .pr.number, title: .pr.title, files: .stats.fileCount, test: .stats.testFileCount, source: .stats.sourceFileCount, skip: .skip }' "${{ steps.prep.outputs.work_dir }}/context.json"
+        echo "::endgroup::"
+
+    - name: Analyze with Claude Agent SDK
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      env:
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        WORK_DIR: ${{ steps.prep.outputs.work_dir }}
+        REPO_ROOT: ${{ github.workspace }}
+        SKILL_PATH: ${{ github.workspace }}/.claude/skills/pr-test-checker/SKILL.md
+        MODEL: ${{ inputs.model }}
+        MAX_TURNS: ${{ inputs.max-turns }}
+      run: node analyze.mjs
+
+    - name: Upsert PR comment
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        WORK_DIR: ${{ steps.prep.outputs.work_dir }}
+      run: |
+        COMMENT_FILE="$WORK_DIR/comment.md"
+        if [ ! -s "$COMMENT_FILE" ]; then
+          echo "::error::comment.md is missing or empty -- analyzer must have failed."
+          exit 1
+        fi
+
+        MARKER="<!-- pr-test-checker -->"
+        # Find an existing comment with our marker. Pull only what we need from
+        # the comments listing (id + body) to keep the response small.
+        EXISTING_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+          --jq "[.[] | select(.body | contains(\"$MARKER\"))][0].id // empty")
+
+        if [ -n "$EXISTING_ID" ]; then
+          echo "Updating existing comment $EXISTING_ID"
+          gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_ID}" \
+            -X PATCH \
+            -F body=@"$COMMENT_FILE"
+        else
+          echo "Creating new comment"
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            -F body=@"$COMMENT_FILE"
+        fi
+
+    - name: Upload analyzer artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: pr-test-checker-${{ inputs.pr-number }}
+        path: ${{ steps.prep.outputs.work_dir }}
+        retention-days: 14

--- a/.github/actions/pr-test-checker/action.yml
+++ b/.github/actions/pr-test-checker/action.yml
@@ -7,6 +7,9 @@ inputs:
   anthropic-api-key:
     description: "Anthropic API key (resolved from 1Password by the caller)"
     required: true
+  repo-root:
+    description: "Absolute path to the PR-head checkout the agent reads source from. The action itself runs from a trusted base-branch checkout; this input lets the workflow point the agent at a separate, untrusted checkout for source-reading only. Must be set for any flow that handles secrets."
+    required: true
   model:
     description: "Anthropic model identifier"
     required: false
@@ -49,12 +52,15 @@ runs:
         echo "work_dir=$WORK_DIR" >> "$GITHUB_OUTPUT"
 
     - name: Gather PR context
+      # Runs the gather script from the action's own directory (i.e. the
+      # trusted base-branch checkout), not from the PR head. PR-head code
+      # must never execute with secrets in scope.
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
         GITHUB_REPOSITORY: ${{ github.repository }}
       run: |
-        node "${{ github.workspace }}/.claude/skills/pr-test-checker/scripts/gather-pr-context.mjs" \
+        node "${{ github.action_path }}/../../../.claude/skills/pr-test-checker/scripts/gather-pr-context.mjs" \
           "${{ inputs.pr-number }}" \
           "${{ steps.prep.outputs.work_dir }}/context.json"
         echo "::group::context.json (summary)"
@@ -62,13 +68,17 @@ runs:
         echo "::endgroup::"
 
     - name: Analyze with Claude Agent SDK
+      # analyze.mjs and SKILL.md both resolve relative to github.action_path
+      # so they are read from the trusted base-branch checkout. Only
+      # REPO_ROOT (where the agent's Read/Grep/Glob tools operate) points
+      # at the untrusted PR-head checkout.
       shell: bash
       working-directory: ${{ github.action_path }}
       env:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         WORK_DIR: ${{ steps.prep.outputs.work_dir }}
-        REPO_ROOT: ${{ github.workspace }}
-        SKILL_PATH: ${{ github.workspace }}/.claude/skills/pr-test-checker/SKILL.md
+        REPO_ROOT: ${{ inputs.repo-root }}
+        SKILL_PATH: ${{ github.action_path }}/../../../.claude/skills/pr-test-checker/SKILL.md
         MODEL: ${{ inputs.model }}
         MAX_TURNS: ${{ inputs.max-turns }}
       run: node analyze.mjs

--- a/.github/actions/pr-test-checker/analyze.mjs
+++ b/.github/actions/pr-test-checker/analyze.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Drive the Claude Agent SDK to grade a PR's test coverage. Reads the
+// pre-built context.json (PR metadata, classified files, diff) and the
+// pr-test-checker SKILL.md, then asks the model for a single graded report.
+// Writes the final markdown to comment.md for the upsert step to post.
+
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WORK_DIR = mustEnv('WORK_DIR');
+const REPO_ROOT = mustEnv('REPO_ROOT');
+const SKILL_PATH = mustEnv('SKILL_PATH');
+const MODEL = process.env.MODEL || 'claude-sonnet-4-6';
+const MAX_TURNS = parsePosIntEnv('MAX_TURNS', 25);
+const PROMPT_WARN_CHARS = parsePosIntEnv('PROMPT_WARN_CHARS', 400_000);
+// Same musl-resolver workaround as e2e-failure-analyzer.
+const CLAUDE_CODE_PATH = process.env.CLAUDE_CODE_PATH || undefined;
+
+function mustEnv(name) {
+	const v = process.env[name];
+	if (!v) {
+		console.error(`Missing required env var: ${name}`);
+		process.exit(2);
+	}
+	return v;
+}
+
+function parsePosIntEnv(name, fallback) {
+	const raw = process.env[name];
+	if (raw === undefined || raw === '') { return fallback; }
+	const n = Number(raw);
+	if (!Number.isInteger(n) || n <= 0) {
+		console.warn(`[analyzer] WARN: invalid ${name}=${raw}, falling back to ${fallback}`);
+		return fallback;
+	}
+	return n;
+}
+
+function readJsonOrExit(path) {
+	if (!existsSync(path)) {
+		console.error(`Required input missing: ${path}`);
+		process.exit(2);
+	}
+	try {
+		return JSON.parse(readFileSync(path, 'utf8'));
+	} catch (err) {
+		console.error(`Failed to parse ${path}: ${err.message}`);
+		process.exit(1);
+	}
+}
+
+// --- Static comment for short-circuited skips -------------------------------
+
+function renderSkipComment(context) {
+	const { skip, pr } = context;
+	const reasonText = {
+		'empty-pr': 'No files changed.',
+		'title-prefix': 'PR title indicates a chore / dependency / docs bump.',
+		'docs-or-config-only': 'All changed files are docs, config, or lockfiles -- no source behavior to test.',
+	}[skip.reason] || skip.detail || 'Skipped by pre-filter.';
+
+	return [
+		'## Test coverage check 🧪',
+		'',
+		`**Verdict:** Not applicable -- ${reasonText}`,
+		'',
+		`### What changed`,
+		`${context.stats.fileCount} file(s), categorized as: ${formatCategoryCounts(context.stats.categoryCounts)}.`,
+		'',
+		'---',
+		`<sub>Triggered by pr-test-checker. Pre-filter short-circuited the LLM check. Run \`/recheck-tests\` if this is wrong.</sub>`,
+	].join('\n');
+}
+
+function formatCategoryCounts(counts) {
+	const entries = Object.entries(counts || {}).sort((a, b) => b[1] - a[1]);
+	if (entries.length === 0) { return '(none)'; }
+	return entries.map(([k, v]) => `${k} (${v})`).join(', ');
+}
+
+// --- Prompt building --------------------------------------------------------
+
+function renderPrHeader(pr, stats) {
+	return [
+		`PR: #${pr.number} -- ${pr.title}`,
+		`Author: ${pr.author}`,
+		`Branch: ${pr.headRef} -> ${pr.baseRef}`,
+		`URL: ${pr.url}`,
+		`Size: +${stats.additions} / -${stats.deletions} across ${stats.fileCount} files`,
+		`Test files in PR: ${stats.testFileCount}; Source files in PR: ${stats.sourceFileCount}`,
+	].join('\n');
+}
+
+function renderPrBody(body) {
+	if (!body || !body.trim()) { return '(empty)'; }
+	// Cap PR body -- some authors paste huge logs.
+	const capped = body.length > 4000 ? body.slice(0, 4000) + '\n[...PR body truncated]' : body;
+	return capped;
+}
+
+function renderFileTable(files) {
+	const lines = ['| File | Category | +/- |', '|------|----------|-----|'];
+	for (const f of files) {
+		lines.push(`| \`${f.path}\` | ${f.category} | +${f.additions}/-${f.deletions} |`);
+	}
+	return lines.join('\n');
+}
+
+function buildUserPrompt(context) {
+	const sections = [
+		'## PR metadata',
+		renderPrHeader(context.pr, context.stats),
+		'',
+		'## PR description',
+		renderPrBody(context.pr.body),
+		'',
+		'## Changed files (pre-classified)',
+		renderFileTable(context.files),
+		'',
+		'## Diff',
+		'```diff',
+		context.diff,
+		'```',
+		context.diffTruncated ? '\n_Note: diff was truncated. Use Read/Grep to inspect specific files if needed._\n' : '',
+		'',
+		'## Repo access',
+		`REPO_ROOT is the sparse checkout root. Test taxonomy lives in \`CLAUDE.md\` and \`.claude/rules/vitest-tests.md\`. You can Read/Grep/Glob within \`src/\`, \`extensions/\`, and \`test/e2e/\` to find existing coverage.`,
+		'',
+		'---',
+		'Investigate per the SKILL.md steps, then output the final graded report as your last message. Output the report exactly once, in the exact markdown template from the skill.',
+	];
+	return sections.join('\n');
+}
+
+// --- Agent loop --------------------------------------------------------------
+
+async function runAgent(systemPrompt, userPrompt) {
+	const assistantMessages = [];
+	let turnCount = 0;
+	let usage = null;
+
+	for await (const message of query({
+		prompt: userPrompt,
+		options: {
+			model: MODEL,
+			cwd: REPO_ROOT,
+			systemPrompt,
+			allowedTools: ['Read', 'Glob', 'Grep'],
+			permissionMode: 'bypassPermissions',
+			maxTurns: MAX_TURNS,
+			...(CLAUDE_CODE_PATH ? { pathToClaudeCodeExecutable: CLAUDE_CODE_PATH } : {}),
+		},
+	})) {
+		if (message.type === 'assistant') {
+			turnCount++;
+			const content = message.message?.content || [];
+			const textBlocks = content.filter(b => b.type === 'text').map(b => b.text);
+			const toolUses = content.filter(b => b.type === 'tool_use').map(b => `${b.name}(${JSON.stringify(b.input).slice(0, 200)})`);
+			if (textBlocks.length) {
+				const joined = textBlocks.join('\n');
+				assistantMessages.push(joined);
+				console.log(`[turn ${turnCount}] assistant text (${joined.length} chars):\n${joined.slice(0, 1000)}${joined.length > 1000 ? '\n...(truncated)' : ''}`);
+			}
+			if (toolUses.length) {
+				console.log(`[turn ${turnCount}] tool calls: ${toolUses.join(' | ')}`);
+			}
+		} else if (message.type === 'result') {
+			usage = message.usage;
+			console.log(`[analyzer] usage: input=${usage?.input_tokens} output=${usage?.output_tokens} cost_usd=${message.total_cost_usd}`);
+		}
+	}
+
+	return { assistantMessages, turnCount, usage };
+}
+
+// --- Report extraction -------------------------------------------------------
+
+const REPORT_HEADER = '## Test coverage check';
+
+function pickReport(messages) {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const m = messages[i];
+		const idx = m.indexOf(REPORT_HEADER);
+		if (idx >= 0) { return m.slice(idx); }
+	}
+	return messages.length ? messages[messages.length - 1] : null;
+}
+
+// --- Comment markup ----------------------------------------------------------
+
+const COMMENT_MARKER = '<!-- pr-test-checker -->';
+
+function wrapWithMarker(body) {
+	return `${COMMENT_MARKER}\n${body}`;
+}
+
+// --- Main --------------------------------------------------------------------
+
+async function main() {
+	const context = readJsonOrExit(join(WORK_DIR, 'context.json'));
+
+	console.log(`[analyzer] PR #${context.pr.number}: ${context.pr.title}`);
+	console.log(`[analyzer] files=${context.stats.fileCount} test=${context.stats.testFileCount} source=${context.stats.sourceFileCount} skip=${context.skip?.reason || 'no'}`);
+
+	// Short-circuit: docs/config-only PRs skip the LLM entirely.
+	if (context.skip) {
+		const skipComment = wrapWithMarker(renderSkipComment(context));
+		writeFileSync(join(WORK_DIR, 'comment.md'), skipComment);
+		console.log(`[analyzer] short-circuited (${context.skip.reason}); wrote static comment`);
+		return;
+	}
+
+	const systemPrompt = readFileSync(SKILL_PATH, 'utf8');
+	const userPrompt = buildUserPrompt(context);
+
+	if (userPrompt.length > PROMPT_WARN_CHARS) {
+		console.warn(`[analyzer] WARN: prompt size ${userPrompt.length} chars exceeds soft threshold ${PROMPT_WARN_CHARS}.`);
+	}
+
+	console.log(`[analyzer] model=${MODEL} maxTurns=${MAX_TURNS} claudePath=${CLAUDE_CODE_PATH || '(default)'}`);
+	console.log(`[analyzer] user prompt (${userPrompt.length} chars):\n${userPrompt.slice(0, 4000)}${userPrompt.length > 4000 ? '\n...(truncated)' : ''}`);
+
+	const { assistantMessages, turnCount, usage } = await runAgent(systemPrompt, userPrompt);
+	console.log(`[analyzer] agent finished after ${turnCount} turn(s); ${assistantMessages.length} assistant text message(s)`);
+
+	const report = pickReport(assistantMessages);
+	if (!report) {
+		const fallback = [
+			'## Test coverage check 🧪',
+			'',
+			'**Verdict:** _Unknown_ -- the analyzer produced no markdown report. Check action logs.',
+			'',
+			'---',
+			'<sub>Triggered by pr-test-checker. Run `/recheck-tests` to retry.</sub>',
+		].join('\n');
+		writeFileSync(join(WORK_DIR, 'comment.md'), wrapWithMarker(fallback));
+		console.error('[analyzer] no markdown report produced; wrote fallback comment');
+		process.exit(1);
+	}
+
+	writeFileSync(join(WORK_DIR, 'comment.md'), wrapWithMarker(report));
+	console.log(`[analyzer] wrote ${report.length} chars to comment.md (turns=${turnCount}, input_tokens=${usage?.input_tokens}, output_tokens=${usage?.output_tokens})`);
+}
+
+main().catch(err => {
+	console.error('[analyzer] fatal:', err);
+	process.exit(1);
+});

--- a/.github/actions/pr-test-checker/analyze.mjs
+++ b/.github/actions/pr-test-checker/analyze.mjs
@@ -66,7 +66,7 @@ function renderSkipComment(context) {
 	}[skip.reason] || skip.detail || 'Skipped by pre-filter.';
 
 	return [
-		'## Test coverage check 🧪',
+		'## PETE\'s assessment 🧪',
 		'',
 		`**Verdict:** Not applicable -- ${reasonText}`,
 		'',
@@ -74,7 +74,7 @@ function renderSkipComment(context) {
 		`${context.stats.fileCount} file(s), categorized as: ${formatCategoryCounts(context.stats.categoryCounts)}.`,
 		'',
 		'---',
-		`<sub>Triggered by pr-test-checker. Pre-filter short-circuited the LLM check. Run \`/recheck-tests\` if this is wrong.</sub>`,
+		`<sub>PETE (Positron Extreme Test Experiment): an LLM-based test-coverage advisor, currently in pilot. Pre-filter short-circuited the LLM check on this PR. Run \`/recheck-tests\` if this is wrong.</sub>`,
 	].join('\n');
 }
 
@@ -181,7 +181,7 @@ async function runAgent(systemPrompt, userPrompt) {
 
 // --- Report extraction -------------------------------------------------------
 
-const REPORT_HEADER = '## Test coverage check';
+const REPORT_HEADER = `## PETE's assessment`;
 
 function pickReport(messages) {
 	for (let i = messages.length - 1; i >= 0; i--) {
@@ -232,12 +232,12 @@ async function main() {
 	const report = pickReport(assistantMessages);
 	if (!report) {
 		const fallback = [
-			'## Test coverage check 🧪',
+			'## PETE\'s assessment 🧪',
 			'',
 			'**Verdict:** _Unknown_ -- the analyzer produced no markdown report. Check action logs.',
 			'',
 			'---',
-			'<sub>Triggered by pr-test-checker. Run `/recheck-tests` to retry.</sub>',
+			'<sub>PETE (Positron Extreme Test Experiment): an LLM-based test-coverage advisor, currently in pilot. Run `/recheck-tests` to retry.</sub>',
 		].join('\n');
 		writeFileSync(join(WORK_DIR, 'comment.md'), wrapWithMarker(fallback));
 		console.error('[analyzer] no markdown report produced; wrote fallback comment');

--- a/.github/actions/pr-test-checker/package-lock.json
+++ b/.github/actions/pr-test-checker/package-lock.json
@@ -1,0 +1,1331 @@
+{
+	"name": "pr-test-checker-action",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "pr-test-checker-action",
+			"dependencies": {
+				"@anthropic-ai/claude-agent-sdk": "^0.2.128"
+			}
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk": {
+			"version": "0.2.141",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.141.tgz",
+			"integrity": "sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw==",
+			"license": "SEE LICENSE IN README.md",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.93.0",
+				"@modelcontextprotocol/sdk": "^1.29.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.141",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.141",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.141",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.141",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.141",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.141",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.141",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.141"
+			},
+			"peerDependencies": {
+				"zod": "^4.0.0"
+			}
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+			"version": "0.2.141",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.141.tgz",
+			"integrity": "sha512-9HZ0ot6+FwOfQ1aeMqQLH4IJGMm/DcP08SysDxscVjBm6l2JjqleHohxi3zid0DurfGweqT+4x9GScJffwg55g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+			"version": "0.2.141",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.141.tgz",
+			"integrity": "sha512-4iAdarJaQ+2R58s6QJswZCzUdz2WQmL5lYG7Y+FLzWbRSROFfcH0QYpmOqSaPXd2KRQhIJwEacqecDZd/Q1XKQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+			"version": "0.2.141",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.141.tgz",
+			"integrity": "sha512-Jdf0ZEwJzOP8sE6rPqdJN+SxMb0/L8sxJg4twCv/7S+Qzk0hJtls+wxSi+0Tjh6EEMaNxJqEGc7S3fx99Wi99Q==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+			"version": "0.2.141",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.141.tgz",
+			"integrity": "sha512-6H1AJ/AVaWNnV22kubUPkOTRzZFH0+qP9k7WlhriHMN9gtgZcVAsITMddDeGjQsQJMCAdhXFd6sgi7TM1LdeOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+			"version": "0.2.141",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.141.tgz",
+			"integrity": "sha512-DVjp72f3HmrRYpbneWZZWIqkUht5kTZXS7wXGFiwzLz6eNYEgjjh+GcsnhIi8UOwZUtNiKUrjZnoP38ovFqV8A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+			"version": "0.2.141",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.141.tgz",
+			"integrity": "sha512-fTI1YuM4cxOa4nSgsyMAdB5ELizkWp+w5Ispo4JnnYtcczMAL4D9GBNjWPW0sUzKvjsJOUVim68SmWLWhUOpXQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+			"version": "0.2.141",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.141.tgz",
+			"integrity": "sha512-Wm10J6kfbufbPGFELokiJ/7Y5Oqug4Uag3HXFsV8g7TWCpaItx/oqVaJoiGptuAtXQB7xGLQVTuk082wER+Y5w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+			"version": "0.2.141",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.141.tgz",
+			"integrity": "sha512-IXuP29YJuWbR5Q6xOHrjFVGG54V2s1FC61UVNwEN5fpxL09MwPnbwtQL6fqgzt/U1MP7vWAwpXZriYAklkH/mg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.93.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.93.0.tgz",
+			"integrity": "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA==",
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@hono/node-server": {
+			"version": "1.19.14",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.14.1"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@hono/node-server": "^1.19.9",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/body-parser": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "^3.1.2",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.0",
+				"iconv-lite": "^0.7.0",
+				"on-finished": "^2.4.1",
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/content-disposition": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.6.0"
+			}
+		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"license": "MIT"
+		},
+		"node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT"
+		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+			"license": "MIT",
+			"dependencies": {
+				"eventsource-parser": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+			"integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express-rate-limit": {
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+			"integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^10.2.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT"
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/hono": {
+			"version": "4.12.19",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+			"integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
+		},
+		"node_modules/ip-address": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"license": "MIT"
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"license": "ISC"
+		},
+		"node_modules/jose": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-to-regexp": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/qs": {
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
+		},
+		"node_modules/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"license": "ISC"
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3",
+				"side-channel-list": "^1.0.0",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT"
+		},
+		"node_modules/type-is": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^2.0.0",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/type-is/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC"
+		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		}
+	}
+}

--- a/.github/actions/pr-test-checker/package.json
+++ b/.github/actions/pr-test-checker/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "pr-test-checker-action",
+	"private": true,
+	"type": "module",
+	"description": "GH composite action that grades PR test coverage via the Claude Agent SDK.",
+	"dependencies": {
+		"@anthropic-ai/claude-agent-sdk": "^0.2.128"
+	}
+}

--- a/.github/workflows/pr-test-checker.yml
+++ b/.github/workflows/pr-test-checker.yml
@@ -1,0 +1,114 @@
+name: "PR Test Checker"
+
+# Grades whether the PR has adequate test coverage and posts a verdict comment.
+# Pilot scope: only runs for PR authors / commenters in the allowlist below.
+# To widen the pilot, edit both ALLOWLIST refs in this file (kept in sync).
+
+on:
+  pull_request:
+    types:
+      - opened
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  on-open:
+    name: Grade on open
+    if: |
+      github.event_name == 'pull_request' &&
+      contains(fromJson('["jonvanausdeln"]'), github.event.pull_request.user.login)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    concurrency:
+      group: pr-test-checker-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          # The agent reads CLAUDE.md, .claude/rules/*.md, and the source trees
+          # to find existing test coverage. The action + skill directories must
+          # be present at the workspace root.
+          sparse-checkout: |
+            .claude/skills/pr-test-checker
+            .claude/rules
+            .github/actions/pr-test-checker
+            CLAUDE.md
+            src
+            extensions
+            test/e2e
+
+      - name: Load Anthropic API key
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
+
+      - name: Run pr-test-checker
+        uses: ./.github/actions/pr-test-checker
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          anthropic-api-key: ${{ env.ANTHROPIC_KEY }}
+
+  on-recheck:
+    name: Re-grade on /recheck-tests
+    # Fires when an allowlisted user comments `/recheck-tests` on a PR. The
+    # issue_comment event covers both issues and PRs; the .pull_request guard
+    # filters to PR comments only.
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/recheck-tests') &&
+      contains(fromJson('["jonvanausdeln"]'), github.event.comment.user.login)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    concurrency:
+      group: pr-test-checker-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Resolve PR head SHA
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          HEAD_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')
+          echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+          sparse-checkout: |
+            .claude/skills/pr-test-checker
+            .claude/rules
+            .github/actions/pr-test-checker
+            CLAUDE.md
+            src
+            extensions
+            test/e2e
+
+      - name: Load Anthropic API key
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
+
+      - name: Run pr-test-checker
+        uses: ./.github/actions/pr-test-checker
+        with:
+          pr-number: ${{ github.event.issue.number }}
+          anthropic-api-key: ${{ env.ANTHROPIC_KEY }}

--- a/.github/workflows/pr-test-checker.yml
+++ b/.github/workflows/pr-test-checker.yml
@@ -3,6 +3,16 @@ name: "PR Test Checker"
 # Grades whether the PR has adequate test coverage and posts a verdict comment.
 # Pilot scope: only runs for PR authors / commenters in the allowlist below.
 # To widen the pilot, edit both ALLOWLIST refs in this file (kept in sync).
+#
+# Security model: each job checks out two trees -- the BASE branch (trusted
+# action + skill code, used to run the analyzer with secrets) and the PR HEAD
+# (untrusted source code, mounted as read-only data for the agent's
+# Read/Grep/Glob tools). The analyzer is invoked from the base checkout via
+# `uses: ./base/.github/actions/pr-test-checker` so that PR-head code is never
+# executed with secrets in scope. This closes the "pwn request" pattern where
+# a fork PR modifies action code, and an allowlisted user comments
+# /recheck-tests (an `issue_comment` event that runs in base context with
+# full secrets, unlike `pull_request` events which strip secrets for forks).
 
 on:
   pull_request:
@@ -27,17 +37,22 @@ jobs:
       group: pr-test-checker-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - name: Checkout
+      - name: Checkout BASE (trusted action + skill code)
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          # The agent reads CLAUDE.md, .claude/rules/*.md, and the source trees
-          # to find existing test coverage. The action + skill directories must
-          # be present at the workspace root.
+          ref: ${{ github.event.repository.default_branch }}
+          path: base
           sparse-checkout: |
             .claude/skills/pr-test-checker
             .claude/rules
             .github/actions/pr-test-checker
+
+      - name: Checkout PR HEAD (untrusted source data)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-head
+          sparse-checkout: |
             CLAUDE.md
             src
             extensions
@@ -51,22 +66,29 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
 
-      - name: Run pr-test-checker
-        uses: ./.github/actions/pr-test-checker
+      - name: Run pr-test-checker (from base, source from PR head)
+        uses: ./base/.github/actions/pr-test-checker
         with:
           pr-number: ${{ github.event.pull_request.number }}
           anthropic-api-key: ${{ env.ANTHROPIC_KEY }}
+          repo-root: ${{ github.workspace }}/pr-head
 
   on-recheck:
     name: Re-grade on /recheck-tests
-    # Fires when an allowlisted user comments `/recheck-tests` on a PR. The
-    # issue_comment event covers both issues and PRs; the .pull_request guard
-    # filters to PR comments only.
+    # Fires when an allowlisted user comments `/recheck-tests` on a PR.
+    # The issue_comment event runs in base-repo context with full secrets
+    # even when the PR is from a fork, so two layers of defense:
+    #   1. BOTH the commenter AND the PR author must be allowlisted (the
+    #      PR-author check blocks comments on fork PRs by non-allowlisted
+    #      authors -- attackers can't bait /recheck-tests on their own PRs).
+    #   2. The job checks out the base branch to RUN the action and the
+    #      PR head only as READ-ONLY DATA -- PR-head code never executes.
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, '/recheck-tests') &&
-      contains(fromJson('["jonvanausdeln"]'), github.event.comment.user.login)
+      contains(fromJson('["jonvanausdeln"]'), github.event.comment.user.login) &&
+      contains(fromJson('["jonvanausdeln"]'), github.event.issue.user.login)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -86,14 +108,22 @@ jobs:
           HEAD_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')
           echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout PR head
+      - name: Checkout BASE (trusted action + skill code)
         uses: actions/checkout@v6
         with:
-          ref: ${{ steps.pr.outputs.head_sha }}
+          ref: ${{ github.event.repository.default_branch }}
+          path: base
           sparse-checkout: |
             .claude/skills/pr-test-checker
             .claude/rules
             .github/actions/pr-test-checker
+
+      - name: Checkout PR HEAD (untrusted source data)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+          path: pr-head
+          sparse-checkout: |
             CLAUDE.md
             src
             extensions
@@ -107,8 +137,9 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
 
-      - name: Run pr-test-checker
-        uses: ./.github/actions/pr-test-checker
+      - name: Run pr-test-checker (from base, source from PR head)
+        uses: ./base/.github/actions/pr-test-checker
         with:
           pr-number: ${{ github.event.issue.number }}
           anthropic-api-key: ${{ env.ANTHROPIC_KEY }}
+          repo-root: ${{ github.workspace }}/pr-head


### PR DESCRIPTION
Stage one of PETE (Positron Extreme Test Experiment).  

I need to merge this into main before I can try it out in CI, I did check that the scripts work when running locally.  After merge, I'll test it out before adding the rest of the workstream users to the allow list.

## Summary

- Introduces a GitHub workflow that uses the Claude Agent SDK to grade whether a PR has adequate test coverage and posts the verdict as a PR comment. Pilot scope: triggers only for `jonvanausdeln` PRs (and `/recheck-tests` comments on those PRs).
- Mirrors the `e2e-failure-analyzer` pattern — composite action + in-repo skill, secrets sourced from 1Password (`op://Positron/Anthropic/credential`).
- Skill rubric grades each PR as **Adequate** / **Adequate via existing coverage** / **Insufficient** / **Not applicable**, with concrete file-path-specific suggestions when coverage is missing. Cheap heuristic pre-filter short-circuits docs/config-only PRs before any LLM call.
- Skill also surfaces a **Deployment note** when changes touch Windows or web hotspots without `@:win` / `@:web` e2e tag coverage, since PR-time e2e runs Linux/Electron by default and Windows/web coverage is opt-in by tag.

### Security model

Each job checks out two trees and keeps them separate:

- **BASE** (trusted): action + skill code, used to run the analyzer **with secrets**.
- **PR HEAD** (untrusted): source code mounted as read-only data for the agent's `Read/Grep/Glob` tools.

The analyzer is invoked from `./base/.github/actions/pr-test-checker` so PR-head code never executes with secrets in scope. This closes the "pwn request" pattern where a fork PR could modify `analyze.mjs` and an allowlisted user commenting `/recheck-tests` (an `issue_comment` event that runs in base context with full secrets) would exfiltrate the Anthropic API key. As defense-in-depth, `/recheck-tests` requires **both** the commenter and the PR author to be allowlisted.

### Calibration (local smoke tests)

| PR | Verdict | Deployment note? | Cost |
|---|---|---|---|
| [#13525](https://github.com/posit-dev/positron/pull/13525) (notebook namespace refactor) | Insufficient | Not added (correctly — pure React refactor, no platform divergence) | ~$0.28 |
| [#13520](https://github.com/posit-dev/positron/pull/13520) (UNC path fix) | Adequate | Added (correctly flagged ext-host test self-skips on Linux CI) | ~$0.22 |
