### PR TITLE
e2e: add notebook release screenshots

### DIFF
--- a/test/e2e/pages/extensions.ts
+++ b/test/e2e/pages/extensions.ts
@@ -119,5 +119,23 @@ export class Extensions {
 		}
 	}
 
-
+	/**
+	 * Install the extension currently shown in the extension editor (details
+	 * pane) if it isn't already installed. No-op when the Uninstall button is
+	 * present. Used by screenshot tests where we need a stable installed state
+	 * regardless of whether the extension shipped pre-installed in the build.
+	 */
+	async installFromEditorIfNotInstalled(timeout = 60_000): Promise<void> {
+		const install = this.code.driver.currentPage
+			.locator('.extension-editor .monaco-action-bar .action-item:not(.disabled) .extension-action.install')
+			.first();
+		const uninstall = this.code.driver.currentPage
+			.locator('.extension-editor .monaco-action-bar .action-item:not(.disabled) .extension-action.uninstall')
+			.first();
+		if (!(await install.isVisible({ timeout: 2_000 }).catch(() => false))) {
+			return;
+		}
+		await install.click();
+		await expect(uninstall).toBeVisible({ timeout });
+	}
 }

--- a/test/e2e/release-screenshots/extension-publisher.screenshot.ts
+++ b/test/e2e/release-screenshots/extension-publisher.screenshot.ts
@@ -71,15 +71,9 @@ test.describe('Release Screenshots - Extension Publisher', () => {
 		await expect(header).toBeVisible();
 		await expect(header.locator('.publisher')).toBeVisible();
 
-		// Air ships pre-installed in some builds but not all. Install it if the
-		// Install button is visible so the screenshot captures the Disable/Uninstall
-		// state every run.
-		const installButton = page.locator('.extension-editor .monaco-action-bar .action-item:not(.disabled) .extension-action.install').first();
-		const uninstallButton = page.locator('.extension-editor .monaco-action-bar .action-item:not(.disabled) .extension-action.uninstall').first();
-		if (await installButton.isVisible({ timeout: 2_000 }).catch(() => false)) {
-			await installButton.click();
-			await expect(uninstallButton).toBeVisible({ timeout: 60_000 });
-		}
+		// Air ships pre-installed in some builds but not all; ensure installed
+		// so the screenshot always captures the Disable/Uninstall state.
+		await extensions.installFromEditorIfNotInstalled();
 
 		await hideToasts(app);
 

--- a/test/e2e/release-screenshots/extension-publisher.screenshot.ts
+++ b/test/e2e/release-screenshots/extension-publisher.screenshot.ts
@@ -63,14 +63,23 @@ test.describe('Release Screenshots - Extension Publisher', () => {
 	test('Release Screenshot - extension-verified-publisher.png', async ({ app, page }) => {
 		const { extensions } = app.workbench;
 
-		// Air ships pre-installed and is published by Posit, so it
-		// reliably has the verified-publisher badge.
+		// Air is published by Posit, so it reliably has the verified-publisher badge.
 		const id = 'posit.air-vscode';
 		await extensions.openExtensionDetails(id);
 
 		const header = page.locator('.extension-editor .header');
 		await expect(header).toBeVisible();
 		await expect(header.locator('.publisher')).toBeVisible();
+
+		// Air ships pre-installed in some builds but not all. Install it if the
+		// Install button is visible so the screenshot captures the Disable/Uninstall
+		// state every run.
+		const installButton = page.locator('.extension-editor .monaco-action-bar .action-item:not(.disabled) .extension-action.install').first();
+		const uninstallButton = page.locator('.extension-editor .monaco-action-bar .action-item:not(.disabled) .extension-action.uninstall').first();
+		if (await installButton.isVisible({ timeout: 2_000 }).catch(() => false)) {
+			await installButton.click();
+			await expect(uninstallButton).toBeVisible({ timeout: 60_000 });
+		}
 
 		await hideToasts(app);
 

--- a/test/e2e/release-screenshots/helpers/layout-utils.ts
+++ b/test/e2e/release-screenshots/helpers/layout-utils.ts
@@ -231,6 +231,41 @@ export async function overrideRuntimeLabel(page: Page): Promise<void> {
 }
 
 /**
+ * Rewrite the workspace folder name shown in the title bar and the top
+ * action bar's folder picker. The default test workspace renders as
+ * "qa-example-content"; docs screenshots use a friendlier folder name like
+ * "positron-demos-notebooks". Replaces only the matching token so other
+ * title-bar text (e.g. "Untitled-1.ipynb — ") is preserved.
+ *
+ * Call this AFTER `waitForStableUI` so any in-flight re-renders don't undo
+ * the rewrite before the screenshot fires.
+ */
+export async function overrideWorkspaceName(
+	page: Page,
+	from: string,
+	to: string,
+): Promise<void> {
+	await page.evaluate(({ from, to }) => {
+		const SELECTORS = [
+			'.titlebar .window-title',
+			'#top-action-bar-current-working-folder',
+		];
+		for (const sel of SELECTORS) {
+			for (const root of document.querySelectorAll(sel)) {
+				const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+				let node: Node | null;
+				while ((node = walker.nextNode())) {
+					const t = node as Text;
+					if (t.nodeValue && t.nodeValue.includes(from)) {
+						t.nodeValue = t.nodeValue.split(from).join(to);
+					}
+				}
+			}
+		}
+	}, { from, to });
+}
+
+/**
  * Standard pre-screenshot cleanup. Composes the smaller helpers in the order
  * that produces a clean, deterministic frame:
  *   1. Hide notification toasts (they cover real UI)

--- a/test/e2e/release-screenshots/helpers/layout-utils.ts
+++ b/test/e2e/release-screenshots/helpers/layout-utils.ts
@@ -198,10 +198,12 @@ export async function waitForStableUI(page: Page, ms = 250): Promise<void> {
  * otherwise surface CI/runner internals — uv project paths, the local
  * Python manager — into docs screenshots.
  *
- * Scoped to the three workbench surfaces that render the runtime label:
- *   - `.top-action-bar-session-manager-face` (top-right interpreter face)
- *   - `.plot-session-name`                   (plots pane header)
- *   - `.tab-header .session-name`            (console session tab)
+ * Scoped to the workbench surfaces that render the runtime label:
+ *   - `.top-action-bar-session-manager-face`     (top-right interpreter face)
+ *   - `.plot-session-name`                       (plots pane header)
+ *   - `.tab-header .session-name`                (console session tab)
+ *   - `.positron-notebook-kernel-status-badge`   (Positron notebook kernel chip)
+ *   - `a.kernel-label`                           (VS Code Jupyter notebook kernel chip)
  *
  * Call this AFTER `waitForStableUI` so any in-flight re-renders don't undo
  * the rewrite before the screenshot fires.
@@ -212,6 +214,8 @@ export async function overrideRuntimeLabel(page: Page): Promise<void> {
 			'.top-action-bar-session-manager-face',
 			'.plot-session-name',
 			'.tab-header .session-name',
+			'.positron-notebook-kernel-status-badge',
+			'a.kernel-label',
 		];
 		const PATTERN = /(Python\s+[\d.]+)\s+\([^)]+\)/g;
 		const REPLACEMENT = '$1 (Venv: .venv)';

--- a/test/e2e/release-screenshots/helpers/screenshot-utils.ts
+++ b/test/e2e/release-screenshots/helpers/screenshot-utils.ts
@@ -135,15 +135,16 @@ export async function capturePanelHires(
 }
 
 /**
- * Composite a captured PNG onto a slightly larger white canvas and paint a
- * soft drop shadow behind it. Approximates the floating-window look of the
- * legacy macOS-chrome screenshots that this repo's CDP captures cannot
- * reproduce directly. Mutates the file in place. Padding scales with the
- * source resolution so it stays proportional at 2x device pixels.
+ * Composite a captured PNG onto a slightly larger white canvas, round the
+ * corners, and paint a soft drop shadow behind it. Approximates the
+ * floating-window look of the legacy macOS-chrome screenshots that this
+ * repo's CDP captures cannot reproduce directly. Mutates the file in place.
+ * Radius and padding are in source pixels (i.e. the captured PNG is at 2x by
+ * default, so radius=24 ≈ 12 CSS px).
  */
 export async function applyDropShadow(
 	filename: string,
-	opts?: { padding?: number; blur?: number; opacity?: number },
+	opts?: { padding?: number; blur?: number; opacity?: number; radius?: number },
 ): Promise<void> {
 	const { createCanvas, loadImage } = await import('canvas');
 	const fs = await import('node:fs/promises');
@@ -152,6 +153,18 @@ export async function applyDropShadow(
 	const padding = opts?.padding ?? 60;
 	const blur = opts?.blur ?? 40;
 	const opacity = opts?.opacity ?? 0.25;
+	const radius = opts?.radius ?? 24;
+
+	// Clip the source image to a rounded rect on a transparent canvas so the
+	// shadow that follows traces the rounded silhouette, not the rectangle.
+	const clipped = createCanvas(img.width, img.height);
+	const clipCtx = clipped.getContext('2d');
+	clipCtx.beginPath();
+	clipCtx.roundRect(0, 0, img.width, img.height, radius);
+	clipCtx.closePath();
+	clipCtx.clip();
+	clipCtx.drawImage(img, 0, 0);
+
 	const W = img.width + padding * 2;
 	const H = img.height + padding * 2;
 	const canvas = createCanvas(W, H);
@@ -162,6 +175,7 @@ export async function applyDropShadow(
 	ctx.shadowBlur = blur;
 	ctx.shadowOffsetX = 0;
 	ctx.shadowOffsetY = Math.round(blur / 3);
-	ctx.drawImage(img, padding, padding);
+	ctx.drawImage(clipped, padding, padding);
+
 	await fs.writeFile(file, canvas.toBuffer('image/png'));
 }

--- a/test/e2e/release-screenshots/helpers/screenshot-utils.ts
+++ b/test/e2e/release-screenshots/helpers/screenshot-utils.ts
@@ -41,7 +41,9 @@ async function cdpCapture(
 
 /**
  * Capture the entire Electron window and write it to the output folder.
- * Used for full-app shots like the Welcome page.
+ * Used for full-app shots like the Welcome page. The capture is wrapped in
+ * a rounded-corner drop shadow halo to mimic a floating macOS window — pass
+ * `{ shadow: false }` to skip when a raw capture is needed.
  *
  * Reads the renderer's reported viewport size and passes it as an explicit
  * clip through CDP at the requested scale (defaults to 2x). Playwright's
@@ -51,13 +53,16 @@ async function cdpCapture(
 export async function captureFullWindow(
 	page: Page,
 	filename: string,
-	opts?: { scale?: number },
+	opts?: { scale?: number; shadow?: boolean },
 ): Promise<void> {
 	const { width, height } = await page.evaluate(() => ({
 		width: window.innerWidth,
 		height: window.innerHeight,
 	}));
 	await cdpCapture(page, { x: 0, y: 0, width, height, scale: opts?.scale ?? DEFAULT_SCALE }, filename);
+	if (opts?.shadow !== false) {
+		await applyDropShadow(filename);
+	}
 }
 
 /**

--- a/test/e2e/release-screenshots/helpers/screenshot-utils.ts
+++ b/test/e2e/release-screenshots/helpers/screenshot-utils.ts
@@ -133,3 +133,35 @@ export async function capturePanelHires(
 ): Promise<void> {
 	await capturePanel(page, locator, filename, { scale });
 }
+
+/**
+ * Composite a captured PNG onto a slightly larger white canvas and paint a
+ * soft drop shadow behind it. Approximates the floating-window look of the
+ * legacy macOS-chrome screenshots that this repo's CDP captures cannot
+ * reproduce directly. Mutates the file in place. Padding scales with the
+ * source resolution so it stays proportional at 2x device pixels.
+ */
+export async function applyDropShadow(
+	filename: string,
+	opts?: { padding?: number; blur?: number; opacity?: number },
+): Promise<void> {
+	const { createCanvas, loadImage } = await import('canvas');
+	const fs = await import('node:fs/promises');
+	const file = outputPath(filename);
+	const img = await loadImage(file);
+	const padding = opts?.padding ?? 60;
+	const blur = opts?.blur ?? 40;
+	const opacity = opts?.opacity ?? 0.25;
+	const W = img.width + padding * 2;
+	const H = img.height + padding * 2;
+	const canvas = createCanvas(W, H);
+	const ctx = canvas.getContext('2d');
+	ctx.fillStyle = '#ffffff';
+	ctx.fillRect(0, 0, W, H);
+	ctx.shadowColor = `rgba(0,0,0,${opacity})`;
+	ctx.shadowBlur = blur;
+	ctx.shadowOffsetX = 0;
+	ctx.shadowOffsetY = Math.round(blur / 3);
+	ctx.drawImage(img, padding, padding);
+	await fs.writeFile(file, canvas.toBuffer('image/png'));
+}

--- a/test/e2e/release-screenshots/jupyter-notebooks.screenshot.ts
+++ b/test/e2e/release-screenshots/jupyter-notebooks.screenshot.ts
@@ -41,7 +41,8 @@ test.describe('Release Screenshots - Jupyter Notebooks', () => {
 
 		await prepareForScreenshot(app, page);
 		await annotate(page, [
-			{ selector: 'a.kernel-label', label: '', color: ANNOTATION_COLOR, padding: 3 },
+			// Wrap the whole kernel-action-view-item so the icon stays inside the box.
+			{ selector: '.kernel-action-view-item', label: '', color: ANNOTATION_COLOR, padding: 3 },
 		]);
 		await captureFullWindow(page, 'jupyter-notebooks-kernel-selector.png');
 	});

--- a/test/e2e/release-screenshots/jupyter-notebooks.screenshot.ts
+++ b/test/e2e/release-screenshots/jupyter-notebooks.screenshot.ts
@@ -5,7 +5,7 @@
 
 import { test } from '../tests/_test.setup';
 import { applyDropShadow, captureFullWindow } from './helpers/screenshot-utils';
-import { prepareForScreenshot, setScreenshotWindowSize } from './helpers/layout-utils';
+import { overrideWorkspaceName, prepareForScreenshot, setScreenshotWindowSize } from './helpers/layout-utils';
 import { annotate, clearAnnotations } from './helpers/annotate-utils';
 
 const ANNOTATION_COLOR = '#dc2626';
@@ -40,6 +40,7 @@ test.describe('Release Screenshots - Jupyter Notebooks', () => {
 		await hotKeys.toggleBottomPanel();
 
 		await prepareForScreenshot(app, page);
+		await overrideWorkspaceName(page, 'qa-example-content', 'positron-demos-notebooks');
 		await annotate(page, [
 			// Wrap the whole kernel-action-view-item so the icon stays inside the box.
 			{ selector: '.kernel-action-view-item', label: '', color: ANNOTATION_COLOR, padding: 3 },

--- a/test/e2e/release-screenshots/jupyter-notebooks.screenshot.ts
+++ b/test/e2e/release-screenshots/jupyter-notebooks.screenshot.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test } from '../tests/_test.setup';
-import { captureFullWindow } from './helpers/screenshot-utils';
+import { applyDropShadow, captureFullWindow } from './helpers/screenshot-utils';
 import { prepareForScreenshot, setScreenshotWindowSize } from './helpers/layout-utils';
 import { annotate, clearAnnotations } from './helpers/annotate-utils';
 
@@ -15,7 +15,7 @@ test.use({
 });
 
 test.beforeEach(async ({ app }) => {
-	await setScreenshotWindowSize(app, { width: 1104, height: 744 });
+	await setScreenshotWindowSize(app, { width: 960, height: 640 });
 });
 
 test.afterEach(async ({ app, page }) => {
@@ -45,5 +45,6 @@ test.describe('Release Screenshots - Jupyter Notebooks', () => {
 			{ selector: '.kernel-action-view-item', label: '', color: ANNOTATION_COLOR, padding: 3 },
 		]);
 		await captureFullWindow(page, 'jupyter-notebooks-kernel-selector.png');
+		await applyDropShadow('jupyter-notebooks-kernel-selector.png');
 	});
 });

--- a/test/e2e/release-screenshots/jupyter-notebooks.screenshot.ts
+++ b/test/e2e/release-screenshots/jupyter-notebooks.screenshot.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test } from '../tests/_test.setup';
+import { captureFullWindow } from './helpers/screenshot-utils';
+import { prepareForScreenshot, setScreenshotWindowSize } from './helpers/layout-utils';
+import { annotate, clearAnnotations } from './helpers/annotate-utils';
+
+const ANNOTATION_COLOR = '#dc2626';
+
+test.use({
+	suiteId: __filename,
+});
+
+test.beforeEach(async ({ app }) => {
+	await setScreenshotWindowSize(app, { width: 1104, height: 744 });
+});
+
+test.afterEach(async ({ app, page }) => {
+	await page.keyboard.press('Escape');
+	await clearAnnotations(page);
+	await app.workbench.hotKeys.closeAllEditors();
+});
+
+test.describe('Release Screenshots - Jupyter Notebooks', () => {
+	/**
+	 * Img Path: https://positron.posit.co/images/jupyter-notebooks-kernel-selector.png
+	 */
+	test('Release Screenshot - jupyter-notebooks-kernel-selector.png', async ({ app, page, python }) => {
+		const { notebooksVscode, hotKeys } = app.workbench;
+
+		await notebooksVscode.createNewNotebook();
+		await notebooksVscode.expectToBeVisible();
+		await notebooksVscode.selectInterpreter('Python');
+
+		await hotKeys.closePrimarySidebar();
+		await hotKeys.closeSecondarySidebar();
+		await hotKeys.toggleBottomPanel();
+
+		await prepareForScreenshot(app, page);
+		await annotate(page, [
+			{ selector: 'a.kernel-label', label: '', color: ANNOTATION_COLOR, padding: 3 },
+		]);
+		await captureFullWindow(page, 'jupyter-notebooks-kernel-selector.png');
+	});
+});

--- a/test/e2e/release-screenshots/jupyter-notebooks.screenshot.ts
+++ b/test/e2e/release-screenshots/jupyter-notebooks.screenshot.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test } from '../tests/_test.setup';
-import { applyDropShadow, captureFullWindow } from './helpers/screenshot-utils';
+import { captureFullWindow } from './helpers/screenshot-utils';
 import { overrideWorkspaceName, prepareForScreenshot, setScreenshotWindowSize } from './helpers/layout-utils';
 import { annotate, clearAnnotations } from './helpers/annotate-utils';
 
@@ -46,6 +46,5 @@ test.describe('Release Screenshots - Jupyter Notebooks', () => {
 			{ selector: '.kernel-action-view-item', label: '', color: ANNOTATION_COLOR, padding: 3 },
 		]);
 		await captureFullWindow(page, 'jupyter-notebooks-kernel-selector.png');
-		await applyDropShadow('jupyter-notebooks-kernel-selector.png');
 	});
 });

--- a/test/e2e/release-screenshots/positron-notebook.screenshot.ts
+++ b/test/e2e/release-screenshots/positron-notebook.screenshot.ts
@@ -5,7 +5,7 @@
 
 import { expect } from '@playwright/test';
 import { test as base } from '../tests/_test.setup';
-import { applyDropShadow, captureFullWindow } from './helpers/screenshot-utils';
+import { captureFullWindow } from './helpers/screenshot-utils';
 import { overrideWorkspaceName, prepareForScreenshot, setScreenshotWindowSize } from './helpers/layout-utils';
 import { annotate, clearAnnotations } from './helpers/annotate-utils';
 
@@ -56,7 +56,6 @@ test.describe('Release Screenshots - Positron Notebook', () => {
 			{ selector: 'button[aria-label="Kernel Actions"]', label: '', color: ANNOTATION_COLOR, padding: 3 },
 		]);
 		await captureFullWindow(page, 'positron-notebook-editor-kernel-selector.png');
-		await applyDropShadow('positron-notebook-editor-kernel-selector.png');
 	});
 
 	/**
@@ -85,7 +84,6 @@ test.describe('Release Screenshots - Positron Notebook', () => {
 			{ selector: '.editor-action-bar-container button[aria-label="Ask Assistant"]', label: '', color: ANNOTATION_COLOR, padding: 3 },
 		]);
 		await captureFullWindow(page, 'positron-notebook-assistant-action-bar.png');
-		await applyDropShadow('positron-notebook-assistant-action-bar.png');
 	});
 
 	/**
@@ -114,6 +112,5 @@ test.describe('Release Screenshots - Positron Notebook', () => {
 		await prepareForScreenshot(app, page);
 		await overrideWorkspaceName(page, 'qa-example-content', 'positron-demos-notebooks');
 		await captureFullWindow(page, 'positron-notebook-assistant-panel.png');
-		await applyDropShadow('positron-notebook-assistant-panel.png');
 	});
 });

--- a/test/e2e/release-screenshots/positron-notebook.screenshot.ts
+++ b/test/e2e/release-screenshots/positron-notebook.screenshot.ts
@@ -75,8 +75,7 @@ test.describe('Release Screenshots - Positron Notebook', () => {
 		await hotKeys.toggleBottomPanel();
 
 		// The button is gated on config.positron.assistant.enable; wait for it to render.
-		const assistantButton = page.locator('.editor-action-bar-container button[aria-label="Ask Assistant"]');
-		await expect(assistantButton).toBeVisible({ timeout: 10000 });
+		await notebooksPositron.expectAssistantButtonsVisible();
 
 		await prepareForScreenshot(app, page);
 		await overrideWorkspaceName(page, 'qa-example-content', 'positron-demos-notebooks');
@@ -102,9 +101,7 @@ test.describe('Release Screenshots - Positron Notebook', () => {
 		await hotKeys.closeSecondarySidebar();
 		await hotKeys.toggleBottomPanel();
 
-		const assistantButton = page.locator('.editor-action-bar-container button[aria-label="Ask Assistant"]');
-		await expect(assistantButton).toBeVisible({ timeout: 10000 });
-		await assistantButton.click();
+		await notebooksPositron.clickAskAssistantButton();
 
 		const panel = page.locator('.positron-modal-dialog-box').filter({ hasText: 'Positron Notebook Assistant' });
 		await expect(panel).toBeVisible({ timeout: 10000 });

--- a/test/e2e/release-screenshots/positron-notebook.screenshot.ts
+++ b/test/e2e/release-screenshots/positron-notebook.screenshot.ts
@@ -5,7 +5,7 @@
 
 import { expect } from '@playwright/test';
 import { test as base } from '../tests/_test.setup';
-import { captureFullWindow } from './helpers/screenshot-utils';
+import { applyDropShadow, captureFullWindow } from './helpers/screenshot-utils';
 import { prepareForScreenshot, setScreenshotWindowSize } from './helpers/layout-utils';
 import { annotate, clearAnnotations } from './helpers/annotate-utils';
 
@@ -26,7 +26,7 @@ test.use({
 });
 
 test.beforeEach(async ({ app }) => {
-	await setScreenshotWindowSize(app, { width: 1104, height: 744 });
+	await setScreenshotWindowSize(app, { width: 960, height: 640 });
 });
 
 test.afterEach(async ({ app, page }) => {
@@ -55,6 +55,7 @@ test.describe('Release Screenshots - Positron Notebook', () => {
 			{ selector: 'button[aria-label="Kernel Actions"]', label: '', color: ANNOTATION_COLOR, padding: 3 },
 		]);
 		await captureFullWindow(page, 'positron-notebook-editor-kernel-selector.png');
+		await applyDropShadow('positron-notebook-editor-kernel-selector.png');
 	});
 
 	/**
@@ -82,6 +83,7 @@ test.describe('Release Screenshots - Positron Notebook', () => {
 			{ selector: '.editor-action-bar-container button[aria-label="Ask Assistant"]', label: '', color: ANNOTATION_COLOR, padding: 3 },
 		]);
 		await captureFullWindow(page, 'positron-notebook-assistant-action-bar.png');
+		await applyDropShadow('positron-notebook-assistant-action-bar.png');
 	});
 
 	/**
@@ -109,5 +111,6 @@ test.describe('Release Screenshots - Positron Notebook', () => {
 
 		await prepareForScreenshot(app, page);
 		await captureFullWindow(page, 'positron-notebook-assistant-panel.png');
+		await applyDropShadow('positron-notebook-assistant-panel.png');
 	});
 });

--- a/test/e2e/release-screenshots/positron-notebook.screenshot.ts
+++ b/test/e2e/release-screenshots/positron-notebook.screenshot.ts
@@ -1,0 +1,113 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from '@playwright/test';
+import { test as base } from '../tests/_test.setup';
+import { captureFullWindow } from './helpers/screenshot-utils';
+import { prepareForScreenshot, setScreenshotWindowSize } from './helpers/layout-utils';
+import { annotate, clearAnnotations } from './helpers/annotate-utils';
+
+const ANNOTATION_COLOR = '#dc2626';
+
+const test = base.extend({
+	beforeApp: [
+		async ({ settingsFile }, use) => {
+			settingsFile.append({ 'positron.notebook.enabled': true });
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
+
+test.use({
+	suiteId: __filename,
+});
+
+test.beforeEach(async ({ app }) => {
+	await setScreenshotWindowSize(app, { width: 1104, height: 744 });
+});
+
+test.afterEach(async ({ app, page }) => {
+	await page.keyboard.press('Escape');
+	await clearAnnotations(page);
+	await app.workbench.hotKeys.closeAllEditors();
+});
+
+test.describe('Release Screenshots - Positron Notebook', () => {
+	/**
+	 * Img Path: https://positron.posit.co/images/positron-notebook-editor-kernel-selector.png
+	 */
+	test('Release Screenshot - positron-notebook-editor-kernel-selector.png', async ({ app, page, python }) => {
+		const { notebooksPositron, hotKeys } = app.workbench;
+
+		await notebooksPositron.createNewNotebook();
+		await notebooksPositron.expectToBeVisible();
+		await notebooksPositron.kernel.select('Python');
+
+		await hotKeys.closePrimarySidebar();
+		await hotKeys.closeSecondarySidebar();
+		await hotKeys.toggleBottomPanel();
+
+		await prepareForScreenshot(app, page);
+		await annotate(page, [
+			{ selector: 'button[aria-label="Kernel Actions"]', label: '', color: ANNOTATION_COLOR, padding: 3 },
+		]);
+		await captureFullWindow(page, 'positron-notebook-editor-kernel-selector.png');
+	});
+
+	/**
+	 * Img Path: https://positron.posit.co/images/positron-notebook-assistant-action-bar.png
+	 */
+	test('Release Screenshot - positron-notebook-assistant-action-bar.png', async ({ app, page, python, settings }) => {
+		const { notebooksPositron, hotKeys } = app.workbench;
+
+		await settings.set({ 'positron.assistant.enable': true }, { keepOpen: false });
+
+		await notebooksPositron.createNewNotebook();
+		await notebooksPositron.expectToBeVisible();
+		await notebooksPositron.kernel.select('Python');
+
+		await hotKeys.closePrimarySidebar();
+		await hotKeys.closeSecondarySidebar();
+		await hotKeys.toggleBottomPanel();
+
+		// The button is gated on config.positron.assistant.enable; wait for it to render.
+		const assistantButton = page.locator('.editor-action-bar-container button[aria-label="Ask Assistant"]');
+		await expect(assistantButton).toBeVisible({ timeout: 10000 });
+
+		await prepareForScreenshot(app, page);
+		await annotate(page, [
+			{ selector: '.editor-action-bar-container button[aria-label="Ask Assistant"]', label: '', color: ANNOTATION_COLOR, padding: 3 },
+		]);
+		await captureFullWindow(page, 'positron-notebook-assistant-action-bar.png');
+	});
+
+	/**
+	 * Img Path: https://positron.posit.co/images/positron-notebook-assistant-panel.png
+	 */
+	test('Release Screenshot - positron-notebook-assistant-panel.png', async ({ app, page, python, settings }) => {
+		const { notebooksPositron, hotKeys } = app.workbench;
+
+		await settings.set({ 'positron.assistant.enable': true }, { keepOpen: false });
+
+		await notebooksPositron.createNewNotebook();
+		await notebooksPositron.expectToBeVisible();
+		await notebooksPositron.kernel.select('Python');
+
+		await hotKeys.closePrimarySidebar();
+		await hotKeys.closeSecondarySidebar();
+		await hotKeys.toggleBottomPanel();
+
+		const assistantButton = page.locator('.editor-action-bar-container button[aria-label="Ask Assistant"]');
+		await expect(assistantButton).toBeVisible({ timeout: 10000 });
+		await assistantButton.click();
+
+		const panel = page.locator('.positron-modal-dialog-box').filter({ hasText: 'Positron Notebook Assistant' });
+		await expect(panel).toBeVisible({ timeout: 10000 });
+
+		await prepareForScreenshot(app, page);
+		await captureFullWindow(page, 'positron-notebook-assistant-panel.png');
+	});
+});

