### PR TITLE
fix update tooltip content and release notes editor icon

### DIFF
--- a/src/vs/platform/update/common/update.ts
+++ b/src/vs/platform/update/common/update.ts
@@ -126,7 +126,7 @@ export interface IUpdateService {
 
 	// --- Start Positron ---
 	updateActiveLanguages(languages: string[]): void;
-	getReleaseNotes(): Promise<string>;
+	getReleaseNotes(version?: string): Promise<string>;
 	resetTelemetryId(): void;
 	// --- End Positron ---
 }

--- a/src/vs/platform/update/common/updateIpc.ts
+++ b/src/vs/platform/update/common/updateIpc.ts
@@ -32,7 +32,7 @@ export class UpdateChannel implements IServerChannel {
 			case 'setInternalOrg': return this.service.setInternalOrg(arg);
 			// --- Start Positron ---
 			case 'updateActiveLanguages': return Promise.resolve(this.service.updateActiveLanguages(arg));
-			case 'getReleaseNotes': return this.service.getReleaseNotes();
+			case 'getReleaseNotes': return this.service.getReleaseNotes(arg);
 			case 'resetTelemetryId': return Promise.resolve(this.service.resetTelemetryId());
 			// --- End Positron ---
 		}
@@ -98,8 +98,8 @@ export class UpdateChannelClient implements IUpdateService {
 		this.channel.call('updateActiveLanguages', languages);
 	}
 
