### PR TITLE
ci: add test tags in auto-update extension PRs

### DIFF
--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -163,7 +163,7 @@ jobs:
               elif ($entry.tags | length) > 0 then
                 "- " + $e + " -> " + ($entry.tags | join(", "))
               else
-                "- " + $e + " -> (no tag" + (if $entry.note then "; " + $entry.note else "" end) + ")"
+                "- " + $e + " -> n/a"
               end
             ) | join("\n")
           ')
@@ -181,9 +181,9 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           echo "updated=$UPDATED" >> "$GITHUB_OUTPUT"
           {
-            echo "tag_bullets<<RENDER_EOF"
+            echo "tag_bullets<<__RENDER_EOF__"
             echo "$TAG_BULLETS"
-            echo "RENDER_EOF"
+            echo "__RENDER_EOF__"
           } >> "$GITHUB_OUTPUT"
           echo "combined_tags=$COMBINED_TAGS" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -138,6 +138,55 @@ jobs:
             git --no-pager diff product.json
           fi
 
+      - name: Render test tags
+        id: render-tags
+        run: |
+          UPDATED=$(jq -rn \
+            --argjson old "$(git show HEAD:product.json)" \
+            --argjson new "$(cat product.json)" \
+            '($old.bootstrapExtensions | map({(.name): .version}) | add) as $ov |
+             ($new.bootstrapExtensions | map({(.name): .version}) | add) as $nv |
+             [$nv | to_entries[] | select(.value != $ov[.key]) | .key] | join(" ")')
+          if [ -z "$UPDATED" ]; then
+            echo "No bootstrap extension version changes detected."
+            echo "updated=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          TAG_MAP=.github/workflows/extensions-tag-map.json
+          TAG_BULLETS=$(echo "$UPDATED" | tr ' ' '\n' | jq -R -s -r --slurpfile map "$TAG_MAP" '
+            (split("\n") | map(select(length > 0))) as $exts |
+            $map[0] as $m |
+            $exts | map(
+              . as $e | $m[$e] as $entry |
+              if $entry == null then
+                "- " + $e + " -> (unmapped; add to extensions-tag-map.json)"
+              elif ($entry.tags | length) > 0 then
+                "- " + $e + " -> " + ($entry.tags | join(", "))
+              else
+                "- " + $e + " -> (no tag" + (if $entry.note then "; " + $entry.note else "" end) + ")"
+              end
+            ) | join("\n")
+          ')
+          COMBINED_TAGS=$(echo "$UPDATED" | tr ' ' '\n' | jq -R -s -r --slurpfile map "$TAG_MAP" '
+            split("\n") | map(select(length > 0)) | map($map[0][.].tags // []) | flatten | unique | join(" ")
+          ')
+          {
+            echo "### Suggested test tags"
+            echo ""
+            echo "$TAG_BULLETS"
+            if [ -n "$COMBINED_TAGS" ]; then
+              echo ""
+              echo "Combined: $COMBINED_TAGS"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "updated=$UPDATED" >> "$GITHUB_OUTPUT"
+          {
+            echo "tag_bullets<<RENDER_EOF"
+            echo "$TAG_BULLETS"
+            echo "RENDER_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "combined_tags=$COMBINED_TAGS" >> "$GITHUB_OUTPUT"
+
       - name: Commit and push
         id: push
         if: inputs.dryrun != true
@@ -172,13 +221,10 @@ jobs:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
           BRANCH: ${{ steps.push.outputs.branch }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          UPDATED: ${{ steps.render-tags.outputs.updated }}
+          TAG_BULLETS: ${{ steps.render-tags.outputs.tag_bullets }}
+          COMBINED_TAGS: ${{ steps.render-tags.outputs.combined_tags }}
         run: |
-          UPDATED=$(jq -rn \
-            --argjson old "$(git show HEAD~1:product.json)" \
-            --argjson new "$(cat product.json)" \
-            '($old.bootstrapExtensions | map({(.name): .version}) | add) as $ov |
-             ($new.bootstrapExtensions | map({(.name): .version}) | add) as $nv |
-             [$nv | to_entries[] | select(.value != $ov[.key]) | .key] | join(" ")')
           EXT_BULLETS=$(echo "$UPDATED" | tr ' ' '\n' | sed 's/^/- /')
           # Truncate title if more than 3 extensions to stay within GitHub's limit
           EXT_ARRAY=($UPDATED)
@@ -188,6 +234,12 @@ jobs:
           else
             FIRST3="${EXT_ARRAY[0]},${EXT_ARRAY[1]},${EXT_ARRAY[2]}"
             TITLE="chore: update bootstrap extensions ($FIRST3 +$((COUNT - 3)) more)"
+          fi
+          COMBINED_LINE=""
+          if [ -n "$COMBINED_TAGS" ]; then
+            COMBINED_LINE="
+
+          Combined: ${COMBINED_TAGS}"
           fi
           PR_URL=$(gh pr create \
             --base main \
@@ -199,7 +251,10 @@ jobs:
           ${EXT_BULLETS}
 
           ### QA Notes
-          Triggered by [nightly extensions check](${RUN_URL}).")
+          Triggered by [nightly extensions check](${RUN_URL}).
+
+          **Suggested test tags:**
+          ${TAG_BULLETS}${COMBINED_LINE}")
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
           echo "updated=$UPDATED" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -170,6 +170,9 @@ jobs:
           COMBINED_TAGS=$(echo "$UPDATED" | tr ' ' '\n' | jq -R -s -r --slurpfile map "$TAG_MAP" '
             split("\n") | map(select(length > 0)) | map($map[0][.].tags // []) | flatten | unique | join(" ")
           ')
+          UNMAPPED=$(echo "$UPDATED" | tr ' ' '\n' | jq -R -s -r --slurpfile map "$TAG_MAP" '
+            split("\n") | map(select(length > 0)) | map(select($map[0][.] == null)) | join(", ")
+          ')
           {
             echo "### Suggested test tags"
             echo ""
@@ -180,12 +183,8 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
           echo "updated=$UPDATED" >> "$GITHUB_OUTPUT"
-          {
-            echo "tag_bullets<<__RENDER_EOF__"
-            echo "$TAG_BULLETS"
-            echo "__RENDER_EOF__"
-          } >> "$GITHUB_OUTPUT"
           echo "combined_tags=$COMBINED_TAGS" >> "$GITHUB_OUTPUT"
+          echo "unmapped=$UNMAPPED" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push
         id: push
@@ -221,9 +220,10 @@ jobs:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
           BRANCH: ${{ steps.push.outputs.branch }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MAP_URL: ${{ github.server_url }}/${{ github.repository }}/blob/main/.github/workflows/extensions-tag-map.json
           UPDATED: ${{ steps.render-tags.outputs.updated }}
-          TAG_BULLETS: ${{ steps.render-tags.outputs.tag_bullets }}
           COMBINED_TAGS: ${{ steps.render-tags.outputs.combined_tags }}
+          UNMAPPED: ${{ steps.render-tags.outputs.unmapped }}
         run: |
           EXT_BULLETS=$(echo "$UPDATED" | tr ' ' '\n' | sed 's/^/- /')
           # Truncate title if more than 3 extensions to stay within GitHub's limit
@@ -235,11 +235,15 @@ jobs:
             FIRST3="${EXT_ARRAY[0]},${EXT_ARRAY[1]},${EXT_ARRAY[2]}"
             TITLE="chore: update bootstrap extensions ($FIRST3 +$((COUNT - 3)) more)"
           fi
-          COMBINED_LINE=""
+          TAGS_LINE=""
           if [ -n "$COMBINED_TAGS" ]; then
-            COMBINED_LINE="
-
-          Combined: ${COMBINED_TAGS}"
+            TAGS_LINE="${COMBINED_TAGS}
+          "
+          fi
+          UNMAPPED_LINE=""
+          if [ -n "$UNMAPPED" ]; then
+            UNMAPPED_LINE="[Unmapped](${MAP_URL}): ${UNMAPPED}
+          "
           fi
           PR_URL=$(gh pr create \
             --base main \
@@ -251,10 +255,7 @@ jobs:
           ${EXT_BULLETS}
 
           ### QA Notes
-          Triggered by [nightly extensions check](${RUN_URL}).
-
-          **Suggested test tags:**
-          ${TAG_BULLETS}${COMBINED_LINE}")
+          ${TAGS_LINE}${UNMAPPED_LINE}Triggered by [nightly extensions check](${RUN_URL}).")
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
           echo "updated=$UPDATED" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/extensions-tag-map.json
+++ b/.github/workflows/extensions-tag-map.json
@@ -1,16 +1,16 @@
 {
-  "charliermarsh.ruff":                         { "tags": [] },
+  "charliermarsh.ruff":                         { "tags": ["@:pyrefly"] },
   "GitHub.vscode-pull-request-github":          { "tags": [] },
   "meta.pyrefly":                               { "tags": ["@:pyrefly"] },
   "ms-python.debugpy":                          { "tags": ["@:debug"] },
-  "ms-toolsai.jupyter":                         { "tags": ["@:jupyter", "@:notebooks", "@:positron-notebooks"] },
-  "ms-toolsai.jupyter-keymap":                  { "tags": ["@:jupyter", "@:notebooks"] },
-  "ms-toolsai.jupyter-renderers":               { "tags": ["@:jupyter", "@:notebooks", "@:positron-notebooks"] },
-  "ms-toolsai.vscode-jupyter-cell-tags":        { "tags": ["@:jupyter", "@:notebooks"] },
-  "ms-toolsai.vscode-jupyter-slideshow":        { "tags": ["@:jupyter", "@:notebooks"] },
+  "ms-toolsai.jupyter":                         { "tags": ["@:positron-notebooks"] },
+  "ms-toolsai.jupyter-keymap":                  { "tags": ["@:positron-notebooks"] },
+  "ms-toolsai.jupyter-renderers":               { "tags": ["@:positron-notebooks"] },
+  "ms-toolsai.vscode-jupyter-cell-tags":        { "tags": ["@:positron-notebooks"] },
+  "ms-toolsai.vscode-jupyter-slideshow":        { "tags": ["@:positron-notebooks"] },
   "posit.air-vscode":                           { "tags": ["@:ark"] },
   "posit.assistant":                            { "tags": ["@:assistant", "@:posit-assistant"] },
-  "posit.publisher":                            { "tags": ["@:publisher"] },
+  "posit.publisher":                            { "tags": ["@:workbench"] },
   "posit.shiny":                                { "tags": ["@:apps"] },
   "quarto.quarto":                              { "tags": ["@:quarto"] }
 }

--- a/.github/workflows/extensions-tag-map.json
+++ b/.github/workflows/extensions-tag-map.json
@@ -1,0 +1,16 @@
+{
+  "charliermarsh.ruff":                         { "tags": [],                                                       "note": "Python linter/formatter; no e2e coverage. Verify Python editor manually." },
+  "GitHub.vscode-pull-request-github":          { "tags": [],                                                       "note": "No e2e coverage of the PR extension. @:scm only covers basic git modify/stage/commit." },
+  "meta.pyrefly":                               { "tags": ["@:pyrefly"] },
+  "ms-python.debugpy":                          { "tags": ["@:debug"] },
+  "ms-toolsai.jupyter":                         { "tags": ["@:jupyter", "@:notebooks", "@:positron-notebooks"] },
+  "ms-toolsai.jupyter-keymap":                  { "tags": ["@:jupyter", "@:notebooks"] },
+  "ms-toolsai.jupyter-renderers":               { "tags": ["@:jupyter", "@:notebooks", "@:positron-notebooks"] },
+  "ms-toolsai.vscode-jupyter-cell-tags":        { "tags": ["@:jupyter", "@:notebooks"] },
+  "ms-toolsai.vscode-jupyter-slideshow":        { "tags": ["@:jupyter", "@:notebooks"] },
+  "posit.air-vscode":                           { "tags": ["@:ark"] },
+  "posit.assistant":                            { "tags": ["@:assistant", "@:posit-assistant"] },
+  "posit.publisher":                            { "tags": ["@:publisher"] },
+  "posit.shiny":                                { "tags": ["@:apps"] },
+  "quarto.quarto":                              { "tags": ["@:quarto"] }
+}

--- a/.github/workflows/extensions-tag-map.json
+++ b/.github/workflows/extensions-tag-map.json
@@ -1,6 +1,6 @@
 {
-  "charliermarsh.ruff":                         { "tags": [],                                                       "note": "Python linter/formatter; no e2e coverage. Verify Python editor manually." },
-  "GitHub.vscode-pull-request-github":          { "tags": [],                                                       "note": "No e2e coverage of the PR extension. @:scm only covers basic git modify/stage/commit." },
+  "charliermarsh.ruff":                         { "tags": [] },
+  "GitHub.vscode-pull-request-github":          { "tags": [] },
   "meta.pyrefly":                               { "tags": ["@:pyrefly"] },
   "ms-python.debugpy":                          { "tags": ["@:debug"] },
   "ms-toolsai.jupyter":                         { "tags": ["@:jupyter", "@:notebooks", "@:positron-notebooks"] },


### PR DESCRIPTION
### Summary
Auto-update extension PRs now add e2e test tags in QA Notes, driven by a checked-in extension -> tag map.

- New `extensions-tag-map.json` maps each bootstrap extension to its e2e tags
- Empty tags render as `n/a`; unmapped extensions get a prompt to add an entry
- Output also written to the run's Summary tab so dryruns are self-evidencing

### QA Notes
Verified via [dryrun](https://github.com/posit-dev/positron/actions/runs/26289005769) dispatch.
Please review the mapping for correctness.🙏  I made my best guess. 