### PR TITLE
e2e: stop asserting recents content on the welcome test

### DIFF
--- a/test/e2e/pages/welcome.ts
+++ b/test/e2e/pages/welcome.ts
@@ -92,18 +92,16 @@ export class Welcome {
 		});
 	}
 
-	async expectRecentToContain(recentItems: string[]) {
-		await test.step(`Verify recent section contains expected items: ${recentItems}`, async () => {
-			if (recentItems.length === 0) {
-				await expect(this.recentSection).toContainText('You have no recent folders,open a folderto start');
-				return;
-			}
-
+	/**
+	 * Verify the "Recent" section renders.
+	 *
+	 * We assert the section is present, not its contents: the app is worker-scoped, so the
+	 * recently-opened list is variable (earlier suites in the worker leave folders in it).
+	 */
+	async expectRecentToBeVisible() {
+		await test.step('Verify recent section is visible', async () => {
 			await expect(this.recentSection).toBeVisible();
 			await expect(this.recentTitle).toHaveText('Recent');
-			for (const item of recentItems) {
-				await expect(this.recentSection.getByRole(BUTTON_ROLE, { name: item })).toBeVisible();
-			}
 		});
 	}
 

--- a/test/e2e/tests/welcome/welcome.test.ts
+++ b/test/e2e/tests/welcome/welcome.test.ts
@@ -29,7 +29,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 			await welcome.expectTabTitleToBe('Welcome');
 			await welcome.expectStartToContain(['New Notebook', 'New File']);
 			await welcome.expectHelpToContain(['Positron Documentation', 'Positron Community Forum', 'Report a Bug', 'Sign Up for Positron Updates']);
-			await welcome.expectRecentToContain([]);
+			await welcome.expectRecentToBeVisible();
 			app.web
 				? await welcome.expectConnectToBeVisible(false)
 				: await welcome.expectConnectToBeVisible(true);
@@ -108,7 +108,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 
 			await welcome.expectStartToContain(['Open Folder...', 'New Folder...', 'New from Git...']);
 			await welcome.expectHelpToContain(['Positron Documentation', 'Positron Community Forum', 'Report a Bug', 'Sign Up for Positron Updates']);
-			await welcome.expectRecentToContain(['qa-example-content']);
+			await welcome.expectRecentToBeVisible();
 		});
 
 		test('Verify clicking on `Open Folder` opens file browser', { tag: [tags.WEB_ONLY] }, async function ({ app, page }) {


### PR DESCRIPTION
### Summary
The welcome page "page header, footer, content" tests flaked because they asserted the recently-opened list's contents, which is worker-variable state (the e2e app and userDataDir are worker-scoped, so folders opened by earlier suites persist and pollute it). Assert that the Recent section renders instead of pinning its contents.

- Replace `expectRecentToContain([])` and `expectRecentToContain(['qa-example-content'])` with a structural `expectRecentToBeVisible()` in both content tests.
- Drop the content-coupled assertion logic from the Welcome POM.

### QA Notes
@:welcome