### PR TITLE
 Language model actions depends on Copilot

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatLanguageModelActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatLanguageModelActions.ts
@@ -19,6 +19,9 @@ import { Codicon } from '../../../../../base/common/codicons.js';
 import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 import { ILanguageModelsProviderGroup } from '../../common/languageModelsConfiguration.js';
+// --- Start Positron ---
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+// --- End Positron ---
 
 class ManageLanguageModelAuthenticationAction extends Action2 {
 	static readonly ID = 'workbench.action.chat.manageLanguageModelAuthentication';
@@ -28,10 +31,23 @@ class ManageLanguageModelAuthenticationAction extends Action2 {
 			id: ManageLanguageModelAuthenticationAction.ID,
 			title: localize2('manageLanguageModelAuthentication', 'Manage Language Model Access...'),
 			category: CHAT_CATEGORY,
-			precondition: ChatContextKeys.enabled,
+			// --- Start Positron ---
+			// Also hide when the user has disabled AI features, to avoid confusion
+			// with Positron's "Configure Language Model Providers" item. Gating via
+			// precondition also hides the action from the command palette (f1).
+			precondition: ContextKeyExpr.and(
+				ChatContextKeys.enabled,
+				ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+			),
+			// --- End Positron ---
 			menu: [{
 				id: MenuId.AccountsContext,
 				order: 100,
+				// --- Start Positron ---
+				// Hide (rather than disable) when AI features are off. The precondition
+				// above gates command palette visibility; this `when` gates the menu.
+				when: ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+				// --- End Positron ---
 			}],
 			f1: true
 		});

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatManagement.contribution.ts
@@ -31,16 +31,13 @@ import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase 
 
 const languageModelsOpenSettingsIcon = registerIcon('language-models-open-settings', Codicon.goToFile, localize('languageModelsOpenSettings', 'Icon for open language models settings commands.'));
 
+// --- Start Positron ---
+// Hide language model management UI when the user has disabled AI features.
 const LANGUAGE_MODELS_ENTITLEMENT_PRECONDITION = ContextKeyExpr.and(
 	ChatContextKeys.enabled,
-	// --- Start Positron ---
-	// Hide language model management UI when the user has disabled AI features.
 	ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
-	// --- End Positron ---
 	ContextKeyExpr.or(
-		// --- Start Positron ---
 		ContextKeyTrueExpr.INSTANCE,
-		// --- End Positron ---
 		ChatContextKeys.Entitlement.planFree,
 		ChatContextKeys.Entitlement.planEdu,
 		ChatContextKeys.Entitlement.planPro,
@@ -50,6 +47,7 @@ const LANGUAGE_MODELS_ENTITLEMENT_PRECONDITION = ContextKeyExpr.and(
 		ChatContextKeys.Entitlement.internal
 	)
 );
+// --- End Positron ---
 
 Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(
 	EditorPaneDescriptor.create(

--- a/src/vs/workbench/contrib/chat/browser/chatManagement/chatManagement.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatManagement/chatManagement.contribution.ts
@@ -31,18 +31,25 @@ import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase 
 
 const languageModelsOpenSettingsIcon = registerIcon('language-models-open-settings', Codicon.goToFile, localize('languageModelsOpenSettings', 'Icon for open language models settings commands.'));
 
-const LANGUAGE_MODELS_ENTITLEMENT_PRECONDITION = ContextKeyExpr.and(ChatContextKeys.enabled, ContextKeyExpr.or(
+const LANGUAGE_MODELS_ENTITLEMENT_PRECONDITION = ContextKeyExpr.and(
+	ChatContextKeys.enabled,
 	// --- Start Positron ---
-	ContextKeyTrueExpr.INSTANCE,
+	// Hide language model management UI when the user has disabled AI features.
+	ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
 	// --- End Positron ---
-	ChatContextKeys.Entitlement.planFree,
-	ChatContextKeys.Entitlement.planEdu,
-	ChatContextKeys.Entitlement.planPro,
-	ChatContextKeys.Entitlement.planProPlus,
-	ChatContextKeys.Entitlement.planBusiness,
-	ChatContextKeys.Entitlement.planEnterprise,
-	ChatContextKeys.Entitlement.internal
-));
+	ContextKeyExpr.or(
+		// --- Start Positron ---
+		ContextKeyTrueExpr.INSTANCE,
+		// --- End Positron ---
+		ChatContextKeys.Entitlement.planFree,
+		ChatContextKeys.Entitlement.planEdu,
+		ChatContextKeys.Entitlement.planPro,
+		ChatContextKeys.Entitlement.planProPlus,
+		ChatContextKeys.Entitlement.planBusiness,
+		ChatContextKeys.Entitlement.planEnterprise,
+		ChatContextKeys.Entitlement.internal
+	)
+);
 
 Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(
 	EditorPaneDescriptor.create(

--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -386,3 +386,37 @@ test.describe.skip('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSI
 		});
 	});
 });
