### PR TITLE
Refresh expiring AWS credentials before they go stale

### DIFF
--- a/extensions/authentication/src/authProvider.ts
+++ b/extensions/authentication/src/authProvider.ts
@@ -64,6 +64,7 @@ export class AuthProvider
 
 	private _chainSession: vscode.AuthenticationSession | undefined;
 	private _chainExpiration: Date | undefined;
+	private _chainResolution: Promise<vscode.AuthenticationSession | undefined> | undefined;
 	private _refreshTimer: ReturnType<typeof setInterval> | undefined;
 	private _disposed = false;
 	private readonly logger: AuthProviderLogger;
@@ -112,12 +113,28 @@ export class AuthProvider
 		return `apiKey-${this.providerId}-${accountId}`;
 	}
 
+	private get chainConfiguredKey(): string {
+		return `authentication.previouslySignedIn.${this.providerId}`;
+	}
+
+	private isChainConfigured(): boolean {
+		return !!this.context.globalState.get<boolean>(this.chainConfiguredKey);
+	}
+
+	/** True if the user has set up this provider, regardless of current session validity. */
+	async isConfigured(): Promise<boolean> {
+		return this.isChainConfigured() || this.getStoredAccounts().length > 0;
+	}
+
 	async getSessions(
 		_scopes?: readonly string[],
 		options?: vscode.AuthenticationProviderSessionOptions
 	): Promise<vscode.AuthenticationSession[]> {
 		// Credential chain (e.g. AWS, Snowflake)
 		if (this.credentialChain) {
+			if (this._chainResolution) {
+				await this._chainResolution;
+			}
 			if (this.shouldRefreshNow()) {
 				await this.resolveChainCredentials();
 			} else if (this.credentialChain.shouldRefresh) {
@@ -231,11 +248,8 @@ export class AuthProvider
 	}
 
 	async removeSession(sessionId: string): Promise<void> {
-		if (this._chainSession?.id === sessionId) {
-			// If the chain can still resolve, re-resolve immediately
-			// instead of leaving an inconsistent state where the
-			// session is gone but registered models still work.
-			if (this.credentialChain?.preventSignOut) {
+		if (this.credentialChain && sessionId === this.providerId) {
+			if (this.credentialChain.preventSignOut) {
 				try {
 					const result = await this.credentialChain.resolve();
 					const token = typeof result === 'string' ? result : result.token;
@@ -263,9 +277,12 @@ export class AuthProvider
 			const removed = this._chainSession;
 			this._chainSession = undefined;
 			this._chainExpiration = undefined;
-			this._onDidChangeSessions.fire({
-				added: [], removed: [removed], changed: [],
-			});
+			await this.context.globalState.update(this.chainConfiguredKey, undefined);
+			if (removed) {
+				this._onDidChangeSessions.fire({
+					added: [], removed: [removed], changed: [],
+				});
+			}
 			this.logger.logSessionChange('removed', 'Chain session removed');
 			return;
 		}
@@ -303,6 +320,22 @@ export class AuthProvider
 		if (!this.credentialChain) {
 			return undefined;
 		}
+		const resolution = this.doResolveChainCredentials();
+		this._chainResolution = resolution;
+		try {
+			return await resolution;
+		} finally {
+			if (this._chainResolution === resolution) {
+				this._chainResolution = undefined;
+			}
+		}
+	}
+
+	private async doResolveChainCredentials(
+	): Promise<vscode.AuthenticationSession | undefined> {
+		if (!this.credentialChain) {
+			return undefined;
+		}
 
 		try {
 			const result = await this.credentialChain.resolve();
@@ -327,6 +360,10 @@ export class AuthProvider
 			this._chainExpiration = expiration;
 			this.startRefreshTimer();
 
+			if (!this.credentialChain.preventSignOut && !this.isChainConfigured()) {
+				await this.context.globalState.update(this.chainConfiguredKey, true);
+			}
+
 			if (!previous) {
 				this._onDidChangeSessions.fire({
 					added: [session], removed: [], changed: [],
@@ -340,7 +377,12 @@ export class AuthProvider
 
 			return session;
 		} catch (err) {
-			this.logger.logCredentialResolution('failed', `${err instanceof Error ? err.message : String(err)}`);
+			const message = err instanceof Error ? err.message : String(err);
+			if (this.isChainConfigured()) {
+				this.logger.warn(`Credential resolution failed for previously signed-in provider: ${message}`);
+			} else {
+				this.logger.logCredentialResolution('failed', message);
+			}
 
 			if (this._chainSession) {
 				const removed = this._chainSession;

--- a/extensions/authentication/src/authProvider.ts
+++ b/extensions/authentication/src/authProvider.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import { randomUUID } from 'crypto';
 import { AuthProviderLogger } from './authProviderLogger';
+import { EXPIRY_REFRESH_BUFFER_MS } from './constants';
 
 interface StoredAccount {
 	readonly id: string;
@@ -23,12 +24,18 @@ export interface WorkbenchCredentialConfig {
 	readonly isAvailable: () => boolean;
 }
 
+/** A credential resolved from a chain, with an optional expiration. */
+export interface ResolvedChainCredential {
+	readonly token: string;
+	readonly expiration?: Date;
+}
+
 /**
  * Credential chain config for providers that resolve credentials
  * from an external source (e.g. AWS SDK credential chain).
  */
 export interface CredentialChainConfig {
-	readonly resolve: () => Promise<string>;
+	readonly resolve: () => Promise<string | ResolvedChainCredential>;
 	readonly refreshIntervalMs?: number;
 	/** Optional check called in getSessions to decide whether to re-resolve. */
 	readonly shouldRefresh?: () => Promise<boolean>;
@@ -56,6 +63,7 @@ export class AuthProvider
 	readonly onDidChangeSessions = this._onDidChangeSessions.event;
 
 	private _chainSession: vscode.AuthenticationSession | undefined;
+	private _chainExpiration: Date | undefined;
 	private _refreshTimer: ReturnType<typeof setInterval> | undefined;
 	private _disposed = false;
 	private readonly logger: AuthProviderLogger;
@@ -110,7 +118,9 @@ export class AuthProvider
 	): Promise<vscode.AuthenticationSession[]> {
 		// Credential chain (e.g. AWS, Snowflake)
 		if (this.credentialChain) {
-			if (this.credentialChain.shouldRefresh) {
+			if (this.shouldRefreshNow()) {
+				await this.resolveChainCredentials();
+			} else if (this.credentialChain.shouldRefresh) {
 				const needsRefresh = await this.credentialChain.shouldRefresh();
 				if (needsRefresh) {
 					await this.resolveChainCredentials();
@@ -227,7 +237,8 @@ export class AuthProvider
 			// session is gone but registered models still work.
 			if (this.credentialChain?.preventSignOut) {
 				try {
-					const token = await this.credentialChain.resolve();
+					const result = await this.credentialChain.resolve();
+					const token = typeof result === 'string' ? result : result.token;
 					if (token) {
 						this.logger.info(
 							'Chain session removal blocked -- ' +
@@ -251,6 +262,7 @@ export class AuthProvider
 			this.stopRefreshTimer();
 			const removed = this._chainSession;
 			this._chainSession = undefined;
+			this._chainExpiration = undefined;
 			this._onDidChangeSessions.fire({
 				added: [], removed: [removed], changed: [],
 			});
@@ -282,8 +294,9 @@ export class AuthProvider
 	}
 
 	/**
-	 * Resolve credentials from the chain, update cache, and
-	 * start the background refresh timer.
+	 * Resolve credentials from the chain, update cache, and start the
+	 * background refresh timer. Fires `added`, `changed`, or `removed`
+	 * depending on how the resolved token compares to the cached one.
 	 */
 	async resolveChainCredentials(
 	): Promise<vscode.AuthenticationSession | undefined> {
@@ -292,13 +305,16 @@ export class AuthProvider
 		}
 
 		try {
-			const accessToken = await this.credentialChain.resolve();
+			const result = await this.credentialChain.resolve();
 			if (this._disposed) {
 				return undefined;
 			}
+			const { token, expiration } = typeof result === 'string'
+				? { token: result, expiration: undefined }
+				: result;
 			const session: vscode.AuthenticationSession = {
 				id: this.providerId,
-				accessToken,
+				accessToken: token,
 				account: {
 					id: this.providerId,
 					label: this.displayName,
@@ -306,16 +322,21 @@ export class AuthProvider
 				scopes: [],
 			};
 
-			const hadSession = !!this._chainSession;
+			const previous = this._chainSession;
 			this._chainSession = session;
+			this._chainExpiration = expiration;
 			this.startRefreshTimer();
 
-			if (!hadSession) {
+			if (!previous) {
 				this._onDidChangeSessions.fire({
 					added: [session], removed: [], changed: [],
 				});
-				this.logger.logCredentialResolution('resolved');
+			} else if (previous.accessToken !== token) {
+				this._onDidChangeSessions.fire({
+					added: [], removed: [], changed: [session],
+				});
 			}
+			this.logger.logCredentialResolution('resolved');
 
 			return session;
 		} catch (err) {
@@ -324,6 +345,7 @@ export class AuthProvider
 			if (this._chainSession) {
 				const removed = this._chainSession;
 				this._chainSession = undefined;
+				this._chainExpiration = undefined;
 				this._onDidChangeSessions.fire({
 					added: [], removed: [removed], changed: [],
 				});
@@ -331,6 +353,18 @@ export class AuthProvider
 			}
 			return undefined;
 		}
+	}
+
+	/**
+	 * Whether the cached chain credential is within the expiry buffer and
+	 * should be re-resolved before being handed out. Chains without an
+	 * expiration return false and rely on the timer or `shouldRefresh` instead.
+	 */
+	private shouldRefreshNow(): boolean {
+		if (!this._chainExpiration) {
+			return false;
+		}
+		return this._chainExpiration.getTime() - Date.now() <= EXPIRY_REFRESH_BUFFER_MS;
 	}
 
 	private startRefreshTimer(): void {

--- a/extensions/authentication/src/constants.ts
+++ b/extensions/authentication/src/constants.ts
@@ -11,6 +11,7 @@ export const IS_RUNNING_ON_PWB =
 export const ANTHROPIC_API_VERSION = '2023-06-01';
 export const KEY_VALIDATION_TIMEOUT_MS = 5000;
 export const CREDENTIAL_REFRESH_INTERVAL_MS = 10 * 60 * 1000;
+export const EXPIRY_REFRESH_BUFFER_MS = 60 * 1000;
 
 export const ANTHROPIC_AUTH_PROVIDER_ID = 'anthropic-api';
 export const POSIT_AUTH_PROVIDER_ID = 'posit-ai';

--- a/extensions/authentication/src/extension.ts
+++ b/extensions/authentication/src/extension.ts
@@ -190,13 +190,15 @@ async function registerAwsProvider(
 		{
 			resolve: async () => {
 				const resolved = await credentialProvider();
-				return JSON.stringify({
-					accessKeyId: resolved.accessKeyId,
-					secretAccessKey: resolved.secretAccessKey,
-					sessionToken: resolved.sessionToken,
-				});
+				return {
+					token: JSON.stringify({
+						accessKeyId: resolved.accessKeyId,
+						secretAccessKey: resolved.secretAccessKey,
+						sessionToken: resolved.sessionToken,
+					}),
+					expiration: resolved.expiration,
+				};
 			},
-			refreshIntervalMs: CREDENTIAL_REFRESH_INTERVAL_MS,
 		}
 	);
 	context.subscriptions.push(

--- a/extensions/authentication/src/positOAuthProvider.ts
+++ b/extensions/authentication/src/positOAuthProvider.ts
@@ -148,6 +148,11 @@ export class PositOAuthProvider extends AuthProvider {
 
 	// --- AuthProvider overrides ---
 
+	override async isConfigured(): Promise<boolean> {
+		const refreshToken = await this.context.secrets.get('posit-ai.refresh_token');
+		return refreshToken !== undefined;
+	}
+
 	override async getSessions(
 		_scopes?: readonly string[],
 		_options?: vscode.AuthenticationProviderSessionOptions

--- a/extensions/authentication/src/test/authProvider.test.ts
+++ b/extensions/authentication/src/test/authProvider.test.ts
@@ -7,6 +7,32 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { AuthProvider } from '../authProvider';
+import { log } from '../log';
+
+function createMockContext(): vscode.ExtensionContext {
+	const secrets = new Map<string, string>();
+	const globalState = new Map<string, unknown>();
+	return {
+		secrets: {
+			get: (key: string) => Promise.resolve(secrets.get(key)),
+			store: (key: string, value: string) => {
+				secrets.set(key, value);
+				return Promise.resolve();
+			},
+			delete: (key: string) => {
+				secrets.delete(key);
+				return Promise.resolve();
+			},
+		},
+		globalState: {
+			get: <T>(key: string) => globalState.get(key) as T | undefined,
+			update: (key: string, value: unknown) => {
+				globalState.set(key, value);
+				return Promise.resolve();
+			},
+		},
+	} as unknown as vscode.ExtensionContext;
+}
 
 suite('AuthProvider', () => {
 	let provider: AuthProvider;
@@ -124,31 +150,6 @@ suite('AuthProvider (credential chain)', () => {
 	let chainProvider: AuthProvider;
 	let resolveResult: string;
 	let resolveShouldFail: boolean;
-
-	function createMockContext(): vscode.ExtensionContext {
-		const secrets = new Map<string, string>();
-		const globalState = new Map<string, unknown>();
-		return {
-			secrets: {
-				get: (key: string) => Promise.resolve(secrets.get(key)),
-				store: (key: string, value: string) => {
-					secrets.set(key, value);
-					return Promise.resolve();
-				},
-				delete: (key: string) => {
-					secrets.delete(key);
-					return Promise.resolve();
-				},
-			},
-			globalState: {
-				get: <T>(key: string) => globalState.get(key) as T | undefined,
-				update: (key: string, value: unknown) => {
-					globalState.set(key, value);
-					return Promise.resolve();
-				},
-			},
-		} as unknown as vscode.ExtensionContext;
-	}
 
 	setup(() => {
 		resolveResult = JSON.stringify({ accessKeyId: 'AKIA', secretAccessKey: 'secret' });
@@ -290,31 +291,6 @@ suite('AuthProvider (credential chain)', () => {
 });
 
 suite('AuthProvider - credential chain refresh', () => {
-	function createMockContext(): vscode.ExtensionContext {
-		const secrets = new Map<string, string>();
-		const globalState = new Map<string, unknown>();
-		return {
-			secrets: {
-				get: (key: string) => Promise.resolve(secrets.get(key)),
-				store: (key: string, value: string) => {
-					secrets.set(key, value);
-					return Promise.resolve();
-				},
-				delete: (key: string) => {
-					secrets.delete(key);
-					return Promise.resolve();
-				},
-			},
-			globalState: {
-				get: <T>(key: string) => globalState.get(key) as T | undefined,
-				update: (key: string, value: unknown) => {
-					globalState.set(key, value);
-					return Promise.resolve();
-				},
-			},
-		} as unknown as vscode.ExtensionContext;
-	}
-
 	const providers: AuthProvider[] = [];
 
 	function track(provider: AuthProvider): AuthProvider {
@@ -521,5 +497,170 @@ suite('AuthProvider - credential chain refresh', () => {
 			provider.dispose();
 			clock.restore();
 		}
+	});
+
+	test('getSessions waits for an in-flight resolution instead of returning no sessions', async () => {
+		let release!: () => void;
+		const gate = new Promise<void>(resolve => { release = resolve; });
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{ resolve: async () => { await gate; return 'x'; } }
+		));
+
+		// Fire-and-forget, like the eager resolve during activation.
+		const resolution = provider.resolveChainCredentials();
+		const sessionsPromise = provider.getSessions();
+		release();
+		await resolution;
+
+		const sessions = await sessionsPromise;
+		assert.strictEqual(sessions.length, 1);
+		assert.strictEqual(sessions[0].accessToken, 'x');
+	});
+});
+
+suite('AuthProvider - configured provider state', () => {
+	const providers: AuthProvider[] = [];
+
+	function track(provider: AuthProvider): AuthProvider {
+		providers.push(provider);
+		return provider;
+	}
+
+	teardown(() => {
+		sinon.restore();
+		while (providers.length) {
+			providers.pop()!.dispose();
+		}
+	});
+
+	test('chain provider is not configured before first resolution', async () => {
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{ resolve: async () => 'x' }
+		));
+
+		assert.strictEqual(await provider.isConfigured(), false);
+	});
+
+	test('successful chain resolution marks the provider configured', async () => {
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{ resolve: async () => 'x' }
+		));
+
+		await provider.resolveChainCredentials();
+
+		assert.strictEqual(await provider.isConfigured(), true);
+	});
+
+	test('failed resolution keeps a previously configured provider configured', async () => {
+		let count = 0;
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{
+				resolve: async () => {
+					if (count++ === 0) { return 'x'; }
+					throw new Error('chain failed');
+				},
+			}
+		));
+
+		await provider.resolveChainCredentials();
+		await provider.resolveChainCredentials();
+
+		assert.strictEqual((await provider.getSessions()).length, 0);
+		assert.strictEqual(await provider.isConfigured(), true);
+	});
+
+	test('chain sign-out clears the configured flag', async () => {
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{ resolve: async () => 'x' }
+		));
+
+		await provider.resolveChainCredentials();
+		await provider.removeSession('test');
+
+		assert.strictEqual(await provider.isConfigured(), false);
+	});
+
+	test('sign-out clears the configured flag even when the cached session is gone', async () => {
+		let count = 0;
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{
+				resolve: async () => {
+					if (count++ === 0) { return 'x'; }
+					throw new Error('chain failed');
+				},
+			}
+		));
+
+		await provider.resolveChainCredentials();
+		await provider.resolveChainCredentials(); // fails, invalidates session
+		await provider.removeSession('test');
+
+		assert.strictEqual(await provider.isConfigured(), false);
+	});
+
+	test('preventSignOut chains are not marked configured', async () => {
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{ resolve: async () => 'x', preventSignOut: true }
+		));
+
+		await provider.resolveChainCredentials();
+
+		assert.strictEqual(await provider.isConfigured(), false);
+	});
+
+	test('stored API keys mark the provider configured until removed', async () => {
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext()
+		));
+
+		await provider.storeKey('acc-1', 'Account', 'sk-key');
+		assert.strictEqual(await provider.isConfigured(), true);
+
+		await provider.removeSession('acc-1');
+		assert.strictEqual(await provider.isConfigured(), false);
+	});
+
+	test('failed resolution for a configured provider logs at warn', async () => {
+		const warnSpy = sinon.spy(log, 'warn');
+		let count = 0;
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{
+				resolve: async () => {
+					if (count++ === 0) { return 'x'; }
+					throw new Error('chain failed');
+				},
+			}
+		));
+
+		await provider.resolveChainCredentials();
+		await provider.resolveChainCredentials();
+
+		const warnings = warnSpy.getCalls().map(call => String(call.args[0]));
+		assert.ok(
+			warnings.some(msg => msg.includes('[Test]') && msg.includes('chain failed')),
+			`expected warn naming provider and error, got: ${warnings.join(' | ')}`
+		);
+	});
+
+	test('failed resolution for an unconfigured provider does not warn', async () => {
+		const warnSpy = sinon.spy(log, 'warn');
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{ resolve: async () => { throw new Error('no creds'); } }
+		));
+
+		await provider.resolveChainCredentials();
+
+		const providerWarnings = warnSpy.getCalls()
+			.filter(call => String(call.args[0]).includes('[Test]'));
+		assert.strictEqual(providerWarnings.length, 0);
 	});
 });

--- a/extensions/authentication/src/test/authProvider.test.ts
+++ b/extensions/authentication/src/test/authProvider.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { AuthProvider } from '../authProvider';
 
@@ -285,5 +286,240 @@ suite('AuthProvider (credential chain)', () => {
 		assert.strictEqual(event.removed!.length, 1);
 		sessions = await chainProvider.getSessions();
 		assert.strictEqual(sessions.length, 0);
+	});
+});
+
+suite('AuthProvider - credential chain refresh', () => {
+	function createMockContext(): vscode.ExtensionContext {
+		const secrets = new Map<string, string>();
+		const globalState = new Map<string, unknown>();
+		return {
+			secrets: {
+				get: (key: string) => Promise.resolve(secrets.get(key)),
+				store: (key: string, value: string) => {
+					secrets.set(key, value);
+					return Promise.resolve();
+				},
+				delete: (key: string) => {
+					secrets.delete(key);
+					return Promise.resolve();
+				},
+			},
+			globalState: {
+				get: <T>(key: string) => globalState.get(key) as T | undefined,
+				update: (key: string, value: unknown) => {
+					globalState.set(key, value);
+					return Promise.resolve();
+				},
+			},
+		} as unknown as vscode.ExtensionContext;
+	}
+
+	const providers: AuthProvider[] = [];
+
+	function track(provider: AuthProvider): AuthProvider {
+		providers.push(provider);
+		return provider;
+	}
+
+	teardown(() => {
+		sinon.restore();
+		while (providers.length) {
+			providers.pop()!.dispose();
+		}
+	});
+
+	test('credentials with no expiry stay signed in without re-resolving (string form)', async () => {
+		let count = 0;
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{ resolve: async () => { count++; return 'x'; } }
+		));
+
+		await provider.resolveChainCredentials();
+		await provider.getSessions();
+		await provider.getSessions();
+		const sessions = await provider.getSessions();
+
+		assert.strictEqual(count, 1);
+		assert.strictEqual(sessions[0].accessToken, 'x');
+	});
+
+	test('credentials with no expiry stay signed in without re-resolving (object form)', async () => {
+		let count = 0;
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{ resolve: async () => { count++; return { token: 'x' }; } }
+		));
+
+		await provider.resolveChainCredentials();
+		await provider.getSessions();
+		await provider.getSessions();
+		await provider.getSessions();
+
+		assert.strictEqual(count, 1);
+	});
+
+	test('credentials still well before expiry are reused, not re-fetched', async () => {
+		let count = 0;
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{
+				resolve: async () => {
+					count++;
+					return { token: 'x', expiration: new Date(Date.now() + 2 * 60 * 1000) };
+				},
+			}
+		));
+
+		await provider.resolveChainCredentials();
+		await provider.getSessions();
+		await provider.getSessions();
+
+		assert.strictEqual(count, 1);
+	});
+
+	test('credentials nearing expiry are refreshed before being handed out', async () => {
+		let count = 0;
+		const tokens = ['x', 'y'];
+		const expirations = [
+			new Date(Date.now() + 30 * 1000),
+			new Date(Date.now() + 60 * 60 * 1000),
+		];
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{
+				resolve: async () => {
+					const i = count++;
+					return { token: tokens[i], expiration: expirations[i] };
+				},
+			}
+		));
+
+		await provider.resolveChainCredentials();
+		const sessions = await provider.getSessions();
+		const after = await provider.getSessions();
+
+		assert.strictEqual(count, 2);
+		assert.strictEqual(sessions[0].accessToken, 'y');
+		// The refreshed 1h expiration re-armed the buffer, so the next
+		// getSessions() does not resolve again.
+		assert.strictEqual(after[0].accessToken, 'y');
+	});
+
+	test('user is signed out when expiring credentials can no longer be refreshed', async () => {
+		let count = 0;
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{
+				resolve: async () => {
+					if (count++ === 0) {
+						return { token: 'x', expiration: new Date(Date.now() + 30 * 1000) };
+					}
+					throw new Error('chain failed');
+				},
+			}
+		));
+
+		await provider.resolveChainCredentials();
+
+		const removedEvents: vscode.AuthenticationSession[] = [];
+		const disposable = provider.onDidChangeSessions(e => {
+			removedEvents.push(...(e.removed ?? []));
+		});
+
+		const sessions = await provider.getSessions();
+		disposable.dispose();
+
+		assert.strictEqual(sessions.length, 0);
+		assert.strictEqual(removedEvents.length, 1);
+		// The invalidated session is the cached chain session, not some other.
+		assert.strictEqual(removedEvents[0].accessToken, 'x');
+	});
+
+	test('refreshed credentials notify consumers that the session changed', async () => {
+		let count = 0;
+		const tokens = ['x', 'y'];
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{ resolve: async () => tokens[count++] }
+		));
+
+		const events = { added: 0, removed: 0, changed: 0 };
+		const changedSessions: vscode.AuthenticationSession[] = [];
+		const disposable = provider.onDidChangeSessions(e => {
+			events.added += e.added?.length ?? 0;
+			events.removed += e.removed?.length ?? 0;
+			events.changed += e.changed?.length ?? 0;
+			changedSessions.push(...(e.changed ?? []));
+		});
+
+		await provider.resolveChainCredentials();
+		await provider.resolveChainCredentials();
+		disposable.dispose();
+
+		assert.deepStrictEqual(events, { added: 1, removed: 0, changed: 1 });
+		// The changed event carries the new token, not the stale one.
+		assert.strictEqual(changedSessions[0].accessToken, 'y');
+	});
+
+	test('signing in resolves credentials and makes the session available', async () => {
+		let count = 0;
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{ resolve: async () => { count++; return 'x'; } }
+		));
+
+		const session = await provider.resolveChainCredentials();
+
+		assert.strictEqual(count, 1);
+		assert.ok(session);
+		assert.strictEqual(session.accessToken, 'x');
+	});
+
+	test('a provider that refreshes on demand still works (Snowflake-style)', async () => {
+		let count = 0;
+		let refreshOnNext = false;
+		const provider = track(new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{
+				resolve: async () => { count++; return 'x'; },
+				shouldRefresh: async () => {
+					const should = refreshOnNext;
+					refreshOnNext = false;
+					return should;
+				},
+			}
+		));
+
+		await provider.resolveChainCredentials();
+		await provider.getSessions();
+		refreshOnNext = true;
+		await provider.getSessions();
+
+		assert.strictEqual(count, 2);
+	});
+
+	test('a provider that refreshes on a timer still works (Vertex-style)', async () => {
+		const clock = sinon.useFakeTimers();
+		let count = 0;
+		// Not tracked for teardown disposal: dispose() clears the interval and
+		// must run while the fake clock owns that timer, before clock.restore().
+		const provider = new AuthProvider(
+			'test', 'Test', createMockContext(), undefined,
+			{ resolve: async () => { count++; return 'x'; }, refreshIntervalMs: 1000 }
+		);
+
+		try {
+			await provider.resolveChainCredentials();
+			assert.strictEqual(count, 1);
+
+			await clock.tickAsync(1000);
+
+			assert.strictEqual(count, 2);
+		} finally {
+			provider.dispose();
+			clock.restore();
+		}
 	});
 });

