### PR TITLE
E2E test: fix notebook test flake with kernel selection

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -71,7 +71,7 @@ test.describe('Notebook Focus and Selection', {
 	});
 
 
-	test('Notebook navigation and default cell selection between tabs', async function ({ app }) {
+	test('Notebook navigation and default cell selection between tabs', async function ({ app, python }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.currentPage.keyboard;
 		await notebooksPositron.newNotebook({ codeCells: 3, markdownCells: 1 });


### PR DESCRIPTION
Start a known interpreter so that notebooks functionality doesn't randomly pick.

@:positron-notebooks @:web @:win