### PR TITLE
CI: make windows package-cache restores soft-fail

### DIFF
--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -260,6 +260,7 @@ jobs:
 
       - name: Restore Python packages cache
         id: cache-python
+        continue-on-error: true
         uses: actions/cache/restore@v5
         with:
           path: ${{ runner.temp }}\uv-cache
@@ -319,6 +320,7 @@ jobs:
 
       - name: Restore R packages cache
         id: cache-r
+        continue-on-error: true
         uses: actions/cache/restore@v5
         with:
           path: |


### PR DESCRIPTION
### Summary
A transient `actions/cache/restore` failure on the Windows e2e runner marked the step as failed and skipped the entire test run, even though it just restores a cache. Make the package-cache restores soft-fail so a flaky restore degrades to a cache miss instead of sinking the job.

- Add `continue-on-error: true` to the Restore Python packages cache step
- Add `continue-on-error: true` to the Restore R packages cache step
- On a failed restore, the install steps reinstall deps fresh (cache miss)
- Mirrors the `continue-on-error` already set on the matching Save-cache steps
- Scoped to the Windows run workflow; macOS/Ubuntu runners have no such restore steps

### QA Notes
CI-only change; no test tags.