### PR TITLE
PETE prompt tuning: surface gaps and e2e recommendation

### DIFF
--- a/.claude/skills/pr-test-checker/SKILL.md
+++ b/.claude/skills/pr-test-checker/SKILL.md
@@ -75,12 +75,26 @@ When the change touches one of these, check whether the relevant e2e test is tag
 - Native UI (no Electron menus, dialogs, or system file pickers)
 - Network (CORS, no raw sockets)
 - Auth flows (typically OAuth-only in web)
+- Lifecycle (shutdown reasons, reload vs quit, session reconnect -- reload is a no-op concept on desktop quit but is the dominant case on web)
 
 To check whether a candidate e2e test has the right tag, Grep its file for `@:win` or `@:web` literally -- the tags appear in test titles or describe blocks.
 
+### Surface-specific code paths
+
+The strongest signal of differential desktop vs web behavior -- much stronger than vague "hotspot" matching:
+
+- **Parallel implementations**: a service has both `src/vs/.../browser/<name>.ts` AND `src/vs/.../electron-sandbox/<name>.ts` files. Common examples: `services/lifecycle/`, `services/host/`, `services/files/`, `services/dialogs/`. A change to (or test of) one path does not cover the other.
+- **Surface branching**: the diff contains `UIKind.Web`, `isWeb`, `platform.isElectron`, `os.platform() === 'win32'`, or paths imported from `browser/` / `electron-sandbox/`. Each branch is its own untested behavior until proven otherwise.
+
+When you see a parallel-implementation file in the diff, Grep its sibling (`browser/foo.ts` <-> `electron-sandbox/foo.ts`) to see if the bug or behavior also exists there. A fix that only lands on one side is half a fix.
+
 ### Decision rule
 
-When the change touches a Windows or web hotspot AND no e2e test is tagged for that surface, add a "Deployment note" to the verdict body -- even when grading Adequate. Don't auto-upgrade to Insufficient on surface risk alone; unit tests are still the cheaper test for pure logic. But name the gap so the author can decide whether to tag an existing e2e test, add a new one, or do a manual cross-surface check.
+Two cases, two responses:
+
+1. **Direct surface gap (Insufficient).** The diff modifies code under `src/vs/.../browser/` (or `electron-sandbox/`), adds web/desktop branching, or touches Windows-specific branching, AND no test exercises the changed path. Name the specific Vitest or extension-host test that should exist. A test that covers only the desktop branch of a `UIKind`-branched function is not coverage of the web branch, and vice versa.
+
+2. **Indirect surface gap (Deployment note, keep verdict).** The diff touches a Windows or web hotspot but doesn't directly modify surface-specific code (e.g., it *consumes* a service whose `browser/`/`electron-sandbox/` implementations diverge), AND no e2e test is tagged for that surface. Add a Deployment note even when grading Adequate -- name the sibling file or branch the author should consider. Don't auto-upgrade to Insufficient on surface risk alone; unit tests are still the cheaper test for pure logic.
 
 ## Investigation steps
 
@@ -98,6 +112,7 @@ Do these in order before writing your verdict:
    - For e2e coverage of UI features, check `test/e2e/tests/` for tagged tests
 4. **Read the candidate test files** to confirm they actually exercise the changed behavior, not just adjacent code. A test that imports a module but doesn't call the new function is not coverage.
 5. **For pure refactors or renames**, existing passing tests are usually sufficient -- but only if the test surface didn't change. Check.
+6. **Check for surface-specific code paths.** Grep the diff for `browser/`, `electron-sandbox/`, `UIKind`, `isWeb`, `platform.isElectron`, or `os.platform()`. For any source file under a `browser/` or `electron-sandbox/` directory, check whether a sibling implementation exists across the split (`Glob` for `**/<name>.ts`) -- a change or test on one side does not cover the other. Apply the Decision rule.
 
 Cap your investigation at ~10-15 tool calls. If you can't determine coverage in that budget, lean toward Insufficient with a note that you couldn't fully verify.
 
@@ -140,9 +155,10 @@ Output **exactly one final assistant message** containing the markdown report be
 For "Adequate" / "Adequate via existing coverage" / "Not applicable": omit this section or write "None.">
 
 ### Deployment note (optional)
