### PR TITLE
Fixes for MacOS in Full Suite run (Electron)

### DIFF
--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -257,6 +257,10 @@ jobs:
         run: |
           brew install --cask xquartz
 
+      - name: Install Playwright browsers
+        run: |
+          npx playwright install chromium
+
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh "${{ inputs.project }}" "${{ inputs.grep }}"
 

--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -265,7 +265,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
-          aws-region: ${{ vars.QA_AWS_REGION }}
+          aws-region: ${{ secrets.QA_AWS_REGION }}
 
       - name: Run Tests (Electron)
         env:

--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -83,6 +83,12 @@ jobs:
         if: ${{ inputs.commit != '' }}
         run: git checkout ${{ inputs.commit }}
 
+      - name: Setup AWS S3 Access
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
+          aws-region: ${{ secrets.QA_AWS_REGION }}
+
       - name: Load secret
         uses: 1password/load-secrets-action@v4
         with:
@@ -91,7 +97,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           ANTHROPIC_KEY: "op://Positron/Anthropic/credential"
           OPENAI_KEY: "op://Positron/OpenAI/credential"
-          POSIT_AUTH_HOST: "op://Posit-AI-Login/website"
+          POSIT_AUTH_HOST: "op://Positron/Posit-AI-Login/website"
           POSIT_EMAIL: "op://Positron/Posit-AI-Login/username"
           POSIT_PASSWORD: "op://Positron/Posit-AI-Login/password"
 
@@ -254,19 +260,6 @@ jobs:
       - name: Transform to Playwright tags $PW_TAGS
         run: bash scripts/pr-tags-transform.sh "${{ inputs.project }}" "${{ inputs.grep }}"
 
-      - name: Generate report directory
-        id: gen_report
-        run: |
-          REPORT_DIR="test-results/$(date +'%Y%m%d%H%M%S')"
-          echo "REPORT_DIR=$REPORT_DIR" >> $GITHUB_ENV
-          echo "report_dir=$REPORT_DIR" >> $GITHUB_OUTPUT
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
-          aws-region: ${{ secrets.QA_AWS_REGION }}
-
       - name: Run Tests (Electron)
         env:
           POSITRON_PY_VER_SEL: 3.10.10
@@ -279,7 +272,7 @@ jobs:
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           E2E_CONNECT_SERVER: ${{ secrets.E2E_CONNECT_SERVER}}
           E2E_CONNECT_APIKEY: ${{ secrets.E2E_CONNECT_APIKEY}}
-          GH_SUMMARY_REPORT: true
+          GH_SUMMARY_REPORT: false # prevent reporting individual shard results to github summary
         run: |
           # Bootstrap extensions first
           npx playwright test test/e2e/tests/extensions/bootstrap-extensions.test.ts --project ${{ inputs.project }} --reporter=null
@@ -296,29 +289,156 @@ jobs:
             SHARD_ARG="--shard=${{ matrix.shard }}/${{ inputs.shards }}"
           fi
 
-          # Run tests
+          # Run tests - don't fail on test failures, let merge-reports determine pass/fail
           SKIP_BOOTSTRAP=true SKIP_CLONE=true npx playwright test \
             --project ${{ inputs.project }} \
             --workers ${{ inputs.workers }} \
             --max-failures ${{ inputs.max_failures }} \
             $GREP_ARG \
-            $SHARD_ARG
+            $SHARD_ARG || true
 
-      - name: Upload Playwright Report to S3
-        if: ${{ success() || failure() }}
-        run: |
-          if [ -d "$REPORT_DIR" ]; then
-            aws s3 sync "$REPORT_DIR" "s3://$AWS_S3_BUCKET/$REPORT_DIR" --only-show-errors
-            REPORT_URL="https://$AWS_S3_BUCKET.s3.amazonaws.com/$REPORT_DIR/index.html"
-            echo "📊 Test Report: $REPORT_URL" >> $GITHUB_STEP_SUMMARY
-          fi
+      - name: Upload Blob Report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: blob-report-${{ inputs.project }}-${{ matrix.shard }}
+          path: blob-report
+          retention-days: 1
 
