### PR TITLE
[DO NOT MERGE] dryrun test: synthetic auto-update PR

### DIFF
--- a/product.json
+++ b/product.json
@@ -146,7 +146,7 @@
 		},
 		{
 			"name": "ms-toolsai.jupyter-keymap",
-			"version": "1.1.2",
+			"version": "1.1.1",
 			"sha256": "3d2998929bb43156f3b428116aee290543c437875df616ec755692219b4afa17",
 			"repo": "https://github.com/Microsoft/vscode-jupyter-keymap",
 			"metadata": {


### PR DESCRIPTION
Synthetic PR to exercise the existing-PR code path of the bootstrap-extensions nightly workflow when run in `dryrun` mode (see #13793).

**Do not merge.** Will be closed and branch deleted after the dryrun completes.

The product.json change (jupyter-keymap version downgrade) is intentional — it lets `PRE_SET` capture a non-empty extension set, fully exercising the reset / reapply / NEW_EXTS computation.