### PR TITLE
Scale action bar in Variables pane more gracefully

### DIFF
--- a/src/vs/workbench/contrib/positronVariables/browser/components/actionBars.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/actionBars.tsx
@@ -17,7 +17,7 @@ import { ActionBarButton } from '../../../../../platform/positronActionBar/brows
 import { ActionBarFilter, ActionBarFilterHandle } from '../../../../../platform/positronActionBar/browser/components/actionBarFilter.js';
 import { SortingMenuButton } from './sortingMenuButton.js';
 import { GroupingMenuButton } from './groupingMenuButton.js';
-import { MemoryUsageMeter, MEMORY_METER_FIXED_WIDTH, MEMORY_METER_COMPACT_FIXED_WIDTH } from './memoryUsageMeter.js';
+import { MemoryUsageMeter, MEMORY_METER_CHROME_WIDTH, MEMORY_METER_NO_BAR_WIDTH, MEMORY_BAR_MAX_WIDTH, MEMORY_BAR_MIN_WIDTH } from './memoryUsageMeter.js';
 import { PositronActionBarContextProvider } from '../../../../../platform/positronActionBar/browser/positronActionBarContext.js';
 import { usePositronVariablesContext } from '../positronVariablesContext.js';
 import { DeleteAllVariablesModalDialog } from '../modalDialogs/deleteAllVariablesModalDialog.js';
