### PR TITLE
Fix Variables pane rendering as empty on move

### DIFF
--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariables.contribution.ts
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariables.contribution.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -17,7 +17,8 @@ import { PositronVariablesRefreshAction } from './positronVariablesActions.js';
 import { IPositronVariablesService } from '../../../services/positronVariables/common/interfaces/positronVariablesService.js';
 import { ICommandAndKeybindingRule, KeybindingWeight, KeybindingsRegistry } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from '../../../common/contributions.js';
-import { Extensions as ViewContainerExtensions, IViewDescriptorService, IViewsRegistry } from '../../../common/views.js';
+import { Extensions as ViewContainerExtensions, IViewsRegistry } from '../../../common/views.js';
+import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { POSITRON_VARIABLES_COLLAPSE, POSITRON_VARIABLES_COPY_AS_HTML, POSITRON_VARIABLES_COPY_AS_TEXT, POSITRON_VARIABLES_EXPAND } from './positronVariablesIdentifiers.js';
 import { POSITRON_SESSION_CONTAINER, positronSessionViewIcon } from '../../positronSession/browser/positronSessionContainer.js';
 
@@ -69,7 +70,7 @@ class PositronVariablesContribution extends Disposable implements IWorkbenchCont
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IPositronVariablesService private readonly _positronVariablesService: IPositronVariablesService,
-		@IViewDescriptorService private readonly _viewDescriptorService: IViewDescriptorService,
+		@IViewsService private readonly _viewsService: IViewsService,
 	) {
 		super();
 		this.registerActions();
@@ -86,34 +87,19 @@ class PositronVariablesContribution extends Disposable implements IWorkbenchCont
 	/**
 	 * Registers the view visibility handler to notify the variables service
 	 * when the Variables pane is explicitly hidden or shown via the "Hide View"
-	 * action.
-	 *
-	 * This doesn't fire when simply switching to another view in the same panel.
+	 * action, or when the view is dragged into a different view container.
 	 */
 	private _registerViewVisibilityHandler(): void {
-		// Get the view container for the Variables view
-		const viewContainer = this._viewDescriptorService.getViewContainerByViewId(POSITRON_VARIABLES_VIEW_ID);
-		if (!viewContainer) {
-			return;
-		}
+		// Set initial visibility state.
+		this._positronVariablesService.setViewVisible(
+			this._viewsService.isViewVisible(POSITRON_VARIABLES_VIEW_ID)
+		);
 
-		const viewContainerModel = this._viewDescriptorService.getViewContainerModel(viewContainer);
-
-		// Set initial visibility state based on whether the view is in the visible descriptors
-		const isVisible = viewContainerModel.isVisible(POSITRON_VARIABLES_VIEW_ID);
-		this._positronVariablesService.setViewVisible(isVisible);
-
-		// Listen for when the view is explicitly shown (via "Show View" or similar)
-		this._register(viewContainerModel.onDidAddVisibleViewDescriptors(added => {
-			if (added.some(ref => ref.viewDescriptor.id === POSITRON_VARIABLES_VIEW_ID)) {
-				this._positronVariablesService.setViewVisible(true);
-			}
-		}));
-
-		// Listen for when the view is explicitly hidden (via "Hide View" context menu)
-		this._register(viewContainerModel.onDidRemoveVisibleViewDescriptors(removed => {
-			if (removed.some(ref => ref.viewDescriptor.id === POSITRON_VARIABLES_VIEW_ID)) {
-				this._positronVariablesService.setViewVisible(false);
+		// Listen for visibility changes on the Variables view regardless of
+		// which container currently hosts it.
+		this._register(this._viewsService.onDidChangeViewVisibility(e => {
+			if (e.id === POSITRON_VARIABLES_VIEW_ID) {
+				this._positronVariablesService.setViewVisible(e.visible);
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariables.contribution.ts
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariables.contribution.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from '../../../../nls.js';
-import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
 import { KeyMod, KeyCode, KeyChord } from '../../../../base/common/keyCodes.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
@@ -96,9 +96,19 @@ class PositronVariablesContribution extends Disposable implements IWorkbenchCont
 		// Used to consolidate multiple rapid visibility changes into a single update.
 		let visibilityUpdateScheduled = false;
 
+		// Tracks whether this contribution is still active (not disposed).
+		// Used to stop a scheduled visibility update from running once the
+		// variables service has been disposed.
+		let active = true;
+		this._register(toDisposable(() => { active = false; }));
+
 		// Recomputes the visibility of the variables view and notifies the variables service.
 		const updateVariablesViewVisibility = () => {
 			visibilityUpdateScheduled = false;
+			// If the contribution has been disposed, do not attempt to update the service.
+			if (!active) {
+				return;
+			}
 			// Find the container the variables view is currently in (if any)
 			const container = this._viewDescriptorService.getViewContainerByViewId(POSITRON_VARIABLES_VIEW_ID);
 			// The variables view is visible if it is in a container and that container considers it visible.

--- a/src/vs/workbench/contrib/positronVariables/browser/positronVariables.contribution.ts
+++ b/src/vs/workbench/contrib/positronVariables/browser/positronVariables.contribution.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from '../../../../nls.js';
-import { Disposable } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { KeyMod, KeyCode, KeyChord } from '../../../../base/common/keyCodes.js';
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { registerAction2 } from '../../../../platform/actions/common/actions.js';
@@ -17,8 +17,7 @@ import { PositronVariablesRefreshAction } from './positronVariablesActions.js';
 import { IPositronVariablesService } from '../../../services/positronVariables/common/interfaces/positronVariablesService.js';
 import { ICommandAndKeybindingRule, KeybindingWeight, KeybindingsRegistry } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from '../../../common/contributions.js';
-import { Extensions as ViewContainerExtensions, IViewsRegistry } from '../../../common/views.js';
-import { IViewsService } from '../../../services/views/common/viewsService.js';
+import { Extensions as ViewContainerExtensions, IViewDescriptorService, IViewsRegistry, ViewContainer } from '../../../common/views.js';
 import { POSITRON_VARIABLES_COLLAPSE, POSITRON_VARIABLES_COPY_AS_HTML, POSITRON_VARIABLES_COPY_AS_TEXT, POSITRON_VARIABLES_EXPAND } from './positronVariablesIdentifiers.js';
 import { POSITRON_SESSION_CONTAINER, positronSessionViewIcon } from '../../positronSession/browser/positronSessionContainer.js';
 
@@ -70,7 +69,7 @@ class PositronVariablesContribution extends Disposable implements IWorkbenchCont
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IPositronVariablesService private readonly _positronVariablesService: IPositronVariablesService,
-		@IViewsService private readonly _viewsService: IViewsService,
+		@IViewDescriptorService private readonly _viewDescriptorService: IViewDescriptorService,
 	) {
 		super();
 		this.registerActions();
@@ -86,20 +85,93 @@ class PositronVariablesContribution extends Disposable implements IWorkbenchCont
 
 	/**
 	 * Registers the view visibility handler to notify the variables service
-	 * when the Variables pane is explicitly hidden or shown via the "Hide View"
+	 * when the Variables pane is explicitly hidden/shown via the "Hide View"
 	 * action, or when the view is dragged into a different view container.
 	 */
 	private _registerViewVisibilityHandler(): void {
-		// Set initial visibility state.
-		this._positronVariablesService.setViewVisible(
-			this._viewsService.isViewVisible(POSITRON_VARIABLES_VIEW_ID)
-		);
+		// This mutable disposable tracks the listeners for the current container,
+		// so we can dispose them when the container changes.
+		const containerSubscriptions = this._register(new MutableDisposable<DisposableStore>());
+		// Tracks whether a visibility update is already scheduled.
+		// Used to consolidate multiple rapid visibility changes into a single update.
+		let visibilityUpdateScheduled = false;
 
-		// Listen for visibility changes on the Variables view regardless of
-		// which container currently hosts it.
-		this._register(this._viewsService.onDidChangeViewVisibility(e => {
-			if (e.id === POSITRON_VARIABLES_VIEW_ID) {
-				this._positronVariablesService.setViewVisible(e.visible);
+		// Recomputes the visibility of the variables view and notifies the variables service.
+		const updateVariablesViewVisibility = () => {
+			visibilityUpdateScheduled = false;
+			// Find the container the variables view is currently in (if any)
+			const container = this._viewDescriptorService.getViewContainerByViewId(POSITRON_VARIABLES_VIEW_ID);
+			// The variables view is visible if it is in a container and that container considers it visible.
+			const visible = !!container && this._viewDescriptorService.getViewContainerModel(container).isVisible(POSITRON_VARIABLES_VIEW_ID);
+			// Notify the variables service of the current visibility.
+			this._positronVariablesService.setViewVisible(visible);
+		};
+
+		// Schedules a check to see if the variables view is visible.
+		const scheduleVisibilityUpdate = () => {
+			if (visibilityUpdateScheduled) {
+				return;
+			}
+			visibilityUpdateScheduled = true;
+
+			/**
+			 * When the variables view is dragged into a new container,
+			 * the source container fires onDidRemoveVisibleViewDescriptors and the
+			 * destination container fires onDidAddVisibleViewDescriptors back to back.
+			 *
+			 * If we set the variables view visibility to false on the remove event immediately,
+			 * the instance and its comm will be torn down before the add event has a chance to
+			 * fire which causes unnecessary teardown and setup of the variables instance.
+			 *
+			 * By deferring the update to the next microtask, we allow both events to be processed
+			 * before we check the visibility, so we only tear down the variables instance when
+			 * the view is actually hidden, not when it is moved between containers.
+			 */
+			queueMicrotask(updateVariablesViewVisibility);
+		};
+
+		// Attaches listeners to a container to track the visibility of the variables view within it.
+		const attachToContainer = (container: ViewContainer) => {
+			const model = this._viewDescriptorService.getViewContainerModel(container);
+			const store = new DisposableStore();
+
+			// Listen to the view being added to the container (e.g. via "Show View" or drag).
+			store.add(model.onDidAddVisibleViewDescriptors(added => {
+				if (added.some(ref => ref.viewDescriptor.id === POSITRON_VARIABLES_VIEW_ID)) {
+					// The view was added to this container. Check if it is visible, and notify the service.
+					scheduleVisibilityUpdate();
+				}
+			}));
+
+			// Listen to the view being removed from the container (e.g. via "Hide View" or drag).
+			store.add(model.onDidRemoveVisibleViewDescriptors(removed => {
+				if (removed.some(ref => ref.viewDescriptor.id === POSITRON_VARIABLES_VIEW_ID)) {
+					// The view was removed from this container. Check if it is still visible in another container, and notify the service.
+					scheduleVisibilityUpdate();
+				}
+			}));
+
+			// Track the current subscriptions so we can dispose them when the view moves to a different container.
+			containerSubscriptions.value = store;
+
+			// Schedule an initial check of the view's visibility in this container,
+			// in case it changed before listeners were registered.
+			scheduleVisibilityUpdate();
+		};
+
+		// Get the view container for the Variables view
+		const viewContainer = this._viewDescriptorService.getViewContainerByViewId(POSITRON_VARIABLES_VIEW_ID);
+		if (!viewContainer) {
+			return;
+		}
+
+		// Bind listeners that checks the visibility of the variables view to the initial container.
+		attachToContainer(viewContainer);
+
+		// Make sure we re-bind these listeners whenever the variables view parent container changes.
+		this._register(this._viewDescriptorService.onDidChangeContainer(e => {
+			if (e.views.some(v => v.id === POSITRON_VARIABLES_VIEW_ID)) {
+				attachToContainer(e.to);
 			}
 		}));
 	}

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -35,13 +35,13 @@ An [example test](https://github.com/posit-dev/positron/blob/main/test/e2e/tests
 
 ### Environment Variables
 
-In order to run the tests you'll need to have four environment variables set. These are so Positron knows what R and Python versions to load. There is an example env file available, just copy this into root of repo `.env.e2e`:
+In order to run the tests you'll need to have four environment variables set. These are so Positron knows what R and Python versions to load. Copy `.env.e2e.example` to `.env.e2e` in the root of the repo and update the values:
 
 ```bash
-export POSITRON_PY_VER_SEL="3.11.5"
-export POSITRON_R_VER_SEL="4.2.1"
-export POSITRON_PY_ALT_VER_SEL='3.13.0 (Pyenv)'
-export POSITRON_R_ALT_VER_SEL='4.4.2'
+POSITRON_PY_VER_SEL=3.11.5
+POSITRON_R_VER_SEL=4.2.1
+POSITRON_PY_ALT_VER_SEL=3.13.0 (Pyenv)
+POSITRON_R_ALT_VER_SEL=4.4.2
 ```
 
 Make sure you have the selected R and Python version installed that you are using for the environment variables.


### PR DESCRIPTION
Fixes #12124

The variables service ties variable instance/comm lifecycles to view visibility instead of tying it to the lifecycle of a runtime session as is done in other panes! The variables service disposes of all variable instances/comms when the Variables view is hidden via `setViewVisible()`. The instances then get recreated when the Variables pane is shown. 

The problem is that the visibility handler logic binds its add/remove listeners (`onDidAddVisibleViewDescriptors`/`onDidRemoveVisibleViewDescriptors`) to whichever container held the view at startup ("Session" view) and never re-bound them if the view moved to a different container.

The fix involved (1) re-binding the visibility listeners whenever the view changes containers and (2) only calling `setViewVisible(false)` when the "Hide 'Variables'" command is fired. 

Note: For (2) when a user moves the variables view a pair of `onDidAddVisibleViewDescriptors`/`onDidRemoveVisibleViewDescriptors` get fired but for "Hide 'Variables'" only `onDidRemoveVisibleViewDescriptors` gets fired. To avoid unnecessarily teardown and setup of the instances and comms when we move the variables view we need to defer updating the visibility to a microtask so both events get batched before we respond to them. I didn't find another obvious way to 

### Screenshots


https://github.com/user-attachments/assets/a7bb8181-4866-4c10-8d11-5cec16e408bb


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix Variables pane rendering as empty after being dragged into a different view container (#12124)


### Validation Steps

### Validation Steps

@:variables

SETUP: enable `interpreters.showSessions` (`Runtimes` pane) so you can watch comm open/close events for each transition below. Move this to the primary side bar so you can view the comms lifecycle while also viewing the variables pane.


1. Start an R or Python session and define a variable (e.g., `x <- 1`). Confirm a variables comm is open in the `Runtimes` pane and the variable `x` shows in the Variables pane.
2. Choose **Stacked Layout**. Drag the Variables pane to sit between `Session` and `Connections` so it becomes its own composite view in the auxiliary bar. Verify:
   - The variables pane renders in the new location
   - In the Runtime view `interpreters.showSessions` the variables comm has NOT been closed/re-opened.
3. Drag Variables back into the Session container. Verify things render and the variables comm has NOT been closed/re-opened. 
4. Use the "Hide View" context menu on Variables, then re-show it. Verify the variables comm closes on hide and reopens on show.
5. Click the Variables pane header to collapse it, then expand. Verify the variables comm has NOT been closed/re-opened. 
6. Toggle the secondary side panel closed, then open. Verify the comm has NOT been closed/re-opened.


<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
