### PR TITLE
Fix `ipydatagrid` failing to render in notebook outputs

### DIFF
--- a/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
+++ b/src/vs/workbench/contrib/positronOutputWebview/browser/notebookOutputWebviewServiceImpl.ts
@@ -450,6 +450,10 @@ ${headContent}
 	 */
 	static readonly CssAddons = `
 <style>
+	body {
+		margin: 0;
+	}
+
 	/* Hide actions button that try and open external pages like opening source code as they don't currently work (See #2829)
 	/* We do support download link clicks, so keep those. */
 	.vega-actions a:not([download]) {

--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
@@ -66,13 +66,12 @@ export function isWheelForwardMessage(message: unknown): message is WheelForward
 		&& typeof m.deltaY === 'number';
 }
 
-// Helper function for TypeScript typing
-function acquireVsCodeApi(): { postMessage: (message: HTMLOutputWebviewMessage) => void } {
-	throw new Error('Function not implemented.');
-}
-
 function webviewMessageCode() {
-	const vscode = acquireVsCodeApi();
+	// acquireVsCodeApi is a global injected by the webview host. Access it
+	// through the window object so the production bundler cannot rename it.
+	// eslint-disable-next-line no-restricted-globals
+	const vscode: { postMessage: (message: HTMLOutputWebviewMessage) => void } =
+		(window as any)['acquireVsCodeApi']();
 
 	const sendSizeMessage = () => {
 		// Get body of the webview and measure content sizes


### PR DESCRIPTION
## Summary
- Fix production bundler renaming `acquireVsCodeApi` in the stringified webview script, causing a ReferenceError that prevents all widget outputs from reporting their height
- Reset default body margin in output webviews so the initial `scrollHeight` doesn't falsely match the empty-output heuristic (150px)

Fixes #13708

## Test plan
- [ ] Open a notebook, run an `ipydatagrid` cell, verify the grid renders
- [ ] Verify other ipywidgets (e.g. sliders, plotly) still render correctly
- [ ] Test in both dev and release builds