### PR TITLE
Viewer: consolidate "Open somewhere else" actions into a single dropdown

### DIFF
--- a/src/vs/workbench/contrib/positronPreview/browser/components/htmlActionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/htmlActionBars.tsx
@@ -17,15 +17,19 @@ import { kPaddingLeft, kPaddingRight } from './actionBars.js';
 import { PreviewHtml } from '../previewHtml.js';
 import { ActionBarRegion } from '../../../../../platform/positronActionBar/browser/components/actionBarRegion.js';
 import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
+import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
 import { ActionBarSeparator } from '../../../../../platform/positronActionBar/browser/components/actionBarSeparator.js';
+import { IAction } from '../../../../../base/common/actions.js';
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { PreviewOpenTarget } from '../positronPreviewSevice.js';
 
 const reload = localize('positron.preview.html.reload', "Reload the content");
 const clear = localize('positron.preview.html.clear', "Clear the content");
-const openInBrowser = localize('positron.preview.html.openInBrowser', "Open the content in the default browser");
-const openInEditor = localize('positron.preview.html.openInEditor', "Open the content in an editor tab");
+const openInBrowserLabel = localize('positron.preview.html.openInBrowser.menu', "Open in Browser");
+const openInEditorLabel = localize('positron.preview.html.openInEditor.menu', "Open in Editor Tab");
+const openInDropdownLabel = localize('positron.preview.html.openInDropdown', "Select where to open");
 
 /**
  * HtmlActionBarsProps interface.
@@ -40,6 +44,12 @@ export const HtmlActionBars = (props: PropsWithChildren<HtmlActionBarsProps>) =>
 
 	const services = usePositronReactServicesContext();
 	const [title, setTitle] = useState(props.preview.html?.title);
+
+	// State for the remembered "Open in..." target. Persisted via the preview
+	// service so it survives remounts and reloads.
+	const [rememberedOpenTarget, setRememberedOpenTarget] = useState<PreviewOpenTarget>(() =>
+		services.positronPreviewService.getDefaultOpenTarget()
+	);
 
 	// Handler for the reload button.
 	const reloadHandler = () => {
@@ -56,14 +66,41 @@ export const HtmlActionBars = (props: PropsWithChildren<HtmlActionBarsProps>) =>
 
 	// Handler for the open in browser button.
 	const openInBrowserHandler = () => {
+		setRememberedOpenTarget(PreviewOpenTarget.Browser);
+		services.positronPreviewService.setDefaultOpenTarget(PreviewOpenTarget.Browser);
 		services.openerService.open(props.preview.uri,
 			{ openExternal: true, fromUserGesture: true });
 	};
 
 	// Handler for open in editor button
 	const openInEditorHandler = () => {
+		setRememberedOpenTarget(PreviewOpenTarget.EditorTab);
+		services.positronPreviewService.setDefaultOpenTarget(PreviewOpenTarget.EditorTab);
 		services.positronPreviewService.openEditor(props.preview.uri, title);
 	};
+
+	// Builds the dropdown actions. The "checked" action is the remembered
+	// target, which is what the split-button's primary click repeats.
+	const openInActions = (): IAction[] => [
+		{
+			id: 'positron.preview.html.openInBrowser',
+			label: openInBrowserLabel,
+			tooltip: '',
+			class: undefined,
+			checked: rememberedOpenTarget === PreviewOpenTarget.Browser,
+			enabled: true,
+			run: openInBrowserHandler,
+		},
+		{
+			id: 'positron.preview.html.openInEditor',
+			label: openInEditorLabel,
+			tooltip: '',
+			class: undefined,
+			checked: rememberedOpenTarget === PreviewOpenTarget.EditorTab,
+			enabled: true,
+			run: openInEditorHandler,
+		},
+	];
 
 	// Main use effect.
 	useEffect(() => {
@@ -95,19 +132,15 @@ export const HtmlActionBars = (props: PropsWithChildren<HtmlActionBarsProps>) =>
 							icon={ThemeIcon.fromId('positron-refresh')}
 							tooltip={reload}
 							onPressed={reloadHandler} />
-						<ActionBarButton
+						<ActionBarMenuButton
+							actions={openInActions}
 							align='right'
-							ariaLabel={openInBrowser}
+							ariaLabel={openInDropdownLabel}
+							dropdownAriaLabel={openInDropdownLabel}
+							dropdownIndicator='enabled-split'
+							dropdownTooltip={openInDropdownLabel}
 							icon={ThemeIcon.fromId('positron-open-in-new-window')}
-							tooltip={openInBrowser}
-							onPressed={openInBrowserHandler} />
-						<ActionBarSeparator />
-						<ActionBarButton
-							align='right'
-							ariaLabel={openInEditor}
-							icon={ThemeIcon.fromId('go-to-file')}
-							tooltip={openInEditor}
-							onPressed={openInEditorHandler} />
+							tooltip={openInDropdownLabel} />
 						<ActionBarSeparator />
 						<ActionBarButton
 							align='right'

--- a/src/vs/workbench/contrib/positronPreview/browser/components/urlActionBars.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/components/urlActionBars.tsx
@@ -14,6 +14,8 @@ import { PositronActionBar } from '../../../../../platform/positronActionBar/bro
 import { PositronActionBarContextProvider } from '../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
 import { ActionBarRegion } from '../../../../../platform/positronActionBar/browser/components/actionBarRegion.js';
 import { ActionBarButton } from '../../../../../platform/positronActionBar/browser/components/actionBarButton.js';
+import { ActionBarMenuButton } from '../../../../../platform/positronActionBar/browser/components/actionBarMenuButton.js';
+import { IAction } from '../../../../../base/common/actions.js';
 import { localize } from '../../../../../nls.js';
 import { PreviewUrl, QUERY_NONCE_PARAMETER } from '../previewUrl.js';
 import { ActionBarSeparator } from '../../../../../platform/positronActionBar/browser/components/actionBarSeparator.js';
@@ -24,6 +26,7 @@ import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { ITerminalInstance } from '../../../terminal/browser/terminal.js';
 import { RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { PreviewOpenTarget } from '../positronPreviewSevice.js';
 
 // Constants.
 const kUrlBarInputName = 'url-bar';
@@ -42,9 +45,10 @@ const navigateBack = localize('positron.preview.navigateBack', "Navigate back to
 const navigateForward = localize('positron.preview.navigateForward', "Navigate back to the next URL");
 const reload = localize('positron.preview.reload', "Reload the current URL");
 const clear = localize('positron.preview.clear', "Clear the current URL");
-const openInBrowser = localize('positron.preview.openInBrowser', "Open the current URL in the default browser");
+const openInBrowserLabel = localize('positron.preview.openInBrowser.menu', "Open in Browser");
+const openInEditorLabel = localize('positron.preview.openInEditor.menu', "Open in Editor Tab");
+const openInDropdownLabel = localize('positron.preview.openInDropdown', "Select where to open");
 const currentUrl = localize('positron.preview.currentUrl', "The current URL");
-const openInEditor = localize('positron.preview.html.openInEditor', "Open the content in an editor tab");
 const interruptExecution = localize('positron.preview.interruptExecution', "Interrupt execution");
 
 /**
@@ -121,7 +125,15 @@ export const UrlActionBars = (props: PropsWithChildren<UrlActionBarsProps>) => {
 		});
 	};
 
+	// State for the remembered "Open in..." target. Persisted via the preview
+	// service so it survives remounts and reloads.
+	const [rememberedOpenTarget, setRememberedOpenTarget] = useState<PreviewOpenTarget>(() =>
+		services.positronPreviewService.getDefaultOpenTarget()
+	);
+
 	const openInEditorHandler = () => {
+		setRememberedOpenTarget(PreviewOpenTarget.EditorTab);
+		services.positronPreviewService.setDefaultOpenTarget(PreviewOpenTarget.EditorTab);
 		services.positronPreviewService.openEditor(currentUri);
 	};
 
@@ -132,9 +144,34 @@ export const UrlActionBars = (props: PropsWithChildren<UrlActionBarsProps>) => {
 
 	// Handler for the open in browser button.
 	const openInBrowserHandler = () => {
+		setRememberedOpenTarget(PreviewOpenTarget.Browser);
+		services.positronPreviewService.setDefaultOpenTarget(PreviewOpenTarget.Browser);
 		services.openerService.open(props.preview.currentUri,
 			{ openExternal: true, fromUserGesture: true });
 	};
+
+	// Builds the dropdown actions. The "checked" action is the remembered
+	// target, which is what the split-button's primary click repeats.
+	const openInActions = (): IAction[] => [
+		{
+			id: 'positron.preview.openInBrowser',
+			label: openInBrowserLabel,
+			tooltip: '',
+			class: undefined,
+			checked: rememberedOpenTarget === PreviewOpenTarget.Browser,
+			enabled: true,
+			run: openInBrowserHandler,
+		},
+		{
+			id: 'positron.preview.openInEditor',
+			label: openInEditorLabel,
+			tooltip: '',
+			class: undefined,
+			checked: rememberedOpenTarget === PreviewOpenTarget.EditorTab,
+			enabled: true,
+			run: openInEditorHandler,
+		},
+	];
 
 	// Perform navigation to the given URL.
 	const navigateToUrl = (url: string) => {
@@ -354,19 +391,15 @@ export const UrlActionBars = (props: PropsWithChildren<UrlActionBarsProps>) => {
 							icon={ThemeIcon.fromId('positron-refresh')}
 							tooltip={reload}
 							onPressed={reloadHandler} />
-						<ActionBarButton
+						<ActionBarMenuButton
+							actions={openInActions}
 							align='right'
-							ariaLabel={openInBrowser}
+							ariaLabel={openInDropdownLabel}
+							dropdownAriaLabel={openInDropdownLabel}
+							dropdownIndicator='enabled-split'
+							dropdownTooltip={openInDropdownLabel}
 							icon={ThemeIcon.fromId('positron-open-in-new-window')}
-							tooltip={openInBrowser}
-							onPressed={openInBrowserHandler} />
-						<ActionBarSeparator />
-						<ActionBarButton
-							align='right'
-							ariaLabel={openInEditor}
-							icon={ThemeIcon.fromId('go-to-file')}
-							tooltip={openInEditor}
-							onPressed={openInEditorHandler} />
+							tooltip={openInDropdownLabel} />
 						<ActionBarSeparator />
 						<ActionBarButton
 							align='right'

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreview.tsx
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreview.tsx
@@ -12,7 +12,7 @@ import { PropsWithChildren, useEffect, useState } from 'react';
 // Other dependencies.
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { PreviewContainer } from './components/previewContainer.js';
-import { IPositronPreviewService } from './positronPreviewSevice.js';
+import { IPositronPreviewService, PreviewOpenTarget } from './positronPreviewSevice.js';
 import { PreviewWebview } from './previewWebview.js';
 import { PositronPreviewViewPane } from './positronPreviewView.js';
 import { UrlActionBars } from './components/urlActionBars.js';
@@ -112,5 +112,5 @@ export const PositronPreview = (props: PropsWithChildren<PositronPreviewProps>) 
 		</>
 	);
 };
-export { IPositronPreviewService };
+export { IPositronPreviewService, PreviewOpenTarget };
 

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewServiceImpl.ts
@@ -1,11 +1,12 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import * as DOM from '../../../../base/browser/dom.js';
 import { Disposable, DisposableMap } from '../../../../base/common/lifecycle.js';
-import { IPositronPreviewService } from './positronPreview.js';
+import { IPositronPreviewService, PreviewOpenTarget } from './positronPreview.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { Event, Emitter } from '../../../../base/common/event.js';
 import { IOverlayWebview, IWebviewService, WebviewExtensionDescription, WebviewInitInfo } from '../../webview/browser/webview.js';
 import { PreviewWebview } from './previewWebview.js';
@@ -31,6 +32,9 @@ import { Schemas } from '../../../../base/common/network.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+
+/** The key used to store the Viewer's default "Open in..." target. */
+const DefaultOpenTargetStorageKey = 'positronPreview.defaultOpenTarget';
 
 /**
  * Positron preview service; keeps track of the set of active previews and
@@ -64,8 +68,12 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IStorageService private readonly _storageService: IStorageService,
 	) {
 		super();
+		this._register(this._items);
+		this._register(this._onDidCreatePreviewWebviewEmitter);
+		this._register(this._onDidChangeActivePreviewWebview);
 		this.onDidCreatePreviewWebview = this._onDidCreatePreviewWebviewEmitter.event;
 		this.onDidChangeActivePreviewWebview = this._onDidChangeActivePreviewWebview.event;
 		this._runtimeSessionService.activeSessions.forEach(runtime => {
@@ -562,6 +570,20 @@ export class PositronPreviewService extends Disposable implements IPositronPrevi
 				path: previewId
 			}),
 		});
+	}
+
+	public getDefaultOpenTarget(): PreviewOpenTarget {
+		const target = this._storageService.get(DefaultOpenTargetStorageKey, StorageScope.WORKSPACE);
+		switch (target) {
+			case PreviewOpenTarget.Browser:
+			case PreviewOpenTarget.EditorTab:
+				return target;
+		}
+		return PreviewOpenTarget.Browser;
+	}
+
+	public setDefaultOpenTarget(target: PreviewOpenTarget): void {
+		this._storageService.store(DefaultOpenTargetStorageKey, target, StorageScope.WORKSPACE, StorageTarget.MACHINE);
 	}
 
 	public editorWebview(editorId: string): PreviewWebview | undefined {

--- a/src/vs/workbench/contrib/positronPreview/browser/positronPreviewSevice.ts
+++ b/src/vs/workbench/contrib/positronPreview/browser/positronPreviewSevice.ts
@@ -28,6 +28,16 @@ export const POSITRON_PREVIEW_HTML_VIEW_TYPE = 'positron.previewHtml';
 export const IPositronPreviewService = createDecorator<IPositronPreviewService>(POSITRON_PREVIEW_SERVICE_ID);
 
 /**
+ * The remembered target for the Viewer action bar "Open in..." split-button.
+ */
+export enum PreviewOpenTarget {
+	/** Open the content in the default external browser. */
+	Browser = 'browser',
+	/** Open the content in an editor tab. */
+	EditorTab = 'editorTab',
+}
+
+/**
  * IPositronPreviewService interface.
  *
  * Note that this service lives in `/contrib/` instead of `/services/` because
@@ -146,4 +156,15 @@ export interface IPositronPreviewService {
 	 * @param title The title for the preview.
 	 */
 	openHtmlString(previewId: string, html: string, title: string): PreviewWebview;
