### PR TITLE
Defend against errors/timing in new folder flow

### DIFF
--- a/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowState.ts
+++ b/src/vs/workbench/browser/positronNewFolderFlow/newFolderFlowState.ts
@@ -148,9 +148,13 @@ export class NewFolderFlowStateManager
 
 		if (this._services.languageRuntimeService.startupPhase === RuntimeStartupPhase.Complete) {
 			// If the runtime startup is already complete, initialize the flow state and update
-			// the interpreter-related state.
+			// the interpreter-related state. Always flip the flag even if init throws, so the
+			// picker doesn't get stuck on "Discovering...".
 			this._initDefaultsFromExtensions()
-				.then(() => {
+				.catch((err) => this._services.logService.error(
+					`[New Folder Flow] _initDefaultsFromExtensions failed: ${err}`
+				))
+				.finally(() => {
 					this._runtimeStartupComplete = true;
 					this._updateInterpreterRelatedState();
 				});
@@ -159,12 +163,20 @@ export class NewFolderFlowStateManager
 			this._register(
 				this._services.languageRuntimeService.onDidChangeRuntimeStartupPhase(
 					async (phase) => {
-						if (phase === RuntimeStartupPhase.Discovering) {
-							// At this phase, the extensions that provide language runtimes will
-							// have been activated.
-							await this._initDefaultsFromExtensions();
-						} else if (phase === RuntimeStartupPhase.Complete) {
-							await this._initDefaultsFromExtensions();
+						try {
+							if (phase === RuntimeStartupPhase.Discovering) {
+								// At this phase, the extensions that provide language runtimes will
+								// have been activated.
+								await this._initDefaultsFromExtensions();
+							} else if (phase === RuntimeStartupPhase.Complete) {
+								await this._initDefaultsFromExtensions();
+							}
+						} catch (err) {
+							this._services.logService.error(
+								`[New Folder Flow] _initDefaultsFromExtensions failed: ${err}`
+							);
+						}
+						if (phase === RuntimeStartupPhase.Complete) {
 							this._runtimeStartupComplete = true;
 							// Once the runtime startup is complete, we can update the
 							// interpreter-related state.
@@ -174,6 +186,23 @@ export class NewFolderFlowStateManager
 				)
 			);
 		}
+
+		// Subscribe to runtime registrations so that runtimes registered after the modal opens
+		// (e.g. R or Python discovered after the user opens New Folder from Template) are
+		// reflected in the interpreter dropdown.
+		this._register(
+			this._services.languageRuntimeService.onDidRegisterRuntime((runtime) => {
+				if (!this._runtimeStartupComplete) {
+					// The Complete phase handler will refresh the interpreter list itself once
+					// startup finishes, so there is nothing to do yet.
+					return;
+				}
+				if (runtime.languageId !== this._getLangId()) {
+					return;
+				}
+				this._updateInterpreterRelatedState();
+			})
+		);
 	}
 
 	//#region Getters & Setters
@@ -636,6 +665,22 @@ export class NewFolderFlowStateManager
 	//#region Private Methods
 
 	/**
+	 * Executes a command, swallowing rejections so that one extension command failing does not
+	 * abort the rest of the flow's initialization (which would leave the picker stuck on
+	 * "Discovering..." because `_runtimeStartupComplete` never flips to true).
+	 */
+	private async _executeCommandSafe<T>(commandId: string, ...args: unknown[]): Promise<T | undefined> {
+		try {
+			return await this._services.commandService.executeCommand<T>(commandId, ...args);
+		} catch (err) {
+			this._services.logService.error(
+				`[New Folder Flow] Command '${commandId}' failed: ${err instanceof Error ? err.message : String(err)}`
+			);
+			return undefined;
+		}
+	}
+
+	/**
 	 * Initializes some defaults provided by the extensions.
 	 */
 	private async _initDefaultsFromExtensions() {
@@ -823,7 +868,7 @@ export class NewFolderFlowStateManager
 	private async _setPythonEnvProviders() {
 		if (!this._pythonEnvProviders?.length) {
 			this._pythonEnvProviders =
-				(await this._services.commandService.executeCommand(
+				(await this._executeCommandSafe<PythonEnvironmentProviderInfo[]>(
 					'python.getCreateEnvironmentProviders'
 				)) ?? [];
 		}
@@ -858,7 +903,7 @@ export class NewFolderFlowStateManager
 		}
 
 		// Check if Conda is installed.
-		this._isCondaInstalled = await this._services.commandService.executeCommand(
+		this._isCondaInstalled = await this._executeCommandSafe<boolean>(
 			'python.isCondaInstalled'
 		);
 		if (!this._isCondaInstalled) {
@@ -869,8 +914,9 @@ export class NewFolderFlowStateManager
 		}
 
 		// Get the Conda Python versions.
-		const pythonVersionInfo: CondaPythonVersionInfo | undefined =
-			await this._services.commandService.executeCommand('python.getCondaPythonVersions');
+		const pythonVersionInfo = await this._executeCommandSafe<CondaPythonVersionInfo>(
+			'python.getCondaPythonVersions'
+		);
 		if (!pythonVersionInfo) {
 			this._services.logService.warn('[New Folder Flow] No Conda Python versions found.');
 			return;
@@ -901,7 +947,7 @@ export class NewFolderFlowStateManager
 		}
 
 		// Check if uv is installed.
-		this._isUvInstalled = await this._services.commandService.executeCommand(
+		this._isUvInstalled = await this._executeCommandSafe<boolean>(
 			'python.isUvInstalled'
 		);
 		if (!this._isUvInstalled) {
@@ -912,8 +958,9 @@ export class NewFolderFlowStateManager
 		}
 
 		// Get the uv Python versions.
-		const pythonVersionInfo: UvPythonVersionInfo | undefined =
-			await this._services.commandService.executeCommand('python.getUvPythonVersions');
+		const pythonVersionInfo = await this._executeCommandSafe<UvPythonVersionInfo>(
+			'python.getUvPythonVersions'
+		);
 		if (!pythonVersionInfo) {
 			this._services.logService.warn('[New Folder Flow] No uv Python versions found.');
 			return;
@@ -955,12 +1002,12 @@ export class NewFolderFlowStateManager
 	private async _setMinimumInterpreterVersions(langIds?: LanguageIds[]): Promise<void> {
 		const langsForMinimumVersions = langIds ?? [LanguageIds.Python, LanguageIds.R];
 		if (langsForMinimumVersions.includes(LanguageIds.Python)) {
-			this._minimumPythonVersion = await this._services.commandService.executeCommand(
+			this._minimumPythonVersion = await this._executeCommandSafe<string>(
 				'python.getMinimumPythonVersion'
 			);
 		}
 		if (langsForMinimumVersions.includes(LanguageIds.R)) {
-			this._minimumRVersion = await this._services.commandService.executeCommand(
+			this._minimumRVersion = await this._executeCommandSafe<string>(
 				'r.getMinimumRVersion'
 			);
 		}


### PR DESCRIPTION

  The interpreter dropdown in _New Folder from Template_ could show "No suitable interpreters found" (or stay stuck on "Discovering...") even when an interpreter was installed and actively running. The dialog never subscribed to registration events, so any runtime registered after the  modal opened was never reflected in the picker.

Separately, `_initDefaultsFromExtensions()` issued several `executeCommand` calls  with no error handling; if any rejected, `_runtimeStartupComplete` never flipped to `true` and the picker stuck on "Discovering...".

  This PR makes two defensive changes:

  - **Subscribe to `onDidRegisterRuntime`.** Once runtime startup is complete, a runtime registered later that matches the current language id triggers `_updateInterpreterRelatedState()`, so the dropdown picks it up.
  - **Swallow per-command failures.** Each extension `executeCommand` call now goes through `_executeCommandSafe()`, which eats exceptions.

Fixes #13711.

  ### Release Notes

  #### New Features

  - N/A

  #### Bug Fixes

  - Fix the interpreter picker in New Folder from Template occasionally missing interpreters (#13711)

  ### Validation Steps

  `@:new-folder-flow @:interpreter`

  This is hard to reproduce deterministically (it depends on runtime registration timing), so validation is primarily
  regression-focused:

  1. Open _Workspace: New Folder from Template_ and select a Python or R template.
  2. Confirm the interpreter dropdown populates with discovered interpreters and does not stay stuck on "Discovering...".
  3. In a window where R/Python is *not* yet running, open the flow and confirm that interpreters still appear once discovery completes (exercising the late-registration path).
  
  Consider disabling the new runtime discovery cache for reproducing, since otherwise "discovery" doesn't last long enough to catch.