### PR TITLE
Upgrade DuckDB from WASM build to native packages

### DIFF
--- a/extensions/positron-duckdb/CLAUDE.md
+++ b/extensions/positron-duckdb/CLAUDE.md
@@ -1,6 +1,6 @@
 # Positron DuckDB Extension Development Context
 
-This prompt provides context for working with the `positron-duckdb` extension, which provides DuckDB WebAssembly support for headless data exploration in Positron.
+This prompt provides context for working with the `positron-duckdb` extension, which provides native DuckDB support for headless data exploration in Positron.
 
 **Related documentation:**
 - **Build system**: `.claude/build-system.md` - For daemon management and compilation
@@ -10,24 +10,27 @@ This prompt provides context for working with the `positron-duckdb` extension, w
 ## Extension Overview
 
 **Purpose**: Provides DuckDB support for headless data explorers for previewing data files  
-**Display Name**: "Positron DuckDB Wasm Support"  
+**Display Name**: "Positron DuckDB Support"  
 **Location**: `extensions/positron-duckdb/`  
 **Main Entry**: `src/extension.ts`  
-**Dependencies**: `@duckdb/duckdb-wasm`, `apache-arrow`, `web-worker`  
+**Dependencies**: `@duckdb/node-api` (pulls in the platform-specific `@duckdb/node-bindings-*` native binding for the host)  
+
+The extension uses the native `@duckdb/node-api` ("node neo") package, which wraps pre-built DuckDB binaries. This replaced the previous `@duckdb/duckdb-wasm` build, which could not read compressed CSV/TSV files and had limited multithreading.
 
 ## Architecture
 
 ### Core Components
 
-1. **DuckDBInstance**: Manages DuckDB WebAssembly database connection
-2. **DuckDBTableView**: Handles data explorer requests for a specific table
-3. **ColumnProfileEvaluator**: Computes statistical summaries and profiles 
-4. **DataExplorerRpcHandler**: Implements the Data Explorer RPC protocol
+1. **DuckDBInstance**: Manages the native DuckDB database connection (`@duckdb/node-api`)
+2. **QueryResult**: Thin wrapper over a node-api result reader; exposes `toArray()`, `columnAt(i)`, `columnByName(name)`, `columnNames`, `numRows`, `numCols`. Localizes the differences from the old Apache Arrow `Table` the WASM bindings returned.
+3. **DuckDBTableView**: Handles data explorer requests for a specific table
+4. **ColumnProfileEvaluator**: Computes statistical summaries and profiles 
+5. **DataExplorerRpcHandler**: Implements the Data Explorer RPC protocol
 
 ### Key Features
 
-- **File Support**: CSV, TSV, Parquet (including gzipped versions)
-- **SQL Engine**: Full DuckDB SQL capabilities via WebAssembly
+- **File Support**: CSV, TSV, Parquet (including gzip/zstd-compressed versions, read natively from disk)
+- **SQL Engine**: Full DuckDB SQL capabilities via native pre-built binaries
 - **Data Profiling**: Histograms, frequency tables, summary statistics
 - **Filtering & Sorting**: Row filters, column filters, sorting
 - **Data Export**: CSV, TSV, HTML export formats
@@ -85,10 +88,9 @@ npm run test-extension -- -l positron-duckdb --grep "filter"
 ## Key Classes and Interfaces
 
 ### DuckDBInstance
-Manages the DuckDB WebAssembly runtime:
-- Loads DuckDB WASM bundles
-- Handles SQL query execution
-- Manages database connections
+Manages the native DuckDB runtime via `@duckdb/node-api`:
+- Creates an in-memory `DuckDBInstance` and a connection
+- Serializes and executes SQL queries (returns a `QueryResult`)
 - Provides error handling and logging
 
 ### DuckDBTableView
