### PR TITLE
Scrub worker env before starting duckdb instance

### DIFF
--- a/extensions/positron-duckdb/src/extension.ts
+++ b/extensions/positron-duckdb/src/extension.ts
@@ -82,6 +82,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as zlib from 'zlib';
 import { WorkerQueryRequest, WorkerQueryResponse } from './duckdbWorkerProtocol';
+import { createWorkerEnv } from './workerEnv.js';
 
 // Set to true when doing development for better console logging
 const DEBUG_LOG = false;
@@ -184,19 +185,12 @@ export class DuckDBInstance {
 	}
 
 	private spawnWorker(): void {
-		// The extension host runs as an Electron process. Forking inherits the
-		// host's `process.execArgv` (and runs the Electron binary), which carries
-		// Chromium-only flags such as `--crash-reporter-directory` that Node
-		// rejects on startup (exit code 9). Force a plain Node child by clearing
-		// `execArgv` and setting `ELECTRON_RUN_AS_NODE`, the same pattern VS Code
-		// uses to fork the TypeScript server (see serverProcess.electron.ts).
-		//
 		// "advanced" serialization uses the V8 structured-clone algorithm, which
 		// preserves bigint and Date values returned by DuckDB.
 		const worker = fork(this.workerPath, [], {
 			serialization: 'advanced',
 			execArgv: [],
-			env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+			env: createWorkerEnv(),
 		});
 		worker.on('message', (message: unknown) => {
 			const response = message as WorkerQueryResponse;

--- a/extensions/positron-duckdb/src/workerEnv.ts
+++ b/extensions/positron-duckdb/src/workerEnv.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Builds a clean environment for the forked worker process.
+ *
+ * The worker is forked from the extension host and run as Node via
+ * ELECTRON_RUN_AS_NODE, which means it executes the Electron binary. If the
+ * extension host's own bootstrap variables are inherited, the child re-runs
+ * VS Code's fork bootstrap instead of the worker entry point: in a dev build,
+ * `VSCODE_ESM_ENTRYPOINT` causes the child to load
+ * `vs/workbench/api/node/extensionHostProcess` (see `src/bootstrap-fork.ts`),
+ * so it tries to become a second extension host and hangs forever -- the worker
+ * never loads its native binding and never answers a query.
+ *
+ * Strip those variables before forking so the child boots straight into the
+ * worker script. Mirrors the env scrub in
+ * `src/vs/platform/agentHost/node/copilot/copilotAgent.ts`.
+ */
+export function createWorkerEnv(): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = { ...process.env, ELECTRON_RUN_AS_NODE: '1' };
+	delete env['NODE_OPTIONS'];
+	delete env['VSCODE_INSPECTOR_OPTIONS'];
+	delete env['VSCODE_ESM_ENTRYPOINT'];
+	delete env['VSCODE_HANDLES_UNCAUGHT_ERRORS'];
+	for (const key of Object.keys(env)) {
+		if (key === 'ELECTRON_RUN_AS_NODE') {
+			continue;
+		}
+		if (key.startsWith('VSCODE_') || key.startsWith('ELECTRON_')) {
+			delete env[key];
+		}
+	}
+	return env;
+}

--- a/extensions/positron-duckdb/src/workerEnv.ts
+++ b/extensions/positron-duckdb/src/workerEnv.ts
@@ -20,18 +20,12 @@
  * `src/vs/platform/agentHost/node/copilot/copilotAgent.ts`.
  */
 export function createWorkerEnv(): NodeJS.ProcessEnv {
-	const env: NodeJS.ProcessEnv = { ...process.env, ELECTRON_RUN_AS_NODE: '1' };
+	const env: NodeJS.ProcessEnv = { ...process.env };
 	delete env['NODE_OPTIONS'];
-	delete env['VSCODE_INSPECTOR_OPTIONS'];
-	delete env['VSCODE_ESM_ENTRYPOINT'];
-	delete env['VSCODE_HANDLES_UNCAUGHT_ERRORS'];
 	for (const key of Object.keys(env)) {
-		if (key === 'ELECTRON_RUN_AS_NODE') {
-			continue;
-		}
 		if (key.startsWith('VSCODE_') || key.startsWith('ELECTRON_')) {
 			delete env[key];
 		}
 	}
-	return env;
+	return { ...env, ELECTRON_RUN_AS_NODE: '1' };
 }


### PR DESCRIPTION
Fixes an issue that can prevent CSV and Parquet data files from loading in development builds; a port of https://github.com/posit-dev/positron/pull/14026/commits/928cc9b380409659ad511441fb83e47e1e078516 to the `positron-duckdb` extension.