### PR TITLE
Bundle posit.slc v0.6.0 for Positron Pro builds

### DIFF
--- a/build/lib/builtInExtensions.ts
+++ b/build/lib/builtInExtensions.ts
@@ -76,8 +76,8 @@ function isUpToDate(extension: IExtensionDefinition): boolean {
 
 function getExtensionDownloadStream(extension: IExtensionDefinition) {
 	// --- Start PWB: Bundle PWB extension ---
-	// the PWB extension is a special case because it's not availble from the marketplace or github
-	if (extension.name === 'rstudio.rstudio-workbench') {
+	// Route any extension with a positUrl to the Posit CDN.
+	if (extension.positUrl) {
 		return ext.fromPositUrl(extension)
 			.pipe(rename(p => p.dirname = `${extension.name}/${p.dirname}`));
 	}

--- a/product.json
+++ b/product.json
@@ -101,6 +101,16 @@
 			"metadata": {
 				"publisherDisplayName": "Posit PBC"
 			}
+		},
+		{
+			"name": "posit.slc",
+			"version": "0.6.0",
+			"positUrl": "https://cdn.posit.co/pwb-components/slc-extension",
+			"type": "reh-web-pwb",
+			"sha256": "a824bc7739e226e1b40ea0f8c4e4f4c6f796fc3b4abfa6e9abe3bd119a30d938",
+			"metadata": {
+				"publisherDisplayName": "Posit PBC"
+			}
 		}
 	],
 	"bootstrapExtensions": [

--- a/product.json
+++ b/product.json
@@ -107,7 +107,7 @@
 			"version": "0.6.0",
 			"positUrl": "https://cdn.posit.co/pwb-components/slc-extension",
 			"type": "reh-web-pwb",
-			"sha256": "a824bc7739e226e1b40ea0f8c4e4f4c6f796fc3b4abfa6e9abe3bd119a30d938",
+			"sha256": "105cd11357bde4c330bf12aac856b0ee3eae2c967bab6037c3dedacd55f59e7d",
 			"metadata": {
 				"publisherDisplayName": "Posit PBC"
 			}


### PR DESCRIPTION
This commit bundles the in-preview `posit.slc` extension with Positron Pro builds using the same general approach we use for the Workbench extension.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

There are no associated end-to-end tests.