### PR TITLE
E2E failure analyzer: shared drift-detection rubric + Slack thread notification

### DIFF
--- a/.claude/skills/e2e-failure-analyzer/SKILL.md
+++ b/.claude/skills/e2e-failure-analyzer/SKILL.md
@@ -103,12 +103,12 @@ Output JSON contains:
     - `trace` - parsed trace data: `timeline` (human-readable string), `errors` (array), `screenshotShas` (array of `{sha1, timestamp}` in chronological order), `lastScreenshotSha1` (legacy: same as last entry of `screenshotShas`)
     - `screenshotPaths` - chronological array of paths to extracted screenshot JPEGs (view with Read tool); the last entry is the failure-state frame, earlier entries show the moments before it
     - `screenshotPath` - legacy alias pointing to the last entry of `screenshotPaths`
-    - `errorContextPath` - path to extracted page snapshot markdown (view with Read tool if needed)
+    - `errorContextPath` - path to the extracted **page snapshot** markdown: Playwright's accessibility-tree snapshot of the page at the moment of failure (including content inside same-origin webview iframes), plus the failing selector and the relevant test source. Primary evidence for locator-not-found / not-visible / element-count / text-or-attribute failures -- Read it to tell a stale test selector from a real product regression (see the [analysis rubric](rubric.md))
   - `logHashes` - array of `{resourceHash, blob}` for logs (extract manually if needed)
 
 **IMPORTANT: View screenshots** using the `screenshotPaths` arrays with the Read tool. You MUST Read **all** screenshots in a **single message** with multiple parallel Read tool calls -- this results in only one approval prompt instead of one per screenshot. View all attempts and all frames per attempt; comparing across retries reveals whether a failure is consistent or intermittent, and comparing the trailing frames *within* an attempt often shows where the test went wrong before the visible error. Screenshots are the most revealing evidence for diagnosing failures. Default frame count per attempt is 3 (configurable via `--screenshots N` on `e2e-process-project.js`).
 
-**View error context** with the Read tool using `errorContextPath` paths if the screenshot and trace timeline are insufficient for diagnosis.
+**View the error-context page snapshot** with the Read tool using `errorContextPath` paths. For any locator-not-found, "not visible", element-count, or text/attribute failure, Read it FIRST (not as a last resort): it captures the failure-state accessibility tree -- the only evidence that distinguishes a stale test selector from a real product regression, since a screenshot cannot. See the [analysis rubric](rubric.md).
 
 ---
 
@@ -131,7 +131,7 @@ For interactive / ad-hoc use, you can call the script directly with any CloudFro
 
 Output JSON is identical to Path A's `e2e-process-project.js` (see the field list above), so the same screenshot-reading and analysis flow applies. The `blob` field is the report directory name (last path segment of the S3 URL) rather than a zip filename, since Path B has no blob zips.
 
-**IMPORTANT: View screenshots** the same way as Path A -- Read all `screenshotPaths` arrays in a single message with multiple parallel Read tool calls, and view `errorContextPath` files when the screenshot and trace timeline aren't enough.
+**IMPORTANT: View screenshots** the same way as Path A -- Read all `screenshotPaths` arrays in a single message with multiple parallel Read tool calls. Read the `errorContextPath` page snapshot FIRST for any locator-not-found / not-visible / attribute / text failure (it is the primary evidence for stale-selector vs product-regression -- see the [analysis rubric](rubric.md)), not just when screenshots and traces fall short.
 
 ---
 
@@ -193,34 +193,9 @@ Include a **History** line in each failure's analysis, e.g.:
 
 ## Step 7: Analyze and Present Results
 
-Using all the data gathered (failures, trace actions, screenshots, logs), analyze the failures. For each failure (or group of related failures), determine:
+For each failure (or group of related failures), apply the shared **[analysis rubric](rubric.md)** to determine its root-cause category, a 1-2 sentence evidence-based explanation, and a suggested action. `rubric.md` is the single source of truth for the root-cause categories, the evidence-reading order (screenshots, trace timeline, test source, and the error-context page snapshot -- read FIRST for any locator/visibility/attribute/text failure), the locator-drift-vs-product-regression decision, historical-data interpretation, and head-commit correlation. The **same file is injected verbatim into the analyzer Action's system prompt**, so local skill runs and the Action reason identically -- edit the rubric there, not here.
 
