### PR TITLE
Fix right-click paste in React text inputs

### DIFF
--- a/src/vs/workbench/browser/actions/test/browser/textInputActions.vitest.tsx
+++ b/src/vs/workbench/browser/actions/test/browser/textInputActions.vitest.tsx
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import React, { useState } from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { createTextInputActions } from '../../textInputActions.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+
+describe('createTextInputActions paste', () => {
+	const PASTE_ACTION_ID = 'editor.action.clipboardPasteAction';
+	const PASTED_TEXT = 'https://github.com/posit-dev/positron-website.git';
+
+	const buildPasteAction = () => {
+		const clipboardService = stubInterface<IClipboardService>({
+			readText: vi.fn().mockResolvedValue(PASTED_TEXT),
+		});
+		const actions = createTextInputActions(clipboardService, new NullLogService());
+		return actions.find(a => a.id === PASTE_ACTION_ID)!;
+	};
+
+	// See posit-dev/positron#12204: assigning element.value directly causes
+	// React's patched setter to update its value tracker, so the subsequent
+	// input event is treated as a no-op and onChange never fires. The paste
+	// action must use the native value setter so React state stays in sync.
+	it('fires onChange in a controlled React <input>', async () => {
+		const onChange = vi.fn();
+		const ControlledInput = () => {
+			const [value, setValue] = useState('');
+			return (
+				<input
+					aria-label='repo-url'
+					value={value}
+					onChange={e => {
+						onChange(e.target.value);
+						setValue(e.target.value);
+					}}
+				/>
+			);
+		};
+
+		render(<ControlledInput />);
+		const input = screen.getByLabelText('repo-url') as HTMLInputElement;
+
+		await act(async () => {
+			await buildPasteAction().run(input);
+		});
+
+		expect(onChange).toHaveBeenCalledWith(PASTED_TEXT);
+		expect(input).toHaveValue(PASTED_TEXT);
+	});
+
+	it('fires onChange in a controlled React <textarea>', async () => {
+		const onChange = vi.fn();
+		const ControlledTextarea = () => {
+			const [value, setValue] = useState('');
+			return (
+				<textarea
+					aria-label='notes'
+					value={value}
+					onChange={e => {
+						onChange(e.target.value);
+						setValue(e.target.value);
+					}}
+				/>
+			);
+		};
+
+		render(<ControlledTextarea />);
+		const textarea = screen.getByLabelText('notes') as HTMLTextAreaElement;
+
+		await act(async () => {
+			await buildPasteAction().run(textarea);
+		});
+
+		expect(onChange).toHaveBeenCalledWith(PASTED_TEXT);
+		expect(textarea).toHaveValue(PASTED_TEXT);
+	});
+
+	it('inserts at the selection range and preserves surrounding text', async () => {
+		const ControlledInput = () => {
+			const [value, setValue] = useState('prefix-suffix');
+			return (
+				<input
+					aria-label='ranged'
+					value={value}
+					onChange={e => setValue(e.target.value)}
+				/>
+			);
+		};
+
+		render(<ControlledInput />);
+		const input = screen.getByLabelText('ranged') as HTMLInputElement;
+		input.setSelectionRange(7, 7); // caret between "prefix-" and "suffix"
+
+		await act(async () => {
+			await buildPasteAction().run(input);
+		});
+
+		expect(input).toHaveValue(`prefix-${PASTED_TEXT}suffix`);
+	});
+
+	it('is a no-op when the target is not an input or textarea', async () => {
+		render(<div aria-label='not-input'>untouched</div>);
+		const div = screen.getByLabelText('not-input');
+
+		await act(async () => {
+			await buildPasteAction().run(div);
+		});
+
+		expect(div).toHaveTextContent('untouched');
+	});
+});

