### PR TITLE
Fix/duckdb worker process isolation

### DIFF
--- a/extensions/positron-duckdb/esbuild.mts
+++ b/extensions/positron-duckdb/esbuild.mts
@@ -12,6 +12,9 @@ run({
 	platform: 'node',
 	entryPoints: {
 		'extension': path.join(srcDir, 'extension.ts'),
+		// The DuckDB native instance runs in this child process (forked by
+		// extension.ts) so a native abort cannot take down the extension host.
+		'duckdbWorker': path.join(srcDir, 'duckdbWorker.ts'),
 	},
 	srcDir,
 	outdir: outDir,

--- a/extensions/positron-duckdb/src/duckdbWorker.ts
+++ b/extensions/positron-duckdb/src/duckdbWorker.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// This module is the entry point for the DuckDB child process. It owns the
+// native `@duckdb/node-api` instance and runs queries on its behalf. Running
+// DuckDB out-of-process isolates the extension host from native failures: a
+// query that exhausts memory aborts (or is OS-killed) only this child, and the
+// host can detect the exit, fail the in-flight request, and respawn. A native
+// abort cannot be caught in-process, so this isolation is the only way to keep
+// the extension host stable when DuckDB runs out of memory.
+
+import { DuckDBConnection, DuckDBInstance } from '@duckdb/node-api';
+import {
+	WorkerQueryRequest,
+	WorkerQueryResponse
+} from './duckdbWorkerProtocol';
+
+/** Send a response to the host, narrowed so TypeScript knows IPC is available. */
+function send(response: WorkerQueryResponse): void {
+	process.send?.(response);
+}
+
+let connection: DuckDBConnection | undefined;
+let initError: Error | undefined;
+
+// Initialize the native database once. Failures (e.g. a native binding that
+// fails to load) are captured and reported per-query rather than crashing.
+const ready: Promise<void> = (async () => {
+	try {
+		const instance = await DuckDBInstance.create(':memory:');
+		connection = await instance.connect();
+		await connection.run(`LOAD icu;
+		SET TIMEZONE='UTC';
+		`);
+	} catch (error) {
+		initError = error instanceof Error ? error : new Error(String(error));
+	}
+})();
+
+// Process queries strictly in the order received. The native connection is not
+// safe for concurrent `runAndReadAll` calls, so we chain them. The async body
+// always replies and never rejects, so the chain cannot break.
+let queue: Promise<void> = Promise.resolve();
+
+process.on('message', (request: WorkerQueryRequest) => {
+	queue = queue.then(async () => {
+		await ready;
+		if (initError || !connection) {
+			send({ kind: 'error', id: request.id, error: (initError ?? new Error('DuckDB failed to initialize')).message });
+			return;
+		}
+		try {
+			const reader = await connection.runAndReadAll(request.sql);
+			// Materialize to plain JS up front so the result can cross the IPC
+			// boundary. `getColumnsJS` coerces values to plain JS (Date, number,
+			// bigint, string, null), all of which the host receives via V8
+			// "advanced" serialization.
+			send({
+				kind: 'result',
+				id: request.id,
+				columnNames: reader.columnNames(),
+				columns: reader.getColumnsJS()
+			});
+		} catch (error) {
+			send({ kind: 'error', id: request.id, error: error instanceof Error ? error.message : String(error) });
+		}
+	});
+});
+
+// If the host goes away, there is nothing left to serve; exit cleanly.
+process.on('disconnect', () => process.exit(0));

--- a/extensions/positron-duckdb/src/duckdbWorkerProtocol.ts
+++ b/extensions/positron-duckdb/src/duckdbWorkerProtocol.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Message shapes exchanged between the extension host and the DuckDB child
+// process (see `duckdbWorker.ts`). Messages are sent with Node's "advanced"
+// (V8 structured clone) serialization, so values may include bigint and Date.
+
+/** Host -> worker: run a SQL query identified by `id`. */
+export interface WorkerQueryRequest {
+	id: number;
+	sql: string;
+}
+
+/** Worker -> host: the result (or error) for the query with the matching `id`. */
+export type WorkerQueryResponse =
+	| {
+		kind: 'result';
+		id: number;
+		/** Column names in column order. */
+		columnNames: string[];
+		/** Materialized result, as one array of values per column. */
+		columns: any[][];
+	}
+	| {
+		kind: 'error';
+		id: number;
+		/** Human-readable error message from DuckDB or the worker. */
+		error: string;
+	};

--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -76,114 +76,190 @@ import {
 function isSelectionRange(spec: ArraySelection): spec is DataSelectionRange {
 	return (spec as DataSelectionRange).first_index !== undefined;
 }
-import { DuckDBConnection, DuckDBInstance as NeoDuckDBInstance, DuckDBResultReader } from '@duckdb/node-api';
+import { ChildProcess, fork } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as zlib from 'zlib';
+import { WorkerQueryRequest, WorkerQueryResponse } from './duckdbWorkerProtocol';
 
 // Set to true when doing development for better console logging
 const DEBUG_LOG = false;
 
 /**
- * A thin wrapper over a materialized `@duckdb/node-api` result that exposes the
- * small set of shapes the rest of the extension relies on.
+ * A query result materialized in the DuckDB worker and reconstructed here from
+ * the column-oriented form that crosses the IPC boundary. Exposes the small set
+ * of shapes the rest of the extension relies on.
  */
 class QueryResult {
-	private _columns: any[][] | undefined;
 	private _rows: any[] | undefined;
-	private _columnNames: string[] | undefined;
 
-	constructor(private readonly result: DuckDBResultReader) { }
+	constructor(
+		private readonly _columnNames: string[],
+		// One array of values per column, in column order.
+		private readonly _columns: any[][]
+	) { }
 
 	/** The number of columns in the result. */
 	get numCols(): number {
-		return this.result.columnCount;
+		return this._columns.length;
 	}
 
 	/** The number of rows in the (materialized) result. */
 	get numRows(): number {
-		return this.result.currentRowCount;
+		return this._columns.length > 0 ? this._columns[0].length : 0;
 	}
 
 	/** The names of the columns, in column order. */
 	get columnNames(): string[] {
-		if (this._columnNames === undefined) {
-			this._columnNames = this.result.columnNames();
-		}
 		return this._columnNames;
 	}
 
-	// Note: the JS accessors (getRowObjectsJS / getColumnsJS) coerce values to
-	// plain JS (e.g. Date for temporal types, number for DECIMAL) rather than
-	// node-api's DuckDBValue wrapper objects, so values that aren't explicitly
-	// CAST to VARCHAR in SQL still render and serialize sanely. Integer types
-	// remain bigint; count/stat call sites wrap those in Number(...).
+	// Note: values are already coerced to plain JS in the worker (Date for
+	// temporal types, number for DECIMAL, bigint for integers, etc.), so values
+	// that aren't explicitly CAST to VARCHAR in SQL still render and serialize
+	// sanely. Integer types remain bigint; count/stat call sites wrap those in
+	// Number(...).
 
 	/** The result rows as plain objects keyed by column name. */
 	toArray(): any[] {
 		if (this._rows === undefined) {
-			this._rows = this.result.getRowObjectsJS();
+			const numRows = this.numRows;
+			const rows: any[] = new Array(numRows);
+			for (let r = 0; r < numRows; r++) {
+				const row: { [name: string]: any } = {};
+				for (let c = 0; c < this._columnNames.length; c++) {
+					row[this._columnNames[c]] = this._columns[c][r];
+				}
+				rows[r] = row;
+			}
+			this._rows = rows;
 		}
 		return this._rows;
 	}
 
 	/** The values for the column at the given index. */
 	columnAt(index: number): any[] {
-		if (this._columns === undefined) {
-			this._columns = this.result.getColumnsJS();
-		}
 		return this._columns[index];
 	}
 
 	/** The values for the column with the given name. */
 	columnByName(name: string): any[] {
-		return this.columnAt(this.columnNames.indexOf(name));
+		return this.columnAt(this._columnNames.indexOf(name));
 	}
 }
 
-class DuckDBInstance {
-	runningQuery: Promise<any> = Promise.resolve();
+/**
+ * Host-side proxy for DuckDB. The native database runs in a separate child
+ * process (`duckdbWorker.ts`); this class forks it, forwards queries over IPC,
+ * and reconstructs results. Isolating the native binding means a query that
+ * exhausts memory aborts only the child: a native abort cannot be caught
+ * in-process, so the child dying is the only thing that keeps the extension
+ * host alive. When the worker dies, in-flight queries reject with a clear
+ * error, `onDidCrash` fires, and the next query transparently respawns it.
+ */
+export class DuckDBInstance {
+	/** Resolved path to the bundled worker entry, emitted next to this module. */
+	private static readonly defaultWorkerPath = path.join(__dirname, 'duckdbWorker.js');
 
-	constructor(private readonly instance: NeoDuckDBInstance, readonly con: DuckDBConnection) { }
+	private _worker: ChildProcess | undefined;
+	private _nextId = 0;
+	private readonly _pending = new Map<number, { resolve: (result: QueryResult) => void; reject: (error: Error) => void }>();
+	private _disposed = false;
 
-	static async create(): Promise<DuckDBInstance> {
-		// Create an in-memory database backed by the native DuckDB binary.
-		const instance = await NeoDuckDBInstance.create(':memory:');
-		const con = await instance.connect();
-		await con.run(`LOAD icu;
-		SET TIMEZONE=\'UTC\';
-		`);
-		return new DuckDBInstance(instance, con);
+	private readonly _onDidCrash = new vscode.EventEmitter<void>();
+	/** Fires when the worker process terminates unexpectedly (e.g. out of memory). */
+	readonly onDidCrash: vscode.Event<void> = this._onDidCrash.event;
+
+	private constructor(private readonly workerPath: string) { }
+
+	/**
+	 * Create a DuckDB instance. `workerPath` overrides the worker entry point and
+	 * exists only for tests (to exercise crash recovery with a stub worker).
+	 */
+	static async create(workerPath: string = DuckDBInstance.defaultWorkerPath): Promise<DuckDBInstance> {
+		const instance = new DuckDBInstance(workerPath);
+		instance.spawnWorker();
+		return instance;
 	}
 
-	/** Closes the connection and releases the native database handle. */
-	close(): void {
-		this.con.closeSync();
-		this.instance.closeSync();
+	private spawnWorker(): void {
+		// "advanced" serialization uses the V8 structured-clone algorithm, which
+		// preserves bigint and Date values returned by DuckDB.
+		const worker = fork(this.workerPath, [], { serialization: 'advanced' });
+		worker.on('message', (message: unknown) => {
+			const response = message as WorkerQueryResponse;
+			const pending = this._pending.get(response.id);
+			if (!pending) {
+				return;
+			}
+			this._pending.delete(response.id);
+			if (response.kind === 'result') {
+				pending.resolve(new QueryResult(response.columnNames, response.columns));
+			} else {
+				pending.reject(new Error(response.error));
+			}
+		});
+		worker.on('exit', (code, signal) => this.onWorkerGone(`exited (code=${code}, signal=${signal})`));
+		worker.on('error', (error) => this.onWorkerGone(`failed to start: ${error.message}`));
+		this._worker = worker;
 	}
 
-	async runQuery(query: string): Promise<QueryResult> {
-		await this.runningQuery;
-		try {
-			const startTime = Date.now();
-			this.runningQuery = this.con.runAndReadAll(query);
+	/**
+	 * Handle the worker process going away. Reject every in-flight query so
+	 * callers fail gracefully rather than hanging, and notify listeners. The
+	 * worker is respawned lazily on the next query.
+	 */
+	private onWorkerGone(detail: string): void {
+		if (this._worker === undefined) {
+			// Already handled (e.g. both 'error' and 'exit' fired), or disposed.
+			return;
+		}
+		this._worker = undefined;
 
-			const result = await this.runningQuery;
-			const elapsedMs = Date.now() - startTime;
-			if (DEBUG_LOG) {
-				console.log(`Took ${elapsedMs} ms to run:\n${query}`);
-			}
-			return new QueryResult(result);
-		} catch (error) {
-			if (DEBUG_LOG) {
-				console.log(`Failed to execute:\n${query}`);
-			}
-			this.runningQuery = Promise.resolve();
-			return Promise.reject(error);
+		const reason = new Error(`The DuckDB process terminated unexpectedly (${detail}). This usually means a query exhausted available memory.`);
+		for (const pending of this._pending.values()) {
+			pending.reject(reason);
+		}
+		this._pending.clear();
+
+		if (!this._disposed) {
+			this._onDidCrash.fire();
 		}
 	}
 
+	/** Closes the worker process and rejects any in-flight queries. */
+	close(): void {
+		this._disposed = true;
+		const worker = this._worker;
+		this._worker = undefined;
+		worker?.kill();
+		for (const pending of this._pending.values()) {
+			pending.reject(new Error('The DuckDB instance was disposed.'));
+		}
+		this._pending.clear();
+		this._onDidCrash.dispose();
+	}
+
+	runQuery(query: string): Promise<QueryResult> {
+		if (this._disposed) {
+			return Promise.reject(new Error('The DuckDB instance was disposed.'));
+		}
+		// Lazily (re)spawn the worker, e.g. after a crash.
+		if (this._worker === undefined) {
+			this.spawnWorker();
+		}
+
+		const id = this._nextId++;
+		const request: WorkerQueryRequest = { id, sql: query };
+		return new Promise<QueryResult>((resolve, reject) => {
+			this._pending.set(id, { resolve, reject });
+			if (DEBUG_LOG) {
+				console.log(`Running query ${id}:\n${query}`);
+			}
+			this._worker!.send(request);
+		});
+	}
 }
 
 type RpcResponse<Type> = Promise<Type | string>;
@@ -1842,10 +1918,17 @@ export class DataExplorerRpcHandler implements vscode.Disposable {
 	private readonly _uriToTableView = new Map<string, DuckDBTableView>();
 	private _tableIndex: number = 0;
 	private _watchers: vscode.Disposable[] = [];
+	private readonly _crashListener: vscode.Disposable;
 
-	constructor(private readonly db: DuckDBInstance) { }
+	constructor(private readonly db: DuckDBInstance) {
+		// If the DuckDB worker crashes (e.g. out of memory), its in-memory tables
+		// are gone with it. Drop the cached table views so the next request for a
+		// dataset re-imports it into the freshly respawned worker.
+		this._crashListener = this.db.onDidCrash(() => this._uriToTableView.clear());
+	}
 
 	dispose() {
+		this._crashListener.dispose();
 		vscode.Disposable.from(...this._watchers).dispose();
 	}
 

--- a/extensions/positron-duckdb/src/test/extension.test.ts
+++ b/extensions/positron-duckdb/src/test/extension.test.ts
@@ -47,6 +47,9 @@ import {
 	ColumnSummaryStats
 } from '../interfaces';
 import { randomBytes, randomUUID } from 'crypto';
+import * as os from 'os';
+import * as fs from 'fs';
+import { DuckDBInstance } from '../extension';
 
 const DEFAULT_FORMAT_OPTIONS: FormatOptions = {
 	large_num_digits: 2,
@@ -3278,5 +3281,43 @@ suite('Positron DuckDB Extension Test Suite', () => {
 				}
 			}
 		});
+	});
+});
+
+suite('DuckDB worker isolation', () => {
+	// A stub worker that speaks the IPC protocol, so we can exercise crash
+	// recovery without depending on the native binding or a real out-of-memory
+	// condition. It crashes hard on a sentinel query and otherwise returns a
+	// trivial one-row result.
+	const STUB_WORKER = `
+		process.on('message', (req) => {
+			if (req.sql === 'CRASH') { process.exit(1); return; }
+			process.send({ kind: 'result', id: req.id, columnNames: ['x'], columns: [[1n]] });
+		});
+	`;
+
+	test('survives a worker crash, rejects the in-flight query, and respawns', async () => {
+		const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'duckdb-stub-worker-'));
+		const stubPath = path.join(dir, 'stubWorker.js');
+		await fs.promises.writeFile(stubPath, STUB_WORKER);
+
+		const db = await DuckDBInstance.create(stubPath);
+		let crashCount = 0;
+		const crashListener = db.onDidCrash(() => { crashCount++; });
+		try {
+			// Normal query round-trips through the worker.
+			assert.strictEqual((await db.runQuery('SELECT 1')).numRows, 1);
+
+			// A crashing query rejects (rather than hanging) and fires onDidCrash.
+			await assert.rejects(db.runQuery('CRASH'), /terminated unexpectedly/);
+			assert.strictEqual(crashCount, 1, 'onDidCrash should fire exactly once');
+
+			// The next query transparently respawns the worker and succeeds.
+			assert.strictEqual((await db.runQuery('SELECT 1')).numRows, 1);
+		} finally {
+			crashListener.dispose();
+			db.close();
+			await fs.promises.rm(dir, { recursive: true, force: true });
+		}
 	});
 });


### PR DESCRIPTION
### Summary

Opening a Parquet file larger than available memory could crash the entire extension host. The `positron-duckdb` extension asks native DuckDB to read the file into an in-memory table; when that allocation exceeds what the machine can provide, DuckDB (or the OS) aborts the process. Because the native binding ran **in the extension host process**, the abort took the host down with it -- and a native abort cannot be caught by any JavaScript `try/catch`.

This PR moves the native DuckDB instance into a dedicated child process, so a native failure can only take down that disposable worker:

- `DuckDBInstance` is now a thin host-side proxy. It forks a worker (`duckdbWorker.ts`), forwards each query over IPC, and reconstructs the result. No call sites changed -- `QueryResult` exposes the same shape as before.
- When the worker exits unexpectedly, in-flight queries reject with a clear error (instead of hanging), an `onDidCrash` event fires, and the worker is respawned transparently on the next query.
- `DataExplorerRpcHandler` listens for `onDidCrash` and drops its cached table views, so datasets re-import into the fresh worker on next access (reusing the existing "recreate on missing" path).

Net effect: opening an oversized file now surfaces a normal "failed to open" error in the Data Explorer instead of crashing the IDE.

**Performance:** the added per-query cost is result-serialization across the process boundary, which scales with payload size. Since the Data Explorer always queries windowed/paginated data, real interactions add well under 1ms (measured: ~0.2ms for a typical cell-data window, ~0.01ms round-trip floor). There is a one-time worker startup cost at activation.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Prevent the extension host from crashing when opening a data file too large to fit in memory; the Data Explorer now reports an error instead.

### Validation Steps

@:data-explorer @:duck-db

1. Open a small/normal Parquet or CSV file in the Data Explorer and confirm it loads, scrolls, sorts, filters, and shows column summaries as before.
2. Open a Parquet file substantially larger than available RAM (e.g. a 10,000 x 10,000 file on a memory-constrained machine).
3. Verify the extension host **does not crash** -- the IDE stays responsive and other extensions keep running.
4. Confirm subsequent file opens still work (the worker has respawned), with no reload required.