### PR TITLE
Include deprecated Packages pane configuration

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -90,7 +90,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			default: true,
 			scope: ConfigurationScope.APPLICATION,
 			description: nls.localize('positron.packages.enable', 'Show the Packages pane.'),
-			deprecationMessage: nls.localize('positron.packages.enable.deprecated', "Deprecated. Use '#packages.enabled#' instead."),
+			markdownDeprecationMessage: nls.localize('positron.packages.enable.deprecated', "Deprecated. Use `#packages.enabled#` instead."),
 			tags: ['preview'],
 		}
 	}

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -91,7 +91,6 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			scope: ConfigurationScope.APPLICATION,
 			description: nls.localize('positron.packages.enable', 'Show the Packages pane.'),
 			markdownDeprecationMessage: nls.localize('positron.packages.enable.deprecated', "Deprecated. Use `#packages.enabled#` instead."),
-			tags: ['preview'],
 		}
 	}
 });

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -91,7 +91,6 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			scope: ConfigurationScope.APPLICATION,
 			description: nls.localize('positron.packages.enable', 'Show the Packages pane.'),
 			deprecationMessage: nls.localize('positron.packages.enable.deprecated', "Deprecated. Use '#packages.enabled#' instead."),
-			included: false,
 			tags: ['preview'],
 		}
 	}

--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -394,7 +394,7 @@ export const tocData: ITOCEntry<string> = {
 				{
 					id: 'features/packages',
 					label: localize('packages', "Packages"),
-					settings: ['packages.*']
+					settings: ['packages.*', 'positron.packages.*']
 				},
 				{
 					id: 'features/plots',

--- a/test/e2e/pages/packages.ts
+++ b/test/e2e/pages/packages.ts
@@ -189,7 +189,7 @@ export class Packages {
 		await expect(this.packagesContainer).toBeVisible();
 
 		await this.searchPackages(packageName);
-		const helpButton = this.packagesContainer.getByRole('button', { name: `Show help for ${packageName}` });
+		const helpButton = this.packagesContainer.getByRole('button', { name: `Show help for ${packageName}`, exact: true });
 
 		await helpButton.click();
 		await this.clearFilter();


### PR DESCRIPTION
If a configuration is not included, its default value is never set as well. This resulted in the ContextKey used to show the sidebar to fail.

If a user never configured this setting previously, it will not be shown to the user. If a user previous configured it, the setting will appear. Once re-enabled to match the default, the setting will actually disappear.

See #13349

Fixes regression in #13642

@:packages-pane