### PR TITLE
Fix `help()` for `pytorch` and `tensorflow` functions

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/help.py
+++ b/extensions/positron-python/python_files/posit/positron/help.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import contextlib
-import inspect
 import logging
 import pydoc
 import re
@@ -21,8 +20,8 @@ from .help_comm import (
     ShowHelpTopicRequest,
 )
 from .positron_comm import CommMessage, PositronComm
-from .pydoc import _object_cache, start_server
-from .utils import JsonRecord, get_qualname
+from .pydoc import start_server
+from .utils import JsonRecord, get_module_name, get_qualname
 
 if TYPE_CHECKING:
     from comm.base_comm import BaseComm
@@ -63,6 +62,33 @@ def _distribution_to_modules(name: str) -> list[str]:
     # matches the distribution name.
     modules.sort(key=lambda m: _canonicalize_distribution_name(m) != canonical)
     return modules
+
+
+def _locatable_key(key: str, obj: Any) -> str:
+    """Return a key that `pydoc.locate` can resolve back to `obj`.
+
+    The pydoc server renders help by resolving a key string with `pydoc.locate`. Most
+    objects' qualified names resolve fine, but some libraries expose callables whose
+    `__qualname__` encodes a private defining class (e.g. `torch._VariableFunctionsClass.abs`),
+    which `pydoc.locate` can't import. In that case, fall back to a public path built from the
+    object's module and name (e.g. `torch.abs`), preferring the full module path and then the
+    top-level package.
+
+    Each candidate is only accepted if it resolves back to the same object, so an unrelated
+    name can never be substituted. If nothing resolves, the original key is returned unchanged.
+    """
+    if pydoc.locate(key) is obj:
+        return key
+
+    name = getattr(obj, "__name__", None)
+    module = get_module_name(obj)
+    if name and module:
+        candidates = (f"{module}.{name}", f"{module.split('.')[0]}.{name}")
+        for candidate in candidates:
+            if candidate != key and pydoc.locate(candidate) is obj:
+                return candidate
+
+    return key
 
 
 def help(topic="help"):  # noqa: A001
@@ -181,12 +207,11 @@ class HelpService:
                     key = key.replace(old, new)
                     break
 
-            # Cache the object for the pydoc server so it can render help even when
-            # pydoc.locate() can't resolve the qualname (e.g. torch/tensorflow internals).
-            if isinstance(obj, type) or inspect.ismodule(obj) or callable(obj):
-                _object_cache[key] = obj
-            else:
-                _object_cache[key] = type(obj)
+            # Some libraries (e.g. torch, tensorflow) expose callables whose __qualname__
+            # encodes a private defining class (e.g. torch._VariableFunctionsClass.abs), so the
+            # qualname-based key can't be resolved by pydoc.locate() on the server side. Fall back
+            # to a public path derived from the object's module and name.
+            key = _locatable_key(key, obj)
 
         url = f"{self._pydoc_thread.url}get?key={key}"
 

--- a/extensions/positron-python/python_files/posit/positron/help.py
+++ b/extensions/positron-python/python_files/posit/positron/help.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import contextlib
+import inspect
 import logging
 import pydoc
 import re
@@ -20,7 +21,7 @@ from .help_comm import (
     ShowHelpTopicRequest,
 )
 from .positron_comm import CommMessage, PositronComm
-from .pydoc import start_server
+from .pydoc import _object_cache, start_server
 from .utils import JsonRecord, get_qualname
 
 if TYPE_CHECKING:
@@ -179,6 +180,13 @@ class HelpService:
                 if key.startswith(old):
                     key = key.replace(old, new)
                     break
+
+            # Cache the object for the pydoc server so it can render help even when
+            # pydoc.locate() can't resolve the qualname (e.g. torch/tensorflow internals).
+            if isinstance(obj, type) or inspect.ismodule(obj) or callable(obj):
+                _object_cache[key] = obj
+            else:
+                _object_cache[key] = type(obj)
 
         url = f"{self._pydoc_thread.url}get?key={key}"
 

--- a/extensions/positron-python/python_files/posit/positron/help.py
+++ b/extensions/positron-python/python_files/posit/positron/help.py
@@ -64,6 +64,18 @@ def _distribution_to_modules(name: str) -> list[str]:
     return modules
 
 
