### PR TITLE
Show the portion of the console working directory that we can

### DIFF
--- a/src/vs/platform/positronActionBar/browser/positronDynamicActionBar.tsx
+++ b/src/vs/platform/positronActionBar/browser/positronDynamicActionBar.tsx
@@ -77,6 +77,13 @@ export interface DynamicActionBarAction {
 	 * should appear as a submenu in the overflow menu.
 	 */
 	overflowContextMenuSubmenu?: OverflowContextMenuSubmenu;
+
+	/**
+	 * When true, the action shrinks to fit the available space instead of
+	 * being dropped from the layout. The action's component is responsible for
+	 * truncating its content (e.g. via CSS text-overflow: ellipsis).
+	 */
+	growable?: boolean;
 }
 
 /**
@@ -301,6 +308,16 @@ export const PositronDynamicActionBar = (props: PositronDynamicActionBarProps) =
 
 				// Handle overflowing.
 				if (separatorWidth + width > layoutWidth) {
+					// Growable actions shrink to fill remaining space instead of being dropped,
+					// as long as the fixed width still fits. The component handles truncation.
+					if (action.growable && action.fixedWidth + separatorWidth <= layoutWidth) {
+						width = layoutWidth - separatorWidth;
+						gridEntries.push({ width, action });
+						layoutWidth = 0;
+						overflowing = true;
+						overflowActions.push(...actions.slice(i + 1).filter(hasOverflowEntry));
+						return;
+					}
 					overflowing = true;
 					overflowActions.push(...actions.slice(i).filter(hasOverflowEntry));
 					return;

--- a/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/actionBar.tsx
@@ -366,6 +366,7 @@ export const ActionBar = (props: ActionBarProps) => {
 			fixedWidth: DEFAULT_ACTION_BAR_BUTTON_WIDTH,
 			text: directoryLabel,
 			separator: false,
+			growable: true,
 			component: <CurrentWorkingDirectory directoryLabel={directoryLabel} />
 		}
 	];

--- a/src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/currentWorkingDirectory.css
@@ -5,6 +5,8 @@
 
 .current-working-directory-label {
 	display: flex;
+	width: 100%;
+	min-width: 0;
 	font-size: 12px;
 	overflow: hidden;
 	align-items: center;
@@ -13,10 +15,12 @@
 
 .current-working-directory-label .codicon {
 	padding-top: 1px;
+	flex-shrink: 0;
 	color: var(--vscode-positronActionBar-foreground);
 }
 
 .current-working-directory-label .label {
+	min-width: 0;
 	overflow: hidden;
 	padding-left: 5px;
 	white-space: nowrap;


### PR DESCRIPTION
A quick change to show the portion of the working directory in the console that we can, instead of letting it disappear when the console is narrow or the directory name is long. You can hover to see the whole thing.

<img width="525" height="350" alt="image" src="https://github.com/user-attachments/assets/8b7d692c-fb1e-459c-b3de-939e4672ddfa" />

This is a pretty simple approach; it might be interesting to collapse _portions_ of the paths so you can see e.g. the beginning and ending segments, but want to keep this simple for now. 

Fixes https://github.com/posit-dev/positron/issues/12772.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix issue causing working directory to disappear in Console tab when it is long or console is narrow (#12772). 


### Validation Steps

1. Change to a directory that has a long name
2. Shrink the Console
3. Hover over the truncated text