### PR TITLE
chore: bump @midleman/playwright-reporter to ^0.48.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
   },
   "devDependencies": {
     "@midleman/github-actions-reporter": "^1.10.1",
-    "@midleman/playwright-reporter": "^0.47.16",
+    "@midleman/playwright-reporter": "^0.48.0",
     "@playwright/cli": "^0.1.1",
     "@playwright/test": "^1.58.2",
     "@stylistic/eslint-plugin-ts": "^2.8.0",


### PR DESCRIPTION
Bumps `@midleman/playwright-reporter` to `^0.48.0`.

### Why
`0.48.0` fixes a sharding bug where e2e shards ran **overlapping** specs while **skipping** others. The reporter's `run-shard` spec discovery was listing only each shard's *native* `--shard` subset instead of the full suite, so each shard sent a different spec set to the predictive-sharding API and got a different partition. `0.48.0` forces full-suite discovery (`--shard=1/1` on the `--list` call) and also records `shardTotal`. Full root-cause writeup: posit-dev/e2e-test-insights#130.

### ⚠️ Lockfile (draft)
This updates `package.json` only — **`package-lock.json` still needs `npm install`** to resolve `0.48.0` (couldn't be included from outside a local checkout; it's ~1 MB). Marking draft until the lock is refreshed.

### Note
`.github/actions/setup-e2e-test-dependencies/action.yml` already runs `npm install @midleman/playwright-reporter@latest`, so e2e CI is *already* pulling `0.48.0` — this just makes the declared dependency range match reality.