### PR TITLE
ci: run e2e failure analyzer at end of merge workflow

### DIFF
--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -14,7 +14,7 @@ inputs:
   model:
     description: "Anthropic model identifier"
     required: false
-    default: "claude-sonnet-4-5"
+    default: "claude-opus-4-7"
   max-turns:
     description: "Maximum agent turns (cost guard)"
     required: false

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -14,7 +14,7 @@ import { readFileSync, existsSync, appendFileSync, writeFileSync, readdirSync, s
 import { join } from 'node:path';
 
 const WORK_DIR = mustEnv('WORK_DIR');
-const MODEL = process.env.MODEL || 'claude-sonnet-4-5';
+const MODEL = process.env.MODEL || 'claude-opus-4-7';
 const STEP_SUMMARY = process.env.GITHUB_STEP_SUMMARY;
 const MAX_TURNS = parsePosIntEnv('MAX_TURNS', 40);
 // Repo workspace (sparse-checkout root). Optional: when present, the agent

--- a/.github/workflows/analyze-e2e-failures.yml
+++ b/.github/workflows/analyze-e2e-failures.yml
@@ -12,6 +12,17 @@ on:
         required: false
         default: "claude-sonnet-4-5"
         type: string
+  workflow_call:
+    inputs:
+      run_url:
+        description: "Full GitHub Actions run URL to analyze"
+        required: true
+        type: string
+      model:
+        description: "Anthropic model"
+        required: false
+        default: "claude-sonnet-4-5"
+        type: string
 
 jobs:
   analyze:

--- a/.github/workflows/analyze-e2e-failures.yml
+++ b/.github/workflows/analyze-e2e-failures.yml
@@ -10,7 +10,7 @@ on:
       model:
         description: "Anthropic model"
         required: false
-        default: "claude-sonnet-4-5"
+        default: "claude-opus-4-7"
         type: string
   workflow_call:
     inputs:
@@ -21,7 +21,7 @@ on:
       model:
         description: "Anthropic model"
         required: false
-        default: "claude-sonnet-4-5"
+        default: "claude-opus-4-7"
         type: string
 
 jobs:

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -120,3 +120,11 @@ jobs:
           slack_channel: "#positron-rstats-test-results"
           filter_jobs: "windows"
           notify_on: "always"
+
+  analyze-e2e-failures:
+    if: ${{ contains(needs.*.result, 'failure') }}
+    needs: [e2e-electron, e2e-windows, e2e-ubuntu-chromium]
+    uses: ./.github/workflows/analyze-e2e-failures.yml
+    with:
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets: inherit

--- a/.github/workflows/test-merge.yml
+++ b/.github/workflows/test-merge.yml
@@ -122,7 +122,7 @@ jobs:
           notify_on: "always"
 
   analyze-e2e-failures:
-    if: ${{ contains(needs.*.result, 'failure') }}
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
     needs: [e2e-electron, e2e-windows, e2e-ubuntu-chromium]
     uses: ./.github/workflows/analyze-e2e-failures.yml
     with:


### PR DESCRIPTION
Next step in getting the analyzer workflow complete.  Note, this still doesn't add a slack message, but results will be readily available.  This will make it easier to improve the analyzer.

- Add a `workflow_call` trigger to `analyze-e2e-failures.yml` so it can be invoked from another workflow (the existing `workflow_dispatch` entry point is untouched).
- Append an `analyze-e2e-failures` job to `test-merge.yml` that fires after the three e2e jobs (`e2e-electron`, `e2e-windows`, `e2e-ubuntu-chromium`) and runs only when one of them reports `failure`. Uses `if: ${{ always() && contains(needs.*.result, 'failure') }}` — the `always()` is required because GitHub Actions implicitly ANDs `success()` into any job-level `if` that doesn't already contain a status check function, which would otherwise skip the analyzer before the `contains()` check ran.
- Bump the default model for the analyzer (workflow inputs, action input, and the `analyze.mjs` fallback) to `claude-opus-4-7` so all entry points agree.


This is hard to test before merging as it's part of the merge workflow.