### PR TITLE
e2e: Skip assistant mcp test while investigating

### DIFF
--- a/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant-mcp.test.ts
@@ -17,7 +17,7 @@ const POSIT_ASSISTANT_PROVIDERS: ModelProvider[] = ['anthropic-api'];
 // Catches regressions where MCP servers in `.positai/settings.json` are
 // ignored — see posit-dev/assistant#1289 (fixed in #1293). Uses the `echo`
 // tool from @modelcontextprotocol/server-everything as a stable reference.
-test.describe('Posit Assistant MCP', {
+test.describe.skip('Posit Assistant MCP', { // skipping while investigating failures
 	tag: [tags.POSIT_ASSISTANT, tags.ASSISTANT, tags.WEB, tags.WIN],
 }, () => {
 


### PR DESCRIPTION
Skip the assistant mcp test for while I investigate and fix it's flakiness


### Validation Steps
@:posit-assistant
<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->
