### PR TITLE
Fix missing environment `module load` when R is installed in a system location

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -388,23 +388,85 @@ async function getBinaries(): Promise<DiscoveredBinaries> {
 }
 
 /**
+ * The kinds of packager metadata an R binary can carry, declared in ascending
+ * order of precedence. When a single binary path is contributed by multiple
+ * sources, the surviving metadata is the one whose kind is declared latest here.
+ * The ordering reflects how much each kind determines correct launch behavior:
+ * metadata that injects a startup command or activates an environment (Module,
+ * Conda, Pixi) outranks the merely descriptive RVersions metadata, which in turn
+ * outranks no metadata at all (a plain system/PATH discovery).
+ *
+ * To add a packager source, declare its kind at the right position here and add
+ * the matching branch to {@link classifyMetadata}; precedence follows declaration
+ * order, so no separate ranking needs maintaining.
+ */
+enum MetadataKind {
+	None = 'none',
+	RVersions = 'rversions',
+	Conda = 'conda',
+	Pixi = 'pixi',
+	Module = 'module',
+}
+
+/** Precedence lookup derived from {@link MetadataKind} declaration order. */
+const METADATA_PRECEDENCE: readonly MetadataKind[] = Object.values(MetadataKind);
+
+/**
+ * Classify packager metadata into one of the {@link MetadataKind} values. The
+ * trailing `never` assignment makes this exhaustive: adding a new PackagerMetadata
+ * variant without handling it here is a compile error.
+ */
+function classifyMetadata(metadata: PackagerMetadata | undefined): MetadataKind {
+	if (!metadata) {
+		return MetadataKind.None;
+	}
+	if (isModuleMetadata(metadata)) {
+		return MetadataKind.Module;
+	}
+	if (isPixiMetadata(metadata)) {
+		return MetadataKind.Pixi;
+	}
+	if (isCondaMetadata(metadata)) {
+		return MetadataKind.Conda;
+	}
+	if (isRVersionsMetadata(metadata)) {
+		return MetadataKind.RVersions;
+	}
+	const unhandled: never = metadata;
+	throw new Error(`Unhandled packager metadata: ${JSON.stringify(unhandled)}`);
+}
+
+/**
+ * Rank packager metadata by its position in {@link METADATA_PRECEDENCE}; higher wins.
+ *
+ * @param metadata The packager metadata to rank, or `undefined` if none.
+ * @returns A numeric priority; higher wins.
+ */
+function metadataPriority(metadata: PackagerMetadata | undefined): number {
+	return METADATA_PRECEDENCE.indexOf(classifyMetadata(metadata));
+}
+
+/**
  * Deduplicate a list of R binaries, merging the reasons for each binary.
- * When the same binary is found via multiple sources, prefer r-versions metadata
- * with a label since it provides a custom display name.
+ * When the same binary is found via multiple sources, retain the metadata that
+ * most affects how the runtime launches (see {@link metadataPriority}). Ties keep
+ * the first-seen metadata for stability.
  * @param binaries Binaries to deduplicate
  * @returns Deduplicated binaries
  */
