### PR TITLE
Fix notebook kernel badge spinning forever

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/KernelStatusBadge.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/KernelStatusBadge.tsx
@@ -52,17 +52,16 @@ export function KernelStatusBadge() {
 		() => languageRuntimeService.startupPhase,
 	));
 
+	// The icon reflects session connection state: a live session drives it
+	// via runtimeState, and no session means Disconnected. The two overrides
+	// (Switching, Discovering) intentionally show Active to communicate a
+	// transition the user kicked off or the app is working through, even
+	// though no session is attached during those windows.
 	let runtimeStatus: RuntimeStatus;
 	if (kernelStatus === NotebookKernelStatus.Switching) {
-		// Switching is user intent to transition; show Active immediately
-		// regardless of the now-stale old session's runtime state.
 		runtimeStatus = RuntimeStatus.Active;
 	} else if (runtimeState !== undefined) {
 		runtimeStatus = runtimeStateToRuntimeStatus[runtimeState];
-	} else if (kernelStatus === NotebookKernelStatus.Exited) {
-		runtimeStatus = RuntimeStatus.Disconnected;
-	} else if (kernel) {
-		runtimeStatus = RuntimeStatus.Active;
 	} else if (kernelStatus === NotebookKernelStatus.Discovering) {
 		runtimeStatus = RuntimeStatus.Active;
 	} else {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/KernelStatusBadge.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/KernelStatusBadge.vitest.tsx
@@ -115,11 +115,10 @@ describe('KernelStatusBadge', () => {
 		expect(screen.getByText('R 4.3.2')).toBeInTheDocument();
 	});
 
-	it('shows active icon and kernel name when a kernel is first selected', () => {
-		// First kernel selection: runOnChange leaves kernelStatus at Unselected.
+	it('shows disconnected icon and kernel name when a kernel is selected but no session is attached', () => {
 		const kernel = makeKernel('Python 3.12', 'python-3.12');
 		renderBadge(makeInstance(NotebookKernelStatus.Unselected, kernel));
-		expect(screen.getByTestId('runtime-status-active')).toBeInTheDocument();
+		expect(screen.getByTestId('runtime-status-disconnected')).toBeInTheDocument();
 		expect(screen.getByText('Python 3.12')).toBeInTheDocument();
 	});
 


### PR DESCRIPTION
Fixes #13688

The notebook kernel badge spun forever when a saved notebook was opened. 

This PR simplifies the badge's icon logic so it reflects session state directly: no attached session means **Disconnected**, a live session drives the icon via its `RuntimeState`, and `Switching` / `Discovering` now only show `Active`. Previously we would fallback to showing `Active` if we had a kernel but no session yet which is what caused the infinite spinner to show up until we interacted with the notebook.

This is closer to what we do for Quarto kernels.

### Screenshots

**BEFORE**

https://github.com/user-attachments/assets/efaf5190-dbd7-41fd-9acb-00fb0bbc686b


**AFTER**

https://github.com/user-attachments/assets/47b3d028-e49d-4149-84cb-68d9f1e0ed06


### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix the notebook kernel badge spinning indefinitely when opening a saved notebook (#13688)

### Validation Steps

@:positron-notebooks 
@:sessions


- Open a saved Python `.ipynb` with a remembered kernel. The badge should show `Disconnected` instead of the `Active` spinner.
- Open a brand-new untitled notebook without ANY console session running: The badge should show **Disconnected** + "No Kernel Selected".
- Change the notebook kernel : The badge should immediately show `Active` with the new kernel name (kernel is in `Switching` state), then the new session attaches and the badge shows `Idle`.
- Restart a live kernel: The badge shows `Active` during Restart and then shows `Idle`.
- Shut down a kernel: The badge shows `Disconnected` + kernel name (kernel is in `Exited` state). 
