### PR TITLE
Cap notebook cell editor height to viewport for drag-select support

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -288,7 +288,10 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 			if (container && height > container.clientHeight) {
 				const containerRect = container.getBoundingClientRect();
 				const editorTop = editorPartRef.current.getBoundingClientRect().top;
-				maxHeight = containerRect.bottom - Math.max(editorTop, containerRect.top);
+				const available = containerRect.bottom - Math.max(editorTop, containerRect.top);
+				if (available > 0) {
+					maxHeight = available;
+				}
 			}
 			editor.layout({
 				height: Math.min(height, maxHeight),

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -277,14 +277,21 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 		}));
 
 		/**
-		 * Resize the editor widget to fill the width of its container and the height of its
-		 * content.
-		 * @param height Height to set. Defaults to checking content height.
+		 * Resize the editor to its content height, capped to the available viewport
+		 * space so tall cells are internally scrollable (enables Monaco's native
+		 * drag-to-scroll selection).
 		 */
 		function resizeEditor(height: number = editor.getContentHeight()) {
 			if (!editorPartRef.current) { return; }
+			const container = instance.cellsContainer;
+			let maxHeight = Infinity;
+			if (container && height > container.clientHeight) {
+				const containerRect = container.getBoundingClientRect();
+				const editorTop = editorPartRef.current.getBoundingClientRect().top;
+				maxHeight = containerRect.bottom - Math.max(editorTop, containerRect.top);
+			}
 			editor.layout({
-				height,
+				height: Math.min(height, maxHeight),
 				width: editorPartRef.current.offsetWidth,
 			});
 		}

--- a/test/e2e/tests/notebooks-positron/notebook-drag-select-scroll.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-drag-select-scroll.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/test/e2e/tests/notebooks-positron/notebook-drag-select-scroll.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-drag-select-scroll.test.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+import { expect } from '@playwright/test';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Notebook Drag Select Past Viewport', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+}, () => {
+
+	test.beforeAll(async function ({ hotKeys }) {
+		await hotKeys.minimizeBottomPanel();
+	});
+
+	test('Tall cell editor is capped to viewport height and scrollable (#13240)', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const page = app.code.driver.currentPage;
+
+		// Create a notebook with a tall code cell (55 lines exceeds any viewport)
+		const lines = Array.from({ length: 55 }, (_, i) => `line_${i} = ${i}`).join('\n');
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.addCodeToCell(0, lines, { fast: true });
+
+		// The editor should be capped to the viewport height (not full content height)
+		const cellsContainer = notebooksPositron.cellsContainer;
+		const editorWidget = notebooksPositron.cell.nth(0).locator('.positron-cell-editor-monaco-widget');
+
+		await expect(async () => {
+			const containerHeight = await cellsContainer.evaluate(el => el.clientHeight);
+			const editorHeight = await editorWidget.evaluate(el => el.getBoundingClientRect().height);
+
+			// Editor must be shorter than or equal to container (it's capped)
+			expect(editorHeight).toBeLessThanOrEqual(containerHeight);
+			// Editor must be significantly smaller than its content (55 lines * ~18px = ~990px)
+			expect(editorHeight).toBeLessThan(900);
+		}).toPass({ timeout: 5000 });
+
+		// The editor should have a visible scrollbar (proving it's internally scrollable)
+		const scrollbar = editorWidget.locator('> .monaco-editor .scrollbar.vertical > .slider').first();
+		await expect(scrollbar).toBeVisible();
+
+		// The scrollbar slider should be smaller than the track (indicating scrollable content)
+		const sliderHeight = await scrollbar.evaluate(el => parseFloat(el.style.height));
+		const trackHeight = await editorWidget.locator('> .monaco-editor .scrollbar.vertical').first().evaluate(
+			el => el.getBoundingClientRect().height
+		);
+		expect(sliderHeight).toBeLessThan(trackHeight);
+	});
+
+	test('Short cells are not capped and show all content without scrollbar', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Create a notebook with a short cell (3 lines)
+		const lines = 'a = 1\nb = 2\nc = 3';
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.addCodeToCell(0, lines, { fast: true });
+
+		// The editor should show all content without an internal scrollbar
+		const editorWidget = notebooksPositron.cell.nth(0).locator('.positron-cell-editor-monaco-widget');
+		const scrollbar = editorWidget.locator('> .monaco-editor .scrollbar.vertical.visible');
+		await expect(scrollbar).toHaveCount(0);
+	});
+});

