### PR TITLE
e2e: bump monaco-workbench readiness timeout to 60s (Windows CI unblock)

### DIFF
--- a/test/e2e/infra/application.ts
+++ b/test/e2e/infra/application.ts
@@ -233,7 +233,7 @@ export class Application {
 	 */
 	private async checkPositronReady(code: Code): Promise<void> {
 		await measureAndLog(
-			() => expect(code.driver.currentPage.locator(READINESS_LOCATORS.monacoWorkbench)).toBeVisible({ timeout: 30000 }),
+			() => expect(code.driver.currentPage.locator(READINESS_LOCATORS.monacoWorkbench)).toBeVisible({ timeout: LOAD_TIMEOUT }),
 			'Application#checkPositronReady: wait for monaco workbench',
 			this.logger
 		);
@@ -272,7 +272,7 @@ export class Application {
 	 */
 	private async checkPositronServerReady(code: Code): Promise<void> {
 		await measureAndLog(
-			() => expect(code.driver.currentPage.locator(READINESS_LOCATORS.monacoWorkbench)).toBeVisible({ timeout: 30000 }),
+			() => expect(code.driver.currentPage.locator(READINESS_LOCATORS.monacoWorkbench)).toBeVisible({ timeout: LOAD_TIMEOUT }),
 			'Application#checkPositronServerReady: wait for monaco workbench',
 			this.logger
 		);


### PR DESCRIPTION
Bumps the two `.monaco-workbench` e2e readiness checks in `Application#checkPositronReady` / `checkPositronServerReady` from a hardcoded `30000` to `LOAD_TIMEOUT` (60s), matching the explorer-view checks that immediately follow them.

### Background

The Windows e2e merge job has been continuously red since the Code OSS 1.118.0 merge. Every failure is the same app-setup assertion timing out during initial app launch:

```
expect(locator('.monaco-workbench')).toBeVisible()  Timeout: 30000ms
Error: element(s) not found
```

Log analysis shows the workbench is actually ready quickly -- `renderer.log` records lifecycle phase 3 (`Restored`) at ~19s -- but Playwright's CDP console channel stalls for ~30s under the heavier 1.118.0 + Electron 39.8 startup on the `windows-2025` runner. All ~917 renderer console events (85% trace-level) arrive in a single burst at ~48s, and during that window the `toBeVisible` poll cannot observe the DOM, so the 30s deadline fires. The workbench is observable by ~51s, within the 90s app-fixture budget.

This bump is the immediate unblock. A follow-up will cap the smoke-driver console echo to eliminate the CDP flood at its source (keeping full-trace on-disk logs).

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:win @:console

This is a CI-infra change with no user-facing behavior. Validation is the PR's own Windows e2e check: the `@:win` / `@:console` runs should pass the app-setup readiness phase that was previously timing out at 30s.