### PR TITLE
Fix test helper to match production setModel-then-attachView order

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/test/browser/testPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/testPositronNotebookInstance.ts
@@ -132,16 +132,8 @@ export function instantiateTestNotebookInstance(
 	));
 	notebook.instantiationService = instantiationService;
 
-	// Attach view with DOM containers
-	const editorContainer = document.createElement('div');
-	const notebookContainer = document.createElement('div');
-	const overlayContainer = document.createElement('div');
-	editorContainer.appendChild(notebookContainer);
-	editorContainer.appendChild(overlayContainer);
-	const scopedContextKeyService = instantiationService.invokeFunction(accessor => accessor.get(IContextKeyService)).createScoped(editorContainer);
-	notebook.attachView(editorContainer, scopedContextKeyService, notebookContainer, overlayContainer);
-
-	// Create the notebook text model directly
+	// Create the notebook text model directly (before attachView, matching
+	// PositronNotebookEditor.setInput production order).
 	const cellDtos = cells.map((cell) => cellToDto(cell));
 	const model = disposables.add(instantiationService.createInstance(
 		NotebookTextModel,
@@ -157,6 +149,15 @@ export function instantiateTestNotebookInstance(
 		}
 	));
 	notebook.setModel(model);
+
+	// Attach view with DOM containers
+	const editorContainer = document.createElement('div');
+	const notebookContainer = document.createElement('div');
+	const overlayContainer = document.createElement('div');
+	editorContainer.appendChild(notebookContainer);
+	editorContainer.appendChild(overlayContainer);
+	const scopedContextKeyService = instantiationService.invokeFunction(accessor => accessor.get(IContextKeyService)).createScoped(editorContainer);
+	notebook.attachView(editorContainer, scopedContextKeyService, notebookContainer, overlayContainer);
 
 	// Auto-attach test editors to all cells (initial and dynamically added).
 	// This mirrors what React's CellEditorMonacoWidget does in production.


### PR DESCRIPTION
The test helper `instantiateTestNotebookInstance` called `attachView` before `setModel`, but production (`PositronNotebookEditor.setInput`) always does `setModel` then `attachView`. This flips the order so tests exercise the real code path and surface bugs that the wrong ordering was hiding.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:web @:positron-notebooks

All notebook unit tests pass (`npx vitest run src/vs/workbench/contrib/positronNotebook/`).