### PR TITLE
Fix plist generation

### DIFF
--- a/build/darwin/sign.ts
+++ b/build/darwin/sign.ts
@@ -127,7 +127,9 @@ async function main(buildDir?: string): Promise<void> {
 			`${infoPlistPath}`
 		]);
 		await spawn('plutil', [
-			'-insert',
+			// --- Start Positron ---
+			'-replace',
+			// --- End Positron ---
 			'NSLocalNetworkUsageDescription',
 			'-string',
 			'The app uses your local network for DNS resolution and to connect to locally running services.',
@@ -136,7 +138,9 @@ async function main(buildDir?: string): Promise<void> {
 
 		if (embeddedInfoPlistPath && fs.existsSync(embeddedInfoPlistPath)) {
 			await spawn('plutil', [
-				'-insert',
+				// --- Start Positron ---
+				'-replace',
+				// --- End Positron ---
 				'NSAppleEventsUsageDescription',
 				'-string',
 				`An application in ${product.embedded.nameLong} wants to use AppleScript.`,
@@ -164,7 +168,9 @@ async function main(buildDir?: string): Promise<void> {
 				`${embeddedInfoPlistPath}`
 			]);
 			await spawn('plutil', [
-				'-insert',
+				// --- Start Positron ---
+				'-replace',
+				// --- End Positron ---
 				'NSLocalNetworkUsageDescription',
 				'-string',
 				`The app uses your local network for DNS resolution and to connect to locally running services.`,


### PR DESCRIPTION
Replace existing plist entries

Upstream added some new plist entries but used the insert action. This causes problems if the plist entry already exists. Other entries use replace which is what we want (inserts but replaces if the entry already exists). 