### PR TITLE
Disable `singlePerResource` for Positron Notebook Editor

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -192,7 +192,6 @@ class PositronNotebookContribution extends Disposable {
 			info.globPattern,
 			editorInfo,
 			{
-				singlePerResource: true,
 				canSupportResource: (resource: URI) => {
 					return extname(resource) === info.extension &&
 						(resource.scheme === Schemas.untitled ||
@@ -270,7 +269,6 @@ class PositronNotebookContribution extends Disposable {
 			// This does not seem to be an issue for file schemes (registered above).
 			cellEditorInfo,
 			{
-				singlePerResource: true,
 				canSupportResource: (resource: URI) => {
 					return extname(resource) === info.extension &&
 						resource.scheme === Schemas.vscodeNotebookCell;


### PR DESCRIPTION
Fixes #13919. Note that you will see all sorts of other issues with split editors because of #13876.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix: Quick Open consolidates split notebook panes instead of activating in-place (#13919)

### Validation Steps

@:positron-notebooks @:web

See the linked issue for a repro.