### PR TITLE
Update welcome text, setting, layout for Posit Assistant migration

### DIFF
--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -239,6 +239,7 @@
             "type": "boolean",
             "default": false,
             "markdownDescription": "%configuration.enable.markdownDescription%",
+            "markdownDeprecationMessage": "%configuration.enable.markdownDeprecationMessage%",
             "tags": [
               "preview"
             ]

--- a/extensions/positron-assistant/package.nls.json
+++ b/extensions/positron-assistant/package.nls.json
@@ -25,6 +25,7 @@
 	"chatParticipants.edit.description": "Edit files in your workspace",
 	"configuration.title": "Positron Assistant",
 	"configuration.enable.markdownDescription": "Enable [Positron Assistant](https://positron.posit.co/assistant), an AI assistant for Positron.\n\nRequires a restart to take effect.",
+	"configuration.enable.markdownDeprecationMessage": "Positron Assistant is being superseded by Posit Assistant. Use `#assistant.enabled#` instead.",
 	"configuration.toolDetails.enable": "Enable tool call input and output details in the chat view. Must be enabled to include tool call details in the chat export.",
 	"configuration.useAnthropicSdk.description": "Use the Anthropic SDK for Anthropic models rather than the generic AI SDK.",
 	"configuration.streamingEdits.enable": "Enable streaming edits in inline editor chats.",

