### PR TITLE
ci: drop deprecated setup-graphviz action and tidy Windows e2e job naming

### DIFF
--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -244,7 +244,7 @@ jobs:
           pyenv global 3.10.10
 
       - name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v2.0.2
+        run: brew install graphviz
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -59,7 +59,7 @@ on:
       display_name:
         required: false
         description: "The name of the job as it will appear in the GitHub Actions UI."
-        default: "e2e-windows-run"
+        default: "electron-win"
         type: string
       upload_logs:
         required: false
@@ -92,8 +92,8 @@ permissions:
   contents: read
 
 jobs:
-  e2e-windows-run:
-    name: ${{ inputs.display_name || 'e2e-windows-run' }}-${{ matrix.shard }}
+  windows:
+    name: ${{ inputs.display_name || 'electron-win' }}-${{ matrix.shard }}
     timeout-minutes: 150
     runs-on: windows-latest-8x
     strategy:
@@ -350,7 +350,7 @@ jobs:
           rig ls
 
       - name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v2.0.2
+        run: choco install graphviz -y --no-progress
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -484,7 +484,7 @@ jobs:
     name: ${{ inputs.display_name }}
     timeout-minutes: 10
     if: ${{ !cancelled() }}
-    needs: [e2e-windows-run]
+    needs: [windows]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test-full-suite.yml
+++ b/.github/workflows/test-full-suite.yml
@@ -178,7 +178,7 @@ jobs:
       skip_cache: ${{ inputs.commit != 'latest' }}
       grep: ${{ inputs.grep || '' }}
       project: "e2e-windows"
-      display_name: "windows"
+      display_name: "electron-win"
       allow_soft_fail: false
       upload_logs: false
       shards: 4

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -39,7 +39,7 @@ jobs:
       save_cache: true
       grep: ""
       project: "e2e-windows"
-      display_name: "windows"
+      display_name: "electron-win"
       allow_soft_fail: true
       upload_logs: false
       shards: 3

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -65,7 +65,7 @@ jobs:
     with:
       save_cache: true
       grep: ${{ needs.pr-tags.outputs.tags }}
-      display_name: "windows"
+      display_name: "electron-win"
       upload_logs: false
       allow_soft_fail: false
     secrets: inherit


### PR DESCRIPTION
### Summary
Two small CI tidy-ups.

- Replace `ts-graphviz/setup-graphviz@v2.0.2` (Node 20, deprecated) with `brew install graphviz` / `choco install graphviz`
- Rename Windows e2e `display_name` to `electron-win` so the dashboard shows `electron-win` alongside `electron-linux` / `chromium-linux`
- Rename inner Windows job key `e2e-windows-run` → `windows`

### QA Notes
n/a