### PR TITLE
Update/data grid cursor

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -219,6 +219,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/contrib/positronPackages",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/contrib/positronConnections",
 			"project": "vscode-workbench"
 		},

--- a/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/classes/dataGridInstance.tsx
@@ -164,8 +164,60 @@ type DefaultCursorOptions = | {
 export type SelectionMode = 'spreadsheet' | 'list-multiple-selection' | 'list-single-selection';
 
 /**
- * SelectionOptions type. Discriminated on `selection`: when selection is disabled, there is
- * nothing for selectionMode to govern, so the type system rejects specifying it.
+ * ListSelectionMode type. The subset of SelectionMode in which a single cursor row drives the
+ * selection. The list-only selection options (selectionFollowsCursor, enterSelects, spaceSelects)
+ * apply only in these modes.
+ */
+type ListSelectionMode = Exclude<SelectionMode, 'spreadsheet'>;
+
+/**
+ * SelectionCursorOptions type. The cursor/commit options for the list selection modes,
+ * discriminated on `selectionFollowsCursor`: `enterSelects` and `spaceSelects` may be specified
+ * only when the selection does NOT follow the cursor. When it does, every navigation already
+ * selects the cursor row, so committing with Enter/Space would be redundant. Exported and reused
+ * by the PositronList and PositronTree option types so they expose and enforce the same shape.
+ */
+export type SelectionCursorOptions =
+	| {
+		// The selection follows the cursor: every navigation re-selects the cursor row. Because
+		// the cursor row is always selected, Enter/Space-to-select would be redundant and is
+		// therefore disallowed.
+		readonly selectionFollowsCursor?: true;
+		readonly enterSelects?: never;
+		readonly spaceSelects?: never;
+	}
+	| {
+		// The cursor (focus) moves independently of the selection. The selection changes only on
+		// explicit action, so Enter and Space can be opted in to commit the selection to the
+		// cursor row.
+		readonly selectionFollowsCursor: false;
+
+		// Whether pressing Enter selects the cursor row.
+		readonly enterSelects?: boolean;
+
+		// Whether pressing Space selects the cursor row.
+		readonly spaceSelects?: boolean;
+	};
+
+/**
+ * Forwards a SelectionCursorOptions value into a DataGridInstance subclass's super() call. The
+ * three fields cannot be passed individually because reading each off the options widens it to
+ * `boolean | undefined`, which loses the correlation the discriminated union relies on (that
+ * enterSelects/spaceSelects exist only when selectionFollowsCursor is false). Returning the slice
+ * as one discriminated value preserves it, so callers can spread `...selectionCursorOptions(opts)`
+ * into the base options. The base class applies the defaults.
+ */
+export function selectionCursorOptions(options: SelectionCursorOptions): SelectionCursorOptions {
+	return options.selectionFollowsCursor
+		? { selectionFollowsCursor: true }
+		: { selectionFollowsCursor: false, enterSelects: options.enterSelects, spaceSelects: options.spaceSelects };
+}
+
+/**
+ * SelectionOptions type. Discriminated on `selection`, `selectionMode`, and (within the list
+ * modes) `selectionFollowsCursor`. The list-only options are meaningful only when a single cursor
+ * row drives the selection, so the type system permits them only in a list mode; within a list
+ * mode the cursor/commit options follow SelectionCursorOptions.
  */
 type SelectionOptions =
 	| {
@@ -174,19 +226,30 @@ type SelectionOptions =
 		// (no highlighted selection) set this to false.
 		selection: false;
 
-		// Disallowed when selection is off, since there is no selection for the cursor to track.
+		// Disallowed when selection is off, since there is no selection to govern.
 		selectionMode?: never;
+		selectionFollowsCursor?: never;
+		enterSelects?: never;
+		spaceSelects?: never;
 	}
 	| {
-		// Selection enabled (the default): mouse clicks and keyboard navigation populate the
-		// cell/column/row selection buckets. Whether Shift and Ctrl/Cmd modifiers extend the
-		// selection depends on selectionMode.
+		// Selection enabled in spreadsheet mode (the default): mouse clicks and keyboard
+		// navigation populate the cell/column/row selection buckets, but the cursor and
+		// selection are independent, so the list-only options below do not apply.
 		selection?: true;
+		selectionMode?: 'spreadsheet';
 
-		// How cursor movement and modifier keys interact with selection. Defaults to
-		// 'spreadsheet'. See SelectionMode for details.
-		selectionMode?: SelectionMode;
-	};
+		// Disallowed in 'spreadsheet' mode, where the cursor and selection are always independent.
+		selectionFollowsCursor?: never;
+		enterSelects?: never;
+		spaceSelects?: never;
+	}
+	| ({
+		// Selection enabled in a list mode: a single cursor row drives the selection, so the
+		// cursor/commit options apply. See SelectionMode for how each list mode behaves.
+		selection?: true;
+		selectionMode: ListSelectionMode;
+	} & SelectionCursorOptions);
 
 /**
  * DataGridOptions type.
@@ -710,6 +773,24 @@ export abstract class DataGridInstance extends Disposable {
 	 */
 	private readonly _selectionMode: SelectionMode;
 
