### PR TITLE
e2e: remove R `cat from .Rprofile` console test

### DIFF
--- a/test/e2e/tests/console/console-r.test.ts
+++ b/test/e2e/tests/console/console-r.test.ts
@@ -22,12 +22,6 @@ test.describe('Console Pane: R', {
 		await app.workbench.console.waitForConsoleContents(process.env.POSITRON_R_VER_SEL!, { expectedCount: 2, timeout: 20000 });
 	});
 
-	test('R - Verify cat from .Rprofile', async function ({ app, r }) {
-		await expect(async () => {
-			await app.workbench.console.waitForConsoleContents('cat from .Rprofile');
-		}).toPass();
-	});
-
 	test('R - Verify cancel button on console bar', async function ({ app, r }) {
 
 		await app.workbench.console.pasteCodeToConsole('Sys.sleep(10)');


### PR DESCRIPTION
### Summary
Removes the `R - Verify cat from .Rprofile` console test; the workspace `.Rprofile` it relied on is no longer present, so the assertion can't pass.

### QA Notes
@:console @:new-folder-flow