--- a/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewWelcomeController.ts
+++ b/src/vs/workbench/contrib/chat/browser/viewsWelcome/chatViewWelcomeController.ts
@@ -179,8 +179,8 @@ export class ChatViewWelcomePart extends Disposable {
 			title.textContent = content.title;
 
 			// --- Start Positron ---
-			// Added a Preview badge to the welcome chat view, with th same styling as the Preview badge in the Settings UI.
-			dom.append(this.element, $('.chat-welcome-view-preview-badge', undefined, localize('chatViewWelcomePreview', "Preview")));
+			// Added a Superseded badge to the welcome chat view, with the same styling as the Preview badge in the Settings UI.
+			dom.append(this.element, $('.chat-welcome-view-preview-badge', undefined, localize('chatViewWelcomeSuperseded', "Superseded")));
 			// --- End Positron ---
 
 			const message = dom.append(this.element, $('.chat-welcome-view-message'));

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1210,7 +1210,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	// --- Start Positron ---
 	private getPositronWelcomeViewContent(additionalMessage: string | IMarkdownString | undefined): IChatViewWelcomeContent {
 		const welcomeTitle = localize('positronAssistant.welcomeTitle', "Positron Assistant");
-		const openLinkMessage = localize('positronAssistant.openLinkMessage', "Try Posit Assistant");
+		const openLinkMessage = localize('positronAssistant.openLinkMessage', "Open Posit Assistant");
 		const learnMoreLinkMessage = localize('positronAssistant.learnMoreLinkMessage', "our documentation");
 		// eslint-disable-next-line local/code-no-unexternalized-strings
 		let welcomeText = localize('positronAssistant.welcomeMessage', `Positron Assistant is being superseded by Posit Assistant, our new AI coding companion for data science.

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -15,7 +15,7 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { toErrorMessage } from '../../../../../base/common/errorMessage.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { hash } from '../../../../../base/common/hash.js';
-import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { createCommandUri, IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Iterable } from '../../../../../base/common/iterator.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, thenIfNotDisposed } from '../../../../../base/common/lifecycle.js';
 import { ResourceSet } from '../../../../../base/common/map.js';
@@ -90,6 +90,9 @@ import { IChatDebugService } from '../../common/chatDebugService.js';
 import './media/positronChat.css';
 import { ILanguageModelsService } from '../../common/languageModels.js';
 import { IPositronDocsService } from '../../../../services/positronDocs/browser/positronDocsService.js';
+import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
+import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
+import { showExtensionsWithIdsCommandId } from '../../../extensions/browser/extensionsActions.js';
 // --- End Positron ---
 
 const $ = dom.$;
@@ -397,6 +400,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		// --- Start Positron ---
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
 		@IPositronDocsService private readonly docsService: IPositronDocsService,
+		@IExtensionService private readonly extensionService: IExtensionService,
 		// --- End Positron ---
 		@IChatModeService private readonly chatModeService: IChatModeService,
 		@IChatLayoutService private readonly chatLayoutService: IChatLayoutService,
@@ -441,6 +445,18 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.requestInProgress = ChatContextKeys.requestInProgress.bindTo(contextKeyService);
 
 		this._register(this.chatEntitlementService.onDidChangeAnonymous(() => this.renderWelcomeViewContentIfNeeded()));
+
+		// --- Start Positron ---
+		// Re-render the welcome view when Posit Assistant is installed or uninstalled
+		// so the "Install"/"Open" link reflects the current install state.
+		this._register(this.extensionService.onDidChangeExtensions(e => {
+			const touchesPositAssistant = (exts: readonly { identifier: ExtensionIdentifier }[]) =>
+				exts.some(ext => ExtensionIdentifier.equals(ext.identifier, ChatWidget.POSIT_ASSISTANT_EXTENSION_ID));
+			if (touchesPositAssistant(e.added) || touchesPositAssistant(e.removed)) {
+				this.renderWelcomeViewContentIfNeeded();
+			}
+		}));
+		// --- End Positron ---
 
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration('chat.tips.enabled')) {
@@ -1208,22 +1224,35 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	}
 
 	// --- Start Positron ---
+	private static readonly POSIT_ASSISTANT_EXTENSION_ID = 'posit.assistant';
+
+	private isPositAssistantInstalled(): boolean {
+		return this.extensionService.extensions.some(ext =>
+			ExtensionIdentifier.equals(ext.identifier, ChatWidget.POSIT_ASSISTANT_EXTENSION_ID));
+	}
+
 	private getPositronWelcomeViewContent(additionalMessage: string | IMarkdownString | undefined): IChatViewWelcomeContent {
 		const welcomeTitle = localize('positronAssistant.welcomeTitle', "Positron Assistant");
-		const openLinkMessage = localize('positronAssistant.openLinkMessage', "Open Posit Assistant");
+		const installed = this.isPositAssistantInstalled();
+		const actionLinkMessage = installed
+			? localize('positronAssistant.openLinkMessage', "Open Posit Assistant")
+			: localize('positronAssistant.installLinkMessage', "Install Posit Assistant");
+		const actionLinkUri = installed
+			? 'command:workbench.view.extension.posit-assistant'
+			: createCommandUri(showExtensionsWithIdsCommandId, [ChatWidget.POSIT_ASSISTANT_EXTENSION_ID]).toString();
 		const learnMoreLinkMessage = localize('positronAssistant.learnMoreLinkMessage', "our documentation");
 		// eslint-disable-next-line local/code-no-unexternalized-strings
 		let welcomeText = localize('positronAssistant.welcomeMessage', `Positron Assistant is being superseded by Posit Assistant, our new AI coding companion for data science.
 
 &nbsp;
 
-{open-link}
+{action-link}
 
 &nbsp;
 
 See {learn-more-link} to learn more.
 `);
-		welcomeText = welcomeText.replace('{open-link}', `[${openLinkMessage}](command:workbench.view.extension.posit-assistant)`);
+		welcomeText = welcomeText.replace('{action-link}', `[${actionLinkMessage}](${actionLinkUri})`);
 		welcomeText = welcomeText.replace('{learn-more-link}', `[${learnMoreLinkMessage}](${this.docsService.getUrl('assistant')})`);
 
 		return {

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -15,7 +15,7 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { toErrorMessage } from '../../../../../base/common/errorMessage.js';
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { hash } from '../../../../../base/common/hash.js';
-import { createCommandUri, IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
+import { IMarkdownString, MarkdownString } from '../../../../../base/common/htmlContent.js';
 import { Iterable } from '../../../../../base/common/iterator.js';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, thenIfNotDisposed } from '../../../../../base/common/lifecycle.js';
 import { ResourceSet } from '../../../../../base/common/map.js';
@@ -89,6 +89,8 @@ import { IChatDebugService } from '../../common/chatDebugService.js';
 // --- Start Positron ---
 import './media/positronChat.css';
 import { ILanguageModelsService } from '../../common/languageModels.js';
+// eslint-disable-next-line no-duplicate-imports
+import { createCommandUri } from '../../../../../base/common/htmlContent.js';
 import { IPositronDocsService } from '../../../../services/positronDocs/browser/positronDocsService.js';
 import { IExtensionService } from '../../../../services/extensions/common/extensions.js';
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';

--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -89,7 +89,6 @@ import { IChatDebugService } from '../../common/chatDebugService.js';
 // --- Start Positron ---
 import './media/positronChat.css';
 import { ILanguageModelsService } from '../../common/languageModels.js';
-import { IPositronAssistantConfigurationService } from '../../../positronAssistant/common/interfaces/positronAssistantService.js';
 import { IPositronDocsService } from '../../../../services/positronDocs/browser/positronDocsService.js';
 // --- End Positron ---
 
@@ -397,7 +396,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		@ILanguageModelToolsService private readonly toolsService: ILanguageModelToolsService,
 		// --- Start Positron ---
 		@ILanguageModelsService private readonly languageModelsService: ILanguageModelsService,
-		@IPositronAssistantConfigurationService private readonly positronAssistantConfigurationService: IPositronAssistantConfigurationService,
 		@IPositronDocsService private readonly docsService: IPositronDocsService,
 		// --- End Positron ---
 		@IChatModeService private readonly chatModeService: IChatModeService,
@@ -1211,55 +1209,27 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 	// --- Start Positron ---
 	private getPositronWelcomeViewContent(additionalMessage: string | IMarkdownString | undefined): IChatViewWelcomeContent {
-		let welcomeText;
-		let welcomeTitle;
-		let tips: IMarkdownString | undefined;
+		const welcomeTitle = localize('positronAssistant.welcomeTitle', "Positron Assistant");
+		const openLinkMessage = localize('positronAssistant.openLinkMessage', "Try Posit Assistant");
+		const learnMoreLinkMessage = localize('positronAssistant.learnMoreLinkMessage', "our documentation");
+		// eslint-disable-next-line local/code-no-unexternalized-strings
+		let welcomeText = localize('positronAssistant.welcomeMessage', `Positron Assistant is being superseded by Posit Assistant, our new AI coding companion for data science.
 
-		// Show a link to enable the assistant if it's not yet enabled
-		if (!this.configurationService.getValue('positron.assistant.enable')) {
-			welcomeTitle = localize('positronAssistant.comingSoonTitle', "Welcome to Positron Assistant");
-			const enableAssistantMessage = localize('positronAssistant.enableAssistantMessage', "Enable Positron Assistant");
-			welcomeText = localize('positronAssistant.comingSoonMessage', "Positron Assistant is under development and is currently available as a preview feature of Positron.\n");
-			welcomeText += `\n\n[${enableAssistantMessage}](command:positron-assistant.enableAssistantSetting)`;
-		} else if (!this.languageModelsService.currentProvider) {
-			// No provider is configured/authenticated - show appropriate setup message
-			const hasEnabledProviders = this.positronAssistantConfigurationService.getEnabledProviders().length > 0;
-			welcomeTitle = localize('positronAssistant.gettingStartedTitle', "Set Up Positron Assistant");
+&nbsp;
 
-			if (hasEnabledProviders) {
-				// Providers are enabled but user needs to sign in
-				const signInMessage = localize('positronAssistant.signInMessage', "Sign in to a provider");
-				welcomeText = localize('positronAssistant.signInSetupMessage', "To start using Positron Assistant, sign in to a provider.");
-				welcomeText += `\n\n[${signInMessage}](command:positron-assistant.configureProviders)`;
-			} else {
-				// No providers enabled - need to enable first
-				const enableProviderMessage = localize('positronAssistant.enableProviderMessage', "Enable a provider");
-				welcomeText = localize('positronAssistant.enableSetupMessage', "To start using Positron Assistant, enable a provider in Settings.");
-				welcomeText += `\n\n[${enableProviderMessage}](command:workbench.action.openSettings?%22positron.assistant.provider%20enable%22)`;
-			}
-		} else {
-			const guideLinkMessage = localize('positronAssistant.guideLinkMessage', "Positron Assistant User Guide");
-			welcomeTitle = localize('positronAssistant.welcomeMessageTitle', "Welcome to Positron Assistant");
-			// eslint-disable-next-line local/code-no-unexternalized-strings
-			welcomeText = localize('positronAssistant.welcomeMessageReady', `Positron Assistant is an AI coding companion designed to accelerate and enhance your data science projects.
+{open-link}
 
-The {guide-link} explains the possibilities and capabilities of Positron Assistant.
+&nbsp;
 
-Always verify results. AI assistants can sometimes produce incorrect code.`);
-			// eslint-disable-next-line local/code-no-unexternalized-strings
-			tips = new MarkdownString(localize('positronAssistant.welcomeMessageReadyTips', `Click on or type $(mention) to select a Chat Participant.
+See {learn-more-link} to learn more.
+`);
+		welcomeText = welcomeText.replace('{open-link}', `[${openLinkMessage}](command:workbench.view.extension.posit-assistant)`);
+		welcomeText = welcomeText.replace('{learn-more-link}', `[${learnMoreLinkMessage}](${this.docsService.getUrl('assistant')})`);
 
-Click on $(attach) or type \`#\` to add context, such as files to your chat.
-
-Type \`/\` to use predefined commands such as \`/help\`.`,
-			), { supportThemeIcons: true, isTrusted: true });
-			welcomeText = welcomeText.replace('{guide-link}', `[${guideLinkMessage}](${this.docsService.getUrl('assistant')})`);
-		}
 		return {
 			title: welcomeTitle,
 			message: new MarkdownString(welcomeText, { supportThemeIcons: true, isTrusted: true }),
 			icon: Codicon.positronAssistant,
-			tips,
 			additionalMessage,
 		};
 	}

--- a/src/vs/workbench/services/positronLayout/browser/layouts/positronAssistantLayout.ts
+++ b/src/vs/workbench/services/positronLayout/browser/layouts/positronAssistantLayout.ts
@@ -5,8 +5,12 @@
 
 import { localize2 } from '../../../../../nls.js';
 import { registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { Parts } from '../../../layout/browser/layoutService.js';
+import { CustomPositronLayoutDescription } from '../../common/positronCustomViews.js';
+import { IPositronLayoutService } from '../interfaces/positronLayoutService.js';
 import { PositronLayoutAction, PositronLayoutInfo } from './layoutAction.js';
 
 
@@ -14,7 +18,10 @@ export const positronAssistantLayout: PositronLayoutInfo = {
 	id: 'workbench.action.positronAssistantLayout',
 	codicon: 'positron-assistant-layout',
 	label: localize2('choseLayout.assistant', 'Assistant Layout'),
-	precondition: ContextKeyExpr.has('config.positron.assistant.enable'),
+	precondition: ContextKeyExpr.or(
+		ContextKeyExpr.has('config.positron.assistant.enable'),
+		ContextKeyExpr.has('config.assistant.enabled'),
+	)!,
 	layoutDescriptor: {
 		[Parts.SIDEBAR_PART]: {
 			size: '30%',
@@ -65,5 +72,23 @@ export const positronAssistantLayout: PositronLayoutInfo = {
 registerAction2(class extends PositronLayoutAction {
 	constructor() {
 		super(positronAssistantLayout);
+	}
+
+	override run(accessor: ServicesAccessor): void {
+		// Prefer Posit Assistant when enabled; fall back to the legacy Positron Assistant chat view container.
+		const configurationService = accessor.get(IConfigurationService);
+		const sidebarContainerId = configurationService.getValue<boolean>('assistant.enabled')
+			? 'posit-assistant'
+			: 'workbench.panel.chat';
+
+		const layoutDescriptor: CustomPositronLayoutDescription = {
+			...positronAssistantLayout.layoutDescriptor,
+			[Parts.SIDEBAR_PART]: {
+				...positronAssistantLayout.layoutDescriptor[Parts.SIDEBAR_PART],
+				viewContainers: [{ id: sidebarContainerId, opened: true }],
+			},
+		};
+
+		accessor.get(IPositronLayoutService).setLayout(layoutDescriptor);
 	}
 });


### PR DESCRIPTION
> [!IMPORTANT]
> We cannot merge this PR until a new version of `posit.assistant` is released. The work done here is against `main` but will be awkward without the work done in https://github.com/posit-dev/assistant/pull/1426.

Fixes #13543

This PR updates the Positron Assistant welcome view to direct folks to Posit Assistant, the new AI coding companion bundled as a built-in extension. Specifically, this PR:

- Rewrites the chat welcome content to a single unified message linking to the Posit Assistant sidebar view (`workbench.view.extension.posit-assistant`) and the user guide. The previous setup/sign-in/ready sub-states are collapsed into one message.
- Renames the "Preview" badge above the welcome message to "Superseded".
- Deprecates `positron.assistant.enable` with a `markdownDeprecationMessage` pointing at `assistant.enabled`, the setting registered by the bundled Posit Assistant extension. This will not keep the setting from working and doing what we need to, but it does keep new people from finding it and gives people more guidance in the Settings UI.

Here is all that together:

<img width="1478" height="1031" alt="Screenshot 2026-05-22 at 11 19 47 AM" src="https://github.com/user-attachments/assets/eb178a25-1c47-4607-ab3a-daa4d4d40993" />

A user who has not ever enabled Positron Assistant will see that same welcome text.

Any feedback on this text?

This PR also updates the Assistant Layout preset so it (1) appears in the command palette and UI when either `positron.assistant.enable` or `assistant.enabled` is on, and (2) opens the `posit-assistant` view container in the sidebar when `assistant.enabled` is set, falling back to the legacy `workbench.panel.chat` container otherwise.

### Release Notes

#### New Features

- Update Positron Assistant welcome view to direct users to Posit Assistant (#13543)

#### Bug Fixes

- N/A

### Validation Steps

@:assistant @:layouts @:posit-assistant

1. With `positron.assistant.enable` unset, open the Positron Assistant view and confirm the welcome shows the unified "Positron Assistant is being superseded..." message, the "Superseded" badge, and the two clickable links ("Try Posit Assistant" opens the sidebar, "Learn more" opens the user guide).
2. Repeat step 1 with `positron.assistant.enable: true` and verify the same unified welcome renders.
3. Open the Settings editor and search for `positron.assistant.enable`. Confirm it renders a deprecation warning that links to `assistant.enabled`.
4. Run the **View: Assistant Layout** command from the command palette:
   - With only `positron.assistant.enable` on, confirm the sidebar opens the legacy chat view container.
   - With `assistant.enabled` on (with or without the legacy setting), confirm the sidebar opens the Posit Assistant view container.
   - With neither setting on, confirm the command does not appear in the palette.