-1. **Root cause category** - one of: flaky test, infrastructure issue, product regression, test environment issue, timeout, test logic bug
-2. **Brief explanation** - 1-2 sentences on what likely went wrong, referencing specific evidence from traces/screenshots/logs
-3. **Suggested action** - what a developer should do next
-
-When analyzing, consider:
-- Multiple tests failing in the same file/suite likely share a root cause
-- `timedOut` status often indicates flakiness or infrastructure slowness
-- Errors mentioning "locator" or "expect" timeouts are usually test/product issues
-- Errors during app startup (e.g., waiting for workbench) are usually infrastructure
-- Check if the failing test has `:soft-fail` tag (known flaky)
-- The screenshot at failure is often the most revealing piece of evidence
-
-### Check the triggering commit
-
-For tests that **failed all retries** (not just flaky), inspect the head commit using the `commit` field from Step 1's `e2e-gather-run-info.js` output (already includes message, author, and changed files).
-
-Compare the changed files against:
-- **The failing test file itself** and its page objects/helpers -- changes here could introduce a test logic bug
-- **Product source code exercised by the test** -- changes to the feature under test could be a real product regression that the test correctly caught
-- **Shared infrastructure** (startup, layout, rendering) -- changes here could alter timing or behavior enough to surface a latent flaky test
-
-If the commit touched relevant files, read the diff and assess causality. A commit that modifies notebook cell rendering is a plausible cause for a notebook cell-count assertion failure, even if the test has flaked before. Conversely, a commit that only changes R interpreter code is unlikely to cause a Python plot test failure.
-
-Include a **Commit** line in the detailed analysis when the commit is relevant, e.g.:
-- "Commit: modified `notebookCellList.ts` (notebook cell rendering) -- **plausible cause**"
-- "Commit: no files related to this test's feature area -- unlikely cause"
+Include a **Commit** line in the detailed analysis when the head commit is relevant (per the rubric), e.g. "Commit: modified `notebookCellList.ts` (notebook cell rendering) -- **plausible cause**" or "Commit: no files related to this test's feature area -- unlikely cause".
 
 ### Additional repo context
 

