### PR TITLE
Fix `ipydatagrid` failing to render in notebook outputs

### DIFF
--- a/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
+++ b/src/vs/workbench/contrib/positronWebviewPreloads/browser/notebookOutputUtils.ts
@@ -66,13 +66,12 @@ export function isWheelForwardMessage(message: unknown): message is WheelForward
 		&& typeof m.deltaY === 'number';
 }
 
-// Helper function for TypeScript typing
-function acquireVsCodeApi(): { postMessage: (message: HTMLOutputWebviewMessage) => void } {
-	throw new Error('Function not implemented.');
-}
-
 function webviewMessageCode() {
-	const vscode = acquireVsCodeApi();
+	// acquireVsCodeApi is a global injected by the webview host. Access it
+	// through the window object so the production bundler cannot rename it.
+	// eslint-disable-next-line no-restricted-globals
+	const vscode: { postMessage: (message: HTMLOutputWebviewMessage) => void } =
+		(window as any)['acquireVsCodeApi']();
 
 	const sendSizeMessage = () => {
 		// Get body of the webview and measure content sizes


### PR DESCRIPTION
## Summary
- Fix production bundler renaming `acquireVsCodeApi` in the stringified webview script, causing a ReferenceError that prevents all widget outputs from reporting their height

Fixes #13708

## Test plan
- [x] Open a notebook, run an `ipydatagrid` cell, verify the grid renders
- [x] Verify other ipywidgets (e.g. sliders, plotly) still render correctly


https://github.com/user-attachments/assets/ff389500-ac33-460b-964a-bec8101372fb

- [x] **Test in both dev and release builds (there is a small chancee this _MAY_ fail in the release build).** 

<img width="1118" height="518" alt="image" src="https://github.com/user-attachments/assets/456a92e1-2653-4620-9e1b-4366f7c24a83" />

@:positron-notebooks @:web @:win