### PR TITLE
Decouple renv lockfile snapshots from R package operations

### DIFF
--- a/extensions/positron-r/src/packages.ts
+++ b/extensions/positron-r/src/packages.ts
@@ -113,9 +113,11 @@ export class RPackageManager {
 
 		let code: string;
 		if (isRenv) {
+			// Don't pass `lock = TRUE`: the lockfile update is decoupled from the
+			// install so a snapshot failure doesn't report the install as failed.
 			const pkgSpecs = packages.map(p => p.version ? `${p.name}@${p.version}` : p.name);
 			const pkgVector = this._formatRVector(pkgSpecs);
-			code = `renv::install(${pkgVector}, lock = TRUE, prompt = FALSE)`;
+			code = `renv::install(${pkgVector}, prompt = FALSE)`;
 		} else {
 			// If we're installing pak itself, don't try to install pak as a side effect.
 			const installingPak = packages.some((pkg) => pkg.name === 'pak');
@@ -135,6 +137,9 @@ export class RPackageManager {
 		}
 
 		await this._execute(code, token);
+		if (isRenv) {
+			this._snapshotRenv();
+		}
 		this._session.invalidatePackageResourceCaches();
 	}
 
@@ -157,10 +162,12 @@ export class RPackageManager {
 
 		let code: string;
 		if (isRenv) {
-			// renv::install supports "pkg@version" syntax
+			// renv::install supports "pkg@version" syntax. Don't pass `lock = TRUE`:
+			// the lockfile update is decoupled from the update so a snapshot failure
+			// doesn't report the update as failed.
 			const pkgSpecs = packages.map(p => p.version ? `${p.name}@${p.version}` : p.name);
 			const pkgVector = this._formatRVector(pkgSpecs);
-			code = `renv::install(${pkgVector}, lock = TRUE, prompt = FALSE)`;
+			code = `renv::install(${pkgVector}, prompt = FALSE)`;
 		} else {
 			const method = await this._resolveMethod(true);
 
@@ -178,6 +185,9 @@ export class RPackageManager {
 		}
 
 		await this._execute(code, token);
+		if (isRenv) {
+			this._snapshotRenv();
+		}
 		this._session.invalidatePackageResourceCaches();
 	}
 
@@ -194,7 +204,10 @@ export class RPackageManager {
 		const isRenv = await this._detectRenv();
 
 		if (isRenv) {
-			await this._execute(`renv::update(lock = TRUE, prompt = FALSE)`, token);
+			// Don't pass `lock = TRUE`: the lockfile update is decoupled from the
+			// update so a snapshot failure doesn't report the update as failed.
+			await this._execute(`renv::update(prompt = FALSE)`, token);
+			this._snapshotRenv();
 		} else {
 			const method = await this._resolveMethod(true);
 
@@ -259,9 +272,10 @@ export class RPackageManager {
 			// Ignore errors from namespace unloading
 		}
 
-		// Update renv lockfile after removal
+		// Update renv lockfile after removal. Decoupled from the remove operation
+		// so a snapshot failure doesn't report the uninstall as failed.
 		if (isRenv) {
-			await this._executeSilently('renv::snapshot(prompt = FALSE)');
+			this._snapshotRenv();
 		}
 
 		this._session.invalidatePackageResourceCaches();
@@ -326,6 +340,62 @@ export class RPackageManager {
 		} catch {
 			return false;
 		}
+	}
+
+	/**
+	 * Whether automatic renv snapshots after package operations are enabled.
+	 * Controlled by the `packages.r.renvAutoSnapshot` setting (default: true).
+	 */
+	private _isAutoSnapshotEnabled(): boolean {
+		return vscode.workspace.getConfiguration('packages.r').get<boolean>('renvAutoSnapshot', true);
+	}
+
+	/**
+	 * Fire `renv::snapshot()` in the console to bring `renv.lock` in sync after a
+	 * package operation. This is deliberately decoupled from the operation that
+	 * triggered it: the snapshot runs as a visible console side effect and its
+	 * success or failure does not affect the package command's result. If the
+	 * snapshot errors (e.g. a read-only `renv.lock`), surface a warning
+	 * notification, since the package operation itself reported success.
+	 *
+	 * No-op when the `packages.r.renvAutoSnapshot` setting is disabled.
+	 */
+	private _snapshotRenv(): void {
+		if (!this._isAutoSnapshotEnabled()) {
+			return;
+		}
+
+		const id = randomUUID();
+		const disp = this._session.onDidReceiveRuntimeMessage((msg) => {
+			if (msg.parent_id !== id) {
+				return;
+			}
+
+			if (msg.type === positron.LanguageRuntimeMessageType.Error) {
+				const showConsole = vscode.l10n.t('Show Console');
+				void vscode.window.showWarningMessage(
+					vscode.l10n.t('Failed to update the renv lockfile with renv::snapshot(). Your renv.lock file may be out of date.'),
+					showConsole
+				).then((selection) => {
+					if (selection === showConsole) {
+						void vscode.commands.executeCommand('workbench.panel.positronConsole.focus');
+					}
+				});
+				disp.dispose();
+			} else if (msg.type === positron.LanguageRuntimeMessageType.State) {
+				const stateMsg = msg as positron.LanguageRuntimeState;
+				if (stateMsg.state === positron.RuntimeOnlineState.Idle) {
+					disp.dispose();
+				}
+			}
+		});
+
+		this._session.execute(
+			'renv::snapshot(prompt = FALSE)',
+			id,
+			positron.RuntimeCodeExecutionMode.NonInteractive,
+			positron.RuntimeErrorBehavior.Continue
+		);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -104,6 +104,13 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			scope: ConfigurationScope.RESOURCE,
 			markdownDescription: nls.localize('positron.packages.r.installer', "Which package installer to use for installing, updating, and removing R packages. Does not affect projects using renv, which always use renv."),
 			tags: ['preview'],
+		},
+		'packages.r.renvAutoSnapshot': {
+			type: 'boolean',
+			default: true,
+			scope: ConfigurationScope.RESOURCE,
+			markdownDescription: nls.localize('positron.packages.r.renvAutoSnapshot', "When using renv, automatically run `renv::snapshot()` in the Console after installing, updating, or removing packages to keep `renv.lock` in sync. The snapshot runs independently, so its success or failure does not affect the package operation."),
+			tags: ['preview'],
 		}
 	}
 });


