### PR TITLE
Fix notebook-kernel-behavior e2e test

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -1760,19 +1760,15 @@ class KernelBase {
 	 */
 	async shutdown(): Promise<void> {
 		await test.step('Shutdown kernel', async () => {
-			// During a kernel restart, the badge icon may briefly show "idle"
-			// before the kernel is actually ready. This happens because the
-			// kernel reports intermediate idle states while it shuts down
-			// and while the new kernel sets up its comms (variables, plots,
-			// and so on). The Shutdown Kernel menu item only becomes
-			// enabled once the kernel is truly ready, so wait for it rather
-			// than relying on the badge before clicking.
-			await expect(async () => {
-				await this.contextMenu.triggerAndVerifyMenuItems({
-					menuTrigger: this.statusBadge,
-					menuItemStates: [{ label: 'Shutdown Kernel', enabled: true }],
-				});
-			}, 'Shutdown Kernel menu item to be enabled').toPass({ timeout: 30000 });
+			// The Shutdown Kernel menu item is gated on the
+			// `notebookHasRunningInterpreter` context key, which only flips
+			// true on `RuntimeState.Ready`. The runtime status icon can read
+			// "idle" during a restart before `Ready` fires (intermediate
+			// state while comms are being set up), so we cannot use the icon
+			// as a readiness signal. Menu items also do not reactively
+			// update once open, so we poll by re-opening the menu until the
+			// item is enabled, then click.
+			await this.waitForMenuItemEnabled('Shutdown Kernel');
 
 			await this.contextMenu.triggerAndClick({
 				menuTrigger: this.statusBadge,
@@ -1780,6 +1776,30 @@ class KernelBase {
 			});
 			await this.expectStatusToBe('disconnected', 15000);
 		});
+	}
+
+	/**
+	 * Poll the kernel context menu until `menuItemLabel` is enabled.
+	 *
+	 * Context-menu items render their enabled state at open-time and do not
+	 * update while open: if the underlying context key flips after the menu
+	 * is shown, the rendered item stays stale until the menu is closed and
+	 * reopened. Each polling iteration therefore opens the menu, checks the
+	 * item, and closes it. The close runs in a `finally` so we don't
+	 * accidentally keep the menu open (otherwise the next iteration's
+	 * click would close the menu instead of open it).
+	 */
+	private async waitForMenuItemEnabled(menuItemLabel: string, timeout = 30000): Promise<void> {
+		await expect(async () => {
+			try {
+				await this.contextMenu.triggerAndVerifyMenuItems({
+					menuTrigger: this.statusBadge,
+					menuItemStates: [{ label: menuItemLabel, enabled: true }],
+				});
+			} finally {
+				await this.statusBadge.page().keyboard.press('Escape').catch(() => { });
+			}
+		}, `${menuItemLabel} menu item to be enabled`).toPass({ timeout });
 	}
 
 	/**

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -50,10 +50,6 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await notebooksPositron.kernel.expectKernelToBe({
 			kernelGroup: 'Python',
 			status: 'active'
-		});
-		await notebooksPositron.kernel.expectKernelToBe({
-			kernelGroup: 'Python',
-			status: 'idle'
 		});
 
 		// shut down kernel and ensure restart toolbar button stays enabled, shutdown menu item is disabled

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -51,6 +51,10 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 			kernelGroup: 'Python',
 			status: 'active'
 		});
+		await notebooksPositron.kernel.expectKernelToBe({
+			kernelGroup: 'Python',
+			status: 'idle'
+		});
 
 		// shut down kernel and ensure restart toolbar button stays enabled, shutdown menu item is disabled
 		await notebooksPositron.kernel.shutdown();


### PR DESCRIPTION
The e2e test "ensure notebook session states update correctly during start, restart, and shutdown" in `notebook-kernel-behavior.test.ts` was failing intermittently on CI after merging #13376. 

The root cause is that the session status icon toggles between `active` and `idle` multiple times during a restart. The test assumes that the first `idle` means we are ready to move on to the next action (shutdown) but we're not because a restart is still in progress.

The test would open the context menu that contains the shutdown action and it would be disabled. Context menus actions don't re-render once the menu is open, we need to close and re-open them to see the change. The `triggerAndVerifyMenuItems` did not do that.

I've updated the test by adding a helper in the positron notebook object which will close/re-open the menu (`waitForMenuItemEnabled`) and only click the action once its enabled.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps
@:interpreter
@:notebooks
@:positron-notebooks
@:sessions

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
