### PR TITLE
E2E test: facilities for controlling workbench tests based on version

### DIFF
--- a/test/e2e/tests/workbench/managed-credentials/managed-credentials-variables.test.ts
+++ b/test/e2e/tests/workbench/managed-credentials/managed-credentials-variables.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test, tags } from '../../_test.setup';
+import { WorkbenchVersion } from '../../../utils/workbench-version';
 
 test.use({
 	suiteId: __filename
@@ -13,14 +14,17 @@ test.describe('Managed Credentials - Environment Variables', {
 	tag: [tags.WORKBENCH]
 }, () => {
 	test('R - Verify managed credentials environment variables are set', async function ({ app, r }) {
+		const workbenchVersion = await WorkbenchVersion.fetchFromContainer();
 
 		// Verify SNOWFLAKE_ACCOUNT environment variable
 		await app.workbench.console.executeCode('R', 'Sys.getenv("SNOWFLAKE_ACCOUNT")');
 		await app.workbench.console.waitForConsoleContents(process.env.SNOWFLAKE_ACCOUNT!);
 
-		// Verify DATABRICKS_HOST environment variable
-		await app.workbench.console.executeCode('R', 'Sys.getenv("DATABRICKS_HOST")');
-		const databricksHost = new URL(process.env.DATABRICKS_URL!).host;
-		await app.workbench.console.waitForConsoleContents(databricksHost);
+		// Verify DATABRICKS_HOST environment variable (only available in 2026.04+)
+		if (workbenchVersion.isGreaterThan('2026.04')) {
+			await app.workbench.console.executeCode('R', 'Sys.getenv("DATABRICKS_HOST")');
+			const databricksHost = new URL(process.env.DATABRICKS_URL!).host;
+			await app.workbench.console.waitForConsoleContents(databricksHost);
+		}
 	});
 });

--- a/test/e2e/utils/workbench-version.ts
+++ b/test/e2e/utils/workbench-version.ts
@@ -1,0 +1,115 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { runDockerCommand } from '../fixtures/test-setup/docker-utils';
+
+/**
+ * Represents a Workbench version in YYYY.MM.PATCH format
+ */
+export class WorkbenchVersion {
+	constructor(
+		public readonly year: number,
+		public readonly month: number,
+		public readonly patch: number
+	) { }
+
+	/**
+	 * Parse a version string in format "YYYY.MM.PATCH+BUILD.TYPE"
+	 * Example: "2026.05.0+218.pro2" -> WorkbenchVersion(2026, 5, 0)
+	 */
+	static parse(versionString: string): WorkbenchVersion {
+		// Extract just the version part before the + sign
+		const versionPart = versionString.split('+')[0].trim();
+		const parts = versionPart.split('.');
+
+		if (parts.length < 2) {
+			throw new Error(`Invalid version format: ${versionString}. Expected format: YYYY.MM.PATCH`);
+		}
+
+		const year = parseInt(parts[0], 10);
+		const month = parseInt(parts[1], 10);
+		const patch = parts.length >= 3 ? parseInt(parts[2], 10) : 0;
+
+		if (isNaN(year) || isNaN(month) || isNaN(patch)) {
+			throw new Error(`Invalid version numbers in: ${versionString}`);
+		}
+
+		return new WorkbenchVersion(year, month, patch);
+	}
+
+	/**
+	 * Fetch the Workbench version from the Docker container
+	 */
+	static async fetchFromContainer(containerName: string = 'test'): Promise<WorkbenchVersion> {
+		const result = await runDockerCommand(
+			`docker exec ${containerName} rstudio-server version`,
+			'Get Workbench version'
+		);
+
+		// Parse output like: "2026.05.0+218.pro2 Workbench (Golden Wattle) for Ubuntu Jammy"
+		const firstLine = result.stdout.trim().split('\n')[0];
+		const versionMatch = firstLine.match(/^([\d.]+\+[\w.]+)/);
+
+		if (!versionMatch) {
+			throw new Error(`Could not parse version from: ${firstLine}`);
+		}
+
+		return WorkbenchVersion.parse(versionMatch[1]);
+	}
+
+	/**
+	 * Check if this version is greater than another version
+	 */
+	isGreaterThan(other: WorkbenchVersion | string): boolean {
+		const otherVersion = typeof other === 'string' ? WorkbenchVersion.parse(other) : other;
+
+		if (this.year !== otherVersion.year) {
+			return this.year > otherVersion.year;
+		}
+		if (this.month !== otherVersion.month) {
+			return this.month > otherVersion.month;
+		}
+		return this.patch > otherVersion.patch;
+	}
+
+	/**
+	 * Check if this version is greater than or equal to another version
+	 */
+	isGreaterThanOrEqualTo(other: WorkbenchVersion | string): boolean {
+		return this.equals(other) || this.isGreaterThan(other);
+	}
+
+	/**
+	 * Check if this version is less than another version
+	 */
+	isLessThan(other: WorkbenchVersion | string): boolean {
+		const otherVersion = typeof other === 'string' ? WorkbenchVersion.parse(other) : other;
+		return !this.isGreaterThanOrEqualTo(otherVersion);
+	}
+
+	/**
+	 * Check if this version is less than or equal to another version
+	 */
+	isLessThanOrEqualTo(other: WorkbenchVersion | string): boolean {
+		return this.equals(other) || this.isLessThan(other);
+	}
+
+	/**
+	 * Check if this version equals another version
+	 */
+	equals(other: WorkbenchVersion | string): boolean {
+		const otherVersion = typeof other === 'string' ? WorkbenchVersion.parse(other) : other;
+		return this.year === otherVersion.year &&
+			this.month === otherVersion.month &&
+			this.patch === otherVersion.patch;
+	}
+
+	/**
+	 * Return string representation in YYYY.MM.PATCH format
+	 */
+	toString(): string {
+		return `${this.year}.${this.month.toString().padStart(2, '0')}.${this.patch}`;
+	}
+}


### PR DESCRIPTION
## Summary

Add version-gated test for DATABRICKS_HOST environment variable in Workbench managed credentials test.

## Details

The `DATABRICKS_HOST` environment variable is only reliably available in Workbench versions 2026.05 and later. This PR adds conditional test logic to only verify this variable when running against compatible versions.

**Changes:**
- Add `WorkbenchVersion` utility class for parsing and comparing Workbench versions from Docker containers
- Update managed credentials test to conditionally check `DATABRICKS_HOST` only when version > 2026.04

**Implementation:**
The utility fetches the version from the container by running `rstudio-server version`, parses the output (e.g., `2026.05.0+218.pro2 Workbench...`), and provides semantic version comparison methods.

**Usage:**
```typescript
const workbenchVersion = await WorkbenchVersion.fetchFromContainer();
if (workbenchVersion.isGreaterThan('2026.04')) {
    // Check DATABRICKS_HOST
}
```

### Validation Steps

@:workbench-stable