-      - name: Upload test artifacts
+      - name: Upload Test Logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7
         with:
-          name: test-artifacts-${{ inputs.display_name }}-${{ matrix.shard }}
-          path: |
-            test-results/
-            !test-results/**/*.webm
+          name: ${{ inputs.project }}-macos-logs-${{ matrix.shard }}
+          path: test-logs
           retention-days: 3
+          if-no-files-found: ignore
+
+  merge-reports:
+    name: ${{ inputs.display_name }}
+    if: ${{ !cancelled() }}
+    needs: [e2e-macos-run]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Setup AWS S3 Access
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
+          aws-region: ${{ secrets.QA_AWS_REGION }}
+
+      - name: Install Playwright
+        run: |
+          # Create clean directory for merge dependencies
+          mkdir -p playwright-merge
+          cd playwright-merge
+          npm init -y
+          npm install @playwright/test @midleman/github-actions-reporter
+
+      - name: Generate Report Directory
+        uses: ./.github/actions/gen-report-dir
+        with:
+          identifier: ${{ inputs.project }}
+
+      - name: Download all blob reports
+        uses: actions/download-artifact@v8
+        with:
+          path: all-blob-reports
+          pattern: blob-report-${{ inputs.project }}-*
+          merge-multiple: true
+
+      - name: Verify all shard reports received
+        id: verify-reports
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXPECTED_SHARDS=${{ inputs.shards }}
+          PROJECT="${{ inputs.project }}"
+          echo "Expected shard count: $EXPECTED_SHARDS"
+
+          # Query GitHub API for artifacts in this run matching our pattern
+          ARTIFACTS=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts --jq '.artifacts[].name' | grep "^blob-report-${PROJECT}-" || true)
+          ARTIFACT_COUNT=$(echo "$ARTIFACTS" | grep -c . || echo 0)
+
+          echo "Found artifacts:"
+          echo "$ARTIFACTS"
+          echo ""
+          echo "Artifact count: $ARTIFACT_COUNT"
+
+          # Check which shards are missing
+          MISSING_SHARDS=""
+          for i in $(seq 1 $EXPECTED_SHARDS); do
+            if ! echo "$ARTIFACTS" | grep -q "^blob-report-${PROJECT}-${i}$"; then
+              MISSING_SHARDS="$MISSING_SHARDS $i"
+            fi
+          done
+
+          if [ -n "$MISSING_SHARDS" ]; then
+            echo "::warning::Missing blob reports for shards:$MISSING_SHARDS"
+            echo "This typically means these shards crashed before uploading their results."
+            echo "missing_reports=true" >> $GITHUB_OUTPUT
+            echo "missing_shards=$MISSING_SHARDS" >> $GITHUB_OUTPUT
+          else
+            echo "All $EXPECTED_SHARDS shard reports received"
+            echo "missing_reports=false" >> $GITHUB_OUTPUT
+            echo "missing_shards=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Merge Playwright Blob Reports, Generate HTML and JSON Reports
+        working-directory: playwright-merge
+        run: |
+          # Create output directory
+          mkdir -p playwright-report
+
+          # Generate HTML report and GH Summary
+          PLAYWRIGHT_HTML_REPORT=playwright-report npx playwright merge-reports \
+            --reporter=@midleman/github-actions-reporter,html \
+            ../all-blob-reports
+
+          # Generate JSON report separately with explicit output path
+          PLAYWRIGHT_JSON_OUTPUT_NAME=playwright-report/results.json npx playwright merge-reports \
+            --reporter=json \
+            ../all-blob-reports
+
+      - name: Upload HTML report to S3
+        if: always()
+        uses: ./.github/actions/upload-report-to-s3
+        with:
+          role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}
+          report-dir: ${{ env.REPORT_DIR }}
+          working-directory: playwright-merge
+
+      - name: Check test results
+        if: always()
+        run: |
+          JSON_REPORT="playwright-merge/playwright-report/results.json"
+          if [ ! -f "$JSON_REPORT" ]; then
+            echo "⚠ JSON report not found at $JSON_REPORT"
+            echo "Contents of playwright-merge/playwright-report:"
+            ls -la playwright-merge/playwright-report/ || true
+            exit 1
+          fi
+
+          node scripts/check-soft-fail-failures.js "$JSON_REPORT" --no-soft-fail
+
+          # Fail if we're missing reports from any shards (even if all available tests passed)
+          if [[ "${{ steps.verify-reports.outputs.missing_reports }}" == "true" ]]; then
+            echo ""
+            echo "::error::Missing shard reports detected!"
+            echo "Missing reports from shards:${{ steps.verify-reports.outputs.missing_shards }}"
+            echo "These shards likely crashed or timed out before uploading results."
+            echo "Check the individual shard jobs above for errors."
+            exit 1
+          fi
+
+      - name: Clean up blob report artifacts
+        if: success()
+        uses: geekyeggo/delete-artifact@v6
+        with:
+          name: blob-report-${{ inputs.project }}-*
+          failOnError: false

