### PR TITLE
Wait for workbench trust to initialize before checking it

### DIFF
--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -524,13 +524,22 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 			}
 		}));
 
-		// If the workspace is not trusted, immediately transition to the
-		// AwaitingTrust phase so the console shows the correct message
-		// (rather than "Waiting for extensions", which is misleading since
-		// extensions won't activate until the workspace is trusted).
-		if (!this._workspaceTrustManagementService.isWorkspaceTrusted()) {
-			this.setStartupPhase(RuntimeStartupPhase.AwaitingTrust);
-		}
+		// If the workspace is not trusted, transition to the AwaitingTrust
+		// phase so the console shows the correct message (rather than "Waiting
+		// for extensions", which is misleading since extensions won't activate
+		// until the workspace is trusted).
+		//
+		// Wait for workspace trust to finish initializing before checking. All
+		// workspaces now open in an untrusted state and may transition to
+		// trusted during startup (e.g. once canonical URIs are resolved), so
+		// checking synchronously here would briefly show the misleading
+		// "Restricted Mode" message for workspaces that are actually trusted.
+		this._workspaceTrustManagementService.workspaceTrustInitialized.then(() => {
+			if (this._startupPhase === RuntimeStartupPhase.Initializing &&
+				!this._workspaceTrustManagementService.isWorkspaceTrusted()) {
+				this.setStartupPhase(RuntimeStartupPhase.AwaitingTrust);
+			}
+		});
 
 		// Find all the sessions that need to be restored.
 		this.findRestoredSessions().then(() => {
@@ -2377,6 +2386,12 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 	 * workspace to be trusted.
 	 */
 	private async startupAfterTrust(): Promise<void> {
+		// Wait for workspace trust to finish initializing before deciding
+		// whether we can proceed. All workspaces open untrusted and may
+		// transition to trusted during startup, so checking trust before it is
+		// initialized could incorrectly enter the AwaitingTrust phase.
+		await this._workspaceTrustManagementService.workspaceTrustInitialized;
+
 		if (this._workspaceTrustManagementService.isWorkspaceTrusted()) {
 			// In a trusted workspace, we can start the startup sequence
 			// immediately.


### PR DESCRIPTION
This change fixes a startup trust issue. Before the change, you might see an "awaiting trust" message in the Console even in trusted workspaces.

The problem was pretty simple: the workbench trust service treats all workspaces as "untrusted" until it is initialized, so we just need to wait for the trust service to finish initializing before we check the trust status. 

Fixes https://github.com/posit-dev/positron/issues/13691.

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix "Cannot start consoles in restricted mode" displaying briefly even in trusted (unrestricted) workspaces (#13691)


### Validation Steps

1. Open a new Positron window with the Console forward in an existing workspace; verify that the "Cannot start consoles in restricted mode" message does not appear
2. Create a new folder in an untrusted directory and then open it in Positron; verify that the Console tab shows "Cannot start consoles in restricted mode" while the workspace is not trusted.