### PR TITLE
Fix notebook cell focus ring showing up in unfocused notebooks

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -731,6 +731,7 @@
 		"--vscode-positronNotebook-cellFocusedBorder",
 		"--vscode-positronNotebook-cellFooterForeground",
 		"--vscode-positronNotebook-cellHoverBorder",
+		"--vscode-positronNotebook-cellInactiveFocusedBorder",
 		"--vscode-positronNotebook-errorForeground",
 		"--vscode-positronNotebook-foreground",
 		"--vscode-positronNotebook-imgPlaceholderBackground",

--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -725,7 +725,6 @@
 		"--vscode-positronNotebook-action-bar-inset",
 		"--vscode-positronNotebook-actionBarBackground",
 		"--vscode-positronNotebook-actionBarBorder",
-		"--vscode-positronNotebook-border",
 		"--vscode-positronNotebook-cell-radius",
 		"--vscode-positronNotebook-cellBorder",
 		"--vscode-positronNotebook-cellFocusedBorder",

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -2051,6 +2051,9 @@ export const POSITRON_NOTEBOOK_CELL_HOVER_BORDER = registerColor('positronNotebo
 // Positron notebook cell border color when focused or being edited.
 export const POSITRON_NOTEBOOK_CELL_FOCUSED_BORDER = registerColor('positronNotebook.cellFocusedBorder', focusBorder, localize('positronNotebook.cellFocusedBorder', "Positron notebook cell border color when focused or being edited."));
 
+// Positron notebook cell border color when selected or being edited in a notebook pane that does not currently have focus.
+export const POSITRON_NOTEBOOK_CELL_INACTIVE_FOCUSED_BORDER = registerColor('positronNotebook.cellInactiveFocusedBorder', POSITRON_NOTEBOOK_CELL_BORDER, localize('positronNotebook.cellInactiveFocusedBorder', "Positron notebook cell border color when selected or being edited in a notebook pane that does not currently have focus."));
+
 // Positron notebook cell action bar background color.
 export const POSITRON_NOTEBOOK_ACTION_BAR_BACKGROUND = registerColor('positronNotebook.actionBarBackground', editorBackground, localize('positronNotebook.actionBarBackground', "Positron notebook cell action bar background color."));
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.css
@@ -35,11 +35,6 @@
 	/* Base state: action bar hidden by default */
 	visibility: hidden;
 
-	/* Always show action bar when cell is active (selected) */
-	&.visible {
-		visibility: visible;
-	}
-
 	/* Toggled by useToggleOnSticky while the bar is stuck to the scrollport.
 	 * Square off the top corners so the bar meets the scroll viewport flush. */
 	&.positron-notebooks-cell-action-bar--stuck {
@@ -49,7 +44,20 @@
 	}
 }
 
