### PR TITLE
ci: fix stable extensions hash failing on spaced fixture paths

### DIFF
--- a/.github/cache-scripts/check-uncached-artifacts.sh
+++ b/.github/cache-scripts/check-uncached-artifacts.sh
@@ -111,6 +111,11 @@ IGNORE_PATTERNS+=(
 	".cpython-"
 	# Git internal objects created by git operations during CI (not source files)
 	".git/"
+	# Agent-harness symlinks recreated by build/npm/postinstall.ts on every
+	# install (.claude/CLAUDE.md -> .github/copilot-instructions.md,
+	# .claude/skills -> .agents/skills). Gitignored dev tooling, not needed by
+	# tests/build, and regenerated idempotently, so nothing to cache.
+	".claude/"
 )
 
 # ============================================================================

--- a/.github/cache-scripts/generate-extensions-hash.sh
+++ b/.github/cache-scripts/generate-extensions-hash.sh
@@ -110,13 +110,21 @@ fi
 # Lock files are modified during npm install (postinstall updates), making them
 # unsuitable for cache keys. package.json only changes when dependencies are
 # intentionally added/removed/updated.
+#
+# Why `tr '\n' '\0' | xargs -0 cat` instead of `xargs cat`?
+# Some vendored fixtures have spaces in their paths (e.g.
+# extensions/copilot/test/simulation/.../simple-js-proj copy/package.json).
+# Plain `xargs` word-splits on whitespace, so cat would receive broken path
+# fragments, exit non-zero, and `set -o pipefail` would abort the whole script
+# ("hash generation failed"). NUL-delimiting passes each path as one argument.
+# (-0 is portable across GNU and BSD/macOS xargs; -d is not.)
 
 echo "Hashing package.json files..."
 
 if [ "$FILTER" == "volatile" ]; then
 	echo "  → Filtering: volatile extensions only"
 	FILTER_PATTERN=$(IFS='|'; echo "${VOLATILE_EXTENSIONS[*]}")
-	FILES_HASH=$(eval "find extensions .vscode -maxdepth 3 -name \"package.json\" -type f -not -path \"*/node_modules/*\" $FIND_EXCLUDES 2>/dev/null" | grep -E "($FILTER_PATTERN)" | sort | xargs cat 2>/dev/null | sha256sum | cut -d' ' -f1)
+	FILES_HASH=$(eval "find extensions .vscode -maxdepth 3 -name \"package.json\" -type f -not -path \"*/node_modules/*\" $FIND_EXCLUDES 2>/dev/null" | grep -E "($FILTER_PATTERN)" | sort | tr '\n' '\0' | xargs -0 cat | sha256sum | cut -d' ' -f1)
 elif [ "$FILTER" == "stable" ]; then
 	echo "  → Filtering: stable extensions only"
 	# Enumerate via git ls-files (deterministic) instead of find (filesystem-
@@ -124,10 +132,10 @@ elif [ "$FILTER" == "stable" ]; then
 	# identical code, so the stable cache key never matched and the cache
 	# missed every run.
 	FILTER_PATTERN=$(IFS='|'; echo "${VOLATILE_EXTENSIONS[*]}")
-	FILES_HASH=$(git ls-files extensions .vscode | grep -E '(^|/)package\.json$' | grep -v '/node_modules/' | grep -v -E "($FILTER_PATTERN)" | sort | xargs cat 2>/dev/null | sha256sum | cut -d' ' -f1)
+	FILES_HASH=$(git ls-files extensions .vscode | grep -E '(^|/)package\.json$' | grep -v '/node_modules/' | grep -v -E "($FILTER_PATTERN)" | sort | tr '\n' '\0' | xargs -0 cat | sha256sum | cut -d' ' -f1)
 else
 	echo "  → No filter: all extensions"
-	FILES_HASH=$(eval "find extensions .vscode -maxdepth 3 -name \"package.json\" -type f -not -path \"*/node_modules/*\" $FIND_EXCLUDES 2>/dev/null" | sort | xargs cat 2>/dev/null | sha256sum | cut -d' ' -f1)
+	FILES_HASH=$(eval "find extensions .vscode -maxdepth 3 -name \"package.json\" -type f -not -path \"*/node_modules/*\" $FIND_EXCLUDES 2>/dev/null" | sort | tr '\n' '\0' | xargs -0 cat | sha256sum | cut -d' ' -f1)
 fi
 
 echo "  ✓ package.json hash: $FILES_HASH"


### PR DESCRIPTION
### Summary
The 1.118.0 merge vendored copilot-chat as `extensions/copilot`, whose test fixture path `simple-js-proj copy/package.json` contains a space. The stable hash pipeline piped the file list to `xargs cat`, which word-split on the space, errored, and aborted under `set -o pipefail` ("Stable extensions hash generation failed") - degrading the stable cache to a timestamp fallback every run.


### QA Notes
Confirm the "Cache Warning: Stable extensions hash generation failed" warning is gone and the stable extensions cache hits on this branch, this is what you see prior to this change:
<img width="1048" height="484" alt="Screenshot 2026-05-28 at 7 42 18 PM" src="https://github.com/user-attachments/assets/7cd3a313-6118-4235-92b5-19a109d9cbd8" />
