### PR TITLE
Fix kernel supervisor shutdown on web

### DIFF
--- a/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
+++ b/extensions/positron-supervisor/src/KallichoreAdapterApi.ts
@@ -1350,27 +1350,6 @@ export class KCApi implements PositronSupervisorApi {
 	}
 
 	/**
-	 * Shuts down the Kallichore server and disposes all resources. Unlike
-	 * `dispose()`, this method sends a shutdown request to the server first,
-	 * which ensures that child processes (e.g. ark.exe on Windows) are
-	 * terminated by the supervisor before Positron exits.
-	 */
-	async shutdown(): Promise<void> {
-		// Only send a shutdown request if the server has actually started; if
-		// the barrier hasn't opened we never connected so there's nothing to
-		// shut down.
-		if (this._started.isOpen()) {
-			try {
-				await this._api.api.shutdownServer();
-			} catch (err) {
-				const message = summarizeError(err);
-				this.log(`Failed to shut down Kallichore server on exit: ${message}`);
-			}
-		}
-		this.dispose();
-	}
-
-	/**
 	 * Clean up the Kallichore server and all sessions. Note that this doesn't
 	 * actually remove the sessions from the server; it just disconnects them
 	 * from the API.

--- a/extensions/positron-supervisor/src/extension.ts
+++ b/extensions/positron-supervisor/src/extension.ts
@@ -69,21 +69,33 @@ export function activate(context: vscode.ExtensionContext): PositronSupervisorAp
 	return API_INSTANCE;
 }
 
+/**
+ * Decides whether `deactivate()` should dispose the supervisor's local
+ * connections. Exported so the decision logic can be exercised in tests
+ * without driving the full extension lifecycle.
+ *
+ * Only desktop Quit disposes:
+ * - Reload/Load: leave sessions in place so they reconnect when the window
+ *   comes back up.
+ * - Web (any reason): the supervisor server is hosted out-of-process and may
+ *   be shared with other clients; let it keep running and rely on its idle
+ *   timeout for cleanup.
+ * - Unknown reason (e.g. RPC race during teardown): also leave it alone --
+ *   we'd rather a stale server than tear down a live one we shouldn't.
+ */
+export function shouldDisposeOnDeactivate(
+	reason: positron.ShutdownReason | undefined,
+	uiKind: vscode.UIKind,
+): boolean {
+	return reason === positron.ShutdownReason.Quit && uiKind === vscode.UIKind.Desktop;
+}
+
 export async function deactivate(): Promise<void> {
 	if (!API_INSTANCE) {
 		return;
 	}
 
-	// On reload, dispose connections only so the server keeps running and
-	// sessions can reconnect when the window comes back up. On any other
-	// shutdown -- and when the reason is unknown (e.g. RPC race during
-	// teardown) -- shut down kcserver so it terminates its child processes
-	// (kernels) cleanly. Without this, on Windows the orphaned processes
-	// survive past Positron exit; on other platforms they linger until the
-	// server's idle timeout fires.
-	if (lastShutdownReason === positron.ShutdownReason.Reload) {
+	if (shouldDisposeOnDeactivate(lastShutdownReason, vscode.env.uiKind)) {
 		API_INSTANCE.dispose();
-	} else {
-		await API_INSTANCE.shutdown();
 	}
 }

--- a/extensions/positron-supervisor/src/test/deactivate.test.ts
+++ b/extensions/positron-supervisor/src/test/deactivate.test.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+import { shouldDisposeOnDeactivate } from '../extension';
+
+suite('shouldDisposeOnDeactivate', () => {
+	test('disposes on desktop Quit', () => {
+		assert.strictEqual(
+			shouldDisposeOnDeactivate(positron.ShutdownReason.Quit, vscode.UIKind.Desktop),
+			true,
+		);
+	});
+
+	test('does not dispose on web Quit', () => {
+		assert.strictEqual(
+			shouldDisposeOnDeactivate(positron.ShutdownReason.Quit, vscode.UIKind.Web),
+			false,
+		);
+	});
+
+	test('does not dispose on desktop Reload', () => {
+		assert.strictEqual(
+			shouldDisposeOnDeactivate(positron.ShutdownReason.Reload, vscode.UIKind.Desktop),
+			false,
+		);
+	});
+
+	test('does not dispose on web Reload', () => {
+		assert.strictEqual(
+			shouldDisposeOnDeactivate(positron.ShutdownReason.Reload, vscode.UIKind.Web),
+			false,
+		);
+	});
+
+	test('does not dispose on desktop Close', () => {
+		assert.strictEqual(
+			shouldDisposeOnDeactivate(positron.ShutdownReason.Close, vscode.UIKind.Desktop),
+			false,
+		);
+	});
+
+	test('does not dispose on desktop Load', () => {
+		assert.strictEqual(
+			shouldDisposeOnDeactivate(positron.ShutdownReason.Load, vscode.UIKind.Desktop),
+			false,
+		);
+	});
+
+	test('does not dispose on web Close', () => {
+		assert.strictEqual(
+			shouldDisposeOnDeactivate(positron.ShutdownReason.Close, vscode.UIKind.Web),
+			false,
+		);
+	});
+
+	test('does not dispose on web Load', () => {
+		assert.strictEqual(
+			shouldDisposeOnDeactivate(positron.ShutdownReason.Load, vscode.UIKind.Web),
+			false,
+		);
+	});
+
+	test('does not dispose when the shutdown reason is unknown (desktop)', () => {
+		assert.strictEqual(
+			shouldDisposeOnDeactivate(undefined, vscode.UIKind.Desktop),
+			false,
+		);
+	});
+
+	test('does not dispose when the shutdown reason is unknown (web)', () => {
+		assert.strictEqual(
+			shouldDisposeOnDeactivate(undefined, vscode.UIKind.Web),
+			false,
+		);
+	});
+});

--- a/src/vs/workbench/services/lifecycle/browser/lifecycleService.ts
+++ b/src/vs/workbench/services/lifecycle/browser/lifecycleService.ts
@@ -137,7 +137,13 @@ export class BrowserLifecycleService extends AbstractLifecycleService {
 
 		// Before Shutdown
 		this._onBeforeShutdown.fire({
-			reason: ShutdownReason.QUIT,
+			// --- Start Positron ---
+			// Prefer the explicit reason recorded by `withExpectedShutdown`
+			// (e.g. RELOAD from host.reload()) so subscribers can distinguish
+			// reload from quit. Upstream hardcodes QUIT here, which breaks
+			// extensions that branch on the shutdown reason during reload.
+			reason: this.shutdownReason ?? ShutdownReason.QUIT,
+			// --- End Positron ---
 			veto(value, id) {
 				handleVeto(value, id);
 			},
@@ -169,7 +175,11 @@ export class BrowserLifecycleService extends AbstractLifecycleService {
 		// First indicate will-shutdown
 		const logService = this.logService;
 		this._onWillShutdown.fire({
-			reason: ShutdownReason.QUIT,
+			// --- Start Positron ---
+			// See the matching comment in `doShutdown`: forward the recorded
+			// reason instead of always reporting QUIT.
+			reason: this.shutdownReason ?? ShutdownReason.QUIT,
+			// --- End Positron ---
 			joiners: () => [], 				// Unsupported in web
 			token: CancellationToken.None, 	// Unsupported in web
 			join(promise, joiner) {

--- a/src/vs/workbench/services/lifecycle/test/browser/lifecycleService.vitest.ts
+++ b/src/vs/workbench/services/lifecycle/test/browser/lifecycleService.vitest.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
+import { ShutdownReason } from '../../common/lifecycle.js';
+import { BrowserLifecycleService } from '../../browser/lifecycleService.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+
+describe('BrowserLifecycleService', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	function createService() {
+		const storage = disposables.add(new InMemoryStorageService());
+		return disposables.add(new BrowserLifecycleService(new NullLogService(), storage));
+	}
+
+	it('onWillShutdown forwards the reason recorded by withExpectedShutdown', async () => {
+		const service = createService();
+		const observed: ShutdownReason[] = [];
+		disposables.add(service.onWillShutdown(e => observed.push(e.reason)));
+
+		await service.withExpectedShutdown(ShutdownReason.RELOAD);
+		await service.shutdown();
+
+		expect(observed).toEqual([ShutdownReason.RELOAD]);
+	});
+
+	it('onBeforeShutdown forwards the reason recorded by withExpectedShutdown', async () => {
+		const service = createService();
+		const observed: ShutdownReason[] = [];
+		disposables.add(service.onBeforeShutdown(e => observed.push(e.reason)));
+
+		await service.withExpectedShutdown(ShutdownReason.CLOSE);
+		await service.shutdown();
+
+		expect(observed).toEqual([ShutdownReason.CLOSE]);
+	});
+
+	it('falls back to QUIT when no reason was recorded', async () => {
+		const service = createService();
+		const observed: ShutdownReason[] = [];
+		disposables.add(service.onWillShutdown(e => observed.push(e.reason)));
+
+		await service.shutdown();
+
+		expect(observed).toEqual([ShutdownReason.QUIT]);
+	});
+});


### PR DESCRIPTION
Fix #13542 

The fix for #13268 didn't address the web launch. The web code was always sending a `QUIT` reason for shutdown.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix shutdown event reason for web


### QA Notes
@:web @:positron-notebooks