### PR TITLE
Search packages as you type in the Packages pane install flow

### DIFF
--- a/extensions/positron-python/src/client/positron/packages/pypiSearch.ts
+++ b/extensions/positron-python/src/client/positron/packages/pypiSearch.ts
@@ -19,28 +19,91 @@ function createAbortSignal(token?: vscode.CancellationToken): AbortSignal | unde
 }
 
 /**
+ * How long the cached PyPI project index stays fresh before it is refetched.
+ * The simple index is multiple MB and changes slowly, so an hour is plenty;
+ * within a session a user almost never needs newly published packages to
+ * appear mid-search.
+ */
+const PYPI_INDEX_TTL_MS = 60 * 60 * 1000;
+
+interface PyPIIndexCache {
+    names: string[];
+    fetchedAt: number;
+}
+
+/** Cached list of every project name on PyPI, populated lazily on first search. */
+let pypiIndexCache: PyPIIndexCache | undefined;
+
+/** Dedupes concurrent index fetches so debounced keystrokes share one download. */
+let pypiIndexInFlight: Promise<string[]> | undefined;
+
+/**
+ * Download the full PyPI simple index (every project name) and cache it.
+ *
+ * Intentionally not tied to a per-query cancellation token: the download is a
+ * shared, cacheable resource, so a superseded query shouldn't abort a fetch the
+ * next query is about to reuse. Even an abandoned first search usefully warms
+ * the cache.
+ */
+async function fetchPyPIIndex(): Promise<string[]> {
+    const response = await fetch('https://pypi.org/simple/', {
+        headers: { Accept: 'application/vnd.pypi.simple.v1+json' },
+    });
+    const json = (await response.json()) as {
+        projects: { name: string }[];
+    };
+    const names = json.projects.map((x) => x.name);
+    pypiIndexCache = { names, fetchedAt: Date.now() };
+    return names;
+}
+
+/**
+ * Return the cached PyPI project index, refetching if missing or stale.
+ */
+async function getPyPIIndex(): Promise<string[]> {
+    if (pypiIndexCache && Date.now() - pypiIndexCache.fetchedAt < PYPI_INDEX_TTL_MS) {
+        return pypiIndexCache.names;
+    }
+    if (!pypiIndexInFlight) {
+        pypiIndexInFlight = fetchPyPIIndex().finally(() => {
+            pypiIndexInFlight = undefined;
+        });
+    }
+    return pypiIndexInFlight;
+}
+
+/**
+ * Clear the cached PyPI index. Intended for unit tests, which share the
+ * module-level cache across cases and need a clean slate per test.
+ */
+export function resetPyPIIndexCacheForTests(): void {
+    pypiIndexCache = undefined;
+    pypiIndexInFlight = undefined;
+}
+
+/**
  * Search PyPI for packages matching a query.
+ *
+ * Backed by a per-session, TTL'd cache of the full simple index so live
+ * (debounced) search filters locally instead of re-downloading multiple MB on
+ * every keystroke.
  */
 export async function searchPyPI(
     query: string,
     token?: vscode.CancellationToken,
 ): Promise<positron.LanguageRuntimePackage[]> {
     try {
-        const response = await fetch('https://pypi.org/simple/', {
-            headers: { Accept: 'application/vnd.pypi.simple.v1+json' },
-            signal: createAbortSignal(token),
-        });
-        const json = (await response.json()) as {
-            projects: { name: string }[];
-        };
-
-        return json.projects
-            .map((x) => x.name)
-            .filter((x) => x.includes(query))
-            .map((x) => ({
-                id: x,
-                name: x,
-                displayName: x,
+        const names = await getPyPIIndex();
+        if (token?.isCancellationRequested) {
+            throw new vscode.CancellationError();
+        }
+        const normalized = query.toLowerCase();
+        return names
+            .filter((name) => name.toLowerCase().includes(normalized))
+            .map((name) => ({
+                id: name,
+                name,
+                displayName: name,
                 version: '0',
             }));
     } catch (e) {

--- a/extensions/positron-python/src/client/positron/packages/pypiSearch.ts
+++ b/extensions/positron-python/src/client/positron/packages/pypiSearch.ts
@@ -26,16 +26,30 @@ function createAbortSignal(token?: vscode.CancellationToken): AbortSignal | unde
  */
 const PYPI_INDEX_TTL_MS = 60 * 60 * 1000;
 
-interface PyPIIndexCache {
+/**
+ * Cap on the number of search results returned. A broad query (e.g. "a")
+ * matches a large fraction of PyPI's ~800k projects; returning them all would
+ * build and serialize a huge array for results no one will scroll. The exact
+ * match is preserved regardless of where it falls (see searchPyPI).
+ */
+const PYPI_MAX_RESULTS = 100;
+
+interface PyPIIndex {
+    /** Project names as published, for display. */
     names: string[];
+    /** names[i] pre-lowercased, so matching doesn't re-allocate on every query. */
+    lower: string[];
+}
+
+interface PyPIIndexCache extends PyPIIndex {
     fetchedAt: number;
 }
 
-/** Cached list of every project name on PyPI, populated lazily on first search. */
+/** Cached index of every project on PyPI, populated lazily on first search. */
 let pypiIndexCache: PyPIIndexCache | undefined;
 
 /** Dedupes concurrent index fetches so debounced keystrokes share one download. */
-let pypiIndexInFlight: Promise<string[]> | undefined;
+let pypiIndexInFlight: Promise<PyPIIndex> | undefined;
 
 /**
  * Download the full PyPI simple index (every project name) and cache it.
@@ -45,7 +59,7 @@ let pypiIndexInFlight: Promise<string[]> | undefined;
  * next query is about to reuse. Even an abandoned first search usefully warms
  * the cache.
  */
-async function fetchPyPIIndex(): Promise<string[]> {
+async function fetchPyPIIndex(): Promise<PyPIIndex> {
     const response = await fetch('https://pypi.org/simple/', {
         headers: { Accept: 'application/vnd.pypi.simple.v1+json' },
     });
@@ -53,16 +67,17 @@ async function fetchPyPIIndex(): Promise<string[]> {
         projects: { name: string }[];
     };
     const names = json.projects.map((x) => x.name);
-    pypiIndexCache = { names, fetchedAt: Date.now() };
-    return names;
+    const lower = names.map((name) => name.toLowerCase());
+    pypiIndexCache = { names, lower, fetchedAt: Date.now() };
+    return { names, lower };
 }
 
 /**
  * Return the cached PyPI project index, refetching if missing or stale.
  */
-async function getPyPIIndex(): Promise<string[]> {
+async function getPyPIIndex(): Promise<PyPIIndex> {
     if (pypiIndexCache && Date.now() - pypiIndexCache.fetchedAt < PYPI_INDEX_TTL_MS) {
-        return pypiIndexCache.names;
+        return pypiIndexCache;
     }
     if (!pypiIndexInFlight) {
         pypiIndexInFlight = fetchPyPIIndex().finally(() => {
@@ -93,19 +108,58 @@ export async function searchPyPI(
     token?: vscode.CancellationToken,
 ): Promise<positron.LanguageRuntimePackage[]> {
     try {
-        const names = await getPyPIIndex();
+        const { names, lower } = await getPyPIIndex();
         if (token?.isCancellationRequested) {
             throw new vscode.CancellationError();
         }
         const normalized = query.toLowerCase();
-        return names
-            .filter((name) => name.toLowerCase().includes(normalized))
-            .map((name) => ({
-                id: name,
-                name,
-                displayName: name,
-                version: '0',
-            }));
+
+        // The simple index is unranked (roughly alphabetical), so rank matches
+        // ourselves: names that start with the query come before names that
+        // merely contain it. Each bucket keeps index order and is capped, so a
+        // broad query stays bounded. The exact match is tracked separately and
+        // forced in below in case it falls outside the cap.
+        const prefixMatches: string[] = [];
+        const containsMatches: string[] = [];
+        let exactName: string | undefined;
+        for (let i = 0; i < lower.length; i++) {
+            const name = lower[i];
+            if (name === normalized) {
+                exactName = names[i];
+            }
+            if (name.startsWith(normalized)) {
+                if (prefixMatches.length < PYPI_MAX_RESULTS) {
+                    prefixMatches.push(names[i]);
+                }
+            } else if (name.includes(normalized)) {
+                if (containsMatches.length < PYPI_MAX_RESULTS) {
+                    containsMatches.push(names[i]);
+                }
+            }
+            // Prefix matches alone fill the cap and the exact match is captured;
+            // nothing later can change the top-capped, prefix-first view.
+            if (prefixMatches.length >= PYPI_MAX_RESULTS && exactName !== undefined) {
+                break;
+            }
+        }
+
+        let results = prefixMatches;
+        if (results.length < PYPI_MAX_RESULTS) {
+            results = results.concat(containsMatches).slice(0, PYPI_MAX_RESULTS);
+        }
+        // The exact match always starts with the query, so it belongs in
+        // prefixMatches; if it was pushed out by the cap, force it into the last
+        // slot so the core layer can still hoist it to the top.
+        if (exactName !== undefined && !results.includes(exactName)) {
+            results[results.length - 1] = exactName;
+        }
+
+        return results.map((name) => ({
+            id: name,
+            name,
+            displayName: name,
+            version: '0',
+        }));
     } catch (e) {
         if (e instanceof Error && e.name === 'AbortError') {
             throw new vscode.CancellationError();

--- a/extensions/positron-python/src/test/positron/pypiSearch.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pypiSearch.unit.test.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { resetPyPIIndexCacheForTests, searchPyPI } from '../../client/positron/packages/pypiSearch';
+
+function makeIndexResponse(names: string[]): Response {
+    return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ projects: names.map((name) => ({ name })) }),
+    } as Response;
+}
+
+suite('searchPyPI', () => {
+    let fetchStub: sinon.SinonStub;
+
+    setup(() => {
+        resetPyPIIndexCacheForTests();
+        fetchStub = sinon.stub(global, 'fetch');
+    });
+
+    teardown(() => {
+        sinon.restore();
+        resetPyPIIndexCacheForTests();
+    });
+
+    test('filters the index by case-insensitive substring and maps to LanguageRuntimePackage', async () => {
+        fetchStub.resolves(makeIndexResponse(['NumPy', 'pandas', 'numba', 'requests']));
+
+        const result = await searchPyPI('num');
+
+        expect(result).to.deep.equal([
+            { id: 'NumPy', name: 'NumPy', displayName: 'NumPy', version: '0' },
+            { id: 'numba', name: 'numba', displayName: 'numba', version: '0' },
+        ]);
+    });
+
+    test('downloads the index once and serves later searches from cache', async () => {
+        fetchStub.resolves(makeIndexResponse(['numpy', 'pandas']));
+
+        await searchPyPI('num');
+        await searchPyPI('pan');
+
+        expect(fetchStub.calledOnce).to.be.true;
+    });
+
+    test('refetches the index once its TTL has elapsed', async () => {
+        const clock = sinon.useFakeTimers();
+        try {
+            fetchStub.resolves(makeIndexResponse(['numpy']));
+
+            await searchPyPI('num');
+            // Advance just past the one-hour TTL.
+            clock.tick(60 * 60 * 1000 + 1);
+            await searchPyPI('num');
+
+            expect(fetchStub.calledTwice).to.be.true;
+        } finally {
+            clock.restore();
+        }
+    });
+
+    test('dedupes concurrent searches into a single index download', async () => {
+        fetchStub.resolves(makeIndexResponse(['numpy', 'pandas']));
+
+        await Promise.all([searchPyPI('num'), searchPyPI('pan')]);
+
+        expect(fetchStub.calledOnce).to.be.true;
+    });
+
+    test('throws CancellationError when the token is cancelled before filtering', async () => {
+        const cts = new vscode.CancellationTokenSource();
+        fetchStub.callsFake(() => {
+            cts.cancel();
+            return Promise.resolve(makeIndexResponse(['numpy']));
+        });
+
+        let caught: unknown;
+        try {
+            await searchPyPI('num', cts.token);
+        } catch (e) {
+            caught = e;
+        }
+        expect(caught).to.be.instanceOf(vscode.CancellationError);
+    });
+});

--- a/extensions/positron-python/src/test/positron/pypiSearch.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/pypiSearch.unit.test.ts
@@ -73,6 +73,37 @@ suite('searchPyPI', () => {
         expect(fetchStub.calledOnce).to.be.true;
     });
 
+    test('ranks prefix matches ahead of substring-only matches', async () => {
+        // Index order puts a substring-only match (django-requests) first.
+        fetchStub.resolves(makeIndexResponse(['django-requests', 'requests', 'requests-oauthlib']));
+
+        const result = await searchPyPI('requests');
+
+        expect(result.map((p) => p.name)).to.deep.equal(['requests', 'requests-oauthlib', 'django-requests']);
+    });
+
+    test('caps a broad query at 100 results', async () => {
+        // 150 names all containing "pkg".
+        const names = Array.from({ length: 150 }, (_, i) => `pkg${i}`);
+        fetchStub.resolves(makeIndexResponse(names));
+
+        const result = await searchPyPI('pkg');
+
+        expect(result).to.have.lengthOf(100);
+    });
+
+    test('keeps an exact match that sorts past the cap', async () => {
+        // 150 substring matches, with the exact match "pkg" last (well past the
+        // 100-result cap).
+        const names = [...Array.from({ length: 150 }, (_, i) => `pkg${i}`), 'pkg'];
+        fetchStub.resolves(makeIndexResponse(names));
+
+        const result = await searchPyPI('pkg');
+
+        expect(result).to.have.lengthOf(100);
+        expect(result.some((p) => p.name === 'pkg')).to.be.true;
+    });
+
     test('throws CancellationError when the token is cancelled before filtering', async () => {
         const cts = new vscode.CancellationTokenSource();
         fetchStub.callsFake(() => {

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { removeAnsiEscapeCodes } from '../../../../base/common/strings.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
@@ -289,8 +289,8 @@ class InstallPackageAction extends Action2 {
 		const cts = new CancellationTokenSource();
 
 		try {
-			const performSearch = async (q: string) => {
-				return await service.searchPackages(q, cts.token);
+			const performSearch = async (q: string, token: CancellationToken) => {
+				return await service.searchPackages(q, token);
 			};
 
 			const performSearchVersions = async (pkg: string) => {

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
@@ -103,15 +103,18 @@ export const updatePackage = async (
 	}
 
 	async function pickPackage(input: MultiStepInput, state: State) {
-		state.packages = await performGetPackages('');
 		const selection = await input.showQuickPick({
 			title,
 			step: 1,
 			totalSteps: 2,
 			placeholder: localize('positronPackages.updatePackagePlaceholder', 'Pick a package to update...'),
-			items: state.packages.map((result) => ({
-				label: result.name,
-			})),
+			items: [],
+			// Show the picker immediately rather than blocking on the package
+			// list before anything appears.
+			loadItems: async () => {
+				state.packages = await performGetPackages('');
+				return state.packages.map((result) => ({ label: result.name }));
+			},
 		});
 
 		state.selectedPackage = selection.label;
@@ -120,16 +123,20 @@ export const updatePackage = async (
 	}
 
 	async function pickVersion(input: MultiStepInput, state: State) {
-		const versions = await performLookup(state.selectedPackage ?? '');
-		const sortedVersions = sortVersionsDescending(versions);
-		state.versions = sortedVersions.map((v) => ({ name: v }));
-
 		const selection = await input.showQuickPick({
 			title,
 			step: 2,
 			totalSteps: 2,
 			placeholder: localize('positronPackages.pickVersionPlaceholder', "Pick a version of {0} to update", state.selectedPackage),
-			items: state.versions.map((version) => ({ label: version.name })),
+			items: [],
+			// Load versions after the picker is shown so a slow lookup doesn't
+			// freeze the previous step on a disabled list.
+			loadItems: async () => {
+				const versions = await performLookup(state.selectedPackage ?? '');
+				const sortedVersions = sortVersionsDescending(versions);
+				state.versions = sortedVersions.map((v) => ({ name: v }));
+				return state.versions.map((version) => ({ label: version.name }));
+			},
 		});
 
 		state.selectedVersion = selection.label;
@@ -166,15 +173,18 @@ export const uninstallPackage = async (
 	}
 
 	async function pickPackage(input: MultiStepInput, state: State) {
-		state.packages = await performGetPackages('');
 		const selection = await input.showQuickPick({
 			title,
 			step: 1,
 			totalSteps: 1,
 			placeholder: localize('positronPackages.uninstallPackagePlaceholder', 'Pick a package to uninstall...'),
-			items: state.packages.map((result) => ({
-				label: result.name,
-			})),
+			items: [],
+			// Show the picker immediately rather than blocking on the package
+			// list before anything appears.
+			loadItems: async () => {
+				state.packages = await performGetPackages('');
+				return state.packages.map((result) => ({ label: result.name }));
+			},
 		});
 
 		state.selectedPackage = selection.label;
@@ -254,6 +264,9 @@ export const installPackage = async (
 			noResultsItem: (query: string) => ({
 				label: localize('positronPackages.noPackagesFound', "No packages found for '{0}'", query),
 			}),
+			errorItem: () => ({
+				label: localize('positronPackages.errorSearchingPackages', 'Error searching packages.'),
+			}),
 		});
 
 		state.selectedPackage = selection.label;
@@ -317,6 +330,13 @@ interface SearchableQuickPickParameters<T extends QuickPickItem> {
 	 * cannot be picked (selecting it is a no-op). Omit to leave the list empty.
 	 */
 	noResultsItem?: (query: string) => T;
+	/**
+	 * Builds the single, non-selectable item shown when {@link search} throws
+	 * (a non-cancellation error), so a failed search reads as an error rather
+	 * than a blank or a false "no results". Cannot be picked. Omit to leave the
+	 * list empty on error.
+	 */
+	errorItem?: (query: string) => T;
 	buttons?: IQuickInputButton[];
 	ignoreFocusOut?: boolean;
 }
@@ -476,6 +496,7 @@ class MultiStepInput {
 		value,
 		search,
 		noResultsItem,
+		errorItem,
 		buttons,
 		ignoreFocusOut,
 	}: P) {
@@ -484,9 +505,9 @@ class MultiStepInput {
 		// cancel it, both to abort the network request and to discard a stale
 		// out-of-order response.
 		let queryCts: CancellationTokenSource | undefined;
-		// The current no-results placeholder item (if shown), held by identity
-		// so selecting it can be ignored.
-		let noResultsPick: T | undefined;
+		// The current non-selectable status placeholder (no-results or error
+		// message), held by identity so selecting it can be ignored.
+		let messagePick: T | undefined;
 		const cancelInFlight = () => {
 			queryCts?.cancel();
 			queryCts?.dispose();
@@ -519,7 +540,7 @@ class MultiStepInput {
 						cancelInFlight();
 						if (!query.trim()) {
 							// Empty query: clear results, don't hit the backend.
-							noResultsPick = undefined;
+							messagePick = undefined;
 							input.items = [];
 							input.busy = false;
 							return;
@@ -527,12 +548,12 @@ class MultiStepInput {
 						queryCts = new CancellationTokenSource();
 						const token = queryCts.token;
 						input.busy = true;
-						if (noResultsPick) {
-							// The "no results" message states a negative about the
+						if (messagePick) {
+							// A status message (no-results / error) describes the
 							// previous query; drop it so it doesn't linger (and read
 							// as a premature verdict) while the new query runs. Real
 							// results are left in place to avoid flicker.
-							noResultsPick = undefined;
+							messagePick = undefined;
 							input.items = [];
 						}
 						try {
@@ -544,19 +565,27 @@ class MultiStepInput {
 								// Show a non-selectable placeholder so an empty
 								// result reads as "nothing found" rather than a
 								// blank, possibly-broken picker.
-								noResultsPick = noResultsItem(query);
-								input.items = [noResultsPick];
+								messagePick = noResultsItem(query);
+								input.items = [messagePick];
 							} else {
-								noResultsPick = undefined;
+								messagePick = undefined;
 								input.items = items;
 							}
 						} catch (error) {
 							if (token.isCancellationRequested || isCancellationError(error)) {
 								return;
 							}
-							// Surface nothing rather than stale results on error.
-							noResultsPick = undefined;
-							input.items = [];
+							if (errorItem) {
+								// Show a non-selectable error placeholder so a
+								// failed search reads as "something went wrong"
+								// rather than a blank (or false "nothing found").
+								messagePick = errorItem(query);
+								input.items = [messagePick];
+							} else {
+								// Surface nothing rather than stale results on error.
+								messagePick = undefined;
+								input.items = [];
+							}
 						} finally {
 							if (!token.isCancellationRequested) {
 								input.busy = false;
@@ -582,7 +611,7 @@ class MultiStepInput {
 					disposables.add(
 						input.onDidChangeSelection((items) => {
 							// Ignore selection of the no-results placeholder.
-							if (items[0] && items[0] !== noResultsPick) {
+							if (items[0] && items[0] !== messagePick) {
 								resolve(items[0]);
 							}
 						}),

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
@@ -3,12 +3,37 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
-import { IDisposable } from '../../../../base/common/lifecycle.js';
+import { Delayer } from '../../../../base/common/async.js';
+import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
+import { isCancellationError } from '../../../../base/common/errors.js';
+import { DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
 import { localize } from '../../../../nls.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { IInputBox, IQuickInput, IQuickInputButton, IQuickInputService, IQuickPickItem, QuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import * as semver from '../../../../base/common/semver/semver.js';
+
+/**
+ * Debounce interval (ms) before firing a package search as the user types. Long
+ * enough to avoid a query per keystroke against the backend, short enough to
+ * still feel live.
+ */
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Move an exact, case-insensitive name match to the front of the results,
+ * leaving the backend's relative ordering of everything else untouched. We
+ * defer to the backend's own ranking (pak/PPM, PyPI) and only guarantee that a
+ * precise name match surfaces first.
+ */
+export function hoistExactMatch(results: PackageSearchResult[], query: string): PackageSearchResult[] {
+	const normalized = query.trim().toLowerCase();
+	const index = results.findIndex((result) => result.name.toLowerCase() === normalized);
+	if (index <= 0) {
+		// Not found, or already first; nothing to reorder.
+		return results;
+	}
+	return [results[index], ...results.slice(0, index), ...results.slice(index + 1)];
+}
 
 interface VersionSearchResult {
 	name: string;
@@ -163,7 +188,7 @@ export const uninstallPackage = async (
 
 export const installPackage = async (
 	accessor: ServicesAccessor,
-	performSearch: (q: string) => Promise<PackageSearchResult[]>,
+	performSearch: (q: string, token: CancellationToken) => Promise<PackageSearchResult[]>,
 	performLookup: (q: string) => Promise<string[]>,
 	performInstall: (pkg: string, version?: string) => Promise<void>,
 	cts?: CancellationTokenSource,
@@ -191,62 +216,49 @@ export const installPackage = async (
 	}
 
 	async function pickVersion(input: MultiStepInput, state: State) {
-		const versions = await performLookup(state.selectedPackage ?? '');
-		const sortedVersions = sortVersionsDescending(versions);
-		state.versions = sortedVersions.map((v) => ({ name: v }));
-
 		const selection = await input.showQuickPick({
 			title,
-			step: 3,
-			totalSteps: 3,
+			step: 2,
+			totalSteps: 2,
 			placeholder: localize('positronPackages.installPackageVersionPlaceholder', "Pick a version of '{0}' to install", state.selectedPackage),
-			items: state.versions.map((version) => ({ label: version.name })),
+			items: [],
+			// Load versions after the picker is shown so a slow lookup (e.g.
+			// conda) doesn't freeze the previous step on a disabled list.
+			loadItems: async () => {
+				const versions = await performLookup(state.selectedPackage ?? '');
+				const sortedVersions = sortVersionsDescending(versions);
+				state.versions = sortedVersions.map((v) => ({ name: v }));
+				return state.versions.map((version) => ({ label: version.name }));
+			},
 		});
 
 		state.selectedVersion = selection.label;
 	}
 
-	async function pickPackage(input: MultiStepInput, state: State) {
-		const selection = await input.showQuickPick({
+	async function searchPackage(input: MultiStepInput, state: State) {
+		const selection = await input.showSearchableQuickPick({
 			title,
-			step: 2,
-			totalSteps: 3,
-			placeholder: localize('positronPackages.installPackagePlaceholder', 'Pick a package to install...'),
-			items: state.packages.map((result) => ({
-				label: result.name,
-			})),
+			step: 1,
+			totalSteps: 2,
+			value: state.query,
+			placeholder: localize('positronPackages.installPackagePlaceholder', 'Search for a package to install...'),
+			search: async (query: string, token: CancellationToken) => {
+				// Remember the query so it's restored when navigating back here.
+				state.query = query;
+				const results = await performSearch(query, token);
+				state.packages = results;
+				// Defer to the backend's ordering, but surface an exact name
+				// match first (see hoistExactMatch).
+				return hoistExactMatch(results, query).map((result) => ({ label: result.name }));
+			},
+			noResultsItem: (query: string) => ({
+				label: localize('positronPackages.noPackagesFound', "No packages found for '{0}'", query),
+			}),
 		});
 
 		state.selectedPackage = selection.label;
 
 		return (input: MultiStepInput) => pickVersion(input, state);
-	}
-
-	async function searchPackage(input: MultiStepInput, state: State) {
-		const query = await input.showInputBox({
-			title,
-			step: 1,
-			totalSteps: 3,
-			value: state.query || '',
-			prompt: localize('positronPackages.installPackagePrompt', 'Search for a package to install...'),
-			perform: async (value: string, input) => {
-				try {
-					state.packages = await performSearch(value);
-				} catch (error) {
-					input.validationMessage = localize('positronPackages.errorSearchingPackages', 'Error searching packages.');
-					throw error;
-				}
-
-				if (state.packages.length === 0) {
-					input.validationMessage = localize('positronPackages.noPackagesFound', "No packages found for '{0}'", value);
-					return Promise.reject();
-				}
-			},
-		});
-
-		state.query = query;
-
-		return (input: MultiStepInput) => pickPackage(input, state);
 	}
 
 	const state = await collectInputs();
@@ -277,6 +289,36 @@ interface QuickPickParameters<T extends QuickPickItem> {
 	ignoreFocusOut?: boolean;
 	placeholder: string;
 	buttons?: IQuickInputButton[];
+	/**
+	 * When provided, the quick pick is shown immediately in a busy state and its
+	 * items are populated from this loader when it resolves, instead of blocking
+	 * on a slow fetch before the picker appears. Keeps the step responsive (Back
+	 * and Escape work while loading) rather than freezing the previous step. The
+	 * token is cancelled if the picker is dismissed before the load completes.
+	 */
+	loadItems?: (token: CancellationToken) => Promise<T[]>;
+}
+
+interface SearchableQuickPickParameters<T extends QuickPickItem> {
+	title: string;
+	step: number;
+	totalSteps: number;
+	placeholder: string;
+	value?: string;
+	/**
+	 * Runs on each (debounced) change to the input value, with a token that is
+	 * cancelled when a newer search supersedes this one or the picker is hidden.
+	 * Returns the items to display, already ordered as they should appear.
+	 */
+	search: (query: string, token: CancellationToken) => Promise<T[]>;
+	/**
+	 * Builds the single, non-selectable item shown when {@link search} returns
+	 * no results, so the picker isn't a confusing blank. The returned item
+	 * cannot be picked (selecting it is a no-op). Omit to leave the list empty.
+	 */
+	noResultsItem?: (query: string) => T;
+	buttons?: IQuickInputButton[];
+	ignoreFocusOut?: boolean;
 }
 
 interface InputBoxParameters {
@@ -345,8 +387,11 @@ class MultiStepInput {
 		ignoreFocusOut,
 		placeholder,
 		buttons,
+		loadItems,
 	}: P) {
 		const disposables: IDisposable[] = [];
+		// Cancels an in-flight loadItems fetch if the picker is dismissed first.
+		let loadCts: CancellationTokenSource | undefined;
 		try {
 			return await new Promise<T | (P extends { buttons: (infer I)[] } ? I : never)>(
 				(resolve, reject) => {
@@ -383,10 +428,186 @@ class MultiStepInput {
 					}
 					this.current = input;
 					this.current.show();
+					if (loadItems) {
+						// Show the picker now and fill it in when the (possibly
+						// slow) fetch returns, rather than freezing the previous
+						// step behind a disabled list.
+						input.busy = true;
+						loadCts = new CancellationTokenSource();
+						const token = loadCts.token;
+						loadItems(token).then(
+							(loaded) => {
+								if (token.isCancellationRequested) {
+									return;
+								}
+								input.items = loaded;
+								input.busy = false;
+							},
+							(error) => {
+								if (token.isCancellationRequested || isCancellationError(error)) {
+									return;
+								}
+								input.busy = false;
+								reject(error);
+							},
+						);
+					}
 				},
 			);
 		} finally {
+			loadCts?.cancel();
+			loadCts?.dispose();
 			disposables.forEach((d) => d.dispose());
+		}
+	}
+
+	/**
+	 * Like {@link showQuickPick}, but the item list is populated live from a
+	 * search callback as the user types, rather than from a fixed list. The
+	 * search is debounced, the previous in-flight query is cancelled when a new
+	 * one starts, and the quick pick's own fuzzy filtering/sorting is disabled
+	 * so results display in the order the callback returns them.
+	 */
+	async showSearchableQuickPick<T extends IQuickPickItem, P extends SearchableQuickPickParameters<T>>({
+		title,
+		step,
+		totalSteps,
+		placeholder,
+		value,
+		search,
+		noResultsItem,
+		buttons,
+		ignoreFocusOut,
+	}: P) {
+		const disposables = new DisposableStore();
+		// Tracks the in-flight query so a superseding search (or hide) can
+		// cancel it, both to abort the network request and to discard a stale
+		// out-of-order response.
+		let queryCts: CancellationTokenSource | undefined;
+		// The current no-results placeholder item (if shown), held by identity
+		// so selecting it can be ignored.
+		let noResultsPick: T | undefined;
+		const cancelInFlight = () => {
+			queryCts?.cancel();
+			queryCts?.dispose();
+			queryCts = undefined;
+		};
+		try {
+			return await new Promise<T | (P extends { buttons: (infer I)[] } ? I : never)>(
+				(resolve, reject) => {
+					const input = this.quickPickService.createQuickPick<T>();
+					input.title = title;
+					input.step = step;
+					input.totalSteps = totalSteps;
+					input.ignoreFocusOut = ignoreFocusOut ?? false;
+					input.placeholder = placeholder;
+					input.value = value ?? '';
+					// Preserve the order returned by the search callback: disable
+					// the quick pick's built-in fuzzy match/sort so it neither
+					// reorders nor hides backend-supplied results.
+					input.matchOnLabel = false;
+					input.matchOnDescription = false;
+					input.matchOnDetail = false;
+					input.sortByLabel = false;
+					input.items = [];
+					input.buttons = [
+						...(this.steps.length > 1 ? [this.quickPickService.backButton] : []),
+						...(buttons || []),
+					];
+
+					const runSearch = async (query: string) => {
+						cancelInFlight();
+						if (!query.trim()) {
+							// Empty query: clear results, don't hit the backend.
+							noResultsPick = undefined;
+							input.items = [];
+							input.busy = false;
+							return;
+						}
+						queryCts = new CancellationTokenSource();
+						const token = queryCts.token;
+						input.busy = true;
+						if (noResultsPick) {
+							// The "no results" message states a negative about the
+							// previous query; drop it so it doesn't linger (and read
+							// as a premature verdict) while the new query runs. Real
+							// results are left in place to avoid flicker.
+							noResultsPick = undefined;
+							input.items = [];
+						}
+						try {
+							const items = await search(query, token);
+							if (token.isCancellationRequested) {
+								return;
+							}
+							if (items.length === 0 && noResultsItem) {
+								// Show a non-selectable placeholder so an empty
+								// result reads as "nothing found" rather than a
+								// blank, possibly-broken picker.
+								noResultsPick = noResultsItem(query);
+								input.items = [noResultsPick];
+							} else {
+								noResultsPick = undefined;
+								input.items = items;
+							}
+						} catch (error) {
+							if (token.isCancellationRequested || isCancellationError(error)) {
+								return;
+							}
+							// Surface nothing rather than stale results on error.
+							noResultsPick = undefined;
+							input.items = [];
+						} finally {
+							if (!token.isCancellationRequested) {
+								input.busy = false;
+							}
+						}
+					};
+
+					const delayer = disposables.add(new Delayer<void>(SEARCH_DEBOUNCE_MS));
+					disposables.add(
+						input.onDidChangeValue((text) => {
+							delayer.trigger(() => runSearch(text));
+						}),
+					);
+					disposables.add(
+						input.onDidTriggerButton((item) => {
+							if (item === this.quickPickService.backButton) {
+								reject(InputFlowAction.back);
+							} else {
+								reject(item);
+							}
+						}),
+					);
+					disposables.add(
+						input.onDidChangeSelection((items) => {
+							// Ignore selection of the no-results placeholder.
+							if (items[0] && items[0] !== noResultsPick) {
+								resolve(items[0]);
+							}
+						}),
+					);
+					disposables.add(
+						input.onDidHide(() => {
+							this.cts?.cancel();
+							reject(InputFlowAction.cancel);
+						}),
+					);
+					if (this.current) {
+						this.current.dispose();
+					}
+					this.current = input;
+					this.current.show();
+					// Restore results immediately when re-entering with a prior
+					// query (e.g. after navigating back from the version step).
+					if ((value ?? '').trim()) {
+						delayer.trigger(() => runSearch(value!));
+					}
+				},
+			);
+		} finally {
+			cancelInFlight();
+			disposables.dispose();
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
@@ -20,6 +20,15 @@ import * as semver from '../../../../base/common/semver/semver.js';
 const SEARCH_DEBOUNCE_MS = 300;
 
 /**
+ * Cap on the number of search results fed to the quick pick. A broad query
+ * (e.g. "a") can match thousands of packages from some backends; rendering them
+ * all is wasteful for results no one will scroll. Applied after the exact-match
+ * hoist so a precise match always survives the cap. Backends may cap further
+ * upstream (pak and PyPI both cap at 100); this is the uniform safety net.
+ */
+const MAX_SEARCH_RESULTS = 100;
+
+/**
  * Move an exact, case-insensitive name match to the front of the results,
  * leaving the backend's relative ordering of everything else untouched. We
  * defer to the backend's own ranking (pak/PPM, PyPI) and only guarantee that a
@@ -258,8 +267,12 @@ export const installPackage = async (
 				const results = await performSearch(query, token);
 				state.packages = results;
 				// Defer to the backend's ordering, but surface an exact name
-				// match first (see hoistExactMatch).
-				return hoistExactMatch(results, query).map((result) => ({ label: result.name }));
+				// match first (see hoistExactMatch), then cap so a broad query
+				// doesn't flood the quick pick. Hoist before the cap so the
+				// exact match always survives it.
+				return hoistExactMatch(results, query)
+					.slice(0, MAX_SEARCH_RESULTS)
+					.map((result) => ({ label: result.name }));
 			},
 			noResultsItem: (query: string) => ({
 				label: localize('positronPackages.noPackagesFound', "No packages found for '{0}'", query),

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesQuickPick.ts
@@ -596,6 +596,12 @@ class MultiStepInput {
 					const delayer = disposables.add(new Delayer<void>(SEARCH_DEBOUNCE_MS));
 					disposables.add(
 						input.onDidChangeValue((text) => {
+							// Abandon any in-flight query immediately, not just when
+							// the next (debounced) search fires: otherwise a slow
+							// query from a previous keystroke can resolve mid-typing
+							// and paint stale results under the newer input. The new
+							// query is still debounced below.
+							cancelInFlight();
 							delayer.trigger(() => runSearch(text));
 						}),
 					);

--- a/src/vs/workbench/contrib/positronPackages/test/browser/positronPackagesQuickPick.vitest.ts
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/positronPackagesQuickPick.vitest.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { hoistExactMatch } from '../../browser/positronPackagesQuickPick.js';
+
+describe('hoistExactMatch', () => {
+	const results = [
+		{ name: 'dplyrutils' },
+		{ name: 'dplyr' },
+		{ name: 'dplyrExtra' },
+	];
+
+	it('moves an exact match to the front, preserving the order of the rest', () => {
+		expect(hoistExactMatch(results, 'dplyr').map((r) => r.name)).toEqual([
+			'dplyr',
+			'dplyrutils',
+			'dplyrExtra',
+		]);
+	});
+
+	it('matches case-insensitively and ignores surrounding whitespace', () => {
+		expect(hoistExactMatch(results, '  DPLYR  ').map((r) => r.name)).toEqual([
+			'dplyr',
+			'dplyrutils',
+			'dplyrExtra',
+		]);
+	});
+
+	it('returns results unchanged when there is no exact match', () => {
+		expect(hoistExactMatch(results, 'plyr')).toBe(results);
+	});
+
+	it('returns results unchanged when the exact match is already first', () => {
+		const alreadyFirst = [{ name: 'tibble' }, { name: 'tibbletime' }];
+		expect(hoistExactMatch(alreadyFirst, 'tibble')).toBe(alreadyFirst);
+	});
+
+	it('handles an empty result set', () => {
+		expect(hoistExactMatch([], 'dplyr')).toEqual([]);
+	});
+});


### PR DESCRIPTION
Fixes #13128

### Summary

Reworks the Packages pane **Install Package** flow so search results appear live as you type, replacing the old type-then-advance input box. The flow collapses from 3 steps to 2 (search + version).

Key changes:

- **Search as you type.** A new debounced (300ms) searchable quick pick queries the backend as you type, cancels the previous in-flight query and any pending debounce on each keystroke (and on selection), shows a busy spinner, and disables the quick pick's own fuzzy match/sort so results display in the backend's order.
- **Result ordering.** Defers to the backend's ranking (pak/PPM, base R, PyPI) but hoists an exact, case-insensitive name match to the top, so a precise match surfaces first.
- **PyPI index caching.** The PyPI simple index (~40MB of JSON) is now cached per session with a 1h TTL and concurrent fetches are deduped, so live search filters locally instead of re-downloading on every keystroke.
- **No more frozen pickers.** The version step (and the Update/Uninstall pickers) now appear immediately with a spinner and fill in when their lookup returns, instead of blocking on a slow lookup behind a disabled list. This was especially noticeable with conda's multi-second lookups.
- **Status feedback.** Empty results show a non-selectable "No packages found for 'x'" item and a failed search shows "Error searching packages." (both cleared when the text input changes. This behavior is different from the typeahead behavior when there are real results, which stay so you can still act on them if you wanted)

Follow-ups intentionally left out of this PR: a richer "search in the browser" affordance for the empty state (#12987), and conda search performance (each query shells out to `conda search` with no caching).

### Release Notes

#### New Features

- Search for packages as you type when installing from the Packages pane, with results ordered to surface exact matches first (#13128)

#### Bug Fixes

- N/A

### Validation Steps

@:packages-pane

1. In an **R** session, open the Packages pane and click **Install Package**.
2. Start typing a package name (e.g. `dpl`) and confirm results appear live without pressing Enter, and that an exact match (e.g. `dplyr`) sorts to the top.
3. Select a package and confirm the version step appears immediately (with a spinner if the lookup is slow) rather than freezing on the search list.
4. Search for gibberish (e.g. `zzzznope`) and confirm a non-selectable "No packages found" message appears rather than a blank list.
5. Repeat in a **Python (pip/uv)** session; confirm the first search may take a moment (index download) and subsequent searches are fast.
6. Confirm **Update Package** and **Uninstall Package** show their pickers immediately instead of pausing before anything appears.

If you really want to experience the brutally slow version, use a conda python session and search for pyfiglet (found) and cowsay (not found).