### PR TITLE
Add S3 HTML report support (Path B) to e2e failure analyzer

### DIFF
--- a/.claude/skills/e2e-failure-analyzer/SKILL.md
+++ b/.claude/skills/e2e-failure-analyzer/SKILL.md
@@ -26,7 +26,8 @@ Scripts live alongside this skill in `scripts/`. Use the base directory path sho
 ### Consolidated scripts (preferred -- fewer tool calls)
 
 - **`e2e-gather-run-info.js`** - Gathers all run metadata, failed jobs, artifacts, non-e2e job log excerpts, and commit info in one call. Replaces multiple `gh api` invocations.
-- **`e2e-process-project.js`** - Processes a merged blob report project end-to-end: extracts failures, scans blobs, extracts/parses traces, extracts screenshots and error-context. Replaces multiple script + unzip invocations.
+- **`e2e-process-project.js`** - **Path A.** Processes a merged blob report project end-to-end: extracts failures, scans blobs, extracts/parses traces, extracts screenshots and error-context. Replaces multiple script + unzip invocations.
+- **`e2e-process-s3.js`** - **Path B.** Processes a CloudFront-hosted Playwright HTML report end-to-end: fetches `index.html`, decodes the embedded base64 `report.zip`, downloads trace + error-context attachments from S3, parses traces, and extracts screencast frames. Produces the same JSON shape as `e2e-process-project.js` so the downstream analyzer treats both paths identically.
 
 ### Standalone scripts (used by consolidated scripts internally, or for ad-hoc debugging)
 
@@ -113,86 +114,24 @@ Output JSON contains:
 
 ## Path B: posit-dev/positron-builds (S3 HTML Reports)
 
-Use the failed e2e jobs already identified in Step 1a. For each failed e2e job:
+### Process the HTML report (single script call)
 
-### B1: Extract Failure Details from Job Logs
+The `e2e-process-s3.js` script handles everything in one call: fetches the report's `index.html`, decodes the embedded base64 `report.zip`, walks failures + per-file detail JSONs, downloads trace and error-context attachments from S3, parses traces, and extracts trailing screencast frames.
 
-The job logs contain full Playwright test output including error messages, stack traces, and attachment paths:
-
-```bash
-gh api repos/posit-dev/positron-builds/actions/jobs/<JOB_ID>/logs 2>&1 | grep -A 20 -E "^\s+\d+\) \[" | head -100
-```
-
-This gives the full test failure output including:
-- Test name and tags
-- Error messages and stack traces
-- Attachment paths (trace, logs, screenshots)
-
-### B2: Get Report URL from Job Logs
-
-The job log contains the S3 report URL:
+For **each** failed e2e job from Step 1, resolve the job's `REPORT_DIR` from its logs (the workflow logs both an unresolved template line containing literal `${IDENTIFIER}` / `${OS_SUFFIX}` and the expanded value -- ignore the template), then run:
 
 ```bash
-gh api repos/posit-dev/positron-builds/actions/jobs/<JOB_ID>/logs 2>&1 | grep -oE 'REPORT_DIR=playwright-report-[^ ]+' | head -1
+node "$SKILL_DIR/scripts/e2e-process-s3.js" \
+  --report-url https://d38p2avprg8il3.cloudfront.net/<REPORT_DIR>/ \
+  --output-dir /tmp/e2e-analysis-<JOB_LABEL> \
+  --cleanup
 ```
 
-The base URL pattern is: `https://d38p2avprg8il3.cloudfront.net/<REPORT_DIR>/`
+For interactive / ad-hoc use, you can call the script directly with any CloudFront-hosted Playwright HTML report URL -- no run ID required.
 
-### B3: Download Screenshots from S3
+Output JSON is identical to Path A's `e2e-process-project.js` (see the field list above), so the same screenshot-reading and analysis flow applies. The `blob` field is the report directory name (last path segment of the S3 URL) rather than a zip filename, since Path B has no blob zips.
 