--- a/scripts/pr-tags-transform.sh
+++ b/scripts/pr-tags-transform.sh
@@ -17,7 +17,7 @@ echo "  * Tags: '$TAGS'"
 OUTPUT=""
 
 # Filter and preprocess tags based on project
-if [[ "$PROJECT" == "e2e-windows" ]]; then
+if [[ "$PROJECT" == "e2e-windows" || "$PROJECT" == "e2e-macOS-ci" ]]; then
   # Remove @:win from the tags
   TAGS=$(echo "$TAGS" | tr ',' '\n' | grep -v "@:win" | sort -u | tr '\n' ',' | sed 's/,$//')
 	# If @:web is present, remove it
@@ -49,8 +49,8 @@ case "$PROJECT" in
   "e2e-chromium"|"e2e-firefox"|"e2e-webkit"|"e2e-edge")
     OUTPUT="(?=.*@:web)"  # Base tag for chromium/web engines
     ;;
-  "e2e-windows")
-    OUTPUT="(?=.*@:win)"  # Base tag for windows
+  "e2e-windows"|"e2e-macOS-ci")
+    OUTPUT="(?=.*@:win)"  # Base tag for windows and macOS
     ;;
   "e2e-electron")
     OUTPUT="" # No prefix for linux


### PR DESCRIPTION
## Add macOS E2E Testing to Full Suite Workflow

Adds the ability to run macOS Electron E2E tests in the Full Suite workflow, following the same build-once-test-multiple-shards pattern as Ubuntu.

### Changes

**New Workflows:**
- `test-e2e-macos-build.yml` - Builds Positron once from source (no CDN download)
- `test-e2e-macos-run.yml` - Runs tests across 4 shards, merges blob reports

**Updated:**
- `test-full-suite.yml` - Added "E2E Tests / Electron (macOS)" checkbox (default: off)
- `scripts/pr-tags-transform.sh` - Added support for `e2e-macOS-ci` project (uses `@:win` tag)

### Architecture

```
setup-macos (build once)
    ↓ artifact
e2e-macos (4 shards in parallel)
    ↓ blob reports
merge-reports (combine results)
```

**Build once:** ~20 min  
**Test 4 shards in parallel:** ~40 min wall time  
**Total:** ~60 min (vs ~180 min if each shard built independently)

### Key Features

- ✅ **Blob report merging** - Unified Playwright report combining all 4 shards
- ✅ **Shard crash detection** - Merge job fails if any shard crashes before uploading
- ✅ **AWS S3 access** - Read access for QA test data, write access for reports
- ✅ **Consistent with Ubuntu/Windows** - Same patterns across all platforms
- ✅ **Test environment** - R 4.5.2 + 4.3.0, Python 3.10.10 + 3.11.0, full QA setup

### Testing

Run via Actions → Test: Full Suite → Check "E2E Tests / Electron (macOS)"

The workflow will build Positron from the current branch, then run the full E2E test suite across 4 shards on macOS arm64 runners.