-	getReleaseNotes(): Promise<string> {
-		return this.channel.call('getReleaseNotes');
+	getReleaseNotes(version?: string): Promise<string> {
+		return this.channel.call('getReleaseNotes', version);
 	}
 
 	resetTelemetryId(): void {

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -416,9 +416,10 @@ export abstract class AbstractUpdateService implements IUpdateService {
 	 * @returns the release notes as a string
 	 */
 	// --- Start Positron ---
-	async getReleaseNotes(): Promise<string> {
+	async getReleaseNotes(version?: string): Promise<string> {
+		const targetVersion = version ?? this.productService.positronVersion;
 		const channel = process.env.POSITRON_UPDATE_CHANNEL ?? this.configurationService.getValue<string>('update.positron.channel');
-		const url = `${this.productService.releaseNotesUrl}/${channel}/release-notes/release-${this.productService.positronVersion}.md`;
+		const url = `${this.productService.releaseNotesUrl}/${channel}/release-notes/release-${targetVersion}.md`;
 		const releaseNotesResponse = await this.requestService.request({ url, callSite: 'update.getReleaseNotes' }, CancellationToken.None);
 
 		if (process.env.POSITRON_UPDATE_CHANNEL) {

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -423,7 +423,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		const releaseNotesResponse = await this.requestService.request({ url, callSite: 'update.getReleaseNotes' }, CancellationToken.None);
 
 		if (process.env.POSITRON_UPDATE_CHANNEL) {
-			this.logService.info('update#getReleaseNotes - using release notes channel from environment variable:', process.env.POSITRON_RELEASE_NOTES_CHANNEL);
+			this.logService.info('update#getReleaseNotes - using release notes channel from environment variable:', process.env.POSITRON_UPDATE_CHANNEL);
 		}
 
 		if (releaseNotesResponse.res.statusCode !== 200) {

--- a/src/vs/platform/update/electron-main/crossAppUpdateIpc.ts
+++ b/src/vs/platform/update/electron-main/crossAppUpdateIpc.ts
@@ -308,8 +308,8 @@ export class CrossAppUpdateCoordinator extends Disposable implements IUpdateServ
 		this.localUpdateService.updateActiveLanguages(languages);
 	}
 
-	getReleaseNotes(): Promise<string> {
-		return this.localUpdateService.getReleaseNotes();
+	getReleaseNotes(version?: string): Promise<string> {
+		return this.localUpdateService.getReleaseNotes(version);
 	}
 
 	resetTelemetryId(): void {

--- a/src/vs/workbench/contrib/update/browser/media/updateTooltip.css
+++ b/src/vs/workbench/contrib/update/browser/media/updateTooltip.css
@@ -39,7 +39,9 @@
 	border-radius: var(--vscode-cornerRadius-large);
 	padding: 5px;
 	flex-shrink: 0;
-	background: url('../../../../browser/media/code-icon.svg') center / contain no-repeat;
+	/* --- Start Positron --- */
+	background: url('../../../../browser/media/positron-icon.svg') center / contain no-repeat;
+	/* --- End Positron --- */
 }
 
 .update-tooltip .product-details {

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -230,7 +230,7 @@ export class ReleaseNotesManager extends Disposable {
 				} else {
 					// --- Start Positron ---
 					// Release notes need to be fetched from the main process to avoid CORS.
-					text = await this._updateService.getReleaseNotes();
+					text = await this._updateService.getReleaseNotes(version);
 					// --- End Positron ---
 				}
 			} catch {

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -130,7 +130,12 @@ export class ReleaseNotesManager extends Disposable {
 				},
 				'releaseNotes',
 				title,
+				// --- Start Positron ---
+				/*
 				Codicon.vscode,
+				*/
+				Codicon.positronLogo,
+				// --- End Positron ---
 				{ group: ACTIVE_GROUP, preserveFocus: false });
 
 			const disposables = new DisposableStore();

--- a/src/vs/workbench/contrib/update/browser/update.contribution.ts
+++ b/src/vs/workbench/contrib/update/browser/update.contribution.ts
@@ -87,8 +87,10 @@ export class ShowReleaseNotesAction extends Action2 {
 			return;
 		}
 
+		const targetVersion = version ?? productService.positronVersion;
+
 		try {
-			await showReleaseNotesInEditor(instantiationService, productService.positronVersion, false);
+			await showReleaseNotesInEditor(instantiationService, targetVersion, false);
 		} catch (err) {
 			throw new Error(localize('update.noReleaseNotesOnline', "This version of {0} does not have release notes available", productService.nameLong));
 		}

--- a/src/vs/workbench/contrib/update/browser/updateTooltip.ts
+++ b/src/vs/workbench/contrib/update/browser/updateTooltip.ts
@@ -5,6 +5,7 @@
 
 import * as dom from '../../../../base/browser/dom.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize } from '../../../../nls.js';
@@ -134,10 +135,24 @@ export class UpdateTooltip extends Disposable {
 
 		// Populate static product info
 		this.updateCurrentVersion();
+
+		// --- Start Positron ---
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('update.positron.channel')) {
+				this.updateReleaseNotesButtonVisibility();
+			}
+		}));
+		// --- End Positron ---
 	}
 
 	private updateCurrentVersion() {
+		// --- Start Positron ---
+		// Use Positron calver, not Code-OSS base version.
+		/*
 		const productVersion = this.productService.version;
+		*/
+		const productVersion = this.productService.positronVersion;
+		// --- End Positron ---
 		if (productVersion) {
 			const currentCommitId = this.productService.commit?.substring(0, 7);
 			this.currentVersionNode.textContent = currentCommitId
@@ -390,17 +405,41 @@ export class UpdateTooltip extends Disposable {
 			this.releaseDateNode.style.display = 'none';
 		}
 
+		// --- Start Positron ---
+		// Use Positron calver for the release-notes lookup, and route the button
+		// visibility through `updateReleaseNotesButtonVisibility` so we can gate
+		// on the Positron `update.positron.channel === 'releases'` setting.
+		/*
 		// Release notes button
 		this.releaseNotesVersion = version ?? this.productService.version;
 		this.releaseNotesButton.style.display = this.releaseNotesVersion ? '' : 'none';
 		this.releaseNotesButton.style.marginRight = this.releaseNotesVersion ? 'auto' : '';
 		this.buttonBar.style.display = this.releaseNotesVersion ? '' : 'none';
+		*/
+		this.releaseNotesVersion = version ?? this.productService.positronVersion;
+		this.updateReleaseNotesButtonVisibility();
+		// --- End Positron ---
 	}
+
+	// --- Start Positron ---
+	// Hide Release Notes on the daily channel: only `releases` publishes per-version notes.
+	private updateReleaseNotesButtonVisibility() {
+		const channel = this.configurationService.getValue<string>('update.positron.channel');
+		const show = !!this.releaseNotesVersion && channel === 'releases';
+		this.releaseNotesButton.style.display = show ? '' : 'none';
+		this.releaseNotesButton.style.marginRight = show ? 'auto' : '';
+		this.buttonBar.style.display = show ? '' : 'none';
+	}
+	// --- End Positron ---
 
 	private renderActionButton(label: string, commandId: string) {
 		this.actionButton.textContent = label;
 		this.actionButton.dataset.commandId = commandId;
 		this.actionButton.style.display = '';
+		// --- Start Positron ---
+		// Ensure the bar shows when only the action button is visible.
+		this.buttonBar.style.display = '';
+		// --- End Positron ---
 	}
 
 	private renderMessage(message: string, icon?: ThemeIcon) {
@@ -439,7 +478,14 @@ export class UpdateTooltip extends Disposable {
 	}
 
 	private runCommandAndClose(command: string, ...args: unknown[]) {
+		// --- Start Positron ---
+		// Surface action errors (e.g. missing release notes) instead of
+		// silently swallowing them as an unhandled rejection.
+		/*
 		this.commandService.executeCommand(command, ...args);
+		*/
+		this.commandService.executeCommand(command, ...args).catch(onUnexpectedError);
+		// --- End Positron ---
 		this.hoverService.hideHover(true);
 	}
 }

--- a/src/vs/workbench/contrib/update/browser/updateTooltip.ts
+++ b/src/vs/workbench/contrib/update/browser/updateTooltip.ts
@@ -5,7 +5,6 @@
 
 import * as dom from '../../../../base/browser/dom.js';
 import { Codicon } from '../../../../base/common/codicons.js';
-import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize } from '../../../../nls.js';
@@ -478,14 +477,7 @@ export class UpdateTooltip extends Disposable {
 	}
 
 	private runCommandAndClose(command: string, ...args: unknown[]) {
-		// --- Start Positron ---
-		// Surface action errors (e.g. missing release notes) instead of
-		// silently swallowing them as an unhandled rejection.
-		/*
 		this.commandService.executeCommand(command, ...args);
-		*/
-		this.commandService.executeCommand(command, ...args).catch(onUnexpectedError);
-		// --- End Positron ---
 		this.hoverService.hideHover(true);
 	}
 }

--- a/src/vs/workbench/contrib/update/test/browser/updateTooltip.vitest.ts
+++ b/src/vs/workbench/contrib/update/test/browser/updateTooltip.vitest.ts
@@ -6,7 +6,6 @@
 /// <reference types="vitest/globals" />
 /// <reference types="@testing-library/jest-dom/vitest" />
 
-import * as errorHandler from '../../../../../base/common/errors.js';
 import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { IConfigurationChangeEvent, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -146,27 +145,6 @@ describe('UpdateTooltip', () => {
 			getReleaseNotesButton(tooltip).click();
 
 			expect(executeCommand).toHaveBeenCalledWith(ShowCurrentReleaseNotesActionId, '2026.07.0');
-		});
-	});
-
-	describe('action button errors', () => {
-		it('routes command rejections to the unexpected-error handler', async () => {
-			executeCommand.mockRejectedValueOnce(new Error('boom'));
-			const captured: unknown[] = [];
-			const original = errorHandler.errorHandler.getUnexpectedErrorHandler();
-			errorHandler.setUnexpectedErrorHandler(e => captured.push(e));
-
-			try {
-				const tooltip = createTooltip();
-				tooltip.renderState(State.AvailableForDownload({ version: '2026.08.0', productVersion: '2026.08.0' }));
-
-				getActionButton(tooltip).click();
-				await vi.waitFor(() => expect(captured).toHaveLength(1));
-
-				expect((captured[0] as Error).message).toBe('boom');
-			} finally {
-				errorHandler.setUnexpectedErrorHandler(original);
-			}
 		});
 	});
 

--- a/src/vs/workbench/contrib/update/test/browser/updateTooltip.vitest.ts
+++ b/src/vs/workbench/contrib/update/test/browser/updateTooltip.vitest.ts
@@ -1,0 +1,185 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+/// <reference types="@testing-library/jest-dom/vitest" />
+
+import * as errorHandler from '../../../../../base/common/errors.js';
+import { IClipboardService } from '../../../../../platform/clipboard/common/clipboardService.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { IConfigurationChangeEvent, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IMeteredConnectionService } from '../../../../../platform/meteredConnection/common/meteredConnection.js';
+import { IProductService } from '../../../../../platform/product/common/productService.js';
+import { State, UpdateType } from '../../../../../platform/update/common/update.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { TestProductService } from '../../../../test/common/workbenchTestServices.js';
+import { UpdateTooltip } from '../../browser/updateTooltip.js';
+import { ShowCurrentReleaseNotesActionId } from '../../common/update.js';
+
+describe('UpdateTooltip', () => {
+	const executeCommand = vi.fn<(command: string, ...args: unknown[]) => Promise<unknown>>();
+
+	const ctx = createTestContainer()
+		.withWorkbenchServices()
+		.stub(IProductService, {
+			...TestProductService,
+			positronVersion: '2026.07.0',
+			version: '1.118.0',
+			commit: 'abc1234deadbeef0',
+		})
+		.stub(ICommandService, { executeCommand })
+		.stub(IClipboardService, { writeText: vi.fn() })
+		.stub(IMeteredConnectionService, stubInterface<IMeteredConnectionService>({ isConnectionMetered: false }))
+		.build();
+
+	function setChannel(value: 'releases' | 'dailies'): void {
+		const config = ctx.get(IConfigurationService) as TestConfigurationService;
+		config.setUserConfiguration('update.positron.channel', value);
+	}
+
+	function fireChannelChange(): void {
+		const config = ctx.get(IConfigurationService) as TestConfigurationService;
+		config.onDidChangeConfigurationEmitter.fire(stubInterface<IConfigurationChangeEvent>({
+			affectsConfiguration: key => key === 'update.positron.channel',
+		}));
+	}
+
+	function createTooltip(): UpdateTooltip {
+		const tooltip = ctx.instantiationService.createInstance(UpdateTooltip);
+		ctx.disposables.add(tooltip);
+		// `toBeVisible()` requires the node to be in the document.
+		document.body.appendChild(tooltip.domNode);
+		ctx.disposables.add({ dispose: () => tooltip.domNode.remove() });
+		return tooltip;
+	}
+
+	function getReleaseNotesButton(tooltip: UpdateTooltip): HTMLButtonElement {
+		// eslint-disable-next-line no-restricted-syntax -- UpdateTooltip is built with dom.$; CSS class names are its only structural contract.
+		const el = tooltip.domNode.querySelector('button.release-notes-button');
+		if (!(el instanceof HTMLButtonElement)) {
+			throw new Error('release-notes-button not found');
+		}
+		return el;
+	}
+
+	function getActionButton(tooltip: UpdateTooltip): HTMLButtonElement {
+		// eslint-disable-next-line no-restricted-syntax -- see getReleaseNotesButton.
+		const el = tooltip.domNode.querySelector('button.action-button');
+		if (!(el instanceof HTMLButtonElement)) {
+			throw new Error('action-button not found');
+		}
+		return el;
+	}
+
+	function getButtonBar(tooltip: UpdateTooltip): HTMLElement {
+		// eslint-disable-next-line no-restricted-syntax -- see getReleaseNotesButton.
+		const el = tooltip.domNode.querySelector('.button-bar');
+		if (!(el instanceof HTMLElement)) {
+			throw new Error('button-bar not found');
+		}
+		return el;
+	}
+
+	function getCurrentVersionText(tooltip: UpdateTooltip): string {
+		// eslint-disable-next-line no-restricted-syntax -- see getReleaseNotesButton.
+		const row = tooltip.domNode.querySelector('.product-version');
+		return row?.textContent ?? '';
+	}
+
+	beforeEach(() => {
+		executeCommand.mockResolvedValue(undefined);
+	});
+
+	describe('current version label', () => {
+		it('shows the Positron calver, not the Code-OSS base version', () => {
+			const tooltip = createTooltip();
+
+			const text = getCurrentVersionText(tooltip);
+			expect(text).toContain('2026.07.0');
+			expect(text).not.toContain('1.118.0');
+			expect(text).toContain('abc1234');
+		});
+	});
+
+	describe('Release Notes button visibility', () => {
+		it('is hidden when the channel is not "releases"', () => {
+			setChannel('dailies');
+			const tooltip = createTooltip();
+
+			tooltip.renderState(State.Idle(UpdateType.Archive));
+
+			expect(getReleaseNotesButton(tooltip)).not.toBeVisible();
+		});
+
+		it('is visible when the channel is "releases" and a version is known', () => {
+			setChannel('releases');
+			const tooltip = createTooltip();
+
+			tooltip.renderState(State.Idle(UpdateType.Archive));
+
+			expect(getReleaseNotesButton(tooltip)).toBeVisible();
+		});
+
+		it('flips visibility when the channel setting changes', () => {
+			setChannel('dailies');
+			const tooltip = createTooltip();
+			tooltip.renderState(State.Idle(UpdateType.Archive));
+			expect(getReleaseNotesButton(tooltip)).not.toBeVisible();
+
+			setChannel('releases');
+			fireChannelChange();
+
+			expect(getReleaseNotesButton(tooltip)).toBeVisible();
+		});
+	});
+
+	describe('Release Notes click', () => {
+		it('forwards the Positron calver to the release notes command', () => {
+			setChannel('releases');
+			const tooltip = createTooltip();
+			tooltip.renderState(State.Idle(UpdateType.Archive));
+
+			getReleaseNotesButton(tooltip).click();
+
+			expect(executeCommand).toHaveBeenCalledWith(ShowCurrentReleaseNotesActionId, '2026.07.0');
+		});
+	});
+
+	describe('action button errors', () => {
+		it('routes command rejections to the unexpected-error handler', async () => {
+			executeCommand.mockRejectedValueOnce(new Error('boom'));
+			const captured: unknown[] = [];
+			const original = errorHandler.errorHandler.getUnexpectedErrorHandler();
+			errorHandler.setUnexpectedErrorHandler(e => captured.push(e));
+
+			try {
+				const tooltip = createTooltip();
+				tooltip.renderState(State.AvailableForDownload({ version: '2026.08.0', productVersion: '2026.08.0' }));
+
+				getActionButton(tooltip).click();
+				await vi.waitFor(() => expect(captured).toHaveLength(1));
+
+				expect((captured[0] as Error).message).toBe('boom');
+			} finally {
+				errorHandler.setUnexpectedErrorHandler(original);
+			}
+		});
+	});
+
+	describe('button bar layout', () => {
+		it('stays visible when only the action button is shown', () => {
+			setChannel('dailies');
+			const tooltip = createTooltip();
+
+			tooltip.renderState(State.AvailableForDownload({ version: '2026.08.0', productVersion: '2026.08.0' }));
+
+			expect(getReleaseNotesButton(tooltip)).not.toBeVisible();
+			expect(getActionButton(tooltip)).toBeVisible();
+			expect(getButtonBar(tooltip)).toBeVisible();
+		});
+	});
+});


### PR DESCRIPTION
Closes #13687

Fixes up the update tooltip (the one that pops up when you hover the `Downloading...` icon in the title bar) and the release notes editor to use Positron info, and stops the Release Notes button from being a dead link on dailies.

- show the Positron calver (e.g. `2026.07.0`) instead of the Code-OSS version (e.g. `1.118.0`) in the tooltip
- use the Positron icon instead of the VS Code icon in the tooltip
- use the Positron logo in the release notes editor
- hide the **Release Notes** button on the daily channel (only `releases` publishes per-version notes); reacts to setting changes with no restart needed
- pass the requested version through to the release notes fetch so `Show Release Notes` for a specific version fetches that version (was hardcoded to current)
- fix a log line that printed `POSITRON_RELEASE_NOTES_CHANNEL` instead of `POSITRON_UPDATE_CHANNEL`

### Release Notes

#### Bug Fixes

- fix update tooltip content and release notes editor icon (#13687)

### QA Notes

- added updateTooltip.vitest.ts

my manual testing steps:

- changed the Positron version in [product.json](product.json) to an older release number, so "Check for Updates" would actually find one (I used `2026.04.0`)
- ran `npm run gulp vscode-darwin-arm64` to get a release build
- quit all other Positrons
- opened the release build
- ran command **Positron: Check for Updates...**
- saw "Downloading..." in the title bar, hovered it, and checked:
  - Positron logo, not the VS Code icon
  - Positron calver, not `1.118.0`
  - with `"update.positron.channel": "releases"`, the **Release Notes** button shows
      - <img width="334" height="207" alt="image" src="https://github.com/user-attachments/assets/c2ea85fa-abe4-49a7-9589-3422f57e8298" />
      - the release notes shows the release notes for the current installed release, not the currently downloading version. This felt a bit unexpected, but is the same as upstream, I believe.
  - flip to `"dailies"`: button disappears, flip back to releases and it returns
      - <img width="338" height="171" alt="image" src="https://github.com/user-attachments/assets/47cfd4f4-1523-4d2b-a35d-182b610d00e8" />
- release notes editor icon is Positron logo
    - <img width="400" alt="image" src="https://github.com/user-attachments/assets/5ea77604-26c9-4239-9abb-6012a9c40948" />

