### PR TITLE
e2e: posit-assistant flake - drop afterAll logout hook

### DIFF
--- a/test/e2e/tests/posit-assistant/posit-assistant.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant.test.ts
@@ -29,10 +29,6 @@ test.describe('Posit Assistant', {
 				await app.workbench.positAssistant.checkForDevBuildUpdate(settings, app.workbench.quickaccess);
 			});
 
-			test.afterAll(async function ({ app }) {
-				await app.workbench.assistant.logoutModelProvider(provider);
-			});
-
 			test(`${provider} - Open Posit Assistant and verify welcome page`, async function ({ app }) {
 				await app.workbench.positAssistant.open();
 				await app.workbench.positAssistant.waitForReady();


### PR DESCRIPTION
### Summary

Removes the `afterAll` logout hook from `posit-assistant.test.ts` to address [this flake](https://connect.posit.it/e2e-test-insights/?tab=test_health&branch=main&date=7&sort=pain&test=anthropic-api+-+Create+data+visualization+via+Posit+Assistant+%28Python%29%7C%7C%7Ctest%2Fe2e%2Ftests%2Fposit-assistant%2Fposit-assistant.test.ts).

- The `app` fixture is worker-scoped and the worker tears down after the spec file finishes, so the logout adds no isolation
- It does add flake surface, which is what we're seeing in CI
- Only one provider in `POSIT_ASSISTANT_PROVIDERS` today; if we add more, prefer a separate spec per provider over re-adding the hook.

### QA Notes
@:posit-assistant @:assistant