### PR TITLE
Fix cell stuck in running state when runtime exits unexpectedly

### DIFF
--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookCellExecution.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookCellExecution.ts
@@ -8,6 +8,7 @@ import { decodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
+import { localize } from '../../../../nls.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageOutputData, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, RuntimeErrorBehavior, ILanguageRuntimeMessageUpdateOutput, RuntimeExitReason, RuntimeOnlineState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
@@ -114,7 +115,7 @@ export class RuntimeNotebookCellExecution extends Disposable {
 				case RuntimeExitReason.StartupFailed:
 				case RuntimeExitReason.Unknown:
 					// Unexpected exit (e.g. a runtime crash): mark the cell as failed.
-					this.error(new Error('The session exited unexpectedly'));
+					this.error(new Error(localize('positron.notebookCell.sessionExitedUnexpectedly', "The session exited unexpectedly.")));
 					break;
 				default:
 					// Expected exit (user-initiated shutdown/restart/switch, or a

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookCellExecution.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookCellExecution.ts
@@ -100,6 +100,13 @@ export class RuntimeNotebookCellExecution extends Disposable {
 			this.handleRuntimeMessageUpdateOutput(message);
 		}));
 
+		// If the session exits unexpectedly (e.g. runtime crash), end the execution.
+		this._register(this._session.onDidEndSession(() => {
+			if (!this._deferred.isSettled) {
+				this.error(new Error('The session exited unexpectedly'));
+			}
+		}));
+
 		this._cellExecution.update([{
 			// Start the execution timer.
 			editType: CellExecutionUpdateType.ExecutionState,

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookCellExecution.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookCellExecution.ts
@@ -5,11 +5,12 @@
 
 import { DeferredPromise } from '../../../../base/common/async.js';
 import { decodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
+import { CancellationError } from '../../../../base/common/errors.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
-import { ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageOutputData, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, RuntimeErrorBehavior, ILanguageRuntimeMessageUpdateOutput, RuntimeOnlineState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeMessageError, ILanguageRuntimeMessageInput, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageOutputData, ILanguageRuntimeMessagePrompt, ILanguageRuntimeMessageState, ILanguageRuntimeMessageStream, RuntimeErrorBehavior, ILanguageRuntimeMessageUpdateOutput, RuntimeExitReason, RuntimeOnlineState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { DATA_EXPLORER_MIME_TYPE } from '../../positronNotebook/browser/getOutputContents.js';
 import { POSITRON_CONSOLE_EXEC_PREFIX } from '../../../services/positronConsole/browser/positronConsoleService.js';
 import { ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
@@ -100,10 +101,27 @@ export class RuntimeNotebookCellExecution extends Disposable {
 			this.handleRuntimeMessageUpdateOutput(message);
 		}));
 
-		// If the session exits unexpectedly (e.g. runtime crash), end the execution.
-		this._register(this._session.onDidEndSession(() => {
-			if (!this._deferred.isSettled) {
-				this.error(new Error('The session exited unexpectedly'));
+		// If the session ends while this cell is still executing, settle the
+		// execution so the run button resets. Branch on the exit reason so that
+		// expected, user-initiated exits (e.g. restarting the runtime mid-run)
+		// aren't reported as a cell failure.
+		this._register(this._session.onDidEndSession((exit) => {
+			if (this._deferred.isSettled) {
+				return;
+			}
+			switch (exit.reason) {
+				case RuntimeExitReason.Error:
+				case RuntimeExitReason.StartupFailed:
+				case RuntimeExitReason.Unknown:
+					// Unexpected exit (e.g. a runtime crash): mark the cell as failed.
+					this.error(new Error('The session exited unexpectedly'));
+					break;
+				default:
+					// Expected exit (user-initiated shutdown/restart/switch, or a
+					// session transfer/extension host reconnect): end the cell
+					// without surfacing a misleading error.
+					this.endInterrupted();
+					break;
 			}
 		}));
 
@@ -155,6 +173,28 @@ export class RuntimeNotebookCellExecution extends Disposable {
 
 		// Reject the deferred promise.
 		this._deferred.error(err);
+
+		// Stop listening for replies.
+		this.dispose();
+	}
+
+	/**
+	 * End the execution because the session ended before it completed (e.g. the
+	 * user restarted the runtime mid-run). Resets the run button without marking
+	 * the cell as either succeeded or failed.
+	 */
+	private endInterrupted(): void {
+		// Complete the cell execution without a success/failure result, so the
+		// run button resets but neither an error output nor a success checkmark
+		// is shown.
+		this._cellExecution.complete({
+			runEndTime: Date.now(),
+		});
+
+		// Reject the deferred promise so the notebook execution queue stops
+		// running later cells against the session that just ended. Use a
+		// CancellationError to signal this is an interruption, not a failure.
+		this._deferred.error(new CancellationError());
 
 		// Stop listening for replies.
 		this.dispose();

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/tests/browser/runtimeNotebookKernel.vitest.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/tests/browser/runtimeNotebookKernel.vitest.ts
@@ -437,8 +437,8 @@ describe('Positron - RuntimeNotebookKernel', () => {
 		// Spy on session.interrupt().
 		const sessionInterruptSpy = vi.spyOn(session, 'interrupt');
 
-		// Exit the session after the execution started but before the interrupt.
-		await session.shutdown(RuntimeExitReason.Shutdown);
+		// Crash the session after the execution started but before the interrupt.
+		await session.shutdown(RuntimeExitReason.Error);
 		await waitForRuntimeState(session, RuntimeState.Exited);
 
 		// Interrupt the execution.
@@ -457,6 +457,57 @@ describe('Positron - RuntimeNotebookKernel', () => {
 			runEndTime: expect.any(Number),
 			lastRunSuccess: false,
 			error: expect.any(Object),
+		});
+	});
+
+	it('cell errors when the session exits unexpectedly mid-execution', async () => {
+		// Start a session.
+		const session = await startSession();
+
+		// Start a long-running execution that never replies with an idle state.
+		const executionStartedPromise = new Promise<void>(resolve => {
+			ctx.disposables.add(session.onDidExecute(() => resolve()));
+		});
+		const executionEndedPromise = kernel.executeNotebookCellsRequest(notebookDocument.uri, [0]);
+		await executionStartedPromise;
+
+		// The runtime crashes mid-execution.
+		await session.shutdown(RuntimeExitReason.Error);
+		await waitForRuntimeState(session, RuntimeState.Exited);
+		await executionEndedPromise;
+
+		// The cell is marked as failed so the run button resets.
+		const execution = getExecution(0).execution;
+		expect(execution.complete).toHaveBeenCalledOnce();
+		expect(execution.complete).toHaveBeenCalledWith({
+			runEndTime: expect.any(Number),
+			lastRunSuccess: false,
+			error: expect.any(Object),
+		});
+	});
+
+	it('cell ends without error when the session is restarted mid-execution', async () => {
+		// Start a session.
+		const session = await startSession();
+
+		// Start a long-running execution that never replies with an idle state.
+		const executionStartedPromise = new Promise<void>(resolve => {
+			ctx.disposables.add(session.onDidExecute(() => resolve()));
+		});
+		const executionEndedPromise = kernel.executeNotebookCellsRequest(notebookDocument.uri, [0]);
+		await executionStartedPromise;
+
+		// The user restarts the runtime mid-execution.
+		await session.shutdown(RuntimeExitReason.Restart);
+		await waitForRuntimeState(session, RuntimeState.Exited);
+		await executionEndedPromise;
+
+		// The cell ends without a misleading error (and without a success result),
+		// so the run button resets but the cell is shown as interrupted.
+		const execution = getExecution(0).execution;
+		expect(execution.complete).toHaveBeenCalledOnce();
+		expect(execution.complete).toHaveBeenCalledWith({
+			runEndTime: expect.any(Number),
 		});
 	});
 });


### PR DESCRIPTION
Closes #12618

When the runtime crashes mid-execution, listen for session end and mark in-flight cells as failed so the play button resets.

## Test steps

1. Open a Python notebook with notebook console enabled
2. Run the heavy numpy repro from the issue and **wait for console to exit unexpectedly**.

```
import numpy as np
import time

print("Edge case: Super intense task...")

results = []

start = time.time()
for i in range(10000):
    A = np.random.rand(1000, 1000)
    B = np.random.rand(1000, 1000)
    C = A @ B 
    
    if i % 10 == 0:
        print(f"Iteration {i} completed.")
    
    results.append(C) 

end = time.time()
print(f"Done! Total time: {end - start:.2f} seconds.")
```

3. Verify the cell play button resets when the runtime exits (goes from Square/Stop button to Play button again.
4. Play button is ready to be triggered again.

<img width="1419" height="900" alt="Image" src="https://github.com/user-attachments/assets/c58423a2-26d3-495c-8281-ad4472405bb8" />

@:positron-notebooks @:notebooks @win @web