### PR TITLE
Add descriptions to Positron notebook context keys & extract helper namespaces

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -40,11 +40,11 @@ import { IExecutionHistoryService } from '../../../services/positronHistory/comm
 import { CodeAttributionSource, IConsoleCodeAttribution } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
 import { createCodeLocation, ICodeLocation } from '../../../services/positronConsole/common/codeLocation.js';
 import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
-import { POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED } from '../../positronNotebook/browser/ContextKeysManager.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { usingQuartoInlineOutput, isQuartoDocument, QUARTO_INLINE_OUTPUT_ENABLED, IS_QUARTO_DOCUMENT } from '../../positronQuarto/common/positronQuartoConfig.js';
 import { getNotebookUriFromActiveEditor } from './getNotebookUriFromActiveEditor.js';
 import { IQuartoExecutionManager } from '../../positronQuarto/common/quartoExecutionTypes.js';
+import { NotebookContextKeys } from '../../positronNotebook/common/notebookContextKeys.js';
 
 /**
  * Positron console command ID's.
@@ -362,7 +362,7 @@ export function registerPositronConsoleActions() {
 				precondition: ContextKeyExpr.and(
 					EditorContextKeys.editorTextFocus,
 					NOTEBOOK_EDITOR_FOCUSED.toNegated(),
-					POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.toNegated()
+					NotebookContextKeys.cellEditorFocused.toNegated()
 				),
 				keybinding: {
 					weight: KeybindingWeight.WorkbenchContrib,
@@ -977,7 +977,7 @@ export function registerPositronConsoleActions() {
 				precondition: ContextKeyExpr.and(
 					EditorContextKeys.editorTextFocus,
 					NOTEBOOK_EDITOR_FOCUSED.toNegated(),
-					POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.toNegated()
+					NotebookContextKeys.cellEditorFocused.toNegated()
 				),
 				keybinding: {
 					weight: KeybindingWeight.WorkbenchContrib,
@@ -1119,7 +1119,7 @@ export function registerPositronConsoleActions() {
 					ContextKeyExpr.and(
 						EditorContextKeys.editorTextFocus,
 						NOTEBOOK_EDITOR_FOCUSED.toNegated(),
-						POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.toNegated()
+						NotebookContextKeys.cellEditorFocused.toNegated()
 					)
 				),
 				keybinding: {
@@ -1170,7 +1170,7 @@ export function registerPositronConsoleActions() {
 					ContextKeyExpr.and(
 						EditorContextKeys.editorTextFocus,
 						NOTEBOOK_EDITOR_FOCUSED.toNegated(),
-						POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.toNegated()
+						NotebookContextKeys.cellEditorFocused.toNegated()
 					)
 				),
 				keybinding: {

--- a/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ContextKeysManager.ts
@@ -1,154 +1,59 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import * as DOM from '../../../../base/browser/dom.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
-import { localize } from '../../../../nls.js';
-import { ContextKeyValue, IContextKey, IScopedContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+import { ContextKeyValue, IContextKey, IScopedContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { NotebookEditorContextKeys } from '../../notebook/browser/viewParts/notebookEditorWidgetContextKeys.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
-
-/**
- * Context key that is set when the Positron notebook editor container is focused.
- */
-export const POSITRON_NOTEBOOK_EDITOR_FOCUSED = new RawContextKey<boolean>('positronNotebookEditorFocused', false, localize('positronNotebookFocused', "Whether a Positron notebook editor or a notebook editor widget (e.g. a cell editor or the find widget) has focus"));
-
-/**
- * Context key that is set when a cell editor (Monaco editor within a notebook cell) is focused.
- * This is more specific than EditorContextKeys.editorTextFocus which applies to ANY Monaco editor.
- */
-export const POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED = new RawContextKey<boolean>('positronNotebookCellEditorFocused', false, localize('positronNotebookCellEditorFocused', "Whether a code editor within a Positron notebook cell is focused"));
-
-/**
- * Context key mirroring the `positron.notebook.experimental` configuration.
- * Used to gate experimental notebook features in `when:` clauses.
- */
-export const POSITRON_NOTEBOOK_EXPERIMENTAL = new RawContextKey<boolean>('positronNotebook.experimental', false, localize('positronNotebookExperimental', "Whether experimental Positron Notebook features are enabled"));
-
-// Cell state context keys
-export const POSITRON_NOTEBOOK_CELL_IS_CODE = new RawContextKey<boolean>('positronNotebookCellIsCode', false);
-export const POSITRON_NOTEBOOK_CELL_IS_MARKDOWN = new RawContextKey<boolean>('positronNotebookCellIsMarkdown', false);
-/**
- * A cell of type 'raw' i.e. one that contains plain text without any rendered outputs or execution capabilities.
- */
-export const POSITRON_NOTEBOOK_CELL_IS_RAW = new RawContextKey<boolean>('positronNotebookCellIsRaw', false);
-export const POSITRON_NOTEBOOK_CELL_IS_RUNNING = new RawContextKey<boolean>('positronNotebookCellIsRunning', false);
-export const POSITRON_NOTEBOOK_CELL_IS_PENDING = new RawContextKey<boolean>('positronNotebookCellIsPending', false);
-export const POSITRON_NOTEBOOK_CELL_IS_FIRST = new RawContextKey<boolean>('positronNotebookCellIsFirst', false);
-export const POSITRON_NOTEBOOK_CELL_IS_LAST = new RawContextKey<boolean>('positronNotebookCellIsLast', false);
-export const POSITRON_NOTEBOOK_CELL_IS_ONLY = new RawContextKey<boolean>('positronNotebookCellIsOnly', false);
-/**
- * Context key that is true when the markdown editor of a cell is open for editing.
- */
-export const POSITRON_NOTEBOOK_CELL_MARKDOWN_EDITOR_OPEN = new RawContextKey<boolean>('positronNotebookCellMarkdownEditorOpen', false);
-/**
- * Context key that is true when a cell is selected which is relevant for multi-cell selection scenarios.
- */
-export const POSITRON_NOTEBOOK_CELL_IS_SELECTED = new RawContextKey<boolean>('positronNotebookCellIsSelected', false);
-/**
- * Context key that is true when the cell is the active/focused cell. In multi-selection contexts,
- * only one cell is active. The active cell is the one that displays its action bar and where cell
- * level keyboard actions take effect.
- */
-export const POSITRON_NOTEBOOK_CELL_IS_ACTIVE = new RawContextKey<boolean>('positronNotebookCellIsActive', false);
-
-export const POSITRON_NOTEBOOK_CELL_CAN_MOVE_UP = new RawContextKey<boolean>('positronNotebookCellCanMoveUp', false);
-export const POSITRON_NOTEBOOK_CELL_CAN_MOVE_DOWN = new RawContextKey<boolean>('positronNotebookCellCanMoveDown', false);
-
-// Output-related context keys
-export const POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS = new RawContextKey<boolean>('positronNotebookCellHasOutputs', false);
-export const POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT = new RawContextKey<number>('positronNotebookCellImageOutputCount', 0);
-export const POSITRON_NOTEBOOK_CELL_JSON_OUTPUT_COUNT = new RawContextKey<number>('positronNotebookCellJsonOutputCount', 0);
-export const POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED = new RawContextKey<boolean>('positronNotebookCellOutputIsCollapsed', false);
-export const POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS = new RawContextKey<boolean>('positronNotebookCellOutputOverflows', false, localize('positronNotebookCellOutputOverflows', "Whether the cell's text output exceeds the line limit"));
-export const POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING = new RawContextKey<boolean>('positronNotebookCellOutputScrolling', false, localize('positronNotebookCellOutputScrolling', "Whether the cell's output is in scrolling mode"));
-
-/**
- * Context key set to true when a cell's output section has DOM focus.
- * Used to gate keyboard shortcuts (e.g. Cmd+C to copy image) so they only
- * fire when the user has explicitly focused the output area.
- */
-export const POSITRON_NOTEBOOK_OUTPUT_FOCUSED = new RawContextKey<boolean>('positronNotebookOutputFocused', false, localize('positronNotebookOutputFocused', "Whether a cell's output area has focus"));
-
-/**
- * Interaction-driven context key set to true when the user right-clicks on an
- * image in the output area, or opens the ellipsis menu for a cell with image
- * output. This key tracks the current menu interaction and is NOT part of the
- * cell context key set or bindCellContextKeys.
- */
-export const POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED = new RawContextKey<boolean>('positronNotebookOutputImageTargeted', false);
-export const POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED = new RawContextKey<boolean>('positronNotebookOutputJsonTargeted', false);
-
-// All cell context keys in one place so we can easily operate on them all at once
-export const POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS = {
-	isCode: POSITRON_NOTEBOOK_CELL_IS_CODE,
-	isMarkdown: POSITRON_NOTEBOOK_CELL_IS_MARKDOWN,
-	isRaw: POSITRON_NOTEBOOK_CELL_IS_RAW,
-	isRunning: POSITRON_NOTEBOOK_CELL_IS_RUNNING,
-	isPending: POSITRON_NOTEBOOK_CELL_IS_PENDING,
-	isFirst: POSITRON_NOTEBOOK_CELL_IS_FIRST,
-	isLast: POSITRON_NOTEBOOK_CELL_IS_LAST,
-	isOnly: POSITRON_NOTEBOOK_CELL_IS_ONLY,
-	markdownEditorOpen: POSITRON_NOTEBOOK_CELL_MARKDOWN_EDITOR_OPEN,
-	isSelected: POSITRON_NOTEBOOK_CELL_IS_SELECTED,
-	isActive: POSITRON_NOTEBOOK_CELL_IS_ACTIVE,
-	canMoveUp: POSITRON_NOTEBOOK_CELL_CAN_MOVE_UP,
-	canMoveDown: POSITRON_NOTEBOOK_CELL_CAN_MOVE_DOWN,
-	hasOutputs: POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
-	imageOutputCount: POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT,
-	jsonOutputCount: POSITRON_NOTEBOOK_CELL_JSON_OUTPUT_COUNT,
-	outputIsCollapsed: POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED,
-	outputOverflows: POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
-	outputScrolling: POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING,
-} as const;
+import { CellContextKeys } from '../common/cellContextKeys.js';
+import { NotebookContextKeys } from '../common/notebookContextKeys.js';
 
 // Interface for the cell context keys
 export type IPositronNotebookCellContextKeys = {
-	readonly [K in keyof typeof POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS]: IContextKey<ContextKeyValue>;
+	readonly [K in keyof typeof CellContextKeys]: IContextKey<ContextKeyValue>;
 };
