### PR TITLE
Fix for 13673

### DIFF
--- a/src/vs/base/browser/positronModalReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalReactRenderer.tsx
@@ -339,6 +339,33 @@ export class PositronModalReactRenderer extends Disposable {
 	}
 
 	/**
+	 * Disposes the contiguous run of popup renderers at the top of the stack, stopping below the
+	 * topmost non-popup renderer (e.g. a modal dialog). A renderer counts as a popup when it has
+	 * registered a bounds provider via setBoundsProvider (PositronModalPopup does; modal dialogs
+	 * do not). This lets a click outside every popup dismiss the whole popup/menu chain while
+	 * leaving an underlying dialog open. When the stack is all popups, this disposes them all,
+	 * matching disposeAll.
+	 */
+	public static disposeTopPopups(): void {
+		// Collect the stack from bottom to top.
+		const renderers: PositronModalReactRenderer[] = [];
+		PositronModalReactRenderer._renderersStack.forEach(renderer => renderers.push(renderer));
+
+		// Walk down from the top while renderers are popups; the lowest popup in this contiguous
+		// run is the base to dispose (dispose() cascades to everything above it).
+		let base: PositronModalReactRenderer | undefined;
+		for (let i = renderers.length - 1; i >= 0; i--) {
+			if (renderers[i]._boundsProvider === undefined) {
+				break;
+			}
+			base = renderers[i];
+		}
+
+		// Dispose the base of the popup run, which cascades to the popups above it.
+		base?.dispose();
+	}
+
+	/**
 	 * Renders the ReactElement that was supplied.
 	 * @param reactElement The ReactElement to render.
 	 */

--- a/src/vs/base/test/browser/positronModalReactRenderer.vitest.ts
+++ b/src/vs/base/test/browser/positronModalReactRenderer.vitest.ts
@@ -312,6 +312,71 @@ describe('PositronModalReactRenderer', () => {
 	});
 
 	/**
+	 * disposeTopPopups test suite.
+	 */
+	describe('disposeTopPopups', () => {
+		it('disposes popups above a dialog, leaving the dialog open', () => {
+			const container = createMockContainer();
+
+			// A modal dialog (no bounds provider) at the bottom of the stack.
+			let dialogDisposed = false;
+			const dialog = disposables.add(new PositronModalReactRenderer({
+				container,
+				onDisposed: () => { dialogDisposed = true; }
+			}));
+			dialog.render(createMockReactElement());
+
+			// A dropdown popup (registers bounds) on top of the dialog.
+			let popupDisposed = false;
+			const popup = disposables.add(new PositronModalReactRenderer({
+				container,
+				onDisposed: () => { popupDisposed = true; }
+			}));
+			popup.render(createMockReactElement());
+			popup.setBoundsProvider(() => new DOMRect(0, 0, 100, 100));
+
+			PositronModalReactRenderer.disposeTopPopups();
+
+			expect({ dialogDisposed, popupDisposed, remaining: container.children.length })
+				.toEqual({ dialogDisposed: false, popupDisposed: true, remaining: 1 });
+
+			dialog.dispose();
+		});
+
+		it('disposes the whole stack when every renderer is a popup', () => {
+			const container = createMockContainer();
+
+			const popup1 = disposables.add(new PositronModalReactRenderer({ container }));
+			popup1.render(createMockReactElement());
+			popup1.setBoundsProvider(() => new DOMRect(0, 0, 100, 100));
+
+			const popup2 = disposables.add(new PositronModalReactRenderer({ container }));
+			popup2.render(createMockReactElement());
+			popup2.setBoundsProvider(() => new DOMRect(50, 50, 100, 100));
+
+			PositronModalReactRenderer.disposeTopPopups();
+
+			expect(container.children.length).toBe(0);
+		});
+
+		it('is a no-op when the top renderer is not a popup', () => {
+			const container = createMockContainer();
+			const dialog = disposables.add(new PositronModalReactRenderer({ container }));
+			dialog.render(createMockReactElement());
+
+			PositronModalReactRenderer.disposeTopPopups();
+
+			expect(container.children.length).toBe(1);
+
+			dialog.dispose();
+		});
+
+		it('is a no-op on an empty stack', () => {
+			expect(() => PositronModalReactRenderer.disposeTopPopups()).not.toThrow();
+		});
+	});
+
+	/**
 	 * isInsideAnyPopup / setBoundsProvider test suite.
 	 */
 	describe('isInsideAnyPopup', () => {

--- a/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronModalPopup/positronModalPopup.tsx
@@ -563,11 +563,12 @@ export const PositronModalPopup = (props: PropsWithChildren<PositronModalPopupPr
 
 			// If the click is outside this popup's bounds, decide what to dismiss.
 			if (!(e.clientX >= clientRect.left && e.clientX <= clientRect.right && e.clientY >= clientRect.top && e.clientY <= clientRect.bottom)) {
-				// If the click is outside every popup in the stack, dismiss the root renderer so
-				// the entire popup stack is dismissed. Otherwise just close this popup (e.g. a
-				// submenu when the user clicks back into its parent menu).
+				// If the click is outside every popup in the stack, dismiss the whole popup/menu
+				// chain (the contiguous run of popups at the top of the stack), leaving any
+				// underlying modal dialog open. Otherwise just close this popup (e.g. a submenu
+				// when the user clicks back into its parent menu).
 				if (!PositronModalReactRenderer.isInsideAnyPopup(e)) {
-					PositronModalReactRenderer.disposeAll();
+					PositronModalReactRenderer.disposeTopPopups();
 				} else {
 					props.renderer.dispose();
 				}


### PR DESCRIPTION
## Description

Fixes #13673

When a modal dialog contains a dropdown list box, clicking anywhere outside the open dropdown dismissed the entire modal stack (the dialog and the dropdown), instead of just closing the dropdown.

### Root cause

A dropdown list box opens as a `PositronModalPopup`, which pushes a second renderer onto `PositronModalReactRenderer`'s stack on top of the dialog. The popup's outside-click handler called `disposeAll()` whenever the click wasn't inside any *popup*. Only `PositronModalPopup` registers bounds via `setBoundsProvider` - modal dialogs never do - so a click inside the dialog (but outside the dropdown) counted as "outside everything," and `disposeAll()` disposed the bottom renderer (the dialog), cascading the whole stack away.

### Fix

Added `PositronModalReactRenderer.disposeTopPopups()`, which disposes only the contiguous run of popup renderers at the top of the stack and stops below the first non-popup renderer (e.g. a dialog). The popup's outside-click handler now calls it instead of `disposeAll()`:

- Dialog + dropdown, click anywhere outside the dropdown -> only the dropdown closes; the dialog stays open.
- Pure menu -> submenu chains still collapse entirely on an outside click (the whole stack is popups), preserving existing behavior.

The change is contained to the renderer and the popup's outside-click handler; the dialog component and `isInsideAnyPopup` are untouched.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed clicking outside a dropdown inside a modal dialog dismissing the entire dialog (#13673)

### Validation Steps

@:modal
@:new-folder-flow
@:data-explorer

1. Open a modal dialog that contains a dropdown list box (e.g. the New Folder/Project flow, or the Add/Edit Filter modal in Data Explorer).
2. Open the dropdown, then click elsewhere inside the dialog (outside the dropdown). Verify only the dropdown closes and the dialog remains open.
3. Click fully outside the dialog and verify behavior is unchanged.
4. Regression check: open a context menu with a submenu, click completely outside, and verify the whole menu chain closes in one click.