### PR TITLE
chore: bump composite actions off Node 20 deprecation

### DIFF
--- a/.github/actions/restore-build-caches/action.yml
+++ b/.github/actions/restore-build-caches/action.yml
@@ -172,7 +172,7 @@ runs:
       if: ${{ inputs.restore-npm-core == 'true' }}
       id: cache-npm-core
       continue-on-error: true
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ steps.cache-paths.outputs.npm-core-paths }}
         key: npm-core-v7-node${{ steps.node-version.outputs.version }}-${{ runner.os }}-${{ steps.distro.outputs.distro }}-${{ steps.package-locks-hash.outputs.hash }}
@@ -181,7 +181,7 @@ runs:
       if: ${{ inputs.restore-npm-extensions == 'true' }}
       id: cache-npm-extensions-volatile
       continue-on-error: true
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ steps.cache-paths.outputs.npm-extensions-volatile-paths }}
         key: npm-extensions-volatile-v1-${{ runner.os }}-${{ steps.distro.outputs.distro }}-${{ steps.extensions-volatile-hash.outputs.hash }}
@@ -190,7 +190,7 @@ runs:
       if: ${{ inputs.restore-npm-extensions == 'true' }}
       id: cache-npm-extensions-stable
       continue-on-error: true
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ steps.cache-paths.outputs.npm-extensions-stable-paths }}
         key: npm-extensions-stable-v4-${{ runner.os }}-${{ steps.distro.outputs.distro }}-${{ steps.extensions-stable-hash.outputs.hash }}
@@ -199,7 +199,7 @@ runs:
       if: ${{ inputs.restore-builtins == 'true' }}
       id: cache-builtins
       continue-on-error: true
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ steps.cache-paths.outputs.builtins-paths }}
         key: builtins-v2-${{ runner.os }}-${{ hashFiles('product.json', 'build/lib/builtInExtensions.ts') }}
@@ -214,7 +214,7 @@ runs:
       if: ${{ inputs.restore-playwright == 'true' }}
       id: cache-playwright
       continue-on-error: true
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ steps.cache-paths.outputs.playwright-paths }}
         key: playwright-v2-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}

--- a/.github/actions/save-build-caches/action.yml
+++ b/.github/actions/save-build-caches/action.yml
@@ -110,7 +110,7 @@ runs:
     - name: Save npm core dependencies cache
       if: ${{ inputs.cache-npm-core-hit == 'false' }}
       continue-on-error: true
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ steps.cache-paths.outputs.npm-core-paths }}
         key: npm-core-v7-node${{ inputs.node-version }}-${{ runner.os }}-${{ steps.distro.outputs.distro }}-${{ inputs.package-locks-hash }}
@@ -118,7 +118,7 @@ runs:
     - name: Save npm volatile extensions cache
       if: ${{ inputs.cache-npm-extensions-volatile-hit == 'false' }}
       continue-on-error: true
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ steps.cache-paths.outputs.npm-extensions-volatile-paths }}
         key: npm-extensions-volatile-v1-${{ runner.os }}-${{ steps.distro.outputs.distro }}-${{ inputs.extensions-volatile-hash }}
@@ -126,7 +126,7 @@ runs:
     - name: Save npm stable extensions cache
       if: ${{ inputs.cache-npm-extensions-stable-hit == 'false' }}
       continue-on-error: true
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ steps.cache-paths.outputs.npm-extensions-stable-paths }}
         key: npm-extensions-stable-v4-${{ runner.os }}-${{ steps.distro.outputs.distro }}-${{ inputs.extensions-stable-hash }}
@@ -134,7 +134,7 @@ runs:
     - name: Save built-in extensions cache
       if: ${{ inputs.cache-builtins-hit == 'false' }}
       continue-on-error: true
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ steps.cache-paths.outputs.builtins-paths }}
         key: builtins-v2-${{ runner.os }}-${{ hashFiles('product.json', 'build/lib/builtInExtensions.ts') }}
@@ -142,7 +142,7 @@ runs:
     - name: Save Playwright browsers cache
       if: ${{ inputs.cache-playwright-hit == 'false' }}
       continue-on-error: true
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ steps.cache-paths.outputs.playwright-paths }}
         key: playwright-v2-${{ runner.os }}-${{ inputs.playwright-version }}

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -64,7 +64,7 @@ runs:
       if: steps.restore-caches.outputs.cache-npm-core-hit != 'true' ||
           steps.restore-caches.outputs.cache-npm-extensions-volatile-hit != 'true' ||
           steps.restore-caches.outputs.cache-npm-extensions-stable-hit != 'true'
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
         ELECTRON_SKIP_BINARY_DOWNLOAD: 1

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -18,7 +18,7 @@ runs:
       run: npm --prefix test/e2e run compile
 
     - name: Setup AWS S3 Access
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.aws-role-to-assume }}
         aws-region: ${{ inputs.aws-region }}

--- a/.github/actions/upload-report-to-s3/action.yml
+++ b/.github/actions/upload-report-to-s3/action.yml
@@ -16,7 +16,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       if: ${{ !cancelled() }}
       with:
         role-to-assume: ${{ inputs.role-to-assume }}


### PR DESCRIPTION
### Summary
Bring the composite actions in `.github/actions/` up to the versions already used in the top-level workflows, clearing the Node 20 deprecation warnings on `setup/build-ubuntu`, `test/unit`, `test/ext-host`, and `e2e/windows-1`.

- `actions/cache/restore@v4` → `@v5` in `restore-build-caches` (5x)
- `actions/cache/save@v4` → `@v5` in `save-build-caches` (5x)
- `nick-fields/retry@v3` → `@v4` in `setup-build-env`

### QA Notes
n/a