### PR TITLE
Respect user visibility settings for top action bar, command center, and aux bar

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1521,6 +1521,9 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				zenModeExitInfo.wasVisible.sideBar = this.isVisible(Parts.SIDEBAR_PART);
 				zenModeExitInfo.wasVisible.panel = this.isVisible(Parts.PANEL_PART);
 				zenModeExitInfo.wasVisible.auxiliaryBar = this.isVisible(Parts.AUXILIARYBAR_PART);
+				// --- Start Positron ---
+				zenModeExitInfo.wasVisible.positronTopActionBar = this.isVisible(Parts.POSITRON_TOP_ACTION_BAR_PART);
+				// --- End Positron ---
 				this.stateModel.setRuntimeValue(LayoutStateKeys.ZEN_MODE_EXIT_INFO, zenModeExitInfo);
 			}
 
@@ -1535,6 +1538,12 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			if (config.hideStatusBar) {
 				this.setStatusBarHidden(true);
 			}
+
+			// --- Start Positron ---
+			if (config.hideTopActionBar) {
+				this.setPositronTopActionBarHidden(true);
+			}
+			// --- End Positron ---
 
 			if (config.hideLineNumbers) {
 				setLineNumbers('off');
@@ -1568,6 +1577,14 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 					const zenModeHideStatusBar = this.configurationService.getValue<boolean>(ZenModeSettings.HIDE_STATUSBAR);
 					this.setStatusBarHidden(zenModeHideStatusBar);
 				}
+
+				// --- Start Positron ---
+				// Top Action Bar
+				if (e.affectsConfiguration(ZenModeSettings.HIDE_TOP_ACTION_BAR)) {
+					const zenModeHideTopActionBar = this.configurationService.getValue<boolean>(ZenModeSettings.HIDE_TOP_ACTION_BAR);
+					this.setPositronTopActionBarHidden(zenModeHideTopActionBar);
+				}
+				// --- End Positron ---
 
 				// Center Layout
 				if (e.affectsConfiguration(ZenModeSettings.CENTER_LAYOUT)) {
@@ -1619,6 +1636,12 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			if (!this.stateModel.getRuntimeValue(LayoutStateKeys.STATUSBAR_HIDDEN, true)) {
 				this.setStatusBarHidden(false);
 			}
+
+			// --- Start Positron ---
+			if (!this.stateModel.getRuntimeValue(LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN, true)) {
+				this.setPositronTopActionBarHidden(false);
+			}
+			// --- End Positron ---
 
 			if (zenModeExitInfo.transitionedToCenteredEditorLayout) {
 				this.centerMainEditorLayout(false, true);
@@ -3061,6 +3084,9 @@ type ZenModeConfiguration = {
 	showTabs: 'multiple' | 'single' | 'none';
 	restore: boolean;
 	silentNotifications: boolean;
+	// --- Start Positron ---
+	hideTopActionBar: boolean;
+	// --- End Positron ---
 };
 
 function getZenModeConfiguration(configurationService: IConfigurationService): ZenModeConfiguration {
@@ -3117,6 +3143,9 @@ const LayoutStateKeys = {
 			auxiliaryBar: false,
 			panel: false,
 			sideBar: false,
+			// --- Start Positron ---
+			positronTopActionBar: false,
+			// --- End Positron ---
 		},
 	}),
 
@@ -3154,7 +3183,7 @@ const LayoutStateKeys = {
 	STATUSBAR_HIDDEN: new RuntimeStateKey<boolean>('statusBar.hidden', StorageScope.WORKSPACE, StorageTarget.MACHINE, false, true),
 
 	// --- Start Positron ---
-	POSITRON_TOP_ACTION_BAR_HIDDEN: new RuntimeStateKey<boolean>('positronTopActionBar.hidden', StorageScope.WORKSPACE, StorageTarget.MACHINE, false),
+	POSITRON_TOP_ACTION_BAR_HIDDEN: new RuntimeStateKey<boolean>('positronTopActionBar.hidden', StorageScope.WORKSPACE, StorageTarget.MACHINE, false, true),
 	// --- End Positron ---
 
 } as const;
@@ -3482,6 +3511,11 @@ class LayoutStateModel extends Disposable {
 				case LayoutStateKeys.SIDEBAR_POSITON:
 					this.stateCache.set(key.name, this.configurationService.getValue(LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION) ?? 'left');
 					break;
+				// --- Start Positron ---
+				case LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN:
+					this.stateCache.set(key.name, !this.configurationService.getValue(LayoutSettings.TOP_ACTION_BAR_VISIBLE));
+					break;
+				// --- End Positron ---
 			}
 		}
 

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -759,6 +759,12 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				this.setStatusBarHidden(change.value as boolean);
 			}
 
