### PR TITLE
Extend AWS STS session duration for e2e Bedrock sign-in test

### DIFF
--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -22,6 +22,10 @@ runs:
       with:
         role-to-assume: ${{ inputs.aws-role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
+        # Session must outlast the full build + sharded test run so the Bedrock
+        # sign-in e2e test doesn't hit an expired STS token (must be <= role
+        # MaxSessionDuration).
+        role-duration-seconds: 21600
 
     - name: Setup Xvfb
       uses: ./.github/actions/setup-xvfb

--- a/.github/workflows/test-e2e-jupyter-ubuntu.yml
+++ b/.github/workflows/test-e2e-jupyter-ubuntu.yml
@@ -72,6 +72,10 @@ jobs:
         with:
           role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
+          # Session must outlast the full build + sharded test run so the Bedrock
+          # sign-in e2e test doesn't hit an expired STS token (must be <= role
+          # MaxSessionDuration).
+          role-duration-seconds: 21600
 
       - name: Load secret
         uses: 1password/load-secrets-action@v4

--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -88,6 +88,10 @@ jobs:
         with:
           role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
+          # Session must outlast the full build + sharded test run so the Bedrock
+          # sign-in e2e test doesn't hit an expired STS token (must be <= role
+          # MaxSessionDuration).
+          role-duration-seconds: 21600
 
       - name: Load secret
         uses: 1password/load-secrets-action@v4
@@ -335,6 +339,10 @@ jobs:
         with:
           role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
+          # Session must outlast the full build + sharded test run so the Bedrock
+          # sign-in e2e test doesn't hit an expired STS token (must be <= role
+          # MaxSessionDuration).
+          role-duration-seconds: 21600
 
       - name: Install Playwright
         run: |

--- a/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
+++ b/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
@@ -59,6 +59,10 @@ jobs:
         with:
           role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
+          # Session must outlast the full build + sharded test run so the Bedrock
+          # sign-in e2e test doesn't hit an expired STS token (must be <= role
+          # MaxSessionDuration).
+          role-duration-seconds: 21600
 
       - name: Setup test dependencies and compile tests
         uses: ./.github/actions/setup-e2e-test-dependencies

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -151,6 +151,10 @@ jobs:
         with:
           role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
+          # Session must outlast the full build + sharded test run so the Bedrock
+          # sign-in e2e test doesn't hit an expired STS token (must be <= role
+          # MaxSessionDuration).
+          role-duration-seconds: 21600
 
       - name: Load secret
         uses: 1password/load-secrets-action@v4
@@ -371,6 +375,10 @@ jobs:
         with:
           role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
+          # Session must outlast the full build + sharded test run so the Bedrock
+          # sign-in e2e test doesn't hit an expired STS token (must be <= role
+          # MaxSessionDuration).
+          role-duration-seconds: 21600
 
       - name: Install Playwright
         run: |

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -366,6 +366,10 @@ jobs:
         with:
           role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
+          # Session must outlast the full build + sharded test run so the Bedrock
+          # sign-in e2e test doesn't hit an expired STS token (must be <= role
+          # MaxSessionDuration).
+          role-duration-seconds: 21600
 
       - name: 🧪 Run Extensions Tests
         if: ${{ matrix.shard == 1 }}
@@ -504,6 +508,10 @@ jobs:
         with:
           role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
+          # Session must outlast the full build + sharded test run so the Bedrock
+          # sign-in e2e test doesn't hit an expired STS token (must be <= role
+          # MaxSessionDuration).
+          role-duration-seconds: 21600
 
       - name: Install Playwright
         shell: bash

--- a/.github/workflows/test-e2e-workbench-ubuntu.yml
+++ b/.github/workflows/test-e2e-workbench-ubuntu.yml
@@ -98,6 +98,10 @@ jobs:
         with:
           role-to-assume: ${{ secrets.QA_AWS_RO_ROLE }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
+          # Session must outlast the full build + sharded test run so the Bedrock
+          # sign-in e2e test doesn't hit an expired STS token (must be <= role
+          # MaxSessionDuration).
+          role-duration-seconds: 21600
 
       - name: Load secret
         uses: 1password/load-secrets-action@v4


### PR DESCRIPTION
The Posit Assistant `amazon-bedrock - Sign in, send hello, sign out` e2e test failed on a nightly run with `The security token included in the request is expired`.

### Summary

The e2e workflows obtain AWS credentials by assuming `QA_AWS_RO_ROLE` via OIDC (`aws-actions/configure-aws-credentials`) with no `role-duration-seconds` set, so the STS session defaults to **1 hour**. The Bedrock sign-in test consumes these env-var credentials through the AWS credential chain. The role is assumed early in the job, then the full build (npm ci, compile, Playwright/R/Python installs) and the sharded test run follow. On a slow run the `amazon-bedrock` test executes more than an hour after the role was assumed, so the token is already expired and `ListFoundationModels` is rejected, leaving 0 Bedrock models and failing the test. This is token expiry, not a permissions problem (the role's Bedrock policy is unchanged), which is why it only flakes on slow runs.

This sets `role-duration-seconds: 21600` (6h) on every step that assumes `QA_AWS_RO_ROLE`, including the shared `setup-test-env` composite action (which covers debian, rhel, sles, suse, pyrefly, and ubuntu). The session now outlasts the full build + sharded test run.

Requires the IAM role's **Maximum session duration** to be >= 6h (already raised).

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (CI-only change; no user-facing impact)

### Validation Steps

@:posit-assistant

The Posit Assistant sign-in suite (including `amazon-bedrock - Sign in, send hello, sign out`) should pass on this PR's e2e run without an expired-STS-token error. Because the change is in the workflow files themselves, this PR's own e2e run exercises the new `role-duration-seconds`.