-<Include this section ONLY when the change touches a Windows or web hotspot AND no e2e test is tagged for that surface (`@:win` for Windows, `@:web` for web). Name the surface and the missing tag. Examples:
+<Include this section ONLY for the **indirect surface gap** case from the Decision rule -- the diff touches a Windows or web hotspot but doesn't directly modify surface-specific code, AND no surface-specific test exists. (For direct gaps in `browser/` / `electron-sandbox/` / surface branching, grade Insufficient and use Suggested additions instead.) Name the surface and the gap. Examples:
 - "Touches Windows path normalization (`foo.ts:23`). No `@:win`-tagged e2e exercises this path, so a Windows-only regression would slip past PR review. Consider tagging an existing e2e test or adding a manual Windows check."
 - "Adds file-picker behavior (`bar.tsx:88`). No `@:web`-tagged e2e covers this; in the web build there are no native dialogs, so this needs a web-aware test or manual check before shipping to web."
+- "Subscribes to `ILifecycleService.onWillShutdown` (`baz.ts:42`). The `browser/lifecycleService.ts` and `electron-sandbox/lifecycleService.ts` implementations diverge in how they fill the shutdown reason; this PR's tests cover the desktop path but not the web equivalent. Consider a Vitest of the web sibling or a `@:web` e2e covering the reload-vs-quit distinction."
 
 Omit entirely if not applicable.>
 

--- a/.claude/skills/pr-test-checker/SKILL.md
+++ b/.claude/skills/pr-test-checker/SKILL.md
@@ -123,6 +123,8 @@ Do these in order before writing your verdict:
 6. **Check for surface-specific code paths.** Grep the diff for `browser/`, `electron-sandbox/`, `UIKind`, `isWeb`, `platform.isElectron`, or `os.platform()`. For any source file under a `browser/` or `electron-sandbox/` directory, check whether a sibling implementation exists across the split (`Glob` for `**/<name>.ts`) -- a change or test on one side does not cover the other. Apply the Decision rule.
 7. **Scan the PR body for `@:` e2e tag mentions.** Tags like `@:posit-assistant`, `@:positron-notebooks`, `@:critical`, `@:web`, `@:win` select which existing e2e tests run in PR CI -- they don't by themselves mean a new e2e test is expected. The tag tells you where existing coverage lives: grep `test/e2e/tests/` for the tag (e.g., `grep -r "@:posit-assistant" test/e2e/tests/`) and read enough of those tests to know whether they cover the new behavior or just adjacent regressions. Only recommend adding a new e2e if the change independently warrants one per the Cost guidance principle (the behavior needs the full app rendered to verify) AND no existing tagged test covers it. If existing tagged tests already cover the new behavior, that's coverage -- note it under "Existing coverage" and move on.
 
+   **Also check for missing tags.** While reading existing tagged e2e tests, note which tags they carry. If a test exercises the area being changed but its tag isn't in the PR body, suggest the tag -- those tests won't run in this PR's CI without it. The authoritative tag list lives at `test/e2e/infra/test-runner/test-tags.ts`. Map the changed feature area to its feature tag by finding e2e tests that import the modified file or its containing service, then reading the tag(s) on those tests. Only suggest **feature** tags (`@:data-explorer`, `@:sessions`, `@:assistant`, `@:plots`, etc.); platform tags (`@:win`, `@:web`) are governed by Deployment coverage and belong in the Deployment note, not here. When unsure whether a tag applies, skip rather than guess. Surface any missing tag in the "Suggested tags" output section.
+
 Cap your investigation at ~10-15 tool calls. If you can't determine coverage in that budget, lean toward Insufficient with a note that you couldn't fully verify.
 
 ## Rubric
@@ -166,6 +168,13 @@ Output **exactly one final assistant message** containing the markdown report be
 - **Add `<test file path>`** (or "Add to `<existing test file>`"): a <Vitest|extension-host|e2e> test for <specific function or behavior>. Justify the runner choice in one phrase ("pure function -- unit suffices" or "spans kernel + console UI -- needs e2e").
 
 For "Adequate" / "Adequate via existing coverage" / "Not applicable": omit this section or write "None.">