--- a/.claude/skills/e2e-failure-analyzer/rubric.md
+++ b/.claude/skills/e2e-failure-analyzer/rubric.md
@@ -1,0 +1,57 @@
+# E2E Failure Analysis Rubric
+
+The single source of truth for how to categorize and reason about an e2e test failure. Two consumers share this file and MUST stay in sync:
+
+- the **e2e-failure-analyzer skill** (`SKILL.md`, Step 7) -- interactive triage, and
+- the **e2e-failure-analyzer GitHub Action** (`analyze.mjs` injects this file verbatim into the model's system prompt).
+
+Edit the rubric here and both pick up the change. Keep it runner-neutral: output format and orchestration (which scripts to run, how to present results, what follow-ups to offer) live in each consumer, not here.
+
+## For each failure (or group of related failures), determine
+
+1. **Root cause category** -- one of: flaky test | infrastructure issue | product regression | locator drift / stale selector (test maintenance) | test environment issue | timeout | test logic bug
+2. **Brief explanation** -- 1-2 sentences citing specific evidence from screenshots, the trace timeline, the error-context page snapshot, or logs.
+3. **Suggested action** -- what a developer should do next.
+
+## Read the evidence before concluding
+
+- **Screenshots:** read every screenshot for an attempt, in chronological order (the last is the failure-state; earlier frames show the moments leading up to it). Comparing them often reveals the real root cause -- the failure message and the final frame can mislead on their own. When reading them as files, read all of them in parallel in a single message.
+- **Trace timeline:** read the full action sequence (selector clicks, navigations, waits) provided with each attempt. It often shows where the test actually went wrong even if the final error points elsewhere -- don't stop at the last action.
+- **Failing test source:** read it before drawing conclusions. The source tells you what the test intends to verify, which page objects/helpers it depends on, and the setup steps -- often the difference between "the assertion is the bug" and "setup failed before reaching the assertion." Test source lives at `test/e2e/<file>` (the Action exposes the checkout as `<REPO_ROOT>`; interactively it is your working tree). When the test imports from `../../pages/`, `../../fixtures/`, or `../../infra/`, read those too if the failure involves their behavior. `infra/` (`workbench.ts`, `code.ts`, the Playwright drivers) is especially useful for failures during workbench startup, session creation, or teardown.
+- **Error-context page snapshot -- READ IT FIRST (not as a last resort) for any failure where a locator was not found, an element was "not visible", an element count was wrong, or a text/attribute assertion failed.** This markdown (`errorContextPath` on each attempt) holds Playwright's accessibility-tree snapshot of the page AT THE MOMENT OF FAILURE -- including content inside same-origin webview iframes -- plus the failing selector and the relevant test source. It is the single best evidence for telling a stale test selector apart from a real product bug. A screenshot CANNOT make this distinction: "the element failed to render" (product bug) and "the element rendered as different markup" (the test's selector is stale) look identical in a JPEG.
+
+## Locator drift vs product regression
+
+Whenever a locator did not match, decide between **locator drift / stale selector** (test maintenance) and **product regression** using the error-context page snapshot:
+
+- Take the target's STABLE, human-meaningful identifier from the failing selector -- its visible text, placeholder, aria-label, or role name -- NOT the structural class/id, which is the part that drifts.
+- Identifier **present but under a different role/shape** than the selector expects (e.g. the selector wants `textarea[placeholder="X"]` but "X" now appears as a generic/div, or a labeled control changed tag or moved) => **locator drift / stale selector**. The element exists; the selector is stale (usually NOT a product bug). Confirm against the page object in `test/e2e/pages/*.ts`: if its selector targets markup that no longer matches the snapshot, it is stale, and the action is to update the selector.
+- Identifier **absent entirely** (no equivalent affordance present) => **product regression**: the element genuinely failed to render.
+- Element **present with its expected role** but the error is a visibility/interactability timeout => timing/flaky, not drift.
+- A **bootstrapped** extension floated to its latest main build at test time (e.g. Posit Assistant) is a common source of locator drift WITH NO POSITRON-SIDE CHANGE: its UI markup changes upstream, so the head commit and changed files look unrelated. An unrelated-looking commit does NOT imply product regression -- check the snapshot for changed markup before concluding either way.
+
+## Other heuristics
+
+- Multiple tests failing in the same file/suite usually share a root cause -- group them.
+- `timedOut` status often indicates flakiness or infrastructure slowness.
+- Failures during app startup (e.g. waiting for the workbench) are usually infrastructure.
+- Tests tagged `:soft-fail` are known flaky.
+
+## Use historical data when available
+
+If historical test-health data is provided, use it to separate regressions from known flakes:
+
+- 0% pass rate on one platform but 100% on others = deterministic platform regression, NOT flaky. Always read the per-environment breakdown, not just the aggregate pass rate.
+- A failure pattern that starts on this run across all platforms at once points to a regression (or an upstream bootstrapped-extension change), not a flake.
+
+## Check the triggering commit
+
+For tests that **failed all retries** (not just flaky), inspect the head commit's changed files and assess causality against:
+
+- **The failing test file itself** and its page objects/helpers -- changes here could introduce a test logic bug or a stale selector.
+- **Product source code exercised by the test** -- changes to the feature under test could be a real product regression the test correctly caught.
+- **Shared infrastructure** (startup, layout, rendering) -- changes here could alter timing or behavior enough to surface a latent flaky test.
+
+A commit that modifies notebook cell rendering is a plausible cause for a notebook cell-count assertion failure, even if the test has flaked before. Conversely, a commit that only changes R interpreter code is unlikely to cause a Python plot test failure. When the commit is relevant, say so explicitly, e.g. "modified `notebookCellList.ts` (notebook cell rendering) -- plausible cause" or "no files related to this test's feature area -- unlikely cause".
+
+**Caveat for bootstrapped extensions:** Posit Assistant (and other extensions floated to their latest main build at test time) change UI markup upstream, so a drift-induced failure leaves NO trace in the head commit's changed files. For a locator failure on such a test, an unrelated-looking commit is expected and is NOT evidence of a product regression -- apply the locator-drift decision above before blaming the product.

