### PR TITLE
SBOM generation

### DIFF
--- a/.github/workflows/release-generate-sbom.yml
+++ b/.github/workflows/release-generate-sbom.yml
@@ -1,0 +1,287 @@
+name: Release - Generate SBOM
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Product Version (e.g., 2025.09.2)"
+        required: true
+        type: string
+      sha:
+        description: "Git SHA to checkout (defaults to workflow ref)"
+        required: false
+        type: string
+      dry-run:
+        description: "Generate SBOM without creating a PR"
+        required: false
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      version:
+        description: "Product Version (e.g., 2025.09.2)"
+        required: true
+        type: string
+      sha:
+        description: "Git SHA to checkout (defaults to workflow ref)"
+        required: false
+        type: string
+      dry-run:
+        description: "Generate SBOM without creating a PR"
+        required: false
+        type: boolean
+        default: true
+      reviewers:
+        description: "Comma-separated list of GitHub usernames to request review from"
+        required: false
+        type: string
+    outputs:
+      pr-url:
+        description: "URL of the created pull request"
+        value: ${{ jobs.generate-sbom.outputs.pr-url }}
+      pr-number:
+        description: "Number of the created pull request"
+        value: ${{ jobs.generate-sbom.outputs.pr-number }}
+      result-url:
+        description: "URL of the created PR or the repository pulls page in dry-run mode"
+        value: ${{ jobs.generate-sbom.outputs.result-url }}
+    secrets:
+      RELEASE_APP_ID:
+        required: true
+      RELEASE_APP_PRIVATE_KEY:
+        required: true
+      SNYK_TOKEN:
+        required: true
+
+env:
+  PRODUCT_VERSION: ${{ inputs.version || 'dev' }}
+  NODE_VERSION: "22.x"
+
+jobs:
+  generate-sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-22.04
+    outputs:
+      pr-url: ${{ steps.set-pr-url.outputs.url }}
+      pr-number: ${{ steps.create-pr.outputs.pull-request-number }}
+      result-url: ${{ steps.set-pr-url.outputs.url }}
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}/positron
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+          path: ${{ github.workspace }}/positron
+          submodules: recursive
+
+      - name: Skip SBOM generation in dry-run mode
+        if: ${{ inputs.dry-run }}
+        run: |
+          echo "[DRY-RUN] Skipping SBOM generation"
+          echo "Version: ${{ env.PRODUCT_VERSION }}"
+          echo ""
+          echo "In dry-run mode, the SBOM build and generation steps are skipped."
+          echo "The workflow will complete successfully without creating a PR."
+
+      - name: Set up Node.js
+        if: ${{ !inputs.dry-run }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Rust and cargo tools
+        if: ${{ !inputs.dry-run }}
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source $HOME/.cargo/env
+          cargo install cargo-cyclonedx --force --locked
+
+      - name: Set Rust PATH
+        if: ${{ !inputs.dry-run }}
+        run: |
+          echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Install Snyk CLI
+        if: ${{ !inputs.dry-run }}
+        run: |
+          npm install -g snyk@1.1301.2
+
+      - name: Install system dependencies
+        if: ${{ !inputs.dry-run }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            curl \
+            git \
+            wget \
+            ca-certificates \
+            jq \
+            libssl-dev \
+            libcurl4-openssl-dev \
+            zlib1g-dev
+
+      - name: Clone Kallichore source for scanning
+        if: ${{ !inputs.dry-run }}
+        run: |
+          # Read Kallichore version from package.json
+          KALLICHORE_VERSION=$(jq -r '.positron.binaryDependencies.kallichore' \
+            extensions/positron-supervisor/package.json)
+
+          echo "Cloning Kallichore v${KALLICHORE_VERSION}..."
+
+          # Clone the specific version
+          git clone --depth 1 --branch "v${KALLICHORE_VERSION}" \
+            https://github.com/posit-dev/kallichore.git \
+            .sbom-tmp/kallichore
+
+          echo "[OK] Cloned Kallichore source"
+
+      - name: Generate SBOM
+        if: ${{ !inputs.dry-run }}
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          cd scripts/sbom
+
+          # Verify tools are installed
+          echo "=== Verifying tools ==="
+          node --version
+          npm --version
+          cargo --version
+          rustc --version
+          snyk --version
+
+          # Authenticate with Snyk if token provided
+          if [ -n "$SNYK_TOKEN" ]; then
+            echo "=== Authenticating with Snyk ==="
+            snyk auth $SNYK_TOKEN
+          fi
+
+          # Install sbom generator npm dependencies
+          npm ci
+
+          # Generate the SBOM
+          npm run generate
+
+      - name: Verify SBOM was generated
+        if: ${{ !inputs.dry-run }}
+        run: |
+          if [ ! -f scripts/sbom/SBOM.json ]; then
+            echo "ERROR: SBOM.json was not generated!"
+            exit 1
+          fi
+          echo "[OK] SBOM.json generated successfully"
+          ls -lh scripts/sbom/SBOM.json
+          echo "Components: $(jq '.components | length' scripts/sbom/SBOM.json)"
+          echo "Dependencies: $(jq '.dependencies | length' scripts/sbom/SBOM.json)"
+
+      - name: Extract short version for filename
+        id: version
+        run: |
+          # Extract just the version number (e.g., "2025.09.2" from "2025.09.2+123")
+          SHORT_VERSION=$(echo "${{ env.PRODUCT_VERSION }}" | sed 's/+.*//')
+          echo "short_version=${SHORT_VERSION}" >> $GITHUB_OUTPUT
+          echo "Full version: ${{ env.PRODUCT_VERSION }}"
+          echo "Short version for filename: ${SHORT_VERSION}"
+
+      - name: Upload SBOM as artifact
+        if: ${{ !inputs.dry-run }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Positron__v${{ steps.version.outputs.short_version }}.sbom
+          path: ${{ github.workspace }}/positron/scripts/sbom/SBOM.json
+          retention-days: 10
+
+      - name: Workflow complete in dry-run mode
+        if: ${{ inputs.dry-run }}
+        run: |
+          echo "[OK] Dry-run mode: Workflow completed successfully"
+          echo "Version: ${{ env.PRODUCT_VERSION }}"
+          echo "Short version: ${{ steps.version.outputs.short_version }}"
+          echo ""
+          echo "SBOM generation and PR creation were skipped."
+
+      - name: Generate GitHub App token
+        if: ${{ !inputs.dry-run }}
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: rstudio
+          repositories: posit-sboms
+
+      - name: Checkout posit-sboms repository
+        if: ${{ !inputs.dry-run }}
+        uses: actions/checkout@v6
+        with:
+          repository: rstudio/posit-sboms
+          path: ${{ github.workspace }}/posit-sboms
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Copy SBOM to posit-sboms repository
+        if: ${{ !inputs.dry-run }}
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/posit-sboms/Positron"
+          cp "${GITHUB_WORKSPACE}/positron/scripts/sbom/SBOM.json" \
+             "${GITHUB_WORKSPACE}/posit-sboms/Positron/Positron__v${{ steps.version.outputs.short_version }}.sbom"
+
+      - name: Sanitize version for branch name
+        if: ${{ !inputs.dry-run }}
+        id: sanitize
+        run: |
+          # Replace special characters with hyphens for branch name
+          SANITIZED=$(echo "${{ env.PRODUCT_VERSION }}" | tr '+' '-' | tr '.' '-')
+          echo "branch_suffix=$SANITIZED" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        id: create-pr
+        if: ${{ !inputs.dry-run }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          path: ${{ github.workspace }}/posit-sboms
+          commit-message: |
+            Add Positron v${{ env.PRODUCT_VERSION }} SBOM
+
+            - Generated SBOM using CycloneDX format
+            - Includes Rust and Node.js dependencies
+          branch: add-positron-sbom-${{ steps.sanitize.outputs.branch_suffix }}
+          delete-branch: true
+          title: "Add Positron ${{ env.PRODUCT_VERSION }} SBOM"
+          body: |
+            ## SBOM Update
+
+            This PR adds the Software Bill of Materials (SBOM) for Positron:
+
+            - **Product Version**: ${{ env.PRODUCT_VERSION }}
+            - **Format**: CycloneDX JSON
+
+            ### Files Updated
+
+            - `Positron/Positron__v${{ steps.version.outputs.short_version }}.sbom` - Complete SBOM file
+
+            ### Testing
+
+            Please verify:
+            - SBOM file is valid CycloneDX format
+            - Version number matches the release version
+            - Component counts are reasonable
+
+            Generated by GitHub Actions
+          labels: |
+            automated
+          reviewers: ${{ inputs.reviewers }}
+
+      - name: Set PR URL
+        id: set-pr-url
+        run: |
+          if [ "${{ inputs.dry-run }}" = "true" ]; then
+            echo "url=https://github.com/posit-dev/positron/pull/1" >> $GITHUB_OUTPUT
+          else
+            echo "url=${{ steps.create-pr.outputs.pull-request-url }}" >> $GITHUB_OUTPUT
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ test-output.json
 test/componentFixtures/.screenshots/*
 !test/componentFixtures/.screenshots/baseline/
 dist
+.sbom-tmp/

--- a/scripts/sbom/.gitignore
+++ b/scripts/sbom/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+out/
+SBOM.json
+package-lock.json
+.sbom-tmp/

--- a/scripts/sbom/package.json
+++ b/scripts/sbom/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "positron-sbom",
+	"version": "1.0.0",
+	"description": "Generate SBOM for Positron",
+	"main": "out/generate-sbom.js",
+	"scripts": {
+		"build": "tsc",
+		"generate": "tsc && node ./out/generate-sbom.js"
+	},
+	"author": "Posit PBC",
+	"license": "MIT",
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"typescript": "^5.7.2"
+	}
+}

--- a/scripts/sbom/src/binary-dependencies.ts
+++ b/scripts/sbom/src/binary-dependencies.ts
@@ -1,0 +1,98 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Project } from './types';
+import { readFileSync } from 'fs';
+import { resolve as resolvePath } from 'path';
+import { getRepoRoot } from './utils';
+
+/**
+ * Binary dependencies that are downloaded as pre-built binaries from external repositories.
+ *
+ * For SBOM generation, we have two strategies:
+ * 1. SCAN_SOURCE: Clone the source repo at the specific version and scan it with cargo-cyclonedx
+ * 2. EXTERNAL_REF: Document as an external reference (placeholder for future SBOM fetch/merge)
+ *
+ * SCAN_SOURCE is preferred when:
+ * - Source repo is public
+ * - Binary is built from that exact source (not vendored deps)
+ * - We want complete dependency coverage NOW
+ */
+
+export type BinaryDependencyStrategy = 'SCAN_SOURCE' | 'EXTERNAL_REF';
+
+export interface BinaryDependency {
+	name: string;
+	version: string | 'submodule';
+	description: string;
+	repository: string;
+	/** Strategy for including in SBOM */
+	strategy: BinaryDependencyStrategy;
+	/** Path to package.json that declares this dependency (for version validation) */
+	packageJsonPath?: string;
+	/** Key in package.json positron.binaryDependencies */
+	packageJsonKey?: string;
+	/** Path where source will be cloned (relative to repo root) */
+	clonePath?: string;
+}
+
+/**
+ * Read the version of a binary dependency from package.json
+ */
+function getVersionFromPackageJson(packageJsonPath: string, key: string): string {
+	try {
+		const fullPath = resolvePath(getRepoRoot(), packageJsonPath);
+		const packageJson = JSON.parse(readFileSync(fullPath, 'utf-8'));
+		return packageJson.positron?.binaryDependencies?.[key] || 'unknown';
+	} catch (error) {
+		console.warn(`Failed to read ${key} version from ${packageJsonPath}: ${error}`);
+		return 'unknown';
+	}
+}
+
+/**
+ * List of binary dependencies downloaded from external repositories.
+ */
+export const BINARY_DEPENDENCIES: BinaryDependency[] = [
+	{
+		name: 'Kallichore',
+		// Version is read from positron-supervisor/package.json at runtime
+		version: getVersionFromPackageJson(
+			'extensions/positron-supervisor/package.json',
+			'kallichore'
+		),
+		description: 'Python kernel server for Positron',
+		repository: 'https://github.com/posit-dev/kallichore',
+		strategy: 'SCAN_SOURCE',
+		packageJsonPath: 'extensions/positron-supervisor/package.json',
+		packageJsonKey: 'kallichore',
+		clonePath: '.sbom-tmp/kallichore'
+	},
+	{
+		name: 'Ark (R Kernel) Prebuild',
+		version: 'submodule',
+		description: 'Pre-built R kernel binary (from posit-dev/positron-ark)',
+		repository: 'https://github.com/posit-dev/positron-ark',
+		strategy: 'EXTERNAL_REF',
+		// Note: Ark source is ALREADY scanned via the git submodule in extensions/positron-r/ark.
+		// The shipped binary comes from a prebuild, but we're scanning the source it was built from.
+		// If prebuild differs significantly (different feature flags, etc), we'd need to fetch
+		// its SBOM from the release assets.
+	}
+];
+
+/**
+ * Convert binary dependencies to Projects that can be scanned.
+ * Only returns projects for dependencies with SCAN_SOURCE strategy.
+ */
+export function getBinaryDependencyProjects(): Project[] {
+	return BINARY_DEPENDENCIES
+		.filter(dep => dep.strategy === 'SCAN_SOURCE' && dep.clonePath && dep.version !== 'submodule')
+		.map(dep => ({
+			name: dep.name,
+			path: dep.clonePath!,
+			type: 'rust' as const
+		}));
+}

--- a/scripts/sbom/src/generate-sbom.ts
+++ b/scripts/sbom/src/generate-sbom.ts
@@ -1,0 +1,151 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { writeFileSync } from 'fs';
+import { resolve as resolvePath } from 'path';
+import { BOM, Component, Dependency } from './types';
+import { PROJECTS } from './projects';
+import {
+	createEmptyBom,
+	checkForSnyk,
+	checkForCargoCyclonedx,
+	getPositronVersion,
+	findRootComponent
+} from './utils';
+import { generateNpmSbom, generateRustSbom } from './generators';
+import { getBinaryDependencyProjects } from './binary-dependencies';
+
+async function main() {
+	console.log('=== Positron SBOM Generator ===\n');
+
+	// Check for required tools
+	console.log('Checking for required tools...');
+	try {
+		await checkForSnyk();
+		console.log('[OK] Snyk CLI found');
+	} catch (error) {
+		console.error(`[ERROR] ${error}`);
+		process.exit(1);
+	}
+
+	try {
+		await checkForCargoCyclonedx();
+		console.log('[OK] cargo-cyclonedx found');
+	} catch (error) {
+		console.error(`[ERROR] ${error}`);
+		process.exit(1);
+	}
+
+	console.log('');
+
+	// Create the root BOM
+	const completeBom = createEmptyBom();
+	const version = getPositronVersion();
+
+	console.log(`Positron version: ${version}\n`);
+
+	// Add binary dependencies that should be scanned from source
+	const binaryProjects = getBinaryDependencyProjects();
+	const allProjects = [...PROJECTS, ...binaryProjects];
+
+	console.log(`Generating SBOMs for ${allProjects.length} projects...\n`);
+	if (binaryProjects.length > 0) {
+		console.log(`  (includes ${binaryProjects.length} binary dependencies scanned from source)\n`);
+	}
+
+	const projectBoms: BOM[] = await Promise.all(
+		allProjects.map((project) => {
+			if (project.type === 'npm') {
+				return generateNpmSbom(project);
+			} else if (project.type === 'rust') {
+				return generateRustSbom(project);
+			} else {
+				console.error(`Unknown project type: ${project.type}`);
+				return Promise.resolve(createEmptyBom());
+			}
+		})
+	);
+
+	console.log('\n=== Merging SBOMs ===\n');
+
+	// Create root dependency node
+	const rootDependency: Required<Dependency> = {
+		ref: completeBom.metadata.component['bom-ref'],
+		dependsOn: []
+	};
+	completeBom.dependencies.push(rootDependency);
+
+	// Merge each project BOM into the complete BOM
+	let depIndex = 1;
+
+	for (let i = 0; i < projectBoms.length; i++) {
+		const bom = projectBoms[i];
+		const project = allProjects[i];
+
+		console.log(`Merging: ${project.name}`);
+
+		// Find the root component for this project
+		const rootComponent = findRootComponent(bom, project.name);
+		if (!rootComponent) {
+			console.warn(`  ⚠ No root component found for ${project.name}, skipping`);
+			continue;
+		}
+
+		const bomRef = `${depIndex}-${rootComponent['bom-ref']}`;
+
+		// Add to root dependencies
+		rootDependency.dependsOn.push(bomRef);
+
+		// Add project as a component
+		const projectComponent: Component = {
+			...rootComponent,
+			'bom-ref': bomRef,
+			name: project.name,
+			type: 'application'
+		};
+
+		completeBom.components.unshift(projectComponent);
+
+		// Add all components from this project
+		if (bom.components?.length) {
+			for (const component of bom.components) {
+				completeBom.components.push({
+					...component,
+					'bom-ref': `${depIndex}-${component['bom-ref']}`
+				});
+			}
+			console.log(`  Added ${bom.components.length} components`);
+		}
+
+		// Add all dependencies from this project
+		if (bom.dependencies?.length) {
+			for (const dep of bom.dependencies) {
+				const newDep: Dependency = {
+					ref: `${depIndex}-${dep.ref}`,
+					dependsOn: dep.dependsOn?.map(d => `${depIndex}-${d}`) || []
+				};
+				completeBom.dependencies.push(newDep);
+			}
+			console.log(`  Added ${bom.dependencies.length} dependencies`);
+		}
+
+		depIndex++;
+	}
+
+	// Write the complete SBOM to disk
+	const outputPath = resolvePath(__dirname, '../SBOM.json');
+	writeFileSync(outputPath, JSON.stringify(completeBom, null, 2));
+
+	console.log('\n=== SBOM Generation Complete ===\n');
+	console.log(`Output: ${outputPath}`);
+	console.log(`Total components: ${completeBom.components.length}`);
+	console.log(`Total dependencies: ${completeBom.dependencies.length}`);
+	console.log('');
+}
+
+main().catch((error) => {
+	console.error('Fatal error:', error);
+	process.exit(1);
+});

--- a/scripts/sbom/src/generators.ts
+++ b/scripts/sbom/src/generators.ts
@@ -1,0 +1,127 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { spawn } from 'child_process';
+import { resolve as resolvePath } from 'path';
+import { BOM, Project } from './types';
+import { createEmptyBom, getRepoRoot } from './utils';
+import { existsSync, readFileSync } from 'fs';
+
+/**
+ * Generate SBOM for an npm project using Snyk
+ */
+export async function generateNpmSbom(project: Project): Promise<BOM> {
+	return new Promise((resolve) => {
+		const resolvedPath = resolvePath(getRepoRoot(), project.path);
+		console.info(`Generating SBOM for npm project: ${project.name} at ${resolvedPath}`);
+
+		const proc = spawn('snyk', ['sbom', '--format=cyclonedx1.4+json', resolvedPath]);
+
+		let buffer = '';
+		let errBuffer = '';
+
+		proc.stdout.on('data', (chunk: Buffer) => {
+			buffer += chunk.toString('utf8');
+		});
+
+		proc.stderr.on('data', (chunk: Buffer) => {
+			errBuffer += chunk.toString('utf8');
+		});
+
+		proc.on('close', (code) => {
+			if (code === 0) {
+				console.info(`[OK] Generated SBOM for: ${project.name}`);
+				try {
+					const bom = JSON.parse(buffer);
+					resolve(bom);
+				} catch (e) {
+					console.error(`[ERROR] Failed to parse SBOM for ${project.name}: ${e}`);
+					console.error('Buffer contents:', buffer);
+					resolve(createEmptyBom());
+				}
+			} else {
+				console.error(`[ERROR] Failed to generate SBOM for: ${project.name} (exit code: ${code})`);
+				if (errBuffer) console.error('stderr:', errBuffer);
+				if (buffer) console.error('stdout:', buffer);
+				resolve(createEmptyBom());
+			}
+		});
+
+		proc.on('error', (err) => {
+			console.error(`[ERROR] Error spawning snyk for ${project.name}:`, err);
+			resolve(createEmptyBom());
+		});
+	});
+}
+
+/**
+ * Generate SBOM for a Rust project using cargo-cyclonedx
+ */
+export async function generateRustSbom(project: Project): Promise<BOM> {
+	return new Promise((resolve) => {
+		const resolvedPath = resolvePath(getRepoRoot(), project.path);
+		console.info(`Generating SBOM for Rust project: ${project.name} at ${resolvedPath}`);
+
+		// Check if Cargo.toml exists
+		const cargoTomlPath = resolvePath(resolvedPath, 'Cargo.toml');
+		if (!existsSync(cargoTomlPath)) {
+			console.error(`[ERROR] Cargo.toml not found at ${cargoTomlPath}`);
+			resolve(createEmptyBom());
+			return;
+		}
+
+		// cargo-cyclonedx writes to stdout
+		const proc = spawn('cargo', ['cyclonedx', '--format', 'json'], {
+			cwd: resolvedPath
+		});
+
+		let buffer = '';
+		let errBuffer = '';
+
+		proc.stdout.on('data', (chunk: Buffer) => {
+			buffer += chunk.toString('utf8');
+		});
+
+		proc.stderr.on('data', (chunk: Buffer) => {
+			errBuffer += chunk.toString('utf8');
+		});
+
+		proc.on('close', (code) => {
+			if (code === 0) {
+				console.info(`[OK] Generated SBOM for: ${project.name}`);
+				try {
+					// cargo-cyclonedx may write the file to disk, try reading it
+					const bomFilePath = resolvePath(resolvedPath, 'target/bom.json');
+					let bomContent = buffer;
+
+					if (!bomContent && existsSync(bomFilePath)) {
+						bomContent = readFileSync(bomFilePath, 'utf-8');
+					}
+
+					if (!bomContent) {
+						console.error(`[ERROR] No SBOM output found for ${project.name}`);
+						resolve(createEmptyBom());
+						return;
+					}
+
+					const bom = JSON.parse(bomContent);
+					resolve(bom);
+				} catch (e) {
+					console.error(`[ERROR] Failed to parse SBOM for ${project.name}: ${e}`);
+					resolve(createEmptyBom());
+				}
+			} else {
+				console.error(`[ERROR] Failed to generate SBOM for: ${project.name} (exit code: ${code})`);
+				if (errBuffer) console.error('stderr:', errBuffer);
+				resolve(createEmptyBom());
+			}
+		});
+
+		proc.on('error', (err) => {
+			console.error(`[ERROR] Error spawning cargo-cyclonedx for ${project.name}:`, err);
+			resolve(createEmptyBom());
+		});
+	});
+}

--- a/scripts/sbom/src/projects.ts
+++ b/scripts/sbom/src/projects.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Project } from './types';
+
+/**
+ * List of projects to include in the SBOM.
+ * Paths are relative to the repository root.
+ *
+ * Note: extensions/positron-copilot-chat and extensions/positron-r/ark
+ * are git submodules and must be initialized before SBOM generation.
+ */
+export const PROJECTS: Project[] = [
+	{
+		name: 'Positron Core',
+		path: '.',
+		type: 'npm'
+	},
+	{
+		name: 'Positron CLI',
+		path: './cli',
+		type: 'rust'
+	},
+	{
+		name: 'Positron Copilot Chat',
+		path: './extensions/positron-copilot-chat',
+		type: 'npm'
+	},
+	{
+		name: 'Ark (R Kernel)',
+		path: './extensions/positron-r/ark',
+		type: 'rust'
+	}
+];

--- a/scripts/sbom/src/types.ts
+++ b/scripts/sbom/src/types.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * CycloneDX 1.4 SBOM types (simplified subset)
+ */
+
+export interface BOM {
+	bomFormat: string;
+	specVersion: string;
+	serialNumber: string;
+	version: number;
+	metadata: Metadata;
+	components: Component[];
+	dependencies: Dependency[];
+}
+
+export interface Metadata {
+	timestamp: string;
+	tools: Tool[];
+	component: Component;
+}
+
+export interface Tool {
+	vendor: string;
+	name: string;
+	version?: string;
+}
+
+export interface Component {
+	"bom-ref": string;
+	type: string;
+	name: string;
+	version?: string;
+	purl?: string;
+	description?: string;
+	licenses?: License[];
+	hashes?: Hash[];
+	externalReferences?: ExternalReference[];
+}
+
+export interface License {
+	license?: {
+		id?: string;
+		name?: string;
+		url?: string;
+	};
+	expression?: string;
+}
+
+export interface Hash {
+	alg: string;
+	content: string;
+}
+
+export interface ExternalReference {
+	type: string;
+	url: string;
+}
+
+export interface Dependency {
+	ref: string;
+	dependsOn?: string[];
+}
+
+/**
+ * Project definition for SBOM generation
+ */
+export interface Project {
+	name: string;
+	path: string;
+	type: 'npm' | 'rust';
+}

--- a/scripts/sbom/src/utils.ts
+++ b/scripts/sbom/src/utils.ts
@@ -1,0 +1,141 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { randomUUID } from 'crypto';
+import { resolve as resolvePath } from 'path';
+import { existsSync, readFileSync } from 'fs';
+import { BOM, Component, Metadata } from './types';
+
+/**
+ * Get the root path of the repository
+ */
+export function getRepoRoot(): string {
+	// This script lives in scripts/sbom/src/, so go up 3 levels
+	return resolvePath(__dirname, '../../..');
+}
+
+/**
+ * Get Positron version from package.json
+ */
+export function getPositronVersion(): string {
+	const packageJsonPath = resolvePath(getRepoRoot(), 'package.json');
+	if (!existsSync(packageJsonPath)) {
+		console.warn('package.json not found, using "dev" version');
+		return 'dev';
+	}
+
+	try {
+		const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+		return packageJson.version || 'dev';
+	} catch (error) {
+		console.warn(`Failed to parse package.json: ${error}`);
+		return 'dev';
+	}
+}
+
+/**
+ * Create an empty CycloneDX BOM
+ */
+export function createEmptyBom(): BOM {
+	const version = getPositronVersion();
+
+	return {
+		bomFormat: 'CycloneDX',
+		specVersion: '1.4',
+		serialNumber: `urn:uuid:${randomUUID()}`,
+		version: 1,
+		metadata: {
+			timestamp: new Date().toISOString(),
+			tools: [
+				{
+					vendor: 'Snyk',
+					name: 'snyk-cli'
+				},
+				{
+					vendor: 'cargo',
+					name: 'cargo-cyclonedx'
+				}
+			],
+			component: {
+				'bom-ref': `positron@${version}`,
+				type: 'application',
+				name: 'Positron',
+				version: version,
+				description: 'Next-generation data science IDE'
+			}
+		},
+		components: [],
+		dependencies: []
+	};
+}
+
+/**
+ * Check if Snyk CLI is installed
+ */
+export async function checkForSnyk(): Promise<void> {
+	const { spawn } = await import('child_process');
+
+	return new Promise((resolve, reject) => {
+		const proc = spawn('snyk', ['--version']);
+		let found = false;
+
+		proc.on('close', (code) => {
+			if (code === 0 || found) {
+				resolve();
+			} else {
+				reject(new Error('Snyk CLI not found. Please install with: npm install -g snyk'));
+			}
+		});
+
+		proc.stdout.on('data', () => {
+			found = true;
+		});
+
+		proc.on('error', () => {
+			reject(new Error('Snyk CLI not found. Please install with: npm install -g snyk'));
+		});
+	});
+}
+
+/**
+ * Check if cargo-cyclonedx is installed
+ */
+export async function checkForCargoCyclonedx(): Promise<void> {
+	const { spawn } = await import('child_process');
+
+	return new Promise((resolve, reject) => {
+		const proc = spawn('cargo', ['cyclonedx', '--version']);
+		let found = false;
+
+		proc.on('close', (code) => {
+			if (code === 0 || found) {
+				resolve();
+			} else {
+				reject(new Error('cargo-cyclonedx not found. Please install with: cargo install cargo-cyclonedx'));
+			}
+		});
+
+		proc.stdout.on('data', () => {
+			found = true;
+		});
+
+		proc.on('error', () => {
+			reject(new Error('cargo-cyclonedx not found. Please install with: cargo install cargo-cyclonedx'));
+		});
+	});
+}
+
+/**
+ * Find the root component in a BOM by matching the name
+ */
+export function findRootComponent(bom: BOM, projectName: string): Component | undefined {
+	// First try the metadata component
+	if (bom.metadata?.component?.name === projectName) {
+		return bom.metadata.component;
+	}
+
+	// Then try to find in components
+	return bom.components.find(c => c.name === projectName);
+}

--- a/scripts/sbom/tsconfig.json
+++ b/scripts/sbom/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "commonjs",
+		"lib": ["ES2020"],
+		"outDir": "./out",
+		"rootDir": "./src",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Adds SBOM (Software Bill of Materials) generation workflow for Positron releases.

## What's Included

**Workflow:** `.github/workflows/release-generate-sbom.yml`
- Manual trigger with version and dry-run options
- Generates CycloneDX 1.4 JSON SBOM
- Creates PR to `rstudio/posit-sboms` with generated SBOM

**SBOM Scripts:** `scripts/sbom/`
- TypeScript-based SBOM generation using Snyk CLI and cargo-cyclonedx
- Scans and merges dependencies from all Positron components

## Dependencies Scanned

The SBOM includes complete dependency trees for:

1. **Positron Core** - Main application (npm/Snyk)
2. **Positron CLI** - Rust CLI tool (cargo-cyclonedx)
3. **Positron Copilot Chat** - Submodule (npm/Snyk)
4. **Ark** - R kernel submodule (cargo-cyclonedx)
5. **Kallichore** - Python kernel server, cloned from `posit-dev/kallichore` at version from `package.json` (cargo-cyclonedx)

## External Setup Required

Summary:

**3 secrets needed in `posit-dev/positron`:**
- `SNYK_TOKEN` - From Snyk account
- `RELEASE_APP_ID` - GitHub App ID
- `RELEASE_APP_PRIVATE_KEY` - GitHub App private key

**GitHub App setup:**
- Create app in `rstudio` org with Contents + PR permissions
- Install on `rstudio/posit-sboms` repository only

## Testing

Dry-run mode (no PR created):
```bash
gh workflow run release-generate-sbom.yml \
  --repo posit-dev/positron \
  --ref main \
  -f version=2025.09.0-test \
  -f dry-run=true
```

Production mode (creates PR):
```bash
gh workflow run release-generate-sbom.yml \
  --repo posit-dev/positron \
  --ref main \
  -f version=2025.09.2 \
  -f dry-run=false
```
