### PR TITLE
ci: bump only mismatched bootstrap extensions

### DIFF
--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -117,17 +117,17 @@ jobs:
           TEST_RESULT: ${{ needs.extensions-linux.result }}
         run: |
           if [ "$TEST_RESULT" = "failure" ] && [ -s mismatched-extensions.txt ]; then
-            MISMATCHED=$(cat mismatched-extensions.txt)
-            echo "Bumping mismatched extensions: $MISMATCHED"
+            read -ra MISMATCHED <<< "$(cat mismatched-extensions.txt)"
+            echo "Bumping mismatched extensions: ${MISMATCHED[*]}"
             {
               echo "### Mismatched bootstrap extensions"
               echo ""
-              echo "$MISMATCHED" | tr ' ' '\n' | sed 's/^/- /'
+              printf -- '- %s\n' "${MISMATCHED[@]}"
             } >> "$GITHUB_STEP_SUMMARY"
-            ./scripts/update-extensions.sh $MISMATCHED
+            ./scripts/update-extensions.sh "${MISMATCHED[@]}"
           else
-            echo "No mismatched extensions detected — bumping meta.pyrefly only."
-            echo "_No mismatched extensions detected — falling back to bumping meta.pyrefly._" >> "$GITHUB_STEP_SUMMARY"
+            echo "No mismatched extensions detected - bumping meta.pyrefly only."
+            echo "_No mismatched extensions detected - falling back to bumping meta.pyrefly._" >> "$GITHUB_STEP_SUMMARY"
             ./scripts/update-extensions.sh meta.pyrefly
           fi
 

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -119,8 +119,15 @@ jobs:
           if [ "$TEST_RESULT" = "failure" ] && [ -s mismatched-extensions.txt ]; then
             MISMATCHED=$(cat mismatched-extensions.txt)
             echo "Bumping mismatched extensions: $MISMATCHED"
+            {
+              echo "### Mismatched bootstrap extensions"
+              echo ""
+              echo "$MISMATCHED" | tr ' ' '\n' | sed 's/^/- /'
+            } >> "$GITHUB_STEP_SUMMARY"
             ./scripts/update-extensions.sh $MISMATCHED
           else
+            echo "No mismatched extensions detected — bumping meta.pyrefly only."
+            echo "_No mismatched extensions detected — falling back to bumping meta.pyrefly._" >> "$GITHUB_STEP_SUMMARY"
             ./scripts/update-extensions.sh meta.pyrefly
           fi
 

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -116,20 +116,19 @@ jobs:
         env:
           TEST_RESULT: ${{ needs.extensions-linux.result }}
         run: |
+          MISMATCHED=()
           if [ "$TEST_RESULT" = "failure" ] && [ -s mismatched-extensions.txt ]; then
             read -ra MISMATCHED <<< "$(cat mismatched-extensions.txt)"
-            echo "Bumping mismatched extensions: ${MISMATCHED[*]}"
-            {
-              echo "### Mismatched bootstrap extensions"
-              echo ""
-              printf -- '- %s\n' "${MISMATCHED[@]}"
-            } >> "$GITHUB_STEP_SUMMARY"
-            ./scripts/update-extensions.sh "${MISMATCHED[@]}"
-          else
-            echo "No mismatched extensions detected - bumping meta.pyrefly only."
-            echo "_No mismatched extensions detected - falling back to bumping meta.pyrefly._" >> "$GITHUB_STEP_SUMMARY"
-            ./scripts/update-extensions.sh meta.pyrefly
           fi
+          # meta.pyrefly is optional in the test, so bump it every run to catch silent drift.
+          EXTENSIONS_TO_BUMP=(meta.pyrefly "${MISMATCHED[@]}")
+          echo "Bumping extensions: ${EXTENSIONS_TO_BUMP[*]}"
+          {
+            echo "### Bootstrap extensions to bump"
+            echo ""
+            printf -- '- %s\n' "${EXTENSIONS_TO_BUMP[@]}"
+          } >> "$GITHUB_STEP_SUMMARY"
+          ./scripts/update-extensions.sh "${EXTENSIONS_TO_BUMP[@]}"
 
       - name: Show product.json diff
         run: |

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: "0 2 * * 1-5"
   workflow_dispatch:
