### PR TITLE
test(e2e): add click-to-cursor-position regression test

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-click-cursor-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-click-cursor-position.test.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+
+test.use({
+	suiteId: __filename
+});
+
+// Regression coverage for cursor placement on click in Positron Notebooks.
+//
+// After exiting edit mode (Esc), clicking a specific line can drop the cursor
+// on a *different* line when the embedded Monaco editor's internal layout is
+// out of sync with what is rendered (a hit-test miscalculation).
+//
+// We can't read Monaco's cursor position directly from Playwright, so we assert
+// the user-visible consequence: click a known line, type a unique marker, and
+// verify the marker landed on the line we clicked. The assertion is keyed off
+// the line's own text (not its DOM/array index), so it does not depend on the
+// order Monaco renders .view-line elements in.
+test.describe('Notebook Click-to-Cursor Position', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.CROSS_BROWSER]
+}, () => {
+
+	test.beforeAll(async function ({ hotKeys }) {
+		await hotKeys.minimizeBottomPanel();
+		await hotKeys.closeSecondarySidebar();
+	});
+
+	test('Clicking a line after Esc places the cursor on that line', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.currentPage.keyboard;
+
+		// Distinct, non-overlapping tokens so the target token matches exactly one
+		// line and is never a substring of another line. The target line is a
+		// function call rather than an assignment to exercise a different line type.
+		const lines = [
+			'alpha = 1',
+			'bravo = 2',
+			'charlie = 3',
+			'delta = 4',
+			'print("clicked")',
+			'echo = 6',
+			'foxtrot = 7',
+			'golf = 8',
+		];
+		const TARGET = 'print';
+		const MARKER = 'ZZZ';
+
+		await notebooksPositron.newNotebook({ codeCells: 1 });
+		await notebooksPositron.addCodeToCell(0, lines.join('\n'), { fast: true });
+
+		// Repro step: press Esc to defocus the cell (exit edit mode).
+		await keyboard.press('Escape');
+		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: false });
+
+		// Repro step: click directly on the target line (the function call).
+		const targetLine = notebooksPositron
+			.editorWidgetAtIndex(0)
+			.locator('.view-line', { hasText: TARGET });
+		await targetLine.click();
+
+		// Wait until the click has put us back in edit mode (editor focused, cursor
+		// placed) before typing, so the marker isn't dropped during the transition.
+		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: true });
+
+		// Normalize to the start of whatever line the cursor actually landed on,
+		// then insert a unique marker there.
+		await keyboard.press('Home');
+		await keyboard.type(MARKER);
+
+		// The marker must be on the line we clicked. If the cursor landed on the
+		// wrong line, the target line will not contain the marker.
+		const content = await notebooksPositron.getCellContent(0);
+		const targetLineText = content.find(l => l.includes(TARGET));
+		expect(
+			targetLineText,
+			`expected the "${TARGET}" line to contain "${MARKER}". Cell lines: ${JSON.stringify(content)}`
+		).toContain(MARKER);
+	});
+});


### PR DESCRIPTION
I tried to repro #14085 and couldn't, so I want to check what happens against the new notebook editor in the CI/CD to see if this is a recurring issue as well.

Checked that the test is stable in the CI, merging would be helpful to identify if aforementioned issue is specific to one user or if it's generally a flake. 

---

## Summary

Adds a minimal Positron Notebooks E2E test for cursor placement on click.

After exiting edit mode (Esc), clicking a specific line should land the cursor on **that** line. When the embedded Monaco editor's internal layout is out of sync with what's rendered, the click hit-test can drop the cursor on a different line.

## How it works

- Creates a code cell with distinct, non-overlapping tokens per line; the target line is a function call (a different line type than the surrounding assignments).
- Presses **Esc** to exit edit mode (the trigger), asserts command mode.
- Clicks the target line, waits for edit mode, then types a unique marker at the line start.
- Asserts the marker landed on the clicked line. The assertion is keyed off the line's **text**, not its index, so it's immune to Monaco's `.view-line` render order.

Cursor position can't be read directly via Playwright, so the test asserts the user-visible consequence (where typed text lands).

## Notes

- Lives in `notebooks-positron/`, which runs against the new notebook editor (`positron.notebook.enabled=true`).
- Draft: opened to observe pass/flake behavior across CI lanes. Tags: `WIN`, `WEB`, `POSITRON_NOTEBOOKS`, `CROSS_BROWSER`.

@:win @:web @:positron-notebooks @:cross-browser