### PR TITLE
Assistant: update notices in provider modal

### DIFF
--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -28,6 +28,16 @@ const positEulaLabel = localize('positron.languageModelConfig.positEula', 'Posit
 const providerTermsOfServiceLabel = localize('positron.languageModelConfig.termsOfService', 'Terms of Service');
 const providerPrivacyPolicyLabel = localize('positron.languageModelConfig.privacyPolicy', 'Privacy Policy');
 
+const POSIT_EULA_URL = 'https://posit.co/about/eula/';
+
+/**
+ * Builds a markdown link fragment `[label](href)` for `EmbeddedLink`, or plain
+ * label text when there's no URL (so the label still renders, just not linked).
+ */
+function linkFragment(label: string, href: string | undefined): string {
+	return href ? `[${label}](${href})` : label;
+}
+
 const apiKeyInputLabel = localize('positron.languageModelConfig.apiKeyInputLabel', 'API Key');
 const signInButtonLabel = localize('positron.languageModelConfig.signIn', 'Sign in');
 const signOutButtonLabel = localize('positron.languageModelConfig.signOut', 'Sign out');
@@ -38,16 +48,20 @@ const copilotSignoutGuidanceLabel = localize(
 );
 
 function getProviderTermsOfServiceText(provider: IProvider) {
+	const eula = linkFragment(positEulaLabel, POSIT_EULA_URL);
+	const tos = linkFragment(providerTermsOfServiceLabel, getProviderTermsOfServiceLink(provider.id));
+	const privacy = linkFragment(providerPrivacyPolicyLabel, getProviderPrivacyPolicyLink(provider.id));
 	if (provider.id === 'openai-compatible') {
 		return localize(
 			'positron.languageModelConfig.openAiCompatible.tos',
-			'A custom provider is considered "Third Party Materials" as defined in the {posit-eula} and subject to the its {provider-tos} and {provider-privacy-policy}.',
+			'A custom provider is considered "Third Party Materials" as defined in the {0} and subject to the its {1} and {2}.',
+			eula, tos, privacy,
 		);
 	}
 	return localize(
 		'positron.languageModelConfig.tos',
-		'{0} is considered "Third Party Materials" as defined in the {posit-eula} and subject to the {0} {provider-tos} and {provider-privacy-policy}.',
-		provider.displayName,
+		'{0} is considered "Third Party Materials" as defined in the {1} and subject to the {0} {2} and {3}.',
+		provider.displayName, eula, tos, privacy,
 	);
 }
 
@@ -89,42 +103,6 @@ function getProviderPrivacyPolicyLink(providerId: string) {
 		default:
 			return undefined;
 	}
-}
-
-/**
- * Interpolates placeholders in a string with React nodes.
- *
- * Scans the input `text` for placeholders in the form `{key}` and replaces each with the result of the `value` function.
- * If `value(key)` returns `undefined`, the original placeholder is left in place.
- *
- * @param text The input string containing zero or more `{key}` placeholders.
- * @param value A function that takes a key and returns a React node to replace the corresponding placeholder, or `undefined` to leave it unchanged.
- * @returns An array of React nodes and strings representing the interpolated text.
- */
-function interpolate(text: string, value: (key: string) => React.ReactNode | undefined): React.ReactNode[] {
-	const nodes: React.ReactNode[] = [];
-	let index = 0;
-	for (const match of text.matchAll(/\{([^\}]+)\}/g)) {
-		// Push text before the match, if any.
-		if (index < match.index) {
-			nodes.push(text.slice(index, match.index));
-		}
-
-		// Push the interpolated value, if there is one, or the original text.
-		const key = match[1];
-		const replacement = value(key) ?? match[0];
-		nodes.push(replacement);
-
-		// Bump the index.
-		index = match.index + match[0].length;
-	}
-
-	// Push remaining text.
-	if (index < text.length) {
-		nodes.push(text.slice(index));
-	}
-
-	return nodes;
 }
 
 /**
@@ -263,43 +241,13 @@ const SignInButton = (props: { authMethod: AuthMethod, authStatus: AuthStatus, o
 }
 
 const ProviderNotice = (props: { provider: IProvider }) => {
-	const termsOfServiceText = getProviderTermsOfServiceText(props.provider);
-	const termsOfService = interpolate(
-		termsOfServiceText,
-		(key) => {
-			switch (key) {
-				case 'posit-eula':
-					return <ExternalLink href='https://posit.co/about/eula/'>{positEulaLabel}</ExternalLink>;
-				case 'provider-tos': {
-					const link = getProviderTermsOfServiceLink(props.provider.id);
-					return link ?
-						<ExternalLink href={link}>{providerTermsOfServiceLabel}</ExternalLink> :
-						providerTermsOfServiceLabel;
-				}
-				case 'provider-privacy-policy': {
-					const link = getProviderPrivacyPolicyLink(props.provider.id);
-					return link ?
-						<ExternalLink href={link}>{providerPrivacyPolicyLabel}</ExternalLink> :
-						providerPrivacyPolicyLabel;
-				}
-				default:
-					return undefined;
-			}
-		},
-	)
-
-	const disclaimerText = getProviderUsageDisclaimerText(props.provider);
+	// Two paragraphs separated by a blank line; EmbeddedLink wraps each in a <p>
+	// and turns the markdown links into anchors.
+	const text = `${getProviderTermsOfServiceText(props.provider)}\n\n${getProviderUsageDisclaimerText(props.provider)}`;
 
 	return <div className='language-model-dialog-tos' id='model-tos'>
-		<p>{termsOfService}</p>
-		<p>{disclaimerText}</p>
+		<EmbeddedLink>{text}</EmbeddedLink>
 	</div>;
-}
-
-const ExternalLink = (props: { href: string, children: React.ReactNode }) => {
-	return <a href={props.href} rel='noreferrer' target='_blank'>
-		{props.children}
-	</a>;
 }
 
 const AutoconfiguredModel = (props: { provider: string; displayName: string; details?: IPositronLanguageModelAutoconfigure; supportsBaseUrl?: boolean }) => {

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -101,14 +101,22 @@ function getProviderUsageDisclaimerText(provider: IProvider) {
 
 function getProviderTermsOfServiceLink(providerId: string) {
 	switch (providerId) {
+		case 'amazon-bedrock':
+			return 'https://aws.amazon.com/service-terms/';
 		case 'anthropic-api':
 			return 'https://www.anthropic.com/legal/consumer-terms';
+		case 'ms-foundry':
+			return 'https://www.microsoft.com/licensing/terms/productoffering/MicrosoftAzure';
 		case 'google':
 			return 'https://cloud.google.com/terms/service-terms';
 		case 'copilot-auth':
 			return 'https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot';
+		case 'openai-api':
+			return 'https://openai.com/policies/row-terms-of-use/';
 		case 'posit-ai':
 			return 'https://posit.co/about/posit-service-terms-of-use';
+		case 'snowflake-cortex':
+			return 'https://www.snowflake.com/en/legal/terms-of-service/';
 		default:
 			return undefined;
 	}
@@ -116,14 +124,22 @@ function getProviderTermsOfServiceLink(providerId: string) {
 
 function getProviderPrivacyPolicyLink(providerId: string) {
 	switch (providerId) {
+		case 'amazon-bedrock':
+			return 'https://aws.amazon.com/privacy/';
 		case 'anthropic-api':
 			return 'https://www.anthropic.com/legal/privacy';
+		case 'ms-foundry':
+			return 'https://privacy.microsoft.com/en-us/privacystatement';
 		case 'google':
 			return 'https://policies.google.com/privacy';
 		case 'copilot-auth':
 			return 'https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement#personal-data-we-collect';
+		case 'openai-api':
+			return 'https://openai.com/policies/row-privacy-policy/';
 		case 'posit-ai':
 			return 'https://posit.co/about/privacy-policy/';
+		case 'snowflake-cortex':
+			return 'https://www.snowflake.com/en/legal/privacy/privacy-policy/';
 		default:
 			return undefined;
 	}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -285,7 +285,7 @@ const ProviderNotice = (props: { provider: IProvider }) => {
 	// and turns the markdown links into anchors.
 	const text = `${getProviderTermsOfServiceText(props.provider)}\n\n${getProviderUsageDisclaimerText(props.provider)}`;
 
-	return <div className='language-model-dialog-tos' id='model-tos'>
+	return <div className='language-model-dialog-tos' data-testid='provider-notice' id='model-tos'>
 		<EmbeddedLink>{text}</EmbeddedLink>
 	</div>;
 }

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -58,6 +58,13 @@ function getProviderTermsOfServiceText(provider: IProvider) {
 			eula, tos, privacy,
 		);
 	}
+	if (provider.id === 'posit-ai') {
+		return localize(
+			'positron.languageModelConfig.positAI.tos',
+			'By using {0}, you agree to the {1} and {2}.',
+			provider.displayName, tos, privacy,
+		);
+	}
 	return localize(
 		'positron.languageModelConfig.tos',
 		'{0} is considered "Third Party Materials" as defined in the {1} and subject to the {0} {2} and {3}.',
@@ -72,11 +79,24 @@ function getProviderUsageDisclaimerText(provider: IProvider) {
 			'Your use of the custom provider is optional and at your sole risk.',
 		);
 	}
-	return localize(
+	const soleRisk = localize(
 		'positron.languageModelConfig.tos2',
 		'Your use of {0} is optional and at your sole risk.',
 		provider.displayName,
 	);
+	if (provider.id === 'posit-ai') {
+		const faq = linkFragment(
+			localize('positron.languageModelConfig.positAiFaq', 'Posit AI FAQ'),
+			'https://docs.posit.co/posit-ai/user/faq/#privacy-data-storage',
+		);
+		const faqNote = localize(
+			'positron.languageModelConfig.positAI.faqNote',
+			'See the {0} for details on privacy and data storage.',
+			faq,
+		);
+		return `${faqNote}\n\n${soleRisk}`;
+	}
+	return soleRisk;
 }
 
 function getProviderTermsOfServiceLink(providerId: string) {
@@ -87,6 +107,8 @@ function getProviderTermsOfServiceLink(providerId: string) {
 			return 'https://cloud.google.com/terms/service-terms';
 		case 'copilot-auth':
 			return 'https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#github-copilot';
+		case 'posit-ai':
+			return 'https://posit.co/about/posit-service-terms-of-use';
 		default:
 			return undefined;
 	}
@@ -100,6 +122,8 @@ function getProviderPrivacyPolicyLink(providerId: string) {
 			return 'https://policies.google.com/privacy';
 		case 'copilot-auth':
 			return 'https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement#personal-data-we-collect';
+		case 'posit-ai':
+			return 'https://posit.co/about/privacy-policy/';
 		default:
 			return undefined;
 	}

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -28,8 +28,6 @@ const positEulaLabel = localize('positron.languageModelConfig.positEula', 'Posit
 const providerTermsOfServiceLabel = localize('positron.languageModelConfig.termsOfService', 'Terms of Service');
 const providerPrivacyPolicyLabel = localize('positron.languageModelConfig.privacyPolicy', 'Privacy Policy');
 
-const POSIT_EULA_URL = 'https://posit.co/about/posit-ai-agreement';
-
 /**
  * Builds a markdown link fragment `[label](href)` for `EmbeddedLink`, or plain
  * label text when there's no URL (so the label still renders, just not linked).
@@ -48,21 +46,21 @@ const copilotSignoutGuidanceLabel = localize(
 );
 
 function getProviderTermsOfServiceText(provider: IProvider) {
-	const eula = linkFragment(positEulaLabel, POSIT_EULA_URL);
 	const tos = linkFragment(providerTermsOfServiceLabel, getProviderTermsOfServiceLink(provider.id));
 	const privacy = linkFragment(providerPrivacyPolicyLabel, getProviderPrivacyPolicyLink(provider.id));
+	const eula = linkFragment(positEulaLabel, 'https://posit.co/about/eula/');
 	if (provider.id === 'openai-compatible') {
 		return localize(
 			'positron.languageModelConfig.openAiCompatible.tos',
-			'A custom provider is considered "Third Party Materials" as defined in the {0} and subject to the its {1} and {2}.',
+			'A custom provider is considered "Third Party Materials" as defined in the {0} and subject to its {1} and {2}.',
 			eula, tos, privacy,
 		);
 	}
 	if (provider.id === 'posit-ai') {
 		return localize(
 			'positron.languageModelConfig.positAI.tos',
-			'By using {0}, you agree to the {1} and {2}.',
-			provider.displayName, tos, privacy,
+			'By using {0}, you agree to the {1}, {0} {2}, and {3}.',
+			provider.displayName, eula, tos, privacy,
 		);
 	}
 	return localize(
@@ -85,16 +83,16 @@ function getProviderUsageDisclaimerText(provider: IProvider) {
 		provider.displayName,
 	);
 	if (provider.id === 'posit-ai') {
-		const faq = linkFragment(
+		const positAiHomeLink = linkFragment(
 			localize('positron.languageModelConfig.positAiHome', 'Posit AI'),
 			'https://posit.ai/',
 		);
-		const faqNote = localize(
-			'positron.languageModelConfig.positAI.faqNote',
-			'Get started with Posit Assistant instantly via a free trial of {0} — a managed service that provides access to frontier LLMs through a single account. Posit AI includes both access to Chat and unlimited Next Edit Suggestions',
-			faq,
+		const gettingStartedNote = localize(
+			'positron.languageModelConfig.positAI.gettingStartedNote',
+			'Get started with Posit Assistant instantly via a free trial of {0}, a managed service that provides access to frontier LLMs through a single account. Posit AI provides access to both Posit Assistant and Next Edit Suggestions.',
+			positAiHomeLink,
 		);
-		return `${faqNote}\n\n${soleRisk}`;
+		return `${gettingStartedNote}\n\n${soleRisk}`;
 	}
 	return soleRisk;
 }
@@ -114,7 +112,7 @@ function getProviderTermsOfServiceLink(providerId: string) {
 		case 'openai-api':
 			return 'https://openai.com/policies/row-terms-of-use/';
 		case 'posit-ai':
-			return 'https://posit.co/about/posit-service-terms-of-use';
+			return 'https://posit.co/about/posit-ai-agreement';
 		case 'snowflake-cortex':
 			return 'https://www.snowflake.com/en/legal/terms-of-service/';
 		default:

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -28,7 +28,7 @@ const positEulaLabel = localize('positron.languageModelConfig.positEula', 'Posit
 const providerTermsOfServiceLabel = localize('positron.languageModelConfig.termsOfService', 'Terms of Service');
 const providerPrivacyPolicyLabel = localize('positron.languageModelConfig.privacyPolicy', 'Privacy Policy');
 
-const POSIT_EULA_URL = 'https://posit.co/about/eula/';
+const POSIT_EULA_URL = 'https://posit.co/about/posit-ai-agreement';
 
 /**
  * Builds a markdown link fragment `[label](href)` for `EmbeddedLink`, or plain
@@ -86,12 +86,12 @@ function getProviderUsageDisclaimerText(provider: IProvider) {
 	);
 	if (provider.id === 'posit-ai') {
 		const faq = linkFragment(
-			localize('positron.languageModelConfig.positAiFaq', 'Posit AI FAQ'),
-			'https://docs.posit.co/posit-ai/user/faq/#privacy-data-storage',
+			localize('positron.languageModelConfig.positAiHome', 'Posit AI'),
+			'https://posit.ai/',
 		);
 		const faqNote = localize(
 			'positron.languageModelConfig.positAI.faqNote',
-			'See the {0} for details on privacy and data storage.',
+			'Get started with Posit Assistant instantly via a free trial of {0} — a managed service that provides access to frontier LLMs through a single account. Posit AI includes both access to Chat and unlimited Next Edit Suggestions',
 			faq,
 		);
 		return `${faqNote}\n\n${soleRisk}`;

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelConfigComponent.tsx
@@ -70,6 +70,27 @@ function getProviderTermsOfServiceText(provider: IProvider) {
 	);
 }
 
+/**
+ * An optional getting-started note shown before the terms of service.
+ */
+function getProviderGettingStartedText(provider: IProvider): string | undefined {
+	switch (provider.id) {
+		case 'posit-ai': {
+			const positAiHomeLink = linkFragment(
+				localize('positron.languageModelConfig.positAiHome', 'Posit AI'),
+				'https://posit.ai/',
+			);
+			return localize(
+				'positron.languageModelConfig.positAI.gettingStartedNote',
+				'Get started with Posit Assistant instantly via a free trial of {0}, a managed service that provides access to frontier LLMs through a single account. Posit AI provides access to both Posit Assistant and Next Edit Suggestions.',
+				positAiHomeLink,
+			);
+		}
+		default:
+			return undefined;
+	}
+}
+
 function getProviderUsageDisclaimerText(provider: IProvider) {
 	if (provider.id === 'openai-compatible') {
 		return localize(
@@ -77,24 +98,11 @@ function getProviderUsageDisclaimerText(provider: IProvider) {
 			'Your use of the custom provider is optional and at your sole risk.',
 		);
 	}
-	const soleRisk = localize(
+	return localize(
 		'positron.languageModelConfig.tos2',
 		'Your use of {0} is optional and at your sole risk.',
 		provider.displayName,
 	);
-	if (provider.id === 'posit-ai') {
-		const positAiHomeLink = linkFragment(
-			localize('positron.languageModelConfig.positAiHome', 'Posit AI'),
-			'https://posit.ai/',
-		);
-		const gettingStartedNote = localize(
-			'positron.languageModelConfig.positAI.gettingStartedNote',
-			'Get started with Posit Assistant instantly via a free trial of {0}, a managed service that provides access to frontier LLMs through a single account. Posit AI provides access to both Posit Assistant and Next Edit Suggestions.',
-			positAiHomeLink,
-		);
-		return `${gettingStartedNote}\n\n${soleRisk}`;
-	}
-	return soleRisk;
 }
 
 function getProviderTermsOfServiceLink(providerId: string) {
@@ -279,9 +287,11 @@ const SignInButton = (props: { authMethod: AuthMethod, authStatus: AuthStatus, o
 }
 
 const ProviderNotice = (props: { provider: IProvider }) => {
-	// Two paragraphs separated by a blank line; EmbeddedLink wraps each in a <p>
-	// and turns the markdown links into anchors.
-	const text = `${getProviderTermsOfServiceText(props.provider)}\n\n${getProviderUsageDisclaimerText(props.provider)}`;
+	const text = [
+		getProviderGettingStartedText(props.provider),
+		getProviderTermsOfServiceText(props.provider),
+		getProviderUsageDisclaimerText(props.provider),
+	].filter(Boolean).join('\n\n');
 
 	return <div className='language-model-dialog-tos' data-testid='provider-notice' id='model-tos'>
 		<EmbeddedLink>{text}</EmbeddedLink>

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/languageModelConfigComponent.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/languageModelConfigComponent.vitest.tsx
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { screen, within } from '@testing-library/react';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { LanguageModelConfigComponent } from '../../browser/components/languageModelConfigComponent.js';
+import { AuthMethod, AuthStatus } from '../../browser/types.js';
+import { IPositronLanguageModelSource, PositronLanguageModelType } from '../../common/interfaces/positronAssistantService.js';
+
+describe('LanguageModelConfigComponent ProviderNotice', () => {
+	const ctx = createTestContainer().withReactServices().build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	function renderNotice(provider: { id: string; displayName: string }): HTMLElement {
+		const source: IPositronLanguageModelSource = {
+			type: PositronLanguageModelType.Chat,
+			provider: { ...provider, settingName: provider.id },
+			supportedOptions: [],
+			defaults: { name: '', model: '' },
+		};
+		rtl.render(
+			<LanguageModelConfigComponent
+				authMethod={AuthMethod.NONE}
+				authStatus={AuthStatus.SIGNED_OUT}
+				closeDialog={() => { }}
+				config={{ type: PositronLanguageModelType.Chat, provider: provider.id, name: '', model: '' }}
+				source={source}
+				onCancel={() => { }}
+				onChange={() => { }}
+				onSignIn={() => { }}
+			/>
+		);
+
+		return screen.getByTestId('provider-notice');
+	}
+
+	function linkHrefs(notice: HTMLElement): Record<string, string> {
+		const result: Record<string, string> = {};
+		for (const a of within(notice).getAllByRole('link')) {
+			result[a.textContent ?? ''] = a.getAttribute('href') ?? '';
+		}
+		return result;
+	}
+
+	it.each([
+		{ id: 'posit-ai', displayName: 'Posit AI' },
+		{ id: 'anthropic-api', displayName: 'Anthropic' },
+		{ id: 'openai-compatible', displayName: 'Custom Provider' },
+		{ id: 'unknown-provider', displayName: 'Some Provider' },
+	])('renders a non-empty provider notice without placeholders for $id', (provider) => {
+		const notice = renderNotice(provider);
+
+		expect(notice).toHaveTextContent(/\S/);
+		expect(notice).not.toHaveTextContent(/\{\d+\}/);
+	});
+
+	it('renders the Posit AI links for terms, privacy, and FAQ', () => {
+		const notice = renderNotice({ id: 'posit-ai', displayName: 'Posit AI' });
+
+		expect(linkHrefs(notice)).toEqual({
+			'Terms of Service': 'https://posit.co/about/posit-service-terms-of-use',
+			'Privacy Policy': 'https://posit.co/about/privacy-policy/',
+			'Posit AI FAQ': 'https://docs.posit.co/posit-ai/user/faq/#privacy-data-storage',
+		});
+	});
+
+	it('renders a known provider with the Posit EULA, ToS, and privacy links', () => {
+		const notice = renderNotice({ id: 'anthropic-api', displayName: 'Anthropic' });
+
+		expect(linkHrefs(notice)).toEqual({
+			'Posit EULA': 'https://posit.co/about/eula/',
+			'Terms of Service': 'https://www.anthropic.com/legal/consumer-terms',
+			'Privacy Policy': 'https://www.anthropic.com/legal/privacy',
+		});
+	});
+
+	it('renders unlinked labels for a provider with no ToS or privacy URLs', () => {
+		const notice = renderNotice({ id: 'unknown-provider', displayName: 'Some Provider' });
+
+		// Only the Posit EULA is linked; the provider ToS/privacy fall back to plain text.
+		expect(notice).toHaveTextContent('Terms of Service');
+		expect(notice).toHaveTextContent('Privacy Policy');
+		expect(linkHrefs(notice)).toEqual({
+			'Posit EULA': 'https://posit.co/about/eula/',
+		});
+	});
+});

--- a/src/vs/workbench/contrib/positronAssistant/test/browser/languageModelConfigComponent.vitest.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/test/browser/languageModelConfigComponent.vitest.tsx
@@ -41,7 +41,7 @@ describe('LanguageModelConfigComponent ProviderNotice', () => {
 
 	function linkHrefs(notice: HTMLElement): Record<string, string> {
 		const result: Record<string, string> = {};
-		for (const a of within(notice).getAllByRole('link')) {
+		for (const a of within(notice).queryAllByRole('link')) {
 			result[a.textContent ?? ''] = a.getAttribute('href') ?? '';
 		}
 		return result;
@@ -59,19 +59,22 @@ describe('LanguageModelConfigComponent ProviderNotice', () => {
 		expect(notice).not.toHaveTextContent(/\{\d+\}/);
 	});
 
-	it('renders the Posit AI links for terms, privacy, and FAQ', () => {
+	it('renders the terms, privacy, and Posit AI home links for posit-ai', () => {
 		const notice = renderNotice({ id: 'posit-ai', displayName: 'Posit AI' });
 
+		// Posit AI's Terms of Service link points to the Posit AI Agreement.
 		expect(linkHrefs(notice)).toEqual({
-			'Terms of Service': 'https://posit.co/about/posit-service-terms-of-use',
+			'Posit EULA': 'https://posit.co/about/eula/',
+			'Terms of Service': 'https://posit.co/about/posit-ai-agreement',
 			'Privacy Policy': 'https://posit.co/about/privacy-policy/',
-			'Posit AI FAQ': 'https://docs.posit.co/posit-ai/user/faq/#privacy-data-storage',
+			'Posit AI': 'https://posit.ai/',
 		});
 	});
 
-	it('renders a known provider with the Posit EULA, ToS, and privacy links', () => {
+	it('renders a known third-party provider with the Posit EULA plus its ToS and privacy links', () => {
 		const notice = renderNotice({ id: 'anthropic-api', displayName: 'Anthropic' });
 
+		// Third-party providers are "Third Party Materials" under the Posit EULA.
 		expect(linkHrefs(notice)).toEqual({
 			'Posit EULA': 'https://posit.co/about/eula/',
 			'Terms of Service': 'https://www.anthropic.com/legal/consumer-terms',
@@ -79,10 +82,10 @@ describe('LanguageModelConfigComponent ProviderNotice', () => {
 		});
 	});
 
-	it('renders unlinked labels for a provider with no ToS or privacy URLs', () => {
+	it('renders the Posit EULA link plus unlinked labels for a provider with no ToS or privacy URLs', () => {
 		const notice = renderNotice({ id: 'unknown-provider', displayName: 'Some Provider' });
 
-		// Only the Posit EULA is linked; the provider ToS/privacy fall back to plain text.
+		// The Posit EULA always links; the ToS/privacy fall back to plain text.
 		expect(notice).toHaveTextContent('Terms of Service');
 		expect(notice).toHaveTextContent('Privacy Policy');
 		expect(linkHrefs(notice)).toEqual({


### PR DESCRIPTION
### Summary

Fixes #14056.

Updates the AI provider notices in the language model config modal:

- Reworks the Posit AI notice wording
- Renders notice links with the `EmbeddedLink` component
- Adds Terms of Service / Privacy Policy links for more providers (Amazon Bedrock, Microsoft Foundry, OpenAI, Snowflake Cortex). Links are from the [assistant provider info docs](https://positron.posit.co/assistant-provider-info.html)

### Release Notes

#### Bug Fixes

- Assistant: updated provider notices in the language model config dialog (#14056)

### Validation Steps

Open the Configure Language Model Providers modal and confirm:

- Posit AI notice wording improved
- Bedrock, Foundry, OpenAI and Snowflake now have clickable privacy/ToS links
- Links for privacy/ToS render properly
