### PR TITLE
Add button to show outline in Positron Notebook Editor action bar

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -56,7 +56,7 @@ import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_EDITOR_ID, POSITRON
 import { getActiveCell, getSelectedCells, SelectionState } from './selectionMachine.js';
 import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_JSON_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING, POSITRON_NOTEBOOK_EXPERIMENTAL, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED } from './ContextKeysManager.js';
 import './contrib/undoRedo/positronNotebookUndoRedo.js';
-import { registerAction2, MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
+import { Action2, registerAction2, MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { ExecuteSelectionInConsoleAction } from './ExecuteSelectionInConsoleAction.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { KernelStatusBadge } from './KernelStatusBadge.js';
@@ -76,6 +76,8 @@ import './AskAssistantAction.js'; // Register AskAssistantAction
 import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED } from '../../../../editor/contrib/find/browser/findModel.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
+import { IViewsService } from '../../../services/views/common/viewsService.js';
+import { IOutlinePane } from '../../outline/browser/outline.js';
 
 export const POSITRON_NOTEBOOK_COMMAND_MODE = ContextKeyExpr.and(
 	POSITRON_NOTEBOOK_EDITOR_FOCUSED,
@@ -2099,6 +2101,38 @@ registerAction2(class extends NotebookAction2 {
 		} else {
 			// If there are no cells, just add a code cell at index 0
 			notebook.addCell(CellKind.Markup, 0, true);
+		}
+	}
+});
+
+// Toggle Outline - Reveals or hides the Outline view in the Explorer pane
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.toggleOutline',
+			title: localize2('toggleOutline', 'Toggle Outline'),
+			icon: ThemeIcon.fromId('list-unordered'),
+			f1: true,
+			category: POSITRON_NOTEBOOK_CATEGORY,
+			positronActionBarOptions: {
+				controlType: 'button',
+				displayTitle: false
+			},
+			menu: {
+				id: MenuId.EditorActionsLeft,
+				group: 'navigation',
+				order: 45,
+				when: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID)
+			}
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const viewsService = accessor.get(IViewsService);
+		if (viewsService.isViewVisible(IOutlinePane.Id)) {
+			viewsService.closeView(IOutlinePane.Id);
+		} else {
+			await viewsService.openView(IOutlinePane.Id, true);
 		}
 	}
 });

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -2106,7 +2106,7 @@ registerAction2(class extends NotebookAction2 {
 });
 
 // Toggle Outline - Reveals or hides the Outline view in the Explorer pane
-registerAction2(class extends Action2 {
+export class ToggleOutlineAction extends Action2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.toggleOutline',
@@ -2135,7 +2135,8 @@ registerAction2(class extends Action2 {
 			await viewsService.openView(IOutlinePane.Id, true);
 		}
 	}
-});
+}
+registerAction2(ToggleOutlineAction);
 
 // Ask Assistant - Opens assistant chat with prompt options for the notebook
 // Action is defined in AskAssistantAction.ts

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/toggleOutlineAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/toggleOutlineAction.vitest.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { ToggleOutlineAction } from '../../browser/positronNotebook.contribution.js';
+import { IOutlinePane } from '../../../outline/browser/outline.js';
+import { IViewsService } from '../../../../services/views/common/viewsService.js';
+
+describe('ToggleOutlineAction', () => {
+	const ctx = createTestContainer()
+		.withWorkbenchServices()
+		.build();
+
+	let isViewVisible: ReturnType<typeof vi.fn<IViewsService['isViewVisible']>>;
+	// openView is generic (<T extends IView>); store it with a wider mock signature and
+	// re-narrow inside the stub via a closure so stubInterface's Partial<IViewsService>
+	// stays type-correct.
+	let openView: ReturnType<typeof vi.fn<(id: string, focus?: boolean) => Promise<unknown>>>;
+	let closeView: ReturnType<typeof vi.fn<IViewsService['closeView']>>;
+
+	beforeEach(() => {
+		isViewVisible = vi.fn();
+		openView = vi.fn<(id: string, focus?: boolean) => Promise<unknown>>().mockResolvedValue(null);
+		closeView = vi.fn();
+		ctx.instantiationService.stub(IViewsService, stubInterface<IViewsService>({
+			isViewVisible,
+			openView: <T>(id: string, focus?: boolean) => openView(id, focus) as Promise<T | null>,
+			closeView,
+		}));
+	});
+
+	async function run(): Promise<void> {
+		const action = new ToggleOutlineAction();
+		await ctx.instantiationService.invokeFunction(accessor => action.run(accessor));
+	}
+
+	it('opens and focuses the outline view when it is not visible', async () => {
+		isViewVisible.mockReturnValue(false);
+
+		await run();
+
+		expect(openView).toHaveBeenCalledWith(IOutlinePane.Id, true);
+		expect(closeView).not.toHaveBeenCalled();
+	});
+
+	it('closes the outline view when it is visible', async () => {
+		isViewVisible.mockReturnValue(true);
+
+		await run();
+
+		expect(closeView).toHaveBeenCalledWith(IOutlinePane.Id);
+		expect(openView).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Fixes #12839

Adds a Toggle Outline button to the Positron notebook editor's action bar. Clicking it opens and focuses the Outline view in the Explorer pane; clicking again collapses it. This makes the notebook table of contents more discoverable for users coming from JupyterHub/JupyterLab who don't expect to find it in a side pane.

The same toggle is reachable from the command palette by searching for `Notebook: Toggle Outline` (command ID is `positronNotebook.toggleOutline`).

### Screenshots

https://github.com/user-attachments/assets/0cd314db-cda8-48b0-b0ef-329813d2d816

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Added a Toggle Outline button to the Positron Notebook Editor action bar (#12839)

#### Bug Fixes

- N/A


### Validation Steps

@:notebooks 
@:positron-notebooks
@:outline

1. Open a Jupyter notebook (`.ipynb`) in the Positron notebook editor.
2. In the editor's action bar, click the new outline button (between the Markdown and Ask Assistant buttons).
3. Verify the Explorer pane opens (if hidden), the Outline section expands and receives focus, and shows the notebook's TOC entries.
4. Click the button again. Verify the Outline section collapses.
5. With the Outline section collapsed, click the button. Verify it expands and focuses again.
6. Switch the sidebar to a different view (e.g. Search), then click the button. Verify the sidebar switches back to Explorer with Outline expanded and focused.
7. Open the command palette and run `Notebook: Toggle Outline`. Verify the same toggle behavior.