+
+### Suggested tags (optional)
+<Include this section when the PR touches a feature area whose existing e2e tests are gated by a tag the PR body didn't include -- the tests exist but won't run on this PR without the tag. List the missing tag(s), the area they cover, and (briefly) the evidence: which test file you found and what it asserts. Examples:
+- "Touches data explorer column logic but no `@:data-explorer` in PR body -- `test/e2e/tests/data-explorer/column-summary.test.ts` would exercise this change at PR time if tagged."
+- "Touches kernel supervisor shutdown but no `@:sessions` in PR body -- `test/e2e/tests/sessions/session-lifecycle.test.ts` covers reload-survives-sessions behavior, won't run without the tag."
+
+Only suggest **feature** tags from `test/e2e/infra/test-runner/test-tags.ts`. Don't suggest platform tags (`@:win`, `@:web`) here -- those belong in the Deployment note. Omit entirely if not applicable.>
 
 ### Deployment note (optional)
 <Include this section ONLY for the **indirect surface gap** case from the Decision rule -- the diff touches a Windows or web hotspot but doesn't directly modify surface-specific code, AND no surface-specific test exists. (For direct gaps in `browser/` / `electron-sandbox/` / surface branching, grade Insufficient and use Suggested additions instead.) Name the surface and the gap. Examples:

--- a/.claude/skills/pr-test-checker/SKILL.md
+++ b/.claude/skills/pr-test-checker/SKILL.md
@@ -32,7 +32,13 @@ Authoritative reference: read `CLAUDE.md` (project root) and `.claude/rules/vite
 
 ## Cost guidance (this affects your suggestions)
 
-Unit tests (Vitest) are cheap and reliable. E2E tests are expensive and prone to flake. **Always recommend the cheapest level that covers the behavior.** Only recommend e2e when the change genuinely needs the full app rendered: cross-process behavior, native UI interactions, multi-service workflows the user would visibly perform. Do not recommend e2e for logic that could be unit-tested with a stubbed service.
+Unit tests (Vitest) are cheap and reliable. E2E tests are expensive and prone to flake. **Default to the cheapest level that covers the behavior.** Don't recommend e2e for logic that could be unit-tested with a stubbed service.
+
+But don't *under*-recommend e2e either. **Recommend an e2e test when the change genuinely needs the full app rendered to verify -- when no unit-level seam can reach what would actually break.** Common patterns (not an exhaustive checklist -- if you can articulate why a unit test can't reach a behavior outside this list, e2e is still the right call):
+- A new user-visible feature gated by an interactive flow: a new provider, panel, modal, command palette entry, or sign-in dialog
+- Cross-process workflows where the user visibly drives the interaction (extension host + workbench UI + a backing service)
+- Auth / credential flows where the contract under test includes the modal UI, not just the resolver function
+- Anything where the bug you're guarding against would only manifest when real services, real persistence, or real rendering are in play
 
 When a unit test would suffice but the author wrote an e2e test, that's worth noting as "consider unit instead" -- but it's not grounds for an Insufficient verdict if the coverage is real.
 
@@ -113,6 +119,7 @@ Do these in order before writing your verdict:
 4. **Read the candidate test files** to confirm they actually exercise the changed behavior, not just adjacent code. A test that imports a module but doesn't call the new function is not coverage.
 5. **For pure refactors or renames**, existing passing tests are usually sufficient -- but only if the test surface didn't change. Check.
 6. **Check for surface-specific code paths.** Grep the diff for `browser/`, `electron-sandbox/`, `UIKind`, `isWeb`, `platform.isElectron`, or `os.platform()`. For any source file under a `browser/` or `electron-sandbox/` directory, check whether a sibling implementation exists across the split (`Glob` for `**/<name>.ts`) -- a change or test on one side does not cover the other. Apply the Decision rule.
+7. **Scan the PR body for `@:` e2e tag mentions.** Tags like `@:posit-assistant`, `@:positron-notebooks`, `@:critical`, `@:web`, `@:win` select which existing e2e tests run in PR CI -- they don't by themselves mean a new e2e test is expected. The tag tells you where existing coverage lives: grep `test/e2e/tests/` for the tag (e.g., `grep -r "@:posit-assistant" test/e2e/tests/`) and read enough of those tests to know whether they cover the new behavior or just adjacent regressions. Only recommend adding a new e2e if the change independently warrants one per the Cost guidance principle (the behavior needs the full app rendered to verify) AND no existing tagged test covers it. If existing tagged tests already cover the new behavior, that's coverage -- note it under "Existing coverage" and move on.
 
 Cap your investigation at ~10-15 tool calls. If you can't determine coverage in that budget, lean toward Insufficient with a note that you couldn't fully verify.
 
@@ -169,8 +176,9 @@ Omit entirely if not applicable.>
 ## Constraints
 
 - **Cite real files only.** Never invent a test file path or function name. If you suggest a test location, it must be either an existing file you read, or a plausible new path next to the source file (`src/.../foo.ts` -> `src/.../test/foo.vitest.ts`).
+- **Verify suggested test scenarios actually apply to this code.** Before suggesting a test for "the legacy X path", "the empty input case", "the disabled state", or any specific scenario, Grep / Read to confirm the scenario exists for the code being changed. A generic mechanism (a `some()` over multiple keys, a switch with multiple cases, a fallback chain) often has branches that are unreachable for a specific instance. Example failure: suggesting "test the legacy `positron.assistant.provider.googleVertex.enable` key" for a brand-new provider that only ever had the new short-prefix key declared -- the legacy form doesn't exist for this provider, so the test would exercise a code path no real config will ever hit. The fix is to grep for the specific key before suggesting it.
 - **Be specific.** "Add tests for the new method" is useless. "Add a Vitest test for `Foo.bar()` covering the empty-input branch (foo.ts:42)" is actionable.
 - **One verdict per PR.** Don't grade individual files. The verdict reflects the worst-covered substantive change.
 - **No hedging in the verdict line.** Pick one and own it. Caveats go in the body.
 - **Keep the report under ~80 lines.** This is a PR comment, not an essay. Group related changes; don't enumerate every file in a 50-file PR.
-- **Don't suggest e2e tests as a default.** They're expensive and flaky. Reach for them only when a unit test genuinely can't cover the behavior.
+- **Don't suggest e2e tests as a default** -- they're expensive and flaky. But when the principle in Cost guidance applies (the change needs the full app rendered to verify, and a unit test can't reach the behavior), suggest e2e. The bullets there are common examples, not a checklist.

--- a/.claude/skills/pr-test-checker/SKILL.md
+++ b/.claude/skills/pr-test-checker/SKILL.md
@@ -26,7 +26,7 @@ The Positron repo has four runners. The right test for a change depends on what 
 | New code under `src/vs/` (pure function, class, service, React component) | **Vitest** | `src/vs/**/test/**/*.vitest.{ts,tsx}` |
 | Touching an **existing** upstream VS Code test file | **Core Mocha** (match the existing pattern; don't create new Mocha tests for new Positron code) | `src/vs/**/test/**/*.test.ts` |
 | Code in `extensions/<name>/` that needs an activated extension host | **Extension-host Mocha** | `extensions/<name>/**/*.test.ts` |
-| User-visible workflow that spans multiple systems (kernel + UI + filesystem) | **Playwright e2e** | `test/e2e/tests/**/*.test.ts` |
+| User-visible workflow that needs the full app rendered to verify (e.g., kernel + UI + filesystem, a sign-in / auth modal flow, a new provider in a configuration dialog, a new command palette entry that drives a panel) | **Playwright e2e** | `test/e2e/tests/**/*.test.ts` |
 
 Authoritative reference: read `CLAUDE.md` (project root) and `.claude/rules/vitest-tests.md` if you need to confirm a runner choice.
 
@@ -87,12 +87,14 @@ To check whether a candidate e2e test has the right tag, Grep its file for `@:wi
 
 ### Surface-specific code paths
 
