### PR TITLE
Fix Custom Provider sign-in against endpoints that reject empty model

### DIFF
--- a/extensions/authentication/src/test/customProvider.test.ts
+++ b/extensions/authentication/src/test/customProvider.test.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+import { validateCustomProviderApiKey } from '../validation/customProvider';
+import { log } from '../log';
+
+suite('validateCustomProviderApiKey', () => {
+	let originalFetch: typeof globalThis.fetch;
+	let requestedBodies: string[];
+	let mockGet: sinon.SinonStub;
+	let logWarnStub: sinon.SinonStub;
+
+	setup(() => {
+		originalFetch = globalThis.fetch;
+		requestedBodies = [];
+
+		mockGet = sinon.stub();
+		const mockConfig: vscode.WorkspaceConfiguration = {
+			get: mockGet,
+			has: sinon.stub(),
+			inspect: sinon.stub(),
+			update: sinon.stub(),
+		};
+		sinon.stub(vscode.workspace, 'getConfiguration').returns(mockConfig);
+		logWarnStub = sinon.stub(log, 'warn');
+	});
+
+	teardown(() => {
+		globalThis.fetch = originalFetch;
+		sinon.restore();
+	});
+
+	function makeConfig(): positron.ai.LanguageModelConfig {
+		return {
+			provider: 'openai-compatible',
+			name: 'Custom Provider',
+			model: '',
+			type: positron.PositronLanguageModelType.Chat,
+			baseUrl: 'https://example.com/v1',
+		};
+	}
+
+	function stubFetch(status: number): void {
+		globalThis.fetch = async (_url, init) => {
+			requestedBodies.push((init?.body as string) ?? '');
+			return { ok: status >= 200 && status < 300, status } as Response;
+		};
+	}
+
+	test('sends empty model when no override is configured', async () => {
+		mockGet.returns(undefined);
+		stubFetch(200);
+
+		await validateCustomProviderApiKey('sk-test', makeConfig());
+
+		assert.deepStrictEqual(JSON.parse(requestedBodies[0]), { model: '', messages: [] });
+	});
+
+	test('sends the first override identifier as the model', async () => {
+		mockGet.withArgs('models.overrides.customProvider').returns([
+			{ name: 'Databricks Claude', identifier: 'databricks-claude-sonnet-4-6' },
+		]);
+		stubFetch(200);
+
+		await validateCustomProviderApiKey('sk-test', makeConfig());
+
+		assert.deepStrictEqual(JSON.parse(requestedBodies[0]), {
+			model: 'databricks-claude-sonnet-4-6',
+			messages: [],
+		});
+	});
+
+	test('soft-fails HTTP 404 with a warning', async () => {
+		mockGet.returns(undefined);
+		stubFetch(404);
+
+		await validateCustomProviderApiKey('sk-test', makeConfig());
+
+		assert.strictEqual(logWarnStub.callCount, 1);
+		assert.match(logWarnStub.firstCall.args[0] as string, /Custom Provider/);
+		assert.match(logWarnStub.firstCall.args[0] as string, /404/);
+	});
+});

--- a/extensions/authentication/src/validation/customProvider.ts
+++ b/extensions/authentication/src/validation/customProvider.ts
@@ -6,6 +6,33 @@
 import * as vscode from 'vscode';
 import * as positron from 'positron';
 import { KEY_VALIDATION_TIMEOUT_MS } from '../constants';
+import { log } from '../log';
+
+interface ModelOverrideEntry {
+	identifier?: string;
+}
+
+/**
+ * Resolve a model identifier to send in the Custom Provider validation
+ * request. Reads the first entry's `identifier` from
+ * `positron.assistant.models.overrides.customProvider`. Returns `''` when
+ * no usable override is configured.
+ */
+function getCustomProviderModel(): string {
+	try {
+		const overrides = vscode.workspace
+			.getConfiguration('positron.assistant')
+			.get<ModelOverrideEntry[]>('models.overrides.customProvider');
+		if (Array.isArray(overrides) && overrides.length > 0) {
+			const first = overrides[0]?.identifier?.trim();
+			if (first) {
+				return first;
+			}
+		}
+	} catch {
+	}
+	return '';
+}
 
 class CustomProviderValidationError extends Error {
 	constructor(message: string) {
@@ -39,10 +66,11 @@ export async function validateCustomProviderApiKey(
 		() => controller.abort(), KEY_VALIDATION_TIMEOUT_MS
 	);
 	try {
+		const model = getCustomProviderModel();
 		const response = await fetch(endpoint, {
 			method: 'POST',
 			headers,
-			body: JSON.stringify({ model: '', messages: [] }),
+			body: JSON.stringify({ model, messages: [] }),
 			signal: controller.signal,
 		});
 
@@ -58,11 +86,8 @@ export async function validateCustomProviderApiKey(
 		}
 
 		if (response.status === 404) {
-			throw new CustomProviderValidationError(
-				vscode.l10n.t(
-					'Custom Provider endpoint not found. Check your base URL.'
-				)
-			);
+			log.warn(`[Custom Provider] Validation endpoint returned 404 for ${endpoint}; saving credentials anyway.`);
+			return;
 		}
 
 		throw new CustomProviderValidationError(vscode.l10n.t(


### PR DESCRIPTION
Fixes #13421 Fixes #13489

Custom Provider sign-in now validates against the user's configured model. When `positron.assistant.models.overrides.customProvider` has at least one entry, the validator sends the first entry's `identifier` as the `model` field on the test request to `/chat/completions`; otherwise it sends an empty string. A 404 response from the endpoint is logged as a warning and treated as a soft success - credentials are saved and the user can proceed. 401, 403, timeouts, and 5xx responses still hard-fail.

This unblocks Databricks `serving-endpoints` and other OpenAI-compatible providers (Moonshot/Kimi, etc.) whose `/chat/completions` route rejects requests without a real model.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix Custom Provider sign-in against OpenAI-compatible endpoints that reject empty model strings (e.g., Databricks) (#13421, #13489)

### Validation Steps

@:assistant

To reproduce against a Databricks workspace (or any provider whose `/chat/completions` rejects empty model strings):

1. In `settings.json`, set:
   ```json
   "positron.assistant.provider.customProvider.enable": true,
   "positron.assistant.models.overrides.customProvider": [
     { "name": "Databricks Claude", "identifier": "databricks-claude-sonnet-4-6" }
   ]
   ```
2. Open Configure Model Providers, pick Custom Provider, enter base URL `https://<workspace>.azuredatabricks.net/serving-endpoints` and your PAT, and sign in.
3. Sign-in succeeds.

Unit coverage in `extensions/authentication/src/test/customProvider.test.ts` - run with `npm run test-extension -- -l authentication --grep validateCustomProviderApiKey`.