### PR TITLE
E2E test: avoid OTP lockout

### DIFF
--- a/test/e2e/pages/workbench/auth.page.ts
+++ b/test/e2e/pages/workbench/auth.page.ts
@@ -6,6 +6,7 @@
 import { expect } from '@playwright/test';
 import { Code } from '../../infra/code.js';
 import { generateTOTP } from '../../utils/totp.js';
+import { isOktaLockedOut, otpRetryDelayMs } from '../../utils/otpRetry.js';
 
 export class AuthPage {
 	get username() { return this.code.driver.currentPage.getByRole('textbox', { name: 'username' }); }
@@ -64,8 +65,10 @@ export class AuthPage {
 		await this.typeIntoField(oktaPassword, serviceAccountPassword);
 		await page.getByRole('button', { name: /^Verify$/ }).click();
 
-		// 4. OTP prompt. TOTPs roll every 30s; if we land on a boundary the code can be rejected.
-		//    Retry up to 3 times: re-fill with a fresh code, submit again.
+		// 4. OTP prompt. The TOTP secret is shared across parallel shards, so a code can be
+		//    rejected (reused by another shard) or the account can be locked out ("too many
+		//    attempts"). Retry up to 3 times, backing off with jitter between attempts so we
+		//    fall into a different TOTP window than the competing shard. See otpRetry.ts.
 		const otpField = page.locator('input[autocomplete="one-time-code"], input[type="tel"], input[type="text"]').first();
 		const verifyOtpButton = page.getByRole('button', { name: /^Verify$/ });
 		const staySignedInYes = page.getByRole('button', { name: /^Yes$/ });
@@ -83,8 +86,10 @@ export class AuthPage {
 				if (attempt === maxAttempts) {
 					throw new Error(`OTP authentication failed after ${maxAttempts} attempts`);
 				}
-				// Wait past the TOTP window boundary, then try again.
-				await page.waitForTimeout(20000);
+				const lockedOut = await isOktaLockedOut(page);
+				const delay = otpRetryDelayMs(lockedOut);
+				this.code.logger.log(`Azure OTP not accepted (attempt ${attempt}/${maxAttempts}, lockedOut=${lockedOut}); backing off ${delay}ms before retry`);
+				await page.waitForTimeout(delay);
 			}
 		}
 

--- a/test/e2e/pages/workbench/dashboard.page.ts
+++ b/test/e2e/pages/workbench/dashboard.page.ts
@@ -7,6 +7,7 @@ import { expect, BrowserContext } from '@playwright/test';
 import { Code } from '../../infra/code.js';
 import { QuickInput } from '../quickInput.js';
 import { generateTOTP } from '../../utils/totp.js';
+import { isOktaLockedOut, otpRetryDelayMs } from '../../utils/otpRetry.js';
 
 export class DashboardPage {
 	get title() { return this.code.driver.currentPage.getByRole('link', { name: 'Workbench projects' }); }
@@ -199,8 +200,10 @@ export class DashboardPage {
 		await verifyButton.click();
 
 		// Complete 2FA authentication. TOTPs roll every 30s and Okta rejects reused codes, so a
-		// parallel shard (e.g. Azure) consuming the same code seconds earlier can knock us out.
-		// Retry up to 3 times: wait past the TOTP window boundary between attempts, then re-fill.
+		// parallel shard (e.g. Azure) consuming the same code seconds earlier can knock us out, or
+		// rapid duplicate submissions can lock the account ("too many attempts"). Retry up to 3
+		// times, backing off with jitter between attempts so we de-align from the competing shard
+		// and land in a different TOTP window (and back off longer on lockout). See otpRetry.ts.
 		await oauthPage.waitForLoadState('networkidle', { timeout: 10000 });
 		const otpField = oauthPage.locator('input[type="text"], input[type="tel"], input[autocomplete="one-time-code"]').first();
 		const verifyOtpButton = oauthPage.locator('button:has-text("Verify"), input[value="Verify"]');
@@ -231,8 +234,10 @@ export class DashboardPage {
 					this.code.logger.log(`OTP not accepted after ${maxOtpAttempts} attempts; falling through to widget-state check`);
 					break;
 				}
-				this.code.logger.log('OTP rejected, waiting for next TOTP window before retry');
-				await oauthPage.waitForTimeout(20000);
+				const lockedOut = await isOktaLockedOut(oauthPage);
+				const delay = otpRetryDelayMs(lockedOut);
+				this.code.logger.log(`Databricks OTP not accepted (attempt ${attempt}/${maxOtpAttempts}, lockedOut=${lockedOut}); backing off ${delay}ms before retry`);
+				await oauthPage.waitForTimeout(delay);
 			}
 		}
 

--- a/test/e2e/utils/otpRetry.ts
+++ b/test/e2e/utils/otpRetry.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Page } from '@playwright/test';
+
+/**
+ * The TOTP rotation period in milliseconds. Codes are only valid for one window and Okta
+ * rejects a code once it has been consumed, so a fresh attempt must land in a later window.
+ */
+const TOTP_PERIOD_MS = 30_000;
+
+/**
+ * Okta copy shown when an account has been rate-limited after too many sign-in attempts.
+ * The exact wording varies ("too many attempts", "account is locked"), so match loosely.
+ */
+const OKTA_LOCKOUT_PATTERN = /too many (unsuccessful )?attempts|account is locked|temporarily locked|locked out/i;
+
+/**
+ * Detect whether Okta has rate-limited the account ("Too many attempts" / lockout screen).
+ *
+ * The service account is shared across parallel shards (Azure, Databricks) and workflows
+ * (release, stable), so rapid duplicate TOTP submissions can trip Okta's lockout. A lockout
+ * is a distinct, longer-lived state than a single rejected code and warrants a longer backoff.
+ *
+ * @param page The Okta page to inspect.
+ * @returns true if a lockout banner is visible.
+ */
+export async function isOktaLockedOut(page: Page): Promise<boolean> {
+	if (page.isClosed()) {
+		return false;
+	}
+	return page.getByText(OKTA_LOCKOUT_PATTERN).first().isVisible().catch(() => false);
+}
+
+/**
+ * Compute how long to wait before re-submitting a TOTP code after a rejection.
+ *
+ * The service account's TOTP secret is shared across parallel consumers. A blind fixed wait
+ * lets two consumers stay phase-aligned: they wake up together, grab the same code, and one
+ * gets rejected again. Randomized jitter de-aligns them so they fall into different windows.
+ *
+ * - Normal rejection: wait just past a full TOTP window so the retry uses a fresh code, plus
+ *   up to one window of jitter to break alignment with a competing shard.
+ * - Lockout: Okta has rate-limited the account; back off substantially longer (and jittered)
+ *   to let the lock clear before trying again.
+ *
+ * @param lockedOut Whether the lockout banner was detected (see {@link isOktaLockedOut}).
+ * @param random Source of randomness in [0, 1); injectable for deterministic tests.
+ * @returns The delay in milliseconds.
+ */
+export function otpRetryDelayMs(lockedOut: boolean, random: () => number = Math.random): number {
+	if (lockedOut) {
+		// 40-60s: long enough to outlast a brief lockout window and de-align from the other shard.
+		return 40_000 + Math.floor(random() * 20_000);
+	}
+	// Just past the 30s window (guarantees a fresh code) plus up to one window of jitter: 31-46s.
+	return TOTP_PERIOD_MS + 1_000 + Math.floor(random() * TOTP_PERIOD_MS);
+}


