### PR TITLE
Fix auth provider baseUrl and setting consistency

### DIFF
--- a/extensions/authentication/package.json
+++ b/extensions/authentication/package.json
@@ -252,7 +252,10 @@
 					"additionalProperties": {
 						"type": "string"
 					},
-					"markdownDescription": "%configuration.openai-compatible.customHeaders.description%"
+					"markdownDescription": "%configuration.openai-compatible.customHeaders.description%",
+					"tags": [
+						"experimental"
+					]
 				},
 				"assistant.provider.googleVertex.enabled": {
 					"type": "boolean",

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -343,6 +343,25 @@ function registerSnowflakeProvider(context: vscode.ExtensionContext): void {
 	);
 	registerAuthProvider('snowflake-cortex', provider, {
 		validateApiKey: validateSnowflakeApiKey,
+		onSave: async (config) => {
+			// baseUrl holds the bare account; persist it as SNOWFLAKE_ACCOUNT,
+			// not as a baseUrl setting like other providers do (#13750).
+			const account = config.baseUrl?.trim();
+			if (!account) {
+				return;
+			}
+			// Read the global scope only, matching the resolve() sync above.
+			const cfg = vscode.workspace.getConfiguration('authentication.snowflake');
+			const inspection = cfg.inspect<Record<string, string>>('credentials');
+			const globalValue = inspection?.globalValue ?? {};
+			if (globalValue.SNOWFLAKE_ACCOUNT !== account) {
+				await cfg.update(
+					'credentials',
+					{ ...globalValue, SNOWFLAKE_ACCOUNT: account },
+					vscode.ConfigurationTarget.Global
+				);
+			}
+		},
 	});
 	provider.resolveChainCredentials().catch(err =>
 		logger.logCredentialResolution(

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -343,16 +343,6 @@ function registerSnowflakeProvider(context: vscode.ExtensionContext): void {
 	);
 	registerAuthProvider('snowflake-cortex', provider, {
 		validateApiKey: validateSnowflakeApiKey,
-		onSave: async (config) => {
-			if (config.baseUrl) {
-				await vscode.workspace
-					.getConfiguration('authentication.snowflake-cortex')
-					.update(
-						'baseUrl', config.baseUrl,
-						vscode.ConfigurationTarget.Global
-					);
-			}
-		},
 	});
 	provider.resolveChainCredentials().catch(err =>
 		logger.logCredentialResolution(

--- a/extensions/authentication/src/providerSources.ts
+++ b/extensions/authentication/src/providerSources.ts
@@ -15,7 +15,7 @@ import {
 	OPENAI_AUTH_PROVIDER_ID,
 	POSIT_AUTH_PROVIDER_ID,
 } from './constants';
-import { getSnowflakeDefaultBaseUrl } from './snowflakeCredentials';
+import { getConfiguredSnowflakeAccount } from './snowflakeCredentials';
 
 function getSavedBaseUrl(configSection: string, fallback?: string): string | undefined {
 	return vscode.workspace
@@ -141,11 +141,13 @@ export function getProviderSources(): positron.ai.LanguageModelSource[] {
 		{
 			type: positron.PositronLanguageModelType.Chat,
 			provider: PROVIDER_METADATA.snowflake,
-			supportedOptions: ['apiKey', 'toolCalls', 'autoconfigure'],
+			supportedOptions: ['apiKey', 'baseUrl', 'toolCalls', 'autoconfigure'],
 			defaults: {
 				name: 'Snowflake Cortex',
 				model: 'claude-4-sonnet',
-				baseUrl: getSnowflakeDefaultBaseUrl(),
+				// baseUrl holds the bare account, not a URL: the Cortex URL is
+				// derived from the account. Don't make it a saved setting (#13750).
+				baseUrl: getConfiguredSnowflakeAccount(),
 				toolCalls: true,
 				autoconfigure: {
 					type: positron.ai.LanguageModelAutoconfigureType.Custom,

--- a/extensions/authentication/src/providerSources.ts
+++ b/extensions/authentication/src/providerSources.ts
@@ -141,7 +141,7 @@ export function getProviderSources(): positron.ai.LanguageModelSource[] {
 		{
 			type: positron.PositronLanguageModelType.Chat,
 			provider: PROVIDER_METADATA.snowflake,
-			supportedOptions: ['apiKey', 'baseUrl', 'toolCalls', 'autoconfigure'],
+			supportedOptions: ['apiKey', 'toolCalls', 'autoconfigure'],
 			defaults: {
 				name: 'Snowflake Cortex',
 				model: 'claude-4-sonnet',

--- a/extensions/authentication/src/providerSources.ts
+++ b/extensions/authentication/src/providerSources.ts
@@ -190,7 +190,7 @@ export function getProviderSources(): positron.ai.LanguageModelSource[] {
 			defaults: {
 				name: 'Gemini 2.5 Flash (Vertex)',
 				model: 'gemini-2.5-flash',
-				baseUrl: getSavedBaseUrl('googleVertex'),
+				baseUrl: getSavedBaseUrl('googleVertex', 'https://aiplatform.googleapis.com'),
 				toolCalls: true,
 				...(vertexFromEnv && {
 					autoconfigure: {

--- a/extensions/authentication/src/snowflakeCredentials.ts
+++ b/extensions/authentication/src/snowflakeCredentials.ts
@@ -248,3 +248,15 @@ export function getSnowflakeDefaultBaseUrl(): string {
 	// Fallback to placeholder if no account is available
 	return 'https://<account_identifier>.snowflakecomputing.com/api/v2/cortex/v1';
 }
+
+/**
+ * Reads the configured Snowflake account identifier from settings, falling
+ * back to the SNOWFLAKE_ACCOUNT environment variable.
+ * @returns The account identifier, or an empty string if not set.
+ */
+export function getConfiguredSnowflakeAccount(): string {
+	const configSettings = vscode.workspace
+		.getConfiguration('authentication.snowflake')
+		.get<SnowflakeProviderVariables>('credentials', {});
+	return configSettings.SNOWFLAKE_ACCOUNT || process.env.SNOWFLAKE_ACCOUNT || '';
+}

--- a/extensions/authentication/src/snowflakeCredentials.ts
+++ b/extensions/authentication/src/snowflakeCredentials.ts
@@ -226,30 +226,6 @@ export async function checkForUpdatedSnowflakeCredentials(
 }
 
 /**
- * Gets the default base URL for Snowflake Cortex, using SNOWFLAKE_ACCOUNT if available
- * @returns Base URL string with account identifier filled in if possible
- */
-export function getSnowflakeDefaultBaseUrl(): string {
-	// Try to get the account from settings or environment variables
-	const configSettings = vscode.workspace
-		.getConfiguration('authentication.snowflake')
-		.get<SnowflakeProviderVariables>('credentials', {});
-	const account = configSettings.SNOWFLAKE_ACCOUNT || process.env.SNOWFLAKE_ACCOUNT;
-
-	if (account) {
-		try {
-			return constructSnowflakeBaseUrl(account);
-		} catch (error) {
-			// If account is invalid, fall back to placeholder
-			log.debug(`[Snowflake] Invalid account identifier '${account}', using placeholder: ${error}`);
-		}
-	}
-
-	// Fallback to placeholder if no account is available
-	return 'https://<account_identifier>.snowflakecomputing.com/api/v2/cortex/v1';
-}
-
-/**
  * Reads the configured Snowflake account identifier from settings, falling
  * back to the SNOWFLAKE_ACCOUNT environment variable.
  * @returns The account identifier, or an empty string if not set.

--- a/extensions/authentication/src/snowflakeCredentials.ts
+++ b/extensions/authentication/src/snowflakeCredentials.ts
@@ -230,14 +230,6 @@ export async function checkForUpdatedSnowflakeCredentials(
  * @returns Base URL string with account identifier filled in if possible
  */
 export function getSnowflakeDefaultBaseUrl(): string {
-	// Prefer a baseUrl previously saved by the user via the config dialog.
-	const savedBaseUrl = vscode.workspace
-		.getConfiguration('authentication.snowflake-cortex')
-		.get<string>('baseUrl');
-	if (savedBaseUrl) {
-		return savedBaseUrl;
-	}
-
 	// Try to get the account from settings or environment variables
 	const configSettings = vscode.workspace
 		.getConfiguration('authentication.snowflake')

--- a/extensions/authentication/src/test/snowflakeCredentials.test.ts
+++ b/extensions/authentication/src/test/snowflakeCredentials.test.ts
@@ -19,6 +19,21 @@ suite('Snowflake Credentials', () => {
 		sinon.restore();
 	});
 
+	suite('Configuration', () => {
+		// Snowflake's base URL is derived from the account identifier, never set
+		// directly. Registering a baseUrl setting would let it diverge from the
+		// account. Guards against anyone adding one. See issue #13750.
+		test('does not contribute a Snowflake baseUrl setting', () => {
+			const manifest = vscode.extensions.getExtension('positron.authentication')?.packageJSON;
+			const properties = manifest?.contributes?.configuration?.properties ?? {};
+			const snowflakeBaseUrlKeys = Object.keys(properties).filter(
+				key => key.toLowerCase().includes('snowflake') && key.toLowerCase().includes('baseurl')
+			);
+
+			assert.deepStrictEqual(snowflakeBaseUrlKeys, []);
+		});
+	});
+
 	suite('Account Validation', () => {
 		test('isValidSnowflakeAccount accepts valid account formats', () => {
 			// Standard org-account format

--- a/extensions/authentication/src/test/snowflakeCredentials.test.ts
+++ b/extensions/authentication/src/test/snowflakeCredentials.test.ts
@@ -9,7 +9,6 @@ import * as vscode from 'vscode';
 import {
 	isValidSnowflakeAccount,
 	constructSnowflakeBaseUrl,
-	getSnowflakeDefaultBaseUrl,
 	detectSnowflakeCredentials,
 } from '../snowflakeCredentials';
 
@@ -78,58 +77,6 @@ suite('Snowflake Credentials', () => {
 				() => constructSnowflakeBaseUrl('invalid@account'),
 				/Invalid Snowflake account identifier/
 			);
-		});
-	});
-
-	suite('Default Base URL', () => {
-		let mockWorkspaceConfig: sinon.SinonStub;
-		let getConfigurationStub: sinon.SinonStub;
-		let processEnvStub: sinon.SinonStub;
-
-		setup(() => {
-			mockWorkspaceConfig = sinon.stub();
-			const mockConfig: vscode.WorkspaceConfiguration = {
-				get: mockWorkspaceConfig,
-				has: sinon.stub(),
-				inspect: sinon.stub(),
-				update: sinon.stub()
-			};
-			getConfigurationStub = sinon.stub(vscode.workspace, 'getConfiguration').returns(mockConfig);
-			processEnvStub = sinon.stub(process, 'env').value({});
-		});
-
-		teardown(() => {
-			getConfigurationStub.restore();
-			processEnvStub.restore();
-		});
-
-		test('getSnowflakeDefaultBaseUrl uses account from configuration', () => {
-			mockWorkspaceConfig.withArgs('credentials', {}).returns({ SNOWFLAKE_ACCOUNT: 'config-account' });
-
-			const url = getSnowflakeDefaultBaseUrl();
-			assert.strictEqual(url, 'https://config-account.snowflakecomputing.com/api/v2/cortex/v1');
-		});
-
-		test('getSnowflakeDefaultBaseUrl uses account from environment', () => {
-			mockWorkspaceConfig.withArgs('credentials', {}).returns({});
-			processEnvStub.value({ SNOWFLAKE_ACCOUNT: 'env-account' });
-
-			const url = getSnowflakeDefaultBaseUrl();
-			assert.strictEqual(url, 'https://env-account.snowflakecomputing.com/api/v2/cortex/v1');
-		});
-
-		test('getSnowflakeDefaultBaseUrl falls back to placeholder when no account available', () => {
-			mockWorkspaceConfig.withArgs('credentials', {}).returns({});
-
-			const url = getSnowflakeDefaultBaseUrl();
-			assert.strictEqual(url, 'https://<account_identifier>.snowflakecomputing.com/api/v2/cortex/v1');
-		});
-
-		test('getSnowflakeDefaultBaseUrl falls back to placeholder for invalid account', () => {
-			mockWorkspaceConfig.withArgs('credentials', {}).returns({ SNOWFLAKE_ACCOUNT: 'invalid@account' });
-
-			const url = getSnowflakeDefaultBaseUrl();
-			assert.strictEqual(url, 'https://<account_identifier>.snowflakecomputing.com/api/v2/cortex/v1');
 		});
 	});
 

--- a/extensions/authentication/src/validation/snowflake.ts
+++ b/extensions/authentication/src/validation/snowflake.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as positron from 'positron';
+import { isValidSnowflakeAccount } from '../snowflakeCredentials';
 
 class SnowflakeValidationError extends Error {
 	constructor(message: string) {
@@ -16,25 +17,26 @@ class SnowflakeValidationError extends Error {
 /**
  * Validate Snowflake Cortex credentials.
  *
- * Snowflake's Cortex REST API does not expose a documented lightweight
- * endpoint suitable for credential validation. Credential errors are
+ * config.baseUrl holds the bare account, not a URL, so validate it as an
+ * account -- don't accept a user-supplied base URL (#13750). Snowflake's Cortex
+ * REST API has no lightweight validation endpoint, so credential errors are
  * surfaced at request time instead.
  */
 export async function validateSnowflakeApiKey(
 	apiKey: string,
 	config: positron.ai.LanguageModelConfig
 ): Promise<void> {
-	const baseUrl = config.baseUrl?.trim();
-	if (!baseUrl) {
+	const account = config.baseUrl?.trim();
+	if (!account) {
 		throw new SnowflakeValidationError(
-			vscode.l10n.t('Snowflake base URL is required')
+			vscode.l10n.t('Snowflake account identifier is required')
 		);
 	}
 
-	if (baseUrl.includes('<account_identifier>')) {
+	if (!isValidSnowflakeAccount(account)) {
 		throw new SnowflakeValidationError(
 			vscode.l10n.t(
-				'Please set your Snowflake account identifier in the base URL'
+				'Please set a valid Snowflake account identifier'
 			)
 		);
 	}

--- a/extensions/positron-assistant/src/providers/snowflake/snowflakeProvider.ts
+++ b/extensions/positron-assistant/src/providers/snowflake/snowflakeProvider.ts
@@ -86,7 +86,7 @@ export class SnowflakeModelProvider extends OpenAICompatibleModelProvider {
 	static source: positron.ai.LanguageModelSource = {
 		type: positron.PositronLanguageModelType.Chat,
 		provider: PROVIDER_METADATA.snowflake,
-		supportedOptions: ['apiKey', 'baseUrl', 'toolCalls', 'autoconfigure'],
+		supportedOptions: ['apiKey', 'toolCalls', 'autoconfigure'],
 		defaults: {
 			name: 'Snowflake Cortex',
 			model: 'claude-4-sonnet',

--- a/extensions/positron-assistant/src/providers/snowflake/snowflakeProvider.ts
+++ b/extensions/positron-assistant/src/providers/snowflake/snowflakeProvider.ts
@@ -18,6 +18,8 @@ function isValidSnowflakeAccount(account: string): boolean {
 		/^[a-zA-Z0-9_-]+$/.test(account);
 }
 
+// The Cortex URL is always derived from SNOWFLAKE_ACCOUNT, never a saved
+// setting. Don't read a user-configured baseUrl here (#13750).
 function getSnowflakeDefaultBaseUrl(): string {
 	const creds = vscode.workspace
 		.getConfiguration('authentication.snowflake')
@@ -86,7 +88,7 @@ export class SnowflakeModelProvider extends OpenAICompatibleModelProvider {
 	static source: positron.ai.LanguageModelSource = {
 		type: positron.PositronLanguageModelType.Chat,
 		provider: PROVIDER_METADATA.snowflake,
-		supportedOptions: ['apiKey', 'toolCalls', 'autoconfigure'],
+		supportedOptions: ['apiKey', 'baseUrl', 'toolCalls', 'autoconfigure'],
 		defaults: {
 			name: 'Snowflake Cortex',
 			model: 'claude-4-sonnet',
@@ -105,7 +107,9 @@ export class SnowflakeModelProvider extends OpenAICompatibleModelProvider {
 
 	/**
 	 * Gets the base URL for the Snowflake Cortex API.
-	 * Overrides the parent implementation to use Snowflake-specific defaults.
+	 *
+	 * At runtime `_config.baseUrl` is the account-derived Cortex URL, not the
+	 * bare account the config modal edits, and is not user-configurable (#13750).
 	 */
 	override get baseUrl() {
 		return this._config.baseUrl || SnowflakeModelProvider.source.defaults.baseUrl!;

--- a/extensions/positron-assistant/src/test/snowflake.test.ts
+++ b/extensions/positron-assistant/src/test/snowflake.test.ts
@@ -6,23 +6,11 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { createOpenAICompatibleFetch } from '../openai-fetch-utils.js';
-import { SnowflakeModelProvider } from '../providers/snowflake/snowflakeProvider.js';
 
 suite('Snowflake Provider', () => {
 
 	teardown(() => {
 		sinon.restore();
-	});
-
-	suite('Supported Options', () => {
-		// The base URL is derived from the account identifier, not user-edited.
-		// See https://github.com/posit-dev/positron/issues/13750
-		test('does not support a user-editable baseUrl', () => {
-			assert.ok(
-				!SnowflakeModelProvider.source.supportedOptions.includes('baseUrl'),
-				'Snowflake Cortex supportedOptions should not include baseUrl'
-			);
-		});
 	});
 
 	suite('Error Message Enhancement', () => {

--- a/extensions/positron-assistant/src/test/snowflake.test.ts
+++ b/extensions/positron-assistant/src/test/snowflake.test.ts
@@ -6,11 +6,23 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { createOpenAICompatibleFetch } from '../openai-fetch-utils.js';
+import { SnowflakeModelProvider } from '../providers/snowflake/snowflakeProvider.js';
 
 suite('Snowflake Provider', () => {
 
 	teardown(() => {
 		sinon.restore();
+	});
+
+	suite('Supported Options', () => {
+		// The base URL is derived from the account identifier, not user-edited.
+		// See https://github.com/posit-dev/positron/issues/13750
+		test('does not support a user-editable baseUrl', () => {
+			assert.ok(
+				!SnowflakeModelProvider.source.supportedOptions.includes('baseUrl'),
+				'Snowflake Cortex supportedOptions should not include baseUrl'
+			);
+		});
 	});
 
 	suite('Error Message Enhancement', () => {

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -170,8 +170,29 @@ export const LanguageModelConfigComponent = (props: LanguageModelConfigComponent
 }
 
 const DEPLOYMENT_URL_PATTERN = /\/openai\/deployments\//;
+const SNOWFLAKE_PROVIDER_ID = 'snowflake-cortex';
 
 const BaseUrl = (props: { baseUrl?: string; signedIn?: boolean; onChange: (newBaseUrl: string) => void; provider: IProvider }) => {
+	// For Snowflake, baseUrl holds the bare account, not a URL: relabel as
+	// "Account Identifier" and pass through. Don't make it a URL input (#13750).
+	if (props.provider.id === SNOWFLAKE_PROVIDER_ID) {
+		const accountLabel = localize('positron.languageModelConfig.snowflakeAccountInputLabel', 'Account Identifier');
+		return (
+			<div className='language-model-authentication-container' id='base-url-input'>
+				{
+					props.signedIn ?
+						<p>{localize('positron.languageModelConfig.snowflakeAccountSignedIn', "Account Identifier: {0}", props.baseUrl)}</p>
+						:
+						<LabeledTextInput
+							label={accountLabel}
+							type='text'
+							value={props.baseUrl ?? ''}
+							onChange={e => { props.onChange(e.currentTarget.value); }} />
+				}
+			</div>
+		);
+	}
+
 	const baseUrlLabel = props.provider.id === 'openai-compatible' ? localize('positron.languageModelConfig.baseUrlOpenAICompatibleInputLabel', 'Base URL (must be OpenAI compatible)') : localize('positron.languageModelConfig.baseUrlInputLabel', 'Base URL');
 	const isDeploymentUrl = props.provider.id === 'ms-foundry' && props.baseUrl ? DEPLOYMENT_URL_PATTERN.test(props.baseUrl) : false;
 


### PR DESCRIPTION
Fixes #13750

### Summary


- **Snowflake Cortex:** Removes`authentication.snowflake-cortex.baseUrl` as it was never fully implemented and Snowflake URLs are defined by the account.
- **Google Vertex AI:** updated the default endpoint to match what the setting description said the default is:
  `https://aiplatform.googleapis.com`
- **Custom Provider:** Added experimental tag to `openai-compatible.customHeaders` to match`openai-compatible.baseUrl` 

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Resolved Snowflake Assistant provider bug referencing a nonexistent setting (#13750)

### Validation Steps

@:posit-assistant

1. Open the language model configuration modal (Configure Providers).
2. Select **Snowflake Cortex** and confirm there is no editable Base URL field;
   the endpoint is derived from the account identifier.
3. Select **Google Vertex AI** (without `GOOGLE_VERTEX_PROJECT` /
   `GOOGLE_VERTEX_LOCATION` env vars set) and confirm the Base URL field
   defaults to `https://aiplatform.googleapis.com`.
4. In Settings, confirm `authentication.openai-compatible.customHeaders` carries
   the `experimental` tag like its `baseUrl` sibling.
