### PR TITLE
e2e: Posit Assistant MCP server from .positai/settings.json

### DIFF
--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -51,10 +51,25 @@ const CODE_BLOCK_INSERT_CURSOR_BUTTON = 'button[aria-label="Insert At Cursor"]';
 const CODE_BLOCK_INSERT_FILE_BUTTON = 'button[aria-label="Insert into New File"]';
 
 // Tool confirmation UI
+const TOOL_CONFIRM_CARD = '.bg-warning';
 const TOOL_ALLOW_BUTTON = 'button.rounded-r-none:has-text("Allow")';
 const TOOL_ALLOW_DROPDOWN_TRIGGER = 'button[aria-label="More allow options"]';
 const TOOL_ALLOW_SESSION_MENU_ITEM = '[role="menuitem"]:has-text("for this session")';
 const TOOL_DECLINE_BUTTON = 'button.rounded-r-none:has-text("Decline")';
+
+// Tool result accordion (rendered in the transcript after a tool runs)
+const TOOL_RESULT_ACCORDION_ITEM = '[data-slot="accordion-item"]';
+
+/**
+ * Posit Assistant qualifies MCP tool names as `mcp__<server>__<tool>` in the
+ * UI. Both the confirmation card and the post-run accordion render this
+ * literal string in a `<span class="font-mono">`, which makes it a stable
+ * signal that a specific MCP server's tool (not a built-in tool or a
+ * different MCP server) was selected and executed.
+ */
+function mcpToolId(server: string, tool: string): string {
+	return `mcp__${server}__${tool}`;
+}
 
 /**
  * Page object for the Posit Assistant extension.
@@ -401,7 +416,58 @@ export class PositAssistant {
 	 * Verifies the tool confirmation dialog is visible.
 	 */
 	async expectToolConfirmVisible(): Promise<void> {
-		await expect(this.frame.locator('.bg-warning').getByRole('heading', { level: 4 })).toBeVisible();
+		await expect(this.frame.locator(TOOL_CONFIRM_CARD).getByRole('heading', { level: 4 })).toBeVisible();
+	}
+
+	/**
+	 * Verifies the tool confirmation dialog is visible AND specifically
+	 * identifies an MCP server + tool (e.g. `mcp__everything__echo`). Stronger
+	 * than `expectToolConfirmVisible()` for MCP tests, where you want to prove
+	 * the model selected the right MCP tool — not a different MCP server's
+	 * tool or a built-in tool with overlapping behavior.
+	 */
+	async expectMcpToolConfirmVisible(server: string, tool: string): Promise<void> {
+		await expect(this.frame.locator(TOOL_CONFIRM_CARD)).toContainText(mcpToolId(server, tool));
+	}
+
+	/**
+	 * Returns a locator for the MCP tool-result accordion item for a specific
+	 * server + tool. The accordion is rendered by Posit Assistant whenever an
+	 * MCP tool actually executes (post-Allow), so its presence is evidence the
+	 * tool ran end-to-end rather than failing silently.
+	 */
+	mcpToolResult(server: string, tool: string) {
+		// `:scope` keeps the :has() match scoped to this accordion item rather
+		// than matching any ancestor that happens to contain the id text.
+		return this.frame.locator(
+			`${TOOL_RESULT_ACCORDION_ITEM}:has(:scope :text("${mcpToolId(server, tool)}"))`,
+		);
+	}
+
+	/**
+	 * Verifies the MCP tool-result accordion for a specific server + tool is
+	 * present in the transcript. Use after `waitForResponseComplete()` to
+	 * confirm the tool actually executed.
+	 */
+	async expectMcpToolResultVisible(server: string, tool: string): Promise<void> {
+		await expect(this.mcpToolResult(server, tool)).toBeVisible();
+	}
+
+	/**
+	 * Expands the MCP tool-result accordion for the given server + tool and
+	 * returns the full text content of the item (header + expanded panel).
+	 * Lets the caller assert on the raw tool output (e.g. `Echo: ${marker}`),
+	 * which is rendered by the UI from the actual MCP response — the model
+	 * cannot fabricate this text even if it sees the prompt.
+	 */
+	async getMcpToolResultText(server: string, tool: string): Promise<string> {
+		const item = this.mcpToolResult(server, tool);
+		const trigger = item.locator('button[aria-expanded]').first();
+		if ((await trigger.getAttribute('aria-expanded')) !== 'true') {
+			await trigger.click();
+		}
+		await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+		return (await item.textContent()) ?? '';
 	}
 
 	/**

--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -454,23 +454,6 @@ export class PositAssistant {
 	}
 
 	/**
-	 * Expands the MCP tool-result accordion for the given server + tool and
-	 * returns the full text content of the item (header + expanded panel).
-	 * Lets the caller assert on the raw tool output (e.g. `Echo: ${marker}`),
-	 * which is rendered by the UI from the actual MCP response — the model
-	 * cannot fabricate this text even if it sees the prompt.
-	 */
-	async getMcpToolResultText(server: string, tool: string): Promise<string> {
-		const item = this.mcpToolResult(server, tool);
-		const trigger = item.locator('button[aria-expanded]').first();
-		if ((await trigger.getAttribute('aria-expanded')) !== 'true') {
-			await trigger.click();
-		}
-		await expect(trigger).toHaveAttribute('aria-expanded', 'true');
-		return (await item.textContent()) ?? '';
-	}
-
-	/**
 	 * Selects "Allow for this session" from the tool confirmation dropdown.
 	 */
 	async allowToolForSession(): Promise<void> {

--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -60,13 +60,7 @@ const TOOL_DECLINE_BUTTON = 'button.rounded-r-none:has-text("Decline")';
 // Tool result accordion (rendered in the transcript after a tool runs)
 const TOOL_RESULT_ACCORDION_ITEM = '[data-slot="accordion-item"]';
 
-/**
- * Posit Assistant qualifies MCP tool names as `mcp__<server>__<tool>` in the
- * UI. Both the confirmation card and the post-run accordion render this
- * literal string in a `<span class="font-mono">`, which makes it a stable
- * signal that a specific MCP server's tool (not a built-in tool or a
- * different MCP server) was selected and executed.
- */
+/** Posit Assistant qualifies MCP tool names as `mcp__<server>__<tool>` in the UI. */
 function mcpToolId(server: string, tool: string): string {
 	return `mcp__${server}__${tool}`;
 }
@@ -419,50 +413,29 @@ export class PositAssistant {
 		await expect(this.frame.locator(TOOL_CONFIRM_CARD).getByRole('heading', { level: 4 })).toBeVisible();
 	}
 
-	/**
-	 * Verifies the tool confirmation dialog is visible AND specifically
-	 * identifies an MCP server + tool (e.g. `mcp__everything__echo`). Stronger
-	 * than `expectToolConfirmVisible()` for MCP tests, where you want to prove
-	 * the model selected the right MCP tool — not a different MCP server's
-	 * tool or a built-in tool with overlapping behavior.
-	 */
+	/** Verifies the tool confirmation dialog identifies a specific MCP server + tool. */
 	async expectMcpToolConfirmVisible(server: string, tool: string): Promise<void> {
 		await expect(this.frame.locator(TOOL_CONFIRM_CARD)).toContainText(mcpToolId(server, tool));
 	}
 
-	/**
-	 * Returns a locator for the MCP tool-result accordion item for a specific
-	 * server + tool. The accordion is rendered by Posit Assistant whenever an
-	 * MCP tool actually executes (post-Allow), so its presence is evidence the
-	 * tool ran end-to-end rather than failing silently.
-	 */
+	/** Locator for the MCP tool-result accordion, rendered after the tool executes. */
 	mcpToolResult(server: string, tool: string) {
-		// `:scope` keeps the :has() match scoped to this accordion item rather
-		// than matching any ancestor that happens to contain the id text.
 		return this.frame.locator(
 			`${TOOL_RESULT_ACCORDION_ITEM}:has(:scope :text("${mcpToolId(server, tool)}"))`,
 		);
 	}
 
-	/**
-	 * Verifies the MCP tool-result accordion for a specific server + tool is
-	 * present in the transcript. Use after `waitForResponseComplete()` to
-	 * confirm the tool actually executed.
-	 */
+	/** Verifies the MCP tool-result accordion is in the transcript. */
 	async expectMcpToolResultVisible(server: string, tool: string): Promise<void> {
 		await expect(this.mcpToolResult(server, tool)).toBeVisible();
 	}
 
 	/**
-	 * Asserts a literal text string is present somewhere in the chat frame DOM.
-	 * Uses `toBeAttached()` rather than `toBeVisible()` because tool-result
-	 * accordion panels use `overflow-hidden` with an animated height that can
-	 * leave content visually hidden (h=0) even when logically rendered. The
-	 * text is in the DOM either way.
+	 * Asserts a literal text string is anywhere in the chat frame DOM.
 	 *
-	 * Useful for asserting a tool's literal output reached the UI (e.g. the
-	 * `Echo: ...` payload returned by `@modelcontextprotocol/server-everything`'s
-	 * echo tool) without depending on the model's natural-language reply.
+	 * Uses `toBeAttached()` not `toBeVisible()`: tool-result accordion panels
+	 * use overflow-hidden + animated height that can read as visually hidden
+	 * even when fully expanded.
 	 */
 	async expectChatContainsText(text: string): Promise<void> {
 		await expect(this.frame.getByText(text, { exact: false }).first()).toBeAttached();

--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -454,6 +454,21 @@ export class PositAssistant {
 	}
 
 	/**
+	 * Asserts a literal text string is present somewhere in the chat frame DOM.
+	 * Uses `toBeAttached()` rather than `toBeVisible()` because tool-result
+	 * accordion panels use `overflow-hidden` with an animated height that can
+	 * leave content visually hidden (h=0) even when logically rendered. The
+	 * text is in the DOM either way.
+	 *
+	 * Useful for asserting a tool's literal output reached the UI (e.g. the
+	 * `Echo: ...` payload returned by `@modelcontextprotocol/server-everything`'s
+	 * echo tool) without depending on the model's natural-language reply.
+	 */
+	async expectChatContainsText(text: string): Promise<void> {
+		await expect(this.frame.getByText(text, { exact: false }).first()).toBeAttached();
+	}
+
+	/**
 	 * Selects "Allow for this session" from the tool confirmation dropdown.
 	 */
 	async allowToolForSession(): Promise<void> {

--- a/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
@@ -88,12 +88,12 @@ test.describe('Posit Assistant MCP', {
 				//    cannot fabricate it from the prompt alone.
 				await app.workbench.positAssistant.expectMcpToolResultVisible('everything', 'echo');
 
-				// 3. The model's reply includes the marker. Combined with checks 1
-				//    and 2 above (which prove the right MCP tool actually ran), this
-				//    rules out the model satisfying the test by replying without
-				//    invoking the tool.
-				const responseText = await app.workbench.positAssistant.getLastResponseText();
-				test.expect(responseText).toContain(marker);
+				// 3. The literal "Echo: <marker>" payload appears somewhere in the
+				//    chat frame DOM. The "Echo: " prefix is from the everything
+				//    server's tools/echo.ts (not the prompt or the user message),
+				//    so a parroting model can't synthesize this exact string —
+				//    only a real tool execution can put it in the UI.
+				await app.workbench.positAssistant.expectChatContainsText(`Echo: ${marker}`);
 			});
 		});
 	}

