### PR TITLE
e2e: remove WIN tag from r-session-hooks reconnect test

### DIFF
--- a/test/e2e/tests/sessions/r-session-hooks.test.ts
+++ b/test/e2e/tests/sessions/r-session-hooks.test.ts
@@ -66,7 +66,6 @@ test.describe('Sessions: R Session Init Hooks', {
 	});
 
 	test('R - Window reload fires only session_reconnect, not session_init or .Rprofile', {
-		tag: [tags.WIN],
 		annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/7593' }]
 	}, async function ({ app, hotKeys }) {
 		test.skip(process.platform === 'linux', 'Session dies after window reload on Linux CI (#7593)');


### PR DESCRIPTION
## Summary
- Remove the unnecessary `tags.WIN` tag from the window-reload reconnect test
- The test already skips Linux via `test.skip` and inherits the `WEB` tag from the describe block, so the WIN-only restriction prevented it from running on macOS CI

## Test plan
- [ ] Verify the reconnect test runs on WEB (Linux) and macOS CI
- [ ] Confirm no test regressions in the sessions suite