### PR TITLE
e2e: set console.showNotebookConsoleActions as a default test setting

### DIFF
--- a/test/e2e/fixtures/settings.json
+++ b/test/e2e/fixtures/settings.json
@@ -20,5 +20,6 @@
 	"posit.assistant.sidebarView": true,
 	"assistant.sidebarView": true,
 	"shiny.previewType": "internal",
-	"terminal.integrated.gpuAcceleration": "off"
+	"terminal.integrated.gpuAcceleration": "off",
+	"console.showNotebookConsoleActions": true
 }

--- a/test/e2e/tests/autocomplete/autocomplete-notebook-console.test.ts
+++ b/test/e2e/tests/autocomplete/autocomplete-notebook-console.test.ts
@@ -16,7 +16,6 @@ test.describe('Autocomplete with Notebook Console', {
 
 	test.afterEach(async function ({ hotKeys, settings }) {
 		await settings.remove([
-			'console.showNotebookConsoleActions',
 			'console.showNotebookConsoles',
 			'positron.quarto.inlineOutput.enabled',
 			'workbench.editor.enablePreview',
@@ -24,17 +23,10 @@ test.describe('Autocomplete with Notebook Console', {
 		await hotKeys.closeAllEditors();
 	});
 
-	test('Python - Autocomplete in script works after opening notebook console', async function ({ app, runCommand, openFile, sessions, hotKeys, settings }) {
+	test('Python - Autocomplete in script works after opening notebook console', async function ({ app, runCommand, openFile, sessions, hotKeys }) {
 		const { editors, console, notebooks } = app.workbench;
 		const page = app.code.driver.currentPage;
 		const keyboard = page.keyboard;
-
-		await test.step('Enable notebook console actions', async () => {
-			await settings.set(
-				{ 'console.showNotebookConsoleActions': true },
-				{ reload: true, waitMs: 1000 }
-			);
-		});
 
 		// Start a Python console session and import pandas
 		await sessions.start(['python']);
@@ -88,17 +80,10 @@ test.describe('Autocomplete with Notebook Console', {
 
 	test('R - Autocomplete in script works after opening notebook console', {
 		tag: [tags.ARK]
-	}, async function ({ app, runCommand, openFile, sessions, hotKeys, settings }) {
+	}, async function ({ app, runCommand, openFile, sessions, hotKeys }) {
 		const { editors, console, notebooks } = app.workbench;
 		const page = app.code.driver.currentPage;
 		const keyboard = page.keyboard;
-
-		await test.step('Enable notebook console actions', async () => {
-			await settings.set(
-				{ 'console.showNotebookConsoleActions': true },
-				{ reload: true, waitMs: 1000 }
-			);
-		});
 
 		// Start an R console session and load arrow
 		await sessions.start(['r']);

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -174,11 +174,8 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 			});
 		});
 
-	test('ensure notebook console attaches and terminates with active kernel', async function ({ app, sessions, settings }) {
+	test('ensure notebook console attaches and terminates with active kernel', async function ({ app, sessions }) {
 		const { notebooksPositron, console } = app.workbench;
-
-		// Enable the notebook console actions setting for this test
-		await settings.set({ 'console.showNotebookConsoleActions': true }, { reload: true, waitMs: 1000 });
 
 		const [, rSession] = await sessions.start(['python', 'r']);
 		await sessions.select(rSession.id);
@@ -206,9 +203,6 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 			kernelGroup: 'R',
 			status: 'disconnected'
 		});
-
-		// Disable the notebook console actions setting after this test
-		await settings.remove(['console.showNotebookConsoleActions']);
 	});
 
 	test('Python - console accepts input after notebook cell execution', {

--- a/test/e2e/tests/sessions/session-interpreter-sync.test.ts
+++ b/test/e2e/tests/sessions/session-interpreter-sync.test.ts
@@ -23,7 +23,6 @@ test.describe('Sessions: Interpreter Sync', {
 	test.beforeAll(async function ({ settings }) {
 		await settings.set(
 			{
-				'console.showNotebookConsoleActions': true,
 				'positron.notebook.enabled': true
 			},
 			{ reload: 'web', waitMs: 1000 }


### PR DESCRIPTION
### Summary
Move `console.showNotebookConsoleActions: true` into the shared `fixtures/settings.json` so all e2e suites inherit it by default.
- Remove the per-test settings override from `notebook-kernel-behavior`, `autocomplete-notebook-console`, and `session-interpreter-sync`
- Drop `settings` from fixture params in the two autocomplete tests that no longer need it individually
- Remove the redundant `console.showNotebookConsoleActions` entry from the `afterEach` cleanup list in the autocomplete suite

### QA Notes
`@:positron-notebooks` `@:console` `@:notebooks`

Note: the test failure is unrelated and it is occurring on main.