### PR TITLE
Add icon for custom provider

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
@@ -67,6 +67,8 @@ export const LanguageModelIcon = (props: { provider: string }) => {
 				return <div className={`language-model icon button-icon codicon codicon-positron-assistant`} />;
 			case 'snowflake-cortex':
 				return <Snowflake className='language-model icon' />;
+			case 'openai-compatible':
+				return <div className={`language-model icon button-icon codicon codicon-wrench`} />;
 			case 'error':
 				return <div className={`language-model icon button-icon codicon codicon-error`} />;
 			case 'echo':


### PR DESCRIPTION
Closes #13554 

Adds an icon for the custom provider in the config provider dialog.

This only adds the icon for the dialog. The model picker will only display the provider name in the grouping.

<img width="604" height="504" alt="image" src="https://github.com/user-attachments/assets/6b3195f8-1d88-4972-b49f-78fd16a36791" />

<img width="602" height="502" alt="image" src="https://github.com/user-attachments/assets/f7923c21-33a6-4883-82f2-78f0e3a73ca7" />


### Release Notes

#### New Features

- Add icon for custom provider in config model provider dialog

#### Bug Fixes

- N/A


### QA Notes