--- a/extensions/authentication/src/test/positOAuthProvider.test.ts
+++ b/extensions/authentication/src/test/positOAuthProvider.test.ts
@@ -116,4 +116,15 @@ suite('PositOAuthProvider', () => {
 		});
 	});
 
+	suite('isConfigured', () => {
+		test('false when no tokens are stored', async () => {
+			assert.strictEqual(await provider.isConfigured(), false);
+		});
+
+		test('true when a refresh token is stored', async () => {
+			storeValidTokens(secrets);
+			assert.strictEqual(await provider.isConfigured(), true);
+		});
+	});
+
 });


### PR DESCRIPTION
Fixes #13856

When AWS credentials expire mid-session, Posit Assistant 
starts failing with "Error making request (HTTP 403): The security token
included in the request is expired." Credentials were only refreshed on a
fixed 10-minute interval, so requests sent between a credential's expiry
and the next poll signed with stale keys. Recovery required reloading
Positron.

Credentials are now refreshed on demand: one within 60 seconds of expiry
is re-resolved before use, so chat keeps working without a reload.

This PR also adds the groundwork for a startup bug.
When credentials are expired at reload, the auth extension now
persists a "previously signed in" flag (`authentication.previouslySignedIn.<providerId>`)
so Assistant can distinguish "configured but expired" from "never configured."
`getSessions` waits for any in-flight chain resolution before answering,
closing the startup race where a consumer querying during activation would
briefly see no sessions. Failures are 
now logged as warnings rather than debug. These changes are the auth extension side; the user-facing notification lands in #14126.

User notifications are being handled in #14126, posit-dev/assistant#1543.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Refresh expiring AWS credentials so Bedrock keeps working in a long-lived Assistant session (#13856)
- Persist provider signed-in state so credential expiry at reload is detectable (#13856)

### Validation Steps

@:posit-assistant

The refresh timing and configured-state behavior are covered by unit tests in
`extensions/authentication/src/test/authProvider.test.ts` (run with
`npm run test-extension -- -l authentication`). End-to-end behavior needs
AWS credentials that expire:

1. Configure Bedrock in Posit Assistant and send a chat message. Confirm
   success.
2. Leave the session idle past the credential lifetime.
3. Send another message. Expected: success (before this change: HTTP 403).
4. Restart Positron with expired credentials. Expected: the Authentication
   output pane logs a warning naming the provider and the error (before this
   change: silent).