### PR TITLE
 Remove "Run Dash App" button from notebooks

### DIFF
--- a/extensions/positron-python/src/client/positron/webAppContexts.ts
+++ b/extensions/positron-python/src/client/positron/webAppContexts.ts
@@ -13,7 +13,7 @@ function getSupportedLibraries(): string[] {
 }
 
 export function detectWebApp(document: vscode.TextDocument): void {
-    if (document.languageId !== 'python') {
+    if (document.languageId !== 'python' || document.uri.scheme === 'vscode-notebook-cell') {
         executeCommand('setContext', 'pythonAppFramework', undefined);
         return;
     }
@@ -101,9 +101,11 @@ export function activateAppDetection(disposables: vscode.Disposable[]): void {
     disposables.push(
         // Trigger when the active editor changes
         vscode.window.onDidChangeActiveTextEditor((editor) => {
+            activeEditor = editor;
             if (editor) {
-                activeEditor = editor;
                 triggerUpdateApp();
+            } else {
+                executeCommand('setContext', 'pythonAppFramework', undefined);
             }
         }),
 

--- a/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/webAppContexts.unit.test.ts
@@ -20,7 +20,8 @@ suite('Discover Web app frameworks', () => {
         document = {
             getText: () => '',
             languageId: 'python',
-        } as vscode.TextDocument;
+            uri: { scheme: 'file' },
+        } as unknown as vscode.TextDocument;
     });
 
     teardown(() => {
@@ -64,6 +65,17 @@ suite('Discover Web app frameworks', () => {
 
             assert.strictEqual(actual, expected);
         });
+    });
+
+    test('should clear context for notebook cell documents', () => {
+        const notebookDocument = {
+            getText: () => 'import dash\napp = Dash(__name__)',
+            languageId: 'python',
+            uri: { scheme: 'vscode-notebook-cell' },
+        } as unknown as vscode.TextDocument;
+        detectWebApp(notebookDocument);
+
+        assert.ok(executeCommandStub.calledOnceWith('setContext', 'pythonAppFramework', undefined));
     });
 
     // Tests for app creation patterns


### PR DESCRIPTION
Fixes #11716.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Removed the "Run Dash App" button from notebooks (#11716)

### Validation Steps

@:apps @:notebooks

1. Open a Positron notebook
2. Create a cell with Dash code (e.g. `from dash import Dash; app = Dash(__name__)`)
3. Verify the Run Dash App button does **not** appear in the toolbar
4. Open a plain `.py` file with Dash imports -- verify the button **does** appear
5. Switch back to the notebook -- verify the button disappears