### PR TITLE
Open same-origin URLs internally in Help pane

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
@@ -511,10 +511,15 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 					// positron-help-navigate message.
 					case 'positron-help-navigate': {
 						// Determine whether to open the URL externally; otherwise, open it in the
-						// help service. This obviously isn't an exact science. At the moment, we
-						// open PDFs externally.
+						// help service. This obviously isn't an exact science. We open PDFs
+						// externally, and we open URLs externally when they're neither localhost
+						// nor on the same origin as the help proxy hosting this entry. The
+						// same-origin check is what lets relative help links resolve internally
+						// when Positron Server is hosted at a non-localhost authority.
 						const url = new URL(message.url);
-						if (!isLocalhost(url.hostname) || url.pathname.toLowerCase().endsWith('.pdf')) {
+						const sourceUrl = new URL(this.sourceUrl);
+						if (url.pathname.toLowerCase().endsWith('.pdf') ||
+							(!isLocalhost(url.hostname) && url.origin !== sourceUrl.origin)) {
 							try {
 								await this._openerService.open(message.url, {
 									openExternal: true


### PR DESCRIPTION
This change fixes an issue that causes links in the Help pane to open in external tabs instead of in the Help pane itself.

The issue is that all non-localhost URLs are opened externally, which makes sense in local dev environments but doesn't hold on Workbench. The fix is to broaden the check so that any URLs on the same origin as Positron Server itself are opened internally.

Fixes https://github.com/posit-dev/positron/issues/13179. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Workbench: Fix issue causing all links in Help pane to open in new tabs instead of inside the Help pane (#13179) 


### Validation Steps

Available in the bug. It is important to also validate the converse: that external URLs continue to open up _outside_ the help pane.

Also note: this _only_ repros when running Positron Server at a non-localhost URL, so it will not reproduce even in Workbench if you host it at `localhost`. 

<img width="584" height="240" alt="image" src="https://github.com/user-attachments/assets/0ba41bc3-d97d-408c-92fb-f79d293b7ec8" />

Test tags: `@:help` 