+    inputs:
+      dryrun:
+        description: 'Dry run: detect mismatches and run the bump script, but skip commit/push/PR/Slack.'
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -61,6 +66,15 @@ jobs:
           echo "Running: npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project e2e-electron --reporter=null"
           npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project e2e-electron --reporter=null
 
+      - name: Upload mismatched extensions list
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mismatched-extensions
+          path: test-logs/mismatched-extensions.txt
+          retention-days: 3
+          if-no-files-found: ignore
+
   auto-update:
     name: 'auto-update-extensions'
     if: always() && needs.extensions-linux.result != 'cancelled'
@@ -90,18 +104,37 @@ jobs:
           git config user.name "positron-bot[bot]"
           git config user.email "positron-bot[bot]@users.noreply.github.com"
 
+      - name: Download mismatched extensions list
+        if: needs.extensions-linux.result == 'failure'
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: mismatched-extensions
+          path: .
+
       - name: Update extensions
         env:
           TEST_RESULT: ${{ needs.extensions-linux.result }}
         run: |
-          if [ "$TEST_RESULT" = "failure" ]; then
-            ./scripts/update-extensions.sh --all
+          if [ "$TEST_RESULT" = "failure" ] && [ -s mismatched-extensions.txt ]; then
+            MISMATCHED=$(cat mismatched-extensions.txt)
+            echo "Bumping mismatched extensions: $MISMATCHED"
+            ./scripts/update-extensions.sh $MISMATCHED
           else
             ./scripts/update-extensions.sh meta.pyrefly
           fi
 
+      - name: Show product.json diff
+        run: |
+          if git diff --quiet product.json; then
+            echo "No changes to product.json."
+          else
+            git --no-pager diff product.json
+          fi
+
       - name: Commit and push
         id: push
+        if: inputs.dryrun != true
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
         run: |
@@ -165,7 +198,7 @@ jobs:
           echo "updated=$UPDATED" >> "$GITHUB_OUTPUT"
 
       - name: Post PR to Slack
-        if: steps.push.outputs.existing_pr != '' || steps.create-pr.outputs.pr_url != ''
+        if: (steps.push.outputs.existing_pr != '' || steps.create-pr.outputs.pr_url != '') && inputs.dryrun != true
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url || steps.push.outputs.existing_pr }}
@@ -186,7 +219,7 @@ jobs:
                }')"
 
   slack-notify:
-    if: always() && needs.extensions-linux.result == 'failure' && needs.auto-update.outputs.pr_url == ''
+    if: always() && needs.extensions-linux.result == 'failure' && needs.auto-update.outputs.pr_url == '' && inputs.dryrun != true
     needs: [extensions-linux, auto-update]
     runs-on: ubuntu-latest
     steps:

--- a/test/e2e/tests/extensions/bootstrap-extensions.test.ts
+++ b/test/e2e/tests/extensions/bootstrap-extensions.test.ts
@@ -183,6 +183,17 @@ async function waitForExtensions(
 		console.log('\n👉 Run script and commit changes:');
 		console.log(`   ./scripts/update-extensions.sh ${Array.from(mismatched).join(' ')}\n`);
 
+		// Surface the mismatched list to CI so the nightly workflow bumps only
+		// the affected extensions instead of every entry in product.json.
+		if (process.env.GITHUB_ACTIONS) {
+			const outDir = 'test-logs';
+			fs.mkdirSync(outDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(outDir, 'mismatched-extensions.txt'),
+				Array.from(mismatched).join(' ')
+			);
+		}
+
 		if (process.env.EXTENSIONS_FAIL_ON_MISMATCH === 'true') {
 			throw new Error('Some extensions were installed with mismatched versions (after grace period). Please check the logs above.');
 		}


### PR DESCRIPTION
### Summary
Instead of bumping `--all` when bootstrap check fails, bump only the extensions the Playwright test flagged as mismatched.

- Test writes mismatched names to test-logs/mismatched-extensions.txt which is used by downstream job
- Adds dryrun workflow_dispatch input that skips commit/push/PR/Slack

### QA Notes
See example "dryrun" [here](https://github.com/posit-dev/positron/actions/runs/26229376554). The diff also displays in the job if you expand the step.