### PR TITLE
Remove Editor Actions toggle

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -141,7 +141,11 @@ export const TITLE_BAR_SETTINGS = [
 	LayoutSettings.ACTIVITY_BAR_LOCATION,
 	LayoutSettings.COMMAND_CENTER,
 	...COMMAND_CENTER_SETTINGS,
-	LayoutSettings.EDITOR_ACTIONS_LOCATION,
+	// --- Start Positron ---
+	// Positron owns workbench.editor.editorActionsLocation via the Editor Action Toolbar,
+	// so the upstream entry in TITLE_BAR_SETTINGS is removed.
+	// LayoutSettings.EDITOR_ACTIONS_LOCATION,
+	// --- End Positron ---
 	LayoutSettings.LAYOUT_ACTIONS,
 	MenuSettings.MenuBarVisibility,
 	TitleBarSetting.TITLE_BAR_STYLE,

--- a/src/vs/workbench/browser/parts/titlebar/titlebarActions.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarActions.ts
@@ -134,7 +134,11 @@ class ToggleCustomTitleBar extends Action2 {
 							ContextKeyExpr.and(
 								ContextKeyExpr.equals('config.workbench.layoutControl.enabled', false),
 								ContextKeyExpr.equals('config.window.commandCenter', false),
-								ContextKeyExpr.notEquals('config.workbench.editor.editorActionsLocation', 'titleBar'),
+								// --- Start Positron ---
+								// Positron owns workbench.editor.editorActionsLocation via the Editor Action
+								// Toolbar, so this clause no longer participates in the visibility logic.
+								// ContextKeyExpr.notEquals('config.workbench.editor.editorActionsLocation', 'titleBar'),
+								// --- End Positron ---
 								ContextKeyExpr.notEquals('config.workbench.activityBar.location', 'top'),
 								ContextKeyExpr.notEquals('config.workbench.activityBar.location', 'bottom')
 							)?.negate()

--- a/src/vs/workbench/browser/parts/titlebar/titlebarActions.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarActions.ts
@@ -6,7 +6,10 @@
 import { ILocalizedString, localize, localize2 } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
-import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+// --- Start Positron ---
+// Unused after the ToggleEditorActions registration below was removed.
+// import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+// --- End Positron ---
 import { LayoutSettings } from '../../../services/layout/browser/layoutService.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr, ContextKeyExpression, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
@@ -218,54 +221,59 @@ registerAction2(class HideCustomTitleBar extends Action2 {
 	}
 });
 
-registerAction2(class ToggleEditorActions extends Action2 {
-	static readonly settingsID = `workbench.editor.editorActionsLocation`;
-	constructor() {
-
-		const titleBarContextCondition = ContextKeyExpr.and(
-			ContextKeyExpr.equals(`config.workbench.editor.showTabs`, 'none').negate(),
-			ContextKeyExpr.equals(`config.${ToggleEditorActions.settingsID}`, 'default'),
-		)?.negate();
-
-		super({
-			id: `toggle.${ToggleEditorActions.settingsID}`,
-			title: localize('toggle.editorActions', 'Editor Actions'),
-			toggled: ContextKeyExpr.equals(`config.${ToggleEditorActions.settingsID}`, 'hidden').negate(),
-			menu: [
-				{ id: MenuId.TitleBarContext, order: 3, when: titleBarContextCondition, group: '2_config' },
-				{ id: MenuId.TitleBarTitleContext, order: 3, when: titleBarContextCondition, group: '2_config' }
-			]
-		});
-	}
-
-	run(accessor: ServicesAccessor, ...args: unknown[]): void {
-		const configService = accessor.get(IConfigurationService);
-		const storageService = accessor.get(IStorageService);
-
-		const location = configService.getValue<string>(ToggleEditorActions.settingsID);
-		if (location === 'hidden') {
-			const showTabs = configService.getValue<string>(LayoutSettings.EDITOR_TABS_MODE);
-
-			// If tabs are visible, then set the editor actions to be in the title bar
-			if (showTabs !== 'none') {
-				configService.updateValue(ToggleEditorActions.settingsID, 'titleBar');
-			}
-
-			// If tabs are not visible, then set the editor actions to the last location the were before being hidden
-			else {
-				const storedValue = storageService.get(ToggleEditorActions.settingsID, StorageScope.PROFILE);
-				configService.updateValue(ToggleEditorActions.settingsID, storedValue ?? 'default');
-			}
-
-			storageService.remove(ToggleEditorActions.settingsID, StorageScope.PROFILE);
-		}
-		// Store the current value (titleBar or default) in the storage service for later to restore
-		else {
-			configService.updateValue(ToggleEditorActions.settingsID, 'hidden');
-			storageService.store(ToggleEditorActions.settingsID, location, StorageScope.PROFILE, StorageTarget.USER);
-		}
-	}
-});
+// --- Start Positron ---
+// Positron supplies its own Editor Action Toolbar, so the upstream "Editor Actions" toggle
+// (title-bar context menu entry + toggle.workbench.editor.editorActionsLocation command) is
+// removed as it is no longer useful.
+// registerAction2(class ToggleEditorActions extends Action2 {
+// 	static readonly settingsID = `workbench.editor.editorActionsLocation`;
+// 	constructor() {
+//
+// 		const titleBarContextCondition = ContextKeyExpr.and(
+// 			ContextKeyExpr.equals(`config.workbench.editor.showTabs`, 'none').negate(),
+// 			ContextKeyExpr.equals(`config.${ToggleEditorActions.settingsID}`, 'default'),
+// 		)?.negate();
+//
+// 		super({
+// 			id: `toggle.${ToggleEditorActions.settingsID}`,
+// 			title: localize('toggle.editorActions', 'Editor Actions'),
+// 			toggled: ContextKeyExpr.equals(`config.${ToggleEditorActions.settingsID}`, 'hidden').negate(),
+// 			menu: [
+// 				{ id: MenuId.TitleBarContext, order: 3, when: titleBarContextCondition, group: '2_config' },
+// 				{ id: MenuId.TitleBarTitleContext, order: 3, when: titleBarContextCondition, group: '2_config' }
+// 			]
+// 		});
+// 	}
+//
+// 	run(accessor: ServicesAccessor, ...args: unknown[]): void {
+// 		const configService = accessor.get(IConfigurationService);
+// 		const storageService = accessor.get(IStorageService);
+//
+// 		const location = configService.getValue<string>(ToggleEditorActions.settingsID);
+// 		if (location === 'hidden') {
+// 			const showTabs = configService.getValue<string>(LayoutSettings.EDITOR_TABS_MODE);
+//
+// 			// If tabs are visible, then set the editor actions to be in the title bar
+// 			if (showTabs !== 'none') {
+// 				configService.updateValue(ToggleEditorActions.settingsID, 'titleBar');
+// 			}
+//
+// 			// If tabs are not visible, then set the editor actions to the last location the were before being hidden
+// 			else {
+// 				const storedValue = storageService.get(ToggleEditorActions.settingsID, StorageScope.PROFILE);
+// 				configService.updateValue(ToggleEditorActions.settingsID, storedValue ?? 'default');
+// 			}
+//
+// 			storageService.remove(ToggleEditorActions.settingsID, StorageScope.PROFILE);
+// 		}
+// 		// Store the current value (titleBar or default) in the storage service for later to restore
+// 		else {
+// 			configService.updateValue(ToggleEditorActions.settingsID, 'hidden');
+// 			storageService.store(ToggleEditorActions.settingsID, location, StorageScope.PROFILE, StorageTarget.USER);
+// 		}
+// 	}
+// });
+// --- End Positron ---
 
 // --- Toolbar actions --- //
 

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -57,7 +57,11 @@ export const enum LayoutSettings {
 	ACTIVITY_BAR_AUTO_HIDE = 'workbench.activityBar.autoHide',
 	ACTIVITY_BAR_COMPACT = 'workbench.activityBar.compact',
 	EDITOR_TABS_MODE = 'workbench.editor.showTabs',
-	EDITOR_ACTIONS_LOCATION = 'workbench.editor.editorActionsLocation',
+	// --- Start Positron ---
+	// Positron owns workbench.editor.editorActionsLocation via the Editor Action Toolbar,
+	// so the upstream enum entry is removed.
+	// EDITOR_ACTIONS_LOCATION = 'workbench.editor.editorActionsLocation',
+	// --- End Positron ---
 	COMMAND_CENTER = 'window.commandCenter',
 	LAYOUT_ACTIONS = 'workbench.layoutControl.enabled',
 	// --- Start Positron ---


### PR DESCRIPTION
## Description

Removed Positron's reliance on the upstream "Editor Actions" toggle now that the Editor Action Toolbar fully owns `workbench.editor.editorActionsLocation`. In [titlebarActions.ts](src/vs/workbench/browser/parts/titlebar/titlebarActions.ts), the `ToggleEditorActions` `registerAction2` block (and its title-bar/title-bar-title context-menu entries) is commented out behind Positron markers, along with the now-orphaned `IStorageService`/`StorageScope`/`StorageTarget` import and the `editorActionsLocation` clause inside `ToggleCustomTitleBar`'s menu `when` chain. In [layoutService.ts](src/vs/workbench/services/layout/browser/layoutService.ts), the existing `EDITOR_ACTIONS_LOCATION` enum entry is wrapped in markers with the same rationale comment. All edits follow the upstream-edit convention — `// --- Start Positron ---` / `// --- End Positron ---` around contiguous, commented-out lines — so the next upstream merge has a clear conflict signal.

This fix removes Editor Actions from the title bar context menu. Before:

<p>
<img width="174" height="71" alt="image" src="https://github.com/user-attachments/assets/4f259c35-b050-4c27-b203-ad2df4913783" />
</p>

After:

<p>
<img width="186" height="45" alt="image" src="https://github.com/user-attachments/assets/ca1f69ab-7ba1-4106-8cd3-923b317919fc" />
</p>

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- #13303 - Remove Editor Actions toggle title bar context menu entry.

### Validation Steps

