### PR TITLE
E2E test: complete the process for the remote-ssh tag

### DIFF
--- a/.github/workflows/build-remote-ssh-linux.yml
+++ b/.github/workflows/build-remote-ssh-linux.yml
@@ -6,6 +6,9 @@ on:
       artifact-name:
         description: "Name of the deb artifact uploaded"
         value: ${{ jobs.build-deb.outputs.artifact-name }}
+      reh-artifact-name:
+        description: "Name of the REH artifact uploaded"
+        value: ${{ jobs.build-reh.outputs.artifact-name }}
 
 permissions:
   contents: read
@@ -103,4 +106,76 @@ jobs:
         with:
           name: positron-deb-remote-ssh-x64
           path: Positron-remote-ssh-x64.deb
+          retention-days: 1
+
+  build-reh:
+    name: Build Positron REH for Remote SSH Tests
+    runs-on: ubuntu-latest-8x
+    timeout-minutes: 180
+    outputs:
+      artifact-name: positron-reh-remote-ssh-x64
+    container:
+      image: ghcr.io/posit-dev/positron-builds-rocky8:3
+      credentials:
+        username: ${{ secrets.POSITRON_GITHUB_RO_USER }}
+        password: ${{ secrets.POSITRON_GITHUB_RO_PAT }}
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      POSITRON_BUILD_NUMBER: 0
+      BUILD_SOURCEVERSION: ${{ github.sha }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Configure Git safe directory
+        run: |
+          git config --global --add safe.directory '*'
+          git rev-parse --show-toplevel
+
+      - name: Install build dependencies
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+          npm_config_arch: x64
+        shell: scl enable gcc-toolset-14 -- bash -eo pipefail {0}
+        run: |
+          # Check versions
+          g++ --version
+          python3 --version
+          pip --version
+
+          # Install build dependencies
+          npm install --prefix build --fetch-timeout 120000
+
+          # Install main dependencies
+          npm ci --fetch-timeout 120000
+
+      - name: Build Positron Remote Extension Host
+        env:
+          npm_config_arch: x64
+          MANGLER_WORKER_POOL_SIZE: 1
+        run: |
+          echo "Building Positron REH with commit SHA: ${{ env.BUILD_SOURCEVERSION }}"
+          npm run gulp vscode-reh-linux-x64
+          cd ..
+          tar czvf positron-reh-remote-ssh-x64.tar.gz vscode-reh-linux-x64
+
+      - name: Upload REH artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: positron-reh-remote-ssh-x64
+          path: ../positron-reh-remote-ssh-x64.tar.gz
           retention-days: 1

--- a/.github/workflows/build-remote-ssh-linux.yml
+++ b/.github/workflows/build-remote-ssh-linux.yml
@@ -57,6 +57,7 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
           npm_config_arch: x64
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: scl enable gcc-toolset-14 -- bash -eo pipefail {0}
         run: |
           # Check versions
@@ -150,6 +151,7 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
           npm_config_arch: x64
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: scl enable gcc-toolset-14 -- bash -eo pipefail {0}
         run: |
           # Check versions

--- a/.github/workflows/build-remote-ssh-linux.yml
+++ b/.github/workflows/build-remote-ssh-linux.yml
@@ -171,11 +171,11 @@ jobs:
           echo "Building Positron REH with commit SHA: ${{ env.BUILD_SOURCEVERSION }}"
           npm run gulp vscode-reh-linux-x64
           cd ..
-          tar czvf positron-reh-remote-ssh-x64.tar.gz vscode-reh-linux-x64
+          tar czvf positron/positron-reh-remote-ssh-x64.tar.gz vscode-reh-linux-x64
 
       - name: Upload REH artifact
         uses: actions/upload-artifact@v7
         with:
           name: positron-reh-remote-ssh-x64
-          path: ../positron-reh-remote-ssh-x64.tar.gz
+          path: positron-reh-remote-ssh-x64.tar.gz
           retention-days: 1

--- a/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
+++ b/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
@@ -69,6 +69,12 @@ jobs:
           name: "positron-deb-remote-ssh-x64"
           path: /tmp/artifacts
 
+      - name: Download REH artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: "positron-reh-remote-ssh-x64"
+          path: /tmp/artifacts
+
       - name: Install Positron from DEB
         run: |
           sudo apt-get update && sudo apt-get install -y xdg-utils
@@ -88,6 +94,31 @@ jobs:
       - name: Install SSH in container
         run: |
           docker exec test /bin/bash -c "/tmp/ssh-install.sh"
+
+      - name: Setup Positron REH in container
+        run: |
+          # Copy REH tarball into container
+          docker cp /tmp/artifacts/positron-reh-remote-ssh-x64.tar.gz test:/tmp/positron-reh-remote-ssh-x64.tar.gz
+
+          # Extract REH into /root/.positron-server
+          docker exec test /bin/bash -c "
+            mkdir -p /root/.positron-server
+            cd /root/.positron-server
+            tar xzf /tmp/positron-reh-remote-ssh-x64.tar.gz --strip-components=1
+            rm /tmp/positron-reh-remote-ssh-x64.tar.gz
+          "
+
+          # Verify extraction
+          docker exec test /bin/bash -c "
+            echo 'Verifying REH extraction...'
+            ls -la /root/.positron-server/
+            if [[ -d /root/.positron-server/bin && -d /root/.positron-server/data && -d /root/.positron-server/extensions ]]; then
+              echo '✓ REH directories found: bin, data, extensions'
+            else
+              echo '✗ REH extraction incomplete'
+              exit 1
+            fi
+          "
 
       - name: Configure xvfb and dbus
         uses: ./.github/actions/setup-xvfb

--- a/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
+++ b/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
@@ -97,13 +97,17 @@ jobs:
 
       - name: Setup Positron REH in container
         run: |
+          # Get the commit SHA to create the versioned directory structure
+          COMMIT_SHA="${{ github.sha }}"
+
           # Copy REH tarball into container
           docker cp /tmp/artifacts/positron-reh-remote-ssh-x64.tar.gz test:/tmp/positron-reh-remote-ssh-x64.tar.gz
 
-          # Extract REH into /root/.positron-server
+          # Extract REH into /root/.positron-server/bin/<commit-sha>
+          # The remote SSH extension expects the structure: ~/.positron-server/bin/<commit>/bin/positron-server
           docker exec test /bin/bash -c "
-            mkdir -p /root/.positron-server
-            cd /root/.positron-server
+            mkdir -p /root/.positron-server/bin/${COMMIT_SHA}
+            cd /root/.positron-server/bin/${COMMIT_SHA}
             tar xzf /tmp/positron-reh-remote-ssh-x64.tar.gz --strip-components=1
             rm /tmp/positron-reh-remote-ssh-x64.tar.gz
           "
@@ -111,9 +115,9 @@ jobs:
           # Verify extraction
           docker exec test /bin/bash -c "
             echo 'Verifying REH extraction...'
-            ls -la /root/.positron-server/
-            if [[ -d /root/.positron-server/bin && -d /root/.positron-server/extensions ]]; then
-              echo '✓ REH directories found: bin, extensions'
+            ls -la /root/.positron-server/bin/${COMMIT_SHA}/
+            if [[ -d /root/.positron-server/bin/${COMMIT_SHA}/bin && -d /root/.positron-server/bin/${COMMIT_SHA}/extensions ]]; then
+              echo '✓ REH directories found at /root/.positron-server/bin/${COMMIT_SHA}/'
             else
               echo '✗ REH extraction incomplete'
               exit 1

--- a/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
+++ b/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
@@ -112,8 +112,8 @@ jobs:
           docker exec test /bin/bash -c "
             echo 'Verifying REH extraction...'
             ls -la /root/.positron-server/
-            if [[ -d /root/.positron-server/bin && -d /root/.positron-server/data && -d /root/.positron-server/extensions ]]; then
-              echo '✓ REH directories found: bin, data, extensions'
+            if [[ -d /root/.positron-server/bin && -d /root/.positron-server/extensions ]]; then
+              echo '✓ REH directories found: bin, extensions'
             else
               echo '✗ REH extraction incomplete'
               exit 1


### PR DESCRIPTION
## Summary

Completes the Remote SSH workflow by adding REH (Remote Extension Host) build and setup steps.

## Context

Remote SSH testing requires both the Positron client (DEB package) and the Remote Extension Host (REH) that runs on the remote machine. In production, the REH is downloaded from a release server, but for dev builds we need to build and package it ourselves.

## Changes

### `build-remote-ssh-linux.yml`
- Added new `build-reh` job that builds the Remote Extension Host
- Builds REH using `npm run gulp vscode-reh-linux-x64`
- Packages as `positron-reh-remote-ssh-x64.tar.gz` and uploads as artifact

### `test-e2e-remote-ssh-ubuntu.yml`
- Downloads the REH artifact alongside the DEB
- Extracts REH into the Docker container at `/root/.positron-server`
- Verifies extraction by checking for `bin`, `data`, and `extensions` directories

The extraction location (`/root/.positron-server`) matches where Positron expects to find the server components during remote connections.

### Validation Steps

@:remote-ssh