-
 
 /**
  * Bind all cell context keys to a scoped context key service
  */
 export function bindCellContextKeys(service: IScopedContextKeyService): IPositronNotebookCellContextKeys {
 	return {
-		isCode: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.isCode.bindTo(service),
-		isMarkdown: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.isMarkdown.bindTo(service),
-		isRaw: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.isRaw.bindTo(service),
-		isRunning: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.isRunning.bindTo(service),
-		isPending: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.isPending.bindTo(service),
-		isFirst: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.isFirst.bindTo(service),
-		isLast: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.isLast.bindTo(service),
-		isOnly: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.isOnly.bindTo(service),
-		markdownEditorOpen: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.markdownEditorOpen.bindTo(service),
-		isSelected: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.isSelected.bindTo(service),
-		isActive: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.isActive.bindTo(service),
-		canMoveUp: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.canMoveUp.bindTo(service),
-		canMoveDown: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.canMoveDown.bindTo(service),
-		hasOutputs: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.hasOutputs.bindTo(service),
-		imageOutputCount: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.imageOutputCount.bindTo(service),
-		jsonOutputCount: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.jsonOutputCount.bindTo(service),
-		outputIsCollapsed: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputIsCollapsed.bindTo(service),
-		outputOverflows: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputOverflows.bindTo(service),
-		outputScrolling: POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.outputScrolling.bindTo(service),
+		isCode: CellContextKeys.isCode.bindTo(service),
+		isMarkdown: CellContextKeys.isMarkdown.bindTo(service),
+		isRaw: CellContextKeys.isRaw.bindTo(service),
+		isRunning: CellContextKeys.isRunning.bindTo(service),
+		isPending: CellContextKeys.isPending.bindTo(service),
+		isFirst: CellContextKeys.isFirst.bindTo(service),
+		isLast: CellContextKeys.isLast.bindTo(service),
+		isOnly: CellContextKeys.isOnly.bindTo(service),
+		markdownEditorOpen: CellContextKeys.markdownEditorOpen.bindTo(service),
+		isSelected: CellContextKeys.isSelected.bindTo(service),
+		isActive: CellContextKeys.isActive.bindTo(service),
+		canMoveUp: CellContextKeys.canMoveUp.bindTo(service),
+		canMoveDown: CellContextKeys.canMoveDown.bindTo(service),
+		hasOutputs: CellContextKeys.hasOutputs.bindTo(service),
+		imageOutputCount: CellContextKeys.imageOutputCount.bindTo(service),
+		jsonOutputCount: CellContextKeys.jsonOutputCount.bindTo(service),
+		outputIsCollapsed: CellContextKeys.outputIsCollapsed.bindTo(service),
+		outputOverflows: CellContextKeys.outputOverflows.bindTo(service),
+		outputScrolling: CellContextKeys.outputScrolling.bindTo(service),
+		outputFocused: CellContextKeys.outputFocused.bindTo(service),
+		outputImageTargeted: CellContextKeys.outputImageTargeted.bindTo(service),
+		outputJsonTargeted: CellContextKeys.outputJsonTargeted.bindTo(service),
 	} satisfies IPositronNotebookCellContextKeys;
 }
 
