### PR TITLE
Harden CI Claude analyzers: disable thinking, alias model, bump action versions

### DIFF
--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -12,9 +12,9 @@ inputs:
     required: false
     default: ""
   model:
-    description: "Anthropic model identifier"
+    description: "Anthropic model identifier (a tier alias like 'opus' always resolves to the latest)"
     required: false
-    default: "claude-opus-4-7"
+    default: "opus"
   max-turns:
     description: "Maximum agent turns (cost guard)"
     required: false

--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -31,7 +31,7 @@ runs:
   using: composite
   steps:
     - name: Set up Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: "20"
 
@@ -225,7 +225,7 @@ runs:
 
     - name: Upload analyzer artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: e2e-failure-analysis
         path: ${{ steps.prep.outputs.work_dir }}

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -14,7 +14,7 @@ import { readFileSync, existsSync, appendFileSync, writeFileSync, readdirSync, s
 import { join } from 'node:path';
 
 const WORK_DIR = mustEnv('WORK_DIR');
-const MODEL = process.env.MODEL || 'claude-opus-4-7';
+const MODEL = process.env.MODEL || 'opus';
 const STEP_SUMMARY = process.env.GITHUB_STEP_SUMMARY;
 const MAX_TURNS = parsePosIntEnv('MAX_TURNS', 40);
 // Repo workspace (sparse-checkout root). Optional: when present, the agent

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -391,6 +391,12 @@ async function main() {
 			allowedTools: ['Read', 'Glob', 'Grep'],
 			permissionMode: 'bypassPermissions',
 			maxTurns: MAX_TURNS,
+			// Extended thinking is disabled. With thinking on (the adaptive
+			// default), cancelling a parallel tool-call batch corrupts the
+			// in-flight thinking blocks and wedges the session with a repeating
+			// 400 ("thinking blocks ... cannot be modified", claude-code#63192).
+			// The report is built from text blocks only, so no output is lost.
+			thinking: { type: 'disabled' },
 			...(CLAUDE_CODE_PATH ? { pathToClaudeCodeExecutable: CLAUDE_CODE_PATH } : {}),
 		},
 	})) {

--- a/.github/actions/pr-test-checker/action.yml
+++ b/.github/actions/pr-test-checker/action.yml
@@ -55,7 +55,7 @@ runs:
 
     - name: Set up Node
       if: steps.idempotency.outputs.skip != 'true'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: "20"
 
@@ -157,7 +157,7 @@ runs:
 
     - name: Upload analyzer artifacts
       if: always() && steps.idempotency.outputs.skip != 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pr-test-checker-${{ inputs.pr-number }}
         path: ${{ steps.prep.outputs.work_dir }}

--- a/.github/actions/pr-test-checker/action.yml
+++ b/.github/actions/pr-test-checker/action.yml
@@ -15,9 +15,9 @@ inputs:
     required: false
     default: "false"
   model:
-    description: "Anthropic model identifier"
+    description: "Anthropic model identifier (a tier alias like 'opus' always resolves to the latest)"
     required: false
-    default: "claude-sonnet-4-6"
+    default: "opus"
   max-turns:
     description: "Maximum agent turns (cost guard)"
     required: false

--- a/.github/actions/pr-test-checker/analyze.mjs
+++ b/.github/actions/pr-test-checker/analyze.mjs
@@ -16,7 +16,7 @@ import { join } from 'node:path';
 const WORK_DIR = mustEnv('WORK_DIR');
 const REPO_ROOT = mustEnv('REPO_ROOT');
 const SKILL_PATH = mustEnv('SKILL_PATH');
-const MODEL = process.env.MODEL || 'claude-sonnet-4-6';
+const MODEL = process.env.MODEL || 'opus';
 const MAX_TURNS = parsePosIntEnv('MAX_TURNS', 25);
 const PROMPT_WARN_CHARS = parsePosIntEnv('PROMPT_WARN_CHARS', 400_000);
 // Same musl-resolver workaround as e2e-failure-analyzer.

--- a/.github/actions/pr-test-checker/analyze.mjs
+++ b/.github/actions/pr-test-checker/analyze.mjs
@@ -154,6 +154,12 @@ async function runAgent(systemPrompt, userPrompt) {
 			allowedTools: ['Read', 'Glob', 'Grep'],
 			permissionMode: 'bypassPermissions',
 			maxTurns: MAX_TURNS,
+			// Extended thinking is disabled. With thinking on (the adaptive
+			// default), cancelling a parallel tool-call batch corrupts the
+			// in-flight thinking blocks and wedges the session with a repeating
+			// 400 ("thinking blocks ... cannot be modified", claude-code#63192).
+			// The report is built from text blocks only, so no output is lost.
+			thinking: { type: 'disabled' },
 			...(CLAUDE_CODE_PATH ? { pathToClaudeCodeExecutable: CLAUDE_CODE_PATH } : {}),
 		},
 	})) {

--- a/.github/workflows/analyze-e2e-failures.yml
+++ b/.github/workflows/analyze-e2e-failures.yml
@@ -8,9 +8,9 @@ on:
         required: true
         type: string
       model:
-        description: "Anthropic model"
+        description: "Anthropic model (a tier alias like 'opus' always resolves to the latest)"
         required: false
-        default: "claude-opus-4-7"
+        default: "opus"
         type: string
   workflow_call:
     inputs:
@@ -19,9 +19,9 @@ on:
         required: true
         type: string
       model:
-        description: "Anthropic model"
+        description: "Anthropic model (a tier alias like 'opus' always resolves to the latest)"
         required: false
-        default: "claude-opus-4-7"
+        default: "opus"
         type: string
 
 jobs:

--- a/.github/workflows/pr-test-checker.yml
+++ b/.github/workflows/pr-test-checker.yml
@@ -41,7 +41,7 @@ jobs:
     name: Grade on PR change
     if: |
       github.event_name == 'pull_request' &&
-      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok"]'), github.event.pull_request.user.login)
+      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok", "midleman"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -101,8 +101,8 @@ jobs:
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, '/recheck-tests') &&
-      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok"]'), github.event.comment.user.login) &&
-      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok"]'), github.event.issue.user.login)
+      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok", "midleman"]'), github.event.comment.user.login) &&
+      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok", "midleman"]'), github.event.issue.user.login)
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pr-test-checker.yml
+++ b/.github/workflows/pr-test-checker.yml
@@ -41,7 +41,7 @@ jobs:
     name: Grade on PR change
     if: |
       github.event_name == 'pull_request' &&
