### PR TITLE
e2e: fix flaky duplicate-kernel-selector in qmd and notebook side-by-side test

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -202,7 +202,7 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		});
 	});
 
-	test('Python - console accepts input after notebook cell execution', {tag: [tags.CONSOLE]}, async function ({ app, sessions }) {
+	test('Python - console accepts input after notebook cell execution', { tag: [tags.CONSOLE] }, async function ({ app, sessions }) {
 		const { notebooksPositron, console } = app.workbench;
 		await sessions.start(['python']);
 		await notebooksPositron.newNotebook();
@@ -223,12 +223,17 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await expect(notebooksPositron.cellOutput(0)).not.toContainText('done');
 	});
 
-	test('opening .qmd alongside notebook does not produce duplicate kernel selectors', async function ({ app, openFile }) {
+	test('opening .qmd alongside notebook does not produce duplicate kernel selectors', async function ({ app, openFile, sessions }) {
 		const { notebooksPositron } = app.workbench;
+
+		await sessions.deleteDisconnectedSessions();
+		await sessions.start(['r']);
+
+		// open .qmd and open notebook
 		await openFile(path.join('workspaces', 'quarto_basic', 'quarto_basic.qmd'));
 		await notebooksPositron.newNotebook();
-		await notebooksPositron.kernel.select('Python');
 
+		// ensure only 1 kernel selector dropdown exists for the notebook editor
 		const kernelButtons = app.code.driver.currentPage
 			.locator('.editor-group-container.active')
 			.getByRole('button', { name: 'Kernel Actions' });


### PR DESCRIPTION
### Summary
Fixes a flaky e2e test that checks for duplicate kernel selectors when opening a .qmd alongside a notebook.

- Add `sessions` fixture and start an R session before the test runs
- Call `deleteDisconnectedSessions()` to ensure a clean session state
- Remove `kernel.select('Python')` which was unreliable without an active session
- Minor whitespace fix on test tag object literal

### QA Notes
@:web @:positron-notebooks