### PR TITLE
Add repo-root input to e2e-failure-analyzer action

### DIFF
--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: "blob (sharded artifacts + merge-reports) or s3 (HTML report). Default: blob."
     required: false
     default: "blob"
+  repo-root:
+    description: "Path to the repo workspace whose test/e2e/ source the analyzer should read. Defaults to $GITHUB_WORKSPACE. positron-builds passes $GITHUB_WORKSPACE/positron because the test source lives in the submodule."
+    required: false
+    default: ${{ github.workspace }}
 runs:
   using: composite
   steps:
@@ -210,7 +214,7 @@ runs:
         WORK_DIR: ${{ steps.prep.outputs.work_dir }}
         # Repo workspace -- the agent reads test source from $REPO_ROOT/test/e2e
         # to understand each failing test's intent (assertions, page-object usage).
-        REPO_ROOT: ${{ github.workspace }}
+        REPO_ROOT: ${{ inputs.repo-root }}
         MODEL: ${{ inputs.model }}
         MAX_TURNS: ${{ inputs.max-turns }}
       run: node analyze.mjs


### PR DESCRIPTION
This is needed to get e2e-failuer-analyzer to find the right repo-root when running from positron-builds

## Summary

- Adds a `repo-root` input to `.github/actions/e2e-failure-analyzer/action.yml` and binds it to the analyze step's `REPO_ROOT` env var.
- Default is `${{ github.workspace }}`, preserving Path A behavior on this repo.
- Lets posit-dev/positron-builds pass `${{ github.workspace }}/positron` so the analyzer reads test source from the submodule path (where `test/e2e/` actually lives in that workflow).

Companion to posit-dev/positron-builds#13627. `analyze.mjs` already reads `REPO_ROOT` from env with an empty-string fallback, so no script changes are needed.
