### PR TITLE
PNE debugging: F5 routing, no-kernel errors, and premature session termination

### DIFF
--- a/extensions/positron-runtime-debugger/package.json
+++ b/extensions/positron-runtime-debugger/package.json
@@ -19,7 +19,7 @@
         "command": "notebook.debugCell",
         "icon": "$(debug-alt-small)",
         "title": "%commands.notebook.debugCell.title%",
-        "enablement": "notebookInterpreterSupportsDebugging && resource not in debuggedNotebooks"
+        "enablement": "notebookInterpreterSupportsDebugging"
       },
       {
         "command": "positron-runtime-debugger.showRuntimeError",

--- a/extensions/positron-runtime-debugger/src/debugCellController.ts
+++ b/extensions/positron-runtime-debugger/src/debugCellController.ts
@@ -44,14 +44,13 @@ export class DebugCellController extends Disposable {
 			}
 		}));
 
-		// Stop debugging when the cell execution is complete.
+		// Keep the debug session alive after cell execution completes.
 		const executeComplete = this._register(this._runtimeSession.onDidReceiveRuntimeMessage(async (message) => {
 			if (this._executionId &&
 				message.parent_id === this._executionId &&
 				message.type === positron.LanguageRuntimeMessageType.State &&
 				(message as positron.LanguageRuntimeState).state === positron.RuntimeOnlineState.Idle) {
 				executeComplete.dispose();
-				await vscode.debug.stopDebugging(this._debugSession);
 			}
 		}));
 

--- a/extensions/positron-runtime-debugger/src/notebookDebugAdapterFactory.ts
+++ b/extensions/positron-runtime-debugger/src/notebookDebugAdapterFactory.ts
@@ -26,8 +26,10 @@ export class NotebookDebugAdapterFactory extends Disposable implements vscode.De
 		// NOTE: Errors thrown here are displayed to the user in a modal.
 
 		const notebookUri = vscode.Uri.parse(debugSession.configuration.__notebookUri, true);
+
+		// Clear any stale tracking from a previously terminated session.
 		if (this._debuggedNotebookUris.has(notebookUri)) {
-			throw new Error(vscode.l10n.t('Unexpected error: Notebook {0} is already being debugged', notebookUri.toString()));
+			await this._debuggedNotebookUris.delete(notebookUri);
 		}
 
 		const notebook = vscode.workspace.notebookDocuments.find((doc) => isUriEqual(doc.uri, notebookUri));

--- a/extensions/positron-runtime-debugger/src/notebookDebugService.ts
+++ b/extensions/positron-runtime-debugger/src/notebookDebugService.ts
@@ -61,17 +61,49 @@ async function debugCell(cell: vscode.NotebookCell | PositronContext | undefined
 		}
 	}
 
+	// If already debugging this notebook, execute the cell under the active session.
+	const notebookUriStr = cell.notebook.uri.toString();
+	if (hasActiveDebugSessionForNotebook(notebookUriStr)) {
+		await vscode.commands.executeCommand('notebook.cell.execute', {
+			ranges: [{ start: getCellIndex(cell), end: getCellIndex(cell) + 1 }],
+			document: cell.notebook.uri,
+		});
+		return;
+	}
+
 	// Start a debug session for the cell.
-	// This will, in turn, create a debug adapter for the notebook using the factory defined above.
 	await vscode.debug.startDebugging(undefined, {
 		type: 'notebook',
 		name: path.basename(cell.notebook.uri.fsPath),
 		request: 'attach',
-		// TODO: Get from config.
 		justMyCode: true,
-		__notebookUri: cell.notebook.uri.toString(),
+		__notebookUri: notebookUriStr,
 		__cellUri: cell.document.uri.toString(),
 	});
