### PR TITLE
python: getRefreshPromise during metadata validation

### DIFF
--- a/extensions/positron-python/src/client/positron/manager.ts
+++ b/extensions/positron-python/src/client/positron/manager.ts
@@ -438,6 +438,12 @@ export class PythonRuntimeManager implements IPythonRuntimeManager, Disposable {
             throw new Error(`Python interpreter path is missing: ${extraData.pythonPath}`);
         }
 
+        // If PET's first-pass discovery is still in flight, wait for it before checking
+        // registeredPythonRuntimes. This prevents session.start() from calling
+        // getInterpreterDetails() before PET has resolved the path, which would poison
+        // the 30-second undefined cache in nativeAPI.ts:resolveEnv().
+        await this.interpreterService.getRefreshPromise();
+
         // Replace the metadata if we can find the runtime in the registered runtimes
         let registeredMetadata = this.registeredPythonRuntimes.get(extraData.pythonPath);
 


### PR DESCRIPTION
Fixes #13521

In the affiliated-runtime auto-start path, `validateMetadata()` in `manager.ts` was checking `registeredPythonRuntimes` before PET's first-pass discovery had completed. The fix awaits `getRefreshPromise()` before the registered-runtimes lookup, so PET has resolved the interpreter before we validate the path.

### Release Notes

#### New Features
- N/A

#### Bug Fixes

- Fix affiliated Python runtime failing to start when PET first-pass discovery is slower than the auto-start path (#13521)

### Validation Steps

@:interpreter

FYI that this is a speculative fix, since I haven't been able to repro the failure. 

The repro would be (on a slow/resource-constrained machine):

1. Open a workspace with a stored Python runtime affiliation (a previously-selected interpreter)
2. Restart Positron and verify the affiliated interpreter starts without "Could not start runtime: failed to resolve interpreter" errors