+			// --- Start Positron ---
+			if (change.key === LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN) {
+				this.setPositronTopActionBarHidden(change.value as boolean);
+			}
+			// --- End Positron ---
+
 			if (change.key === LayoutStateKeys.SIDEBAR_POSITON) {
 				this.setSideBarPosition(change.value as Position);
 			}
@@ -3220,6 +3226,12 @@ class LayoutStateModel extends Disposable {
 			this.setRuntimeValueAndFire(LayoutStateKeys.STATUSBAR_HIDDEN, !this.configurationService.getValue(LegacyWorkbenchLayoutSettings.STATUSBAR_VISIBLE));
 		}
 
+		// --- Start Positron ---
+		if (configurationChangeEvent.affectsConfiguration(LayoutSettings.TOP_ACTION_BAR_VISIBLE)) {
+			this.setRuntimeValueAndFire(LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN, !this.configurationService.getValue(LayoutSettings.TOP_ACTION_BAR_VISIBLE));
+		}
+		// --- End Positron ---
+
 		if (configurationChangeEvent.affectsConfiguration(LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION)) {
 			this.setRuntimeValueAndFire(LayoutStateKeys.SIDEBAR_POSITON, positionFromString(this.configurationService.getValue(LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION) ?? 'left'));
 		}
