### PR TITLE
remove broken problemMatchers for copilot tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -101,7 +101,7 @@
 				"group": "buildWatchers",
 				"close": false
 			},
-			"problemMatcher": "$esbuild-watch"
+			"problemMatcher": []
 		},
 		{
 			"label": "Positron - Build",
@@ -223,7 +223,7 @@
 				"group": "buildKillers",
 				"close": true
 			},
-			"problemMatcher": "$esbuild"
+			"problemMatcher": []
 		},
 		{
 			"label": "Kill VS Code - Build",


### PR DESCRIPTION
- This is a follow-up to https://github.com/posit-dev/positron/pull/14046

Two copilot tasks in `.vscode/tasks.json` fail to load with:

```
Error: Invalid problemMatcher reference: $esbuild-watch
Error: Invalid problemMatcher reference: $esbuild
```

You'll see these if you use the `Positron - Build` or `Kill Positron Build Watchers` tasks.

`$esbuild` and `$esbuild-watch` aren't built-in VS Code matchers. They come from the third-party `connor4312.esbuild-problem-matchers` extension, which isn't in positrons's `.vscode/extensions.json` recommendations, so devs aren't prompted to install it and the references don't exist as a result.

These two tasks were added in the Code OSS 1.118.0 merge (3ce43af34).

A problem matcher parses a task's output into Problems pane entries. Since the references don't resolve today, nothing is being parsed anyway, so `[]` doesn't lose any functionality, it just clears the errors mentioned above.

## Test steps

- Reload the window so tasks.json gets re-parsed
- Run **Tasks: Run Task** and confirm neither task errors on load
- Run `Positron - Build` (the default, which depends on `Copilot - Build`) and confirm the copilot watcher starts and rebuilds
- Run `Kill Positron Build Watchers` and confirm all Positron build watcher tasks are killed, including copilot
