### PR TITLE
Add Remote WSL e2e test mechanism (#11721)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,6 +32,7 @@ const baseIgnore = [
 	'example.test.ts',
 	'**/workbench/**',
 	'**/remote-ssh/**',
+	'**/remote-wsl/**',
 	'**/assistant-eval/**',
 	'**/release-screenshots/**',
 ];
@@ -90,12 +91,14 @@ export default defineConfig<CustomTestOptions>({
 					'example.test.ts',
 					'**/workbench/**',
 					'**/remote-ssh/**',
+					'**/remote-wsl/**',
 					// Note: assistant-eval NOT ignored here - runs on e2e-electron only
 				]
 				: [
 					'example.test.ts',
 					'**/workbench/**',
 					'**/remote-ssh/**',
+					'**/remote-wsl/**',
 					'**/lsp/**',
 					// Note: assistant-eval NOT ignored here - runs on e2e-electron only
 				],
@@ -197,6 +200,20 @@ export default defineConfig<CustomTestOptions>({
 				useExternalServer: false,
 			},
 			grep: /@:remote-ssh/
+		},
+		{
+			name: 'e2e-remote-wsl',
+			testIgnore: [
+				'example.test.ts',
+				'**/assistant-eval/**',
+				'**/workbench/**',
+			],
+			use: {
+				artifactDir: 'e2e-remote-wsl',
+				headless: false,
+				useExternalServer: false,
+			},
+			grep: /@:remote-wsl/
 		},
 		{
 			name: 'e2e-jupyter',

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -9,6 +9,7 @@ This document provides guidelines and setup instructions for effectively running
 - [Dependencies](#dependencies)
 - [Running Tests](#running-tests)
 - [Test Project](#test-project)
+- [Remote WSL Tests](#remote-wsl-tests)
 - [Pull Requests and Test Tags](#pull-requests-and-test-tags)
 - [Running Tests in Github Actions](#running-tests-in-github-actions)
 - [Notes About Updating Specific Tests](#notes-about-updating-specific-tests)
@@ -191,6 +192,40 @@ Before any of the tests start executing the test framework clones down the [QA C
 For Python, add any package requirements to the `requirements.txt` file in the root of the [QA Content Examples](https://github.com/posit-dev/qa-example-content) repo. We generally do NOT pin them to a specific version, as test can be run against different versions of python and conflicts could arise. If this becomes a problem, we can revisit this mechanism.
 
 For R, add any package requirements to the "imports" section of the `DESCRIPTION` file in the root of the [QA Content Examples](https://github.com/posit-dev/qa-example-content) repo.
+
+## Remote WSL Tests
+
+The `e2e-remote-wsl` project (tag `@:remote-wsl`, tests under `test/e2e/tests/remote-wsl/`) exercises connecting Positron to a [WSL](https://learn.microsoft.com/windows/wsl/) distro via the `open-remote-wsl` extension. These tests run **only on Windows** and are excluded from the normal suites.
+
+### Prerequisites
+
+- Windows with WSL installed and at least one glibc-based distro registered (e.g. `Ubuntu`). The REH (remote extension host) is a glibc `linux-x64` binary, so musl distros (Alpine) won't work. Pick the distro with `POSITRON_WSL_DISTRO` (defaults to `Ubuntu`).
+- A Positron REH tarball reachable from inside the distro. A dev build's `product.json` has no `commit`/`version`, so the extension's default download URL (a CDN template with `${version}`/`${commit}`) can't be resolved. Provide a local tarball instead and point the extension at it with `POSITRON_WSL_SERVER_DOWNLOAD_URL`.
+
+### Build a local REH
+
+```bash
+# From the repo root. Produces ../vscode-reh-linux-x64
+npm run gulp vscode-reh-linux-x64
+
+# Package it so `bin/positron-server` lands at the tarball root (the extension extracts with
+# --strip-components 1, stripping the top-level vscode-reh-linux-x64/ directory).
+tar czf positron-reh-linux-x64.tar.gz -C .. vscode-reh-linux-x64
+```
+
+### Run
+
+```bash
+# Dev build (no BUILD). The file:// URL is read from inside the distro via /mnt/c.
+POSITRON_WSL_DISTRO=Ubuntu \
+POSITRON_WSL_SERVER_DOWNLOAD_URL=file:///mnt/c/path/to/positron-reh-linux-x64.tar.gz \
+npx playwright test --project e2e-remote-wsl --workers=1
+```
+
+The test connects to the distro, waits for the `WSL: <distro>` remote indicator, and runs `uname` in a terminal to confirm the workbench is executing inside Linux.
+
+> [!NOTE]
+> CI for this project (a Windows runner that provisions WSL + the REH) is not yet wired up; it is planned as a follow-up.
 
 ## Pull Requests and Test Tags
 

--- a/test/e2e/infra/test-runner/test-tags.ts
+++ b/test/e2e/infra/test-runner/test-tags.ts
@@ -91,6 +91,7 @@ export enum TestTags {
 	WORKBENCH = '@:workbench',
 	WORKBENCH_STABLE = '@:workbench-stable',
 	REMOTE_SSH = '@:remote-ssh',
+	REMOTE_WSL = '@:remote-wsl',
 
 	// soft fail tag for tests that shouldn't fail merge to main
 	SOFT_FAIL = '@:soft-fail'

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -165,3 +165,58 @@ export function createWorkbenchFromPage(parentCode: Code, page: playwright.Page)
 	const code = createCodeFromPage(parentCode, page);
 	return new Workbench(code);
 }
+
+/**
+ * Waits for a new Electron window to appear, optionally running a trigger that opens it.
+ *
+ * Used by the remote backend tests (remote-ssh, remote-wsl) where connecting to a remote opens
+ * the workbench in a fresh window. Pair the returned page with {@link createWorkbenchFromPage}.
+ *
+ * @param app The Electron application to watch for new windows.
+ * @param trigger Optional action that opens the new window. Recommended so the listener is armed
+ *   before the window appears.
+ * @param opts.timeout How long to wait for the new window, in ms (default 30000).
+ * @param opts.loadState The load state to wait for on the new page (default 'domcontentloaded').
+ */
+export async function waitForAnyNewWindow(
+	app: playwright.ElectronApplication,
+	trigger?: () => Promise<void> | void,
+	opts: { timeout?: number; loadState?: 'load' | 'domcontentloaded' | 'networkidle' } = {}
+): Promise<playwright.Page> {
+	const { timeout = 30_000, loadState = 'domcontentloaded' } = opts;
+
+	// Snapshot existing windows so we can detect a new one even if the event is missed.
+	const before = new Set(app.windows());
+
+	// Start waiting for a new 'window' event *before* we trigger anything.
+	const eventWait = app.waitForEvent('window', { timeout }).catch(() => null);
+
+	// Optionally run whatever opens the window (recommended).
+	if (trigger) { await trigger(); }
+
+	// If we caught the event, great.
+	let win = await eventWait;
+
+	// Fallback: CI flake where window opened before listener -- scan for any new page.
+	if (!win) {
+		const start = Date.now();
+		while (Date.now() - start < timeout) {
+			const current = app.windows();
+			for (const p of current) {
+				if (!before.has(p)) {
+					win = p;
+					break;
+				}
+			}
+			if (win) { break; }
+			await new Promise(r => setTimeout(r, 100));
+		}
+	}
+
+	if (!win) { throw new Error('No new window appeared within timeout'); }
+
+	// Ensure it's at least minimally ready and on top
+	await win.waitForLoadState(loadState).catch(() => { });
+	await win.bringToFront().catch(() => { });
+	return win;
+}

--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -141,14 +141,21 @@ test.describe('Remote SSH', {
 	});
 });
 
-const flaskAppCode = `from flask import Flask
-
-app = Flask(__name__)
-
-@app.route('/')
-def hello():
-	return 'Hello, World!'
-
-if __name__ == '__main__':
-	app.run(debug=True)
-`;
+// Built as an array of lines so the embedded Python keeps its 4-space indentation
+// (it is typed into Monaco, which auto-indents new lines with spaces; a literal tab
+// here would mix tabs and spaces and raise a Python TabError). Authoring the spaces
+// as string content -- rather than source-line indentation -- also satisfies the
+// tabs-only hygiene check.
+const flaskAppCode = [
+	'from flask import Flask',
+	'',
+	'app = Flask(__name__)',
+	'',
+	'@app.route(\'/\')',
+	'def hello():',
+	'    return \'Hello, World!\'',
+	'',
+	'if __name__ == \'__main__\':',
+	'    app.run(debug=True)',
+	'',
+].join('\n');

--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -3,12 +3,11 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ElectronApplication, Page } from 'playwright';
 import { expect } from '@playwright/test';
 import { test, tags } from '../_test.setup';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
-import { createWorkbenchFromPage } from '../../infra/workbench';
+import { createWorkbenchFromPage, waitForAnyNewWindow } from '../../infra/workbench';
 import { pythonDynamicPlot } from '../shared/plots.constants.js';
 const settingsPath = require('node:path').resolve(__dirname, '../../fixtures/settingsDocker.json');
 
@@ -25,50 +24,6 @@ function sshKeyscan(host: string, port: number, knownHostsPath: string) {
 	fs.mkdirSync(require('node:path').dirname(knownHostsPath), { recursive: true });
 	fs.appendFileSync(knownHostsPath, out);
 }
-
-async function waitForAnyNewWindow(
-	app: ElectronApplication,
-	trigger?: () => Promise<void> | void,
-	opts: { timeout?: number; loadState?: 'load' | 'domcontentloaded' | 'networkidle' } = {}
-): Promise<Page> {
-	const { timeout = 30_000, loadState = 'domcontentloaded' } = opts;
-
-	// Snapshot existing windows so we can detect a new one even if the event is missed.
-	const before = new Set(app.windows());
-
-	// Start waiting for a new 'window' event *before* we trigger anything.
-	const eventWait = app.waitForEvent('window', { timeout }).catch(() => null);
-
-	// Optionally run whatever opens the window (recommended).
-	if (trigger) { await trigger(); }
-
-	// If we caught the event, great.
-	let win = await eventWait;
-
-	// Fallback: CI flake where window opened before listener—scan for any new page.
-	if (!win) {
-		const start = Date.now();
-		while (Date.now() - start < timeout) {
-			const current = app.windows();
-			for (const p of current) {
-				if (!before.has(p)) {
-					win = p;
-					break;
-				}
-			}
-			if (win) { break; }
-			await new Promise(r => setTimeout(r, 100));
-		}
-	}
-
-	if (!win) { throw new Error('No new window appeared within timeout'); }
-
-	// Ensure it’s at least minimally ready and on top
-	await win.waitForLoadState(loadState).catch(() => { });
-	await win.bringToFront().catch(() => { });
-	return win;
-}
-
 
 test.describe('Remote SSH', {
 	tag: [tags.REMOTE_SSH]
@@ -192,8 +147,8 @@ app = Flask(__name__)
 
 @app.route('/')
 def hello():
-    return 'Hello, World!'
+	return 'Hello, World!'
 
 if __name__ == '__main__':
-    app.run(debug=True)
+	app.run(debug=True)
 `;

--- a/test/e2e/tests/remote-wsl/remote-wsl.test.ts
+++ b/test/e2e/tests/remote-wsl/remote-wsl.test.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from '@playwright/test';
+import { test, tags } from '../_test.setup';
+import { createWorkbenchFromPage, waitForAnyNewWindow } from '../../infra/workbench';
+
+test.use({
+	suiteId: __filename
+});
+
+// The WSL distro to connect to. Override with POSITRON_WSL_DISTRO; defaults to 'Ubuntu'.
+const WSL_DISTRO = process.env.POSITRON_WSL_DISTRO || 'Ubuntu';
+
+// A URL (typically file://) pointing at a Positron REH (remote extension host) tarball reachable
+// from inside the distro, e.g. file:///mnt/c/path/to/positron-reh-linux-x64.tar.gz.
+//
+// This is required for dev builds: product.json carries no commit/version, so the default
+// `remote.WSL.serverDownloadUrlTemplate` (a CDN URL with ${version}/${commit} placeholders)
+// cannot be resolved and the server install would fail. Pointing at a local tarball with no
+// placeholders sidesteps that. See the "Remote WSL Tests" section of test/e2e/README.md.
+const WSL_SERVER_DOWNLOAD_URL = process.env.POSITRON_WSL_SERVER_DOWNLOAD_URL;
+
+test.describe('Remote WSL', {
+	tag: [tags.REMOTE_WSL]
+}, () => {
+
+	test.beforeAll(async ({ settings }) => {
+		// `remote.WSL.serverDownloadUrlTemplate` is an application-scoped setting, so it must live in
+		// user settings (which `settings.set` writes). The WSL resolver reads it when installing the
+		// server inside the distro.
+		if (WSL_SERVER_DOWNLOAD_URL) {
+			await settings.set({ 'remote.WSL.serverDownloadUrlTemplate': WSL_SERVER_DOWNLOAD_URL });
+		}
+	});
+
+	test('Verify Positron connects to a WSL distro', async function ({ app }) {
+
+		const wslWin = await test.step(`Connect to WSL distro "${WSL_DISTRO}"`, async () => {
+			// Connecting opens the workbench in a new window, so arm the listener before triggering.
+			const wslWinPromise = waitForAnyNewWindow(app.code.electronApp!, async () => {
+				// The remote-indicator entries ("Connect to WSL", "Connect to WSL using Distro...")
+				// reuse the current window. Invoke the "in New Window" variant from the Command
+				// Palette instead so we get a fresh window to drive, mirroring the remote-ssh flow.
+				await app.workbench.quickaccess.runCommand('openremotewsl.connectUsingDistroInNewWindow');
+
+				// Pick the target distro from the distro quick pick the command opens.
+				await app.workbench.quickInput.waitForQuickInputOpened();
+				await app.workbench.quickInput.selectQuickInputElementContaining(WSL_DISTRO);
+			}, { timeout: 60_000 });
+
+			const wslWin = await wslWinPromise;
+
+			// The resolver shows a "Setting up WSL Distro: <distro>" notification while it installs and
+			// starts the server. Once connected, the remote indicator reads "WSL: <distro>". Allow a
+			// generous timeout to cover the one-time server install.
+			const remoteIndicator = wslWin.locator('.statusbar-item[id="status.host"]');
+			await expect(remoteIndicator).toContainText(`WSL: ${WSL_DISTRO}`, { timeout: 120_000 });
+
+			return wslWin;
+		});
+
+		const wslWorkbench = createWorkbenchFromPage(app.code, wslWin);
+
+		await test.step('Verify the remote runs in Linux', async () => {
+			// A trivial liveness check that proves the workbench is executing inside the distro:
+			// `uname` prints "Linux" (only in the output, not the echoed command).
+			await wslWorkbench.terminal.createTerminal();
+			await wslWorkbench.terminal.runCommandInTerminal('uname');
+			await wslWorkbench.terminal.waitForTerminalText('Linux');
+		});
+	});
+});

--- a/test/e2e/tests/remote-wsl/remote-wsl.test.ts
+++ b/test/e2e/tests/remote-wsl/remote-wsl.test.ts
@@ -37,6 +37,9 @@ test.describe('Remote WSL', {
 	});
 
 	test('Verify Positron connects to a WSL distro', async function ({ app }) {
+		// Connecting installs/starts the remote server in the distro the first time, which can be
+		// slow (a cold REH download). Triple the default test timeout to absorb that.
+		test.slow();
 
 		const wslWin = await test.step(`Connect to WSL distro "${WSL_DISTRO}"`, async () => {
 			// Connecting opens the workbench in a new window, so arm the listener before triggering.
@@ -57,7 +60,7 @@ test.describe('Remote WSL', {
 			// starts the server. Once connected, the remote indicator reads "WSL: <distro>". Allow a
 			// generous timeout to cover the one-time server install.
 			const remoteIndicator = wslWin.locator('.statusbar-item[id="status.host"]');
-			await expect(remoteIndicator).toContainText(`WSL: ${WSL_DISTRO}`, { timeout: 120_000 });
+			await expect(remoteIndicator).toContainText(`WSL: ${WSL_DISTRO}`, { timeout: 180_000 });
 
 			return wslWin;
 		});


### PR DESCRIPTION
Part of #11721

### Summary

Adds a basic e2e test that connects Positron to a WSL distro via the `open-remote-wsl` extension, establishing the mechanism (Playwright project, tag, test, docs) in the same shape as the existing remote-ssh suite.

- New `e2e-remote-wsl` Playwright project (selected by the `remote-wsl` tag) and the corresponding tag entry; the spec is excluded from the normal electron/web suites.
- `test/e2e/tests/remote-wsl/remote-wsl.test.ts`: connect to a distro via "Connect to WSL using Distro in New Window...", wait for the `WSL: <distro>` remote indicator, then run `uname` in a terminal to confirm the workbench is executing in Linux. Distro and the REH download URL come from `POSITRON_WSL_DISTRO` / `POSITRON_WSL_SERVER_DOWNLOAD_URL`.
- Lifts `waitForAnyNewWindow` into `infra/workbench.ts` so both remote-ssh and remote-wsl share it (also corrects a pre-existing whitespace-indentation hygiene error in the remote-ssh flask fixture).
- Documents prerequisites, local REH provisioning, and the run command in the e2e README.

Verified passing locally against an installed dailies build (the bundled extension auto-downloads the matching REH from the CDN).

CI for the WSL project (a Windows runner that provisions WSL + the REH, plus the `remote-wsl` PR-tag wiring) is a deferred follow-up; this PR is the test mechanism only.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:remote-ssh

This PR refactors `remote-ssh.test.ts` (shared `waitForAnyNewWindow` helper + a flask-fixture whitespace fix), so the remote-ssh tag above runs the remote-ssh e2e suite in CI to confirm that test still passes.

The new WSL test (tagged `remote-wsl`) does not yet run in CI (no Windows + WSL job). To run it locally on Windows with WSL installed:

```bash
POSITRON_WSL_DISTRO=Ubuntu-24.04 \
BUILD=/path/to/installed/Positron \
npx playwright test --project e2e-remote-wsl --workers=1
```
