### PR TITLE
E2E test: add ability to run MacOS tests to full suite

### DIFF
--- a/.github/workflows/test-e2e-macos-build.yml
+++ b/.github/workflows/test-e2e-macos-build.yml
@@ -1,0 +1,103 @@
+name: "E2E: Build Positron (macOS)"
+
+on:
+  workflow_call:
+    inputs:
+      commit:
+        description: "Commit SHA to test"
+        required: false
+        default: ""
+        type: string
+      arch:
+        required: false
+        description: "Architecture to build (arm64 or x64)."
+        default: arm64
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    name: build-macos-${{ inputs.arch }}
+    timeout-minutes: 60
+    runs-on: ${{ inputs.arch == 'arm64' && 'macos-latest-xlarge' || 'macos-latest-large' }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      POSITRON_BUILD_NUMBER: 0
+      LANG: "en_US.UTF-8"
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install E2E test dependencies
+        run: |
+          npm --prefix test/e2e ci --prefer-offline --no-audit --no-fund
+
+      - name: Install node dependencies
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+          npm_config_arch: ${{ inputs.arch }}
+        run: |
+          npm ci --fetch-timeout 120000
+
+      - name: Compile Positron and Download Electron
+        env:
+          npm_config_arch: ${{ inputs.arch }}
+        run: |
+          npm exec -- npm-run-all --max-old-space-size=8192 -p compile "electron x64"
+
+      - name: Download built-in extensions (prelaunch)
+        run: |
+          npm run prelaunch
+
+      - name: Clone QA example content
+        run: |
+          echo "Cloning QA example content (always fresh)..."
+          git clone --depth=1 --branch main https://github.com/posit-dev/qa-example-content.git /tmp/qa-example-content-cache
+          COMMIT_SHA=$(cd /tmp/qa-example-content-cache && git rev-parse HEAD)
+          echo "$COMMIT_SHA" > /tmp/qa-example-content-cache/.cached-commit
+          echo "Cloned QA content at commit: $COMMIT_SHA"
+
+      - name: Create Build Artifact
+        run: |
+          # Ensure QA example content is bundled
+          mkdir -p test/e2e
+          if [ -d "/tmp/qa-example-content-cache" ]; then
+            echo "Copying cached QA content to workspace"
+            cp -R /tmp/qa-example-content-cache test/e2e/qa-example-content-cache || true
+          else
+            echo "Warning: QA content cache not found at /tmp/qa-example-content-cache"
+          fi
+
+          # Create a tarball of the positron workspace
+          mkdir -p /tmp/artifacts
+          cd ..
+
+          echo "Creating build artifact (excluding .git)"
+          tar \
+            --exclude='positron/.git' \
+            --exclude='positron/.npm-cache' \
+            --exclude='positron/.pip-cache' \
+            -czf /tmp/artifacts/positron-build.tar.gz positron
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: "positron-build-macos-${{ inputs.arch }}"
+          path: /tmp/artifacts
+          retention-days: 1
+          compression-level: 0

--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -1,0 +1,324 @@
+name: "Test: E2E (macOS) — Run-only"
+
+on:
+  workflow_call:
+    inputs:
+      commit:
+        description: "Commit SHA to test"
+        required: false
+        default: ""
+        type: string
+      grep:
+        required: false
+        description: "Only run tests matching this regex. Supports tags (comma-separated), titles, filenames. Confirm pattern matching locally with: npx playwright test --grep=<regex>"
+        default: ""
+        type: string
+      project:
+        required: false
+        description: "The name of the Playwright project to run tests for."
+        default: "e2e-macOS-ci"
+        type: string
+      workers:
+        required: false
+        description: "Number of parallel workers to use, defaults to 2."
+        default: 2
+        type: number
+      shards:
+        required: false
+        description: "Total number of shards (for display purposes and shard argument)"
+        default: 1
+        type: number
+      matrix:
+        required: false
+        description: "Pre-calculated matrix JSON from caller workflow"
+        default: '{"shard":[1]}'
+        type: string
+      display_name:
+        required: false
+        description: "The name of the job as it will appear in the GitHub Actions UI."
+        default: "macos"
+        type: string
+      max_failures:
+        required: false
+        description: "Maximum number of test failures before aborting. Should be calculated as: base_max_failures / number_of_shards (e.g., 10 / 4 = 3 for 4 shards)."
+        type: number
+        default: 10
+      enable_diagnostic_logging:
+        required: false
+        description: "Enable diagnostic logging (free memory, process list, CPU usage) at the end of each test."
+        type: boolean
+        default: false
+      arch:
+        required: false
+        description: "Architecture to test (arm64 or x64)."
+        default: arm64
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  e2e-macos-run:
+    name: ${{ inputs.display_name || 'macos' }}-${{ matrix.shard }}
+    timeout-minutes: 120
+    runs-on: ${{ inputs.arch == 'arm64' && 'macos-latest-xlarge' || 'macos-latest-large' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(inputs.matrix) }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      POSITRON_BUILD_NUMBER: 0
+      AWS_S3_BUCKET: positron-test-reports
+      DATABRICKS_WORKSPACE: ${{ secrets.DATABRICKS_WORKSPACE }}
+      DATABRICKS_PAT: ${{ secrets.DATABRICKS_PAT }}
+      LANG: "en_US.UTF-8"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Checkout specific commit
+        if: ${{ inputs.commit != '' }}
+        run: git checkout ${{ inputs.commit }}
+
+      - name: Load secret
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
+          OPENAI_KEY: "op://Positron/OpenAI/credential"
+          POSIT_AUTH_HOST: "op://Posit-AI-Login/website"
+          POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
+          POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
+
+      - name: Configure display resolution
+        run: |
+          echo "Current display configuration:"
+          system_profiler SPDisplaysDataType
+
+          brew install displayplacer
+
+          echo "Current displayplacer configuration:"
+          displayplacer list
+
+          # The Intel (x64) runner only supports hz:30 color_depth:4 at 1920x1080;
+          # the arm64 runner supports hz:60 color_depth:7.
+          if [ "${{ inputs.arch }}" = "x64" ]; then
+            displayplacer "res:1920x1080 hz:30 color_depth:4 enabled:true scaling:off origin:(0,0) degree:0"
+          else
+            displayplacer "res:1920x1080 hz:60 color_depth:7 enabled:true scaling:off origin:(0,0) degree:0"
+          fi
+
+          echo "New configuration:"
+          displayplacer list
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install system dependencies
+        run: |
+          brew install gdal udunits
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: "positron-build-macos-${{ inputs.arch }}"
+          path: /tmp/artifacts
+
+      - name: Extract build artifact
+        run: |
+          cd ..
+          if [ -f /tmp/artifacts/positron-build.tar.gz ]; then
+            echo "Extracting gzip archive"
+            tar -xzf /tmp/artifacts/positron-build.tar.gz || true
+            echo "Cleaning up compressed archive to free disk space"
+            rm -f /tmp/artifacts/positron-build.tar.gz
+          else
+            echo "No build artifact found in /tmp/artifacts"
+            ls -la /tmp/artifacts || true
+            exit 1
+          fi
+
+          if [ -d positron ]; then
+            echo "Build extracted successfully"
+            ls -la positron | head -20
+          fi
+
+      - name: Seed system tmp cache from bundled cache
+        run: |
+          if [ -d test/e2e/qa-example-content-cache ]; then
+            rm -rf /tmp/qa-example-content-cache || true
+            mv test/e2e/qa-example-content-cache /tmp/qa-example-content-cache || true
+            if [ -f /tmp/qa-example-content-cache/.cached-commit ]; then
+              echo "✓ Seeded /tmp/qa-example-content-cache"
+            fi
+          fi
+
+      - name: Validate bundled QA cache
+        run: |
+          echo "Checking for seeded QA cache at /tmp/qa-example-content-cache/.cached-commit"
+          if [ -f /tmp/qa-example-content-cache/.cached-commit ]; then
+            echo "✓ Cached commit found: $(cat /tmp/qa-example-content-cache/.cached-commit)"
+          else
+            echo "✗ Cached commit missing at /tmp/qa-example-content-cache/.cached-commit"
+            echo "Contents of /tmp:"; ls -la /tmp || true
+            exit 1
+          fi
+
+      - name: Install Rig and R
+        run: |
+          if brew list --cask | grep -q "^r$"; then
+            brew uninstall r
+          fi
+          R_VERSION="4.5.2"
+          R_ALTERNATE_VERSION="4.3.0"
+          echo "Installing R version $R_VERSION using Rig..."
+          brew tap r-lib/rig
+          brew install --cask rig
+          rig add "$R_VERSION"
+          echo "Installing R version $R_ALTERNATE_VERSION using Rig..."
+          rig add "$R_ALTERNATE_VERSION"
+
+      - name: Install R packages for 4.5.2
+        run: |
+          curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/DESCRIPTION --output DESCRIPTION
+          Rscript -e "options(pak.install_binary = TRUE, repos = c(CRAN = 'https://packagemanager.posit.co/cran/latest')); pak::local_install_dev_deps(ask = FALSE)"
+
+      - name: Install pyenv and Python
+        run: |
+          brew install pyenv
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
+          eval "$(pyenv init -)"
+          pyenv install 3.10.10
+          pyenv install 3.11.0
+          pyenv global 3.10.10
+
+      - name: Install Python dependencies
+        run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
+          eval "$(pyenv init -)"
+          pyenv global 3.10.10
+          curl https://raw.githubusercontent.com/posit-dev/qa-example-content/main/requirements.txt --output requirements.txt
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      # The Intel runner is slow enough that the first matplotlib import in a
+      # test can spend 10-30s building the font cache and trip a test timeout.
+      - name: Pre-warm matplotlib font cache
+        if: ${{ inputs.arch == 'x64' }}
+        run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
+          eval "$(pyenv init -)"
+          python -c "import matplotlib.pyplot as plt; plt.figure()"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install ipykernel for 3.11.0
+        run: |
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init --path)"
+          eval "$(pyenv init -)"
+          pyenv global 3.11.0
+          python -m pip install --upgrade pip
+          python -m pip install ipykernel
+          pyenv global 3.10.10
+
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2.0.2
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tinytex: true
+
+      - name: Install XQuartz
+        run: |
+          brew install --cask xquartz
+
+      - name: Transform to Playwright tags $PW_TAGS
+        run: bash scripts/pr-tags-transform.sh "${{ inputs.project }}" "${{ inputs.grep }}"
+
+      - name: Generate report directory
+        id: gen_report
+        run: |
+          REPORT_DIR="test-results/$(date +'%Y%m%d%H%M%S')"
+          echo "REPORT_DIR=$REPORT_DIR" >> $GITHUB_ENV
+          echo "report_dir=$REPORT_DIR" >> $GITHUB_OUTPUT
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
+          aws-region: ${{ vars.QA_AWS_REGION }}
+
+      - name: Run Tests (Electron)
+        env:
+          POSITRON_PY_VER_SEL: 3.10.10
+          POSITRON_R_VER_SEL: 4.5.2
+          POSITRON_PY_ALT_VER_SEL: 3.11.0
+          POSITRON_R_ALT_VER_SEL: 4.3.0
+          REPORTER_REPO_NAME: positron
+          COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
+          CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+          PWTEST_BLOB_DO_NOT_REMOVE: 1
+          E2E_CONNECT_SERVER: ${{ secrets.E2E_CONNECT_SERVER}}
+          E2E_CONNECT_APIKEY: ${{ secrets.E2E_CONNECT_APIKEY}}
+          GH_SUMMARY_REPORT: true
+        run: |
+          # Bootstrap extensions first
+          npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project ${{ inputs.project }} --reporter=null
+
+          # Build grep arguments
+          GREP_ARG=""
+          if [ -n "${{ inputs.grep }}" ]; then
+            GREP_ARG="--grep ${{ inputs.grep }}"
+          fi
+
+          # Calculate shard if we have more than 1 shard
+          SHARD_ARG=""
+          if [ "${{ inputs.shards }}" -gt "1" ]; then
+            SHARD_ARG="--shard=${{ matrix.shard }}/${{ inputs.shards }}"
+          fi
+
+          # Run tests
+          SKIP_BOOTSTRAP=true SKIP_CLONE=true npx playwright test \
+            --project ${{ inputs.project }} \
+            --workers ${{ inputs.workers }} \
+            --max-failures ${{ inputs.max_failures }} \
+            $GREP_ARG \
+            $SHARD_ARG
+
+      - name: Upload Playwright Report to S3
+        if: ${{ success() || failure() }}
+        run: |
+          if [ -d "$REPORT_DIR" ]; then
+            aws s3 sync "$REPORT_DIR" "s3://$AWS_S3_BUCKET/$REPORT_DIR" --only-show-errors
+            REPORT_URL="https://$AWS_S3_BUCKET.s3.amazonaws.com/$REPORT_DIR/index.html"
+            echo "📊 Test Report: $REPORT_URL" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload test artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-artifacts-${{ inputs.display_name }}-${{ matrix.shard }}
+          path: |
+            test-results/
+            !test-results/**/*.webm
+          retention-days: 3

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -39,6 +39,11 @@ on:
         required: false
         default: true
         type: boolean
+      run_e2e_macos:
+        description: "E2E Tests / Electron (macOS)"
+        required: false
+        default: false
+        type: boolean
       run_e2e_browser:
         description: "E2E Tests / Chromium (Ubuntu)"
         required: false
@@ -132,6 +137,16 @@ jobs:
       commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
       skip_cache: ${{ inputs.commit != 'latest' }}
 
+  setup-macos:
+    name: setup-macos
+    needs: [validate-commit]
+    if: ${{ !failure() && !cancelled() && inputs.run_e2e_macos }}
+    uses: ./.github/workflows/test-e2e-macos-build.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
+      arch: arm64
+
   e2e-electron:
     name: e2e
     needs: [setup]
@@ -170,6 +185,23 @@ jobs:
       matrix: '{"shard":[1,2,3,4]}'
       max_failures: 6  # 20 max failures / 4 shards = 5, rounded to 6 to avoid premature failure of the entire suite
       enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
+
+  e2e-macos:
+    name: e2e
+    needs: [setup-macos]
+    if: ${{ !failure() && !cancelled() && (github.event_name == 'schedule' || inputs.run_e2e_macos) }}
+    uses: ./.github/workflows/test-e2e-macos-run.yml
+    secrets: inherit
+    with:
+      commit: ${{ inputs.commit != 'latest' && inputs.commit || '' }}
+      grep: ${{ inputs.grep || '' }}
+      project: "e2e-macOS-ci"
+      display_name: "macos"
+      shards: 4
+      matrix: '{"shard":[1,2,3,4]}'
+      max_failures: 6  # 20 max failures / 4 shards = 5, rounded to 6 to avoid premature failure of the entire suite
+      enable_diagnostic_logging: ${{ inputs.enable_diagnostic_logging }}
+      arch: arm64
 
   e2e-chromium:
     name: e2e
@@ -349,7 +381,7 @@ jobs:
   slack-notify:
     if: always()
     needs:
-      [validate-commit, e2e-electron, e2e-windows, e2e-chromium, e2e-rhel, e2e-chromium-rhel, e2e-suse, e2e-chromium-suse, e2e-sles, e2e-chromium-sles, e2e-debian, e2e-chromium-debian, unit-tests, ext-host-tests]
+      [validate-commit, e2e-electron, e2e-windows, e2e-macos, e2e-chromium, e2e-rhel, e2e-chromium-rhel, e2e-suse, e2e-chromium-suse, e2e-sles, e2e-chromium-sles, e2e-debian, e2e-chromium-debian, unit-tests, ext-host-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
I need to merge this to start testing.
It just will allow us to test MacOS Desktop in full suite, which now we can only do nightly in positron-builds.