### PR TITLE
Update Posit Assistant layout action to ensure correct view focus on web

### DIFF
--- a/src/vs/workbench/services/positronLayout/browser/layouts/positronAssistantLayout.ts
+++ b/src/vs/workbench/services/positronLayout/browser/layouts/positronAssistantLayout.ts
@@ -8,6 +8,8 @@ import { registerAction2 } from '../../../../../platform/actions/common/actions.
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { ViewContainerLocation } from '../../../../common/views.js';
+import { IPaneCompositePartService } from '../../../panecomposite/browser/panecomposite.js';
 import { Parts } from '../../../layout/browser/layoutService.js';
 import { CustomPositronLayoutDescription } from '../../common/positronCustomViews.js';
 import { IPositronLayoutService } from '../interfaces/positronLayoutService.js';
@@ -74,7 +76,7 @@ registerAction2(class extends PositronLayoutAction {
 		super(positronAssistantLayout);
 	}
 
-	override run(accessor: ServicesAccessor): void {
+	override async run(accessor: ServicesAccessor): Promise<void> {
 		// Prefer Posit Assistant when enabled; fall back to the legacy Positron Assistant chat view container.
 		const configurationService = accessor.get(IConfigurationService);
 		const sidebarContainerId = configurationService.getValue<boolean>('assistant.enabled')
@@ -90,5 +92,12 @@ registerAction2(class extends PositronLayoutAction {
 		};
 
 		accessor.get(IPositronLayoutService).setLayout(layoutDescriptor);
+
+		// The layout opens the sidebar container fire-and-forget; for an
+		// extension-contributed, webview-backed composite (Posit Assistant) that
+		// open can lose a race with the surrounding layout work on web and leave
+		// the sidebar on the previously active view. Await an explicit open so the
+		// correct view is reliably revealed and focused on every platform.
+		await accessor.get(IPaneCompositePartService).openPaneComposite(sidebarContainerId, ViewContainerLocation.Sidebar, true);
 	}
 });

--- a/test/e2e/tests/layouts/layouts.test.ts
+++ b/test/e2e/tests/layouts/layouts.test.ts
@@ -138,7 +138,7 @@ test.describe('Layouts', { tag: [tags.WEB, tags.LAYOUTS, tags.WIN, tags.WORKBENC
 		});
 	});
 
-	test.describe('Assistant Layout', () => {
+	test.describe('Assistant Layout', { tag: [tags.ASSISTANT, tags.POSIT_ASSISTANT] }, () => {
 		test.afterEach('Reset Layout', async function ({ app }) {
 			await app.workbench.layouts.enterLayout('stacked');
 		});


### PR DESCRIPTION
Follow-up to #13971 (which fixed #13933).

The E2E coverage added in #13971 surfaced a gap that the "Assistant Layout" preset did reliably open the Posit Assistant view on Electron but failed on web (chromium), consistently (0% pass, not a flake), while the legacy chat fallback passed on both.

### Root cause

Custom layouts apply their sidebar view through `_setCustomPartSize` in `layout.ts`, which calls `partView.openPaneComposite(id)` fire-and-forget (no `await`, synchronous method). For a core composite like `workbench.panel.chat`, that opens synchronously so it works. For the extension-contributed, webview-backed Posit Assistant composite (`workbench.view.extension.posit-assistant`) the open is slower, so on web it loses the race to the surrounding synchronous layout work and the sidebar stays on whatever view was already active (Explorer / the legacy assistant). The open is attempted only once at layout time and never retried, so the test's 15s assertion could never recover, which is why it failed on retry too.

### Fix

In the Assistant layout action, after `setLayout(...)`, await an explicit `IPaneCompositePartService.openPaneComposite(sidebarContainerId, ViewContainerLocation.Sidebar, true)`. Awaiting plus `focus: true` reliably reveals and focuses the correct sidebar view on every platform; on Electron it is effectively free since the composite is already opening. The same call covers both the Posit Assistant path and the legacy `workbench.panel.chat` fallback, so the code stays uniform and the fallback keeps working. The `accessor.get(...)` runs before the first `await`, so the `ServicesAccessor` is still valid.

No changes to the E2E tests were needed; hopefully they now pass on web because the layout actually switches the sidebar. 🤞 

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Reliably open the Posit Assistant view when running the Assistant layout on web (#13933)

### Validation Steps

@:layouts @:assistant @:posit-assistant @:web

1. With `assistant.enabled` on, run the **View: Assistant Layout** command and confirm the Posit Assistant view opens and is focused in the sidebar (verify on both web and desktop).
2. With `assistant.enabled` off and `positron.assistant.enable` on, run the command and confirm the legacy Chat view opens in the sidebar.
3. In both cases, confirm the panel shows Console and Terminal, and the auxiliary bar shows the Session view with Variables and Plots.