-function deduplicateRBinaries(binaries: RBinary[]) {
+export function deduplicateRBinaries(binaries: RBinary[]) {
 	const binariesMap = binaries.reduce((acc, binary) => {
 		if (acc.has(binary.path)) {
 			const existingBinary = acc.get(binary.path)!;
 			const mergedReasons = Array.from(new Set([...existingBinary.reasons, ...binary.reasons]));
 
-			// Prefer r-versions metadata with a label over other metadata
-			let preferredMetadata = existingBinary.packagerMetadata;
-			if (binary.packagerMetadata && isRVersionsMetadata(binary.packagerMetadata) && binary.packagerMetadata.label) {
-				preferredMetadata = binary.packagerMetadata;
-			}
+			// Keep whichever metadata most affects how the runtime launches. The
+			// incoming entry only wins on a strictly higher priority, so ties
+			// preserve the first-seen metadata.
+			const preferredMetadata =
+				metadataPriority(binary.packagerMetadata) > metadataPriority(existingBinary.packagerMetadata)
+					? binary.packagerMetadata
+					: existingBinary.packagerMetadata;
 
 			acc.set(binary.path, { ...existingBinary, reasons: mergedReasons, packagerMetadata: preferredMetadata });
 		} else {

--- a/extensions/positron-r/src/test/deduplicate.test.ts
+++ b/extensions/positron-r/src/test/deduplicate.test.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import './mocha-setup';
+
+import * as assert from 'assert';
+import { deduplicateRBinaries, RBinary } from '../provider';
+import { ModuleMetadata, ReasonDiscovered, RVersionsMetadata } from '../r-installation';
+
+const MODULE_METADATA: ModuleMetadata = {
+	type: 'module',
+	environmentName: 'r/4.5.3',
+	modules: ['r/4.5.3'],
+	startupCommand: 'module load r/4.5.3',
+};
+
+const RVERSIONS_LABELED: RVersionsMetadata = {
+	type: 'rversions',
+	label: 'R 4.5.3 (Production)',
+};
+
+suite('deduplicateRBinaries', () => {
+
+	test('retains module metadata when the system binary is discovered first', () => {
+		// Regression for #13936: a module-managed R that resolves to a path the
+		// system scanner also finds must keep its module startupCommand.
+		const binaries: RBinary[] = [
+			{ path: '/opt/R/4.5.3/bin/R', reasons: [ReasonDiscovered.PATH] },
+			{ path: '/opt/R/4.5.3/bin/R', reasons: [ReasonDiscovered.MODULE], packagerMetadata: MODULE_METADATA },
+		];
+
+		const result = deduplicateRBinaries(binaries);
+
+		assert.strictEqual(result.length, 1);
+		assert.deepStrictEqual(result[0], {
+			path: '/opt/R/4.5.3/bin/R',
+			reasons: [ReasonDiscovered.PATH, ReasonDiscovered.MODULE],
+			packagerMetadata: MODULE_METADATA,
+		});
+	});
+
+	test('retains module metadata regardless of discovery order', () => {
+		const binaries: RBinary[] = [
+			{ path: '/opt/R/4.5.3/bin/R', reasons: [ReasonDiscovered.MODULE], packagerMetadata: MODULE_METADATA },
+			{ path: '/opt/R/4.5.3/bin/R', reasons: [ReasonDiscovered.PATH] },
+		];
+
+		const result = deduplicateRBinaries(binaries);
+
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].packagerMetadata, MODULE_METADATA);
+		assert.deepStrictEqual(result[0].reasons, [ReasonDiscovered.MODULE, ReasonDiscovered.PATH]);
+	});
+
+	test('still prefers r-versions metadata with a label over no metadata', () => {
+		const binaries: RBinary[] = [
+			{ path: '/opt/R/4.5.3/bin/R', reasons: [ReasonDiscovered.PATH] },
+			{ path: '/opt/R/4.5.3/bin/R', reasons: [ReasonDiscovered.RVERSIONS], packagerMetadata: RVERSIONS_LABELED },
+		];
+
+		const result = deduplicateRBinaries(binaries);
+
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].packagerMetadata, RVERSIONS_LABELED);
+	});
+
+	test('prefers module metadata over r-versions metadata for the same path', () => {
+		const binaries: RBinary[] = [
+			{ path: '/opt/R/4.5.3/bin/R', reasons: [ReasonDiscovered.RVERSIONS], packagerMetadata: RVERSIONS_LABELED },
+			{ path: '/opt/R/4.5.3/bin/R', reasons: [ReasonDiscovered.MODULE], packagerMetadata: MODULE_METADATA },
+		];
+
+		const result = deduplicateRBinaries(binaries);
+
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].packagerMetadata, MODULE_METADATA);
+	});
+
+	test('keeps distinct binary paths separate', () => {
+		const binaries: RBinary[] = [
+			{ path: '/opt/R/4.5.3/bin/R', reasons: [ReasonDiscovered.MODULE], packagerMetadata: MODULE_METADATA },
+			{ path: '/usr/bin/R', reasons: [ReasonDiscovered.PATH] },
+		];
+
+		const result = deduplicateRBinaries(binaries);
+
+		assert.strictEqual(result.length, 2);
+	});
+});


### PR DESCRIPTION
A module-managed R interpreter that resolves to a binary path the system scanner also discovers (e.g. `/opt/R/4.5.3/bin/R`) was merged into a single runtime that discarded the module metadata. The runtime launched as plain System R, so the `module load ...` startup command never ran and module-provided dependencies (MKL/TBB/MPI/gdal, `LD_LIBRARY_PATH`, etc.) were missing.

`deduplicateRBinaries()` keys binaries by path and merges entries found via multiple sources. On merge it only ever preferred r-versions metadata with a label, so module metadata (which carries the `startupCommand`) lost to the first-seen System entry. This PR replaces that narrow rule with a declarative precedence over packager-metadata kinds, so launch-affecting metadata (Module, Conda, Pixi) is retained over a bare system discovery regardless of discovery order.

Fixes #13936.

### Why R only

This is specific to positron-r. positron-python stores module metadata in a separate path-keyed side table (`moduleMetadataMap`) rather than on the environment record that flows through deduplication, and looks it up by path independently when constructing the runtime. The R failure mode (metadata dropped during the path-keyed merge) therefore cannot occur on the Python side, so no corresponding change is needed there.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Load environment modules for R interpreters found at standard `/opt/R/<version>` locations, when specified in settings (#13936)

### Validation Steps

@:interpreter @:environment-modules

On Linux with environment-modules configured:

1. Configure an R module environment whose R resolves to a standard `/opt/R/<version>/bin/R`.
2. Start the R runtime.
3. Verify the runtime's source is **Module** (not System) and that the launch command includes `module load ...`.
4. Confirm module-provided env vars (e.g. `LD_LIBRARY_PATH`) and dependencies are present in the session.
