### PR TITLE
e2e: posit-assistant MCP flake - drop afterAll logout

### DIFF
--- a/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
@@ -45,8 +45,10 @@ test.describe('Posit Assistant MCP', {
 				await app.workbench.positAssistant.checkForDevBuildUpdate(settings, app.workbench.quickaccess);
 			});
 
-			test.afterAll(async function ({ app, cleanup }) {
-				await app.workbench.assistant.logoutModelProvider(provider);
+			test.afterAll(async function ({ cleanup }) {
+				// No logout: the `app` fixture is worker-scoped and tears down
+				// after this spec finishes, so signing out adds no isolation - it
+				// only adds flake surface.
 				await cleanup.removeTestFolder('.positai');
 			});
 


### PR DESCRIPTION
### Summary

Drops the `afterAll` logout from `posit-assistant-mcp.test.ts` to fix a teardown flake where `logoutModelProvider` timed out clicking the Sign Out button.

- The `app` fixture is worker-scoped and tears down after the spec finishes, so signing out adds no isolation - only flake surface
- Same fix as #13847 (`posit-assistant.test.ts`)

### QA Notes
@:posit-assistant