### PR TITLE
e2e: de-flake DuckDB connection test (connect-icon timeout on macOS CI)

### DIFF
--- a/test/e2e/tests/connections/connections-duckdb.test.ts
+++ b/test/e2e/tests/connections/connections-duckdb.test.ts
@@ -42,7 +42,14 @@ test.describe('DuckDB Connection', {
 
 		await app.workbench.console.pasteCodeToConsole(connectionCode, true);
 
-		await app.code.driver.currentPage.locator('.codicon-arrow-circle-right').click({ timeout: 30000 });
+		// Deterministically reveal the Connections pane instead of relying on the
+		// kernel's best-effort Focus comm event. viewConnection() then opens the
+		// connection from the list, or no-ops when the pane already landed in the
+		// connection's detail view -- so the test doesn't depend on the connect
+		// icon being present in a specific render state (flaky 30s timeout seen on
+		// macOS CI, where the comm-driven reveal raced and lost).
+		await app.workbench.connections.openConnectionPane();
+		await app.workbench.connections.viewConnection('DuckDB');
 
 		await app.workbench.connections.expandConnectionDetails('db');
 


### PR DESCRIPTION
## Summary

De-flakes the `Python - Can establish a DuckDB connection` test in `test/e2e/tests/connections/connections-duckdb.test.ts`, which intermittently failed on macOS-ARM CI with a 30s `locator.click` timeout waiting for `.codicon-arrow-circle-right`.

## Root cause

After pasting the connection code, the test immediately clicked a raw `.codicon-arrow-circle-right` locator. That icon only exists once the Connections pane is revealed and its React list mounts. The test relied entirely on the kernel's best-effort `Focus` comm event (from `register_connection`'s "already opened" path) to reveal the pane. Under CI load that reveal raced and lost, so the list never mounted and the icon never appeared, failing on both the initial attempt and the retry.

## Fix

- Deterministically reveal the pane with `openConnectionPane()` instead of depending on the racy comm-driven reveal.
- Use the existing `viewConnection()` page-object helper instead of a raw selector click. It opens the connection from the list view, or no-ops when the pane already landed directly in the connection's detail view (`%connection_show` opens the connection, so the pane often renders the detail view with no connect icon present). This removes the dependence on a specific render state.

## Testing

- `npm run compile --prefix test/e2e`: clean
- Ran locally against the installed build (`e2e-electron`): passes consistently (~48s).

Tags: @:web @:connections @:win