-
 /**
  * Reset all cell context keys to their default values
- *
- * @param keys - The cell context keys object to reset, or undefined if not available
  */
 export function resetCellContextKeys(keys: IPositronNotebookCellContextKeys | undefined): void {
 	if (!keys) {
 		return;
 	}
 
-	// Reset each context key to its default value in a type-safe manner
 	Object.values(keys).forEach(contextKey => {
 		contextKey.reset();
 	});
@@ -182,7 +87,7 @@ export class PositronNotebookContextKeyManager extends Disposable {
 
 		const { scopedContextKeyService, scopedInstantiationService } = this._notebookInstance;
 
-		const positronEditorFocus = POSITRON_NOTEBOOK_EDITOR_FOCUSED.bindTo(scopedContextKeyService);
+		const positronEditorFocus = NotebookContextKeys.editorFocused.bindTo(scopedContextKeyService);
 
 		disposables.add(toDisposable(() => positronEditorFocus.reset()));
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/actions.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/actions.ts
@@ -14,7 +14,7 @@ import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/con
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
-import { POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../ContextKeysManager.js';
+import { NotebookContextKeys } from '../../../common/notebookContextKeys.js';
 import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 import { NotebookAction2 } from '../../NotebookAction2.js';
 import { getNotebookInstanceFromActiveEditorPane } from '../../notebookUtils.js';
@@ -74,7 +74,7 @@ registerPositronNotebookFindAction({
 	id: 'positronNotebook.find.start',
 	title: localize2('positron.notebook.find.start.title', 'Find'),
 	keybinding: [{
-		when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+		when: NotebookContextKeys.editorFocused,
 		primary: KeyCode.KeyF | KeyMod.CtrlCmd,
 		weight: KeybindingWeight.EditorContrib
 	}],
@@ -87,7 +87,7 @@ registerPositronNotebookFindAction({
 	title: localize2('positron.notebook.find.hide.title', 'Hide Find'),
 	keybinding: [{
 		when: ContextKeyExpr.and(
-			POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+			NotebookContextKeys.editorFocused,
 			CONTEXT_FIND_WIDGET_VISIBLE,
 		),
 		primary: KeyCode.Escape,
@@ -102,14 +102,14 @@ registerPositronNotebookFindAction({
 	title: localize2('positron.notebook.find.next.title', 'Find Next'),
 	keybinding: [{
 		// From cell editor
-		when: POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED,
+		when: NotebookContextKeys.cellEditorFocused,
 		primary: KeyCode.F3,
 		mac: { primary: KeyMod.CtrlCmd | KeyCode.KeyG, secondary: [KeyCode.F3] },
 		weight: KeybindingWeight.EditorContrib
 	}, {
 		// From find widget
 		when: ContextKeyExpr.and(
-			POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+			NotebookContextKeys.editorFocused,
 			CONTEXT_FIND_INPUT_FOCUSED,
 		),
 		primary: KeyCode.Enter,
@@ -124,7 +124,7 @@ registerPositronNotebookFindAction({
 	title: localize2('positron.notebook.find.previous.title', 'Find Previous'),
 	keybinding: [{
 		// From cell editor
-		when: POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED,
+		when: NotebookContextKeys.cellEditorFocused,
 		primary: KeyMod.Shift | KeyCode.F3,
 		mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyG, secondary: [KeyMod.Shift | KeyCode.F3] },
 		weight: KeybindingWeight.EditorContrib
@@ -132,7 +132,7 @@ registerPositronNotebookFindAction({
 	{
 		// From find widget
 		when: ContextKeyExpr.and(
-			POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+			NotebookContextKeys.editorFocused,
 			CONTEXT_FIND_INPUT_FOCUSED,
 		),
 		primary: KeyMod.Shift | KeyCode.Enter,
@@ -149,7 +149,7 @@ registerPositronNotebookFindAction({
 	id: 'positronNotebook.find.replaceStart',
 	title: localize2('positron.notebook.find.replaceStart.title', 'Find and Replace'),
 	keybinding: [{
-		when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+		when: NotebookContextKeys.editorFocused,
 		primary: KeyCode.KeyH | KeyMod.CtrlCmd,
 		mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyF },
 		weight: KeybindingWeight.EditorContrib
@@ -163,14 +163,14 @@ registerPositronNotebookFindAction({
 	title: localize2('positron.notebook.find.replace.title', 'Replace'),
 	keybinding: [{
 		when: ContextKeyExpr.and(
-			POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+			NotebookContextKeys.editorFocused,
 			CONTEXT_FIND_WIDGET_VISIBLE,
 		),
 		primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Digit1,
 		weight: KeybindingWeight.EditorContrib + 5
 	}, {
 		when: ContextKeyExpr.and(
-			POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+			NotebookContextKeys.editorFocused,
 			CONTEXT_FIND_WIDGET_VISIBLE,
 			CONTEXT_REPLACE_INPUT_FOCUSED,
 		),
@@ -186,14 +186,14 @@ registerPositronNotebookFindAction({
 	title: localize2('positron.notebook.find.replaceAll.title', 'Replace All'),
 	keybinding: [{
 		when: ContextKeyExpr.and(
-			POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+			NotebookContextKeys.editorFocused,
 			CONTEXT_FIND_WIDGET_VISIBLE,
 		),
 		primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Enter,
 		weight: KeybindingWeight.EditorContrib + 5
 	}, {
 		when: ContextKeyExpr.and(
-			POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+			NotebookContextKeys.editorFocused,
 			CONTEXT_FIND_WIDGET_VISIBLE,
 			CONTEXT_REPLACE_INPUT_FOCUSED,
 		),

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/actions.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/actions.tsx
@@ -12,7 +12,7 @@ import { ServicesAccessor } from '../../../../../../platform/instantiation/commo
 import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
 import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 import { NotebookAction2 } from '../../NotebookAction2.js';
-import { POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../ContextKeysManager.js';
+import { NotebookContextKeys } from '../../../common/notebookContextKeys.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
 import { GhostCellController } from './controller.js';
 import { REQUEST_GHOST_CELL_SUGGESTION_COMMAND_ID, SHOW_GHOST_CELL_INFO_COMMAND_ID } from './config.js';
@@ -44,8 +44,8 @@ registerGhostCellAction({
 		// Require notebook DOM focus and exclude cell editor focus to avoid
 		// stealing Cmd+Shift+G from terminal Find Previous or notebook Find Previous
 		when: ContextKeyExpr.and(
-			POSITRON_NOTEBOOK_EDITOR_FOCUSED,
-			POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.negate()
+			NotebookContextKeys.editorFocused,
+			NotebookContextKeys.cellEditorFocused.negate()
 		),
 		// Must be higher than editor.action.announceCursorPosition (WorkbenchContrib + 10)
 		weight: KeybindingWeight.WorkbenchContrib + 50,

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/undoRedo/positronNotebookUndoRedo.ts
@@ -6,7 +6,7 @@
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { WorkbenchPhase, registerWorkbenchContribution2 } from '../../../../../common/contributions.js';
 import { UndoCommand, RedoCommand } from '../../../../../../editor/browser/editorExtensions.js';
-import { POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED } from '../../ContextKeysManager.js';
+import { NotebookContextKeys } from '../../../common/notebookContextKeys.js';
 import { IUndoRedoService } from '../../../../../../platform/undoRedo/common/undoRedo.js';
 import { IEditorService } from '../../../../../services/editor/common/editorService.js';
 import { getNotebookInstanceFromActiveEditorPane } from '../../notebookUtils.js';
@@ -34,8 +34,8 @@ function shouldHandleUndoRedo(editorService: IEditorService): boolean {
 	const { scopedContextKeyService } = instance;
 
 	// Read context keys from the scoped context service that actually has these keys bound
-	const containerFocused = scopedContextKeyService.getContextKeyValue<boolean>(POSITRON_NOTEBOOK_EDITOR_FOCUSED.key) ?? false;
-	const cellEditorFocused = scopedContextKeyService.getContextKeyValue<boolean>(POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.key) ?? false;
+	const containerFocused = scopedContextKeyService.getContextKeyValue<boolean>(NotebookContextKeys.editorFocused.key) ?? false;
+	const cellEditorFocused = scopedContextKeyService.getContextKeyValue<boolean>(NotebookContextKeys.cellEditorFocused.key) ?? false;
 
 	// Handle undo/redo if the container is focused OR a cell editor is focused OR the notebook is empty
 	// This allows undo to work even when typing in a cell (common after adding a new cell)

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -27,7 +27,7 @@ import { PositronNotebookCellGeneral } from '../PositronNotebookCells/PositronNo
 import { useObservedValue } from '../useObservedValue.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { autorun, autorunDelta } from '../../../../../base/common/observable.js';
-import { POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED } from '../ContextKeysManager.js';
+import { NotebookContextKeys } from '../../common/notebookContextKeys.js';
 import { CellSelectionType, SelectionState } from '../selectionMachine.js';
 import { InQuickPickContextKey } from '../../../../browser/quickaccess.js';
 import { EditorContextKeys } from '../../../../../editor/common/editorContextKeys.js';
@@ -184,7 +184,7 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 
 		// Bind the cell editor focused context key to the editor's internal scoped service
 		// (CodeEditorWidget creates this synchronously in its constructor)
-		const cellEditorFocusedKey = POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.bindTo(editor.contextKeyService);
+		const cellEditorFocusedKey = NotebookContextKeys.cellEditorFocused.bindTo(editor.contextKeyService);
 
 		// Track whether the most recent mousedown had modifier keys held.
 		// Monaco's _onMouseDown calls focus() BEFORE emitting onMouseDown,

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCodeCell.tsx
@@ -35,7 +35,7 @@ import { DataExplorerCellOutput } from './DataExplorerCellOutput.js';
 import { JsonOutput } from './JsonOutput.js';
 import { NotebookErrorBoundary } from '../NotebookErrorBoundary.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
-import { POSITRON_NOTEBOOK_OUTPUT_FOCUSED, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED } from '../ContextKeysManager.js';
+import { CellContextKeys } from '../../common/cellContextKeys.js';
 import { useCellScopedContextKeyService } from './CellContextKeyServiceProvider.js';
 import { useScrollingIndicator } from './useScrollingIndicator.js';
 import { CellOutputActionBar } from './CellOutputActionBar.js';
@@ -62,19 +62,19 @@ const CellOutputsSection = React.memo(function CellOutputsSection({ cell, output
 	const perCellScrolling = useObservedValue(cell.outputScrolling);
 	const contextKeyService = useCellScopedContextKeyService();
 	const outputOverflowsKey = useMemo(
-		() => contextKeyService ? POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS.bindTo(contextKeyService) : undefined,
+		() => contextKeyService ? CellContextKeys.outputOverflows.bindTo(contextKeyService) : undefined,
 		[contextKeyService]
 	);
 	const outputImageTargeted = useMemo(
-		() => contextKeyService ? POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED.bindTo(contextKeyService) : undefined,
+		() => contextKeyService ? CellContextKeys.outputImageTargeted.bindTo(contextKeyService) : undefined,
 		[contextKeyService]
 	);
 	const outputJsonTargeted = useMemo(
-		() => contextKeyService ? POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED.bindTo(contextKeyService) : undefined,
+		() => contextKeyService ? CellContextKeys.outputJsonTargeted.bindTo(contextKeyService) : undefined,
 		[contextKeyService]
 	);
 	const outputFocusedKey = useMemo(
-		() => contextKeyService ? POSITRON_NOTEBOOK_OUTPUT_FOCUSED.bindTo(contextKeyService) : undefined,
+		() => contextKeyService ? CellContextKeys.outputFocused.bindTo(contextKeyService) : undefined,
 		[contextKeyService]
 	);
 	const { selectionStateMachine } = useNotebookInstance();

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -56,7 +56,8 @@ import { IPYNB_VIEW_TYPE } from '../../notebook/browser/notebookBrowser.js';
 import { IPositronNotebookEditorOptions } from './positronNotebookEditorTypes.js';
 import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID, PositronNotebookActionId, PositronNotebookCellActionBarLeftGroup, PositronNotebookCellOutputActionGroup, usingPositronNotebooks } from '../common/positronNotebookCommon.js';
 import { getActiveCell, getSelectedCells, SelectionState } from './selectionMachine.js';
-import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS as CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_JSON_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS, POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING, POSITRON_NOTEBOOK_EXPERIMENTAL, POSITRON_NOTEBOOK_OUTPUT_FOCUSED, POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED, POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED } from './ContextKeysManager.js';
+import { CellContextKeys } from '../common/cellContextKeys.js';
+import { NotebookContextKeys } from '../common/notebookContextKeys.js';
 import './contrib/undoRedo/positronNotebookUndoRedo.js';
 import { Action2, registerAction2, MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
 import { ExecuteSelectionInConsoleAction } from './ExecuteSelectionInConsoleAction.js';
@@ -82,8 +83,8 @@ import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { IOutlinePane } from '../../outline/browser/outline.js';
 
 export const POSITRON_NOTEBOOK_COMMAND_MODE = ContextKeyExpr.and(
-	POSITRON_NOTEBOOK_EDITOR_FOCUSED,
-	POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED.toNegated(),
+	NotebookContextKeys.editorFocused,
+	NotebookContextKeys.cellEditorFocused.toNegated(),
 	CONTEXT_FIND_INPUT_FOCUSED.toNegated(),
 	CONTEXT_REPLACE_INPUT_FOCUSED.toNegated(),
 );
@@ -137,7 +138,7 @@ class PositronNotebookContribution extends Disposable {
 		super();
 
 		this._register(bindContextKey(
-			POSITRON_NOTEBOOK_EXPERIMENTAL,
+			NotebookContextKeys.experimental,
 			contextKeyService,
 			reader => positronNotebookService.experimentsEnabled.read(reader),
 		));
@@ -559,7 +560,7 @@ registerAction2(class extends NotebookAction2 {
 			title: localize2('positronNotebook.cell.quitEdit', "Exit Cell Edit Mode"),
 			keybinding: {
 				when: ContextKeyExpr.and(
-					POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED,
+					NotebookContextKeys.cellEditorFocused,
 					// Don't exit when multiple selections are active (escape should cancel multi selection first #10385)
 					EditorContextKeys.hasMultipleSelections.toNegated(),
 					// Don't exit when text is selected (escape should deselect first)
@@ -847,9 +848,9 @@ registerAction2(class extends NotebookAction2 {
 				group: PositronNotebookCellActionBarLeftGroup.Primary,
 				order: 1, // gauranteed to be the first item in the cell action bar
 				when: ContextKeyExpr.and(
-					CELL_CONTEXT_KEYS.isCode.isEqualTo(true),
-					CELL_CONTEXT_KEYS.isRunning.toNegated(),
-					CELL_CONTEXT_KEYS.isPending.toNegated()
+					CellContextKeys.isCode.isEqualTo(true),
+					CellContextKeys.isRunning.toNegated(),
+					CellContextKeys.isPending.toNegated()
 				)
 			}
 		});
@@ -875,10 +876,10 @@ registerAction2(class extends NotebookAction2 {
 				group: PositronNotebookCellActionBarLeftGroup.Primary,
 				order: 1, // gauranteed to be the first item in the cell action bar
 				when: ContextKeyExpr.and(
-					CELL_CONTEXT_KEYS.isCode.isEqualTo(true),
+					CellContextKeys.isCode.isEqualTo(true),
 					ContextKeyExpr.or(
-						CELL_CONTEXT_KEYS.isRunning.isEqualTo(true),
-						CELL_CONTEXT_KEYS.isPending.isEqualTo(true)
+						CellContextKeys.isRunning.isEqualTo(true),
+						CellContextKeys.isPending.isEqualTo(true)
 					)
 				)
 			}
@@ -903,10 +904,10 @@ registerAction2(class extends NotebookAction2 {
 			menu: {
 				id: MenuId.PositronNotebookCellActionBarLeft,
 				order: 10,
-				when: CELL_CONTEXT_KEYS.isCode
+				when: CellContextKeys.isCode
 			},
 			keybinding: {
-				when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+				when: NotebookContextKeys.editorFocused,
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.Alt | KeyMod.Shift | KeyCode.Enter
 			}
@@ -943,16 +944,16 @@ registerAction2(class extends NotebookAction2 {
 				id: MenuId.PositronNotebookCellActionBarLeft,
 				order: 20,
 				when: ContextKeyExpr.and(
-					CELL_CONTEXT_KEYS.isCode.isEqualTo(true),
-					CELL_CONTEXT_KEYS.isFirst.toNegated()
+					CellContextKeys.isCode.isEqualTo(true),
+					CellContextKeys.isFirst.toNegated()
 				)
 			}, {
 				id: MenuId.PositronNotebookCellContext,
 				group: PositronNotebookCellActionGroup.Execution,
 				order: 10,
 				when: ContextKeyExpr.and(
-					CELL_CONTEXT_KEYS.isCode.isEqualTo(true),
-					CELL_CONTEXT_KEYS.isFirst.toNegated()
+					CellContextKeys.isCode.isEqualTo(true),
+					CellContextKeys.isFirst.toNegated()
 				)
 			}]
 		});
@@ -988,16 +989,16 @@ registerAction2(class extends NotebookAction2 {
 				id: MenuId.PositronNotebookCellActionBarLeft,
 				order: 21,
 				when: ContextKeyExpr.and(
-					CELL_CONTEXT_KEYS.isCode.isEqualTo(true),
-					CELL_CONTEXT_KEYS.isLast.toNegated()
+					CellContextKeys.isCode.isEqualTo(true),
+					CellContextKeys.isLast.toNegated()
 				)
 			}, {
 				id: MenuId.PositronNotebookCellContext,
 				group: PositronNotebookCellActionGroup.Execution,
 				order: 20,
 				when: ContextKeyExpr.and(
-					CELL_CONTEXT_KEYS.isCode.isEqualTo(true),
-					CELL_CONTEXT_KEYS.isLast.toNegated()
+					CellContextKeys.isCode.isEqualTo(true),
+					CellContextKeys.isLast.toNegated()
 				)
 			}]
 		});
@@ -1033,8 +1034,8 @@ export class OpenMarkdownEditorAction extends NotebookAction2 {
 				group: PositronNotebookCellActionBarLeftGroup.Primary,
 				order: 10,
 				when: ContextKeyExpr.and(
-					CELL_CONTEXT_KEYS.isMarkdown.isEqualTo(true),
-					CELL_CONTEXT_KEYS.markdownEditorOpen.toNegated()
+					CellContextKeys.isMarkdown.isEqualTo(true),
+					CellContextKeys.markdownEditorOpen.toNegated()
 				)
 			}
 		});
@@ -1070,8 +1071,8 @@ export class ViewMarkdownAction extends NotebookAction2 {
 				group: PositronNotebookCellActionBarLeftGroup.Primary,
 				order: 10,
 				when: ContextKeyExpr.and(
-					CELL_CONTEXT_KEYS.isMarkdown.isEqualTo(true),
-					CELL_CONTEXT_KEYS.markdownEditorOpen.isEqualTo(true)
+					CellContextKeys.isMarkdown.isEqualTo(true),
+					CellContextKeys.markdownEditorOpen.isEqualTo(true)
 				)
 			}
 		});
@@ -1099,7 +1100,7 @@ registerAction2(class extends NotebookAction2 {
 			id: 'positronNotebook.cell.executeOrToggleEditor',
 			title: localize2('positronNotebook.cell.executeOrToggleEditor', "Execute Cell or Toggle Editor"),
 			keybinding: {
-				when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+				when: NotebookContextKeys.editorFocused,
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.CtrlCmd | KeyCode.Enter
 			}
@@ -1161,7 +1162,7 @@ registerAction2(class extends NotebookAction2 {
 			id: 'positronNotebook.cell.executeAndSelectBelow',
 			title: localize2('positronNotebook.cell.executeAndSelectBelow', "Execute Cell and Select Below"),
 			keybinding: {
-				when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+				when: NotebookContextKeys.editorFocused,
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.Shift | KeyCode.Enter
 			}
@@ -1207,7 +1208,7 @@ registerAction2(class extends NotebookAction2 {
 			id: 'positronNotebook.cell.executeAndInsertBelow',
 			title: localize2('positronNotebook.cell.executeAndInsertBelow', "Execute Cell and Insert Below"),
 			keybinding: {
-				when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+				when: NotebookContextKeys.editorFocused,
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.Alt | KeyCode.Enter
 			}
@@ -1353,10 +1354,10 @@ export class MoveCellUpAction extends NotebookAction2 {
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
 				order: 10,
 				group: PositronNotebookCellActionGroup.Order,
-				when: CELL_CONTEXT_KEYS.canMoveUp
+				when: CellContextKeys.canMoveUp
 			},
 			keybinding: {
-				when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+				when: NotebookContextKeys.editorFocused,
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.Alt | KeyCode.UpArrow
 			}
@@ -1380,10 +1381,10 @@ export class MoveCellDownAction extends NotebookAction2 {
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
 				order: 20,
 				group: PositronNotebookCellActionGroup.Order,
-				when: CELL_CONTEXT_KEYS.canMoveDown
+				when: CellContextKeys.canMoveDown
 			},
 			keybinding: {
-				when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+				when: NotebookContextKeys.editorFocused,
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.Alt | KeyCode.DownArrow
 			}
@@ -1407,12 +1408,12 @@ export class ChangeToCodeAction extends NotebookAction2 {
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
 				group: PositronNotebookCellActionGroup.CellType,
 				order: 10,
-				when: ContextKeyExpr.or(CELL_CONTEXT_KEYS.isCode.toNegated(), CELL_CONTEXT_KEYS.isRaw)
+				when: ContextKeyExpr.or(CellContextKeys.isCode.toNegated(), CellContextKeys.isRaw)
 			}, {
 				id: MenuId.PositronNotebookCellContext,
 				group: PositronNotebookCellActionGroup.CellType,
 				order: 10,
-				when: ContextKeyExpr.or(CELL_CONTEXT_KEYS.isCode.toNegated(), CELL_CONTEXT_KEYS.isRaw)
+				when: ContextKeyExpr.or(CellContextKeys.isCode.toNegated(), CellContextKeys.isRaw)
 			}],
 			keybinding: {
 				when: POSITRON_NOTEBOOK_COMMAND_MODE,
@@ -1441,12 +1442,12 @@ export class ChangeToMarkdownAction extends NotebookAction2 {
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
 				group: PositronNotebookCellActionGroup.CellType,
 				order: 20,
-				when: CELL_CONTEXT_KEYS.isMarkdown.toNegated()
+				when: CellContextKeys.isMarkdown.toNegated()
 			}, {
 				id: MenuId.PositronNotebookCellContext,
 				group: PositronNotebookCellActionGroup.CellType,
 				order: 20,
-				when: CELL_CONTEXT_KEYS.isMarkdown.toNegated()
+				when: CellContextKeys.isMarkdown.toNegated()
 			}],
 			keybinding: {
 				when: POSITRON_NOTEBOOK_COMMAND_MODE,
@@ -1473,12 +1474,12 @@ export class ChangeToRawAction extends NotebookAction2 {
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
 				group: PositronNotebookCellActionGroup.CellType,
 				order: 30,
-				when: CELL_CONTEXT_KEYS.isRaw.toNegated()
+				when: CellContextKeys.isRaw.toNegated()
 			}, {
 				id: MenuId.PositronNotebookCellContext,
 				group: PositronNotebookCellActionGroup.CellType,
 				order: 30,
-				when: CELL_CONTEXT_KEYS.isRaw.toNegated()
+				when: CellContextKeys.isRaw.toNegated()
 			}],
 			keybinding: {
 				when: POSITRON_NOTEBOOK_COMMAND_MODE,
@@ -1504,10 +1505,10 @@ registerAction2(class extends NotebookAction2 {
 				id: MenuId.PositronNotebookCellContext,
 				group: PositronNotebookCellActionGroup.CellType,
 				order: 40,
-				when: POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED,
+				when: NotebookContextKeys.cellEditorFocused,
 			}],
 			keybinding: {
-				when: POSITRON_NOTEBOOK_CELL_EDITOR_FOCUSED,
+				when: NotebookContextKeys.cellEditorFocused,
 				weight: KeybindingWeight.EditorContrib,
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Minus
 			}
@@ -1602,10 +1603,10 @@ registerAction2(class extends NotebookAction2 {
 					group: PositronNotebookCellOutputActionGroup.Visibility,
 					order: 0,
 					when: ContextKeyExpr.and(
-						POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
-						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated(),
-						POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
-						POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING
+						CellContextKeys.hasOutputs,
+						CellContextKeys.outputIsCollapsed.toNegated(),
+						CellContextKeys.outputOverflows,
+						CellContextKeys.outputScrolling
 					)
 				},
 				{
@@ -1613,10 +1614,10 @@ registerAction2(class extends NotebookAction2 {
 					group: PositronNotebookCellOutputActionGroup.Visibility,
 					order: 0,
 					when: ContextKeyExpr.and(
-						POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
-						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated(),
-						POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
-						POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING
+						CellContextKeys.hasOutputs,
+						CellContextKeys.outputIsCollapsed.toNegated(),
+						CellContextKeys.outputOverflows,
+						CellContextKeys.outputScrolling
 					)
 				}
 			]
@@ -1645,10 +1646,10 @@ registerAction2(class extends NotebookAction2 {
 					group: PositronNotebookCellOutputActionGroup.Visibility,
 					order: 0,
 					when: ContextKeyExpr.and(
-						POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
-						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated(),
-						POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
-						POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING.toNegated()
+						CellContextKeys.hasOutputs,
+						CellContextKeys.outputIsCollapsed.toNegated(),
+						CellContextKeys.outputOverflows,
+						CellContextKeys.outputScrolling.toNegated()
 					)
 				},
 				{
@@ -1656,10 +1657,10 @@ registerAction2(class extends NotebookAction2 {
 					group: PositronNotebookCellOutputActionGroup.Visibility,
 					order: 0,
 					when: ContextKeyExpr.and(
-						POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
-						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated(),
-						POSITRON_NOTEBOOK_CELL_OUTPUT_OVERFLOWS,
-						POSITRON_NOTEBOOK_CELL_OUTPUT_SCROLLING.toNegated()
+						CellContextKeys.hasOutputs,
+						CellContextKeys.outputIsCollapsed.toNegated(),
+						CellContextKeys.outputOverflows,
+						CellContextKeys.outputScrolling.toNegated()
 					)
 				}
 			]
@@ -1687,8 +1688,8 @@ registerAction2(class extends NotebookAction2 {
 				group: PositronNotebookCellOutputActionGroup.Visibility,
 				order: 1,
 				when: ContextKeyExpr.and(
-					POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
-					POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated()
+					CellContextKeys.hasOutputs,
+					CellContextKeys.outputIsCollapsed.toNegated()
 				)
 			}
 		});
@@ -1715,8 +1716,8 @@ registerAction2(class extends NotebookAction2 {
 				group: PositronNotebookCellOutputActionGroup.Visibility,
 				order: 2,
 				when: ContextKeyExpr.and(
-					POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
-					POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED
+					CellContextKeys.hasOutputs,
+					CellContextKeys.outputIsCollapsed
 				)
 			}
 		});
@@ -1748,7 +1749,7 @@ registerAction2(class extends NotebookAction2 {
 					id: MenuId.PositronNotebookCellOutputActionContext,
 					group: PositronNotebookCellOutputActionGroup.Destructive,
 					order: 1,
-					when: POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS
+					when: CellContextKeys.hasOutputs
 				},
 			]
 		});
@@ -1773,10 +1774,10 @@ export class CopyOutputAction extends NotebookAction2 {
 			keybinding: {
 				primary: KeyMod.CtrlCmd | KeyCode.KeyC,
 				when: ContextKeyExpr.and(
-					POSITRON_NOTEBOOK_EDITOR_FOCUSED,
-					POSITRON_NOTEBOOK_OUTPUT_FOCUSED,
-					POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS,
-					POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated(),
+					NotebookContextKeys.editorFocused,
+					CellContextKeys.outputFocused,
+					CellContextKeys.hasOutputs,
+					CellContextKeys.outputIsCollapsed.toNegated(),
 				),
 				weight: KeybindingWeight.EditorContrib,
 			},
@@ -1866,8 +1867,8 @@ class CopyOutputImageAction extends NotebookAction2 {
 						// Show the static "Copy Image" action only when there is exactly one
 						// image output. For multiple images, users can right-click individual
 						// images to copy them.
-						ContextKeyExpr.equals(POSITRON_NOTEBOOK_CELL_IMAGE_OUTPUT_COUNT.key, 1),
-						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated()
+						ContextKeyExpr.equals(CellContextKeys.imageOutputCount.key, 1),
+						CellContextKeys.outputIsCollapsed.toNegated()
 					)
 				},
 				{
@@ -1875,8 +1876,8 @@ class CopyOutputImageAction extends NotebookAction2 {
 					group: PositronNotebookCellOutputActionGroup.Copy,
 					order: 1,
 					when: ContextKeyExpr.and(
-						POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED,
-						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated()
+						CellContextKeys.outputImageTargeted,
+						CellContextKeys.outputIsCollapsed.toNegated()
 					)
 				},
 			],
@@ -1927,8 +1928,8 @@ registerAction2(class extends NotebookAction2 {
 					group: PositronNotebookCellOutputActionGroup.Copy,
 					order: 2,
 					when: ContextKeyExpr.and(
-						ContextKeyExpr.equals(POSITRON_NOTEBOOK_CELL_JSON_OUTPUT_COUNT.key, 1),
-						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated()
+						ContextKeyExpr.equals(CellContextKeys.jsonOutputCount.key, 1),
+						CellContextKeys.outputIsCollapsed.toNegated()
 					)
 				},
 				{
@@ -1936,8 +1937,8 @@ registerAction2(class extends NotebookAction2 {
 					group: PositronNotebookCellOutputActionGroup.Copy,
 					order: 2,
 					when: ContextKeyExpr.and(
-						POSITRON_NOTEBOOK_OUTPUT_JSON_TARGETED,
-						POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.toNegated()
+						CellContextKeys.outputJsonTargeted,
+						CellContextKeys.outputIsCollapsed.toNegated()
 					)
 				},
 			],
@@ -2252,6 +2253,6 @@ MenuRegistry.appendMenuItem(MenuId.EditorContext, {
 	// Only show these menu items when a notebook editor has focus to
 	// avoid these menu items showing up in other editors, such as the
 	// output panel (which is a monaco editor).
-	when: POSITRON_NOTEBOOK_EDITOR_FOCUSED,
+	when: NotebookContextKeys.editorFocused,
 	order: 0
 });

--- a/src/vs/workbench/contrib/positronNotebook/browser/usePositronNotebookExperimental.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/usePositronNotebookExperimental.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { usePositronReactServicesContext } from '../../../../base/browser/positronReactRendererContext.js';
-import { POSITRON_NOTEBOOK_EXPERIMENTAL } from './ContextKeysManager.js';
+import { NotebookContextKeys } from '../common/notebookContextKeys.js';
 import { useContextKeyValue } from './useContextKeyValue.js';
 
 /**
@@ -13,5 +13,5 @@ import { useContextKeyValue } from './useContextKeyValue.js';
  */
 export function usePositronNotebookExperimental(): boolean {
 	const contextKeyService = usePositronReactServicesContext().contextKeyService;
-	return useContextKeyValue(contextKeyService, POSITRON_NOTEBOOK_EXPERIMENTAL) ?? false;
+	return useContextKeyValue(contextKeyService, NotebookContextKeys.experimental) ?? false;
 }

--- a/src/vs/workbench/contrib/positronNotebook/common/cellContextKeys.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/cellContextKeys.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+
+/** All cell context keys in one place so we can easily operate on them all at once. */
+export namespace CellContextKeys {
+	export const isCode = new RawContextKey<boolean>('positronNotebookCellIsCode', false);
+	export const isMarkdown = new RawContextKey<boolean>('positronNotebookCellIsMarkdown', false);
+	/** A cell of type 'raw' i.e. one that contains plain text without any rendered outputs or execution capabilities. */
+	export const isRaw = new RawContextKey<boolean>('positronNotebookCellIsRaw', false);
+	export const isRunning = new RawContextKey<boolean>('positronNotebookCellIsRunning', false);
+	export const isPending = new RawContextKey<boolean>('positronNotebookCellIsPending', false);
+	export const isFirst = new RawContextKey<boolean>('positronNotebookCellIsFirst', false);
+	export const isLast = new RawContextKey<boolean>('positronNotebookCellIsLast', false);
+	export const isOnly = new RawContextKey<boolean>('positronNotebookCellIsOnly', false);
+	/** True when the markdown editor of a cell is open for editing. */
+	export const markdownEditorOpen = new RawContextKey<boolean>('positronNotebookCellMarkdownEditorOpen', false);
+	/** True when a cell is selected (relevant for multi-cell selection scenarios). */
+	export const isSelected = new RawContextKey<boolean>('positronNotebookCellIsSelected', false);
+	/** True when the cell is the active/focused cell (displays its action bar and receives cell-level keyboard actions). */
+	export const isActive = new RawContextKey<boolean>('positronNotebookCellIsActive', false);
+	export const canMoveUp = new RawContextKey<boolean>('positronNotebookCellCanMoveUp', false);
+	export const canMoveDown = new RawContextKey<boolean>('positronNotebookCellCanMoveDown', false);
+	export const hasOutputs = new RawContextKey<boolean>('positronNotebookCellHasOutputs', false);
+	export const imageOutputCount = new RawContextKey<number>('positronNotebookCellImageOutputCount', 0);
+	export const jsonOutputCount = new RawContextKey<number>('positronNotebookCellJsonOutputCount', 0);
+	export const outputIsCollapsed = new RawContextKey<boolean>('positronNotebookCellOutputIsCollapsed', false);
+	export const outputOverflows = new RawContextKey<boolean>('positronNotebookCellOutputOverflows', false, localize('positronNotebookCellOutputOverflows', "Whether the cell's text output exceeds the line limit"));
+	export const outputScrolling = new RawContextKey<boolean>('positronNotebookCellOutputScrolling', false, localize('positronNotebookCellOutputScrolling', "Whether the cell's output is in scrolling mode"));
+	/** Set when a cell's output section has DOM focus. */
+	export const outputFocused = new RawContextKey<boolean>('positronNotebookOutputFocused', false, localize('positronNotebookOutputFocused', "Whether a cell's output area has focus"));
+	/** Set when the user right-clicks on an image in the output area, or opens the ellipsis menu for a cell with image output. */
+	export const outputImageTargeted = new RawContextKey<boolean>('positronNotebookOutputImageTargeted', false);
+	/** Set when the user right-clicks on JSON output or opens the ellipsis menu for a cell with JSON output. */
+	export const outputJsonTargeted = new RawContextKey<boolean>('positronNotebookOutputJsonTargeted', false);
+}

--- a/src/vs/workbench/contrib/positronNotebook/common/cellContextKeys.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/cellContextKeys.ts
@@ -8,33 +8,33 @@ import { RawContextKey } from '../../../../platform/contextkey/common/contextkey
 
 /** All cell context keys in one place so we can easily operate on them all at once. */
 export namespace CellContextKeys {
-	export const isCode = new RawContextKey<boolean>('positronNotebookCellIsCode', false);
-	export const isMarkdown = new RawContextKey<boolean>('positronNotebookCellIsMarkdown', false);
+	export const isCode = new RawContextKey<boolean>('positronNotebookCellIsCode', false, { type: 'boolean', description: localize('positronNotebookCellIsCode', "Whether the cell is a code cell") });
+	export const isMarkdown = new RawContextKey<boolean>('positronNotebookCellIsMarkdown', false, { type: 'boolean', description: localize('positronNotebookCellIsMarkdown', "Whether the cell is a markdown cell") });
 	/** A cell of type 'raw' i.e. one that contains plain text without any rendered outputs or execution capabilities. */
-	export const isRaw = new RawContextKey<boolean>('positronNotebookCellIsRaw', false);
-	export const isRunning = new RawContextKey<boolean>('positronNotebookCellIsRunning', false);
-	export const isPending = new RawContextKey<boolean>('positronNotebookCellIsPending', false);
-	export const isFirst = new RawContextKey<boolean>('positronNotebookCellIsFirst', false);
-	export const isLast = new RawContextKey<boolean>('positronNotebookCellIsLast', false);
-	export const isOnly = new RawContextKey<boolean>('positronNotebookCellIsOnly', false);
+	export const isRaw = new RawContextKey<boolean>('positronNotebookCellIsRaw', false, { type: 'boolean', description: localize('positronNotebookCellIsRaw', "Whether the cell is a raw cell i.e. one that contains plain text without any rendered outputs or execution capabilities") });
+	export const isRunning = new RawContextKey<boolean>('positronNotebookCellIsRunning', false, { type: 'boolean', description: localize('positronNotebookCellIsRunning', "Whether the cell is currently running") });
+	export const isPending = new RawContextKey<boolean>('positronNotebookCellIsPending', false, { type: 'boolean', description: localize('positronNotebookCellIsPending', "Whether the cell is pending execution") });
+	export const isFirst = new RawContextKey<boolean>('positronNotebookCellIsFirst', false, { type: 'boolean', description: localize('positronNotebookCellIsFirst', "Whether the cell is the first cell in the notebook") });
+	export const isLast = new RawContextKey<boolean>('positronNotebookCellIsLast', false, { type: 'boolean', description: localize('positronNotebookCellIsLast', "Whether the cell is the last cell in the notebook") });
+	export const isOnly = new RawContextKey<boolean>('positronNotebookCellIsOnly', false, { type: 'boolean', description: localize('positronNotebookCellIsOnly', "Whether the cell is the only cell in the notebook") });
 	/** True when the markdown editor of a cell is open for editing. */
-	export const markdownEditorOpen = new RawContextKey<boolean>('positronNotebookCellMarkdownEditorOpen', false);
+	export const markdownEditorOpen = new RawContextKey<boolean>('positronNotebookCellMarkdownEditorOpen', false, { type: 'boolean', description: localize('positronNotebookCellMarkdownEditorOpen', "Whether the markdown editor of a cell is open for editing") });
 	/** True when a cell is selected (relevant for multi-cell selection scenarios). */
-	export const isSelected = new RawContextKey<boolean>('positronNotebookCellIsSelected', false);
+	export const isSelected = new RawContextKey<boolean>('positronNotebookCellIsSelected', false, { type: 'boolean', description: localize('positronNotebookCellIsSelected', "Whether the cell is selected") });
 	/** True when the cell is the active/focused cell (displays its action bar and receives cell-level keyboard actions). */
-	export const isActive = new RawContextKey<boolean>('positronNotebookCellIsActive', false);
-	export const canMoveUp = new RawContextKey<boolean>('positronNotebookCellCanMoveUp', false);
-	export const canMoveDown = new RawContextKey<boolean>('positronNotebookCellCanMoveDown', false);
-	export const hasOutputs = new RawContextKey<boolean>('positronNotebookCellHasOutputs', false);
-	export const imageOutputCount = new RawContextKey<number>('positronNotebookCellImageOutputCount', 0);
-	export const jsonOutputCount = new RawContextKey<number>('positronNotebookCellJsonOutputCount', 0);
-	export const outputIsCollapsed = new RawContextKey<boolean>('positronNotebookCellOutputIsCollapsed', false);
-	export const outputOverflows = new RawContextKey<boolean>('positronNotebookCellOutputOverflows', false, localize('positronNotebookCellOutputOverflows', "Whether the cell's text output exceeds the line limit"));
-	export const outputScrolling = new RawContextKey<boolean>('positronNotebookCellOutputScrolling', false, localize('positronNotebookCellOutputScrolling', "Whether the cell's output is in scrolling mode"));
+	export const isActive = new RawContextKey<boolean>('positronNotebookCellIsActive', false, { type: 'boolean', description: localize('positronNotebookCellIsActive', "Whether the cell is the active cell") });
+	export const canMoveUp = new RawContextKey<boolean>('positronNotebookCellCanMoveUp', false, { type: 'boolean', description: localize('positronNotebookCellCanMoveUp', "Whether the cell can be moved up") });
+	export const canMoveDown = new RawContextKey<boolean>('positronNotebookCellCanMoveDown', false, { type: 'boolean', description: localize('positronNotebookCellCanMoveDown', "Whether the cell can be moved down") });
+	export const hasOutputs = new RawContextKey<boolean>('positronNotebookCellHasOutputs', false, { type: 'boolean', description: localize('positronNotebookCellHasOutputs', "Whether the cell has any outputs") });
+	export const imageOutputCount = new RawContextKey<number>('positronNotebookCellImageOutputCount', 0, { type: 'number', description: localize('positronNotebookCellImageOutputCount', "The number of image outputs in the cell") });
+	export const jsonOutputCount = new RawContextKey<number>('positronNotebookCellJsonOutputCount', 0, { type: 'number', description: localize('positronNotebookCellJsonOutputCount', "The number of JSON outputs in the cell") });
+	export const outputIsCollapsed = new RawContextKey<boolean>('positronNotebookCellOutputIsCollapsed', false, { type: 'boolean', description: localize('positronNotebookCellOutputIsCollapsed', "Whether the cell output is collapsed") });
+	export const outputOverflows = new RawContextKey<boolean>('positronNotebookCellOutputOverflows', false, { type: 'boolean', description: localize('positronNotebookCellOutputOverflows', "Whether the cell's text output exceeds the line limit") });
+	export const outputScrolling = new RawContextKey<boolean>('positronNotebookCellOutputScrolling', false, { type: 'boolean', description: localize('positronNotebookCellOutputScrolling', "Whether the cell's output is in scrolling mode") });
 	/** Set when a cell's output section has DOM focus. */
-	export const outputFocused = new RawContextKey<boolean>('positronNotebookOutputFocused', false, localize('positronNotebookOutputFocused', "Whether a cell's output area has focus"));
+	export const outputFocused = new RawContextKey<boolean>('positronNotebookOutputFocused', false, { type: 'boolean', description: localize('positronNotebookOutputFocused', "Whether a cell's output area has focus") });
 	/** Set when the user right-clicks on an image in the output area, or opens the ellipsis menu for a cell with image output. */
-	export const outputImageTargeted = new RawContextKey<boolean>('positronNotebookOutputImageTargeted', false);
+	export const outputImageTargeted = new RawContextKey<boolean>('positronNotebookOutputImageTargeted', false, { type: 'boolean', description: localize('positronNotebookOutputImageTargeted', "Whether an image output is targeted by a context menu") });
 	/** Set when the user right-clicks on JSON output or opens the ellipsis menu for a cell with JSON output. */
-	export const outputJsonTargeted = new RawContextKey<boolean>('positronNotebookOutputJsonTargeted', false);
+	export const outputJsonTargeted = new RawContextKey<boolean>('positronNotebookOutputJsonTargeted', false, { type: 'boolean', description: localize('positronNotebookOutputJsonTargeted', "Whether a JSON output is targeted by a context menu") });
 }

--- a/src/vs/workbench/contrib/positronNotebook/common/notebookContextKeys.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/notebookContextKeys.ts
@@ -9,11 +9,9 @@ import { RawContextKey } from '../../../../platform/contextkey/common/contextkey
 /** Notebook-level context keys for the Positron notebook editor. */
 export namespace NotebookContextKeys {
 	/** Set when the Positron notebook editor container is focused. */
-	export const editorFocused = new RawContextKey<boolean>('positronNotebookEditorFocused', false, localize('positronNotebookFocused', "Whether a Positron notebook editor or a notebook editor widget (e.g. a cell editor or the find widget) has focus"));
-
+	export const editorFocused = new RawContextKey<boolean>('positronNotebookEditorFocused', false, { type: 'boolean', description: localize('positronNotebookFocused', "Whether a Positron notebook editor or a notebook editor widget (e.g. a cell editor or the find widget) has focus") });
 	/** Set when a cell editor (Monaco editor within a notebook cell) is focused. */
-	export const cellEditorFocused = new RawContextKey<boolean>('positronNotebookCellEditorFocused', false, localize('positronNotebookCellEditorFocused', "Whether a code editor within a Positron notebook cell is focused"));
-
+	export const cellEditorFocused = new RawContextKey<boolean>('positronNotebookCellEditorFocused', false, { type: 'boolean', description: localize('positronNotebookCellEditorFocused', "Whether a code editor within a Positron notebook cell is focused") });
 	/** Mirrors the `positron.notebook.experimental` configuration. */
-	export const experimental = new RawContextKey<boolean>('positronNotebook.experimental', false, localize('positronNotebookExperimental', "Whether experimental Positron Notebook features are enabled"));
+	export const experimental = new RawContextKey<boolean>('positronNotebook.experimental', false, { type: 'boolean', description: localize('positronNotebookExperimental', "Whether experimental Positron Notebook features are enabled") });
 }

--- a/src/vs/workbench/contrib/positronNotebook/common/notebookContextKeys.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/notebookContextKeys.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+
+/** Notebook-level context keys for the Positron notebook editor. */
+export namespace NotebookContextKeys {
+	/** Set when the Positron notebook editor container is focused. */
+	export const editorFocused = new RawContextKey<boolean>('positronNotebookEditorFocused', false, localize('positronNotebookFocused', "Whether a Positron notebook editor or a notebook editor widget (e.g. a cell editor or the find widget) has focus"));
+
+	/** Set when a cell editor (Monaco editor within a notebook cell) is focused. */
+	export const cellEditorFocused = new RawContextKey<boolean>('positronNotebookCellEditorFocused', false, localize('positronNotebookCellEditorFocused', "Whether a code editor within a Positron notebook cell is focused"));
+
+	/** Mirrors the `positron.notebook.experimental` configuration. */
+	export const experimental = new RawContextKey<boolean>('positronNotebook.experimental', false, localize('positronNotebookExperimental', "Whether experimental Positron Notebook features are enabled"));
+}

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputFocus.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputFocus.vitest.tsx
@@ -18,7 +18,8 @@ import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { ISize } from '../../../../../base/browser/positronReactRenderer.js';
 import { IScopedContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
-import { POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS, POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED, POSITRON_NOTEBOOK_EDITOR_FOCUSED, POSITRON_NOTEBOOK_OUTPUT_FOCUSED } from '../../browser/ContextKeysManager.js';
+import { CellContextKeys } from '../../common/cellContextKeys.js';
+import { NotebookContextKeys } from '../../common/notebookContextKeys.js';
 import { NotebookInstanceProvider } from '../../browser/NotebookInstanceProvider.js';
 import { EnvironentProvider } from '../../browser/EnvironmentProvider.js';
 import { NotebookCodeCell } from '../../browser/notebookCells/NotebookCodeCell.js';
@@ -95,10 +96,10 @@ describe('Notebook output focus state', () => {
 		return { cells, notebook };
 	}
 
-	describe('POSITRON_NOTEBOOK_OUTPUT_FOCUSED context key', () => {
+	describe('CellContextKeys.outputFocused context key', () => {
 		it('is defined with key positronNotebookOutputFocused', () => {
-			expect(POSITRON_NOTEBOOK_OUTPUT_FOCUSED).toBeDefined();
-			expect(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key).toBe('positronNotebookOutputFocused');
+			expect(CellContextKeys.outputFocused).toBeDefined();
+			expect(CellContextKeys.outputFocused.key).toBe('positronNotebookOutputFocused');
 		});
 
 		it('can be bound and set on a scoped context key service', () => {
@@ -108,14 +109,14 @@ describe('Notebook output focus state', () => {
 			const cellContextKeyService = notebook.scopedContextKeyService.createScoped(cellElement);
 			ctx.disposables.add(cellContextKeyService);
 
-			expect(cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(undefined);
+			expect(cellContextKeyService.getContextKeyValue(CellContextKeys.outputFocused.key)).toBe(undefined);
 
-			const outputFocused = POSITRON_NOTEBOOK_OUTPUT_FOCUSED.bindTo(cellContextKeyService);
+			const outputFocused = CellContextKeys.outputFocused.bindTo(cellContextKeyService);
 			outputFocused.set(true);
-			expect(cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(true);
+			expect(cellContextKeyService.getContextKeyValue(CellContextKeys.outputFocused.key)).toBe(true);
 
 			outputFocused.set(false);
-			expect(cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(false);
+			expect(cellContextKeyService.getContextKeyValue(CellContextKeys.outputFocused.key)).toBe(false);
 		});
 	});
 
@@ -160,7 +161,7 @@ describe('Notebook output focus state', () => {
 			const outputSection = screen.getByTestId('cell-output');
 			outputSection.focus();
 
-			expect(contextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(true);
+			expect(contextKeyService.getContextKeyValue(CellContextKeys.outputFocused.key)).toBe(true);
 		});
 
 		it('sets positronNotebookOutputFocused to false when output section loses focus', () => {
@@ -168,10 +169,10 @@ describe('Notebook output focus state', () => {
 
 			const outputSection = screen.getByTestId('cell-output');
 			outputSection.focus();
-			expect(contextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(true);
+			expect(contextKeyService.getContextKeyValue(CellContextKeys.outputFocused.key)).toBe(true);
 
 			outputSection.blur();
-			expect(contextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(false);
+			expect(contextKeyService.getContextKeyValue(CellContextKeys.outputFocused.key)).toBe(false);
 		});
 
 		it('keeps positronNotebookOutputFocused true when focus moves to a child element', () => {
@@ -179,7 +180,7 @@ describe('Notebook output focus state', () => {
 
 			const outputSection = screen.getByTestId('cell-output');
 			outputSection.focus();
-			expect(contextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(true);
+			expect(contextKeyService.getContextKeyValue(CellContextKeys.outputFocused.key)).toBe(true);
 
 			// Directly fire blur with relatedTarget inside the output section to
 			// isolate the guard logic (avoid relying on re-focus bubbling).
@@ -187,7 +188,7 @@ describe('Notebook output focus state', () => {
 			outputSection.appendChild(child);
 			fireEvent.blur(outputSection, { relatedTarget: child });
 
-			expect(contextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key)).toBe(true);
+			expect(contextKeyService.getContextKeyValue(CellContextKeys.outputFocused.key)).toBe(true);
 		});
 	});
 
@@ -231,10 +232,10 @@ describe('Notebook output focus state', () => {
 
 			const whenClause = keybinding.when;
 			expect(whenClause).toBeDefined();
-			expect(whenClause?.serialize()).toContain(POSITRON_NOTEBOOK_EDITOR_FOCUSED.key);
-			expect(whenClause?.serialize()).toContain(POSITRON_NOTEBOOK_OUTPUT_FOCUSED.key);
-			expect(whenClause?.serialize()).toContain(POSITRON_NOTEBOOK_CELL_HAS_OUTPUTS.key);
-			expect(whenClause?.serialize()).toContain(`!${POSITRON_NOTEBOOK_CELL_OUTPUT_COLLAPSED.key}`);
+			expect(whenClause?.serialize()).toContain(NotebookContextKeys.editorFocused.key);
+			expect(whenClause?.serialize()).toContain(CellContextKeys.outputFocused.key);
+			expect(whenClause?.serialize()).toContain(CellContextKeys.hasOutputs.key);
+			expect(whenClause?.serialize()).toContain(`!${CellContextKeys.outputIsCollapsed.key}`);
 		});
 
 		it('has the correct action ID', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookUndoRedo.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookUndoRedo.vitest.ts
@@ -11,7 +11,7 @@ import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
 import { IEditorPane } from '../../../../common/editor.js';
-import { POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../browser/ContextKeysManager.js';
+import { NotebookContextKeys } from '../../common/notebookContextKeys.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../common/positronNotebookCommon.js';
 import { handleNotebookRedo, handleNotebookUndo } from '../../browser/contrib/undoRedo/positronNotebookUndoRedo.js';
 import { NotebookOperationType } from '../../browser/IPositronNotebookInstance.js';
@@ -312,7 +312,7 @@ describe('PositronNotebookInstance undo/redo', () => {
 			const editorService = stubInterface<IEditorService>({
 				activeEditorPane: makeNotebookEditorPane(notebook),
 			});
-			POSITRON_NOTEBOOK_EDITOR_FOCUSED.bindTo(notebook.scopedContextKeyService).set(false);
+			NotebookContextKeys.editorFocused.bindTo(notebook.scopedContextKeyService).set(false);
 
 			const result = handleNotebookUndo(editorService, ctx.get(IUndoRedoService));
 
@@ -332,7 +332,7 @@ describe('PositronNotebookInstance undo/redo', () => {
 			const editorService = stubInterface<IEditorService>({
 				activeEditorPane: makeNotebookEditorPane(notebook),
 			});
-			POSITRON_NOTEBOOK_EDITOR_FOCUSED.bindTo(notebook.scopedContextKeyService).set(false);
+			NotebookContextKeys.editorFocused.bindTo(notebook.scopedContextKeyService).set(false);
 
 			const result = handleNotebookRedo(editorService, ctx.get(IUndoRedoService));
 
@@ -350,7 +350,7 @@ describe('PositronNotebookInstance undo/redo', () => {
 			const editorService = stubInterface<IEditorService>({
 				activeEditorPane: makeNotebookEditorPane(notebook),
 			});
-			POSITRON_NOTEBOOK_EDITOR_FOCUSED.bindTo(notebook.scopedContextKeyService).set(true);
+			NotebookContextKeys.editorFocused.bindTo(notebook.scopedContextKeyService).set(true);
 
 			const setOpSpy = vi.spyOn(notebook, 'setCurrentOperation');
 
@@ -379,7 +379,7 @@ describe('PositronNotebookInstance undo/redo', () => {
 			const editorService = stubInterface<IEditorService>({
 				activeEditorPane: makeNotebookEditorPane(notebook),
 			});
-			POSITRON_NOTEBOOK_EDITOR_FOCUSED.bindTo(notebook.scopedContextKeyService).set(true);
+			NotebookContextKeys.editorFocused.bindTo(notebook.scopedContextKeyService).set(true);
 
 			const setOpSpy = vi.spyOn(notebook, 'setCurrentOperation');
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.vitest.ts
@@ -8,7 +8,7 @@
 import { VSBuffer } from '../../../../../base/common/buffer.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { CellEditType, CellKind } from '../../../notebook/common/notebookCommon.js';
-import { POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED } from '../../browser/ContextKeysManager.js';
+import { CellContextKeys } from '../../common/cellContextKeys.js';
 import { createTestPositronNotebookInstance, TestCellInput } from './testPositronNotebookInstance.js';
 
 function pngOutputItem() {
@@ -162,23 +162,23 @@ describe('Positron Notebook Cell Outputs', () => {
 
 			// Defaults to false
 			expect(
-				cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED.key),
+				cellContextKeyService.getContextKeyValue(CellContextKeys.outputImageTargeted.key),
 				'outputImageTargeted should not be set by default'
 			).toBe(undefined);
 
 			// Can be bound and set to true (as the context menu handler does)
-			const outputImageTargeted = POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED.bindTo(cellContextKeyService);
+			const outputImageTargeted = CellContextKeys.outputImageTargeted.bindTo(cellContextKeyService);
 			outputImageTargeted.set(true);
 
 			expect(
-				cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED.key),
+				cellContextKeyService.getContextKeyValue(CellContextKeys.outputImageTargeted.key),
 				'outputImageTargeted should be true after being set'
 			).toBe(true);
 
 			// Can be set back to false
 			outputImageTargeted.set(false);
 			expect(
-				cellContextKeyService.getContextKeyValue(POSITRON_NOTEBOOK_OUTPUT_IMAGE_TARGETED.key),
+				cellContextKeyService.getContextKeyValue(CellContextKeys.outputImageTargeted.key),
 				'outputImageTargeted should be false after being cleared'
 			).toBe(false);
 		});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/selectionKeybindings.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/selectionKeybindings.vitest.ts
@@ -9,7 +9,8 @@ import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
-import { POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS, POSITRON_NOTEBOOK_EDITOR_FOCUSED } from '../../browser/ContextKeysManager.js';
+import { CellContextKeys } from '../../common/cellContextKeys.js';
+import { NotebookContextKeys } from '../../common/notebookContextKeys.js';
 import { IPositronNotebookInstance } from '../../browser/IPositronNotebookInstance.js';
 import { CellSelectionType, getActiveCell, getSelectedCells, SelectionState } from '../../browser/selectionMachine.js';
 import {
@@ -215,12 +216,12 @@ describe('Notebook selection keybinding actions', () => {
 			const action = new MoveCellUpAction();
 			expect(action.desc.id).toBe('positronNotebook.cell.moveUp');
 			expect(action.desc.keybinding?.primary).toBe(KeyMod.Alt | KeyCode.UpArrow);
-			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_EDITOR_FOCUSED);
+			expect(action.desc.keybinding?.when).toBe(NotebookContextKeys.editorFocused);
 			// Menu entry: cell action bar submenu, gated on canMoveUp so the
 			// item disappears at the first cell where the move would no-op.
 			const menu = Array.isArray(action.desc.menu) ? action.desc.menu[0] : action.desc.menu;
 			expect(menu?.id).toBe(MenuId.PositronNotebookCellActionBarSubmenu);
-			expect(menu?.when).toBe(POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.canMoveUp);
+			expect(menu?.when).toBe(CellContextKeys.canMoveUp);
 		});
 
 		it('moves the selected cell up by one and selection follows', () => {
@@ -242,10 +243,10 @@ describe('Notebook selection keybinding actions', () => {
 			const action = new MoveCellDownAction();
 			expect(action.desc.id).toBe('positronNotebook.cell.moveDown');
 			expect(action.desc.keybinding?.primary).toBe(KeyMod.Alt | KeyCode.DownArrow);
-			expect(action.desc.keybinding?.when).toBe(POSITRON_NOTEBOOK_EDITOR_FOCUSED);
+			expect(action.desc.keybinding?.when).toBe(NotebookContextKeys.editorFocused);
 			const menu = Array.isArray(action.desc.menu) ? action.desc.menu[0] : action.desc.menu;
 			expect(menu?.id).toBe(MenuId.PositronNotebookCellActionBarSubmenu);
-			expect(menu?.when).toBe(POSITRON_NOTEBOOK_CELL_CONTEXT_KEYS.canMoveDown);
+			expect(menu?.when).toBe(CellContextKeys.canMoveDown);
 		});
 
 		it('moves the selected cell down by one and selection follows', () => {


### PR DESCRIPTION
Fixes #13795

Adds structured `{ type, description }` metadata to all Positron notebook context key declarations so that autocompletion help strings appear when editing `when` clauses in `keybindings.json` and `package.json`.

<img width="1006" height="404" alt="Screenshot 2026-05-27 at 15 36 16" src="https://github.com/user-attachments/assets/44c83e99-d9b5-4309-a07e-ff6dd3ee2e6e" />

Also extracts context key declarations into `common/` modules (`cellContextKeys.ts`, `notebookContextKeys.ts`) which is a little cleaner, and a step toward a bigger refactor to how we handle context keys related to fixing https://github.com/posit-dev/positron/issues/10466.

### Release Notes

#### New Features
- Positron notebook context keys show descriptions in autocompletions in `keybindings.json` and extension `package.json` (#13795)

#### Bug Fixes
- N/A

### QA Notes

@:positron-notebooks @web

1. Open `keybindings.json` via the command palette
2. Start typing a `when` clause and type `positronNotebook`
3. Verify that context key suggestions include descriptions (e.g. "Whether the cell is a code cell")