### PR TITLE
Remove no-op kernel selection on `rename` and `saveAs`

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookEditorInput.ts
@@ -22,7 +22,6 @@ import { IRuntimeSessionService } from '../../../services/runtimeSession/common/
 import { Schemas } from '../../../../base/common/network.js';
 import { IWorkingCopyIdentifier } from '../../../services/workingCopy/common/workingCopy.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../common/positronNotebookCommon.js';
-import { INotebookKernelService } from '../../notebook/common/notebookKernelService.js';
 import { NotebookProviderInfo } from '../../notebook/common/notebookProvider.js';
 import { IPYNB_VIEW_TYPE } from '../../notebook/browser/notebookBrowser.js';
 
@@ -102,7 +101,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 		public readonly viewType: string,
 		// Borrow notebook resolver service from vscode notebook renderer.
 		@INotebookEditorModelResolverService private readonly _notebookModelResolverService: INotebookEditorModelResolverService,
-		@INotebookKernelService private readonly _notebookKernelService: INotebookKernelService,
 		@INotebookService private readonly _notebookService: INotebookService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextKeyService _contextKeyService: IContextKeyService,
@@ -298,14 +296,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 			this._logService.error('Failed to reassign notebook session URI', error);
 		}
 
-		// Select the kernel for the new URI.
-		// The kernel service should handle deselecting the kernel for the old URI if it was untitled
-		// to ensure that new untitled notebooks start with clean state
-		const kernel = this.notebookInstance.kernel.get();
-		if (kernel) {
-			this._notebookKernelService.selectKernelForNotebook(kernel, { uri: this.resource, notebookType: this.viewType });
-		}
-
 		// Use the model's saveAs method which handles the actual file saving
 		return await this._editorModelReference.object.saveAs(target);
 	}
@@ -424,12 +414,6 @@ export class PositronNotebookEditorInput extends EditorInput {
 		} catch (error) {
 			// Log error but don't fail the rename operation
 			this._logService.error('Failed to reassign notebook session URI during rename', error);
-		}
-
-		// select the kernel for the new URI
-		const kernel = this.notebookInstance.kernel.get();
-		if (kernel) {
-			this._notebookKernelService.selectKernelForNotebook(kernel, { uri: this.resource, notebookType: this.viewType });
 		}
 
 		// Return editor with new resource to keep the editor open


### PR DESCRIPTION
It was a no-op since it used the old URI instead of the `target`. I confirmed locally that saving an untitled notebook and renaming a notebook both retain the notebook runtime session.

This gets us one step closer to decoupling `PositronNotebookEditorInput` and `PositronNotebookInstance`, needed for #13876.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A


### Validation Steps

@:positron-notebooks @:web

Should be no behavior changes, in particular we should not regress on these:
- Renaming an existing notebook should retain the same runtime session
- Saving an untitled notebook should retain the same runtime session