+
+/**
+ * Verifies that the "Manage Language Model Access..." action is gated by the
+ * `chat.disableAIFeatures` setting. The precondition gates command palette
+ * visibility; this test exercises that gate in both directions.
+ * @see https://github.com/posit-dev/positron/pull/14054
+ */
+test.describe('Language Model Access Gating', { tag: [tags.ASSISTANT] }, () => {
+	const COMMAND_TITLE = 'Manage Language Model Access';
+
+	test.afterEach('Reset chat.disableAIFeatures', async function ({ settings }) {
+		await settings.remove(['chat.disableAIFeatures']);
+	});
+
+	test('Hidden from command palette when AI features are disabled', async function ({ app, settings }) {
+		await settings.set({ 'chat.disableAIFeatures': true }, { reload: true });
+
+		await app.workbench.hotKeys.openCommandPalette();
+		await app.workbench.quickInput.type(`>${COMMAND_TITLE}`);
+		const firstResult = await app.workbench.quickInput.waitForQuickInputElementText();
+		expect(firstResult).toBe('No matching commands');
+		await app.workbench.quickInput.closeQuickInput();
+	});
+
+	test('Visible in command palette when AI features are enabled', async function ({ app, settings }) {
+		await settings.set({ 'chat.disableAIFeatures': false }, { reload: true });
+
+		await app.workbench.hotKeys.openCommandPalette();
+		await app.workbench.quickInput.type(`>${COMMAND_TITLE}`);
+		const firstResult = await app.workbench.quickInput.waitForQuickInputElementText();
+		expect(firstResult).toContain(COMMAND_TITLE);
+		await app.workbench.quickInput.closeQuickInput();
+	});
+});

--- a/test/e2e/tests/assistant/positron-assistant.test.ts
+++ b/test/e2e/tests/assistant/positron-assistant.test.ts
@@ -386,37 +386,3 @@ test.describe.skip('Positron Assistant Chat Tokens', { tag: [tags.WIN, tags.ASSI
 		});
 	});
 });
-
-/**
- * Verifies that the "Manage Language Model Access..." action is gated by the
- * `chat.disableAIFeatures` setting. The precondition gates command palette
- * visibility; this test exercises that gate in both directions.
- * @see https://github.com/posit-dev/positron/pull/14054
- */
-test.describe('Language Model Access Gating', { tag: [tags.ASSISTANT] }, () => {
-	const COMMAND_TITLE = 'Manage Language Model Access';
-
-	test.afterEach('Reset chat.disableAIFeatures', async function ({ settings }) {
-		await settings.remove(['chat.disableAIFeatures']);
-	});
-
-	test('Hidden from command palette when AI features are disabled', async function ({ app, settings }) {
-		await settings.set({ 'chat.disableAIFeatures': true }, { reload: true });
-
-		await app.workbench.hotKeys.openCommandPalette();
-		await app.workbench.quickInput.type(`>${COMMAND_TITLE}`);
-		const firstResult = await app.workbench.quickInput.waitForQuickInputElementText();
-		expect(firstResult).toBe('No matching commands');
-		await app.workbench.quickInput.closeQuickInput();
-	});
-
-	test('Visible in command palette when AI features are enabled', async function ({ app, settings }) {
-		await settings.set({ 'chat.disableAIFeatures': false }, { reload: true });
-
-		await app.workbench.hotKeys.openCommandPalette();
-		await app.workbench.quickInput.type(`>${COMMAND_TITLE}`);
-		const firstResult = await app.workbench.quickInput.waitForQuickInputElementText();
-		expect(firstResult).toContain(COMMAND_TITLE);
-		await app.workbench.quickInput.closeQuickInput();
-	});
-});

