### PR TITLE
Make macOS console Ctrl+N / Ctrl+P history navigation user-overridable keybindings

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -582,34 +582,6 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				break;
 			}
 
-			case KeyCode.KeyP: {
-				// Bind Ctrl+P to navigate history up ("Previous"). This is a GNU
-				// readline keybinding.
-				//
-				// <C-N> and <C-P> are only bound on macOS. This is because on
-				// Windows and Linux, <C-P> is the binding for opening the
-				// Command Palette.
-				if (isMacintosh) {
-					if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && !e.altGraphKey) {
-						consumeEvent();
-						navigateHistoryUp(e);
-					}
-				}
-				break;
-			}
-
-			case KeyCode.KeyN: {
-				// Bind Ctrl+N to navigate history down ("Next"). This is a GNU
-				// readline keybinding.
-				if (isMacintosh) {
-					if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && !e.altGraphKey) {
-						consumeEvent();
-						navigateHistoryDown(e);
-					}
-				}
-				break;
-			}
-
 			// Tab processing.
 			case KeyCode.Tab: {
 				// If the history browser is active, accept the selected history entry and

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -441,7 +441,7 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				updateCodeEditorWidgetPosition(Position.Last, Position.Last);
 			}
 		}
-	}
+	};
 
 	// Key down event handler.
 	const keyDownHandler = async (e: IKeyboardEvent) => {

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -740,7 +740,7 @@ export function registerPositronConsoleActions() {
 									logService.warn(
 										nextStatementRange.line ?
 											`Can't compute advancement due to a syntax error on line ${nextStatementRange.line + 1}.` :
-											"Can't compute advancement due to a syntax error."
+											`Can't compute advancement due to a syntax error.`
 									);
 									break;
 								}

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -1263,8 +1263,10 @@ export function registerPositronConsoleActions() {
 				keybinding: {
 					primary: KeyCode.DownArrow,
 					// Ctrl+N ("Next") is a GNU readline keybinding bound only on
-					// macOS. On Windows/Linux raw Ctrl+N opens a new window.
-					mac: { primary: KeyMod.WinCtrl | KeyCode.KeyN },
+					// macOS. On Windows/Linux raw Ctrl+N opens a new window. The
+					// mac override repeats the DownArrow primary so the arrow key
+					// stays bound on macOS.
+					mac: { primary: KeyCode.DownArrow, secondary: [KeyMod.WinCtrl | KeyCode.KeyN] },
 					when: ContextKeyExpr.and(
 						PositronConsoleFocused,
 						SuggestContext.Visible.toNegated(),
@@ -1314,8 +1316,10 @@ export function registerPositronConsoleActions() {
 				keybinding: {
 					primary: KeyCode.UpArrow,
 					// Ctrl+P ("Previous") is a GNU readline keybinding bound only on
-					// macOS. On Windows/Linux raw Ctrl+P opens the Command Palette.
-					mac: { primary: KeyMod.WinCtrl | KeyCode.KeyP },
+					// macOS. On Windows/Linux raw Ctrl+P opens the Command Palette. The
+					// mac override repeats the UpArrow primary so the arrow key stays
+					// bound on macOS.
+					mac: { primary: KeyCode.UpArrow, secondary: [KeyMod.WinCtrl | KeyCode.KeyP] },
 					when: ContextKeyExpr.and(
 						PositronConsoleFocused,
 						SuggestContext.Visible.toNegated(),

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -1262,6 +1262,9 @@ export function registerPositronConsoleActions() {
 				category,
 				keybinding: {
 					primary: KeyCode.DownArrow,
+					// Ctrl+N ("Next") is a GNU readline keybinding bound only on
+					// macOS. On Windows/Linux raw Ctrl+N opens a new window.
+					mac: { primary: KeyMod.WinCtrl | KeyCode.KeyN },
 					when: ContextKeyExpr.and(
 						PositronConsoleFocused,
 						SuggestContext.Visible.toNegated(),
@@ -1310,6 +1313,9 @@ export function registerPositronConsoleActions() {
 				category,
 				keybinding: {
 					primary: KeyCode.UpArrow,
+					// Ctrl+P ("Previous") is a GNU readline keybinding bound only on
+					// macOS. On Windows/Linux raw Ctrl+P opens the Command Palette.
+					mac: { primary: KeyMod.WinCtrl | KeyCode.KeyP },
 					when: ContextKeyExpr.and(
 						PositronConsoleFocused,
 						SuggestContext.Visible.toNegated(),

--- a/src/vs/workbench/contrib/positronConsole/test/browser/consoleHistoryKeybindings.vitest.ts
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/consoleHistoryKeybindings.vitest.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { OperatingSystem } from '../../../../../base/common/platform.js';
+import { KeybindingsRegistry } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { USLayoutResolvedKeybinding } from '../../../../../platform/keybinding/common/usLayoutResolvedKeybinding.js';
+import { registerPositronConsoleActions } from '../../browser/positronConsoleActions.js';
+
+// Register the console actions once so their default keybindings land in the
+// KeybindingsRegistry. registerAction2 only records metadata, so this needs no
+// workbench services. Mirrors the upstream chatQueueActions keybinding test.
+registerPositronConsoleActions();
+
+// The three input-history navigation actions that carry default keybindings.
+const NAV_COMMAND_IDS = [
+	'workbench.action.positronConsole.navigateInputHistoryDown',
+	'workbench.action.positronConsole.navigateInputHistoryUp',
+	'workbench.action.positronConsole.navigateInputHistoryUpUsingPrefixMatch',
+];
+
+/**
+ * Resolve, for a given OS, the set of dispatch chords bound to each history-nav
+ * command. `getDefaultKeybindingsForOS` re-applies the mac/linux/win platform
+ * overrides from the raw rules, so this works regardless of the host the test
+ * runs on. Returns a `{ commandId: sortedDispatchChords }` map.
+ */
+function navBindingsForOS(os: OperatingSystem): Record<string, string[]> {
+	const result: Record<string, string[]> = {};
+	for (const item of KeybindingsRegistry.getDefaultKeybindingsForOS(os)) {
+		if (!item.command || !NAV_COMMAND_IDS.includes(item.command) || !item.keybinding) {
+			continue;
+		}
+		const resolved = USLayoutResolvedKeybinding.resolveKeybinding(item.keybinding, os)[0];
+		const dispatch = resolved.getDispatchChords().join(' ');
+		(result[item.command] ??= []).push(dispatch);
+	}
+	for (const command of Object.keys(result)) {
+		result[command].sort();
+	}
+	return result;
+}
+
+describe('Console input-history navigation keybindings', () => {
+	// On macOS the arrow keys MUST stay bound alongside the readline Ctrl+N /
+	// Ctrl+P bindings. This snapshot is the regression guard for that:
+	// Ctrl+N / Ctrl+P appear in addition to, never instead of, Up/Down.
+	it('binds Up/Down on macOS alongside the readline Ctrl+N / Ctrl+P bindings', () => {
+		expect(navBindingsForOS(OperatingSystem.Macintosh)).toMatchInlineSnapshot(`
+			{
+			  "workbench.action.positronConsole.navigateInputHistoryDown": [
+			    "DownArrow",
+			    "ctrl+N",
+			  ],
+			  "workbench.action.positronConsole.navigateInputHistoryUp": [
+			    "UpArrow",
+			    "ctrl+P",
+			  ],
+			  "workbench.action.positronConsole.navigateInputHistoryUpUsingPrefixMatch": [
+			    "meta+UpArrow",
+			  ],
+			}
+		`);
+	});
+
+	// On Windows/Linux the readline bindings must NOT apply: raw Ctrl+N opens a
+	// new window and Ctrl+P opens the Command Palette. Only the arrows (and
+	// Ctrl+Up for prefix match) are bound here.
+	it('binds only the arrows on Linux/Windows, never Ctrl+N / Ctrl+P', () => {
+		expect(navBindingsForOS(OperatingSystem.Linux)).toMatchInlineSnapshot(`
+			{
+			  "workbench.action.positronConsole.navigateInputHistoryDown": [
+			    "DownArrow",
+			  ],
+			  "workbench.action.positronConsole.navigateInputHistoryUp": [
+			    "UpArrow",
+			  ],
+			  "workbench.action.positronConsole.navigateInputHistoryUpUsingPrefixMatch": [
+			    "ctrl+UpArrow",
+			  ],
+			}
+		`);
+		expect(navBindingsForOS(OperatingSystem.Windows)).toMatchInlineSnapshot(`
+			{
+			  "workbench.action.positronConsole.navigateInputHistoryDown": [
+			    "DownArrow",
+			  ],
+			  "workbench.action.positronConsole.navigateInputHistoryUp": [
+			    "UpArrow",
+			  ],
+			  "workbench.action.positronConsole.navigateInputHistoryUpUsingPrefixMatch": [
+			    "ctrl+UpArrow",
+			  ],
+			}
+		`);
+	});
+});


### PR DESCRIPTION
- Fixes #9500
- Related to https://github.com/posit-dev/positron/pull/13836 and https://github.com/posit-dev/positron/issues/7380

On macOS, the console swallowed <kbd>Ctrl+N</kbd> / <kbd>Ctrl+P</kbd> in a hardcoded `keyDownHandler` switch in `consoleInput.tsx`, so a user-defined keybinding for those keys (e.g. trying to use <kbd>Ctrl+N</kbd> to do `type` for `%in%` or anything like that) could never win; the React handler consumed the event before the keybinding service saw it. This migrates the two readline-style history navigation bindings onto the existing `NavigateInputHistoryDown` / `NavigateInputHistoryUp` actions as `mac` overrides (<kbd>Ctrl+N</kbd> / <kbd>Ctrl+P</kbd>), and deletes the switch cases. User overrides now win through normal weight resolution, and the bindings appear in the Keyboard Shortcuts UI.

This is macOS-only behavior. On Windows/Linux these keys were never bound GNU readline conventions or intercepted by the console (<kbd>Ctrl+P</kbd> is the Command Palette, <kbd>Ctrl+N</kbd>  opens a new window), so there is no change on those platforms.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Allow user keybindings for <kbd>Ctrl+N</kbd> / <kbd>Ctrl+P</kbd> to take effect in the console on macOS (#9500)

### Validation Steps

@:console @:win

On macOS, in an R console:

1. Add this to `keybindings.json` (args can be anything):
   ```json
   {
     "key": "ctrl+n",
     "command": "type",
     "args": { "text": "%in%" },
     "when": "editorLangId == r"
   }
   ```
2. Place the cursor in the console and press <kbd>Ctrl+N</kbd>; it inserts `%in%` (does NOT navigate history).
3. Remove the override. Press <kbd>Ctrl+N</kbd> / <kbd>Ctrl+P</kbd>. History navigation works as before.
4. Confirm the migrated actions appear in the Keyboard Shortcuts UI with their <kbd>Ctrl+N</kbd> / <kbd>Ctrl+P</kbd> bindings:

<img width="955" height="386" alt="Screenshot_2026-05-29_at_6_22_49 PM" src="https://github.com/user-attachments/assets/48201881-ffaa-4b7e-a4bd-34f62c6d6e26" />

On Windows/Linux: confirm <kbd>Ctrl+N</kbd> still opens a new window and <kbd>Ctrl+P</kbd> still opens the Command Palette (no change).
