### PR TITLE
Align card help and update buttons to card edge

### DIFF
--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -211,6 +211,15 @@
 	justify-content: center;
 }
 
+/*
+ * In card mode the help button lives inside the header row, which baseline-aligns
+ * the name/version text. Center the icon-only button on the text line instead of
+ * letting its baseline (its bottom edge) sit on the text baseline.
+ */
+.packages-list-item.item-size-card .packages-list-item-header .packages-list-item-help {
+	align-self: center;
+}
+
 .packages-list-item .packages-list-item-help .codicon {
 	font-size: 13px;
 }

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -337,6 +337,17 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 				});
 			};
 
+			const helpButton = (
+				<Button
+					ariaLabel={localize('positronPackages.showHelpAriaLabel', "Show help for {0}", name)}
+					className='packages-list-item-help'
+					tooltip={localize('positronPackages.showHelpTooltip', "Show help for {0}", name)}
+					onPressed={() => { void showHelpForPackage(name); }}
+				>
+					<span className='codicon codicon-book' />
+				</Button>
+			);
+
 			return (
 				// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 				<div
@@ -373,6 +384,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 									&#x2191;
 								</div>
 							)}
+							{itemSize === 'card' && helpButton}
 						</div>
 						{itemSize === 'card' && (
 							<div className='packages-list-item-description-row'>
@@ -392,14 +404,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 							</div>
 						)}
 					</div>
-					<Button
-						ariaLabel={localize('positronPackages.showHelpAriaLabel', "Show help for {0}", name)}
-						className='packages-list-item-help'
-						tooltip={localize('positronPackages.showHelpTooltip', "Show help for {0}", name)}
-						onPressed={() => { void showHelpForPackage(name); }}
-					>
-						<span className='codicon codicon-book' />
-					</Button>
+					{itemSize === 'row' && helpButton}
 				</div>
 			);
 		};


### PR DESCRIPTION
See #12925

This specifically fixes this comment https://github.com/posit-dev/positron/issues/12925#issuecomment-4544948160

In the packages pane card view, the help button sat as a sibling of the content column with `margin-left: auto`, which shrank the content column's right edge and offset the update button inwards. Move the help button into the header row in card mode so both the help and update buttons share the card's right edge. Row mode is unchanged.

### Screenshots

Proper alignment now:

<img width="372" height="266" alt="Screenshot 2026-05-27 at 4 32 55 PM" src="https://github.com/user-attachments/assets/ad90d1a9-8251-451a-b414-0831abc91e52" />
<img width="585" height="614" alt="Screenshot 2026-05-27 at 4 32 50 PM" src="https://github.com/user-attachments/assets/f37077d0-876b-4e67-86b1-ef6e8d94dcb5" />


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:packages-pane

1. Open the Packages pane with R or Python.
2. Switch to card view using the action bar item-size toggle.
3. Verify the help button (book icon) sits at the right edge of the card's first row.
4. For a package with an available update, verify the Update button sits at the right edge of the card's second row, aligned vertically with the help button above it.
5. Switch to row view and verify the help button still sits at the row's right edge.