+	/**
+	 * Gets a value which indicates whether, in the list selection modes, the selection tracks
+	 * the cursor as it moves.
+	 */
+	private readonly _selectionFollowsCursor: boolean;
+
+	/**
+	 * Gets a value which indicates whether, in the list selection modes, pressing Enter selects
+	 * the cursor row.
+	 */
+	private readonly _enterSelects: boolean;
+
+	/**
+	 * Gets a value which indicates whether, in the list selection modes, pressing Space selects
+	 * the cursor row.
+	 */
+	private readonly _spaceSelects: boolean;
+
 	//#endregion Private Properties - Settings
 
 	//#region Private Properties
@@ -772,6 +853,16 @@ export abstract class DataGridInstance extends Disposable {
 	 * The onDidChangeColumnSorting event emitter.
 	 */
 	private readonly _onDidChangeColumnSortingEmitter = this._register(new Emitter<boolean>);
+
+	/**
+	 * The onEnter event emitter.
+	 */
+	private readonly _onEnterEmitter = this._register(new Emitter<void>);
+
+	/**
+	 * The onSpace event emitter.
+	 */
+	private readonly _onSpaceEmitter = this._register(new Emitter<void>);
 
 	//#endregion Private Events
 
@@ -872,6 +963,13 @@ export abstract class DataGridInstance extends Disposable {
 		// SelectionOptions.
 		this._selection = options.selection ?? true;
 		this._selectionMode = options.selectionMode ?? 'spreadsheet';
+		// In the list modes, the selection does not follow the cursor by default; the cursor
+		// (focus) moves independently and Enter/Space commit the selection to the cursor row.
+		// When the selection does follow the cursor, every navigation already selects it, so
+		// Enter/Space-to-select default off (and are disallowed by the options type anyway).
+		this._selectionFollowsCursor = options.selectionFollowsCursor ?? false;
+		this._enterSelects = options.enterSelects ?? !this._selectionFollowsCursor;
+		this._spaceSelects = options.spaceSelects ?? !this._selectionFollowsCursor;
 
 		// Allocate and initialize the layout managers.
 		this._columnLayoutManager = new LayoutManager(this._defaultColumnWidth);
@@ -1090,6 +1188,31 @@ export abstract class DataGridInstance extends Disposable {
 	 */
 	get selectionMode() {
 		return this._selectionMode;
+	}
+
+	/**
+	 * Gets a value which indicates whether, in the list selection modes, keyboard navigation
+	 * makes the selection track the cursor row. When false, the cursor (focus) moves
+	 * independently of the selection. Has no effect in 'spreadsheet' mode.
+	 */
+	get selectionFollowsCursor() {
+		return this._selectionFollowsCursor;
+	}
+
+	/**
+	 * Gets a value which indicates whether, in the list selection modes, pressing Enter selects
+	 * the cursor row. Has no effect in 'spreadsheet' mode.
+	 */
+	get enterSelects() {
+		return this._enterSelects;
+	}
+
+	/**
+	 * Gets a value which indicates whether, in the list selection modes, pressing Space selects
+	 * the cursor row. Has no effect in 'spreadsheet' mode.
+	 */
+	get spaceSelects() {
+		return this._spaceSelects;
 	}
 
 	/**
@@ -1331,6 +1454,20 @@ export abstract class DataGridInstance extends Disposable {
 	 * onDidChangeColumnSorting event.
 	 */
 	readonly onDidChangeColumnSorting = this._onDidChangeColumnSortingEmitter.event;
+
+	/**
+	 * onEnter event. Fires when the user presses Enter on the cursor row, regardless of whether
+	 * Enter also commits the selection (enterSelects). Lets consumers act on the cursor row
+	 * independently of selection (e.g. expand/collapse in a tree).
+	 */
+	readonly onEnter = this._onEnterEmitter.event;
+
+	/**
+	 * onSpace event. Fires when the user presses Space on the cursor row, regardless of whether
+	 * Space also commits the selection (spaceSelects). Lets consumers act on the cursor row
+	 * independently of selection (e.g. expand/collapse in a tree).
+	 */
+	readonly onSpace = this._onSpaceEmitter.event;
 
 	//#endregion Public Events
 
@@ -3484,14 +3621,29 @@ export abstract class DataGridInstance extends Disposable {
 	}
 
 	/**
-	 * Called when the user presses Enter while the data grid has focus and the cursor is
-	 * already showing. Subclasses can override to implement an "activation" action (e.g.
-	 * expand/collapse a row, open the focused item). The base implementation does nothing.
+	 * Called when the user presses Enter while the data grid has focus and the cursor is showing.
+	 * Called regardless of whether Enter also commits the selection (enterSelects), so a tree can
+	 * expand/collapse the cursor row even while Enter selects it. The base implementation raises
+	 * the onEnter event; subclasses can override to implement a custom action instead.
 	 *
 	 * The host (DataGridWaffle) handles consuming the keyboard event and the showCursor()
 	 * gating before this is called, so overrides only need to implement the action itself.
 	 */
 	async onEnterKey(): Promise<void> {
+		this._onEnterEmitter.fire();
+	}
+
+	/**
+	 * Called when the user presses Space while the data grid has focus and the cursor is showing.
+	 * Called regardless of whether Space also commits the selection (spaceSelects), so a tree can
+	 * expand/collapse the cursor row even while Space selects it. The base implementation raises
+	 * the onSpace event; subclasses can override to implement a custom action instead.
+	 *
+	 * The host (DataGridWaffle) handles consuming the keyboard event and the showCursor()
+	 * gating before this is called, so overrides only need to implement the action itself.
+	 */
+	async onSpaceKey(): Promise<void> {
+		this._onSpaceEmitter.fire();
 	}
 
 	/**

--- a/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
+++ b/src/vs/workbench/browser/positronDataGrid/components/dataGridWaffle.tsx
@@ -176,8 +176,10 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 		// Applies the per-key selection policy around cursor navigation. In spreadsheet mode
 		// (the default), selection is cleared before the cursor moves so cursor and selection
 		// are independent. In either list mode, selection collapses onto the new cursor row
-		// after the move so the selection tracks the cursor. The `selection` guards keep these
-		// no-ops when selection is disabled on the grid.
+		// after the move so the selection tracks the cursor -- unless selectionFollowsCursor is
+		// false, in which case the cursor (focus) moves independently and the selection is left
+		// untouched. The `selection` guards keep these no-ops when selection is disabled on the
+		// grid.
 		const selectionMode = context.instance.selectionMode;
 		const isListMode = selectionMode === 'list-multiple-selection' || selectionMode === 'list-single-selection';
 		const navigationSelection = {
@@ -187,7 +189,7 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 				}
 			},
 			afterMoveCursor: () => {
-				if (context.instance.selection && isListMode) {
+				if (context.instance.selection && isListMode && context.instance.selectionFollowsCursor) {
 					context.instance.selectRow(context.instance.cursorRowIndex);
 				}
 			}
@@ -233,11 +235,18 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 					return;
 				}
 
-				// If selection is enabled, process the key.
-				if (context.instance.selection) {
-					// Consume the event only if there's an action supported for it
+				// Plain Space: in the list modes, when spaceSelects is set, commit the selection to
+				// the cursor row. Then always raise onSpace so consumers can act on the cursor row
+				// independently of selection (e.g. expand/collapse in a tree).
+				if (!e.ctrlKey && !e.shiftKey) {
 					consumeEvent();
-
+					if (context.instance.selection && isListMode && context.instance.spaceSelects) {
+						context.instance.selectRow(context.instance.cursorRowIndex);
+					}
+					await context.instance.onSpaceKey();
+				} else if (context.instance.selection) {
+					// Modifier combinations build selections (spreadsheet / multi-select list).
+					consumeEvent();
 					if (e.ctrlKey && !e.shiftKey) {
 						context.instance.selectColumn(context.instance.cursorColumnIndex);
 					} else if (e.shiftKey && !e.ctrlKey) {
@@ -260,7 +269,12 @@ export const DataGridWaffle = forwardRef<HTMLDivElement>((_: unknown, ref) => {
 					return;
 				}
 
-				// Defer to the instance's Enter handler.
+				// In the list modes, when enterSelects is set, Enter commits the selection to the
+				// cursor row. Then always raise onEnter so consumers can act on the cursor row
+				// independently of selection (e.g. expand/collapse in a tree).
+				if (context.instance.selection && isListMode && context.instance.enterSelects) {
+					context.instance.selectRow(context.instance.cursorRowIndex);
+				}
 				await context.instance.onEnterKey();
 				break;
 			}

--- a/src/vs/workbench/browser/positronList/classes/positronListInstance.tsx
+++ b/src/vs/workbench/browser/positronList/classes/positronListInstance.tsx
@@ -10,9 +10,8 @@ import './positronListInstance.css';
 import { JSX, ReactNode } from 'react';
 
 // Other dependencies.
-import { Emitter, Event } from '../../../../base/common/event.js';
 import { positronClassNames } from '../../../../base/common/positronUtilities.js';
-import { DataGridInstance, MouseSelectionType, RowSelectionState } from '../../positronDataGrid/classes/dataGridInstance.js';
+import { DataGridInstance, MouseSelectionType, RowSelectionState, SelectionCursorOptions, selectionCursorOptions } from '../../positronDataGrid/classes/dataGridInstance.js';
 
 /**
  * PositronListItemContext interface. Passed to the caller's itemRenderer so the rendered item
@@ -122,7 +121,8 @@ type PositronListSectionOptions<TSection> = [TSection] extends [never]
 export type PositronListInstanceOptions<TItem, TSection> =
 	& PositronListBaseOptions
 	& PositronListItemOptions<TItem>
-	& PositronListSectionOptions<TSection>;
+	& PositronListSectionOptions<TSection>
+	& SelectionCursorOptions;
 
 /**
  * PositronListInstance class.
@@ -152,17 +152,7 @@ export class PositronListInstance<TItem, TSection = never> extends DataGridInsta
 	// The current section renderer, if any.
 	private _sectionRenderer?: PositronListSectionRenderer<TSection>;
 
-	// Fires when the user activates an item (Enter key on a focused row).
-	private readonly _onDidActivateEmitter = this._register(new Emitter<TItem>());
-
 	//#endregion Private Properties
-
-	//#region Public Events
-
-	// Fires when the user activates an item (Enter key on a focused row).
-	readonly onDidActivate: Event<TItem> = this._onDidActivateEmitter.event;
-
-	//#endregion Public Events
 
 	//#region Constructor
 
@@ -191,6 +181,7 @@ export class PositronListInstance<TItem, TSection = never> extends DataGridInsta
 			internalCursor: false,
 			selection: true,
 			selectionMode: options.selectionMode ?? 'list-single-selection',
+			...selectionCursorOptions(options),
 		});
 
 		// Default to applying the built-in focused/selected classes.
@@ -405,20 +396,6 @@ export class PositronListInstance<TItem, TSection = never> extends DataGridInsta
 		mouseSelectionType: MouseSelectionType
 	): Promise<void> {
 		await this.mouseSelectRow(rowIndex, mouseSelectionType);
-	}
-
-	/**
-	 * Fires onDidActivate for the currently focused item. PositronList wraps this with its
-	 * onActivate prop. The cursor should already be on an item -- section rows are skipped by
-	 * keyboard navigation and rejected by click handling -- so this is a defensive guard.
-	 */
-	override async onEnterKey(): Promise<void> {
-		const entry = this._entries[this.cursorRowIndex];
-		if (entry === undefined || entry.kind !== 'item') {
-			return;
-		}
-
-		this._onDidActivateEmitter.fire(entry.item);
 	}
 
 	//#endregion DataGridInstance Implementation

--- a/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.tsx
+++ b/src/vs/workbench/browser/positronTree/classes/positronTreeInstance.tsx
@@ -12,7 +12,7 @@ import { JSX, ReactNode, MouseEvent as ReactMouseEvent } from 'react';
 // Other dependencies.
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { positronClassNames } from '../../../../base/common/positronUtilities.js';
-import { DataGridInstance, MouseSelectionType, RowSelectionState } from '../../positronDataGrid/classes/dataGridInstance.js';
+import { DataGridInstance, MouseSelectionType, RowSelectionState, SelectionCursorOptions, selectionCursorOptions } from '../../positronDataGrid/classes/dataGridInstance.js';
 import { TreeNode, TreeNodeContext, VisibleNode } from './treeNode.js';
 import { buildVisibleNodes, findParentIndex } from './treeProjection.js';
 
@@ -35,9 +35,10 @@ export type PositronTreeGetRoots<T> = () => Promise<readonly TreeNode<T>[]>;
 export type PositronTreeGetChildren<T> = (node: TreeNode<T>) => Promise<readonly TreeNode<T>[]>;
 
 /**
- * PositronTreeInstanceOptions type.
+ * PositronTreeBaseOptions type. The tree options other than the cursor/commit options, which come
+ * from SelectionCursorOptions (see PositronTreeInstanceOptions).
  */
-export interface PositronTreeInstanceOptions<T> {
+interface PositronTreeBaseOptions<T> {
 	// Async fetcher for the root nodes.
 	readonly getRoots: PositronTreeGetRoots<T>;
 
@@ -57,6 +58,15 @@ export interface PositronTreeInstanceOptions<T> {
 	readonly useDefaultStyling?: boolean;
 }
 
+/**
+ * PositronTreeInstanceOptions type. Defaults to not tracking the cursor: the cursor (focus) moves
+ * independently and Enter/Space commit the selection to the cursor row (both default to true). Set
+ * selectionFollowsCursor true to make the selection follow the cursor on every move, in which case
+ * Enter/Space-to-select are redundant and disallowed.
+ */
+export type PositronTreeInstanceOptions<T> = PositronTreeBaseOptions<T> & SelectionCursorOptions;
+
+// Per-level indent width in pixels, used when options.indentWidth is not supplied.
 const DEFAULT_INDENT_WIDTH = 12;
 
 /**
@@ -102,18 +112,12 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 	// "loading initial data" from "no roots."
 	private _initialLoadCompleted = false;
 
-	// Fires when the user activates a row (Enter key on the focused row).
-	private readonly _onDidActivateEmitter = this._register(new Emitter<TreeNode<T>>());
-
 	// Fires when the tree's loading state changes (initial load, roots fetch, or per-node fetch).
 	private readonly _onDidChangeLoadingEmitter = this._register(new Emitter<void>());
 
 	//#endregion Private Properties
 
 	//#region Public Events
-
-	// Fires when the user activates a row (Enter key on the focused row).
-	readonly onDidActivate: Event<TreeNode<T>> = this._onDidActivateEmitter.event;
 
 	// Fires when loading state changes.
 	readonly onDidChangeLoading: Event<void> = this._onDidChangeLoadingEmitter.event;
@@ -142,6 +146,7 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 			internalCursor: false,
 			selection: true,
 			selectionMode: 'list-single-selection',
+			...selectionCursorOptions(options),
 		});
 
 		this._getRoots = options.getRoots;
@@ -541,18 +546,6 @@ export class PositronTreeInstance<T> extends DataGridInstance {
 				this.fireOnDidUpdateEvent();
 			}
 		}
-	}
-
-	/**
-	 * Enter activates the focused row. Activation is intentionally distinct from expansion:
-	 * Enter signals "open / use this node," not "toggle the twisty." Toggle is left/right arrow.
-	 */
-	override async onEnterKey(): Promise<void> {
-		const visible = this._visibleNodes[this.cursorRowIndex];
-		if (visible === undefined) {
-			return;
-		}
-		this._onDidActivateEmitter.fire(visible.node);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -412,14 +412,6 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 		listInstance.setItemRenderer(renderItem);
 	}, [listInstance, deduplicatedPackages, services, itemSize, showHelpForPackage]);
 
-	// Enter on the focused row sets selection to that row.
-	useEffect(() => {
-		const disposable = listInstance.onDidActivate(() => {
-			listInstance.selectRow(listInstance.cursorRowIndex);
-		});
-		return () => disposable.dispose();
-	}, [listInstance]);
-
 	// Sync the currently-selected package's name into the packages service. onDidUpdate fires
 	// for any instance change (selection, cursor, scroll), so we dedupe before pushing.
 	useEffect(() => {


### PR DESCRIPTION
### Summary

Reworks how the Data Grid couples the cursor (focus) to the selection, so list- and tree-style consumers can move focus with the keyboard without changing the selection, and commit selection explicitly via click, Enter, or Space.

`DataGridInstance` gains three orthogonal, type-checked options for the list selection modes plus two events:

- **`selectionFollowsCursor`** - when `true`, keyboard navigation re-selects the cursor row on every move (the prior behavior); when `false`, the cursor moves independently and the selection only changes on explicit action.
- **`enterSelects` / `spaceSelects`** - whether Enter / Space commit the selection to the cursor row. The options type only permits these when `selectionFollowsCursor` is `false` (when the selection already tracks the cursor, they would be redundant), enforced via a discriminated `SelectionCursorOptions` union shared by the grid, list, and tree.
- **`onEnter` / `onSpace`** - events raised on every Enter / plain-Space press (regardless of whether the key also selects), so consumers can act on the cursor row independently - e.g. expand/collapse a tree node while the row is also selected.

`PositronListInstance` and `PositronTreeInstance` expose these through their options (defaulting to decoupled cursor + Enter/Space-to-select) and inherit `onEnter`/`onSpace` from the base. The now-redundant `onDidActivate` events and their `onEnterKey` overrides were removed; Packages drops its old `onDidActivate` -> `selectRow` wiring since the grid now commits the selection on Enter directly.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:data-explorer @:connections @:packages-pane

1. **Packages pane**: focus the list and use Up/Down arrows - the focus indicator moves without changing the selection. Press Enter, Space, or click a row - the selection commits to that row.
2. **Data Connections pane**: same - arrow keys move focus only; click/Enter/Space select the focused entry.
3. **Data Explorer summary panel**: confirm Enter still toggles the focused column's expansion and Tab navigation is unchanged.
4. Confirm no regressions in Data Explorer table selection (spreadsheet mode: arrows clear selection, Shift+arrows extend, Ctrl/Cmd+click and Shift+click build row selections).