### PR TITLE
e2e: fix posit assistant chat input locator change

### DIFF
--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -27,8 +27,8 @@ const TRUST_BUTTON = 'button.bg-primary:has-text("Trust this workspace")';
 // Welcome/landing page elements
 const WELCOME_TITLE = '.text-4xl:has-text("Posit Assistant")';
 
-// Chat input area
-const CHAT_INPUT = 'textarea[placeholder="Ask Posit Assistant... Type / to see commands"]';
+// Chat input area (contenteditable div, not textarea — placeholder rendered as sibling element)
+const CHAT_INPUT = '[contenteditable="true"]';
 const SEND_BUTTON = 'button:has(svg.lucide-arrow-up)';
 const STOP_BUTTON = 'button:has(svg.lucide-square)';
 
@@ -111,7 +111,7 @@ export class PositAssistant {
 	 */
 	async acceptTrustDialogIfPresent(): Promise<void> {
 		const trustDialog = this.frame.locator(TRUST_DIALOG);
-		const isVisible = await trustDialog.isVisible().catch(() => false);
+		const isVisible = await trustDialog.isVisible({ timeout: 5000 }).catch(() => false);
 		if (isVisible) {
 			await trustDialog.locator(TRUST_BUTTON).click();
 		}

--- a/test/e2e/tests/posit-assistant/posit-assistant.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant.test.ts
@@ -26,7 +26,7 @@ test.describe('Posit Assistant', {
 				// Ensure we're running the latest Posit Assistant dev build.
 				// Enables the auto dev-build update check, triggers the check,
 				// and accepts the resulting "Update Now" / "Reload" toasts.
-				await app.workbench.positAssistant.checkForDevBuildUpdate(settings, app.workbench.quickaccess);
+				await app.workbench.positAssistant.checkForDevBuildUpdate(settings, app.workbench.quickaccess, { toastTimeout: 10000 });
 			});
 
 			test(`${provider} - Open Posit Assistant and verify welcome page`, async function ({ app }) {


### PR DESCRIPTION
### Summary
Fixes flaky Posit Assistant e2e tests by correcting a stale selector and adding explicit timeouts.

- Update `CHAT_INPUT` selector from `textarea[placeholder="..."]` to `[contenteditable="true"]` — the element changed from textarea to a contenteditable div
- Noticed some really long lag times in the test (30s each by default), added a couple explicit wait times:
   - Add `{ timeout: 5000 }` to `trustDialog.isVisible()` 
   - Add `{ toastTimeout: 10000 }` to `checkForDevBuildUpdate`
   
### QA Notes
@:posit-assistant @:web