### PR TITLE
Fix `Kill Positron Build Watchers` task after upstream merge

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -490,7 +490,8 @@
 				"Kill Ext - Build",
 				"Kill Core - Transpile",
 				"Kill Core - Typecheck",
-				"Kill E2E Tests - Build"
+				"Kill E2E Tests - Build",
+				"Kill Copilot - Build"
 			],
 			"group": "build",
 			"problemMatcher": []

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -203,6 +203,18 @@
 		},
 		{
 			"type": "npm",
+			"script": "kill-watch-e2ed",
+			"label": "Kill E2E Tests - Build",
+			"group": "build",
+			"presentation": {
+				"reveal": "never",
+				"group": "buildKillers",
+				"close": true
+			},
+			"problemMatcher": "$tsc"
+		},
+		{
+			"type": "npm",
 			"script": "kill-watch-copilotd",
 			"label": "Kill Copilot - Build",
 			"group": "build",


### PR DESCRIPTION
After the upstream merge, `Tasks > Run Task` --> `Kill Positron Build Watchers` would result in this error showing in the OUTPUT log:

```
Couldn't resolve dependent task 'Kill E2E Tests - Build' in workspace folder 'file:///Users/.../positron'
```

We just need to add back the `Kill E2E Tests - Build` task, and I also added `Kill Copilot - Build` to `Kill Positron Build Watchers`.

To test, run `Kill Positron Build Watchers` and confirm all the build tasks are killed without the error.