### PR TITLE
e2e: fix web flake in notebook multi-select Shift+Enter test

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -230,9 +230,16 @@ test.describe('Notebook Focus and Selection', {
 		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: true, isActive: true });
 	});
 
-	test('Multi-select + Shift+Enter runs all selected code cells', async function ({ app }) {
+	test('Multi-select + Shift+Enter runs all selected code cells', async function ({ app, sessions }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.currentPage.keyboard;
+
+		// Clear any sessions leaked by earlier tests/specs sharing this worker.
+		// closeAllEditors() (folder afterEach) closes notebook tabs but does not
+		// shut down their kernels, so orphaned sessions accumulate and drop to a
+		// `disconnected` state on the web runtime. They starve the kernel we
+		// select below, which then never reaches `idle`. Start from a clean slate.
+		await sessions.deleteAll();
 
 		// Create notebook with 3 code cells containing executable Python
 		await notebooksPositron.newNotebook({ codeCells: 3 });

--- a/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-focus-and-selection.test.ts
@@ -20,6 +20,48 @@ test.describe('Notebook Focus and Selection', {
 		await hotKeys.closeSecondarySidebar();
 	});
 
+	test('Multi-select + Shift+Enter runs all selected code cells', async function ({ app, sessions }) {
+		const { notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.currentPage.keyboard;
+
+		// Create notebook with 3 code cells containing executable Python
+		await notebooksPositron.newNotebook({ codeCells: 3 });
+		await notebooksPositron.kernel.select('Python');
+
+		// Put executable code in each cell
+		await notebooksPositron.selectCellAtIndex(0);
+		await keyboard.press('Enter');
+		await keyboard.type('1 + 1');
+
+		await notebooksPositron.selectCellAtIndex(1);
+		await keyboard.press('Enter');
+		await keyboard.type('2 + 2');
+
+		await notebooksPositron.selectCellAtIndex(2);
+		await keyboard.press('Enter');
+		await keyboard.type('3 + 3');
+
+		// Multi-select all 3 cells: select cell 0, then Shift+ArrowDown twice
+		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
+		await keyboard.press('Shift+ArrowDown');
+		await keyboard.press('Shift+ArrowDown');
+		await notebooksPositron.expectCellsToBeSelected([0, 1, 2]);
+
+		// Press Shift+Enter to run all selected cells
+		await keyboard.press('Shift+Enter');
+
+		// Verify all 3 cells got execution order badges
+		await notebooksPositron.expectExecutionOrder([
+			{ index: 0, order: 1 },
+			{ index: 1, order: 2 },
+			{ index: 2, order: 3 },
+		]);
+
+		// Verify multi-selection is preserved
+		await notebooksPositron.expectCellsToBeSelected([0, 1, 2]);
+		await notebooksPositron.expectNoActiveSpinners();
+	});
+
 	test('Click away and back: code cell re-enters edit mode, markdown stays in view mode', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.currentPage.keyboard;
@@ -228,55 +270,6 @@ test.describe('Notebook Focus and Selection', {
 
 		await notebooksPositron.expectCellIndexToBeSelected(0, { isSelected: false });
 		await notebooksPositron.expectCellIndexToBeSelected(2, { isSelected: true, inEditMode: true, isActive: true });
-	});
-
-	test('Multi-select + Shift+Enter runs all selected code cells', async function ({ app, sessions }) {
-		const { notebooksPositron } = app.workbench;
-		const keyboard = app.code.driver.currentPage.keyboard;
-
-		// Clear any sessions leaked by earlier tests/specs sharing this worker.
-		// closeAllEditors() (folder afterEach) closes notebook tabs but does not
-		// shut down their kernels, so orphaned sessions accumulate and drop to a
-		// `disconnected` state on the web runtime. They starve the kernel we
-		// select below, which then never reaches `idle`. Start from a clean slate.
-		await sessions.deleteAll();
-
-		// Create notebook with 3 code cells containing executable Python
-		await notebooksPositron.newNotebook({ codeCells: 3 });
-		await notebooksPositron.kernel.select('Python');
-
-		// Put executable code in each cell
-		await notebooksPositron.selectCellAtIndex(0);
-		await keyboard.press('Enter');
-		await keyboard.type('1 + 1');
-
-		await notebooksPositron.selectCellAtIndex(1);
-		await keyboard.press('Enter');
-		await keyboard.type('2 + 2');
-
-		await notebooksPositron.selectCellAtIndex(2);
-		await keyboard.press('Enter');
-		await keyboard.type('3 + 3');
-
-		// Multi-select all 3 cells: select cell 0, then Shift+ArrowDown twice
-		await notebooksPositron.selectCellAtIndex(0, { editMode: false });
-		await keyboard.press('Shift+ArrowDown');
-		await keyboard.press('Shift+ArrowDown');
-		await notebooksPositron.expectCellsToBeSelected([0, 1, 2]);
-
-		// Press Shift+Enter to run all selected cells
-		await keyboard.press('Shift+Enter');
-
-		// Verify all 3 cells got execution order badges
-		await notebooksPositron.expectExecutionOrder([
-			{ index: 0, order: 1 },
-			{ index: 1, order: 2 },
-			{ index: 2, order: 3 },
-		]);
-
-		// Verify multi-selection is preserved
-		await notebooksPositron.expectCellsToBeSelected([0, 1, 2]);
-		await notebooksPositron.expectNoActiveSpinners();
 	});
 
 	test('Multi-select and insert cell above/below becomes the active cell', async function ({ app }) {


### PR DESCRIPTION
### Summary
Fixes a web-only flake in the "Multi-select + Shift+Enter runs all selected code cells" test, where the notebook kernel reached `disconnected` instead of `idle`.

- Root cause: the folder `afterEach` closes notebook editors but does not shut down their kernels, so orphaned sessions accumulate across the shared worker and drop to `disconnected` on the web runtime.
- Those orphaned sessions starve the kernel selected by `kernel.select('Python')`, which then never reaches `idle`.
- Clear all sessions at the start of the test so the new kernel starts from a clean slate.

### QA Notes
@:web @:positron-notebooks