### PR TITLE
Auth extension: set snowflake partner tag in setting

### DIFF
--- a/extensions/authentication/package.json
+++ b/extensions/authentication/package.json
@@ -113,7 +113,9 @@
 				},
 				"authentication.snowflake.customHeaders": {
 					"type": "object",
-					"default": {},
+					"default": {
+						"User-Agent": "posit_positron"
+					},
 					"additionalProperties": {
 						"type": "string"
 					},

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -12,7 +12,7 @@ import { registerAuthProvider, showConfigurationDialog } from './configDialog';
 import { PROVIDER_METADATA } from './providerSources';
 import { normalizeToV1Url, validateAnthropicApiKey, validateCustomProviderApiKey, validateFoundryApiKey, validateGeminiApiKey, validateOpenaiApiKey, validateSnowflakeApiKey } from './validation';
 import { FOUNDRY_MANAGED_CREDENTIALS, hasManagedCredentials } from './managedCredentials';
-import { detectSnowflakeCredentials, getSnowflakeConnectionsTomlPath } from './snowflakeCredentials';
+import { detectSnowflakeCredentials, getSnowflakeConnectionsTomlPath, seedSnowflakePartnerTagHeader } from './snowflakeCredentials';
 import { PositOAuthProvider } from './positOAuthProvider';
 import * as fs from 'fs';
 import { log } from './log';
@@ -358,6 +358,13 @@ function registerSnowflakeProvider(context: vscode.ExtensionContext): void {
 			`Initial credential resolution failed: ${err}`
 		)
 	);