--- a/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
@@ -62,15 +62,13 @@ test.describe('Posit Assistant MCP', {
 				await app.workbench.positAssistant.open();
 				await app.workbench.positAssistant.waitForReady();
 
-				// A unique marker the LLM can't have produced from priors. The echo
-				// tool prepends "Echo: " (see @modelcontextprotocol/server-everything's
-				// tools/echo.ts), so the literal string "Echo: <marker>" can only
-				// appear in the UI if the tool actually ran — a parroting model
-				// would only have the marker, not the prefix.
+				// A unique marker the LLM can't have produced from priors. If the
+				// echo tool is reachable, this string round-trips through the MCP
+				// server and surfaces in the assistant reply.
 				const marker = 'positron-mcp-echo-marker-7f31b9c4';
 
 				await app.workbench.positAssistant.sendMessage(
-					`Call the "echo" tool from the "everything" MCP server with this exact message: ${marker}.`,
+					`Call the "echo" tool from the "everything" MCP server with this exact message: ${marker}. Then reply with only the echoed text.`,
 					false,
 					{ newConversation: true },
 				);
@@ -86,13 +84,16 @@ test.describe('Posit Assistant MCP', {
 
 				// 2. The result accordion for this specific MCP tool is rendered
 				//    in the transcript — proof the tool actually executed end-to-end.
+				//    The UI renders this block only when a tool runs, so the model
+				//    cannot fabricate it from the prompt alone.
 				await app.workbench.positAssistant.expectMcpToolResultVisible('everything', 'echo');
 
-				// 3. The expanded accordion body contains the tool's literal output.
-				//    `Echo: ` comes from the tool source, not the prompt, so this is
-				//    real evidence the MCP server ran (not just LLM parroting).
-				const toolResultText = await app.workbench.positAssistant.getMcpToolResultText('everything', 'echo');
-				test.expect(toolResultText).toContain(`Echo: ${marker}`);
+				// 3. The model's reply includes the marker. Combined with checks 1
+				//    and 2 above (which prove the right MCP tool actually ran), this
+				//    rules out the model satisfying the test by replying without
+				//    invoking the tool.
+				const responseText = await app.workbench.positAssistant.getLastResponseText();
+				test.expect(responseText).toContain(marker);
 			});
 		});
 	}