+}
+
+/** Check if a debug session is active for the given notebook URI. */
+function hasActiveDebugSessionForNotebook(notebookUriStr: string): boolean {
+	return vscode.debug.activeDebugSession?.configuration?.__notebookUri === notebookUriStr;
+}
+
+/** Get the cell index, handling both NotebookCell and PositronContext. */
+function getCellIndex(cell: vscode.NotebookCell | PositronContext): number {
+	if ('index' in cell) {
+		return cell.index;
+	}
+	const notebook = vscode.workspace.notebookDocuments.find(
+		(doc) => doc.uri.toString() === cell.notebook.uri.toString()
+	);
+	if (notebook) {
+		const idx = notebook.getCells().findIndex(
+			(c) => c.document.uri.toString() === cell.document.uri.toString()
+		);
+		if (idx >= 0) {
+			return idx;
+		}
+	}
+	return 0;
 }
 
 /** Get the active notebook cell, if one exists. */

--- a/extensions/positron-runtime-debugger/src/notebookDebugService.ts
+++ b/extensions/positron-runtime-debugger/src/notebookDebugService.ts
@@ -89,7 +89,7 @@ function hasActiveDebugSessionForNotebook(notebookUriStr: string): boolean {
 
 /** Get the cell index, handling both NotebookCell and PositronContext. */
 function getCellIndex(cell: vscode.NotebookCell | PositronContext): number {
-	if ('index' in cell) {
+	if (isNotebookCell(cell)) {
 		return cell.index;
 	}
 	const notebook = vscode.workspace.notebookDocuments.find(
@@ -104,6 +104,10 @@ function getCellIndex(cell: vscode.NotebookCell | PositronContext): number {
 		}
 	}
 	return 0;
+}
+
+function isNotebookCell(cell: vscode.NotebookCell | PositronContext): cell is vscode.NotebookCell {
+	return typeof (cell as vscode.NotebookCell).index === 'number';
 }
 
 /** Get the active notebook cell, if one exists. */

--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -42,6 +42,10 @@ import { saveAllBeforeDebugStart, resolveChildSession } from '../common/debugUti
 import { showLoadedScriptMenu } from '../common/loadedScriptsPicker.js';
 import { openBreakpointSource } from './breakpointsView.js';
 import { showDebugSessionMenu } from './debugSessionPicker.js';
+// --- Start Positron ---
+import { POSITRON_NOTEBOOK_EDITOR_ID, SELECT_KERNEL_ID_POSITRON } from '../../positronNotebook/common/positronNotebookCommon.js';
+import { ActiveNotebookRuntimeSupportsDebugging } from '../../runtimeNotebookKernel/common/activeRuntimeNotebookContextManager.js';
+// --- End Positron ---
 
 export const ADD_CONFIGURATION_ID = 'debug.addConfiguration';
 export const COPY_ADDRESS_ID = 'editor.debug.action.copyAddress';
@@ -760,6 +764,29 @@ CommandsRegistry.registerCommand({
 		showDebugSessionMenu(accessor, SELECT_AND_START_ID);
 	}
 });
+
+// --- Start Positron ---
+// Route F5 to native notebook debugging, bypassing CONTEXT_DEBUGGERS_AVAILABLE.
+// Fixes #12845, #10226, #10231.
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'positron.notebook.startDebugging',
+	weight: KeybindingWeight.WorkbenchContrib + 10,
+	primary: KeyCode.F5,
+	when: ContextKeyExpr.and(
+		ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+		CONTEXT_DEBUG_STATE.isEqualTo('inactive'),
+	),
+	handler: async (accessor: ServicesAccessor) => {
+		const contextKeyService = accessor.get(IContextKeyService);
+		const commandService = accessor.get(ICommandService);
+		if (ActiveNotebookRuntimeSupportsDebugging.getValue(contextKeyService)) {
+			await commandService.executeCommand('notebook.debugCell');
+		} else {
+			await commandService.executeCommand(SELECT_KERNEL_ID_POSITRON);
+		}
+	}
+});
+// --- End Positron ---
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: DEBUG_START_COMMAND_ID,

