### PR TITLE
server: don't spawn kcserver until license is verified

### DIFF
--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -170,6 +170,24 @@ if (shouldSpawnCli) {
 		(globalThis as { vscodeServerListenTime?: number }).vscodeServerListenTime = performance.now();
 
 		await getRemoteExtensionHostAgentServer();
+
+		// --- Start Positron ---
+		// Start the kernel supervisor only after the license check in
+		// getRemoteExtensionHostAgentServer() passes. If the license is
+		// missing or invalid, createServer() calls process.exit(1) before
+		// reaching this point, so the supervisor is never spawned and no
+		// orphaned kcserver processes accumulate on repeated restart attempts.
+		//
+		// If hasWebUi is false this is a headless REH server (e.g. remote
+		// SSH) that manages its own kernels and does not require a license.
+		const hasWebUi =
+			fs.existsSync(FileAccess.asFileUri('vs/code/browser/workbench/workbench.html').fsPath);
+		if (hasWebUi) {
+			await startKernelSupervisor();
+		} else {
+			console.info('Skipping Kernel Supervisor startup for headless REH server.');
+		}
+		// --- End Positron ---
 	});
 
 	process.on('exit', () => {
@@ -178,23 +196,6 @@ if (shouldSpawnCli) {
 			_remoteExtensionHostAgentServer.dispose();
 		}
 	});
-
-	// --- Start Positron ---
-	// In web mode (used in Posit Workbench), start the Positron Kernel
-	// Supervisor process that will manage all the kernels for all the windows
-	// that connect to this server. This speeds session startup significantly
-	// since the supervisor is already running when the first window connects.
-	//
-	// If hasWebUi is false, then this is a headless REH server (probably remote
-	// SSH) and we'll let it manage its own kernels.
-	const hasWebUi =
-		fs.existsSync(FileAccess.asFileUri('vs/code/browser/workbench/workbench.html').fsPath);
-	if (hasWebUi) {
-		await startKernelSupervisor();
-	} else {
-		console.info('Skipping Kernel Supervisor startup for headless REH server.');
-	}
-	// --- End Positron ---
 }
 
 function sanitizeStringArg(val: unknown): string | undefined {

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -173,13 +173,14 @@ if (shouldSpawnCli) {
 
 		// --- Start Positron ---
 		// Start the kernel supervisor only after the license check in
-		// getRemoteExtensionHostAgentServer() passes. If the license is
-		// missing or invalid, createServer() calls process.exit(1) before
-		// reaching this point, so the supervisor is never spawned and no
-		// orphaned kcserver processes accumulate on repeated restart attempts.
+		// getRemoteExtensionHostAgentServer() passes.
 		//
-		// If hasWebUi is false this is a headless REH server (e.g. remote
-		// SSH) that manages its own kernels and does not require a license.
+		// In web mode (used in Posit Workbench), start the Positron Kernel
+		// Supervisor process that will manage all the kernels for all the windows
+		// that connect to this server.
+		//
+		// If hasWebUi is false, then this is a headless REH server (probably remote
+		// SSH) and we'll let it manage its own kernels.
 		const hasWebUi =
 			fs.existsSync(FileAccess.asFileUri('vs/code/browser/workbench/workbench.html').fsPath);
 		if (hasWebUi) {


### PR DESCRIPTION
Fixes #13123

Moves `startKernelSupervisor()` inside the `getRemoteExtensionHostAgentServer()` callback so it runs only after the license check passes. 

Before, kcserver spawned before the license check, so if the license was missing or invalid `createServer()` would call `process.exit(1)` and leave orphaned `kcserver` process behind. On repeated restart attempts these orphaned processes accumulated.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix orphaned `kcserver` processes accumulating when the server exits due to a missing or invalid license (#13123)

### Validation Steps
  
@:workbench @:remote-ssh @:web

**License failure path:**
  1. Start a Positron server with a missing or invalid license (eg, in JupyterHub)
  2. Verify the server exits cleanly with no orphaned `kcserver` processes

NOTE that the general "is this thing on" checking for remote-ssh and workbench is covered by the e2e tests.