### PR TITLE
Clean up Positron / VS Code launch targets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -768,7 +768,11 @@
 	],
 	"compounds": [
 		{
+			// --- Start Positron ---
+			// Rename this to "Positron".
+			// "name": "VS Code",
 			"name": "Positron",
+			// --- End Positron ---
 			"stopAll": true,
 			"configurations": [
 				"Launch Positron Internal",
@@ -783,11 +787,38 @@
 				"order": 1
 			}
 		},
+		// --- Start Positron ---
+		// Remove the VS Code Agents launch target, since this doesn't exist in
+		// Positron.
+		// {
+		// 	"name": "VS Code Agents",
+		// 	"stopAll": true,
+		// 	"configurations": [
+		// 		"Launch VS Code Agents Internal",
+		// 		"Attach to Main Process",
+		// 		"Attach to Extension Host",
+		// 		"Attach to Shared Process",
+		// 	],
+		// 	"preLaunchTask": "Ensure Prelaunch Dependencies",
+		// 	"presentation": {
+		// 		"group": "0_vscode",
+		// 		"order": 1
+		// 	}
+		// },
+		// --- End Positron ---
 		{
+			// --- Start Positron ---
+			// Rename this to "Positron"
+			// "name": "VS Code (Hot Reload)",
 			"name": "Positron (Hot Reload)",
+			// --- End Positron ---
 			"stopAll": true,
 			"configurations": [
+				// --- Start Positron ---
+				// Rename this to "Positron"
+				// "Launch VS Code Internal (Hot Reload)",
 				"Launch Positron Internal (Hot Reload)",
+				// --- End Positron ---
 				"Attach to Main Process",
 				"Attach to Extension Host",
 				"Attach to Shared Process",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -378,7 +378,11 @@
 			// To debug observables you also need the extension "ms-vscode.debug-value-editor"
 			"type": "chrome",
 			"request": "launch",
-			"name": "Launch VS Code Internal (Hot Reload)",
+			// --- Start Positron ---
+			// Rename this to "Positron"
+			// "name": "Launch VS Code Internal (Hot Reload)",
+			"name": "Launch Positron Internal (Hot Reload)",
+			// --- End Positron ---
 			"windows": {
 				"runtimeExecutable": "${workspaceFolder}/scripts/code.bat"
 			},

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -436,21 +436,24 @@
 				"order": 2
 			}
 		},
-		{
-			"type": "node",
-			"request": "launch",
-			"name": "VS Code Agent Host",
-			"outputCapture": "std",
-			"program": "./scripts/code-agent-host.js",
-			"args": ["--port", "7777", "--without-connection-token"],
-			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
-			],
-			"presentation": {
-				"group": "0_vscode",
-				"order": 2
-			}
-		},
+		// --- Start Positron ---
+		// Skip the Agent Host launch target for Positron.
+		// {
+		// 	"type": "node",
+		// 	"request": "launch",
+		// 	"name": "VS Code Agent Host",
+		// 	"outputCapture": "std",
+		// 	"program": "./scripts/code-agent-host.js",
+		// 	"args": ["--port", "7777", "--without-connection-token"],
+		// 	"outFiles": [
+		// 		"${workspaceFolder}/out/**/*.js"
+		// 	],
+		// 	"presentation": {
+		// 		"group": "0_vscode",
+		// 		"order": 2
+		// 	}
+		// },
+		// --- End Positron ---
 		{
 			"type": "node",
 			"request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -784,25 +784,10 @@
 			}
 		},
 		{
-			"name": "VS Code Agents",
+			"name": "Positron (Hot Reload)",
 			"stopAll": true,
 			"configurations": [
-				"Launch VS Code Agents Internal",
-				"Attach to Main Process",
-				"Attach to Extension Host",
-				"Attach to Shared Process",
-			],
-			"preLaunchTask": "Ensure Prelaunch Dependencies",
-			"presentation": {
-				"group": "0_vscode",
-				"order": 1
-			}
-		},
-		{
-			"name": "VS Code (Hot Reload)",
-			"stopAll": true,
-			"configurations": [
-				"Launch VS Code Internal (Hot Reload)",
+				"Launch Positron Internal (Hot Reload)",
 				"Attach to Main Process",
 				"Attach to Extension Host",
 				"Attach to Shared Process",


### PR DESCRIPTION
Right now our debug launch targets are polluted with some VS Code launch targets that have crept in from upstream merges over the last year.

<img width="439" height="247" alt="image" src="https://github.com/user-attachments/assets/c019b6cf-619a-4d66-a642-9f5062424883" />

This change cleans up the targets, removing the ones that don't apply to us and renaming the remainder to refer to Positron instead of VS Code.

<img width="434" height="196" alt="image" src="https://github.com/user-attachments/assets/590a3efe-7da3-4508-913a-b51661550b48" />
