### PR TITLE
Make console Ctrl+R reverse history search a user-overridable keybinding

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -552,26 +552,6 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 				break;
 			}
 
-			// Ctrl-R handling.
-			case KeyCode.KeyR: {
-				// When Ctrl-R is pressed, engage a reverse history search (like bash).
-				if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && !e.altGraphKey) {
-					const isDebugMode = isForegroundDebugSession(services.contextKeyService);
-					const entries =
-						services.executionHistoryService.getInputEntries(
-							props.positronConsoleInstance.runtimeMetadata.languageId
-						).filter(entry => {
-							// Show debug entries when in debug mode, non-debug entries otherwise.
-							const isDebugEntry = entry.debug && entry.debug !== 'inactive';
-							return isDebugMode ? isDebugEntry : !isDebugEntry;
-						});
-					engageHistoryBrowser(new HistoryInfixMatchStrategy(entries));
-					consumeEvent();
-				}
-
-				break;
-			}
-
 			case KeyCode.KeyU: {
 				// Bind Ctrl+U to `deleteAllLeft`
 				if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && !e.altGraphKey) {
@@ -1027,6 +1007,23 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			} else {
 				navigateHistoryUp();
 			}
+
+			// Focus the code editor widget.
+			codeEditorWidget.focus();
+		}));
+
+		// Add the onDidEngageHistoryInfixSearch event handler.
+		disposableStore.add(props.positronConsoleInstance.onDidEngageHistoryInfixSearch(() => {
+			// Engage a reverse history search (like bash) using the infix match strategy.
+			const isDebugMode = isForegroundDebugSession(services.contextKeyService);
+			const entries = services.executionHistoryService.getInputEntries(
+				props.positronConsoleInstance.runtimeMetadata.languageId
+			).filter(entry => {
+				// Show debug entries when in debug mode, non-debug entries otherwise.
+				const isDebugEntry = entry.debug && entry.debug !== 'inactive';
+				return isDebugMode ? isDebugEntry : !isDebugEntry;
+			});
+			engageHistoryBrowser(new HistoryInfixMatchStrategy(entries));
 
 			// Focus the code editor widget.
 			codeEditorWidget.focus();

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -1416,9 +1416,7 @@ export function registerPositronConsoleActions() {
 					primary: KeyMod.CtrlCmd | KeyCode.KeyR,
 					mac: { primary: KeyMod.WinCtrl | KeyCode.KeyR },
 					when: PositronConsoleFocused,
-					// Ensure reverse history search wins over "Open Recent..."
-					// while the console is focused.
-					weight: KeybindingWeight.WorkbenchContrib + 1,
+					weight: KeybindingWeight.WorkbenchContrib,
 				},
 			});
 		}

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -61,6 +61,7 @@ const enum PositronConsoleCommandId {
 	NavigateInputHistoryDown = 'workbench.action.positronConsole.navigateInputHistoryDown',
 	NavigateInputHistoryUp = 'workbench.action.positronConsole.navigateInputHistoryUp',
 	NavigateInputHistoryUpUsingPrefixMatch = 'workbench.action.positronConsole.navigateInputHistoryUpUsingPrefixMatch',
+	EngageHistoryInfixSearch = 'workbench.action.positronConsole.engageHistoryInfixSearch',
 	ShowNotebookConsole = 'workbench.action.positronConsole.showNotebookConsole'
 }
 
