### PR TITLE
Align `workbench.secondarySideBar.defaultVisibility` with upstream behavior

### DIFF
--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
@@ -205,10 +205,7 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 			pinnedViewContainersKey: AuxiliaryBarPart.pinnedViewsKey,
 			placeholderViewContainersKey: AuxiliaryBarPart.placeholdeViewContainersKey,
 			viewContainersWorkspaceStateKey: AuxiliaryBarPart.viewContainersWorkspaceStateKey,
-			// --- Start Positron ---
-			// Do not use icons.
-			icon: false,
-			// --- End Positron ---
+			icon: !this.configuration.showLabels,
 			orientation: ActionsOrientation.HORIZONTAL,
 			recomputeSizes: true,
 			activityHoverOptions: {


### PR DESCRIPTION
Fixes #7644
Closes #13577

Setting `workbench.secondarySideBar.showLabel` to `false` should cause the Secondary Side Bar items to render as icons, but the option had no effect because we hardcoded `icon: false` in `AuxiliaryBarPart.getCompositeBarOptions()`. This PR removes that override and lets the setting drive the rendering, matching upstream VS Code behavior. This PR basically removes a change we made back in https://github.com/posit-dev/positron/commit/1d467d97d12dff4e82e6ace345d5cbc1d434ee1a and now this bit of this file is _exactly_ the same as upstream.

Thanks to @albersonmiranda for the original fix in #13577! I am applying the fix here as a non-fork PR so that CI can run because of the problems outlined in #6628.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Respect `workbench.secondarySideBar.showLabel` so Secondary Side Bar items can render as icons (#7644)

### Validation Steps

@:layouts

1. Open Positron with the default layout.
2. Verify Secondary Side Bar items render with labels (default).
3. Open Settings and set `Workbench > Secondary Side Bar > Show Label` to off.
4. Verify Secondary Side Bar items now render as icons only.
5. Toggle the setting back on and confirm labels return without needing a reload.
