### PR TITLE
ci: append PR link to Slack notification titles

### DIFF
--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -277,7 +277,7 @@ jobs:
                (if $ext != "" then "\n\n" + ($ext | split(" ") | map("• " + .) | join("\n")) else "" end) as $bullets |
                {
                  channel: $channel,
-                 text: ("📦 *Bootstrap Extensions Updated*\nposit-dev/positron · <" + $pr_url + "|PR #" + $pr_num + ">" + $bullets)
+                 text: ("📦 *Bootstrap Extensions Updated* · <" + $pr_url + "|PR #" + $pr_num + ">" + $bullets)
                }')"
 
   slack-notify:

--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -355,7 +355,7 @@ jobs:
               --arg version "$VERSION" \
               '{
                 channel: $channel,
-                text: ("📸 *Screenshots Updated · Positron " + $version + "*\nposit-dev/positron-website · <" + $pr_url + "|PR #" + $pr_number + ">")
+                text: ("📸 *Screenshots Updated · Positron " + $version + "* · <" + $pr_url + "|PR #" + $pr_number + ">")
               }')"
 
   slack-notify:


### PR DESCRIPTION
### Summary
Consolidate the Slack notifications for bootstrap-extension updates and release-screenshot publishes so the PR link sits on the title line instead of a separate `posit-dev/positron · PR #N` line below.

- `📦 *Bootstrap Extensions Updated* · PR #N` (extensions-check-nightly)
- `📸 *Screenshots Updated · Positron <version>* · PR #N` (release-screenshots, publish mode)
- Bullet list of updated extensions still appears below the title in the bootstrap message.

### QA Notes
n/a