### PR TITLE
ci: reuse open bootstrap-extensions PR across nightly runs

### DIFF
--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -124,14 +124,16 @@ jobs:
           PR_REVIEW=$(echo "$PR_INFO" | jq -r '.reviewDecision // ""')
           echo "Found existing PR #$PR_NUMBER on branch $PR_BRANCH (review: ${PR_REVIEW:-none})"
 
-          # Treat any review attention as a signal to add commits rather than force-push.
-          # /pulls/.../comments only covers inline review-thread comments; /issues/.../comments
-          # covers the main conversation tab — both must be checked to avoid clobbering a
-          # teammate's "please hold off" note with a force-push.
-          REVIEW_COMMENTS=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/comments" --jq 'length')
-          ISSUE_COMMENTS=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --jq 'length')
+          # Treat any human review attention as a signal to add commits rather than force-push.
+          # /pulls/.../comments covers inline review-thread comments; /issues/.../comments
+          # covers the main conversation tab — both must be checked, and bot accounts
+          # (positron-bot, github-actions, etc.) are filtered out so routine automation
+          # doesn't trip the safeguard.
+          BOT_FILTER='[.[] | select((.user.type // "User") != "Bot")] | length'
+          REVIEW_COMMENTS=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/comments" --jq "$BOT_FILTER")
+          ISSUE_COMMENTS=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --jq "$BOT_FILTER")
           NON_BOT_COMMITS=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/commits" \
-            --jq '[.[] | select((.author.login // "") != "positron-bot[bot]")] | length')
+            --jq '[.[] | select((.author.type // "User") != "Bot")] | length')
           if [ "$REVIEW_COMMENTS" -gt 0 ] || [ "$ISSUE_COMMENTS" -gt 0 ] || [ "$NON_BOT_COMMITS" -gt 0 ] || [ -n "$PR_REVIEW" ]; then
             MODE=additive
           else

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -84,7 +84,7 @@ jobs:
       contents: write
       pull-requests: write
     outputs:
-      pr_url: ${{ steps.create-pr.outputs.pr_url || steps.push.outputs.existing_pr }}
+      pr_url: ${{ steps.create-pr.outputs.pr_url || steps.detect.outputs.pr_url }}
     steps:
       - name: Generate POSITRON_BOT token
         id: bot-token
@@ -103,6 +103,71 @@ jobs:
         run: |
           git config user.name "positron-bot[bot]"
           git config user.email "positron-bot[bot]@users.noreply.github.com"
