### PR TITLE
ci: add Slack notifications for release screenshots and extensions check

### DIFF
--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -167,7 +167,6 @@ jobs:
       - name: Post PR to Slack
         if: steps.push.outputs.existing_pr != '' || steps.create-pr.outputs.pr_url != ''
         env:
-          # Ensure SLACK_TOKEN_TEST_STATUS has access to #positron-qa, or swap for a token that does
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url || steps.push.outputs.existing_pr }}
           UPDATED: ${{ steps.create-pr.outputs.updated }}
@@ -176,14 +175,14 @@ jobs:
             -H "Authorization: Bearer $SLACK_TOKEN" \
             -H "Content-Type: application/json" \
             -d "$(jq -n \
-              --arg channel "#positron-qa" \
+              --arg channel "#positron-dev" \
               --arg pr_url "$PR_URL" \
               --arg ext "$UPDATED" \
               '($pr_url | split("/") | last) as $pr_num |
-               (if $ext != "" then ($ext | split(" ") | map("• " + .) | join("\n")) else "" end) as $bullets |
+               (if $ext != "" then "\n\n" + ($ext | split(" ") | map("• " + .) | join("\n")) else "" end) as $bullets |
                {
                  channel: $channel,
-                 text: ("bootstrap extensions update | <" + $pr_url + "|PR #" + $pr_num + ">" + (if $bullets != "" then "\n\n" + $bullets else "" end))
+                 text: ("📦 *Bootstrap Extensions Updated*\nposit-dev/positron · <" + $pr_url + "|PR #" + $pr_num + ">" + $bullets)
                }')"
 
   slack-notify:

--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -271,6 +271,7 @@ jobs:
 
       - name: Open pull request
         if: env.MODE == 'publish' && steps.gate.outputs.decision == 'publish'
+        id: open-pr
         env:
           CLS: ${{ runner.temp }}/classification.json
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
@@ -309,10 +310,34 @@ jobs:
             --title "Update screenshots for Positron $VERSION" \
             --body "$BODY")
           echo "Opened PR: $PR_URL"
+          PR_NUMBER="${PR_URL##*/}"
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           # Reviewer assignment is best-effort - if the user isn't a collaborator
           # on the target repo (422), don't fail the workflow over it.
           gh pr edit "$PR_URL" --add-reviewer marieidleman \
             || echo "::warning::Could not assign reviewer marieidleman (not a collaborator?)"
+
+      - name: Notify Slack on publish success
+        if: env.MODE == 'publish' && steps.gate.outputs.decision == 'publish'
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
+          PR_URL: ${{ steps.open-pr.outputs.pr_url }}
+          PR_NUMBER: ${{ steps.open-pr.outputs.pr_number }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          curl -s -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg channel "#positron-dev" \
+              --arg pr_url "$PR_URL" \
+              --arg pr_number "$PR_NUMBER" \
+              --arg version "$VERSION" \
+              '{
+                channel: $channel,
+                text: ("📸 *Screenshots Updated · Positron " + $version + "*\nposit-dev/positron-website · <" + $pr_url + "|PR #" + $pr_number + ">")
+              }')"
 
   slack-notify:
     # Nightly is on a schedule; failures should page #positron-test-results.


### PR DESCRIPTION
### Summary
Add/update Slack notifications to release screenshot, extension update workflows so the team gets pinged when publish runs complete.
- Both workflows (release screenshots, extension updates) post to `#positron-dev` when PR is opened
- `release-screenshots.yml`: posts to Slack on publish-mode success after a PR is opened on positron-website
- `extensions-check-nightly.yml`: updated existing slack notification to be same format and also post to dev channel now too 


### QA Notes
What to expect in #positron-dev channel when a PR is opened:
<img width="403" height="82" alt="Screenshot 2026-05-19 at 2 26 57 PM" src="https://github.com/user-attachments/assets/e6181b0c-e304-425f-8464-141caea8b893" />