--- a/src/vs/workbench/browser/actions/textInputActions.ts
+++ b/src/vs/workbench/browser/actions/textInputActions.ts
@@ -44,7 +44,27 @@ export function createTextInputActions(clipboardService: IClipboardService, logS
 					const selectionStart = element.selectionStart || 0;
 					const selectionEnd = element.selectionEnd || 0;
 
-					element.value = `${element.value.substring(0, selectionStart)}${clipboardText}${element.value.substring(selectionEnd, element.value.length)}`;
+					const newValue = `${element.value.substring(0, selectionStart)}${clipboardText}${element.value.substring(selectionEnd, element.value.length)}`;
+
+					// --- Start Positron ---
+					// React patches the value setter on HTMLInputElement/HTMLTextAreaElement
+					// prototypes to keep its internal value tracker in sync. Assigning
+					// `element.value` directly therefore updates React's tracker, and the
+					// subsequent input event is treated as a no-op by React, so controlled
+					// components never see an onChange. Use the underlying native setter to
+					// bypass React's patch; the dispatched input event then fires onChange
+					// as expected. See posit-dev/positron#12204.
+					const proto = isHTMLInputElement(element)
+						? HTMLInputElement.prototype
+						: HTMLTextAreaElement.prototype;
+					const nativeValueSetter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+					if (nativeValueSetter) {
+						nativeValueSetter.call(element, newValue);
+					} else {
+						element.value = newValue;
+					}
+					// --- End Positron ---
+
 					element.selectionStart = selectionStart + clipboardText.length;
 					element.selectionEnd = element.selectionStart;
 					element.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));

--- a/src/vs/workbench/browser/actions/textInputActions.ts
+++ b/src/vs/workbench/browser/actions/textInputActions.ts
@@ -44,16 +44,17 @@ export function createTextInputActions(clipboardService: IClipboardService, logS
 					const selectionStart = element.selectionStart || 0;
 					const selectionEnd = element.selectionEnd || 0;
 
-					const newValue = `${element.value.substring(0, selectionStart)}${clipboardText}${element.value.substring(selectionEnd, element.value.length)}`;
-
 					// --- Start Positron ---
 					// React patches the value setter on HTMLInputElement/HTMLTextAreaElement
-					// prototypes to keep its internal value tracker in sync. Assigning
+					// instances to keep its internal value tracker in sync. Assigning
 					// `element.value` directly therefore updates React's tracker, and the
 					// subsequent input event is treated as a no-op by React, so controlled
-					// components never see an onChange. Use the underlying native setter to
+					// components never see an onChange. Use the prototype's native setter to
 					// bypass React's patch; the dispatched input event then fires onChange
 					// as expected. See posit-dev/positron#12204.
+					//
+					// element.value = `${element.value.substring(0, selectionStart)}${clipboardText}${element.value.substring(selectionEnd, element.value.length)}`;
+					const newValue = `${element.value.substring(0, selectionStart)}${clipboardText}${element.value.substring(selectionEnd, element.value.length)}`;
 					const proto = isHTMLInputElement(element)
 						? HTMLInputElement.prototype
 						: HTMLTextAreaElement.prototype;


### PR DESCRIPTION
Fixes #12204

The workbench context-menu paste action assigned `element.value` directly, which triggers React's instance-level value setter and updates React's internal value tracker. The subsequent `input` event then looked like a no-op to React, so controlled components never received an `onChange`. The pasted text was visible in the DOM but React state stayed empty, causing dialogs like "New Folder from Git" to reject the URL as missing.

This PR uses the prototype's native value setter to mutate the element so React's tracker stays out of date, then dispatches the `input` event as before. Non-React inputs (VS Code's `InputBox`, find widget, etc.) call the same prototype setter today, so behavior is unchanged for them.

Adds a Vitest unit test that fails without the fix and passes with it.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix right-click paste in "New Folder from Git" and other Positron text-input dialogs (#12204)

### Validation Steps

@:new-folder-flow @:modal

1. File > New Folder from Git
2. Copy a repository URL such as `https://github.com/posit-dev/positron-website.git` to your clipboard
3. Right-click in the "Git repository URL" field and choose **Paste**
4. Click **OK**
5. Verify the clone proceeds and no "A git repository URL was not provided" error appears
6. Repeat with `cmd+V` / `ctrl+V` to confirm keyboard paste still works