### PR TITLE
ci: avoid SIGPIPE in e2e-failure-analyzer awk pipeline

### DIFF
--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -155,14 +155,18 @@ runs:
 
           # Resolve REPORT_DIR from the job's logs. The workflow logs both an
           # unresolved template line (REPORT_DIR="...-${IDENTIFIER}-${OS_SUFFIX}")
-          # and the expanded value (REPORT_DIR: playwright-report-<run>-<attempt>-<id>-<os>).
-          # Skip the template line, take the first concrete match. Single awk pass
-          # rather than grep | grep | head -1 to avoid head closing its stdin while
-          # upstream grep is still writing -- under `set -e -o pipefail` that
-          # manifests as "grep: write error: Broken pipe" + exit 2 on large logs.
+          # and the expanded value. Skip the template, capture the first concrete
+          # match, emit it at END. Avoiding `exit` here is deliberate -- it would
+          # close awk's stdin mid-pipeline, SIGPIPE upstream printf, and under
+          # `set -e -o pipefail` kill the step (manifests as "printf: write error:
+          # Broken pipe" on large log payloads).
           LOGS=$(gh api "repos/$REPO/actions/jobs/$JOB_ID/logs" 2>/dev/null || true)
-          REPORT_DIR=$(printf '%s' "$LOGS" \
-            | awk '!/\${/ && match($0, /playwright-report-[A-Za-z0-9_-]+/) { print substr($0, RSTART, RLENGTH); exit }')
+          REPORT_DIR=$(printf '%s' "$LOGS" | awk '
+            !/\${/ && !found && match($0, /playwright-report-[A-Za-z0-9_-]+/) {
+              found = substr($0, RSTART, RLENGTH)
+            }
+            END { if (found) print found }
+          ')
 
           if [ -z "$REPORT_DIR" ]; then
             echo "Could not resolve REPORT_DIR from logs of job $JOB_ID. Skipping."


### PR DESCRIPTION
## Summary

Follow-up to #13693. That PR replaced `grep | grep | head -1` with a single awk pipeline to avoid `head` closing its stdin and SIGPIPE-ing upstream `grep`. But the new awk script kept the same shape of bug: it calls `exit` after the first match, which closes awk's stdin and SIGPIPEs the upstream `printf`. Under `set -e -o pipefail` the step still dies.

posit-dev/positron-builds CI confirms this with `printf: write error: Broken pipe` on real job logs. Small local logs don't reproduce because `printf` finishes writing before awk's `exit` closes the pipe.

Fix: rewrite the awk script as an END-block accumulator. awk reads all input, captures the first concrete match into a variable, prints it at END. No early termination, no pipe-close race.

The trade-off is reading the whole log instead of bailing on the first match. `gh api .../jobs/$ID/logs` payloads are bounded (~10MB max), so the cost is negligible compared to eliminating the race for good.

## Test plan

- [ ] Trigger `analyze-e2e-failures.yml` on positron — should still work end-to-end (the awk script's external behavior is unchanged: prints the first concrete match or nothing).
- [ ] positron-builds end-to-end will validate the SIGPIPE doesn't recur on real CI log sizes once positron-builds bumps to this SHA.