### PR TITLE
Fix New Folder workflow dropdown/popup and add regression guard for renderer stack popup disposal

### DIFF
--- a/src/vs/base/browser/positronModalReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalReactRenderer.tsx
@@ -339,6 +339,20 @@ export class PositronModalReactRenderer extends Disposable {
 	}
 
 	/**
+	 * Returns true if any renderer *below* the given renderer has a bounds provider registered.
+	 * This indicates a persistent parent (e.g. a dialog) that should survive child dismissal.
+	 */
+	public static hasPersistentParent(renderer: PositronModalReactRenderer): boolean {
+		let found = false;
+		PositronModalReactRenderer._renderersStack.forEach(r => {
+			if (r !== renderer && r._boundsProvider !== undefined) {
+				found = true;
+			}
+		});
+		return found;
+	}
+
+	/**
 	 * Renders the ReactElement that was supplied.
 	 * @param reactElement The ReactElement to render.
 	 */

--- a/src/vs/base/test/browser/positronModalReactRenderer.vitest.ts
+++ b/src/vs/base/test/browser/positronModalReactRenderer.vitest.ts
@@ -440,4 +440,46 @@ describe('PositronModalReactRenderer', () => {
 			expect(callbackCalled).toBe(false);
 		});
 	});
+
+	/**
+	 * Popup dismiss does not tear down parent dialog test suite.
+	 */
+	describe('popup dismiss does not tear down parent dialog', () => {
+		it('disposing a child renderer leaves the parent intact', () => {
+			const container = createMockContainer();
+
+			const dialog = disposables.add(new PositronModalReactRenderer({ container }));
+			dialog.render(createMockReactElement());
+
+			const popup = disposables.add(new PositronModalReactRenderer({ container }));
+			popup.render(createMockReactElement());
+
+			expect(container.children.length).toBe(2);
+
+			popup.dispose();
+
+			expect(container.children.length).toBe(1);
+
+			dialog.dispose();
+		});
+
+		it('dialog with registered bounds prevents disposeAll from outside click', () => {
+			const container = createMockContainer();
+
+			const dialog = disposables.add(new PositronModalReactRenderer({ container }));
+			dialog.render(createMockReactElement());
+			dialog.setBoundsProvider(() => new DOMRect(100, 100, 500, 400));
+
+			const popup = disposables.add(new PositronModalReactRenderer({ container }));
+			popup.render(createMockReactElement());
+
+			// Click inside dialog bounds -- isInsideAnyPopup should return true,
+			// preventing disposeAll from tearing down the dialog
+			const e = new MouseEvent('mousedown', { clientX: 200, clientY: 200 });
+			expect(PositronModalReactRenderer.isInsideAnyPopup(e)).toBe(true);
+
+			popup.dispose();
+			dialog.dispose();
+		});
+	});
 });

--- a/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalDialog/positronModalDialog.tsx
@@ -98,6 +98,10 @@ export const PositronModalDialog = (props: PropsWithChildren<PositronModalDialog
 
 	// Set up keyboard and resize event handlers.
 	useEffect(() => {
+		// Register bounds so child popups know clicks inside this dialog are not
+		// "outside" the renderer stack.
+		props.renderer.setBoundsProvider(() => dialogBoxRef.current.getBoundingClientRect());
+
 		// Create a disposable store for the event handlers we'll add.
 		const disposableStore = new DisposableStore();
 

--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -563,13 +563,14 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 
 			// If the click is outside this popup's bounds, decide what to dismiss.
 			if (!(e.clientX >= clientRect.left && e.clientX <= clientRect.right && e.clientY >= clientRect.top && e.clientY <= clientRect.bottom)) {
-				// If the click is outside every popup in the stack, dismiss the root renderer so
-				// the entire popup stack is dismissed. Otherwise just close this popup (e.g. a
-				// submenu when the user clicks back into its parent menu).
-				if (!PositronModalReactRenderer.isInsideAnyPopup(e)) {
-					PositronModalReactRenderer.disposeAll();
-				} else {
+				if (PositronModalReactRenderer.isInsideAnyPopup(e)) {
+					// Click landed inside another renderer in the stack (e.g. a parent
+					// menu or a dialog hosting this dropdown) -- close only this popup.
 					props.renderer.dispose();
+				} else {
+					// Click is outside every registered renderer -- dismiss the entire
+					// stack so all menus/popups close in one click.
+					PositronModalReactRenderer.disposeAll();
 				}
 			}
 		}));

--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -567,6 +567,10 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 					// Click landed inside another renderer in the stack (e.g. a parent
 					// menu or a dialog hosting this dropdown) -- close only this popup.
 					props.renderer.dispose();
+				} else if (PositronModalReactRenderer.hasPersistentParent(props.renderer)) {
+					// A parent dialog exists in the stack -- close only this popup so
+					// the dialog survives.
+					props.renderer.dispose();
 				} else {
 					// Click is outside every registered renderer -- dismiss the entire
 					// stack so all menus/popups close in one click.


### PR DESCRIPTION
Closes #13673. 

## Summary

- Add vitest coverage for popup-inside-dialog disposal path (previously untested)
- Test exposed missing bounds registration in `PositronModalDialog` -- fixed inline

## Tests

- [x] `npx vitest run src/vs/base/test/browser/positronModalReactRenderer.vitest.ts`
- [x] New Folder wizard: dropdown dismissal does _not_ close dialog (by either clicking outside of dropdown or outside of dialog). Preventing dialog closure when clicking outside of dialog (while dropdown is open) was addressed by commit `ccc2aaa4`. 
- [x] Other context menus still close on outside click, as expected (either via 'Cancel' buttons or via clicking-outside dismissal)

@:new-folder-flow @:modal

## Before vs. After Behavior

### Before: Clicking outside of the dropdown area(s) closes the entire window

User loses progress of their 'New Folder From Template' workflow and has to go through it from the very beginning. 

https://github.com/user-attachments/assets/0b9086dd-93f9-40ea-a6ea-c33eda189562

### After: Clicking outside of the dropdown area(s) does NOT close the entire window

This is what one would expect: when they click outside of the dropdown area(s) (in orange in #13673), only the dropdown should close; NOT the entire dialog. 

If user wants to close the dialog, the 'Cancel' button is there and fulfills that desire. 

https://github.com/user-attachments/assets/530e1a74-975c-4f6c-928f-8f6a29dfc77f

