### PR TITLE
Fix `IPython.display.Audio` playback in notebooks

### DIFF
--- a/src/vs/base/browser/domSanitize.ts
+++ b/src/vs/base/browser/domSanitize.ts
@@ -14,6 +14,7 @@ import dompurify, * as DomPurifyTypes from './dompurify/dompurify.js';
 export const basicMarkupHtmlTags = Object.freeze([
 	'a',
 	'abbr',
+	'audio',
 	'b',
 	'bdo',
 	'blockquote',

--- a/src/vs/code/electron-browser/workbench/workbench-dev.html
+++ b/src/vs/code/electron-browser/workbench/workbench-dev.html
@@ -19,6 +19,8 @@
 				;
 				media-src
 					'self'
+					data:
+					https:
 				;
 				frame-src
 					'self'

--- a/src/vs/code/electron-browser/workbench/workbench.html
+++ b/src/vs/code/electron-browser/workbench/workbench.html
@@ -19,6 +19,8 @@
 				;
 				media-src
 					'self'
+					data:
+					https:
 				;
 				frame-src
 					'self'


### PR DESCRIPTION
## Summary
- Add `data:` and `https:` to CSP `media-src` directive so audio elements can load base64-encoded and remote audio sources
- Add `audio` to the DOMPurify tag allow-list (was already present for `video`)

Fixes #10452

## Test plan
- [x] Open a Python notebook in Positron
- [x] Run: `from IPython.display import Audio; Audio("https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3")`
- [x] Verify the audio player is interactive (not grayed out) and plays audio

## Note
- No unit test needed: the fix is a CSP config change and a static allow-list entry, neither of which
  is unit-testable.

https://github.com/user-attachments/assets/c762d412-79b3-40de-a535-56d682b98afe

@:positron-notebooks @:win @:web

