### PR TITLE
e2e: support running `e2e-server` tests against arm-local Docker container

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -236,5 +236,12 @@
 		".github/skills/.local": true,
 		".agents/skills/.local": true,
 		".claude/skills/.local": true,
+	},
+	// --- Container e2e testing ---
+	// Sets a stable test data path that can be bind-mounted into the arm-local docker container.
+	// Required for e2e-server tests run from the UI against the container.
+	// See dockerfiles/arm-local/README.md for setup instructions.
+	"playwright.env": {
+		"POSITRON_TEST_DATA_PATH": "/tmp/positron-e2e"
 	}
 }

--- a/scripts/e2e-start-server.sh
+++ b/scripts/e2e-start-server.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
 # Start the Positron code server for external e2e testing
-# Usage: ./scripts/start-e2e-server.sh [port] [token]
+# Usage: ./scripts/start-e2e-server.sh [port] [token] [user-data-dir] [host]
+#
+# host defaults to 127.0.0.1. Pass 0.0.0.0 when the server needs to be
+# reachable from outside the machine (e.g. inside a Docker container with
+# port forwarding).
 
 PORT=${1:-8080}
 TOKEN=${2:-dev-token}
 USER_DATA_DIR=${3:-"$HOME/.positron-e2e-test"}
+HOST=${4:-127.0.0.1}
 
 echo "Starting Positron code server for e2e testing..."
+echo "Host: $HOST"
 echo "Port: $PORT"
 echo "Token: $TOKEN"
 echo "User Data Dir: $USER_DATA_DIR"
@@ -18,7 +24,7 @@ echo ""
 # are handled by the test fixture system.
 
 # Start the server with additional e2e options
-./scripts/code-server.sh --no-launch --connection-token "$TOKEN" --port "$PORT" \
+./scripts/code-server.sh --no-launch --host "$HOST" --connection-token "$TOKEN" --port "$PORT" \
 	--user-data-dir "$USER_DATA_DIR" \
 	--disable-telemetry \
 	--disable-experiments \

--- a/test/e2e/fixtures/test-setup/options.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/options.fixtures.ts
@@ -29,7 +29,7 @@ export interface CustomTestOptions {
 
 export function OptionsFixture() {
 	return async (logsPath: string, logger: any, snapshots: boolean, project: CustomTestOptions, workerInfo: playwright.WorkerInfo) => {
-		const TEST_DATA_PATH = join(os.tmpdir(), 'vscsmoke');
+		const TEST_DATA_PATH = process.env.POSITRON_TEST_DATA_PATH || join(os.tmpdir(), 'vscsmoke');
 		const EXTENSIONS_PATH = join(TEST_DATA_PATH, 'extensions-dir');
 		const WORKSPACE_PATH = join(TEST_DATA_PATH, 'qa-example-content');
 		const SPEC_CRASHES_PATH = join(ROOT_PATH, '.build', 'crashes', project.artifactDir, TEMP_DIR);

--- a/test/e2e/tests/_global.setup.ts
+++ b/test/e2e/tests/_global.setup.ts
@@ -10,7 +10,7 @@ import { cloneTestRepo, prepareTestEnv } from '../infra/test-runner';
 
 const ROOT_PATH = process.cwd();
 const LOGS_ROOT_PATH = join(ROOT_PATH, 'test-logs');
-const TEST_DATA_PATH = join(os.tmpdir(), 'vscsmoke');
+const TEST_DATA_PATH = process.env.POSITRON_TEST_DATA_PATH || join(os.tmpdir(), 'vscsmoke');
 const WORKSPACE_PATH = join(TEST_DATA_PATH, 'qa-example-content');
 
 async function globalSetup() {


### PR DESCRIPTION
### Summary
Enables running `e2e-server` browser tests from the Positron UI against a Positron server running in the arm-local Docker container.
- Add `POSITRON_TEST_DATA_PATH` env var support in global setup and options fixtures — falls back to existing `os.tmpdir()/vscsmoke` behavior when unset
- Add `--host` parameter to `e2e-start-server.sh` (defaults to `127.0.0.1`, pass `0.0.0.0` when running inside a container with port forwarding)
- Set `POSITRON_TEST_DATA_PATH=/tmp/positron-e2e` in `.vscode/settings.json` via `playwright.env` — points to a path that can be bind-mounted into the container so the server can access test workspaces created by the Mac test runner

### QA Notes
No impact on existing test runs — `POSITRON_TEST_DATA_PATH` is only active when set, and `--host` defaults to `127.0.0.1` as before. Requires companion PR in qa-example-content for the container-side setup.