### PR TITLE
chore: bump @midleman/playwright-reporter to 0.47.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
       },
       "devDependencies": {
         "@midleman/github-actions-reporter": "^1.10.1",
-        "@midleman/playwright-reporter": "^0.47.15",
+        "@midleman/playwright-reporter": "^0.47.16",
         "@playwright/test": "^1.58.2",
         "@stylistic/eslint-plugin-ts": "^2.8.0",
         "@swc/core": "1.3.62",
@@ -3519,9 +3519,9 @@
       }
     },
     "node_modules/@midleman/playwright-reporter": {
-      "version": "0.47.15",
-      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.47.15.tgz",
-      "integrity": "sha512-vw7TNMxlSi1OPJQ+RIAmyYbr/bfajA7xDUCnGX4357Gf4qhnFyTmNSNwFgXRt5Z4S1Kl2FMJJKTq0FZYVPuaXA==",
+      "version": "0.47.16",
+      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.47.16.tgz",
+      "integrity": "sha512-OTVFLDXqyI81wCYKxGPHASbt7kICe7FrYimfGsHE/3MgNBmpysi0m3/elYMnxHBcRJtgQBqNqSYg+L1vo7ci/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
   },
   "devDependencies": {
     "@midleman/github-actions-reporter": "^1.10.1",
-    "@midleman/playwright-reporter": "^0.47.15",
+    "@midleman/playwright-reporter": "^0.47.16",
     "@playwright/test": "^1.58.2",
     "@stylistic/eslint-plugin-ts": "^2.8.0",
     "@swc/core": "1.3.62",


### PR DESCRIPTION
### Summary
Picks up the shard collision warning released in 0.47.16: the reporter now emits a `console.warn` at startup when the auto-generated shard ID may be shared by sibling CI jobs (which silently overwrites their results in S3).
- Bumps `devDependencies."@midleman/playwright-reporter"` from `^0.47.15` to `^0.47.16`
- Lockfile updated to match

### QA Notes
n/a