### PR TITLE
Use devtools::install() instead of pak

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -244,8 +244,8 @@
           "positron.r.localPackageInstallMethod": {
             "scope": "window",
             "type": "string",
-            "enum": ["pak", "base"],
-            "default": "pak",
+            "enum": ["devtools", "base"],
+            "default": "devtools",
             "markdownDescription": "%r.configuration.localPackageInstallMethod.description%"
           }
         }

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -82,7 +82,7 @@
 	"r.configuration.symbols.includeAssignmentsInBlocks.description": "Controls whether assigned objects inside `{}` blocks are included as document symbols, in addition to top-level assignments. Reopen files or restart the server for the setting to take effect.",
 	"r.configuration.workspaceSymbols.includeCommentSections.description": "Controls whether comment sections like `# My section ---` are included as workspace symbols.",
 	"r.configuration.autoConvertFilePaths.description": "Automatically convert file paths when pasting files from file manager into R scripts. Converts backslashes (\\) to forward slashes (/), adds quotes, and formats multiple files as R vectors.",
-	"r.configuration.localPackageInstallMethod.description": "How to install the local R package project. When set to `pak`, uses `pak::local_install()`. When set to `base`, uses `R CMD INSTALL`.",
+	"r.configuration.localPackageInstallMethod.description": "How to install the local R package project. When set to `devtools`, uses `devtools::install(build = FALSE)`. When set to `base`, uses `R CMD INSTALL`.",
 	"r.configuration.defaultRepositories.description": "The default repositories to use for R package installation, if no repository is otherwise specified in R startup scripts (restart Positron to apply).\n\nThe default repositories will be set as the `repos` option in R.",
 	"r.configuration.defaultRepositories.auto.description": "Automatically choose a default repository, or use a repos.conf file if it exists.",
 	"r.configuration.defaultRepositories.rstudio.description": "Use the RStudio CRAN mirror (cran.rstudio.com)",

--- a/extensions/positron-r/src/tasks.ts
+++ b/extensions/positron-r/src/tasks.ts
@@ -28,7 +28,7 @@ export async function providePackageTasks(context: vscode.ExtensionContext): Pro
 	);
 }
 
-type InstallMethod = 'pak' | 'base';
+type InstallMethod = 'devtools' | 'base';
 
 function getPackageInstallTask(installMethod: InstallMethod) {
 	if (installMethod === 'base') {
@@ -43,8 +43,8 @@ function getPackageInstallTask(installMethod: InstallMethod) {
 	return {
 		task: 'r.task.packageInstall',
 		message: vscode.l10n.t('{taskName}', { taskName: 'Install R package' }),
-		rcode: 'pak::local_install(upgrade = FALSE)',
-		package: 'pak',
+		rcode: 'devtools::install(build = FALSE)',
+		package: 'devtools',
 		envVars: null
 	};
 }
@@ -56,7 +56,7 @@ export async function getRPackageTasks(editorFilePath?: string): Promise<vscode.
 	const binpath = RSessionManager.instance.getLastBinpath();
 
 	const config = vscode.workspace.getConfiguration('positron.r');
-	const installMethod = config.get<InstallMethod>('localPackageInstallMethod', 'pak');
+	const installMethod = config.get<InstallMethod>('localPackageInstallMethod', 'devtools');
 
 	const taskData = [
 		{

--- a/test/e2e/tests/r-pkg-development/r-pkg-development.test.ts
+++ b/test/e2e/tests/r-pkg-development/r-pkg-development.test.ts
@@ -83,7 +83,7 @@ test.describe('R Package Development', { tag: [tags.R_PKG_DEVELOPMENT, tags.ARK]
 			await app.workbench.console.waitForConsoleContents('"testfun"');
 
 			// Reset setting to default
-			await settings.set({ 'positron.r.localPackageInstallMethod': 'pak' });
+			await settings.set({ 'positron.r.localPackageInstallMethod': 'devtools' });
 		});
 	});
 });


### PR DESCRIPTION
Closes #11875
Closes #1733

@:r-pkg-development

When working in an R package, the *R: Install R Package and Restart R* gesture now defaults to [`devtools::install(build = FALSE)`](https://devtools.r-lib.org/reference/install.html), instead of `pak::local_install(upgrade = FALSE)`. The rationale for this switch is laid out in the issue.

This also affects the `positron.r.localPackageInstallMethod` configuration point, where `devtools` replaces `pak`.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- *R: Install R Package and Restart R* now defaults to `devtools::install(build = FALSE)`, instead of `pak::local_install(upgrade = FALSE)`. The values of the `positron.r.localPackageInstallMethod` setting can now be `"devtools"` or `"base"`.

#### Bug Fixes

- N/A


### Validation Steps

* Open a workspace in Positron that is also an R package.
* Make sure you've got devtools >= 2.5.2.
* Make sure you don't have `positron.r.localPackageInstallMethod` configured in `settings.json`.
* Do *R: Install R Package and Restart R*. In the terminal that fulfills this, you should see invocation of `devtools::install(build = FALSE)`:

```
Executing task: '/Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/bin/R' --quiet --no-restore --no-save -e 'devtools::install(build = FALSE)'
```

### For discussion:

Should we put a minimum version on devtools, in order to get new, desirable behaviour of `devtools::install()`? It seems too strong a requirement and yet people will not have the experience we really want for them if they have older devtools.

It feels like the "devtools vs. base" question is bigger than just how to wire up *R: Install R Package and Restart R*. Are we going to deal with this more holistically? Recall that RStudio has a project-level setting for "Use devtools package functions if available".

Here are all the package dev commands:

| Command | Display name | Backed by |
|---|---|---|
| `r.packageLoad` | Load R Package | `devtools::load_all()` — hardcoded |
| `r.packageBuild` | Build R Package | `devtools::build()` — hardcoded |
| `r.packageInstall` | Install R Package and Restart R | `devtools::install(build = FALSE)` or `R CMD INSTALL` — configurable (this PR) |
| `r.packageTest` | Test R Package in Terminal | `devtools::test()` — hardcoded (task) |
| `r.packageTestExplorer` | Test R Package in Test Explorer | runs testthat via test explorer, which also uses devtools/testthat |
| `r.packageCheck` | Check R Package | `devtools::check()` — hardcoded (task) |
| `r.packageDocument` | Document R Package | `devtools::document()` — hardcoded |


Are we going to offer devtools vs base for others? In the abstract, it feels like we should. But here in reality it doesn't really make sense. Making this sort of thing clearcut and easier is precisely why devtools & friends exist! Only a couple of these even have a clearcut definition for a base implementation.

Related: the idea of making it possible for an advanced and opinionated user to take full control of these gestures: #3242.