+
+      - name: Detect existing auto-update PR
+        id: detect
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+        run: |
+          # Find an open auto-update PR (branch prefix matches our convention).
+          PR_INFO=$(gh pr list --base main --state open \
+            --json number,url,headRefName,reviewDecision \
+            --jq '[.[] | select(.headRefName | startswith("automated/update-extensions"))] | first // empty')
+          if [ -z "$PR_INFO" ]; then
+            echo "No existing auto-update PR found; a new one will be created if needed."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PR_NUMBER=$(echo "$PR_INFO" | jq -r .number)
+          PR_URL=$(echo "$PR_INFO" | jq -r .url)
+          PR_BRANCH=$(echo "$PR_INFO" | jq -r .headRefName)
+          PR_REVIEW=$(echo "$PR_INFO" | jq -r '.reviewDecision // ""')
+          echo "Found existing PR #$PR_NUMBER on branch $PR_BRANCH (review: ${PR_REVIEW:-none})"
+
+          # Treat any review attention as a signal to add commits rather than force-push.
+          REVIEW_COMMENTS=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/comments" --jq 'length')
+          NON_BOT_COMMITS=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/commits" \
+            --jq '[.[] | select((.author.login // "") != "positron-bot[bot]")] | length')
+          if [ "$REVIEW_COMMENTS" -gt 0 ] || [ "$NON_BOT_COMMITS" -gt 0 ] || [ -n "$PR_REVIEW" ]; then
+            MODE=additive
+          else
+            MODE=reset
+          fi
+          echo "Reuse mode: $MODE (review comments: $REVIEW_COMMENTS, non-bot commits: $NON_BOT_COMMITS, review decision: ${PR_REVIEW:-none})"
+          {
+            echo "exists=true"
+            echo "pr_number=$PR_NUMBER"
+            echo "pr_url=$PR_URL"
+            echo "pr_branch=$PR_BRANCH"
+            echo "mode=$MODE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Prepare branch and capture pre-update state
+        id: prepare
+        if: steps.detect.outputs.exists == 'true' && inputs.dryrun != true
+        env:
+          PR_BRANCH: ${{ steps.detect.outputs.pr_branch }}
+        run: |
+          git fetch origin "$PR_BRANCH" main
+          git checkout "$PR_BRANCH"
+          # Capture the extension set already on the PR (before any reset/reapply).
+          # Drives the Slack "new extensions" trigger downstream.
+          PRE_SET=$(jq -rn \
+            --argjson old "$(git show origin/main:product.json)" \
+            --argjson new "$(cat product.json)" \
+            '($old.bootstrapExtensions | map({(.name): .version}) | add) as $ov |
+             ($new.bootstrapExtensions | map({(.name): .version}) | add) as $nv |
+             [$nv | to_entries[] | select(.value != $ov[.key]) | .key] | sort | join(" ")')
+          echo "Pre-update extension set: ${PRE_SET:-<empty>}"
+          echo "pre_set=$PRE_SET" >> "$GITHUB_OUTPUT"
+
+      - name: Reset branch to main (clean reapply)
+        if: steps.detect.outputs.exists == 'true' && steps.detect.outputs.mode == 'reset' && inputs.dryrun != true
+        env:
+          PR_BRANCH: ${{ steps.detect.outputs.pr_branch }}
+        run: |
+          echo "Resetting $PR_BRANCH to origin/main; the bump script will reapply today's changes from scratch."
+          git reset --hard origin/main
 
       - name: Download mismatched extensions list
         if: needs.extensions-linux.result == 'failure'
@@ -140,18 +205,34 @@ jobs:
 
       - name: Render test tags
         id: render-tags
+        env:
+          PRE_SET: ${{ steps.prepare.outputs.pre_set }}
         run: |
+          # Compare against origin/main so reused PRs report the *full* bump set,
+          # not just today's incremental change on top of an existing commit.
+          git fetch origin main
           UPDATED=$(jq -rn \
-            --argjson old "$(git show HEAD:product.json)" \
+            --argjson old "$(git show origin/main:product.json)" \
             --argjson new "$(cat product.json)" \
             '($old.bootstrapExtensions | map({(.name): .version}) | add) as $ov |
              ($new.bootstrapExtensions | map({(.name): .version}) | add) as $nv |
-             [$nv | to_entries[] | select(.value != $ov[.key]) | .key] | join(" ")')
+             [$nv | to_entries[] | select(.value != $ov[.key]) | .key] | sort | join(" ")')
           if [ -z "$UPDATED" ]; then
             echo "No bootstrap extension version changes detected."
             echo "updated=" >> "$GITHUB_OUTPUT"
+            echo "new_exts=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Extensions newly added on top of the existing PR (empty for a brand-new PR).
+          if [ -z "$PRE_SET" ]; then
+            NEW_EXTS="$UPDATED"
+          else
+            NEW_EXTS=$(comm -23 \
+              <(printf '%s\n' $UPDATED | sort -u) \
+              <(printf '%s\n' $PRE_SET | sort -u) \
+              | tr '\n' ' ' | sed 's/ *$//')
+          fi
+          echo "new_exts=$NEW_EXTS" >> "$GITHUB_OUTPUT"
           TAG_MAP=.github/workflows/extensions-tag-map.json
           TAG_BULLETS=$(echo "$UPDATED" | tr ' ' '\n' | jq -R -s -r --slurpfile map "$TAG_MAP" '
             (split("\n") | map(select(length > 0))) as $exts |
@@ -191,34 +272,54 @@ jobs:
         if: inputs.dryrun != true
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+          EXISTS: ${{ steps.detect.outputs.exists }}
+          MODE: ${{ steps.detect.outputs.mode }}
+          PR_BRANCH: ${{ steps.detect.outputs.pr_branch }}
         run: |
-          # Skip if an open auto-update PR already exists to avoid duplicates
-          EXISTING=$(gh pr list --base main --state open \
-            --json headRefName,url \
-            --jq '.[] | select(.headRefName | startswith("automated/update-extensions")) | .url' \
-            | head -1 || true)
-          if [ -n "$EXISTING" ]; then
-            echo "Open auto-update PR already exists: $EXISTING — skipping"
-            echo "existing_pr=$EXISTING" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [ "$EXISTS" = "true" ]; then
+            BRANCH="$PR_BRANCH"
+            git add product.json
+            if git diff --staged --quiet && git diff --quiet origin/main -- product.json; then
+              echo "Existing PR is already current — nothing to commit or push."
+              exit 0
+            fi
+            if git diff --staged --quiet; then
+              echo "No working-tree changes after update; existing PR commits already cover it."
+              echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+              echo "reused=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            git commit -m "chore: update bootstrap extensions"
+            if [ "$MODE" = "reset" ]; then
+              git push --force-with-lease origin "$BRANCH"
+            else
+              git push origin "$BRANCH"
+            fi
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+            echo "reused=true" >> "$GITHUB_OUTPUT"
+          else
+            BRANCH="automated/update-extensions-$(date +%Y%m%d-%H%M%S)"
+            git checkout -b "$BRANCH"
+            git add product.json
+            if git diff --staged --quiet; then
+              echo "No changes to product.json — skipping PR"
+              exit 0
+            fi
+            git commit -m "chore: update bootstrap extensions"
+            git push origin "$BRANCH"
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+            echo "reused=false" >> "$GITHUB_OUTPUT"
           fi
-          BRANCH="automated/update-extensions-$(date +%Y%m%d-%H%M%S)"
-          git checkout -b "$BRANCH"
-          git add product.json
-          if git diff --staged --quiet; then
-            echo "No changes to product.json — skipping PR"
-            exit 0
-          fi
-          git commit -m "chore: update bootstrap extensions"
-          git push origin "$BRANCH"
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
-      - name: Create pull request
+      - name: Create or update pull request
         id: create-pr
-        if: steps.push.outputs.branch != ''
+        if: steps.push.outputs.branch != '' && inputs.dryrun != true
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
           BRANCH: ${{ steps.push.outputs.branch }}
+          REUSED: ${{ steps.push.outputs.reused }}
+          EXISTING_PR_NUMBER: ${{ steps.detect.outputs.pr_number }}
+          EXISTING_PR_URL: ${{ steps.detect.outputs.pr_url }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           MAP_URL: ${{ github.server_url }}/${{ github.repository }}/blob/main/.github/workflows/extensions-tag-map.json
           UPDATED: ${{ steps.render-tags.outputs.updated }}
@@ -245,34 +346,54 @@ jobs:
             UNMAPPED_LINE="[Unmapped](${MAP_URL}): ${UNMAPPED}
           "
           fi
-          PR_URL=$(gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "$TITLE" \
-            --body "### Summary
+          BODY="### Summary
           Update bootstrap extensions detected as out-of-date by the nightly check.
 
           ${EXT_BULLETS}
 
           ### QA Notes
-          ${TAGS_LINE}${UNMAPPED_LINE}Triggered by [nightly extensions check](${RUN_URL}).")
+          ${TAGS_LINE}${UNMAPPED_LINE}Triggered by [nightly extensions check](${RUN_URL}).
+
+          _This PR is auto-managed by the nightly bootstrap-extensions workflow; the title and body may be overwritten on subsequent runs._"
+          if [ "$REUSED" = "true" ]; then
+            gh pr edit "$EXISTING_PR_NUMBER" --title "$TITLE" --body "$BODY" >/dev/null
+            PR_URL="$EXISTING_PR_URL"
+            echo "Updated existing PR: $PR_URL"
+          else
+            PR_URL=$(gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "$TITLE" \
+              --body "$BODY")
+            echo "Created new PR: $PR_URL"
+          fi
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
           echo "updated=$UPDATED" >> "$GITHUB_OUTPUT"
 
       - name: Post PR to Slack
-        if: (steps.push.outputs.existing_pr != '' || steps.create-pr.outputs.pr_url != '') && inputs.dryrun != true
+        if: steps.create-pr.outputs.pr_url != '' && inputs.dryrun != true
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
-          PR_URL: ${{ steps.create-pr.outputs.pr_url || steps.push.outputs.existing_pr }}
+          PR_URL: ${{ steps.create-pr.outputs.pr_url }}
           UPDATED: ${{ steps.create-pr.outputs.updated }}
+          NEW_EXTS: ${{ steps.render-tags.outputs.new_exts }}
+          REUSED: ${{ steps.push.outputs.reused }}
         run: |
+          # Skip the repost when reusing a PR that didn't gain any new extensions today.
+          if [ "$REUSED" = "true" ] && [ -z "$NEW_EXTS" ]; then
+            echo "Reused existing PR with no new extensions — skipping Slack repost."
+            exit 0
+          fi
+          # Slack bullets reflect today's contribution: the newly added subset for reuse,
+          # or the full set for a brand-new PR.
+          BULLET_EXTS="${NEW_EXTS:-$UPDATED}"
           curl -s -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_TOKEN" \
             -H "Content-Type: application/json" \
             -d "$(jq -n \
               --arg channel "#positron-dev" \
               --arg pr_url "$PR_URL" \
-              --arg ext "$UPDATED" \
+              --arg ext "$BULLET_EXTS" \
               '($pr_url | split("/") | last) as $pr_num |
                (if $ext != "" then "\n\n" + ($ext | split(" ") | map("• " + .) | join("\n")) else "" end) as $bullets |
                {

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Prepare branch and capture pre-update state
         id: prepare
-        if: steps.detect.outputs.exists == 'true' && inputs.dryrun != true
+        if: steps.detect.outputs.exists == 'true'
         env:
           PR_BRANCH: ${{ steps.detect.outputs.pr_branch }}
         run: |
@@ -162,7 +162,7 @@ jobs:
           echo "pre_set=$PRE_SET" >> "$GITHUB_OUTPUT"
 
       - name: Reset branch to main (clean reapply)
-        if: steps.detect.outputs.exists == 'true' && steps.detect.outputs.mode == 'reset' && inputs.dryrun != true
+        if: steps.detect.outputs.exists == 'true' && steps.detect.outputs.mode == 'reset'
         env:
           PR_BRANCH: ${{ steps.detect.outputs.pr_branch }}
         run: |
@@ -269,12 +269,12 @@ jobs:
 
       - name: Commit and push
         id: push
-        if: inputs.dryrun != true
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
           EXISTS: ${{ steps.detect.outputs.exists }}
           MODE: ${{ steps.detect.outputs.mode }}
           PR_BRANCH: ${{ steps.detect.outputs.pr_branch }}
+          DRYRUN: ${{ inputs.dryrun }}
         run: |
           if [ "$EXISTS" = "true" ]; then
             BRANCH="$PR_BRANCH"
@@ -289,11 +289,19 @@ jobs:
               echo "reused=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            git commit -m "chore: update bootstrap extensions"
-            if [ "$MODE" = "reset" ]; then
-              git push --force-with-lease origin "$BRANCH"
+            if [ "$DRYRUN" = "true" ]; then
+              if [ "$MODE" = "reset" ]; then
+                echo "[dryrun] Would commit and force-push to existing branch $BRANCH (reset mode)."
+              else
+                echo "[dryrun] Would commit and push to existing branch $BRANCH (additive mode)."
+              fi
             else
-              git push origin "$BRANCH"
+              git commit -m "chore: update bootstrap extensions"
+              if [ "$MODE" = "reset" ]; then
+                git push --force-with-lease origin "$BRANCH"
+              else
+                git push origin "$BRANCH"
+              fi
             fi
             echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
             echo "reused=true" >> "$GITHUB_OUTPUT"
@@ -305,15 +313,19 @@ jobs:
               echo "No changes to product.json — skipping PR"
               exit 0
             fi
-            git commit -m "chore: update bootstrap extensions"
-            git push origin "$BRANCH"
+            if [ "$DRYRUN" = "true" ]; then
+              echo "[dryrun] Would commit and push new branch $BRANCH."
+            else
+              git commit -m "chore: update bootstrap extensions"
+              git push origin "$BRANCH"
+            fi
             echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
             echo "reused=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create or update pull request
         id: create-pr
-        if: steps.push.outputs.branch != '' && inputs.dryrun != true
+        if: steps.push.outputs.branch != ''
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
           BRANCH: ${{ steps.push.outputs.branch }}
@@ -325,6 +337,7 @@ jobs:
           UPDATED: ${{ steps.render-tags.outputs.updated }}
           COMBINED_TAGS: ${{ steps.render-tags.outputs.combined_tags }}
           UNMAPPED: ${{ steps.render-tags.outputs.unmapped }}
+          DRYRUN: ${{ inputs.dryrun }}
         run: |
           EXT_BULLETS=$(echo "$UPDATED" | tr ' ' '\n' | sed 's/^/- /')
           # Truncate title if more than 3 extensions to stay within GitHub's limit
@@ -355,7 +368,18 @@ jobs:
           ${TAGS_LINE}${UNMAPPED_LINE}Triggered by [nightly extensions check](${RUN_URL}).
 
           _This PR is auto-managed by the nightly bootstrap-extensions workflow; the title and body may be overwritten on subsequent runs._"
-          if [ "$REUSED" = "true" ]; then
+          if [ "$DRYRUN" = "true" ]; then
+            if [ "$REUSED" = "true" ]; then
+              echo "[dryrun] Would update existing PR #$EXISTING_PR_NUMBER ($EXISTING_PR_URL)"
+              PR_URL="$EXISTING_PR_URL"
+            else
+              echo "[dryrun] Would create new PR from branch $BRANCH"
+              PR_URL="https://example.invalid/dryrun"
+            fi
+            echo "[dryrun] Title: $TITLE"
+            echo "[dryrun] Body:"
+            printf '%s\n' "$BODY" | sed 's/^/[dryrun]   /'
+          elif [ "$REUSED" = "true" ]; then
             gh pr edit "$EXISTING_PR_NUMBER" --title "$TITLE" --body "$BODY" >/dev/null
             PR_URL="$EXISTING_PR_URL"
             echo "Updated existing PR: $PR_URL"
@@ -371,13 +395,14 @@ jobs:
           echo "updated=$UPDATED" >> "$GITHUB_OUTPUT"
 
       - name: Post PR to Slack
-        if: steps.create-pr.outputs.pr_url != '' && inputs.dryrun != true
+        if: steps.create-pr.outputs.pr_url != ''
         env:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN_TEST_STATUS }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}
           UPDATED: ${{ steps.create-pr.outputs.updated }}
           NEW_EXTS: ${{ steps.render-tags.outputs.new_exts }}
           REUSED: ${{ steps.push.outputs.reused }}
+          DRYRUN: ${{ inputs.dryrun }}
         run: |
           # Skip the repost when reusing a PR that didn't gain any new extensions today.
           if [ "$REUSED" = "true" ] && [ -z "$NEW_EXTS" ]; then
@@ -387,19 +412,25 @@ jobs:
           # Slack bullets reflect today's contribution: the newly added subset for reuse,
           # or the full set for a brand-new PR.
           BULLET_EXTS="${NEW_EXTS:-$UPDATED}"
+          PAYLOAD=$(jq -n \
+            --arg channel "#positron-dev" \
+            --arg pr_url "$PR_URL" \
+            --arg ext "$BULLET_EXTS" \
+            '($pr_url | split("/") | last) as $pr_num |
+             (if $ext != "" then "\n\n" + ($ext | split(" ") | map("• " + .) | join("\n")) else "" end) as $bullets |
+             {
+               channel: $channel,
+               text: ("📦 *Bootstrap Extensions Updated* · <" + $pr_url + "|PR #" + $pr_num + ">" + $bullets)
+             }')
+          if [ "$DRYRUN" = "true" ]; then
+            echo "[dryrun] Would post to Slack:"
+            printf '%s\n' "$PAYLOAD" | sed 's/^/[dryrun]   /'
+            exit 0
+          fi
           curl -s -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_TOKEN" \
             -H "Content-Type: application/json" \
-            -d "$(jq -n \
-              --arg channel "#positron-dev" \
-              --arg pr_url "$PR_URL" \
-              --arg ext "$BULLET_EXTS" \
-              '($pr_url | split("/") | last) as $pr_num |
-               (if $ext != "" then "\n\n" + ($ext | split(" ") | map("• " + .) | join("\n")) else "" end) as $bullets |
-               {
-                 channel: $channel,
-                 text: ("📦 *Bootstrap Extensions Updated* · <" + $pr_url + "|PR #" + $pr_num + ">" + $bullets)
-               }')"
+            -d "$PAYLOAD"
 
   slack-notify:
     if: always() && needs.extensions-linux.result == 'failure' && needs.auto-update.outputs.pr_url == '' && inputs.dryrun != true

--- a/.github/workflows/extensions-check-nightly.yml
+++ b/.github/workflows/extensions-check-nightly.yml
@@ -125,15 +125,19 @@ jobs:
           echo "Found existing PR #$PR_NUMBER on branch $PR_BRANCH (review: ${PR_REVIEW:-none})"
 
           # Treat any review attention as a signal to add commits rather than force-push.
+          # /pulls/.../comments only covers inline review-thread comments; /issues/.../comments
+          # covers the main conversation tab — both must be checked to avoid clobbering a
+          # teammate's "please hold off" note with a force-push.
           REVIEW_COMMENTS=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/comments" --jq 'length')
+          ISSUE_COMMENTS=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --jq 'length')
           NON_BOT_COMMITS=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/commits" \
             --jq '[.[] | select((.author.login // "") != "positron-bot[bot]")] | length')
-          if [ "$REVIEW_COMMENTS" -gt 0 ] || [ "$NON_BOT_COMMITS" -gt 0 ] || [ -n "$PR_REVIEW" ]; then
+          if [ "$REVIEW_COMMENTS" -gt 0 ] || [ "$ISSUE_COMMENTS" -gt 0 ] || [ "$NON_BOT_COMMITS" -gt 0 ] || [ -n "$PR_REVIEW" ]; then
             MODE=additive
           else
             MODE=reset
           fi
-          echo "Reuse mode: $MODE (review comments: $REVIEW_COMMENTS, non-bot commits: $NON_BOT_COMMITS, review decision: ${PR_REVIEW:-none})"
+          echo "Reuse mode: $MODE (review comments: $REVIEW_COMMENTS, issue comments: $ISSUE_COMMENTS, non-bot commits: $NON_BOT_COMMITS, review decision: ${PR_REVIEW:-none})"
           {
             echo "exists=true"
             echo "pr_number=$PR_NUMBER"
@@ -280,7 +284,13 @@ jobs:
             BRANCH="$PR_BRANCH"
             git add product.json
             if git diff --staged --quiet && git diff --quiet origin/main -- product.json; then
-              echo "Existing PR is already current — nothing to commit or push."
+              # Reset-mode + no bumps needed: working tree matches origin/main and the
+              # existing PR's commits on the remote are untouched. We intentionally don't
+              # set branch/reused outputs here — skipping create-pr means the existing
+              # title/body stay as-is, which still accurately describe the PR's content.
+              # (Refreshing now would render an empty extension list, since UPDATED is
+              # computed from working tree vs origin/main and is empty in this path.)
+              echo "Reset produced no diff vs main — existing PR untouched."
               exit 0
             fi
             if git diff --staged --quiet; then


### PR DESCRIPTION
### Summary
Make the nightly bootstrap-extensions workflow update the existing open PR instead of opening a fresh one each day.

- Detect open auto-update PR; force-push a clean diff if untouched, commit additively if a teammate has engaged (review, comment, or non-bot commit)
- Extend `dryrun` to preview branch / PR / Slack decisions without side effects

### QA Notes
See example dry run [here](https://github.com/posit-dev/positron/actions/runs/26512847150). (Expand job steps in `auto-update-extensions` to review)