@@ -1386,6 +1387,52 @@ export function registerPositronConsoleActions() {
 				accessor.get(INotificationService).notify({
 					severity: Severity.Info,
 					message: localize('positron.navigateInputHistory.noActiveConsole', "Cannot navigate input history. A console is not active."),
+					sticky: false
+				});
+			}
+		}
+	});
+
+	/**
+	 * Register the action to engage a reverse history search using infix matching.
+	 */
+	registerAction2(class extends Action2 {
+		/**
+		 * Constructor.
+		 */
+		constructor() {
+			super({
+				id: PositronConsoleCommandId.EngageHistoryInfixSearch,
+				title: {
+					value: localize('workbench.action.positronConsole.engageHistoryInfixSearch', "Reverse History Search"),
+					original: 'Reverse History Search'
+				},
+				f1: true,
+				category,
+				keybinding: {
+					// Ctrl+R on all platforms (like GNU readline's reverse-i-search).
+					// CtrlCmd is Ctrl on Windows/Linux; the mac override uses WinCtrl
+					// (raw Ctrl) so macOS gets Ctrl+R rather than Cmd+R.
+					primary: KeyMod.CtrlCmd | KeyCode.KeyR,
+					mac: { primary: KeyMod.WinCtrl | KeyCode.KeyR },
+					when: PositronConsoleFocused,
+					weight: KeybindingWeight.WorkbenchContrib,
+				},
+			});
+		}
+
+		/**
+		 * Runs action.
+		 * @param accessor The services accessor.
+		 */
+		async run(accessor: ServicesAccessor) {
+			const positronConsoleService = accessor.get(IPositronConsoleService);
+			if (positronConsoleService.activePositronConsoleInstance) {
+				positronConsoleService.activePositronConsoleInstance.engageHistoryInfixSearch();
+			} else {
+				accessor.get(INotificationService).notify({
+					severity: Severity.Info,
+					message: localize('positron.engageHistoryInfixSearch.noActiveConsole', "Cannot search input history. A console is not active."),
 					sticky: false
 				});
 			}

--- a/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/positronConsoleActions.ts
@@ -1416,7 +1416,9 @@ export function registerPositronConsoleActions() {
 					primary: KeyMod.CtrlCmd | KeyCode.KeyR,
 					mac: { primary: KeyMod.WinCtrl | KeyCode.KeyR },
 					when: PositronConsoleFocused,
-					weight: KeybindingWeight.WorkbenchContrib,
+					// Ensure reverse history search wins over "Open Recent..."
+					// while the console is focused.
+					weight: KeybindingWeight.WorkbenchContrib + 1,
 				},
 			});
 		}

--- a/src/vs/workbench/contrib/positronConsole/test/browser/consoleHistoryKeybindings.vitest.ts
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/consoleHistoryKeybindings.vitest.ts
@@ -15,11 +15,12 @@ import { registerPositronConsoleActions } from '../../browser/positronConsoleAct
 // workbench services. Mirrors the upstream chatQueueActions keybinding test.
 registerPositronConsoleActions();
 
-// The three input-history navigation actions that carry default keybindings.
+// The input-history navigation actions that carry default keybindings.
 const NAV_COMMAND_IDS = [
 	'workbench.action.positronConsole.navigateInputHistoryDown',
 	'workbench.action.positronConsole.navigateInputHistoryUp',
 	'workbench.action.positronConsole.navigateInputHistoryUpUsingPrefixMatch',
+	'workbench.action.positronConsole.engageHistoryInfixSearch',
 ];
 
 /**
@@ -51,6 +52,9 @@ describe('Console input-history navigation keybindings', () => {
 	it('binds Up/Down on macOS alongside the readline Ctrl+N / Ctrl+P bindings', () => {
 		expect(navBindingsForOS(OperatingSystem.Macintosh)).toMatchInlineSnapshot(`
 			{
+			  "workbench.action.positronConsole.engageHistoryInfixSearch": [
+			    "ctrl+R",
+			  ],
 			  "workbench.action.positronConsole.navigateInputHistoryDown": [
 			    "DownArrow",
 			    "ctrl+N",
@@ -66,12 +70,16 @@ describe('Console input-history navigation keybindings', () => {
 		`);
 	});
 
-	// On Windows/Linux the readline bindings must NOT apply: raw Ctrl+N opens a
-	// new window and Ctrl+P opens the Command Palette. Only the arrows (and
-	// Ctrl+Up for prefix match) are bound here.
+	// On Windows/Linux the readline Ctrl+N / Ctrl+P bindings must NOT apply: raw
+	// Ctrl+N opens a new window and Ctrl+P opens the Command Palette. Only the
+	// arrows (plus Ctrl+Up for prefix match and Ctrl+R for reverse search, which
+	// are platform-independent) are bound here.
 	it('binds only the arrows on Linux/Windows, never Ctrl+N / Ctrl+P', () => {
 		expect(navBindingsForOS(OperatingSystem.Linux)).toMatchInlineSnapshot(`
 			{
+			  "workbench.action.positronConsole.engageHistoryInfixSearch": [
+			    "ctrl+R",
+			  ],
 			  "workbench.action.positronConsole.navigateInputHistoryDown": [
 			    "DownArrow",
 			  ],
@@ -85,6 +93,9 @@ describe('Console input-history navigation keybindings', () => {
 		`);
 		expect(navBindingsForOS(OperatingSystem.Windows)).toMatchInlineSnapshot(`
 			{
+			  "workbench.action.positronConsole.engageHistoryInfixSearch": [
+			    "ctrl+R",
+			  ],
 			  "workbench.action.positronConsole.navigateInputHistoryDown": [
 			    "DownArrow",
 			  ],

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -370,6 +370,11 @@ export interface IPositronConsoleInstance {
 	readonly onDidNavigateInputHistoryUp: Event<DidNavigateInputHistoryUpEventArgs>;
 
 	/**
+	 * The onDidEngageHistoryInfixSearch event.
+	 */
+	readonly onDidEngageHistoryInfixSearch: Event<void>;
+
+	/**
 	 * The onDidClearInputHistory event.
 	 */
 	readonly onDidClearInputHistory: Event<void>;
