### PR TITLE
Add snowflake.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,8 @@ product.json.backup
 *.lic
 .superset/
 test/e2e/release-screenshots/output/
+# Log file written to cwd by the snowflake-sdk dependency (positron-catalog-explorer)
+snowflake.log
 # --- End Positron ---
 test-output.json
 test/componentFixtures/.screenshots/*


### PR DESCRIPTION
## Why

The `snowflake-sdk` dependency (pulled in by the `positron-catalog-explorer` extension) initializes a winston file logger whose default path is `snowflake.log` in the current working directory. When the SDK gets loaded with the repo as the cwd, it drops a `snowflake.log` into the Positron root:

```json
{"level":"INFO","message":"[3:28:48.909 PM]: Custom credential manager is set by a user."}
```

This shows up as an untracked file in `git status` and risks being accidentally committed.

## What

Adds `snowflake.log` to `.gitignore` (in the Positron-maintained section) with a comment noting where it comes from, so the artifact stays out of the working tree's tracked changes.

## Scope / follow-up

This is a guard, not a root-cause fix. The SDK still writes the file; we're keeping it out of source control.

Note there are two distinct ways `snowflake.log` ends up in the repo root:

- **Install time** (what prompted this PR) - the SDK is loaded during `npm install` with the repo as cwd. The trigger hasn't been tracked down; the `.gitignore` entry is what covers this case.
- **Runtime** - when a user connects to a Snowflake catalog, `registerSnowflakeCatalog` in `extensions/positron-catalog-explorer/src/catalogs/snowflake.ts` calls `snowflake.configure(...)` and currently lets `logFilePath` fall back to the cwd. That path could separately be pointed at the extension's log directory (`context.logUri`), but it would not affect the install-time case above.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
