### PR TITLE
Add P3M telemetry params to extension gallery requests

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -32,7 +32,7 @@ import { format2 } from '../../../base/common/strings.js';
 import { ExtensionGalleryResourceType, Flag, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService, ExtensionGalleryManifestStatus } from './extensionGalleryManifest.js';
 import { TelemetryTrustedValue } from '../../telemetry/common/telemetryUtils.js';
 // --- Start Positron ---
-import { appendPositronGalleryParams, formatPositronVersion, getPositronSessionType, PositronCheckTrigger } from './positronGalleryTelemetry.js';
+import { appendPositronGalleryParams, formatPositronVersion, GalleryUsageDataConfigKey, getPositronSessionType, PositronCheckTrigger } from './positronGalleryTelemetry.js';
 // --- End Positron ---
 
 const CURRENT_TARGET_PLATFORM = isWeb ? TargetPlatform.WEB : getTargetPlatform(platform, arch);
@@ -780,11 +780,13 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		// Tag the resource-API URI templates with telemetry params here, so every
 		// downstream GET (including the unpkg fallback) carries them. The params are
 		// added before format2 expands {publisher}/{name}, which preserves them.
+		const sendUsageData = this.configurationService.getValue<boolean>(GalleryUsageDataConfigKey) !== false;
 		const positronGalleryParams = (url: string) => appendPositronGalleryParams(
 			url,
 			options.checkTrigger,
 			getPositronSessionType(),
 			formatPositronVersion(this.productService.positronVersion, this.productService.positronBuildNumber),
+			sendUsageData,
 		);
 		resourceApi = {
 			uri: positronGalleryParams(resourceApi.uri),
@@ -1429,11 +1431,13 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		// --- Start Positron ---
 		// Tag the outgoing POST URL with distribution type + Positron version, plus the
 		// update-check trigger (read off the Query state) when applicable
+		const sendUsageData = this.configurationService.getValue<boolean>(GalleryUsageDataConfigKey) !== false;
 		const taggedQueryApi = appendPositronGalleryParams(
 			extensionsQueryApi,
 			query.checkTrigger,
 			getPositronSessionType(),
 			formatPositronVersion(this.productService.positronVersion, this.productService.positronBuildNumber),
+			sendUsageData,
 		);
 		// --- End Positron ---
 

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -1493,12 +1493,6 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		const stopWatch = new StopWatch();
 		let context: IRequestContext | undefined, errorCode: ExtensionGalleryErrorCode | undefined, total: number = 0;
 
-		// --- Start Positron ---
-		// TEMP: log the tagged gallery query URL so we can verify P3M telemetry params land
-		// on the wire. Remove before merging.
-		this.logService.info(`[p3m] POST ${taggedQueryApi}`);
-		// --- End Positron ---
-
 		try {
 			context = await this.requestService.request({
 				type: 'POST',
@@ -1642,13 +1636,6 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		let context;
 		let errorCode: string | undefined;
 		const stopWatch = new StopWatch();
-
-		// --- Start Positron ---
-		// TEMP: log the per-extension resource-API GET URL (pre-tagged by
-		// getExtensionsUsingResourceApi) so we can verify P3M telemetry params land on the
-		// wire. Remove before merging.
-		this.logService.info(`[p3m] GET ${uri.toString(true)}`);
-		// --- End Positron ---
 
 		try {
 			const commonHeaders = await this.commonHeadersPromise;

--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -31,6 +31,9 @@ import { StopWatch } from '../../../base/common/stopwatch.js';
 import { format2 } from '../../../base/common/strings.js';
 import { ExtensionGalleryResourceType, Flag, getExtensionGalleryManifestResourceUri, IExtensionGalleryManifest, IExtensionGalleryManifestService, ExtensionGalleryManifestStatus } from './extensionGalleryManifest.js';
 import { TelemetryTrustedValue } from '../../telemetry/common/telemetryUtils.js';
+// --- Start Positron ---
+import { appendPositronGalleryParams, formatPositronVersion, getPositronSessionType, PositronCheckTrigger } from './positronGalleryTelemetry.js';
+// --- End Positron ---
 
 const CURRENT_TARGET_PLATFORM = isWeb ? TargetPlatform.WEB : getTargetPlatform(platform, arch);
 const SEARCH_ACTIVITY_HEADER_NAME = 'X-Market-Search-Activity-Id';
@@ -150,6 +153,10 @@ interface IQueryState {
 	readonly criteria: ICriterium[];
 	readonly assetTypes: string[];
 	readonly source?: string;
+	// --- Start Positron ---
+	// Tag for P3M telemetry. Read in queryRawGalleryExtensions to build URL params.
+	readonly checkTrigger?: PositronCheckTrigger;
+	// --- End Positron ---
 }
 
 const DefaultQueryState: IQueryState = {
@@ -253,6 +260,9 @@ class Query {
 	get criteria(): ICriterium[] { return this.state.criteria; }
 	get assetTypes(): string[] { return this.state.assetTypes; }
 	get source(): string | undefined { return this.state.source; }
+	// --- Start Positron ---
+	get checkTrigger(): PositronCheckTrigger | undefined { return this.state.checkTrigger; }
+	// --- End Positron ---
 	get searchText(): string {
 		const criterium = this.state.criteria.filter(criterium => criterium.filterType === FilterType.SearchText)[0];
 		return criterium && criterium.value ? criterium.value : '';
@@ -291,6 +301,12 @@ class Query {
 	withSource(source: string): Query {
 		return new Query({ ...this.state, source });
 	}
+
+	// --- Start Positron ---
+	withCheckTrigger(checkTrigger: PositronCheckTrigger | undefined): Query {
+		return new Query({ ...this.state, checkTrigger });
+	}
+	// --- End Positron ---
 }
 
 function getStatistic(statistics: IRawGalleryExtensionStatistics[], name: string): number {
@@ -732,6 +748,11 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		if (options.source) {
 			query = query.withSource(options.source);
 		}
+		// --- Start Positron ---
+		// Stash checkTrigger on the Query state. Read at the POST chokepoint in
+		// queryRawGalleryExtensions to tag the outgoing URL for P3M.
+		query = query.withCheckTrigger(options.checkTrigger);
+		// --- End Positron ---
 
 		const { extensions } = await this.queryGalleryExtensions(
 			query,
@@ -754,6 +775,22 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 	}
 
 	private async getExtensionsUsingResourceApi(extensionInfos: ReadonlyArray<IExtensionInfo>, options: IExtensionQueryOptions, resourceApi: { uri: string; fallback?: string }, extensionGalleryManifest: IExtensionGalleryManifest, token: CancellationToken): Promise<IGalleryExtension[]> {
+
+		// --- Start Positron ---
+		// Tag the resource-API URI templates with telemetry params here, so every
+		// downstream GET (including the unpkg fallback) carries them. The params are
+		// added before format2 expands {publisher}/{name}, which preserves them.
+		const positronGalleryParams = (url: string) => appendPositronGalleryParams(
+			url,
+			options.checkTrigger,
+			getPositronSessionType(),
+			formatPositronVersion(this.productService.positronVersion, this.productService.positronBuildNumber),
+		);
+		resourceApi = {
+			uri: positronGalleryParams(resourceApi.uri),
+			fallback: resourceApi.fallback ? positronGalleryParams(resourceApi.fallback) : undefined,
+		};
+		// --- End Positron ---
 
 		const result: IGalleryExtension[] = [];
 		const toQuery: IExtensionInfo[] = [];
@@ -1188,6 +1225,10 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 	}
 
 	private async queryGalleryExtensions(query: Query, criteria: ExtensionsCriteria, extensionGalleryManifest: IExtensionGalleryManifest, token: CancellationToken): Promise<{ extensions: IGalleryExtension[]; total: number }> {
+		// --- Start Positron ---
+		// Snapshot the parent query's checkTrigger at entry so the recursive version-fetch block below can read it
+		const parentCheckTrigger = query.checkTrigger;
+		// --- End Positron ---
 		const flags = query.flags;
 
 		/**
@@ -1299,7 +1340,10 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 				.withFlags(...flags.filter(flag => flag !== Flag.IncludeLatestVersionOnly), Flag.IncludeVersions)
 				.withPage(1, needAllVersions.size)
 				.withFilter(FilterType.ExtensionId, ...needAllVersions.keys());
-			const { extensions } = await this.queryGalleryExtensions(query, criteria, extensionGalleryManifest, token);
+			// --- Start Positron ---
+			// const { extensions } = await this.queryGalleryExtensions(query, criteria, extensionGalleryManifest, token);
+			const { extensions } = await this.queryGalleryExtensions(query.withCheckTrigger(parentCheckTrigger), criteria, extensionGalleryManifest, token);
+			// --- End Positron ---
 			this.telemetryService.publicLog2<GalleryServiceAdditionalQueryEvent, GalleryServiceAdditionalQueryClassification>('galleryService:additionalQuery', {
 				duration: stopWatch.elapsed(),
 				count: needAllVersions.size
@@ -1382,6 +1426,17 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 			throw new Error('No extension gallery query service configured.');
 		}
 
+		// --- Start Positron ---
+		// Tag the outgoing POST URL with distribution type + Positron version, plus the
+		// update-check trigger (read off the Query state) when applicable
+		const taggedQueryApi = appendPositronGalleryParams(
+			extensionsQueryApi,
+			query.checkTrigger,
+			getPositronSessionType(),
+			formatPositronVersion(this.productService.positronVersion, this.productService.positronBuildNumber),
+		);
+		// --- End Positron ---
+
 		query = query
 			/* Always exclude non validated extensions */
 			.withFlags(...query.flags, Flag.ExcludeNonValidated)
@@ -1434,10 +1489,19 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		const stopWatch = new StopWatch();
 		let context: IRequestContext | undefined, errorCode: ExtensionGalleryErrorCode | undefined, total: number = 0;
 
+		// --- Start Positron ---
+		// TEMP: log the tagged gallery query URL so we can verify P3M telemetry params land
+		// on the wire. Remove before merging.
+		this.logService.info(`[p3m] POST ${taggedQueryApi}`);
+		// --- End Positron ---
+
 		try {
 			context = await this.requestService.request({
 				type: 'POST',
-				url: extensionsQueryApi,
+				// --- Start Positron ---
+				// url: extensionsQueryApi,
+				url: taggedQueryApi,
+				// --- End Positron ---
 				data,
 				headers
 			}, token);
@@ -1574,6 +1638,13 @@ export abstract class AbstractExtensionGalleryService implements IExtensionGalle
 		let context;
 		let errorCode: string | undefined;
 		const stopWatch = new StopWatch();
+
+		// --- Start Positron ---
+		// TEMP: log the per-extension resource-API GET URL (pre-tagged by
+		// getExtensionsUsingResourceApi) so we can verify P3M telemetry params land on the
+		// wire. Remove before merging.
+		this.logService.info(`[p3m] GET ${uri.toString(true)}`);
+		// --- End Positron ---
 
 		try {
 			const commonHeaders = await this.commonHeadersPromise;

--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -389,6 +389,11 @@ export interface IExtensionQueryOptions {
 	compatible?: boolean;
 	queryAllVersions?: boolean;
 	source?: string;
+	// --- Start Positron ---
+	// Why this gallery request was issued. Plumbed to the outgoing request URL so P3M can
+	// bucket update-check traffic. See positronGalleryTelemetry.ts.
+	checkTrigger?: import('./positronGalleryTelemetry.js').PositronCheckTrigger;
+	// --- End Positron ---
 }
 
 export interface IExtensionGalleryCapabilities {

--- a/src/vs/platform/extensionManagement/common/positronGalleryTelemetry.ts
+++ b/src/vs/platform/extensionManagement/common/positronGalleryTelemetry.ts
@@ -6,6 +6,13 @@
 import { isElectron, isWeb, isWorkbench } from '../../../base/common/platform.js';
 
 /**
+ * Setting key for opting out of P3M gallery telemetry. Boolean; defaults to true.
+ * Admins (e.g. PWB) can flip it false via the normal settings.json mechanisms to
+ * disable Positron-specific query params on extension gallery requests.
+ */
+export const GalleryUsageDataConfigKey = 'extensions.gallery.sendUsageData';
+
+/**
  * Why a particular gallery request was issued. Only set on update-check requests; left
  * undefined for browse / other gallery traffic so P3M can distinguish the two buckets.
  */
@@ -78,9 +85,9 @@ export function isP3MGalleryUrl(url: string): boolean {
 /**
  * Appends Positron telemetry params to a gallery request URL.
  *
- * Gated to P3M URLs only via {@link isP3MGalleryUrl}: non-P3M galleries receive the
- * URL unchanged. This avoids leaking Positron-specific telemetry to Open VSX or any
- * other gallery a PWB / enterprise build might point at.
+ * Returns the URL unchanged when any of these gates fail:
+ * - `sendUsageData` is false (admin / user opt-out via {@link GalleryUsageDataConfigKey}).
+ * - The URL hostname is not a P3M-hosted gallery (see {@link isP3MGalleryUrl}).
  *
  * P3M's log pipeline captures `request_url` and `user_agent` only. URL params are the
  * portable way to surface check-trigger, session-type, and version across desktop
@@ -95,8 +102,9 @@ export function appendPositronGalleryParams(
 	checkTrigger: PositronCheckTrigger | undefined,
 	sessionType: PositronSessionType,
 	positronVersion: string,
+	sendUsageData: boolean,
 ): string {
-	if (!isP3MGalleryUrl(url)) {
+	if (!sendUsageData || !isP3MGalleryUrl(url)) {
 		return url;
 	}
 	const params: string[] = [];

--- a/src/vs/platform/extensionManagement/common/positronGalleryTelemetry.ts
+++ b/src/vs/platform/extensionManagement/common/positronGalleryTelemetry.ts
@@ -59,7 +59,28 @@ export function formatPositronVersion(positronVersion: string, positronBuildNumb
 }
 
 /**
+ * Whether the URL points at a P3M-hosted gallery. We only attach telemetry params to
+ * P3M URLs so non-P3M galleries (Open VSX, internal proxies, custom forks) don't
+ * receive Positron-specific telemetry they didn't ask for.
+ *
+ * Matches `p3m.dev` and any subdomain (e.g. `staging.p3m.dev`). Hostname parsing
+ * avoids substring-attack collisions like `p3m.dev.attacker.com`.
+ */
+export function isP3MGalleryUrl(url: string): boolean {
+	try {
+		const host = new URL(url).hostname;
+		return host === 'p3m.dev' || host.endsWith('.p3m.dev');
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Appends Positron telemetry params to a gallery request URL.
+ *
+ * Gated to P3M URLs only via {@link isP3MGalleryUrl}: non-P3M galleries receive the
+ * URL unchanged. This avoids leaking Positron-specific telemetry to Open VSX or any
+ * other gallery a PWB / enterprise build might point at.
  *
  * P3M's log pipeline captures `request_url` and `user_agent` only. URL params are the
  * portable way to surface check-trigger, session-type, and version across desktop
@@ -75,6 +96,9 @@ export function appendPositronGalleryParams(
 	sessionType: PositronSessionType,
 	positronVersion: string,
 ): string {
+	if (!isP3MGalleryUrl(url)) {
+		return url;
+	}
 	const params: string[] = [];
 	if (checkTrigger) {
 		params.push(`positron-check-trigger=${encodeURIComponent(checkTrigger)}`);

--- a/src/vs/platform/extensionManagement/common/positronGalleryTelemetry.ts
+++ b/src/vs/platform/extensionManagement/common/positronGalleryTelemetry.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isElectron, isWeb, isWorkbench } from '../../../base/common/platform.js';
+
+/**
+ * Why a particular gallery request was issued. Only set on update-check requests; left
+ * undefined for browse / other gallery traffic so P3M can distinguish the two buckets.
+ */
+export type PositronCheckTrigger =
+	| 'startup'            // First auto-check after LifecyclePhase.Eventually.
+	| 'periodic'           // 12h re-fire of the auto-check timer.
+	| 'positron-updated'   // Positron itself reported a product update.
+	| 'setting-change'     // User changed auto-check or allowed-extensions setting.
+	| 'extension-toggled'  // User enabled/disabled an installed extension.
+	| 'network-unmetered'; // Connection flipped off-metered; resume checks.
+
+/** Which Positron distribution / process the request is coming from. */
+export type PositronSessionType =
+	| 'desktop'           // Electron app (user's local machine).
+	| 'workbench'         // PWB-hosted Positron, browser tab side.
+	| 'workbench-server'  // PWB-hosted Positron, Node backend (RS_SERVER_URL set).
+	| 'positron-server'   // Positron Server such as JupyterHub, browser tab side.
+	| 'remote-server';    // Non-PWB Node backend: JupyterHub, remote SSH / WSL / dev container backend.
+
+/**
+ * Detects which Positron process is making the gallery request.
+ *
+ * PWB and other PS each split into a client (browser tab) and a server (Node backend)
+ * process; both can independently hit the gallery, and we tag them separately so P3M
+ * can correlate or count them as needed.
+ *
+ */
+export function getPositronSessionType(): PositronSessionType {
+	if (isWorkbench) {
+		return isWeb ? 'workbench' : 'workbench-server';
+	}
+	if (isWeb) {
+		return 'positron-server';
+	}
+	if (!isElectron) {
+		return 'remote-server';
+	}
+	return 'desktop';
+}
+
+/**
+ * Formats the Positron version for the gallery `positron-version` param. Combines the
+ * three-part overlay version with the build number so P3M can distinguish builds within a
+ * release. A build number of 0 (dev / local builds) is omitted.
+ */
+export function formatPositronVersion(positronVersion: string, positronBuildNumber: number): string {
+	if (positronBuildNumber && positronBuildNumber > 0) {
+		return `${positronVersion}-${positronBuildNumber}`;
+	}
+	return positronVersion;
+}
+
+/**
+ * Appends Positron telemetry params to a gallery request URL.
+ *
+ * P3M's log pipeline captures `request_url` and `user_agent` only. URL params are the
+ * portable way to surface check-trigger, session-type, and version across desktop
+ * (Electron), Positron Server (browser), and Workbench (PWB). Browsers strip
+ * `User-Agent` overrides, so a header-based approach would not work uniformly.
+ *
+ * `checkTrigger` is omitted from the URL when undefined (browse / non-update-check
+ * traffic). `positron-session-type` and `positron-version` are always sent.
+ */
+export function appendPositronGalleryParams(
+	url: string,
+	checkTrigger: PositronCheckTrigger | undefined,
+	sessionType: PositronSessionType,
+	positronVersion: string,
+): string {
+	const params: string[] = [];
+	if (checkTrigger) {
+		params.push(`positron-check-trigger=${encodeURIComponent(checkTrigger)}`);
+	}
+	params.push(`positron-session-type=${encodeURIComponent(sessionType)}`);
+	params.push(`positron-version=${encodeURIComponent(positronVersion)}`);
+	const separator = url.includes('?') ? '&' : '?';
+	return `${url}${separator}${params.join('&')}`;
+}

--- a/src/vs/platform/extensionManagement/test/common/positronGalleryTelemetry.vitest.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronGalleryTelemetry.vitest.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="vitest/globals" />
 
-import { appendPositronGalleryParams, formatPositronVersion } from '../../common/positronGalleryTelemetry.js';
+import { appendPositronGalleryParams, formatPositronVersion, isP3MGalleryUrl } from '../../common/positronGalleryTelemetry.js';
 
 describe('positronGalleryTelemetry', function () {
 	describe('formatPositronVersion', function () {
@@ -46,6 +46,55 @@ describe('positronGalleryTelemetry', function () {
 				const result = appendPositronGalleryParams(baseUrl, undefined, sessionType, '2026.06.0');
 				expect(result).toContain(`positron-session-type=${sessionType}`);
 			}
+		});
+
+		it('returns the URL unchanged for non-P3M galleries', () => {
+			const openVsx = 'https://open-vsx.org/vscode/gallery/extensionquery';
+			expect(appendPositronGalleryParams(openVsx, 'startup', 'desktop', '2026.06.0')).toBe(openVsx);
+
+			const internal = 'https://gallery.internal.example.com/extensionquery';
+			expect(appendPositronGalleryParams(internal, 'periodic', 'workbench', '2026.06.0')).toBe(internal);
+		});
+
+		it('tags P3M subdomains (e.g. staging)', () => {
+			const staging = 'https://staging.p3m.dev/openvsx/latest/vscode/gallery/extensionquery';
+			const result = appendPositronGalleryParams(staging, 'startup', 'desktop', '2026.06.0');
+			expect(result).toContain('positron-check-trigger=startup');
+		});
+
+		it('does not tag URLs that merely contain p3m.dev as substring', () => {
+			const spoof = 'https://p3m.dev.attacker.com/extensionquery';
+			expect(appendPositronGalleryParams(spoof, 'startup', 'desktop', '2026.06.0')).toBe(spoof);
+		});
+
+		it('tolerates URI template placeholders in the path', () => {
+			const template = 'https://p3m.dev/openvsx/latest/vscode/gallery/{publisher}/{name}/latest';
+			const result = appendPositronGalleryParams(template, 'startup', 'desktop', '2026.06.0');
+			expect(result).toContain('positron-check-trigger=startup');
+		});
+	});
+
+	describe('isP3MGalleryUrl', function () {
+		it('matches p3m.dev exactly', () => {
+			expect(isP3MGalleryUrl('https://p3m.dev/openvsx/latest/vscode/gallery/extensionquery')).toBe(true);
+		});
+
+		it('matches p3m.dev subdomains', () => {
+			expect(isP3MGalleryUrl('https://staging.p3m.dev/foo')).toBe(true);
+		});
+
+		it('rejects unrelated hosts', () => {
+			expect(isP3MGalleryUrl('https://open-vsx.org/vscode/gallery/extensionquery')).toBe(false);
+			expect(isP3MGalleryUrl('https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery')).toBe(false);
+		});
+
+		it('rejects substring collisions', () => {
+			expect(isP3MGalleryUrl('https://p3m.dev.attacker.com/foo')).toBe(false);
+		});
+
+		it('returns false for malformed URLs', () => {
+			expect(isP3MGalleryUrl('not a url')).toBe(false);
+			expect(isP3MGalleryUrl('')).toBe(false);
 		});
 	});
 });

--- a/src/vs/platform/extensionManagement/test/common/positronGalleryTelemetry.vitest.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronGalleryTelemetry.vitest.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { appendPositronGalleryParams, formatPositronVersion } from '../../common/positronGalleryTelemetry.js';
+
+describe('positronGalleryTelemetry', function () {
+	describe('formatPositronVersion', function () {
+		it('appends build number when greater than zero', () => {
+			expect(formatPositronVersion('2026.06.0', 42)).toBe('2026.06.0-42');
+		});
+
+		it('omits build number when zero', () => {
+			expect(formatPositronVersion('2026.06.0', 0)).toBe('2026.06.0');
+		});
+	});
+
+	describe('appendPositronGalleryParams', function () {
+		const baseUrl = 'https://p3m.dev/openvsx/latest/vscode/gallery/extensionquery';
+
+		it('always appends session-type and version', () => {
+			const result = appendPositronGalleryParams(baseUrl, undefined, 'desktop', '2026.06.0-42');
+			expect(result).toBe(`${baseUrl}?positron-session-type=desktop&positron-version=2026.06.0-42`);
+		});
+
+		it('includes check-trigger when provided', () => {
+			const result = appendPositronGalleryParams(baseUrl, 'startup', 'desktop', '2026.06.0-42');
+			expect(result).toBe(`${baseUrl}?positron-check-trigger=startup&positron-session-type=desktop&positron-version=2026.06.0-42`);
+		});
+
+		it('uses & separator when URL already has a query string', () => {
+			const result = appendPositronGalleryParams(`${baseUrl}?foo=1`, 'periodic', 'workbench', '2026.06.0-42');
+			expect(result).toBe(`${baseUrl}?foo=1&positron-check-trigger=periodic&positron-session-type=workbench&positron-version=2026.06.0-42`);
+		});
+
+		it('encodes special characters in version', () => {
+			const result = appendPositronGalleryParams(baseUrl, 'positron-updated', 'positron-server', '2026.06.0+dev');
+			expect(result).toContain('positron-version=2026.06.0%2Bdev');
+		});
+
+		it('emits every session-type value without alteration', () => {
+			for (const sessionType of ['desktop', 'workbench', 'workbench-server', 'positron-server', 'remote-server'] as const) {
+				const result = appendPositronGalleryParams(baseUrl, undefined, sessionType, '2026.06.0');
+				expect(result).toContain(`positron-session-type=${sessionType}`);
+			}
+		});
+	});
+});

--- a/src/vs/platform/extensionManagement/test/common/positronGalleryTelemetry.vitest.ts
+++ b/src/vs/platform/extensionManagement/test/common/positronGalleryTelemetry.vitest.ts
@@ -22,55 +22,65 @@ describe('positronGalleryTelemetry', function () {
 		const baseUrl = 'https://p3m.dev/openvsx/latest/vscode/gallery/extensionquery';
 
 		it('always appends session-type and version', () => {
-			const result = appendPositronGalleryParams(baseUrl, undefined, 'desktop', '2026.06.0-42');
+			const result = appendPositronGalleryParams(baseUrl, undefined, 'desktop', '2026.06.0-42', true);
 			expect(result).toBe(`${baseUrl}?positron-session-type=desktop&positron-version=2026.06.0-42`);
 		});
 
 		it('includes check-trigger when provided', () => {
-			const result = appendPositronGalleryParams(baseUrl, 'startup', 'desktop', '2026.06.0-42');
+			const result = appendPositronGalleryParams(baseUrl, 'startup', 'desktop', '2026.06.0-42', true);
 			expect(result).toBe(`${baseUrl}?positron-check-trigger=startup&positron-session-type=desktop&positron-version=2026.06.0-42`);
 		});
 
 		it('uses & separator when URL already has a query string', () => {
-			const result = appendPositronGalleryParams(`${baseUrl}?foo=1`, 'periodic', 'workbench', '2026.06.0-42');
+			const result = appendPositronGalleryParams(`${baseUrl}?foo=1`, 'periodic', 'workbench', '2026.06.0-42', true);
 			expect(result).toBe(`${baseUrl}?foo=1&positron-check-trigger=periodic&positron-session-type=workbench&positron-version=2026.06.0-42`);
 		});
 
 		it('encodes special characters in version', () => {
-			const result = appendPositronGalleryParams(baseUrl, 'positron-updated', 'positron-server', '2026.06.0+dev');
+			const result = appendPositronGalleryParams(baseUrl, 'positron-updated', 'positron-server', '2026.06.0+dev', true);
 			expect(result).toContain('positron-version=2026.06.0%2Bdev');
 		});
 
 		it('emits every session-type value without alteration', () => {
 			for (const sessionType of ['desktop', 'workbench', 'workbench-server', 'positron-server', 'remote-server'] as const) {
-				const result = appendPositronGalleryParams(baseUrl, undefined, sessionType, '2026.06.0');
+				const result = appendPositronGalleryParams(baseUrl, undefined, sessionType, '2026.06.0', true);
 				expect(result).toContain(`positron-session-type=${sessionType}`);
 			}
 		});
 
 		it('returns the URL unchanged for non-P3M galleries', () => {
 			const openVsx = 'https://open-vsx.org/vscode/gallery/extensionquery';
-			expect(appendPositronGalleryParams(openVsx, 'startup', 'desktop', '2026.06.0')).toBe(openVsx);
+			expect(appendPositronGalleryParams(openVsx, 'startup', 'desktop', '2026.06.0', true)).toBe(openVsx);
 
 			const internal = 'https://gallery.internal.example.com/extensionquery';
-			expect(appendPositronGalleryParams(internal, 'periodic', 'workbench', '2026.06.0')).toBe(internal);
+			expect(appendPositronGalleryParams(internal, 'periodic', 'workbench', '2026.06.0', true)).toBe(internal);
 		});
 
 		it('tags P3M subdomains (e.g. staging)', () => {
 			const staging = 'https://staging.p3m.dev/openvsx/latest/vscode/gallery/extensionquery';
-			const result = appendPositronGalleryParams(staging, 'startup', 'desktop', '2026.06.0');
+			const result = appendPositronGalleryParams(staging, 'startup', 'desktop', '2026.06.0', true);
 			expect(result).toContain('positron-check-trigger=startup');
 		});
 
 		it('does not tag URLs that merely contain p3m.dev as substring', () => {
 			const spoof = 'https://p3m.dev.attacker.com/extensionquery';
-			expect(appendPositronGalleryParams(spoof, 'startup', 'desktop', '2026.06.0')).toBe(spoof);
+			expect(appendPositronGalleryParams(spoof, 'startup', 'desktop', '2026.06.0', true)).toBe(spoof);
 		});
 
 		it('tolerates URI template placeholders in the path', () => {
 			const template = 'https://p3m.dev/openvsx/latest/vscode/gallery/{publisher}/{name}/latest';
-			const result = appendPositronGalleryParams(template, 'startup', 'desktop', '2026.06.0');
+			const result = appendPositronGalleryParams(template, 'startup', 'desktop', '2026.06.0', true);
 			expect(result).toContain('positron-check-trigger=startup');
+		});
+
+		it('returns the URL unchanged when sendUsageData is false', () => {
+			const result = appendPositronGalleryParams(baseUrl, 'startup', 'desktop', '2026.06.0', false);
+			expect(result).toBe(baseUrl);
+		});
+
+		it('respects sendUsageData=false even on a P3M URL with a trigger', () => {
+			const result = appendPositronGalleryParams(baseUrl, 'periodic', 'workbench-server', '2026.06.0-42', false);
+			expect(result).toBe(baseUrl);
 		});
 	});
 

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -169,6 +169,15 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				scope: ConfigurationScope.APPLICATION,
 				tags: ['usesOnlineServices']
 			},
+			// --- Start Positron ---
+			'extensions.gallery.sendUsageData': {
+				type: 'boolean',
+				description: localize('positron.extensions.gallery.sendUsageData', "When enabled, sends Positron distribution type, version, and update-check trigger as query parameters on extension gallery requests. No user-identifying data is sent. Disable this to stop sending these parameters."),
+				default: true,
+				scope: ConfigurationScope.APPLICATION,
+				tags: ['usesOnlineServices']
+			},
+			// --- End Positron ---
 			'extensions.ignoreRecommendations': {
 				type: 'boolean',
 				description: localize('extensionsIgnoreRecommendations', "When enabled, the notifications for extension recommendations will not be shown."),

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -28,6 +28,9 @@ import {
 	shouldRequireRepositorySignatureFor,
 	IGalleryExtensionVersion
 } from '../../../../platform/extensionManagement/common/extensionManagement.js';
+// --- Start Positron ---
+import { PositronCheckTrigger } from '../../../../platform/extensionManagement/common/positronGalleryTelemetry.js';
+// --- End Positron ---
 import { IWorkbenchExtensionEnablementService, EnablementState, IExtensionManagementServerService, IExtensionManagementServer, IWorkbenchExtensionManagementService, IResourceExtension } from '../../../services/extensionManagement/common/extensionManagement.js';
 import { getGalleryExtensionTelemetryData, getLocalExtensionTelemetryData, areSameExtensions, groupByExtension, getGalleryExtensionId, findMatchingMaliciousEntry } from '../../../../platform/extensionManagement/common/extensionManagementUtil.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
@@ -1132,13 +1135,19 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			}
 			if (e.affectsConfiguration(AutoCheckUpdatesConfigurationKey)) {
 				if (this.isAutoCheckUpdatesEnabled()) {
-					this.checkForUpdates(`Enabled auto check updates`);
+					// --- Start Positron ---
+					// this.checkForUpdates(`Enabled auto check updates`);
+					this.checkForUpdates(`Enabled auto check updates`, undefined, 'setting-change');
+					// --- End Positron ---
 				}
 			}
 		}));
 		this._register(this.extensionEnablementService.onEnablementChanged(platformExtensions => {
 			if (this.isAutoCheckUpdatesEnabled() && this.getAutoUpdateValue() === 'onlyEnabledExtensions' && platformExtensions.some(e => this.extensionEnablementService.isEnabled(e))) {
-				this.checkForUpdates('Extension enablement changed');
+				// --- Start Positron ---
+				// this.checkForUpdates('Extension enablement changed');
+				this.checkForUpdates('Extension enablement changed', undefined, 'extension-toggled');
+				// --- End Positron ---
 			}
 		}));
 		this._register(Event.debounce(this.onChange, () => undefined, 100)(() => this.hasOutdatedExtensionsContextKey.set(this.outdated.length > 0)));
@@ -1149,20 +1158,29 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 					comment: 'Report when update check is triggered on product update';
 				}>('extensions:updatecheckonproductupdate');
 				if (this.isAutoCheckUpdatesEnabled()) {
-					this.checkForUpdates('Product update');
+					// --- Start Positron ---
+					// this.checkForUpdates('Product update');
+					this.checkForUpdates('Product update', undefined, 'positron-updated');
+					// --- End Positron ---
 				}
 			}
 		}));
 
 		this._register(this.allowedExtensionsService.onDidChangeAllowedExtensionsConfigValue(() => {
 			if (this.isAutoCheckUpdatesEnabled()) {
-				this.checkForUpdates('Allowed extensions changed');
+				// --- Start Positron ---
+				// this.checkForUpdates('Allowed extensions changed');
+				this.checkForUpdates('Allowed extensions changed', undefined, 'setting-change');
+				// --- End Positron ---
 			}
 		}));
 
 		this._register(this.meteredConnectionService.onDidChangeIsConnectionMetered(() => {
 			if (this.isAutoCheckUpdatesEnabled()) {
-				this.checkForUpdates('Connection is no longer metered');
+				// --- Start Positron ---
+				// this.checkForUpdates('Connection is no longer metered');
+				this.checkForUpdates('Connection is no longer metered', undefined, 'network-unmetered');
+				// --- End Positron ---
 			}
 			if (isWeb && !this.isAutoUpdateEnabled()) {
 				this.autoUpdateBuiltinExtensions();
@@ -1938,7 +1956,12 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		return ExtensionState.Uninstalled;
 	}
 
-	async checkForUpdates(reason?: string, onlyBuiltin?: boolean): Promise<void> {
+	// --- Start Positron ---
+	// Added trailing checkTrigger so callers can label why the check fired. Plumbed onto
+	// the outgoing gallery request via IExtensionQueryOptions.checkTrigger for P3M.
+	// async checkForUpdates(reason?: string, onlyBuiltin?: boolean): Promise<void> {
+	async checkForUpdates(reason?: string, onlyBuiltin?: boolean, checkTrigger?: PositronCheckTrigger): Promise<void> {
+		// --- End Positron ---
 		if (reason) {
 			this.logService.trace(`[Extensions]: Checking for updates. Reason: ${reason}`);
 		} else {
@@ -1989,7 +2012,10 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 				count: infos.length,
 			});
 			this.logService.trace(`Checking updates for extensions`, infos.map(e => e.id).join(', '));
-			const galleryExtensions = await this.galleryService.getExtensions(infos, { targetPlatform, compatible: true, productVersion: this.getProductVersion() }, CancellationToken.None);
+			// --- Start Positron ---
+			// const galleryExtensions = await this.galleryService.getExtensions(infos, { targetPlatform, compatible: true, productVersion: this.getProductVersion() }, CancellationToken.None);
+			const galleryExtensions = await this.galleryService.getExtensions(infos, { targetPlatform, compatible: true, productVersion: this.getProductVersion(), checkTrigger }, CancellationToken.None);
+			// --- End Positron ---
 			if (galleryExtensions.length) {
 				await this.syncInstalledExtensionsWithGallery(galleryExtensions, infos);
 			}
@@ -2131,11 +2157,22 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 		return this.configurationService.getValue(AutoCheckUpdatesConfigurationKey);
 	}
 
+	// --- Start Positron ---
+	// Tracks whether the first (startup) auto check has fired so that subsequent
+	// 12h-interval re-fires get tagged as `periodic` for P3M telemetry.
+	private hasFiredStartupCheck = false;
+	// --- End Positron ---
+
 	private eventuallyCheckForUpdates(immediate = false): void {
 		this.updatesCheckDelayer.cancel();
 		this.updatesCheckDelayer.trigger(async () => {
 			if (this.isAutoCheckUpdatesEnabled()) {
-				await this.checkForUpdates();
+				// --- Start Positron ---
+				// await this.checkForUpdates();
+				const checkTrigger: PositronCheckTrigger = this.hasFiredStartupCheck ? 'periodic' : 'startup';
+				this.hasFiredStartupCheck = true;
+				await this.checkForUpdates(undefined, undefined, checkTrigger);
+				// --- End Positron ---
 			}
 			this.eventuallyCheckForUpdates();
 		}, immediate ? 0 : this.getUpdatesCheckInterval()).then(undefined, err => null);


### PR DESCRIPTION
- [x] TODO for myself: 🚨remove temporary logging of URLs before merging! 🚨 

Closes posit-dev/positron-builds#946

This PR adds three query params to outgoing extension gallery requests that go to P3M (`p3m.dev`):

- `positron-check-trigger` (optional): why an update check fired. One of `startup`, `periodic`, `positron-updated`, `setting-change`, `extension-toggled`, `network-unmetered`. Omitted on browse and other non-update-check traffic, so its presence by itself signals "this was an update check."
- `positron-session-type` (always): which Positron process emitted the request. One of `desktop` (includes front end for remote SSH sessions), `workbench` (front end), `workbench-server` (back end for Workbench), `positron-server` (front end for JupyterHub, etc), `remote-server` (back end for remote SSH, WSL, JupyterHub, etc).
- `positron-version` (always): three-part Positron version with build number, e.g. `2026.06.0-42`.

Tagging is gated to `p3m.dev` hostnames only. Anybody that overrides `extensionsGallery.serviceUrl` to point at Open VSX or another gallery such as an enterprise PPM receive the URL unchanged. No new user-correlatable data is sent (for example, no UUID is currently attached).

The query params can be toggled off with the `extensions.gallery.sendUsageData` setting, to be used by, for example, Workbench admins.

The params apply to both gallery code paths: the bulk POST to `/extensionquery` and the per-extension GET to `/{publisher}/{name}/latest`.

Any P3M counting is going to take some careful thought. One logical update check fans out into many HTTP requests (one GET per installed extension plus 1-3 POSTs), all carrying the same `positron-check-trigger`. For example, counting up POSTs to <https://p3m.dev/openvsx/latest/vscode/gallery/extensionquery?positron-check-trigger=startup> will overcount session starts by ~3. We might look at counting something like GETS to <https://p3m.dev/openvsx/latest/vscode/gallery/quarto/quarto/latest?positron-check-trigger=startup> for a few extensions and comparing; that estimate would get us something close to session starts.

### Release Notes

#### New Features

- Send distribution type, Positron version, and update-check trigger as query params on extension gallery requests to P3M, for load sizing and traffic disambiguation (posit-dev/positron-builds#946).

#### Bug Fixes

- N/A

### Validation Steps

@:extensions

1. Launch Positron and check the Output panel "Log (Window)" for `[p3m] POST` and `[p3m] GET` lines. Confirm each URL has `positron-check-trigger=startup&positron-session-type=desktop&positron-version=...` appended.
2. Trigger a periodic check (shorten `UpdatesCheckInterval` temporarily or wait 12h) and confirm `positron-check-trigger=periodic`.
3. Toggle an installed extension off/on; confirm `positron-check-trigger=extension-toggled`.
4. Toggle the `extensions.autoCheckUpdates` setting; confirm `positron-check-trigger=setting-change`.
5. Search the Extensions view (browse path); confirm `positron-session-type` and `positron-version` are present but `positron-check-trigger` is absent.
6. Connect to a remote (SSH/WSL/dev container) and install a workspace extension. Confirm the remote-side hit tags `positron-session-type=remote-server` while desktop-side hits stay `positron-session-type=desktop`.
7. Override `product.json` locally to set `extensionsGallery.serviceUrl` to `https://open-vsx.org/vscode/gallery`. Confirm no `positron-*` params are appended.
8. Change `extensions.gallery.sendUsageData` setting from its default and confirm that the query params are not added.
