### PR TITLE
e2e: drop brittle Echo prefix assertion in posit-assistant-mcp

### DIFF
--- a/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
@@ -69,11 +69,10 @@ test.describe('Posit Assistant MCP', {
 				// latency past the default 60s.
 				await app.workbench.positAssistant.waitForResponseComplete(120000);
 
+				// The result accordion only renders after a real MCP roundtrip
+				// completes, so its presence is positive evidence the tool ran -
+				// no need to inspect natural-language reply or accordion content.
 				await app.workbench.positAssistant.expectMcpToolResultVisible('everything', 'echo');
-				// "Echo: " is the prefix from server-everything's tools/echo.ts —
-				// not present in the prompt — so finding it in the DOM is positive
-				// evidence of a real tool execution, not LLM parroting.
-				await app.workbench.positAssistant.expectChatContainsText(`Echo: ${marker}`);
 			});
 		});
 	}


### PR DESCRIPTION
The new posit-assistant-mcp test from #13805 started flaking on win/electron (3/5 runs) and ubuntu/electron (0/5). The `Echo: ${marker}` check assumed the tool-result accordion content was always attached to the chat-frame DOM, but it lazy-renders, and Sonnet often replies with only the bare marker (following the prompt literally).

The remaining `expectMcpToolResultVisible` assertion is sufficient end-to-end evidence: the assistant extension only renders that accordion after a real MCP roundtrip completes, so its presence proves the MCP server was discovered, called, and returned a result. That still catches the original regression (#1289, MCP servers in `.positai/settings.json` being ignored) without depending on UI animations or model prose.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:posit-assistant @:win

Run the test and confirm it passes on win/electron and ubuntu/electron:

```
npx playwright test test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts --project e2e-electron
```