-The strongest signal of differential desktop vs web behavior -- much stronger than vague "hotspot" matching:
+The strongest signal for **direct** surface gaps -- when the diff itself sits on one side of a surface split:
 
 - **Parallel implementations**: a service has both `src/vs/.../browser/<name>.ts` AND `src/vs/.../electron-sandbox/<name>.ts` files. Common examples: `services/lifecycle/`, `services/host/`, `services/files/`, `services/dialogs/`. A change to (or test of) one path does not cover the other.
 - **Surface branching**: the diff contains `UIKind.Web`, `isWeb`, `platform.isElectron`, `os.platform() === 'win32'`, or paths imported from `browser/` / `electron-sandbox/`. Each branch is its own untested behavior until proven otherwise.
 
 When you see a parallel-implementation file in the diff, Grep its sibling (`browser/foo.ts` <-> `electron-sandbox/foo.ts`) to see if the bug or behavior also exists there. A fix that only lands on one side is half a fix.
+
+The Windows/web **hotspots** lists above are the corresponding signal for **indirect** gaps -- the diff doesn't live in a surface-split directory, but it consumes a service whose `browser/`/`electron-sandbox/` implementations diverge (e.g., subscribes to `ILifecycleService.onWillShutdown`). Apply both lenses: surface-path check first (direct), then hotspot check (indirect).
 
 ### Decision rule
 