-The HTML report's `data/` directory contains PNGs (on-test-end screenshots) and ZIPs (traces, logs). Find PNG filenames from the upload log:
-
-```bash
-gh api repos/posit-dev/positron-builds/actions/jobs/<JOB_ID>/logs 2>&1 | grep -oE 'data/[a-f0-9]+\.png' | sort -u
-```
-
-Download and view each PNG with the Read tool:
-```bash
-curl -s -o /tmp/pw-screenshot-N.png "https://d38p2avprg8il3.cloudfront.net/<REPORT_DIR>/data/<HASH>.png"
-```
-
-There are typically only 5-15 PNGs per job (one per failed/flaky test attempt). Download all and view them.
-
-### B4: Download Traces from S3
-
-Find trace zips by checking sizes of data/ zips (traces are typically >1MB while logs are <500KB):
-
-```bash
-# Get all data zip hashes from upload log
-ZIPS=$(gh api repos/posit-dev/positron-builds/actions/jobs/<JOB_ID>/logs 2>&1 | grep -oE 'data/[a-f0-9]+\.zip' | sort -u)
-
-# Check sizes to find traces (>1MB)
-for hash in $(echo "$ZIPS" | sed 's|data/||' | head -30); do
-  size=$(curl -sI "https://d38p2avprg8il3.cloudfront.net/<REPORT_DIR>/data/${hash}" | grep -i content-length | awk '{print $2}' | tr -d '\r')
-  [ "$size" -gt 1000000 ] 2>/dev/null && echo "$size $hash"
-done | sort -rn
-```
-
-Download and verify trace zips:
-```bash
-curl -s -o /tmp/pw-trace.zip "https://d38p2avprg8il3.cloudfront.net/<REPORT_DIR>/data/<HASH>.zip"
-unzip -l /tmp/pw-trace.zip | head -5  # Should show trace.trace + resources/*.jpeg
-```
-
-Then extract and parse the trace using the same script as Path A:
-```bash
-mkdir -p /tmp/trace-contents && unzip -o /tmp/pw-trace.zip trace.trace -d /tmp/trace-contents
-node "$SKILL_DIR/scripts/e2e-parse-trace.js" /tmp/trace-contents/trace.trace
-```
-
-Extract the last screenshot from the trace zip using the sha1 from the script output:
-```bash
-unzip -o /tmp/pw-trace.zip "resources/<LAST_SCREENSHOT>.jpeg" -d /tmp/trace-contents
-```
-
-### B5: Download Logs from S3
-
-Logs zips are typically 300-500KB and contain `e2e-test-runner.log`, `main.log`, `window1/` directory, etc:
-
-```bash
-curl -s -o /tmp/pw-logs.zip "https://d38p2avprg8il3.cloudfront.net/<REPORT_DIR>/data/<HASH>.zip"
-unzip -l /tmp/pw-logs.zip | head -5  # Should show e2e-test-runner.log, main.log, etc.
-```
+**IMPORTANT: View screenshots** the same way as Path A -- Read all `screenshotPaths` arrays in a single message with multiple parallel Read tool calls, and view `errorContextPath` files when the screenshot and trace timeline aren't enough.
 
 ---
 
@@ -315,13 +254,8 @@ Offer to:
 
 ## Cleanup
 
-**Path A**: If you used `--cleanup` with `e2e-process-project.js`, the download/merge artifacts are already removed. Only the `--output-dir` remains (screenshots and error-context). Remove it with exact paths (no globs):
+**Path A and Path B**: If you used `--cleanup` with `e2e-process-project.js` / `e2e-process-s3.js`, the intermediate download/unzip dirs are already removed. Only the `--output-dir` remains (screenshots and error-context). Remove it with exact paths (no globs):
 
 ```bash
-rm -rf /tmp/e2e-analysis-<PROJECT>
-```
-
-**Path B**: Remove artifacts with exact paths:
-```bash
-rm -rf /tmp/pw-screenshots /tmp/pw-traces /tmp/pw-logs
+rm -rf /tmp/e2e-analysis-<PROJECT_OR_JOB_LABEL>
 ```

