### PR TITLE
E2E test: add licenses for workbench and connect

### DIFF
--- a/.github/actions/setup-workbench-docker/action.yml
+++ b/.github/actions/setup-workbench-docker/action.yml
@@ -19,10 +19,31 @@ inputs:
     description: 'Optional path to custom Positron workbench tar.gz to install instead of downloading'
     required: false
     default: ''
+  workbench-license-path:
+    description: 'Path to Workbench license file'
+    required: false
+    default: '/tmp/workbench.lic'
+  connect-license-path:
+    description: 'Path to Connect license file'
+    required: false
+    default: '/tmp/connect.lic'
 
 runs:
   using: 'composite'
   steps:
+    - name: Prepare Connect license for volume mount
+      shell: bash
+      run: |
+        # Create connect directory if it doesn't exist
+        mkdir -p dockerfiles/connect
+        # Copy Connect license to the location expected by docker-compose volume mount
+        if [ -f "${{ inputs.connect-license-path }}" ]; then
+          cp "${{ inputs.connect-license-path }}" dockerfiles/connect/connect.lic
+          echo "Connect license copied to dockerfiles/connect/connect.lic"
+        else
+          echo "Warning: Connect license not found at ${{ inputs.connect-license-path }}"
+        fi
+
     - name: Start Docker Compose Services
       shell: bash
       run: |
@@ -51,6 +72,11 @@ runs:
         docker cp positronDownload.sh test:/tmp/positronDownload.sh
         docker cp get-latest-wb-noble-url.sh test:/tmp/get-latest-wb-noble-url.sh
         docker cp configure-datasources.sh test:/tmp/configure-datasources.sh
+
+        # Copy Workbench license into test container if it exists
+        if [ -f "${{ inputs.workbench-license-path }}" ]; then
+          docker cp "${{ inputs.workbench-license-path }}" test:/tmp/workbench.lic
+        fi
 
         # Make scripts executable
         docker exec test chmod +x /tmp/install-workbench.sh

--- a/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
+++ b/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
@@ -150,7 +150,7 @@ jobs:
           PW_PROJECT_NAME: e2e-remote-ssh
         run: |
           export DISPLAY=:10
-          BUILD=/usr/share/positron npx playwright test --project e2e-remote-ssh --retries=1 --workers=1 --grep="${{ inputs.grep }}"
+          BUILD=/usr/share/positron npx playwright test --project e2e-remote-ssh --retries=1 --workers=1
 
       - name: Upload Playwright Report to S3
         if: always()

--- a/.github/workflows/test-e2e-workbench-ubuntu.yml
+++ b/.github/workflows/test-e2e-workbench-ubuntu.yml
@@ -100,8 +100,8 @@ jobs:
           SNOWFLAKE_CLIENT_SECRET: "op://Positron/Snowflake-WB-Auto/client-secret"
           SNOWFLAKE_USERNAME: "op://Positron/Snowflake-WB-Auto/username"
           SNOWFLAKE_PASSWORD: "op://Positron/Snowflake-WB-Auto/password"
-          WORKBENCH_LICENSE: "op://Positron/Workbench-lic-WB-Auto"
-          CONNECT_LICENSE: "op://Positron/Connect-lic-WB-Auto"
+          WORKBENCH_LICENSE: "op://Positron/Workbench-lic-WB-Auto/notesPlain"
+          CONNECT_LICENSE: "op://Positron/Connect-lic-WB-Auto/notesPlain"
 
       - name: Write license files
         run: |

--- a/.github/workflows/test-e2e-workbench-ubuntu.yml
+++ b/.github/workflows/test-e2e-workbench-ubuntu.yml
@@ -100,6 +100,13 @@ jobs:
           SNOWFLAKE_CLIENT_SECRET: "op://Positron/Snowflake-WB-Auto/client-secret"
           SNOWFLAKE_USERNAME: "op://Positron/Snowflake-WB-Auto/username"
           SNOWFLAKE_PASSWORD: "op://Positron/Snowflake-WB-Auto/password"
+          WORKBENCH_LICENSE: "op://Positron/Workbench-lic-WB-Auto"
+          CONNECT_LICENSE: "op://Positron/Connect-lic-WB-Auto"
+
+      - name: Write license files
+        run: |
+          echo "$WORKBENCH_LICENSE" > /tmp/workbench.lic
+          echo "$CONNECT_LICENSE" > /tmp/connect.lic
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/dockerfiles/connect/.gitignore
+++ b/dockerfiles/connect/.gitignore
@@ -1,0 +1,2 @@
+# Ignore Connect license file
+connect.lic

--- a/dockerfiles/docker-compose.workbench.yml
+++ b/dockerfiles/docker-compose.workbench.yml
@@ -67,6 +67,7 @@ services:
       - connect-data:/var/lib/rstudio-connect
       - /var/lib/rstudio-connect
       - ./connect/rstudio-connect.gcfg:/etc/rstudio-connect/rstudio-connect.gcfg:ro
+      - ./connect/connect.lic:/var/lib/rstudio-connect/connect.lic:ro
       - connect_tokens:/tokens
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3939"]


### PR DESCRIPTION
## Summary

Add Workbench and Connect license configuration for e2e workbench tests, pulling licenses from 1Password.

This follows the same pattern as [posit-dev/qa-example-content#136](https://github.com/posit-dev/qa-example-content/pull/136), but adapted to pull licenses from 1Password instead of local files.

## Changes

### Workflow
- Added `WORKBENCH_LICENSE` and `CONNECT_LICENSE` to the existing 1Password secrets loading step
- Licenses are written to temporary files (`/tmp/workbench.lic` and `/tmp/connect.lic`)

### Docker Setup Action
- Added inputs for license file paths (defaults to `/tmp/` locations)
- Copies Connect license to `dockerfiles/connect/connect.lic` before starting Docker (required for volume mount)
- Copies Workbench license into test container at `/tmp/workbench.lic` (picked up by `install-workbench.sh`)

### Docker Compose
- Added volume mount for Connect license: `./connect/connect.lic:/var/lib/rstudio-connect/connect.lic:ro`

### Gitignore
- Added `dockerfiles/connect/.gitignore` to prevent accidentally committing license files

## License Sources

- **Workbench**: `op://Positron/Workbench-lic-WB-Auto`
- **Connect**: `op://Positron/Connect-lic-WB-Auto`

Note: also using this PR to test remote-ssh infrastructure that was added in a prev PR

### Validation Steps

@:workbench @:remote-ssh