-/* Show action bar when cell is hovered (includes drag handle hover) */
+/*
+ * Show the action bar for the active cell, but only when the notebook pane itself
+ * has focus. Without the focus-within gate, side-by-side notebooks would each
+ * present their active cell's action bar as if both were focused.
+ */
+.positron-notebook-editor:focus-within .positron-notebooks-cell-action-bar.visible {
+	visibility: visible;
+}
+
+/*
+ * Show action bar when cell is hovered (includes drag handle hover).
+ * Hover access is intentionally not gated on focus-within -- users can still
+ * trigger actions on an unfocused notebook by hovering.
+ */
 .sortable-cell:hover > .positron-notebook-cell .positron-notebooks-cell-action-bar {
 	visibility: visible;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -154,6 +154,30 @@ focus indicator. Revert the selection border to avoid a doubled ring. */
 .positron-notebook-markdown-cell .positron-notebook-cell-outputs:has(.empty-output-msg) {
 	border-style: dashed;
 	border-color: var(--vscode-positronNotebook-cellBorder);
+}
+
+
+/* === Inactive Notebook Pane: dim the cell focus border when the notebook does not have focus === */
+
+/*
+ * When focus leaves the entire notebook pane (e.g. have two side-by-side notebooks open),
+ * selected/editing cells fall back to the muted inactive border so only the truly focused
+ * notebook shows the active blue focus ring.
+ */
+.positron-notebook-editor:not(:focus-within) .positron-notebook-cell.selected .positron-notebook-editor-section,
+.positron-notebook-editor:not(:focus-within) .positron-notebook-code-cell.selected .positron-notebook-cell-outputs,
+.positron-notebook-editor:not(:focus-within) .positron-notebook-cell.editing .positron-notebook-editor-section,
+.positron-notebook-editor:not(:focus-within) .positron-notebook-code-cell.editing .positron-notebook-cell-outputs,
+.positron-notebook-editor:not(:focus-within) .positron-notebook-cell.selected .positron-notebook-editor-container:not(.editor-hidden),
+.positron-notebook-editor:not(:focus-within) .positron-notebook-cell.editing .positron-notebook-editor-container:not(.editor-hidden),
+.positron-notebook-editor:not(:focus-within) .positron-notebook-markdown-cell.selected .positron-notebook-cell-outputs,
+.positron-notebook-editor:not(:focus-within) .positron-notebook-markdown-cell.editing .positron-notebook-cell-outputs {
+	border-color: var(--vscode-positronNotebook-cellInactiveFocusedBorder);
+}
+
+.positron-notebook-editor:not(:focus-within) .positron-notebook-cell.selected:has(.positron-notebook-outputs-section.no-outputs) .positron-notebook-editor-section,
+.positron-notebook-editor:not(:focus-within) .positron-notebook-cell.editing:has(.positron-notebook-outputs-section.no-outputs) .positron-notebook-editor-section {
+	border-bottom-color: var(--vscode-positronNotebook-cellInactiveFocusedBorder);
 }
 
 

--- a/test/e2e/tests/notebooks-positron/notebook-side-by-side.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-side-by-side.test.ts
@@ -104,6 +104,10 @@ test.describe('Notebook Side-by-Side Isolation', {
 			// Focus the RIGHT notebook by clicking its cell
 			await rightNotebook.cell(0).click();
 
+			// Hover the LEFT cell to reveal its action bar -- the unfocused notebook's
+			// active-cell action bar is hidden by default and only reappears on hover.
+			await leftNotebook.cell(0).hover();
+
 			// Verify clicking "Run Cell" in the LEFT notebook runs the cell in the LEFT notebook, not the focused RIGHT notebook
 			await leftNotebook.runCellButton(0).click();
 			await expect(leftNotebook.cellOutput(0)).toContainText('left_nb', { timeout: 30000 });


### PR DESCRIPTION
Fixes #12740

### Summary

When two `.ipynb` notebooks are open side-by-side in the Positron Notebook editor, both panes previously rendered the active cell's blue focus border and surfaced the cell's action bar by default, making both notebooks look as if they had focus. 

This PR fixes that by introducing a `positronNotebook.cellInactiveFocusedBorder` theme color that we can use when an active cell's editor tab is not focused. Builds on the theme colors introduced in #13768.

### Screenshots

https://github.com/user-attachments/assets/771e057f-6236-47a1-9436-2d14dfdc8725

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Side-by-side Positron notebooks now visually distinguish the focused pane from the unfocused pane: the unfocused pane's selected cell shows a muted border, and its action bar no longer auto-appears (#12740).

### Validation Steps

@:notebooks 
@:positron-notebooks

1. Open two `.ipynb` notebooks side-by-side in the Positron Notebook editor.
2. Click a cell in the left notebook → its border turns blue and the cell action bar is shown.
3. Click a cell in the right notebook → the left notebook's selected cell border falls back to the default border color, and its action bar disappears. The right notebook's selected cell now shows the active blue border and action bar.
4. With focus still on the right notebook, hover any cell in the left notebook → the action bar should reappear on hover.
5. Click outside both notebooks (terminal, sidebar, etc.) → neither pane shows the active focus styling on its selected cell.
6. Optional theming check: add the snippet below to `workbench.colorCustomizations` in `settings.json` and confirm the inactive-focused border picks up the bright override only when the parent notebook lacks focus.

   ```jsonc
   "workbench.colorCustomizations": {
     "positronNotebook.cellInactiveFocusedBorder": "#ff00aa" // hot pink when notebook pane is unfocused
   }
   ```
