### PR TITLE
python: add command to install python using uv

### DIFF
--- a/extensions/positron-python/package.json
+++ b/extensions/positron-python/package.json
@@ -373,6 +373,11 @@
                 "title": "%python.command.python.createEnvironment.title%"
             },
             {
+                "category": "Python",
+                "command": "python.installPythonViaUv",
+                "title": "%python.command.python.installPythonViaUv.title%"
+            },
+            {
                 "command": "python.installPackages",
                 "title": "Install Python Packages",
                 "category": "Python"
@@ -1553,6 +1558,12 @@
                     "category": "Python",
                     "command": "python.createEnvironment",
                     "title": "%python.command.python.createEnvironment.title%",
+                    "when": "!virtualWorkspace && shellExecutionSupported"
+                },
+                {
+                    "category": "Python",
+                    "command": "python.installPythonViaUv",
+                    "title": "%python.command.python.installPythonViaUv.title%",
                     "when": "!virtualWorkspace && shellExecutionSupported"
                 },
                 {

--- a/extensions/positron-python/package.nls.json
+++ b/extensions/positron-python/package.nls.json
@@ -9,6 +9,7 @@
     "python.languageModelTools.configure_python_environment.userDescription": "Configure a Python Environment for a workspace",
     "python.command.python.startNativeREPL.title": "Start Native Python REPL",
     "python.command.python.createEnvironment.title": "Create Environment...",
+    "python.command.python.installPythonViaUv.title": "Install Python via uv",
     "python.command.python.createNewFile.title": "New Python File",
     "python.command.python.createPyprojectToml.title": "Create pyproject.toml If Not Found",
     "python.command.python.createTerminal.title": "Create Terminal",

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -292,21 +292,29 @@ export namespace InterpreterQuickPickList {
 
     export namespace UvInstall {
         export const noVersionsAvailable = l10n.t('No Python versions available for installation');
-        export const installed = l10n.t('(installed)');
+        export const alreadyInstalledSeparator = l10n.t('Already installed');
         export const selectVersion = l10n.t('Select a Python version to install');
         export const selectVersionTitle = l10n.t('Install Python via uv');
-        export const installingPython = l10n.t('Installing Python');
+        export const installingPython = l10n.t('Setting up Python');
         export const installingUv = l10n.t('Installing uv');
         export const selectingVersion = l10n.t('Loading available versions');
         export const pythonVersionLabel = (version: string) => l10n.t('Python {0}', version);
         export const installingPythonVersion = (version: string) => l10n.t('Installing Python {0}', version);
+        export const alreadyInstalledMessage = (version: string) => l10n.t('Python {0} is already installed', version);
         export const installSuccess = (version: string) => l10n.t('Python {0} installed successfully', version);
-        export const configureSuccess = (version: string) => l10n.t('Python {0} configured successfully', version);
+        export const configureSuccess = (version: string) =>
+            l10n.t('Virtual environment created with Python {0}', version);
         export const installFailed = (version: string) => l10n.t('Failed to install Python {0}', version);
         export const uvInstallFailed = l10n.t('Failed to install uv');
         export const createVenvPrompt = (version: string, workspaceFolder: string) =>
             l10n.t(
                 'Python {0} was installed. Would you like to use this version to create a virtual environment at: `{1}`?',
+                version,
+                `${workspaceFolder}/.venv`,
+            );
+        export const createVenvPromptAlreadyInstalled = (version: string, workspaceFolder: string) =>
+            l10n.t(
+                'Python {0} is installed. Would you like to use it to create a virtual environment at: `{1}`?',
                 version,
                 `${workspaceFolder}/.venv`,
             );

--- a/extensions/positron-python/src/client/common/utils/localize.ts
+++ b/extensions/positron-python/src/client/common/utils/localize.ts
@@ -301,9 +301,15 @@ export namespace InterpreterQuickPickList {
         export const pythonVersionLabel = (version: string) => l10n.t('Python {0}', version);
         export const installingPythonVersion = (version: string) => l10n.t('Installing Python {0}', version);
         export const installSuccess = (version: string) => l10n.t('Python {0} installed successfully', version);
+        export const configureSuccess = (version: string) => l10n.t('Python {0} configured successfully', version);
         export const installFailed = (version: string) => l10n.t('Failed to install Python {0}', version);
         export const uvInstallFailed = l10n.t('Failed to install uv');
-        export const createVenvPrompt = l10n.t('Create a virtual environment in your workspace?');
+        export const createVenvPrompt = (version: string, workspaceFolder: string) =>
+            l10n.t(
+                'Python {0} was installed. Would you like to use this version to create a virtual environment at: `{1}`?',
+                version,
+                `${workspaceFolder}/.venv`,
+            );
         export const yesRecommended = l10n.t('Yes (recommended)');
         export const creatingVenv = l10n.t('Creating virtual environment');
         export const venvCreated = l10n.t('Virtual environment created');

--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -519,13 +519,13 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
             if (sessionsToShutdown.length > 0) {
                 traceInfo(`Shutting down ${sessionsToShutdown.length} sessions using Python runtime at ${pythonPath}`);
                 await Promise.all(
-                    sessionsToShutdown.map(async (session) => {
-                        session.shutdown(positron.RuntimeExitReason.Shutdown);
-                    }),
+                    sessionsToShutdown.map((session) => session.shutdown(positron.RuntimeExitReason.Shutdown)),
                 );
-                // Remove the runtime from our registry so we can recreate it
-                this.registeredPythonRuntimes.delete(pythonPath);
             }
+
+            // clear stale entry so registerLanguageRuntime below fires _onDidDiscoverRuntime
+            // for the new runtime vs. leaving Positron with an orphaned stale entry.
+            this.registeredPythonRuntimes.delete(pythonPath);
         }
 
         // Get the interpreter corresponding to the new runtime.

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
@@ -12,6 +12,9 @@ import { isUvInstalled, getAvailablePythonVersions, resetUvCache, isWindowsArm64
 import { Common, InterpreterQuickPickList } from '../../../common/utils/localize';
 import { getWorkspaceFolders } from '../../../common/vscodeApis/workspaceApis';
 import { createUvVenv } from '../../creation/provider/uvCreationProvider';
+import { ExistingVenvAction, deleteEnvironment, pickExistingVenvAction } from '../../creation/provider/venvUtils';
+import { getVenvExecutable, hasVenv } from '../../creation/common/commonUtils';
+import { MultiStepAction } from '../../../common/vscodeApis/windowApis';
 import { refreshEnvironments } from '../../../envExt/api.internal';
 
 /**
@@ -153,6 +156,47 @@ async function createGlobalVenv(
 }
 
 /**
+ * Creates a uv venv at the given folder, reusing the Create Environment "use
+ * existing / delete and recreate" flow when a `.venv` already exists there. uv
+ * fails outright if a `.venv` already exists, so this collision must be handled.
+ *
+ * @param folder The folder to create the venv in (the open workspace, or a
+ *   home-directory stand-in for the global `~/.venv` case).
+ * @param create Creates the venv once any existing one has been resolved.
+ * @returns `venvPython` is the venv's Python executable (from a fresh create or
+ *   an existing env the user chose to keep), or undefined if creation failed or
+ *   the user backed out. `attempted` reports whether creation actually ran, so
+ *   callers only show success/failure messages when a create was tried.
+ */
+async function createVenvHandlingExisting(
+    folder: vscode.WorkspaceFolder,
+    create: () => Promise<string | undefined>,
+): Promise<{ venvPython: string | undefined; attempted: boolean }> {
+    try {
+        const existingVenvAction = (await hasVenv(folder))
+            ? await pickExistingVenvAction(folder)
+            : ExistingVenvAction.Create;
+
+        if (existingVenvAction === ExistingVenvAction.UseExisting) {
+            return { venvPython: getVenvExecutable(folder), attempted: false };
+        }
+        if (existingVenvAction === ExistingVenvAction.Recreate) {
+            if (!(await deleteEnvironment(folder, undefined))) {
+                throw new Error('Failed to delete existing virtual environment');
+            }
+        }
+        return { venvPython: await create(), attempted: true };
+    } catch (ex) {
+        // User backed out of the existing-venv prompt - skip venv creation and
+        // fall back to the base interpreter.
+        if (ex !== MultiStepAction.Back && ex !== MultiStepAction.Cancel) {
+            throw ex;
+        }
+        return { venvPython: undefined, attempted: false };
+    }
+}
+
+/**
  * Shows a quick pick for selecting a Python version to install.
  * @returns The selected version (and identifier on Windows ARM64), or undefined if cancelled
  */
@@ -257,23 +301,41 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
 
                     if (createVenv?.id === 'yes') {
                         progress.report({ message: InterpreterQuickPickList.UvInstall.creatingVenv });
-                        venvPython = await createUvVenv(workspaces[0], selected.version, progress);
-                        if (venvPython) {
-                            vscode.window.showInformationMessage(InterpreterQuickPickList.UvInstall.venvCreated);
-                        } else {
-                            // Venv creation failed - warn the user
-                            vscode.window.showWarningMessage(InterpreterQuickPickList.UvInstall.venvCreationFailed);
+                        const workspace = workspaces[0];
+                        const result = await createVenvHandlingExisting(workspace, () =>
+                            createUvVenv(workspace, selected.version, progress),
+                        );
+                        venvPython = result.venvPython;
+                        if (result.attempted) {
+                            if (venvPython) {
+                                vscode.window.showInformationMessage(InterpreterQuickPickList.UvInstall.venvCreated);
+                            } else {
+                                // Venv creation failed - warn the user
+                                vscode.window.showWarningMessage(InterpreterQuickPickList.UvInstall.venvCreationFailed);
+                            }
                         }
                     }
                 } else {
-                    // No workspace - create a global venv at ~/.venv
-                    venvPython = await createGlobalVenv(selected.version, progress);
-                    if (venvPython) {
-                        vscode.window.showInformationMessage(
-                            InterpreterQuickPickList.UvInstall.globalVenvCreated(getGlobalVenvPath()),
-                        );
-                    } else {
-                        vscode.window.showWarningMessage(InterpreterQuickPickList.UvInstall.venvCreationFailed);
+                    // No workspace - create (or reuse) a global venv at ~/.venv. The existing-venv
+                    // helpers are workspace-folder based, so wrap the home directory in a
+                    // WorkspaceFolder to reuse the same use-existing / recreate handling.
+                    const homeFolder: vscode.WorkspaceFolder = {
+                        uri: vscode.Uri.file(os.homedir()),
+                        name: 'home',
+                        index: 0,
+                    };
+                    const result = await createVenvHandlingExisting(homeFolder, () =>
+                        createGlobalVenv(selected.version, progress),
+                    );
+                    venvPython = result.venvPython;
+                    if (result.attempted) {
+                        if (venvPython) {
+                            vscode.window.showInformationMessage(
+                                InterpreterQuickPickList.UvInstall.globalVenvCreated(getGlobalVenvPath()),
+                            );
+                        } else {
+                            vscode.window.showWarningMessage(InterpreterQuickPickList.UvInstall.venvCreationFailed);
+                        }
                     }
                 }
 

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
@@ -202,7 +202,9 @@ async function createVenvHandlingExisting(
  * Shows a quick pick for selecting a Python version to install.
  * @returns The selected version (and identifier on Windows ARM64), or undefined if cancelled
  */
-async function selectPythonVersion(): Promise<{ version: string; identifier?: string } | undefined> {
+async function selectPythonVersion(): Promise<
+    { version: string; identifier?: string; isInstalled: boolean; path?: string } | undefined
+> {
     const versions = await getAvailablePythonVersions();
 
     if (versions.length === 0) {
@@ -213,6 +215,8 @@ async function selectPythonVersion(): Promise<{ version: string; identifier?: st
     interface VersionQuickPickItem extends vscode.QuickPickItem {
         version: string;
         identifier: string;
+        isInstalled: boolean;
+        path?: string;
     }
 
     const items: VersionQuickPickItem[] = versions.map((v) => ({
@@ -221,6 +225,8 @@ async function selectPythonVersion(): Promise<{ version: string; identifier?: st
         detail: v.path,
         version: v.version,
         identifier: v.identifier,
+        isInstalled: v.isInstalled,
+        path: v.path,
     }));
 
     const selected = await vscode.window.showQuickPick(items, {
@@ -235,8 +241,13 @@ async function selectPythonVersion(): Promise<{ version: string; identifier?: st
     // On Windows ARM64, return the identifier so we can install the correct architecture
     // On other platforms, just return the version
     return isWindowsArm64()
-        ? { version: selected.version, identifier: selected.identifier }
-        : { version: selected.version };
+        ? {
+              version: selected.version,
+              identifier: selected.identifier,
+              isInstalled: selected.isInstalled,
+              path: selected.path,
+          }
+        : { version: selected.version, isInstalled: selected.isInstalled, path: selected.path };
 }
 
 /**
@@ -256,7 +267,10 @@ export interface InstallPythonResult {
  * Flow: install uv if needed -> pick version -> install Python -> offer venv creation
  */
 export async function installPythonViaUv(): Promise<InstallPythonResult> {
-    return vscode.window.withProgress(
+    let installedVersion: string | undefined;
+    let wasAlreadyInstalled = false;
+
+    const result = await vscode.window.withProgress(
         { location: vscode.ProgressLocation.Notification, title: InterpreterQuickPickList.UvInstall.installingPython },
         async (progress) => {
             try {
@@ -276,15 +290,22 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                     return { success: false, error: 'Cancelled' };
                 }
 
-                progress.report({
-                    message: InterpreterQuickPickList.UvInstall.installingPythonVersion(selected.version),
-                });
-                const pythonPath = await installPythonVersionAndGetPath(selected.version, selected.identifier);
-                if (!pythonPath) {
-                    return {
-                        success: false,
-                        error: InterpreterQuickPickList.UvInstall.installFailed(selected.version),
-                    };
+                let pythonPath: string | undefined;
+                if (selected.isInstalled && selected.path) {
+                    // Version is already installed locally - skip the install step
+                    pythonPath = selected.path;
+                    wasAlreadyInstalled = true;
+                } else {
+                    progress.report({
+                        message: InterpreterQuickPickList.UvInstall.installingPythonVersion(selected.version),
+                    });
+                    pythonPath = await installPythonVersionAndGetPath(selected.version, selected.identifier);
+                    if (!pythonPath) {
+                        return {
+                            success: false,
+                            error: InterpreterQuickPickList.UvInstall.installFailed(selected.version),
+                        };
+                    }
                 }
 
                 // Create venv - either in workspace or in global location
@@ -292,29 +313,21 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                 let venvPython: string | undefined;
 
                 if (workspaces && workspaces.length > 0) {
-                    // Workspace is open - offer to create venv there
-                    const createVenv = await vscode.window.showQuickPick(
-                        [
-                            { label: InterpreterQuickPickList.UvInstall.yesRecommended, id: 'yes' },
-                            { label: Common.bannerLabelNo, id: 'no' },
-                        ],
-                        { title: InterpreterQuickPickList.UvInstall.createVenvPrompt },
+                    const createVenv = await vscode.window.showInformationMessage(
+                        InterpreterQuickPickList.UvInstall.createVenvPrompt(selected.version, workspaces[0].name),
+                        InterpreterQuickPickList.UvInstall.yesRecommended,
+                        Common.bannerLabelNo,
                     );
 
-                    if (createVenv?.id === 'yes') {
+                    if (createVenv === InterpreterQuickPickList.UvInstall.yesRecommended) {
                         progress.report({ message: InterpreterQuickPickList.UvInstall.creatingVenv });
                         const workspace = workspaces[0];
-                        const result = await createVenvHandlingExisting(workspace, () =>
+                        const venvResult = await createVenvHandlingExisting(workspace, () =>
                             createUvVenv(workspace, selected.version, progress),
                         );
-                        venvPython = result.venvPython;
-                        if (result.attempted) {
-                            if (venvPython) {
-                                vscode.window.showInformationMessage(InterpreterQuickPickList.UvInstall.venvCreated);
-                            } else {
-                                // Venv creation failed - warn the user
-                                vscode.window.showWarningMessage(InterpreterQuickPickList.UvInstall.venvCreationFailed);
-                            }
+                        venvPython = venvResult.venvPython;
+                        if (venvResult.attempted && !venvPython) {
+                            progress.report({ message: InterpreterQuickPickList.UvInstall.venvCreationFailed });
                         }
                     }
                 } else {
@@ -326,18 +339,12 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                         name: 'home',
                         index: 0,
                     };
-                    const result = await createVenvHandlingExisting(homeFolder, () =>
+                    const venvResult = await createVenvHandlingExisting(homeFolder, () =>
                         createGlobalVenv(selected.version, progress),
                     );
-                    venvPython = result.venvPython;
-                    if (result.attempted) {
-                        if (venvPython) {
-                            vscode.window.showInformationMessage(
-                                InterpreterQuickPickList.UvInstall.globalVenvCreated(getGlobalVenvPath()),
-                            );
-                        } else {
-                            vscode.window.showWarningMessage(InterpreterQuickPickList.UvInstall.venvCreationFailed);
-                        }
+                    pythonPath = venvResult.venvPython;
+                    if (venvResult.attempted && !venvPython) {
+                        progress.report({ message: InterpreterQuickPickList.UvInstall.venvCreationFailed });
                     }
                 }
 
@@ -348,16 +355,21 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                     traceError(`Failed to refresh environments: ${err}`);
                 });
 
-                // Return the venv Python if created, otherwise fall back to base Python
-                const finalPythonPath = venvPython ?? pythonPath;
-                vscode.window.showInformationMessage(
-                    InterpreterQuickPickList.UvInstall.installSuccess(selected.version),
-                );
-                return { success: true, pythonPath: finalPythonPath };
+                installedVersion = selected.version;
+                return { success: true, pythonPath: pythonPath };
             } catch (error) {
                 traceError(`installPythonViaUv failed: ${error}`);
                 return { success: false, error: String(error) };
             }
         },
     );
+
+    if (result.success && installedVersion) {
+        const msg = wasAlreadyInstalled
+            ? InterpreterQuickPickList.UvInstall.configureSuccess(installedVersion)
+            : InterpreterQuickPickList.UvInstall.installSuccess(installedVersion);
+        vscode.window.showInformationMessage(msg);
+    }
+
+    return result;
 }

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
@@ -342,8 +342,8 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                     const venvResult = await createVenvHandlingExisting(homeFolder, () =>
                         createGlobalVenv(selected.version, progress),
                     );
-                    pythonPath = venvResult.venvPython;
-                    if (venvResult.attempted && !venvPython) {
+                    pythonPath = venvResult.venvPython ?? pythonPath;
+                    if (venvResult.attempted && !venvResult.venvPython) {
                         progress.report({ message: InterpreterQuickPickList.UvInstall.venvCreationFailed });
                     }
                 }
@@ -356,7 +356,7 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                 });
 
                 installedVersion = selected.version;
-                return { success: true, pythonPath: pythonPath };
+                return { success: true, pythonPath: venvPython ?? pythonPath };
             } catch (error) {
                 traceError(`installPythonViaUv failed: ${error}`);
                 return { success: false, error: String(error) };

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
@@ -182,7 +182,9 @@ async function createVenvHandlingExisting(
         }
         if (existingVenvAction === ExistingVenvAction.Recreate) {
             if (!(await deleteEnvironment(folder, undefined))) {
-                throw new Error('Failed to delete existing virtual environment');
+                // Delete failed - warn the user but don't abort the overall install.
+                // Python itself was installed successfully; fall back to the base interpreter.
+                return { venvPython: undefined, attempted: true };
             }
         }
         return { venvPython: await create(), attempted: true };

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
@@ -219,17 +219,34 @@ async function selectPythonVersion(): Promise<
         path?: string;
     }
 
-    const items: VersionQuickPickItem[] = versions.map((v) => ({
+    const uninstalled = versions.filter((v) => !v.isInstalled);
+    const installed = versions.filter((v) => v.isInstalled);
+
+    const items: (VersionQuickPickItem | vscode.QuickPickItem)[] = uninstalled.map((v) => ({
         label: InterpreterQuickPickList.UvInstall.pythonVersionLabel(v.version),
-        description: v.isInstalled ? InterpreterQuickPickList.UvInstall.installed : undefined,
-        detail: v.path,
         version: v.version,
         identifier: v.identifier,
-        isInstalled: v.isInstalled,
-        path: v.path,
+        isInstalled: false,
     }));
 
-    const selected = await vscode.window.showQuickPick(items, {
+    if (installed.length > 0) {
+        items.push({
+            label: InterpreterQuickPickList.UvInstall.alreadyInstalledSeparator,
+            kind: vscode.QuickPickItemKind.Separator,
+        });
+        for (const v of installed) {
+            items.push({
+                label: InterpreterQuickPickList.UvInstall.pythonVersionLabel(v.version),
+                detail: v.path,
+                version: v.version,
+                identifier: v.identifier,
+                isInstalled: true,
+                path: v.path,
+            });
+        }
+    }
+
+    const selected = await vscode.window.showQuickPick(items as VersionQuickPickItem[], {
         placeHolder: InterpreterQuickPickList.UvInstall.selectVersion,
         title: InterpreterQuickPickList.UvInstall.selectVersionTitle,
     });
@@ -269,6 +286,7 @@ export interface InstallPythonResult {
 export async function installPythonViaUv(): Promise<InstallPythonResult> {
     let installedVersion: string | undefined;
     let wasAlreadyInstalled = false;
+    let venvWasCreated = false;
 
     const result = await vscode.window.withProgress(
         { location: vscode.ProgressLocation.Notification, title: InterpreterQuickPickList.UvInstall.installingPython },
@@ -290,17 +308,20 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                     return { success: false, error: 'Cancelled' };
                 }
 
-                let pythonPath: string | undefined;
+                let resolvedPath: string | undefined;
                 if (selected.isInstalled && selected.path) {
-                    // Version is already installed locally - skip the install step
-                    pythonPath = selected.path;
+                    // Version is already installed - skip the install step
+                    resolvedPath = selected.path;
                     wasAlreadyInstalled = true;
+                    progress.report({
+                        message: InterpreterQuickPickList.UvInstall.alreadyInstalledMessage(selected.version),
+                    });
                 } else {
                     progress.report({
                         message: InterpreterQuickPickList.UvInstall.installingPythonVersion(selected.version),
                     });
-                    pythonPath = await installPythonVersionAndGetPath(selected.version, selected.identifier);
-                    if (!pythonPath) {
+                    resolvedPath = await installPythonVersionAndGetPath(selected.version, selected.identifier);
+                    if (!resolvedPath) {
                         return {
                             success: false,
                             error: InterpreterQuickPickList.UvInstall.installFailed(selected.version),
@@ -310,11 +331,16 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
 
                 // Create venv - either in workspace or in global location
                 const workspaces = getWorkspaceFolders();
-                let venvPython: string | undefined;
 
                 if (workspaces && workspaces.length > 0) {
+                    const venvPrompt = wasAlreadyInstalled
+                        ? InterpreterQuickPickList.UvInstall.createVenvPromptAlreadyInstalled(
+                              selected.version,
+                              workspaces[0].name,
+                          )
+                        : InterpreterQuickPickList.UvInstall.createVenvPrompt(selected.version, workspaces[0].name);
                     const createVenv = await vscode.window.showInformationMessage(
-                        InterpreterQuickPickList.UvInstall.createVenvPrompt(selected.version, workspaces[0].name),
+                        venvPrompt,
                         InterpreterQuickPickList.UvInstall.yesRecommended,
                         Common.bannerLabelNo,
                     );
@@ -325,8 +351,10 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                         const venvResult = await createVenvHandlingExisting(workspace, () =>
                             createUvVenv(workspace, selected.version, progress),
                         );
-                        venvPython = venvResult.venvPython;
-                        if (venvResult.attempted && !venvPython) {
+                        if (venvResult.venvPython) {
+                            resolvedPath = venvResult.venvPython;
+                            venvWasCreated = true;
+                        } else if (venvResult.attempted) {
                             progress.report({ message: InterpreterQuickPickList.UvInstall.venvCreationFailed });
                         }
                     }
@@ -342,8 +370,10 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                     const venvResult = await createVenvHandlingExisting(homeFolder, () =>
                         createGlobalVenv(selected.version, progress),
                     );
-                    pythonPath = venvResult.venvPython ?? pythonPath;
-                    if (venvResult.attempted && !venvResult.venvPython) {
+                    if (venvResult.venvPython) {
+                        resolvedPath = venvResult.venvPython;
+                        venvWasCreated = true;
+                    } else if (venvResult.attempted) {
                         progress.report({ message: InterpreterQuickPickList.UvInstall.venvCreationFailed });
                     }
                 }
@@ -356,7 +386,7 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                 });
 
                 installedVersion = selected.version;
-                return { success: true, pythonPath: venvPython ?? pythonPath };
+                return { success: true, pythonPath: resolvedPath };
             } catch (error) {
                 traceError(`installPythonViaUv failed: ${error}`);
                 return { success: false, error: String(error) };
@@ -365,10 +395,14 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
     );
 
     if (result.success && installedVersion) {
-        const msg = wasAlreadyInstalled
-            ? InterpreterQuickPickList.UvInstall.configureSuccess(installedVersion)
-            : InterpreterQuickPickList.UvInstall.installSuccess(installedVersion);
-        vscode.window.showInformationMessage(msg);
+        if (!wasAlreadyInstalled) {
+            // Python was freshly installed - always notify
+            vscode.window.showInformationMessage(InterpreterQuickPickList.UvInstall.installSuccess(installedVersion));
+        } else if (venvWasCreated) {
+            // Python was already installed but a new venv was created
+            vscode.window.showInformationMessage(InterpreterQuickPickList.UvInstall.configureSuccess(installedVersion));
+        }
+        // Already installed + no venv created: nothing changed, no notification needed
     }
 
     return result;

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uvPythonInstaller.ts
@@ -353,7 +353,7 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                         );
                         if (venvResult.venvPython) {
                             resolvedPath = venvResult.venvPython;
-                            venvWasCreated = true;
+                            venvWasCreated = venvResult.attempted;
                         } else if (venvResult.attempted) {
                             progress.report({ message: InterpreterQuickPickList.UvInstall.venvCreationFailed });
                         }
@@ -372,7 +372,7 @@ export async function installPythonViaUv(): Promise<InstallPythonResult> {
                     );
                     if (venvResult.venvPython) {
                         resolvedPath = venvResult.venvPython;
-                        venvWasCreated = true;
+                        venvWasCreated = venvResult.attempted;
                     } else if (venvResult.attempted) {
                         progress.report({ message: InterpreterQuickPickList.UvInstall.venvCreationFailed });
                     }

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -225,7 +225,14 @@ export async function registerCreateEnvironmentFeatures(
                 // (onDidSelectItem) lets Positron start the returned runtimeId itself, so
                 // handleInstallPythonResult only registers - the palette command must start it here.
                 if (handled?.runtimeId) {
-                    await positron.runtime.selectLanguageRuntime(handled.runtimeId);
+                    // Best-effort: start the runtime in the console. A failure here does
+                    // not mean the install failed - the runtime is still registered and
+                    // will appear in the session picker.
+                    try {
+                        await positron.runtime.selectLanguageRuntime(handled.runtimeId);
+                    } catch (startError) {
+                        traceError(`Failed to start runtime after Python install: ${startError}`);
+                    }
                 }
                 return handled;
             } catch (error) {

--- a/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/creation/createEnvApi.ts
@@ -220,7 +220,14 @@ export async function registerCreateEnvironmentFeatures(
         registerCommand(Commands.InstallPythonViaUv, async () => {
             try {
                 const result = await installPythonViaUv();
-                return await handleInstallPythonResult(result, pythonRuntimeManager);
+                const handled = await handleInstallPythonResult(result, pythonRuntimeManager);
+                // Start the newly installed runtime in the Console. The runtime-picker path
+                // (onDidSelectItem) lets Positron start the returned runtimeId itself, so
+                // handleInstallPythonResult only registers - the palette command must start it here.
+                if (handled?.runtimeId) {
+                    await positron.runtime.selectLanguageRuntime(handled.runtimeId);
+                }
+                return handled;
             } catch (error) {
                 traceError(`installPythonViaUv command failed: ${error}`);
                 showErrorMessage(InterpreterQuickPickList.UvInstall.installCommandFailed);

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import { anything, when, reset, verify } from 'ts-mockito';
+import { anything, when, reset } from 'ts-mockito';
 import { MultiStepAction } from '../../../../client/common/vscodeApis/windowApis';
 import * as fileUtils from '../../../../client/pythonEnvironments/common/externalDependencies';
 import * as logging from '../../../../client/logging';
@@ -342,6 +342,10 @@ suite('UV Python Installer Tests', () => {
             when(
                 mockedVSCodeNamespaces.window!.showInformationMessage(anything(), anything(), anything(), anything()),
             ).thenResolve(InterpreterQuickPickList.UvInstall.confirmUvInstallYes as any);
+            // Default: user accepts venv creation when prompted (3 args: message, yes button, no button)
+            when(mockedVSCodeNamespaces.window!.showInformationMessage(anything(), anything(), anything())).thenResolve(
+                InterpreterQuickPickList.UvInstall.yesRecommended as any,
+            );
             when(mockedVSCodeNamespaces.window!.showInformationMessage(anything())).thenResolve(undefined);
             when(mockedVSCodeNamespaces.window!.showWarningMessage(anything())).thenResolve(undefined);
 
@@ -459,11 +463,8 @@ suite('UV Python Installer Tests', () => {
             getAvailablePythonVersionsStub.resolves([
                 { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
             ]);
-            // User selects version, then accepts venv creation
-            quickPickResponses = [
-                { version: '3.13', label: 'Python 3.13' },
-                { id: 'yes', label: 'Yes' },
-            ];
+            // User selects version (venv creation uses showInformationMessage - default returns yes)
+            quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
             // uv python install succeeds
             execStub.onFirstCall().resolves({ stdout: '' });
             // uv python find returns path
@@ -487,11 +488,12 @@ suite('UV Python Installer Tests', () => {
             getAvailablePythonVersionsStub.resolves([
                 { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
             ]);
-            // User selects version, then declines venv creation
-            quickPickResponses = [
-                { version: '3.13', label: 'Python 3.13' },
-                { id: 'no', label: 'No' },
-            ];
+            // User selects version (venv creation uses showInformationMessage - user dismisses)
+            quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
+            // Override: user dismisses the venv creation notification
+            when(mockedVSCodeNamespaces.window!.showInformationMessage(anything(), anything(), anything())).thenResolve(
+                undefined,
+            );
             // uv python install succeeds
             execStub.onFirstCall().resolves({ stdout: '' });
             // uv python find returns path
@@ -513,11 +515,8 @@ suite('UV Python Installer Tests', () => {
             getAvailablePythonVersionsStub.resolves([
                 { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
             ]);
-            // User selects version, then accepts venv creation
-            quickPickResponses = [
-                { version: '3.13', label: 'Python 3.13' },
-                { id: 'yes', label: 'Yes' },
-            ];
+            // User selects version (venv creation uses showInformationMessage - default returns yes)
+            quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
             // uv python install succeeds
             execStub.onFirstCall().resolves({ stdout: '' });
             // uv python find returns path
@@ -544,17 +543,14 @@ suite('UV Python Installer Tests', () => {
                 getAvailablePythonVersionsStub.resolves([
                     { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
                 ]);
-                // version select, then "yes" to create venv
-                quickPickResponses = [
-                    { version: '3.13', label: 'Python 3.13' },
-                    { id: 'yes', label: 'Yes' },
-                ];
+                // version select only - venv creation uses showInformationMessage (default: yes)
+                quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
                 execStub.onFirstCall().resolves({ stdout: '' }); // uv python install
                 execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' }); // uv python find
                 getWorkspaceFoldersStub.returns([mockWorkspace]);
             }
 
-            test('Recreate: delete fails → succeeds with base Python and shows a warning', async () => {
+            test('Recreate: delete fails → succeeds with base Python and reports failure via progress', async () => {
                 arrangeWorkspaceInstall();
                 hasVenvStub.resolves(true);
                 pickExistingVenvActionStub.resolves(venvUtils.ExistingVenvAction.Recreate);
@@ -566,7 +562,12 @@ suite('UV Python Installer Tests', () => {
                 assert.strictEqual(result.success, true);
                 assert.strictEqual(result.pythonPath, '/usr/local/bin/python3.13');
                 assert.ok(!createUvVenvStub.called, 'should not attempt venv after failed delete');
-                verify(mockedVSCodeNamespaces.window!.showWarningMessage(anything())).once();
+                assert.ok(
+                    mockProgress.report.calledWithMatch({
+                        message: InterpreterQuickPickList.UvInstall.venvCreationFailed,
+                    }),
+                    'should report venv creation failure via progress',
+                );
             });
 
             test('User cancels existing-venv prompt → succeeds with base Python', async () => {
@@ -717,13 +718,16 @@ suite('UV Python Installer Tests', () => {
             assert.ok(result.error?.includes('3.13'));
         });
 
-        test('Dismissing "create venv?" quick pick falls back to base Python', async () => {
+        test('Dismissing "create venv?" notification falls back to base Python', async () => {
             isUvInstalledStub.resolves(true);
             getAvailablePythonVersionsStub.resolves([
                 { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
             ]);
-            // User selects version, then dismisses the "create venv?" prompt (Escape)
-            quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }, undefined];
+            // User selects version, then dismisses the "create venv?" notification (Escape)
+            quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
+            when(mockedVSCodeNamespaces.window!.showInformationMessage(anything(), anything(), anything())).thenResolve(
+                undefined,
+            );
             execStub.onFirstCall().resolves({ stdout: '' });
             execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' });
             const mockWorkspace = { uri: { fsPath: '/test/workspace' }, name: 'test', index: 0 };
@@ -744,6 +748,69 @@ suite('UV Python Installer Tests', () => {
             assert.strictEqual(result.success, false);
             assert.ok(result.error?.includes('Unexpected error'));
             assert.ok(traceErrorStub.called);
+        });
+
+        test('Skips uv python install when version is already installed (workspace)', async () => {
+            isUvInstalledStub.resolves(true);
+            getAvailablePythonVersionsStub.resolves([
+                {
+                    version: '3.13',
+                    isInstalled: true,
+                    path: '/usr/local/bin/python3.13',
+                    identifier: 'cpython-3.13.1-macos-aarch64-none',
+                },
+            ]);
+            // Selected item carries isInstalled and path
+            quickPickResponses = [
+                {
+                    version: '3.13',
+                    label: 'Python 3.13',
+                    isInstalled: true,
+                    path: '/usr/local/bin/python3.13',
+                    identifier: 'cpython-3.13.1-macos-aarch64-none',
+                },
+            ];
+            const mockWorkspace = { uri: { fsPath: '/test/workspace' }, name: 'test', index: 0 };
+            getWorkspaceFoldersStub.returns([mockWorkspace]);
+            createUvVenvStub.resolves('/test/workspace/.venv/bin/python');
+
+            const result = await installPythonViaUv();
+
+            assert.strictEqual(result.success, true);
+            assert.strictEqual(result.pythonPath, '/test/workspace/.venv/bin/python');
+            // No exec calls - install and find are both skipped
+            assert.strictEqual(execStub.callCount, 0);
+        });
+
+        test('Skips uv python install when version is already installed (no workspace)', async () => {
+            isUvInstalledStub.resolves(true);
+            getAvailablePythonVersionsStub.resolves([
+                {
+                    version: '3.13',
+                    isInstalled: true,
+                    path: '/usr/local/bin/python3.13',
+                    identifier: 'cpython-3.13.1-macos-aarch64-none',
+                },
+            ]);
+            quickPickResponses = [
+                {
+                    version: '3.13',
+                    label: 'Python 3.13',
+                    isInstalled: true,
+                    path: '/usr/local/bin/python3.13',
+                    identifier: 'cpython-3.13.1-macos-aarch64-none',
+                },
+            ];
+            getWorkspaceFoldersStub.returns(undefined);
+            // Only the uv venv creation exec call should happen
+            execStub.onFirstCall().resolves({ stdout: '' });
+
+            const result = await installPythonViaUv();
+
+            assert.strictEqual(result.success, true);
+            assert.strictEqual(result.pythonPath, getExpectedGlobalVenvPython());
+            // Only one exec call - for global venv creation (no install or find)
+            assert.strictEqual(execStub.callCount, 1);
         });
 
         test('Reports progress at each step', async () => {

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
@@ -7,7 +7,8 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import { anything, when, reset } from 'ts-mockito';
+import { anything, when, reset, verify } from 'ts-mockito';
+import { MultiStepAction } from '../../../../client/common/vscodeApis/windowApis';
 import * as fileUtils from '../../../../client/pythonEnvironments/common/externalDependencies';
 import * as logging from '../../../../client/logging';
 import * as uv from '../../../../client/pythonEnvironments/common/environmentManagers/uv';
@@ -553,6 +554,73 @@ suite('UV Python Installer Tests', () => {
                 getWorkspaceFoldersStub.returns([mockWorkspace]);
             }
 
+            test('Recreate: delete fails → succeeds with base Python and shows a warning', async () => {
+                arrangeWorkspaceInstall();
+                hasVenvStub.resolves(true);
+                pickExistingVenvActionStub.resolves(venvUtils.ExistingVenvAction.Recreate);
+                deleteEnvironmentStub.resolves(false);
+
+                const result = await installPythonViaUv();
+
+                // Python was installed - the delete failure must not discard it
+                assert.strictEqual(result.success, true);
+                assert.strictEqual(result.pythonPath, '/usr/local/bin/python3.13');
+                assert.ok(!createUvVenvStub.called, 'should not attempt venv after failed delete');
+                verify(mockedVSCodeNamespaces.window!.showWarningMessage(anything())).once();
+            });
+
+            test('User cancels existing-venv prompt → succeeds with base Python', async () => {
+                arrangeWorkspaceInstall();
+                hasVenvStub.resolves(true);
+                pickExistingVenvActionStub.callsFake(async () => {
+                    throw MultiStepAction.Cancel;
+                });
+
+                const result = await installPythonViaUv();
+
+                assert.strictEqual(result.success, true);
+                assert.strictEqual(result.pythonPath, '/usr/local/bin/python3.13');
+                assert.ok(!deleteEnvironmentStub.called);
+                assert.ok(!createUvVenvStub.called);
+            });
+
+            test('User backs out of existing-venv prompt → succeeds with base Python', async () => {
+                arrangeWorkspaceInstall();
+                hasVenvStub.resolves(true);
+                pickExistingVenvActionStub.callsFake(async () => {
+                    throw MultiStepAction.Back;
+                });
+
+                const result = await installPythonViaUv();
+
+                assert.strictEqual(result.success, true);
+                assert.strictEqual(result.pythonPath, '/usr/local/bin/python3.13');
+                assert.ok(!deleteEnvironmentStub.called);
+                assert.ok(!createUvVenvStub.called);
+            });
+
+            test('Global use existing: returns existing ~/.venv Python without creating', async () => {
+                isUvInstalledStub.resolves(true);
+                getAvailablePythonVersionsStub.resolves([
+                    { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
+                ]);
+                quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
+                execStub.onFirstCall().resolves({ stdout: '' }); // uv python install
+                execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' }); // uv python find
+                getWorkspaceFoldersStub.returns(undefined);
+                hasVenvStub.resolves(true);
+                pickExistingVenvActionStub.resolves(venvUtils.ExistingVenvAction.UseExisting);
+                getVenvExecutableStub.returns(getExpectedGlobalVenvPython());
+
+                const result = await installPythonViaUv();
+
+                assert.strictEqual(result.success, true);
+                assert.strictEqual(result.pythonPath, getExpectedGlobalVenvPython());
+                assert.ok(!deleteEnvironmentStub.called);
+                // Only install + find — no venv creation exec call
+                assert.strictEqual(execStub.callCount, 2);
+            });
+
             test('Recreate: detects existing venv, prompts, then deletes before recreating', async () => {
                 arrangeWorkspaceInstall();
                 hasVenvStub.resolves(true);
@@ -632,6 +700,40 @@ suite('UV Python Installer Tests', () => {
                     'action prompt should run before delete',
                 );
             });
+        });
+
+        test('Returns error when uv python find returns empty string after install', async () => {
+            isUvInstalledStub.resolves(true);
+            getAvailablePythonVersionsStub.resolves([
+                { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
+            ]);
+            quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
+            execStub.onFirstCall().resolves({ stdout: '' }); // uv python install succeeds
+            execStub.onSecondCall().resolves({ stdout: '' }); // uv python find returns nothing
+
+            const result = await installPythonViaUv();
+
+            assert.strictEqual(result.success, false);
+            assert.ok(result.error?.includes('3.13'));
+        });
+
+        test('Dismissing "create venv?" quick pick falls back to base Python', async () => {
+            isUvInstalledStub.resolves(true);
+            getAvailablePythonVersionsStub.resolves([
+                { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
+            ]);
+            // User selects version, then dismisses the "create venv?" prompt (Escape)
+            quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }, undefined];
+            execStub.onFirstCall().resolves({ stdout: '' });
+            execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' });
+            const mockWorkspace = { uri: { fsPath: '/test/workspace' }, name: 'test', index: 0 };
+            getWorkspaceFoldersStub.returns([mockWorkspace]);
+
+            const result = await installPythonViaUv();
+
+            assert.strictEqual(result.success, true);
+            assert.strictEqual(result.pythonPath, '/usr/local/bin/python3.13');
+            assert.ok(!createUvVenvStub.called);
         });
 
         test('Handles unexpected errors gracefully', async () => {

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
@@ -13,6 +13,8 @@ import * as logging from '../../../../client/logging';
 import * as uv from '../../../../client/pythonEnvironments/common/environmentManagers/uv';
 import * as workspaceApis from '../../../../client/common/vscodeApis/workspaceApis';
 import * as uvCreationProvider from '../../../../client/pythonEnvironments/creation/provider/uvCreationProvider';
+import * as commonCreationUtils from '../../../../client/pythonEnvironments/creation/common/commonUtils';
+import * as venvUtils from '../../../../client/pythonEnvironments/creation/provider/venvUtils';
 import * as apiInternal from '../../../../client/envExt/api.internal';
 import { getAvailablePythonVersions } from '../../../../client/pythonEnvironments/common/environmentManagers/uv';
 import { installPythonViaUv } from '../../../../client/pythonEnvironments/common/environmentManagers/uvPythonInstaller';
@@ -285,6 +287,10 @@ suite('UV Python Installer Tests', () => {
         let getWorkspaceFoldersStub: sinon.SinonStub;
         let createUvVenvStub: sinon.SinonStub;
         let getAvailablePythonVersionsStub: sinon.SinonStub;
+        let hasVenvStub: sinon.SinonStub;
+        let pickExistingVenvActionStub: sinon.SinonStub;
+        let deleteEnvironmentStub: sinon.SinonStub;
+        let getVenvExecutableStub: sinon.SinonStub;
 
         const mockProgress = {
             report: sinon.stub(),
@@ -298,6 +304,12 @@ suite('UV Python Installer Tests', () => {
             isUvInstalledStub = sinon.stub(uv, 'isUvInstalled');
             getWorkspaceFoldersStub = sinon.stub(workspaceApis, 'getWorkspaceFolders');
             createUvVenvStub = sinon.stub(uvCreationProvider, 'createUvVenv');
+            // Stub the existing-venv handling helpers. Defaults: no existing venv,
+            // so tests fall through to the create path unless they opt in.
+            hasVenvStub = sinon.stub(commonCreationUtils, 'hasVenv').resolves(false);
+            getVenvExecutableStub = sinon.stub(commonCreationUtils, 'getVenvExecutable');
+            pickExistingVenvActionStub = sinon.stub(venvUtils, 'pickExistingVenvAction');
+            deleteEnvironmentStub = sinon.stub(venvUtils, 'deleteEnvironment').resolves(true);
             // Stub getAvailablePythonVersions from uv module
             getAvailablePythonVersionsStub = sinon.stub(uv, 'getAvailablePythonVersions');
             // Stub refreshEnvironments to avoid actual environment refresh
@@ -519,6 +531,107 @@ suite('UV Python Installer Tests', () => {
 
             assert.strictEqual(result.success, true);
             assert.strictEqual(result.pythonPath, '/usr/local/bin/python3.13');
+        });
+
+        suite('Existing venv handling', () => {
+            const mockWorkspace = { uri: { fsPath: '/test/workspace' }, name: 'test', index: 0 };
+
+            // Sets up a successful install where a workspace is open and the user
+            // accepts venv creation, leaving the existing-venv branch to decide.
+            function arrangeWorkspaceInstall(): void {
+                isUvInstalledStub.resolves(true);
+                getAvailablePythonVersionsStub.resolves([
+                    { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
+                ]);
+                // version select, then "yes" to create venv
+                quickPickResponses = [
+                    { version: '3.13', label: 'Python 3.13' },
+                    { id: 'yes', label: 'Yes' },
+                ];
+                execStub.onFirstCall().resolves({ stdout: '' }); // uv python install
+                execStub.onSecondCall().resolves({ stdout: '/usr/local/bin/python3.13' }); // uv python find
+                getWorkspaceFoldersStub.returns([mockWorkspace]);
+            }
+
+            test('Recreate: detects existing venv, prompts, then deletes before recreating', async () => {
+                arrangeWorkspaceInstall();
+                hasVenvStub.resolves(true);
+                pickExistingVenvActionStub.resolves(venvUtils.ExistingVenvAction.Recreate);
+                createUvVenvStub.resolves('/test/workspace/.venv/bin/python');
+
+                const result = await installPythonViaUv();
+
+                assert.strictEqual(result.success, true);
+                assert.strictEqual(result.pythonPath, '/test/workspace/.venv/bin/python');
+                // Intended sequence: detect existing -> prompt action -> delete -> recreate
+                assert.ok(hasVenvStub.calledOnce, 'hasVenv should be called once');
+                assert.ok(pickExistingVenvActionStub.calledOnce, 'pickExistingVenvAction should be called once');
+                assert.ok(deleteEnvironmentStub.calledOnce, 'deleteEnvironment should be called once');
+                assert.ok(createUvVenvStub.calledOnce, 'createUvVenv should be called once');
+                assert.ok(
+                    hasVenvStub.calledBefore(pickExistingVenvActionStub),
+                    'hasVenv should run before the action prompt',
+                );
+                assert.ok(
+                    pickExistingVenvActionStub.calledBefore(deleteEnvironmentStub),
+                    'action prompt should run before delete',
+                );
+                assert.ok(deleteEnvironmentStub.calledBefore(createUvVenvStub), 'delete should run before recreate');
+            });
+
+            test('Use Existing: keeps the existing venv without deleting or recreating', async () => {
+                arrangeWorkspaceInstall();
+                hasVenvStub.resolves(true);
+                pickExistingVenvActionStub.resolves(venvUtils.ExistingVenvAction.UseExisting);
+                getVenvExecutableStub.returns('/test/workspace/.venv/bin/python');
+
+                const result = await installPythonViaUv();
+
+                assert.strictEqual(result.success, true);
+                assert.strictEqual(result.pythonPath, '/test/workspace/.venv/bin/python');
+                assert.ok(getVenvExecutableStub.calledOnce, 'getVenvExecutable should resolve the existing env');
+                assert.ok(!deleteEnvironmentStub.called, 'deleteEnvironment should not be called');
+                assert.ok(!createUvVenvStub.called, 'createUvVenv should not be called');
+            });
+
+            test('No existing venv: creates directly without prompting', async () => {
+                arrangeWorkspaceInstall();
+                hasVenvStub.resolves(false);
+                createUvVenvStub.resolves('/test/workspace/.venv/bin/python');
+
+                const result = await installPythonViaUv();
+
+                assert.strictEqual(result.success, true);
+                assert.ok(!pickExistingVenvActionStub.called, 'should not prompt when no venv exists');
+                assert.ok(!deleteEnvironmentStub.called, 'should not delete when no venv exists');
+                assert.ok(createUvVenvStub.calledOnce, 'createUvVenv should be called once');
+            });
+
+            test('Global recreate: deletes existing ~/.venv before recreating', async () => {
+                isUvInstalledStub.resolves(true);
+                getAvailablePythonVersionsStub.resolves([
+                    { version: '3.13', isInstalled: false, identifier: 'cpython-3.13.1-macos-aarch64-none' },
+                ]);
+                quickPickResponses = [{ version: '3.13', label: 'Python 3.13' }];
+                execStub.onCall(0).resolves({ stdout: '' }); // uv python install
+                execStub.onCall(1).resolves({ stdout: '/usr/local/bin/python3.13' }); // uv python find
+                execStub.onCall(2).resolves({ stdout: '' }); // uv venv (global) recreate
+                // No workspace -> global ~/.venv path
+                getWorkspaceFoldersStub.returns(undefined);
+
+                hasVenvStub.resolves(true);
+                pickExistingVenvActionStub.resolves(venvUtils.ExistingVenvAction.Recreate);
+
+                const result = await installPythonViaUv();
+
+                assert.strictEqual(result.success, true);
+                assert.strictEqual(result.pythonPath, getExpectedGlobalVenvPython());
+                assert.ok(deleteEnvironmentStub.calledOnce, 'deleteEnvironment should be called once');
+                assert.ok(
+                    pickExistingVenvActionStub.calledBefore(deleteEnvironmentStub),
+                    'action prompt should run before delete',
+                );
+            });
         });
 
         test('Handles unexpected errors gracefully', async () => {


### PR DESCRIPTION
Fixes #13256

  ### Summary

Exposes a "Python: Install Python via uv" command in the Command Palette that runs the existing uv install + venv creation flow on demand. Previously this flow was only triggered at startup when no Python was detected.

This PR also adds handling for existing `.venv` directories during the uv install flow (uv fails if a `.venv` already exists, so users are now prompted to reuse or delete and recreate). The selected runtime is started in the Console immediately after installation when triggered via the command palette.

^ This behavior means this is a pretty valid way to create a new venv in a workspace using uv. I originally had hesitations of using this over the `Create Environment` command, but I think all roads are probably good to help users getting started with Python/venvs.

  ### Release Notes

  #### New Features
  - Added "Python: Install Python via uv" command to the Command Palette for on-demand uv-managed Python installation (#13256)

  #### Bug Fixes
  - N/A

  ### Validation Steps

  @:interpreter

  1. Open Positron with no Python environment 
  2. Open the Command Palette and run "Python: Install Python via uv"
  3. Verify the uv install + venv creation flow runs end to end
  4. Verify the new runtime starts in the Console on completion
  5. Run the command again when a `.venv` already exists and verify you are prompted to reuse or delete and recreate