--- a/test/e2e/release-screenshots/positron-notebook.screenshot.ts
+++ b/test/e2e/release-screenshots/positron-notebook.screenshot.ts
@@ -6,7 +6,7 @@
 import { expect } from '@playwright/test';
 import { test as base } from '../tests/_test.setup';
 import { applyDropShadow, captureFullWindow } from './helpers/screenshot-utils';
-import { prepareForScreenshot, setScreenshotWindowSize } from './helpers/layout-utils';
+import { overrideWorkspaceName, prepareForScreenshot, setScreenshotWindowSize } from './helpers/layout-utils';
 import { annotate, clearAnnotations } from './helpers/annotate-utils';
 
 const ANNOTATION_COLOR = '#dc2626';
@@ -51,6 +51,7 @@ test.describe('Release Screenshots - Positron Notebook', () => {
 		await hotKeys.toggleBottomPanel();
 
 		await prepareForScreenshot(app, page);
+		await overrideWorkspaceName(page, 'qa-example-content', 'positron-demos-notebooks');
 		await annotate(page, [
 			{ selector: 'button[aria-label="Kernel Actions"]', label: '', color: ANNOTATION_COLOR, padding: 3 },
 		]);
@@ -79,6 +80,7 @@ test.describe('Release Screenshots - Positron Notebook', () => {
 		await expect(assistantButton).toBeVisible({ timeout: 10000 });
 
 		await prepareForScreenshot(app, page);
+		await overrideWorkspaceName(page, 'qa-example-content', 'positron-demos-notebooks');
 		await annotate(page, [
 			{ selector: '.editor-action-bar-container button[aria-label="Ask Assistant"]', label: '', color: ANNOTATION_COLOR, padding: 3 },
 		]);
@@ -110,6 +112,7 @@ test.describe('Release Screenshots - Positron Notebook', () => {
 		await expect(panel).toBeVisible({ timeout: 10000 });
 
 		await prepareForScreenshot(app, page);
+		await overrideWorkspaceName(page, 'qa-example-content', 'positron-demos-notebooks');
 		await captureFullWindow(page, 'positron-notebook-assistant-panel.png');
 		await applyDropShadow('positron-notebook-assistant-panel.png');
 	});


### PR DESCRIPTION
### Summary
Adds 4 notebook release screenshot tests:

- Positron notebook editor kernel selector (annotated kernel chip)
- Positron notebook assistant action bar button (annotated)
- Positron notebook assistant panel (full panel open)
- Jupyter notebook kernel selector (annotated kernel chip)

Also modified full screen captures to always add the shadow box effect.

### QA Notes
See updated screenshot report [here](https://github.com/posit-dev/positron/actions/runs/26175760452).