### PR TITLE
fix: toggle Run All to Stop button during notebook cell execution

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -253,7 +253,7 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	/**
 	 * Cancels all currently executing cells in the notebook.
 	 */
-	cancelExecution(): void;
+	cancelExecution(): Promise<void>;
 
 	/**
 	 * Clears the output of a specific cell, or the active cell if none is provided.

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -251,6 +251,11 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	runAllCells(): Promise<void>;
 
 	/**
+	 * Cancels all currently executing cells in the notebook.
+	 */
+	cancelExecution(): void;
+
+	/**
 	 * Clears the output of a specific cell, or the active cell if none is provided.
 	 */
 	clearCellOutput(cell?: IPositronNotebookCell, skipContentEvent?: boolean): void;

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -251,11 +251,6 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	runAllCells(): Promise<void>;
 
 	/**
-	 * Cancels all currently executing cells in the notebook.
-	 */
-	cancelExecution(): Promise<void>;
-
-	/**
 	 * Clears the output of a specific cell, or the active cell if none is provided.
 	 */
 	clearCellOutput(cell?: IPositronNotebookCell, skipContentEvent?: boolean): void;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -391,7 +391,7 @@ export type ParsedOutput = ParsedTextOutput |
 	dataUrl: string;
 } |
 {
-	type: 'interupt';
+	type: 'interrupt';
 	trace: string;
 } |
 {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -95,13 +95,9 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<IPositro
 
 	private _containerScopedContextKeyService: IScopedContextKeyService | undefined;
 
-	override get scopedContextKeyService(): IContextKeyService | undefined {
-		return this._containerScopedContextKeyService;
-	}
-
 	/**
 	 * Expose the notebook's scoped context to the editor pane so that `when`
-	 * clauses for menus and `precondition` clausess for actions on the editor
+	 * clauses for menus and `precondition` clauses for actions on the editor
 	 * action bar can resolve notebook scoped context keys (e.g. NOTEBOOK_KERNEL).
 	 */
 	override get scopedContextKeyService(): IContextKeyService | undefined {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditor.tsx
@@ -95,6 +95,10 @@ export class PositronNotebookEditor extends AbstractEditorWithViewState<IPositro
 
 	private _containerScopedContextKeyService: IScopedContextKeyService | undefined;
 
+	override get scopedContextKeyService(): IContextKeyService | undefined {
+		return this._containerScopedContextKeyService;
+	}
+
 	/**
 	 * Expose the notebook's scoped context to the editor pane so that `when`
 	 * clauses for menus and `precondition` clausess for actions on the editor

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1109,12 +1109,12 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		await this._runCells(this.cells.get());
 	}
 
-	cancelExecution(): void {
+	async cancelExecution(): Promise<void> {
 		this._assertTextModel();
 		const cells = this.cells.get();
 		const executingCells = cells.filter(cell => Boolean(this.notebookExecutionStateService.getCellExecution(cell.uri)));
 		if (executingCells.length > 0) {
-			this.notebookExecutionService.cancelNotebookCells(this.textModel, executingCells.map(c => c.model as NotebookCellTextModel));
+			await this.notebookExecutionService.cancelNotebookCells(this.textModel, executingCells.map(c => c.model as NotebookCellTextModel));
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1112,10 +1112,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	async cancelExecution(): Promise<void> {
 		this._assertTextModel();
 		const cells = this.cells.get();
-		const executingCells = cells.filter(cell => Boolean(this.notebookExecutionStateService.getCellExecution(cell.uri)));
-		if (executingCells.length > 0) {
-			await this.notebookExecutionService.cancelNotebookCells(this.textModel, executingCells.map(c => c.model as NotebookCellTextModel));
-		}
+		await this.notebookExecutionService.cancelNotebookCells(this.textModel, cells.map(c => c.model as NotebookCellTextModel));
 	}
 
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -2342,7 +2342,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		const hasExecutions = [...cells].some(cell => Boolean(this.notebookExecutionStateService.getCellExecution(cell.uri)));
 
 		if (hasExecutions) {
-			this.notebookExecutionService.cancelNotebookCells(this.textModel, Array.from(cells).map(c => c.model as NotebookCellTextModel));
+			await this.cancelExecution();
 			return;
 		}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -2342,7 +2342,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		const hasExecutions = [...cells].some(cell => Boolean(this.notebookExecutionStateService.getCellExecution(cell.uri)));
 
 		if (hasExecutions) {
-			await this.cancelExecution();
+			await this.notebookExecutionService.cancelNotebookCells(this.textModel, Array.from(cells).map(c => c.model as NotebookCellTextModel));
 			return;
 		}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1109,13 +1109,6 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		await this._runCells(this.cells.get());
 	}
 
-	async cancelExecution(): Promise<void> {
-		this._assertTextModel();
-		const cells = this.cells.get();
-		await this.notebookExecutionService.cancelNotebookCells(this.textModel, cells.map(c => c.model as NotebookCellTextModel));
-	}
-
-
 	/**
 	 * Adds a new cell to the notebook at the specified index.
 	 * @param type The type of cell to add (`CellKind`)

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1109,6 +1109,15 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		await this._runCells(this.cells.get());
 	}
 
+	cancelExecution(): void {
+		this._assertTextModel();
+		const cells = this.cells.get();
+		const executingCells = cells.filter(cell => Boolean(this.notebookExecutionStateService.getCellExecution(cell.uri)));
+		if (executingCells.length > 0) {
+			this.notebookExecutionService.cancelNotebookCells(this.textModel, executingCells.map(c => c.model as NotebookCellTextModel));
+		}
+	}
+
 
 	/**
 	 * Adds a new cell to the notebook at the specified index.

--- a/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/getOutputContents.ts
@@ -123,7 +123,7 @@ export function parseOutputData(outputItem: IOutputItemDto): ParsedOutput {
 		const parsedMessage = JSON.parse(message);
 
 		if (parsedMessage?.name === 'KeyboardInterrupt') {
-			return { type: 'interupt', trace: parsedMessage.traceback };
+			return { type: 'interrupt', trace: parsedMessage.traceback };
 		}
 
 		if (parsedMessage?.name === 'Runtime Error') {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -339,9 +339,9 @@ const CellOutput = React.memo(function CellOutput(output: CellOutputProps) {
 	}
 
 	switch (parsed.type) {
-		case 'interupt':
+		case 'interrupt':
 			return <div className='notebook-error'>
-				{localize('cellExecutionKeyboardInterupt', 'Cell execution stopped due to keyboard interupt.')}
+				{localize('cellExecutionKeyboardInterrupt', 'Cell execution stopped due to keyboard interrupt.')}
 			</div>;
 		case 'image':
 			return <img alt='output image' src={parsed.dataUrl} />;

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -70,6 +70,7 @@ import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
 import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
 import { PositronNotebookPromptContribution } from './positronNotebookPrompt.js';
 import { ActiveNotebookHasRunningRuntime } from '../../runtimeNotebookKernel/common/activeRuntimeNotebookContextManager.js';
+import { NOTEBOOK_HAS_SOMETHING_RUNNING } from '../../notebook/common/notebookContextKeys.js';
 import { NotebookAction2 } from './NotebookAction2.js';
 import './AskAssistantAction.js'; // Register AskAssistantAction
 import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED } from '../../../../editor/contrib/find/browser/findModel.js';
@@ -1893,7 +1894,10 @@ registerAction2(class extends NotebookAction2 {
 				id: MenuId.EditorActionsLeft,
 				group: 'navigation',
 				order: 10,
-				when: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID)
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+					NOTEBOOK_HAS_SOMETHING_RUNNING.toNegated()
+				)
 			},
 			keybinding: {
 				when: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
@@ -1905,6 +1909,44 @@ registerAction2(class extends NotebookAction2 {
 
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
 		notebook.runAllCells();
+	}
+});
+
+// Interrupt Execution - Stops all currently running cells
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.interruptExecution',
+			title: localize2('interruptExecution', 'Interrupt'),
+			icon: ThemeIcon.fromId('notebook-stop'),
+			f1: true,
+			category: POSITRON_NOTEBOOK_CATEGORY,
+			positronActionBarOptions: {
+				controlType: 'button',
+				displayTitle: false
+			},
+			menu: {
+				id: MenuId.EditorActionsLeft,
+				group: 'navigation',
+				order: 10,
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+					NOTEBOOK_HAS_SOMETHING_RUNNING
+				)
+			},
+			keybinding: {
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+					NOTEBOOK_HAS_SOMETHING_RUNNING
+				),
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter
+			}
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
+		notebook.cancelExecution();
 	}
 });
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1915,13 +1915,13 @@ registerAction2(class extends NotebookAction2 {
 	}
 });
 
-// Interrupt Execution - Stops all currently running cells
+// Stop All Cells - cancels execution of every running cell.
 registerAction2(class extends NotebookAction2 {
 	constructor() {
 		super({
-			id: 'positronNotebook.interruptExecution',
-			title: localize2('interruptExecution', 'Interrupt'),
-			icon: ThemeIcon.fromId('notebook-stop'),
+			id: 'positronNotebook.stopAllCells',
+			title: localize2('stopAllCells', 'Stop'),
+			icon: ThemeIcon.fromId('primitive-square'),
 			f1: true,
 			category: POSITRON_NOTEBOOK_CATEGORY,
 			positronActionBarOptions: {
@@ -1949,7 +1949,9 @@ registerAction2(class extends NotebookAction2 {
 	}
 
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
-		return notebook.cancelExecution();
+		// runAllCells delegates to _runCells, which sees the live executions and
+		// routes to cancelNotebookCells instead of executeNotebookCells.
+		return notebook.runAllCells();
 	}
 });
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1900,7 +1900,10 @@ registerAction2(class extends NotebookAction2 {
 				)
 			},
 			keybinding: {
-				when: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+					NOTEBOOK_HAS_SOMETHING_RUNNING.toNegated()
+				),
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter
 			}

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -1911,7 +1911,7 @@ registerAction2(class extends NotebookAction2 {
 	}
 
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
-		notebook.runAllCells();
+		return notebook.runAllCells();
 	}
 });
 
@@ -1949,7 +1949,7 @@ registerAction2(class extends NotebookAction2 {
 	}
 
 	override runNotebookAction(notebook: IPositronNotebookInstance, _accessor: ServicesAccessor) {
-		notebook.cancelExecution();
+		return notebook.cancelExecution();
 	}
 });
 

--- a/test/e2e/tests/notebooks-positron/notebook-run-interrupt-toggle.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-run-interrupt-toggle.test.ts
@@ -14,117 +14,39 @@ test.describe('Positron Notebooks: Run All / Interrupt Toggle', {
 	tag: [tags.POSITRON_NOTEBOOKS, tags.WIN, tags.WEB]
 }, () => {
 
-	test('Python - Run All button toggles to Interrupt while cells are executing', {
+	test('Python - Run All toggles to Interrupt during execution, cancels, and prevents subsequent cells', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10493' }]
-	}, async function ({ app, python }) {
+	}, async function ({ app, page, python, hotKeys }) {
 		const { notebooksPositron } = app.workbench;
 
-		const runAllButton = notebooksPositron.editorActionBar.getByRole('button', { name: 'Run All', exact: true });
-		const interruptButton = notebooksPositron.editorActionBar.getByRole('button', { name: 'Interrupt', exact: true });
-
-		await test.step('Setup: create notebook with a long-running cell', async () => {
-			await notebooksPositron.newNotebook();
-			await notebooksPositron.kernel.select('Python');
-			await notebooksPositron.addCodeToCell(0, 'import time; time.sleep(30)', { run: false });
-		});
-
-		await test.step('Verify Run All is visible and Interrupt is not before execution', async () => {
-			await expect(runAllButton).toBeVisible();
-			await expect(interruptButton).not.toBeVisible();
-		});
-
-		await test.step('Click Run All and verify it switches to Interrupt', async () => {
-			await runAllButton.click();
-			await expect(interruptButton).toBeVisible({ timeout: 10000 });
-			await expect(runAllButton).not.toBeVisible();
-		});
-
-		await test.step('Click Interrupt and verify it switches back to Run All', async () => {
-			await interruptButton.click();
-			await expect(runAllButton).toBeVisible({ timeout: 15000 });
-			await expect(interruptButton).not.toBeVisible();
-		});
-	});
-
-	test('Python - Interrupt button cancels execution and cell stops running', {
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10493' }]
-	}, async function ({ app, python }) {
-		const { notebooksPositron } = app.workbench;
-
-		const runAllButton = notebooksPositron.editorActionBar.getByRole('button', { name: 'Run All', exact: true });
-		const interruptButton = notebooksPositron.editorActionBar.getByRole('button', { name: 'Interrupt', exact: true });
-
-		await test.step('Setup: create notebook with an infinite loop cell', async () => {
+		await test.step('Create notebook with infinite loop followed by a print cell', async () => {
 			await notebooksPositron.newNotebook();
 			await notebooksPositron.kernel.select('Python');
 			await notebooksPositron.addCodeToCell(0, 'while True: pass', { run: false });
-		});
-
-		await test.step('Run All and wait for Interrupt to appear', async () => {
-			await runAllButton.click();
-			await expect(interruptButton).toBeVisible({ timeout: 10000 });
-		});
-
-		await test.step('Click Interrupt to stop the infinite loop', async () => {
-			await interruptButton.click();
-			await expect(runAllButton).toBeVisible({ timeout: 15000 });
-		});
-
-		await test.step('Verify cell execution stopped with an error', async () => {
-			await notebooksPositron.expectNoActiveSpinners();
-		});
-	});
-
-	test('Python - Run All completes normally for fast cells without showing Interrupt', {
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10493' }]
-	}, async function ({ app, python }) {
-		const { notebooksPositron } = app.workbench;
-
-		const runAllButton = notebooksPositron.editorActionBar.getByRole('button', { name: 'Run All', exact: true });
-
-		await test.step('Setup: create notebook with a fast cell', async () => {
-			await notebooksPositron.newNotebook();
-			await notebooksPositron.kernel.select('Python');
-			await notebooksPositron.addCodeToCell(0, 'print("hello")', { run: false });
-		});
-
-		await test.step('Run All and verify it completes and button returns', async () => {
-			await runAllButton.click();
-			await notebooksPositron.expectNoActiveSpinners();
-			await expect(runAllButton).toBeVisible({ timeout: 15000 });
-		});
-
-		await test.step('Verify output was produced', async () => {
-			await notebooksPositron.expectOutputAtIndex(0, ['hello']);
-		});
-	});
-
-	test('Python - Run All with multiple cells shows Interrupt during execution', {
-		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10493' }]
-	}, async function ({ app, python }) {
-		const { notebooksPositron } = app.workbench;
-
-		const runAllButton = notebooksPositron.editorActionBar.getByRole('button', { name: 'Run All', exact: true });
-		const interruptButton = notebooksPositron.editorActionBar.getByRole('button', { name: 'Interrupt', exact: true });
-
-		await test.step('Setup: create notebook with multiple cells', async () => {
-			await notebooksPositron.newNotebook();
-			await notebooksPositron.kernel.select('Python');
-			await notebooksPositron.addCodeToCell(0, 'import time; time.sleep(30)', { run: false });
 			await notebooksPositron.addCell('code');
-			await notebooksPositron.addCodeToCell(1, 'print("cell 2")', { run: false });
+			await notebooksPositron.addCodeToCell(1, 'print("This should NOT be printed")', { run: false });
 		});
 
-		await test.step('Click Run All and verify Interrupt appears', async () => {
-			await runAllButton.click();
-			await expect(interruptButton).toBeVisible({ timeout: 10000 });
-			await expect(runAllButton).not.toBeVisible();
+		await test.step('Trigger Run All via Cmd+Shift+Enter', async () => {
+			await notebooksPositron.selectCellAtIndex(0);
+			await hotKeys.pressHotKeys('Meta+Shift+Enter');
 		});
 
-		await test.step('Interrupt all and verify Run All returns', async () => {
-			await interruptButton.click();
-			await expect(runAllButton).toBeVisible({ timeout: 15000 });
-			await notebooksPositron.expectNoActiveSpinners();
+		await test.step('Verify cell is executing', async () => {
+			await notebooksPositron.expectSpinnerAtIndex(0, true, 10000);
+		});
+
+		await test.step('Trigger Interrupt via Cmd+Shift+Enter', async () => {
+			await hotKeys.pressHotKeys('Meta+Shift+Enter');
+		});
+
+		await test.step('Verify execution was interrupted', async () => {
+			await notebooksPositron.expectNoActiveSpinners(30000);
+			await expect(notebooksPositron.cellOutput(0)).toContainText('keyboard interupt', { timeout: 10000 });
+		});
+
+		await test.step('Verify second cell was NOT executed', async () => {
+			await expect(notebooksPositron.cellOutput(1)).not.toContainText('This should NOT be printed');
 		});
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-run-interrupt-toggle.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-run-interrupt-toggle.test.ts
@@ -11,7 +11,7 @@ test.use({
 });
 
 test.describe('Positron Notebooks: Run All / Interrupt Toggle', {
-	tag: [tags.POSITRON_NOTEBOOKS, tags.WIN, tags.WEB]
+	tag: [tags.POSITRON_NOTEBOOKS]
 }, () => {
 
 	test('Python - Run All toggles to Interrupt during execution, cancels, and prevents subsequent cells', {

--- a/test/e2e/tests/notebooks-positron/notebook-run-interrupt-toggle.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-run-interrupt-toggle.test.ts
@@ -16,8 +16,9 @@ test.describe('Positron Notebooks: Run All / Interrupt Toggle', {
 
 	test('Python - Run All toggles to Interrupt during execution, cancels, and prevents subsequent cells', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10493' }]
-	}, async function ({ app, page, python, hotKeys }) {
+	}, async function ({ app, python }) {
 		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.page.keyboard;
 
 		await test.step('Create notebook with infinite loop followed by a print cell', async () => {
 			await notebooksPositron.newNotebook();
@@ -29,7 +30,7 @@ test.describe('Positron Notebooks: Run All / Interrupt Toggle', {
 
 		await test.step('Trigger Run All via Cmd+Shift+Enter', async () => {
 			await notebooksPositron.selectCellAtIndex(0);
-			await hotKeys.pressHotKeys('Meta+Shift+Enter');
+			await keyboard.press('Meta+Shift+Enter');
 		});
 
 		await test.step('Verify cell is executing', async () => {
@@ -37,7 +38,7 @@ test.describe('Positron Notebooks: Run All / Interrupt Toggle', {
 		});
 
 		await test.step('Trigger Interrupt via Cmd+Shift+Enter', async () => {
-			await hotKeys.pressHotKeys('Meta+Shift+Enter');
+			await keyboard.press('Meta+Shift+Enter');
 		});
 
 		await test.step('Verify execution was interrupted', async () => {

--- a/test/e2e/tests/notebooks-positron/notebook-run-interrupt-toggle.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-run-interrupt-toggle.test.ts
@@ -1,0 +1,130 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Positron Notebooks: Run All / Interrupt Toggle', {
+	tag: [tags.POSITRON_NOTEBOOKS, tags.WIN, tags.WEB]
+}, () => {
+
+	test('Python - Run All button toggles to Interrupt while cells are executing', {
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10493' }]
+	}, async function ({ app, python }) {
+		const { notebooksPositron } = app.workbench;
+
+		const runAllButton = notebooksPositron.editorActionBar.getByRole('button', { name: 'Run All', exact: true });
+		const interruptButton = notebooksPositron.editorActionBar.getByRole('button', { name: 'Interrupt', exact: true });
+
+		await test.step('Setup: create notebook with a long-running cell', async () => {
+			await notebooksPositron.newNotebook();
+			await notebooksPositron.kernel.select('Python');
+			await notebooksPositron.addCodeToCell(0, 'import time; time.sleep(30)', { run: false });
+		});
+
+		await test.step('Verify Run All is visible and Interrupt is not before execution', async () => {
+			await expect(runAllButton).toBeVisible();
+			await expect(interruptButton).not.toBeVisible();
+		});
+
+		await test.step('Click Run All and verify it switches to Interrupt', async () => {
+			await runAllButton.click();
+			await expect(interruptButton).toBeVisible({ timeout: 10000 });
+			await expect(runAllButton).not.toBeVisible();
+		});
+
+		await test.step('Click Interrupt and verify it switches back to Run All', async () => {
+			await interruptButton.click();
+			await expect(runAllButton).toBeVisible({ timeout: 15000 });
+			await expect(interruptButton).not.toBeVisible();
+		});
+	});
+
+	test('Python - Interrupt button cancels execution and cell stops running', {
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10493' }]
+	}, async function ({ app, python }) {
+		const { notebooksPositron } = app.workbench;
+
+		const runAllButton = notebooksPositron.editorActionBar.getByRole('button', { name: 'Run All', exact: true });
+		const interruptButton = notebooksPositron.editorActionBar.getByRole('button', { name: 'Interrupt', exact: true });
+
+		await test.step('Setup: create notebook with an infinite loop cell', async () => {
+			await notebooksPositron.newNotebook();
+			await notebooksPositron.kernel.select('Python');
+			await notebooksPositron.addCodeToCell(0, 'while True: pass', { run: false });
+		});
+
+		await test.step('Run All and wait for Interrupt to appear', async () => {
+			await runAllButton.click();
+			await expect(interruptButton).toBeVisible({ timeout: 10000 });
+		});
+
+		await test.step('Click Interrupt to stop the infinite loop', async () => {
+			await interruptButton.click();
+			await expect(runAllButton).toBeVisible({ timeout: 15000 });
+		});
+
+		await test.step('Verify cell execution stopped with an error', async () => {
+			await notebooksPositron.expectNoActiveSpinners();
+		});
+	});
+
+	test('Python - Run All completes normally for fast cells without showing Interrupt', {
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10493' }]
+	}, async function ({ app, python }) {
+		const { notebooksPositron } = app.workbench;
+
+		const runAllButton = notebooksPositron.editorActionBar.getByRole('button', { name: 'Run All', exact: true });
+
+		await test.step('Setup: create notebook with a fast cell', async () => {
+			await notebooksPositron.newNotebook();
+			await notebooksPositron.kernel.select('Python');
+			await notebooksPositron.addCodeToCell(0, 'print("hello")', { run: false });
+		});
+
+		await test.step('Run All and verify it completes and button returns', async () => {
+			await runAllButton.click();
+			await notebooksPositron.expectNoActiveSpinners();
+			await expect(runAllButton).toBeVisible({ timeout: 15000 });
+		});
+
+		await test.step('Verify output was produced', async () => {
+			await notebooksPositron.expectOutputAtIndex(0, ['hello']);
+		});
+	});
+
+	test('Python - Run All with multiple cells shows Interrupt during execution', {
+		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10493' }]
+	}, async function ({ app, python }) {
+		const { notebooksPositron } = app.workbench;
+
+		const runAllButton = notebooksPositron.editorActionBar.getByRole('button', { name: 'Run All', exact: true });
+		const interruptButton = notebooksPositron.editorActionBar.getByRole('button', { name: 'Interrupt', exact: true });
+
+		await test.step('Setup: create notebook with multiple cells', async () => {
+			await notebooksPositron.newNotebook();
+			await notebooksPositron.kernel.select('Python');
+			await notebooksPositron.addCodeToCell(0, 'import time; time.sleep(30)', { run: false });
+			await notebooksPositron.addCell('code');
+			await notebooksPositron.addCodeToCell(1, 'print("cell 2")', { run: false });
+		});
+
+		await test.step('Click Run All and verify Interrupt appears', async () => {
+			await runAllButton.click();
+			await expect(interruptButton).toBeVisible({ timeout: 10000 });
+			await expect(runAllButton).not.toBeVisible();
+		});
+
+		await test.step('Interrupt all and verify Run All returns', async () => {
+			await interruptButton.click();
+			await expect(runAllButton).toBeVisible({ timeout: 15000 });
+			await notebooksPositron.expectNoActiveSpinners();
+		});
+	});
+});

--- a/test/e2e/tests/notebooks-positron/notebook-run-interrupt-toggle.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-run-interrupt-toggle.test.ts
@@ -19,6 +19,8 @@ test.describe('Positron Notebooks: Run All / Interrupt Toggle', {
 	}, async function ({ app, python }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.page.keyboard;
+		const mod = process.platform === 'darwin' ? 'Meta' : 'Control';
+		const runAllOrInterrupt = `${mod}+Shift+Enter`;
 
 		await test.step('Create notebook with infinite loop followed by a print cell', async () => {
 			await notebooksPositron.newNotebook();
@@ -28,17 +30,17 @@ test.describe('Positron Notebooks: Run All / Interrupt Toggle', {
 			await notebooksPositron.addCodeToCell(1, 'print("This should NOT be printed")', { run: false });
 		});
 
-		await test.step('Trigger Run All via Cmd+Shift+Enter', async () => {
+		await test.step('Trigger Run All via keyboard shortcut', async () => {
 			await notebooksPositron.selectCellAtIndex(0);
-			await keyboard.press('Meta+Shift+Enter');
+			await keyboard.press(runAllOrInterrupt);
 		});
 
 		await test.step('Verify cell is executing', async () => {
 			await notebooksPositron.expectSpinnerAtIndex(0, true, 10000);
 		});
 
-		await test.step('Trigger Interrupt via Cmd+Shift+Enter', async () => {
-			await keyboard.press('Meta+Shift+Enter');
+		await test.step('Trigger Interrupt via keyboard shortcut', async () => {
+			await keyboard.press(runAllOrInterrupt);
 		});
 
 		await test.step('Verify execution was interrupted', async () => {

--- a/test/e2e/tests/notebooks-positron/notebook-run-interrupt-toggle.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-run-interrupt-toggle.test.ts
@@ -18,7 +18,7 @@ test.describe('Positron Notebooks: Run All / Interrupt Toggle', {
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10493' }]
 	}, async function ({ app, python }) {
 		const { notebooksPositron } = app.workbench;
-		const keyboard = app.code.driver.page.keyboard;
+		const keyboard = app.code.driver.currentPage.keyboard;
 		const mod = process.platform === 'darwin' ? 'Meta' : 'Control';
 		const runAllOrInterrupt = `${mod}+Shift+Enter`;
 
@@ -45,7 +45,7 @@ test.describe('Positron Notebooks: Run All / Interrupt Toggle', {
 
 		await test.step('Verify execution was interrupted', async () => {
 			await notebooksPositron.expectNoActiveSpinners(30000);
-			await expect(notebooksPositron.cellOutput(0)).toContainText('keyboard interupt', { timeout: 10000 });
+			await expect(notebooksPositron.cellOutput(0)).toContainText('keyboard interrupt', { timeout: 10000 });
 		});
 
 		await test.step('Verify second cell was NOT executed', async () => {


### PR DESCRIPTION
## Summary
- Add a Stop All Cells action (`positronNotebook.stopAllCells`) that appears in the editor toolbar when cells are running, replacing the Run All button via `NOTEBOOK_HAS_SOMETHING_RUNNING` context key
- Reuses existing `runAllCells()` which already routes to `cancelNotebookCells` when executions are active
- Fix typo: `'interupt'` → `'interrupt'` across type definition, parser, renderer, and e2e test

Closes #10493

## Test plan
- [x] E2E test verifies Run All → Stop toggle, interrupt, and that subsequent cells are not executed
- [x] Passes locally in headed mode (13s)
- [x] TypeScript compilation clean (0 errors)

@:positron-notebooks