### PR TITLE
E2E test: skip notebook test which relies on reloadWindow

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
@@ -51,7 +51,8 @@ test.describe('Positron Notebooks: Scroll Position', {
 		}, { timeout: 5000 }).toBeLessThanOrEqual(1);
 	});
 
-	test('Scroll position is restored after window reload', async function ({ app, hotKeys }) {
+	// skipping because reloadWindow is unreliable
+	test.skip('Scroll position is restored after window reload', async function ({ app, hotKeys }) {
 		const { notebooksPositron } = app.workbench;
 
 		// Open the notebook


### PR DESCRIPTION
Skipping buggy test which relies on problematic reloadWindow