### PR TITLE
e2e test - Python `venv` auto-creation

### DIFF
--- a/test/e2e/tests/interpreters/python-venv-creation.test.ts
+++ b/test/e2e/tests/interpreters/python-venv-creation.test.ts
@@ -13,7 +13,7 @@ test.use({
 });
 
 test.describe('Python Venv Auto-Creation', {
-	tag: [tags.INTERPRETER]
+	tag: [tags.INTERPRETER, tags.WIN, tags.WEB]
 }, () => {
 
 	const fixtureBase = 'qa-example-content/workspaces/python-venv-creation';

--- a/test/e2e/tests/interpreters/python-venv-creation.test.ts
+++ b/test/e2e/tests/interpreters/python-venv-creation.test.ts
@@ -18,29 +18,12 @@ test.describe('Python Venv Auto-Creation', {
 }, () => {
 	test.slow();
 
-	const fixtureBase = 'qa-example-content/workspaces/python-venv-creation';
-
 	test.beforeAll(async function ({ settings }) {
 		await settings.set({
 			'python.createEnvironment.trigger': 'prompt',
 			'interpreters.startupBehavior': 'auto',
+			'python.defaultInterpreterPath': '/usr/bin/python3',
 		}, { reload: 'web' });
-	});
-
-	test('Notification appears for workspace with requirements.txt', async function ({ app, openFolder }) {
-		await openFolder(`${fixtureBase}/with-requirements`);
-		await app.workbench.sessions.expectNoStartUpMessaging();
-
-		const toast = app.workbench.toasts.toastNotification.filter({ hasText: /requirements\.txt/ });
-		await expect(toast).toBeVisible({ timeout: 60000 });
-		await app.workbench.toasts.expectToastWithTitle(/uv/);
-		await app.workbench.toasts.closeWithHeader(/requirements\.txt/);
-	});
-
-	test('No notification when .venv already exists', async function ({ app, openFolder }) {
-		await openFolder(`${fixtureBase}/with-existing-venv`);
-
-		await app.workbench.toasts.expectToastWithTitleNotToAppear(/requirements\.txt/);
 	});
 
 	test('Clicking Yes creates venv', async function ({ app, openFolder }) {
@@ -65,5 +48,21 @@ test.describe('Python Venv Auto-Creation', {
 		} finally {
 			await fs.rm(tempWorkspace, { recursive: true, force: true }).catch(() => { });
 		}
+	});
+
+	test('Notification appears for workspace with requirements.txt', async function ({ app, openFolder }) {
+		await openFolder('workspaces/python-venv-creation/with-requirements');
+		await app.workbench.sessions.expectNoStartUpMessaging();
+
+		const toast = app.workbench.toasts.toastNotification.filter({ hasText: /requirements\.txt/ });
+		await expect(toast).toBeVisible({ timeout: 60000 });
+		await app.workbench.toasts.expectToastWithTitle(/uv/);
+		await app.workbench.toasts.closeWithHeader(/requirements\.txt/);
+	});
+
+	test('No notification when .venv already exists', async function ({ app, openFolder }) {
+		await openFolder('with-existing-venv');
+
+		await app.workbench.toasts.expectToastWithTitleNotToAppear(/requirements\.txt/);
 	});
 });

--- a/test/e2e/tests/interpreters/python-venv-creation.test.ts
+++ b/test/e2e/tests/interpreters/python-venv-creation.test.ts
@@ -29,20 +29,20 @@ test.describe('Python Venv Auto-Creation', {
 
 	test('Notification appears for workspace with requirements.txt', async function ({ app, openFolder }) {
 		await openFolder(`${fixtureBase}/with-requirements`);
+		await app.workbench.sessions.expectNoStartUpMessaging();
 
 		await app.workbench.toasts.waitForAppear(/requirements\.txt/, { timeout: 60000 });
 		await app.workbench.toasts.expectToastWithTitle(/uv/);
 		await app.workbench.toasts.closeWithHeader(/requirements\.txt/);
 	});
 
-	test('No notification when .venv already exists', async function ({ app, openFolder, hotKeys }) {
-		await hotKeys.reloadWindow(true);
+	test('No notification when .venv already exists', async function ({ app, openFolder }) {
 		await openFolder(`${fixtureBase}/with-existing-venv`);
 
 		await app.workbench.toasts.expectToastWithTitleNotToAppear(/requirements\.txt/);
 	});
 
-	test('Clicking Yes creates venv', async function ({ app, openFolder, hotKeys }) {
+	test('Clicking Yes creates venv', async function ({ app, openFolder }) {
 		test.skip(process.env.IS_OPENSUSE === 'true', 'Skip on openSuse');
 
 		const tempWorkspace = path.join(os.tmpdir(), 'vscsmoke', 'qa-example-content', 'venv-creation-test');
@@ -50,8 +50,8 @@ test.describe('Python Venv Auto-Creation', {
 		await fs.writeFile(path.join(tempWorkspace, 'requirements.txt'), 'requests\n');
 
 		try {
-			await hotKeys.reloadWindow(true);
 			await openFolder('qa-example-content/venv-creation-test');
+			await app.workbench.sessions.expectNoStartUpMessaging();
 
 			await app.workbench.toasts.waitForAppear(/requirements\.txt/, { timeout: 60000 });
 			await app.workbench.toasts.clickButton('Yes', { notificationFilter: /requirements\.txt/ });

--- a/test/e2e/tests/interpreters/python-venv-creation.test.ts
+++ b/test/e2e/tests/interpreters/python-venv-creation.test.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import path from 'path';
+import * as fs from 'fs/promises';
+import { expect } from '@playwright/test';
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Python Venv Auto-Creation', {
+	tag: [tags.INTERPRETER]
+}, () => {
+
+	const fixtureBase = 'qa-example-content/workspaces/python-venv-creation';
+
+	test.beforeAll(async function ({ settings }) {
+		await settings.set({
+			'python.createEnvironment.trigger': 'prompt',
+			'interpreters.startupBehavior': 'auto',
+		}, { reload: 'web' });
+	});
+
+	test('Notification appears for workspace with requirements.txt', {
+		tag: [tags.CRITICAL]
+	}, async function ({ app, openFolder }) {
+		await openFolder(path.join(fixtureBase, 'with-requirements'));
+
+		await app.workbench.toasts.waitForAppear(/requirements\.txt/, { timeout: 30000 });
+		await app.workbench.toasts.expectToastWithTitle(/uv/);
+		await app.workbench.toasts.closeWithHeader(/requirements\.txt/);
+	});
+
+	test('No notification when .venv already exists', async function ({ app, openFolder, hotKeys }) {
+		// Reload to reset the run-once guard from prior test
+		await hotKeys.reloadWindow(true);
+		await openFolder(path.join(fixtureBase, 'with-existing-venv'));
+
+		await app.workbench.toasts.expectToastWithTitleNotToAppear(/requirements\.txt/);
+	});
+
+	test('Clicking Yes creates venv and installs deps', {
+		tag: [tags.CRITICAL]
+	}, async function ({ app, openFolder, hotKeys }) {
+		test.skip(process.env.IS_OPENSUSE === 'true', 'Skip on openSuse');
+
+		const tempWorkspace = '/tmp/vscsmoke/qa-example-content/venv-creation-test';
+		await fs.mkdir(tempWorkspace, { recursive: true });
+		await fs.writeFile(path.join(tempWorkspace, 'requirements.txt'), 'requests\n');
+
+		try {
+			await hotKeys.reloadWindow(true);
+			await openFolder('qa-example-content/venv-creation-test');
+
+			await app.workbench.toasts.waitForAppear(/requirements\.txt/, { timeout: 30000 });
+			await app.workbench.toasts.clickButton('Yes', { notificationFilter: /requirements\.txt/ });
+
+			const venvPath = path.join(tempWorkspace, '.venv');
+			await expect(async () => {
+				await fs.access(venvPath);
+			}).toPass({ timeout: 60000 });
+		} finally {
+			await fs.rm(tempWorkspace, { recursive: true, force: true }).catch(() => { });
+		}
+	});
+});

--- a/test/e2e/tests/interpreters/python-venv-creation.test.ts
+++ b/test/e2e/tests/interpreters/python-venv-creation.test.ts
@@ -3,8 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import path from 'path';
+import * as os from 'os';
 import * as fs from 'fs/promises';
+import * as path from 'path';
 import { expect } from '@playwright/test';
 import { test, tags } from '../_test.setup';
 
@@ -15,6 +16,7 @@ test.use({
 test.describe('Python Venv Auto-Creation', {
 	tag: [tags.INTERPRETER, tags.WIN, tags.WEB]
 }, () => {
+	test.slow();
 
 	const fixtureBase = 'qa-example-content/workspaces/python-venv-creation';
 
@@ -28,27 +30,26 @@ test.describe('Python Venv Auto-Creation', {
 	test('Notification appears for workspace with requirements.txt', {
 		tag: [tags.CRITICAL]
 	}, async function ({ app, openFolder }) {
-		await openFolder(path.join(fixtureBase, 'with-requirements'));
+		await openFolder(`${fixtureBase}/with-requirements`);
 
-		await app.workbench.toasts.waitForAppear(/requirements\.txt/, { timeout: 30000 });
+		await app.workbench.toasts.waitForAppear(/requirements\.txt/, { timeout: 60000 });
 		await app.workbench.toasts.expectToastWithTitle(/uv/);
 		await app.workbench.toasts.closeWithHeader(/requirements\.txt/);
 	});
 
 	test('No notification when .venv already exists', async function ({ app, openFolder, hotKeys }) {
-		// Reload to reset the run-once guard from prior test
 		await hotKeys.reloadWindow(true);
-		await openFolder(path.join(fixtureBase, 'with-existing-venv'));
+		await openFolder(`${fixtureBase}/with-existing-venv`);
 
 		await app.workbench.toasts.expectToastWithTitleNotToAppear(/requirements\.txt/);
 	});
 
-	test('Clicking Yes creates venv and installs deps', {
+	test('Clicking Yes creates venv', {
 		tag: [tags.CRITICAL]
 	}, async function ({ app, openFolder, hotKeys }) {
 		test.skip(process.env.IS_OPENSUSE === 'true', 'Skip on openSuse');
 
-		const tempWorkspace = '/tmp/vscsmoke/qa-example-content/venv-creation-test';
+		const tempWorkspace = path.join(os.tmpdir(), 'vscsmoke', 'qa-example-content', 'venv-creation-test');
 		await fs.mkdir(tempWorkspace, { recursive: true });
 		await fs.writeFile(path.join(tempWorkspace, 'requirements.txt'), 'requests\n');
 
@@ -56,7 +57,7 @@ test.describe('Python Venv Auto-Creation', {
 			await hotKeys.reloadWindow(true);
 			await openFolder('qa-example-content/venv-creation-test');
 
-			await app.workbench.toasts.waitForAppear(/requirements\.txt/, { timeout: 30000 });
+			await app.workbench.toasts.waitForAppear(/requirements\.txt/, { timeout: 60000 });
 			await app.workbench.toasts.clickButton('Yes', { notificationFilter: /requirements\.txt/ });
 
 			const venvPath = path.join(tempWorkspace, '.venv');

--- a/test/e2e/tests/interpreters/python-venv-creation.test.ts
+++ b/test/e2e/tests/interpreters/python-venv-creation.test.ts
@@ -3,6 +3,20 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/*
+Summary:
+- Verifies the Python venv auto-creation notification flow.
+- Requires a global Python interpreter (non-venv, non-conda) for the trigger to fire.
+- Tests run in sequence; each openFolder changes the workspace, so paths are
+	relative to where the picker starts after the previous test.
+
+|Test              |Workspace                     |Expected behavior                  |
+|------------------|------------------------------|-----------------------------------|
+|Clicking Yes      |temp dir with requirements.txt|Notification appears, .venv created|
+|Notification shows|fixture with requirements.txt |Toast mentions requirements.txt + uv|
+|No notification   |fixture with existing .venv   |No toast appears                   |
+*/
+
 import * as os from 'os';
 import * as fs from 'fs/promises';
 import * as path from 'path';

--- a/test/e2e/tests/interpreters/python-venv-creation.test.ts
+++ b/test/e2e/tests/interpreters/python-venv-creation.test.ts
@@ -31,7 +31,8 @@ test.describe('Python Venv Auto-Creation', {
 		await openFolder(`${fixtureBase}/with-requirements`);
 		await app.workbench.sessions.expectNoStartUpMessaging();
 
-		await app.workbench.toasts.waitForAppear(/requirements\.txt/, { timeout: 60000 });
+		const toast = app.workbench.toasts.toastNotification.filter({ hasText: /requirements\.txt/ });
+		await expect(toast).toBeVisible({ timeout: 60000 });
 		await app.workbench.toasts.expectToastWithTitle(/uv/);
 		await app.workbench.toasts.closeWithHeader(/requirements\.txt/);
 	});
@@ -53,7 +54,8 @@ test.describe('Python Venv Auto-Creation', {
 			await openFolder('qa-example-content/venv-creation-test');
 			await app.workbench.sessions.expectNoStartUpMessaging();
 
-			await app.workbench.toasts.waitForAppear(/requirements\.txt/, { timeout: 60000 });
+			const toast = app.workbench.toasts.toastNotification.filter({ hasText: /requirements\.txt/ });
+			await expect(toast).toBeVisible({ timeout: 60000 });
 			await app.workbench.toasts.clickButton('Yes', { notificationFilter: /requirements\.txt/ });
 
 			const venvPath = path.join(tempWorkspace, '.venv');

--- a/test/e2e/tests/interpreters/python-venv-creation.test.ts
+++ b/test/e2e/tests/interpreters/python-venv-creation.test.ts
@@ -14,7 +14,7 @@ test.use({
 });
 
 test.describe('Python Venv Auto-Creation', {
-	tag: [tags.INTERPRETER, tags.WIN, tags.WEB]
+	tag: [tags.INTERPRETER, tags.WEB]
 }, () => {
 	test.slow();
 
@@ -27,9 +27,7 @@ test.describe('Python Venv Auto-Creation', {
 		}, { reload: 'web' });
 	});
 
-	test('Notification appears for workspace with requirements.txt', {
-		tag: [tags.CRITICAL]
-	}, async function ({ app, openFolder }) {
+	test('Notification appears for workspace with requirements.txt', async function ({ app, openFolder }) {
 		await openFolder(`${fixtureBase}/with-requirements`);
 
 		await app.workbench.toasts.waitForAppear(/requirements\.txt/, { timeout: 60000 });
@@ -44,9 +42,7 @@ test.describe('Python Venv Auto-Creation', {
 		await app.workbench.toasts.expectToastWithTitleNotToAppear(/requirements\.txt/);
 	});
 
-	test('Clicking Yes creates venv', {
-		tag: [tags.CRITICAL]
-	}, async function ({ app, openFolder, hotKeys }) {
+	test('Clicking Yes creates venv', async function ({ app, openFolder, hotKeys }) {
 		test.skip(process.env.IS_OPENSUSE === 'true', 'Skip on openSuse');
 
 		const tempWorkspace = path.join(os.tmpdir(), 'vscsmoke', 'qa-example-content', 'venv-creation-test');


### PR DESCRIPTION
## Summary
- E2E Playwright tests for the venv auto-creation notification flow
- Notification appears for workspace with `requirements.txt` and no `.venv`
- No notification when `.venv` already exists
- Clicking Yes creates the environment

Depends on https://github.com/posit-dev/qa-example-content/pull/138.

Addresses https://github.com/posit-dev/positron/issues/13437 (e2e layer). I focused on writing less e2e tests here to prevent furthering pressure against the CI, hence why this e2e test suite is quite minimal.

## Test plan
- [x] Merge `qa-example-content` fixtures first
- [x] `npx playwright test python-venv-creation --project e2e-electron` passes locally
- [x] CI passes 

@:interpreter @:web