### PR TITLE
E2E test: fix PR tagging for workbench

### DIFF
--- a/scripts/pr-tags-parse.sh
+++ b/scripts/pr-tags-parse.sh
@@ -26,8 +26,11 @@ if [[ -z "$PULL_REQUEST_BODY" ]]; then
 	exit 1
 fi
 
-# Sanitize the PR BODY by removing newlines and escaping double quotes
-PR_BODY=$(echo "$PULL_REQUEST_BODY" | tr '\n' ' ' | sed 's/"/\\"/g')
+# Sanitize the PR BODY by stripping carriage returns (GitHub returns CRLF line
+# endings), collapsing newlines to spaces, and escaping double quotes. Stripping
+# CR first ensures a tag at end-of-line isn't immediately followed by a stray
+# '\r', which would defeat the boundary checks below.
+PR_BODY=$(echo "$PULL_REQUEST_BODY" | tr -d '\r' | tr '\n' ' ' | sed 's/"/\\"/g')
 
 echo "Parsing tags from PR body..."
 
@@ -75,7 +78,10 @@ if echo "$PR_BODY" | grep -q "@:pyrefly"; then
 	echo "Found pyrefly tag in PR body. Setting to run pyrefly tests."
 	echo "pyrefly_tag_found=true" >> "$GITHUB_OUTPUT"
 fi
-if echo "$PR_BODY" | grep -qE "@:workbench( |\$|,)"; then
+# Match a bare '@:workbench' tag but not longer variants like '@:workbench-stable'
+# or '@:workbench-snowflake'. The tag must be followed by a non-tag character
+# (anything outside [a-zA-Z0-9_-]) or the end of the string.
+if echo "$PR_BODY" | grep -qE "@:workbench([^a-zA-Z0-9_-]|\$)"; then
 	echo "Found workbench tag in PR body. Setting to run workbench tests."
 	echo "workbench_tag_found=true" >> "$GITHUB_OUTPUT"
 fi


### PR DESCRIPTION
Fix to tag parsing both:

@:workbench
@:workbench-stable

work at the same time