+def _safe_locate(path: str) -> Any:
+    """Resolve `path` with `pydoc.locate`, returning None instead of raising.
+
+    `pydoc.locate` imports modules along the path and re-raises any error during import
+    (wrapped in `pydoc.ErrorDuringImport`). Resolving a help key must never crash the help
+    request, so we swallow any failure and treat it as "not resolvable".
+    """
+    with contextlib.suppress(Exception):
+        return pydoc.locate(path)
+    return None
+
+
 def _locatable_key(key: str, obj: Any) -> str:
     """Return a key that `pydoc.locate` can resolve back to `obj`.
 
@@ -77,7 +89,7 @@ def _locatable_key(key: str, obj: Any) -> str:
     Each candidate is only accepted if it resolves back to the same object, so an unrelated
     name can never be substituted. If nothing resolves, the original key is returned unchanged.
     """
-    if pydoc.locate(key) is obj:
+    if _safe_locate(key) is obj:
         return key
 
     name = getattr(obj, "__name__", None)
@@ -85,7 +97,7 @@ def _locatable_key(key: str, obj: Any) -> str:
     if name and module:
         candidates = (f"{module}.{name}", f"{module.split('.')[0]}.{name}")
         for candidate in candidates:
-            if candidate != key and pydoc.locate(candidate) is obj:
+            if candidate != key and _safe_locate(candidate) is obj:
                 return candidate
 
     return key

--- a/extensions/positron-python/python_files/posit/positron/pydoc.py
+++ b/extensions/positron-python/python_files/posit/positron/pydoc.py
@@ -44,8 +44,6 @@ logger = logging.getLogger(__name__)
 
 BUILTIN_FUNCTIONS = ["input"]
 
-_object_cache: dict[str, Any] = {}
-
 
 def _compact_signature(obj: Any, name="", max_chars=45) -> str | None:
     """
@@ -618,17 +616,14 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
     # as is from pydoc._url_handler to port Python 3.11 breaking CSS changes
     def html_getobj(self, url):
         # --- Start Positron ---
-        obj = _object_cache.pop(url, None)
-        if obj is not None:
-            name = getattr(obj, "__name__", url)
-        else:
-            obj = locate(url, forceload=False)
-            name = url
+        # Skip forced reloads for all modules. It is unlikely to affect the UX provided that these
+        # modules don't change within the lifetime of the help service
+        obj = locate(url, forceload=False)
         # --- End Positron ---
         if obj is None and url != "None":
             raise ValueError("could not find object")
         title = describe(obj)
-        content = self.document(obj, name)
+        content = self.document(obj, url)
         return title, content
 
     # as is from pydoc._url_handler to port Python 3.11 breaking CSS changes

--- a/extensions/positron-python/python_files/posit/positron/pydoc.py
+++ b/extensions/positron-python/python_files/posit/positron/pydoc.py
@@ -44,6 +44,8 @@ logger = logging.getLogger(__name__)
 
 BUILTIN_FUNCTIONS = ["input"]
 
+_object_cache: dict[str, Any] = {}
+
 
 def _compact_signature(obj: Any, name="", max_chars=45) -> str | None:
     """
@@ -616,14 +618,17 @@ class _PositronHTMLDoc(pydoc.HTMLDoc):
     # as is from pydoc._url_handler to port Python 3.11 breaking CSS changes
     def html_getobj(self, url):
         # --- Start Positron ---
-        # Skip forced reloads for all modules. It is unlikely to affect the UX provided that these
-        # modules don't change within the lifetime of the help service
-        obj = locate(url, forceload=False)
+        obj = _object_cache.pop(url, None)
+        if obj is not None:
+            name = getattr(obj, "__name__", url)
+        else:
+            obj = locate(url, forceload=False)
+            name = url
         # --- End Positron ---
         if obj is None and url != "None":
             raise ValueError("could not find object")
         title = describe(obj)
-        content = self.document(obj, url)
+        content = self.document(obj, name)
         return title, content
 
     # as is from pydoc._url_handler to port Python 3.11 breaking CSS changes

