### PR TITLE
Fix detached/ghost Quarto cell toolbars

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoCellToolbar.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoCellToolbar.ts
@@ -25,6 +25,18 @@ import { getWindow } from '../../../../base/browser/dom.js';
 export class QuartoCellToolbar extends Disposable implements IOverlayWidget {
 	readonly allowEditorOverflow = false;
 
+	private static _nextId = 0;
+
+	/**
+	 * A stable id for this overlay widget, assigned once at construction.
+	 *
+	 * The editor keys overlay widgets by their `getId()` at `addOverlayWidget`
+	 * time, so the id must remain stable for the widget's lifetime. Deriving it
+	 * from the mutable `_cell.id` would break removal after `updateCell()`
+	 * reassigns the cell, leaving a ghost toolbar in the DOM.
+	 */
+	private readonly _id = `quarto-cell-toolbar-${QuartoCellToolbar._nextId++}`;
+
 	private readonly _domNode: HTMLElement;
 	private _runButton!: HTMLButtonElement;
 	private _runAboveButton!: HTMLButtonElement;
@@ -72,7 +84,7 @@ export class QuartoCellToolbar extends Disposable implements IOverlayWidget {
 	}
 
 	getId(): string {
-		return `quarto-cell-toolbar-${this._cell.id}`;
+		return this._id;
 	}
 
 	getDomNode(): HTMLElement {


### PR DESCRIPTION
In some situations, Quarto cell toolbars could become orphaned, which left them detached without any way to be reattached, so they floated in place like ghosts. 

The fix is just to use a stable, independent ID for the cell toolbar instead of trying to derive it from the cell ID.

Fixes https://github.com/posit-dev/positron/issues/13984. 


### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Fix issue that can cause floating/ghost Quarto cell toolbars after deleting a cell (#13984)


### Validation Steps

See https://github.com/posit-dev/positron/issues/13984.

Test tags: :@quarto 