### PR TITLE
E2E test: OAuth backoff needs more time

### DIFF
--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -140,7 +140,11 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 			await stop();
 			renamedLogsPath = await renameTempLogsDir(logger, logsPath, workerInfo);
 		}
-	}, { scope: 'worker', auto: true, timeout: 90000 }],
+		// Workbench projects sign in through Okta inside start(). That auth shares one TOTP
+		// account across parallel shards, so a rejected/locked-out code triggers a jittered
+		// backoff (see otpRetry.ts) of up to ~60s before re-submitting. 90s left no room for a
+		// backoff to complete alongside OAuth navigation, so allow headroom for one retry.
+	}, { scope: 'worker', auto: true, timeout: 180000 }],
 
 	assistant: [
 		async ({ app }, use) => {


### PR DESCRIPTION
Increasing the app start timeout so that it can accommodate backoffs where OTPs shared across shards are concerned.