+
+	// Make the partner-tag User-Agent available to Posit Assistant via the
+	// shared customHeaders setting. See seedSnowflakePartnerTagHeader for rules.
+	seedSnowflakePartnerTagHeader().catch(err =>
+		logger.logOperationError('seed Snowflake partner tag', err)
+	);
+
 	logger.info('Registered auth provider');
 }
 

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -361,7 +361,7 @@ function registerSnowflakeProvider(context: vscode.ExtensionContext): void {
 
 	// Make the partner-tag User-Agent available to Posit Assistant via the
 	// shared customHeaders setting. See seedSnowflakePartnerTagHeader for rules.
-	seedSnowflakePartnerTagHeader().catch(err =>
+	seedSnowflakePartnerTagHeader(context).catch(err =>
 		logger.logOperationError('seed Snowflake partner tag', err)
 	);
 

--- a/extensions/authentication/src/snowflakeCredentials.ts
+++ b/extensions/authentication/src/snowflakeCredentials.ts
@@ -226,6 +226,19 @@ export async function checkForUpdatedSnowflakeCredentials(
 }
 
 /**
+ * Default partner tag. Matches the schema default of
+ * `authentication.snowflake.customHeaders` in package.json, so that a fresh
+ * install or a "Reset Setting" produces this value without any write.
+ */
+export const DEFAULT_SNOWFLAKE_PARTNER_TAG = 'posit_positron';
+
+/**
+ * globalState key for the last User-Agent we wrote into customHeaders. Used to
+ * tell our prior seed apart from a value the user typed.
+ */
+const LAST_SEEDED_USER_AGENT_KEY = 'snowflake.lastSeededUserAgent';
+
+/**
  * Resolves the Snowflake partner tag sent as the User-Agent header on Cortex
  * requests. The tag lets Snowflake attribute traffic to Posit; Workbench-managed
  * environments override it via SF_PARTNER (e.g. `posit_workbench_positron`).
@@ -237,7 +250,7 @@ export function getSnowflakePartnerTag(): string {
 	const envVars = vscode.workspace
 		.getConfiguration('environmentVariables')
 		.get<Record<string, string>>('set') ?? {};
-	return envVars['SF_PARTNER'] || process.env.SF_PARTNER || 'posit_positron';
+	return envVars['SF_PARTNER'] || process.env.SF_PARTNER || DEFAULT_SNOWFLAKE_PARTNER_TAG;
 }
 
 /**
@@ -245,25 +258,46 @@ export function getSnowflakePartnerTag(): string {
  * as the User-Agent header, so Posit Assistant reads it from there instead of
  * redoing the lookup itself.
  *
- * Two rules:
- * - Skip if the user already set User-Agent. customHeaders is the escape
- *   hatch for enterprise gateways, and we don't clobber it.
- * - Write to the scope where customHeaders is currently defined (most
- *   specific wins). Object settings don't merge across scopes, so a global
- *   write can be hidden by a workspace-level value.
- *
- * Seeded once at activation; subsequent SF_PARTNER changes require a reload.
- * Users who need a different tag mid-session can edit
- * authentication.snowflake.customHeaders directly.
+ * Strategy:
+ * - The schema default already carries `User-Agent: posit_positron`, so we
+ *   only write when the desired tag differs from that default (e.g. Workbench
+ *   sets SF_PARTNER=posit_workbench_positron).
+ * - We track the last value we wrote in globalState so that on a later
+ *   activation we can tell our own prior seed from a user customization. The
+ *   current User-Agent is considered "ours to overwrite" when it is unset,
+ *   equals the schema default, or matches the value we last seeded. Anything
+ *   else means the user customized it -- leave alone.
+ * - Writes target the most specific scope where customHeaders is defined
+ *   (folder > workspace > global), since object settings don't merge across
+ *   scopes.
  *
  * @returns true if a write was made, false if seeding was skipped.
  */
-export async function seedSnowflakePartnerTagHeader(): Promise<boolean> {
+export async function seedSnowflakePartnerTagHeader(
+	context: vscode.ExtensionContext
+): Promise<boolean> {
+	const desired = getSnowflakePartnerTag();
 	const cfg = vscode.workspace.getConfiguration('authentication.snowflake');
-	const effective = cfg.get<Record<string, string>>('customHeaders', {});
-	if (effective['User-Agent']) {
+	const current = cfg.get<Record<string, string>>('customHeaders', {});
+	const currentUserAgent = current['User-Agent'];
+
+	if (currentUserAgent === desired) {
 		return false;
 	}
+
+	// Schema default carries the value; only seed when overriding.
+	if (desired === DEFAULT_SNOWFLAKE_PARTNER_TAG && currentUserAgent === undefined) {
+		return false;
+	}
+
+	const lastSeeded = context.globalState.get<string>(LAST_SEEDED_USER_AGENT_KEY);
+	const isOurs = currentUserAgent === undefined ||
+		currentUserAgent === DEFAULT_SNOWFLAKE_PARTNER_TAG ||
+		currentUserAgent === lastSeeded;
+	if (!isOurs) {
+		return false;
+	}
+
 	const inspection = cfg.inspect<Record<string, string>>('customHeaders');
 	let target: vscode.ConfigurationTarget;
 	let base: Record<string, string>;
@@ -277,11 +311,8 @@ export async function seedSnowflakePartnerTagHeader(): Promise<boolean> {
 		target = vscode.ConfigurationTarget.Global;
 		base = inspection?.globalValue ?? {};
 	}
-	await cfg.update(
-		'customHeaders',
-		{ ...base, 'User-Agent': getSnowflakePartnerTag() },
-		target
-	);
+	await cfg.update('customHeaders', { ...base, 'User-Agent': desired }, target);
+	await context.globalState.update(LAST_SEEDED_USER_AGENT_KEY, desired);
 	return true;
 }
 

--- a/extensions/authentication/src/snowflakeCredentials.ts
+++ b/extensions/authentication/src/snowflakeCredentials.ts
@@ -226,6 +226,66 @@ export async function checkForUpdatedSnowflakeCredentials(
 }
 
 /**
+ * Resolves the Snowflake partner tag sent as the User-Agent header on Cortex
+ * requests. The tag lets Snowflake attribute traffic to Posit; Workbench-managed
+ * environments override it via SF_PARTNER (e.g. `posit_workbench_positron`).
+ *
+ * Precedence: environmentVariables.set.SF_PARTNER, then process.env.SF_PARTNER,
+ * then the default `posit_positron`.
+ */
+export function getSnowflakePartnerTag(): string {
+	const envVars = vscode.workspace
+		.getConfiguration('environmentVariables')
+		.get<Record<string, string>>('set') ?? {};
+	return envVars['SF_PARTNER'] || process.env.SF_PARTNER || 'posit_positron';
+}
+
+/**
+ * Seeds the Snowflake partner tag into `authentication.snowflake.customHeaders`
+ * as the User-Agent header, so Posit Assistant reads it from there instead of
+ * redoing the lookup itself.
+ *
+ * Two rules:
+ * - Skip if the user already set User-Agent. customHeaders is the escape
+ *   hatch for enterprise gateways, and we don't clobber it.
+ * - Write to the scope where customHeaders is currently defined (most
+ *   specific wins). Object settings don't merge across scopes, so a global
+ *   write can be hidden by a workspace-level value.
+ *
+ * Seeded once at activation; subsequent SF_PARTNER changes require a reload.
+ * Users who need a different tag mid-session can edit
+ * authentication.snowflake.customHeaders directly.
+ *
+ * @returns true if a write was made, false if seeding was skipped.
+ */
+export async function seedSnowflakePartnerTagHeader(): Promise<boolean> {
+	const cfg = vscode.workspace.getConfiguration('authentication.snowflake');
+	const effective = cfg.get<Record<string, string>>('customHeaders', {});
+	if (effective['User-Agent']) {
+		return false;
+	}
+	const inspection = cfg.inspect<Record<string, string>>('customHeaders');
+	let target: vscode.ConfigurationTarget;
+	let base: Record<string, string>;
+	if (inspection?.workspaceFolderValue !== undefined) {
+		target = vscode.ConfigurationTarget.WorkspaceFolder;
+		base = inspection.workspaceFolderValue;
+	} else if (inspection?.workspaceValue !== undefined) {
+		target = vscode.ConfigurationTarget.Workspace;
+		base = inspection.workspaceValue;
+	} else {
+		target = vscode.ConfigurationTarget.Global;
+		base = inspection?.globalValue ?? {};
+	}
+	await cfg.update(
+		'customHeaders',
+		{ ...base, 'User-Agent': getSnowflakePartnerTag() },
+		target
+	);
+	return true;
+}
+
+/**
  * Gets the default base URL for Snowflake Cortex, using SNOWFLAKE_ACCOUNT if available
  * @returns Base URL string with account identifier filled in if possible
  */

--- a/extensions/authentication/src/test/snowflakeCredentials.test.ts
+++ b/extensions/authentication/src/test/snowflakeCredentials.test.ts
@@ -10,6 +10,8 @@ import {
 	isValidSnowflakeAccount,
 	constructSnowflakeBaseUrl,
 	getSnowflakeDefaultBaseUrl,
+	getSnowflakePartnerTag,
+	seedSnowflakePartnerTagHeader,
 	detectSnowflakeCredentials,
 } from '../snowflakeCredentials';
 
@@ -115,6 +117,124 @@ suite('Snowflake Credentials', () => {
 
 			const url = getSnowflakeDefaultBaseUrl();
 			assert.strictEqual(url, 'https://<account_identifier>.snowflakecomputing.com/api/v2/cortex/v1');
+		});
+	});
+
+	suite('Partner Tag', () => {
+		let mockWorkspaceConfig: sinon.SinonStub;
+		let getConfigurationStub: sinon.SinonStub;
+		let processEnvStub: sinon.SinonStub;
+
+		setup(() => {
+			mockWorkspaceConfig = sinon.stub();
+			const mockConfig: vscode.WorkspaceConfiguration = {
+				get: mockWorkspaceConfig,
+				has: sinon.stub(),
+				inspect: sinon.stub(),
+				update: sinon.stub()
+			};
+			getConfigurationStub = sinon.stub(vscode.workspace, 'getConfiguration').returns(mockConfig);
+			processEnvStub = sinon.stub(process, 'env').value({});
+		});
+
+		teardown(() => {
+			getConfigurationStub.restore();
+			processEnvStub.restore();
+		});
+
+		test('getSnowflakePartnerTag prefers environmentVariables.set.SF_PARTNER', () => {
+			mockWorkspaceConfig.withArgs('set').returns({ SF_PARTNER: 'setting_value' });
+			processEnvStub.value({ SF_PARTNER: 'env_value' });
+
+			assert.strictEqual(getSnowflakePartnerTag(), 'setting_value');
+		});
+
+		test('getSnowflakePartnerTag falls back to process.env.SF_PARTNER', () => {
+			mockWorkspaceConfig.withArgs('set').returns({});
+			processEnvStub.value({ SF_PARTNER: 'env_value' });
+
+			assert.strictEqual(getSnowflakePartnerTag(), 'env_value');
+		});
+
+		test('getSnowflakePartnerTag defaults to posit_positron', () => {
+			mockWorkspaceConfig.withArgs('set').returns({});
+
+			assert.strictEqual(getSnowflakePartnerTag(), 'posit_positron');
+		});
+	});
+
+	suite('Seed Partner Tag Header', () => {
+		let getStub: sinon.SinonStub;
+		let inspectStub: sinon.SinonStub;
+		let updateStub: sinon.SinonStub;
+		let getConfigurationStub: sinon.SinonStub;
+
+		setup(() => {
+			getStub = sinon.stub();
+			inspectStub = sinon.stub();
+			updateStub = sinon.stub().resolves();
+			const mockConfig: vscode.WorkspaceConfiguration = {
+				get: getStub,
+				has: sinon.stub(),
+				inspect: inspectStub,
+				update: updateStub,
+			};
+			getConfigurationStub = sinon
+				.stub(vscode.workspace, 'getConfiguration')
+				.callsFake((section?: string) => {
+					if (section === 'authentication.snowflake') {
+						return mockConfig;
+					}
+					// Empty config for SF_PARTNER lookup so the seeded
+					// User-Agent is always the default partner tag.
+					return { get: () => ({}) } as unknown as vscode.WorkspaceConfiguration;
+				});
+			sinon.stub(process, 'env').value({});
+		});
+
+		teardown(() => {
+			getConfigurationStub.restore();
+		});
+
+		test('skips write when User-Agent is already set in effective config', async () => {
+			getStub.withArgs('customHeaders', {}).returns({ 'User-Agent': 'user-custom' });
+			inspectStub.withArgs('customHeaders').returns({ globalValue: { 'User-Agent': 'user-custom' } });
+
+			const wrote = await seedSnowflakePartnerTagHeader();
+
+			assert.strictEqual(wrote, false);
+			assert.strictEqual(updateStub.called, false);
+		});
+
+		test('writes to most-specific scope where customHeaders is defined, merging existing keys', async () => {
+			getStub.withArgs('customHeaders', {}).returns({ 'X-Tenant': 'acme' });
+			inspectStub.withArgs('customHeaders').returns({
+				globalValue: { 'X-Global': 'g' },
+				workspaceValue: { 'X-Tenant': 'acme' },
+			});
+
+			const wrote = await seedSnowflakePartnerTagHeader();
+
+			assert.strictEqual(wrote, true);
+			assert.deepStrictEqual(updateStub.firstCall.args, [
+				'customHeaders',
+				{ 'X-Tenant': 'acme', 'User-Agent': 'posit_positron' },
+				vscode.ConfigurationTarget.Workspace,
+			]);
+		});
+
+		test('falls back to Global when customHeaders is not defined at any scope', async () => {
+			getStub.withArgs('customHeaders', {}).returns({});
+			inspectStub.withArgs('customHeaders').returns({});
+
+			const wrote = await seedSnowflakePartnerTagHeader();
+
+			assert.strictEqual(wrote, true);
+			assert.deepStrictEqual(updateStub.firstCall.args, [
+				'customHeaders',
+				{ 'User-Agent': 'posit_positron' },
+				vscode.ConfigurationTarget.Global,
+			]);
 		});
 	});
 

--- a/extensions/authentication/src/test/snowflakeCredentials.test.ts
+++ b/extensions/authentication/src/test/snowflakeCredentials.test.ts
@@ -163,16 +163,31 @@ suite('Snowflake Credentials', () => {
 		});
 	});
 
