### PR TITLE
Fix Runtime Startup Diagnostics dropping the Discovery Cache section

### DIFF
--- a/src/vs/workbench/contrib/positronStartupDiagnostics/browser/positronStartupDiagnosticsEditor.ts
+++ b/src/vs/workbench/contrib/positronStartupDiagnostics/browser/positronStartupDiagnosticsEditor.ts
@@ -180,46 +180,11 @@ class PositronStartupDiagnosticsContentProvider implements ITextModelContentProv
 	}
 
 	private async _updateModel(): Promise<void> {
-		Promise.all([
-			// Wait for the timer service barrier so _addSystemInfo can read
-			// startupMetrics, but cap the wait. The diagnostics report's job is to
-			// surface state even when startup is wedged (which is exactly when the
-			// barrier may not open), so we render best-effort if the wait expires.
-			raceTimeout(this._timerService.whenReady(), 5000)
-		]).then(async () => {
-			if (this._model && !this._model.isDisposed()) {
-				const md = new MarkdownBuilder();
-				md.heading(1, 'Positron Runtime Startup Diagnostics');
-				md.blank();
-				this._addSystemInfo(md);
-				md.blank();
-				this._addAffiliatedRuntimes(md);
-				md.blank();
-				this._addActiveRuntimes(md);
-				md.blank();
-				this._addTimeToFirstRuntime(md);
-				md.blank();
-				this._addStartupPhaseTiming(md);
-				md.blank();
-				this._addRawPerfMarks(md);
-				md.blank();
-				this._addPerSessionTiming(md);
-				md.blank();
-				this._addInterpreterSettings(md);
-				md.blank();
-				this._addAdminEnforcedSettings(md);
-				md.blank();
-				await this._addSessionLaunchInfo(md);
-				md.blank();
-				this._addDiscoveredRuntimes(md);
-				md.blank();
-				this._addDiscoveryCache(md);
-				md.blank();
-				this._addExtensionHostStatus(md);
-				md.blank();
-				await this._addOutputChannels(md);
-			}
-		});
+		// Wait for the timer service barrier so _addSystemInfo can read
+		// startupMetrics, but cap the wait. The diagnostics report's job is to
+		// surface state even when startup is wedged (which is exactly when the
+		// barrier may not open), so we render best-effort if the wait expires.
+		await raceTimeout(this._timerService.whenReady(), 5000);
 
 		if (!this._model || this._model.isDisposed()) {
 			return;
@@ -250,11 +215,17 @@ class PositronStartupDiagnosticsContentProvider implements ITextModelContentProv
 		md.blank();
 		this._addDiscoveredRuntimes(md);
 		md.blank();
+		this._addDiscoveryCache(md);
+		md.blank();
 		this._addExtensionHostStatus(md);
 		md.blank();
 		await this._addOutputChannels(md);
 
-		this._model.setValue(md.value);
+		// Re-check after the awaits above; the model may have been disposed
+		// while we were gathering data.
+		if (this._model && !this._model.isDisposed()) {
+			this._model.setValue(md.value);
+		}
 	}
 
 	private _addSystemInfo(md: MarkdownBuilder): void {

--- a/test/e2e/tests/diagnostics/startupDiagnostics.test.ts
+++ b/test/e2e/tests/diagnostics/startupDiagnostics.test.ts
@@ -29,4 +29,28 @@ test.describe('Runtime Startup Diagnostics', {
 		await expect(viewLines.getByText('Positron Runtime Startup Diagnostics', { exact: false })).toBeVisible({ timeout: 30000 });
 		await expect(viewLines.getByText('System Information', { exact: false })).toBeVisible({ timeout: 30000 });
 	});
+
+	test('Discovery Cache section is included in the report', async function ({ app, runCommand, hotKeys }) {
+		const { clipboard } = app.workbench;
+
+		await runCommand('positron.startupDiagnostics.show');
+
+		// Wait for the report to render past the "Loading..." placeholder before
+		// reading it; see the sibling test for why these two headers are used.
+		const viewLines = app.code.driver.currentPage.locator('.monaco-editor .view-lines');
+		await expect(viewLines.getByText('Positron Runtime Startup Diagnostics', { exact: false })).toBeVisible({ timeout: 30000 });
+
+		// The "Discovery Cache" heading lives below the fold, and Monaco
+		// virtualizes view-lines so off-screen text is not in the DOM. Select-all
+		// + copy reads the full model regardless of what is rendered. This section
+		// was silently dropped once by a bad upstream merge, so guard its presence.
+		await viewLines.click();
+		await hotKeys.selectAll();
+		await clipboard.copy();
+
+		await expect(async () => {
+			const text = await clipboard.getClipboardText();
+			expect(text).toContain('Discovery Cache');
+		}).toPass({ timeout: 5000 });
+	});
 });


### PR DESCRIPTION
Fixes https://github.com/posit-dev/positron/issues/14022

The Runtime Startup Diagnostics report (`positron.startupDiagnostics.show`) stopped rendering the Discovery Cache section. The upstream merge (#13572) added a `raceTimeout` cap and a best-effort `.catch()` around the report build, but the conflict resolution duplicated the build body instead of editing it in place. The duplicate that actually calls `setValue` omitted `_addDiscoveryCache` and ran before the timer service barrier resolved, so the cache section disappeared and timing data could be read before `startupMetrics` was populated.

This collapses `_updateModel()` back to a single build path: await the capped `raceTimeout(whenReady(), 5000)`, build the report once (including the Discovery Cache section), then `setValue` once. An e2e test now asserts the Discovery Cache section is present so this cannot silently regress again.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Restore the Discovery Cache section in the Runtime Startup Diagnostics report (#14022)

### Validation Steps

@:sessions

1. Run the _Runtime Startup Diagnostics_ command from the Command Palette.
2. Confirm the report renders past the "Loading..." placeholder.
3. Scroll to the "Discovery Cache" section and confirm it is present, with the this-session counters, per-bucket state, and discovery root signatures.