-      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok", "midleman"]'), github.event.pull_request.user.login)
+      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok", "midleman", "testlabauto"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -101,8 +101,8 @@ jobs:
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
       contains(github.event.comment.body, '/recheck-tests') &&
-      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok", "midleman"]'), github.event.comment.user.login) &&
-      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok", "midleman"]'), github.event.issue.user.login)
+      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok", "midleman", "testlabauto"]'), github.event.comment.user.login) &&
+      contains(fromJson('["jonvanausdeln", "sharon-wang", "melissa-barca", "samclark2015", "timtmok", "midleman", "testlabauto"]'), github.event.issue.user.login)
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What

Two pilot-phase GitHub Actions drive the Claude Agent SDK:
- `.github/actions/e2e-failure-analyzer` (analyzes e2e run failures)
- `.github/actions/pr-test-checker` (PETE: grades PR test coverage)

This PR fixes a run-wedging API error in both, future-proofs their model selection, clears a Node deprecation, and widens the PETE pilot allowlist.

## Changes

### 1. Disable extended thinking (the actual bug fix)

Both analyzers were failing with a repeating API 400:

```
API Error: 400 messages.N.content.M: `thinking` or `redacted_thinking` blocks in the
latest assistant message cannot be modified. These blocks must remain as they were in
the original response.
```

This is [claude-code#63192](https://github.com/anthropics/claude-code/issues/63192): with extended thinking enabled (the adaptive default), cancelling a batch of parallel tool calls -- e.g. when one `Read` targets a path outside the sparse checkout and errors, auto-cancelling the rest -- corrupts the in-flight `thinking` blocks. The bad message stays in history, so every subsequent turn replays the same 400 and the run is wedged. Mass-reported upstream on 2026-05-28; not yet fixed in any CLI release.

Fix: set `thinking: { type: "disabled" }` in the `query()` options of both analyzers. This removes the corruptible thinking blocks entirely, neutralizing the failure mode independent of CLI/SDK version. Both reports are assembled from `text` blocks only, so no user-visible output is lost. (`{ type: "enabled", budgetTokens: N }` would not help -- it still emits thinking blocks; `disabled` is the only config that removes the failure surface.)

### 2. Use the `opus` model tier alias instead of pinned versions

Both analyzers pinned exact model IDs (e2e: `claude-opus-4-7`, PETE: `claude-sonnet-4-6`), which break when a specific version is retired. The Agent SDK / CLI accept the bare tier alias `opus`, which always resolves to the latest model in that tier. Every default and fallback now uses `opus`, so neither action needs a manual bump when a new model ships.

> [!IMPORTANT]
> This moves **pr-test-checker from Sonnet to Opus** -- a capability and cost change for the test grader, not just an alias swap. Intentional, but calling it out for review.

### 3. Bump Node-20 action versions

`setup-node@v4 -> @v6` and `upload-artifact@v4 -> @v7` in both actions. These two were the only stragglers in the repo still on the Node-20 action versions; everything else already uses `@v6`/`@v7`. Clears the Node-20 deprecation warning ahead of the 2026-06-02 forced-Node-24 cutoff. Inputs used (`name`, `path`, `retention-days`, `node-version`) are unchanged across the bump.

### 4. Widen PETE allowlist

Add `midleman` to the `pr-test-checker.yml` allowlist -- all three refs (the `on-open` author check, and both the commenter and author checks in `on-recheck`).

## Validation

The e2e analyzer was manually dispatched on this branch and run end-to-end, confirming all three code changes:

- [x] Completes without the 400 (thinking disabled) -- runs the full parallel-Read path that previously wedged it.
- [x] `model=opus` resolves correctly (no `not_found`) and produces a full report.
- [x] No Node-20 deprecation annotation on the run (`@v6`/`@v7` bump).

`pr-test-checker` carries the identical thinking fix, `opus` alias, and version bumps, but runs its action from the base/`main` checkout by design (pwn-request hardening), so it cannot be exercised pre-merge -- it takes effect on merge.