### PR TITLE
test: skip IntSlider arrow keys change value test due to known issue

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-ipywidgets-slider.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-ipywidgets-slider.test.ts
@@ -19,7 +19,9 @@ test.describe('Positron Notebooks: ipywidgets', {
 		await notebooksPositron.kernel.select('Python');
 	});
 
-	test('IntSlider arrow keys change value', async function ({ app }) {
+	test.skip('IntSlider arrow keys change value', {
+		annotation: { type: 'issue', description: 'https://github.com/posit-dev/positron/issues/13646' }
+	}, async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		await notebooksPositron.addCodeToCell(0, `
 import ipywidgets as ipw


### PR DESCRIPTION
Skip intslider ipywidget test due to https://github.com/posit-dev/positron/issues/13646

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
