### PR TITLE
ci: fix e2e-failure-analyzer for positron-builds caller

### DIFF
--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -24,9 +24,9 @@ inputs:
     required: false
     default: "blob"
   repo-root:
-    description: "Path to the repo workspace whose test/e2e/ source the analyzer should read. Defaults to $GITHUB_WORKSPACE. positron-builds passes $GITHUB_WORKSPACE/positron because the test source lives in the submodule."
+    description: "Path to the repo workspace whose test/e2e/ source and .claude/skills/ helpers the analyzer should read. Defaults to $GITHUB_WORKSPACE. positron-builds passes $GITHUB_WORKSPACE/positron because both the test source and helper scripts live in the submodule."
     required: false
-    default: ${{ github.workspace }}
+    default: ""
 runs:
   using: composite
   steps:
@@ -65,7 +65,7 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        node "${{ github.workspace }}/.claude/skills/e2e-failure-analyzer/scripts/e2e-gather-run-info.js" \
+        node "${{ inputs.repo-root || github.workspace }}/.claude/skills/e2e-failure-analyzer/scripts/e2e-gather-run-info.js" \
           "${{ inputs.run-url }}" > "${{ steps.prep.outputs.work_dir }}/run-info.json"
         echo "::group::run-info.json"
         cat "${{ steps.prep.outputs.work_dir }}/run-info.json"
@@ -94,7 +94,7 @@ runs:
           mkdir -p "$OUT"
           echo "::group::Process project $PROJECT"
           # cwd = action dir so npx finds @playwright/test from action's node_modules
-          node "${{ github.workspace }}/.claude/skills/e2e-failure-analyzer/scripts/e2e-process-project.js" \
+          node "${{ inputs.repo-root || github.workspace }}/.claude/skills/e2e-failure-analyzer/scripts/e2e-process-project.js" \
             --download \
             --run-id "$RUN_ID" \
             --repo "$REPO" \
@@ -156,13 +156,13 @@ runs:
           # Resolve REPORT_DIR from the job's logs. The workflow logs both an
           # unresolved template line (REPORT_DIR="...-${IDENTIFIER}-${OS_SUFFIX}")
           # and the expanded value (REPORT_DIR: playwright-report-<run>-<attempt>-<id>-<os>).
-          # Filter out lines containing literal ${ to skip the template, then
-          # extract the first concrete playwright-report-* token.
+          # Skip the template line, take the first concrete match. Single awk pass
+          # rather than grep | grep | head -1 to avoid head closing its stdin while
+          # upstream grep is still writing -- under `set -e -o pipefail` that
+          # manifests as "grep: write error: Broken pipe" + exit 2 on large logs.
           LOGS=$(gh api "repos/$REPO/actions/jobs/$JOB_ID/logs" 2>/dev/null || true)
           REPORT_DIR=$(printf '%s' "$LOGS" \
-            | grep -v '\${' \
-            | grep -oE 'playwright-report-[A-Za-z0-9_-]+' \
-            | head -1)
+            | awk '!/\${/ && match($0, /playwright-report-[A-Za-z0-9_-]+/) { print substr($0, RSTART, RLENGTH); exit }')
 
           if [ -z "$REPORT_DIR" ]; then
             echo "Could not resolve REPORT_DIR from logs of job $JOB_ID. Skipping."
@@ -173,7 +173,7 @@ runs:
           REPORT_URL="$CDN_BASE/$REPORT_DIR/"
           echo "Report URL: $REPORT_URL"
 
-          node "${{ github.workspace }}/.claude/skills/e2e-failure-analyzer/scripts/e2e-process-s3.js" \
+          node "${{ inputs.repo-root || github.workspace }}/.claude/skills/e2e-failure-analyzer/scripts/e2e-process-s3.js" \
             --report-url "$REPORT_URL" \
             --output-dir "$OUT" \
             --cleanup \
@@ -196,7 +196,7 @@ runs:
         # The e2e-test-insights API uses a single "positron" repo ID for both
         # posit-dev/positron and posit-dev/positron-builds (same tests, same
         # storage) -- do not parameterize this on the source GH repo.
-        node "${{ github.workspace }}/.claude/skills/e2e-failure-analyzer/scripts/e2e-query-history.js" \
+        node "${{ inputs.repo-root || github.workspace }}/.claude/skills/e2e-failure-analyzer/scripts/e2e-query-history.js" \
           --repo positron \
           --run-id "$RUN_ID" \
           --lookback-days 14 \
@@ -214,7 +214,7 @@ runs:
         WORK_DIR: ${{ steps.prep.outputs.work_dir }}
         # Repo workspace -- the agent reads test source from $REPO_ROOT/test/e2e
         # to understand each failing test's intent (assertions, page-object usage).
-        REPO_ROOT: ${{ inputs.repo-root }}
+        REPO_ROOT: ${{ inputs.repo-root || github.workspace }}
         MODEL: ${{ inputs.model }}
         MAX_TURNS: ${{ inputs.max-turns }}
       run: node analyze.mjs


### PR DESCRIPTION
## Summary

Three follow-ups to [#13671](https://github.com/posit-dev/positron/pull/13671) needed before the e2e-failure-analyzer action can run from [posit-dev/positron-builds](https://github.com/posit-dev/positron-builds), where the action lives in a submodule and the test source isn't at `$GITHUB_WORKSPACE`. All in [.github/actions/e2e-failure-analyzer/action.yml](.github/actions/e2e-failure-analyzer/action.yml):

- Apply `inputs.repo-root || github.workspace` at all five consumers. #13671 wired the input through to `REPO_ROOT` but left the four helper-script paths hardcoded to `github.workspace`, so positron-builds hit `MODULE_NOT_FOUND` on the first script call.
- Change the `repo-root` default from `${{ github.workspace }}` to `""`. Input defaults aren't guaranteed to evaluate expressions reliably across all contexts; falling back at each usage site is the defensive pattern (also flagged by roborev on #13671).
- Replace the `REPORT_DIR` pipeline (`grep | grep | head -1`) with a single `awk` pass. Under `set -e -o pipefail`, `head -1` closes its stdin after the first match and upstream `grep` gets SIGPIPE while writing the next line — kills the step on real CI log payloads.

The existing positron caller ([analyze-e2e-failures.yml](.github/workflows/analyze-e2e-failures.yml)) doesn't pass `repo-root`, so the `||` fallback resolves to `github.workspace` everywhere — behavior is unchanged for in-repo runs.

## Test plan

- [ ] Trigger `Analyze E2E Failures` on positron against a recent failed run; confirm the gather/process/history steps still find the helper scripts at `$GITHUB_WORKSPACE/.claude/skills/...` and the analyzer reads test source as before.
- [ ] Once merged, bump positron-builds' submodule pin to this SHA and confirm the end-to-end analyzer run succeeds with `repo-root: ${{ github.workspace }}/positron`.