--- a/.claude/skills/e2e-failure-analyzer/scripts/e2e-process-s3.js
+++ b/.claude/skills/e2e-failure-analyzer/scripts/e2e-process-s3.js
@@ -1,0 +1,424 @@
+#!/usr/bin/env node
+// Processes a CloudFront-hosted Playwright HTML report end-to-end (positron-builds
+// non-sharded runs). Fetches index.html, decodes the embedded base64 report.zip,
+// reads report.json + per-file detail JSONs, downloads trace and error-context
+// attachments from S3, parses traces, and extracts screencast frames.
+//
+// Output JSON matches e2e-process-project.js exactly so analyze.mjs handles
+// Path A and Path B interchangeably.
+//
+// Usage:
+//   node e2e-process-s3.js --report-url <S3_URL> --output-dir <DIR> \
+//     [--last N] [--screenshots N] [--cleanup]
+//
+// <S3_URL> is a Playwright HTML report base URL, e.g.:
+//   https://d38p2avprg8il3.cloudfront.net/playwright-report-<run>-<attempt>-<id>-<os>/
+//
+// Options:
+//   --report-url <url>   CloudFront base URL of the Playwright HTML report (required)
+//   --output-dir <dir>   Where to save screenshots and error-context (required)
+//   --last <N>           Number of trace actions to show (default: 500)
+//   --screenshots <N>    Number of trailing screencast frames to extract per attempt (default: 3)
+//   --cleanup            Remove the intermediate tmp dir after processing (default: keep)
+
+import { readFileSync, existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join, resolve } from 'path';
+import { execFileSync } from 'child_process';
+import { tmpdir } from 'os';
+import { randomBytes } from 'crypto';
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+const cliArgs = process.argv.slice(2);
+let reportUrl = null;
+let outputDir = null;
+let lastN = 500;
+let screenshotsN = 3;
+let doCleanup = false;
+
+function parseNonNegInt(name, raw) {
+	const n = Number(raw);
+	if (!Number.isInteger(n) || n < 0) {
+		console.error(`Invalid ${name}: ${raw} (expected non-negative integer)`);
+		process.exit(1);
+	}
+	return n;
+}
+
+for (let i = 0; i < cliArgs.length; i++) {
+	switch (cliArgs[i]) {
+		case '--report-url': reportUrl = cliArgs[++i]; break;
+		case '--output-dir': outputDir = cliArgs[++i]; break;
+		case '--last': lastN = parseNonNegInt('--last', cliArgs[++i]); break;
+		case '--screenshots': screenshotsN = parseNonNegInt('--screenshots', cliArgs[++i]); break;
+		case '--cleanup': doCleanup = true; break;
+		default:
+			console.error(`Unknown argument: ${cliArgs[i]}`);
+			process.exit(1);
+	}
+}
+
+if (!reportUrl || !outputDir) {
+	console.error('Usage: node e2e-process-s3.js --report-url <S3_URL> --output-dir <DIR> [--last N] [--screenshots N] [--cleanup]');
+	process.exit(1);
+}
+
+// Normalize report URL to end with a single slash for clean joins.
+if (!reportUrl.endsWith('/')) { reportUrl += '/'; }
+
+// Last non-empty path segment of the URL serves as the "blob" id (traceability
+// only; Path B has no actual blob zip).
+const blobName = (() => {
+	try {
+		const u = new URL(reportUrl);
+		const parts = u.pathname.split('/').filter(Boolean);
+		return parts[parts.length - 1] || u.hostname;
+	} catch {
+		return reportUrl.replace(/\/+$/, '').split('/').pop() || 'unknown';
+	}
+})();
+
+const resolvedOutputDir = resolve(outputDir);
+mkdirSync(join(resolvedOutputDir, 'screenshots'), { recursive: true });
+mkdirSync(join(resolvedOutputDir, 'error-context'), { recursive: true });
+
+const tmpWorkDir = join(tmpdir(), `e2e-process-s3-${randomBytes(4).toString('hex')}`);
+mkdirSync(tmpWorkDir, { recursive: true });
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FAIL = new Set(['failed', 'timedOut', 'interrupted']);
+
+async function fetchToBuffer(url) {
+	const res = await fetch(url);
+	if (!res.ok) {
+		throw new Error(`HTTP ${res.status} ${res.statusText} for ${url}`);
+	}
+	const ab = await res.arrayBuffer();
+	return Buffer.from(ab);
+}
+
+async function fetchToFile(url, destPath) {
+	const buf = await fetchToBuffer(url);
+	writeFileSync(destPath, buf);
+	return destPath;
+}
+
+/** Extract a single file from a zip to a destination directory. Returns the extracted path or null. */
+function unzipFile(zipPath, entryPath, destDir) {
+	try {
+		mkdirSync(destDir, { recursive: true });
+		execFileSync('unzip', ['-o', zipPath, entryPath, '-d', destDir], {
+			stdio: ['pipe', 'pipe', 'pipe'],
+		});
+		const extracted = join(destDir, entryPath);
+		return existsSync(extracted) ? extracted : null;
+	} catch {
+		return null;
+	}
+}
+
+function unzipAll(zipPath, destDir) {
+	mkdirSync(destDir, { recursive: true });
+	execFileSync('unzip', ['-o', zipPath, '-d', destDir], {
+		stdio: ['pipe', 'pipe', 'pipe'],
+	});
+}
+
+/**
+ * Parse a Playwright trace.trace file into a timeline plus the trailing
+ * screencast frames. Identical to the parser in e2e-process-project.js; kept
+ * inline here to avoid cross-script imports.
+ */
+function parseTrace(tracePath) {
+	const content = readFileSync(tracePath, 'utf8');
+	const lines = content.split('\n').filter(Boolean);
+	const events = [];
+	for (const line of lines) {
+		try { events.push(JSON.parse(line)); } catch { /* skip */ }
+	}
+
+	const actions = events.filter(e => e.type === 'before' || e.type === 'after');
+	const recent = lastN === 0 ? [] : actions.slice(-lastN);
+
+	const timelineLines = [];
+	timelineLines.push(`=== Action Timeline (last ${recent.length} of ${actions.length} events) ===\n`);
+
+	for (const a of recent) {
+		if (a.type === 'before') {
+			let info = `${a.class || '?'}.${a.method || '?'}`;
+			if (a.startTime != null) info += ` (t=${Math.round(a.startTime)})`;
+			if (a.params?.selector) info += ` selector: ${a.params.selector}`;
+			if (a.params?.url) info += ` url: ${a.params.url}`;
+			timelineLines.push(`[before] ${info}`);
+		} else {
+			const err = a.error?.message?.slice(0, 300);
+			if (err) {
+				timelineLines.push(`[after]  ERROR: ${err}`);
+			} else {
+				let info = 'ok';
+				if (a.endTime != null) info += ` (t=${Math.round(a.endTime)})`;
+				timelineLines.push(`[after]  ${info}`);
+			}
+		}
+	}
+
+	const screenshots = events.filter(e => e.type === 'screencast-frame');
+	const trailingScreenshots = screenshotsN === 0 ? [] : screenshots.slice(-screenshotsN);
+	const lastScreenshot = trailingScreenshots.length > 0 ? trailingScreenshots[trailingScreenshots.length - 1] : null;
+
+	if (trailingScreenshots.length > 0) {
+		timelineLines.push(`\n=== Screenshots ===`);
+		timelineLines.push(`Total screencast frames: ${screenshots.length}`);
+		timelineLines.push(`Extracting last ${trailingScreenshots.length} frame(s):`);
+		for (let i = 0; i < trailingScreenshots.length; i++) {
+			const s = trailingScreenshots[i];
+			timelineLines.push(`  [${i}] sha1=${s.sha1} timestamp=${s.timestamp}`);
+		}
+	}
+
+	const errorEvents = events.filter(e => e.type === 'after' && e.error);
+	const errors = errorEvents.map(e => (e.error.message || '').slice(0, 500));
+
+	if (errors.length > 0) {
+		timelineLines.push(`\n=== Errors (${errors.length}) ===`);
+		for (const err of errors) {
+			timelineLines.push(`- ${err}`);
+		}
+	}
+
+	return {
+		timeline: timelineLines.join('\n'),
+		errors,
+		screenshotShas: trailingScreenshots.map(s => ({ sha1: s.sha1, timestamp: s.timestamp })),
+		lastScreenshotSha1: lastScreenshot?.sha1 || null,
+	};
+}
+
+/**
+ * Extract the playwrightReportBase64 payload from a Playwright HTML report's
+ * index.html. The template element holds a `data:application/zip;base64,...`
+ * URL; return just the base64 string.
+ */
+function extractReportBase64(html) {
+	const m = html.match(/<template id="playwrightReportBase64">data:application\/zip;base64,([^<]+)<\/template>/);
+	if (!m) {
+		throw new Error('Could not find <template id="playwrightReportBase64"> in index.html');
+	}
+	return m[1];
+}
+
+/** Extract the sha-style hash from an attachment path like "data/<sha>.zip" or "data/<sha>.md". */
+function hashFromPath(p) {
+	const m = String(p || '').match(/([a-f0-9]{20,})\./);
+	return m ? m[1] : null;
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: download and unpack the embedded report.zip
+// ---------------------------------------------------------------------------
+
+const indexUrl = `${reportUrl}index.html`;
+process.stderr.write(`Fetching ${indexUrl}...\n`);
+const indexHtml = (await fetchToBuffer(indexUrl)).toString('utf8');
+
+process.stderr.write('Extracting embedded report.zip...\n');
+const reportZipPath = join(tmpWorkDir, 'report.zip');
+writeFileSync(reportZipPath, Buffer.from(extractReportBase64(indexHtml), 'base64'));
+
+const reportDir = join(tmpWorkDir, 'report-contents');
+process.stderr.write('Unzipping report archive...\n');
+unzipAll(reportZipPath, reportDir);
+
+const reportJsonPath = join(reportDir, 'report.json');
+if (!existsSync(reportJsonPath)) {
+	console.error(`report.json not found in ${reportDir}`);
+	process.exit(1);
+}
+const report = JSON.parse(readFileSync(reportJsonPath, 'utf8'));
+
+// ---------------------------------------------------------------------------
+// Step 2: walk files, find failed tests, build core arrays
+// ---------------------------------------------------------------------------
+
+const failures = [];
+const failedTests = [];
+const testDetailsList = [];
+
+for (const fileSummary of report.files || []) {
+	const hasFailures = (fileSummary.tests || []).some(t => t.outcome === 'unexpected' || t.outcome === 'flaky');
+	if (!hasFailures) continue;
+
+	const detailPath = join(reportDir, `${fileSummary.fileId}.json`);
+	if (!existsSync(detailPath)) {
+		process.stderr.write(`WARN: detail file missing for ${fileSummary.fileName} (${fileSummary.fileId})\n`);
+		continue;
+	}
+	const detail = JSON.parse(readFileSync(detailPath, 'utf8'));
+
+	for (const test of detail.tests || []) {
+		if (test.outcome !== 'unexpected' && test.outcome !== 'flaky') continue;
+
+		const failedResults = (test.results || []).filter(r => FAIL.has(r.status));
+
+		// HARD failures (exhausted retries) go into the top-level failures[].
+		if (test.outcome === 'unexpected') {
+			failures.push({
+				title: test.title,
+				file: detail.fileName,
+				tags: test.tags || [],
+				suite: (test.path || []).filter(Boolean).join(' > '),
+				project: test.projectName || 'unknown',
+				errors: failedResults.map(r => ({
+					status: r.status,
+					error: (r.errors?.[0]?.message || '').slice(0, 2000),
+					snippet: (r.errors?.[0]?.codeframe || '').slice(0, 1000),
+				})),
+			});
+		}
+
+		// All failed attempts (incl. flaky recoveries) go into failedTests[].
+		for (const r of failedResults) {
+			failedTests.push({
+				testId: test.testId,
+				title: test.title,
+				file: detail.fileName,
+				status: r.status,
+				blob: blobName,
+			});
+		}
+
+		// Stash for the per-attempt processing pass below.
+		testDetailsList.push({ test, detail, failedResults });
+	}
+}
+
+process.stderr.write(`Found ${failures.length} hard failures, ${failedTests.length} failed attempts across ${testDetailsList.length} unique failed tests.\n`);
+
+// ---------------------------------------------------------------------------
+// Step 3: per-attempt processing -- download traces + error-context, parse,
+// extract screencast frames.
+// ---------------------------------------------------------------------------
+
+const testDetails = [];
+
+for (const { test, detail, failedResults } of testDetailsList) {
+	const shortId = test.testId.slice(0, 12);
+	const attempts = [];
+	const logHashes = [];
+
+	for (let i = 0; i < failedResults.length; i++) {
+		const r = failedResults[i];
+		const traceAtt = (r.attachments || []).find(a => a.name === 'trace' && a.contentType === 'application/zip');
+		const errCtxAtt = (r.attachments || []).find(a => a.name === 'error-context' && a.contentType === 'text/markdown');
+		const logsAtts = (r.attachments || []).filter(a => /^logs[-_]/.test(a.name || '') && a.contentType === 'application/zip');
+
+		for (const lAtt of logsAtts) {
+			const hash = hashFromPath(lAtt.path);
+			if (hash) { logHashes.push({ resourceHash: hash, blob: blobName }); }
+		}
+
+		let traceData = null;
+		let screenshotPath = null;
+		const screenshotPaths = [];
+
+		if (traceAtt?.path) {
+			process.stderr.write(`  Processing trace for ${shortId} attempt ${i}...\n`);
+			const traceUrl = `${reportUrl}${traceAtt.path}`;
+			const localTraceZip = join(tmpWorkDir, `trace-${shortId}-${i}.zip`);
+
+			try {
+				await fetchToFile(traceUrl, localTraceZip);
+				// Trace zip from S3 is the trace itself (not a wrapper around resources/<sha>.zip
+				// like Path A's blob format). Extract trace.trace directly.
+				const traceExtractDir = join(tmpWorkDir, `trace-extracted-${shortId}-${i}`);
+				const tracePath = unzipFile(localTraceZip, 'trace.trace', traceExtractDir);
+
+				if (tracePath) {
+					traceData = parseTrace(tracePath);
+
+					// Extract trailing N screencast frames in chronological order.
+					const frames = traceData.screenshotShas || [];
+					for (let j = 0; j < frames.length; j++) {
+						const sha = frames[j].sha1;
+						if (!sha) { continue; }
+						const ssFileName = `${shortId}-attempt${i}-frame${j}.jpeg`;
+						const ssDestPath = join(resolvedOutputDir, 'screenshots', ssFileName);
+						const ssEntry = `resources/${sha}`;
+						const ssTempDir = join(tmpWorkDir, `ss-${shortId}-${i}-${j}`);
+						const ssExtracted = unzipFile(localTraceZip, ssEntry, ssTempDir);
+
+						if (ssExtracted) {
+							writeFileSync(ssDestPath, readFileSync(ssExtracted));
+							screenshotPaths.push(ssDestPath);
+						}
+					}
+					screenshotPath = screenshotPaths.length > 0
+						? screenshotPaths[screenshotPaths.length - 1]
+						: null;
+				}
+			} catch (err) {
+				process.stderr.write(`  WARN: failed to process trace ${traceUrl}: ${err.message}\n`);
+			}
+		}
+
+		let errorContextPath = null;
+		if (errCtxAtt?.path) {
+			const ctxUrl = `${reportUrl}${errCtxAtt.path}`;
+			const mdFileName = `${shortId}-attempt${i}.md`;
+			const mdDestPath = join(resolvedOutputDir, 'error-context', mdFileName);
+			try {
+				await fetchToFile(ctxUrl, mdDestPath);
+				errorContextPath = mdDestPath;
+			} catch (err) {
+				process.stderr.write(`  WARN: failed to download error-context ${ctxUrl}: ${err.message}\n`);
+			}
+		}
+
+		attempts.push({
+			attemptIndex: i,
+			trace: traceData,
+			screenshotPath,
+			screenshotPaths,
+			errorContextPath,
+		});
+	}
+
+	const firstFailed = failedResults[0];
+	testDetails.push({
+		testId: test.testId,
+		title: test.title,
+		file: detail.fileName,
+		status: firstFailed?.status || null,
+		blob: blobName,
+		attemptCount: failedResults.length,
+		attempts,
+		logHashes,
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup + output
+// ---------------------------------------------------------------------------
+
+if (doCleanup) {
+	try { rmSync(tmpWorkDir, { recursive: true, force: true }); } catch { /* best effort */ }
+} else {
+	process.stderr.write(`(temp dir kept at ${tmpWorkDir} -- pass --cleanup to remove)\n`);
+}
+
+const result = {
+	outputDir: resolvedOutputDir,
+	failures,
+	failedTests,
+	testDetails,
+};
+
+console.log(JSON.stringify(result, null, 2));
+
+process.stderr.write(`\nDone. Screenshots: ${join(resolvedOutputDir, 'screenshots')}\n`);
+process.stderr.write(`Total: ${failures.length} final failures, ${testDetails.length} unique failed tests, ` +
+	`${testDetails.reduce((sum, t) => sum + t.attempts.length, 0)} trace attempts processed.\n`);

--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -139,6 +139,12 @@ runs:
         while IFS=$'\t' read -r JOB_ID JOB_NAME; do
           [ -z "$JOB_ID" ] && continue
           DIR_NAME=$(sanitize "$JOB_NAME")
+          # If two jobs sanitize to the same directory name (e.g., names that
+          # differ only in stripped punctuation), append the job ID so neither
+          # silently overwrites the other.
+          if [ -d "$WORK_DIR/$DIR_NAME" ]; then
+            DIR_NAME="${DIR_NAME}-${JOB_ID}"
+          fi
           OUT="$WORK_DIR/$DIR_NAME"
           mkdir -p "$OUT"
           echo "::group::Process e2e job $JOB_ID ($JOB_NAME) -> $DIR_NAME"

--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "Maximum agent turns (cost guard)"
     required: false
     default: "40"
+  data-source:
+    description: "blob (sharded artifacts + merge-reports) or s3 (HTML report). Default: blob."
+    required: false
+    default: "blob"
 runs:
   using: composite
   steps:
@@ -63,7 +67,8 @@ runs:
         cat "${{ steps.prep.outputs.work_dir }}/run-info.json"
         echo "::endgroup::"
 
-    - name: Process each project
+    - name: Process each project (blob path)
+      if: ${{ inputs.data-source == 'blob' }}
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -76,7 +81,7 @@ runs:
         PROJECTS=$(jq -r '.projects // [] | .[]' "$RUN_INFO")
 
         if [ -z "$PROJECTS" ]; then
-          echo "No e2e projects found (likely positron-builds run -- Path B not implemented in v1)."
+          echo "No e2e projects found (no blob report artifacts on this run)."
           exit 0
         fi
 
@@ -97,6 +102,76 @@ runs:
             }
           echo "::endgroup::"
         done
+
+    - name: Process each failed e2e job (s3 path)
+      if: ${{ inputs.data-source == 's3' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      working-directory: ${{ github.action_path }}
+      run: |
+        WORK_DIR="${{ steps.prep.outputs.work_dir }}"
+        RUN_INFO="$WORK_DIR/run-info.json"
+        REPO=$(jq -r '.repo' "$RUN_INFO")
+        CDN_BASE="https://d38p2avprg8il3.cloudfront.net"
+
+        # Stream {id, name} pairs as tab-separated records so job names with
+        # spaces or slashes don't break the loop.
+        E2E_JOBS=$(jq -r '.failedJobs[] | select(.isE2e == true) | "\(.id)\t\(.name)"' "$RUN_INFO")
+
+        if [ -z "$E2E_JOBS" ]; then
+          echo "No failed e2e jobs found in run-info.json."
+          exit 0
+        fi
+
+        # Sanitize a job name into a safe directory name. analyze.mjs's
+        # discoverProjectDirs filters to e2e-* subdirs, so prepend "e2e-" if
+        # the sanitized form doesn't already start with it.
+        sanitize() {
+          local s
+          s=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g')
+          case "$s" in
+            e2e-*) printf '%s' "$s" ;;
+            *)     printf 'e2e-%s' "$s" ;;
+          esac
+        }
+
+        while IFS=$'\t' read -r JOB_ID JOB_NAME; do
+          [ -z "$JOB_ID" ] && continue
+          DIR_NAME=$(sanitize "$JOB_NAME")
+          OUT="$WORK_DIR/$DIR_NAME"
+          mkdir -p "$OUT"
+          echo "::group::Process e2e job $JOB_ID ($JOB_NAME) -> $DIR_NAME"
+
+          # Resolve REPORT_DIR from the job's logs. The workflow logs both an
+          # unresolved template line (REPORT_DIR="...-${IDENTIFIER}-${OS_SUFFIX}")
+          # and the expanded value (REPORT_DIR: playwright-report-<run>-<attempt>-<id>-<os>).
+          # Filter out lines containing literal ${ to skip the template, then
+          # extract the first concrete playwright-report-* token.
+          LOGS=$(gh api "repos/$REPO/actions/jobs/$JOB_ID/logs" 2>/dev/null || true)
+          REPORT_DIR=$(printf '%s' "$LOGS" \
+            | grep -v '\${' \
+            | grep -oE 'playwright-report-[A-Za-z0-9_-]+' \
+            | head -1)
+
+          if [ -z "$REPORT_DIR" ]; then
+            echo "Could not resolve REPORT_DIR from logs of job $JOB_ID. Skipping."
+            echo "::endgroup::"
+            continue
+          fi
+
+          REPORT_URL="$CDN_BASE/$REPORT_DIR/"
+          echo "Report URL: $REPORT_URL"
+
+          node "${{ github.workspace }}/.claude/skills/e2e-failure-analyzer/scripts/e2e-process-s3.js" \
+            --report-url "$REPORT_URL" \
+            --output-dir "$OUT" \
+            --cleanup \
+            > "$OUT/result.json" || {
+              echo "Failed to process e2e job $JOB_ID (exit $?). Continuing."
+            }
+          echo "::endgroup::"
+        done <<< "$E2E_JOBS"
 
     - name: Query historical test health
       if: ${{ inputs.e2e-insights-api-key != '' }}


### PR DESCRIPTION
This is needed before I can test out the skill running in positron-builds repo.  It just breaks up the logic to handle how tests run in that repo.

## Summary

Extends the e2e failure analyzer to handle non-sharded Playwright HTML reports hosted on CloudFront (posit-dev/positron-builds layout). The existing sharded blob report path (Path A, posit-dev/positron) is unchanged.

- **`scripts/e2e-process-s3.js`** (new) -- fetches the report's `index.html`, decodes the embedded base64 `report.zip`, walks `report.json` + per-file detail JSONs, downloads trace and error-context attachments from S3, parses traces, and extracts trailing screencast frames. Output JSON matches `e2e-process-project.js` exactly so [analyze.mjs](.github/actions/e2e-failure-analyzer/analyze.mjs) handles both paths interchangeably.
- **`action.yml`** -- adds a `data-source` input (default `blob`, unchanged behavior for existing callers). When `s3`, the blob/merge step is skipped and a new step iterates failed e2e jobs, resolves each `REPORT_DIR` from the job's logs (ignoring the unresolved `${IDENTIFIER}` / `${OS_SUFFIX}` template line), and runs the new script per job into `e2e-<sanitized-job-name>/result.json`.
- **`SKILL.md`** -- replaces the previous B1-B5 grep-and-curl procedure with a single-script Path B procedure mirroring Path A.

The positron-builds workflow that flips this to `data-source: s3` lands in a separate PR.

## Test plan

- [x] Run `e2e-process-s3.js` locally against `playwright-report-26022162198-1-electron-ubuntu` (2026-05-18 nightly): 5 hard failures + 17 failed attempts across 12 unique tests extracted, 45 screencast frames + 11 error-context files written, output JSON shape matches `e2e-process-project.js` (top keys, failure shape, attempt shape, trace fields).
- [ ] Verify existing posit-dev/positron e2e analyzer callers still pass (Path A default unchanged).
- [ ] Once the positron-builds caller PR lands, exercise the s3 branch end-to-end against a real run.