### PR TITLE
Defend against missing extension paths

### DIFF
--- a/src/vs/workbench/api/common/extHostExtensionService.ts
+++ b/src/vs/workbench/api/common/extHostExtensionService.ts
@@ -367,12 +367,23 @@ export abstract class AbstractExtHostExtensionService extends Disposable impleme
 			return extUriBiasedIgnorePathCase.ignorePathCasing(key);
 		});
 		// const tst = TernarySearchTree.forUris<IExtensionDescription>(key => true);
+		// --- Start Positron ---
+		// Skip extensions whose location can't be resolved (e.g. directory was
+		// removed after a version swap). A single missing path used to reject
+		// the whole index and prevent the extension host from ever becoming
+		// ready.
 		await Promise.all(extensions.map(async (ext) => {
-			if (this._getEntryPoint(ext)) {
+			if (!this._getEntryPoint(ext)) {
+				return;
+			}
+			try {
 				const uri = await this._realPathExtensionUri(ext.extensionLocation);
 				tst.set(uri, ext);
+			} catch (err) {
+				this._logService.warn(`Skipping extension '${ext.identifier.value}' in path index; cannot resolve ${ext.extensionLocation.toString()}: ${err}`);
 			}
 		}));
+		// --- End Positron ---
 		return tst;
 	}
 
@@ -1013,19 +1024,30 @@ export abstract class AbstractExtHostExtensionService extends Disposable impleme
 		// eslint-disable-next-line local/code-no-any-casts
 		extensionsDelta.toAdd.forEach((extension) => (<any>extension).extensionLocation = URI.revive(extension.extensionLocation));
 
-		const { globalRegistry, myExtensions } = applyExtensionsDelta(this._activationEventsReader, this._globalRegistry, this._myRegistry, extensionsDelta);
-		const newSearchTree = await this._createExtensionPathIndex(myExtensions);
-		const extensionsPaths = await this.getExtensionPathIndex();
-		extensionsPaths.setSearchTree(newSearchTree);
-		this._globalRegistry.set(globalRegistry.getAllExtensionDescriptions());
-		this._myRegistry.set(myExtensions);
+		// --- Start Positron ---
+		// Defend against the preamble throwing. If we let an error escape here,
+		// `_startExtensionHost()` is never called, `_readyToRunExtensions` is
+		// never opened, and every subsequent `$activate*` RPC hangs forever --
+		// the IDE stalls in "Preparing" with the extension host alive but
+		// useless.
+		try {
+			const { globalRegistry, myExtensions } = applyExtensionsDelta(this._activationEventsReader, this._globalRegistry, this._myRegistry, extensionsDelta);
+			const newSearchTree = await this._createExtensionPathIndex(myExtensions);
+			const extensionsPaths = await this.getExtensionPathIndex();
+			extensionsPaths.setSearchTree(newSearchTree);
+			this._globalRegistry.set(globalRegistry.getAllExtensionDescriptions());
+			this._myRegistry.set(myExtensions);
 
-		if (isCI) {
-			this._logService.info(`$startExtensionHost: global extensions: ${printExtIds(this._globalRegistry)}`);
-			this._logService.info(`$startExtensionHost: local extensions: ${printExtIds(this._myRegistry)}`);
+			if (isCI) {
+				this._logService.info(`$startExtensionHost: global extensions: ${printExtIds(this._globalRegistry)}`);
+				this._logService.info(`$startExtensionHost: local extensions: ${printExtIds(this._myRegistry)}`);
+			}
+		} catch (err) {
+			this._logService.error(`$startExtensionHost: error preparing extension registry; continuing with extension host startup`, err);
 		}
 
 		return this._startExtensionHost();
+		// --- End Positron ---
 	}
 
 	public $activateByEvent(activationEvent: string, activationKind: ActivationKind): Promise<void> {

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -1002,8 +1002,15 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 
 		// --- Start Positron ---
 		// When all the extension hosts have started, we can notify the main
-		// thread.
-		Promise.all(allExtensionHostStartups).then(() => {
+		// thread. Always open the barrier -- if a host's startup rejected, we
+		// log it but still release waiters so the workbench doesn't hang
+		// silently.
+		Promise.allSettled(allExtensionHostStartups).then((results) => {
+			for (const result of results) {
+				if (result.status === 'rejected') {
+					this._logService.error(`Extension host startup failed`, result.reason);
+				}
+			}
 			this._allExtensionHostsStarted.open();
 		});
 		// --- End Positron ---


### PR DESCRIPTION
Prior to this change, Positron could hang during startup with the UI stuck in "Preparing", the extension host process alive but no extensions activating, and most of the workbench frozen. The trigger was a stale extension directory on disk, typically a bootstrap  extension whose old versioned folder (e.g. `posit.air-vscode-0.24.0-darwin-arm64`) had been removed but was still referenced by the in-memory extension registry after a version update.

The root cause was in the extension host's `$startExtensionHost`: it built a path index by calling `realpath` on every registered  extension's location inside a `Promise.all`. A single missing directory threw `ENOENT`, rejected the whole `Promise.all`, and prevented `_startExtensionHost()` from ever running ... which meant the `_readyToRunExtensions` barrier never opened, so every subsequent `$activate` RPC waited forever. On the renderer side, the Positron-added `Promise.all(allExtensionHostStartups).then(...)` had no `.catch`, so the failure didn't even surface as a visible error.

We now defend against this in three ways:

  1. `_createExtensionPathIndex` now skips and logs individual extensions whose paths can't be resolved instead of failing the whole index build.
  2. `$startExtensionHost` wraps its registry-prep preamble in try/catch so `_startExtensionHost()` is always called and the host always becomes ready, even if the path index build hits an unexpected error.
  3. The renderer-side `Promise.all` on extension-host startups is now `Promise.allSettled`, with each rejection logged and the `_allExtensionHostsStarted` barrier always opened so failures are observable instead of silent.

Fixes #12864.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Address occasional hang in "Preparing" when starting Positron after updating to a new version (#12864)


### Validation Steps

Manually deleting an installed extension's directory while leaving its entry in the registry; confirm Positron now starts normally with a warning in the log rather than hanging in "Preparing".
