### PR TITLE
E2E test: packages pane test additions for pyenv and uninstall

### DIFF
--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -368,6 +368,21 @@ export class Console {
 		}).toPass({ timeout: 10000 });
 	}
 
+	/**
+	 * Focuses the console by clicking its panel label, bypassing the `Cmd+K F`
+	 * chord that {@link focus} relies on. That chord silently leaks `F` into the
+	 * terminal when the terminal holds focus (e.g. after a terminal-based package
+	 * install/uninstall), so use this to take focus off the terminal deterministically.
+	 * Clicks unconditionally, unlike {@link clickConsoleTab} which only clicks when
+	 * the console input is hidden.
+	 */
+	async clickConsoleLabel() {
+		await this.code.driver.currentPage
+			.locator('a.action-label[aria-label="Console"]')
+			.first()
+			.click();
+	}
+
 	async interruptExecution() {
 		await this.code.driver.currentPage.getByLabel('Interrupt execution').click();
 	}

--- a/test/e2e/pages/packages.ts
+++ b/test/e2e/pages/packages.ts
@@ -131,6 +131,20 @@ export class Packages {
 	}
 
 	/**
+	 * Asserts that a package row is absent from the currently filtered list.
+	 * Retries past the post-uninstall refresh delay (the package provider
+	 * re-emits its snapshot asynchronously — R uninstalls via pak can take
+	 * tens of seconds before the row disappears).
+	 * @param name The exact package name that should no longer appear.
+	 * @param timeout Max time to wait for the row to disappear.
+	 */
+	async expectPackageNotInList(name: string, timeout = 60_000): Promise<void> {
+		await this.clickPackagesButton();
+		const row = this.packagesContainer.locator('.packages-list-item-name', { hasText: name });
+		await expect(row).toHaveCount(0, { timeout });
+	}
+
+	/**
 	 * Click the filter funnel to open the Filter/Sort options menu.
 	 * Asserts the top-level menu is visible.
 	 */
@@ -245,5 +259,30 @@ export class Packages {
 		// Wait for the "Installing packages..." toast to appear and then disappear
 		await this.toasts.waitForAppear('Installing packages...', { timeout: 10000 });
 		await this.toasts.waitForDisappear('Installing packages...', { timeout: 60000 });
+	}
+
+	/**
+	 * Uninstalls a package via the row's right-click context menu.
+	 * Right-clicks the package row to open the context menu and clicks "Uninstall
+	 * Package". The command normally shows a confirmation dialog, but under the
+	 * smoke test driver `DialogService.confirm()` auto-confirms without rendering
+	 * a dialog (see `skipDialogs()` in dialogService.ts), so there is nothing to
+	 * click here -- the uninstall proceeds directly.
+	 *
+	 * Returns once the action is dispatched; use {@link expectPackageNotInList} to
+	 * wait for the package to actually drop out of the list.
+	 * @param packageName The name of the package to uninstall (e.g., 'cowsay')
+	 */
+	async uninstallPackage(packageName: string): Promise<void> {
+		await this.clickPackagesButton();
+
+		// Right-click the package row to open its context menu, then click "Uninstall Package".
+		const row = this.packagesContainer.locator('.packages-list-item-name', { hasText: packageName });
+		await this.contextMenu.triggerAndClick({
+			menuTrigger: row.first(),
+			menuItemLabel: 'Uninstall Package',
+			menuTriggerButton: 'right',
+			exact: true
+		});
 	}
 }