--- a/test/e2e/tests/notebooks-positron/notebook-drag-select-scroll.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-drag-select-scroll.test.ts
@@ -21,7 +21,6 @@ test.describe('Notebook Drag Select Past Viewport', {
 
 	test('Tall cell editor is capped to viewport height and scrollable (#13240)', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
-		const page = app.code.driver.currentPage;
 
 		// Create a notebook with a tall code cell (55 lines exceeds any viewport)
 		const lines = Array.from({ length: 55 }, (_, i) => `line_${i} = ${i}`).join('\n');


### PR DESCRIPTION
## Summary

Fixes #13240 and #13251. 
- Drag-selecting text in a tall Positron notebook cell should scroll past the viewport boundary. 
- Functionality should be tested via automated test, without relying on scrolling, which could lead to a likely flaky test of low value. 

**The fix:** Cap the Monaco editor height to the available viewport space when cell content exceeds it. This gives the editor an internal scrollbar, enabling Monaco's built-in `TopBottomDragScrolling` which already handles edge detection, scroll acceleration, and selection extension during drag.

## Approach

The fix is a one-function change to `resizeEditor()` in `CellEditorMonacoWidget.tsx`: 

- If the editor's content height exceeds the cells container viewport, cap it to the available space between the editor's top position and the container's bottom edge.
- Short cells are unaffected: they still render at full content height with no scrollbar (negative test 2 confirms that). 

### Comparison with VS Code notebooks

VS Code's native notebook takes the same core principle (cap editor height to viewport) but implements it via `CodeCellLayout.layoutEditor()`, which is a ~200-line layout engine that dynamically adjusts the editor's height, top offset, and internal scroll position on every notebook scroll event. This creates the illusion of full-height cells while keeping editors viewport-constrained. 

#### Important remark on what Claude initially suggested

The VS Code layout engine approach (initially encouraged by Claude) might not be the best fit for the PNE because:

1. Architecture mismatch: the PNE uses React components with native CSS overflow scrolling, not a virtualized list with imperative layout control. Porting `CodeCellLayout` would mean fighting the existing design rather than working with it.
2. Maintenance burden: 200+ lines of scroll math with pointer-drag gating, content height stability tracking, and scroll direction detection is a significant long-term liability/maintenance. And I worry that could conflict with other parts and general notebook scrolling. 

#### This PR's approach (and the tradeoff!)

This PR takes a simpler, static cap approach. The trade-off is a **visible scrollbar on tall cells** (see recording below), but it keeps the implementation minimal and aligned with the PNE's architecture. It can be evolved toward the VS Code model later if the UX warrants it.

https://github.com/user-attachments/assets/d12ba65f-3b17-4daf-82b4-e28a3f7872f8

## Test plan

- [x] E2e regression tests added (`notebook-drag-select-scroll.test.ts`)
- [x] Open a notebook with a cell containing 15+ lines
- [x] Drag-select downward past the visible area: viewport should auto-scroll
- [x] Drag-select upward past the top edge: viewport should auto-scroll up
- [x] Short cells (< viewport height) should show all content without a scrollbar
- [x] Shift+Down arrow selection past the bottom also scrolls to follow cursor
- [x] CI should pass (positive test with tall cell and negative test with short cell)

@:positron-notebooks @:notebooks @:web @:win 