--- a/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { test, tags } from '../_test.setup';
+import { ModelProvider } from '../../pages/positronAssistant';
+
+test.use({
+	suiteId: __filename
+});
+
+const POSIT_ASSISTANT_PROVIDERS: ModelProvider[] = ['anthropic-api'];
+
+// Posit Assistant reads MCP server configuration from `.positai/settings.json`
+// in the workspace root. This test catches regressions of the class of bug
+// reported in posit-dev/assistant#1289 (fixed in posit-dev/assistant#1293),
+// where MCP servers configured in .positai/settings.json were ignored.
+//
+// We use the upstream MCP reference server "@modelcontextprotocol/server-everything"
+// for its stable `echo` tool, which simply returns the input message.
+test.describe('Posit Assistant MCP', {
+	tag: [tags.POSIT_ASSISTANT, tags.ASSISTANT, tags.WEB, tags.WIN],
+}, () => {
+
+	for (const provider of POSIT_ASSISTANT_PROVIDERS) {
+		test.describe(provider, () => {
+			test.beforeAll(async function ({ app, settings }) {
+				// Write the MCP server config into the workspace .positai/settings.json
+				// BEFORE activating Posit Assistant. The fix watches this file, but
+				// writing it up-front avoids relying on watcher timing for the first
+				// MCP startup.
+				const positaiDir = join(app.workspacePathOrFolder, '.positai');
+				mkdirSync(positaiDir, { recursive: true });
+				// `npx` on Windows is a .cmd shim; spawning it directly from the
+				// assistant's stdio launcher fails, so wrap with `cmd /c`.
+				const command = process.platform === 'win32'
+					? ['cmd', '/c', 'npx', '-y', '@modelcontextprotocol/server-everything']
+					: ['npx', '-y', '@modelcontextprotocol/server-everything'];
+				writeFileSync(
+					join(positaiDir, 'settings.json'),
+					JSON.stringify({ mcpServers: { everything: { command } } }, null, 2),
+				);
+
+				await app.workbench.assistant.loginModelProvider(provider);
+				// Maximize the sidebar so the Posit Assistant webview is not
+				// obscured by outer-page elements on small CI viewports.
+				await app.workbench.quickaccess.runCommand('workbench.action.fullSizedSidebar');
+				// Ensure we're running the latest Posit Assistant dev build, which
+				// contains the MCP-from-.positai fix.
+				await app.workbench.positAssistant.checkForDevBuildUpdate(settings, app.workbench.quickaccess);
+			});
+
+			test.afterAll(async function ({ app, cleanup }) {
+				await app.workbench.assistant.logoutModelProvider(provider);
+				await cleanup.removeTestFolder('.positai');
+			});
+
+			test(`${provider} - Use echo tool from MCP server configured in .positai/settings.json`, async function ({ app }) {
+				await app.workbench.positAssistant.open();
+				await app.workbench.positAssistant.waitForReady();
+
+				// A unique marker the LLM can't have produced from priors. If the
+				// echo tool is reachable, this string round-trips through the MCP
+				// server and surfaces in the response.
+				const marker = 'positron-mcp-echo-marker-7f31b9c4';
+
+				await app.workbench.positAssistant.sendMessage(
+					`Call the "echo" tool from the "everything" MCP server with this exact message: ${marker}. Then reply with only the echoed text.`,
+					false,
+					{ newConversation: true },
+				);
+
+				// MCP tool calls go through the same allow/decline confirmation flow
+				// as built-in tools. If MCP wasn't loaded from .positai/settings.json,
+				// the model has no tool to call and this assertion will time out.
+				await app.workbench.positAssistant.expectToolConfirmVisible();
+				await app.workbench.positAssistant.allowToolOnce();
+				// MCP server startup (npx fetch + launch) can push first-tool latency
+				// past the default 60s. Give it more headroom.
+				await app.workbench.positAssistant.waitForResponseComplete(120000);
+
+				const responseText = await app.workbench.positAssistant.getLastResponseText();
+				test.expect(responseText).toContain(marker);
+			});
+		});
+	}
+
+});