@@ -3258,6 +3270,9 @@ class LayoutStateModel extends Disposable {
 		// Apply legacy settings
 		this.stateCache.set(LayoutStateKeys.ACTIVITYBAR_HIDDEN.name, this.isActivityBarHidden());
 		this.stateCache.set(LayoutStateKeys.STATUSBAR_HIDDEN.name, !this.configurationService.getValue(LegacyWorkbenchLayoutSettings.STATUSBAR_VISIBLE));
+		// --- Start Positron ---
+		this.stateCache.set(LayoutStateKeys.POSITRON_TOP_ACTION_BAR_HIDDEN.name, !this.configurationService.getValue(LayoutSettings.TOP_ACTION_BAR_VISIBLE));
+		// --- End Positron ---
 		this.stateCache.set(LayoutStateKeys.SIDEBAR_POSITON.name, positionFromString(this.configurationService.getValue(LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION) ?? 'left'));
 
 		// Set dynamic defaults: part sizing and side bar visibility

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -3358,8 +3358,13 @@ class LayoutStateModel extends Disposable {
 
 		// --- Start Positron ---
 		// In Positron, the auxiliary bar and panel are not hidden by default and the panel defaults
-		// to 50% height.
-		LayoutStateKeys.AUXILIARYBAR_HIDDEN.defaultValue = false;
+		// to 50% height. Respect explicit user configuration of the secondary side bar visibility.
+		const auxBarVisibilityConfigured = isConfigured(
+			this.configurationService.inspect(WorkbenchLayoutSettings.AUXILIARYBAR_DEFAULT_VISIBILITY)
+		);
+		if (!auxBarVisibilityConfigured) {
+			LayoutStateKeys.AUXILIARYBAR_HIDDEN.defaultValue = false;
+		}
 		LayoutStateKeys.PANEL_HIDDEN.defaultValue = false;
 		LayoutStateKeys.PANEL_SIZE.defaultValue = mainContainerDimension.height / 2;
 
@@ -3371,7 +3376,9 @@ class LayoutStateModel extends Disposable {
 		if (!layoutInitialized) {
 			LayoutStateKeys.SIDEBAR_HIDDEN.defaultValue = false;
 			LayoutStateKeys.PANEL_HIDDEN.defaultValue = false;
-			LayoutStateKeys.AUXILIARYBAR_HIDDEN.defaultValue = false;
+			if (!auxBarVisibilityConfigured) {
+				LayoutStateKeys.AUXILIARYBAR_HIDDEN.defaultValue = false;
+			}
 			LayoutStateKeys.SIDEBAR_SIZE.defaultValue = Math.round(mainContainerDimension.width * 0.15);
 			LayoutStateKeys.PANEL_LAST_NON_MAXIMIZED_HEIGHT.defaultValue = Math.round(mainContainerDimension.height * 0.4);
 			LayoutStateKeys.AUXILIARYBAR_SIZE.defaultValue = Math.round(mainContainerDimension.width * 0.3);

--- a/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
+++ b/src/vs/workbench/browser/parts/positronTopActionBar/positronTopActionBar.tsx
@@ -27,6 +27,8 @@ import { TopActionBarCustomFolderMenu } from './components/topActionBarCustomFol
 import { TopActionBarSessionManager } from './components/topActionBarSessionManager.js';
 import { SAVE_ALL_COMMAND_ID } from '../../../contrib/files/browser/fileConstants.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
+import { LayoutSettings } from '../../../services/layout/browser/layoutService.js';
+import { usePositronConfiguration } from '../../../../base/browser/positronReactHooks.js';
 
 // Constants.
 const kHorizontalPadding = 4;
@@ -72,6 +74,9 @@ export const PositronTopActionBar = (props: PositronTopActionBarProps) => {
 		props.positronTopActionBarContainer.width > kFulllCenterUIBreak
 	);
 
+	// When the title bar hosts the command center, suppress the center region here to avoid duplication.
+	const commandCenterInTitleBar = usePositronConfiguration<boolean>(LayoutSettings.COMMAND_CENTER) === true;
+
 	// Main useEffect.
 	useEffect(() => {
 		// Create the disposable store for cleanup.
@@ -108,7 +113,7 @@ export const PositronTopActionBar = (props: PositronTopActionBarProps) => {
 								icon={ThemeIcon.fromId('positron-save-all')}
 							/>
 						</ActionBarRegion>
-						{showCenterUI && (
+						{showCenterUI && !commandCenterInTitleBar && (
 							<ActionBarRegion location='center'>
 								<PositronActionBar nestedActionBar={true}>
 									{showFullCenterUI && (

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -811,13 +811,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 	}
 
 	protected get isCommandCenterVisible() {
-		// --- Start Positron ---
-		// Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
-		return false;
-		/*
 		return !this.isCompact && this.configurationService.getValue<boolean>(LayoutSettings.COMMAND_CENTER) !== false;
-		*/
-		// --- End Positron ---
 	}
 
 	private get editorActionsEnabled(): boolean {

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -1003,6 +1003,13 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'default': true,
 				'description': localize('zenMode.hideActivityBar', "Controls whether turning on Zen Mode also hides the activity bar either at the left or right of the workbench.")
 			},
+			// --- Start Positron ---
+			'zenMode.hideTopActionBar': {
+				'type': 'boolean',
+				'default': true,
+				'description': localize('positron.zenMode.hideTopActionBar', "Controls whether turning on Zen Mode also hides the top action bar.")
+			},
+			// --- End Positron ---
 			'zenMode.hideLineNumbers': {
 				'type': 'boolean',
 				'default': true,

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -852,7 +852,13 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			},
 			[LayoutSettings.COMMAND_CENTER]: {
 				type: 'boolean',
+				// --- Start Positron ---
+				// Positron hides the command center by default; users can opt-in to display it in the title bar.
+				/*
 				default: true,
+				*/
+				default: false,
+				// --- End Positron ---
 				markdownDescription: isWeb ?
 					localize('window.commandCenterWeb', "Show command launcher together with the window title.") :
 					localize({ key: 'window.commandCenter', comment: ['{0}, {1} is a placeholder for a setting identifier.'] }, "Show command launcher together with the window title. This setting only has an effect when {0} is not set to {1}.", '`#window.customTitleBarVisibility#`', '`never`')

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -47,6 +47,9 @@ export const enum ZenModeSettings {
 	FULLSCREEN = 'zenMode.fullScreen',
 	RESTORE = 'zenMode.restore',
 	SILENT_NOTIFICATIONS = 'zenMode.silentNotifications',
+	// --- Start Positron ---
+	HIDE_TOP_ACTION_BAR = 'zenMode.hideTopActionBar',
+	// --- End Positron ---
 }
 
 export const enum LayoutSettings {


### PR DESCRIPTION
Fixes #10149
Fixes #11629
Fixes #13113

Closes #13483, the original PR from @ivanovanatoliy with the first commit here

This PR is a bundled set of changes that make Positron's UI component visibility settings actually do what they say. Previously, several user-facing visibility settings either had no effect at all or were only partially wired; this PR makes them honor explicit user configuration consistently, and adds Zen mode integration for the top action bar.

I do want to highlight that the work in this PR lets users _undo_ some of our opinionated Positron UI affordances. I am advocating that this is the right call, and that we were too heavy handed before by turning a lot of this off. It is true that, for example, turning off `workbench.topActionBar.visible` will remove the ability to use the interpreter picker and the workspace switcher UI, but you can get to those actions from the command palette still. Some folks prefer a more streamlined interface!

- **Top action bar visibility setting** (fixes #13113, originally from @ivanovanatoliy in #13483): `workbench.topActionBar.visible` now actually hides and shows the custom Positron top action bar at runtime. The setting was already registered and the toggle command updated the configuration value, but that value was not connected to actual workbench part visibility.

- **Zen mode integration**: Also related to Positron's custom top bar, added a new `zenMode.hideTopActionBar` setting (default `true`). Entering Zen now hides the top action bar; exiting restores it to the user's persisted visibility. This mirrors how Zen handles the activity bar and status bar.

- **Command center** (fixes #10149): `window.commandCenter` is no longer hardcoded off. Positron defaults it to `false` so existing users see no change, but users who set it to `true` get the command center in the title bar. I also set this up so that when `window.commandCenter` is `true`, the Positron top action bar suppresses its own center region (command center + nav buttons) to avoid duplication. The title bar command center already contributes the same nav actions via `MenuId.CommandCenter`. This is not a huge, difficult amount of code for us to maintain in the long run.

- **Secondary side bar default visibility** (fixes #11629): `workbench.secondarySideBar.defaultVisibility` is now honored when the user has explicitly configured it at any scope. Previously Positron's unconditional "always visible" override clobbered the user's setting at startup.

Related to that last one, `workbench.secondarySideBar.defaultVisibility` controls the default visibility for new workspaces only (this is upstream behavior). Workspaces with existing per-workspace runtime state (from prior Positron sessions) keep that cached state on reopen. Setting `"hidden"` will take effect on workspaces Positron has not seen before.

## Release Notes

### New Features

- N/A

### Bug Fixes

- The `workbench.topActionBar.visible` setting now hides and shows the top action bar at runtime (#13113).
- The `window.commandCenter` setting can now be enabled to show the command center in the title bar (#10149).
- The `workbench.secondarySideBar.defaultVisibility` setting is now honored when explicitly configured (#11629).

## Validation Steps

@:top-action-bar @:layouts

### Top action bar visibility

1. In `settings.json`, set `"workbench.topActionBar.visible": false`. The top action bar hides immediately, no reload needed.
2. Toggle back to `true`. It reappears.

### Zen mode

1. Enter Zen mode (Cmd/Ctrl+K Z). The top action bar hides along with the side bar, panel, and aux bar.
2. Exit Zen. Top action bar restored.
3. Set `"zenMode.hideTopActionBar": false`. Enter Zen again. The top action bar stays visible.
4. Inside Zen, toggle `zenMode.hideTopActionBar` in `settings.json`. The top action bar shows or hides live without exiting Zen.

### Command center

1. Default: command center is in the Positron top action bar (the "Search" pill).
2. Set `"window.commandCenter": true`. Command center now appears in the title bar; the top action bar's center region (search pill + nav arrows) disappears so there is no duplicate.
3. Toggle back to `false`. Title bar command center hides; top action bar's reappears.

### Secondary side bar

1. In `settings.json`, set `"workbench.secondarySideBar.defaultVisibility": "hidden"`.
2. Open Positron with no workspace (empty window). The secondary side bar is hidden.
3. Open a directory you have never opened in Positron before. The secondary side bar is hidden.
4. Workspaces you have opened previously keep their cached visibility state; this setting controls only workspaces Positron has not seen before.
