### PR TITLE
Feature/notebook cell tags

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -739,6 +739,8 @@
 		"--vscode-positronNotebook-cellFooterForeground",
 		"--vscode-positronNotebook-cellHoverBorder",
 		"--vscode-positronNotebook-cellInactiveFocusedBorder",
+		"--vscode-positronNotebook-cellTagBorder",
+		"--vscode-positronNotebook-cellTagHoverForeground",
 		"--vscode-positronNotebook-errorForeground",
 		"--vscode-positronNotebook-foreground",
 		"--vscode-positronNotebook-imgPlaceholderBackground",

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -2060,6 +2060,14 @@ export const POSITRON_NOTEBOOK_ACTION_BAR_BACKGROUND = registerColor('positronNo
 // Positron notebook cell action bar border and separator color.
 export const POSITRON_NOTEBOOK_ACTION_BAR_BORDER = registerColor('positronNotebook.actionBarBorder', editorWidgetBorder, localize('positronNotebook.actionBarBorder', "Positron notebook cell action bar border and separator color."));
 
+// Positron notebook cell tag pill border color. Defaults to the cell border so the
+// pills stay visible in themes where the widget border is transparent.
+export const POSITRON_NOTEBOOK_CELL_TAG_BORDER = registerColor('positronNotebook.cellTagBorder', POSITRON_NOTEBOOK_CELL_BORDER, localize('positronNotebook.cellTagBorder', "Positron notebook cell tag pill border color."));
+
+// Positron notebook cell tag hover accent color (text, border, and background wash
+// of the add-tag affordance on hover).
+export const POSITRON_NOTEBOOK_CELL_TAG_HOVER_FOREGROUND = registerColor('positronNotebook.cellTagHoverForeground', textLinkForeground, localize('positronNotebook.cellTagHoverForeground', "Positron notebook cell tag hover accent color."));
+
 // *************************************************************************************************
 // *************************************************************************************************
 // *************************************************************************************************

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -201,6 +201,14 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	readonly selectionStateMachine: SelectionStateMachine;
 
 	/**
+	 * Whether cell tags are hidden across this notebook. Toggled by the "Toggle
+	 * Cell Tag Visibility" command via {@link toggleCellTagsHidden}. This is
+	 * transient view state -- it is not persisted, so reopening the notebook shows
+	 * tags again.
+	 */
+	readonly cellTagsHidden: IObservable<boolean>;
+
+	/**
 	 * Find the cell that currently has DOM focus within the notebook container.
 	 * Useful for keyboard navigation where Tab moves focus but doesn't change selection.
 	 * @returns The focused cell, or null if no cell has focus
@@ -551,4 +559,10 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	 * Grabs focus for this notebook based on the current selection state.
 	 */
 	grabFocus(): void;
+
+	/**
+	 * Toggle whether cell tags are shown across this notebook (see
+	 * {@link cellTagsHidden}).
+	 */
+	toggleCellTagsHidden(): void;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/IPositronNotebookInstance.ts
@@ -565,4 +565,9 @@ export interface IPositronNotebookInstance extends IPositronNotebookEditor {
 	 * {@link cellTagsHidden}).
 	 */
 	toggleCellTagsHidden(): void;
+
+	/**
+	 * Remove every tag from every cell in the notebook (a single undoable edit).
+	 */
+	removeAllCellTags(): void;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -20,13 +20,13 @@ export type ExecutionStatus = 'running' | 'pending' | 'idle';
 
 /**
  * The outcome of {@link IPositronNotebookCell.addTag} and
- * {@link IPositronNotebookCell.renameTag}. `'empty'` means the tag was blank
- * after trimming; `'duplicate'` means it already existed on the cell; `'failed'`
- * means the write could not be applied (e.g. no text model, or the cell is no
- * longer in the notebook). Callers pass this to `notifyTagResult` to surface
- * feedback.
+ * {@link IPositronNotebookCell.renameTag}. `'added'` is a silent success
+ * (including a blank input, which is a no-op); `'duplicate'` means the tag
+ * already existed on the cell; `'failed'` means the write could not be applied
+ * (e.g. no text model, or the cell is no longer in the notebook). Callers pass
+ * this to `notifyTagResult` to surface feedback.
  */
-export type AddTagResult = 'added' | 'duplicate' | 'empty' | 'failed';
+export type AddTagResult = 'added' | 'duplicate' | 'failed';
 
 export enum CellSelectionStatus {
 	Unselected = 'unselected',

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -18,6 +18,13 @@ import { ICellRevealOptions } from './PositronNotebookCell.js';
 
 export type ExecutionStatus = 'running' | 'pending' | 'idle';
 
+/**
+ * The outcome of {@link IPositronNotebookCell.addTag}. `'empty'` means the tag
+ * was blank after trimming; `'duplicate'` means it already existed. Callers use
+ * this to decide whether to surface feedback (e.g. a notification on a duplicate).
+ */
+export type AddTagResult = 'added' | 'duplicate' | 'empty';
+
 export enum CellSelectionStatus {
 	Unselected = 'unselected',
 	Selected = 'selected',
@@ -89,6 +96,27 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	 * Code cells override this to return their outputs observable.
 	 */
 	readonly outputs: IObservable<NotebookCellOutputs[]> | undefined;
+
+	/**
+	 * The cell's tags as an observable. In the .ipynb file these live in the
+	 * nbformat cell's `metadata.tags` array; the ipynb serializer maps that onto
+	 * the nested `metadata.metadata.tags` of the VS Code cell model, which is
+	 * what this observable reads. Tags round-trip across save/reload.
+	 */
+	readonly tags: IObservable<string[]>;
+
+	/**
+	 * Replace the cell's tags. Writes through to the nested `metadata.metadata.tags`
+	 * (see {@link tags}) and persists to the notebook document.
+	 */
+	setTags(tags: string[]): void;
+
+	/**
+	 * Append a single tag, enforcing the tag-set invariant: the tag is trimmed,
+	 * and an empty or duplicate tag is ignored. Delegates to {@link setTags}.
+	 * Returns the {@link AddTagResult} so callers can surface feedback.
+	 */
+	addTag(tag: string): AddTagResult;
 
 	/**
 	 * Delete this cell

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -19,11 +19,12 @@ import { ICellRevealOptions } from './PositronNotebookCell.js';
 export type ExecutionStatus = 'running' | 'pending' | 'idle';
 
 /**
- * The outcome of {@link IPositronNotebookCell.addTag}. `'empty'` means the tag
- * was blank after trimming; `'duplicate'` means it already existed; `'failed'`
+ * The outcome of {@link IPositronNotebookCell.addTag} and
+ * {@link IPositronNotebookCell.renameTag}. `'empty'` means the tag was blank
+ * after trimming; `'duplicate'` means it already existed on the cell; `'failed'`
  * means the write could not be applied (e.g. no text model, or the cell is no
- * longer in the notebook). Callers use this to decide whether to surface
- * feedback (e.g. a notification on a duplicate).
+ * longer in the notebook). Callers pass this to `notifyTagResult` to surface
+ * feedback.
  */
 export type AddTagResult = 'added' | 'duplicate' | 'empty' | 'failed';
 
@@ -108,19 +109,29 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	readonly tags: IObservable<string[]>;
 
 	/**
-	 * Replace the cell's tags. Writes through to the nested `metadata.metadata.tags`
-	 * (see {@link tags}) and persists to the notebook document. Returns `true` if
-	 * the write was applied, or `false` if it was skipped (no text model, or the
-	 * cell is no longer in the notebook) so callers can report the real outcome.
-	 */
-	setTags(tags: string[]): boolean;
-
-	/**
 	 * Append a single tag, enforcing the tag-set invariant: the tag is trimmed,
-	 * and an empty or duplicate tag is ignored. Delegates to {@link setTags}.
-	 * Returns the {@link AddTagResult} so callers can surface feedback.
+	 * and an empty or duplicate tag is ignored. Persists to the notebook document
+	 * (see {@link tags}). Returns the {@link AddTagResult} so callers can surface
+	 * feedback.
 	 */
 	addTag(tag: string): AddTagResult;
+
+	/**
+	 * Remove a tag from the cell. A tag that isn't present is a no-op. Persists to
+	 * the notebook document. Returns `true` if the resulting state was applied
+	 * (including the no-op case), or `false` if the write was skipped (no text
+	 * model, or the cell is no longer in the notebook) so callers can surface the
+	 * real outcome.
+	 */
+	removeTag(tag: string): boolean;
+
+	/**
+	 * Rename an existing tag, enforcing the tag-set invariant: the new value is
+	 * trimmed, and a rename onto an empty, missing, or duplicate target is rejected
+	 * without writing. Persists to the notebook document. Returns the
+	 * {@link AddTagResult} so callers can surface feedback.
+	 */
+	renameTag(oldTag: string, newTag: string): AddTagResult;
 
 	/**
 	 * Delete this cell

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -19,11 +19,12 @@ import { ICellRevealOptions } from './PositronNotebookCell.js';
 export type ExecutionStatus = 'running' | 'pending' | 'idle';
 
 /**
- * The outcome of a tag write. `'added'` is success (a blank input is a vacuous
- * success), `'duplicate'` means the tag already existed, and `'failed'` means
- * the write could not be applied (no text model, or the cell left the notebook).
+ * The outcome of a tag write. `'ok'` means the desired state holds, whether the
+ * write happened or was a no-op (blank input, removing an absent tag).
+ * `'duplicate'` means the tag already existed, and `'failed'` means the write
+ * could not be applied (no text model, or the cell left the notebook).
  */
-export type AddTagResult = 'added' | 'duplicate' | 'failed';
+export type TagWriteResult = 'ok' | 'duplicate' | 'failed';
 
 export enum CellSelectionStatus {
 	Unselected = 'unselected',
@@ -105,21 +106,22 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 
 	/**
 	 * Append a trimmed tag. Blank or duplicate input is ignored. Returns the write
-	 * {@link AddTagResult}.
+	 * {@link TagWriteResult}.
 	 */
-	addTag(tag: string): AddTagResult;
+	addTag(tag: string): TagWriteResult;
 
 	/**
-	 * Remove a tag (an absent tag is a no-op). Returns `false` only if the write
-	 * was skipped (no text model, or the cell left the notebook).
+	 * Remove a tag (an absent tag is a no-op success). Returns the write
+	 * {@link TagWriteResult}.
 	 */
-	removeTag(tag: string): boolean;
+	removeTag(tag: string): TagWriteResult;
 
 	/**
-	 * Rename a tag to a trimmed value. A blank, missing, or duplicate target is
-	 * rejected without writing. Returns the write {@link AddTagResult}.
+	 * Rename a tag to a trimmed value. A missing or duplicate target is rejected
+	 * without writing; a blank value is a no-op. Returns the write
+	 * {@link TagWriteResult}.
 	 */
-	renameTag(oldTag: string, newTag: string): AddTagResult;
+	renameTag(oldTag: string, newTag: string): TagWriteResult;
 
 	/**
 	 * Whether an inline tag-add input should be shown for this cell. Lives on the

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -19,12 +19,9 @@ import { ICellRevealOptions } from './PositronNotebookCell.js';
 export type ExecutionStatus = 'running' | 'pending' | 'idle';
 
 /**
- * The outcome of {@link IPositronNotebookCell.addTag} and
- * {@link IPositronNotebookCell.renameTag}. `'added'` is a silent success
- * (including a blank input, which is a no-op); `'duplicate'` means the tag
- * already existed on the cell; `'failed'` means the write could not be applied
- * (e.g. no text model, or the cell is no longer in the notebook). Callers pass
- * this to `notifyTagResult` to surface feedback.
+ * The outcome of a tag write. `'added'` is success (a blank input is a vacuous
+ * success), `'duplicate'` means the tag already existed, and `'failed'` means
+ * the write could not be applied (no text model, or the cell left the notebook).
  */
 export type AddTagResult = 'added' | 'duplicate' | 'failed';
 
@@ -101,58 +98,41 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	readonly outputs: IObservable<NotebookCellOutputs[]> | undefined;
 
 	/**
-	 * The cell's tags as an observable. In the .ipynb file these live in the
-	 * nbformat cell's `metadata.tags` array; the ipynb serializer maps that onto
-	 * the nested `metadata.metadata.tags` of the VS Code cell model, which is
-	 * what this observable reads. Tags round-trip across save/reload.
+	 * The cell's tags, normalized to a unique string list. Persisted to the
+	 * notebook document so they round-trip across save/reload.
 	 */
 	readonly tags: IObservable<string[]>;
 
 	/**
-	 * Append a single tag, enforcing the tag-set invariant: the tag is trimmed,
-	 * and an empty or duplicate tag is ignored. Persists to the notebook document
-	 * (see {@link tags}). Returns the {@link AddTagResult} so callers can surface
-	 * feedback.
+	 * Append a trimmed tag. Blank or duplicate input is ignored. Returns the write
+	 * {@link AddTagResult}.
 	 */
 	addTag(tag: string): AddTagResult;
 
 	/**
-	 * Remove a tag from the cell. A tag that isn't present is a no-op. Persists to
-	 * the notebook document. Returns `true` if the resulting state was applied
-	 * (including the no-op case), or `false` if the write was skipped (no text
-	 * model, or the cell is no longer in the notebook) so callers can surface the
-	 * real outcome.
+	 * Remove a tag (an absent tag is a no-op). Returns `false` only if the write
+	 * was skipped (no text model, or the cell left the notebook).
 	 */
 	removeTag(tag: string): boolean;
 
 	/**
-	 * Rename an existing tag, enforcing the tag-set invariant: the new value is
-	 * trimmed, and a rename onto an empty, missing, or duplicate target is rejected
-	 * without writing. Persists to the notebook document. Returns the
-	 * {@link AddTagResult} so callers can surface feedback.
+	 * Rename a tag to a trimmed value. A blank, missing, or duplicate target is
+	 * rejected without writing. Returns the write {@link AddTagResult}.
 	 */
 	renameTag(oldTag: string, newTag: string): AddTagResult;
 
 	/**
-	 * Whether an inline tag-add input should be shown for this cell. The "Add Tag"
-	 * command and the tag bar's add affordance turn this on; the bar turns it off
-	 * when the input commits or is cancelled. It lives on the cell (rather than the
-	 * bar's local React state) so the command can open the inline input from
-	 * outside React, and so the code cell footer can stay expanded while the input
+	 * Whether an inline tag-add input should be shown for this cell. Lives on the
+	 * cell rather than the bar's React state so the "Add Tag" command can open the
+	 * input from outside React, and the code cell footer can stay expanded while it
 	 * is open.
 	 */
 	readonly isAddingTag: IObservable<boolean>;
 
-	/**
-	 * Request the inline tag-add input for this cell (the "Add Tag" command entry
-	 * point). The tag bar reacts by showing a focused, empty tag input.
-	 */
+	/** Show the inline tag-add input (the "Add Tag" command entry point). */
 	beginAddTag(): void;
 
-	/**
-	 * Dismiss the inline tag-add input for this cell (called by the bar once the
-	 * input commits or is cancelled).
-	 */
+	/** Hide the inline tag-add input (after the input commits or is cancelled). */
 	endAddTag(): void;
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -156,6 +156,13 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	endAddTag(): void;
 
 	/**
+	 * Whether cell tags are hidden across the owning notebook (a transient,
+	 * per-notebook toggle). Surfaced on the cell so the tag bar / footer can hide
+	 * tags without reaching for the notebook instance.
+	 */
+	readonly cellTagsHidden: IObservable<boolean>;
+
+	/**
 	 * Delete this cell
 	 */
 	delete(): void;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -138,11 +138,13 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	endAddTag(): void;
 
 	/**
-	 * Whether cell tags are hidden across the owning notebook (a transient,
-	 * per-notebook toggle). Surfaced on the cell so the tag bar / footer can hide
-	 * tags without reaching for the notebook instance.
+	 * Whether the cell's tag UI (tag pills or the inline add input) should
+	 * currently render: false when the owning notebook hides tags (a transient,
+	 * per-notebook toggle) or when there is neither a tag nor an in-progress
+	 * tag-add. Owned by the cell so the tag bar and the code cell footer share
+	 * one visibility predicate instead of each re-deriving it.
 	 */
-	readonly cellTagsHidden: IObservable<boolean>;
+	readonly tagUIVisible: IObservable<boolean>;
 
 	/**
 	 * Delete this cell

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -20,10 +20,12 @@ export type ExecutionStatus = 'running' | 'pending' | 'idle';
 
 /**
  * The outcome of {@link IPositronNotebookCell.addTag}. `'empty'` means the tag
- * was blank after trimming; `'duplicate'` means it already existed. Callers use
- * this to decide whether to surface feedback (e.g. a notification on a duplicate).
+ * was blank after trimming; `'duplicate'` means it already existed; `'failed'`
+ * means the write could not be applied (e.g. no text model, or the cell is no
+ * longer in the notebook). Callers use this to decide whether to surface
+ * feedback (e.g. a notification on a duplicate).
  */
-export type AddTagResult = 'added' | 'duplicate' | 'empty';
+export type AddTagResult = 'added' | 'duplicate' | 'empty' | 'failed';
 
 export enum CellSelectionStatus {
 	Unselected = 'unselected',
@@ -107,9 +109,11 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 
 	/**
 	 * Replace the cell's tags. Writes through to the nested `metadata.metadata.tags`
-	 * (see {@link tags}) and persists to the notebook document.
+	 * (see {@link tags}) and persists to the notebook document. Returns `true` if
+	 * the write was applied, or `false` if it was skipped (no text model, or the
+	 * cell is no longer in the notebook) so callers can report the real outcome.
 	 */
-	setTags(tags: string[]): void;
+	setTags(tags: string[]): boolean;
 
 	/**
 	 * Append a single tag, enforcing the tag-set invariant: the tag is trimmed,

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -134,6 +134,28 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	renameTag(oldTag: string, newTag: string): AddTagResult;
 
 	/**
+	 * Whether an inline tag-add input should be shown for this cell. The "Add Tag"
+	 * command and the tag bar's add affordance turn this on; the bar turns it off
+	 * when the input commits or is cancelled. It lives on the cell (rather than the
+	 * bar's local React state) so the command can open the inline input from
+	 * outside React, and so the code cell footer can stay expanded while the input
+	 * is open.
+	 */
+	readonly isAddingTag: IObservable<boolean>;
+
+	/**
+	 * Request the inline tag-add input for this cell (the "Add Tag" command entry
+	 * point). The tag bar reacts by showing a focused, empty tag input.
+	 */
+	beginAddTag(): void;
+
+	/**
+	 * Dismiss the inline tag-add input for this cell (called by the bar once the
+	 * input commits or is cancelled).
+	 */
+	endAddTag(): void;
+
+	/**
 	 * Delete this cell
 	 */
 	delete(): void;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -219,7 +219,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		this._instance.deleteCell(this);
 	}
 
-	setTags(tags: string[]): boolean {
+	private setTags(tags: string[]): boolean {
 		// Skip no-op writes: applyEdits replaces the metadata object and fires a
 		// change even for identical content, which would add an undo entry and
 		// dirty the notebook. A no-op leaves the desired state in place, so report
@@ -276,6 +276,39 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		// Report the actual write outcome rather than assuming success: setTags
 		// no-ops when the text model is unavailable or the cell is detached.
 		return this.setTags([...existing, value]) ? 'added' : 'failed';
+	}
+
+	removeTag(tag: string): boolean {
+		const existing = this.tags.get();
+		if (!existing.includes(tag)) {
+			// Already absent: the desired state holds, so report success without
+			// writing (mirrors the no-op skip in setTags).
+			return true;
+		}
+		return this.setTags(existing.filter(t => t !== tag));
+	}
+
+	renameTag(oldTag: string, newTag: string): AddTagResult {
+		const value = newTag.trim();
+		if (!value) {
+			return 'empty';
+		}
+		const existing = this.tags.get();
+		const index = existing.indexOf(oldTag);
+		if (index < 0) {
+			// The tag being renamed is gone (the cell changed underneath us).
+			return 'failed';
+		}
+		// Reject a rename onto a different existing tag. Renaming to the unchanged
+		// value matches only its own index, so it falls through to a setTags no-op.
+		if (existing.some((t, i) => i !== index && t === value)) {
+			return 'duplicate';
+		}
+		const next = [...existing];
+		next[index] = value;
+		// Report the actual write outcome rather than assuming success: setTags
+		// no-ops when the text model is unavailable or the cell is detached.
+		return this.setTags(next) ? 'added' : 'failed';
 	}
 
 	// Add placeholder run method to be overridden by subclasses

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -199,6 +199,15 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	}
 
 	/**
+	 * Notebook-wide tag visibility, surfaced on the cell so the tag bar and footer
+	 * (which only hold the cell) can react without reaching for the notebook
+	 * instance. Delegates to the owning instance.
+	 */
+	get cellTagsHidden(): IObservable<boolean> {
+		return this._instance.cellTagsHidden;
+	}
+
+	/**
 	 * Get the handle number for cell from cell model
 	 */
 	get handle(): number {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -17,7 +17,8 @@ import { CellEditType, CellKind, NotebookCellExecutionState } from '../../../not
 import { IPositronNotebookCell, CellSelectionStatus, ExecutionStatus, NotebookCellOutputs, AddTagResult } from './IPositronNotebookCell.js';
 import { CellSelectionType } from '../selectionMachine.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
-import { derived, IObservable, IObservableSignal, observableFromEvent, observableSignal, observableValue } from '../../../../../base/common/observable.js';
+import { derived, IObservable, IObservableSignal, observableFromEvent, observableFromEventOpts, observableSignal, observableValue } from '../../../../../base/common/observable.js';
+import { equals as arraysEqual } from '../../../../../base/common/arrays.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { ITextEditorOptions } from '../../../../../platform/editor/common/editor.js';
 import { applyTextEditorOptions } from '../../../../common/editor/editorOptions.js';
@@ -111,10 +112,24 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		// metadata (`metadata.metadata.tags`). This nested location is the only
 		// one the ipynb serializer persists to the file, so reading it here lets
 		// tags round-trip across save/reload.
-		this.tags = observableFromEvent(
-			this,
+		//
+		// nbformat tags are a set of labels, but an externally authored file can
+		// carry duplicate entries. Collapse them on read so the tag-bar UI's
+		// "values are unique" assumption holds (no colliding React keys, and
+		// edit/remove can't mis-target or drop a sibling occurrence). A later
+		// setTags write persists the de-duplicated list back to the file.
+		//
+		// onDidChangeMetadata fires for any metadata change (execution status,
+		// collapse, language id), so a structural comparator keeps the observable
+		// stable -- a fresh-but-equal array from de-duplication won't notify and
+		// re-render the tag bar on unrelated changes.
+		this.tags = observableFromEventOpts(
+			{ owner: this, debugName: 'cellTags', equalsFn: arraysEqual },
 			this.model.onDidChangeMetadata,
-			() => /** @description cellTags */((this.model.metadata.metadata as Record<string, unknown> | undefined)?.tags as string[] | undefined) ?? [],
+			() => {
+				const raw = (this.model.metadata.metadata as Record<string, unknown> | undefined)?.tags as string[] | undefined;
+				return raw ? [...new Set(raw)] : [];
+			},
 		);
 
 		// Track this cell's current execution

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -197,14 +197,14 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		this._instance.deleteCell(this);
 	}
 
-	setTags(tags: string[]): void {
+	setTags(tags: string[]): boolean {
 		const textModel = this._instance.textModel;
 		if (!textModel) {
-			return;
+			return false;
 		}
 		const index = this.index;
 		if (index < 0) {
-			return;
+			return false;
 		}
 		// nbformat tags live under the nested `metadata.metadata.tags`, which is
 		// the only location the ipynb serializer writes to the file. PartialMetadata
@@ -227,6 +227,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 				metadata: { metadata: nestedMetadata }
 			}
 		], true, undefined, () => undefined, undefined, true);
+		return true;
 	}
 
 	addTag(tag: string): AddTagResult {
@@ -238,8 +239,9 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		if (existing.includes(value)) {
 			return 'duplicate';
 		}
-		this.setTags([...existing, value]);
-		return 'added';
+		// Report the actual write outcome rather than assuming success: setTags
+		// no-ops when the text model is unavailable or the cell is detached.
+		return this.setTags([...existing, value]) ? 'added' : 'failed';
 	}
 
 	// Add placeholder run method to be overridden by subclasses

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -220,6 +220,13 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	}
 
 	setTags(tags: string[]): boolean {
+		// Skip no-op writes: applyEdits replaces the metadata object and fires a
+		// change even for identical content, which would add an undo entry and
+		// dirty the notebook. A no-op leaves the desired state in place, so report
+		// success without writing (e.g. committing a tag edit without changes).
+		if (arraysEqual(this.tags.get(), tags)) {
+			return true;
+		}
 		const textModel = this._instance.textModel;
 		if (!textModel) {
 			return false;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -113,22 +113,28 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		// one the ipynb serializer persists to the file, so reading it here lets
 		// tags round-trip across save/reload.
 		//
-		// nbformat tags are a set of labels, but an externally authored file can
-		// carry duplicate entries. Collapse them on read so the tag-bar UI's
-		// "values are unique" assumption holds (no colliding React keys, and
-		// edit/remove can't mis-target or drop a sibling occurrence). A later
-		// setTags write persists the de-duplicated list back to the file.
+		// nbformat tags are meant to be an array of string labels, but this is
+		// untrusted file data an external notebook or extension can violate.
+		// Normalize on read: ignore a non-array value, drop non-string entries,
+		// and collapse duplicates so the tag-bar UI's "values are unique"
+		// assumption holds (no colliding React keys, and edit/remove can't
+		// mis-target or drop a sibling occurrence) and a malformed value can't
+		// throw or render garbage. A later setTags write persists the normalized
+		// list back to the file.
 		//
 		// onDidChangeMetadata fires for any metadata change (execution status,
 		// collapse, language id), so a structural comparator keeps the observable
-		// stable -- a fresh-but-equal array from de-duplication won't notify and
+		// stable -- a fresh-but-equal array from normalization won't notify and
 		// re-render the tag bar on unrelated changes.
 		this.tags = observableFromEventOpts(
 			{ owner: this, debugName: 'cellTags', equalsFn: arraysEqual },
 			this.model.onDidChangeMetadata,
 			() => {
-				const raw = (this.model.metadata.metadata as Record<string, unknown> | undefined)?.tags as string[] | undefined;
-				return raw ? [...new Set(raw)] : [];
+				const raw = (this.model.metadata.metadata as Record<string, unknown> | undefined)?.tags;
+				if (!Array.isArray(raw)) {
+					return [];
+				}
+				return [...new Set(raw.filter((tag): tag is string => typeof tag === 'string'))];
 			},
 		);
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -229,6 +229,11 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		if (arraysEqual(this.tags.get(), tags)) {
 			return true;
 		}
+		// Tag edits are document mutations, so respect a read-only notebook
+		// (mirrors the reorder guard in PositronNotebookComponent).
+		if (this._instance.isReadOnly) {
+			return false;
+		}
 		const textModel = this._instance.textModel;
 		if (!textModel) {
 			return false;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -82,6 +82,11 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	/** Whether the inline tag-add input is currently requested for this cell. */
 	private readonly _isAddingTag = observableValue<boolean>('cellIsAddingTag', false);
 	public readonly isAddingTag: IObservable<boolean> = this._isAddingTag;
+	/**
+	 * The single visibility predicate for this cell's tag UI (pills + inline add
+	 * input); see {@link IPositronNotebookCell.tagUIVisible}.
+	 */
+	public readonly tagUIVisible: IObservable<boolean>;
 	private readonly _editorFocusRequested = observableSignal<void>('editorFocusRequested');
 	private _modelRef: IReference<IResolvedTextEditorModel> | undefined;
 
@@ -127,6 +132,13 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 				}
 				return [...new Set(raw.filter((tag): tag is string => typeof tag === 'string'))];
 			},
+		);
+
+		// The tag UI shows when the cell has a tag or an inline add is in
+		// progress, unless the notebook-wide toggle hides tags.
+		this.tagUIVisible = derived(this, reader =>
+			!this._instance.cellTagsHidden.read(reader) &&
+			(this.tags.read(reader).length > 0 || this._isAddingTag.read(reader))
 		);
 
 		// Track this cell's current execution
@@ -183,11 +195,6 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 
 	get notebookUri(): URI {
 		return this._instance.uri;
-	}
-
-	/** Notebook-wide tag visibility; delegates to the owning instance. */
-	get cellTagsHidden(): IObservable<boolean> {
-		return this._instance.cellTagsHidden;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -14,7 +14,7 @@ import { IScopedContextKeyService } from '../../../../../platform/contextkey/com
 import { NotebookCellTextModel } from '../../../notebook/common/model/notebookCellTextModel.js';
 import { CellDecorationManager } from './CellDecorationManager.js';
 import { CellEditType, CellKind, NotebookCellExecutionState } from '../../../notebook/common/notebookCommon.js';
-import { IPositronNotebookCell, CellSelectionStatus, ExecutionStatus, NotebookCellOutputs, AddTagResult } from './IPositronNotebookCell.js';
+import { IPositronNotebookCell, CellSelectionStatus, ExecutionStatus, NotebookCellOutputs, TagWriteResult } from './IPositronNotebookCell.js';
 import { CellSelectionType } from '../selectionMachine.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
 import { derived, IObservable, IObservableSignal, observableFromEvent, observableFromEventOpts, observableSignal, observableValue } from '../../../../../base/common/observable.js';
@@ -243,35 +243,35 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		return true;
 	}
 
-	addTag(tag: string): AddTagResult {
+	addTag(tag: string): TagWriteResult {
 		const value = tag.trim();
 		if (!value) {
-			// Blank input is a silent no-op; report it as a (vacuous) success.
-			return 'added';
+			// Blank input: nothing to add, the desired state already holds.
+			return 'ok';
 		}
 		const existing = this.tags.get();
 		if (existing.includes(value)) {
 			return 'duplicate';
 		}
 		// setTags reports false if the write was skipped; surface that as 'failed'.
-		return this.setTags([...existing, value]) ? 'added' : 'failed';
+		return this.setTags([...existing, value]) ? 'ok' : 'failed';
 	}
 
-	removeTag(tag: string): boolean {
+	removeTag(tag: string): TagWriteResult {
 		const existing = this.tags.get();
 		if (!existing.includes(tag)) {
-			// Already absent: the desired state holds, so report success without
-			// writing (mirrors the no-op skip in setTags).
-			return true;
+			// Already absent: the desired state holds without writing (mirrors the
+			// no-op skip in setTags).
+			return 'ok';
 		}
-		return this.setTags(existing.filter(t => t !== tag));
+		return this.setTags(existing.filter(t => t !== tag)) ? 'ok' : 'failed';
 	}
 
-	renameTag(oldTag: string, newTag: string): AddTagResult {
+	renameTag(oldTag: string, newTag: string): TagWriteResult {
 		const value = newTag.trim();
 		if (!value) {
-			// Blank input is a silent no-op; report it as a (vacuous) success.
-			return 'added';
+			// Blank input: nothing to rename to, the desired state already holds.
+			return 'ok';
 		}
 		const existing = this.tags.get();
 		const index = existing.indexOf(oldTag);
@@ -287,7 +287,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		const next = [...existing];
 		next[index] = value;
 		// setTags reports false if the write was skipped; surface that as 'failed'.
-		return this.setTags(next) ? 'added' : 'failed';
+		return this.setTags(next) ? 'ok' : 'failed';
 	}
 
 	beginAddTag(): void {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -19,6 +19,7 @@ import { CellSelectionType } from '../selectionMachine.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
 import { derived, IObservable, IObservableSignal, observableFromEvent, observableFromEventOpts, observableSignal, observableValue } from '../../../../../base/common/observable.js';
 import { equals as arraysEqual } from '../../../../../base/common/arrays.js';
+import { isObject } from '../../../../../base/common/types.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { ITextEditorOptions } from '../../../../../platform/editor/common/editor.js';
 import { applyTextEditorOptions } from '../../../../common/editor/editorOptions.js';
@@ -233,9 +234,14 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		// preserve sibling keys (vscode.languageId, collapsed, etc.) rather than
 		// replacing it. Drop the `tags` key entirely when empty, per nbformat
 		// convention. computeUndoRedo stays true so tag changes remain undoable.
-		const nestedMetadata: Record<string, unknown> = {
-			...((this.model.metadata.metadata as Record<string, unknown> | undefined) ?? {})
-		};
+		//
+		// metadata.metadata is untrusted file data; only spread it when it is a
+		// plain object, otherwise spreading a scalar/array would inject numeric
+		// keys into the persisted metadata.
+		const existingNested = this.model.metadata.metadata;
+		const nestedMetadata: Record<string, unknown> = isObject(existingNested)
+			? { ...(existingNested as Record<string, unknown>) }
+			: {};
 		if (tags.length > 0) {
 			nestedMetadata.tags = tags;
 		} else {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -13,8 +13,8 @@ import { Range } from '../../../../../editor/common/core/range.js';
 import { IScopedContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { NotebookCellTextModel } from '../../../notebook/common/model/notebookCellTextModel.js';
 import { CellDecorationManager } from './CellDecorationManager.js';
-import { CellKind, NotebookCellExecutionState } from '../../../notebook/common/notebookCommon.js';
-import { IPositronNotebookCell, CellSelectionStatus, ExecutionStatus, NotebookCellOutputs } from './IPositronNotebookCell.js';
+import { CellEditType, CellKind, NotebookCellExecutionState } from '../../../notebook/common/notebookCommon.js';
+import { IPositronNotebookCell, CellSelectionStatus, ExecutionStatus, NotebookCellOutputs, AddTagResult } from './IPositronNotebookCell.js';
 import { CellSelectionType } from '../selectionMachine.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
 import { derived, IObservable, IObservableSignal, observableFromEvent, observableSignal, observableValue } from '../../../../../base/common/observable.js';
@@ -75,6 +75,8 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	protected readonly _editor = observableValue<ICodeEditor | undefined>('cellEditor', undefined);
 	public readonly editor: IObservable<ICodeEditor | undefined> = this._editor;
 	protected readonly _internalMetadata;
+	/** Cell tags, derived from the nested nbformat `metadata.metadata.tags`. */
+	public readonly tags: IObservable<string[]>;
 	private readonly _editorFocusRequested = observableSignal<void>('editorFocusRequested');
 	private _modelRef: IReference<IResolvedTextEditorModel> | undefined;
 
@@ -103,6 +105,16 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 			this,
 			this.model.onDidChangeInternalMetadata,
 			() => /** @description internalMetadata */ this.model.internalMetadata,
+		);
+
+		// Observable of the cell's tags, sourced from the nested nbformat
+		// metadata (`metadata.metadata.tags`). This nested location is the only
+		// one the ipynb serializer persists to the file, so reading it here lets
+		// tags round-trip across save/reload.
+		this.tags = observableFromEvent(
+			this,
+			this.model.onDidChangeMetadata,
+			() => /** @description cellTags */((this.model.metadata.metadata as Record<string, unknown> | undefined)?.tags as string[] | undefined) ?? [],
 		);
 
 		// Track this cell's current execution
@@ -183,6 +195,51 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 
 	delete(): void {
 		this._instance.deleteCell(this);
+	}
+
+	setTags(tags: string[]): void {
+		const textModel = this._instance.textModel;
+		if (!textModel) {
+			return;
+		}
+		const index = this.index;
+		if (index < 0) {
+			return;
+		}
+		// nbformat tags live under the nested `metadata.metadata.tags`, which is
+		// the only location the ipynb serializer writes to the file. PartialMetadata
+		// is a shallow top-level merge, so spread the existing nested object to
+		// preserve sibling keys (vscode.languageId, collapsed, etc.) rather than
+		// replacing it. Drop the `tags` key entirely when empty, per nbformat
+		// convention. computeUndoRedo stays true so tag changes remain undoable.
+		const nestedMetadata: Record<string, unknown> = {
+			...((this.model.metadata.metadata as Record<string, unknown> | undefined) ?? {})
+		};
+		if (tags.length > 0) {
+			nestedMetadata.tags = tags;
+		} else {
+			delete nestedMetadata.tags;
+		}
+		textModel.applyEdits([
+			{
+				editType: CellEditType.PartialMetadata,
+				index,
+				metadata: { metadata: nestedMetadata }
+			}
+		], true, undefined, () => undefined, undefined, true);
+	}
+
+	addTag(tag: string): AddTagResult {
+		const value = tag.trim();
+		if (!value) {
+			return 'empty';
+		}
+		const existing = this.tags.get();
+		if (existing.includes(value)) {
+			return 'duplicate';
+		}
+		this.setTags([...existing, value]);
+		return 'added';
 	}
 
 	// Add placeholder run method to be overridden by subclasses

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -112,24 +112,11 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 			() => /** @description internalMetadata */ this.model.internalMetadata,
 		);
 
-		// Observable of the cell's tags, sourced from the nested nbformat
-		// metadata (`metadata.metadata.tags`). This nested location is the only
-		// one the ipynb serializer persists to the file, so reading it here lets
-		// tags round-trip across save/reload.
-		//
-		// nbformat tags are meant to be an array of string labels, but this is
-		// untrusted file data an external notebook or extension can violate.
-		// Normalize on read: ignore a non-array value, drop non-string entries,
-		// and collapse duplicates so the tag-bar UI's "values are unique"
-		// assumption holds (no colliding React keys, and edit/remove can't
-		// mis-target or drop a sibling occurrence) and a malformed value can't
-		// throw or render garbage. A later setTags write persists the normalized
-		// list back to the file.
-		//
-		// onDidChangeMetadata fires for any metadata change (execution status,
-		// collapse, language id), so a structural comparator keeps the observable
-		// stable -- a fresh-but-equal array from normalization won't notify and
-		// re-render the tag bar on unrelated changes.
+		// Read tags from the nested nbformat metadata (see applyTagsToNestedMetadata).
+		// This is untrusted file data, so normalize on read: ignore a non-array,
+		// drop non-string entries, and dedupe -- the tag bar relies on values being
+		// unique (React keys, edit/remove targeting). equalsFn keeps the observable
+		// stable since onDidChangeMetadata fires on any metadata change, not just tags.
 		this.tags = observableFromEventOpts(
 			{ owner: this, debugName: 'cellTags', equalsFn: arraysEqual },
 			this.model.onDidChangeMetadata,
@@ -198,11 +185,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		return this._instance.uri;
 	}
 
-	/**
-	 * Notebook-wide tag visibility, surfaced on the cell so the tag bar and footer
-	 * (which only hold the cell) can react without reaching for the notebook
-	 * instance. Delegates to the owning instance.
-	 */
+	/** Notebook-wide tag visibility; delegates to the owning instance. */
 	get cellTagsHidden(): IObservable<boolean> {
 		return this._instance.cellTagsHidden;
 	}
@@ -247,10 +230,8 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		if (index < 0) {
 			return false;
 		}
-		// nbformat tags live under the nested `metadata.metadata.tags`, the only
-		// location the ipynb serializer writes to the file (see
-		// applyTagsToNestedMetadata). computeUndoRedo stays true so tag changes
-		// remain undoable.
+		// Write to the nested nbformat location (see applyTagsToNestedMetadata). The
+		// trailing `true` is computeUndoRedo, so tag changes remain undoable.
 		const nestedMetadata = applyTagsToNestedMetadata(this.model.metadata.metadata, tags);
 		textModel.applyEdits([
 			{
@@ -272,8 +253,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		if (existing.includes(value)) {
 			return 'duplicate';
 		}
-		// Report the actual write outcome rather than assuming success: setTags
-		// no-ops when the text model is unavailable or the cell is detached.
+		// setTags reports false if the write was skipped; surface that as 'failed'.
 		return this.setTags([...existing, value]) ? 'added' : 'failed';
 	}
 
@@ -306,8 +286,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		}
 		const next = [...existing];
 		next[index] = value;
-		// Report the actual write outcome rather than assuming success: setTags
-		// no-ops when the text model is unavailable or the cell is detached.
+		// setTags reports false if the write was skipped; surface that as 'failed'.
 		return this.setTags(next) ? 'added' : 'failed';
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -79,6 +79,9 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	protected readonly _internalMetadata;
 	/** Cell tags, derived from the nested nbformat `metadata.metadata.tags`. */
 	public readonly tags: IObservable<string[]>;
+	/** Whether the inline tag-add input is currently requested for this cell. */
+	private readonly _isAddingTag = observableValue<boolean>('cellIsAddingTag', false);
+	public readonly isAddingTag: IObservable<boolean> = this._isAddingTag;
 	private readonly _editorFocusRequested = observableSignal<void>('editorFocusRequested');
 	private _modelRef: IReference<IResolvedTextEditorModel> | undefined;
 
@@ -311,6 +314,14 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		// Report the actual write outcome rather than assuming success: setTags
 		// no-ops when the text model is unavailable or the cell is detached.
 		return this.setTags(next) ? 'added' : 'failed';
+	}
+
+	beginAddTag(): void {
+		this._isAddingTag.set(true, undefined);
+	}
+
+	endAddTag(): void {
+		this._isAddingTag.set(false, undefined);
 	}
 
 	// Add placeholder run method to be overridden by subclasses

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -19,7 +19,7 @@ import { CellSelectionType } from '../selectionMachine.js';
 import { PositronNotebookInstance } from '../PositronNotebookInstance.js';
 import { derived, IObservable, IObservableSignal, observableFromEvent, observableFromEventOpts, observableSignal, observableValue } from '../../../../../base/common/observable.js';
 import { equals as arraysEqual } from '../../../../../base/common/arrays.js';
-import { isObject } from '../../../../../base/common/types.js';
+import { applyTagsToNestedMetadata } from './cellTagsMetadata.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { ITextEditorOptions } from '../../../../../platform/editor/common/editor.js';
 import { applyTextEditorOptions } from '../../../../common/editor/editorOptions.js';
@@ -247,25 +247,11 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		if (index < 0) {
 			return false;
 		}
-		// nbformat tags live under the nested `metadata.metadata.tags`, which is
-		// the only location the ipynb serializer writes to the file. PartialMetadata
-		// is a shallow top-level merge, so spread the existing nested object to
-		// preserve sibling keys (vscode.languageId, collapsed, etc.) rather than
-		// replacing it. Drop the `tags` key entirely when empty, per nbformat
-		// convention. computeUndoRedo stays true so tag changes remain undoable.
-		//
-		// metadata.metadata is untrusted file data; only spread it when it is a
-		// plain object, otherwise spreading a scalar/array would inject numeric
-		// keys into the persisted metadata.
-		const existingNested = this.model.metadata.metadata;
-		const nestedMetadata: Record<string, unknown> = isObject(existingNested)
-			? { ...(existingNested as Record<string, unknown>) }
-			: {};
-		if (tags.length > 0) {
-			nestedMetadata.tags = tags;
-		} else {
-			delete nestedMetadata.tags;
-		}
+		// nbformat tags live under the nested `metadata.metadata.tags`, the only
+		// location the ipynb serializer writes to the file (see
+		// applyTagsToNestedMetadata). computeUndoRedo stays true so tag changes
+		// remain undoable.
+		const nestedMetadata = applyTagsToNestedMetadata(this.model.metadata.metadata, tags);
 		textModel.applyEdits([
 			{
 				editType: CellEditType.PartialMetadata,

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -267,7 +267,8 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	addTag(tag: string): AddTagResult {
 		const value = tag.trim();
 		if (!value) {
-			return 'empty';
+			// Blank input is a silent no-op; report it as a (vacuous) success.
+			return 'added';
 		}
 		const existing = this.tags.get();
 		if (existing.includes(value)) {
@@ -291,7 +292,8 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	renameTag(oldTag: string, newTag: string): AddTagResult {
 		const value = newTag.trim();
 		if (!value) {
-			return 'empty';
+			// Blank input is a silent no-op; report it as a (vacuous) success.
+			return 'added';
 		}
 		const existing = this.tags.get();
 		const index = existing.indexOf(oldTag);

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/cellTagsMetadata.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/cellTagsMetadata.ts
@@ -9,15 +9,12 @@ import { isObject } from '../../../../../base/common/types.js';
  * Merge a tag list into an nbformat cell's nested metadata object.
  *
  * nbformat tags live under the nested `metadata.metadata.tags` -- the only
- * location the ipynb serializer writes to the file, so tags round-trip across
- * save/reload. A cell metadata edit (PartialMetadata) is a shallow top-level
- * merge, so the existing nested object is spread to preserve sibling keys
- * (`vscode.languageId`, `collapsed`, etc.) rather than replacing it. The `tags`
- * key is dropped entirely when the list is empty, per nbformat convention.
- *
- * `existingNested` is untrusted file data; it is only spread when it is a plain
- * object, otherwise spreading a scalar/array would inject numeric keys into the
- * persisted metadata.
+ * location the ipynb serializer persists, so tags round-trip across save/reload.
+ * A PartialMetadata edit is a shallow top-level merge, so the existing nested
+ * object is spread to preserve sibling keys (`collapsed`, `vscode.languageId`),
+ * and the `tags` key is dropped when the list is empty (nbformat convention).
+ * `existingNested` is untrusted file data, so it is only spread when it is a
+ * plain object; spreading a scalar/array would inject numeric keys.
  */
 export function applyTagsToNestedMetadata(existingNested: unknown, tags: string[]): Record<string, unknown> {
 	const nestedMetadata: Record<string, unknown> = isObject(existingNested)

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/cellTagsMetadata.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/cellTagsMetadata.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isObject } from '../../../../../base/common/types.js';
+
+/**
+ * Merge a tag list into an nbformat cell's nested metadata object.
+ *
+ * nbformat tags live under the nested `metadata.metadata.tags` -- the only
+ * location the ipynb serializer writes to the file, so tags round-trip across
+ * save/reload. A cell metadata edit (PartialMetadata) is a shallow top-level
+ * merge, so the existing nested object is spread to preserve sibling keys
+ * (`vscode.languageId`, `collapsed`, etc.) rather than replacing it. The `tags`
+ * key is dropped entirely when the list is empty, per nbformat convention.
+ *
+ * `existingNested` is untrusted file data; it is only spread when it is a plain
+ * object, otherwise spreading a scalar/array would inject numeric keys into the
+ * persisted metadata.
+ */
+export function applyTagsToNestedMetadata(existingNested: unknown, tags: string[]): Record<string, unknown> {
+	const nestedMetadata: Record<string, unknown> = isObject(existingNested)
+		? { ...(existingNested as Record<string, unknown>) }
+		: {};
+	if (tags.length > 0) {
+		nestedMetadata.tags = tags;
+	} else {
+		delete nestedMetadata.tags;
+	}
+	return nestedMetadata;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -112,6 +112,13 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 */
 	public readonly container = observableValue<HTMLElement | undefined>('positronNotebookContainer', undefined);
 
+	/**
+	 * Whether cell tags are hidden across this notebook. Transient view state (not
+	 * persisted); toggled by the "Toggle Cell Tag Visibility" command.
+	 */
+	private readonly _cellTagsHidden = observableValue<boolean>('positronNotebookCellTagsHidden', false);
+	public readonly cellTagsHidden: IObservable<boolean> = this._cellTagsHidden;
+
 	private _scopedContextKeyService: IContextKeyService | undefined;
 
 	private _scopedInstantiationService = this._register(new MutableDisposable<IInstantiationService>());
@@ -2336,6 +2343,14 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 				this.currentContainer?.focus({ preventScroll: true });
 				break;
 		}
+	}
+
+	/**
+	 * Toggle whether cell tags are shown across this notebook (see
+	 * {@link cellTagsHidden}).
+	 */
+	toggleCellTagsHidden(): void {
+		this._cellTagsHidden.set(!this._cellTagsHidden.get(), undefined);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -16,6 +16,7 @@ import { NotebookLayoutInfo } from '../../notebook/browser/notebookViewEvents.js
 import { NotebookOptions } from '../../notebook/browser/notebookOptions.js';
 import { NotebookTextModel } from '../../notebook/common/model/notebookTextModel.js';
 import { CellEditType, CellKind, ICellEditOperation, ISelectionState, SelectionStateType, ICellReplaceEdit, NotebookCellExecutionState, ICellDto2, diff } from '../../notebook/common/notebookCommon.js';
+import { applyTagsToNestedMetadata } from './PositronNotebookCells/cellTagsMetadata.js';
 import { INotebookExecutionService } from '../../notebook/common/notebookExecutionService.js';
 import { INotebookExecutionStateService } from '../../notebook/common/notebookExecutionStateService.js';
 import { createNotebookCell } from './PositronNotebookCells/createNotebookCell.js';
@@ -2351,6 +2352,35 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 */
 	toggleCellTagsHidden(): void {
 		this._cellTagsHidden.set(!this._cellTagsHidden.get(), undefined);
+	}
+
+	/**
+	 * Removes every tag from every cell in the notebook in a single undoable edit.
+	 * A no-op when no cell has tags.
+	 */
+	removeAllCellTags(): void {
+		this._assertTextModel();
+		const textModel = this.textModel;
+		const cells = this.cells.get();
+		const edits: ICellEditOperation[] = [];
+		for (let index = 0; index < cells.length; index++) {
+			// `this.cells` and `textModel.cells` are index-aligned (see
+			// clearCellOutputsByIndex). Skip cells with no tags so undo only spans
+			// the cells that actually changed.
+			if (cells[index].tags.get().length === 0) {
+				continue;
+			}
+			edits.push({
+				editType: CellEditType.PartialMetadata,
+				index,
+				metadata: { metadata: applyTagsToNestedMetadata(textModel.cells[index].metadata.metadata, []) }
+			});
+		}
+		if (edits.length === 0) {
+			return;
+		}
+		const computeUndoRedo = !this.isReadOnly || textModel.viewType === 'interactive';
+		textModel.applyEdits(edits, true, undefined, () => undefined, undefined, computeUndoRedo);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -2356,9 +2356,15 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 
 	/**
 	 * Removes every tag from every cell in the notebook in a single undoable edit.
-	 * A no-op when no cell has tags.
+	 * A no-op when no cell has tags or the notebook is read-only.
 	 */
 	removeAllCellTags(): void {
+		// Tag edits are document mutations, so respect a read-only notebook
+		// (mirrors the reorder guard in PositronNotebookComponent and setTags on
+		// the cell).
+		if (this.isReadOnly) {
+			return;
+		}
 		this._assertTextModel();
 		const textModel = this.textModel;
 		const cells = this.cells.get();
@@ -2379,8 +2385,9 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		if (edits.length === 0) {
 			return;
 		}
-		const computeUndoRedo = !this.isReadOnly || textModel.viewType === 'interactive';
-		textModel.applyEdits(edits, true, undefined, () => undefined, undefined, computeUndoRedo);
+		// The trailing `true` is computeUndoRedo, so the removal remains undoable
+		// (the read-only guard above already excluded the non-undoable case).
+		textModel.applyEdits(edits, true, undefined, () => undefined, undefined, true);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/cellTags/actions.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/cellTags/actions.ts
@@ -1,0 +1,124 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { timeout } from '../../../../../../base/common/async.js';
+import { localize, localize2 } from '../../../../../../nls.js';
+import { MenuId, registerAction2 } from '../../../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
+import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
+import { POSITRON_NOTEBOOK_CATEGORY, POSITRON_NOTEBOOK_EDITOR_ID, PositronNotebookCellActionGroup } from '../../../common/positronNotebookCommon.js';
+import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
+import { NotebookAction2 } from '../../NotebookAction2.js';
+import { getActiveCell } from '../../selectionMachine.js';
+
+// Add Tag - opens the inline tag input on the active cell by flipping the cell's
+// isAddingTag signal (the tag bar reacts by showing a focused input). This is the
+// entry point for the first tag; once a cell has tags, the bar's hover add pill
+// adds further tags.
+export class AddTagAction extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.addTag',
+			title: localize2('positronNotebook.cell.addTag', "Add Tag"),
+			category: POSITRON_NOTEBOOK_CATEGORY,
+			f1: true,
+			// Don't refocus the cell before running -- we're about to open the inline
+			// tag input and want it to keep focus.
+			grabFocusOnRun: false,
+			// Gate on the active editor, not editor focus: right-clicking rendered
+			// markdown content doesn't move DOM focus into the notebook container,
+			// so a focus-based precondition would show these disabled in the
+			// markdown cell context menu.
+			precondition: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+			menu: [{
+				// The cell action bar "..." submenu -- the only general cell menu
+				// available on code cells (their right-click menu is output-only).
+				id: MenuId.PositronNotebookCellActionBarSubmenu,
+				group: PositronNotebookCellActionGroup.Tags,
+			}, {
+				// Right-click menu -- currently wired up on markdown cells.
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Tags,
+			}]
+		});
+	}
+
+	override async runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+		const notificationService = accessor.get(INotificationService);
+
+		const state = notebook.selectionStateMachine.state.get();
+		// Every selection state except NoCells has an active cell, and NoCells has
+		// no selection either, so the active cell is the only target to consider.
+		const cell = getActiveCell(state);
+		if (!cell) {
+			notificationService.info(
+				localize('positron.notebook.cellTag.noCell', "Select a cell to add a tag.")
+			);
+			return;
+		}
+
+		// The menu/palette that launched this command is still closing and will
+		// restore focus to the notebook cell. Wait a tick so that happens first,
+		// otherwise the cell refocus would steal focus from the inline tag input we
+		// are about to open (blur-committing it as empty before the user types).
+		await timeout(0);
+		cell.beginAddTag();
+	}
+}
+registerAction2(AddTagAction);
+
+// Toggle Cell Tag Visibility - hides or shows all cell tags across the notebook.
+// Transient per-notebook view state (see IPositronNotebookInstance.cellTagsHidden);
+// not persisted, so reopening the notebook shows tags again.
+export class ToggleCellTagsAction extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.toggleCellTags',
+			title: localize2('positronNotebook.toggleCellTags', "Toggle Cell Tag Visibility"),
+			category: POSITRON_NOTEBOOK_CATEGORY,
+			f1: true,
+			precondition: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+			menu: [{
+				id: MenuId.PositronNotebookCellActionBarSubmenu,
+				group: PositronNotebookCellActionGroup.Tags,
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Tags,
+			}]
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance) {
+		notebook.toggleCellTagsHidden();
+	}
+}
+registerAction2(ToggleCellTagsAction);
+
+// Remove All Cell Tags - clears every tag from every cell in the notebook in a
+// single undoable edit.
+export class RemoveAllCellTagsAction extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.removeAllCellTags',
+			title: localize2('positronNotebook.removeAllCellTags', "Remove All Cell Tags"),
+			category: POSITRON_NOTEBOOK_CATEGORY,
+			f1: true,
+			precondition: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
+			menu: [{
+				id: MenuId.PositronNotebookCellActionBarSubmenu,
+				group: PositronNotebookCellActionGroup.Tags,
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Tags,
+			}]
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance) {
+		notebook.removeAllCellTags();
+	}
+}
+registerAction2(RemoveAllCellTagsAction);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
@@ -83,28 +83,62 @@ brief width + opacity transition so a row of tags stays calm rather than jumping
 	color: var(--vscode-foreground);
 }
 
-/* Ghost add affordance: no border or fill, matching the footer's metadata icon
-color at rest. */
+/* Add affordance, styled to match the tag pills (thin outline, fully rounded).
+Hidden at rest and revealed on hover of the tag bar (or keyboard focus) so an
+untouched row stays calm. Sticks to the right edge when the row overflows
+horizontally, so it stays reachable even in large tag sets. */
 .positron-notebook-cell-tag-add {
 	display: inline-flex;
 	align-items: center;
-	justify-content: center;
+	box-sizing: border-box;
 	flex-shrink: 0;
-	width: 16px;
-	height: 16px;
-	border: none;
+	gap: 3px;
+	height: 18px;
+	padding: 0 8px;
+	border: 1px solid var(--vscode-widget-border);
 	border-radius: 999px;
-	background: transparent;
+	/* Opaque so tags scrolling underneath it (while sticky) don't bleed through. */
+	background-color: var(--vscode-notebook-cellEditorBackground);
 	color: var(--vscode-positronNotebook-cellFooterForeground, var(--vscode-descriptionForeground));
+	font-size: 11px;
+	line-height: 1;
 	cursor: pointer;
-	padding: 0;
-	transition: color 120ms ease, background-color 120ms ease;
+	position: sticky;
+	right: 0;
+	/* Revealed via opacity (kept in layout) so hovering doesn't reflow the row. */
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 120ms ease, color 120ms ease, background-color 120ms ease, border-color 120ms ease;
 }
 
-/* On hover the add control picks up the accent/link color with a faint
-accent-tinted fill (the accent token mixed down to a low-opacity wash). */
+.positron-notebook-cell-tags:hover .positron-notebook-cell-tag-add,
+.positron-notebook-cell-tags:focus-within .positron-notebook-cell-tag-add {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+/* On hover the add pill picks up the accent/link color with a faint accent-tinted
+fill. The wash is mixed over the opaque footer background (not transparent) so the
+pill stays opaque while sticky. */
 .positron-notebook-cell-tag-add:hover {
 	color: var(--vscode-textLink-foreground);
+	border-color: var(--vscode-textLink-foreground);
+	background-color: color-mix(in srgb, var(--vscode-textLink-foreground) 12%, var(--vscode-notebook-cellEditorBackground));
+}
+
+.positron-notebook-cell-tag-add-label {
+	white-space: nowrap;
+}
+
+/* Standalone (markdown / raw) cells render the bar on the cell background with no
+footer chrome behind it, and the row wraps instead of scrolling -- so the add pill
+needs neither the opaque backdrop nor the sticky pin. */
+.positron-notebook-cell-tags.standalone .positron-notebook-cell-tag-add {
+	position: static;
+	background-color: transparent;
+}
+
+.positron-notebook-cell-tags.standalone .positron-notebook-cell-tag-add:hover {
 	background-color: color-mix(in srgb, var(--vscode-textLink-foreground) 12%, transparent);
 }
 
@@ -125,6 +159,14 @@ accent-tinted fill (the accent token mixed down to a low-opacity wash). */
 	/* Some codicon glyphs (close/plus) aren't centered within their glyph */
 	/* canvas -- see IconedButton.css. Nudge in em so it scales with size. */
 	transform: translate(0.04em, 0.04em);
+}
+
+/* The add pill sits the plus glyph inline next to its label, so it wants a
+readable glyph size rather than the tiny centered-icon treatment above. */
+.codicon[class*='codicon-'].positron-notebook-cell-tag-add-icon {
+	font-size: 11px;
+	line-height: 1;
+	color: inherit;
 }
 
 .positron-notebook-cell-tag-input {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
@@ -162,36 +162,28 @@ needs neither the opaque backdrop nor the sticky pin. */
 	background-color: color-mix(in srgb, var(--vscode-textLink-foreground) 12%, transparent);
 }
 
-/* Color + centering for the close codicon. The workbench base rule
-.monaco-workbench .codicon[class*='codicon-'] forces font-size: 16px at
-specificity (0,3,0), so this override is scoped under the tag bar to reach (0,4,0)
-and win -- otherwise the smaller size and inherited color are ignored. color:inherit
-lets the affordance drive its own glyph color per state (otherwise the glyph
-resolves to a higher-contrast icon foreground up the cascade). */
+/* Tag codicons (close + plus) are scoped under the tag bar to reach specificity
+(0,4,0) and beat the workbench base `.monaco-workbench .codicon[class*='codicon-']`
+16px rule (0,3,0) -- otherwise the 10px size and inherited color are ignored.
+`add-small` in particular is drawn to fill its em box, so it reads heavy at the
+label's 11px; 10px keeps the plus at the label's cap height. color:inherit lets
+each affordance drive its own glyph color per state. */
+.positron-notebook-cell-tags .codicon[class*='codicon-'].positron-notebook-cell-tag-icon,
+.positron-notebook-cell-tags .codicon[class*='codicon-'].positron-notebook-cell-tag-add-icon {
+	font-size: 10px;
+	line-height: 1;
+	color: inherit;
+}
+
+/* The close glyph also fills and centers within the pill's flex box. Some codicon
+glyphs aren't centered in their canvas (see IconedButton.css), so nudge in em. */
 .positron-notebook-cell-tags .codicon[class*='codicon-'].positron-notebook-cell-tag-icon {
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	width: 100%;
 	height: 100%;
-	font-size: 10px;
-	line-height: 1;
-	color: inherit;
-	/* Some codicon glyphs (close/plus) aren't centered within their glyph */
-	/* canvas -- see IconedButton.css. Nudge in em so it scales with size. */
 	transform: translate(0.04em, 0.04em);
-}
-
-/* The add pill sits the plus glyph inline next to its label. Codicons scale with
-font-size, and `add-small` is drawn to fill most of its em box, so it reads heavy
-at the label's 11px -- size it down so the plus matches the label's cap height
-rather than overpowering it. Scoped under the tag bar to reach specificity (0,4,0)
-and beat the workbench base `.monaco-workbench .codicon[class*='codicon-']` 16px
-rule (0,3,0). */
-.positron-notebook-cell-tags .codicon[class*='codicon-'].positron-notebook-cell-tag-add-icon {
-	font-size: 10px;
-	line-height: 1;
-	color: inherit;
 }
 
 /* Intrinsic width from current value (grows while editing); capped to match the

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
@@ -20,6 +20,18 @@
 	font-size: var(--vscode-bodyFontSize-xSmall);
 }
 
+/* "You're in the group" cue while keyboard-navigating the bar (it is a single
+tab stop with arrow-key movement inside, so the group needs to read as entered).
+The focused control's own ring comes from the workbench-wide `button:focus`
+rule; this outline is the group-level layer of the toolbar pattern.
+`:has(button:focus-visible)` keeps it keyboard-only and excludes the inline
+tag input, which carries its own focusBorder. */
+.positron-notebook-cell-tags:has(button:focus-visible) {
+	outline: 1px solid var(--vscode-focusBorder);
+	outline-offset: 2px;
+	border-radius: 2px;
+}
+
 /* Standalone placement (markdown / raw cells, which have no footer). */
 .positron-notebook-cell-tags.standalone {
 	flex: initial;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
@@ -6,11 +6,12 @@
 .positron-notebook-cell-tags {
 	display: inline-flex;
 	flex: 1 1 auto;
-	flex-wrap: nowrap;
+	/* Large tag sets wrap onto extra rows (in both the footer and standalone
+	placements) rather than scrolling horizontally -- a scrollable row has no
+	visual affordance that more tags exist. */
+	flex-wrap: wrap;
 	align-items: center;
 	min-width: 0;
-	overflow-x: auto;
-	overflow-y: hidden;
 	/* Small, consistent gaps between pills and the add control. */
 	gap: 4px;
 	/* Tag-bar typography for footer and standalone (markdown / raw) placement.
@@ -22,8 +23,6 @@
 /* Standalone placement (markdown / raw cells, which have no footer). */
 .positron-notebook-cell-tags.standalone {
 	flex: initial;
-	flex-wrap: wrap;
-	overflow: visible;
 	margin: 4px 1rem 6px 1rem;
 }
 
@@ -111,8 +110,7 @@ the pill's trailing padding on hover to keep the right inset balanced with the l
 
 /* Add affordance, styled to match the tag pills (thin outline, fully rounded).
 Hidden at rest and revealed on hover of the tag bar (or keyboard focus) so an
-untouched row stays calm. Sticks to the right edge when the row overflows
-horizontally, so it stays reachable even in large tag sets. */
+untouched row stays calm. */
 .positron-notebook-cell-tags .positron-notebook-cell-tag-add {
 	display: inline-flex;
 	align-items: center;
@@ -123,14 +121,11 @@ horizontally, so it stays reachable even in large tag sets. */
 	padding: 0 8px;
 	border: 1px solid var(--vscode-positronNotebook-cellTagBorder);
 	border-radius: 999px;
-	/* Opaque so tags scrolling underneath it (while sticky) don't bleed through. */
-	background-color: var(--vscode-notebook-cellEditorBackground);
+	background-color: transparent;
 	color: var(--vscode-positronNotebook-cellFooterForeground, var(--vscode-descriptionForeground));
 	font-size: var(--vscode-bodyFontSize-xSmall);
 	line-height: 1;
 	cursor: pointer;
-	position: sticky;
-	right: 0;
 	/* Revealed via opacity (kept in layout) so hovering doesn't reflow the row. */
 	opacity: 0;
 	pointer-events: none;
@@ -144,28 +139,15 @@ horizontally, so it stays reachable even in large tag sets. */
 }
 
 /* On hover the add pill picks up the tag hover accent color with a faint
-accent-tinted fill. The wash is mixed over the opaque footer background (not
-transparent) so the pill stays opaque while sticky. */
+accent-tinted fill. */
 .positron-notebook-cell-tags .positron-notebook-cell-tag-add:hover {
 	color: var(--vscode-positronNotebook-cellTagHoverForeground);
 	border-color: var(--vscode-positronNotebook-cellTagHoverForeground);
-	background-color: color-mix(in srgb, var(--vscode-positronNotebook-cellTagHoverForeground) 12%, var(--vscode-notebook-cellEditorBackground));
+	background-color: color-mix(in srgb, var(--vscode-positronNotebook-cellTagHoverForeground) 12%, transparent);
 }
 
 .positron-notebook-cell-tags .positron-notebook-cell-tag-add-label {
 	white-space: nowrap;
-}
-
-/* Standalone (markdown / raw) cells render the bar on the cell background with no
-footer chrome behind it, and the row wraps instead of scrolling -- so the add pill
-needs neither the opaque backdrop nor the sticky pin. */
-.positron-notebook-cell-tags.standalone .positron-notebook-cell-tag-add {
-	position: static;
-	background-color: transparent;
-}
-
-.positron-notebook-cell-tags.standalone .positron-notebook-cell-tag-add:hover {
-	background-color: color-mix(in srgb, var(--vscode-positronNotebook-cellTagHoverForeground) 12%, transparent);
 }
 
 /* Tag codicons (close + plus) are scoped under the tag bar to reach specificity

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
@@ -142,12 +142,13 @@ needs neither the opaque backdrop nor the sticky pin. */
 	background-color: color-mix(in srgb, var(--vscode-textLink-foreground) 12%, transparent);
 }
 
-/* Color + centering for the close / add codicons. */
-/* The base rule .codicon[class*='codicon-'] has specificity (0,2,0), so this */
-/* override matches its structure to win -- including the color. color:inherit */
-/* lets each affordance drive its own glyph color per state (otherwise the */
-/* glyph resolves to a higher-contrast icon foreground up the cascade). */
-.codicon[class*='codicon-'].positron-notebook-cell-tag-icon {
+/* Color + centering for the close codicon. The workbench base rule
+.monaco-workbench .codicon[class*='codicon-'] forces font-size: 16px at
+specificity (0,3,0), so this override is scoped under the tag bar to reach (0,4,0)
+and win -- otherwise the smaller size and inherited color are ignored. color:inherit
+lets the affordance drive its own glyph color per state (otherwise the glyph
+resolves to a higher-contrast icon foreground up the cascade). */
+.positron-notebook-cell-tags .codicon[class*='codicon-'].positron-notebook-cell-tag-icon {
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -161,10 +162,14 @@ needs neither the opaque backdrop nor the sticky pin. */
 	transform: translate(0.04em, 0.04em);
 }
 
-/* The add pill sits the plus glyph inline next to its label, so it wants a
-readable glyph size rather than the tiny centered-icon treatment above. */
-.codicon[class*='codicon-'].positron-notebook-cell-tag-add-icon {
-	font-size: 11px;
+/* The add pill sits the plus glyph inline next to its label. Codicons scale with
+font-size, and `add-small` is drawn to fill most of its em box, so it reads heavy
+at the label's 11px -- size it down so the plus matches the label's cap height
+rather than overpowering it. Scoped under the tag bar to reach specificity (0,4,0)
+and beat the workbench base `.monaco-workbench .codicon[class*='codicon-']` 16px
+rule (0,3,0). */
+.positron-notebook-cell-tags .codicon[class*='codicon-'].positron-notebook-cell-tag-add-icon {
+	font-size: 10px;
 	line-height: 1;
 	color: inherit;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
@@ -13,6 +13,8 @@
 	overflow-y: hidden;
 	/* Small, consistent gaps between pills and the add control. */
 	gap: 4px;
+	/* Tag-bar typography for footer and standalone (markdown / raw) placement. */
+	font-size: 11px;
 }
 
 /* Standalone placement (markdown / raw cells, which have no footer). */
@@ -42,12 +44,20 @@ metadata, not a button. */
 	transition: padding-inline-end 120ms ease;
 }
 
-.positron-notebook-cell-tag-label {
+/* Button typography in the tag bar. The workbench reset
+`.monaco-workbench button { font-size: 100% }` is (0,1,1) and beats a single tag-bar
+class on its own; code cells only looked correct because the footer sets 11px so
+100% still computed to 11px -- standalone markdown / raw cells do not. Scoped under
+the tag bar (0,2,1) so explicit 11px wins in every placement. */
+.positron-notebook-cell-tags .positron-notebook-cell-tag-label {
 	border: none;
 	background: transparent;
 	color: inherit;
 	font-size: 11px;
-	line-height: 1;
+	/* overflow:hidden (for the ellipsis) clips the line box, and at line-height:1
+	that box is too short for descenders (j/p/g) -- give it room; the 18px pill
+	centers the taller line box with space to spare. */
+	line-height: 1.4;
 	padding: 0;
 	cursor: text;
 	max-width: 200px;
@@ -58,7 +68,7 @@ metadata, not a button. */
 
 /* Close affordance: hidden at rest, revealed on hover / keyboard focus with a
 brief width + opacity transition so a row of tags stays calm rather than jumping. */
-.positron-notebook-cell-tag-remove {
+.positron-notebook-cell-tags .positron-notebook-cell-tag-remove {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -74,8 +84,8 @@ brief width + opacity transition so a row of tags stays calm rather than jumping
 	transition: width 120ms ease, opacity 120ms ease, margin-left 120ms ease;
 }
 
-.positron-notebook-cell-tag:hover .positron-notebook-cell-tag-remove,
-.positron-notebook-cell-tag:focus-within .positron-notebook-cell-tag-remove {
+.positron-notebook-cell-tags .positron-notebook-cell-tag:hover .positron-notebook-cell-tag-remove,
+.positron-notebook-cell-tags .positron-notebook-cell-tag:focus-within .positron-notebook-cell-tag-remove {
 	width: 14px;
 	margin-left: 2px;
 	opacity: 1;
@@ -83,13 +93,13 @@ brief width + opacity transition so a row of tags stays calm rather than jumping
 
 /* The revealed close icon carries whitespace within its own glyph canvas, so trim
 the pill's trailing padding on hover to keep the right inset balanced with the left. */
-.positron-notebook-cell-tag:hover,
-.positron-notebook-cell-tag:focus-within {
+.positron-notebook-cell-tags .positron-notebook-cell-tag:hover,
+.positron-notebook-cell-tags .positron-notebook-cell-tag:focus-within {
 	padding-inline-end: 3px;
 }
 
 /* Hovering the close icon itself brightens it toward the primary text color. */
-.positron-notebook-cell-tag-remove:hover {
+.positron-notebook-cell-tags .positron-notebook-cell-tag-remove:hover {
 	color: var(--vscode-foreground);
 }
 
@@ -97,7 +107,7 @@ the pill's trailing padding on hover to keep the right inset balanced with the l
 Hidden at rest and revealed on hover of the tag bar (or keyboard focus) so an
 untouched row stays calm. Sticks to the right edge when the row overflows
 horizontally, so it stays reachable even in large tag sets. */
-.positron-notebook-cell-tag-add {
+.positron-notebook-cell-tags .positron-notebook-cell-tag-add {
 	display: inline-flex;
 	align-items: center;
 	box-sizing: border-box;
@@ -130,13 +140,13 @@ horizontally, so it stays reachable even in large tag sets. */
 /* On hover the add pill picks up the accent/link color with a faint accent-tinted
 fill. The wash is mixed over the opaque footer background (not transparent) so the
 pill stays opaque while sticky. */
-.positron-notebook-cell-tag-add:hover {
+.positron-notebook-cell-tags .positron-notebook-cell-tag-add:hover {
 	color: var(--vscode-textLink-foreground);
 	border-color: var(--vscode-textLink-foreground);
 	background-color: color-mix(in srgb, var(--vscode-textLink-foreground) 12%, var(--vscode-notebook-cellEditorBackground));
 }
 
-.positron-notebook-cell-tag-add-label {
+.positron-notebook-cell-tags .positron-notebook-cell-tag-add-label {
 	white-space: nowrap;
 }
 
@@ -184,11 +194,16 @@ rule (0,3,0). */
 	color: inherit;
 }
 
-.positron-notebook-cell-tag-input {
+/* Intrinsic width from current value (grows while editing); capped to match the
+display pill: 200px label + 16px horizontal padding + 2px border. */
+.positron-notebook-cell-tags .positron-notebook-cell-tag-input {
 	flex: 0 0 auto;
+	box-sizing: border-box;
 	height: 18px;
-	min-width: 50px;
-	width: 70px;
+	min-width: 70px;
+	max-width: 218px;
+	width: auto;
+	field-sizing: content;
 	border-radius: 999px;
 	border: 1px solid var(--vscode-focusBorder);
 	background-color: var(--vscode-input-background);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
@@ -13,8 +13,10 @@
 	overflow-y: hidden;
 	/* Small, consistent gaps between pills and the add control. */
 	gap: 4px;
-	/* Tag-bar typography for footer and standalone (markdown / raw) placement. */
-	font-size: 11px;
+	/* Tag-bar typography for footer and standalone (markdown / raw) placement.
+	The registered size token (11px by default) keeps the bar in step with themes
+	or users that bump the base font sizes. */
+	font-size: var(--vscode-bodyFontSize-xSmall);
 }
 
 /* Standalone placement (markdown / raw cells, which have no footer). */
@@ -32,9 +34,13 @@ metadata, not a button. */
 	align-items: center;
 	box-sizing: border-box;
 	flex-shrink: 0;
-	height: 18px;
+	/* 18px at the default 11px font; tracks the size token so a larger font
+	doesn't clip descenders. */
+	height: calc(var(--vscode-bodyFontSize-xSmall) + 7px);
 	padding: 0 8px;
-	border: 1px solid var(--vscode-widget-border);
+	/* A dedicated tag border color: the widget border is transparent in some
+	minimal themes, which left the pills invisible. */
+	border: 1px solid var(--vscode-positronNotebook-cellTagBorder);
 	border-radius: 999px;
 	background: transparent;
 	/* Muted footer text; also drives the close icon color via inherit. */
@@ -48,12 +54,12 @@ metadata, not a button. */
 `.monaco-workbench button { font-size: 100% }` is (0,1,1) and beats a single tag-bar
 class on its own; code cells only looked correct because the footer sets 11px so
 100% still computed to 11px -- standalone markdown / raw cells do not. Scoped under
-the tag bar (0,2,1) so explicit 11px wins in every placement. */
+the tag bar (0,2,1) so the explicit size wins in every placement. */
 .positron-notebook-cell-tags .positron-notebook-cell-tag-label {
 	border: none;
 	background: transparent;
 	color: inherit;
-	font-size: 11px;
+	font-size: var(--vscode-bodyFontSize-xSmall);
 	/* overflow:hidden (for the ellipsis) clips the line box, and at line-height:1
 	that box is too short for descenders (j/p/g) -- give it room; the 18px pill
 	centers the taller line box with space to spare. */
@@ -113,14 +119,14 @@ horizontally, so it stays reachable even in large tag sets. */
 	box-sizing: border-box;
 	flex-shrink: 0;
 	gap: 3px;
-	height: 18px;
+	height: calc(var(--vscode-bodyFontSize-xSmall) + 7px);
 	padding: 0 8px;
-	border: 1px solid var(--vscode-widget-border);
+	border: 1px solid var(--vscode-positronNotebook-cellTagBorder);
 	border-radius: 999px;
 	/* Opaque so tags scrolling underneath it (while sticky) don't bleed through. */
 	background-color: var(--vscode-notebook-cellEditorBackground);
 	color: var(--vscode-positronNotebook-cellFooterForeground, var(--vscode-descriptionForeground));
-	font-size: 11px;
+	font-size: var(--vscode-bodyFontSize-xSmall);
 	line-height: 1;
 	cursor: pointer;
 	position: sticky;
@@ -137,13 +143,13 @@ horizontally, so it stays reachable even in large tag sets. */
 	pointer-events: auto;
 }
 
-/* On hover the add pill picks up the accent/link color with a faint accent-tinted
-fill. The wash is mixed over the opaque footer background (not transparent) so the
-pill stays opaque while sticky. */
+/* On hover the add pill picks up the tag hover accent color with a faint
+accent-tinted fill. The wash is mixed over the opaque footer background (not
+transparent) so the pill stays opaque while sticky. */
 .positron-notebook-cell-tags .positron-notebook-cell-tag-add:hover {
-	color: var(--vscode-textLink-foreground);
-	border-color: var(--vscode-textLink-foreground);
-	background-color: color-mix(in srgb, var(--vscode-textLink-foreground) 12%, var(--vscode-notebook-cellEditorBackground));
+	color: var(--vscode-positronNotebook-cellTagHoverForeground);
+	border-color: var(--vscode-positronNotebook-cellTagHoverForeground);
+	background-color: color-mix(in srgb, var(--vscode-positronNotebook-cellTagHoverForeground) 12%, var(--vscode-notebook-cellEditorBackground));
 }
 
 .positron-notebook-cell-tags .positron-notebook-cell-tag-add-label {
@@ -159,18 +165,18 @@ needs neither the opaque backdrop nor the sticky pin. */
 }
 
 .positron-notebook-cell-tags.standalone .positron-notebook-cell-tag-add:hover {
-	background-color: color-mix(in srgb, var(--vscode-textLink-foreground) 12%, transparent);
+	background-color: color-mix(in srgb, var(--vscode-positronNotebook-cellTagHoverForeground) 12%, transparent);
 }
 
 /* Tag codicons (close + plus) are scoped under the tag bar to reach specificity
 (0,4,0) and beat the workbench base `.monaco-workbench .codicon[class*='codicon-']`
 16px rule (0,3,0) -- otherwise the 10px size and inherited color are ignored.
 `add-small` in particular is drawn to fill its em box, so it reads heavy at the
-label's 11px; 10px keeps the plus at the label's cap height. color:inherit lets
-each affordance drive its own glyph color per state. */
+label size; one pixel under it keeps the plus at the label's cap height.
+color:inherit lets each affordance drive its own glyph color per state. */
 .positron-notebook-cell-tags .codicon[class*='codicon-'].positron-notebook-cell-tag-icon,
 .positron-notebook-cell-tags .codicon[class*='codicon-'].positron-notebook-cell-tag-add-icon {
-	font-size: 10px;
+	font-size: calc(var(--vscode-bodyFontSize-xSmall) - 1px);
 	line-height: 1;
 	color: inherit;
 }
@@ -191,7 +197,7 @@ display pill: 200px label + 16px horizontal padding + 2px border. */
 .positron-notebook-cell-tags .positron-notebook-cell-tag-input {
 	flex: 0 0 auto;
 	box-sizing: border-box;
-	height: 18px;
+	height: calc(var(--vscode-bodyFontSize-xSmall) + 7px);
 	min-width: 70px;
 	max-width: 218px;
 	width: auto;
@@ -200,7 +206,7 @@ display pill: 200px label + 16px horizontal padding + 2px border. */
 	border: 1px solid var(--vscode-focusBorder);
 	background-color: var(--vscode-input-background);
 	color: var(--vscode-input-foreground);
-	font-size: 11px;
+	font-size: var(--vscode-bodyFontSize-xSmall);
 	line-height: 1;
 	padding: 0 8px;
 	outline: none;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
@@ -37,6 +37,9 @@ metadata, not a button. */
 	background: transparent;
 	/* Muted footer text; also drives the close icon color via inherit. */
 	color: var(--vscode-positronNotebook-cellFooterForeground, var(--vscode-descriptionForeground));
+	/* Animate the trailing-padding trim on hover (see the :hover rule below) so it
+	moves in step with the close icon's reveal. */
+	transition: padding-inline-end 120ms ease;
 }
 
 .positron-notebook-cell-tag-label {
@@ -76,6 +79,13 @@ brief width + opacity transition so a row of tags stays calm rather than jumping
 	width: 14px;
 	margin-left: 2px;
 	opacity: 1;
+}
+
+/* The revealed close icon carries whitespace within its own glyph canvas, so trim
+the pill's trailing padding on hover to keep the right inset balanced with the left. */
+.positron-notebook-cell-tag:hover,
+.positron-notebook-cell-tag:focus-within {
+	padding-inline-end: 3px;
 }
 
 /* Hovering the close icon itself brightens it toward the primary text color. */
@@ -154,7 +164,7 @@ resolves to a higher-contrast icon foreground up the cascade). */
 	justify-content: center;
 	width: 100%;
 	height: 100%;
-	font-size: 7px;
+	font-size: 10px;
 	line-height: 1;
 	color: inherit;
 	/* Some codicon glyphs (close/plus) aren't centered within their glyph */

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
@@ -5,14 +5,21 @@
 
 .positron-notebook-cell-tags {
 	display: inline-flex;
-	flex-wrap: wrap;
+	flex: 1 1 auto;
+	flex-wrap: nowrap;
 	align-items: center;
+	min-width: 0;
+	overflow-x: auto;
+	overflow-y: hidden;
 	/* Small, consistent gaps between pills and the add control. */
 	gap: 4px;
 }
 
 /* Standalone placement (markdown / raw cells, which have no footer). */
 .positron-notebook-cell-tags.standalone {
+	flex: initial;
+	flex-wrap: wrap;
+	overflow: visible;
 	margin: 4px 1rem 6px 1rem;
 }
 
@@ -22,6 +29,7 @@ metadata, not a button. */
 	display: inline-flex;
 	align-items: center;
 	box-sizing: border-box;
+	flex-shrink: 0;
 	height: 18px;
 	padding: 0 8px;
 	border: 1px solid var(--vscode-widget-border);
@@ -81,6 +89,7 @@ color at rest. */
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
+	flex-shrink: 0;
 	width: 16px;
 	height: 16px;
 	border: none;
@@ -119,6 +128,7 @@ accent-tinted fill (the accent token mixed down to a low-opacity wash). */
 }
 
 .positron-notebook-cell-tag-input {
+	flex: 0 0 auto;
 	height: 18px;
 	min-width: 50px;
 	width: 70px;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.css
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.positron-notebook-cell-tags {
+	display: inline-flex;
+	flex-wrap: wrap;
+	align-items: center;
+	/* Small, consistent gaps between pills and the add control. */
+	gap: 4px;
+}
+
+/* Standalone placement (markdown / raw cells, which have no footer). */
+.positron-notebook-cell-tags.standalone {
+	margin: 4px 1rem 6px 1rem;
+}
+
+/* Quiet pill: a thin outline, fully rounded, with no fill so it reads as calm
+metadata, not a button. */
+.positron-notebook-cell-tag {
+	display: inline-flex;
+	align-items: center;
+	box-sizing: border-box;
+	height: 18px;
+	padding: 0 8px;
+	border: 1px solid var(--vscode-widget-border);
+	border-radius: 999px;
+	background: transparent;
+	/* Muted footer text; also drives the close icon color via inherit. */
+	color: var(--vscode-positronNotebook-cellFooterForeground, var(--vscode-descriptionForeground));
+}
+
+.positron-notebook-cell-tag-label {
+	border: none;
+	background: transparent;
+	color: inherit;
+	font-size: 11px;
+	line-height: 1;
+	padding: 0;
+	cursor: text;
+	max-width: 200px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+/* Close affordance: hidden at rest, revealed on hover / keyboard focus with a
+brief width + opacity transition so a row of tags stays calm rather than jumping. */
+.positron-notebook-cell-tag-remove {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 0;
+	height: 14px;
+	opacity: 0;
+	overflow: hidden;
+	border: none;
+	background: transparent;
+	color: inherit;
+	cursor: pointer;
+	padding: 0;
+	transition: width 120ms ease, opacity 120ms ease, margin-left 120ms ease;
+}
+
+.positron-notebook-cell-tag:hover .positron-notebook-cell-tag-remove,
+.positron-notebook-cell-tag:focus-within .positron-notebook-cell-tag-remove {
+	width: 14px;
+	margin-left: 2px;
+	opacity: 1;
+}
+
+/* Hovering the close icon itself brightens it toward the primary text color. */
+.positron-notebook-cell-tag-remove:hover {
+	color: var(--vscode-foreground);
+}
+
+/* Ghost add affordance: no border or fill, matching the footer's metadata icon
+color at rest. */
+.positron-notebook-cell-tag-add {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 16px;
+	height: 16px;
+	border: none;
+	border-radius: 999px;
+	background: transparent;
+	color: var(--vscode-positronNotebook-cellFooterForeground, var(--vscode-descriptionForeground));
+	cursor: pointer;
+	padding: 0;
+	transition: color 120ms ease, background-color 120ms ease;
+}
+
+/* On hover the add control picks up the accent/link color with a faint
+accent-tinted fill (the accent token mixed down to a low-opacity wash). */
+.positron-notebook-cell-tag-add:hover {
+	color: var(--vscode-textLink-foreground);
+	background-color: color-mix(in srgb, var(--vscode-textLink-foreground) 12%, transparent);
+}
+
+/* Color + centering for the close / add codicons. */
+/* The base rule .codicon[class*='codicon-'] has specificity (0,2,0), so this */
+/* override matches its structure to win -- including the color. color:inherit */
+/* lets each affordance drive its own glyph color per state (otherwise the */
+/* glyph resolves to a higher-contrast icon foreground up the cascade). */
+.codicon[class*='codicon-'].positron-notebook-cell-tag-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
+	font-size: 7px;
+	line-height: 1;
+	color: inherit;
+	/* Some codicon glyphs (close/plus) aren't centered within their glyph */
+	/* canvas -- see IconedButton.css. Nudge in em so it scales with size. */
+	transform: translate(0.04em, 0.04em);
+}
+
+.positron-notebook-cell-tag-input {
+	height: 18px;
+	min-width: 50px;
+	width: 70px;
+	border-radius: 999px;
+	border: 1px solid var(--vscode-focusBorder);
+	background-color: var(--vscode-input-background);
+	color: var(--vscode-input-foreground);
+	font-size: 11px;
+	line-height: 1;
+	padding: 0 8px;
+	outline: none;
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -47,8 +47,9 @@ function stopTagBarBubble(e: React.MouseEvent) {
  * the bottom of the cell.
  *
  * Keyboard-wise the bar is a toolbar-pattern composite widget: a single tab
- * stop (the add control, which leads the row), with the arrow keys moving
- * between the controls inside and Escape returning focus to the cell.
+ * stop (the first tag, falling back to the add control on a tagless cell),
+ * with the arrow keys moving between the controls inside and Escape
+ * returning focus to the cell.
  */
 export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell; standalone?: boolean }) {
 	const { notificationService } = usePositronReactServicesContext();
@@ -100,10 +101,11 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 		notifyTagResult(notificationService, cell.addTag(raw), raw.trim());
 	};
 
-	// The bar is a composite widget with a single tab stop (the add control,
-	// tabIndex 0); everything else is tabIndex -1 and reached with the arrow
-	// keys, per the WAI-ARIA toolbar pattern. This keeps a long tag list from
-	// adding a tab stop per tag for keyboard users traversing the notebook.
+	// The bar is a composite widget with a single tab stop (the first tag's
+	// label, or the add control when the cell has no tags); everything else is
+	// tabIndex -1 and reached with the arrow keys, per the WAI-ARIA toolbar
+	// pattern. This keeps a long tag list from adding a tab stop per tag for
+	// keyboard users traversing the notebook.
 	const handleBarKeyDown = (e: React.KeyboardEvent) => {
 		// The inline tag input handles (and stops) its own keys.
 		if (isHTMLInputElement(e.target)) {
@@ -161,30 +163,6 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 			onKeyDown={handleBarKeyDown}
 			onMouseDown={stopTagBarBubble}
 		>
-			{isAddingTag ? (
-				<TagInput
-					initialValue=''
-					onCancel={() => cell.endAddTag()}
-					onCommit={commitAdd}
-				/>
-			) : (
-				<button
-					aria-label={localize('positron.notebook.cellTag.add', "Add tag")}
-					className='positron-notebook-cell-tag-add'
-					// The bar's single tab stop; the tags that follow are
-					// reached with the arrow keys (see handleBarKeyDown).
-					tabIndex={0}
-					title={localize('positron.notebook.cellTag.add', "Add tag")}
-					type='button'
-					onClick={(e) => { stopTagBarPointer(e); cell.beginAddTag(); }}
-					onMouseDown={stopTagBarPointer}
-				>
-					<Icon className='positron-notebook-cell-tag-add-icon' icon={Codicon.addSmall} />
-					<span className='positron-notebook-cell-tag-add-label'>
-						{localize('positron.notebook.cellTag.add', "Add tag")}
-					</span>
-				</button>
-			)}
 			{tags.map((tag) =>
 				editingTag === tag ? (
 					// The edit target is tracked by tag value (the cell model
@@ -204,7 +182,9 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 						<button
 							aria-label={localize('positron.notebook.cellTag.edit', "Edit tag {0}", tag)}
 							className='positron-notebook-cell-tag-label'
-							tabIndex={-1}
+							// The first tag is the bar's tab stop (see the
+							// roving-tabindex note on handleBarKeyDown).
+							tabIndex={tag === tags[0] ? 0 : -1}
 							title={localize('positron.notebook.cellTag.editHint', "Click to edit tag")}
 							type='button'
 							onClick={(e) => { stopTagBarPointer(e); setEditingTag(tag); }}
@@ -225,6 +205,30 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 						</button>
 					</span>
 				)
+			)}
+			{isAddingTag ? (
+				<TagInput
+					initialValue=''
+					onCancel={() => cell.endAddTag()}
+					onCommit={commitAdd}
+				/>
+			) : (
+				<button
+					aria-label={localize('positron.notebook.cellTag.add', "Add tag")}
+					className='positron-notebook-cell-tag-add'
+					// Only the bar's tab stop when there are no tags ahead of it
+					// (see the roving-tabindex note on handleBarKeyDown).
+					tabIndex={tags.length === 0 ? 0 : -1}
+					title={localize('positron.notebook.cellTag.add', "Add tag")}
+					type='button'
+					onClick={(e) => { stopTagBarPointer(e); cell.beginAddTag(); }}
+					onMouseDown={stopTagBarPointer}
+				>
+					<Icon className='positron-notebook-cell-tag-add-icon' icon={Codicon.addSmall} />
+					<span className='positron-notebook-cell-tag-add-label'>
+						{localize('positron.notebook.cellTag.add', "Add tag")}
+					</span>
+				</button>
 			)}
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -17,6 +17,7 @@ import { usePositronReactServicesContext } from '../../../../../base/browser/pos
 import { Icon } from '../../../../../platform/positronActionBar/browser/components/icon.js';
 import { IPositronNotebookCell } from '../PositronNotebookCells/IPositronNotebookCell.js';
 import { useObservedValue } from '../useObservedValue.js';
+import { notifyTagResult } from './cellTagNotifications.js';
 
 // Tag-bar clicks must not bubble to the cell wrapper's selection handler, which
 // would re-focus the cell container and blur an open tag input.
@@ -46,57 +47,30 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 		return null;
 	}
 
-	const notifyDuplicate = (tag: string) => {
-		notificationService.info(
-			localize('positron.notebook.cellTag.duplicate', "Tag '{0}' is already on this cell.", tag)
-		);
-	};
-
 	const removeTag = (tag: string) => {
-		const latestTags = cell.tags.get();
-		if (!latestTags.includes(tag)) {
-			return;
+		// The cell owns the membership check and the write; only surface a failed
+		// write (e.g. detached cell), otherwise removal is silent.
+		if (!cell.removeTag(tag)) {
+			notifyTagResult(notificationService, 'failed', tag);
 		}
-		cell.setTags(latestTags.filter(t => t !== tag));
 	};
 
 	const commitEdit = (originalTag: string, raw: string) => {
 		setEditingTag(null);
-		const latestTags = cell.tags.get();
-		const index = latestTags.indexOf(originalTag);
-		if (index < 0) {
-			return;
-		}
-		const value = raw.trim();
-		if (!value) {
+		// Clearing the input removes the tag; otherwise the cell owns trim /
+		// missing / duplicate handling and reports the outcome to surface.
+		if (!raw.trim()) {
 			removeTag(originalTag);
 			return;
 		}
-		// Renaming onto an existing tag is rejected; tell the user why rather
-		// than silently reverting.
-		if (latestTags.some((t, i) => i !== index && t === value)) {
-			notifyDuplicate(value);
-			return;
-		}
-		const next = [...latestTags];
-		next[index] = value;
-		cell.setTags(next);
+		notifyTagResult(notificationService, cell.renameTag(originalTag, raw), raw.trim());
 	};
 
 	const commitAdd = (raw: string) => {
 		setAdding(false);
-		const value = raw.trim();
-		// The cell enforces trim / empty / duplicate handling; surface a toast
-		// when the tag already exists (or the write failed) so the committed
-		// input doesn't just vanish without feedback.
-		const result = cell.addTag(value);
-		if (result === 'duplicate') {
-			notifyDuplicate(value);
-		} else if (result === 'failed') {
-			notificationService.info(
-				localize('positron.notebook.cellTag.addFailed', "Could not add tag '{0}'.", value)
-			);
-		}
+		// The cell enforces trim / empty / duplicate handling and reports the
+		// outcome; surface a toast so a rejected input doesn't vanish silently.
+		notifyTagResult(notificationService, cell.addTag(raw), raw.trim());
 	};
 
 	return (

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -19,9 +19,16 @@ import { IPositronNotebookCell } from '../PositronNotebookCells/IPositronNoteboo
 import { useObservedValue } from '../useObservedValue.js';
 import { notifyTagResult } from './cellTagNotifications.js';
 
-// Tag-bar clicks must not bubble to the cell wrapper's selection handler, which
-// would re-focus the cell container and blur an open tag input.
-function stopCellSelection(e: React.MouseEvent) {
+// Tag-bar pointer events must not bubble to the cell wrapper's selection handler.
+// Buttons also call preventDefault on mousedown so the browser does not move focus
+// off the cell container (see positron Button / CellActionButton); the input only
+// stops propagation so it can still receive focus when clicked.
+function stopTagBarPointer(e: React.MouseEvent) {
+	e.preventDefault();
+	e.stopPropagation();
+}
+
+function stopTagBarBubble(e: React.MouseEvent) {
 	e.stopPropagation();
 }
 
@@ -62,7 +69,11 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 		// write (e.g. detached cell), otherwise removal is silent.
 		if (!cell.removeTag(tag)) {
 			notifyTagResult(notificationService, 'failed', tag);
+			return;
 		}
+		// The remove button unmounts on success; keep focus on this cell so selection
+		// chrome does not flicker onto the following cell.
+		cell.container?.focus({ preventScroll: true });
 	};
 
 	const commitEdit = (originalTag: string, raw: string) => {
@@ -84,7 +95,11 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 	};
 
 	return (
-		<div className={positronClassNames('positron-notebook-cell-tags', { standalone })} data-testid='cell-tags-bar'>
+		<div
+			className={positronClassNames('positron-notebook-cell-tags', { standalone })}
+			data-testid='cell-tags-bar'
+			onMouseDown={stopTagBarBubble}
+		>
 			{tags.map((tag) =>
 				editingTag === tag ? (
 					// The edit target is tracked by tag value (the cell model
@@ -106,7 +121,8 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 							className='positron-notebook-cell-tag-label'
 							title={localize('positron.notebook.cellTag.editHint', "Click to edit tag")}
 							type='button'
-							onClick={(e) => { stopCellSelection(e); setEditingTag(tag); }}
+							onMouseDown={stopTagBarPointer}
+							onClick={(e) => { stopTagBarPointer(e); setEditingTag(tag); }}
 						>
 							{tag}
 						</button>
@@ -115,7 +131,8 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 							className='positron-notebook-cell-tag-remove'
 							title={localize('positron.notebook.cellTag.remove', "Remove tag {0}", tag)}
 							type='button'
-							onClick={(e) => { stopCellSelection(e); removeTag(tag); }}
+							onMouseDown={stopTagBarPointer}
+							onClick={(e) => { stopTagBarPointer(e); removeTag(tag); }}
 						>
 							<Icon className='positron-notebook-cell-tag-icon' icon={Codicon.close} />
 						</button>
@@ -134,7 +151,8 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 					className='positron-notebook-cell-tag-add'
 					title={localize('positron.notebook.cellTag.add', "Add tag")}
 					type='button'
-					onClick={(e) => { stopCellSelection(e); cell.beginAddTag(); }}
+					onMouseDown={stopTagBarPointer}
+					onClick={(e) => { stopTagBarPointer(e); cell.beginAddTag(); }}
 				>
 					<Icon className='positron-notebook-cell-tag-add-icon' icon={Codicon.addSmall} />
 					<span className='positron-notebook-cell-tag-add-label'>
@@ -172,7 +190,8 @@ function TagInput({ initialValue, onCommit, onCancel }: {
 			value={value}
 			onBlur={() => onCommit(value)}
 			onChange={(e) => setValue(e.target.value)}
-			onClick={stopCellSelection}
+			onMouseDown={stopTagBarBubble}
+			onClick={stopTagBarBubble}
 			// Stop keystrokes from reaching the notebook's command-mode handlers.
 			onKeyDown={(e) => {
 				if (e.key === 'Enter') {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -42,7 +42,13 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 	const { notificationService } = usePositronReactServicesContext();
 	const tags = useObservedValue(cell.tags);
 	const isAddingTag = useObservedValue(cell.isAddingTag);
+	const cellTagsHidden = useObservedValue(cell.cellTagsHidden);
 	const [editingTag, setEditingTag] = React.useState<string | null>(null);
+
+	// The notebook can hide all cell tags (a transient, per-notebook toggle).
+	if (cellTagsHidden) {
+		return null;
+	}
 
 	// Nothing to show unless the cell has a tag or a tag-add was requested (via
 	// the command or the hover add pill). The passive add pill only appears once

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -58,6 +58,33 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 	const tagUIVisible = useObservedValue(cell.tagUIVisible);
 	const [editingTag, setEditingTag] = React.useState<string | null>(null);
 	const barRef = React.useRef<HTMLDivElement>(null);
+	// A committed edit or a removed tag unmounts the focused control, which would
+	// drop the keyboard focus ring to <body>. removeTag / commitEdit record the
+	// tag whose pill to focus next; this effect restores it once the render commits.
+	const pendingFocusRef = React.useRef<string | null>(null);
+
+	React.useLayoutEffect(() => {
+		const pendingTag = pendingFocusRef.current;
+		pendingFocusRef.current = null;
+		const bar = barRef.current;
+		if (pendingTag === null || !bar) {
+			return;
+		}
+		// Match by tag value (not a `[data-tag="..."]` selector, which breaks on
+		// values with quotes or other selector syntax).
+		// eslint-disable-next-line no-restricted-syntax -- enumerating the bar's own tag labels to find one by value, not reaching into structure
+		const labels = Array.from(bar.querySelectorAll<HTMLButtonElement>('.positron-notebook-cell-tag-label'));
+		labels.find(label => label.dataset.tag === pendingTag)?.focus();
+	});
+
+	// True when DOM focus is currently inside the bar -- i.e. the user is driving
+	// it by keyboard, so a mutation should keep the focus ring in the bar. A
+	// mouse interaction leaves focus outside (the buttons preventDefault their
+	// mousedown), and a blur-driven commit has already moved focus away.
+	const barHasFocus = () => {
+		const bar = barRef.current;
+		return !!bar && bar.contains(bar.ownerDocument.activeElement);
+	};
 
 	// The cell owns the visibility predicate: nothing to show unless the cell has
 	// a tag or a tag-add was requested (via the command or the hover add pill),
@@ -74,9 +101,18 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 		if (result !== 'ok') {
 			return;
 		}
-		// The remove button unmounts on success; keep focus on this cell so selection
-		// chrome does not flicker onto the following cell.
-		cell.container?.focus({ preventScroll: true });
+		// The removed control unmounts. For a keyboard removal with tags left, keep
+		// the focus ring in the bar by landing on the neighbor that slides into this
+		// slot (or the new last tag). Otherwise -- a mouse removal (focus was never
+		// in the bar), or removing the last tag (the whole bar unmounts as
+		// tagUIVisible turns false) -- pin focus to the cell so selection chrome does
+		// not flicker onto the following cell.
+		const remaining = tags.filter(t => t !== tag);
+		if (barHasFocus() && remaining.length > 0) {
+			pendingFocusRef.current = remaining[Math.min(tags.indexOf(tag), remaining.length - 1)];
+		} else {
+			cell.container?.focus({ preventScroll: true });
+		}
 	};
 
 	const commitEdit = (originalTag: string, raw: string) => {
@@ -87,7 +123,14 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 			removeTag(originalTag);
 			return;
 		}
-		notifyTagResult(notificationService, cell.renameTag(originalTag, raw), raw.trim());
+		const result = cell.renameTag(originalTag, raw);
+		notifyTagResult(notificationService, result, raw.trim());
+		// Return the focus ring to the pill once the input unmounts -- but only for
+		// an Enter commit (focus still in the bar); a blur commit means the user
+		// already moved focus elsewhere. A rejected rename keeps the original tag.
+		if (barHasFocus()) {
+			pendingFocusRef.current = result === 'ok' ? raw.trim() : originalTag;
+		}
 	};
 
 	const commitAdd = (raw: string) => {
@@ -178,6 +221,9 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 						<button
 							aria-label={localize('positron.notebook.cellTag.edit', "Edit tag {0}", tag)}
 							className='positron-notebook-cell-tag-label'
+							// Lets the focus-restoration effect find this pill by value
+							// after a neighbor is removed or this tag is renamed.
+							data-tag={tag}
 							// The first tag is the bar's tab stop (see the
 							// roving-tabindex note on handleBarKeyDown).
 							tabIndex={tag === tags[0] ? 0 : -1}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -38,7 +38,7 @@ function stopCellSelection(e: React.MouseEvent) {
 export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell; standalone?: boolean }) {
 	const { notificationService } = usePositronReactServicesContext();
 	const tags = useObservedValue(cell.tags);
-	const [editingIndex, setEditingIndex] = React.useState<number | null>(null);
+	const [editingTag, setEditingTag] = React.useState<string | null>(null);
 	const [adding, setAdding] = React.useState(false);
 
 	// No tags -> no UI at all (including the add affordance).
@@ -52,24 +52,33 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 		);
 	};
 
-	const removeTag = (index: number) => {
-		cell.setTags(tags.filter((_, i) => i !== index));
+	const removeTag = (tag: string) => {
+		const latestTags = cell.tags.get();
+		if (!latestTags.includes(tag)) {
+			return;
+		}
+		cell.setTags(latestTags.filter(t => t !== tag));
 	};
 
-	const commitEdit = (index: number, raw: string) => {
-		setEditingIndex(null);
+	const commitEdit = (originalTag: string, raw: string) => {
+		setEditingTag(null);
+		const latestTags = cell.tags.get();
+		const index = latestTags.indexOf(originalTag);
+		if (index < 0) {
+			return;
+		}
 		const value = raw.trim();
 		if (!value) {
-			removeTag(index);
+			removeTag(originalTag);
 			return;
 		}
 		// Renaming onto an existing tag is rejected; tell the user why rather
 		// than silently reverting.
-		if (tags.some((t, i) => i !== index && t === value)) {
+		if (latestTags.some((t, i) => i !== index && t === value)) {
 			notifyDuplicate(value);
 			return;
 		}
-		const next = [...tags];
+		const next = [...latestTags];
 		next[index] = value;
 		cell.setTags(next);
 	};
@@ -86,17 +95,18 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 
 	return (
 		<div className={positronClassNames('positron-notebook-cell-tags', { standalone })} data-testid='cell-tags-bar'>
-			{tags.map((tag, index) =>
-				editingIndex === index ? (
-					// Keys are the tag value (tags are unique), so a mid-list removal
-					// doesn't re-key surviving pills by position and misassociate an
-					// open input. The `edit-` prefix differs from the display key so
-					// switching modes remounts TagInput (re-running its focus effect).
+			{tags.map((tag) =>
+				editingTag === tag ? (
+					// The edit target is tracked by tag value (tags are unique), not by
+					// position, so a tag-list change while an input is open can't shift
+					// the open input onto a different pill. Keys are the tag value for
+					// the same reason. The `edit-` prefix differs from the display key
+					// so switching modes remounts TagInput (re-running its focus effect).
 					<TagInput
 						key={`edit-${tag}`}
 						initialValue={tag}
-						onCancel={() => setEditingIndex(null)}
-						onCommit={(value) => commitEdit(index, value)}
+						onCancel={() => setEditingTag(null)}
+						onCommit={(value) => commitEdit(tag, value)}
 					/>
 				) : (
 					<span key={tag} className='positron-notebook-cell-tag'>
@@ -105,7 +115,7 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 							className='positron-notebook-cell-tag-label'
 							title={localize('positron.notebook.cellTag.editHint', "Click to edit tag")}
 							type='button'
-							onClick={(e) => { stopCellSelection(e); setEditingIndex(index); }}
+							onClick={(e) => { stopCellSelection(e); setEditingTag(tag); }}
 						>
 							{tag}
 						</button>
@@ -114,7 +124,7 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 							className='positron-notebook-cell-tag-remove'
 							title={localize('positron.notebook.cellTag.remove', "Remove tag {0}", tag)}
 							type='button'
-							onClick={(e) => { stopCellSelection(e); removeTag(index); }}
+							onClick={(e) => { stopCellSelection(e); removeTag(tag); }}
 						>
 							<Icon className='positron-notebook-cell-tag-icon' icon={Codicon.close} />
 						</button>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -72,10 +72,11 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 	}
 
 	const removeTag = (tag: string) => {
-		// The cell owns the membership check and the write; only surface a failed
-		// write (e.g. detached cell), otherwise removal is silent.
-		if (!cell.removeTag(tag)) {
-			notifyTagResult(notificationService, 'failed', tag);
+		// The cell owns the membership check and the write; notifyTagResult only
+		// surfaces a failed write (e.g. detached cell), removal is otherwise silent.
+		const result = cell.removeTag(tag);
+		notifyTagResult(notificationService, result, tag);
+		if (result !== 'ok') {
 			return;
 		}
 		// The remove button unmounts on success; keep focus on this cell so selection

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -136,7 +136,7 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 					type='button'
 					onClick={(e) => { stopCellSelection(e); cell.beginAddTag(); }}
 				>
-					<Icon className='positron-notebook-cell-tag-add-icon' icon={Codicon.add} />
+					<Icon className='positron-notebook-cell-tag-add-icon' icon={Codicon.addSmall} />
 					<span className='positron-notebook-cell-tag-add-label'>
 						{localize('positron.notebook.cellTag.add', "Add tag")}
 					</span>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
+import { isHTMLInputElement } from '../../../../../base/browser/dom.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
@@ -44,6 +45,10 @@ function stopTagBarBubble(e: React.MouseEvent) {
  * On code cells this is embedded in the cell footer alongside the execution
  * status; markdown / raw cells (which have no footer) render it standalone at
  * the bottom of the cell.
+ *
+ * Keyboard-wise the bar is a toolbar-pattern composite widget: a single tab
+ * stop (the add control, which leads the row), with the arrow keys moving
+ * between the controls inside and Escape returning focus to the cell.
  */
 export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell; standalone?: boolean }) {
 	const { notificationService } = usePositronReactServicesContext();
@@ -51,6 +56,7 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 	const isAddingTag = useObservedValue(cell.isAddingTag);
 	const cellTagsHidden = useObservedValue(cell.cellTagsHidden);
 	const [editingTag, setEditingTag] = React.useState<string | null>(null);
+	const barRef = React.useRef<HTMLDivElement>(null);
 
 	// The notebook can hide all cell tags (a transient, per-notebook toggle).
 	if (cellTagsHidden) {
@@ -94,12 +100,91 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 		notifyTagResult(notificationService, cell.addTag(raw), raw.trim());
 	};
 
+	// The bar is a composite widget with a single tab stop (the add control,
+	// tabIndex 0); everything else is tabIndex -1 and reached with the arrow
+	// keys, per the WAI-ARIA toolbar pattern. This keeps a long tag list from
+	// adding a tab stop per tag for keyboard users traversing the notebook.
+	const handleBarKeyDown = (e: React.KeyboardEvent) => {
+		// The inline tag input handles (and stops) its own keys.
+		if (isHTMLInputElement(e.target)) {
+			return;
+		}
+		switch (e.key) {
+			case 'ArrowRight':
+			case 'ArrowLeft':
+			case 'Home':
+			case 'End': {
+				// Move focus within the bar instead of letting the notebook's
+				// command-mode keybindings move the cell selection.
+				e.preventDefault();
+				e.stopPropagation();
+				// eslint-disable-next-line no-restricted-syntax -- enumerating the bar's own buttons in DOM order for roving focus, not reaching into structure via a fragile selector
+				const buttons = Array.from(barRef.current?.querySelectorAll('button') ?? []);
+				if (buttons.length === 0) {
+					return;
+				}
+				const current = buttons.indexOf(e.target as HTMLButtonElement);
+				const next =
+					e.key === 'Home' ? 0 :
+						e.key === 'End' ? buttons.length - 1 :
+							// Wrap around at the ends.
+							(current + (e.key === 'ArrowRight' ? 1 : -1) + buttons.length) % buttons.length;
+				buttons[next].focus();
+				break;
+			}
+			case 'Enter':
+			case ' ': {
+				// Let the focused button's native activation run, but keep the
+				// key from reaching the notebook's command-mode keybindings --
+				// Enter would otherwise put the cell into edit mode on top of
+				// the tag action.
+				e.stopPropagation();
+				break;
+			}
+			case 'Escape': {
+				// Hand focus back to the cell so notebook-level navigation resumes.
+				e.preventDefault();
+				e.stopPropagation();
+				cell.container?.focus({ preventScroll: true });
+				break;
+			}
+		}
+	};
+
 	return (
 		<div
+			ref={barRef}
+			aria-label={localize('positron.notebook.cellTag.toolbar', "Cell tags")}
 			className={positronClassNames('positron-notebook-cell-tags', { standalone })}
 			data-testid='cell-tags-bar'
+			role='toolbar'
+			onKeyDown={handleBarKeyDown}
 			onMouseDown={stopTagBarBubble}
 		>
+			{isAddingTag ? (
+				<TagInput
+					initialValue=''
+					onCancel={() => cell.endAddTag()}
+					onCommit={commitAdd}
+				/>
+			) : (
+				<button
+					aria-label={localize('positron.notebook.cellTag.add', "Add tag")}
+					className='positron-notebook-cell-tag-add'
+					// The bar's single tab stop; the tags that follow are
+					// reached with the arrow keys (see handleBarKeyDown).
+					tabIndex={0}
+					title={localize('positron.notebook.cellTag.add', "Add tag")}
+					type='button'
+					onClick={(e) => { stopTagBarPointer(e); cell.beginAddTag(); }}
+					onMouseDown={stopTagBarPointer}
+				>
+					<Icon className='positron-notebook-cell-tag-add-icon' icon={Codicon.addSmall} />
+					<span className='positron-notebook-cell-tag-add-label'>
+						{localize('positron.notebook.cellTag.add', "Add tag")}
+					</span>
+				</button>
+			)}
 			{tags.map((tag) =>
 				editingTag === tag ? (
 					// The edit target is tracked by tag value (the cell model
@@ -119,46 +204,27 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 						<button
 							aria-label={localize('positron.notebook.cellTag.edit', "Edit tag {0}", tag)}
 							className='positron-notebook-cell-tag-label'
+							tabIndex={-1}
 							title={localize('positron.notebook.cellTag.editHint', "Click to edit tag")}
 							type='button'
-							onMouseDown={stopTagBarPointer}
 							onClick={(e) => { stopTagBarPointer(e); setEditingTag(tag); }}
+							onMouseDown={stopTagBarPointer}
 						>
 							{tag}
 						</button>
 						<button
 							aria-label={localize('positron.notebook.cellTag.remove', "Remove tag {0}", tag)}
 							className='positron-notebook-cell-tag-remove'
+							tabIndex={-1}
 							title={localize('positron.notebook.cellTag.remove', "Remove tag {0}", tag)}
 							type='button'
-							onMouseDown={stopTagBarPointer}
 							onClick={(e) => { stopTagBarPointer(e); removeTag(tag); }}
+							onMouseDown={stopTagBarPointer}
 						>
 							<Icon className='positron-notebook-cell-tag-icon' icon={Codicon.close} />
 						</button>
 					</span>
 				)
-			)}
-			{isAddingTag ? (
-				<TagInput
-					initialValue=''
-					onCancel={() => cell.endAddTag()}
-					onCommit={commitAdd}
-				/>
-			) : (
-				<button
-					aria-label={localize('positron.notebook.cellTag.add', "Add tag")}
-					className='positron-notebook-cell-tag-add'
-					title={localize('positron.notebook.cellTag.add', "Add tag")}
-					type='button'
-					onMouseDown={stopTagBarPointer}
-					onClick={(e) => { stopTagBarPointer(e); cell.beginAddTag(); }}
-				>
-					<Icon className='positron-notebook-cell-tag-add-icon' icon={Codicon.addSmall} />
-					<span className='positron-notebook-cell-tag-add-label'>
-						{localize('positron.notebook.cellTag.add', "Add tag")}
-					</span>
-				</button>
 			)}
 		</div>
 	);
@@ -190,7 +256,6 @@ function TagInput({ initialValue, onCommit, onCancel }: {
 			value={value}
 			onBlur={() => onCommit(value)}
 			onChange={(e) => setValue(e.target.value)}
-			onMouseDown={stopTagBarBubble}
 			onClick={stopTagBarBubble}
 			// Stop keystrokes from reaching the notebook's command-mode handlers.
 			onKeyDown={(e) => {
@@ -203,6 +268,7 @@ function TagInput({ initialValue, onCommit, onCancel }: {
 				}
 				e.stopPropagation();
 			}}
+			onMouseDown={stopTagBarBubble}
 		/>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -126,7 +126,10 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 					type='button'
 					onClick={(e) => { stopCellSelection(e); setAdding(true); }}
 				>
-					<Icon className='positron-notebook-cell-tag-icon' icon={Codicon.add} />
+					<Icon className='positron-notebook-cell-tag-add-icon' icon={Codicon.add} />
+					<span className='positron-notebook-cell-tag-add-label'>
+						{localize('positron.notebook.cellTag.add', "Add tag")}
+					</span>
 				</button>
 			)}
 		</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -55,19 +55,14 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 	const { notificationService } = usePositronReactServicesContext();
 	const tags = useObservedValue(cell.tags);
 	const isAddingTag = useObservedValue(cell.isAddingTag);
-	const cellTagsHidden = useObservedValue(cell.cellTagsHidden);
+	const tagUIVisible = useObservedValue(cell.tagUIVisible);
 	const [editingTag, setEditingTag] = React.useState<string | null>(null);
 	const barRef = React.useRef<HTMLDivElement>(null);
 
-	// The notebook can hide all cell tags (a transient, per-notebook toggle).
-	if (cellTagsHidden) {
-		return null;
-	}
-
-	// Nothing to show unless the cell has a tag or a tag-add was requested (via
-	// the command or the hover add pill). The passive add pill only appears once
-	// the first tag exists; tag-add requests open the inline input below.
-	if (tags.length === 0 && !isAddingTag) {
+	// The cell owns the visibility predicate: nothing to show unless the cell has
+	// a tag or a tag-add was requested (via the command or the hover add pill),
+	// and the notebook can hide all cell tags (a transient, per-notebook toggle).
+	if (!tagUIVisible) {
 		return null;
 	}
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -28,9 +28,11 @@ function stopCellSelection(e: React.MouseEvent) {
 /**
  * Renders the tag pills for a cell along with inline add / edit affordances.
  *
- * Renders nothing until the cell has at least one tag -- by design, the add
- * affordance only appears once the first tag exists. The first tag is added
- * via the "Add Tag" command (right-click menu / command palette).
+ * Renders nothing until the cell has at least one tag or a tag-add has been
+ * requested. The passive add affordance (a pill revealed on hover) only appears
+ * once the first tag exists; the first tag is added through the "Add Tag" command
+ * (right-click menu / command palette), which opens the inline input by flipping
+ * the cell's `isAddingTag` signal.
  *
  * On code cells this is embedded in the cell footer alongside the execution
  * status; markdown / raw cells (which have no footer) render it standalone at
@@ -39,11 +41,13 @@ function stopCellSelection(e: React.MouseEvent) {
 export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell; standalone?: boolean }) {
 	const { notificationService } = usePositronReactServicesContext();
 	const tags = useObservedValue(cell.tags);
+	const isAddingTag = useObservedValue(cell.isAddingTag);
 	const [editingTag, setEditingTag] = React.useState<string | null>(null);
-	const [adding, setAdding] = React.useState(false);
 
-	// No tags -> no UI at all (including the add affordance).
-	if (tags.length === 0) {
+	// Nothing to show unless the cell has a tag or a tag-add was requested (via
+	// the command or the hover add pill). The passive add pill only appears once
+	// the first tag exists; tag-add requests open the inline input below.
+	if (tags.length === 0 && !isAddingTag) {
 		return null;
 	}
 
@@ -67,7 +71,7 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 	};
 
 	const commitAdd = (raw: string) => {
-		setAdding(false);
+		cell.endAddTag();
 		// The cell enforces trim / empty / duplicate handling and reports the
 		// outcome; surface a toast so a rejected input doesn't vanish silently.
 		notifyTagResult(notificationService, cell.addTag(raw), raw.trim());
@@ -112,10 +116,10 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 					</span>
 				)
 			)}
-			{adding ? (
+			{isAddingTag ? (
 				<TagInput
 					initialValue=''
-					onCancel={() => setAdding(false)}
+					onCancel={() => cell.endAddTag()}
 					onCommit={commitAdd}
 				/>
 			) : (
@@ -124,7 +128,7 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 					className='positron-notebook-cell-tag-add'
 					title={localize('positron.notebook.cellTag.add', "Add tag")}
 					type='button'
-					onClick={(e) => { stopCellSelection(e); setAdding(true); }}
+					onClick={(e) => { stopCellSelection(e); cell.beginAddTag(); }}
 				>
 					<Icon className='positron-notebook-cell-tag-add-icon' icon={Codicon.add} />
 					<span className='positron-notebook-cell-tag-add-label'>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -97,7 +97,8 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 		<div className={positronClassNames('positron-notebook-cell-tags', { standalone })} data-testid='cell-tags-bar'>
 			{tags.map((tag) =>
 				editingTag === tag ? (
-					// The edit target is tracked by tag value (tags are unique), not by
+					// The edit target is tracked by tag value (the cell model
+					// de-duplicates tags on read, so values are unique), not by
 					// position, so a tag-list change while an input is open can't shift
 					// the open input onto a different pill. Keys are the tag value for
 					// the same reason. The `edit-` prefix differs from the display key

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -1,0 +1,185 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './CellTagsBar.css';
+
+// React.
+import React from 'react';
+
+// Other dependencies.
+import { localize } from '../../../../../nls.js';
+import { Codicon } from '../../../../../base/common/codicons.js';
+import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
+import { Icon } from '../../../../../platform/positronActionBar/browser/components/icon.js';
+import { IPositronNotebookCell } from '../PositronNotebookCells/IPositronNotebookCell.js';
+import { useObservedValue } from '../useObservedValue.js';
+
+// Tag-bar clicks must not bubble to the cell wrapper's selection handler, which
+// would re-focus the cell container and blur an open tag input.
+function stopCellSelection(e: React.MouseEvent) {
+	e.stopPropagation();
+}
+
+/**
+ * Renders the tag pills for a cell along with inline add / edit affordances.
+ *
+ * Renders nothing until the cell has at least one tag -- by design, the add
+ * affordance only appears once the first tag exists. The first tag is added
+ * via the "Add Tag" command (right-click menu / command palette).
+ *
+ * On code cells this is embedded in the cell footer alongside the execution
+ * status; markdown / raw cells (which have no footer) render it standalone at
+ * the bottom of the cell.
+ */
+export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell; standalone?: boolean }) {
+	const { notificationService } = usePositronReactServicesContext();
+	const tags = useObservedValue(cell.tags);
+	const [editingIndex, setEditingIndex] = React.useState<number | null>(null);
+	const [adding, setAdding] = React.useState(false);
+
+	// No tags -> no UI at all (including the add affordance).
+	if (tags.length === 0) {
+		return null;
+	}
+
+	const notifyDuplicate = (tag: string) => {
+		notificationService.info(
+			localize('positron.notebook.cellTag.duplicate', "Tag '{0}' is already on this cell.", tag)
+		);
+	};
+
+	const removeTag = (index: number) => {
+		cell.setTags(tags.filter((_, i) => i !== index));
+	};
+
+	const commitEdit = (index: number, raw: string) => {
+		setEditingIndex(null);
+		const value = raw.trim();
+		if (!value) {
+			removeTag(index);
+			return;
+		}
+		// Renaming onto an existing tag is rejected; tell the user why rather
+		// than silently reverting.
+		if (tags.some((t, i) => i !== index && t === value)) {
+			notifyDuplicate(value);
+			return;
+		}
+		const next = [...tags];
+		next[index] = value;
+		cell.setTags(next);
+	};
+
+	const commitAdd = (raw: string) => {
+		setAdding(false);
+		const value = raw.trim();
+		// The cell enforces trim / empty / duplicate handling; surface a toast
+		// when the tag already exists so the committed input doesn't just vanish.
+		if (cell.addTag(value) === 'duplicate') {
+			notifyDuplicate(value);
+		}
+	};
+
+	return (
+		<div className={positronClassNames('positron-notebook-cell-tags', { standalone })} data-testid='cell-tags-bar'>
+			{tags.map((tag, index) =>
+				editingIndex === index ? (
+					// Keys are the tag value (tags are unique), so a mid-list removal
+					// doesn't re-key surviving pills by position and misassociate an
+					// open input. The `edit-` prefix differs from the display key so
+					// switching modes remounts TagInput (re-running its focus effect).
+					<TagInput
+						key={`edit-${tag}`}
+						initialValue={tag}
+						onCancel={() => setEditingIndex(null)}
+						onCommit={(value) => commitEdit(index, value)}
+					/>
+				) : (
+					<span key={tag} className='positron-notebook-cell-tag'>
+						<button
+							aria-label={localize('positron.notebook.cellTag.edit', "Edit tag {0}", tag)}
+							className='positron-notebook-cell-tag-label'
+							title={localize('positron.notebook.cellTag.editHint', "Click to edit tag")}
+							type='button'
+							onClick={(e) => { stopCellSelection(e); setEditingIndex(index); }}
+						>
+							{tag}
+						</button>
+						<button
+							aria-label={localize('positron.notebook.cellTag.remove', "Remove tag {0}", tag)}
+							className='positron-notebook-cell-tag-remove'
+							title={localize('positron.notebook.cellTag.remove', "Remove tag {0}", tag)}
+							type='button'
+							onClick={(e) => { stopCellSelection(e); removeTag(index); }}
+						>
+							<Icon className='positron-notebook-cell-tag-icon' icon={Codicon.close} />
+						</button>
+					</span>
+				)
+			)}
+			{adding ? (
+				<TagInput
+					initialValue=''
+					onCancel={() => setAdding(false)}
+					onCommit={commitAdd}
+				/>
+			) : (
+				<button
+					aria-label={localize('positron.notebook.cellTag.add', "Add tag")}
+					className='positron-notebook-cell-tag-add'
+					title={localize('positron.notebook.cellTag.add', "Add tag")}
+					type='button'
+					onClick={(e) => { stopCellSelection(e); setAdding(true); }}
+				>
+					<Icon className='positron-notebook-cell-tag-icon' icon={Codicon.add} />
+				</button>
+			)}
+		</div>
+	);
+}
+
+/**
+ * A small inline text input used for both adding a new tag and editing an
+ * existing one. Commits on Enter or blur; cancels on Escape.
+ */
+function TagInput({ initialValue, onCommit, onCancel }: {
+	initialValue: string;
+	onCommit: (value: string) => void;
+	onCancel: () => void;
+}) {
+	const [value, setValue] = React.useState(initialValue);
+	const inputRef = React.useRef<HTMLInputElement>(null);
+
+	React.useEffect(() => {
+		inputRef.current?.focus();
+		inputRef.current?.select();
+	}, []);
+
+	return (
+		<input
+			ref={inputRef}
+			className='positron-notebook-cell-tag-input'
+			placeholder={localize('positron.notebook.cellTag.placeholder', "tag")}
+			spellCheck={false}
+			value={value}
+			onBlur={() => onCommit(value)}
+			onChange={(e) => setValue(e.target.value)}
+			onClick={stopCellSelection}
+			// Stop keystrokes from reaching the notebook's command-mode handlers.
+			onKeyDown={(e) => {
+				if (e.key === 'Enter') {
+					e.preventDefault();
+					onCommit(value);
+				} else if (e.key === 'Escape') {
+					e.preventDefault();
+					onCancel();
+				}
+				e.stopPropagation();
+			}}
+		/>
+	);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellTagsBar.tsx
@@ -87,9 +87,15 @@ export function CellTagsBar({ cell, standalone }: { cell: IPositronNotebookCell;
 		setAdding(false);
 		const value = raw.trim();
 		// The cell enforces trim / empty / duplicate handling; surface a toast
-		// when the tag already exists so the committed input doesn't just vanish.
-		if (cell.addTag(value) === 'duplicate') {
+		// when the tag already exists (or the write failed) so the committed
+		// input doesn't just vanish without feedback.
+		const result = cell.addTag(value);
+		if (result === 'duplicate') {
 			notifyDuplicate(value);
+		} else if (result === 'failed') {
+			notificationService.info(
+				localize('positron.notebook.cellTag.addFailed', "Could not add tag '{0}'.", value)
+			);
 		}
 	};
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.css
@@ -106,11 +106,9 @@
 	background-color: var(--vscode-widget-border);
 }
 
-/* Vertical separator between the execution metadata and the tag row. Shares the
-1px widget-border look of the duration/timestamp separator above, but is a real
-flex item rather than a ::after pseudo-element because it divides two flex
-children of the footer (metadata vs tag bar) instead of two inline text spans.
-The two rules intentionally use different mechanisms -- don't merge them. */
+/* Vertical separator between the execution metadata and the tag bar. A real flex
+item (not a ::after like the duration separator above) since it divides two flex
+children rather than two inline text spans. */
 .code-cell-footer-tags-separator {
 	flex-shrink: 0;
 	width: 1px;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.css
@@ -8,9 +8,16 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	padding: 0px 1rem;
-	height: 24px;
+	box-sizing: border-box;
+	padding: 3px 1rem;
+	/* Auto height with a 24px floor: the tag bar wraps large tag sets onto
+	extra rows, so the footer grows with it. The vertical padding keeps wrapped
+	pills off the footer borders while a single row still totals 24px. */
+	min-height: 24px;
 	overflow: hidden;
+	/* Lets the height transition below animate from the auto height when
+	collapsing (no-op where unsupported; the collapse then snaps). */
+	interpolate-size: allow-keywords;
 
 	/* Visual separators from editor content above and outputs below */
 	border-top: 1px solid var(--vscode-widget-border);
@@ -28,12 +35,16 @@
 	cursor: default;
 
 	/* Animate expand/collapse */
-	transition: height 150ms ease-out, opacity 150ms ease-out,
+	transition: height 150ms ease-out, min-height 150ms ease-out,
+		padding 150ms ease-out, opacity 150ms ease-out,
 		border-top-width 150ms ease-out, border-bottom-width 150ms ease-out;
 }
 
 .positron-notebook-code-cell-footer.collapsed {
 	height: 0;
+	min-height: 0;
+	padding-top: 0;
+	padding-bottom: 0;
 	opacity: 0;
 	border-top-width: 0;
 	border-bottom-width: 0;

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.css
@@ -4,10 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 .positron-notebook-code-cell-footer {
-	/* Layout */
+	/* Layout: execution metadata on its own row with the tag bar stacked beneath,
+	so a wrapped tag set no longer crowds (and vertically off-centers) the metadata.
+	justify-content centers a lone metadata row (the common, tagless footer) within
+	the 24px floor; it is a no-op once both rows are present and fill the height. */
 	display: flex;
-	align-items: center;
-	gap: 8px;
+	flex-direction: column;
+	align-items: stretch;
+	justify-content: center;
+	gap: 4px;
 	box-sizing: border-box;
 	padding: 3px 1rem;
 	/* Auto height with a 24px floor: the tag bar wraps large tag sets onto
@@ -59,6 +64,14 @@
 /* Override inherited cursor from .positron-notebook class for children spans */
 .positron-notebook-code-cell-footer span {
 	cursor: default;
+}
+
+/* Execution metadata row (status icon + timing text). A horizontal flex row
+inside the column-stacked footer; preserves the original icon-to-text spacing. */
+.code-cell-footer-metadata {
+	display: flex;
+	align-items: center;
+	gap: 8px;
 }
 
 .code-cell-footer-icon {
@@ -114,15 +127,5 @@
 	top: 1px;
 	bottom: 1px;
 	width: 1px;
-	background-color: var(--vscode-widget-border);
-}
-
-/* Vertical separator between the execution metadata and the tag bar. A real flex
-item (not a ::after like the duration separator above) since it divides two flex
-children rather than two inline text spans. */
-.code-cell-footer-tags-separator {
-	flex-shrink: 0;
-	width: 1px;
-	height: 14px;
 	background-color: var(--vscode-widget-border);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.css
@@ -105,3 +105,15 @@
 	width: 1px;
 	background-color: var(--vscode-widget-border);
 }
+
+/* Vertical separator between the execution metadata and the tag row. Shares the
+1px widget-border look of the duration/timestamp separator above, but is a real
+flex item rather than a ::after pseudo-element because it divides two flex
+children of the footer (metadata vs tag bar) instead of two inline text spans.
+The two rules intentionally use different mechanisms -- don't merge them. */
+.code-cell-footer-tags-separator {
+	flex-shrink: 0;
+	width: 1px;
+	height: 14px;
+	background-color: var(--vscode-widget-border);
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
@@ -40,6 +40,7 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 	const executionStatus = useDebouncedObservedValue(cell.executionStatus, isRunningOrPending);
 	const tags = useObservedValue(cell.tags);
 	const isAddingTag = useObservedValue(cell.isAddingTag);
+	const cellTagsHidden = useObservedValue(cell.cellTagsHidden);
 	const executionOrder = useObservedValue(cell.lastExecutionOrder);
 	const duration = useDebouncedObservedValue(cell.lastExecutionDuration);
 	const lastRunEndTime = useDebouncedObservedValue(cell.lastRunEndTime);
@@ -98,9 +99,13 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 	// isPending guard keeps the clock icon visible for queued cells.
 	// Tags also keep the footer open, since they now live here.
 	const hasTags = tags.length > 0;
-	// An in-progress tag add keeps the footer open even on a cold cell, so the
-	// inline tag input the "Add Tag" command opens has somewhere to render.
-	const isCollapsed = !isPending && !hasCurrentSessionContent && !hasTags && !isAddingTag;
+	// When the notebook hides tags, the tag bar (and its inline add input) render
+	// nothing, so a hidden tag row no longer keeps the footer open or warrants a
+	// divider. An in-progress tag add otherwise keeps a cold cell's footer open so
+	// the input the "Add Tag" command opens has somewhere to render.
+	const hasVisibleTags = hasTags && !cellTagsHidden;
+	const isAddingVisible = isAddingTag && !cellTagsHidden;
+	const isCollapsed = !isPending && !hasCurrentSessionContent && !hasVisibleTags && !isAddingVisible;
 
 	const dataExecutionStatus = executionStatus || 'idle';
 
@@ -210,7 +215,7 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 		>
 			{renderIcon()}
 			{renderText()}
-			{hasMetadata && hasTags && <span aria-hidden='true' className='code-cell-footer-tags-separator' data-testid='cell-footer-tags-separator' />}
+			{hasMetadata && hasVisibleTags && <span aria-hidden='true' className='code-cell-footer-tags-separator' data-testid='cell-footer-tags-separator' />}
 			<CellTagsBar cell={cell} />
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
@@ -19,6 +19,7 @@ import { formatCellDuration, formatTimestamp, getRelativeTime, isMoreThanOneHour
 import { Icon } from '../../../../../platform/positronActionBar/browser/components/icon.js';
 import { Codicon } from '../../../../../base/common/codicons.js';
 import { positronClassNames } from '../../../../../base/common/positronUtilities.js';
+import { CellTagsBar } from './CellTagsBar.js';
 
 interface CodeCellStatusFooterProps {
 	cell: PositronNotebookCodeCell;
@@ -37,6 +38,7 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 	// Debounce "clearing" transitions to prevent visual flash during fast re-executions.
 	// Only delay transitions to running/pending/undefined; new values propagate immediately.
 	const executionStatus = useDebouncedObservedValue(cell.executionStatus, isRunningOrPending);
+	const tags = useObservedValue(cell.tags);
 	const executionOrder = useObservedValue(cell.lastExecutionOrder);
 	const duration = useDebouncedObservedValue(cell.lastExecutionDuration);
 	const lastRunEndTime = useDebouncedObservedValue(cell.lastRunEndTime);
@@ -85,10 +87,17 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 
 	const isPending = executionStatus === 'pending';
 
+	// Whether the footer shows any execution metadata (icon and/or timing text)
+	// ahead of the tag row. Gates the divider so a tag-only footer (or the
+	// standalone markdown placement) doesn't render an orphan separator.
+	const hasMetadata = isCurrentlyRunning || isPending || hasTimingInfo;
+
 	// Collapse the footer when there's no execution info to display.
 	// This covers cells that have never been run and cells only run in a previous session.
 	// isPending guard keeps the clock icon visible for queued cells.
-	const isCollapsed = !isPending && !hasCurrentSessionContent;
+	// Tags also keep the footer open, since they now live here.
+	const hasTags = tags.length > 0;
+	const isCollapsed = !isPending && !hasCurrentSessionContent && !hasTags;
 
 	const dataExecutionStatus = executionStatus || 'idle';
 
@@ -198,6 +207,8 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 		>
 			{renderIcon()}
 			{renderText()}
+			{hasMetadata && hasTags && <span aria-hidden='true' className='code-cell-footer-tags-separator' data-testid='cell-footer-tags-separator' />}
+			<CellTagsBar cell={cell} />
 		</div>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
@@ -39,6 +39,7 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 	// Only delay transitions to running/pending/undefined; new values propagate immediately.
 	const executionStatus = useDebouncedObservedValue(cell.executionStatus, isRunningOrPending);
 	const tags = useObservedValue(cell.tags);
+	const isAddingTag = useObservedValue(cell.isAddingTag);
 	const executionOrder = useObservedValue(cell.lastExecutionOrder);
 	const duration = useDebouncedObservedValue(cell.lastExecutionDuration);
 	const lastRunEndTime = useDebouncedObservedValue(cell.lastRunEndTime);
@@ -97,7 +98,9 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 	// isPending guard keeps the clock icon visible for queued cells.
 	// Tags also keep the footer open, since they now live here.
 	const hasTags = tags.length > 0;
-	const isCollapsed = !isPending && !hasCurrentSessionContent && !hasTags;
+	// An in-progress tag add keeps the footer open even on a cold cell, so the
+	// inline tag input the "Add Tag" command opens has somewhere to render.
+	const isCollapsed = !isPending && !hasCurrentSessionContent && !hasTags && !isAddingTag;
 
 	const dataExecutionStatus = executionStatus || 'idle';
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
@@ -87,9 +87,9 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 
 	const isPending = executionStatus === 'pending';
 
-	// Whether the footer shows any execution metadata (icon and/or timing text)
-	// ahead of the tag row. Gates the divider so a tag-only footer doesn't render
-	// an orphan separator.
+	// Whether the footer shows any execution metadata (icon and/or timing text).
+	// Gates the metadata row so a tag-only footer doesn't render an empty row
+	// above the tags.
 	const hasMetadata = isCurrentlyRunning || isPending || hasTimingInfo;
 
 	// Collapse the footer when there's no execution info to display.
@@ -205,9 +205,12 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 			data-execution-status={dataExecutionStatus}
 			role='status'
 		>
-			{renderIcon()}
-			{renderText()}
-			{hasMetadata && tagUIVisible && <span aria-hidden='true' className='code-cell-footer-tags-separator' data-testid='cell-footer-tags-separator' />}
+			{hasMetadata &&
+				<div className='code-cell-footer-metadata' data-testid='cell-footer-metadata'>
+					{renderIcon()}
+					{renderText()}
+				</div>
+			}
 			<CellTagsBar cell={cell} />
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
@@ -38,9 +38,7 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 	// Debounce "clearing" transitions to prevent visual flash during fast re-executions.
 	// Only delay transitions to running/pending/undefined; new values propagate immediately.
 	const executionStatus = useDebouncedObservedValue(cell.executionStatus, isRunningOrPending);
-	const tags = useObservedValue(cell.tags);
-	const isAddingTag = useObservedValue(cell.isAddingTag);
-	const cellTagsHidden = useObservedValue(cell.cellTagsHidden);
+	const tagUIVisible = useObservedValue(cell.tagUIVisible);
 	const executionOrder = useObservedValue(cell.lastExecutionOrder);
 	const duration = useDebouncedObservedValue(cell.lastExecutionDuration);
 	const lastRunEndTime = useDebouncedObservedValue(cell.lastRunEndTime);
@@ -97,15 +95,9 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 	// Collapse the footer when there's no execution info to display.
 	// This covers cells that have never been run and cells only run in a previous session.
 	// isPending guard keeps the clock icon visible for queued cells.
-	// Tags also keep the footer open, since they now live here.
-	const hasTags = tags.length > 0;
-	// When the notebook hides tags, the tag bar (and its inline add input) render
-	// nothing, so a hidden tag row no longer keeps the footer open or warrants a
-	// divider. An in-progress tag add otherwise keeps a cold cell's footer open so
-	// the input the "Add Tag" command opens has somewhere to render.
-	const hasVisibleTags = hasTags && !cellTagsHidden;
-	const isAddingVisible = isAddingTag && !cellTagsHidden;
-	const isCollapsed = !isPending && !hasCurrentSessionContent && !hasVisibleTags && !isAddingVisible;
+	// A visible tag UI (tags or an in-progress add; the cell owns the predicate)
+	// also keeps the footer open, since the tag bar lives here.
+	const isCollapsed = !isPending && !hasCurrentSessionContent && !tagUIVisible;
 
 	const dataExecutionStatus = executionStatus || 'idle';
 
@@ -215,7 +207,7 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 		>
 			{renderIcon()}
 			{renderText()}
-			{hasMetadata && hasVisibleTags && <span aria-hidden='true' className='code-cell-footer-tags-separator' data-testid='cell-footer-tags-separator' />}
+			{hasMetadata && tagUIVisible && <span aria-hidden='true' className='code-cell-footer-tags-separator' data-testid='cell-footer-tags-separator' />}
 			<CellTagsBar cell={cell} />
 		</div>
 	);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
@@ -88,8 +88,8 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 	const isPending = executionStatus === 'pending';
 
 	// Whether the footer shows any execution metadata (icon and/or timing text)
-	// ahead of the tag row. Gates the divider so a tag-only footer (or the
-	// standalone markdown placement) doesn't render an orphan separator.
+	// ahead of the tag row. Gates the divider so a tag-only footer doesn't render
+	// an orphan separator.
 	const hasMetadata = isCurrentlyRunning || isPending || hasTimingInfo;
 
 	// Collapse the footer when there's no execution info to display.

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -160,7 +160,7 @@ focus indicator. Revert the selection border to avoid a doubled ring. */
 /*
  * NotebookCellWrapper focuses the cell container (tabIndex=0) when selected.
  * The workbench draws outline on [tabindex="0"]:focus, which wraps the whole cell
- * including standalone tags below markdown/raw content — a second ring on top of the
+ * including standalone tags below markdown/raw content -- a second ring on top of the
  * selection border on .positron-notebook-cell-outputs / editor-section.
  */
 .positron-notebook-editor .positron-notebook-cell.selected:focus,

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellSelection.css
@@ -156,6 +156,17 @@ focus indicator. Revert the selection border to avoid a doubled ring. */
 	border-color: var(--vscode-positronNotebook-cellBorder);
 }
 
+/* === Selected cell focus: suppress global workbench outline === */
+/*
+ * NotebookCellWrapper focuses the cell container (tabIndex=0) when selected.
+ * The workbench draws outline on [tabindex="0"]:focus, which wraps the whole cell
+ * including standalone tags below markdown/raw content — a second ring on top of the
+ * selection border on .positron-notebook-cell-outputs / editor-section.
+ */
+.positron-notebook-editor .positron-notebook-cell.selected:focus,
+.positron-notebook-editor .positron-notebook-cell.editing:focus {
+	outline: none;
+}
 
 /* === Inactive Notebook Pane: dim the cell focus border when the notebook does not have focus === */
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellWrapper.tsx
@@ -17,6 +17,7 @@ import { CellSelectionType, SelectionState } from '../selectionMachine.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { useObservedValue } from '../useObservedValue.js';
 import { NotebookCellActionBar } from './NotebookCellActionBar.js';
+import { CellTagsBar } from './CellTagsBar.js';
 import { CellProvider } from './CellProvider.js';
 import { ScreenReaderOnly } from '../../../../../base/browser/ui/positronComponents/ScreenReaderOnly.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
@@ -219,6 +220,9 @@ export function NotebookCellWrapper({ cell, children }: {
 			>
 				{children}
 			</NotebookErrorBoundary>
+			{/* Code cells render their tags inside the footer; markdown / raw cells */}
+			{/* have no footer, so they show tags standalone at the cell bottom. */}
+			{!cell.isCodeCell() && <CellTagsBar standalone cell={cell} />}
 		</CellProvider>
 		<ScreenReaderOnly>
 			{announcement}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/cellTagNotifications.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/cellTagNotifications.ts
@@ -8,9 +8,10 @@ import { INotificationService } from '../../../../../platform/notification/commo
 import { AddTagResult } from '../PositronNotebookCells/IPositronNotebookCell.js';
 
 /**
- * Surface user feedback for a tag write outcome ({@link AddTagResult}). Shared by
- * the inline tag bar and the "Add Tag" command so the result -> notification
- * mapping (and its localized strings) lives in one place.
+ * Surface user feedback for a tag write outcome ({@link AddTagResult}). Used by
+ * the inline tag bar's add / edit / remove paths so the result -> notification
+ * mapping (and its localized strings) lives in one place and is unit-testable in
+ * isolation.
  *
  * `'duplicate'` and `'failed'` show an info toast; `'added'` is silent -- a
  * successful write (or a blank no-op input) needs no toast.

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/cellTagNotifications.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/cellTagNotifications.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../../nls.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { AddTagResult } from '../PositronNotebookCells/IPositronNotebookCell.js';
+
+/**
+ * Surface user feedback for a tag write outcome ({@link AddTagResult}). Shared by
+ * the inline tag bar and the "Add Tag" command so the result -> notification
+ * mapping (and its localized strings) lives in one place.
+ *
+ * `'duplicate'` and `'failed'` show an info toast; `'added'` and `'empty'` are
+ * silent -- a successful write needs no toast, and a blank input just closes.
+ */
+export function notifyTagResult(notificationService: INotificationService, result: AddTagResult, tag: string): void {
+	if (result === 'duplicate') {
+		notificationService.info(
+			localize('positron.notebook.cellTag.duplicate', "Tag '{0}' is already on this cell.", tag)
+		);
+	} else if (result === 'failed') {
+		notificationService.info(
+			localize('positron.notebook.cellTag.writeFailed', "Could not update the cell's tags.")
+		);
+	}
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/cellTagNotifications.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/cellTagNotifications.ts
@@ -5,18 +5,18 @@
 
 import { localize } from '../../../../../nls.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
-import { AddTagResult } from '../PositronNotebookCells/IPositronNotebookCell.js';
+import { TagWriteResult } from '../PositronNotebookCells/IPositronNotebookCell.js';
 
 /**
- * Surface user feedback for a tag write outcome ({@link AddTagResult}). Used by
+ * Surface user feedback for a tag write outcome ({@link TagWriteResult}). Used by
  * the inline tag bar's add / edit / remove paths so the result -> notification
  * mapping (and its localized strings) lives in one place and is unit-testable in
  * isolation.
  *
- * `'duplicate'` and `'failed'` show an info toast; `'added'` is silent -- a
- * successful write (or a blank no-op input) needs no toast.
+ * `'duplicate'` and `'failed'` show an info toast; `'ok'` is silent -- the
+ * desired state holds, so there is nothing to surface.
  */
-export function notifyTagResult(notificationService: INotificationService, result: AddTagResult, tag: string): void {
+export function notifyTagResult(notificationService: INotificationService, result: TagWriteResult, tag: string): void {
 	if (result === 'duplicate') {
 		notificationService.info(
 			localize('positron.notebook.cellTag.duplicate', "Tag '{0}' is already on this cell.", tag)

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/cellTagNotifications.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/cellTagNotifications.ts
@@ -12,8 +12,8 @@ import { AddTagResult } from '../PositronNotebookCells/IPositronNotebookCell.js'
  * the inline tag bar and the "Add Tag" command so the result -> notification
  * mapping (and its localized strings) lives in one place.
  *
- * `'duplicate'` and `'failed'` show an info toast; `'added'` and `'empty'` are
- * silent -- a successful write needs no toast, and a blank input just closes.
+ * `'duplicate'` and `'failed'` show an info toast; `'added'` is silent -- a
+ * successful write (or a blank no-op input) needs no toast.
  */
 export function notifyTagResult(notificationService: INotificationService, result: AddTagResult, tag: string): void {
 	if (result === 'duplicate') {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -681,9 +681,9 @@ export class AddTagAction extends NotebookAction2 {
 		const notificationService = accessor.get(INotificationService);
 
 		const state = notebook.selectionStateMachine.state.get();
-		// Prefer the active cell; fall back to the first selected cell so the
-		// command works from the palette/action bar without a single active cell.
-		const cell = getActiveCell(state) ?? getSelectedCells(state)[0];
+		// Every selection state except NoCells has an active cell, and NoCells has
+		// no selection either, so the active cell is the only target to consider.
+		const cell = getActiveCell(state);
 		if (!cell) {
 			notificationService.info(
 				localize('positron.notebook.cellTag.noCell', "Select a cell to add a tag.")

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -650,7 +650,7 @@ KeybindingsRegistry.registerKeybindingRule({
 // Add Tag - prompts for a tag name and appends it to the active cell's tags.
 // This is the entry point for the first tag; once a cell has tags, further
 // tags can be added inline via the tag bar's "+" affordance.
-registerAction2(class extends NotebookAction2 {
+export class AddTagAction extends NotebookAction2 {
 	constructor() {
 		super({
 			id: 'positronNotebook.cell.addTag',
@@ -704,15 +704,22 @@ registerAction2(class extends NotebookAction2 {
 		});
 
 		// The cell enforces trim / empty / duplicate handling; surface a toast
-		// when the tag already exists so the user knows nothing was added.
+		// when the tag already exists (or the write failed) so the user knows
+		// nothing was added.
 		const value = (tag ?? '').trim();
-		if (cell.addTag(value) === 'duplicate') {
+		const result = cell.addTag(value);
+		if (result === 'duplicate') {
 			notificationService.info(
 				localize('positron.notebook.cellTag.duplicate', "Tag '{0}' is already on this cell.", value)
 			);
+		} else if (result === 'failed') {
+			notificationService.info(
+				localize('positron.notebook.cellTag.addFailed', "Could not add tag '{0}'.", value)
+			);
 		}
 	}
-});
+}
+registerAction2(AddTagAction);
 
 registerAction2(class extends NotebookAction2 {
 	constructor() {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -660,7 +660,11 @@ export class AddTagAction extends NotebookAction2 {
 			// Don't refocus the cell before running -- we're about to open the inline
 			// tag input and want it to keep focus.
 			grabFocusOnRun: false,
-			precondition: NotebookContextKeys.editorFocused,
+			// Gate on the active editor, not editor focus: right-clicking rendered
+			// markdown content doesn't move DOM focus into the notebook container,
+			// so a focus-based precondition would show these disabled in the
+			// markdown cell context menu.
+			precondition: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
 			menu: [{
 				// The cell action bar "..." submenu -- the only general cell menu
 				// available on code cells (their right-click menu is output-only).
@@ -708,7 +712,7 @@ export class ToggleCellTagsAction extends NotebookAction2 {
 			title: localize2('positronNotebook.toggleCellTags', "Toggle Cell Tag Visibility"),
 			category: POSITRON_NOTEBOOK_CATEGORY,
 			f1: true,
-			precondition: NotebookContextKeys.editorFocused,
+			precondition: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
 			menu: [{
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
 				group: PositronNotebookCellActionGroup.Tags,
@@ -734,7 +738,7 @@ export class RemoveAllCellTagsAction extends NotebookAction2 {
 			title: localize2('positronNotebook.removeAllCellTags', "Remove All Cell Tags"),
 			category: POSITRON_NOTEBOOK_CATEGORY,
 			f1: true,
-			precondition: NotebookContextKeys.editorFocused,
+			precondition: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
 			menu: [{
 				id: MenuId.PositronNotebookCellActionBarSubmenu,
 				group: PositronNotebookCellActionGroup.Tags,

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -698,6 +698,33 @@ export class AddTagAction extends NotebookAction2 {
 }
 registerAction2(AddTagAction);
 
+// Toggle Cell Tag Visibility - hides or shows all cell tags across the notebook.
+// Transient per-notebook view state (see IPositronNotebookInstance.cellTagsHidden);
+// not persisted, so reopening the notebook shows tags again.
+export class ToggleCellTagsAction extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.toggleCellTags',
+			title: localize2('positronNotebook.toggleCellTags', "Toggle Cell Tag Visibility"),
+			category: POSITRON_NOTEBOOK_CATEGORY,
+			f1: true,
+			precondition: NotebookContextKeys.editorFocused,
+			menu: [{
+				id: MenuId.PositronNotebookCellActionBarSubmenu,
+				group: PositronNotebookCellActionGroup.Tags,
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Tags,
+			}]
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance) {
+		notebook.toggleCellTagsHidden();
+	}
+}
+registerAction2(ToggleCellTagsAction);
+
 registerAction2(class extends NotebookAction2 {
 	constructor() {
 		super({

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -13,13 +13,13 @@ import './contrib/outline/positronNotebookOutline.contribution.js';
 import './notebookCells/InlineDataExplorerActions.js';
 import './SelectPositronNotebookKernelAction.js';
 import './contrib/visualize/VisualizeAction.js';
+import './contrib/cellTags/actions.js';
 
 import { copyImageToClipboard, isCopyImageMenuArg } from './copyImageUtils.js';
 import { isCopyJsonMenuArg, serializeJsonOutput } from './copyJsonUtils.js';
 import { getPlainTextOutputContent, isParsedTextOutput } from './getOutputContents.js';
 import { getActiveWindow, isEditableElement, isHTMLElement } from '../../../../base/browser/dom.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { timeout } from '../../../../base/common/async.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize, localize2 } from '../../../../nls.js';
@@ -55,7 +55,7 @@ import { bindContextKey } from '../../../../platform/observable/common/platformO
 import { IPositronNotebookService } from './positronNotebookService.js';
 import { IPYNB_VIEW_TYPE } from '../../notebook/browser/notebookBrowser.js';
 import { IPositronNotebookEditorOptions } from './positronNotebookEditorTypes.js';
-import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID, PositronNotebookActionId, PositronNotebookCellActionBarLeftGroup, PositronNotebookCellOutputActionGroup, usingPositronNotebooks } from '../common/positronNotebookCommon.js';
+import { POSITRON_EXECUTE_CELL_COMMAND_ID, POSITRON_NOTEBOOK_CATEGORY, POSITRON_NOTEBOOK_EDITOR_ID, POSITRON_NOTEBOOK_EDITOR_INPUT_ID, PositronNotebookActionId, PositronNotebookCellActionBarLeftGroup, PositronNotebookCellActionGroup, PositronNotebookCellOutputActionGroup, usingPositronNotebooks } from '../common/positronNotebookCommon.js';
 import { getActiveCell, getSelectedCells, SelectionState } from './selectionMachine.js';
 import { CellContextKeys } from '../common/cellContextKeys.js';
 import { NotebookContextKeys } from '../common/notebookContextKeys.js';
@@ -89,18 +89,6 @@ export const POSITRON_NOTEBOOK_COMMAND_MODE = ContextKeyExpr.and(
 	CONTEXT_FIND_INPUT_FOCUSED.toNegated(),
 	CONTEXT_REPLACE_INPUT_FOCUSED.toNegated(),
 );
-
-const POSITRON_NOTEBOOK_CATEGORY = localize2('positronNotebook.category', 'Notebook');
-
-// Group IDs used to organize cell actions in menus and context menus
-enum PositronNotebookCellActionGroup {
-	Clipboard = '0_clipboard',
-	CellType = '1_celltype',
-	Insert = '2_insert',
-	Order = '3_order',
-	Execution = '4_execution',
-	Tags = '5_tags',
-}
 
 /**
  * Infer the notebook view type from a resource's file extension.
@@ -645,115 +633,6 @@ KeybindingsRegistry.registerKeybindingRule({
 // Register delete command with UI in one call
 // For built-in commands, we don't need to manage the disposable since they live
 // for the lifetime of the application
-
-// Add Tag - opens the inline tag input on the active cell by flipping the cell's
-// isAddingTag signal (the tag bar reacts by showing a focused input). This is the
-// entry point for the first tag; once a cell has tags, the bar's hover add pill
-// adds further tags.
-export class AddTagAction extends NotebookAction2 {
-	constructor() {
-		super({
-			id: 'positronNotebook.cell.addTag',
-			title: localize2('positronNotebook.cell.addTag', "Add Tag"),
-			category: POSITRON_NOTEBOOK_CATEGORY,
-			f1: true,
-			// Don't refocus the cell before running -- we're about to open the inline
-			// tag input and want it to keep focus.
-			grabFocusOnRun: false,
-			// Gate on the active editor, not editor focus: right-clicking rendered
-			// markdown content doesn't move DOM focus into the notebook container,
-			// so a focus-based precondition would show these disabled in the
-			// markdown cell context menu.
-			precondition: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
-			menu: [{
-				// The cell action bar "..." submenu -- the only general cell menu
-				// available on code cells (their right-click menu is output-only).
-				id: MenuId.PositronNotebookCellActionBarSubmenu,
-				group: PositronNotebookCellActionGroup.Tags,
-			}, {
-				// Right-click menu -- currently wired up on markdown cells.
-				id: MenuId.PositronNotebookCellContext,
-				group: PositronNotebookCellActionGroup.Tags,
-			}]
-		});
-	}
-
-	override async runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
-		const notificationService = accessor.get(INotificationService);
-
-		const state = notebook.selectionStateMachine.state.get();
-		// Every selection state except NoCells has an active cell, and NoCells has
-		// no selection either, so the active cell is the only target to consider.
-		const cell = getActiveCell(state);
-		if (!cell) {
-			notificationService.info(
-				localize('positron.notebook.cellTag.noCell', "Select a cell to add a tag.")
-			);
-			return;
-		}
-
-		// The menu/palette that launched this command is still closing and will
-		// restore focus to the notebook cell. Wait a tick so that happens first,
-		// otherwise the cell refocus would steal focus from the inline tag input we
-		// are about to open (blur-committing it as empty before the user types).
-		await timeout(0);
-		cell.beginAddTag();
-	}
-}
-registerAction2(AddTagAction);
-
-// Toggle Cell Tag Visibility - hides or shows all cell tags across the notebook.
-// Transient per-notebook view state (see IPositronNotebookInstance.cellTagsHidden);
-// not persisted, so reopening the notebook shows tags again.
-export class ToggleCellTagsAction extends NotebookAction2 {
-	constructor() {
-		super({
-			id: 'positronNotebook.toggleCellTags',
-			title: localize2('positronNotebook.toggleCellTags', "Toggle Cell Tag Visibility"),
-			category: POSITRON_NOTEBOOK_CATEGORY,
-			f1: true,
-			precondition: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
-			menu: [{
-				id: MenuId.PositronNotebookCellActionBarSubmenu,
-				group: PositronNotebookCellActionGroup.Tags,
-			}, {
-				id: MenuId.PositronNotebookCellContext,
-				group: PositronNotebookCellActionGroup.Tags,
-			}]
-		});
-	}
-
-	override runNotebookAction(notebook: IPositronNotebookInstance) {
-		notebook.toggleCellTagsHidden();
-	}
-}
-registerAction2(ToggleCellTagsAction);
-
-// Remove All Cell Tags - clears every tag from every cell in the notebook in a
-// single undoable edit.
-export class RemoveAllCellTagsAction extends NotebookAction2 {
-	constructor() {
-		super({
-			id: 'positronNotebook.removeAllCellTags',
-			title: localize2('positronNotebook.removeAllCellTags', "Remove All Cell Tags"),
-			category: POSITRON_NOTEBOOK_CATEGORY,
-			f1: true,
-			precondition: ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
-			menu: [{
-				id: MenuId.PositronNotebookCellActionBarSubmenu,
-				group: PositronNotebookCellActionGroup.Tags,
-			}, {
-				id: MenuId.PositronNotebookCellContext,
-				group: PositronNotebookCellActionGroup.Tags,
-			}]
-		});
-	}
-
-	override runNotebookAction(notebook: IPositronNotebookInstance) {
-		notebook.removeAllCellTags();
-	}
-}
-registerAction2(RemoveAllCellTagsAction);
 
 registerAction2(class extends NotebookAction2 {
 	constructor() {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -19,6 +19,7 @@ import { isCopyJsonMenuArg, serializeJsonOutput } from './copyJsonUtils.js';
 import { getPlainTextOutputContent, isParsedTextOutput } from './getOutputContents.js';
 import { getActiveWindow, isEditableElement, isHTMLElement } from '../../../../base/browser/dom.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
+import { timeout } from '../../../../base/common/async.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { URI } from '../../../../base/common/uri.js';
 import { localize, localize2 } from '../../../../nls.js';
@@ -66,6 +67,7 @@ import { KernelStatusBadge } from './KernelStatusBadge.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { UpdateNotebookWorkingDirectoryAction } from './UpdateNotebookWorkingDirectoryAction.js';
@@ -98,6 +100,7 @@ enum PositronNotebookCellActionGroup {
 	Insert = '2_insert',
 	Order = '3_order',
 	Execution = '4_execution',
+	Tags = '5_tags',
 }
 
 /**
@@ -643,6 +646,73 @@ KeybindingsRegistry.registerKeybindingRule({
 // Register delete command with UI in one call
 // For built-in commands, we don't need to manage the disposable since they live
 // for the lifetime of the application
+
+// Add Tag - prompts for a tag name and appends it to the active cell's tags.
+// This is the entry point for the first tag; once a cell has tags, further
+// tags can be added inline via the tag bar's "+" affordance.
+registerAction2(class extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.addTag',
+			title: localize2('positronNotebook.cell.addTag', "Add Tag"),
+			category: POSITRON_NOTEBOOK_CATEGORY,
+			f1: true,
+			// Don't refocus the cell before running -- we're about to open a quick
+			// input and want it to keep focus.
+			grabFocusOnRun: false,
+			precondition: NotebookContextKeys.editorFocused,
+			menu: [{
+				// The cell action bar "..." submenu -- the only general cell menu
+				// available on code cells (their right-click menu is output-only).
+				id: MenuId.PositronNotebookCellActionBarSubmenu,
+				group: PositronNotebookCellActionGroup.Tags,
+			}, {
+				// Right-click menu -- currently wired up on markdown cells.
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Tags,
+			}]
+		});
+	}
+
+	override async runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+		// Extract services up front; the accessor is only valid synchronously.
+		const quickInputService = accessor.get(IQuickInputService);
+		const notificationService = accessor.get(INotificationService);
+
+		const state = notebook.selectionStateMachine.state.get();
+		// Prefer the active cell; fall back to the first selected cell so the
+		// command works from the palette/action bar without a single active cell.
+		const cell = getActiveCell(state) ?? getSelectedCells(state)[0];
+		if (!cell) {
+			notificationService.info(
+				localize('positron.notebook.cellTag.noCell', "Select a cell to add a tag.")
+			);
+			return;
+		}
+
+		// The menu/palette that launched this command is still closing and will
+		// restore focus to the notebook cell. Wait a tick so that happens first,
+		// otherwise it steals focus from the quick input and dismisses it.
+		await timeout(0);
+
+		const tag = await quickInputService.input({
+			prompt: localize('positron.notebook.cellTag.prompt', "Tag name"),
+			placeHolder: localize('positron.notebook.cellTag.placeholder', "tag"),
+			// Belt and suspenders: if focus is still stolen momentarily, don't
+			// auto-dismiss the input.
+			ignoreFocusLost: true,
+		});
+
+		// The cell enforces trim / empty / duplicate handling; surface a toast
+		// when the tag already exists so the user knows nothing was added.
+		const value = (tag ?? '').trim();
+		if (cell.addTag(value) === 'duplicate') {
+			notificationService.info(
+				localize('positron.notebook.cellTag.duplicate', "Tag '{0}' is already on this cell.", value)
+			);
+		}
+	}
+});
 
 registerAction2(class extends NotebookAction2 {
 	constructor() {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -67,13 +67,11 @@ import { KernelStatusBadge } from './KernelStatusBadge.js';
 import { KeybindingsRegistry, KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
-import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { UpdateNotebookWorkingDirectoryAction } from './UpdateNotebookWorkingDirectoryAction.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
 import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
-import { notifyTagResult } from './notebookCells/cellTagNotifications.js';
 import { PositronNotebookPromptContribution } from './positronNotebookPrompt.js';
 import { ActiveNotebookHasRunningRuntime } from '../../runtimeNotebookKernel/common/activeRuntimeNotebookContextManager.js';
 import { NOTEBOOK_HAS_SOMETHING_RUNNING } from '../../notebook/common/notebookContextKeys.js';
@@ -648,9 +646,10 @@ KeybindingsRegistry.registerKeybindingRule({
 // For built-in commands, we don't need to manage the disposable since they live
 // for the lifetime of the application
 
-// Add Tag - prompts for a tag name and appends it to the active cell's tags.
-// This is the entry point for the first tag; once a cell has tags, further
-// tags can be added inline via the tag bar's "+" affordance.
+// Add Tag - opens the inline tag input on the active cell by flipping the cell's
+// isAddingTag signal (the tag bar reacts by showing a focused input). This is the
+// entry point for the first tag; once a cell has tags, the bar's hover add pill
+// adds further tags.
 export class AddTagAction extends NotebookAction2 {
 	constructor() {
 		super({
@@ -658,8 +657,8 @@ export class AddTagAction extends NotebookAction2 {
 			title: localize2('positronNotebook.cell.addTag', "Add Tag"),
 			category: POSITRON_NOTEBOOK_CATEGORY,
 			f1: true,
-			// Don't refocus the cell before running -- we're about to open a quick
-			// input and want it to keep focus.
+			// Don't refocus the cell before running -- we're about to open the inline
+			// tag input and want it to keep focus.
 			grabFocusOnRun: false,
 			precondition: NotebookContextKeys.editorFocused,
 			menu: [{
@@ -676,8 +675,6 @@ export class AddTagAction extends NotebookAction2 {
 	}
 
 	override async runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
-		// Extract services up front; the accessor is only valid synchronously.
-		const quickInputService = accessor.get(IQuickInputService);
 		const notificationService = accessor.get(INotificationService);
 
 		const state = notebook.selectionStateMachine.state.get();
@@ -693,21 +690,10 @@ export class AddTagAction extends NotebookAction2 {
 
 		// The menu/palette that launched this command is still closing and will
 		// restore focus to the notebook cell. Wait a tick so that happens first,
-		// otherwise it steals focus from the quick input and dismisses it.
+		// otherwise the cell refocus would steal focus from the inline tag input we
+		// are about to open (blur-committing it as empty before the user types).
 		await timeout(0);
-
-		const tag = await quickInputService.input({
-			prompt: localize('positron.notebook.cellTag.prompt', "Tag name"),
-			placeHolder: localize('positron.notebook.cellTag.placeholder', "tag"),
-			// Belt and suspenders: if focus is still stolen momentarily, don't
-			// auto-dismiss the input.
-			ignoreFocusLost: true,
-		});
-
-		// The cell enforces trim / empty / duplicate handling and reports the
-		// outcome; surface a toast so the user knows when nothing was added.
-		const value = (tag ?? '').trim();
-		notifyTagResult(notificationService, cell.addTag(value), value);
+		cell.beginAddTag();
 	}
 }
 registerAction2(AddTagAction);

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -725,6 +725,32 @@ export class ToggleCellTagsAction extends NotebookAction2 {
 }
 registerAction2(ToggleCellTagsAction);
 
+// Remove All Cell Tags - clears every tag from every cell in the notebook in a
+// single undoable edit.
+export class RemoveAllCellTagsAction extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.removeAllCellTags',
+			title: localize2('positronNotebook.removeAllCellTags', "Remove All Cell Tags"),
+			category: POSITRON_NOTEBOOK_CATEGORY,
+			f1: true,
+			precondition: NotebookContextKeys.editorFocused,
+			menu: [{
+				id: MenuId.PositronNotebookCellActionBarSubmenu,
+				group: PositronNotebookCellActionGroup.Tags,
+			}, {
+				id: MenuId.PositronNotebookCellContext,
+				group: PositronNotebookCellActionGroup.Tags,
+			}]
+		});
+	}
+
+	override runNotebookAction(notebook: IPositronNotebookInstance) {
+		notebook.removeAllCellTags();
+	}
+}
+registerAction2(RemoveAllCellTagsAction);
+
 registerAction2(class extends NotebookAction2 {
 	constructor() {
 		super({

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -73,6 +73,7 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { UpdateNotebookWorkingDirectoryAction } from './UpdateNotebookWorkingDirectoryAction.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
 import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
+import { notifyTagResult } from './notebookCells/cellTagNotifications.js';
 import { PositronNotebookPromptContribution } from './positronNotebookPrompt.js';
 import { ActiveNotebookHasRunningRuntime } from '../../runtimeNotebookKernel/common/activeRuntimeNotebookContextManager.js';
 import { NOTEBOOK_HAS_SOMETHING_RUNNING } from '../../notebook/common/notebookContextKeys.js';
@@ -703,20 +704,10 @@ export class AddTagAction extends NotebookAction2 {
 			ignoreFocusLost: true,
 		});
 
-		// The cell enforces trim / empty / duplicate handling; surface a toast
-		// when the tag already exists (or the write failed) so the user knows
-		// nothing was added.
+		// The cell enforces trim / empty / duplicate handling and reports the
+		// outcome; surface a toast so the user knows when nothing was added.
 		const value = (tag ?? '').trim();
-		const result = cell.addTag(value);
-		if (result === 'duplicate') {
-			notificationService.info(
-				localize('positron.notebook.cellTag.duplicate', "Tag '{0}' is already on this cell.", value)
-			);
-		} else if (result === 'failed') {
-			notificationService.info(
-				localize('positron.notebook.cellTag.addFailed', "Could not add tag '{0}'.", value)
-			);
-		}
+		notifyTagResult(notificationService, cell.addTag(value), value);
 	}
 }
 registerAction2(AddTagAction);

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookCommon.ts
@@ -3,6 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { localize2 } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { POSITRON_NOTEBOOK_ENABLED_KEY } from './positronNotebookConfig.js';
 
@@ -21,6 +22,18 @@ export const SELECT_KERNEL_ID_POSITRON = 'positronNotebook.selectKernel';
  */
 export function usingPositronNotebooks(configurationService: IConfigurationService): boolean {
 	return configurationService.getValue<boolean>(POSITRON_NOTEBOOK_ENABLED_KEY);
+}
+
+export const POSITRON_NOTEBOOK_CATEGORY = localize2('positronNotebook.category', 'Notebook');
+
+// Group IDs used to organize cell actions in menus and context menus
+export enum PositronNotebookCellActionGroup {
+	Clipboard = '0_clipboard',
+	CellType = '1_celltype',
+	Insert = '2_insert',
+	Order = '3_order',
+	Execution = '4_execution',
+	Tags = '5_tags',
 }
 
 // Group IDs used to visually differentiate actions in the cell action bar

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/addTagCommand.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/addTagCommand.vitest.ts
@@ -51,18 +51,6 @@ describe('AddTagAction', () => {
 		return { accessor, info };
 	}
 
-	it('notifies the user when the typed tag is a duplicate', async () => {
-		const notebook = createLabelledTestNotebook(1, ctx);
-		const cell = notebook.cells.get()[0];
-		notebook.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
-		vi.spyOn(cell, 'addTag').mockReturnValue('duplicate');
-		const { accessor, info } = createAccessor('data');
-
-		await new TestableAddTagAction().testRun(notebook, accessor);
-
-		expect(info).toHaveBeenCalledWith(expect.stringContaining('data'));
-	});
-
 	it('adds the tag silently when the write succeeds', async () => {
 		const notebook = createLabelledTestNotebook(1, ctx);
 		const cell = notebook.cells.get()[0];

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/addTagCommand.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/addTagCommand.vitest.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { ServiceIdentifier, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
+import { INotificationService, NotificationMessage } from '../../../../../platform/notification/common/notification.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { IPositronNotebookInstance } from '../../browser/IPositronNotebookInstance.js';
+import { CellSelectionType } from '../../browser/selectionMachine.js';
+import { AddTagAction } from '../../browser/positronNotebook.contribution.js';
+import { createLabelledTestNotebook } from './testPositronNotebookInstance.js';
+
+/**
+ * Verifies the "Add Tag" command surfaces feedback for the non-write outcomes
+ * the cell model reports. The command body lives in `runNotebookAction`, so a
+ * test-only subclass exposes it without standing up an active editor pane.
+ */
+describe('AddTagAction', () => {
+	const ctx = createTestContainer().withNotebookEditorServices().build();
+
+	class TestableAddTagAction extends AddTagAction {
+		public testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+
+	/**
+	 * Builds an accessor whose quick input resolves to `typed`, returning the
+	 * notification spy so the test can assert what the command surfaced.
+	 */
+	function createAccessor(typed: string) {
+		const info = vi.fn<(message: NotificationMessage | NotificationMessage[]) => void>();
+		const quickInput = stubInterface<IQuickInputService>({ input: async () => typed });
+		const notifications = stubInterface<INotificationService>({ info });
+		const accessor: ServicesAccessor = {
+			get<T>(id: ServiceIdentifier<T>): T {
+				if (id === IQuickInputService) {
+					return quickInput as unknown as T;
+				}
+				if (id === INotificationService) {
+					return notifications as unknown as T;
+				}
+				throw new Error(`Unexpected service request: ${String(id)}`);
+			},
+		};
+		return { accessor, info };
+	}
+
+	it('notifies the user when the tag write fails', async () => {
+		const notebook = createLabelledTestNotebook(1, ctx);
+		const cell = notebook.cells.get()[0];
+		notebook.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
+		// 'failed' is the model's no-write outcome (detached cell / no text model);
+		// the command must surface it rather than dropping the typed tag silently.
+		vi.spyOn(cell, 'addTag').mockReturnValue('failed');
+		const { accessor, info } = createAccessor('oops');
+
+		await new TestableAddTagAction().testRun(notebook, accessor);
+
+		expect(info).toHaveBeenCalledWith(expect.stringContaining('oops'));
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/addTagCommand.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/addTagCommand.vitest.ts
@@ -11,7 +11,7 @@ import { createTestContainer } from '../../../../../test/vitest/positronTestCont
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { IPositronNotebookInstance } from '../../browser/IPositronNotebookInstance.js';
 import { CellSelectionType } from '../../browser/selectionMachine.js';
-import { AddTagAction } from '../../browser/positronNotebook.contribution.js';
+import { AddTagAction } from '../../browser/contrib/cellTags/actions.js';
 import { createLabelledTestNotebook } from './testPositronNotebookInstance.js';
 
 /**

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/addTagCommand.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/addTagCommand.vitest.ts
@@ -51,21 +51,6 @@ describe('AddTagAction', () => {
 		return { accessor, info };
 	}
 
-	it('notifies the user when the tag write fails', async () => {
-		const notebook = createLabelledTestNotebook(1, ctx);
-		const cell = notebook.cells.get()[0];
-		notebook.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
-		// 'failed' is the model's no-write outcome (detached cell / no text model);
-		// the command must surface it rather than dropping the typed tag silently.
-		vi.spyOn(cell, 'addTag').mockReturnValue('failed');
-		const { accessor, info } = createAccessor('oops');
-
-		await new TestableAddTagAction().testRun(notebook, accessor);
-
-		// The shared helper shows a generic write-failure toast (no tag value).
-		expect(info).toHaveBeenCalledWith(expect.stringContaining('Could not update'));
-	});
-
 	it('notifies the user when the typed tag is a duplicate', async () => {
 		const notebook = createLabelledTestNotebook(1, ctx);
 		const cell = notebook.cells.get()[0];

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/addTagCommand.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/addTagCommand.vitest.ts
@@ -62,6 +62,45 @@ describe('AddTagAction', () => {
 
 		await new TestableAddTagAction().testRun(notebook, accessor);
 
-		expect(info).toHaveBeenCalledWith(expect.stringContaining('oops'));
+		// The shared helper shows a generic write-failure toast (no tag value).
+		expect(info).toHaveBeenCalledWith(expect.stringContaining('Could not update'));
+	});
+
+	it('notifies the user when the typed tag is a duplicate', async () => {
+		const notebook = createLabelledTestNotebook(1, ctx);
+		const cell = notebook.cells.get()[0];
+		notebook.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
+		vi.spyOn(cell, 'addTag').mockReturnValue('duplicate');
+		const { accessor, info } = createAccessor('data');
+
+		await new TestableAddTagAction().testRun(notebook, accessor);
+
+		expect(info).toHaveBeenCalledWith(expect.stringContaining('data'));
+	});
+
+	it('adds the tag silently when the write succeeds', async () => {
+		const notebook = createLabelledTestNotebook(1, ctx);
+		const cell = notebook.cells.get()[0];
+		notebook.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
+		const addTag = vi.spyOn(cell, 'addTag').mockReturnValue('added');
+		const { accessor, info } = createAccessor('fresh');
+
+		await new TestableAddTagAction().testRun(notebook, accessor);
+
+		expect(addTag).toHaveBeenCalledWith('fresh');
+		// A successful add needs no toast.
+		expect(info).not.toHaveBeenCalled();
+	});
+
+	it('prompts the user to select a cell when none is selected', async () => {
+		// With no active or selected cell (an empty notebook) the command can't
+		// target anything, so it surfaces guidance instead of opening the quick
+		// input.
+		const notebook = createLabelledTestNotebook(0, ctx);
+		const { accessor, info } = createAccessor('ignored');
+
+		await new TestableAddTagAction().testRun(notebook, accessor);
+
+		expect(info).toHaveBeenCalledWith(expect.stringContaining('Select a cell'));
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/addTagCommand.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/addTagCommand.vitest.ts
@@ -6,7 +6,6 @@
 /// <reference types="vitest/globals" />
 
 import { ServiceIdentifier, ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
-import { IQuickInputService } from '../../../../../platform/quickinput/common/quickInput.js';
 import { INotificationService, NotificationMessage } from '../../../../../platform/notification/common/notification.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
@@ -16,9 +15,10 @@ import { AddTagAction } from '../../browser/positronNotebook.contribution.js';
 import { createLabelledTestNotebook } from './testPositronNotebookInstance.js';
 
 /**
- * Verifies the "Add Tag" command surfaces feedback for the non-write outcomes
- * the cell model reports. The command body lives in `runNotebookAction`, so a
- * test-only subclass exposes it without standing up an active editor pane.
+ * Verifies the "Add Tag" command opens the active cell's inline tag input (via
+ * the cell's `beginAddTag` signal) and surfaces guidance when there's no cell to
+ * target. The command body lives in `runNotebookAction`, so a test-only subclass
+ * exposes it without standing up an active editor pane.
  */
 describe('AddTagAction', () => {
 	const ctx = createTestContainer().withNotebookEditorServices().build();
@@ -30,18 +30,14 @@ describe('AddTagAction', () => {
 	}
 
 	/**
-	 * Builds an accessor whose quick input resolves to `typed`, returning the
-	 * notification spy so the test can assert what the command surfaced.
+	 * Builds an accessor exposing a notification spy so the test can assert what
+	 * the command surfaced.
 	 */
-	function createAccessor(typed: string) {
+	function createAccessor() {
 		const info = vi.fn<(message: NotificationMessage | NotificationMessage[]) => void>();
-		const quickInput = stubInterface<IQuickInputService>({ input: async () => typed });
 		const notifications = stubInterface<INotificationService>({ info });
 		const accessor: ServicesAccessor = {
 			get<T>(id: ServiceIdentifier<T>): T {
-				if (id === IQuickInputService) {
-					return quickInput as unknown as T;
-				}
 				if (id === INotificationService) {
 					return notifications as unknown as T;
 				}
@@ -51,26 +47,25 @@ describe('AddTagAction', () => {
 		return { accessor, info };
 	}
 
-	it('adds the tag silently when the write succeeds', async () => {
+	it('opens the inline tag input on the active cell', async () => {
 		const notebook = createLabelledTestNotebook(1, ctx);
 		const cell = notebook.cells.get()[0];
 		notebook.selectionStateMachine.selectCell(cell, CellSelectionType.Normal);
-		const addTag = vi.spyOn(cell, 'addTag').mockReturnValue('added');
-		const { accessor, info } = createAccessor('fresh');
+		const beginAddTag = vi.spyOn(cell, 'beginAddTag');
+		const { accessor, info } = createAccessor();
 
 		await new TestableAddTagAction().testRun(notebook, accessor);
 
-		expect(addTag).toHaveBeenCalledWith('fresh');
-		// A successful add needs no toast.
+		expect(beginAddTag).toHaveBeenCalled();
+		// Opening the input needs no toast.
 		expect(info).not.toHaveBeenCalled();
 	});
 
 	it('prompts the user to select a cell when none is selected', async () => {
 		// With no active or selected cell (an empty notebook) the command can't
-		// target anything, so it surfaces guidance instead of opening the quick
-		// input.
+		// target anything, so it surfaces guidance instead of opening the input.
 		const notebook = createLabelledTestNotebook(0, ctx);
-		const { accessor, info } = createAccessor('ignored');
+		const { accessor, info } = createAccessor();
 
 		await new TestableAddTagAction().testRun(notebook, accessor);
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCellTagCommands.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCellTagCommands.vitest.ts
@@ -6,9 +6,10 @@
 /// <reference types="vitest/globals" />
 
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { CellKind } from '../../../notebook/common/notebookCommon.js';
 import { IPositronNotebookInstance } from '../../browser/IPositronNotebookInstance.js';
-import { ToggleCellTagsAction } from '../../browser/positronNotebook.contribution.js';
-import { createLabelledTestNotebook } from './testPositronNotebookInstance.js';
+import { RemoveAllCellTagsAction, ToggleCellTagsAction } from '../../browser/positronNotebook.contribution.js';
+import { createLabelledTestNotebook, createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
 
 /**
  * Notebook-wide tag commands operate on the whole notebook rather than a single
@@ -33,5 +34,27 @@ describe('ToggleCellTagsAction', () => {
 		expect(notebook.cellTagsHidden.get()).toBe(true);
 		action.testRun(notebook);
 		expect(notebook.cellTagsHidden.get()).toBe(false);
+	});
+});
+
+describe('RemoveAllCellTagsAction', () => {
+	const ctx = createTestContainer().withNotebookEditorServices().build();
+
+	class TestableRemoveAllCellTagsAction extends RemoveAllCellTagsAction {
+		public testRun(notebook: IPositronNotebookInstance) {
+			return this.runNotebookAction(notebook);
+		}
+	}
+
+	it('clears tags from every cell in the notebook', () => {
+		const notebook = createTestPositronNotebookInstance([
+			['a', 'python', CellKind.Code, [], { metadata: { tags: ['keep', 'drop'] } }],
+			['b', 'python', CellKind.Code, [], { metadata: { tags: ['x'] } }],
+			['c', 'python', CellKind.Code],
+		], ctx);
+
+		new TestableRemoveAllCellTagsAction().testRun(notebook);
+
+		expect(notebook.cells.get().map(c => c.tags.get())).toEqual([[], [], []]);
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCellTagCommands.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCellTagCommands.vitest.ts
@@ -8,7 +8,7 @@
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { CellKind } from '../../../notebook/common/notebookCommon.js';
 import { IPositronNotebookInstance } from '../../browser/IPositronNotebookInstance.js';
-import { RemoveAllCellTagsAction, ToggleCellTagsAction } from '../../browser/positronNotebook.contribution.js';
+import { RemoveAllCellTagsAction, ToggleCellTagsAction } from '../../browser/contrib/cellTags/actions.js';
 import { createLabelledTestNotebook, createTestPositronNotebookInstance } from './testPositronNotebookInstance.js';
 
 /**

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCellTagCommands.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCellTagCommands.vitest.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { IPositronNotebookInstance } from '../../browser/IPositronNotebookInstance.js';
+import { ToggleCellTagsAction } from '../../browser/positronNotebook.contribution.js';
+import { createLabelledTestNotebook } from './testPositronNotebookInstance.js';
+
+/**
+ * Notebook-wide tag commands operate on the whole notebook rather than a single
+ * cell. Their bodies live in `runNotebookAction`, so test-only subclasses expose
+ * them without standing up an active editor pane.
+ */
+describe('ToggleCellTagsAction', () => {
+	const ctx = createTestContainer().withNotebookEditorServices().build();
+
+	class TestableToggleCellTagsAction extends ToggleCellTagsAction {
+		public testRun(notebook: IPositronNotebookInstance) {
+			return this.runNotebookAction(notebook);
+		}
+	}
+
+	it('toggles notebook-wide cell tag visibility', () => {
+		const notebook = createLabelledTestNotebook(1, ctx);
+		const action = new TestableToggleCellTagsAction();
+
+		expect(notebook.cellTagsHidden.get()).toBe(false);
+		action.testRun(notebook);
+		expect(notebook.cellTagsHidden.get()).toBe(true);
+		action.testRun(notebook);
+		expect(notebook.cellTagsHidden.get()).toBe(false);
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCellTagCommands.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCellTagCommands.vitest.ts
@@ -57,4 +57,16 @@ describe('RemoveAllCellTagsAction', () => {
 
 		expect(notebook.cells.get().map(c => c.tags.get())).toEqual([[], [], []]);
 	});
+
+	it('is a no-op on a read-only notebook', () => {
+		// Tag edits are document mutations; a read-only notebook keeps its tags.
+		const notebook = createTestPositronNotebookInstance([
+			['a', 'python', CellKind.Code, [], { metadata: { tags: ['kept'] } }],
+		], ctx);
+		vi.spyOn(notebook, 'isReadOnly', 'get').mockReturnValue(true);
+
+		new TestableRemoveAllCellTagsAction().testRun(notebook);
+
+		expect(notebook.cells.get()[0].tags.get()).toEqual(['kept']);
+	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCellWrapper.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCellWrapper.vitest.tsx
@@ -226,3 +226,52 @@ describe('NotebookCellWrapper CellProvider', () => {
 	});
 
 });
+
+describe('NotebookCellWrapper tag placement', () => {
+	const ctx = createTestContainer().withNotebookEditorServices().withReactServices().build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	function renderWrapper(notebook: TestPositronNotebookInstance) {
+		const cell = notebook.cells.get()[0];
+		const environmentBundle = {
+			size: observableValue<ISize>('test-size', { width: 800, height: 600 }),
+			scopedContextKeyProviderCallback: () => stubInterface<IScopedContextKeyService>({}),
+		};
+		rtl.render(
+			<NotebookInstanceProvider instance={notebook}>
+				<EnvironentProvider environmentBundle={environmentBundle}>
+					<NotebookCellWrapper cell={cell}>{null}</NotebookCellWrapper>
+				</EnvironentProvider>
+			</NotebookInstanceProvider>
+		);
+	}
+
+	/** A single tagged cell of the given kind/language (tags seeded in metadata). */
+	function taggedNotebook(language: string, cellKind: CellKind) {
+		return createTestPositronNotebookInstance([{
+			source: 'content',
+			mime: undefined,
+			language,
+			cellKind,
+			outputs: [],
+			metadata: { metadata: { tags: ['tagged'] } },
+			internalMetadata: {},
+		}], ctx);
+	}
+
+	it('places a tagged markdown cell tag bar standalone', () => {
+		// Markdown / raw cells have no footer, so the wrapper renders the bar
+		// itself with the standalone modifier.
+		renderWrapper(taggedNotebook('markdown', CellKind.Markup));
+
+		expect(screen.getByTestId('cell-tags-bar')).toHaveClass('standalone');
+	});
+
+	it('does not place a standalone tag bar on a code cell', () => {
+		// Code cells render their tags inside CodeCellStatusFooter (not part of the
+		// wrapper), so the wrapper's standalone placement is skipped.
+		renderWrapper(taggedNotebook('python', CellKind.Code));
+
+		expect(screen.queryByTestId('cell-tags-bar')).not.toBeInTheDocument();
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -150,16 +150,18 @@ describe('CellTagsBar', () => {
 		expect(renameTag).toHaveBeenCalledWith('old', 'new');
 	});
 
-	it('is a single-tab-stop toolbar with the add control leading the row', () => {
+	it('is a single-tab-stop toolbar entered at the first tag, with the add control last', () => {
 		const { cell } = createTagCell(['data', 'wip']);
 		rtl.render(<CellTagsBar cell={cell} />);
 
 		const buttons = screen.getAllByRole('button');
 		expect(screen.getByRole('toolbar')).toBeInTheDocument();
-		// The add control leads and is the only tab stop; tags are reached with
-		// the arrow keys so a long tag list doesn't add a tab stop per tag.
-		expect(buttons[0]).toHaveAccessibleName('Add tag');
+		// The first tag is the only tab stop; the rest of the row (including
+		// the trailing add control) is reached with the arrow keys so a long
+		// tag list doesn't add a tab stop per tag.
+		expect(buttons[0]).toHaveAccessibleName('Edit tag data');
 		expect(buttons[0]).toHaveAttribute('tabindex', '0');
+		expect(buttons[buttons.length - 1]).toHaveAccessibleName('Add tag');
 		for (const button of buttons.slice(1)) {
 			expect(button).toHaveAttribute('tabindex', '-1');
 		}
@@ -170,21 +172,21 @@ describe('CellTagsBar', () => {
 		const { cell } = createTagCell(['data']);
 		rtl.render(<CellTagsBar cell={cell} />);
 
-		// Tab enters the bar at its single tab stop, the add control.
+		// Tab enters the bar at its single tab stop, the first tag.
 		await user.tab();
-		expect(screen.getByRole('button', { name: 'Add tag' })).toHaveFocus();
-
-		await user.keyboard('{ArrowRight}');
 		expect(screen.getByRole('button', { name: 'Edit tag data' })).toHaveFocus();
 
 		await user.keyboard('{ArrowRight}');
 		expect(screen.getByRole('button', { name: 'Remove tag data' })).toHaveFocus();
 
-		// The ends wrap around.
 		await user.keyboard('{ArrowRight}');
 		expect(screen.getByRole('button', { name: 'Add tag' })).toHaveFocus();
+
+		// The ends wrap around.
+		await user.keyboard('{ArrowRight}');
+		expect(screen.getByRole('button', { name: 'Edit tag data' })).toHaveFocus();
 		await user.keyboard('{ArrowLeft}');
-		expect(screen.getByRole('button', { name: 'Remove tag data' })).toHaveFocus();
+		expect(screen.getByRole('button', { name: 'Add tag' })).toHaveFocus();
 	});
 
 	it('activates the focused control with Enter without leaking the key to the notebook', async () => {
@@ -202,7 +204,7 @@ describe('CellTagsBar', () => {
 		);
 
 		await user.tab();
-		await user.keyboard('{ArrowRight}{Enter}');
+		await user.keyboard('{Enter}');
 
 		expect(screen.getByRole('textbox')).toHaveFocus();
 		expect(outerKeyDown).not.toHaveBeenCalled();

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -82,13 +82,6 @@ describe('CellTagsBar', () => {
 		expect(screen.queryByTestId('cell-tags-bar')).not.toBeInTheDocument();
 	});
 
-	it('applies the standalone modifier for the non-footer placement', () => {
-		const { cell } = createTagCell(['x']);
-		rtl.render(<CellTagsBar standalone cell={cell} />);
-
-		expect(screen.getByTestId('cell-tags-bar')).toHaveClass('standalone');
-	});
-
 	it('opens a focused inline input on an untagged cell when a tag-add is requested', () => {
 		// The "Add Tag" command flips the cell's isAddingTag signal; the bar must
 		// open the inline input even though an untagged cell renders nothing at rest.

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -7,7 +7,7 @@
 
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { observableValue } from '../../../../../../base/common/observable.js';
+import { derived, observableValue } from '../../../../../../base/common/observable.js';
 import { createTestContainer } from '../../../../../../test/vitest/positronTestContainer.js';
 import { setupRTLRenderer } from '../../../../../../test/vitest/reactTestingLibrary.js';
 import { stubInterface } from '../../../../../../test/vitest/stubInterface.js';
@@ -27,6 +27,11 @@ function createTagCell(initial: string[] = []) {
 	const tags = observableValue<string[]>('tags', [...initial]);
 	const isAddingTag = observableValue<boolean>('isAddingTag', false);
 	const cellTagsHidden = observableValue<boolean>('cellTagsHidden', false);
+	// Mirrors the real cell's tagUIVisible derivation so the stub honors the
+	// same contract the bar renders against.
+	const tagUIVisible = derived(reader =>
+		!cellTagsHidden.read(reader) && (tags.read(reader).length > 0 || isAddingTag.read(reader))
+	);
 	const addTag = vi.fn((tag: string): TagWriteResult => {
 		tags.set([...tags.get(), tag], undefined);
 		return 'ok';
@@ -43,7 +48,7 @@ function createTagCell(initial: string[] = []) {
 	// signal the "Add Tag" command flips), so wire them to the observable.
 	const beginAddTag = vi.fn(() => isAddingTag.set(true, undefined));
 	const endAddTag = vi.fn(() => isAddingTag.set(false, undefined));
-	const cell = stubInterface<IPositronNotebookCell>({ tags, isAddingTag, cellTagsHidden, addTag, removeTag, renameTag, beginAddTag, endAddTag });
+	const cell = stubInterface<IPositronNotebookCell>({ tags, isAddingTag, tagUIVisible, addTag, removeTag, renameTag, beginAddTag, endAddTag });
 	return { cell, tags, isAddingTag, cellTagsHidden, addTag, removeTag, renameTag, beginAddTag, endAddTag };
 }
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -16,38 +16,62 @@ import { CellTagsBar } from '../../../browser/notebookCells/CellTagsBar.js';
 import { AddTagResult, IPositronNotebookCell } from '../../../browser/PositronNotebookCells/IPositronNotebookCell.js';
 
 /**
- * A minimal cell exposing just the tag surface the bar touches. `setTags` is a
- * spy that also writes through to the observable, so the rendered pills reflect
- * the new state after edit/remove (mirroring the real cell model). `addTag`
- * mirrors the real trim/dedup/append behavior and also writes through, which
- * lets tests cover interactions between blur-committed adds and same-click
- * handlers that read the latest tag state.
+ * A minimal cell exposing just the tag surface the bar touches. The mutation
+ * verbs (addTag / removeTag / renameTag) mirror the real cell model's
+ * trim / dedup / membership behavior and write through to the observable, so the
+ * rendered pills reflect the new state and interaction tests (e.g. a blur-commit
+ * racing a same-click removal) read the latest tag state just like production.
  */
 function createTagCell(initial: string[] = []) {
 	// The real cell model de-duplicates tags on read, so the bar never sees
 	// duplicate values. Mirror that here so this stub is a faithful stand-in for
 	// a file loaded with duplicate tags.
 	const tags = observableValue<string[]>('tags', [...new Set(initial)]);
-	const setTags = vi.fn((next: string[]) => tags.set(next, undefined));
 	const addTag = vi.fn((tag: string): AddTagResult => {
 		const value = tag.trim();
 		if (!value) {
 			return 'empty';
 		}
-		const latestTags = tags.get();
-		if (latestTags.includes(value)) {
+		const latest = tags.get();
+		if (latest.includes(value)) {
 			return 'duplicate';
 		}
-		setTags([...latestTags, value]);
+		tags.set([...latest, value], undefined);
 		return 'added';
 	});
-	const cell = stubInterface<IPositronNotebookCell>({ tags, setTags, addTag });
-	return { cell, tags, setTags, addTag };
+	const removeTag = vi.fn((tag: string): boolean => {
+		const latest = tags.get();
+		if (!latest.includes(tag)) {
+			return true;
+		}
+		tags.set(latest.filter(t => t !== tag), undefined);
+		return true;
+	});
+	const renameTag = vi.fn((oldTag: string, newTag: string): AddTagResult => {
+		const value = newTag.trim();
+		if (!value) {
+			return 'empty';
+		}
+		const latest = tags.get();
+		const index = latest.indexOf(oldTag);
+		if (index < 0) {
+			return 'failed';
+		}
+		if (latest.some((t, i) => i !== index && t === value)) {
+			return 'duplicate';
+		}
+		const next = [...latest];
+		next[index] = value;
+		tags.set(next, undefined);
+		return 'added';
+	});
+	const cell = stubInterface<IPositronNotebookCell>({ tags, addTag, removeTag, renameTag });
+	return { cell, tags, addTag, removeTag, renameTag };
 }
 
 describe('CellTagsBar', () => {
 	// The bar reads INotificationService from the React services context to toast
-	// on a duplicate tag, so wire a stub we can assert against.
+	// on a duplicate or failed write, so wire a stub we can assert against.
 	const notificationInfo = vi.fn();
 	const ctx = createTestContainer()
 		.withReactServices()
@@ -76,6 +100,29 @@ describe('CellTagsBar', () => {
 		rtl.render(<CellTagsBar standalone cell={cell} />);
 
 		expect(screen.getByTestId('cell-tags-bar')).toHaveClass('standalone');
+	});
+
+	it('focuses the input when the add affordance opens', async () => {
+		const user = userEvent.setup();
+		const { cell } = createTagCell(['data']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Add tag' }));
+
+		// The TagInput focus effect must run on mount, or the typed value is lost.
+		expect(screen.getByRole('textbox')).toHaveFocus();
+	});
+
+	it('focuses the input when an edit opens', async () => {
+		const user = userEvent.setup();
+		const { cell } = createTagCell(['old']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Edit tag old' }));
+
+		// Switching a pill into edit mode remounts TagInput (distinct `edit-` key),
+		// so its focus effect re-runs and focuses the edit input.
+		expect(screen.getByRole('textbox')).toHaveFocus();
 	});
 
 	it('forwards an Enter-committed add to cell.addTag', async () => {
@@ -131,8 +178,8 @@ describe('CellTagsBar', () => {
 
 	it('notifies the user when a committed add fails to write', async () => {
 		// addTag returns 'failed' when the write can't be applied (detached cell,
-		// no text model). The bar must surface that rather than dropping the tag
-		// silently.
+		// no text model). The bar surfaces a generic write-failure toast rather
+		// than dropping the tag silently.
 		const user = userEvent.setup();
 		const { cell, addTag } = createTagCell(['data']);
 		addTag.mockReturnValue('failed');
@@ -141,12 +188,12 @@ describe('CellTagsBar', () => {
 		await user.click(screen.getByRole('button', { name: 'Add tag' }));
 		await user.type(screen.getByRole('textbox'), 'oops{Enter}');
 
-		expect(notificationInfo).toHaveBeenCalledWith(expect.stringContaining('oops'));
+		expect(notificationInfo).toHaveBeenCalledWith(expect.stringContaining('Could not update'));
 	});
 
-	it('edits a tag in place', async () => {
+	it('forwards an in-place edit to cell.renameTag', async () => {
 		const user = userEvent.setup();
-		const { cell, setTags } = createTagCell(['old']);
+		const { cell, renameTag, tags } = createTagCell(['old']);
 		rtl.render(<CellTagsBar cell={cell} />);
 
 		await user.click(screen.getByRole('button', { name: 'Edit tag old' }));
@@ -154,12 +201,13 @@ describe('CellTagsBar', () => {
 		await user.clear(input);
 		await user.type(input, 'new{Enter}');
 
-		expect(setTags).toHaveBeenCalledWith(['new']);
+		expect(renameTag).toHaveBeenCalledWith('old', 'new');
+		expect(tags.get()).toEqual(['new']);
 	});
 
 	it('notifies and does not rename when an edit duplicates another tag', async () => {
 		const user = userEvent.setup();
-		const { cell, setTags } = createTagCell(['keep', 'rename-me']);
+		const { cell, tags } = createTagCell(['keep', 'rename-me']);
 		rtl.render(<CellTagsBar cell={cell} />);
 
 		await user.click(screen.getByRole('button', { name: 'Edit tag rename-me' }));
@@ -168,31 +216,33 @@ describe('CellTagsBar', () => {
 		await user.type(input, 'keep{Enter}');
 
 		expect(notificationInfo).toHaveBeenCalledWith(expect.stringContaining('keep'));
-		expect(setTags).not.toHaveBeenCalled();
+		// The rejected rename leaves the tag list unchanged.
+		expect(tags.get()).toEqual(['keep', 'rename-me']);
 	});
 
 	it('removes a tag via its close affordance', async () => {
 		const user = userEvent.setup();
-		const { cell, setTags } = createTagCell(['keep', 'drop']);
+		const { cell, removeTag, tags } = createTagCell(['keep', 'drop']);
 		rtl.render(<CellTagsBar cell={cell} />);
 
 		await user.click(screen.getByRole('button', { name: 'Remove tag drop' }));
 
-		expect(setTags).toHaveBeenCalledWith(['keep']);
+		expect(removeTag).toHaveBeenCalledWith('drop');
+		expect(tags.get()).toEqual(['keep']);
 	});
 
-	it('keeps the surviving pills consistent after removing a middle tag', async () => {
+	it('keeps the surviving pills in order after removing a middle tag', async () => {
 		// Pills are keyed by tag value, so a mid-list removal must re-render to
-		// exactly the survivors without misassociating any pill by position.
+		// exactly the survivors, in order, without misassociating any pill by
+		// position. Each pill's edit button carries its tag as text.
 		const user = userEvent.setup();
 		const { cell } = createTagCell(['a', 'b', 'c']);
 		rtl.render(<CellTagsBar cell={cell} />);
 
 		await user.click(screen.getByRole('button', { name: 'Remove tag b' }));
 
-		expect(screen.queryByText('b')).not.toBeInTheDocument();
-		expect(screen.getByText('a')).toBeInTheDocument();
-		expect(screen.getByText('c')).toBeInTheDocument();
+		const labels = screen.getAllByRole('button', { name: /^Edit tag / }).map(b => b.textContent);
+		expect(labels).toEqual(['a', 'c']);
 	});
 
 	it('renders one pill per value for a file loaded with duplicate tags', () => {
@@ -209,19 +259,20 @@ describe('CellTagsBar', () => {
 		// removeTag operates on the de-duplicated list, so it can't drop a sibling
 		// occurrence -- only 'x' survives.
 		const user = userEvent.setup();
-		const { cell, setTags } = createTagCell(['dup', 'dup', 'x']);
+		const { cell, removeTag, tags } = createTagCell(['dup', 'dup', 'x']);
 		rtl.render(<CellTagsBar cell={cell} />);
 
 		await user.click(screen.getByRole('button', { name: 'Remove tag dup' }));
 
-		expect(setTags).toHaveBeenCalledWith(['x']);
+		expect(removeTag).toHaveBeenCalledWith('dup');
+		expect(tags.get()).toEqual(['x']);
 	});
 
 	it('edits the de-duplicated tag without mis-targeting a sibling', async () => {
-		// commitEdit resolves against the de-duplicated list, so the rename lands
+		// renameTag resolves against the de-duplicated list, so the rename lands
 		// on the single 'dup' occurrence and leaves 'x' untouched.
 		const user = userEvent.setup();
-		const { cell, setTags } = createTagCell(['dup', 'dup', 'x']);
+		const { cell, renameTag, tags } = createTagCell(['dup', 'dup', 'x']);
 		rtl.render(<CellTagsBar cell={cell} />);
 
 		await user.click(screen.getByRole('button', { name: 'Edit tag dup' }));
@@ -229,19 +280,21 @@ describe('CellTagsBar', () => {
 		await user.clear(input);
 		await user.type(input, 'renamed{Enter}');
 
-		expect(setTags).toHaveBeenCalledWith(['renamed', 'x']);
+		expect(renameTag).toHaveBeenCalledWith('dup', 'renamed');
+		expect(tags.get()).toEqual(['renamed', 'x']);
 	});
 
 	it('removes a tag when an edit commits empty', async () => {
 		const user = userEvent.setup();
-		const { cell, setTags } = createTagCell(['gone']);
+		const { cell, removeTag, tags } = createTagCell(['gone']);
 		rtl.render(<CellTagsBar cell={cell} />);
 
 		await user.click(screen.getByRole('button', { name: 'Edit tag gone' }));
 		await user.clear(screen.getByRole('textbox'));
 		await user.keyboard('{Enter}');
 
-		expect(setTags).toHaveBeenCalledWith([]);
+		expect(removeTag).toHaveBeenCalledWith('gone');
+		expect(tags.get()).toEqual([]);
 	});
 
 	it('keeps a blur-committed add when the same click removes another tag', async () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -13,7 +13,7 @@ import { setupRTLRenderer } from '../../../../../../test/vitest/reactTestingLibr
 import { stubInterface } from '../../../../../../test/vitest/stubInterface.js';
 import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
 import { CellTagsBar } from '../../../browser/notebookCells/CellTagsBar.js';
-import { AddTagResult, IPositronNotebookCell } from '../../../browser/PositronNotebookCells/IPositronNotebookCell.js';
+import { IPositronNotebookCell, TagWriteResult } from '../../../browser/PositronNotebookCells/IPositronNotebookCell.js';
 
 /**
  * A minimal cell stub. The tag-set invariant (trim / dedup / duplicate
@@ -27,17 +27,17 @@ function createTagCell(initial: string[] = []) {
 	const tags = observableValue<string[]>('tags', [...initial]);
 	const isAddingTag = observableValue<boolean>('isAddingTag', false);
 	const cellTagsHidden = observableValue<boolean>('cellTagsHidden', false);
-	const addTag = vi.fn((tag: string): AddTagResult => {
+	const addTag = vi.fn((tag: string): TagWriteResult => {
 		tags.set([...tags.get(), tag], undefined);
-		return 'added';
+		return 'ok';
 	});
-	const removeTag = vi.fn((tag: string): boolean => {
+	const removeTag = vi.fn((tag: string): TagWriteResult => {
 		tags.set(tags.get().filter(t => t !== tag), undefined);
-		return true;
+		return 'ok';
 	});
-	const renameTag = vi.fn((oldTag: string, newTag: string): AddTagResult => {
+	const renameTag = vi.fn((oldTag: string, newTag: string): TagWriteResult => {
 		tags.set(tags.get().map(t => (t === oldTag ? newTag : t)), undefined);
-		return 'added';
+		return 'ok';
 	});
 	// The bar reads isAddingTag and drives it through begin/endAddTag (the same
 	// signal the "Add Tag" command flips), so wire them to the observable.
@@ -240,7 +240,7 @@ describe('CellTagsBar', () => {
 		// of silently no-opping.
 		const user = userEvent.setup();
 		const { cell, removeTag } = createTagCell(['keep', 'drop']);
-		removeTag.mockReturnValue(false);
+		removeTag.mockReturnValue('failed');
 		rtl.render(<CellTagsBar cell={cell} />);
 
 		await user.click(screen.getByRole('button', { name: 'Remove tag drop' }));

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -129,6 +129,21 @@ describe('CellTagsBar', () => {
 		expect(notificationInfo).toHaveBeenCalledWith(expect.stringContaining('data'));
 	});
 
+	it('notifies the user when a committed add fails to write', async () => {
+		// addTag returns 'failed' when the write can't be applied (detached cell,
+		// no text model). The bar must surface that rather than dropping the tag
+		// silently.
+		const user = userEvent.setup();
+		const { cell, addTag } = createTagCell(['data']);
+		addTag.mockReturnValue('failed');
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Add tag' }));
+		await user.type(screen.getByRole('textbox'), 'oops{Enter}');
+
+		expect(notificationInfo).toHaveBeenCalledWith(expect.stringContaining('oops'));
+	});
+
 	it('edits a tag in place', async () => {
 		const user = userEvent.setup();
 		const { cell, setTags } = createTagCell(['old']);

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -5,7 +5,7 @@
 
 /// <reference types="vitest/globals" />
 
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { createTestContainer } from '../../../../../../test/vitest/positronTestContainer.js';
@@ -25,6 +25,7 @@ import { AddTagResult, IPositronNotebookCell } from '../../../browser/PositronNo
  */
 function createTagCell(initial: string[] = []) {
 	const tags = observableValue<string[]>('tags', [...initial]);
+	const isAddingTag = observableValue<boolean>('isAddingTag', false);
 	const addTag = vi.fn((tag: string): AddTagResult => {
 		tags.set([...tags.get(), tag], undefined);
 		return 'added';
@@ -37,8 +38,12 @@ function createTagCell(initial: string[] = []) {
 		tags.set(tags.get().map(t => (t === oldTag ? newTag : t)), undefined);
 		return 'added';
 	});
-	const cell = stubInterface<IPositronNotebookCell>({ tags, addTag, removeTag, renameTag });
-	return { cell, tags, addTag, removeTag, renameTag };
+	// The bar reads isAddingTag and drives it through begin/endAddTag (the same
+	// signal the "Add Tag" command flips), so wire them to the observable.
+	const beginAddTag = vi.fn(() => isAddingTag.set(true, undefined));
+	const endAddTag = vi.fn(() => isAddingTag.set(false, undefined));
+	const cell = stubInterface<IPositronNotebookCell>({ tags, isAddingTag, addTag, removeTag, renameTag, beginAddTag, endAddTag });
+	return { cell, tags, isAddingTag, addTag, removeTag, renameTag, beginAddTag, endAddTag };
 }
 
 describe('CellTagsBar', () => {
@@ -71,6 +76,19 @@ describe('CellTagsBar', () => {
 		rtl.render(<CellTagsBar standalone cell={cell} />);
 
 		expect(screen.getByTestId('cell-tags-bar')).toHaveClass('standalone');
+	});
+
+	it('opens a focused inline input on an untagged cell when a tag-add is requested', () => {
+		// The "Add Tag" command flips the cell's isAddingTag signal; the bar must
+		// open the inline input even though an untagged cell renders nothing at rest.
+		const { cell, isAddingTag } = createTagCell([]);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+
+		act(() => isAddingTag.set(true, undefined));
+
+		expect(screen.getByRole('textbox')).toHaveFocus();
 	});
 
 	it('forwards an Enter-committed add to cell.addTag', async () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -215,6 +215,38 @@ describe('CellTagsBar', () => {
 		expect(outerKeyDown).not.toHaveBeenCalled();
 	});
 
+	it('keeps the focus ring in the bar by landing on a neighbor after a keyboard removal', async () => {
+		// A removed control unmounts; a keyboard user must not lose the focus ring
+		// to <body>. Arrow to the second tag's remove control and activate it.
+		const user = userEvent.setup();
+		const { cell, removeTag } = createTagCell(['keep', 'drop']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.tab();
+		await user.keyboard('{ArrowRight}{ArrowRight}{ArrowRight}');
+		expect(screen.getByRole('button', { name: 'Remove tag drop' })).toHaveFocus();
+		await user.keyboard('{Enter}');
+
+		expect(removeTag).toHaveBeenCalledWith('drop');
+		// Focus slides to the neighbor that now occupies the row, not <body>.
+		expect(screen.getByRole('button', { name: 'Edit tag keep' })).toHaveFocus();
+	});
+
+	it('returns focus to the pill after an Enter-committed edit', async () => {
+		const user = userEvent.setup();
+		const { cell } = createTagCell(['old']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Edit tag old' }));
+		const input = screen.getByRole('textbox');
+		await user.clear(input);
+		await user.type(input, 'new{Enter}');
+
+		// The input unmounts on commit; focus returns to the renamed pill rather
+		// than dropping to <body>.
+		expect(screen.getByRole('button', { name: 'Edit tag new' })).toHaveFocus();
+	});
+
 	it('removes a tag via its close affordance', async () => {
 		const user = userEvent.setup();
 		const { cell, removeTag } = createTagCell(['keep', 'drop']);

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -1,0 +1,179 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { observableValue } from '../../../../../../base/common/observable.js';
+import { createTestContainer } from '../../../../../../test/vitest/positronTestContainer.js';
+import { setupRTLRenderer } from '../../../../../../test/vitest/reactTestingLibrary.js';
+import { stubInterface } from '../../../../../../test/vitest/stubInterface.js';
+import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
+import { CellTagsBar } from '../../../browser/notebookCells/CellTagsBar.js';
+import { AddTagResult, IPositronNotebookCell } from '../../../browser/PositronNotebookCells/IPositronNotebookCell.js';
+
+/**
+ * A minimal cell exposing just the tag surface the bar touches. `setTags` is a
+ * spy that also writes through to the observable, so the rendered pills reflect
+ * the new state after edit/remove (mirroring the real cell model). `addTag` is a
+ * spy that returns `'added'` by default; its trim/dedup/append invariant is
+ * covered by the cell-model tests, so the bar tests just drive its return value.
+ */
+function createTagCell(initial: string[] = []) {
+	const tags = observableValue<string[]>('tags', initial);
+	const setTags = vi.fn((next: string[]) => tags.set(next, undefined));
+	const addTag = vi.fn((_tag: string): AddTagResult => 'added');
+	const cell = stubInterface<IPositronNotebookCell>({ tags, setTags, addTag });
+	return { cell, setTags, addTag };
+}
+
+describe('CellTagsBar', () => {
+	// The bar reads INotificationService from the React services context to toast
+	// on a duplicate tag, so wire a stub we can assert against.
+	const notificationInfo = vi.fn();
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(INotificationService, { info: notificationInfo })
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	it('renders a pill for each tag', () => {
+		const { cell } = createTagCell(['data', 'wip']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		// Assert the visible label text of each pill.
+		expect(screen.getByText('data')).toBeInTheDocument();
+		expect(screen.getByText('wip')).toBeInTheDocument();
+	});
+
+	it('renders nothing (including the add affordance) when there are no tags', () => {
+		const { cell } = createTagCell([]);
+		const { container } = rtl.render(<CellTagsBar cell={cell} />);
+
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it('applies the standalone modifier for the non-footer placement', () => {
+		const { cell } = createTagCell(['x']);
+		rtl.render(<CellTagsBar standalone cell={cell} />);
+
+		expect(screen.getByTestId('cell-tags-bar')).toHaveClass('standalone');
+	});
+
+	it('forwards an Enter-committed add to cell.addTag', async () => {
+		const user = userEvent.setup();
+		const { cell, addTag } = createTagCell(['data']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Add tag' }));
+		await user.type(screen.getByRole('textbox'), 'fresh{Enter}');
+
+		// The cell owns trim / dedup; the bar just forwards the typed value.
+		expect(addTag).toHaveBeenCalledWith('fresh');
+	});
+
+	it('forwards a blur-committed add to cell.addTag', async () => {
+		const user = userEvent.setup();
+		const { cell, addTag } = createTagCell(['data']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Add tag' }));
+		await user.type(screen.getByRole('textbox'), 'viablur');
+		// Tab away to blur the input.
+		await user.tab();
+
+		expect(addTag).toHaveBeenCalledWith('viablur');
+	});
+
+	it('cancels an add on Escape without calling addTag', async () => {
+		const user = userEvent.setup();
+		const { cell, addTag } = createTagCell(['data']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Add tag' }));
+		await user.type(screen.getByRole('textbox'), 'discard{Escape}');
+
+		expect(addTag).not.toHaveBeenCalled();
+		// The input is gone and the add affordance is back.
+		expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Add tag' })).toBeInTheDocument();
+	});
+
+	it('notifies the user when a committed add is a duplicate', async () => {
+		const user = userEvent.setup();
+		const { cell, addTag } = createTagCell(['data']);
+		addTag.mockReturnValue('duplicate');
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Add tag' }));
+		await user.type(screen.getByRole('textbox'), 'data{Enter}');
+
+		expect(notificationInfo).toHaveBeenCalledWith(expect.stringContaining('data'));
+	});
+
+	it('edits a tag in place', async () => {
+		const user = userEvent.setup();
+		const { cell, setTags } = createTagCell(['old']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Edit tag old' }));
+		const input = screen.getByRole('textbox');
+		await user.clear(input);
+		await user.type(input, 'new{Enter}');
+
+		expect(setTags).toHaveBeenCalledWith(['new']);
+	});
+
+	it('notifies and does not rename when an edit duplicates another tag', async () => {
+		const user = userEvent.setup();
+		const { cell, setTags } = createTagCell(['keep', 'rename-me']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Edit tag rename-me' }));
+		const input = screen.getByRole('textbox');
+		await user.clear(input);
+		await user.type(input, 'keep{Enter}');
+
+		expect(notificationInfo).toHaveBeenCalledWith(expect.stringContaining('keep'));
+		expect(setTags).not.toHaveBeenCalled();
+	});
+
+	it('removes a tag via its close affordance', async () => {
+		const user = userEvent.setup();
+		const { cell, setTags } = createTagCell(['keep', 'drop']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Remove tag drop' }));
+
+		expect(setTags).toHaveBeenCalledWith(['keep']);
+	});
+
+	it('keeps the surviving pills consistent after removing a middle tag', async () => {
+		// Pills are keyed by tag value, so a mid-list removal must re-render to
+		// exactly the survivors without misassociating any pill by position.
+		const user = userEvent.setup();
+		const { cell } = createTagCell(['a', 'b', 'c']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Remove tag b' }));
+
+		expect(screen.queryByText('b')).not.toBeInTheDocument();
+		expect(screen.getByText('a')).toBeInTheDocument();
+		expect(screen.getByText('c')).toBeInTheDocument();
+	});
+
+	it('removes a tag when an edit commits empty', async () => {
+		const user = userEvent.setup();
+		const { cell, setTags } = createTagCell(['gone']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Edit tag gone' }));
+		await user.clear(screen.getByRole('textbox'));
+		await user.keyboard('{Enter}');
+
+		expect(setTags).toHaveBeenCalledWith([]);
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -16,53 +16,25 @@ import { CellTagsBar } from '../../../browser/notebookCells/CellTagsBar.js';
 import { AddTagResult, IPositronNotebookCell } from '../../../browser/PositronNotebookCells/IPositronNotebookCell.js';
 
 /**
- * A minimal cell exposing just the tag surface the bar touches. The mutation
- * verbs (addTag / removeTag / renameTag) mirror the real cell model's
- * trim / dedup / membership behavior and write through to the observable, so the
- * rendered pills reflect the new state and interaction tests (e.g. a blur-commit
- * racing a same-click removal) read the latest tag state just like production.
+ * A minimal cell stub. The tag-set invariant (trim / dedup / duplicate
+ * rejection) lives in the real model and is tested in
+ * `positronNotebookCell.vitest.ts`, so these verbs are plain spies that write
+ * through to the observable -- just enough for the bar to re-render. Tests assert
+ * the bar calls the right verb with the right value; they do not re-check the
+ * invariant against this double.
  */
 function createTagCell(initial: string[] = []) {
-	// The real cell model de-duplicates tags on read, so the bar never sees
-	// duplicate values. Mirror that here so this stub is a faithful stand-in for
-	// a file loaded with duplicate tags.
-	const tags = observableValue<string[]>('tags', [...new Set(initial)]);
+	const tags = observableValue<string[]>('tags', [...initial]);
 	const addTag = vi.fn((tag: string): AddTagResult => {
-		const value = tag.trim();
-		if (!value) {
-			return 'empty';
-		}
-		const latest = tags.get();
-		if (latest.includes(value)) {
-			return 'duplicate';
-		}
-		tags.set([...latest, value], undefined);
+		tags.set([...tags.get(), tag], undefined);
 		return 'added';
 	});
 	const removeTag = vi.fn((tag: string): boolean => {
-		const latest = tags.get();
-		if (!latest.includes(tag)) {
-			return true;
-		}
-		tags.set(latest.filter(t => t !== tag), undefined);
+		tags.set(tags.get().filter(t => t !== tag), undefined);
 		return true;
 	});
 	const renameTag = vi.fn((oldTag: string, newTag: string): AddTagResult => {
-		const value = newTag.trim();
-		if (!value) {
-			return 'empty';
-		}
-		const latest = tags.get();
-		const index = latest.indexOf(oldTag);
-		if (index < 0) {
-			return 'failed';
-		}
-		if (latest.some((t, i) => i !== index && t === value)) {
-			return 'duplicate';
-		}
-		const next = [...latest];
-		next[index] = value;
-		tags.set(next, undefined);
+		tags.set(tags.get().map(t => (t === oldTag ? newTag : t)), undefined);
 		return 'added';
 	});
 	const cell = stubInterface<IPositronNotebookCell>({ tags, addTag, removeTag, renameTag });
@@ -71,7 +43,7 @@ function createTagCell(initial: string[] = []) {
 
 describe('CellTagsBar', () => {
 	// The bar reads INotificationService from the React services context to toast
-	// on a duplicate or failed write, so wire a stub we can assert against.
+	// on a rejected write, so wire a stub we can assert against.
 	const notificationInfo = vi.fn();
 	const ctx = createTestContainer()
 		.withReactServices()
@@ -83,7 +55,6 @@ describe('CellTagsBar', () => {
 		const { cell } = createTagCell(['data', 'wip']);
 		rtl.render(<CellTagsBar cell={cell} />);
 
-		// Assert the visible label text of each pill.
 		expect(screen.getByText('data')).toBeInTheDocument();
 		expect(screen.getByText('wip')).toBeInTheDocument();
 	});
@@ -102,35 +73,14 @@ describe('CellTagsBar', () => {
 		expect(screen.getByTestId('cell-tags-bar')).toHaveClass('standalone');
 	});
 
-	it('focuses the input when the add affordance opens', async () => {
-		const user = userEvent.setup();
-		const { cell } = createTagCell(['data']);
-		rtl.render(<CellTagsBar cell={cell} />);
-
-		await user.click(screen.getByRole('button', { name: 'Add tag' }));
-
-		// The TagInput focus effect must run on mount, or the typed value is lost.
-		expect(screen.getByRole('textbox')).toHaveFocus();
-	});
-
-	it('focuses the input when an edit opens', async () => {
-		const user = userEvent.setup();
-		const { cell } = createTagCell(['old']);
-		rtl.render(<CellTagsBar cell={cell} />);
-
-		await user.click(screen.getByRole('button', { name: 'Edit tag old' }));
-
-		// Switching a pill into edit mode remounts TagInput (distinct `edit-` key),
-		// so its focus effect re-runs and focuses the edit input.
-		expect(screen.getByRole('textbox')).toHaveFocus();
-	});
-
-	it('forwards an Enter-committed add to cell.addTag', async () => {
+	it('focuses the input and forwards an Enter-committed add to cell.addTag', async () => {
 		const user = userEvent.setup();
 		const { cell, addTag } = createTagCell(['data']);
 		rtl.render(<CellTagsBar cell={cell} />);
 
 		await user.click(screen.getByRole('button', { name: 'Add tag' }));
+		// The input must take focus on open, or the typed value is lost.
+		expect(screen.getByRole('textbox')).toHaveFocus();
 		await user.type(screen.getByRole('textbox'), 'fresh{Enter}');
 
 		// The cell owns trim / dedup; the bar just forwards the typed value.
@@ -164,92 +114,50 @@ describe('CellTagsBar', () => {
 		expect(screen.getByRole('button', { name: 'Add tag' })).toBeInTheDocument();
 	});
 
-	it('notifies the user when a committed add is a duplicate', async () => {
+	it('focuses the input and forwards an in-place edit to cell.renameTag', async () => {
 		const user = userEvent.setup();
-		const { cell, addTag } = createTagCell(['data']);
-		addTag.mockReturnValue('duplicate');
-		rtl.render(<CellTagsBar cell={cell} />);
-
-		await user.click(screen.getByRole('button', { name: 'Add tag' }));
-		await user.type(screen.getByRole('textbox'), 'data{Enter}');
-
-		expect(notificationInfo).toHaveBeenCalledWith(expect.stringContaining('data'));
-	});
-
-	it('notifies the user when a committed add fails to write', async () => {
-		// addTag returns 'failed' when the write can't be applied (detached cell,
-		// no text model). The bar surfaces a generic write-failure toast rather
-		// than dropping the tag silently.
-		const user = userEvent.setup();
-		const { cell, addTag } = createTagCell(['data']);
-		addTag.mockReturnValue('failed');
-		rtl.render(<CellTagsBar cell={cell} />);
-
-		await user.click(screen.getByRole('button', { name: 'Add tag' }));
-		await user.type(screen.getByRole('textbox'), 'oops{Enter}');
-
-		expect(notificationInfo).toHaveBeenCalledWith(expect.stringContaining('Could not update'));
-	});
-
-	it('forwards an in-place edit to cell.renameTag', async () => {
-		const user = userEvent.setup();
-		const { cell, renameTag, tags } = createTagCell(['old']);
+		const { cell, renameTag } = createTagCell(['old']);
 		rtl.render(<CellTagsBar cell={cell} />);
 
 		await user.click(screen.getByRole('button', { name: 'Edit tag old' }));
 		const input = screen.getByRole('textbox');
+		// Switching a pill to edit mode remounts TagInput (distinct `edit-` key),
+		// so its focus effect re-runs and focuses the edit input.
+		expect(input).toHaveFocus();
 		await user.clear(input);
 		await user.type(input, 'new{Enter}');
 
 		expect(renameTag).toHaveBeenCalledWith('old', 'new');
-		expect(tags.get()).toEqual(['new']);
-	});
-
-	it('notifies and does not rename when an edit duplicates another tag', async () => {
-		const user = userEvent.setup();
-		const { cell, tags } = createTagCell(['keep', 'rename-me']);
-		rtl.render(<CellTagsBar cell={cell} />);
-
-		await user.click(screen.getByRole('button', { name: 'Edit tag rename-me' }));
-		const input = screen.getByRole('textbox');
-		await user.clear(input);
-		await user.type(input, 'keep{Enter}');
-
-		expect(notificationInfo).toHaveBeenCalledWith(expect.stringContaining('keep'));
-		// The rejected rename leaves the tag list unchanged.
-		expect(tags.get()).toEqual(['keep', 'rename-me']);
-	});
-
-	it('notifies the user when an edit fails to write', async () => {
-		// renameTag returns 'failed' when the write can't be applied; the bar must
-		// surface the generic write-failure toast rather than dropping the rename.
-		const user = userEvent.setup();
-		const { cell, renameTag } = createTagCell(['old']);
-		renameTag.mockReturnValue('failed');
-		rtl.render(<CellTagsBar cell={cell} />);
-
-		await user.click(screen.getByRole('button', { name: 'Edit tag old' }));
-		const input = screen.getByRole('textbox');
-		await user.clear(input);
-		await user.type(input, 'new{Enter}');
-
-		expect(notificationInfo).toHaveBeenCalledWith(expect.stringContaining('Could not update'));
 	});
 
 	it('removes a tag via its close affordance', async () => {
 		const user = userEvent.setup();
-		const { cell, removeTag, tags } = createTagCell(['keep', 'drop']);
+		const { cell, removeTag } = createTagCell(['keep', 'drop']);
 		rtl.render(<CellTagsBar cell={cell} />);
 
 		await user.click(screen.getByRole('button', { name: 'Remove tag drop' }));
 
 		expect(removeTag).toHaveBeenCalledWith('drop');
-		expect(tags.get()).toEqual(['keep']);
 	});
 
-	it('notifies the user when a removal fails to write', async () => {
-		// removeTag returns false when the write can't be applied; the bar must
-		// surface the generic write-failure toast rather than silently no-op.
+	it('routes an edit cleared to empty through removeTag', async () => {
+		const user = userEvent.setup();
+		const { cell, removeTag } = createTagCell(['gone']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Edit tag gone' }));
+		await user.clear(screen.getByRole('textbox'));
+		await user.keyboard('{Enter}');
+
+		// Clearing the field is the bar's "remove" affordance -- it routes to
+		// removeTag rather than renaming to an empty value.
+		expect(removeTag).toHaveBeenCalledWith('gone');
+	});
+
+	it('notifies the user when a write is rejected', async () => {
+		// The result -> toast mapping is the model/helper's job; here we only prove
+		// the bar surfaces a rejected write (the uniform-feedback behavior) instead
+		// of silently no-opping.
 		const user = userEvent.setup();
 		const { cell, removeTag } = createTagCell(['keep', 'drop']);
 		removeTag.mockReturnValue(false);
@@ -262,7 +170,7 @@ describe('CellTagsBar', () => {
 
 	it('keeps the surviving pills in order after removing a middle tag', async () => {
 		// Pills are keyed by tag value, so a mid-list removal must re-render to
-		// exactly the survivors, in order, without misassociating any pill by
+		// exactly the survivors, in order, without misassociating a pill by
 		// position. Each pill's edit button carries its tag as text.
 		const user = userEvent.setup();
 		const { cell } = createTagCell(['a', 'b', 'c']);
@@ -272,58 +180,6 @@ describe('CellTagsBar', () => {
 
 		const labels = screen.getAllByRole('button', { name: /^Edit tag / }).map(b => b.textContent);
 		expect(labels).toEqual(['a', 'c']);
-	});
-
-	it('renders one pill per value for a file loaded with duplicate tags', () => {
-		// The cell model collapses duplicates on read, so the bar shows a single
-		// pill per value with no colliding keys.
-		const { cell } = createTagCell(['dup', 'dup', 'x']);
-		rtl.render(<CellTagsBar cell={cell} />);
-
-		expect(screen.getAllByText('dup')).toHaveLength(1);
-		expect(screen.getByText('x')).toBeInTheDocument();
-	});
-
-	it('removes only the de-duplicated tag, leaving the others', async () => {
-		// removeTag operates on the de-duplicated list, so it can't drop a sibling
-		// occurrence -- only 'x' survives.
-		const user = userEvent.setup();
-		const { cell, removeTag, tags } = createTagCell(['dup', 'dup', 'x']);
-		rtl.render(<CellTagsBar cell={cell} />);
-
-		await user.click(screen.getByRole('button', { name: 'Remove tag dup' }));
-
-		expect(removeTag).toHaveBeenCalledWith('dup');
-		expect(tags.get()).toEqual(['x']);
-	});
-
-	it('edits the de-duplicated tag without mis-targeting a sibling', async () => {
-		// renameTag resolves against the de-duplicated list, so the rename lands
-		// on the single 'dup' occurrence and leaves 'x' untouched.
-		const user = userEvent.setup();
-		const { cell, renameTag, tags } = createTagCell(['dup', 'dup', 'x']);
-		rtl.render(<CellTagsBar cell={cell} />);
-
-		await user.click(screen.getByRole('button', { name: 'Edit tag dup' }));
-		const input = screen.getByRole('textbox');
-		await user.clear(input);
-		await user.type(input, 'renamed{Enter}');
-
-		expect(renameTag).toHaveBeenCalledWith('dup', 'renamed');
-		expect(tags.get()).toEqual(['renamed', 'x']);
-	});
-
-	it('removes a tag when an edit commits empty', async () => {
-		const user = userEvent.setup();
-		const { cell, removeTag, tags } = createTagCell(['gone']);
-		rtl.render(<CellTagsBar cell={cell} />);
-
-		await user.click(screen.getByRole('button', { name: 'Edit tag gone' }));
-		await user.clear(screen.getByRole('textbox'));
-		await user.keyboard('{Enter}');
-
-		expect(removeTag).toHaveBeenCalledWith('gone');
-		expect(tags.get()).toEqual([]);
 	});
 
 	it('keeps a blur-committed add when the same click removes another tag', async () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -73,14 +73,12 @@ describe('CellTagsBar', () => {
 		expect(screen.getByTestId('cell-tags-bar')).toHaveClass('standalone');
 	});
 
-	it('focuses the input and forwards an Enter-committed add to cell.addTag', async () => {
+	it('forwards an Enter-committed add to cell.addTag', async () => {
 		const user = userEvent.setup();
 		const { cell, addTag } = createTagCell(['data']);
 		rtl.render(<CellTagsBar cell={cell} />);
 
 		await user.click(screen.getByRole('button', { name: 'Add tag' }));
-		// The input must take focus on open, or the typed value is lost.
-		expect(screen.getByRole('textbox')).toHaveFocus();
 		await user.type(screen.getByRole('textbox'), 'fresh{Enter}');
 
 		// The cell owns trim / dedup; the bar just forwards the typed value.
@@ -165,46 +163,6 @@ describe('CellTagsBar', () => {
 
 		await user.click(screen.getByRole('button', { name: 'Remove tag drop' }));
 
-		expect(notificationInfo).toHaveBeenCalledWith(expect.stringContaining('Could not update'));
-	});
-
-	it('keeps the surviving pills in order after removing a middle tag', async () => {
-		// Pills are keyed by tag value, so a mid-list removal must re-render to
-		// exactly the survivors, in order, without misassociating a pill by
-		// position. Each pill's edit button carries its tag as text.
-		const user = userEvent.setup();
-		const { cell } = createTagCell(['a', 'b', 'c']);
-		rtl.render(<CellTagsBar cell={cell} />);
-
-		await user.click(screen.getByRole('button', { name: 'Remove tag b' }));
-
-		const labels = screen.getAllByRole('button', { name: /^Edit tag / }).map(b => b.textContent);
-		expect(labels).toEqual(['a', 'c']);
-	});
-
-	it('keeps a blur-committed add when the same click removes another tag', async () => {
-		const user = userEvent.setup();
-		const { cell, tags } = createTagCell(['keep']);
-		rtl.render(<CellTagsBar cell={cell} />);
-
-		await user.click(screen.getByRole('button', { name: 'Add tag' }));
-		await user.type(screen.getByRole('textbox'), 'fresh');
-		await user.click(screen.getByRole('button', { name: 'Remove tag keep' }));
-
-		expect(tags.get()).toEqual(['fresh']);
-	});
-
-	it('keeps a blur-committed edit when the same click removes another tag', async () => {
-		const user = userEvent.setup();
-		const { cell, tags } = createTagCell(['rename-me', 'drop']);
-		rtl.render(<CellTagsBar cell={cell} />);
-
-		await user.click(screen.getByRole('button', { name: 'Edit tag rename-me' }));
-		const input = screen.getByRole('textbox');
-		await user.clear(input);
-		await user.type(input, 'renamed');
-		await user.click(screen.getByRole('button', { name: 'Remove tag drop' }));
-
-		expect(tags.get()).toEqual(['renamed']);
+		expect(notificationInfo).toHaveBeenCalled();
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -150,6 +150,64 @@ describe('CellTagsBar', () => {
 		expect(renameTag).toHaveBeenCalledWith('old', 'new');
 	});
 
+	it('is a single-tab-stop toolbar with the add control leading the row', () => {
+		const { cell } = createTagCell(['data', 'wip']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		const buttons = screen.getAllByRole('button');
+		expect(screen.getByRole('toolbar')).toBeInTheDocument();
+		// The add control leads and is the only tab stop; tags are reached with
+		// the arrow keys so a long tag list doesn't add a tab stop per tag.
+		expect(buttons[0]).toHaveAccessibleName('Add tag');
+		expect(buttons[0]).toHaveAttribute('tabindex', '0');
+		for (const button of buttons.slice(1)) {
+			expect(button).toHaveAttribute('tabindex', '-1');
+		}
+	});
+
+	it('moves focus through the controls with arrow keys', async () => {
+		const user = userEvent.setup();
+		const { cell } = createTagCell(['data']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		// Tab enters the bar at its single tab stop, the add control.
+		await user.tab();
+		expect(screen.getByRole('button', { name: 'Add tag' })).toHaveFocus();
+
+		await user.keyboard('{ArrowRight}');
+		expect(screen.getByRole('button', { name: 'Edit tag data' })).toHaveFocus();
+
+		await user.keyboard('{ArrowRight}');
+		expect(screen.getByRole('button', { name: 'Remove tag data' })).toHaveFocus();
+
+		// The ends wrap around.
+		await user.keyboard('{ArrowRight}');
+		expect(screen.getByRole('button', { name: 'Add tag' })).toHaveFocus();
+		await user.keyboard('{ArrowLeft}');
+		expect(screen.getByRole('button', { name: 'Remove tag data' })).toHaveFocus();
+	});
+
+	it('activates the focused control with Enter without leaking the key to the notebook', async () => {
+		// Regression: keys handled inside the bar must not bubble out of it,
+		// where the notebook's command-mode keybindings live -- Enter would
+		// otherwise put the cell into edit mode on top of opening the tag editor.
+		const user = userEvent.setup();
+		const outerKeyDown = vi.fn();
+		const { cell } = createTagCell(['data']);
+		rtl.render(
+			// eslint-disable-next-line jsx-a11y/no-static-element-interactions -- stand-in for the notebook's key handling, not UI under test
+			<div onKeyDown={outerKeyDown}>
+				<CellTagsBar cell={cell} />
+			</div>
+		);
+
+		await user.tab();
+		await user.keyboard('{ArrowRight}{Enter}');
+
+		expect(screen.getByRole('textbox')).toHaveFocus();
+		expect(outerKeyDown).not.toHaveBeenCalled();
+	});
+
 	it('removes a tag via its close affordance', async () => {
 		const user = userEvent.setup();
 		const { cell, removeTag } = createTagCell(['keep', 'drop']);

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -24,7 +24,10 @@ import { AddTagResult, IPositronNotebookCell } from '../../../browser/PositronNo
  * handlers that read the latest tag state.
  */
 function createTagCell(initial: string[] = []) {
-	const tags = observableValue<string[]>('tags', initial);
+	// The real cell model de-duplicates tags on read, so the bar never sees
+	// duplicate values. Mirror that here so this stub is a faithful stand-in for
+	// a file loaded with duplicate tags.
+	const tags = observableValue<string[]>('tags', [...new Set(initial)]);
 	const setTags = vi.fn((next: string[]) => tags.set(next, undefined));
 	const addTag = vi.fn((tag: string): AddTagResult => {
 		const value = tag.trim();
@@ -175,6 +178,43 @@ describe('CellTagsBar', () => {
 		expect(screen.queryByText('b')).not.toBeInTheDocument();
 		expect(screen.getByText('a')).toBeInTheDocument();
 		expect(screen.getByText('c')).toBeInTheDocument();
+	});
+
+	it('renders one pill per value for a file loaded with duplicate tags', () => {
+		// The cell model collapses duplicates on read, so the bar shows a single
+		// pill per value with no colliding keys.
+		const { cell } = createTagCell(['dup', 'dup', 'x']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		expect(screen.getAllByText('dup')).toHaveLength(1);
+		expect(screen.getByText('x')).toBeInTheDocument();
+	});
+
+	it('removes only the de-duplicated tag, leaving the others', async () => {
+		// removeTag operates on the de-duplicated list, so it can't drop a sibling
+		// occurrence -- only 'x' survives.
+		const user = userEvent.setup();
+		const { cell, setTags } = createTagCell(['dup', 'dup', 'x']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Remove tag dup' }));
+
+		expect(setTags).toHaveBeenCalledWith(['x']);
+	});
+
+	it('edits the de-duplicated tag without mis-targeting a sibling', async () => {
+		// commitEdit resolves against the de-duplicated list, so the rename lands
+		// on the single 'dup' occurrence and leaves 'x' untouched.
+		const user = userEvent.setup();
+		const { cell, setTags } = createTagCell(['dup', 'dup', 'x']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Edit tag dup' }));
+		const input = screen.getByRole('textbox');
+		await user.clear(input);
+		await user.type(input, 'renamed{Enter}');
+
+		expect(setTags).toHaveBeenCalledWith(['renamed', 'x']);
 	});
 
 	it('removes a tag when an edit commits empty', async () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -26,6 +26,7 @@ import { AddTagResult, IPositronNotebookCell } from '../../../browser/PositronNo
 function createTagCell(initial: string[] = []) {
 	const tags = observableValue<string[]>('tags', [...initial]);
 	const isAddingTag = observableValue<boolean>('isAddingTag', false);
+	const cellTagsHidden = observableValue<boolean>('cellTagsHidden', false);
 	const addTag = vi.fn((tag: string): AddTagResult => {
 		tags.set([...tags.get(), tag], undefined);
 		return 'added';
@@ -42,8 +43,8 @@ function createTagCell(initial: string[] = []) {
 	// signal the "Add Tag" command flips), so wire them to the observable.
 	const beginAddTag = vi.fn(() => isAddingTag.set(true, undefined));
 	const endAddTag = vi.fn(() => isAddingTag.set(false, undefined));
-	const cell = stubInterface<IPositronNotebookCell>({ tags, isAddingTag, addTag, removeTag, renameTag, beginAddTag, endAddTag });
-	return { cell, tags, isAddingTag, addTag, removeTag, renameTag, beginAddTag, endAddTag };
+	const cell = stubInterface<IPositronNotebookCell>({ tags, isAddingTag, cellTagsHidden, addTag, removeTag, renameTag, beginAddTag, endAddTag });
+	return { cell, tags, isAddingTag, cellTagsHidden, addTag, removeTag, renameTag, beginAddTag, endAddTag };
 }
 
 describe('CellTagsBar', () => {
@@ -69,6 +70,16 @@ describe('CellTagsBar', () => {
 		const { container } = rtl.render(<CellTagsBar cell={cell} />);
 
 		expect(container).toBeEmptyDOMElement();
+	});
+
+	it('renders nothing when the notebook hides cell tags', () => {
+		const { cell, cellTagsHidden } = createTagCell(['data']);
+		rtl.render(<CellTagsBar cell={cell} />);
+		expect(screen.getByTestId('cell-tags-bar')).toBeInTheDocument();
+
+		act(() => cellTagsHidden.set(true, undefined));
+
+		expect(screen.queryByTestId('cell-tags-bar')).not.toBeInTheDocument();
 	});
 
 	it('applies the standalone modifier for the non-footer placement', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -18,16 +18,28 @@ import { AddTagResult, IPositronNotebookCell } from '../../../browser/PositronNo
 /**
  * A minimal cell exposing just the tag surface the bar touches. `setTags` is a
  * spy that also writes through to the observable, so the rendered pills reflect
- * the new state after edit/remove (mirroring the real cell model). `addTag` is a
- * spy that returns `'added'` by default; its trim/dedup/append invariant is
- * covered by the cell-model tests, so the bar tests just drive its return value.
+ * the new state after edit/remove (mirroring the real cell model). `addTag`
+ * mirrors the real trim/dedup/append behavior and also writes through, which
+ * lets tests cover interactions between blur-committed adds and same-click
+ * handlers that read the latest tag state.
  */
 function createTagCell(initial: string[] = []) {
 	const tags = observableValue<string[]>('tags', initial);
 	const setTags = vi.fn((next: string[]) => tags.set(next, undefined));
-	const addTag = vi.fn((_tag: string): AddTagResult => 'added');
+	const addTag = vi.fn((tag: string): AddTagResult => {
+		const value = tag.trim();
+		if (!value) {
+			return 'empty';
+		}
+		const latestTags = tags.get();
+		if (latestTags.includes(value)) {
+			return 'duplicate';
+		}
+		setTags([...latestTags, value]);
+		return 'added';
+	});
 	const cell = stubInterface<IPositronNotebookCell>({ tags, setTags, addTag });
-	return { cell, setTags, addTag };
+	return { cell, tags, setTags, addTag };
 }
 
 describe('CellTagsBar', () => {
@@ -175,5 +187,31 @@ describe('CellTagsBar', () => {
 		await user.keyboard('{Enter}');
 
 		expect(setTags).toHaveBeenCalledWith([]);
+	});
+
+	it('keeps a blur-committed add when the same click removes another tag', async () => {
+		const user = userEvent.setup();
+		const { cell, tags } = createTagCell(['keep']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Add tag' }));
+		await user.type(screen.getByRole('textbox'), 'fresh');
+		await user.click(screen.getByRole('button', { name: 'Remove tag keep' }));
+
+		expect(tags.get()).toEqual(['fresh']);
+	});
+
+	it('keeps a blur-committed edit when the same click removes another tag', async () => {
+		const user = userEvent.setup();
+		const { cell, tags } = createTagCell(['rename-me', 'drop']);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Edit tag rename-me' }));
+		const input = screen.getByRole('textbox');
+		await user.clear(input);
+		await user.type(input, 'renamed');
+		await user.click(screen.getByRole('button', { name: 'Remove tag drop' }));
+
+		expect(tags.get()).toEqual(['renamed']);
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTagsBar.vitest.tsx
@@ -220,6 +220,22 @@ describe('CellTagsBar', () => {
 		expect(tags.get()).toEqual(['keep', 'rename-me']);
 	});
 
+	it('notifies the user when an edit fails to write', async () => {
+		// renameTag returns 'failed' when the write can't be applied; the bar must
+		// surface the generic write-failure toast rather than dropping the rename.
+		const user = userEvent.setup();
+		const { cell, renameTag } = createTagCell(['old']);
+		renameTag.mockReturnValue('failed');
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Edit tag old' }));
+		const input = screen.getByRole('textbox');
+		await user.clear(input);
+		await user.type(input, 'new{Enter}');
+
+		expect(notificationInfo).toHaveBeenCalledWith(expect.stringContaining('Could not update'));
+	});
+
 	it('removes a tag via its close affordance', async () => {
 		const user = userEvent.setup();
 		const { cell, removeTag, tags } = createTagCell(['keep', 'drop']);
@@ -229,6 +245,19 @@ describe('CellTagsBar', () => {
 
 		expect(removeTag).toHaveBeenCalledWith('drop');
 		expect(tags.get()).toEqual(['keep']);
+	});
+
+	it('notifies the user when a removal fails to write', async () => {
+		// removeTag returns false when the write can't be applied; the bar must
+		// surface the generic write-failure toast rather than silently no-op.
+		const user = userEvent.setup();
+		const { cell, removeTag } = createTagCell(['keep', 'drop']);
+		removeTag.mockReturnValue(false);
+		rtl.render(<CellTagsBar cell={cell} />);
+
+		await user.click(screen.getByRole('button', { name: 'Remove tag drop' }));
+
+		expect(notificationInfo).toHaveBeenCalledWith(expect.stringContaining('Could not update'));
 	});
 
 	it('keeps the surviving pills in order after removing a middle tag', async () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/cellTagNotifications.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/cellTagNotifications.vitest.ts
@@ -29,14 +29,9 @@ describe('notifyTagResult', () => {
 		expect(info).toHaveBeenCalledWith(expect.stringContaining('Could not update'));
 	});
 
-	it('is silent for a successful add', () => {
+	it('is silent for added and empty results', () => {
 		const { notificationService, info } = setup();
 		notifyTagResult(notificationService, 'added', 'wip');
-		expect(info).not.toHaveBeenCalled();
-	});
-
-	it('is silent for an empty tag', () => {
-		const { notificationService, info } = setup();
 		notifyTagResult(notificationService, 'empty', 'wip');
 		expect(info).not.toHaveBeenCalled();
 	});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/cellTagNotifications.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/cellTagNotifications.vitest.ts
@@ -29,9 +29,9 @@ describe('notifyTagResult', () => {
 		expect(info).toHaveBeenCalledWith(expect.stringContaining('Could not update'));
 	});
 
-	it('is silent for a successful add', () => {
+	it('is silent for a successful write', () => {
 		const { notificationService, info } = setup();
-		notifyTagResult(notificationService, 'added', 'wip');
+		notifyTagResult(notificationService, 'ok', 'wip');
 		expect(info).not.toHaveBeenCalled();
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/cellTagNotifications.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/cellTagNotifications.vitest.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { INotificationService } from '../../../../../../platform/notification/common/notification.js';
+import { stubInterface } from '../../../../../../test/vitest/stubInterface.js';
+import { notifyTagResult } from '../../../browser/notebookCells/cellTagNotifications.js';
+
+describe('notifyTagResult', () => {
+	function setup() {
+		const info = vi.fn();
+		const notificationService = stubInterface<INotificationService>({ info });
+		return { notificationService, info };
+	}
+
+	it('shows a tag-specific toast for a duplicate', () => {
+		const { notificationService, info } = setup();
+		notifyTagResult(notificationService, 'duplicate', 'wip');
+		expect(info).toHaveBeenCalledWith(expect.stringContaining('wip'));
+	});
+
+	it('shows a generic toast for a failed write', () => {
+		const { notificationService, info } = setup();
+		notifyTagResult(notificationService, 'failed', 'wip');
+		// The failure toast is operation-agnostic and omits the tag value.
+		expect(info).toHaveBeenCalledWith(expect.stringContaining('Could not update'));
+	});
+
+	it('is silent for a successful add', () => {
+		const { notificationService, info } = setup();
+		notifyTagResult(notificationService, 'added', 'wip');
+		expect(info).not.toHaveBeenCalled();
+	});
+
+	it('is silent for an empty tag', () => {
+		const { notificationService, info } = setup();
+		notifyTagResult(notificationService, 'empty', 'wip');
+		expect(info).not.toHaveBeenCalled();
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/cellTagNotifications.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/cellTagNotifications.vitest.ts
@@ -29,10 +29,9 @@ describe('notifyTagResult', () => {
 		expect(info).toHaveBeenCalledWith(expect.stringContaining('Could not update'));
 	});
 
-	it('is silent for added and empty results', () => {
+	it('is silent for a successful add', () => {
 		const { notificationService, info } = setup();
 		notifyTagResult(notificationService, 'added', 'wip');
-		notifyTagResult(notificationService, 'empty', 'wip');
 		expect(info).not.toHaveBeenCalled();
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
@@ -7,6 +7,7 @@
 
 import { screen } from '@testing-library/react';
 import { observableValue } from '../../../../../../base/common/observable.js';
+import { createTestContainer } from '../../../../../../test/vitest/positronTestContainer.js';
 import { setupRTLRenderer } from '../../../../../../test/vitest/reactTestingLibrary.js';
 import { stubInterface } from '../../../../../../test/vitest/stubInterface.js';
 import { CodeCellStatusFooter } from '../../../browser/notebookCells/CodeCellStatusFooter.js';
@@ -19,10 +20,14 @@ interface CellState {
 	lastExecutionDuration?: number;
 	lastRunEndTime?: number;
 	lastRunSuccess?: boolean;
+	tags?: string[];
 }
 
 describe('CodeCellStatusFooter', () => {
-	const rtl = setupRTLRenderer();
+	// The footer embeds CellTagsBar, which reads the React services context, so
+	// render through the provider tree rather than the prop-only renderer.
+	const ctx = createTestContainer().withReactServices().build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
 	function renderFooter(state: CellState = {}, hasError = false) {
 		const cell = stubInterface<PositronNotebookCodeCell>({
@@ -31,6 +36,8 @@ describe('CodeCellStatusFooter', () => {
 			lastExecutionDuration: observableValue<number | undefined>('lastExecutionDuration', state.lastExecutionDuration),
 			lastRunEndTime: observableValue<number | undefined>('lastRunEndTime', state.lastRunEndTime),
 			lastRunSuccess: observableValue<boolean | undefined>('lastRunSuccess', state.lastRunSuccess),
+			tags: observableValue<string[]>('tags', state.tags ?? []),
+			setTags: vi.fn(),
 			isInViewport: () => true,
 		});
 
@@ -116,5 +123,21 @@ describe('CodeCellStatusFooter', () => {
 		renderFooter({ lastExecutionOrder: 1 });
 
 		expect(getFooter({ hidden: true })).toHaveClass('collapsed');
+	});
+
+	describe('tag separator', () => {
+		it('renders the separator only when both execution metadata and tags are present', () => {
+			renderFooter({ ...completedState, executionStatus: 'idle', lastRunSuccess: true, tags: ['wip'] });
+
+			expect(screen.getByTestId('cell-footer-tags-separator')).toBeInTheDocument();
+		});
+
+		it('omits the separator for a tag-only footer so there is no orphan divider', () => {
+			// No execution metadata: tags keep the footer open, but the separator
+			// would be an orphan with nothing before it, so it must not render.
+			renderFooter({ tags: ['wip'] });
+
+			expect(screen.queryByTestId('cell-footer-tags-separator')).not.toBeInTheDocument();
+		});
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
@@ -131,20 +131,20 @@ describe('CodeCellStatusFooter', () => {
 		expect(getFooter({ hidden: true })).toHaveClass('collapsed');
 	});
 
-	// The footer hosts the tag bar, so its collapse/divider layout depends on the
+	// The footer hosts the tag bar, so its collapse/stack layout depends on the
 	// cell's tag UI visibility as well as execution metadata: a visible tag UI
 	// (tags or an in-progress tag-add) keeps it open, hiding tags notebook-wide
-	// collapses it, and the divider only appears when execution metadata precedes
-	// the tag UI (otherwise it is an orphan with nothing before it).
-	const tagLayoutCases: { name: string; state: CellState; collapsed: boolean; separator: boolean }[] = [
-		{ name: 'execution metadata and tags', state: { ...completedState, executionStatus: 'idle', lastRunSuccess: true, tags: ['wip'] }, collapsed: false, separator: true },
-		{ name: 'execution metadata and a tag-add in progress', state: { ...completedState, executionStatus: 'idle', lastRunSuccess: true, isAddingTag: true }, collapsed: false, separator: true },
-		{ name: 'tags only', state: { tags: ['wip'] }, collapsed: false, separator: false },
-		{ name: 'tags hidden notebook-wide', state: { tags: ['wip'], cellTagsHidden: true }, collapsed: true, separator: false },
-		{ name: 'a tag-add in progress', state: { isAddingTag: true }, collapsed: false, separator: false },
+	// collapses it, and the execution-metadata row appears above the tags only
+	// when there is execution metadata to show (otherwise the tags are alone).
+	const tagLayoutCases: { name: string; state: CellState; collapsed: boolean; metadata: boolean }[] = [
+		{ name: 'execution metadata and tags', state: { ...completedState, executionStatus: 'idle', lastRunSuccess: true, tags: ['wip'] }, collapsed: false, metadata: true },
+		{ name: 'execution metadata and a tag-add in progress', state: { ...completedState, executionStatus: 'idle', lastRunSuccess: true, isAddingTag: true }, collapsed: false, metadata: true },
+		{ name: 'tags only', state: { tags: ['wip'] }, collapsed: false, metadata: false },
+		{ name: 'tags hidden notebook-wide', state: { tags: ['wip'], cellTagsHidden: true }, collapsed: true, metadata: false },
+		{ name: 'a tag-add in progress', state: { isAddingTag: true }, collapsed: false, metadata: false },
 	];
 
-	it.each(tagLayoutCases)('tag footer layout with $name', ({ state, collapsed, separator }) => {
+	it.each(tagLayoutCases)('tag footer layout with $name', ({ state, collapsed, metadata }) => {
 		renderFooter(state);
 		const footer = getFooter({ hidden: true });
 
@@ -153,10 +153,10 @@ describe('CodeCellStatusFooter', () => {
 		} else {
 			expect(footer).not.toHaveClass('collapsed');
 		}
-		if (separator) {
-			expect(screen.getByTestId('cell-footer-tags-separator')).toBeInTheDocument();
+		if (metadata) {
+			expect(screen.getByTestId('cell-footer-metadata')).toBeInTheDocument();
 		} else {
-			expect(screen.queryByTestId('cell-footer-tags-separator')).not.toBeInTheDocument();
+			expect(screen.queryByTestId('cell-footer-metadata')).not.toBeInTheDocument();
 		}
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
@@ -32,6 +32,9 @@ describe('CodeCellStatusFooter', () => {
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
 	function renderFooter(state: CellState = {}, hasError = false) {
+		// Mirrors the real cell's tagUIVisible derivation (tags or an in-progress
+		// add, unless the notebook hides tags).
+		const tagUIVisible = ((state.tags?.length ?? 0) > 0 || (state.isAddingTag ?? false)) && !(state.cellTagsHidden ?? false);
 		const cell = stubInterface<PositronNotebookCodeCell>({
 			executionStatus: observableValue<ExecutionStatus>('executionStatus', state.executionStatus ?? 'idle'),
 			lastExecutionOrder: observableValue<number | undefined>('lastExecutionOrder', state.lastExecutionOrder),
@@ -40,7 +43,7 @@ describe('CodeCellStatusFooter', () => {
 			lastRunSuccess: observableValue<boolean | undefined>('lastRunSuccess', state.lastRunSuccess),
 			tags: observableValue<string[]>('tags', state.tags ?? []),
 			isAddingTag: observableValue<boolean>('isAddingTag', state.isAddingTag ?? false),
-			cellTagsHidden: observableValue<boolean>('cellTagsHidden', state.cellTagsHidden ?? false),
+			tagUIVisible: observableValue<boolean>('tagUIVisible', tagUIVisible),
 			isInViewport: () => true,
 		});
 
@@ -128,13 +131,14 @@ describe('CodeCellStatusFooter', () => {
 		expect(getFooter({ hidden: true })).toHaveClass('collapsed');
 	});
 
-	// The footer hosts the tag bar, so its collapse/divider layout depends on tag
-	// state as well as execution metadata: visible tags or an in-progress tag-add
-	// keep it open, hiding tags notebook-wide collapses it, and the divider only
-	// appears when execution metadata precedes the tags (otherwise it is an orphan
-	// with nothing before it).
+	// The footer hosts the tag bar, so its collapse/divider layout depends on the
+	// cell's tag UI visibility as well as execution metadata: a visible tag UI
+	// (tags or an in-progress tag-add) keeps it open, hiding tags notebook-wide
+	// collapses it, and the divider only appears when execution metadata precedes
+	// the tag UI (otherwise it is an orphan with nothing before it).
 	const tagLayoutCases: { name: string; state: CellState; collapsed: boolean; separator: boolean }[] = [
 		{ name: 'execution metadata and tags', state: { ...completedState, executionStatus: 'idle', lastRunSuccess: true, tags: ['wip'] }, collapsed: false, separator: true },
+		{ name: 'execution metadata and a tag-add in progress', state: { ...completedState, executionStatus: 'idle', lastRunSuccess: true, isAddingTag: true }, collapsed: false, separator: true },
 		{ name: 'tags only', state: { tags: ['wip'] }, collapsed: false, separator: false },
 		{ name: 'tags hidden notebook-wide', state: { tags: ['wip'], cellTagsHidden: true }, collapsed: true, separator: false },
 		{ name: 'a tag-add in progress', state: { isAddingTag: true }, collapsed: false, separator: false },

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
@@ -128,39 +128,31 @@ describe('CodeCellStatusFooter', () => {
 		expect(getFooter({ hidden: true })).toHaveClass('collapsed');
 	});
 
-	it('stays open while a tag-add is in progress, even with no execution metadata or tags', () => {
-		// The "Add Tag" command flips isAddingTag to open the inline input; the
-		// footer must un-collapse so the input has somewhere to render.
-		renderFooter({ isAddingTag: true });
+	// The footer hosts the tag bar, so its collapse/divider layout depends on tag
+	// state as well as execution metadata: visible tags or an in-progress tag-add
+	// keep it open, hiding tags notebook-wide collapses it, and the divider only
+	// appears when execution metadata precedes the tags (otherwise it is an orphan
+	// with nothing before it).
+	const tagLayoutCases: { name: string; state: CellState; collapsed: boolean; separator: boolean }[] = [
+		{ name: 'execution metadata and tags', state: { ...completedState, executionStatus: 'idle', lastRunSuccess: true, tags: ['wip'] }, collapsed: false, separator: true },
+		{ name: 'tags only', state: { tags: ['wip'] }, collapsed: false, separator: false },
+		{ name: 'tags hidden notebook-wide', state: { tags: ['wip'], cellTagsHidden: true }, collapsed: true, separator: false },
+		{ name: 'a tag-add in progress', state: { isAddingTag: true }, collapsed: false, separator: false },
+	];
 
-		expect(getFooter()).not.toHaveClass('collapsed');
-	});
+	it.each(tagLayoutCases)('tag footer layout with $name', ({ state, collapsed, separator }) => {
+		renderFooter(state);
+		const footer = getFooter({ hidden: true });
 
-	it('collapses a tag-only footer and drops the divider when the notebook hides tags', () => {
-		// Tags are the only thing keeping this footer open; hiding them notebook-wide
-		// must collapse it rather than leave an empty row with an orphan divider.
-		renderFooter({ tags: ['wip'], cellTagsHidden: true });
-
-		expect(getFooter({ hidden: true })).toHaveClass('collapsed');
-		expect(screen.queryByTestId('cell-footer-tags-separator')).not.toBeInTheDocument();
-	});
-
-	describe('tag separator', () => {
-		it('renders the separator only when both execution metadata and tags are present', () => {
-			renderFooter({ ...completedState, executionStatus: 'idle', lastRunSuccess: true, tags: ['wip'] });
-
+		if (collapsed) {
+			expect(footer).toHaveClass('collapsed');
+		} else {
+			expect(footer).not.toHaveClass('collapsed');
+		}
+		if (separator) {
 			expect(screen.getByTestId('cell-footer-tags-separator')).toBeInTheDocument();
-		});
-
-		it('omits the separator for a tag-only footer so there is no orphan divider', () => {
-			// No execution metadata: tags keep the footer open, but the separator
-			// would be an orphan with nothing before it, so it must not render.
-			renderFooter({ tags: ['wip'] });
-
-			// Tags alone keep the footer open (the tag bar lives here); without this
-			// the bar would render into a collapsed, zero-height footer.
-			expect(getFooter()).not.toHaveClass('collapsed');
+		} else {
 			expect(screen.queryByTestId('cell-footer-tags-separator')).not.toBeInTheDocument();
-		});
+		}
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
@@ -37,7 +37,6 @@ describe('CodeCellStatusFooter', () => {
 			lastRunEndTime: observableValue<number | undefined>('lastRunEndTime', state.lastRunEndTime),
 			lastRunSuccess: observableValue<boolean | undefined>('lastRunSuccess', state.lastRunSuccess),
 			tags: observableValue<string[]>('tags', state.tags ?? []),
-			setTags: vi.fn(),
 			isInViewport: () => true,
 		});
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
@@ -136,6 +136,9 @@ describe('CodeCellStatusFooter', () => {
 			// would be an orphan with nothing before it, so it must not render.
 			renderFooter({ tags: ['wip'] });
 
+			// Tags alone keep the footer open (the tag bar lives here); without this
+			// the bar would render into a collapsed, zero-height footer.
+			expect(getFooter()).not.toHaveClass('collapsed');
 			expect(screen.queryByTestId('cell-footer-tags-separator')).not.toBeInTheDocument();
 		});
 	});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
@@ -21,6 +21,7 @@ interface CellState {
 	lastRunEndTime?: number;
 	lastRunSuccess?: boolean;
 	tags?: string[];
+	isAddingTag?: boolean;
 }
 
 describe('CodeCellStatusFooter', () => {
@@ -37,6 +38,7 @@ describe('CodeCellStatusFooter', () => {
 			lastRunEndTime: observableValue<number | undefined>('lastRunEndTime', state.lastRunEndTime),
 			lastRunSuccess: observableValue<boolean | undefined>('lastRunSuccess', state.lastRunSuccess),
 			tags: observableValue<string[]>('tags', state.tags ?? []),
+			isAddingTag: observableValue<boolean>('isAddingTag', state.isAddingTag ?? false),
 			isInViewport: () => true,
 		});
 
@@ -122,6 +124,14 @@ describe('CodeCellStatusFooter', () => {
 		renderFooter({ lastExecutionOrder: 1 });
 
 		expect(getFooter({ hidden: true })).toHaveClass('collapsed');
+	});
+
+	it('stays open while a tag-add is in progress, even with no execution metadata or tags', () => {
+		// The "Add Tag" command flips isAddingTag to open the inline input; the
+		// footer must un-collapse so the input has somewhere to render.
+		renderFooter({ isAddingTag: true });
+
+		expect(getFooter()).not.toHaveClass('collapsed');
 	});
 
 	describe('tag separator', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
@@ -22,6 +22,7 @@ interface CellState {
 	lastRunSuccess?: boolean;
 	tags?: string[];
 	isAddingTag?: boolean;
+	cellTagsHidden?: boolean;
 }
 
 describe('CodeCellStatusFooter', () => {
@@ -39,6 +40,7 @@ describe('CodeCellStatusFooter', () => {
 			lastRunSuccess: observableValue<boolean | undefined>('lastRunSuccess', state.lastRunSuccess),
 			tags: observableValue<string[]>('tags', state.tags ?? []),
 			isAddingTag: observableValue<boolean>('isAddingTag', state.isAddingTag ?? false),
+			cellTagsHidden: observableValue<boolean>('cellTagsHidden', state.cellTagsHidden ?? false),
 			isInViewport: () => true,
 		});
 
@@ -132,6 +134,15 @@ describe('CodeCellStatusFooter', () => {
 		renderFooter({ isAddingTag: true });
 
 		expect(getFooter()).not.toHaveClass('collapsed');
+	});
+
+	it('collapses a tag-only footer and drops the divider when the notebook hides tags', () => {
+		// Tags are the only thing keeping this footer open; hiding them notebook-wide
+		// must collapse it rather than leave an empty row with an orphan divider.
+		renderFooter({ tags: ['wip'], cellTagsHidden: true });
+
+		expect(getFooter({ hidden: true })).toHaveClass('collapsed');
+		expect(screen.queryByTestId('cell-footer-tags-separator')).not.toBeInTheDocument();
 	});
 
 	describe('tag separator', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
@@ -110,6 +110,14 @@ describe('PositronNotebookCell tags', () => {
 		expect(cell.tags.get()).toEqual(['seeded']);
 	});
 
+	it('de-duplicates tags read from an externally authored file', () => {
+		// nbformat tags are a set of labels, but a hand-edited file can carry
+		// duplicates. Collapsing them on read (first occurrence wins, order
+		// preserved) keeps the tag-bar UI's "values are unique" assumption true.
+		const cell = createCellWithMetadata({ metadata: { tags: ['dup', 'dup', 'x'] } });
+		expect(cell.tags.get()).toEqual(['dup', 'x']);
+	});
+
 	it('ignores tags at the non-persisted top-level metadata location', () => {
 		// The ipynb serializer never writes top-level cell metadata to the file,
 		// so tags found there are not real and must be ignored.

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
@@ -173,6 +173,16 @@ describe('PositronNotebookCell tags', () => {
 		expect(cell.tags.get()).toEqual([]);
 	});
 
+	it('setTags ignores a non-object nested metadata value instead of spreading it', () => {
+		// metadata.metadata is untrusted; spreading a scalar would inject numeric
+		// keys (e.g. {0:'a',1:'b',...}). A malformed value is dropped and only the
+		// tag metadata is written.
+		const cell = createCellWithMetadata({ metadata: 'abc' });
+		cell.setTags(['tag']);
+
+		expect(cell.model.metadata.metadata).toEqual({ tags: ['tag'] });
+	});
+
 	it('addTag trims, appends, and reports "added"', () => {
 		const cell = createCellWithMetadata({ metadata: { tags: ['first'] } });
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
@@ -110,18 +110,11 @@ describe('PositronNotebookCell tags', () => {
 		expect(cell.tags.get()).toEqual(['seeded']);
 	});
 
-	it('de-duplicates tags read from an externally authored file', () => {
-		// nbformat tags are a set of labels, but a hand-edited file can carry
-		// duplicates. Collapsing them on read (first occurrence wins, order
-		// preserved) keeps the tag-bar UI's "values are unique" assumption true.
-		const cell = createCellWithMetadata({ metadata: { tags: ['dup', 'dup', 'x'] } });
-		expect(cell.tags.get()).toEqual(['dup', 'x']);
-	});
-
 	it('drops non-string tag entries and de-duplicates the rest', () => {
 		// tags is untrusted file data; an external writer can violate the
 		// string-array contract. Non-string entries are filtered out (rather than
-		// rendered as garbage) and survivors are de-duplicated.
+		// rendered as garbage) and duplicate survivors are collapsed (the repeated
+		// 'ok' yields a single entry).
 		const cell = createCellWithMetadata({ metadata: { tags: ['ok', 42, null, 'ok', { x: 1 }] } });
 		expect(cell.tags.get()).toEqual(['ok']);
 	});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
@@ -253,6 +253,34 @@ describe('PositronNotebookCell tags', () => {
 		expect(cell.tags.get()).toEqual(['a']);
 	});
 
+	it('tag writes fail on a read-only notebook', () => {
+		// Tag edits are document mutations, so a read-only notebook rejects them
+		// at the setTags choke point and the verbs report 'failed'.
+		const notebook = createTestPositronNotebookInstance([{
+			source: 'print("hello")',
+			mime: undefined,
+			language: 'python',
+			cellKind: CellKind.Code,
+			outputs: [],
+			metadata: { metadata: { tags: ['seeded'] } },
+			internalMetadata: {},
+		}], ctx);
+		vi.spyOn(notebook, 'isReadOnly', 'get').mockReturnValue(true);
+		const cell = notebook.cells.get()[0];
+
+		expect({
+			add: cell.addTag('new'),
+			remove: cell.removeTag('seeded'),
+			rename: cell.renameTag('seeded', 'renamed'),
+			tags: cell.tags.get(),
+		}).toEqual({
+			add: 'failed',
+			remove: 'failed',
+			rename: 'failed',
+			tags: ['seeded'],
+		});
+	});
+
 	it('tagUIVisible folds tags, an in-progress add, and the notebook-wide hide toggle', () => {
 		// The cell owns the tag UI visibility predicate the tag bar and the code
 		// cell footer both render against.

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
@@ -170,6 +170,15 @@ describe('PositronNotebookCell tags', () => {
 		expect(cell.addTag('  dup  ')).toBe('duplicate');
 		expect(cell.tags.get()).toEqual(['dup']);
 	});
+
+	it('addTag reports "failed" when the write cannot be applied to a detached cell', () => {
+		// Once the cell is removed from the notebook its index is -1, so setTags
+		// no-ops. addTag must report that instead of claiming the tag was added.
+		const cell = createCellWithMetadata({ metadata: { tags: ['first'] } });
+		cell.delete();
+
+		expect(cell.addTag('second')).toBe('failed');
+	});
 });
 
 /** Tests to ensure that the test harness is correctly setup, useful for debugging the test harness */

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
@@ -118,6 +118,21 @@ describe('PositronNotebookCell tags', () => {
 		expect(cell.tags.get()).toEqual(['dup', 'x']);
 	});
 
+	it('drops non-string tag entries and de-duplicates the rest', () => {
+		// tags is untrusted file data; an external writer can violate the
+		// string-array contract. Non-string entries are filtered out (rather than
+		// rendered as garbage) and survivors are de-duplicated.
+		const cell = createCellWithMetadata({ metadata: { tags: ['ok', 42, null, 'ok', { x: 1 }] } });
+		expect(cell.tags.get()).toEqual(['ok']);
+	});
+
+	it('treats a non-array tags value as no tags', () => {
+		// A malformed scalar/object tags value must not throw when read (e.g.
+		// spreading a non-iterable); it is ignored entirely.
+		const cell = createCellWithMetadata({ metadata: { tags: 'not-an-array' } });
+		expect(cell.tags.get()).toEqual([]);
+	});
+
 	it('ignores tags at the non-persisted top-level metadata location', () => {
 		// The ipynb serializer never writes top-level cell metadata to the file,
 		// so tags found there are not real and must be ignored.

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
@@ -125,8 +125,8 @@ describe('PositronNotebookCell tags', () => {
 
 	it('a tag write lands in the nested location, not the top level', () => {
 		const cell = createCellWithMetadata({});
-		expect(cell.addTag('important')).toBe('added');
-		expect(cell.addTag('wip')).toBe('added');
+		expect(cell.addTag('important')).toBe('ok');
+		expect(cell.addTag('wip')).toBe('ok');
 
 		expect((cell.model.metadata.metadata as Record<string, unknown>).tags).toEqual(['important', 'wip']);
 		expect(cell.model.metadata.tags).toBeUndefined();
@@ -140,7 +140,7 @@ describe('PositronNotebookCell tags', () => {
 		const cell = createCellWithMetadata({
 			metadata: { collapsed: true, vscode: { languageId: 'python' } },
 		});
-		expect(cell.addTag('tag')).toBe('added');
+		expect(cell.addTag('tag')).toBe('ok');
 
 		expect(cell.model.metadata.metadata).toEqual({
 			collapsed: true,
@@ -151,7 +151,7 @@ describe('PositronNotebookCell tags', () => {
 
 	it('removing the last tag drops the tags key per nbformat convention', () => {
 		const cell = createCellWithMetadata({ metadata: { tags: ['gone'], collapsed: true } });
-		expect(cell.removeTag('gone')).toBe(true);
+		expect(cell.removeTag('gone')).toBe('ok');
 
 		expect(cell.model.metadata.metadata).toEqual({ collapsed: true });
 		expect(cell.tags.get()).toEqual([]);
@@ -162,7 +162,7 @@ describe('PositronNotebookCell tags', () => {
 		// keys (e.g. {0:'a',1:'b',...}). A malformed value is dropped and only the
 		// tag metadata is written.
 		const cell = createCellWithMetadata({ metadata: 'abc' });
-		expect(cell.addTag('tag')).toBe('added');
+		expect(cell.addTag('tag')).toBe('ok');
 
 		expect(cell.model.metadata.metadata).toEqual({ tags: ['tag'] });
 	});
@@ -175,21 +175,21 @@ describe('PositronNotebookCell tags', () => {
 		const cell = createCellWithMetadata({ metadata: { tags: ['a', 'b'] } });
 		const before = cell.model.metadata;
 
-		expect(cell.renameTag('a', 'a')).toBe('added');
+		expect(cell.renameTag('a', 'a')).toBe('ok');
 		expect(cell.model.metadata).toBe(before);
 	});
 
-	it('addTag trims, appends, and reports "added"', () => {
+	it('addTag trims, appends, and reports "ok"', () => {
 		const cell = createCellWithMetadata({ metadata: { tags: ['first'] } });
 
-		expect(cell.addTag('  second  ')).toBe('added');
+		expect(cell.addTag('  second  ')).toBe('ok');
 		expect(cell.tags.get()).toEqual(['first', 'second']);
 	});
 
 	it('addTag is a silent no-op for a whitespace-only tag', () => {
 		const cell = createCellWithMetadata({ metadata: { tags: ['first'] } });
 
-		expect(cell.addTag('   ')).toBe('added');
+		expect(cell.addTag('   ')).toBe('ok');
 		expect(cell.tags.get()).toEqual(['first']);
 	});
 
@@ -212,7 +212,7 @@ describe('PositronNotebookCell tags', () => {
 	it('removeTag filters the tag and reports success', () => {
 		const cell = createCellWithMetadata({ metadata: { tags: ['a', 'b', 'c'] } });
 
-		expect(cell.removeTag('b')).toBe(true);
+		expect(cell.removeTag('b')).toBe('ok');
 		expect(cell.tags.get()).toEqual(['a', 'c']);
 	});
 
@@ -220,22 +220,22 @@ describe('PositronNotebookCell tags', () => {
 		const cell = createCellWithMetadata({ metadata: { tags: ['a'] } });
 		const before = cell.model.metadata;
 
-		expect(cell.removeTag('missing')).toBe(true);
+		expect(cell.removeTag('missing')).toBe('ok');
 		expect(cell.model.metadata).toBe(before);
 		expect(cell.tags.get()).toEqual(['a']);
 	});
 
-	it('renameTag trims, replaces in place, and reports "added"', () => {
+	it('renameTag trims, replaces in place, and reports "ok"', () => {
 		const cell = createCellWithMetadata({ metadata: { tags: ['old', 'keep'] } });
 
-		expect(cell.renameTag('old', '  new  ')).toBe('added');
+		expect(cell.renameTag('old', '  new  ')).toBe('ok');
 		expect(cell.tags.get()).toEqual(['new', 'keep']);
 	});
 
 	it('renameTag is a silent no-op for a whitespace-only value', () => {
 		const cell = createCellWithMetadata({ metadata: { tags: ['old'] } });
 
-		expect(cell.renameTag('old', '   ')).toBe('added');
+		expect(cell.renameTag('old', '   ')).toBe('ok');
 		expect(cell.tags.get()).toEqual(['old']);
 	});
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
@@ -86,6 +86,92 @@ describe('PositronNotebookCell', () => {
 
 });
 
+describe('PositronNotebookCell tags', () => {
+	const ctx = createTestContainer().withNotebookEditorServices().build();
+
+	/** Create a single-code-cell notebook, seeding the cell's metadata. */
+	function createCellWithMetadata(metadata: Record<string, unknown>): PositronNotebookCodeCell {
+		const notebook = createTestPositronNotebookInstance([{
+			source: 'print("hello")',
+			mime: undefined,
+			language: 'python',
+			cellKind: CellKind.Code,
+			outputs: [],
+			metadata,
+			internalMetadata: {},
+		}], ctx);
+		return notebook.cells.get()[0] as PositronNotebookCodeCell;
+	}
+
+	it('reads tags from the nested nbformat metadata location', () => {
+		// On reload the ipynb deserializer stores the file's cell metadata under
+		// `metadata.metadata`, so the observable must read tags from there.
+		const cell = createCellWithMetadata({ metadata: { tags: ['seeded'] } });
+		expect(cell.tags.get()).toEqual(['seeded']);
+	});
+
+	it('ignores tags at the non-persisted top-level metadata location', () => {
+		// The ipynb serializer never writes top-level cell metadata to the file,
+		// so tags found there are not real and must be ignored.
+		const cell = createCellWithMetadata({ tags: ['ignored'] });
+		expect(cell.tags.get()).toEqual([]);
+	});
+
+	it('setTags writes to the nested location, not the top level', () => {
+		const cell = createCellWithMetadata({});
+		cell.setTags(['important', 'wip']);
+
+		expect((cell.model.metadata.metadata as Record<string, unknown>).tags).toEqual(['important', 'wip']);
+		expect(cell.model.metadata.tags).toBeUndefined();
+		expect(cell.tags.get()).toEqual(['important', 'wip']);
+	});
+
+	it('setTags preserves sibling nested metadata keys', () => {
+		// PartialMetadata is a shallow top-level merge, so the nested object is
+		// replaced wholesale unless setTags spreads it. Verify collapsed state
+		// and the vscode language id survive a tag edit.
+		const cell = createCellWithMetadata({
+			metadata: { collapsed: true, vscode: { languageId: 'python' } },
+		});
+		cell.setTags(['tag']);
+
+		expect(cell.model.metadata.metadata).toEqual({
+			collapsed: true,
+			vscode: { languageId: 'python' },
+			tags: ['tag'],
+		});
+	});
+
+	it('setTags([]) drops the tags key per nbformat convention', () => {
+		const cell = createCellWithMetadata({ metadata: { tags: ['gone'], collapsed: true } });
+		cell.setTags([]);
+
+		expect(cell.model.metadata.metadata).toEqual({ collapsed: true });
+		expect(cell.tags.get()).toEqual([]);
+	});
+
+	it('addTag trims, appends, and reports "added"', () => {
+		const cell = createCellWithMetadata({ metadata: { tags: ['first'] } });
+
+		expect(cell.addTag('  second  ')).toBe('added');
+		expect(cell.tags.get()).toEqual(['first', 'second']);
+	});
+
+	it('addTag reports "empty" and adds nothing for a whitespace-only tag', () => {
+		const cell = createCellWithMetadata({ metadata: { tags: ['first'] } });
+
+		expect(cell.addTag('   ')).toBe('empty');
+		expect(cell.tags.get()).toEqual(['first']);
+	});
+
+	it('addTag reports "duplicate" and adds nothing for an existing tag', () => {
+		const cell = createCellWithMetadata({ metadata: { tags: ['dup'] } });
+
+		expect(cell.addTag('  dup  ')).toBe('duplicate');
+		expect(cell.tags.get()).toEqual(['dup']);
+	});
+});
+
 /** Tests to ensure that the test harness is correctly setup, useful for debugging the test harness */
 describe('PositronNotebookCell Test Harness', () => {
 	const ctx = createTestContainer().withNotebookEditorServices().build();

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
@@ -183,6 +183,18 @@ describe('PositronNotebookCell tags', () => {
 		expect(cell.model.metadata.metadata).toEqual({ tags: ['tag'] });
 	});
 
+	it('setTags skips the write when the tag list is unchanged', () => {
+		// applyEdits replaces the metadata object (a new reference) and fires a
+		// change even for identical content, which would add an undo entry and
+		// dirty the notebook. A no-op (e.g. committing a tag edit without changes)
+		// must leave the metadata object untouched.
+		const cell = createCellWithMetadata({ metadata: { tags: ['a', 'b'] } });
+		const before = cell.model.metadata;
+
+		expect(cell.setTags(['a', 'b'])).toBe(true);
+		expect(cell.model.metadata).toBe(before);
+	});
+
 	it('addTag trims, appends, and reports "added"', () => {
 		const cell = createCellWithMetadata({ metadata: { tags: ['first'] } });
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
@@ -252,6 +252,36 @@ describe('PositronNotebookCell tags', () => {
 		expect(cell.renameTag('missing', 'new')).toBe('failed');
 		expect(cell.tags.get()).toEqual(['a']);
 	});
+
+	it('tagUIVisible folds tags, an in-progress add, and the notebook-wide hide toggle', () => {
+		// The cell owns the tag UI visibility predicate the tag bar and the code
+		// cell footer both render against.
+		const notebook = createTestPositronNotebookInstance([{
+			source: 'print("hello")',
+			mime: undefined,
+			language: 'python',
+			cellKind: CellKind.Code,
+			outputs: [],
+			metadata: {},
+			internalMetadata: {},
+		}], ctx);
+		const cell = notebook.cells.get()[0];
+		expect(cell.tagUIVisible.get()).toBe(false);
+
+		// An in-progress add shows the UI on an untagged cell; ending it hides it.
+		cell.beginAddTag();
+		expect(cell.tagUIVisible.get()).toBe(true);
+		cell.endAddTag();
+		expect(cell.tagUIVisible.get()).toBe(false);
+
+		expect(cell.addTag('tag')).toBe('ok');
+		expect(cell.tagUIVisible.get()).toBe(true);
+
+		// The notebook-wide toggle hides the UI without touching the tags.
+		notebook.toggleCellTagsHidden();
+		expect(cell.tagUIVisible.get()).toBe(false);
+		expect(cell.tags.get()).toEqual(['tag']);
+	});
 });
 
 /** Tests to ensure that the test harness is correctly setup, useful for debugging the test harness */

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
@@ -103,34 +103,24 @@ describe('PositronNotebookCell tags', () => {
 		return notebook.cells.get()[0] as PositronNotebookCodeCell;
 	}
 
-	it('reads tags from the nested nbformat metadata location', () => {
-		// On reload the ipynb deserializer stores the file's cell metadata under
-		// `metadata.metadata`, so the observable must read tags from there.
-		const cell = createCellWithMetadata({ metadata: { tags: ['seeded'] } });
-		expect(cell.tags.get()).toEqual(['seeded']);
-	});
+	it('normalizes tags read from cell metadata', () => {
+		// tags live under the nested `metadata.metadata` (the only location the
+		// ipynb serializer persists) and are untrusted file data, so the read drops
+		// non-strings, dedupes, and ignores a non-array or a top-level value.
+		const tagsFor = (metadata: Record<string, unknown>) =>
+			createCellWithMetadata(metadata).tags.get();
 
-	it('drops non-string tag entries and de-duplicates the rest', () => {
-		// tags is untrusted file data; an external writer can violate the
-		// string-array contract. Non-string entries are filtered out (rather than
-		// rendered as garbage) and duplicate survivors are collapsed (the repeated
-		// 'ok' yields a single entry).
-		const cell = createCellWithMetadata({ metadata: { tags: ['ok', 42, null, 'ok', { x: 1 }] } });
-		expect(cell.tags.get()).toEqual(['ok']);
-	});
-
-	it('treats a non-array tags value as no tags', () => {
-		// A malformed scalar/object tags value must not throw when read (e.g.
-		// spreading a non-iterable); it is ignored entirely.
-		const cell = createCellWithMetadata({ metadata: { tags: 'not-an-array' } });
-		expect(cell.tags.get()).toEqual([]);
-	});
-
-	it('ignores tags at the non-persisted top-level metadata location', () => {
-		// The ipynb serializer never writes top-level cell metadata to the file,
-		// so tags found there are not real and must be ignored.
-		const cell = createCellWithMetadata({ tags: ['ignored'] });
-		expect(cell.tags.get()).toEqual([]);
+		expect({
+			nested: tagsFor({ metadata: { tags: ['seeded'] } }),
+			malformedEntries: tagsFor({ metadata: { tags: ['ok', 42, null, 'ok', { x: 1 }] } }),
+			nonArray: tagsFor({ metadata: { tags: 'not-an-array' } }),
+			topLevel: tagsFor({ tags: ['ignored'] }),
+		}).toEqual({
+			nested: ['seeded'],
+			malformedEntries: ['ok'],
+			nonArray: [],
+			topLevel: [],
+		});
 	});
 
 	it('a tag write lands in the nested location, not the top level', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
@@ -140,23 +140,24 @@ describe('PositronNotebookCell tags', () => {
 		expect(cell.tags.get()).toEqual([]);
 	});
 
-	it('setTags writes to the nested location, not the top level', () => {
+	it('a tag write lands in the nested location, not the top level', () => {
 		const cell = createCellWithMetadata({});
-		cell.setTags(['important', 'wip']);
+		expect(cell.addTag('important')).toBe('added');
+		expect(cell.addTag('wip')).toBe('added');
 
 		expect((cell.model.metadata.metadata as Record<string, unknown>).tags).toEqual(['important', 'wip']);
 		expect(cell.model.metadata.tags).toBeUndefined();
 		expect(cell.tags.get()).toEqual(['important', 'wip']);
 	});
 
-	it('setTags preserves sibling nested metadata keys', () => {
+	it('a tag write preserves sibling nested metadata keys', () => {
 		// PartialMetadata is a shallow top-level merge, so the nested object is
-		// replaced wholesale unless setTags spreads it. Verify collapsed state
+		// replaced wholesale unless the write spreads it. Verify collapsed state
 		// and the vscode language id survive a tag edit.
 		const cell = createCellWithMetadata({
 			metadata: { collapsed: true, vscode: { languageId: 'python' } },
 		});
-		cell.setTags(['tag']);
+		expect(cell.addTag('tag')).toBe('added');
 
 		expect(cell.model.metadata.metadata).toEqual({
 			collapsed: true,
@@ -165,33 +166,33 @@ describe('PositronNotebookCell tags', () => {
 		});
 	});
 
-	it('setTags([]) drops the tags key per nbformat convention', () => {
+	it('removing the last tag drops the tags key per nbformat convention', () => {
 		const cell = createCellWithMetadata({ metadata: { tags: ['gone'], collapsed: true } });
-		cell.setTags([]);
+		expect(cell.removeTag('gone')).toBe(true);
 
 		expect(cell.model.metadata.metadata).toEqual({ collapsed: true });
 		expect(cell.tags.get()).toEqual([]);
 	});
 
-	it('setTags ignores a non-object nested metadata value instead of spreading it', () => {
+	it('a tag write ignores a non-object nested metadata value instead of spreading it', () => {
 		// metadata.metadata is untrusted; spreading a scalar would inject numeric
 		// keys (e.g. {0:'a',1:'b',...}). A malformed value is dropped and only the
 		// tag metadata is written.
 		const cell = createCellWithMetadata({ metadata: 'abc' });
-		cell.setTags(['tag']);
+		expect(cell.addTag('tag')).toBe('added');
 
 		expect(cell.model.metadata.metadata).toEqual({ tags: ['tag'] });
 	});
 
-	it('setTags skips the write when the tag list is unchanged', () => {
+	it('a no-op tag write is skipped and leaves the metadata object untouched', () => {
 		// applyEdits replaces the metadata object (a new reference) and fires a
 		// change even for identical content, which would add an undo entry and
-		// dirty the notebook. A no-op (e.g. committing a tag edit without changes)
+		// dirty the notebook. Renaming a tag to its current value is a no-op and
 		// must leave the metadata object untouched.
 		const cell = createCellWithMetadata({ metadata: { tags: ['a', 'b'] } });
 		const before = cell.model.metadata;
 
-		expect(cell.setTags(['a', 'b'])).toBe(true);
+		expect(cell.renameTag('a', 'a')).toBe('added');
 		expect(cell.model.metadata).toBe(before);
 	});
 
@@ -217,12 +218,63 @@ describe('PositronNotebookCell tags', () => {
 	});
 
 	it('addTag reports "failed" when the write cannot be applied to a detached cell', () => {
-		// Once the cell is removed from the notebook its index is -1, so setTags
+		// Once the cell is removed from the notebook its index is -1, so the write
 		// no-ops. addTag must report that instead of claiming the tag was added.
 		const cell = createCellWithMetadata({ metadata: { tags: ['first'] } });
 		cell.delete();
 
 		expect(cell.addTag('second')).toBe('failed');
+	});
+
+	it('removeTag filters the tag and reports success', () => {
+		const cell = createCellWithMetadata({ metadata: { tags: ['a', 'b', 'c'] } });
+
+		expect(cell.removeTag('b')).toBe(true);
+		expect(cell.tags.get()).toEqual(['a', 'c']);
+	});
+
+	it('removeTag is a no-op success for a tag that is not present', () => {
+		const cell = createCellWithMetadata({ metadata: { tags: ['a'] } });
+		const before = cell.model.metadata;
+
+		expect(cell.removeTag('missing')).toBe(true);
+		expect(cell.model.metadata).toBe(before);
+		expect(cell.tags.get()).toEqual(['a']);
+	});
+
+	it('removeTag reports failure when the write cannot be applied to a detached cell', () => {
+		const cell = createCellWithMetadata({ metadata: { tags: ['a'] } });
+		cell.delete();
+
+		expect(cell.removeTag('a')).toBe(false);
+	});
+
+	it('renameTag trims, replaces in place, and reports "added"', () => {
+		const cell = createCellWithMetadata({ metadata: { tags: ['old', 'keep'] } });
+
+		expect(cell.renameTag('old', '  new  ')).toBe('added');
+		expect(cell.tags.get()).toEqual(['new', 'keep']);
+	});
+
+	it('renameTag reports "empty" and writes nothing for a whitespace-only value', () => {
+		const cell = createCellWithMetadata({ metadata: { tags: ['old'] } });
+
+		expect(cell.renameTag('old', '   ')).toBe('empty');
+		expect(cell.tags.get()).toEqual(['old']);
+	});
+
+	it('renameTag reports "duplicate" when the new value is another existing tag', () => {
+		const cell = createCellWithMetadata({ metadata: { tags: ['a', 'b'] } });
+
+		expect(cell.renameTag('a', 'b')).toBe('duplicate');
+		expect(cell.tags.get()).toEqual(['a', 'b']);
+	});
+
+	it('renameTag reports "failed" when the original tag is no longer present', () => {
+		const cell = createCellWithMetadata({ metadata: { tags: ['a'] } });
+
+		expect(cell.renameTag('missing', 'new')).toBe('failed');
+		expect(cell.tags.get()).toEqual(['a']);
 	});
 });
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCell.vitest.ts
@@ -196,10 +196,10 @@ describe('PositronNotebookCell tags', () => {
 		expect(cell.tags.get()).toEqual(['first', 'second']);
 	});
 
-	it('addTag reports "empty" and adds nothing for a whitespace-only tag', () => {
+	it('addTag is a silent no-op for a whitespace-only tag', () => {
 		const cell = createCellWithMetadata({ metadata: { tags: ['first'] } });
 
-		expect(cell.addTag('   ')).toBe('empty');
+		expect(cell.addTag('   ')).toBe('added');
 		expect(cell.tags.get()).toEqual(['first']);
 	});
 
@@ -235,13 +235,6 @@ describe('PositronNotebookCell tags', () => {
 		expect(cell.tags.get()).toEqual(['a']);
 	});
 
-	it('removeTag reports failure when the write cannot be applied to a detached cell', () => {
-		const cell = createCellWithMetadata({ metadata: { tags: ['a'] } });
-		cell.delete();
-
-		expect(cell.removeTag('a')).toBe(false);
-	});
-
 	it('renameTag trims, replaces in place, and reports "added"', () => {
 		const cell = createCellWithMetadata({ metadata: { tags: ['old', 'keep'] } });
 
@@ -249,10 +242,10 @@ describe('PositronNotebookCell tags', () => {
 		expect(cell.tags.get()).toEqual(['new', 'keep']);
 	});
 
-	it('renameTag reports "empty" and writes nothing for a whitespace-only value', () => {
+	it('renameTag is a silent no-op for a whitespace-only value', () => {
 		const cell = createCellWithMetadata({ metadata: { tags: ['old'] } });
 
-		expect(cell.renameTag('old', '   ')).toBe('empty');
+		expect(cell.renameTag('old', '   ')).toBe('added');
 		expect(cell.tags.get()).toEqual(['old']);
 	});
 


### PR DESCRIPTION
Resolves #1532

### Summary

This PR adds support for cell tags in positron notebooks. We expose a fairly simple UI on top of the metadata and make it easy to add, remove, and edit the tags. 

The tag-mutation rules (trim, no blanks, no duplicates) live in the cell model, so the UI is just a thin presentation layer over it.

**How the tag bar shows up:**

- A cell with no tags shows nothing by default - no clutter on untagged cells.
- The first tag is added through the **Add Tag** command (right-click menu / command palette), which opens the inline input on that cell.
- Once a cell has at least one tag, a passive "Add tag" pill is revealed on hover so you can add more without the command.
- **Toggle Cell Tag Visibility** hides/shows all tags for the notebook (a transient, per-notebook toggle), and **Remove All Cell Tags** clears them across the whole notebook.

On code cells the tag bar lives in the cell footer alongside the execution status; markdown and raw cells render it standalone at the bottom of the cell.

### Demo

https://github.com/user-attachments/assets/66dd4dac-a7e7-4570-85dc-77a1b21c61ae


### Release Notes

#### New Features

- Added inline cell tag support to Positron notebooks, with commands to add, remove, and toggle visibility of tags (#1532)

#### Bug Fixes

- N/A

### Validation Steps

`@:positron-notebooks`

1. Open a Jupyter notebook in the Positron notebook editor.
2. On an untagged cell, confirm no tag bar is shown. Run the **Add Tag** command and confirm the inline input opens. Try this on both code and markdown cells.
3. With at least one tag present, hover the cell and confirm the "Add tag" pill appears; use it to add a second tag.
4. Try adding a duplicate or blank tag and confirm you get the expected toast / no-op.
5. Make sure **Toggle Cell Tag Visibility** does what it says on the tin. Same with delete all cell tags.
6. Save, close, and reopen the notebook to confirm tags persist in cell metadata.