@@ -504,6 +509,11 @@ export interface IPositronConsoleInstance {
 	 * @param usingPrefixMatch A value which indicates whether to use the prefix match strategy.
 	 */
 	navigateInputHistoryUp(usingPrefixMatch: boolean): void;
+
+	/**
+	 * Engages a reverse history search using infix matching.
+	 */
+	engageHistoryInfixSearch(): void;
 
 	/**
 	 * Clears the input history.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -1294,6 +1294,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	private readonly _onDidNavigateInputHistoryUpEmitter = this._register(new Emitter<DidNavigateInputHistoryUpEventArgs>());
 
 	/**
+	 * The onDidEngageHistoryInfixSearch event emitter.
+	 */
+	private readonly _onDidEngageHistoryInfixSearchEmitter = this._register(new Emitter<void>());
+
+	/**
 	 * The onDidClearInputHistory event emitter.
 	 */
 	private readonly _onDidClearInputHistoryEmitter = this._register(new Emitter<void>);
@@ -1646,6 +1651,11 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	readonly onDidNavigateInputHistoryUp = this._onDidNavigateInputHistoryUpEmitter.event;
 
 	/**
+	 * onDidEngageHistoryInfixSearch event.
+	 */
+	readonly onDidEngageHistoryInfixSearch = this._onDidEngageHistoryInfixSearchEmitter.event;
+
+	/**
 	 * onDidClearInputHistory event.
 	 */
 	readonly onDidClearInputHistory = this._onDidClearInputHistoryEmitter.event;
@@ -1783,6 +1793,13 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 		this._onDidNavigateInputHistoryUpEmitter.fire({
 			usingPrefixMatch,
 		});
+	}
+
+	/**
+	 * Engages a reverse history search using infix matching.
+	 */
+	engageHistoryInfixSearch(): void {
+		this._onDidEngageHistoryInfixSearchEmitter.fire();
 	}
 
 	/**

--- a/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
@@ -304,6 +304,7 @@ export class TestPositronConsoleInstance implements IPositronConsoleInstance {
 	private readonly _onDidClearConsoleEmitter = new Emitter<void>();
 	private readonly _onDidNavigateInputHistoryDownEmitter = new Emitter<void>();
 	private readonly _onDidNavigateInputHistoryUpEmitter = new Emitter<DidNavigateInputHistoryUpEventArgs>();
+	private readonly _onDidEngageHistoryInfixSearchEmitter = new Emitter<void>();
 	private readonly _onDidClearInputHistoryEmitter = new Emitter<void>();
 	private readonly _onDidSetPendingCodeEmitter = new Emitter<string | undefined>();
 	private readonly _onDidExecuteCodeEmitter = new Emitter<ILanguageRuntimeCodeExecutedEvent>();
@@ -371,6 +372,10 @@ export class TestPositronConsoleInstance implements IPositronConsoleInstance {
 
 	get onDidNavigateInputHistoryUp(): Event<DidNavigateInputHistoryUpEventArgs> {
 		return this._onDidNavigateInputHistoryUpEmitter.event;
+	}
+
+	get onDidEngageHistoryInfixSearch(): Event<void> {
+		return this._onDidEngageHistoryInfixSearchEmitter.event;
 	}
 
 	get onDidClearInputHistory(): Event<void> {
@@ -523,6 +528,10 @@ export class TestPositronConsoleInstance implements IPositronConsoleInstance {
 		this._onDidNavigateInputHistoryUpEmitter.fire({
 			usingPrefixMatch,
 		});
+	}
+
+	engageHistoryInfixSearch(): void {
+		this._onDidEngageHistoryInfixSearchEmitter.fire();
 	}
 
 	clearInputHistory(): void {

--- a/test/e2e/fixtures/keybindings.json
+++ b/test/e2e/fixtures/keybindings.json
@@ -47,6 +47,15 @@
         "command": "workbench.action.reloadWindow"
     },
     {
+        // Disable the dev-only Ctrl+R reload binding (ReloadWindowAction, gated on
+        // IsDevelopmentContext) so it does not shadow the console's Ctrl+R reverse
+        // history search. This binding only exists in the compiled build the e2e
+        // suite runs against, not in built Positron; reload is driven via the entry
+        // above instead.
+        "key": "cmd+r",
+        "command": "-workbench.action.reloadWindow"
+    },
+    {
         "key": "cmd+j x",
         "command": "resetGettingStartedProgress" // Reset Welcome Walkthrough Progress
     },

--- a/test/e2e/fixtures/keybindings.json
+++ b/test/e2e/fixtures/keybindings.json
@@ -43,7 +43,7 @@
         "command": "workbench.action.positronFourPaneDataScienceLayout" // Views: Stacked Layout
     },
     {
-        "key": "cmd+r r",
+        "key": "cmd+b r",
         "command": "workbench.action.reloadWindow"
     },
     {

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -245,7 +245,7 @@ export class HotKeys {
 	}
 
 	public async reloadWindow(waitForReady = false) {
-		await this.pressHotKeys('Cmd+R R', 'Reload window');
+		await this.pressHotKeys('Cmd+B R', 'Reload window');
 
 		// wait for workbench to disappear, reappear and be ready
 		await this.code.driver.currentPage.waitForTimeout(3000);


### PR DESCRIPTION
Addresses part of #7380

This PR migrates the console's <kbd>Ctrl+R</kbd> reverse history search from the hardcoded `keyDownHandler` switch in `consoleInput.tsx` to a registered `Action2` with a keybinding. This is the third PR in the effort to convert hardcoded console keybindings into properly registered actions (following #13836 and #13903).

The action fires a new `onDidEngageHistoryInfixSearch` event on the console instance, mirroring the existing input-history navigation plumbing; the React component subscribes and engages the history browser with the infix match strategy. Because the binding is now registered, it shows up in the Keyboard Shortcuts UI and can be overridden by users:

<img width="852" height="280" alt="Screenshot 2026-06-02 at 7 52 11 PM" src="https://github.com/user-attachments/assets/5420b9aa-4d16-4d95-a2f0-9fa0ac02d29f" />

The keybinding uses `KeyMod.CtrlCmd` as the default primary with a `mac` override of `KeyMod.WinCtrl`, so it resolves to raw <kbd>Ctrl+R</kbd> on macOS, Linux, and Windows (matching the old switch's physical <kbd>Ctrl</kbd> check). The per-platform snapshot test added in #13903 was extended to lock this resolution down.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Reverse history search (<kbd>Ctrl+R</kbd>) in the console is now a registered keybinding, so it appears in the Keyboard Shortcuts UI and can be reassigned (#7380)

### Validation Steps

@:console

1. In an R or Python console, press <kbd>Ctrl+R</kbd>: the reverse history search widget engages.
2. Type a partial substring that appears in the middle of a previous entry: confirm it matches (infix, not just prefix).
3. Press <kbd>Esc</kbd>: the widget closes.
4. Open the Keyboard Shortcuts UI and search for "Reverse History Search": confirm the command is listed with <kbd>Ctrl+R</kbd> bound, and that it can be reassigned.
5. Invoke "Reverse History Search" from the Command Palette: same behavior as the keybinding.