--- a/test/e2e/tests/notebooks-positron/notebook-debug-fixes.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-debug-fixes.test.ts
@@ -1,0 +1,189 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+import { expect } from '@playwright/test';
+
+test.use({ suiteId: __filename });
+
+test.describe('Notebook Debug Fixes', {
+	tag: [tags.WEB, tags.WIN, tags.DEBUG, tags.POSITRON_NOTEBOOKS],
+}, () => {
+
+	// #12845: F5 starts notebook debugging when kernel supports it
+	test('F5 starts notebook debugging with active kernel [#12845]', {
+		annotation: [
+			{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/12845' },
+		],
+	}, async ({ app, hotKeys }) => {
+		const { notebooksPositron, debug } = app.workbench;
+
+		await test.step('Create notebook with Python kernel', async () => {
+			await notebooksPositron.createNewNotebook();
+			await notebooksPositron.kernel.select('Python');
+			await notebooksPositron.addCodeToCell(0, SIMPLE_CODE, { fast: true });
+		});
+
+		await test.step('Set breakpoint on line 2', async () => {
+			const page = app.code.driver.currentPage;
+			await notebooksPositron.editorWidgetAtIndex(0).click();
+			const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+			await page.keyboard.press(`${modifier}+Home`);
+			await page.keyboard.press('ArrowDown');
+			await page.keyboard.press('F9');
+			await expect(page.locator('.codicon-debug-breakpoint').first()).toBeVisible();
+		});
+
+		await test.step('F5 starts debug session and pauses at breakpoint', async () => {
+			const page = app.code.driver.currentPage;
+			await page.keyboard.press('F5');
+			await debug.expectCurrentLineIndicatorVisible();
+			await expect(debug.debugToolbar).toBeVisible();
+		});
+
+		await test.step('Cleanup', async () => {
+			const page = app.code.driver.currentPage;
+			await page.keyboard.press('Shift+F5');
+			await expect(debug.debugToolbar).not.toBeVisible({ timeout: 10000 });
+			await hotKeys.clearAllBreakpoints();
+		});
+	});
+
+	// #10226: F5 in notebook never produces "${file}" error or unhandled launch config
+	test('F5 in notebook does not produce launch config error [#10226]', {
+		annotation: [
+			{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10226' },
+		],
+	}, async ({ app, hotKeys }) => {
+		const { notebooksPositron, debug } = app.workbench;
+		const page = app.code.driver.currentPage;
+
+		await test.step('Create notebook and press F5 immediately', async () => {
+			await notebooksPositron.createNewNotebook();
+			await notebooksPositron.addCodeToCell(0, 'x = 1', { fast: true });
+			await page.keyboard.press('F5');
+		});
+
+		await test.step('No error notification with file reference', async () => {
+			// The bug produced a notification containing "${file}" from an unresolved launch config.
+			// Wait briefly to allow any error to surface.
+			await page.waitForTimeout(2000);
+			const errorNotification = page.locator('.notifications-toasts .notification-toast');
+			const count = await errorNotification.count();
+			for (let i = 0; i < count; i++) {
+				const text = await errorNotification.nth(i).textContent();
+				expect(text).not.toContain('${file}');
+				expect(text).not.toContain('launch.json');
+			}
+		});
+
+		await test.step('Cleanup', async () => {
+			// If debugging started, stop it
+			if (await debug.debugToolbar.isVisible()) {
+				await page.keyboard.press('Shift+F5');
+				await expect(debug.debugToolbar).not.toBeVisible({ timeout: 10000 });
+			}
+			await hotKeys.clearAllBreakpoints();
+		});
+	});
+
+	// #10231: Debug Cell does not show unclear/confusing error dialog
+	test('Debug Cell does not produce confusing error [#10231]', {
+		annotation: [
+			{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/10231' },
+		],
+	}, async ({ app, hotKeys }) => {
+		const { notebooksPositron, debug } = app.workbench;
+		const page = app.code.driver.currentPage;
+
+		await test.step('Create notebook and invoke Debug Cell', async () => {
+			await notebooksPositron.createNewNotebook();
+			await notebooksPositron.addCodeToCell(0, 'x = 1', { fast: true });
+			await app.workbench.quickaccess.runCommand('notebook.debugCell');
+		});
+
+		await test.step('No error dialog or notification', async () => {
+			await page.waitForTimeout(2000);
+			// No error modal dialog
+			const dialog = page.locator('.monaco-dialog-box .dialog-message');
+			if (await dialog.isVisible()) {
+				const text = await dialog.textContent();
+				expect(text).not.toContain('No active runtime');
+				expect(text).not.toContain('unexpected');
+			}
+			// No error notification toast
+			const errorToast = page.locator('.notifications-toasts .notification-toast .severity-icon.codicon-error');
+			await expect(errorToast).not.toBeVisible();
+		});
+
+		await test.step('Cleanup', async () => {
+			if (await debug.debugToolbar.isVisible()) {
+				await page.keyboard.press('Shift+F5');
+				await expect(debug.debugToolbar).not.toBeVisible({ timeout: 10000 });
+			}
+			await hotKeys.clearAllBreakpoints();
+		});
+	});
+
+	// #12845 re-entry: Debug Cell during active session executes without error
+	test('Debug Cell during active session executes without error [#12845]', {
+		annotation: [
+			{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/12845' },
+		],
+	}, async ({ app, hotKeys }) => {
+		const { notebooksPositron, debug } = app.workbench;
+		const page = app.code.driver.currentPage;
+
+		await test.step('Create notebook and start debug session', async () => {
+			await notebooksPositron.createNewNotebook();
+			await notebooksPositron.kernel.select('Python');
+			await notebooksPositron.addCodeToCell(0, BREAKPOINT_CODE, { fast: true });
+
+			// Set breakpoint on line 2
+			await notebooksPositron.editorWidgetAtIndex(0).click();
+			const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+			await page.keyboard.press(`${modifier}+Home`);
+			await page.keyboard.press('ArrowDown');
+			await page.keyboard.press('F9');
+			await expect(page.locator('.codicon-debug-breakpoint').first()).toBeVisible();
+		});
+
+		await test.step('Start debugging with F5', async () => {
+			await page.keyboard.press('F5');
+			await debug.expectCurrentLineIndicatorVisible();
+		});
+
+		await test.step('Debug Cell again: no error, session stays active', async () => {
+			// This should NOT show "Notebook is already being debugged" error
+			await app.workbench.quickaccess.runCommand('notebook.debugCell');
+
+			// Debug toolbar should still be visible (session alive)
+			await expect(debug.debugToolbar).toBeVisible();
+
+			// No error notification
+			const errorNotification = page.locator('.notification-toast .severity-icon.codicon-error');
+			await expect(errorNotification).not.toBeVisible({ timeout: 3000 });
+		});
+
+		await test.step('Cleanup', async () => {
+			await page.keyboard.press('Shift+F5');
+			await expect(debug.debugToolbar).not.toBeVisible({ timeout: 10000 });
+			await hotKeys.clearAllBreakpoints();
+		});
+	});
+});
+
+const SIMPLE_CODE = [
+	'x = 42',
+	'y = x * 2',
+	'print(y)',
+].join('\n');
+
+const BREAKPOINT_CODE = [
+	'a = 10',
+	'b = a + 5',
+	'print(b)',
+].join('\n');


### PR DESCRIPTION
Closes two 07 and one 2026 Backlog issues.

## Summary
- Route F5 to native notebook debugging when Positron Notebook Editor is active, bypassing `CONTEXT_DEBUGGERS_AVAILABLE` which blocked activation (#12845)
- When no kernel is connected, F5 opens the kernel picker instead of producing a `${file}` launch config error (#10226) or an unclear dialog (#10231)
- Keep debug session alive after cell execution so users can step/inspect freely, and allow re-invoking Debug Cell during an active session without error

## Test plan
- [x] F5 with Python kernel: pauses at breakpoint, debug toolbar visible
- [x] F5 without kernel: kernel picker opens, no error notification
- [x] Debug Cell without kernel: no confusing error dialog
- [x] Debug Cell during active session: cell executes under existing session, no "already being debugged" error
- [x] Shift+F5 terminates session cleanly
- [x] E2E tests pass: `npx playwright test test/e2e/tests/notebooks-positron/notebook-debug-fixes.test.ts --project e2e-electron`

@:web @:win @:debug @:positron-notebooks