### PR DESCRIPTION
## E2E: lockout-aware OTP backoff with jitter

### Problem

The Azure and Databricks e2e shards both authenticate against the same Okta
service account using the same shared TOTP secret. When they run concurrently
(parallel matrix shards within a workflow, plus release/stable workflows firing
at once), they grab the same TOTP code seconds apart. Okta rejects the reused
code, and rapid duplicate failures trip the account's "Too many attempts"
lockout, failing the test.

The existing retry logic waited a blind, fixed 20s between attempts. That:
- Doesn't guarantee a fresh code (20s < the 30s TOTP window, so a retry can
  re-grab the same code).
- Keeps the competing shards phase-aligned, so they wake up together and
  collide again.
- Treats a lockout the same as a single rejected code.

### Change

New shared helper `test/e2e/utils/otpRetry.ts`:
- `isOktaLockedOut(page)` detects the lockout banner specifically.
- `otpRetryDelayMs(lockedOut)` returns a jittered backoff:
  - **Normal rejection:** 31-46s (just past a full TOTP window so the retry uses
    a fresh code, plus jitter to de-align from the other shard).
  - **Lockout:** 40-60s to let the rate-limit clear.

Both auth flows (`auth.page.ts` Azure, `dashboard.page.ts` Databricks) now use
this instead of the fixed 20s wait, and log the detected lockout state and
chosen delay.

### Notes

Backoff values are bounded to fit the 2-min per-test timeout; Playwright's
`--retries=1` remains the whole-test backstop. This is a resilience fix, not a
root-cause fix -- the real solution is separate service accounts per consumer,
tracked separately.


@:workbench
@:workbench-stable
