### PR TITLE
Update/positron list single selection

### DIFF
--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.tsx
@@ -158,9 +158,8 @@ type DefaultCursorOptions = | {
  *   - 'list-multiple-selection': the cursor row is always selected (re-selected after every
  *     move), and Shift+navigation, Shift+click, Ctrl/Cmd+click, and selectAll build multi-row
  *     selections.
- *   - 'list-single-selection': the selection is always exactly the cursor row. Shift+navigation,
- *     Shift+click, Ctrl/Cmd+click, and selectAll collapse to a plain single-row select on the
- *     cursor.
+ *   - 'list-single-selection': the selection tracks the cursor row as a single-row selection.
+ *     Shift+navigation, Shift+click, and Ctrl/Cmd+click do not create multi-row selections.
  */
 export type SelectionMode = 'spreadsheet' | 'list-multiple-selection' | 'list-single-selection';
 

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.tsx
@@ -150,14 +150,19 @@ type DefaultCursorOptions = | {
 };
 
 /**
- * SelectionMode type. Controls how plain (non-shift) keyboard navigation interacts with the
- * selection:
- *   - 'spreadsheet' (default): navigation clears selection -- cursor and selection are separate.
- *   - 'list': navigation re-selects the cursor row after moving -- single-select tracks the cursor.
- *
- * Shift+navigation goes through extendRowSelection regardless of the mode.
+ * SelectionMode type. Controls how the grid couples cursor movement, keyboard, and mouse input to
+ * the selection:
+ *   - 'spreadsheet' (default): cursor and selection are independent. Plain navigation clears the
+ *     selection; Shift+navigation extends it; Ctrl/Cmd+click and Shift+click build multi/range
+ *     row selections.
+ *   - 'list-multiple-selection': the cursor row is always selected (re-selected after every
+ *     move), and Shift+navigation, Shift+click, Ctrl/Cmd+click, and selectAll build multi-row
+ *     selections.
+ *   - 'list-single-selection': the selection is always exactly the cursor row. Shift+navigation,
+ *     Shift+click, Ctrl/Cmd+click, and selectAll collapse to a plain single-row select on the
+ *     cursor.
  */
-export type SelectionMode = 'spreadsheet' | 'list';
+export type SelectionMode = 'spreadsheet' | 'list-multiple-selection' | 'list-single-selection';
 
 /**
  * SelectionOptions type. Discriminated on `selection`: when selection is disabled, there is
@@ -175,11 +180,12 @@ type SelectionOptions =
 	}
 	| {
 		// Selection enabled (the default): mouse clicks and keyboard navigation populate the
-		// cell/column/row selection buckets, and shift-modified keys extend the selection.
+		// cell/column/row selection buckets. Whether Shift and Ctrl/Cmd modifiers extend the
+		// selection depends on selectionMode.
 		selection?: true;
 
-		// How plain (non-shift) navigation interacts with selection. Defaults to 'spreadsheet'.
-		// See SelectionMode for details.
+		// How cursor movement and modifier keys interact with selection. Defaults to
+		// 'spreadsheet'. See SelectionMode for details.
 		selectionMode?: SelectionMode;
 	};
 
@@ -701,7 +707,7 @@ export abstract class DataGridInstance extends Disposable {
 	private readonly _selection: boolean;
 
 	/**
-	 * Gets the selection mode -- 'spreadsheet' (default) or 'list'. See SelectionMode for details.
+	 * Gets the selection mode.
 	 */
 	private readonly _selectionMode: SelectionMode;
 
@@ -2255,14 +2261,14 @@ export abstract class DataGridInstance extends Disposable {
 	 * Mouse selects a cell.
 	 * @param columnIndex The column index.
 	 * @param rowIndex The row index.
-	 * @param selectionType The mouse selection type.
+	 * @param mouseSelectionType The mouse selection type.
 	 * @returns A Promise<boolean> that resolves when the operation is complete.
 	 */
 	async mouseSelectCell(
 		columnIndex: number,
 		rowIndex: number,
 		pinned: boolean,
-		selectionType: MouseSelectionType
+		mouseSelectionType: MouseSelectionType
 	): Promise<void> {
 		// Subclass-marked non-selectable rows (e.g. section headers) absorb the click silently;
 		// the cursor stays put and the current selection is preserved.
@@ -2277,7 +2283,7 @@ export abstract class DataGridInstance extends Disposable {
 		this._rowSelectionIndexes = undefined;
 
 		// Process the selection based on selection type.
-		switch (selectionType) {
+		switch (mouseSelectionType) {
 			// Single selection.
 			case MouseSelectionType.Single: {
 				// Clear cell selection.
@@ -2382,10 +2388,10 @@ export abstract class DataGridInstance extends Disposable {
 	/**
 	 * Mouse selects a column.
 	 * @param columnIndex The column index.
-	 * @param selectionType The selection type.
+	 * @param mouseSelectionType The selection type.
 	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	async mouseSelectColumn(columnIndex: number, selectionType: MouseSelectionType): Promise<void> {
+	async mouseSelectColumn(columnIndex: number, mouseSelectionType: MouseSelectionType): Promise<void> {
 		// Clear cell selection.
 		this._cellSelectionIndexes = undefined;
 
@@ -2403,7 +2409,7 @@ export abstract class DataGridInstance extends Disposable {
 		};
 
 		// Process the selection based on selection type.
-		switch (selectionType) {
+		switch (mouseSelectionType) {
 			// Single selection.
 			case MouseSelectionType.Single: {
 				// Single select the column.
@@ -2517,14 +2523,20 @@ export abstract class DataGridInstance extends Disposable {
 	/**
 	 * Mouse selects a row.
 	 * @param rowIndex The row index.
-	 * @param selectionType The selection type.
+	 * @param mouseSelectionType The selection type.
 	 * @returns A Promise<void> that resolves when the operation is complete.
 	 */
-	async mouseSelectRow(rowIndex: number, selectionType: MouseSelectionType): Promise<void> {
+	async mouseSelectRow(rowIndex: number, mouseSelectionType: MouseSelectionType): Promise<void> {
 		// Subclass-marked non-selectable rows (e.g. section headers) absorb the click silently;
 		// the cursor stays put and the current selection is preserved.
 		if (!this.isRowSelectable(rowIndex)) {
 			return;
+		}
+
+		// In 'list-single-selection' mode the selection is always exactly the cursor row, so
+		// Shift+click (Range) and Ctrl/Cmd+click (Multi) collapse to a plain single-row click.
+		if (this._selectionMode === 'list-single-selection') {
+			mouseSelectionType = MouseSelectionType.Single;
 		}
 
 		// Clear cell selection.
@@ -2544,7 +2556,7 @@ export abstract class DataGridInstance extends Disposable {
 		};
 
 		// Process the selection based on selection type.
-		switch (selectionType) {
+		switch (mouseSelectionType) {
 			// Single selection.
 			case MouseSelectionType.Single: {
 				// Single select the row.

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridColumnHeader.tsx
@@ -12,7 +12,7 @@ import { MouseEvent, useRef } from 'react';
 // Other dependencies.
 import * as nls from '../../../../nls.js';
 import { IDataColumn } from '../interfaces/dataColumn.js';
-import { selectionType } from '../utilities/mouseUtilities.js';
+import { mouseSelectionType } from '../utilities/mouseUtilities.js';
 import { ColumnSelectionState } from '../classes/dataGridInstance.js';
 import { usePositronDataGridContext } from '../positronDataGridContext.js';
 import { positronClassNames } from '../../../../base/common/positronUtilities.js';
@@ -69,7 +69,7 @@ export const DataGridColumnHeader = (props: DataGridColumnHeaderProps) => {
 		// If the column selection state is None, and selection is enabled, mouse-select the column.
 		// Otherwise, scroll the column into view.
 		if (columnSelectionState === ColumnSelectionState.None && context.instance.selection) {
-			await context.instance.mouseSelectColumn(props.columnIndex, selectionType(e));
+			await context.instance.mouseSelectColumn(props.columnIndex, mouseSelectionType(e));
 		} else {
 			await context.instance.scrollToColumn(props.columnIndex);
 		}

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowCell.tsx
@@ -10,7 +10,7 @@ import './dataGridRowCell.css';
 import { MouseEvent, useRef } from 'react';
 
 // Other dependencies.
-import { selectionType } from '../utilities/mouseUtilities.js';
+import { mouseSelectionType } from '../utilities/mouseUtilities.js';
 import { CellSelectionState } from '../classes/dataGridInstance.js';
 import { usePositronDataGridContext } from '../positronDataGridContext.js';
 import { positronClassNames } from '../../../../base/common/positronUtilities.js';
@@ -69,7 +69,7 @@ export const DataGridRowCell = (props: DataGridRowCellProps) => {
 					props.columnIndex,
 					props.rowIndex,
 					props.pinned,
-					selectionType(e)
+					mouseSelectionType(e)
 				);
 			} else {
 				// Scroll to the cell.

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridRowHeader.tsx
@@ -11,7 +11,7 @@ import { MouseEvent, useRef } from 'react';
 
 // Other dependencies.
 import { positronClassNames } from '../../../../base/common/positronUtilities.js';
-import { selectionType } from '../utilities/mouseUtilities.js';
+import { mouseSelectionType } from '../utilities/mouseUtilities.js';
 import { RowSelectionState } from '../classes/dataGridInstance.js';
 import { VerticalSplitter } from '../../../../base/browser/ui/positronComponents/splitters/verticalSplitter.js';
 import { HorizontalSplitter } from '../../../../base/browser/ui/positronComponents/splitters/horizontalSplitter.js';
@@ -58,7 +58,7 @@ export const DataGridRowHeader = (props: DataGridRowHeaderProps) => {
 		// If the row selection state is None, and selection is enabled, mouse-select the row.
 		// Otherwise, scroll the row into view.
 		if (rowSelectionState === RowSelectionState.None && context.instance.selection) {
-			await context.instance.mouseSelectRow(props.rowIndex, selectionType(e));
+			await context.instance.mouseSelectRow(props.rowIndex, mouseSelectionType(e));
 		} else {
 			await context.instance.scrollToRow(props.rowIndex);
 		}

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -175,21 +175,28 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 
 		// Applies the per-key selection policy around cursor navigation. In spreadsheet mode
 		// (the default), selection is cleared before the cursor moves so cursor and selection
-		// are independent. In list mode, selection collapses onto the new cursor row after the
-		// move so single-select tracks the cursor. The `selection` guards keep these no-ops
-		// when selection is disabled on the grid.
+		// are independent. In either list mode, selection collapses onto the new cursor row
+		// after the move so the selection tracks the cursor. The `selection` guards keep these
+		// no-ops when selection is disabled on the grid.
+		const selectionMode = context.instance.selectionMode;
+		const isListMode = selectionMode === 'list-multiple-selection' || selectionMode === 'list-single-selection';
 		const navigationSelection = {
 			beforeMoveCursor: () => {
-				if (context.instance.selection && context.instance.selectionMode === 'spreadsheet') {
+				if (context.instance.selection && selectionMode === 'spreadsheet') {
 					context.instance.clearSelection();
 				}
 			},
 			afterMoveCursor: () => {
-				if (context.instance.selection && context.instance.selectionMode === 'list') {
+				if (context.instance.selection && isListMode) {
 					context.instance.selectRow(context.instance.cursorRowIndex);
 				}
 			}
 		};
+
+		// In 'list-single-selection' mode the selection is always exactly the cursor row, so
+		// Shift extension keys fall through to plain navigation (which collapses onto the cursor
+		// via afterMoveCursor). Ctrl+Shift+Space (select all) is likewise gated off below.
+		const allowExtend = selectionMode !== 'list-single-selection';
 
 		// Process the code.
 		switch (e.code) {
@@ -235,7 +242,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 						context.instance.selectColumn(context.instance.cursorColumnIndex);
 					} else if (e.shiftKey && !e.ctrlKey) {
 						context.instance.selectRow(context.instance.cursorRowIndex);
-					} else if (e.ctrlKey && e.shiftKey) {
+					} else if (e.ctrlKey && e.shiftKey && allowExtend) {
 						context.instance.selectAll();
 					}
 				}
@@ -268,8 +275,8 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 					return;
 				}
 
-				// Shift + Home does nothing.
-				if (e.shiftKey) {
+				// Shift + Home extends the row selection up by one screen.
+				if (e.shiftKey && allowExtend) {
 					context.instance.extendRowSelectionUp(ExtendRowSelectionBy.Screen);
 					return;
 				}
@@ -313,8 +320,8 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 					return;
 				}
 
-				// Shift + End does nothing.
-				if (e.shiftKey) {
+				// Shift + End extends the row selection down by one screen.
+				if (e.shiftKey && allowExtend) {
 					context.instance.extendRowSelectionDown(ExtendRowSelectionBy.Screen);
 					return;
 				}
@@ -367,7 +374,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 				}
 
 				// Range selection.
-				if (e.shiftKey) {
+				if (e.shiftKey && allowExtend) {
 					context.instance.extendRowSelectionUp(ExtendRowSelectionBy.Page);
 					return;
 				}
@@ -399,7 +406,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 				}
 
 				// Range selection.
-				if (e.shiftKey) {
+				if (e.shiftKey && allowExtend) {
 					context.instance.extendRowSelectionDown(ExtendRowSelectionBy.Page);
 					return;
 				}
@@ -433,7 +440,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 				// When selection is enabled, perform selection processing.
 				if (context.instance.selection) {
 					// Extend selection up.
-					if (e.shiftKey) {
+					if (e.shiftKey && allowExtend) {
 						context.instance.extendRowSelectionUp(ExtendRowSelectionBy.Row);
 						return;
 					}
@@ -469,7 +476,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 				// When selection is enabled, perform selection processing.
 				if (context.instance.selection) {
 					// Extend selection down.
-					if (e.shiftKey) {
+					if (e.shiftKey && allowExtend) {
 						context.instance.extendRowSelectionDown(ExtendRowSelectionBy.Row);
 						return;
 					}
@@ -505,7 +512,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 				// When selection is enabled, perform selection processing.
 				if (context.instance.selection) {
 					// Extend selection left.
-					if (e.shiftKey) {
+					if (e.shiftKey && allowExtend) {
 						context.instance.extendColumnSelectionLeft(ExtendColumnSelectionBy.Column);
 						return;
 					}
@@ -541,7 +548,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 				// When selection is enabled, perform selection processing.
 				if (context.instance.selection) {
 					// Extend selection right.
-					if (e.shiftKey) {
+					if (e.shiftKey && allowExtend) {
 						context.instance.extendColumnSelectionRight(ExtendColumnSelectionBy.Column);
 						return;
 					}

--- a/src/vs/workbench/browser/positronDataGrid/utilities/mouseUtilities.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/utilities/mouseUtilities.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2023-2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2023-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -15,7 +15,7 @@ import { MouseSelectionType } from '../classes/dataGridInstance.js';
  * @param e The MouseEvent.
  * @returns The MouseSelectionType.
  */
-export const selectionType = (e: MouseEvent): MouseSelectionType => {
+export const mouseSelectionType = (e: MouseEvent): MouseSelectionType => {
 	// Shift (for range) has a higher priority than the meta / ctrl key (for multiple).
 	if (e.shiftKey) {
 		return MouseSelectionType.Range;

--- a/src/vs/workbench/browser/positronList/classes/positronListInstance.tsx
+++ b/src/vs/workbench/browser/positronList/classes/positronListInstance.tsx
@@ -66,11 +66,19 @@ export type ListEntry<TItem, TSection> =
 	| { readonly kind: 'section'; readonly section: TSection };
 
 /**
+ * PositronListSelectionMode type. Multiple- or single-selection mode for the list.
+ */
+export type PositronListSelectionMode = 'list-multiple-selection' | 'list-single-selection';
+
+/**
  * PositronListBaseOptions type. Options common to both sectioned and non-sectioned lists.
  */
 type PositronListBaseOptions = {
 	// A value which indicates whether to use the default styling.
 	readonly useDefaultStyling?: boolean;
+
+	// Multiple- or single-selection mode. Defaults to 'list-single-selection'.
+	readonly selectionMode?: PositronListSelectionMode;
 };
 
 /**
@@ -182,7 +190,7 @@ export class PositronListInstance<TItem, TSection = never> extends DataGridInsta
 			cellBorders: false,
 			internalCursor: false,
 			selection: true,
-			selectionMode: 'list',
+			selectionMode: options.selectionMode ?? 'list-single-selection',
 		});
 
 		// Default to applying the built-in focused/selected classes.
@@ -394,9 +402,9 @@ export class PositronListInstance<TItem, TSection = never> extends DataGridInsta
 		_columnIndex: number,
 		rowIndex: number,
 		_pinned: boolean,
-		selectionType: MouseSelectionType
+		mouseSelectionType: MouseSelectionType
 	): Promise<void> {
-		await this.mouseSelectRow(rowIndex, selectionType);
+		await this.mouseSelectRow(rowIndex, mouseSelectionType);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionsPanel.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/components/dataConnectionsPanel.tsx
@@ -70,7 +70,7 @@ export const DataConnectionsPanel = ({ active }: DataConnectionsPanelProps) => {
 		// Disposable store to hold our listeners so we can clean them up on unmount.
 		const disposableStore = new DisposableStore();
 
-		// Subscribe to future changes.
+		// Subscribe to future changes in instances and profiles.
 		disposableStore.add(positronDataConnectionsService.onDidChangeInstances(updatedInstances => {
 			setInstances(updatedInstances);
 		}));
@@ -81,7 +81,7 @@ export const DataConnectionsPanel = ({ active }: DataConnectionsPanelProps) => {
 		// Resync to current state. The lazy useState initializers ran during render; the service
 		// may have fired a change between then and now (effect commit).
 		setInstances(positronDataConnectionsService.getInstances());
-		setProfiles(Array.from({ length: 100 }, () => positronDataConnectionsService.getProfiles()).flat());
+		setProfiles(positronDataConnectionsService.getProfiles());
 
 		// Clean up listeners on unmount.
 		return () => disposableStore.dispose();

--- a/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
+++ b/src/vs/workbench/services/positronDataExplorer/browser/tableSummaryDataGridInstance.tsx
@@ -27,7 +27,7 @@ import { BackendState, ColumnDisplayType, ColumnProfileType, SearchSchemaSortOrd
  */
 const SUMMARY_HEIGHT = 34;
 const PROFILE_LINE_HEIGHT = 20;
-const OVERSCAN_FACTOR = 3
+const OVERSCAN_FACTOR = 3;
 
 /**
  * TableSummaryDataGridInstance class.


### PR DESCRIPTION
## Summary

Splits the DataGrid `'list'` selection mode into two distinct modes and wires the new single-selection variant through the keyboard and mouse handlers.

## Changes

### `SelectionMode` is now three-valued

`'list'` -> `'list-multiple-selection'` | `'list-single-selection'`. The previous `'list'` mode mapped to today's `'list-multiple-selection'`. The new `'list-single-selection'` mode guarantees the selection is always exactly the cursor row.

| Mode | Cursor vs. selection | Shift+nav / Shift+click | Ctrl/Cmd+click | Select all |
|---|---|---|---|---|
| `spreadsheet` (default) | Independent | Extends | Multi-selects | Enabled |
| `list-multiple-selection` | Selection follows cursor | Extends | Multi-selects | Enabled |
| `list-single-selection` | Selection == cursor row | Collapses to single | Collapses to single | No-op |

### Keyboard (`dataGridWaffle.tsx`)

- `afterMoveCursor` now re-selects the cursor row for *either* list mode (previously just `'list'`).
- New `allowExtend` gate (`selectionMode !== 'list-single-selection'`) disables `Shift+Arrow`, `Shift+Home/End`, `Shift+PageUp/PageDown`, and `Ctrl+Shift+Space` (select all) in single-selection mode -- they fall through to plain navigation, which collapses onto the cursor via `afterMoveCursor`.
- Drive-by: `Shift+Home` / `Shift+End` now extend the row selection by a screen (previously documented as "does nothing"). This applies in `spreadsheet` and `list-multiple-selection`.

### Mouse (`dataGridInstance.tsx`)

`mouseSelectRow` collapses `MouseSelectionType.Range` (Shift+click) and `MouseSelectionType.Multi` (Ctrl/Cmd+click) to `Single` when the grid is in `'list-single-selection'`.

### PositronList (`positronListInstance.tsx`)

- New `PositronListSelectionMode` type exported alongside `ListEntry`.
- New optional `selectionMode` on `PositronListBaseOptions`. **Default is `'list-single-selection'`** -- existing PositronList consumers move from multi to single by default.

### Rename: `selectionType` -> `mouseSelectionType`

The free function in `mouseUtilities.tsx` and the parameter on `mouseSelectCell` / `mouseSelectColumn` / `mouseSelectRow` were renamed to disambiguate from the new `SelectionMode` concept. Pure rename, no behavior change. Call sites in `dataGridColumnHeader.tsx`, `dataGridRowCell.tsx`, `dataGridRowHeader.tsx`, and the `PositronListInstance.mouseSelectCell` override updated to match.

### Drive-by

- Missing semicolon on `OVERSCAN_FACTOR` in `tableSummaryDataGridInstance.tsx`.
- Copyright bump in `mouseUtilities.tsx` to 2026.

## Migration notes

Any existing caller passing `selectionMode: 'list'` to `DataGridInstance` will fail to compile -- pick `'list-multiple-selection'` (previous behavior) or `'list-single-selection'`. `PositronListInstance` consumers get `'list-single-selection'` by default and must opt in to multi-selection.

Tests:
@:data-explorer

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

- N/A