@@ -132,7 +134,11 @@ You must pick exactly one verdict:
 | **Adequate** | The PR adds tests that cover the new/changed behavior at the cheapest viable level. Cite the test file(s) and what behavior they cover. |
 | **Adequate via existing coverage** | The PR doesn't add tests, but existing tests already exercise the changed code paths (pure refactor, rename, behavior-preserving cleanup, or trivially-covered new code). Cite the specific test file(s) and lines/describes you verified. |
 | **Insufficient** | At least one substantive source change has no test coverage -- neither in the PR nor in existing tests. Name the gap and suggest specific additions. |
-| **Not applicable** | The PR is docs-only, config-only, dependency bumps, or otherwise has no testable behavior change. (Most "Not applicable" PRs short-circuit before you're invoked; reaching this verdict from your seat means the heuristic missed.) |
+| **Not applicable** | The PR has no testable behavior change. Examples: docs-only, config-only, dependency bumps, logging/telemetry/instrumentation additions, type-only changes, copyright/formatting. (Most short-circuit before you're invoked; reaching this verdict from your seat means the heuristic missed, or the change is observability-only.) |
+
+**What counts as a "substantive" change** (drives the Insufficient threshold): a behavior change a reasonable reader would expect to assert against -- new branches, new functions, modified return values, new error paths, observable side effects, fixed bugs. **Not substantive:** comments, copyright/formatting, logging-only additions, telemetry, type-only changes, behavior-preserving refactors/renames where the test surface is unchanged. When in doubt, ask: "could a future regression here go undetected without a new test?" If no -> not substantive.
+
+**For bug-fix PRs**, adequate coverage means a *regression test* -- one that fails on `main` and passes after the fix. If the PR claims to fix a specific issue (e.g., "Fix #1234" in the title or body, or a clear bug description) but the new/modified tests don't exercise the exact branch the fix touches, treat it as **Insufficient** -- the fix isn't pinned in place and the bug can recur. Cite the specific test case (`it(...)` block) that pins the fix; vague coverage of adjacent code doesn't count.
 
 Be conservative on **Adequate via existing coverage** -- only use it when you've actually read the existing test and confirmed it exercises the changed path. "There's probably a test somewhere" is Insufficient.
 


### PR DESCRIPTION
Tunes the `pr-test-checker` skill prompt based on two feedback cases.

## Changes

### Web/desktop surface gaps ([PR #13697 feedback](https://github.com/posit-dev/positron/pull/13697))

Background: the [original PR #13657](https://github.com/posit-dev/positron/pull/13657) added shutdown-event infrastructure with good desktop test coverage, but the web `BrowserLifecycleService` had a pre-existing bug hardcoding `QUIT` that no test caught. #13697 was the follow-up fix. PETE wouldn't catch this kind of gap with the existing prompt.

- Adds **lifecycle** to the Web hotspots list (shutdown reasons, reload vs quit, session reconnect).
- New **Surface-specific code paths** subsection covering parallel `browser/` and `electron-sandbox/` implementations plus `UIKind`/`isWeb`/`platform.isElectron`/`os.platform()` branching.
- Rewrites the **Decision rule** as two cases:
  1. Direct surface gap (diff modifies surface-specific code without a corresponding test) -> **Insufficient**
  2. Indirect surface gap (consumes a surface-split service) -> **Deployment note, keep verdict**
- Adds an Investigation step to Grep for surface markers and check siblings across the split.

### E2e recommendation tuning and scenario verification ([PR #13699 feedback](https://github.com/posit-dev/positron/pull/13699))

Background: PETE graded #13699 Adequate. Two complaints:
1. Suggested a test for the *legacy* `positron.assistant.provider.googleVertex.enable` key -- a legacy key that never existed for this brand-new provider. PETE hallucinated the scenario by seeing the dual-key `some()` mechanism in the code without grepping to confirm the legacy form was actually declared for Vertex.
2. Didn't suggest an e2e test even though the PR adds a new auth provider with a sign-in modal -- a textbook e2e case. The old Cost guidance over-anchored on "default to unit".

- Rewrites **Cost guidance** to lead with a principle (recommend e2e when the change genuinely needs the full app rendered to verify) plus illustrative examples and a catch-all bullet so PETE doesn't treat the list as exhaustive.
- Adds an Investigation step about scanning the PR body for `@:` e2e tags -- framed correctly: tags select *existing* tests for CI, they're not a request for new ones. A new e2e is only recommended when the change independently warrants one AND no existing tagged test covers it.
- New Constraint: **verify suggested test scenarios actually apply.** Grep before suggesting tests for specific scenarios; generic mechanisms (`some()` over keys, switches, fallback chains) often have branches unreachable for a specific instance.