--- a/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
@@ -62,28 +62,37 @@ test.describe('Posit Assistant MCP', {
 				await app.workbench.positAssistant.open();
 				await app.workbench.positAssistant.waitForReady();
 
-				// A unique marker the LLM can't have produced from priors. If the
-				// echo tool is reachable, this string round-trips through the MCP
-				// server and surfaces in the response.
+				// A unique marker the LLM can't have produced from priors. The echo
+				// tool prepends "Echo: " (see @modelcontextprotocol/server-everything's
+				// tools/echo.ts), so the literal string "Echo: <marker>" can only
+				// appear in the UI if the tool actually ran — a parroting model
+				// would only have the marker, not the prefix.
 				const marker = 'positron-mcp-echo-marker-7f31b9c4';
 
 				await app.workbench.positAssistant.sendMessage(
-					`Call the "echo" tool from the "everything" MCP server with this exact message: ${marker}. Then reply with only the echoed text.`,
+					`Call the "echo" tool from the "everything" MCP server with this exact message: ${marker}.`,
 					false,
 					{ newConversation: true },
 				);
 
-				// MCP tool calls go through the same allow/decline confirmation flow
-				// as built-in tools. If MCP wasn't loaded from .positai/settings.json,
-				// the model has no tool to call and this assertion will time out.
-				await app.workbench.positAssistant.expectToolConfirmVisible();
+				// 1. The confirm card identifies the specific MCP tool. If the
+				//    model picked a different tool (or no MCP tool at all because
+				//    .positai/settings.json wasn't loaded), this fails.
+				await app.workbench.positAssistant.expectMcpToolConfirmVisible('everything', 'echo');
 				await app.workbench.positAssistant.allowToolOnce();
 				// MCP server startup (npx fetch + launch) can push first-tool latency
 				// past the default 60s. Give it more headroom.
 				await app.workbench.positAssistant.waitForResponseComplete(120000);
 
-				const responseText = await app.workbench.positAssistant.getLastResponseText();
-				test.expect(responseText).toContain(marker);
+				// 2. The result accordion for this specific MCP tool is rendered
+				//    in the transcript — proof the tool actually executed end-to-end.
+				await app.workbench.positAssistant.expectMcpToolResultVisible('everything', 'echo');
+
+				// 3. The expanded accordion body contains the tool's literal output.
+				//    `Echo: ` comes from the tool source, not the prompt, so this is
+				//    real evidence the MCP server ran (not just LLM parroting).
+				const toolResultText = await app.workbench.positAssistant.getMcpToolResultText('everything', 'echo');
+				test.expect(toolResultText).toContain(`Echo: ${marker}`);
 			});
 		});
 	}

