### PR TITLE
Always show Help action for packages in Packages pane

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -305,6 +305,15 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 				services.contextMenuService.showContextMenu({
 					getActions: () => [
 						{
+							id: 'showHelp',
+							label: localize('positronPackages.showHelp', "Show Help"),
+							tooltip: localize('positronPackages.showHelp', "Show Help"),
+							class: undefined,
+							enabled: true,
+							run: () => { void showHelpForPackage(name); }
+						},
+						new Separator(),
+						{
 							id: 'copy',
 							label: localize('positronPackages.copyPackage', "Copy '{0} ({1})'", name, version),
 							tooltip: localize('positronPackages.copyPackage', "Copy '{0} ({1})'", name, version),
@@ -398,16 +407,14 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 							</div>
 						)}
 					</div>
-					{attached === true && (
-						<Button
-							ariaLabel={localize('positronPackages.showHelpAriaLabel', "Show help for {0}", name)}
-							className='packages-list-item-help'
-							tooltip={localize('positronPackages.showHelpTooltip', "Show help for {0}", name)}
-							onPressed={() => { void showHelpForPackage(name); }}
-						>
-							<span className='codicon codicon-book' />
-						</Button>
-					)}
+					<Button
+						ariaLabel={localize('positronPackages.showHelpAriaLabel', "Show help for {0}", name)}
+						className='packages-list-item-help'
+						tooltip={localize('positronPackages.showHelpTooltip', "Show help for {0}", name)}
+						onPressed={() => { void showHelpForPackage(name); }}
+					>
+						<span className='codicon codicon-book' />
+					</Button>
 				</div>
 			);
 		};


### PR DESCRIPTION
Now that Python help can be loaded from disk for installed, but unimported packages, the Help button no longer needs to be gated on attached state. Also exposes Show Help in the row context menu.

See #12899

Context menu:

<img width="341" height="292" alt="Screenshot 2026-05-26 at 9 54 16 AM" src="https://github.com/user-attachments/assets/01555728-e8af-42af-a2c8-cc16ab43c8ea" />

R:

<img width="319" height="1012" alt="Screenshot 2026-05-26 at 9 54 05 AM" src="https://github.com/user-attachments/assets/1756607d-e363-423b-9ca9-3b9e3fb5c03c" />
<img width="332" height="1022" alt="Screenshot 2026-05-26 at 9 54 12 AM" src="https://github.com/user-attachments/assets/b9b4ec5f-0f3b-4e1d-8b06-713cd9c1020c" />

Python:

<img width="317" height="1006" alt="Screenshot 2026-05-26 at 9 54 27 AM" src="https://github.com/user-attachments/assets/7a188530-737f-4176-8798-e135406df96c" />
<img width="322" height="1028" alt="Screenshot 2026-05-26 at 9 54 22 AM" src="https://github.com/user-attachments/assets/9eb73cf7-1887-4373-8b0f-1224716be58c" />


### Release Notes

#### New Features

- Show "Show Help" button and add it to the context menu for every package in the packages pane.

#### Bug Fixes

- N/A


### Validation Steps

Open the packages pane
There should be a book icon next to every package.
Check both R and Python sessions
Check both the row and card toggles