### PR TITLE
Fix moving a notebook to another editor group

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -34,7 +34,6 @@ import { EditorContextKeys } from '../../../../../editor/common/editorContextKey
 import { CTX_INLINE_CHAT_FOCUSED } from '../../../../contrib/inlineChat/common/inlineChat.js';
 import { CONTEXT_FIND_INPUT_FOCUSED, CONTEXT_REPLACE_INPUT_FOCUSED } from '../../../../../editor/contrib/find/browser/findModel.js';
 import { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
-import { useCellScopedContextKeyService } from './CellProvider.js';
 
 /**
  *
@@ -99,14 +98,13 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 	const services = usePositronReactServicesContext();
 	const environment = useEnvironment();
 	const instance = useNotebookInstance();
-	const cellContextKeyService = useCellScopedContextKeyService();
 
 	// Create an element ref to contain the editor
 	const editorPartRef = React.useRef<HTMLDivElement>(null);
 
 	// Create the editor
 	React.useEffect(() => {
-		if (!editorPartRef.current || !cellContextKeyService) { return; }
+		if (!editorPartRef.current || !cell.scopedContextKeyService) { return; }
 
 		const disposables = new DisposableStore();
 
@@ -116,7 +114,7 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 		// This ensures cell-level context keys (e.g. positronNotebookCellIsFirst) are visible
 		// to menus evaluated inside the editor. CodeEditorWidget will create its own child scope
 		// from this one for editor-specific keys.
-		const editorContextKeyService = cellContextKeyService.createScoped(editorPartRef.current);
+		const editorContextKeyService = cell.scopedContextKeyService.createScoped(editorPartRef.current);
 		disposables.add(editorContextKeyService);
 
 		// CRITICAL: Set the inCompositeEditor flag to change editor behavior
@@ -308,7 +306,7 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 			disposables.dispose();
 			cell.detachEditor();
 		};
-	}, [cell, cellContextKeyService, environment, instance, services.configurationService, services.contextKeyService, services.instantiationService, services.logService]);
+	}, [cell, environment, instance, services.configurationService, services.contextKeyService, services.instantiationService, services.logService]);
 
 	// Watch for editor focus requests from the cell
 	React.useLayoutEffect(() => {

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellOutputActionBar.tsx
@@ -16,7 +16,6 @@ import { CellActionButton } from './actionBar/CellActionButton.js';
 import { useMenu } from '../useMenu.js';
 import { useMenuActions } from '../useMenuActions.js';
 import { useWheelForwarding } from './useWheelForwarding.js';
-import { useCellScopedContextKeyService } from './CellProvider.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { PositronNotebookCodeCell } from '../PositronNotebookCells/PositronNotebookCodeCell.js';
 
@@ -27,8 +26,7 @@ interface CellOutputActionBarProps {
 
 export function CellOutputActionBar({ cell, scrollTargetRef }: CellOutputActionBarProps) {
 	const instance = useNotebookInstance();
-	const contextKeyService = useCellScopedContextKeyService();
-	const menu = useMenu(MenuId.PositronNotebookCellOutputActionBar, contextKeyService);
+	const menu = useMenu(MenuId.PositronNotebookCellOutputActionBar, cell.scopedContextKeyService);
 	const actionGroups = useMenuActions(menu);
 
 	// Forward wheel events to the scrollable output container so scrolling

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellProvider.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellProvider.tsx
@@ -7,7 +7,6 @@
 import React from 'react';
 
 // Other dependencies.
-import { IScopedContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IPositronNotebookCell, IPositronNotebookCodeCell } from '../PositronNotebookCells/IPositronNotebookCell.js';
 
 /**
@@ -46,14 +45,4 @@ export function useCodeCell(): IPositronNotebookCodeCell {
 		throw new Error('useCodeCell must be used within a code cell');
 	}
 	return cell;
-}
-
-/**
- * Hook to consume the cell-scoped context key service from the current cell.
- *
- * @returns The scoped context key service, or undefined if outside a CellProvider.
- */
-export function useCellScopedContextKeyService(): IScopedContextKeyService | undefined {
-	const cell = React.useContext(CellContext);
-	return cell?.scopedContextKeyService;
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/InlineDataExplorer.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/InlineDataExplorer.tsx
@@ -24,7 +24,7 @@ import { MenuId, MenuItemAction } from '../../../../../platform/actions/common/a
 import type { IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { useMenu } from '../useMenu.js';
 import { useMenuActions } from '../useMenuActions.js';
-import { useCellScopedContextKeyService, useCodeCell } from './CellProvider.js';
+import { useCodeCell } from './CellProvider.js';
 import type { IInlineDataExplorerActionContext } from './InlineDataExplorerActions.js';
 import { InlineDataExplorerActionButton } from './InlineDataExplorerActionButton.js';
 
@@ -73,14 +73,12 @@ const HEADER_MENU_OPTIONS = { shouldForwardArgs: true } as const;
  * only when the parent provides an `actionContext` -- typically when the inline
  * grid is connected and not stale.
  */
-export function InlineDataExplorerHeader({ title, shape, actionContext, contextKeyService: providedContextKeyService }: {
+export function InlineDataExplorerHeader({ title, shape, actionContext, contextKeyService }: {
 	title: string;
 	shape: { rows: number; columns: number };
 	actionContext: IInlineDataExplorerActionContext | undefined;
 	contextKeyService?: IContextKeyService;
 }) {
-	const cellScopedContextKeyService = useCellScopedContextKeyService();
-	const contextKeyService = providedContextKeyService ?? cellScopedContextKeyService;
 	const menu = useMenu(MenuId.PositronNotebookInlineDataExplorerHeader, contextKeyService);
 	const actionGroups = useMenuActions(menu, HEADER_MENU_OPTIONS);
 
@@ -271,6 +269,7 @@ export function InlineDataExplorer(props: InlineDataExplorerProps) {
 		<div ref={containerRef} className='inline-data-explorer-container inline-data-explorer-container--clears-output-actions' style={{ height: `${dynamicHeight}px` }}>
 			<InlineDataExplorerHeader
 				actionContext={actionContext}
+				contextKeyService={cell.scopedContextKeyService}
 				shape={shape}
 				title={title}
 			/>

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellActionBar.tsx
@@ -17,7 +17,6 @@ import { CellActionButton } from './actionBar/CellActionButton.js';
 import { useObservedValue } from '../useObservedValue.js';
 import { useMenu } from '../useMenu.js';
 import { MenuId } from '../../../../../platform/actions/common/actions.js';
-import { useCellScopedContextKeyService } from './CellProvider.js';
 import { useMenuActions } from '../useMenuActions.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
 import { PositronNotebookCellActionBarLeftGroup } from '../../common/positronNotebookCommon.js';
@@ -35,7 +34,7 @@ interface NotebookCellActionBarProps {
 export function NotebookCellActionBar({ cell }: NotebookCellActionBarProps) {
 	// Context
 	const instance = useNotebookInstance();
-	const contextKeyService = useCellScopedContextKeyService();
+	const contextKeyService = cell.scopedContextKeyService;
 
 	// State
 	const [isMenuOpen, setIsMenuOpen] = useState(false);

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/useCellContextMenu.tsx
@@ -10,7 +10,6 @@ import { useEffect, useRef } from 'react';
 import { ActionRunner, IAction } from '../../../../../base/common/actions.js';
 import { IMenuActionOptions, MenuId } from '../../../../../platform/actions/common/actions.js';
 import { useNotebookInstance } from '../NotebookInstanceProvider.js';
-import { useCellScopedContextKeyService } from './CellProvider.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { CellSelectionType } from '../selectionMachine.js';
 import { IPositronNotebookCell } from '../PositronNotebookCells/IPositronNotebookCell.js';
@@ -39,7 +38,6 @@ export interface UseCellContextMenuOptions {
  */
 export function useCellContextMenu({ cell, menuId }: UseCellContextMenuOptions) {
 	const instance = useNotebookInstance();
-	const contextKeyService = useCellScopedContextKeyService();
 	const { contextMenuService } = usePositronReactServicesContext();
 	const actionRunnerRef = useRef<ActionRunner | undefined>(undefined);
 
@@ -89,7 +87,7 @@ export function useCellContextMenu({ cell, menuId }: UseCellContextMenuOptions) 
 		contextMenuService.showContextMenu({
 			menuId,
 			menuActionOptions,
-			contextKeyService,
+			contextKeyService: cell.scopedContextKeyService,
 			getAnchor: () => anchor,
 			actionRunner: actionRunnerRef.current,
 			getActions,

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/InlineDataExplorerHeader.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/InlineDataExplorerHeader.vitest.tsx
@@ -5,7 +5,6 @@
 
 /// <reference types="vitest/globals" />
 
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Event } from '../../../../../../base/common/event.js';
@@ -17,10 +16,8 @@ import { MockContextKeyService } from '../../../../../../platform/keybinding/tes
 import { createTestContainer } from '../../../../../../test/vitest/positronTestContainer.js';
 import { setupRTLRenderer } from '../../../../../../test/vitest/reactTestingLibrary.js';
 import { stubInterface } from '../../../../../../test/vitest/stubInterface.js';
-import { CellProvider } from '../../../browser/notebookCells/CellProvider.js';
 import { InlineDataExplorerHeader } from '../../../browser/notebookCells/InlineDataExplorer.js';
 import type { IInlineDataExplorerActionContext } from '../../../browser/notebookCells/InlineDataExplorerActions.js';
-import { IPositronNotebookCell } from '../../../browser/PositronNotebookCells/IPositronNotebookCell.js';
 
 /** Minimal MenuItemAction stub for rendering and click dispatch. */
 function mockAction(id: string, label: string, iconId: string, run: (...args: unknown[]) => Promise<unknown> = () => Promise.resolve()): MenuItemAction {
@@ -66,12 +63,12 @@ describe('InlineDataExplorerHeader', () => {
 		getActions,
 	};
 
-	const contextKeyService = new MockContextKeyService();
+	const mockContextKeyService = new MockContextKeyService();
 
 	const ctx = createTestContainer()
 		.withReactServices()
 		.stub(IMenuService, { createMenu: () => menu })
-		.stub(IContextKeyService, contextKeyService)
+		.stub(IContextKeyService, mockContextKeyService)
 		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
@@ -79,54 +76,41 @@ describe('InlineDataExplorerHeader', () => {
 		menuActions = [];
 	});
 
-	function renderHeader(actionContext: IInlineDataExplorerActionContext | undefined, options?: {
-		contextKeyService?: IContextKeyService;
-		withCellProvider?: boolean;
-	}) {
-		const header = (
+	function renderHeader(
+		actionContext?: IInlineDataExplorerActionContext,
+		contextKeyService?: IContextKeyService,
+	) {
+		return rtl.render(
 			<InlineDataExplorerHeader
 				actionContext={actionContext}
-				contextKeyService={options?.contextKeyService}
+				contextKeyService={contextKeyService}
 				shape={{ rows: 1234, columns: 5 }}
 				title='df'
 			/>
 		);
-
-		if (options?.withCellProvider === false) {
-			return rtl.render(header);
-		}
-
-		const cell = stubInterface<IPositronNotebookCell>({
-			scopedContextKeyService: contextKeyService,
-		});
-		return rtl.render(
-			<CellProvider cell={cell}>
-				{header}
-			</CellProvider>
-		);
 	}
 
 	it('renders title and shape', () => {
-		renderHeader(undefined);
+		renderHeader();
 		expect(screen.getByText('df')).toBeInTheDocument();
 		expect(screen.getByText(/1,234 rows x 5 columns/)).toBeInTheDocument();
 	});
 
-	it('renders registered menu actions when actionContext is provided', () => {
+	it('renders registered menu actions when actionContext and contextKeyService are provided', () => {
 		menuActions = [['navigation', [mockAction('test.openExplorer', 'Open in Data Explorer', 'go-to-file')]]];
-		renderHeader(buildActionContext());
-		expect(screen.getByRole('button', { name: /Open in Data Explorer/ })).toBeInTheDocument();
-	});
-
-	it('renders registered menu actions with an explicit context service outside a cell provider', () => {
-		menuActions = [['navigation', [mockAction('test.openExplorer', 'Open in Data Explorer', 'go-to-file')]]];
-		renderHeader(buildActionContext(), { contextKeyService, withCellProvider: false });
+		renderHeader(buildActionContext(), mockContextKeyService);
 		expect(screen.getByRole('button', { name: /Open in Data Explorer/ })).toBeInTheDocument();
 	});
 
 	it('does not render action buttons when actionContext is undefined', () => {
 		menuActions = [['navigation', [mockAction('test.openExplorer', 'Open in Data Explorer', 'go-to-file')]]];
-		renderHeader(undefined);
+		renderHeader(undefined, mockContextKeyService);
+		expect(screen.queryByRole('button', { name: /Open in Data Explorer/ })).not.toBeInTheDocument();
+	});
+
+	it('does not render action buttons when contextKeyService is undefined', () => {
+		menuActions = [['navigation', [mockAction('test.openExplorer', 'Open in Data Explorer', 'go-to-file')]]];
+		renderHeader(buildActionContext(), undefined);
 		expect(screen.queryByRole('button', { name: /Open in Data Explorer/ })).not.toBeInTheDocument();
 	});
 
@@ -143,7 +127,7 @@ describe('InlineDataExplorerHeader', () => {
 			mockAction('test.openExplorer', 'Open in Data Explorer', 'go-to-file'),
 			submenuAction,
 		]]];
-		renderHeader(buildActionContext());
+		renderHeader(buildActionContext(), mockContextKeyService);
 		expect(screen.getByRole('button', { name: /Open in Data Explorer/ })).toBeInTheDocument();
 		expect(screen.queryByRole('button', { name: /Sub Menu/ })).not.toBeInTheDocument();
 	});
@@ -152,19 +136,19 @@ describe('InlineDataExplorerHeader', () => {
 		const user = userEvent.setup();
 		const run = vi.fn().mockResolvedValue(undefined);
 		menuActions = [['navigation', [mockAction('test.openExplorer', 'Open in Data Explorer', 'go-to-file', run)]]];
-		const actionCtx = buildActionContext();
-		renderHeader(actionCtx);
+		const actionContext = buildActionContext();
+		renderHeader(actionContext, mockContextKeyService);
 
 		await user.click(screen.getByRole('button', { name: /Open in Data Explorer/ }));
 
-		expect(run).toHaveBeenCalledWith(actionCtx);
+		expect(run).toHaveBeenCalledWith(actionContext);
 	});
 
 	// Regression: MenuItemAction.run drops caller-supplied args unless
 	// shouldForwardArgs is set on the menu options. Without this, ctx never
 	// reaches the registered Action2 and run() throws on `ctx.commId`.
 	it('requests menu actions with shouldForwardArgs so ctx flows through', () => {
-		renderHeader(undefined);
+		renderHeader(undefined, mockContextKeyService);
 		expect(getActions).toHaveBeenCalledWith(expect.objectContaining({ shouldForwardArgs: true }));
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookMarkdownCell.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookMarkdownCell.vitest.tsx
@@ -47,7 +47,6 @@ vi.mock('../../browser/notebookCells/CellProvider.js', () => ({
 	CellProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 	useCell: () => ({ scopedContextKeyService: undefined }),
 	useCodeCell: () => { throw new Error('not a code cell'); },
-	useCellScopedContextKeyService: () => undefined,
 }));
 
 describe('NotebookMarkdownCell', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputFocus.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookOutputFocus.vitest.tsx
@@ -36,7 +36,6 @@ vi.mock('../../browser/notebookCells/CellProvider.js', () => ({
 	CellProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 	useCell: () => ({ scopedContextKeyService: undefined }),
 	useCodeCell: () => { throw new Error('not a code cell'); },
-	useCellScopedContextKeyService: () => undefined,
 }));
 vi.mock('../../browser/notebookCells/CellEditorMonacoWidget.js', () => ({
 	CellEditorMonacoWidget: () => <div data-testid='mock-editor' />,

--- a/test/e2e/tests/notebooks-positron/notebook-side-by-side.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-side-by-side.test.ts
@@ -29,8 +29,7 @@ test.describe('Notebook Side-by-Side Isolation', {
 		await hotKeys.minimizeBottomPanel();
 	});
 
-	// https://github.com/posit-dev/positron/issues/13876
-	test.skip('Notebook action buttons target their own notebook, not the focused one',
+	test('Notebook action buttons target their own notebook, not the focused one',
 		async function ({ app, sessions, runCommand }) {
 			const { notebooksPositron, editors } = app.workbench;
 


### PR DESCRIPTION
Fixes #13992.

The problem was that `useCellEditorWidget` would sometimes try to run its effect with a stale disposed context key service. The fix is to rather use `useCell` and always get the current scoped context key service from it.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:positron-notebooks @:web

See #13992.