### PR TITLE
Reduce the top and bottom padding in a notebook

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
@@ -18,7 +18,8 @@
 		var(--vscode-positronNotebook-action-bar-h) / 2
 	);
 	--_positron-notebook-cell-gap: 4px;
-	--_positron-notebook-cells-padding-block: 1.5rem;
+	/* Match the top/bottom padding to the cell gap */
+	--_positron-notebook-cells-padding-block: var(--_positron-notebook-cell-gap);
 	--_positron-notebook-add-cell-buttons-height: 26px; /* Icon 18px + padding 8px */
 	/* Gap between buttons in cell and output action bars */
 	--_positron-notebook-cell-action-bar-button-gap: 0.25rem;


### PR DESCRIPTION
Fixes #13564

The area above the first cell in a notebook had `1.5rem` (24px) of top/bottom padding which was too large and made folks assume some sort of content was missing there. This PR reduces the padding to match the cell gap which is `4px` so the `+ Code`
  / `+ Markdown` buttons at the top of the file match the spacing of the buttons between the cells.

### Screenshots


https://github.com/user-attachments/assets/93148c36-5338-441e-b6ba-39af9e7d0c19




### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Reduce the top/bottom padding in Positron notebooks so the first cell feels visually anchored (#13564)


### Validation Steps

@:positron-notebooks

- Open a Positron notebook and verify the space above the top `+ Code` / `+ Markdown` buttons is visually reduced.


<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
