### PR TITLE
Use .html docs URLs so Workbench links resolve

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/widget/chatWidget.ts
@@ -1325,7 +1325,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 See {learn-more-link} to learn more.
 `);
 		welcomeText = welcomeText.replace('{action-link}', `[${actionLinkMessage}](${actionLinkUri})`);
-		welcomeText = welcomeText.replace('{learn-more-link}', `[${learnMoreLinkMessage}](${this.docsService.getUrl('assistant')})`);
+		welcomeText = welcomeText.replace('{learn-more-link}', `[${learnMoreLinkMessage}](${this.docsService.getUrl('assistant.html')})`);
 
 		return {
 			title: welcomeTitle,

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookPrompt.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebookPrompt.ts
@@ -96,7 +96,7 @@ export class PositronNotebookPromptContribution extends Disposable implements IW
 				{
 					label: localize('positron.notebook.prompt.learnMore', 'Learn more'),
 					run: () => {
-						this.openerService.open(URI.parse(this.docsService.getUrl('positron-notebook-editor')));
+						this.openerService.open(URI.parse(this.docsService.getUrl('positron-notebook-editor.html')));
 					}
 				},
 				{

--- a/src/vs/workbench/contrib/update/browser/update.contribution.ts
+++ b/src/vs/workbench/contrib/update/browser/update.contribution.ts
@@ -83,7 +83,7 @@ export class ShowReleaseNotesAction extends Action2 {
 		if (isWeb) {
 			const openerService = accessor.get(IOpenerService);
 			const docsService = accessor.get(IPositronDocsService);
-			await openerService.open(URI.parse(docsService.getUrl('release-notes')));
+			await openerService.open(URI.parse(docsService.getUrl('release-notes.html')));
 			return;
 		}
 


### PR DESCRIPTION
Fixes #13964

In Workbench, *Show Release Notes* opened a page that didn't resolve because Workbench serves the docs without an `.html` fallback, so the link never reached the release notes file. This passes the `.html` extension at the call site so the link requests the real file. The notebook editor and Assistant docs links have the same problem and are fixed the same way.

I'll be creating a follow up PR in rstudio/rstudio-pro that adds `.html` fallback to Workbench's nginx docs config so these links resolve there too. This PR is necessary so that when older versions of Workbench upgrade to a recent build of Positron, the docs will work as expected.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed *Show Release Notes* not resolving in Workbench (#13964)

### Validation Steps

@:web @:workbench 

In Workbench, run *Positron: Show Release Notes* from the Command Palette and confirm the release notes page opens.