--- a/test/e2e/tests/packages-pane/packages-pane.test.ts
+++ b/test/e2e/tests/packages-pane/packages-pane.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { test, tags } from '../_test.setup';
+import { SessionRuntimes } from '../../pages/sessions.js';
 
 test.use({
 	suiteId: __filename
@@ -22,21 +23,37 @@ test.describe('Packages Pane', {
 	test.afterEach(async function ({ app }) {
 		await app.workbench.packages.clearFilter();
 		await app.workbench.packages.closePackagesPane();
+		// The Python package manager runs in the terminal, leaving it focused.
+		// Click the console label to take focus off the terminal so the next
+		// iteration's console.focus() (Cmd+K F) chord resolves instead of leaking
+		// 'F' into the terminal and corrupting the next install.
+		await app.workbench.console.clickConsoleLabel();
 	});
 
-	test('Python - Install and search package', { tag: [tags.WIN] },
-		async function ({ app, python: _python }) {
-			const { packages } = app.workbench;
+	// python is uv; pythonAlt is pyenv
+	const pythonRuntimes: SessionRuntimes[] = ['python', 'pythonAlt'];
 
-			await packages.verifyPackagesList();
+	pythonRuntimes.forEach((runtime) => {
+		test(`Python - Install, search, and uninstall package (${runtime})`, { tag: [tags.WIN] },
+			async function ({ app, sessions }) {
+				const { packages } = app.workbench;
 
-			// install package and verify it shows up in the list
-			await packages.installPackage('cowsay');
-			await packages.searchPackages('cowsay');
-			await packages.expectPackageInList('cowsay');
-		});
+				await sessions.start(runtime);
 
-	test('R - Install and search package', { tag: [tags.WIN] },
+				await packages.verifyPackagesList();
+
+				// install package and verify it shows up in the list
+				await packages.installPackage('cowsay');
+				await packages.searchPackages('cowsay');
+				await packages.expectPackageInList('cowsay');
+
+				// uninstall package and verify it is removed from the list
+				await packages.uninstallPackage('cowsay');
+				await packages.expectPackageNotInList('cowsay');
+			});
+	});
+
+	test('R - Install, search, and uninstall package', { tag: [tags.WIN] },
 		async function ({ app, r: _r }) {
 			const { packages } = app.workbench;
 
@@ -46,6 +63,10 @@ test.describe('Packages Pane', {
 			await packages.installPackage('cowsay');
 			await packages.searchPackages('cowsay');
 			await packages.expectPackageInList('cowsay');
+
+			// uninstall package and verify it is removed from the list
+			await packages.uninstallPackage('cowsay');
+			await packages.expectPackageNotInList('cowsay');
 		});
 
 	test.describe('Help button', { tag: [tags.HELP] }, () => {


### PR DESCRIPTION
## Summary

Extends the Packages Pane e2e tests to cover **package uninstall** and to exercise a **pyenv-backed Python interpreter** in addition to the existing uv one.

## Changes

### Test coverage
- **Uninstall flow added** to both the Python and R cases. After install + search, the tests now right-click the package row, choose **Uninstall Package**, and assert the package drops out of the list.
- **Python test is now data-driven** over `['python', 'pythonAlt']`:
  - `python` exercises the **uv**-managed interpreter (existing behavior).
  - `pythonAlt` was added to exercise its underlying interpreter type, **pyenv**, so we cover both Python environment managers.
- Renamed the test titles to reflect the wider scope: `... Install, search, and uninstall package`.

### Page objects (`test/e2e/pages/`)
- `packages.ts`
  - `uninstallPackage(name)` - opens the row's right-click context menu and clicks **Uninstall Package**. The command's confirmation dialog is auto-confirmed under the smoke-test driver (`DialogService.confirm()` short-circuits via `skipDialogs()`), so there is no dialog to click.
  - `expectPackageNotInList(name)` - polls until the package row is gone (mirrors `expectPackageInList`), tolerating the package provider's async re-snapshot.
- `console.ts`
  - `clickConsoleLabel()` - focuses the console by clicking its panel label, bypassing the `Cmd+K F` chord that `console.focus()` relies on (see below). Unlike `clickConsoleTab()`, it clicks unconditionally.

### Flake fix: stray `F` typed into the terminal
The Python package manager runs `pip install`/`pip uninstall` **in the terminal**, leaving the terminal focused at the end of an iteration. The next iteration's `sessions.start()` calls `console.focus()`, which uses the `Cmd+K F` "Focus Console" chord. When the terminal holds focus, that chord does not resolve and the trailing `F` leaks straight into the terminal (`KeybindingService#dispatch "F" [No matching keybinding]`), corrupting the following install (manifesting as `FFF` in the terminal and a failing `expectPackageInList`).

The `afterEach` now calls `console.clickConsoleLabel()` to deterministically pull focus off the terminal before the next iteration runs, so the chord resolves correctly. R is unaffected (its package manager runs in the console, not the terminal).

> Note: the underlying fragility in `focusConsole()` (`Cmd+K F`) is left as-is to keep this change contained; hardening it globally is a possible follow-up.

## How to test
```bash
npx playwright test test/e2e/tests/packages-pane/packages-pane.test.ts --project e2e-electron

@:web @:packages-pane @:win