@@ -194,8 +194,17 @@ export const ActionBars = (props: PropsWithChildren<{}>) => {
 		kPaddingLeft + kPaddingRight;
 
 	// Include the memory meter when enabled and the action bar is wide enough.
-	// Three visual states: full (bar + label), compact (label only), hidden.
+	// Three visual states based on available space:
+	//   - Bar + label + arrow: bar scales between MIN and MAX widths.
+	//   - Label + arrow: bar omitted when even a minimum-width bar won't fit.
+	//   - Hidden: not enough room for the label.
 	// When no snapshot is available yet, show in loading state with "Mem" label.
+	//
+	// Note: we pre-compute the meter's full pixel width and pass it via
+	// `fixedWidth` rather than letting DynamicActionBar measure the label
+	// itself. DAB's measurement uses a 12px-font exemplar, but the label
+	// renders at 10px (see memoryUsageMeter.css), so DAB would over-allocate
+	// the meter cell and steal space from the sorting button.
 	if (memoryEnabled) {
 		const loading = !memorySnapshot;
 		const sizeLabel = loading
@@ -205,29 +214,27 @@ export const ActionBars = (props: PropsWithChildren<{}>) => {
 				memorySnapshot.positronOverheadBytes +
 				memorySnapshot.extensionHostOverheadBytes
 			);
-		// Approximate the text width at 12px font. The DynamicActionBar
-		// measures precisely via Canvas; this just needs to be close enough
-		// for the show/hide threshold (slightly under is fine -- the
-		// DynamicActionBar handles overflow gracefully if we're off by a few px).
-		const textWidth = sizeLabel.length * 5.5;
-		const fullMeterWidth = MEMORY_METER_FIXED_WIDTH + textWidth + DEFAULT_ACTION_BAR_SEPARATOR_WIDTH;
-		const compactMeterWidth = MEMORY_METER_COMPACT_FIXED_WIDTH + textWidth + DEFAULT_ACTION_BAR_SEPARATOR_WIDTH;
+		// Approximate the label's rendered width at 10px font, clamped to the
+		// CSS min-width on .memory-size-label. Slightly conservative so the
+		// content never overflows the cell.
+		const labelWidth = Math.max(35, Math.ceil(sizeLabel.length * 6));
 
-		if (actionBarWidth >= baseWidth + fullMeterWidth) {
-			// Full meter: bar + label + arrow.
+		// Space remaining for the meter after the other actions and a separator.
+		const meterSpace = actionBarWidth - baseWidth - DEFAULT_ACTION_BAR_SEPARATOR_WIDTH;
+		const spaceForBar = meterSpace - MEMORY_METER_CHROME_WIDTH - labelWidth;
+
+		if (spaceForBar >= MEMORY_BAR_MIN_WIDTH) {
+			const barWidth = Math.min(MEMORY_BAR_MAX_WIDTH, Math.floor(spaceForBar));
 			rightActions.push({
-				fixedWidth: MEMORY_METER_FIXED_WIDTH,
-				text: sizeLabel,
+				fixedWidth: MEMORY_METER_CHROME_WIDTH + barWidth + labelWidth,
+				separator: true,
+				component: <MemoryUsageMeter barWidth={barWidth} loading={loading} snapshot={memorySnapshot} />
+			});
+		} else if (meterSpace >= MEMORY_METER_NO_BAR_WIDTH + labelWidth) {
+			rightActions.push({
+				fixedWidth: MEMORY_METER_NO_BAR_WIDTH + labelWidth,
 				separator: true,
 				component: <MemoryUsageMeter loading={loading} snapshot={memorySnapshot} />
-			});
-		} else if (actionBarWidth >= baseWidth + compactMeterWidth) {
-			// Compact meter: label + arrow only (no bar).
-			rightActions.push({
-				fixedWidth: MEMORY_METER_COMPACT_FIXED_WIDTH,
-				text: sizeLabel,
-				separator: true,
-				component: <MemoryUsageMeter compact loading={loading} snapshot={memorySnapshot} />
 			});
 		}
 		// Otherwise: hidden entirely.

--- a/src/vs/workbench/contrib/positronVariables/browser/components/memoryUsageBar.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/memoryUsageBar.tsx
@@ -15,6 +15,7 @@ import { IMemoryUsageSnapshot } from '../../../../../platform/positronMemoryUsag
 interface MemoryUsageBarProps {
 	snapshot: IMemoryUsageSnapshot;
 	className?: string;
+	style?: React.CSSProperties;
 	highlightedIds?: ReadonlySet<string> | null;
 	onSegmentHover?: (id: string | null) => void;
 }
@@ -29,7 +30,7 @@ interface MemoryUsageBarProps {
  * table row highlights exactly one sub-segment in this bar, and vice versa.
  */
 export const MemoryUsageBar = (props: MemoryUsageBarProps) => {
-	const { snapshot, className, highlightedIds, onSegmentHover } = props;
+	const { snapshot, className, style, highlightedIds, onSegmentHover } = props;
 	const total = snapshot.totalSystemMemory || 1; // avoid division by zero
 
 	// Build sub-segments: one per session, one per overhead item, one for other.
@@ -91,7 +92,7 @@ export const MemoryUsageBar = (props: MemoryUsageBarProps) => {
 		: 'memory-bar-container';
 
 	return (
-		<div className={containerClass}>
+		<div className={containerClass} style={style}>
 			{elements}
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronVariables/browser/components/memoryUsageMeter.css
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/memoryUsageMeter.css
@@ -68,8 +68,8 @@
 
 /* Toolbar-specific bar sizing */
 
+/* Bar width is set via inline style so it scales with the available space. */
 .memory-usage-meter .memory-bar-container {
-	width: 100px;
 	flex-shrink: 0;
 	height: 10px;
 }

--- a/src/vs/workbench/contrib/positronVariables/browser/components/memoryUsageMeter.tsx
+++ b/src/vs/workbench/contrib/positronVariables/browser/components/memoryUsageMeter.tsx
@@ -22,20 +22,31 @@ import { MemoryUsageDropdown } from './memoryUsageDropdown.js';
 import { MemoryUsageBar } from './memoryUsageBar.js';
 
 /**
- * The fixed-width portion of the full meter (bar + arrow + gaps + padding),
- * excluding the dynamic size label text.
+ * The fixed-width portion of the meter when the bar is present, excluding the
+ * bar itself and the dynamic size label text.
  *
- * bar(100) + gap(6) + gap(6) + arrow(14) + padding(4+4) = 134
+ * gap(6) + gap(6) + arrow(14) + padding(4+4) = 34
  */
-export const MEMORY_METER_FIXED_WIDTH = 134;
+export const MEMORY_METER_CHROME_WIDTH = 34;
 
 /**
- * The fixed-width portion of the compact meter (arrow + gap + padding only,
- * no bar), excluding the dynamic size label text.
+ * The fixed-width portion of the meter when the bar is omitted (label + arrow
+ * only), excluding the dynamic size label text.
  *
  * gap(6) + arrow(14) + padding(4+4) = 28
  */
-export const MEMORY_METER_COMPACT_FIXED_WIDTH = 28;
+export const MEMORY_METER_NO_BAR_WIDTH = 28;
+
+/**
+ * The bar's maximum width (when the action bar has ample space).
+ */
+export const MEMORY_BAR_MAX_WIDTH = 100;
+
+/**
+ * The bar's minimum width before the caller should fall back to a label-only
+ * meter (no bar).
+ */
+export const MEMORY_BAR_MIN_WIDTH = 27;
 
 /**
  * The label shown while memory data is still being computed.
@@ -52,7 +63,12 @@ const computingLabel = localize('positron.memoryUsage.computing', "Computing mem
  */
 interface MemoryUsageMeterProps {
 	snapshot?: IMemoryUsageSnapshot;
-	compact?: boolean;
+	/**
+	 * Width of the segmented bar, in px. Scales between MEMORY_BAR_MIN_WIDTH
+	 * and MEMORY_BAR_MAX_WIDTH. Omit to render a label-only meter (no bar) for
+	 * very narrow layouts.
+	 */
+	barWidth?: number;
 	loading?: boolean;
 }
 
@@ -64,7 +80,7 @@ interface MemoryUsageMeterProps {
  * When `loading` is true, renders an empty bar with a "Mem" label. Clicking
  * in this state shows a popup with a "Computing memory usage..." message.
  */
-export const MemoryUsageMeter = ({ snapshot, compact, loading }: MemoryUsageMeterProps) => {
+export const MemoryUsageMeter = ({ snapshot, barWidth, loading }: MemoryUsageMeterProps) => {
 	// Services.
 	const services = usePositronReactServicesContext();
 	const actionBarContext = usePositronActionBarContext();
@@ -130,8 +146,8 @@ export const MemoryUsageMeter = ({ snapshot, compact, loading }: MemoryUsageMete
 				onMouseEnter={onMouseEnter}
 				onMouseLeave={onMouseLeave}
 			>
-				{!compact && (
-					<div className='memory-bar-container'>
+				{barWidth !== undefined && (
+					<div className='memory-bar-container' style={{ width: barWidth }}>
 						{/* Empty bar -- no segments */}
 					</div>
 				)}
@@ -191,7 +207,9 @@ export const MemoryUsageMeter = ({ snapshot, compact, loading }: MemoryUsageMete
 			onMouseEnter={onMouseEnter}
 			onMouseLeave={onMouseLeave}
 		>
-			{!compact && <MemoryUsageBar snapshot={snapshot} />}
+			{barWidth !== undefined && (
+				<MemoryUsageBar snapshot={snapshot} style={{ width: barWidth }} />
+			)}
 			<span className='memory-size-label'>{sizeLabel}</span>
 			<div className='memory-drop-down-arrow codicon codicon-positron-drop-down-arrow' />
 		</div>


### PR DESCRIPTION
Cleans up some janky width adaption in the Variables pane. Before, the memory usage meter was all-or-nothing and the sorting button jumped around a bit (appearing and disappearing and appearing again).

https://github.com/user-attachments/assets/553ba055-d51c-4daa-b12a-09d89149e954

Now, the memory usage meter scales a bit and the layout is stable.

https://github.com/user-attachments/assets/b4a72712-dc16-4878-93fc-967d8a4c79c7

Closes https://github.com/posit-dev/positron/issues/12734. 

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Improve layout of the Variables pane at narrower widths (#12734)


### Validation Steps

Make the Variables pane wide. Then, make it narrow. Then, make it wide again.