### PR TITLE
Fix LSP connection error notification on restart

### DIFF
--- a/extensions/positron-python/src/client/positron/lsp.ts
+++ b/extensions/positron-python/src/client/positron/lsp.ts
@@ -349,6 +349,21 @@ export class PythonLsp implements vscode.Disposable {
         this._outputChannel.appendLine('Waiting for client to initialize before stopping');
         await this._initializing;
 
+        // Suppress the "Connection to server got closed" toast that
+        // vscode-languageclient force-shows when the connection close races
+        // with `stop()`: if the socket close handler fires while `$state ===
+        // Stopping` (between `connection.dispose()` and the `finally` block
+        // in `shutdown()`), our `PythonErrorHandler.closed()` is bypassed and
+        // the notification is forced. See posit-dev/positron#7593.
+        const origError = this._client.error.bind(this._client);
+        this._client.error = (message, data, showNotification) => {
+            if (typeof message === 'string' && /Connection to server got closed/.test(message)) {
+                origError(message, data, false);
+                return;
+            }
+            origError(message, data, showNotification);
+        };
+
         // Ideally we'd just wait for `this._client!.stop()`. In practice, the
         // promise returned by `stop()` never resolves if the server side is
         // disconnected, so rather than awaiting it when the runtime has exited,

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -289,6 +289,21 @@ export class ArkLsp implements vscode.Disposable {
 		// partially initialized client.
 		await this._initializing;
 
+		// Suppress the "Connection to server got closed" toast that
+		// vscode-languageclient force-shows when the connection close races
+		// with `stop()`: if the socket close handler fires while `$state ===
+		// Stopping` (between `connection.dispose()` and the `finally` block
+		// in `shutdown()`), our `RErrorHandler.closed()` is bypassed and the
+		// notification is forced. See posit-dev/positron#7593.
+		const origError = this.client.error.bind(this.client);
+		this.client.error = (message, data, showNotification) => {
+			if (typeof message === 'string' && /Connection to server got closed/.test(message)) {
+				origError(message, data, false);
+				return;
+			}
+			origError(message, data, showNotification);
+		};
+
 		// Ideally we'd just wait for `this._client!.stop()`. In practice, the
 		// promise returned by `stop()` never resolves if the server side is
 		// disconnected, so rather than awaiting it when the runtime has exited,

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -146,10 +146,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		});
 	});
 
-	test.skip('ensure existing notebooks use their correct interpreter kernel',
-		{
-			annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7593' }] // <--- test is failing on chromium only
-		},
+	test('ensure existing notebooks use their correct interpreter kernel',
 		async function ({ app, sessions }) {
 			const { notebooksPositron } = app.workbench;
 			const pythonNotebook = path.join('workspaces', 'data-explorer-update-datasets', 'pandas-update-dataframe.ipynb');


### PR DESCRIPTION
Closes https://github.com/posit-dev/positron/issues/7593

@midleman @rodrigosf672 Could you please see if this branch fixes your skipped tests?

I think the notification is due to our `closed()` handler (https://github.com/posit-dev/positron/blob/a76797499b70ec4ddca02a06f1d51a76c43c6cf2/extensions/positron-r/src/error-handler.ts#L40-L43) not being called when the client is already stopping: https://github.com/lionel-/vscode-languageserver-node/blob/f5e23e29b76c42fad882aa84933d46ba9b412183/client/src/common/client.ts#L1827-L1833. This prevents our handler from setting `handled` to true.

To work around this, we hook into the client's `error` handler to manually ignore these errors.

<!-- Thank you for submitting a pull request.
If this is your first pull request you can find information about
contributing here:
  * https://github.com/posit-dev/positron/blob/main/CONTRIBUTING.md

We recommend synchronizing your branch with the latest changes in the
main branch by either pulling or rebasing.
-->

<!--
  Describe briefly what problem this pull request resolves, or what
  new feature it introduces. Include screenshots of any new or altered
  UI. Reference the associated issue with a closing keyword such as
  "Fixes #123" so GitHub automatically closes the issue when this PR
  is merged. If there are any details about your approach that are
  unintuitive or you want to draw attention to, please describe them
  here.
-->


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

Verified manually on my Linux laptop.

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->

@:ark @:web