--- a/.github/actions/e2e-failure-analyzer/action.yml
+++ b/.github/actions/e2e-failure-analyzer/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: "Path to the repo workspace whose test/e2e/ source and .claude/skills/ helpers the analyzer should read. Defaults to $GITHUB_WORKSPACE. positron-builds passes $GITHUB_WORKSPACE/positron because both the test source and helper scripts live in the submodule."
     required: false
     default: ""
+  webhook-secret:
+    description: "e2e-test-insights webhook secret (X-Webhook-Secret). When set together with e2e-insights-api-key, the analyzer appends a link to its report into the analyzed run's Slack thread. Leave empty to skip the Slack post."
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -222,6 +226,82 @@ runs:
         MODEL: ${{ inputs.model }}
         MAX_TURNS: ${{ inputs.max-turns }}
       run: node analyze.mjs
+
+    - name: Post analysis link to Slack thread
+      if: always()
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        WORK_DIR: ${{ steps.prep.outputs.work_dir }}
+        # Same Connect API key used for the history query -- it authenticates
+        # against the same connect.posit.it/e2e-test-insights-api host.
+        CONNECT_API_KEY: ${{ inputs.e2e-insights-api-key }}
+        WEBHOOK_SECRET: ${{ inputs.webhook-secret }}
+        API_URL: "https://connect.posit.it/e2e-test-insights-api"
+      run: |
+        # Append the analysis report link to the failing run's Slack thread.
+        # The dashboard opens a thread for any run with failures/flakes, and the
+        # analyzer only runs on such runs, so a thread should already exist.
+        # Posting is best-effort: a webhook failure must never fail this job.
+        if [ -z "$WEBHOOK_SECRET" ] || [ -z "$CONNECT_API_KEY" ]; then
+          echo "Webhook secret or Connect API key not provided; skipping Slack thread append."
+          exit 0
+        fi
+        if [ ! -f "$WORK_DIR/analysis-report.md" ]; then
+          echo "No analysis-report.md produced; skipping Slack thread append."
+          exit 0
+        fi
+
+        # The e2e-test-insights API uses a single "positron" repo ID for both
+        # posit-dev/positron and posit-dev/positron-builds (same as the history
+        # query step) -- do not parameterize this on the source GH repo.
+        REPO_ID="positron"
+
+        # workflow_run_id must identify the run that registered the Slack thread:
+        # the run being analyzed (run-info.json), which is NOT necessarily the run
+        # the analyzer executes in (they coincide for posit-dev/positron).
+        WORKFLOW_RUN_ID=$(jq -r '.runId // empty' "$WORK_DIR/run-info.json")
+        if [ -z "$WORKFLOW_RUN_ID" ]; then
+          echo "::warning::Could not read runId from run-info.json; skipping Slack thread append."
+          exit 0
+        fi
+
+        # Link to this analyzer job's step summary (where the report is rendered).
+        # Resolve the numeric job ID for the #summary-<id> anchor by matching the
+        # in-progress job on this runner; fall back to the run page if unresolved.
+        RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+        JOB_ID=$(gh api \
+          "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs" \
+          --paginate \
+          --jq ".jobs[] | select(.runner_name == \"${RUNNER_NAME}\" and .status == \"in_progress\") | .id" \
+          2>/dev/null | head -1 || true)
+        if [ -n "$JOB_ID" ]; then
+          LINK="${RUN_URL}#summary-${JOB_ID}"
+        else
+          echo "Could not resolve analyzer job ID; linking to the run page."
+          LINK="$RUN_URL"
+        fi
+
+        payload=$(jq -n \
+          --arg repo_id "$REPO_ID" \
+          --arg run_id "$WORKFLOW_RUN_ID" \
+          --arg text "E2E failure analysis complete: <${LINK}|View report>" \
+          '{repo_id: $repo_id, workflow_run_id: $run_id, text: $text}')
+
+        response=$(curl -s -w "\n%{http_code}" -X POST \
+          "${API_URL}/webhooks/thread-append" \
+          -H "Authorization: Key ${CONNECT_API_KEY}" \
+          -H "X-Webhook-Secret: ${WEBHOOK_SECRET}" \
+          -H "Content-Type: application/json" \
+          -d "$payload")
+
+        http_code=$(echo "$response" | tail -1)
+        body=$(echo "$response" | sed '$d')
+        if [ "$http_code" = "200" ] || [ "$http_code" = "202" ]; then
+          echo "Slack thread append queued (HTTP $http_code): $body"
+        else
+          echo "::warning::Slack thread append failed (HTTP $http_code): $body"
+        fi
 
     - name: Upload analyzer artifacts
       if: always()