--- a/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
@@ -14,13 +14,9 @@ test.use({
 
 const POSIT_ASSISTANT_PROVIDERS: ModelProvider[] = ['anthropic-api'];
 
-// Posit Assistant reads MCP server configuration from `.positai/settings.json`
-// in the workspace root. This test catches regressions of the class of bug
-// reported in posit-dev/assistant#1289 (fixed in posit-dev/assistant#1293),
-// where MCP servers configured in .positai/settings.json were ignored.
-//
-// We use the upstream MCP reference server "@modelcontextprotocol/server-everything"
-// for its stable `echo` tool, which simply returns the input message.
+// Catches regressions where MCP servers in `.positai/settings.json` are
+// ignored — see posit-dev/assistant#1289 (fixed in #1293). Uses the `echo`
+// tool from @modelcontextprotocol/server-everything as a stable reference.
 test.describe('Posit Assistant MCP', {
 	tag: [tags.POSIT_ASSISTANT, tags.ASSISTANT, tags.WEB, tags.WIN],
 }, () => {
@@ -28,14 +24,12 @@ test.describe('Posit Assistant MCP', {
 	for (const provider of POSIT_ASSISTANT_PROVIDERS) {
 		test.describe(provider, () => {
 			test.beforeAll(async function ({ app, settings }) {
-				// Write the MCP server config into the workspace .positai/settings.json
-				// BEFORE activating Posit Assistant. The fix watches this file, but
-				// writing it up-front avoids relying on watcher timing for the first
-				// MCP startup.
+				// Write `.positai/settings.json` before activating the assistant
+				// so we don't rely on the file watcher for the first MCP startup.
 				const positaiDir = join(app.workspacePathOrFolder, '.positai');
 				mkdirSync(positaiDir, { recursive: true });
-				// `npx` on Windows is a .cmd shim; spawning it directly from the
-				// assistant's stdio launcher fails, so wrap with `cmd /c`.
+				// On Windows `npx` is a .cmd shim; wrap with `cmd /c` so the
+				// assistant's stdio launcher can spawn it.
 				const command = process.platform === 'win32'
 					? ['cmd', '/c', 'npx', '-y', '@modelcontextprotocol/server-everything']
 					: ['npx', '-y', '@modelcontextprotocol/server-everything'];
@@ -48,8 +42,6 @@ test.describe('Posit Assistant MCP', {
 				// Maximize the sidebar so the Posit Assistant webview is not
 				// obscured by outer-page elements on small CI viewports.
 				await app.workbench.quickaccess.runCommand('workbench.action.fullSizedSidebar');
-				// Ensure we're running the latest Posit Assistant dev build, which
-				// contains the MCP-from-.positai fix.
 				await app.workbench.positAssistant.checkForDevBuildUpdate(settings, app.workbench.quickaccess);
 			});
 
@@ -62,9 +54,7 @@ test.describe('Posit Assistant MCP', {
 				await app.workbench.positAssistant.open();
 				await app.workbench.positAssistant.waitForReady();
 
-				// A unique marker the LLM can't have produced from priors. If the
-				// echo tool is reachable, this string round-trips through the MCP
-				// server and surfaces in the assistant reply.
+				// Unique marker so any positive match has to come from this run.
 				const marker = 'positron-mcp-echo-marker-7f31b9c4';
 
 				await app.workbench.positAssistant.sendMessage(
@@ -73,26 +63,16 @@ test.describe('Posit Assistant MCP', {
 					{ newConversation: true },
 				);
 
-				// 1. The confirm card identifies the specific MCP tool. If the
-				//    model picked a different tool (or no MCP tool at all because
-				//    .positai/settings.json wasn't loaded), this fails.
 				await app.workbench.positAssistant.expectMcpToolConfirmVisible('everything', 'echo');
 				await app.workbench.positAssistant.allowToolOnce();
-				// MCP server startup (npx fetch + launch) can push first-tool latency
-				// past the default 60s. Give it more headroom.
+				// MCP server startup (npx fetch + launch) can push first-tool
+				// latency past the default 60s.
 				await app.workbench.positAssistant.waitForResponseComplete(120000);
 
-				// 2. The result accordion for this specific MCP tool is rendered
-				//    in the transcript — proof the tool actually executed end-to-end.
-				//    The UI renders this block only when a tool runs, so the model
-				//    cannot fabricate it from the prompt alone.
 				await app.workbench.positAssistant.expectMcpToolResultVisible('everything', 'echo');
-
-				// 3. The literal "Echo: <marker>" payload appears somewhere in the
-				//    chat frame DOM. The "Echo: " prefix is from the everything
-				//    server's tools/echo.ts (not the prompt or the user message),
-				//    so a parroting model can't synthesize this exact string —
-				//    only a real tool execution can put it in the UI.
+				// "Echo: " is the prefix from server-everything's tools/echo.ts —
+				// not present in the prompt — so finding it in the DOM is positive
+				// evidence of a real tool execution, not LLM parroting.
 				await app.workbench.positAssistant.expectChatContainsText(`Echo: ${marker}`);
 			});
 		});


### PR DESCRIPTION
Fixes #13650

Adds an e2e test that catches regressions of the class reported in posit-dev/assistant#1289 (fixed in posit-dev/assistant#1293), where MCP servers configured in workspace `.positai/settings.json` were ignored by Posit Assistant.

The test:
1. Writes a `.positai/settings.json` to the workspace pointing at the upstream `@modelcontextprotocol/server-everything` reference server.
2. Opens Posit Assistant and asks the model to call the `echo` tool with a unique marker.
3. Asserts the confirm card identifies `mcp__everything__echo`, the post-Allow tool-result accordion appears, and the literal `Echo: <marker>` payload (from the server's source, not the prompt) is in the chat DOM. Together these prove the MCP config was loaded, the right tool was selected, and it actually executed — not just LLM parroting.

Also adds three reusable helpers on the `PositAssistant` page object: `expectMcpToolConfirmVisible`, `expectMcpToolResultVisible`, and `expectChatContainsText`.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:posit-assistant @:assistant @:web @:win

Run the new test:

```
npx playwright test test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts --project e2e-electron
```

It exercises the full path: `.positai/settings.json` is read on assistant startup, the `everything` MCP server boots via `npx`, the model invokes the `echo` tool through MCP, and the tool's literal output reaches the UI.