--- a/test/e2e/tests/posit-assistant/posit-assistant.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant.test.ts
@@ -171,8 +171,14 @@ test.describe('Language Model Access Gating', { tag: [tags.POSIT_ASSISTANT, tags
 
 		await app.workbench.hotKeys.openCommandPalette();
 		await app.workbench.quickInput.type(`>${COMMAND_TITLE}`);
-		const firstResult = await app.workbench.quickInput.waitForQuickInputElementText();
-		expect(firstResult).toBe('No matching commands');
+		// With the command gated out, the picker falls back to fuzzy "similar
+		// commands" (e.g. "Configure Language Model Providers"), so we can't rely
+		// on a "No matching commands" message. Wait for the list to render, then
+		// assert the gated command itself is absent from the results.
+		await app.workbench.quickInput.waitForQuickInputElementText();
+		await expect(
+			app.workbench.quickInput.quickInputResult.filter({ hasText: COMMAND_TITLE })
+		).toHaveCount(0);
 		await app.workbench.quickInput.closeQuickInput();
 	});
 

--- a/test/e2e/tests/posit-assistant/posit-assistant.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 import { ModelProvider } from '../../pages/positronAssistant';
 
 test.use({
@@ -151,4 +151,38 @@ test.describe('Posit Assistant', {
 		});
 	}
 
+});
+
+/**
+ * Verifies that the "Manage Language Model Access..." action is gated by the
+ * `chat.disableAIFeatures` setting. The precondition gates command palette
+ * visibility; this test exercises that gate in both directions.
+ * @see https://github.com/posit-dev/positron/pull/14054
+ */
+test.describe('Language Model Access Gating', { tag: [tags.POSIT_ASSISTANT, tags.ASSISTANT] }, () => {
+	const COMMAND_TITLE = 'Manage Language Model Access';
+
+	test.afterEach('Reset chat.disableAIFeatures', async function ({ settings }) {
+		await settings.remove(['chat.disableAIFeatures']);
+	});
+
+	test('Hidden from command palette when AI features are disabled', async function ({ app, settings }) {
+		await settings.set({ 'chat.disableAIFeatures': true }, { reload: true });
+
+		await app.workbench.hotKeys.openCommandPalette();
+		await app.workbench.quickInput.type(`>${COMMAND_TITLE}`);
+		const firstResult = await app.workbench.quickInput.waitForQuickInputElementText();
+		expect(firstResult).toBe('No matching commands');
+		await app.workbench.quickInput.closeQuickInput();
+	});
+
+	test('Visible in command palette when AI features are enabled', async function ({ app, settings }) {
+		await settings.set({ 'chat.disableAIFeatures': false }, { reload: true });
+
+		await app.workbench.hotKeys.openCommandPalette();
+		await app.workbench.quickInput.type(`>${COMMAND_TITLE}`);
+		const firstResult = await app.workbench.quickInput.waitForQuickInputElementText();
+		expect(firstResult).toContain(COMMAND_TITLE);
+		await app.workbench.quickInput.closeQuickInput();
+	});
 });


### PR DESCRIPTION
Closes #13630 

Changes the conditions on the language model access and management to depend on Copilot. Specifically, the Disable AI Features will disable these actions and prevent them from showing in the accounts menu and in the command palette.

Action is hidden in accounts menu
<img width="366" height="137" alt="image" src="https://github.com/user-attachments/assets/1d702ed8-d051-4201-84a1-40c97ce94bc2" />

Actions do not show in command palette
<img width="604" height="154" alt="image" src="https://github.com/user-attachments/assets/86bf9659-cc44-45b1-b512-80b68de3cb73" />


### Release Notes

#### New Features

- Clarify enablement of language model management actions

#### Bug Fixes

- N/A


### QA Notes
@:assistant