--- a/.github/actions/e2e-failure-analyzer/analyze.mjs
+++ b/.github/actions/e2e-failure-analyzer/analyze.mjs
@@ -12,6 +12,7 @@
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import { readFileSync, existsSync, appendFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const WORK_DIR = mustEnv('WORK_DIR');
 const MODEL = process.env.MODEL || 'opus';
@@ -291,25 +292,16 @@ function renderHistorySummary(history, historyMap) {
 	return `Per-test history pre-rendered inline with each failure below. (${total} tests in history blob, lookback ${history.lookback_days || '?'} days, branch ${history.branch || '?'}.)`;
 }
 
-const SYSTEM_PROMPT = `You are an e2e test failure triage analyst for the Positron IDE project. You produce concise, evidence-based markdown reports for GitHub Actions step summaries.
+const SYSTEM_PROMPT_HEAD = `You are an e2e test failure triage analyst for the Positron IDE project. You produce concise, evidence-based markdown reports for GitHub Actions step summaries.
 
-For each failure or group of related failures, determine:
-1. Root cause category -- one of: flaky test | infrastructure issue | product regression | test environment issue | timeout | test logic bug
-2. Brief explanation (1-2 sentences) referencing specific evidence from screenshots, trace timelines, or logs
-3. Suggested action for a developer
+Apply the analysis rubric below to every failure. It is the shared source of truth for root-cause categories and the reasoning that distinguishes a stale test selector from a real product bug; the e2e-failure-analyzer skill uses the same rubric file, so local triage and this Action reason identically.`;
 
-Process:
-- READ EVERY SCREENSHOT IN PARALLEL with multiple Read tool calls in a single message. Each attempt may have several screenshots in chronological order; the last is the failure-state, the earlier ones show what the page looked like in the moments leading up to it. Comparing them is often what reveals the real root cause -- the failure message and the final frame can be misleading on their own.
-- READ THE FULL TRACE TIMELINE in the prompt. The action sequence (selector clicks, navigations, waits) often shows where a test actually went wrong even if the final error points elsewhere. Don't stop at the last action.
-- READ THE FAILING TEST'S SOURCE FILE before drawing conclusions. The test file path is provided in each failure entry. If REPO_ROOT is set in the input header, the absolute path is \`<REPO_ROOT>/test/e2e/<file>\`. Reading the source tells you what the test actually intends to verify, what page objects/helpers it depends on, and the setup steps -- often the difference between "the assertion is the bug" vs "setup failed before reaching the assertion." When the test imports from \`../../pages/\`, \`../../fixtures/\`, or \`../../infra/\`, Read those too if the failure involves their behavior. \`infra/\` is especially useful when the failure happens during workbench startup, session creation, or teardown -- look at \`workbench.ts\`, \`code.ts\`, or the playwright drivers there. Do this BEFORE writing the analysis, not after.
-- View error-context markdown files when screenshots, trace timelines, and source code are insufficient.
-- Multiple tests failing in the same file/suite usually share a root cause -- group them.
+// Runner-specific instructions appended after the shared rubric: pre-computed
+// severity (the Action computes it; the model must not second-guess it) and the
+// exact step-summary output contract.
+const SYSTEM_PROMPT_TAIL = `This run also provides pre-computed severity and requires a specific output format.
+
 - The Severity for each test is pre-computed and labeled in the input ("Severity: HARD" or "Severity: FLAKY"). Use that label VERBATIM in your output. Do NOT recompute severity from retry counts, root cause, or history -- the input label is authoritative. A test can have root cause "flaky test" and severity "HARD" simultaneously: that means the test failed all retries on this run AND its history shows it's prone to flaking.
-- Tests tagged \`:soft-fail\` are known flaky.
-- If historical data is provided, use it to distinguish regressions from known flakes:
-  - 0% pass rate on one platform but 100% on others = deterministic platform regression, NOT flaky
-  - Always read environment_breakdown, not just aggregate pass_rate
-- Consider the head commit's changed files: do they touch code exercised by the failing test? Mention this in the per-failure analysis when relevant.
 
 Output the FINAL REPORT as your last message. The report MUST be valid GitHub-flavored markdown starting with the heading \`## Summary\`. Do not include images, raw JSON, or commentary outside the report. Do not include any text before \`## Summary\` in the final message.
 
@@ -327,9 +319,9 @@ Order the rows: **all hard-severity failures first, then all flaky-severity fail
 
 For each distinct failure (or group), provide:
 - **<test name>** (<platform>) -- <root cause category>
-  - Evidence: <1-2 sentences citing what the screenshot/trace shows>
+  - Evidence: <1-2 sentences citing what the screenshot/trace/page snapshot shows>
   - Commit: <relevant changed files, or "no related changes">
-  - History: <history line per the SKILL.md format, or "no data available">
+  - History: <history line, or "no data available">
   - Action: <what the developer should do>
 
 Constraints:
@@ -337,6 +329,44 @@ Constraints:
 - Use Posit / Positron terminology (workbench, console, runtime, plot view, etc.).
 - Do not embed image markdown -- screenshots aren't rendered in step summaries.
 - Do not invent file paths, test names, or error messages -- only cite what's in the input.`;
+
+// Minimal degraded-mode rubric used only if rubric.md cannot be read. Keep it
+// short and obviously partial -- it is NOT a parallel source of truth.
+const RUBRIC_FALLBACK = `## Analysis rubric (fallback -- rubric.md could not be loaded)
+
+For each failure determine: (1) root cause -- one of flaky test | infrastructure issue | product regression | locator drift / stale selector | test environment issue | timeout | test logic bug; (2) a 1-2 sentence evidence-based explanation; (3) a suggested action. For any locator-not-found / not-visible / attribute / text failure, read the error-context page snapshot (errorContextPath) FIRST and decide locator drift (the target's stable text/label is present under different markup -- the test selector is stale) vs product regression (the target is genuinely absent). A bootstrapped extension floated to latest main (e.g. Posit Assistant) is a common drift source with no Positron-side change.`;
+
+/**
+ * Load the shared analysis rubric (.claude/skills/e2e-failure-analyzer/rubric.md).
+ * Resolves it the same way action.yml resolves the helper scripts -- under
+ * REPO_ROOT -- with a fallback relative to this file for ad-hoc runs, and a
+ * minimal inline fallback so a missing/moved file never silently drops the rubric.
+ */
+function loadRubric() {
+	const candidates = [
+		REPO_ROOT ? join(REPO_ROOT, '.claude/skills/e2e-failure-analyzer/rubric.md') : null,
+		fileURLToPath(new URL('../../../.claude/skills/e2e-failure-analyzer/rubric.md', import.meta.url)),
+	].filter(Boolean);
+	for (const p of candidates) {
+		try {
+			const text = readFileSync(p, 'utf8').trim();
+			if (text) {
+				console.log(`[analyzer] loaded analysis rubric from ${p}`);
+				return text;
+			}
+		} catch { /* try next candidate */ }
+	}
+	console.warn('[analyzer] WARN: could not load rubric.md from any known location; using minimal inline fallback');
+	return RUBRIC_FALLBACK;
+}
+
+const SYSTEM_PROMPT = `${SYSTEM_PROMPT_HEAD}
+
+--- BEGIN ANALYSIS RUBRIC (.claude/skills/e2e-failure-analyzer/rubric.md) ---
+${loadRubric()}
+--- END ANALYSIS RUBRIC ---
+
+${SYSTEM_PROMPT_TAIL}`;
 
 async function main() {
 	const runInfo = readJsonIfExists(join(WORK_DIR, 'run-info.json'));

--- a/.github/workflows/analyze-e2e-failures.yml
+++ b/.github/workflows/analyze-e2e-failures.yml
@@ -68,4 +68,5 @@ jobs:
           run-url: ${{ inputs.run_url }}
           anthropic-api-key: ${{ env.ANTHROPIC_KEY }}
           e2e-insights-api-key: ${{ env.E2E_INSIGHTS_KEY }}
+          webhook-secret: ${{ secrets.E2E_INSIGHTS_WEBHOOK_SECRET }}
           model: ${{ inputs.model }}


### PR DESCRIPTION
## What

Two related improvements to the e2e-failure-analyzer:

### 1. Shared drift-detection rubric (`ccd7b45`)
Promotes the already-extracted Playwright **error-context page snapshot** (the failure-moment ARIA tree) to primary evidence and adds an explicit **locator drift vs product regression** decision rule. Previously the analyzer reasoned mostly from JPEG screenshots, which cannot distinguish "the element failed to render" (product bug) from "the element rendered as different markup" (stale test selector).

- New single source of truth: `.claude/skills/e2e-failure-analyzer/rubric.md`, consumed by **both** the interactive skill (`SKILL.md`) and the GitHub Action (`analyze.mjs` injects it verbatim into the model's system prompt). One file, no duplication, the two consumers reason identically.
- Output format, severity-verbatim rules, and orchestration stay per-consumer; only the shared reasoning lives in `rubric.md`.
- Calls out bootstrapped extensions (e.g. Posit Assistant, floated to latest `main` at test time) as a common drift source with no Positron-side change.

### 2. Slack thread notification (`3974106`)
When the analyzer finishes, it appends a link to its report into the analyzed run's Slack thread via the e2e-test-insights `thread-append` webhook.

- New optional `webhook-secret` input on the action + a best-effort "Post analysis link to Slack thread" step.
- Reuses the existing `e2e-insights-api-key` as the Connect API key (same `connect.posit.it/e2e-test-insights-api` host as the history query).
- Links to the analyzer job's step summary (`#summary-<jobId>`); falls back to the run page if the job ID can't be resolved.
- `workflow_run_id` is the **analyzed** run (from `run-info.json`), not the analyzer's own run -- correct for both posit-dev/positron (they coincide) and positron-builds/s3 (they differ).
- No-ops cleanly when the secret/key/report is missing; a webhook failure only emits a `::warning::` and never fails the job.

## Testing

Validated end-to-end via two `workflow_dispatch` runs of `analyze-e2e-failures.yml` on this branch:

- **Plumbing/guards** (run against a non-e2e failure): `Slack thread append queued (HTTP 200): {"status":"queued","workflow_run_id":"..."}`, anchored job-summary link, clean skip paths.
- **Full report** (run against a run with real e2e failures): substantive report posted; the analyzer correctly applied the new rubric -- explicitly ruling out locator drift and a product regression for an MCP-server test-environment issue, and classifying a Ctrl+K chord-swallow as known-flaky using historical data.

## Known limitation (follow-up, intentionally out of scope)

The analyzer discovers projects from surviving `blob-report-*` artifacts. A project whose report job goes **green** (its only failures were `:soft-fail`-tagged or flaked-and-recovered) has its blob reports deleted by the workflow's `if: success()` cleanup step, so those failures are invisible to the analyzer. The merged report still lands on S3 (`if: always()`), so a future change can fall back to the S3 path for green-but-soft-failing projects. Tracked separately to keep this PR scoped.