+
+	/**
+	 * Gets the remembered "Open in..." target for the Viewer action bar.
+	 * Defaults to {@link PreviewOpenTarget.Browser} for new users.
+	 */
+	getDefaultOpenTarget(): PreviewOpenTarget;
+
+	/**
+	 * Persists the remembered "Open in..." target for the Viewer action bar.
+	 */
+	setDefaultOpenTarget(target: PreviewOpenTarget): void;
 }

--- a/src/vs/workbench/contrib/positronPreview/test/electron-browser/positronPreviewService.vitest.ts
+++ b/src/vs/workbench/contrib/positronPreview/test/electron-browser/positronPreviewService.vitest.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { IStorageService, StorageScope, StorageTarget } from '../../../../../platform/storage/common/storage.js';
+import { PositronPreviewService } from '../../browser/positronPreviewServiceImpl.js';
+import { IPositronPreviewService, PreviewOpenTarget } from '../../browser/positronPreviewSevice.js';
+
+describe('Positron - Preview Service', () => {
+
+	const ctx = createTestContainer().withWorkbenchServices().build();
+	let previewService: IPositronPreviewService;
+	let storageService: IStorageService;
+
+	const STORAGE_KEY = 'positronPreview.defaultOpenTarget';
+
+	beforeEach(() => {
+		previewService = ctx.disposables.add(ctx.instantiationService.createInstance(PositronPreviewService));
+		storageService = ctx.instantiationService.invokeFunction(accessor => accessor.get(IStorageService));
+		storageService.remove(STORAGE_KEY, StorageScope.WORKSPACE);
+	});
+
+	it('getDefaultOpenTarget validates stored values and falls back when unrecognized', () => {
+		storageService.store(STORAGE_KEY, 'someUnknownValue', StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		expect(previewService.getDefaultOpenTarget()).toBe(PreviewOpenTarget.Browser);
+	});
+});

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -135,7 +135,7 @@ export class Workbench {
 		this.notebooksPositron = new PositronNotebooks(code, this.quickInput, this.quickaccess, this.hotKeys, this.contextMenu);
 		this.welcome = new Welcome(code);
 		this.terminal = new Terminal(code, this.quickaccess);
-		this.viewer = new Viewer(code);
+		this.viewer = new Viewer(code, this.contextMenu);
 		this.editor = new Editor(code, this.toasts);
 		this.testExplorer = new TestExplorer(code);
 		this.outline = new Outline(code, this.quickaccess);

--- a/test/e2e/pages/viewer.ts
+++ b/test/e2e/pages/viewer.ts
@@ -5,12 +5,15 @@
 
 import test, { expect, FrameLocator, Locator } from '@playwright/test';
 import { Code } from '../infra/code';
+import { ContextMenu } from './dialog-contextMenu.js';
 
 const OUTER_FRAME = '.webview';
 const INNER_FRAME = '#active-frame';
 const REFRESH_BUTTON = '.codicon-positron-refresh';
 const VIEWER_PANEL = '[id="workbench.panel.positronPreview"]';
 const ACTION_BAR = '.positron-action-bar';
+const OPEN_IN_DROPDOWN_BUTTON = '.preview-action-bar .action-bar-button-drop-down-button[aria-label="Select where to open"]';
+const OPEN_IN_PRIMARY_BUTTON = '.preview-action-bar .action-bar-button-action-button[aria-label="Select where to open"]';
 
 const FULL_APP = 'body';
 
@@ -20,7 +23,7 @@ export class Viewer {
 	get viewerFrame(): FrameLocator { return this.code.driver.currentPage.frameLocator(OUTER_FRAME).frameLocator(INNER_FRAME); }
 	get interruptButton(): Locator { return this.code.driver.currentPage.locator(ACTION_BAR).getByRole('button', { name: 'Interrupt execution' }); }
 
-	constructor(private code: Code) { }
+	constructor(private code: Code, private contextMenu: ContextMenu) { }
 
 	getViewerLocator(locator: string): Locator {
 		return this.viewerFrame.locator(locator);
@@ -50,7 +53,20 @@ export class Viewer {
 	}
 
 	async openViewerToEditor() {
-		await this.code.driver.currentPage.locator('.codicon-go-to-file').click();
+		await test.step('Open Viewer content in editor tab via "Open in..." dropdown', async () => {
+			const dropdownButton = this.code.driver.currentPage.locator(OPEN_IN_DROPDOWN_BUTTON);
+			await this.contextMenu.triggerAndClick({
+				menuTrigger: dropdownButton,
+				menuItemLabel: /Open in Editor Tab$/,
+				menuItemType: 'menuitemcheckbox'
+			});
+		});
+	}
+
+	async clickOpenInPrimaryButton() {
+		await test.step('Click primary half of "Open in..." split button', async () => {
+			await this.code.driver.currentPage.locator(OPEN_IN_PRIMARY_BUTTON).click();
+		});
 	}
 
 	async expectViewerPanelVisible(timeout = 10000): Promise<void> {


### PR DESCRIPTION
Fixes #13068, finishing the Viewer pane after #13592 covered the Plots pane

This PR reworks the Viewer pane action bar to consolidate its two "Open somewhere else" buttons ("Open in Browser" and "Open in Editor Tab") into a single split button dropdown on the right side. It uses the same Positron custom icon as the Plots dropdown and the editor pane, so all three places now match! The dropdown applies to both viewer variants, the URL viewer (Shiny / Streamlit / dashboards):

<img width="551" height="410" alt="Screenshot 2026-05-18 at 8 06 00 PM" src="https://github.com/user-attachments/assets/cc4e6795-da83-4f0a-b57d-4707b75f4dde" />

And the HTML viewer (HTML file, Quarto preview):

<img width="558" height="540" alt="Screenshot 2026-05-18 at 8 06 35 PM" src="https://github.com/user-attachments/assets/fa4c5ff0-6b86-4c3c-bb48-079d98ed8629" />


I set this up with the same persistence pattern as #13592:

- The split button's primary (icon) click repeats the user's most recent choice.
- The choice is persisted via the preview service, so it survives switching content types, switching between the URL and HTML viewers, and reloading the window. Both viewer variants share one preference.
- When no prior choice exists, the menu visually checks the fallback (Browser) so the user can see what the primary click will do.

User-facing strings are now title case to match the project style: "Open in Browser", "Open in Editor Tab".

While I was here, I also registered a couple of long-lived disposables (`DisposableMap`, the two `Emitter`s) on `PositronPreviewService` that had been leaking at service-shutdown time. IIUC it would be harmless in production (the service is a singleton) but it was flagged by the new vitest coverage, which is pretty nice!

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Consolidate the Viewer pane's "Open in..." actions into a single dropdown with consistent placement and iconography (#13068)

### Validation Steps

@:apps @:viewer @:quarto @:web @:win

1. Start a Python Shiny or Streamlit app so its output appears in the Viewer.
2. Confirm the action bar shows a single "Open in..." split-button on the right (next to Clear), with no separate browser or editor icons.
3. Open the dropdown. Confirm it lists "Open in Browser" and "Open in Editor Tab".
4. Click "Open in Editor Tab". Confirm the content opens in an editor tab.
5. Return to the Viewer, reopen the dropdown, and confirm "Open in Editor Tab" is now checked.
6. Click the split button's icon area (not the caret). Confirm it repeats the "Open in Editor Tab" action.
7. Click "Open in Browser". Confirm the content opens in the system browser.
8. Reopen the dropdown. Confirm "Open in Browser" is now checked.
9. Reload the window. Confirm the checked option is preserved.
10. Open an HTML preview (for example a Quarto `quarto preview` output, or an htmlwidget). Confirm the same dropdown appears with the same two options and the same checked state shared across viewer types.
