### PR TITLE
E2E test: add PR handling for running remote ssh tests

### DIFF
--- a/.github/workflows/build-remote-ssh-linux.yml
+++ b/.github/workflows/build-remote-ssh-linux.yml
@@ -1,0 +1,106 @@
+name: "Build: Remote SSH (Linux x64)"
+
+on:
+  workflow_call:
+    outputs:
+      artifact-name:
+        description: "Name of the deb artifact uploaded"
+        value: ${{ jobs.build-deb.outputs.artifact-name }}
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build-deb:
+    name: Build Positron DEB for Remote SSH Tests
+    runs-on: ubuntu-latest-8x
+    timeout-minutes: 180
+    outputs:
+      artifact-name: positron-deb-remote-ssh-x64
+    container:
+      image: ghcr.io/posit-dev/positron-builds-rocky8:3
+      credentials:
+        username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
+        password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      POSITRON_BUILD_NUMBER: 0
+      BUILD_SOURCEVERSION: ${{ github.sha }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Configure Git safe directory
+        run: |
+          git config --global --add safe.directory '*'
+          git rev-parse --show-toplevel
+
+      - name: Install build dependencies
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+          npm_config_arch: x64
+        shell: scl enable gcc-toolset-14 -- bash -eo pipefail {0}
+        run: |
+          # Check versions
+          g++ --version
+          python3 --version
+          pip --version
+
+          # Install build dependencies
+          npm install --prefix build --fetch-timeout 120000
+
+          # Install main dependencies
+          npm ci --fetch-timeout 120000
+
+      - name: Build Positron Client
+        env:
+          npm_config_arch: x64
+          MANGLER_WORKER_POOL_SIZE: 1
+        run: |
+          echo "Building Positron Client with commit SHA: ${{ env.BUILD_SOURCEVERSION }}"
+          npm run gulp vscode-linux-x64
+
+      - name: Correct Permissions
+        run: |
+          pushd ../VSCode-linux-x64/resources/app/extensions
+          find . -type f -name "*.ts" -exec chmod -x {} +
+          sed -i 's|#!/usr/bin/env python\b|#!/usr/bin/env python3|g' positron-python/python_files/lib/ipykernel/py3/jupyter_core/troubleshoot.py
+          popd
+
+      - name: Prepare Linux packages
+        env:
+          STRIP: /usr/bin/true
+          PERL5LIB: /root/.cpan/build:$PERL5LIB
+        run: |
+          npm run gulp vscode-linux-x64-prepare-deb
+
+      - name: Build DEB package
+        env:
+          STRIP: /usr/bin/true
+        run: |
+          echo "Building Positron DEB with commit SHA: ${{ env.BUILD_SOURCEVERSION }}"
+          npm run gulp vscode-linux-x64-build-deb
+          DEB_FILENAME="Positron-remote-ssh-x64.deb"
+          mv .build/linux/deb/*/deb/*.deb "$DEB_FILENAME"
+
+      - name: Upload DEB artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: positron-deb-remote-ssh-x64
+          path: Positron-remote-ssh-x64.deb
+          retention-days: 1

--- a/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
+++ b/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
@@ -1,0 +1,175 @@
+name: "Test: E2E Remote SSH (Ubuntu)"
+
+on:
+  workflow_call:
+    inputs:
+      grep:
+        required: false
+        description: "Only run tests matching this regex. Supports tags (comma-separated), titles, filenames."
+        default: "@:remote-ssh"
+        type: string
+      display_name:
+        required: false
+        description: "The name of the job as it will appear in the GitHub Actions UI."
+        default: "remote-ssh"
+        type: string
+      upload_logs:
+        required: false
+        description: "Whether or not to upload e2e test logs."
+        type: boolean
+        default: true
+      allow_soft_fail:
+        required: false
+        description: "Whether to allow tests marked with :soft-fail to fail without failing the job."
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
+jobs:
+  e2e-remote-ssh-ubuntu:
+    name: ${{ inputs.display_name || 'remote-ssh' }}
+    runs-on: ubuntu-latest-8x
+    timeout-minutes: 80
+
+    env:
+      AWS_S3_BUCKET: positron-test-reports
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      R_LIBS_SITE: /usr/local/lib/R/site-library
+      R_LIBS_USER: /usr/local/lib/R/site-library
+      GH_SUMMARY_REPORT: true
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
+          password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
+          aws-region: ${{ secrets.QA_AWS_REGION }}
+
+      - name: Setup test dependencies and compile tests
+        uses: ./.github/actions/setup-e2e-test-dependencies
+
+      - name: Download DEB artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: "positron-deb-remote-ssh-x64"
+          path: /tmp/artifacts
+
+      - name: Install Positron from DEB
+        run: |
+          sudo apt-get update && sudo apt-get install -y xdg-utils
+          sudo dpkg -i /tmp/artifacts/Positron-remote-ssh-x64.deb
+
+      - name: Start Docker Container
+        run: |
+          docker run -d --name test -p 3456:22 ghcr.io/posit-dev/positron-ubuntu24-amd64:116 \
+            /bin/bash -c 'while true; do sleep 3600; done'
+
+      - name: Download SSH install script
+        run: |
+          curl -L -o ssh-install.sh https://raw.githubusercontent.com/posit-dev/qa-example-content/main/dockerfiles/arm-local/ssh-install.sh
+          docker cp ssh-install.sh test:/tmp/ssh-install.sh
+          docker exec test chmod +x /tmp/ssh-install.sh
+
+      - name: Install SSH in container
+        run: |
+          docker exec test /bin/bash -c "/tmp/ssh-install.sh"
+
+      - name: Configure xvfb and dbus
+        uses: ./.github/actions/setup-xvfb
+
+      - name: Configure SSH host "remote"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+
+          touch /tmp/known_hosts
+          chmod 644 /tmp/known_hosts
+          ssh-keyscan -p 3456 127.0.0.1 >> /tmp/known_hosts 2>/dev/null || true
+
+          tmpcfg="$(mktemp)"
+          if [[ -f ~/.ssh/config ]]; then
+            awk '
+              BEGIN{skip=0}
+              $1=="Host" && $2=="remote"{skip=1; next}
+              skip && $1=="Host"{skip=0}
+              !skip{print}
+            ' ~/.ssh/config > "$tmpcfg"
+          fi
+
+          {
+            echo "Host remote"
+            echo "  HostName 127.0.0.1"
+            echo "  Port 3456"
+            echo "  User root"
+            echo "  UserKnownHostsFile /tmp/known_hosts"
+            echo "  StrictHostKeyChecking yes"
+          } >> "$tmpcfg"
+
+          mv "$tmpcfg" ~/.ssh/config
+          chmod 600 ~/.ssh/config
+
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12.6'
+
+      - name: Generate Report Directory
+        uses: ./.github/actions/gen-report-dir
+        with:
+          identifier: e2e-remote-ssh
+
+      - name: Run tests (host → container)
+        env:
+          POSITRON_PY_VER_SEL: "3.12.6"
+          POSITRON_R_VER_SEL: 4.5.2
+          POSITRON_PY_ALT_VER_SEL: "3.13.0"
+          POSITRON_R_ALT_VER_SEL: 4.4.2
+          POSITRON_PY_REMOTE_VER_SEL: 3.10.12
+          POSITRON_R_REMOTE_VER_SEL: 4.5.2
+          PWTEST_BLOB_DO_NOT_REMOVE: 1
+          REPORTER_REPO_NAME: positron
+          CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+          PW_PROJECT_NAME: e2e-remote-ssh
+        run: |
+          export DISPLAY=:10
+          BUILD=/usr/share/positron npx playwright test --project e2e-remote-ssh --retries=1 --workers=1 --grep="${{ inputs.grep }}"
+
+      - name: Upload Playwright Report to S3
+        if: always()
+        uses: ./.github/actions/upload-report-to-s3
+        with:
+          role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
+          report-dir: ${{ env.REPORT_DIR }}
+
+      - name: Upload Test Logs
+        if: ${{ always() && inputs.upload_logs }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-remote-ssh-ubuntu-logs
+          path: test-logs
+          retention-days: 3
+          if-no-files-found: ignore
+
+      - name: Teardown
+        if: always()
+        run: |
+          docker stop -t 10 test || true
+          docker rm -f test || true

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -31,6 +31,7 @@ jobs:
       workbench_tag_found: ${{ steps.pr-tags.outputs.workbench_tag_found }}
       workbench_stable_tag_found: ${{ steps.pr-tags.outputs.workbench_stable_tag_found }}
       jupyter_tag_found: ${{ steps.pr-tags.outputs.jupyter_tag_found }}
+      remote_ssh_tag_found: ${{ steps.pr-tags.outputs.remote_ssh_tag_found }}
 
     steps:
       - uses: actions/checkout@v6
@@ -257,6 +258,25 @@ jobs:
       grep: ${{ needs.pr-tags.outputs.tags }}
       display_name: "jupyter"
       install_license: true
+      upload_logs: false
+      allow_soft_fail: false
+    secrets: inherit
+
+  build-remote-ssh:
+    needs: pr-tags
+    if: ${{ needs.pr-tags.outputs.remote_ssh_tag_found == 'true' }}
+    name: build
+    uses: ./.github/workflows/build-remote-ssh-linux.yml
+    secrets: inherit
+
+  e2e-remote-ssh:
+    needs: [pr-tags, build-remote-ssh]
+    if: ${{ needs.pr-tags.outputs.remote_ssh_tag_found == 'true' }}
+    name: e2e
+    uses: ./.github/workflows/test-e2e-remote-ssh-ubuntu.yml
+    with:
+      grep: ${{ needs.pr-tags.outputs.tags }}
+      display_name: "remote-ssh"
       upload_logs: false
       allow_soft_fail: false
     secrets: inherit

--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -87,6 +87,10 @@ if echo "$PR_BODY" | grep -q "@:jupyter"; then
 	echo "Found jupyter tag in PR body. Setting to run jupyter tests."
 	echo "jupyter_tag_found=true" >> "$GITHUB_OUTPUT"
 fi
+if echo "$PR_BODY" | grep -q "@:remote-ssh"; then
+	echo "Found remote-ssh tag in PR body. Setting to run remote-ssh tests."
+	echo "remote_ssh_tag_found=true" >> "$GITHUB_OUTPUT"
+fi
 
 # Check if @:all is present in the PR body
 if echo "$PR_BODY" | grep -q "@:all"; then


### PR DESCRIPTION
Handling for the remote-ssh tag. When PRs are tagged, the remote SSH tests will run against a freshly built installer.