### PR TITLE
Insert Quarto cells from history pane

### DIFF
--- a/src/vs/workbench/contrib/positronHistory/browser/components/positronHistoryPanel.tsx
+++ b/src/vs/workbench/contrib/positronHistory/browser/components/positronHistoryPanel.tsx
@@ -33,6 +33,9 @@ import { getSectionLabel, isSameSection } from './historyGrouping.js';
 import { FontInfo } from '../../../../../editor/common/config/fontInfo.js';
 import { isMacintosh } from '../../../../../base/common/platform.js';
 import * as DOM from '../../../../../base/browser/dom.js';
+import { IQuartoDocumentModelService } from '../../../positronQuarto/browser/quartoDocumentModelService.js';
+import { isQuartoDocument } from '../../../positronQuarto/common/positronQuartoConfig.js';
+import { buildQuartoCellInsertion } from '../quartoInsertion.js';
 import './positronHistoryPanel.css';
 
 // Localized strings
@@ -1002,6 +1005,42 @@ export const PositronHistoryPanel = (props: PositronHistoryPanelProps) => {
 		const position = editor.getPosition();
 		if (!position) {
 			return;
+		}
+
+		// In a Quarto document, if the cursor is in prose (outside any code
+		// cell), wrap the inserted code in a new cell whose language matches
+		// the history language. Inside a cell, fall through to a plain insert.
+		const model = editor.getModel();
+		if (model && currentLanguage &&
+			isQuartoDocument(model.uri.path, model.getLanguageId())) {
+			const quartoModelService = instantiationService.invokeFunction(accessor =>
+				accessor.get(IQuartoDocumentModelService)
+			);
+			const quartoModel = quartoModelService.getModel(model);
+			if (!quartoModel.getCellAtLine(position.lineNumber)) {
+				const lineNumber = position.lineNumber;
+				const currentLineEmpty = model.getLineContent(lineNumber).trim() === '';
+				const nextLineNumber = lineNumber + 1;
+				const nextLineEmpty = nextLineNumber > model.getLineCount() ||
+					model.getLineContent(nextLineNumber).trim() === '';
+				const cellText = buildQuartoCellInsertion(
+					combinedText,
+					currentLanguage,
+					currentLineEmpty,
+					nextLineEmpty,
+				);
+				const endColumn = model.getLineMaxColumn(lineNumber);
+				editor.executeEdits('positron-history', [{
+					range: {
+						startLineNumber: lineNumber,
+						startColumn: endColumn,
+						endLineNumber: lineNumber,
+						endColumn: endColumn
+					},
+					text: cellText
+				}]);
+				return;
+			}
 		}
 
 		// Insert the code at the cursor position with a trailing newline

--- a/src/vs/workbench/contrib/positronHistory/browser/quartoInsertion.ts
+++ b/src/vs/workbench/contrib/positronHistory/browser/quartoInsertion.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Build the text to insert when creating a new Quarto code cell at the end of
+ * the cursor's line. The leading and trailing newlines are chosen so the new
+ * cell is always separated from surrounding content by exactly one blank line.
+ *
+ * @param code The code content to place inside the cell.
+ * @param language The cell language id (e.g. 'r', 'python').
+ * @param currentLineEmpty True if the cursor's line has no non-whitespace content.
+ * @param nextLineEmpty True if the line after the cursor is empty or there is no next line.
+ */
+export function buildQuartoCellInsertion(
+	code: string,
+	language: string,
+	currentLineEmpty: boolean,
+	nextLineEmpty: boolean,
+): string {
+	const leading = currentLineEmpty ? '\n' : '\n\n';
+	const trailing = nextLineEmpty ? '\n' : '\n\n';
+	return `${leading}\`\`\`{${language}}\n${code}\n\`\`\`${trailing}`;
+}

--- a/src/vs/workbench/contrib/positronHistory/test/browser/quartoInsertion.vitest.ts
+++ b/src/vs/workbench/contrib/positronHistory/test/browser/quartoInsertion.vitest.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { buildQuartoCellInsertion } from '../../browser/quartoInsertion.js';
+
+describe('buildQuartoCellInsertion', () => {
+	it('wraps code with blank lines on both sides when surrounded by prose', () => {
+		expect(buildQuartoCellInsertion('df <- 1', 'r', false, false))
+			.toMatchInlineSnapshot(`
+				"
+
+				\`\`\`{r}
+				df <- 1
+				\`\`\`
+
+				"
+			`);
+	});
+
+	it('omits leading blank line when the cursor is on an empty line', () => {
+		expect(buildQuartoCellInsertion('df <- 1', 'r', true, false))
+			.toMatchInlineSnapshot(`
+				"
+				\`\`\`{r}
+				df <- 1
+				\`\`\`
+
+				"
+			`);
+	});
+
+	it('omits trailing blank line when the next line is empty or EOF', () => {
+		expect(buildQuartoCellInsertion('df <- 1', 'r', false, true))
+			.toMatchInlineSnapshot(`
+				"
+
+				\`\`\`{r}
+				df <- 1
+				\`\`\`
+				"
+			`);
+	});
+});


### PR DESCRIPTION
This change improves the behavior of the History pane when inserting into Quarto documents. After the change, inserting code into a prose region of Quarto doc will automatically wrap the code in the appropriate cell markup.

Closes https://github.com/posit-dev/positron/issues/12737. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- Inserting code into Quarto documents from the History pane now automatically adds cell demarcation (#12737)

#### Bug Fixes

- N/A


### Validation Steps

1. Open a Quarto document and place cursor in prose section
2. Open the History pane
3. Right-click any entry -> Send to Editor
4. Verify code inserted with cell demarcation
5. Repeat but verify that no fences are added when cursor is already in a code cell
6. Repeat but verify that no fences are added when cursor is not in a Quarto file