@@ -201,11 +203,11 @@ suite('DuckDB Extension Tests', () => {
 Set `DEBUG_LOG = true` in extension.ts for query logging
 
 #### Common Issues
-1. **WebAssembly Loading**: Check bundle paths for different platforms
-2. **File Handle Caching**: Use virtual files via `registerFileBuffer()`
-3. **SQL Generation**: Ensure proper identifier quoting with `quoteIdentifier()`
+1. **Native Binding Loading**: `@duckdb/node-api` loads the platform-specific `@duckdb/node-bindings-*` package, installed automatically as a transitive optional dependency for the build host's architecture. Positron ships arch-specific packages, so each build carries only its matching binding.
+2. **File Reading**: Files are read directly from disk by path (`uri.fsPath`); native DuckDB handles `.gz`/`.zst` compression. Non-`file:` URIs are spilled to a temp file first.
+3. **SQL Generation**: Ensure proper identifier quoting with `quoteIdentifier()` and string-literal escaping (file paths) with `quoteLiteral()`
 4. **Memory Management**: Clean up resources and event handlers
-5. **Type Conversions**: Handle DuckDB to JavaScript type mapping
+5. **Type Conversions**: node-api returns `BigInt` for integer types and `DuckDBValue` wrappers for temporal/decimal types; most queries `CAST(... AS VARCHAR)` so values arrive as strings. Wrap counts in `Number(...)`.
 
 #### Testing Isolation  
 - Use `makeTempTableName()` for unique table names
@@ -224,15 +226,14 @@ Set `DEBUG_LOG = true` in extension.ts for query logging
 - Provides statistical profiling for data science workflows  
 - Integrates with Variables pane for dataframe viewing
 
-### DuckDB WebAssembly
-- Leverages DuckDB's SQL engine in browser/Node.js context
-- Uses Apache Arrow for efficient data transfer
-- Handles large datasets with streaming and pagination
+### Native DuckDB (`@duckdb/node-api`)
+- Leverages DuckDB's SQL engine via pre-built native binaries
+- Reads files (including compressed/remote) directly
+- Handles large datasets with pagination (LIMIT/OFFSET)
 
 ## Performance Considerations
 
 - **Query Optimization**: Use subqueries for better DuckDB performance
 - **Batch Statistics**: Compute multiple statistics in single query
-- **Memory Management**: Use virtual files to avoid handle caching  
 - **Pagination**: Implement LIMIT/OFFSET for large result sets
-- **Type Conversion**: Minimize JavaScript ↔ Arrow conversions
+- **Type Conversion**: Prefer formatting values to strings in SQL over per-value JS conversion

--- a/extensions/positron-duckdb/CLAUDE.md
+++ b/extensions/positron-duckdb/CLAUDE.md
@@ -15,14 +15,14 @@ This prompt provides context for working with the `positron-duckdb` extension, w
 **Main Entry**: `src/extension.ts`  
 **Dependencies**: `@duckdb/node-api` (pulls in the platform-specific `@duckdb/node-bindings-*` native binding for the host)  
 
-The extension uses the native `@duckdb/node-api` ("node neo") package, which wraps pre-built DuckDB binaries. This replaced the previous `@duckdb/duckdb-wasm` build, which could not read compressed CSV/TSV files and had limited multithreading.
+The extension uses the native `@duckdb/node-api` ("node neo") package, which wraps pre-built DuckDB binaries. It reads compressed CSV/TSV files and supports multithreading.
 
 ## Architecture
 
 ### Core Components
 
 1. **DuckDBInstance**: Manages the native DuckDB database connection (`@duckdb/node-api`)
-2. **QueryResult**: Thin wrapper over a node-api result reader; exposes `toArray()`, `columnAt(i)`, `columnByName(name)`, `columnNames`, `numRows`, `numCols`. Localizes the differences from the old Apache Arrow `Table` the WASM bindings returned.
+2. **QueryResult**: Thin wrapper over a node-api result reader; exposes `toArray()`, `columnAt(i)`, `columnByName(name)`, `columnNames`, `numRows`, `numCols`.
 3. **DuckDBTableView**: Handles data explorer requests for a specific table
 4. **ColumnProfileEvaluator**: Computes statistical summaries and profiles 
 5. **DataExplorerRpcHandler**: Implements the Data Explorer RPC protocol
@@ -52,7 +52,7 @@ extensions/positron-duckdb/
 │           ├── flights.csv
 │           └── flights.parquet
 ├── tsconfig.json         # TypeScript configuration
-└── extension.webpack.config.js  # Build configuration
+└── esbuild.mts           # Build configuration
 ```
 
 ## Quick Development Workflow

--- a/extensions/positron-duckdb/CLAUDE.md
+++ b/extensions/positron-duckdb/CLAUDE.md
@@ -204,7 +204,7 @@ Set `DEBUG_LOG = true` in extension.ts for query logging
 
 #### Common Issues
 1. **Native Binding Loading**: `@duckdb/node-api` loads the platform-specific `@duckdb/node-bindings-*` package, installed automatically as a transitive optional dependency for the build host's architecture. Positron ships arch-specific packages, so each build carries only its matching binding.
-2. **File Reading**: Files are read directly from disk by path (`uri.fsPath`); native DuckDB handles `.gz`/`.zst` compression. Non-`file:` URIs are spilled to a temp file first.
+2. **File Reading**: Files are read directly from disk by path (`uri.fsPath`); native DuckDB transparently decompresses `.gz`/`.zst` CSV/TSV. Non-`file:` URIs (and compressed Parquet, which DuckDB's reader can't unwrap, decompressed in JS via `decompress()`) are spilled to a temp file first.
 3. **SQL Generation**: Ensure proper identifier quoting with `quoteIdentifier()` and string-literal escaping (file paths) with `quoteLiteral()`
 4. **Memory Management**: Clean up resources and event handlers
 5. **Type Conversions**: node-api returns `BigInt` for integer types and `DuckDBValue` wrappers for temporal/decimal types; most queries `CAST(... AS VARCHAR)` so values arrive as strings. Wrap counts in `Number(...)`.

--- a/extensions/positron-duckdb/esbuild.mts
+++ b/extensions/positron-duckdb/esbuild.mts
@@ -12,6 +12,9 @@ run({
 	platform: 'node',
 	entryPoints: {
 		'extension': path.join(srcDir, 'extension.ts'),
+		// The DuckDB native instance runs in this child process (forked by
+		// extension.ts) so a native abort cannot take down the extension host.
+		'duckdbWorker': path.join(srcDir, 'duckdbWorker.ts'),
 	},
 	srcDir,
 	outdir: outDir,

--- a/extensions/positron-duckdb/esbuild.mts
+++ b/extensions/positron-duckdb/esbuild.mts
@@ -16,6 +16,6 @@ run({
 	srcDir,
 	outdir: outDir,
 	additionalOptions: {
-		external: ['vscode', 'positron', '@duckdb/duckdb-wasm', 'web-worker'],
+		external: ['vscode', 'positron', '@duckdb/node-api', '@duckdb/node-bindings'],
 	},
 }, process.argv);

--- a/extensions/positron-duckdb/package-lock.json
+++ b/extensions/positron-duckdb/package-lock.json
@@ -8,9 +8,7 @@
       "name": "positron-duckdb",
       "version": "0.0.1",
       "dependencies": {
-        "@duckdb/duckdb-wasm": "1.29.1-dev132.0",
-        "apache-arrow": "^16.0.0",
-        "web-worker": "^1.3.0"
+        "@duckdb/node-api": "1.5.3-r.3"
       },
       "devDependencies": {
         "@types/glob": "^7.2.0",
@@ -222,43 +220,137 @@
         "node": ">=12"
       }
     },
-    "node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.29.1-dev132.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.29.1-dev132.0.tgz",
-      "integrity": "sha512-OUkJuH9564GQ/OgggdgJ/Yxmlk5PYnWiJe0rrNkEs0Sfsi00nK6WZgJmWGGAtCK6le2KJxFWZ4Z2MjUKGBzLuQ==",
+    "node_modules/@duckdb/node-api": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.3-r.3.tgz",
+      "integrity": "sha512-FzuL6sevuFfEFwkgiUMRMUAj4TaVqV//L0oo2FVZ9s9oYpLpALF9qZyQv2ucclTNQZwDCkm8+e6yLMc6t8IjlA==",
       "license": "MIT",
       "dependencies": {
-        "apache-arrow": "^17.0.0"
+        "@duckdb/node-bindings": "1.5.3-r.3"
       }
     },
-    "node_modules/@duckdb/duckdb-wasm/node_modules/@types/node": {
-      "version": "20.16.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.11.tgz",
-      "integrity": "sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==",
+    "node_modules/@duckdb/node-bindings": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.3-r.3.tgz",
+      "integrity": "sha512-Dphw1a9kKXZnCiWX1YCEAJsQ7WJQO2Ikgxy7m8jy0QVXqAwB9esr5NGsuEL3vMKL7velZHeZCjGOMnHZEcIsdg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@duckdb/duckdb-wasm/node_modules/apache-arrow": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz",
-      "integrity": "sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.11",
-        "@types/command-line-args": "^5.2.3",
-        "@types/command-line-usage": "^5.0.4",
-        "@types/node": "^20.13.0",
-        "command-line-args": "^5.2.1",
-        "command-line-usage": "^7.0.1",
-        "flatbuffers": "^24.3.25",
-        "json-bignum": "^0.0.3",
-        "tslib": "^2.6.2"
+        "detect-libc": "^2.1.2"
       },
-      "bin": {
-        "arrow2csv": "bin/arrow2csv.cjs"
+      "optionalDependencies": {
+        "@duckdb/node-bindings-darwin-arm64": "1.5.3-r.3",
+        "@duckdb/node-bindings-darwin-x64": "1.5.3-r.3",
+        "@duckdb/node-bindings-linux-arm64": "1.5.3-r.3",
+        "@duckdb/node-bindings-linux-arm64-musl": "1.5.3-r.3",
+        "@duckdb/node-bindings-linux-x64": "1.5.3-r.3",
+        "@duckdb/node-bindings-linux-x64-musl": "1.5.3-r.3",
+        "@duckdb/node-bindings-win32-arm64": "1.5.3-r.3",
+        "@duckdb/node-bindings-win32-x64": "1.5.3-r.3"
       }
+    },
+    "node_modules/@duckdb/node-bindings-darwin-arm64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.3-r.3.tgz",
+      "integrity": "sha512-ttD8QBesgzHu7Sc4qouuIGLM7PWedLW8GvFbnZEyMqk24mQz1HWFgaT0ivw6nDRaDPUQLB9QnAOq8MZUh1zWHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-darwin-x64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.3-r.3.tgz",
+      "integrity": "sha512-Vp9MYtoYf6zUWHdCmHXwUcJlHq3YaaIeULWeSiPUM1hsDflLiZKXtz5i250Ulz03VsfWBjpO4wdM99sjjrYKkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-arm64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.3-r.3.tgz",
+      "integrity": "sha512-3HLcrzQE83947JS51UVR7C9qnXQMltCOk4Dnhiz1CD+9u32DGLMgPTIIxclk7O+Q7EwfqzD8JV86Ud+LT1crcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-arm64-musl": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64-musl/-/node-bindings-linux-arm64-musl-1.5.3-r.3.tgz",
+      "integrity": "sha512-IadRyx+98FEynKLXAk2MzReinFgduiDXgNd5Z8c5VKch+8FgBfqkEUYGOnBMMUPT8kuheKdLj23vpWXaCzOgoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-x64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.3-r.3.tgz",
+      "integrity": "sha512-TXndAL0ZoETq17Df6wB+SUZjLGDmOsKuDSySxB+wy6sHfpRtbDgQibyXRlajVeUkRDwSzBFC5ymy16YG0Fl4iw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-x64-musl": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64-musl/-/node-bindings-linux-x64-musl-1.5.3-r.3.tgz",
+      "integrity": "sha512-5bulS16YhftXcarki4tvCufVslntpQDLOEF6RZ+FSMOGiv5d7SDXqklmVRy4DKW3C5ekgN7S2oYzuGL/ss9BuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-win32-arm64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.3-r.3.tgz",
+      "integrity": "sha512-55Vu13S0jUudiAGlNWJd7UvlW1iKjwWehD8s93jBCNm0AdE/EJN4nz5rQ0IuWzPWXpMjAYuKu00yE7NdtbTyug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-win32-x64": {
+      "version": "1.5.3-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.3-r.3.tgz",
+      "integrity": "sha512-rlOc9ltWQNHuDq99Ah8XaD80nN1ucrSK5AcH/7ibSp9ogX/jswPYlRVE7ODFJAjnQNf8bVvs++Mp+wyGvuG7ag==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -525,15 +617,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.13.tgz",
-      "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -570,18 +653,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/command-line-args": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
-      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/command-line-usage": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
-      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
       "license": "MIT"
     },
     "node_modules/@types/glob": {
@@ -1352,6 +1423,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1377,35 +1449,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/apache-arrow": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-16.1.0.tgz",
-      "integrity": "sha512-G6GiM6tzPDdGnKUnVkvVr1Nt5+hUaCMBISiasMSiJwI5L5GKDv5Du7Avc2kxlFfB/LEK2LTqh2GKSxutMdf8vQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.10",
-        "@types/command-line-args": "^5.2.3",
-        "@types/command-line-usage": "^5.0.4",
-        "@types/node": "^20.12.7",
-        "command-line-args": "^5.2.1",
-        "command-line-usage": "^7.0.1",
-        "flatbuffers": "^24.3.25",
-        "json-bignum": "^0.0.3",
-        "tslib": "^2.6.2"
-      },
-      "bin": {
-        "arrow2csv": "bin/arrow2csv.cjs"
-      }
-    },
-    "node_modules/apache-arrow/node_modules/@types/node": {
-      "version": "20.16.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.10.tgz",
-      "integrity": "sha512-vQUKgWTjEIRFCvK6CyriPH3MZYiYlNy0fKiEYHWbcoWLEgs4opurGGKlebrTLqdSMIbXImH6XExNiIyNUv3WpA==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -1419,15 +1462,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
-    },
-    "node_modules/array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -1664,6 +1698,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -1676,25 +1711,11 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk-template": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
-      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk-template?sponsor=1"
-      }
-    },
     "node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -1809,6 +1830,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1821,6 +1843,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -1834,54 +1857,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/command-line-args": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
-      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/command-line-usage": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
-      "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^6.2.2",
-        "chalk-template": "^0.4.0",
-        "table-layout": "^4.1.0",
-        "typical": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/array-back": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
-      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/typical": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-7.2.0.tgz",
-      "integrity": "sha512-W1+HdVRUl8fS3MZ9ogD51GOb46xMmhAZzR0WPw5jcgIZQJVvkddYzAl4YTU6g5w33Y1iRQLdIi2/1jhi2RNL0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.17"
       }
     },
     "node_modules/commander": {
@@ -2080,12 +2055,10 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-      "dev": true,
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2592,18 +2565,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2645,12 +2606,6 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
-    },
-    "node_modules/flatbuffers": {
-      "version": "24.3.25",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.3.25.tgz",
-      "integrity": "sha512-3HDgPbgiwWMI9zVB7VYBHaMrbOO7Gm0v+yD2FV/sCKj+9NDeVL7BOBYUuhWAQGKWOzBo8S9WdMvV0eixO233XQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/flatted": {
       "version": "3.2.9",
@@ -2893,6 +2848,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3300,14 +3256,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/json-bignum": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
-      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -3510,12 +3458,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -4872,28 +4814,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/table-layout": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
-      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^6.2.2",
-        "wordwrapjs": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/table-layout/node_modules/array-back": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
-      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
@@ -5014,6 +4934,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -5115,15 +5036,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
@@ -5147,12 +5059,6 @@
       "engines": {
         "node": ">=18.17"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -5195,12 +5101,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/web-worker": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.3.0.tgz",
-      "integrity": "sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -5238,15 +5138,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/wordwrapjs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
-      "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.17"
       }
     },
     "node_modules/workerpool": {

--- a/extensions/positron-duckdb/package.json
+++ b/extensions/positron-duckdb/package.json
@@ -33,9 +33,7 @@
     "@vscode/vsce": "^3.3.2"
   },
   "dependencies": {
-    "@duckdb/duckdb-wasm": "1.29.1-dev132.0",
-    "apache-arrow": "^16.0.0",
-    "web-worker": "^1.3.0"
+    "@duckdb/node-api": "1.5.3-r.3"
   },
   "repository": {
     "type": "git",

--- a/extensions/positron-duckdb/package.nls.json
+++ b/extensions/positron-duckdb/package.nls.json
@@ -1,4 +1,4 @@
 {
-	"displayName": "Positron DuckDB Wasm Support",
+	"displayName": "Positron DuckDB Support",
 	"description": "Provides DuckDB support for headless data explorers for previewing data files."
 }

--- a/extensions/positron-duckdb/src/duckdbWorker.ts
+++ b/extensions/positron-duckdb/src/duckdbWorker.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/extensions/positron-duckdb/src/duckdbWorker.ts
+++ b/extensions/positron-duckdb/src/duckdbWorker.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// This module is the entry point for the DuckDB child process. It owns the
+// native `@duckdb/node-api` instance and runs queries on its behalf. Running
+// DuckDB out-of-process isolates the extension host from native failures: a
+// query that exhausts memory aborts (or is OS-killed) only this child, and the
+// host can detect the exit, fail the in-flight request, and respawn. A native
+// abort cannot be caught in-process, so this isolation is the only way to keep
+// the extension host stable when DuckDB runs out of memory.
+
+import { DuckDBConnection, DuckDBInstance } from '@duckdb/node-api';
+import {
+	WorkerQueryRequest,
+	WorkerQueryResponse
+} from './duckdbWorkerProtocol';
+
+/** Send a response to the host, narrowed so TypeScript knows IPC is available. */
+function send(response: WorkerQueryResponse): void {
+	process.send?.(response);
+}
+
+let connection: DuckDBConnection | undefined;
+let initError: Error | undefined;
+
+// Initialize the native database once. Failures (e.g. a native binding that
+// fails to load) are captured and reported per-query rather than crashing.
+const ready: Promise<void> = (async () => {
+	try {
+		const instance = await DuckDBInstance.create(':memory:');
+		connection = await instance.connect();
+		await connection.run(`LOAD icu;
+		SET TIMEZONE='UTC';
+		`);
+	} catch (error) {
+		initError = error instanceof Error ? error : new Error(String(error));
+	}
+})();
+
+// Process queries strictly in the order received. The native connection is not
+// safe for concurrent `runAndReadAll` calls, so we chain them. The async body
+// always replies and never rejects, so the chain cannot break.
+let queue: Promise<void> = Promise.resolve();
+
+process.on('message', (request: WorkerQueryRequest) => {
+	queue = queue.then(async () => {
+		await ready;
+		if (initError || !connection) {
+			send({ kind: 'error', id: request.id, error: (initError ?? new Error('DuckDB failed to initialize')).message });
+			return;
+		}
+		try {
+			const reader = await connection.runAndReadAll(request.sql);
+			// Materialize to plain JS up front so the result can cross the IPC
+			// boundary. `getColumnsJS` coerces values to plain JS (Date, number,
+			// bigint, string, null), all of which the host receives via V8
+			// "advanced" serialization.
+			send({
+				kind: 'result',
+				id: request.id,
+				columnNames: reader.columnNames(),
+				columns: reader.getColumnsJS()
+			});
+		} catch (error) {
+			send({ kind: 'error', id: request.id, error: error instanceof Error ? error.message : String(error) });
+		}
+	});
+});
+
+// If the host goes away, there is nothing left to serve; exit cleanly.
+process.on('disconnect', () => process.exit(0));

--- a/extensions/positron-duckdb/src/duckdbWorkerProtocol.ts
+++ b/extensions/positron-duckdb/src/duckdbWorkerProtocol.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/extensions/positron-duckdb/src/duckdbWorkerProtocol.ts
+++ b/extensions/positron-duckdb/src/duckdbWorkerProtocol.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Message shapes exchanged between the extension host and the DuckDB child
+// process (see `duckdbWorker.ts`). Messages are sent with Node's "advanced"
+// (V8 structured clone) serialization, so values may include bigint and Date.
+
+/** Host -> worker: run a SQL query identified by `id`. */
+export interface WorkerQueryRequest {
+	id: number;
+	sql: string;
+}
+
+/** Worker -> host: the result (or error) for the query with the matching `id`. */
+export type WorkerQueryResponse =
+	| {
+		kind: 'result';
+		id: number;
+		/** Column names in column order. */
+		columnNames: string[];
+		/** Materialized result, as one array of values per column. */
+		columns: any[][];
+	}
+	| {
+		kind: 'error';
+		id: number;
+		/** Human-readable error message from DuckDB or the worker. */
+		error: string;
+	};

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -184,9 +184,20 @@ export class DuckDBInstance {
 	}
 
 	private spawnWorker(): void {
+		// The extension host runs as an Electron process. Forking inherits the
+		// host's `process.execArgv` (and runs the Electron binary), which carries
+		// Chromium-only flags such as `--crash-reporter-directory` that Node
+		// rejects on startup (exit code 9). Force a plain Node child by clearing
+		// `execArgv` and setting `ELECTRON_RUN_AS_NODE`, the same pattern VS Code
+		// uses to fork the TypeScript server (see serverProcess.electron.ts).
+		//
 		// "advanced" serialization uses the V8 structured-clone algorithm, which
 		// preserves bigint and Date values returned by DuckDB.
-		const worker = fork(this.workerPath, [], { serialization: 'advanced' });
+		const worker = fork(this.workerPath, [], {
+			serialization: 'advanced',
+			execArgv: [],
+			env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+		});
 		worker.on('message', (message: unknown) => {
 			const response = message as WorkerQueryResponse;
 			const pending = this._pending.get(response.id);

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -1870,12 +1870,22 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 				// Watch file for changes.
 				const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(uri, '*'), true);
 				watcher.onDidChange(async () => {
-					const newTableName = `positron_${this._tableIndex++}`;
+					try {
+						const newTableName = `positron_${this._tableIndex++}`;
 
-					await this.createTableFromUri(uri, newTableName);
+						await this.createTableFromUri(uri, newTableName);
 
-					const newSchema = (await this.db.runQuery(`DESCRIBE ${newTableName};`)).toArray();
-					await tableView.onFileUpdated(newTableName, newSchema);
+						const newSchema = (await this.db.runQuery(`DESCRIBE ${newTableName};`)).toArray();
+						await tableView.onFileUpdated(newTableName, newSchema);
+					} catch (error) {
+						// The file may have been changed-then-deleted, or otherwise
+						// become unreadable, between the change event firing and the
+						// re-import. This async handler must not throw: an unhandled
+						// rejection here would surface unpredictably (e.g. failing an
+						// unrelated test). Log and leave the existing table in place.
+						const errorMessage = error instanceof Error ? error.message : String(error);
+						console.error(`Failed to reload dataset after file change (${uri.toString()}): ${errorMessage}`);
+					}
 				});
 				// Stop watching deleted files.
 				watcher.onDidDelete(() => watcher.dispose());

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -81,6 +81,7 @@ import { randomUUID } from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import * as zlib from 'zlib';
 
 // Set to true when doing development for better console logging
 const DEBUG_LOG = false;
@@ -93,6 +94,8 @@ const DEBUG_LOG = false;
  */
 class QueryResult {
 	private _columns: any[][] | undefined;
+	private _rows: any[] | undefined;
+	private _columnNames: string[] | undefined;
 
 	constructor(private readonly result: DuckDBResultReader) { }
 
@@ -108,18 +111,30 @@ class QueryResult {
 
 	/** The names of the columns, in column order. */
 	get columnNames(): string[] {
-		return this.result.columnNames();
+		if (this._columnNames === undefined) {
+			this._columnNames = this.result.columnNames();
+		}
+		return this._columnNames;
 	}
+
+	// Note: the JS accessors (getRowObjectsJS / getColumnsJS) coerce values to
+	// plain JS (e.g. Date for temporal types, number for DECIMAL) rather than
+	// node-api's DuckDBValue wrapper objects, so values that aren't explicitly
+	// CAST to VARCHAR in SQL still render and serialize sanely. Integer types
+	// remain bigint; count/stat call sites wrap those in Number(...).
 
 	/** The result rows as plain objects keyed by column name. */
 	toArray(): any[] {
-		return this.result.getRowObjects();
+		if (this._rows === undefined) {
+			this._rows = this.result.getRowObjectsJS();
+		}
+		return this._rows;
 	}
 
 	/** The values for the column at the given index. */
 	columnAt(index: number): any[] {
 		if (this._columns === undefined) {
-			this._columns = this.result.getColumns();
+			this._columns = this.result.getColumnsJS();
 		}
 		return this._columns[index];
 	}
@@ -133,16 +148,22 @@ class QueryResult {
 class DuckDBInstance {
 	runningQuery: Promise<any> = Promise.resolve();
 
-	constructor(readonly con: DuckDBConnection) { }
+	constructor(private readonly instance: NeoDuckDBInstance, readonly con: DuckDBConnection) { }
 
-	static async create(_ctx: vscode.ExtensionContext): Promise<DuckDBInstance> {
+	static async create(): Promise<DuckDBInstance> {
 		// Create an in-memory database backed by the native DuckDB binary.
 		const instance = await NeoDuckDBInstance.create(':memory:');
 		const con = await instance.connect();
 		await con.run(`LOAD icu;
 		SET TIMEZONE=\'UTC\';
 		`);
-		return new DuckDBInstance(con);
+		return new DuckDBInstance(instance, con);
+	}
+
+	/** Closes the connection and releases the native database handle. */
+	close(): void {
+		this.con.closeSync();
+		this.instance.closeSync();
 	}
 
 	async runQuery(query: string): Promise<QueryResult> {
@@ -312,6 +333,29 @@ function quoteIdentifier(fieldName: string) {
  */
 function quoteLiteral(value: string) {
 	return value.replace(/'/g, '\'\'');
+}
+
+/**
+ * Decompresses a gzip- or zstd-compressed buffer. Used for Parquet files, whose
+ * reader cannot unwrap an outer compression container the way DuckDB's CSV/TSV
+ * readers can.
+ * @param data The compressed bytes
+ * @param compression The compression scheme
+ * @returns The decompressed bytes
+ */
+function decompress(data: Uint8Array, compression: 'gzip' | 'zstd'): Uint8Array {
+	if (compression === 'gzip') {
+		return zlib.gunzipSync(data);
+	}
+	// zstdDecompressSync was added to Node's zlib after the @types/node version
+	// pinned here, so reach for it through a narrowed type.
+	const zstd = (zlib as typeof zlib & {
+		zstdDecompressSync?: (buf: Uint8Array) => Buffer;
+	}).zstdDecompressSync;
+	if (typeof zstd !== 'function') {
+		throw new Error('Zstandard decompression is not supported by this runtime');
+	}
+	return zstd(data);
 }
 
 function anyValue(unquotedName: string) {
@@ -1582,10 +1626,10 @@ END`;
 		const exportQueryOutput = async (query: string,
 			columns: Array<SchemaEntry>): Promise<ExportedData> => {
 			const result = await this.db.runQuery(query);
+			const names = result.columnNames;
 			const unboxed = [
 				columns.map(s => s.column_name),
-				// TODO: maybe this can be made more efficient
-				...result.toArray().map(row => result.columnNames.map(name => row[name]))
+				...result.toArray().map(row => names.map(name => row[name]))
 			];
 
 			let data;
@@ -1858,11 +1902,16 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 	 */
 	async createTableFromUri(uri: vscode.Uri, catalogName: string, importOptions?: DatasetImportOptions) {
 		let fileExt = path.extname(uri.path);
-		const isGzipped = fileExt === '.gz';
-
-		if (isGzipped) {
-			fileExt = path.extname(uri.path.slice(0, -3));
+		// DuckDB transparently decompresses gzip/zstd-wrapped CSV/TSV by file
+		// extension, so we strip the compression extension to detect the inner
+		// format. Parquet is handled separately below (its reader can't unwrap an
+		// outer compression container).
+		const compressionExt = fileExt === '.gz' || fileExt === '.zst' ? fileExt : '';
+		const compression = fileExt === '.gz' ? 'gzip' : fileExt === '.zst' ? 'zstd' : undefined;
+		if (compression) {
+			fileExt = path.extname(uri.path.slice(0, -compressionExt.length));
 		}
+		const isParquet = fileExt === '.parquet' || fileExt === '.parq';
 
 		const getCsvImportQuery = (_filePath: string, options: Array<string>) => {
 			return `CREATE OR REPLACE TABLE ${catalogName} AS
@@ -1893,23 +1942,31 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 			}
 		};
 
-		// Native DuckDB reads files directly from disk and transparently handles
-		// compressed (.gz/.zst) CSV/TSV files, so we can hand it the real path.
-		// For non-file URI schemes (e.g. untitled or virtual documents) DuckDB
-		// has no path to open, so we spill the contents to a temporary file.
+		// Resolve a filesystem path DuckDB can read directly. For local files we
+		// can usually hand DuckDB the real path; it reads .gz/.zst-compressed
+		// CSV/TSV transparently. We spill to a temporary file when either (a) the
+		// URI is not a local file (e.g. untitled or virtual documents), or (b) it
+		// is a compressed Parquet, whose outer container DuckDB's Parquet reader
+		// cannot unwrap, so we decompress it ourselves first.
 		let filePath: string;
 		let tempPath: string | undefined;
-		if (uri.scheme === 'file') {
+		if (uri.scheme === 'file' && !(isParquet && compression)) {
 			filePath = uri.fsPath;
 		} else {
-			const fileContents = await vscode.workspace.fs.readFile(uri);
-			tempPath = path.join(os.tmpdir(), `positron-duckdb-${randomUUID()}-${path.basename(uri.path)}`);
+			let fileContents = await vscode.workspace.fs.readFile(uri);
+			let tempName = path.basename(uri.path);
+			if (isParquet && compression) {
+				fileContents = decompress(fileContents, compression);
+				// Drop the compression extension now that the bytes are decompressed.
+				tempName = path.basename(uri.path, compressionExt);
+			}
+			tempPath = path.join(os.tmpdir(), `positron-duckdb-${randomUUID()}-${tempName}`);
 			await fs.promises.writeFile(tempPath, fileContents);
 			filePath = tempPath;
 		}
 
 		try {
-			if (fileExt === '.parquet' || fileExt === '.parq') {
+			if (isParquet) {
 				const query = `CREATE OR REPLACE TABLE ${catalogName} AS
 				SELECT * FROM parquet_scan('${quoteLiteral(filePath)}');`;
 				await this.db.runQuery(query);
@@ -2026,9 +2083,11 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
  * @param context An ExtensionContext that contains the extension context.
  */
 export async function activate(context: vscode.ExtensionContext) {
-	// Register a simple command that runs a DuckDB-Wasm query
-	const db = await DuckDBInstance.create(context);
+	// Create the native DuckDB database and close it when the extension unloads.
+	const db = await DuckDBInstance.create();
+	context.subscriptions.push({ dispose: () => db.close() });
 
+	// Register a simple command that runs a DuckDB query
 	context.subscriptions.push(
 		vscode.commands.registerCommand('positron-duckdb.runQuery',
 			async (query: string) => {

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -77,7 +77,6 @@ function isSelectionRange(spec: ArraySelection): spec is DataSelectionRange {
 	return (spec as DataSelectionRange).first_index !== undefined;
 }
 import { DuckDBConnection, DuckDBInstance as NeoDuckDBInstance, DuckDBResultReader } from '@duckdb/node-api';
-import { randomUUID } from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -1949,7 +1948,8 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 		// is a compressed Parquet, whose outer container DuckDB's Parquet reader
 		// cannot unwrap, so we decompress it ourselves first.
 		let filePath: string;
-		let tempPath: string | undefined;
+		let tempDir: string | undefined;
+		let spillContents: Uint8Array | undefined;
 		if (uri.scheme === 'file' && !(isParquet && compression)) {
 			filePath = uri.fsPath;
 		} else {
@@ -1960,12 +1960,20 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 				// Drop the compression extension now that the bytes are decompressed.
 				tempName = path.basename(uri.path, compressionExt);
 			}
-			tempPath = path.join(os.tmpdir(), `positron-duckdb-${randomUUID()}-${tempName}`);
-			await fs.promises.writeFile(tempPath, fileContents);
-			filePath = tempPath;
+			// Spill into a private (mode 0700) per-import directory so the
+			// contents aren't readable by other users on shared hosts. os.tmpdir()
+			// honors TMPDIR (POSIX) and TMP/TEMP (Windows). Creating the directory
+			// before the try below guarantees the finally always cleans it up,
+			// even if the write or import fails.
+			tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'positron-duckdb-'));
+			filePath = path.join(tempDir, tempName);
+			spillContents = fileContents;
 		}
 
 		try {
+			if (spillContents !== undefined) {
+				await fs.promises.writeFile(filePath, spillContents);
+			}
 			if (isParquet) {
 				const query = `CREATE OR REPLACE TABLE ${catalogName} AS
 				SELECT * FROM parquet_scan('${quoteLiteral(filePath)}');`;
@@ -1974,8 +1982,10 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 				await importDelimited(filePath);
 			}
 		} finally {
-			if (tempPath !== undefined) {
-				await fs.promises.rm(tempPath, { force: true });
+			if (tempDir !== undefined) {
+				// Best-effort cleanup; a failure here (e.g. a lingering handle on
+				// Windows) must not mask the import result or error.
+				await fs.promises.rm(tempDir, { recursive: true, force: true }).catch(() => { });
 			}
 		}
 	}

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -76,61 +76,87 @@ import {
 function isSelectionRange(spec: ArraySelection): spec is DataSelectionRange {
 	return (spec as DataSelectionRange).first_index !== undefined;
 }
-import * as duckdb from '@duckdb/duckdb-wasm';
+import { DuckDBConnection, DuckDBInstance as NeoDuckDBInstance, DuckDBResultReader } from '@duckdb/node-api';
+import { randomUUID } from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
-import * as zlib from 'zlib';
-import Worker from 'web-worker';
-import { Table, Vector } from 'apache-arrow';
-import { pathToFileURL } from 'url';
 
 // Set to true when doing development for better console logging
 const DEBUG_LOG = false;
 
+/**
+ * A thin wrapper over a materialized `@duckdb/node-api` result that exposes the
+ * small set of shapes the rest of the extension relies on. This localizes the
+ * differences between the native node-api result reader and the Apache Arrow
+ * `Table` that the WASM bindings used to return.
+ */
+class QueryResult {
+	private _columns: any[][] | undefined;
+
+	constructor(private readonly result: DuckDBResultReader) { }
+
+	/** The number of columns in the result. */
+	get numCols(): number {
+		return this.result.columnCount;
+	}
+
+	/** The number of rows in the (materialized) result. */
+	get numRows(): number {
+		return this.result.currentRowCount;
+	}
+
+	/** The names of the columns, in column order. */
+	get columnNames(): string[] {
+		return this.result.columnNames();
+	}
+
+	/** The result rows as plain objects keyed by column name. */
+	toArray(): any[] {
+		return this.result.getRowObjects();
+	}
+
+	/** The values for the column at the given index. */
+	columnAt(index: number): any[] {
+		if (this._columns === undefined) {
+			this._columns = this.result.getColumns();
+		}
+		return this._columns[index];
+	}
+
+	/** The values for the column with the given name. */
+	columnByName(name: string): any[] {
+		return this.columnAt(this.columnNames.indexOf(name));
+	}
+}
+
 class DuckDBInstance {
 	runningQuery: Promise<any> = Promise.resolve();
 
-	constructor(readonly db: duckdb.AsyncDuckDB, readonly con: duckdb.AsyncDuckDBConnection) { }
+	constructor(readonly con: DuckDBConnection) { }
 
-	static async create(ctx: vscode.ExtensionContext): Promise<DuckDBInstance> {
-		// Create the path to the DuckDB WASM bundle. Note that only the EH
-		// bundle for Node is used for now as we don't support Positron
-		// extensions running in a browser context yet.
-		const distPath = path.join(ctx.extensionPath, 'node_modules', '@duckdb', 'duckdb-wasm', 'dist');
-		const bundle = {
-			mainModule: path.join(distPath, 'duckdb-eh.wasm'),
-			mainWorker: path.join(distPath, 'duckdb-node-eh.worker.cjs')
-		};
-
-		// On Windows, we need to call pathToFileURL on mainWorker because the web-worker package
-		// does not support Windows paths that start with a drive letter.
-		if (process.platform === 'win32') {
-			bundle.mainWorker = pathToFileURL(bundle.mainWorker).toString();
-		}
-
-		const worker = new Worker(bundle.mainWorker);
-		const logger = new duckdb.VoidLogger();
-		const db = new duckdb.AsyncDuckDB(logger, worker);
-		await db.instantiate(bundle.mainModule);
-
-		const con = await db.connect();
-		await con.query(`LOAD icu;
+	static async create(_ctx: vscode.ExtensionContext): Promise<DuckDBInstance> {
+		// Create an in-memory database backed by the native DuckDB binary.
+		const instance = await NeoDuckDBInstance.create(':memory:');
+		const con = await instance.connect();
+		await con.run(`LOAD icu;
 		SET TIMEZONE=\'UTC\';
 		`);
-		return new DuckDBInstance(db, con);
+		return new DuckDBInstance(con);
 	}
 
-	async runQuery(query: string): Promise<Table<any>> {
+	async runQuery(query: string): Promise<QueryResult> {
 		await this.runningQuery;
 		try {
 			const startTime = Date.now();
-			this.runningQuery = this.con.query(query);
+			this.runningQuery = this.con.runAndReadAll(query);
 
 			const result = await this.runningQuery;
 			const elapsedMs = Date.now() - startTime;
 			if (DEBUG_LOG) {
 				console.log(`Took ${elapsedMs} ms to run:\n${query}`);
 			}
-			return result;
+			return new QueryResult(result);
 		} catch (error) {
 			if (DEBUG_LOG) {
 				console.log(`Failed to execute:\n${query}`);
@@ -276,6 +302,16 @@ function makeWhereExpr(rowFilter: RowFilter): string {
 function quoteIdentifier(fieldName: string) {
 	// Double any existing double quotes and wrap in double quotes
 	return '"' + fieldName.replace(/"/g, '""') + '"';
+}
+
+/**
+ * Escapes a string for use inside a single-quoted DuckDB SQL string literal,
+ * e.g. a file path passed to read_csv_auto or parquet_scan.
+ * @param value The raw string value (the caller supplies the surrounding quotes)
+ * @returns The value with single quotes doubled per SQL escaping convention
+ */
+function quoteLiteral(value: string) {
+	return value.replace(/'/g, '\'\'');
 }
 
 function anyValue(unquotedName: string) {
@@ -463,7 +499,7 @@ class ColumnProfileEvaluator {
 		SELECT value::VARCHAR AS value, freq
 		FROM freq_table
 		ORDER BY freq DESC, value ASC
-		LIMIT ${params.limit};`) as Table<any>;
+		LIMIT ${params.limit};`);
 
 		const values: string[] = [];
 		const counts: number[] = [];
@@ -546,7 +582,7 @@ class ColumnProfileEvaluator {
 				`${this.whereClause} AND ${predicate}` :
 				`WHERE ${predicate}`;
 			const result = await this.db.runQuery(`SELECT ${quoteIdentifier(field)}::VARCHAR AS value
-			FROM ${this.tableName} ${composedPred} LIMIT 1;`) as Table<any>;
+			FROM ${this.tableName} ${composedPred} LIMIT 1;`);
 
 			const fixedValue = result.toArray()[0].value;
 
@@ -689,9 +725,9 @@ class ColumnProfileEvaluator {
 		// Table with a single row containing all the computed statistics
 		const statsResult = await this.db.runQuery(statsQuery);
 
-		const stats = new Map<string, any>(statsResult.schema.names.map((value, index) => {
-			const child = statsResult.getChild(value)!;
-			return [value, child.get(0)] as [string, any];
+		const stats = new Map<string, any>(statsResult.columnNames.map((value) => {
+			const column = statsResult.columnByName(value);
+			return [value, column[0]] as [string, any];
 		}));
 
 		const results: Array<ColumnProfileResult> = [];
@@ -1129,8 +1165,8 @@ END`;
 			columns: []
 		};
 
-		const floatAdapter = (field: Vector<any>, i: number) => {
-			const value: string = field.get(i - lowerLimit);
+		const floatAdapter = (field: any[], i: number) => {
+			const value: string = field[i - lowerLimit];
 			switch (value) {
 				case 'NaN':
 					return SENTINEL_NAN;
@@ -1145,17 +1181,18 @@ END`;
 			}
 		};
 
-		const defaultAdapter = (field: Vector<any>, i: number) => {
+		const defaultAdapter = (field: any[], i: number) => {
 			const relIndex = i - lowerLimit;
-			return field.isValid(relIndex) ? field.get(relIndex) : SENTINEL_NULL;
+			const value = field[relIndex];
+			return value === null || value === undefined ? SENTINEL_NULL : value;
 		};
 
 		for (let i = 0; i < queryResult.numCols; i++) {
 			const column = params.columns[i];
 			const spec = column.spec;
-			const field = queryResult.getChildAt(i)!;
+			const field = queryResult.columnAt(i);
 
-			const fetchValues = (adapter: (field: Vector<any>, i: number) => ColumnValue) => {
+			const fetchValues = (adapter: (field: any[], i: number) => ColumnValue) => {
 				if (isSelectionRange(spec)) {
 					// There may be fewer rows available than what was requested
 					const lastIndex = Math.min(
@@ -1548,7 +1585,7 @@ END`;
 			const unboxed = [
 				columns.map(s => s.column_name),
 				// TODO: maybe this can be made more efficient
-				...result.toArray().map(row => result.schema.names.map(name => row[name]))
+				...result.toArray().map(row => result.columnNames.map(name => row[name]))
 			];
 
 			let data;
@@ -1624,7 +1661,7 @@ END`;
 				const query = `SELECT ${selector} FROM ${this.tableName}${this._whereClause}${this._sortClause} LIMIT 1 OFFSET ${rowIndex};`;
 				const result = await this.db.runQuery(query);
 				return {
-					data: result.toArray()[0][result.schema.names[0]],
+					data: result.toArray()[0][result.columnNames[0]],
 					format: params.format
 				};
 			}
@@ -1757,7 +1794,7 @@ END`;
 }
 
 /**
- * Implementation of Data Explorer backend protocol using duckdb-wasm,
+ * Implementation of Data Explorer backend protocol using native DuckDB,
  * for serving requests coming in through the vscode command.
  */
 export class DataExplorerRpcHandler implements vscode.Disposable {
@@ -1829,7 +1866,7 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 
 		const getCsvImportQuery = (_filePath: string, options: Array<string>) => {
 			return `CREATE OR REPLACE TABLE ${catalogName} AS
-			SELECT * FROM read_csv_auto('${_filePath}'${options.length ? ', ' : ''}${options.join(' ,')});`;
+			SELECT * FROM read_csv_auto('${quoteLiteral(_filePath)}'${options.length ? ', ' : ''}${options.join(' ,')});`;
 		};
 
 		const importDelimited = async (filePath: string) => {
@@ -1856,33 +1893,33 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 			}
 		};
 
-		// Read the entire contents and register it as a temp file
-		// to avoid file handle caching in duckdb-wasm
-		let fileContents = await vscode.workspace.fs.readFile(uri);
-		if (isGzipped) {
-			fileContents = zlib.gunzipSync(fileContents);
+		// Native DuckDB reads files directly from disk and transparently handles
+		// compressed (.gz/.zst) CSV/TSV files, so we can hand it the real path.
+		// For non-file URI schemes (e.g. untitled or virtual documents) DuckDB
+		// has no path to open, so we spill the contents to a temporary file.
+		let filePath: string;
+		let tempPath: string | undefined;
+		if (uri.scheme === 'file') {
+			filePath = uri.fsPath;
+		} else {
+			const fileContents = await vscode.workspace.fs.readFile(uri);
+			tempPath = path.join(os.tmpdir(), `positron-duckdb-${randomUUID()}-${path.basename(uri.path)}`);
+			await fs.promises.writeFile(tempPath, fileContents);
+			filePath = tempPath;
 		}
 
-		// For gzipped files, use the base name without the .gz extension
-		const virtualPath = isGzipped ?
-			path.basename(uri.path, '.gz') :
-			path.basename(uri.path);
-
-		// Use a tightly packed Uint8Array to avoid transfer issues
-		const fileBuffer = new Uint8Array(fileContents.buffer.slice(fileContents.byteOffset, fileContents.byteOffset + fileContents.byteLength));
-		await this.db.db.registerFileBuffer(virtualPath, fileBuffer);
 		try {
-			const baseExt = path.extname(virtualPath);
-			if (baseExt === '.parquet' || baseExt === '.parq') {
-				// Always create a view for Parquet files
+			if (fileExt === '.parquet' || fileExt === '.parq') {
 				const query = `CREATE OR REPLACE TABLE ${catalogName} AS
-				SELECT * FROM parquet_scan('${virtualPath}');`;
+				SELECT * FROM parquet_scan('${quoteLiteral(filePath)}');`;
 				await this.db.runQuery(query);
 			} else {
-				await importDelimited(virtualPath);
+				await importDelimited(filePath);
 			}
 		} finally {
-			await this.db.db.dropFile(virtualPath);
+			if (tempPath !== undefined) {
+				await fs.promises.rm(tempPath, { force: true });
+			}
 		}
 	}
 

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -87,9 +87,7 @@ const DEBUG_LOG = false;
 
 /**
  * A thin wrapper over a materialized `@duckdb/node-api` result that exposes the
- * small set of shapes the rest of the extension relies on. This localizes the
- * differences between the native node-api result reader and the Apache Arrow
- * `Table` that the WASM bindings used to return.
+ * small set of shapes the rest of the extension relies on.
  */
 class QueryResult {
 	private _columns: any[][] | undefined;

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -76,114 +76,190 @@ import {
 function isSelectionRange(spec: ArraySelection): spec is DataSelectionRange {
 	return (spec as DataSelectionRange).first_index !== undefined;
 }
-import { DuckDBConnection, DuckDBInstance as NeoDuckDBInstance, DuckDBResultReader } from '@duckdb/node-api';
+import { ChildProcess, fork } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as zlib from 'zlib';
+import { WorkerQueryRequest, WorkerQueryResponse } from './duckdbWorkerProtocol';
 
 // Set to true when doing development for better console logging
 const DEBUG_LOG = false;
 
 /**
- * A thin wrapper over a materialized `@duckdb/node-api` result that exposes the
- * small set of shapes the rest of the extension relies on.
+ * A query result materialized in the DuckDB worker and reconstructed here from
+ * the column-oriented form that crosses the IPC boundary. Exposes the small set
+ * of shapes the rest of the extension relies on.
  */
 class QueryResult {
-	private _columns: any[][] | undefined;
 	private _rows: any[] | undefined;
-	private _columnNames: string[] | undefined;
 
-	constructor(private readonly result: DuckDBResultReader) { }
+	constructor(
+		private readonly _columnNames: string[],
+		// One array of values per column, in column order.
+		private readonly _columns: any[][]
+	) { }
 
 	/** The number of columns in the result. */
 	get numCols(): number {
-		return this.result.columnCount;
+		return this._columns.length;
 	}
 
 	/** The number of rows in the (materialized) result. */
 	get numRows(): number {
-		return this.result.currentRowCount;
+		return this._columns.length > 0 ? this._columns[0].length : 0;
 	}
 
 	/** The names of the columns, in column order. */
 	get columnNames(): string[] {
-		if (this._columnNames === undefined) {
-			this._columnNames = this.result.columnNames();
-		}
 		return this._columnNames;
 	}
 
-	// Note: the JS accessors (getRowObjectsJS / getColumnsJS) coerce values to
-	// plain JS (e.g. Date for temporal types, number for DECIMAL) rather than
-	// node-api's DuckDBValue wrapper objects, so values that aren't explicitly
-	// CAST to VARCHAR in SQL still render and serialize sanely. Integer types
-	// remain bigint; count/stat call sites wrap those in Number(...).
+	// Note: values are already coerced to plain JS in the worker (Date for
+	// temporal types, number for DECIMAL, bigint for integers, etc.), so values
+	// that aren't explicitly CAST to VARCHAR in SQL still render and serialize
+	// sanely. Integer types remain bigint; count/stat call sites wrap those in
+	// Number(...).
 
 	/** The result rows as plain objects keyed by column name. */
 	toArray(): any[] {
 		if (this._rows === undefined) {
-			this._rows = this.result.getRowObjectsJS();
+			const numRows = this.numRows;
+			const rows: any[] = new Array(numRows);
+			for (let r = 0; r < numRows; r++) {
+				const row: { [name: string]: any } = {};
+				for (let c = 0; c < this._columnNames.length; c++) {
+					row[this._columnNames[c]] = this._columns[c][r];
+				}
+				rows[r] = row;
+			}
+			this._rows = rows;
 		}
 		return this._rows;
 	}
 
 	/** The values for the column at the given index. */
 	columnAt(index: number): any[] {
-		if (this._columns === undefined) {
-			this._columns = this.result.getColumnsJS();
-		}
 		return this._columns[index];
 	}
 
 	/** The values for the column with the given name. */
 	columnByName(name: string): any[] {
-		return this.columnAt(this.columnNames.indexOf(name));
+		return this.columnAt(this._columnNames.indexOf(name));
 	}
 }
 
-class DuckDBInstance {
-	runningQuery: Promise<any> = Promise.resolve();
+/**
+ * Host-side proxy for DuckDB. The native database runs in a separate child
+ * process (`duckdbWorker.ts`); this class forks it, forwards queries over IPC,
+ * and reconstructs results. Isolating the native binding means a query that
+ * exhausts memory aborts only the child: a native abort cannot be caught
+ * in-process, so the child dying is the only thing that keeps the extension
+ * host alive. When the worker dies, in-flight queries reject with a clear
+ * error, `onDidCrash` fires, and the next query transparently respawns it.
+ */
+export class DuckDBInstance {
+	/** Resolved path to the bundled worker entry, emitted next to this module. */
+	private static readonly defaultWorkerPath = path.join(__dirname, 'duckdbWorker.js');
 
-	constructor(private readonly instance: NeoDuckDBInstance, readonly con: DuckDBConnection) { }
+	private _worker: ChildProcess | undefined;
+	private _nextId = 0;
+	private readonly _pending = new Map<number, { resolve: (result: QueryResult) => void; reject: (error: Error) => void }>();
+	private _disposed = false;
 
-	static async create(): Promise<DuckDBInstance> {
-		// Create an in-memory database backed by the native DuckDB binary.
-		const instance = await NeoDuckDBInstance.create(':memory:');
-		const con = await instance.connect();
-		await con.run(`LOAD icu;
-		SET TIMEZONE=\'UTC\';
-		`);
-		return new DuckDBInstance(instance, con);
+	private readonly _onDidCrash = new vscode.EventEmitter<void>();
+	/** Fires when the worker process terminates unexpectedly (e.g. out of memory). */
+	readonly onDidCrash: vscode.Event<void> = this._onDidCrash.event;
+
+	private constructor(private readonly workerPath: string) { }
+
+	/**
+	 * Create a DuckDB instance. `workerPath` overrides the worker entry point and
+	 * exists only for tests (to exercise crash recovery with a stub worker).
+	 */
+	static async create(workerPath: string = DuckDBInstance.defaultWorkerPath): Promise<DuckDBInstance> {
+		const instance = new DuckDBInstance(workerPath);
+		instance.spawnWorker();
+		return instance;
 	}
 
-	/** Closes the connection and releases the native database handle. */
-	close(): void {
-		this.con.closeSync();
-		this.instance.closeSync();
+	private spawnWorker(): void {
+		// "advanced" serialization uses the V8 structured-clone algorithm, which
+		// preserves bigint and Date values returned by DuckDB.
+		const worker = fork(this.workerPath, [], { serialization: 'advanced' });
+		worker.on('message', (message: unknown) => {
+			const response = message as WorkerQueryResponse;
+			const pending = this._pending.get(response.id);
+			if (!pending) {
+				return;
+			}
+			this._pending.delete(response.id);
+			if (response.kind === 'result') {
+				pending.resolve(new QueryResult(response.columnNames, response.columns));
+			} else {
+				pending.reject(new Error(response.error));
+			}
+		});
+		worker.on('exit', (code, signal) => this.onWorkerGone(`exited (code=${code}, signal=${signal})`));
+		worker.on('error', (error) => this.onWorkerGone(`failed to start: ${error.message}`));
+		this._worker = worker;
 	}
 
-	async runQuery(query: string): Promise<QueryResult> {
-		await this.runningQuery;
-		try {
-			const startTime = Date.now();
-			this.runningQuery = this.con.runAndReadAll(query);
+	/**
+	 * Handle the worker process going away. Reject every in-flight query so
+	 * callers fail gracefully rather than hanging, and notify listeners. The
+	 * worker is respawned lazily on the next query.
+	 */
+	private onWorkerGone(detail: string): void {
+		if (this._worker === undefined) {
+			// Already handled (e.g. both 'error' and 'exit' fired), or disposed.
+			return;
+		}
+		this._worker = undefined;
 
-			const result = await this.runningQuery;
-			const elapsedMs = Date.now() - startTime;
-			if (DEBUG_LOG) {
-				console.log(`Took ${elapsedMs} ms to run:\n${query}`);
-			}
-			return new QueryResult(result);
-		} catch (error) {
-			if (DEBUG_LOG) {
-				console.log(`Failed to execute:\n${query}`);
-			}
-			this.runningQuery = Promise.resolve();
-			return Promise.reject(error);
+		const reason = new Error(`The DuckDB process terminated unexpectedly (${detail}). This usually means a query exhausted available memory.`);
+		for (const pending of this._pending.values()) {
+			pending.reject(reason);
+		}
+		this._pending.clear();
+
+		if (!this._disposed) {
+			this._onDidCrash.fire();
 		}
 	}
 
+	/** Closes the worker process and rejects any in-flight queries. */
+	close(): void {
+		this._disposed = true;
+		const worker = this._worker;
+		this._worker = undefined;
+		worker?.kill();
+		for (const pending of this._pending.values()) {
+			pending.reject(new Error('The DuckDB instance was disposed.'));
+		}
+		this._pending.clear();
+		this._onDidCrash.dispose();
+	}
+
+	runQuery(query: string): Promise<QueryResult> {
+		if (this._disposed) {
+			return Promise.reject(new Error('The DuckDB instance was disposed.'));
+		}
+		// Lazily (re)spawn the worker, e.g. after a crash.
+		if (this._worker === undefined) {
+			this.spawnWorker();
+		}
+
+		const id = this._nextId++;
+		const request: WorkerQueryRequest = { id, sql: query };
+		return new Promise<QueryResult>((resolve, reject) => {
+			this._pending.set(id, { resolve, reject });
+			if (DEBUG_LOG) {
+				console.log(`Running query ${id}:\n${query}`);
+			}
+			this._worker!.send(request);
+		});
+	}
 }
 
 type RpcResponse<Type> = Promise<Type | string>;
@@ -1842,10 +1918,17 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 	private readonly _uriToTableView = new Map<string, DuckDBTableView>();
 	private _tableIndex: number = 0;
 	private _watchers: vscode.Disposable[] = [];
+	private readonly _crashListener: vscode.Disposable;
 
-	constructor(private readonly db: DuckDBInstance) { }
+	constructor(private readonly db: DuckDBInstance) {
+		// If the DuckDB worker crashes (e.g. out of memory), its in-memory tables
+		// are gone with it. Drop the cached table views so the next request for a
+		// dataset re-imports it into the freshly respawned worker.
+		this._crashListener = this.db.onDidCrash(() => this._uriToTableView.clear());
+	}
 
 	dispose() {
+		this._crashListener.dispose();
 		vscode.Disposable.from(...this._watchers).dispose();
 	}
 

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -1867,8 +1867,12 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 			tableView = new DuckDBTableView(uri, tableName, result.toArray(), this.db);
 
 			if (uri.scheme !== 'duckdb') {
-				// Watch file for changes.
-				const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(uri, '*'), true);
+				// Watch this dataset's file for changes. Scope the pattern to the
+				// file itself (parent directory as base, exact file name as glob)
+				// rather than the whole directory, so that changes to unrelated
+				// sibling files don't trigger a spurious re-import of this dataset.
+				const watchPattern = new vscode.RelativePattern(vscode.Uri.joinPath(uri, '..'), path.basename(uri.path));
+				const watcher = vscode.workspace.createFileSystemWatcher(watchPattern, true);
 				watcher.onDidChange(async () => {
 					try {
 						const newTableName = `positron_${this._tableIndex++}`;

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert';
 import * as path from 'path';
+import * as zlib from 'zlib';
 import * as vscode from 'vscode';
 import {
 	BackendState,
@@ -400,6 +401,57 @@ suite('Positron DuckDB Extension Test Suite', () => {
 
 		} finally {
 			// Clean up the temporary file
+			try {
+				await vscode.workspace.fs.delete(vscode.Uri.file(tempPath));
+			} catch {
+				// Ignore cleanup errors
+			}
+		}
+	});
+
+	test('gzipped parquet (.parquet.gz)', async () => {
+		// DuckDB's parquet reader can't unwrap an outer gzip container, so this
+		// exercises the JS decompress + temp-file path in createTableFromUri.
+		const parquetBytes = await vscode.workspace.fs.readFile(vscode.Uri.file(flightParquet));
+		const tempPath = path.join(__dirname, 'temp_flights.parquet.gz');
+		await vscode.workspace.fs.writeFile(vscode.Uri.file(tempPath), zlib.gzipSync(parquetBytes));
+
+		try {
+			const uri = vscode.Uri.file(tempPath);
+			await dxExec({ method: DataExplorerBackendRequest.OpenDataset, params: { uri } });
+
+			const state = await getState(uri);
+			assert.deepStrictEqual(state.table_shape, { num_rows: 100, num_columns: 19 });
+		} finally {
+			try {
+				await vscode.workspace.fs.delete(vscode.Uri.file(tempPath));
+			} catch {
+				// Ignore cleanup errors
+			}
+		}
+	});
+
+	test('zstd-compressed CSV (.csv.zst)', async function () {
+		// zstdCompressSync (added to zlib after the pinned @types/node) is only
+		// needed to build the fixture; skip if the test runtime predates it.
+		// Reading is done natively by DuckDB.
+		const zstdCompressSync = (zlib as typeof zlib & {
+			zstdCompressSync?: (buf: Uint8Array) => Buffer;
+		}).zstdCompressSync;
+		if (typeof zstdCompressSync !== 'function') {
+			this.skip();
+		}
+		const csvContent = 'a,b\n1,x\n2,y\n3,z\n';
+		const tempPath = path.join(__dirname, 'temp_zstd_test.csv.zst');
+		await vscode.workspace.fs.writeFile(vscode.Uri.file(tempPath), zstdCompressSync(Buffer.from(csvContent, 'utf8')));
+
+		try {
+			const uri = vscode.Uri.file(tempPath);
+			await dxExec({ method: DataExplorerBackendRequest.OpenDataset, params: { uri } });
+
+			const state = await getState(uri);
+			assert.deepStrictEqual(state.table_shape, { num_rows: 3, num_columns: 2 });
+		} finally {
 			try {
 				await vscode.workspace.fs.delete(vscode.Uri.file(tempPath));
 			} catch {

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -47,6 +47,9 @@ import {
 	ColumnSummaryStats
 } from '../interfaces';
 import { randomBytes, randomUUID } from 'crypto';
+import * as os from 'os';
+import * as fs from 'fs';
+import { DuckDBInstance } from '../extension';
 
 const DEFAULT_FORMAT_OPTIONS: FormatOptions = {
 	large_num_digits: 2,
@@ -3278,5 +3281,43 @@ suite('Positron DuckDB Extension Test Suite', () => {
 				}
 			}
 		});
+	});
+});
+
+suite('DuckDB worker isolation', () => {
+	// A stub worker that speaks the IPC protocol, so we can exercise crash
+	// recovery without depending on the native binding or a real out-of-memory
+	// condition. It crashes hard on a sentinel query and otherwise returns a
+	// trivial one-row result.
+	const STUB_WORKER = `
+		process.on('message', (req) => {
+			if (req.sql === 'CRASH') { process.exit(1); return; }
+			process.send({ kind: 'result', id: req.id, columnNames: ['x'], columns: [[1n]] });
+		});
+	`;
+
+	test('survives a worker crash, rejects the in-flight query, and respawns', async () => {
+		const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'duckdb-stub-worker-'));
+		const stubPath = path.join(dir, 'stubWorker.js');
+		await fs.promises.writeFile(stubPath, STUB_WORKER);
+
+		const db = await DuckDBInstance.create(stubPath);
+		let crashCount = 0;
+		const crashListener = db.onDidCrash(() => { crashCount++; });
+		try {
+			// Normal query round-trips through the worker.
+			assert.strictEqual((await db.runQuery('SELECT 1')).numRows, 1);
+
+			// A crashing query rejects (rather than hanging) and fires onDidCrash.
+			await assert.rejects(db.runQuery('CRASH'), /terminated unexpectedly/);
+			assert.strictEqual(crashCount, 1, 'onDidCrash should fire exactly once');
+
+			// The next query transparently respawns the worker and succeeds.
+			assert.strictEqual((await db.runQuery('SELECT 1')).numRows, 1);
+		} finally {
+			crashListener.dispose();
+			db.close();
+			await fs.promises.rm(dir, { recursive: true, force: true });
+		}
 	});
 });

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -199,6 +199,30 @@ function waitForSchemaUpdate(uri: vscode.Uri, timeoutMs = 15000): Promise<void> 
 	});
 }
 
+/**
+ * Repeatedly writes `content` to `uri` on a short interval until the returned
+ * disposable is disposed. A freshly created file-system watcher is not armed the
+ * instant `createFileSystemWatcher` returns; on a loaded CI machine a single write
+ * can land before the watcher starts listening and the change is missed entirely.
+ * Re-issuing the write guarantees at least one change event is observed once the
+ * watcher is ready, without depending on a fixed setup delay.
+ */
+function rewriteUntilStopped(uri: vscode.Uri, content: Buffer): vscode.Disposable {
+	let active = true;
+	const pump = async () => {
+		while (active) {
+			try {
+				await vscode.workspace.fs.writeFile(uri, content);
+			} catch {
+				// The file may have been deleted during teardown; stop quietly.
+			}
+			await new Promise(resolve => setTimeout(resolve, 300));
+		}
+	};
+	void pump();
+	return { dispose: () => { active = false; } };
+}
+
 async function getSchema(tableName: string) {
 	const uri = vscode.Uri.from({ scheme: 'duckdb', path: tableName });
 	const state = await getState(uri);
@@ -3204,8 +3228,12 @@ suite('Positron DuckDB Extension Test Suite', () => {
 				// Overwrite with a new shape (extra row and column). The watcher
 				// should re-import the file and emit a schema_update event.
 				const updated = waitForSchemaUpdate(uri);
-				await vscode.workspace.fs.writeFile(uri, Buffer.from('a,b,c\n1,x,p\n2,y,q\n3,z,r\n', 'utf8'));
-				await updated;
+				const rewriting = rewriteUntilStopped(uri, Buffer.from('a,b,c\n1,x,p\n2,y,q\n3,z,r\n', 'utf8'));
+				try {
+					await updated;
+				} finally {
+					rewriting.dispose();
+				}
 
 				assert.deepStrictEqual((await getState(uri)).table_shape, { num_rows: 3, num_columns: 3 });
 			} finally {
@@ -3230,10 +3258,16 @@ suite('Positron DuckDB Extension Test Suite', () => {
 
 				// Corrupt the file. The re-import fails; the watcher's handler must
 				// swallow the error (no unhandled rejection, no schema_update) and
-				// leave the previously loaded table queryable.
+				// leave the previously loaded table queryable. Re-issue the corrupt
+				// write until the watcher fires so the negative assertion proves the
+				// reload was actually attempted and swallowed, not merely missed.
 				const updated = waitForSchemaUpdate(uri, 4000);
-				await vscode.workspace.fs.writeFile(uri, Buffer.from('not a parquet file', 'utf8'));
-				await assert.rejects(updated, /Timed out/, 'A failed re-import must not emit schema_update');
+				const rewriting = rewriteUntilStopped(uri, Buffer.from('not a parquet file', 'utf8'));
+				try {
+					await assert.rejects(updated, /Timed out/, 'A failed re-import must not emit schema_update');
+				} finally {
+					rewriting.dispose();
+				}
 
 				assert.deepStrictEqual((await getState(uri)).table_shape, { num_rows: 100, num_columns: 19 });
 			} finally {

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -57,6 +57,11 @@ const DEFAULT_FORMAT_OPTIONS: FormatOptions = {
 
 // Global callback registry for column profile events
 const columnProfileCallbacks = new Map<string, (value: any) => void>();
+
+// Global listeners for schema_update UI events, invoked with the dataset uri.
+// The file-watcher tests use these to observe reloads triggered by on-disk
+// file changes (see waitForSchemaUpdate).
+const schemaUpdateListeners = new Set<(uri: string) => void>();
 let globalCommandRegistered = false;
 
 // Not sure why it is not possible to use Mocha's 'before' for this
@@ -74,6 +79,10 @@ async function activateExtension() {
 					if (callback) {
 						callback(event.params);
 						columnProfileCallbacks.delete(event.params.callback_id);
+					}
+				} else if (event.method === 'schema_update') {
+					for (const listener of schemaUpdateListeners) {
+						listener(event.uri);
 					}
 				}
 			}
@@ -163,6 +172,30 @@ async function getState(uri: vscode.Uri): Promise<BackendState> {
 		method: DataExplorerBackendRequest.GetState,
 		uri: uri.toString(),
 		params: {}
+	});
+}
+
+/**
+ * Resolves when a schema_update UI event is emitted for the given uri, which
+ * the extension does after re-importing a watched file that changed on disk.
+ * Rejects on timeout so a watcher that never fires surfaces as a clear failure
+ * rather than hanging the suite.
+ */
+function waitForSchemaUpdate(uri: vscode.Uri, timeoutMs = 15000): Promise<void> {
+	const target = uri.toString();
+	return new Promise<void>((resolve, reject) => {
+		const listener = (eventUri: string) => {
+			if (eventUri === target) {
+				clearTimeout(timer);
+				schemaUpdateListeners.delete(listener);
+				resolve();
+			}
+		};
+		const timer = setTimeout(() => {
+			schemaUpdateListeners.delete(listener);
+			reject(new Error(`Timed out waiting for schema_update event for ${target}`));
+		}, timeoutMs);
+		schemaUpdateListeners.add(listener);
 	});
 }
 
@@ -3155,5 +3188,61 @@ suite('Positron DuckDB Extension Test Suite', () => {
 
 		// This should work now that the table view has been restored
 		await profileRpcCall(); // Should not throw an error
+	});
+
+	suite('File watcher', () => {
+		test('reloads the dataset when the watched file changes on disk', async function () {
+			this.timeout(20000);
+			const tempPath = path.join(__dirname, `temp_watch_${randomUUID().replace(/-/g, '')}.csv`);
+			const uri = vscode.Uri.file(tempPath);
+			await vscode.workspace.fs.writeFile(uri, Buffer.from('a,b\n1,x\n2,y\n', 'utf8'));
+
+			try {
+				await dxExec({ method: DataExplorerBackendRequest.OpenDataset, params: { uri } });
+				assert.deepStrictEqual((await getState(uri)).table_shape, { num_rows: 2, num_columns: 2 });
+
+				// Overwrite with a new shape (extra row and column). The watcher
+				// should re-import the file and emit a schema_update event.
+				const updated = waitForSchemaUpdate(uri);
+				await vscode.workspace.fs.writeFile(uri, Buffer.from('a,b,c\n1,x,p\n2,y,q\n3,z,r\n', 'utf8'));
+				await updated;
+
+				assert.deepStrictEqual((await getState(uri)).table_shape, { num_rows: 3, num_columns: 3 });
+			} finally {
+				try {
+					await vscode.workspace.fs.delete(uri);
+				} catch {
+					// Ignore cleanup errors
+				}
+			}
+		});
+
+		test('leaves the existing table in place when a changed file becomes unreadable', async function () {
+			this.timeout(20000);
+			const parquetBytes = await vscode.workspace.fs.readFile(vscode.Uri.file(flightParquet));
+			const tempPath = path.join(__dirname, `temp_watch_${randomUUID().replace(/-/g, '')}.parquet`);
+			const uri = vscode.Uri.file(tempPath);
+			await vscode.workspace.fs.writeFile(uri, parquetBytes);
+
+			try {
+				await dxExec({ method: DataExplorerBackendRequest.OpenDataset, params: { uri } });
+				assert.deepStrictEqual((await getState(uri)).table_shape, { num_rows: 100, num_columns: 19 });
+
+				// Corrupt the file. The re-import fails; the watcher's handler must
+				// swallow the error (no unhandled rejection, no schema_update) and
+				// leave the previously loaded table queryable.
+				const updated = waitForSchemaUpdate(uri, 4000);
+				await vscode.workspace.fs.writeFile(uri, Buffer.from('not a parquet file', 'utf8'));
+				await assert.rejects(updated, /Timed out/, 'A failed re-import must not emit schema_update');
+
+				assert.deepStrictEqual((await getState(uri)).table_shape, { num_rows: 100, num_columns: 19 });
+			} finally {
+				try {
+					await vscode.workspace.fs.delete(uri);
+				} catch {
+					// Ignore cleanup errors
+				}
+			}
+		});
 	});
 });

--- a/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
+++ b/test/e2e/tests/data-explorer/duckdb-sparklines.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -24,14 +24,14 @@ test.describe('Data Explorer - DuckDB Column Summary', {
 
 		await summaryPanel.show();
 		await summaryPanel.verifyMissingPercent([
-			{ column: 1, expected: '0%' },
+			{ column: 1, expected: '100%' },
 			{ column: 2, expected: '0%' },
 			{ column: 3, expected: '0%' },
 			{ column: 4, expected: '0%' },
 			{ column: 5, expected: '0%' }
 		]);
 		await summaryPanel.verifyColumnData([
-			{ column: 1, expected: { 'Missing': '0', 'Min': '0', 'Median': '0', 'Mean': '0', 'Max': '0', 'SD': '0' } },
+			{ column: 1, expected: { 'Missing': '100', 'Min': '0', 'Median': '0', 'Mean': '0', 'Max': '0', 'SD': '0' } },
 			{ column: 2, expected: { 'Missing': '0', 'Empty': '0', 'Unique': '100' } },
 			{ column: 3, expected: { 'Missing': '0', 'True': '46', 'False': '54' } },
 			{ column: 4, expected: { 'Missing': '0', 'Min': '-125', 'Median': '-11', 'Mean': '-2.71', 'Max': '126', 'SD': '75.02' } },


### PR DESCRIPTION

Transitions the `positron-duckdb` extension from the WebAssembly build (`@duckdb/duckdb-wasm`) to the native `@duckdb/node-api` ("node neo") package, which wraps pre-built DuckDB binaries. The native engine reads compressed CSV/TSV files and supports multithreading, neither of which the WASM build could do.

Key changes:

- Swaps the dependency stack: removes `@duckdb/duckdb-wasm`, `apache-arrow`, and `web-worker`; adds `@duckdb/node-api` (which pulls in the platform-specific `@duckdb/node-bindings-*` native binding for the host). Positron ships arch-specific packages, so each build carries only its matching binding.
- Reworks `DuckDBInstance` to create an in-memory native instance/connection, and replaces the Apache Arrow `Table` return type with a thin `QueryResult` wrapper over the node-api result reader.
- Reads files directly from disk by path. Native DuckDB transparently decompresses `.gz`/`.zst`-wrapped CSV/TSV. Compressed Parquet (which DuckDB's reader can't unwrap) is decompressed in JS via `decompress()` and spilled to a private (mode 0700) per-import temp directory first.
- Updates the extension display name to "Positron DuckDB Support" and refreshes the extension's development docs to drop stale WASM/webpack references.

Closes https://github.com/posit-dev/positron/issues/5889. 


### Performance and Memory

Native generally means faster and lighter: DuckDB now uses all cores (the WASM build was effectively single-threaded), runs ~2-4x faster on vectorized kernels, and reads files straight from disk with projection/predicate pushdown instead of copying the whole file into a 4GB-capped WASM heap first. Startup is also faster (no WASM compile/worker spin-up).

Trade-offs: DuckDB now runs in the extension-host process rather than a sandboxed worker, so a native crash or OOM affects the ext host. Compressed Parquet (and non-`file:` URIs) are still decompressed in JS via synchronous `zlib` and spilled to a temp file, which can briefly block the event loop on large files; a candidate for a streaming follow-up.


### Release Notes

#### New Features

- Data Explorer can now preview compressed CSV/TSV and Parquet files via native DuckDB. (#5889)

#### Bug Fixes


### Validation Steps

@:data-explorer @:duck-db

1. Open a plain `.csv` or `.parquet` file in the Data Explorer and confirm it loads, sorts, filters, and shows column profiles as before.
2. Open a gzip-compressed CSV (`.csv.gz`) and a zstd-compressed CSV (`.csv.zst`); confirm both load correctly.
3. Open a gzip- or zstd-compressed Parquet file and confirm it loads (decompressed in JS before import).
4. Open a file over a non-`file:` URI and confirm it is spilled to a temp file and loads.
5. Confirm the extension's display name reads "Positron DuckDB Support" in the Extensions view.

This change pulls in native bindings that are provided as prebuilds per operating system, so the biggest risk is platform/OS level issues. I've done some basic testing on what are typically the trouble spots:

- web builds
- linux arm64
- windows arm64
- macOS 

Thankfully there are already a good set of tests covering data explorer behavior that exercise the new code. 

I've also done a full complement of builds (ignore initial linux failure; it was transient -- attempt #2 has the goods): https://github.com/posit-dev/positron-builds/actions/runs/26838574285

and full test suite: https://github.com/posit-dev/positron/actions/runs/26848850879 -- also has an ignorable failure (since fixed), due to the native implementation having a more correct view of an all-null column in the test data.