### PR TITLE
Install latest extension version regardless of gallery ordering

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -31,6 +31,9 @@ import { StopWatch } from '../../../base/common/stopwatch.js';
 import { format2 } from '../../../base/common/strings.js';
 import { ExtensionGalleryResourceType, Flag, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService, ExtensionGalleryManifestStatus } from './extensionGalleryManifest.js';
 import { TelemetryTrustedValue } from '../../telemetry/common/telemetryUtils.js';
+// --- Start Positron ---
+import { filterLatestExtensionVersionsForTargetPlatformPositron } from './positronGalleryVersionFilter.js';
+// --- End Positron ---
 
 const CURRENT_TARGET_PLATFORM = isWeb ? TargetPlatform.WEB : getTargetPlatform(platform, arch);
 const SEARCH_ACTIVITY_HEADER_NAME = 'X-Market-Search-Activity-Id';
@@ -864,7 +867,14 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 
 	private async getValidRawGalleryExtensionVersionFromLatestVersions(rawGalleryExtension: IRawGalleryExtension, latestVersions: IRawGalleryExtensionVersion[], extensionInfo: IExtensionInfo, options: IExtensionQueryOptions, allTargetPlatforms: TargetPlatform[]): Promise<IRawGalleryExtensionVersion | null> {
 		const targetPlatform = options.targetPlatform ?? CURRENT_TARGET_PLATFORM;
-		const latestExtensionVersionsForTargetPlatform = filterLatestExtensionVersionsForTargetPlatform(latestVersions, targetPlatform, allTargetPlatforms);
+		// --- Start Positron ---
+		// const latestExtensionVersionsForTargetPlatform = filterLatestExtensionVersionsForTargetPlatform(latestVersions, targetPlatform, allTargetPlatforms);
+		// Use the order-invariant Positron filter instead of upstream's
+		// `filterLatestExtensionVersionsForTargetPlatform`, which assumes versions are sorted
+		// descending by semver. Open VSX and P3M do not always honor that ordering, which
+		// caused Positron to install old extension versions (issue #12619).
+		const latestExtensionVersionsForTargetPlatform = filterLatestExtensionVersionsForTargetPlatformPositron(latestVersions, targetPlatform, allTargetPlatforms);
+		// --- End Positron ---
 
 		// First, find a valid version matching the requested type (pre-release or release)
 		const result = await this.getValidRawGalleryExtensionVersion(

--- a/src/vs/platform/extensionManagement/common/positronGalleryVersionFilter.ts
+++ b/src/vs/platform/extensionManagement/common/positronGalleryVersionFilter.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as semver from '../../../base/common/semver/semver.js';
+import { TargetPlatform } from '../../extensions/common/extensions.js';
+import { isTargetPlatformCompatible, toTargetPlatform } from './extensionManagement.js';
+import { IRawGalleryExtensionVersion } from './extensionGalleryService.js';
+
+const PRE_RELEASE_PROPERTY = 'Microsoft.VisualStudio.Code.PreRelease';
+
+function getTargetPlatformForExtensionVersion(version: IRawGalleryExtensionVersion): TargetPlatform {
+	return version.targetPlatform ? toTargetPlatform(version.targetPlatform) : TargetPlatform.UNDEFINED;
+}
+
+function isPreReleaseVersion(version: IRawGalleryExtensionVersion): boolean {
+	const value = version.properties?.find(p => p.key === PRE_RELEASE_PROPERTY)?.value;
+	return value === 'true';
+}
+
+/**
+ * Positron replacement for the upstream `filterLatestExtensionVersionsForTargetPlatform`.
+ *
+ * The upstream implementation assumes the input is sorted by version descending and picks
+ * the first compatible entry it encounters. That assumption holds for the Microsoft Marketplace
+ * but not for Open VSX or Posit Public Package Manager (P3M), which have historically returned
+ * versions in ascending order. When the assumption is violated, the resolver picks the OLDEST
+ * compatible version instead of the newest (issue #12619).
+ *
+ * This implementation is order-invariant: the result is the same regardless of how the input
+ * array is ordered. The returned list contains:
+ *
+ * 1. All versions that are NOT compatible with the target platform (preserved for downstream
+ *    consumers that compute supported-platform metadata).
+ * 2. At most one compatible release version: the highest semver. If two compatible releases share
+ *    the same version, the one whose target platform exactly matches `targetPlatform` is preferred
+ *    over a universal/undefined entry.
+ * 3. At most one compatible pre-release version, selected by the same rule.
+ *
+ * @param versions - Array of extension versions in any order
+ * @param targetPlatform - The target platform to filter for (e.g., LINUX_X64, WIN32_X64)
+ * @param allTargetPlatforms - All target platforms the extension supports
+ * @returns Filtered array of versions relevant for the target platform
+ */
+export function filterLatestExtensionVersionsForTargetPlatformPositron(versions: IRawGalleryExtensionVersion[], targetPlatform: TargetPlatform, allTargetPlatforms: TargetPlatform[]): IRawGalleryExtensionVersion[] {
+	const latestVersions: IRawGalleryExtensionVersion[] = [];
+	let bestRelease: IRawGalleryExtensionVersion | undefined;
+	let bestPreRelease: IRawGalleryExtensionVersion | undefined;
+
+	const isBetter = (candidate: IRawGalleryExtensionVersion, current: IRawGalleryExtensionVersion): boolean => {
+		if (semver.gt(candidate.version, current.version)) {
+			return true;
+		}
+		if (semver.gt(current.version, candidate.version)) {
+			return false;
+		}
+		const candidateExactMatch = getTargetPlatformForExtensionVersion(candidate) === targetPlatform;
+		const currentExactMatch = getTargetPlatformForExtensionVersion(current) === targetPlatform;
+		return candidateExactMatch && !currentExactMatch;
+	};
+
+	for (const version of versions) {
+		const versionTargetPlatform = getTargetPlatformForExtensionVersion(version);
+		const isCompatibleWithTargetPlatform = isTargetPlatformCompatible(versionTargetPlatform, allTargetPlatforms, targetPlatform);
+
+		if (!isCompatibleWithTargetPlatform) {
+			latestVersions.push(version);
+			continue;
+		}
+
+		if (isPreReleaseVersion(version)) {
+			if (!bestPreRelease || isBetter(version, bestPreRelease)) {
+				bestPreRelease = version;
+			}
+		} else {
+			if (!bestRelease || isBetter(version, bestRelease)) {
+				bestRelease = version;
+			}
+		}
+	}
+
+	if (bestRelease) {
+		latestVersions.push(bestRelease);
+	}
+	if (bestPreRelease) {
+		latestVersions.push(bestPreRelease);
+	}
+
+	return latestVersions;
+}

--- a/src/vs/platform/extensionManagement/common/positronGalleryVersionFilter.ts
+++ b/src/vs/platform/extensionManagement/common/positronGalleryVersionFilter.ts
@@ -23,10 +23,19 @@ function isPreReleaseVersion(version: IRawGalleryExtensionVersion): boolean {
  * Positron replacement for the upstream `filterLatestExtensionVersionsForTargetPlatform`.
  *
  * The upstream implementation assumes the input is sorted by version descending and picks
- * the first compatible entry it encounters. That assumption holds for the Microsoft Marketplace
- * but not for Open VSX or Posit Public Package Manager (P3M), which have historically returned
- * versions in ascending order. When the assumption is violated, the resolver picks the OLDEST
- * compatible version instead of the newest (issue #12619).
+ * the first compatible entry it encounters. P3M (Positron's default gallery) honors that
+ * assumption on both `/vscode/gallery/extensionquery` and `/vscode/gallery/{publisher}/{name}/latest`,
+ * so the default install path is correct without this filter.
+ *
+ * Open VSX, which Positron also supports as a configurable gallery, does not. Despite the name,
+ * Open VSX's `/vscode/gallery/{publisher}/{name}/latest` returns every version of the extension
+ * in ascending semver order with per-platform variants interleaved. When Positron's resolver
+ * consumes that response, the upstream filter picks the OLDEST compatible version instead of
+ * the newest (issue #12619). Reproducible as of May 2026 with a single curl against open-vsx.org.
+ *
+ * (P3M previously had a related ASC-ordering bug on these endpoints, fixed server-side in PPM
+ * hotfix 2026.04.2, rstudio/package-manager#17916. Keeping this filter order-invariant also
+ * guards against future regressions on either backend.)
  *
  * This implementation is order-invariant: the result is the same regardless of how the input
  * array is ordered. The returned list contains:

--- a/src/vs/platform/extensionManagement/test/common/positronGalleryVersionFilter.vitest.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronGalleryVersionFilter.vitest.ts
@@ -104,9 +104,10 @@ describe('filterLatestExtensionVersionsForTargetPlatformPositron', () => {
 		expect(result).toEqual([universal]);
 	});
 
-	it('picks the newest platform-specific when later versions drop universal (claude-code shape)', () => {
-		// anthropic.claude-code shipped a universal VSIX through 2.1.89, then per-platform
-		// only from 2.1.90+. Resolver should pick the newest linux-x64, not the last universal.
+	it('picks the newest platform-specific when later versions drop universal', () => {
+		// An extension may ship a universal VSIX for a while and then transition to per-platform
+		// builds. The resolver must pick the newest per-platform version compatible with the
+		// target, not regress to the last universal.
 		const lastUniversal = aExtensionVersion('2.1.89', TargetPlatform.UNIVERSAL);
 		const newerLinux = aExtensionVersion('2.1.90', TargetPlatform.LINUX_X64);
 		const newerDarwin = aExtensionVersion('2.1.90', TargetPlatform.DARWIN_X64);

--- a/src/vs/platform/extensionManagement/test/common/positronGalleryVersionFilter.vitest.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronGalleryVersionFilter.vitest.ts
@@ -1,0 +1,174 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { IRawGalleryExtensionVersion } from '../../common/extensionGalleryService.js';
+import { filterLatestExtensionVersionsForTargetPlatformPositron } from '../../common/positronGalleryVersionFilter.js';
+import { TargetPlatform } from '../../../extensions/common/extensions.js';
+
+function aExtensionVersion(version: string, targetPlatform?: TargetPlatform): IRawGalleryExtensionVersion {
+	return { version, targetPlatform } as IRawGalleryExtensionVersion;
+}
+
+function aPreReleaseExtensionVersion(version: string, targetPlatform?: TargetPlatform): IRawGalleryExtensionVersion {
+	return {
+		version,
+		targetPlatform,
+		properties: [{ key: 'Microsoft.VisualStudio.Code.PreRelease', value: 'true' }]
+	} as IRawGalleryExtensionVersion;
+}
+
+describe('filterLatestExtensionVersionsForTargetPlatformPositron', () => {
+
+	it('returns an empty array for empty input', () => {
+		const result = filterLatestExtensionVersionsForTargetPlatformPositron([], TargetPlatform.WIN32_X64, [TargetPlatform.WIN32_X64]);
+		expect(result).toEqual([]);
+	});
+
+	it('returns the single version when only one is provided', () => {
+		const v = aExtensionVersion('1.0.0', TargetPlatform.WIN32_X64);
+		const result = filterLatestExtensionVersionsForTargetPlatformPositron([v], TargetPlatform.WIN32_X64, [TargetPlatform.WIN32_X64]);
+		expect(result).toEqual([v]);
+	});
+
+	it('picks the newest version when input is ascending (Open VSX shape)', () => {
+		// posit.publisher pre-P3M: gallery returned versions ASC, resolver picked oldest.
+		const oldest = aExtensionVersion('1.36.0', TargetPlatform.DARWIN_ARM64);
+		const middle = aExtensionVersion('1.37.0', TargetPlatform.DARWIN_ARM64);
+		const newest = aExtensionVersion('2.7.0', TargetPlatform.DARWIN_ARM64);
+
+		const result = filterLatestExtensionVersionsForTargetPlatformPositron(
+			[oldest, middle, newest],
+			TargetPlatform.DARWIN_ARM64,
+			[TargetPlatform.DARWIN_ARM64]
+		);
+
+		expect(result).toEqual([newest]);
+	});
+
+	it('picks the newest version when input is descending (Marketplace shape)', () => {
+		const newest = aExtensionVersion('2.7.0', TargetPlatform.WIN32_X64);
+		const middle = aExtensionVersion('1.37.0', TargetPlatform.WIN32_X64);
+		const oldest = aExtensionVersion('1.36.0', TargetPlatform.WIN32_X64);
+
+		const result = filterLatestExtensionVersionsForTargetPlatformPositron(
+			[newest, middle, oldest],
+			TargetPlatform.WIN32_X64,
+			[TargetPlatform.WIN32_X64]
+		);
+
+		expect(result).toEqual([newest]);
+	});
+
+	it('includes the highest compatible release and highest compatible pre-release', () => {
+		const release = aExtensionVersion('1.0.0', TargetPlatform.WIN32_X64);
+		const prerelease = aPreReleaseExtensionVersion('1.1.0', TargetPlatform.WIN32_X64);
+
+		const result = filterLatestExtensionVersionsForTargetPlatformPositron(
+			[prerelease, release],
+			TargetPlatform.WIN32_X64,
+			[TargetPlatform.WIN32_X64]
+		);
+
+		expect(result).toContain(release);
+		expect(result).toContain(prerelease);
+		expect(result).toHaveLength(2);
+	});
+
+	it('prefers exact platform match over universal at the same semver', () => {
+		const universal = aExtensionVersion('1.0.0');
+		const exact = aExtensionVersion('1.0.0', TargetPlatform.WIN32_X64);
+
+		const result = filterLatestExtensionVersionsForTargetPlatformPositron(
+			[universal, exact],
+			TargetPlatform.WIN32_X64,
+			[TargetPlatform.WIN32_X64]
+		);
+
+		expect(result).toEqual([exact]);
+	});
+
+	it('prefers higher semver universal over lower semver platform-specific', () => {
+		const universal = aExtensionVersion('2.0.0');
+		const exact = aExtensionVersion('1.0.0', TargetPlatform.WIN32_X64);
+
+		const result = filterLatestExtensionVersionsForTargetPlatformPositron(
+			[exact, universal],
+			TargetPlatform.WIN32_X64,
+			[TargetPlatform.WIN32_X64]
+		);
+
+		expect(result).toEqual([universal]);
+	});
+
+	it('picks the newest platform-specific when later versions drop universal (claude-code shape)', () => {
+		// anthropic.claude-code shipped a universal VSIX through 2.1.89, then per-platform
+		// only from 2.1.90+. Resolver should pick the newest linux-x64, not the last universal.
+		const lastUniversal = aExtensionVersion('2.1.89', TargetPlatform.UNIVERSAL);
+		const newerLinux = aExtensionVersion('2.1.90', TargetPlatform.LINUX_X64);
+		const newerDarwin = aExtensionVersion('2.1.90', TargetPlatform.DARWIN_X64);
+		const newestLinux = aExtensionVersion('2.1.139', TargetPlatform.LINUX_X64);
+		const newestDarwin = aExtensionVersion('2.1.139', TargetPlatform.DARWIN_X64);
+
+		const result = filterLatestExtensionVersionsForTargetPlatformPositron(
+			[lastUniversal, newerLinux, newerDarwin, newestLinux, newestDarwin],
+			TargetPlatform.LINUX_X64,
+			[TargetPlatform.LINUX_X64, TargetPlatform.DARWIN_X64]
+		);
+
+		expect(result).toContain(newestLinux);
+		expect(result).not.toContain(lastUniversal);
+		expect(result).not.toContain(newerLinux);
+	});
+
+	it('always includes non-compatible platform versions unchanged', () => {
+		const compat = aExtensionVersion('1.0.0', TargetPlatform.WIN32_X64);
+		const otherPlatform = aExtensionVersion('1.0.0', TargetPlatform.DARWIN_X64);
+
+		const result = filterLatestExtensionVersionsForTargetPlatformPositron(
+			[compat, otherPlatform],
+			TargetPlatform.WIN32_X64,
+			[TargetPlatform.WIN32_X64, TargetPlatform.DARWIN_X64]
+		);
+
+		expect(result).toContain(compat);
+		expect(result).toContain(otherPlatform);
+	});
+
+	it('produces the same result regardless of input order', () => {
+		const v1 = aExtensionVersion('1.0.0', TargetPlatform.WIN32_X64);
+		const v2 = aExtensionVersion('2.0.0');
+		const v3 = aExtensionVersion('2.0.0', TargetPlatform.WIN32_X64);
+		const v4 = aPreReleaseExtensionVersion('2.1.0', TargetPlatform.WIN32_X64);
+		const v5 = aPreReleaseExtensionVersion('2.1.0');
+		const v6 = aExtensionVersion('1.5.0', TargetPlatform.DARWIN_X64); // non-compatible
+		const allTargetPlatforms = [TargetPlatform.WIN32_X64, TargetPlatform.DARWIN_X64];
+
+		const ascending = filterLatestExtensionVersionsForTargetPlatformPositron(
+			[v1, v6, v2, v3, v5, v4],
+			TargetPlatform.WIN32_X64,
+			allTargetPlatforms
+		);
+		const descending = filterLatestExtensionVersionsForTargetPlatformPositron(
+			[v4, v5, v3, v2, v6, v1],
+			TargetPlatform.WIN32_X64,
+			allTargetPlatforms
+		);
+		const shuffled = filterLatestExtensionVersionsForTargetPlatformPositron(
+			[v3, v1, v5, v6, v4, v2],
+			TargetPlatform.WIN32_X64,
+			allTargetPlatforms
+		);
+
+		// Expected pick: 2.0.0 WIN (exact match beats universal at same semver),
+		//                2.1.0 WIN (same rule for pre-release),
+		//                plus the non-compatible DARWIN entry.
+		const expected = new Set([v3, v4, v6]);
+		expect(new Set(ascending)).toEqual(expected);
+		expect(new Set(descending)).toEqual(expected);
+		expect(new Set(shuffled)).toEqual(expected);
+	});
+});


### PR DESCRIPTION
Fixes #12619

To start with, should we ship this at all? The active bug now exists only when using Open VSX `/latest`. P3M's server-side ordering bug (rstudio/package-manager#17916) is fixed in 2026.04.2, and the `anthropic.claude-code` report on the issue thread turned out to be a P3M scanner+cache bug, not this resolver path. So the client-side fix is needed only for users who configure the gallery to Open VSX (which Positron supports but no longer defaults to). I am open to closing this and maybe filing the `/latest` bug against Open VSX upstream instead? I do feel confused why this problem isn't reported more broadly by folks who use Open VSX. I think the answer is that people only hit this when they search exactly `publisher.name` rather than just a search query with words.

In terms of what is actually proposed here, upstream's `filterLatestExtensionVersionsForTargetPlatform` assumes the gallery returns versions in descending semver order and picks the first compatible entry. P3M now honors that assumption on both `/vscode/gallery/extensionquery` and `/vscode/gallery/{publisher}/{name}/latest`, so the default install path is unaffected.

Open VSX's `/latest` endpoint does not. Despite the name, it returns every version of the extension in ascending semver order with per-platform variants interleaved. The upstream filter picks the oldest compatible version. You can see it for yourself today:

```bash
curl -s 'https://open-vsx.org/vscode/gallery/posit/publisher/latest' \
  | jq '[.versions[] | .version] | {first_3: .[0:3], last_3: .[-3:]}'
# first_3: 1.36.0 release (per-platform), last_3: 2.6.0 / 2.7.1 universal
```

This PR adds an order-invariant filter in a new file alongside the upstream one, and swaps the single call site in `extensionGalleryService.ts` behind `// --- Start Positron ---` markers. The new filter picks the highest-semver compatible release and pre-release, with ties broken by exact platform match over universal. Behavior is identical to upstream when the input is already DESC (P3M and Microsoft Marketplace).

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Install the latest version of extensions regardless of gallery ordering (#12619)

### Validation Steps

@:extensions

To verify the user-facing fix manually against Open VSX:

1. Configure Positron to use Open VSX as the extension gallery
2. Uninstall `posit.publisher`
3. Install `posit.publisher` from the Extensions panel
4. Confirm the installed version is `2.6.0` (release) or `2.7.1` (pre-release), not `1.36.0` / `1.37.19`

Users on the default P3M gallery should see no behavioral difference.