### PR DESCRIPTION
Fixes #12627

When using renv, R package operations bound the `renv.lock` update to the operation itself: install/update passed `lock = TRUE`, and uninstall awaited a silent `renv::snapshot()`. If that lockfile update failed (for example, a read-only `renv.lock`), the Packages pane reported the package operation as failed even though the package was actually installed or removed.

This PR decouples the two. The package operation now runs on its own and reports its own success or failure. On success, `renv::snapshot()` runs as a separate, non-awaited side effect that is visible in the Console. If the snapshot errors, a warning notification with a **Show Console** button is shown instead of failing the command.

A new `packages.r.renvAutoSnapshot` setting (default: enabled) controls whether the automatic snapshot runs at all.

<img width="675" height="141" alt="Screenshot 2026-06-03 at 3 15 12 PM" src="https://github.com/user-attachments/assets/d226a057-f32b-4166-98b4-094096cf334a" />

Package operations are now independent of the renv snapshot operation. Having the two notifications is a little noisy, but I think it is the most simple approach and most clear. We could maybe combine them, but it would make it more difficult to investigate both issues as the actions would look more like an either/or when they are truly independent. And so if independent, they should have their own independent notifications.

<img width="505" height="281" alt="Screenshot 2026-06-03 at 3 04 14 PM" src="https://github.com/user-attachments/assets/5addc73b-266e-4d6b-b68f-4e5144e05ab4" />
<img width="503" height="274" alt="Screenshot 2026-06-03 at 3 04 42 PM" src="https://github.com/user-attachments/assets/f7f79ec0-074b-412c-a7d7-021a7557ab29" />
<img width="492" height="274" alt="Screenshot 2026-06-03 at 3 04 53 PM" src="https://github.com/user-attachments/assets/3ab3dc30-1c89-49c1-a59c-557c470837af" />

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- R package install/update/uninstall in renv projects no longer report failure when only the `renv.lock` snapshot fails (#12627)

### Validation Steps

@:packages-pane

1. Open an renv project with an active R session. Instructions here https://rstudio.github.io/renv/articles/renv.html#getting-started Basically open a new R project and run `renv::init()`
2. Make the lockfile read-only in the Console: `Sys.chmod("renv.lock", mode = "0444")`.
3. Install, update, or uninstall a package from the Packages pane.
4. Verify the operation reports **success** (no "Failed to..." error), and that a separate warning notification appears noting the lockfile could not be updated, with a **Show Console** button that focuses the Console.
5. Restore write access: `Sys.chmod("renv.lock", mode = "0644")`, repeat an operation, and verify `renv::snapshot()` runs in the Console and updates `renv.lock` with no warning.
6. Set `packages.r.renvAutoSnapshot` to `false` and verify package operations no longer trigger a snapshot.
