### PR TITLE
Widen PETE pilot allowlist

### DIFF
--- a/.claude/skills/pr-test-checker/SKILL.md
+++ b/.claude/skills/pr-test-checker/SKILL.md
@@ -147,7 +147,7 @@ For "Adequate" / "Adequate via existing coverage" / "Not applicable": omit this 
 Omit entirely if not applicable.>
 
 ---
-<sub>PETE (Positron Extreme Test Experiment) — LLM-based test-coverage advisor, in pilot. Triggers on PR open and `/recheck-tests`. Wrong verdict? Run `/recheck-tests` or ping @jonvanausdeln.</sub>
+<small>PETE (Positron Extreme Test Experiment) - LLM-based test-coverage advisor, in pilot. Triggers on PR open and on `/recheck-tests` comments. Wrong verdict? Add a `/recheck-tests` comment to this PR to re-run, or ping @jonvanausdeln.</small>
 ```
 
 ## Constraints

--- a/.github/workflows/pr-test-checker.yml
+++ b/.github/workflows/pr-test-checker.yml
@@ -27,7 +27,7 @@ jobs:
     name: Grade on open
     if: |
       github.event_name == 'pull_request' &&
-      contains(fromJson('["jonvanausdeln"]'), github.event.pull_request.user.login)
+      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -87,8 +87,8 @@ jobs:
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, '/recheck-tests') &&
-      contains(fromJson('["jonvanausdeln"]'), github.event.comment.user.login) &&
-      contains(fromJson('["jonvanausdeln"]'), github.event.issue.user.login)
+      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok"]'), github.event.comment.user.login) &&
+      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok"]'), github.event.issue.user.login)
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Add `sharon-wang`, `melissa-barca`, `samclark2015`, and `timtmok` to the PR Test Checker (PETE) pilot allowlist in `.github/workflows/pr-test-checker.yml` alongside `jonvanausdeln`.
- Updates all three `fromJson(...)` references in the workflow so they stay in sync — the `on-open` PR-author check, the `on-recheck` commenter check, and the `on-recheck` PR-author check. The security model requires the same allowlist on all three.

No other files changed. SKILL.md footer (`ping @jonvanausdeln`) left as-is per the pilot owner.

## Test plan
- [ ] After merge, open a PR as one of the newly added users and verify the `Grade on open` job runs.
- [ ] Comment `/recheck-tests` on a PR authored by an allowlisted user and verify the `Re-grade on /recheck-tests` job runs.
- [ ] Confirm a PR from a non-allowlisted author still skips both jobs.