### PR TITLE
skills: add test value and falsifiability checks to vitest author/review skills

### DIFF
--- a/.claude/skills/author-vitest-tests/SKILL.md
+++ b/.claude/skills/author-vitest-tests/SKILL.md
@@ -117,13 +117,13 @@ Format the plan like this:
 >
 > **Stubs:** short list of services you intend to stub, with a one-line reason each
 >
-> **Test cases:** (annotate tests that will use `toMatchInlineSnapshot()` with `[snapshot]`)
+> **Test cases:** (annotate tests that will use `toMatchInlineSnapshot()` with `[snapshot]`; for each, add a one-line regression hypothesis — what breaks in the product if this test fails?)
 > - **<describe block 1>**
->   - <test name 1>
->   - <test name 2> `[snapshot]`
+>   - <test name 1> — *<regression hypothesis>*
+>   - <test name 2> `[snapshot]` — *<regression hypothesis>*
 > - **<describe block 2>**
->   - <test name 3>
->   - <test name 4> `[snapshot]`
+>   - <test name 3> — *<regression hypothesis>*
+>   - <test name 4> `[snapshot]` — *<regression hypothesis>*
 >
 > Total: <bullet count> tests (<snapshot count> snapshots). Anything you want added, dropped, or reshaped before I write?
 
@@ -192,6 +192,7 @@ Present the dev with a summary:
 
 ## Hard rules
 
+- **Test for regressions, not coverage.** Before writing any test, state what user-visible or system-observable regression it guards against. If you can't answer, skip the test. A test that verifies an internal counter, array index, or call count — where the real invariant is a downstream side-effect — is testing structure, not behavior. Coverage is a side-effect of good tests, not a goal.
 - **Don't over-test.** Test public behavior, not implementation details.
 - **Don't export internals for testing.** Test behavior through rendered output or public API.
 - **Don't write E2E tests.** Flag for E2E if needed, but don't write them.

--- a/.claude/skills/author-vitest-tests/SKILL.md
+++ b/.claude/skills/author-vitest-tests/SKILL.md
@@ -117,13 +117,13 @@ Format the plan like this:
 >
 > **Stubs:** short list of services you intend to stub, with a one-line reason each
 >
-> **Test cases:** (annotate tests that will use `toMatchInlineSnapshot()` with `[snapshot]`; for each, add a one-line regression hypothesis — what breaks in the product if this test fails?)
+> **Test cases:** (annotate tests that will use `toMatchInlineSnapshot()` with `[snapshot]`)
 > - **<describe block 1>**
->   - <test name 1> — *<regression hypothesis>*
->   - <test name 2> `[snapshot]` — *<regression hypothesis>*
+>   - <test name 1>
+>   - <test name 2> `[snapshot]`
 > - **<describe block 2>**
->   - <test name 3> — *<regression hypothesis>*
->   - <test name 4> `[snapshot]` — *<regression hypothesis>*
+>   - <test name 3>
+>   - <test name 4> `[snapshot]`
 >
 > Total: <bullet count> tests (<snapshot count> snapshots). Anything you want added, dropped, or reshaped before I write?
 

--- a/.claude/skills/review-vitest-tests/SKILL.md
+++ b/.claude/skills/review-vitest-tests/SKILL.md
@@ -21,6 +21,14 @@ $ARGUMENTS should contain the test file path(s) to review. For each test file, a
 
 Evaluate each test file against this checklist. Report ONLY items that fail -- don't list passing items. Also flag any cross-file inconsistencies (e.g., same service stubbed differently, different assertion styles for the same pattern).
 
+### 0. Test value and falsifiability
+
+For each test, ask: **what specific production code change would make it fail, and does that change represent a user-visible or system-observable regression?**
+
+Flag any test where the answer is "I'm not sure" or where the test only verifies an implementation detail with no behavioral consequence — e.g., an internal counter value, a private array index, or a call count when the real invariant is a downstream side-effect. Coverage is a side-effect of good tests, not a goal. Every test should guard a specific regression that would matter.
+
+Concrete check: mentally delete or mutate the production code path the test exercises. Would a user or the system notice the breakage? If not, the test is verifying structure, not behavior — flag it with a suggested behavioral rewrite or recommend dropping it.
+
 ### 1. Unused declarations and import bloat
 
 Any variables, emitters, or imports declared but never referenced in a test? Suite-level `let` variables that only exist for setup wiring should be inlined into the stub objects instead. Also flag excessive imports: if 5+ service identifiers are imported only for `.stub()` calls, suggest extracting the stubs into a helper function to reduce the import block.


### PR DESCRIPTION
### Summary
Adds explicit guidance to both vitest skills that tests should guard real regressions, not just add coverage.

- \`review-vitest-tests\`: new checklist item #0 -- for each test, ask what production code change would make it fail and whether that represents an observable regression; flag tests that only verify implementation details
- \`author-vitest-tests\`: new hard rule -- before writing any test, state what regression it guards against; coverage is a side-effect of good tests, not a goal

### QA Notes
Skill-only change, no source code affected.