+	suite('Schema default', () => {
+		test('customHeaders default contains User-Agent partner tag so "Reset Setting" produces a valid tag', () => {
+			const ext = vscode.extensions.getExtension('positron.authentication');
+			assert.ok(ext, 'authentication extension should be available');
+			const customHeaders = ext.packageJSON
+				?.contributes?.configuration?.properties?.['authentication.snowflake.customHeaders'];
+			assert.deepStrictEqual(customHeaders?.default, { 'User-Agent': 'posit_positron' });
+		});
+	});
+
 	suite('Seed Partner Tag Header', () => {
 		let getStub: sinon.SinonStub;
 		let inspectStub: sinon.SinonStub;
 		let updateStub: sinon.SinonStub;
 		let getConfigurationStub: sinon.SinonStub;
+		let processEnvStub: sinon.SinonStub;
+		let envSetReturn: Record<string, string>;
+		let globalStateStore: Map<string, unknown>;
+		let context: vscode.ExtensionContext;
 
 		setup(() => {
 			getStub = sinon.stub();
 			inspectStub = sinon.stub();
 			updateStub = sinon.stub().resolves();
+			envSetReturn = {};
 			const mockConfig: vscode.WorkspaceConfiguration = {
 				get: getStub,
 				has: sinon.stub(),
@@ -185,55 +200,103 @@ suite('Snowflake Credentials', () => {
 					if (section === 'authentication.snowflake') {
 						return mockConfig;
 					}
-					// Empty config for SF_PARTNER lookup so the seeded
-					// User-Agent is always the default partner tag.
-					return { get: () => ({}) } as unknown as vscode.WorkspaceConfiguration;
+					return {
+						get: (key: string) => key === 'set' ? envSetReturn : undefined,
+					} as unknown as vscode.WorkspaceConfiguration;
 				});
-			sinon.stub(process, 'env').value({});
+			processEnvStub = sinon.stub(process, 'env').value({});
+			globalStateStore = new Map();
+			context = {
+				globalState: {
+					get: (key: string) => globalStateStore.get(key),
+					update: async (key: string, value: unknown) => { globalStateStore.set(key, value); },
+				},
+			} as unknown as vscode.ExtensionContext;
 		});
 
 		teardown(() => {
 			getConfigurationStub.restore();
+			processEnvStub.restore();
 		});
 
-		test('skips write when User-Agent is already set in effective config', async () => {
-			getStub.withArgs('customHeaders', {}).returns({ 'User-Agent': 'user-custom' });
-			inspectStub.withArgs('customHeaders').returns({ globalValue: { 'User-Agent': 'user-custom' } });
+		test('skips write when User-Agent already equals desired (schema default in effect)', async () => {
+			getStub.withArgs('customHeaders', {}).returns({ 'User-Agent': 'posit_positron' });
+			inspectStub.withArgs('customHeaders').returns({});
 
-			const wrote = await seedSnowflakePartnerTagHeader();
+			const wrote = await seedSnowflakePartnerTagHeader(context);
 
 			assert.strictEqual(wrote, false);
 			assert.strictEqual(updateStub.called, false);
 		});
 
+		test('skips write when desired is the default and no User-Agent is set yet', async () => {
+			getStub.withArgs('customHeaders', {}).returns({});
+			inspectStub.withArgs('customHeaders').returns({});
+
+			const wrote = await seedSnowflakePartnerTagHeader(context);
+
+			assert.strictEqual(wrote, false);
+			assert.strictEqual(updateStub.called, false);
+		});
+
+		test('skips write when user has customized User-Agent', async () => {
+			processEnvStub.value({ SF_PARTNER: 'posit_workbench_positron' });
+			getStub.withArgs('customHeaders', {}).returns({ 'User-Agent': 'user-custom' });
+			inspectStub.withArgs('customHeaders').returns({ globalValue: { 'User-Agent': 'user-custom' } });
+
+			const wrote = await seedSnowflakePartnerTagHeader(context);
+
+			assert.strictEqual(wrote, false);
+			assert.strictEqual(updateStub.called, false);
+		});
+
+		test('overwrites schema-default User-Agent when SF_PARTNER differs', async () => {
+			processEnvStub.value({ SF_PARTNER: 'posit_workbench_positron' });
+			getStub.withArgs('customHeaders', {}).returns({ 'User-Agent': 'posit_positron' });
+			inspectStub.withArgs('customHeaders').returns({});
+
+			const wrote = await seedSnowflakePartnerTagHeader(context);
+
+			assert.strictEqual(wrote, true);
+			assert.deepStrictEqual(updateStub.firstCall.args, [
+				'customHeaders',
+				{ 'User-Agent': 'posit_workbench_positron' },
+				vscode.ConfigurationTarget.Global,
+			]);
+			assert.strictEqual(globalStateStore.get('snowflake.lastSeededUserAgent'), 'posit_workbench_positron');
+		});
+
+		test('overwrites previously seeded value when SF_PARTNER changes', async () => {
+			globalStateStore.set('snowflake.lastSeededUserAgent', 'old_tag');
+			processEnvStub.value({ SF_PARTNER: 'new_tag' });
+			getStub.withArgs('customHeaders', {}).returns({ 'User-Agent': 'old_tag' });
+			inspectStub.withArgs('customHeaders').returns({ globalValue: { 'User-Agent': 'old_tag' } });
+
+			const wrote = await seedSnowflakePartnerTagHeader(context);
+
+			assert.strictEqual(wrote, true);
+			assert.deepStrictEqual(updateStub.firstCall.args, [
+				'customHeaders',
+				{ 'User-Agent': 'new_tag' },
+				vscode.ConfigurationTarget.Global,
+			]);
+		});
+
 		test('writes to most-specific scope where customHeaders is defined, merging existing keys', async () => {
-			getStub.withArgs('customHeaders', {}).returns({ 'X-Tenant': 'acme' });
+			processEnvStub.value({ SF_PARTNER: 'posit_workbench_positron' });
+			getStub.withArgs('customHeaders', {}).returns({ 'X-Tenant': 'acme', 'User-Agent': 'posit_positron' });
 			inspectStub.withArgs('customHeaders').returns({
 				globalValue: { 'X-Global': 'g' },
 				workspaceValue: { 'X-Tenant': 'acme' },
 			});
 
-			const wrote = await seedSnowflakePartnerTagHeader();
+			const wrote = await seedSnowflakePartnerTagHeader(context);
 
 			assert.strictEqual(wrote, true);
 			assert.deepStrictEqual(updateStub.firstCall.args, [
 				'customHeaders',
-				{ 'X-Tenant': 'acme', 'User-Agent': 'posit_positron' },
+				{ 'X-Tenant': 'acme', 'User-Agent': 'posit_workbench_positron' },
 				vscode.ConfigurationTarget.Workspace,
-			]);
-		});
-
-		test('falls back to Global when customHeaders is not defined at any scope', async () => {
-			getStub.withArgs('customHeaders', {}).returns({});
-			inspectStub.withArgs('customHeaders').returns({});
-
-			const wrote = await seedSnowflakePartnerTagHeader();
-
-			assert.strictEqual(wrote, true);
-			assert.deepStrictEqual(updateStub.firstCall.args, [
-				'customHeaders',
-				{ 'User-Agent': 'posit_positron' },
-				vscode.ConfigurationTarget.Global,
 			]);
 		});
 	});


### PR DESCRIPTION
Fixes #13731

### Summary

Moves Snowflake partner-tag resolution into the authentication extension so Posit Assistant (and any future consumer) reads the `User-Agent` from `authentication.snowflake.customHeaders` instead of re-implementing the lookup. This gives us one source of truth for the value and lets `authentication.snowflake.customHeaders` (added in #13664) actually carry the partner tag by default.

On activation, the Snowflake auth provider seeds `customHeaders["User-Agent"]` with the resolved partner tag. Resolution precedence is `environmentVariables.set.SF_PARTNER`, then `process.env.SF_PARTNER`, then the default `posit_positron`. The schema default for `customHeaders` is `{ "User-Agent": "posit_positron" }`, so "Reset Setting" gives you a valid tag instead of blanking the value.

Two guardrails:

- The extension remembers the last `User-Agent` it wrote (in `globalState`) and only overwrites values it wrote itself. If you've customised `User-Agent` in `customHeaders`, your value stays. The setting is the escape hatch for enterprise gateways and we don't clobber it.
- The write targets the most specific configuration scope where `customHeaders` is defined (workspace folder, then workspace, then global), since object settings don't merge across scopes.

Seeding runs on each activation, so changing `SF_PARTNER` and relaunching picks up the new tag automatically. No need to edit `customHeaders` by hand.

The duplicate resolution in `positron-assistant`'s `snowflakeProvider.ts` can be removed in the Positron Assistant deprecation.

### Validation Steps

@:posit-assistant

This is a config-seeding change with no direct UI. Validate manually:

1. Remove any existing `authentication.snowflake.customHeaders` setting and reload the window.
2. Open Settings, search for `authentication.snowflake.customHeaders`. Confirm it contains `"User-Agent": "posit_positron"`.
3. Quit Positron, relaunch with `SF_PARTNER=test-user-agent` set in the environment, and confirm the value now reflects `test-user-agent`.
4. With the same setup, quit and relaunch without `SF_PARTNER` set. Confirm the value reverts to `posit_positron` (the extension overwrites its own prior seed).
5. Set `User-Agent` to a custom value in `authentication.snowflake.customHeaders`, reload, and confirm the value is preserved (not overwritten).
6. Unit tests:

```
npm run test-extension -- -l authentication --grep snowflakeCredentials
```

I was able to confirm this works by adding debug logging locally, and confirming that the user agent header was included with the snowflake request. There is not currently a way to see the headers directly from Posit Assistant.

1. Set `SNOWFLAKE_ACCOUNT` in `authentication.snowflake.credentials`
2. Login with Snowflake provider
3. Send chat message in Posit Assistant
4. See debug logs in devtools console, which include the user agent
