### PR TITLE
Assistant/Auth/NES: update settings with status tag

### DIFF
--- a/extensions/authentication/package.json
+++ b/extensions/authentication/package.json
@@ -117,7 +117,10 @@
 					"additionalProperties": {
 						"type": "string"
 					},
-					"markdownDescription": "%configuration.snowflake.customHeaders.description%"
+					"markdownDescription": "%configuration.snowflake.customHeaders.description%",
+					"tags": [
+						"preview"
+					]
 				},
 				"authentication.anthropic.baseUrl": {
 					"type": "string",
@@ -130,12 +133,18 @@
 					"additionalProperties": {
 						"type": "string"
 					},
-					"markdownDescription": "%configuration.anthropic.customHeaders.description%"
+					"markdownDescription": "%configuration.anthropic.customHeaders.description%",
+					"tags": [
+						"preview"
+					]
 				},
 				"authentication.foundry.baseUrl": {
 					"type": "string",
 					"default": "",
-					"description": "%configuration.foundry.baseUrl.description%"
+					"description": "%configuration.foundry.baseUrl.description%",
+					"tags": [
+						"preview"
+					]
 				},
 				"authentication.foundry.customHeaders": {
 					"type": "object",
@@ -143,7 +152,10 @@
 					"additionalProperties": {
 						"type": "string"
 					},
-					"markdownDescription": "%configuration.foundry.customHeaders.description%"
+					"markdownDescription": "%configuration.foundry.customHeaders.description%",
+					"tags": [
+						"preview"
+					]
 				},
 				"authentication.openai-api.baseUrl": {
 					"type": "string",
@@ -156,12 +168,19 @@
 					"additionalProperties": {
 						"type": "string"
 					},
-					"markdownDescription": "%configuration.openai-api.customHeaders.description%"
+					"markdownDescription": "%configuration.openai-api.customHeaders.description%",
+					"tags": [
+						"preview"
+					]
 				},
 				"authentication.google.baseUrl": {
 					"type": "string",
 					"default": "",
-					"description": "%configuration.google.baseUrl.description%"
+					"description": "%configuration.google.baseUrl.description%",
+					"tags": [
+						"experimental",
+						"advanced"
+					]
 				},
 				"authentication.google.customHeaders": {
 					"type": "object",
@@ -169,12 +188,19 @@
 					"additionalProperties": {
 						"type": "string"
 					},
-					"markdownDescription": "%configuration.google.customHeaders.description%"
+					"markdownDescription": "%configuration.google.customHeaders.description%",
+					"tags": [
+						"experimental",
+						"advanced"
+					]
 				},
 				"authentication.openai-compatible.baseUrl": {
 					"type": "string",
 					"default": "",
-					"description": "%configuration.openai-compatible.baseUrl.description%"
+					"description": "%configuration.openai-compatible.baseUrl.description%",
+					"tags": [
+						"experimental"
+					]
 				},
 				"authentication.openai-compatible.customHeaders": {
 					"type": "object",
@@ -182,7 +208,10 @@
 					"additionalProperties": {
 						"type": "string"
 					},
-					"markdownDescription": "%configuration.openai-compatible.customHeaders.description%"
+					"markdownDescription": "%configuration.openai-compatible.customHeaders.description%",
+					"tags": [
+						"experimental"
+					]
 				}
 			}
 		}

--- a/extensions/next-edit-suggestions/package.json
+++ b/extensions/next-edit-suggestions/package.json
@@ -46,12 +46,18 @@
 						"markdown": false,
 						"scminput": false
 					},
-					"description": "%configuration.enable.description%"
+					"description": "%configuration.enable.description%",
+					"tags": [
+						"preview"
+					]
 				},
 				"nextEditSuggestions.selectedCompletionModel": {
 					"type": "string",
 					"default": "",
-					"description": "%configuration.selectedCompletionModel.description%"
+					"description": "%configuration.selectedCompletionModel.description%",
+					"tags": [
+						"preview"
+					]
 				}
 			}
 		}

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -491,7 +491,10 @@
           "positron.assistant.models.preference.githubCopilot": {
             "type": "string",
             "default": "",
-            "markdownDescription": "%configuration.models.preference.githubCopilot.description%"
+            "markdownDescription": "%configuration.models.preference.githubCopilot.description%",
+            "tags": [
+              "preview"
+            ]
           },
           "positron.assistant.models.preference.amazonBedrock": {
             "type": "string",
@@ -506,7 +509,10 @@
           "positron.assistant.models.preference.msFoundry": {
             "type": "string",
             "default": "",
-            "markdownDescription": "%configuration.models.preference.msFoundry.description%"
+            "markdownDescription": "%configuration.models.preference.msFoundry.description%",
+            "tags": [
+              "preview"
+            ]
           },
           "positron.assistant.models.preference.openAI": {
             "type": "string",
@@ -516,7 +522,10 @@
           "positron.assistant.models.preference.customProvider": {
             "type": "string",
             "default": "",
-            "markdownDescription": "%configuration.models.preference.customProvider.description%"
+            "markdownDescription": "%configuration.models.preference.customProvider.description%",
+            "tags": [
+              "experimental"
+            ]
           },
           "positron.assistant.models.preference.positAI": {
             "type": "string",
@@ -528,6 +537,7 @@
             "default": "",
             "markdownDescription": "%configuration.models.preference.google.description%",
             "tags": [
+              "experimental",
               "advanced"
             ]
           },
@@ -681,6 +691,9 @@
             "type": "array",
             "default": [],
             "markdownDescription": "%configuration.models.overrides.msFoundry.description%",
+            "tags": [
+              "preview"
+            ],
             "items": {
               "type": "object",
               "properties": {
@@ -753,6 +766,9 @@
             "type": "array",
             "default": [],
             "markdownDescription": "%configuration.models.overrides.customProvider.description%",
+            "tags": [
+              "experimental"
+            ],
             "items": {
               "type": "object",
               "properties": {
@@ -828,6 +844,7 @@
             "default": [],
             "markdownDescription": "%configuration.models.overrides.google.description%",
             "tags": [
+              "experimental",
               "advanced"
             ],
             "items": {


### PR DESCRIPTION
I noticed some inconsistencies with setting statuses. Here is a sweep!

- Preview: custom headers (new feature), GitHub Copilot, Microsoft Foundry, Next Edit Suggestions (new feature)
- Experimental: custom provider/OpenAI-compatible, Google (Gemini) <-- these are all experimental providers

Preview features and providers should have their corresponding settings set to Preview at least; same logic for experimental providers.

Closes https://github.com/posit-dev/positron/issues/13732