### PR TITLE
Rename Packages pane enable setting to `packages.enabled`

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -90,7 +90,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			default: true,
 			scope: ConfigurationScope.APPLICATION,
 			description: nls.localize('positron.packages.enable', 'Show the Packages pane.'),
-			deprecationMessage: nls.localize('positron.packages.enable.deprecated', "Deprecated. Use 'packages.enabled' instead."),
+			deprecationMessage: nls.localize('positron.packages.enable.deprecated', "Deprecated. Use '#packages.enabled#' instead."),
 			included: false,
 			tags: ['preview'],
 		}

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -31,7 +31,10 @@ import { PositronPackagesView } from './positronPackagesView.js';
 
 export const POSITRON_PACKAGES_VIEW_CONTAINER_ID = 'workbench.viewContainer.positronPackages';
 
-const POSITRON_PACKAGES_ENABLED = ContextKeyExpr.equals('config.positron.packages.enable', true);
+const POSITRON_PACKAGES_ENABLED = ContextKeyExpr.and(
+	ContextKeyExpr.equals('config.packages.enabled', true),
+	ContextKeyExpr.equals('config.positron.packages.enable', true),
+)!;
 
 const viewContainer = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry).registerViewContainer({
 	id: POSITRON_PACKAGES_VIEW_CONTAINER_ID,
@@ -75,11 +78,20 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 	type: 'object',
 	title: nls.localize('packagesConfigurationTitle', 'Packages'),
 	properties: {
+		'packages.enabled': {
+			type: 'boolean',
+			default: true,
+			scope: ConfigurationScope.APPLICATION,
+			description: nls.localize('positron.packages.enabled', 'Show the Packages pane.'),
+			tags: ['preview'],
+		},
 		'positron.packages.enable': {
 			type: 'boolean',
 			default: true,
 			scope: ConfigurationScope.APPLICATION,
 			description: nls.localize('positron.packages.enable', 'Show the Packages pane.'),
+			deprecationMessage: nls.localize('positron.packages.enable.deprecated', "Deprecated. Use 'packages.enabled' instead."),
+			included: false,
 			tags: ['preview'],
 		}
 	}

--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -394,7 +394,7 @@ export const tocData: ITOCEntry<string> = {
 				{
 					id: 'features/packages',
 					label: localize('packages', "Packages"),
-					settings: ['positron.packages.*']
+					settings: ['packages.*']
 				},
 				{
 					id: 'features/plots',

--- a/test/e2e/tests/environment-pane/environment-pane.test.ts
+++ b/test/e2e/tests/environment-pane/environment-pane.test.ts
@@ -15,7 +15,7 @@ test.describe('Environment Pane', {
 
 	test.beforeAll(async function ({ settings }) {
 		await settings.set({
-			'positron.packages.enable': true
+			'packages.enabled': true
 		}, { reload: 'web' });
 	});
 


### PR DESCRIPTION
Adds `packages.enabled` as the canonical setting and hides the old `positron.packages.enable` behind included:false and a deprecationMessage. Both keys are honored: the pane is hidden if either is set to false, so existing user settings.json files keep working with no migration.

See #13349

This is the second time we're renaming this key, so would like to get a strong upvote on the configuration name.