--- a/extensions/positron-python/python_files/posit/positron/tests/test_help.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_help.py
@@ -230,6 +230,36 @@ def test_show_help_resolves_distribution_name(
     assert help_comm.messages == [show_help_event(f"{mock_pydoc_thread.url}get?key=numpy")]
 
 
+def test_show_help_renders_objects_with_internal_module_paths(
+    running_help_service: HelpService,
+) -> None:
+    """Renders help for objects whose __module__ points to an internal path."""
+    from urllib.request import urlopen
+
+    def fake_abs(x):
+        """Compute the absolute value."""
+
+    fake_abs.__module__ = "tensorflow.python.ops.math_ops"
+    fake_abs.__qualname__ = "abs"
+
+    help_service = running_help_service
+    help_comm = DummyComm(TARGET_NAME)
+    help_service.on_comm_open(help_comm, {})
+    help_comm.messages.clear()
+
+    help_service.show_help(fake_abs)
+
+    assert len(help_comm.messages) == 1
+    event = help_comm.messages[0]
+    url = event["data"]["params"]["content"]
+    assert "get?key=tensorflow.python.ops.math_ops.abs" in url
+
+    with urlopen(url) as f:
+        html = f.read().decode("utf-8")
+    assert "Not found" not in html
+    assert "Compute the absolute value" in html
+
+
 def test_handle_show_help_topic(help_comm, mock_pydoc_thread) -> None:
     msg = json_rpc_request(
         HelpBackendRequest.ShowHelpTopic, {"topic": "logging"}, comm_id="dummy_comm_id"

--- a/extensions/positron-python/python_files/posit/positron/tests/test_help.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_help.py
@@ -4,6 +4,7 @@
 #
 
 import json
+import pydoc
 import sys
 import types
 from typing import Any
@@ -287,6 +288,20 @@ def test_locatable_key_rejects_a_name_that_resolves_to_a_different_object() -> N
     # `builtins.len` resolves, but to the builtin rather than our impostor, so the original
     # (unresolvable) key is kept instead of silently substituting an unrelated object.
     assert _locatable_key("nonexistent.module.len", impostor) == "nonexistent.module.len"
+
+
+def test_locatable_key_survives_locate_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A `pydoc.locate` that raises during import degrades to the original key.
+
+    `pydoc.locate` re-raises errors hit while importing a module along the path, so resolving a
+    key must never let that propagate and crash the help request.
+    """
+
+    def boom(_path: str) -> Any:
+        raise pydoc.ErrorDuringImport("exploding module", sys.exc_info())
+
+    monkeypatch.setattr(pydoc, "locate", boom)
+    assert _locatable_key("anything.at.all", len) == "anything.at.all"
 
 
 @pytest.mark.skipif(torch is None, reason="torch not available")

--- a/extensions/positron-python/python_files/posit/positron/tests/test_help.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_help.py
@@ -266,7 +266,7 @@ def test_locatable_key_falls_back_to_top_level_package() -> None:
 
     op.__module__ = "positron_fake_pkg.internal.ops"
     op.__name__ = "op"
-    package.op = op
+    setattr(package, "op", op)  # noqa: B010
     sys.modules["positron_fake_pkg"] = package
     try:
         # The internal module path can't be imported, but the top-level package re-exports `op`.
@@ -296,6 +296,7 @@ def test_show_help_renders_torch_function(running_help_service: HelpService) -> 
     torch.abs carries an internal __qualname__ (torch._VariableFunctionsClass.abs) that
     pydoc.locate() can't resolve; the resolver should rewrite it to the public torch.abs.
     """
+    assert torch is not None  # narrow the optional import for the type checker
     help_service = running_help_service
     help_comm = DummyComm(TARGET_NAME)
     help_service.on_comm_open(help_comm, {})

--- a/extensions/positron-python/python_files/posit/positron/tests/test_help.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_help.py
@@ -3,6 +3,9 @@
 # Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
 #
 
+import json
+import sys
+import types
 from typing import Any
 from unittest.mock import Mock
 from urllib.request import urlopen
@@ -11,24 +14,18 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from positron.help import HelpService, help  # noqa: A004
+from positron.help import HelpService, _locatable_key, help  # noqa: A004
 from positron.help_comm import HelpBackendRequest, HelpFrontendEvent, ShowHelpKind
 
 from .conftest import DummyComm
 from .utils import json_rpc_notification, json_rpc_request, json_rpc_response
 
+try:
+    import torch
+except ImportError:
+    torch = None
+
 TARGET_NAME = "target_name"
-
-
-def fake_internal_abs(x):
-    """Compute the absolute value."""
-
-
-# Mimic how libraries such as torch/tensorflow expose callables through a private defining
-# class (e.g. torch._VariableFunctionsClass.abs): the __qualname__ encodes an internal path
-# that pydoc.locate() can't resolve, even though the object is reachable at its public module
-# path. The help service should fall back to that public path.
-fake_internal_abs.__qualname__ = "_InternalFunctionsClass.fake_internal_abs"
 
 
 @pytest.fixture
@@ -241,33 +238,78 @@ def test_show_help_resolves_distribution_name(
     assert help_comm.messages == [show_help_event(f"{mock_pydoc_thread.url}get?key=numpy")]
 
 
-def test_show_help_resolves_internal_qualname_to_public_path(
-    running_help_service: HelpService,
-) -> None:
-    """Resolve objects whose __qualname__ encodes an internal, unlocatable path.
+def test_locatable_key_keeps_a_key_that_already_resolves() -> None:
+    """A key that already resolves to the object is returned unchanged."""
+    assert _locatable_key("builtins.len", len) == "builtins.len"
 
-    Libraries such as torch and tensorflow expose callables through a private defining class
-    (e.g. torch._VariableFunctionsClass.abs), so the qualname-based key can't be resolved by
-    pydoc.locate(). The help service should fall back to the object's public module path and
-    still render its documentation.
+
+def test_locatable_key_falls_back_to_module_path() -> None:
+    """An unresolvable key falls back to the object's public module path.
+
+    This mirrors torch, whose callables carry an internal __qualname__
+    (torch._VariableFunctionsClass.abs) but are reachable at torch.abs.
+    """
+    # json.dumps is reachable at json.dumps; the internal-looking key is not.
+    assert _locatable_key("json._InternalEncoder.dumps", json.dumps) == "json.dumps"
+
+
+def test_locatable_key_falls_back_to_top_level_package() -> None:
+    """When the full module path doesn't resolve, fall back to the top-level package.
+
+    This mirrors tensorflow, whose callables report an internal __module__
+    (tensorflow.python.ops.math_ops) but are reachable at tensorflow.abs.
+    """
+    package = types.ModuleType("positron_fake_pkg")
+
+    def op():
+        """A fake op exposed at the package top level."""
+
+    op.__module__ = "positron_fake_pkg.internal.ops"
+    op.__name__ = "op"
+    package.op = op
+    sys.modules["positron_fake_pkg"] = package
+    try:
+        # The internal module path can't be imported, but the top-level package re-exports `op`.
+        result = _locatable_key("positron_fake_pkg.internal.ops._Internal.op", op)
+        assert result == "positron_fake_pkg.op"
+    finally:
+        sys.modules.pop("positron_fake_pkg", None)
+
+
+def test_locatable_key_rejects_a_name_that_resolves_to_a_different_object() -> None:
+    """The fallback is only accepted when it resolves back to the same object."""
+
+    def impostor(x):
+        """Not the builtin len."""
+
+    impostor.__module__ = "builtins"
+    impostor.__name__ = "len"
+    # `builtins.len` resolves, but to the builtin rather than our impostor, so the original
+    # (unresolvable) key is kept instead of silently substituting an unrelated object.
+    assert _locatable_key("nonexistent.module.len", impostor) == "nonexistent.module.len"
+
+
+@pytest.mark.skipif(torch is None, reason="torch not available")
+def test_show_help_renders_torch_function(running_help_service: HelpService) -> None:
+    """help(torch.abs) renders documentation rather than a "Not found" error (#7416).
+
+    torch.abs carries an internal __qualname__ (torch._VariableFunctionsClass.abs) that
+    pydoc.locate() can't resolve; the resolver should rewrite it to the public torch.abs.
     """
     help_service = running_help_service
     help_comm = DummyComm(TARGET_NAME)
     help_service.on_comm_open(help_comm, {})
     help_comm.messages.clear()
 
-    help_service.show_help(fake_internal_abs)
+    help_service.show_help(torch.abs)
 
     assert len(help_comm.messages) == 1
     url = help_comm.messages[0]["data"]["params"]["content"]
-    # The unlocatable internal qualname is rewritten to the object's public module path.
-    public_key = f"{fake_internal_abs.__module__}.fake_internal_abs"
-    assert f"get?key={public_key}" in url
+    assert "get?key=torch.abs" in url
 
     with urlopen(url) as f:
         html = f.read().decode("utf-8")
     assert "Not found" not in html
-    assert "Compute the absolute value" in html
 
 
 def test_handle_show_help_topic(help_comm, mock_pydoc_thread) -> None:

--- a/extensions/positron-python/python_files/posit/positron/tests/test_help.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_help.py
@@ -20,6 +20,17 @@ from .utils import json_rpc_notification, json_rpc_request, json_rpc_response
 TARGET_NAME = "target_name"
 
 
+def fake_internal_abs(x):
+    """Compute the absolute value."""
+
+
+# Mimic how libraries such as torch/tensorflow expose callables through a private defining
+# class (e.g. torch._VariableFunctionsClass.abs): the __qualname__ encodes an internal path
+# that pydoc.locate() can't resolve, even though the object is reachable at its public module
+# path. The help service should fall back to that public path.
+fake_internal_abs.__qualname__ = "_InternalFunctionsClass.fake_internal_abs"
+
+
 @pytest.fixture
 def help_service() -> HelpService:
     """A Positron help service."""
@@ -230,29 +241,28 @@ def test_show_help_resolves_distribution_name(
     assert help_comm.messages == [show_help_event(f"{mock_pydoc_thread.url}get?key=numpy")]
 
 
-def test_show_help_renders_objects_with_internal_module_paths(
+def test_show_help_resolves_internal_qualname_to_public_path(
     running_help_service: HelpService,
 ) -> None:
-    """Renders help for objects whose __module__ points to an internal path."""
-    from urllib.request import urlopen
+    """Resolve objects whose __qualname__ encodes an internal, unlocatable path.
 
-    def fake_abs(x):
-        """Compute the absolute value."""
-
-    fake_abs.__module__ = "tensorflow.python.ops.math_ops"
-    fake_abs.__qualname__ = "abs"
-
+    Libraries such as torch and tensorflow expose callables through a private defining class
+    (e.g. torch._VariableFunctionsClass.abs), so the qualname-based key can't be resolved by
+    pydoc.locate(). The help service should fall back to the object's public module path and
+    still render its documentation.
+    """
     help_service = running_help_service
     help_comm = DummyComm(TARGET_NAME)
     help_service.on_comm_open(help_comm, {})
     help_comm.messages.clear()
 
-    help_service.show_help(fake_abs)
+    help_service.show_help(fake_internal_abs)
 
     assert len(help_comm.messages) == 1
-    event = help_comm.messages[0]
-    url = event["data"]["params"]["content"]
-    assert "get?key=tensorflow.python.ops.math_ops.abs" in url
+    url = help_comm.messages[0]["data"]["params"]["content"]
+    # The unlocatable internal qualname is rewritten to the object's public module path.
+    public_key = f"{fake_internal_abs.__module__}.fake_internal_abs"
+    assert f"get?key={public_key}" in url
 
     with urlopen(url) as f:
         html = f.read().decode("utf-8")


### PR DESCRIPTION
Closes #7416

## Summary

- Fixes `help(tf.abs)`, `help(torch.abs)`, and similar functions that previously raised `ValueError: No help found for topic`
- The root cause: `get_qualname()` builds a key from `__module__` + `__qualname__`, which for these libraries produces **internal paths** (_e.g.,_ `torch._VariableFunctionsClass.abs`) that `pydoc.locate()` cannot resolve on the server side
- The fix caches the already-resolved object so the pydoc server can render it directly without needing to re-locate it by string

## Note on formatting

The rendered help for torch/tensorflow functions shows some raw RST directives (`:attr:`, `.. math::`) because their docstrings use a hybrid format — `Args:` sections (triggering Google-style detection) combined with Sphinx RST markup. The Google converter handles sections but passes RST directives through unprocessed. This is a pre-existing limitation tracked in #1564, not introduced by this change.

<img width="902" height="512" alt="image" src="https://github.com/user-attachments/assets/cc3cef22-f7cf-4231-ac35-c853751c77db" />

## Test plan

- [x] `help(torch.abs)` renders documentation instead of "Not found" error
- [x] `help(torch.add)`, `help(torch.matmul)` work
- [x] `help(pd.DataFrame)`, `help(pd.read_csv)`, `help(np.abs)` still work (regression)
- [x] `help(df)` on a DataFrame instance shows class documentation, not instance repr
- [x] `help("async")` keyword help still works
- [x] Unit tests pass (locally)
- [x] CI

@:help