### PR TITLE
e2e test - layered R reconnect assertions to test CI

### DIFF
--- a/test/e2e/tests/sessions/r-reconnect-layers.test.ts
+++ b/test/e2e/tests/sessions/r-reconnect-layers.test.ts
@@ -73,6 +73,7 @@ test.describe('Sessions: R Reconnect Layers', {
 	test('Layer 5: Hook cat() output appears in console after reload without user action', async function ({ app, hotKeys }) {
 		const { console } = app.workbench;
 
+		await console.focus();
 		await console.clearButton.click();
 		await hotKeys.reloadWindow(true);
 		await console.waitForReady('>', 60000);

--- a/test/e2e/tests/sessions/r-reconnect-layers.test.ts
+++ b/test/e2e/tests/sessions/r-reconnect-layers.test.ts
@@ -11,7 +11,7 @@ test.use({
 });
 
 test.describe('Sessions: R Reconnect Layers', {
-	tag: [tags.CONSOLE, tags.SESSIONS, tags.ARK, tags.WEB]
+	tag: [tags.CONSOLE, tags.SESSIONS, tags.ARK, tags.WEB, tags.WIN]
 }, () => {
 
 	test.beforeAll(async function ({ app, openFolder, settings }) {

--- a/test/e2e/tests/sessions/r-reconnect-layers.test.ts
+++ b/test/e2e/tests/sessions/r-reconnect-layers.test.ts
@@ -26,7 +26,7 @@ test.describe('Sessions: R Reconnect Layers', {
 		const { console } = app.workbench;
 
 		// The .Rprofile in this workspace does cat("[.Rprofile] top-level code executed\n")
-		// Verify we can see that — confirms we're using the right .Rprofile
+		// Verify we can see that to confirm we're using the right .Rprofile (most basic confirmation)
 		await console.waitForConsoleContents('[.Rprofile] top-level code executed', { timeout: 30000 });
 	});
 
@@ -37,7 +37,7 @@ test.describe('Sessions: R Reconnect Layers', {
 		await hotKeys.reloadWindow(true);
 		await console.waitForReady('>', 60000);
 
-		// Can we run code and see output? Most basic thing after reconnect.
+		// Can we run code and see output? Most basic thing after reconnect (must work).
 		await console.executeCode('R', 'cat("[layer2] hello")');
 		// Use exact match so we don't also pick up the input line containing cat(...)
 		await console.waitForConsoleContents('[layer2] hello', { timeout: 30000, exact: true });
@@ -46,7 +46,7 @@ test.describe('Sessions: R Reconnect Layers', {
 	test('Layer 3: Session is the same R process after reload (variable persists)', async function ({ app, hotKeys }) {
 		const { console } = app.workbench;
 
-		// Set something before reload
+		// Set something before reload to check survivability
 		await console.executeCode('R', 'layer3_marker <- "survived"');
 		await console.waitForReady('>');
 
@@ -54,7 +54,7 @@ test.describe('Sessions: R Reconnect Layers', {
 		await hotKeys.reloadWindow(true);
 		await console.waitForReady('>', 60000);
 
-		// Query the variable — if it's there, same process
+		// Query the variable: if it's there, same process
 		await console.executeCode('R', 'cat(paste0("[layer3] marker=", layer3_marker))');
 		await console.waitForConsoleContents('[layer3] marker=survived', { timeout: 30000, exact: true });
 	});
@@ -66,7 +66,7 @@ test.describe('Sessions: R Reconnect Layers', {
 		await hotKeys.reloadWindow(true);
 		await console.waitForReady('>', 60000);
 
-		// .Rprofile top-level cat() should not appear in post-reload output
+		// .Rprofile top-level cat() should not appear in post-reload output (this should pass quickly after console is ready)
 		await console.waitForConsoleContents('[.Rprofile] top-level code executed', { expectedCount: 0, timeout: 5000 });
 	});
 
@@ -79,6 +79,7 @@ test.describe('Sessions: R Reconnect Layers', {
 
 		// The session_reconnect hook does cat("[hook:reconnect] fired\n")
 		// This output should appear without executing anything
-		await console.waitForConsoleContents('[hook:reconnect] fired', { timeout: 30000 });
+		// Set timeout to 60s instead to rule out Claude's confusing hypothesis of timing issue
+		await console.waitForConsoleContents('[hook:reconnect] fired', { timeout: 60000 });
 	});
 });

--- a/test/e2e/tests/sessions/r-reconnect-layers.test.ts
+++ b/test/e2e/tests/sessions/r-reconnect-layers.test.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { join } from 'path';
+import { test, expect, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Sessions: R Reconnect Layers', {
+	tag: [tags.CONSOLE, tags.SESSIONS, tags.ARK, tags.WEB]
+}, () => {
+
+	test.beforeAll(async function ({ app, openFolder, settings }) {
+		await settings.set({
+			'interpreters.startupBehavior': 'auto'
+		});
+		await openFolder(join('qa-example-content/workspaces/r-session-hooks'));
+		await app.workbench.console.waitForReadyAndStarted('>', 60000);
+	});
+
+	test('Layer 1: .Rprofile ran on startup', async function ({ app }) {
+		const { console } = app.workbench;
+
+		// The .Rprofile in this workspace does cat("[.Rprofile] top-level code executed\n")
+		// Verify we can see that — confirms we're using the right .Rprofile
+		await console.waitForConsoleContents('[.Rprofile] top-level code executed', { timeout: 30000 });
+	});
+
+	test('Layer 2: Console accepts and displays code output after reload', async function ({ app, hotKeys }) {
+		const { console } = app.workbench;
+
+		await console.clearButton.click();
+		await hotKeys.reloadWindow(true);
+		await console.waitForReady('>', 60000);
+
+		// Can we run code and see output? Most basic thing after reconnect.
+		await console.executeCode('R', 'cat("[layer2] hello")');
+		// Use exact match so we don't also pick up the input line containing cat(...)
+		await console.waitForConsoleContents('[layer2] hello', { timeout: 30000, exact: true });
+	});
+
+	test('Layer 3: Session is the same R process after reload (variable persists)', async function ({ app, hotKeys }) {
+		const { console } = app.workbench;
+
+		// Set something before reload
+		await console.executeCode('R', 'layer3_marker <- "survived"');
+		await console.waitForReady('>');
+
+		await console.clearButton.click();
+		await hotKeys.reloadWindow(true);
+		await console.waitForReady('>', 60000);
+
+		// Query the variable — if it's there, same process
+		await console.executeCode('R', 'cat(paste0("[layer3] marker=", layer3_marker))');
+		await console.waitForConsoleContents('[layer3] marker=survived', { timeout: 30000, exact: true });
+	});
+
+	test('Layer 4: .Rprofile does NOT re-run after reload', async function ({ app, hotKeys }) {
+		const { console } = app.workbench;
+
+		await console.clearButton.click();
+		await hotKeys.reloadWindow(true);
+		await console.waitForReady('>', 60000);
+
+		// .Rprofile top-level cat() should not appear in post-reload output
+		await console.waitForConsoleContents('[.Rprofile] top-level code executed', { expectedCount: 0, timeout: 5000 });
+	});
+
+	test('Layer 5: Hook cat() output appears in console after reload without user action', async function ({ app, hotKeys }) {
+		const { console } = app.workbench;
+
+		await console.clearButton.click();
+		await hotKeys.reloadWindow(true);
+		await console.waitForReady('>', 60000);
+
+		// The session_reconnect hook does cat("[hook:reconnect] fired\n")
+		// This output should appear without executing anything
+		await console.waitForConsoleContents('[hook:reconnect] fired', { timeout: 30000 });
+	});
+});

--- a/test/e2e/tests/sessions/r-reconnect-layers.test.ts
+++ b/test/e2e/tests/sessions/r-reconnect-layers.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect, tags } from '../_test.setup';
+import { test, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename


### PR DESCRIPTION
### Summary

Because of the CI failure in #13557, I'm adding this PR here to test the R reconnect layers. This does not need to be merged, it's a test against the CI — unless we decide there is some value in having that in the CI as e2e as well. I've certified that all 5 tests pass locally. 

### Goal
Verify the behavior of R session reconnect layers, focusing on how `.Rprofile` and session hooks behave across reloads. The tests ensure that the R environment behaves correctly in terms of startup scripts, variable persistence, and hook outputs after reloading the session.

### Local Tests
- [x] `.Rprofile` runs on startup
- [x] Console displays output after reload
- [x] Same R process reconnects (variable persists)
- [x] `.Rprofile` does NOT re-run on reconnect
- [x] Hook `cat()` output appears unprompted after reload

### CI Tests (_before_ fix for https://github.com/posit-dev/positron/issues/13542 was merged into main)
- [x] `.Rprofile` runs on startup
- [x] Console displays output after reload
- [x] Same R process reconnects (variable persists)
- [x] `.Rprofile` does NOT re-run on reconnect
- [ ] Hook `cat()` output appears unprompted after reload

### CI Tests (_after_ fix)
- [x] `.Rprofile` runs on startup
- [x] Console displays output after reload
- [x] Same R process reconnects (variable persists)
- [x] `.Rprofile` does NOT re-run on reconnect
- [ ] Hook `cat()` output appears unprompted after reload

@:console @:sessions @:ark @:win @:web