### PR TITLE
Fix "Assistant" layout preset not opening the Posit Assistant extension view

### DIFF
--- a/src/vs/workbench/services/positronLayout/browser/layouts/positronAssistantLayout.ts
+++ b/src/vs/workbench/services/positronLayout/browser/layouts/positronAssistantLayout.ts
@@ -78,7 +78,7 @@ registerAction2(class extends PositronLayoutAction {
 		// Prefer Posit Assistant when enabled; fall back to the legacy Positron Assistant chat view container.
 		const configurationService = accessor.get(IConfigurationService);
 		const sidebarContainerId = configurationService.getValue<boolean>('assistant.enabled')
-			? 'posit-assistant'
+			? 'workbench.view.extension.posit-assistant'
 			: 'workbench.panel.chat';
 
 		const layoutDescriptor: CustomPositronLayoutDescription = {

--- a/test/e2e/pages/layouts.ts
+++ b/test/e2e/pages/layouts.ts
@@ -159,6 +159,18 @@ export class Layouts {
 	}
 
 	/**
+	 * Assert which view container is currently active (showing) in the sidebar by
+	 * its title. The sidebar can be visible while showing the wrong view, so this
+	 * checks the actual active composite rather than mere visibility.
+	 * @param title The expected title text of the active sidebar view (e.g. 'Chat').
+	 */
+	async expectActiveSidebarView(title: string): Promise<void> {
+		await test.step(`Expect active sidebar view to be "${title}"`, async () => {
+			await expect(this.sidebar.locator('.composite.title h2')).toHaveText(title);
+		});
+	}
+
+	/**
 	 * Assert that the bottom panel is visible or not visible.
 	 * @param visible Whether the panel should be visible.
 	 */

--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -92,6 +92,16 @@ export class PositAssistant {
 		if (isSelected !== 'true') {
 			await button.click();
 		}
+		await this.expectViewOpen();
+	}
+
+	/**
+	 * Assert the Posit Assistant view is the active view in the sidebar by checking
+	 * that its activity bar button is selected. This avoids waiting on the webview
+	 * to load, so it is a reliable signal that the view container itself is open.
+	 */
+	async expectViewOpen(): Promise<void> {
+		const button = this.code.driver.currentPage.locator(ACTIVITY_BAR_BUTTON);
 		await expect(button.locator('..')).toHaveAttribute('aria-selected', 'true');
 	}
 

--- a/test/e2e/tests/layouts/layouts.test.ts
+++ b/test/e2e/tests/layouts/layouts.test.ts
@@ -143,16 +143,25 @@ test.describe('Layouts', { tag: [tags.WEB, tags.LAYOUTS, tags.WIN, tags.WORKBENC
 			await app.workbench.layouts.enterLayout('stacked');
 		});
 
+		test.afterAll('Reset Settings', async function ({ settings }) {
+			// `assistant.enabled` is worker-scoped; clear it once so it doesn't leak to other files
+			await settings.remove(['assistant.enabled']);
+		});
 
-		test('Verify Assistant Layout displays all three main parts', async function ({ app }) {
+
+		test('Verify Assistant Layout displays all three main parts and opens the legacy chat view', async function ({ app, settings }) {
 			const layouts = app.workbench.layouts;
+
+			// Pin the legacy fallback branch (Posit Assistant disabled)
+			await settings.set({ 'assistant.enabled': false });
 
 			// Enter assistant layout
 			await layouts.enterLayout('assistant');
 
 			// ------ Sidebar -------
-			// Should be visible with the Chat view
+			// Should open and focus the legacy Chat view
 			await expect(layouts.sidebar).toBeVisible();
+			await layouts.expectActiveSidebarView('Chat');
 
 			// ------ Panel -------
 			// Should be visible with Console and Terminal tabs
@@ -173,6 +182,21 @@ test.describe('Layouts', { tag: [tags.WEB, tags.LAYOUTS, tags.WIN, tags.WORKBENC
 			// Both sections should be expanded
 			await expect(variablesSection).toHaveAttribute('aria-expanded', 'true');
 			await expect(plotsSection).toHaveAttribute('aria-expanded', 'true');
+		});
+
+		test('Verify Assistant Layout opens the Posit Assistant view when enabled', async function ({ app, settings }) {
+			const layouts = app.workbench.layouts;
+
+			// Enable Posit Assistant so the layout targets its view container
+			await settings.set({ 'assistant.enabled': true });
+
+			// Enter assistant layout
+			await layouts.enterLayout('assistant');
+
+			// ------ Sidebar -------
+			// Should open and focus the Posit Assistant view
+			await expect(layouts.sidebar).toBeVisible();
+			await app.workbench.positAssistant.expectViewOpen();
 		});
 	});
 });


### PR DESCRIPTION
Fixes #13933

The Assistant layout preset stopped opening the assistant pane. Instead selecting it left the sidebar focused on whatever view was already open. When Posit Assistant is enabled (`assistant.enabled`), the layout tried to open a view container with the ID `posit-assistant`, but extension-contributed containers are registered at runtime with a `workbench.view.extension.` prefix (see `viewsExtensionPoint.ts`). Since no container matched `posit-assistant`, `openPaneComposite` silently no-opped and the sidebar never switched. This PR opens the correct container ID, `workbench.view.extension.posit-assistant`. I think when I worked on this in https://github.com/posit-dev/positron/pull/13725 I already had Posit Assistant as the last view for that pane and was only looking at other changes for the layout.

This PR also strengthens the E2E coverage so a regression like this could be caught in the future. The Assistant layout test now asserts the *active* sidebar view rather than mere sidebar visibility, with one case for the legacy `workbench.panel.chat` fallback and one for the `assistant.enabled` Posit Assistant path. This will have to get switched around if/when we change defaults for settings.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix the Assistant layout preset not opening the Posit Assistant pane (#13933)

### Validation Steps

@:layouts @:assistant @:posit-assistant

1. With `assistant.enabled` on, run the **View: Assistant Layout** command from the command palette and confirm the Posit Assistant view opens and is focused in the sidebar.
2. With `assistant.enabled` off and `positron.assistant.enable` on, run the command and confirm the legacy Chat view opens in the sidebar.
3. In both cases, confirm the panel shows Console and Terminal, and the auxiliary bar shows the Session view with Variables and Plots.
