### PR TITLE
Prefer Quarto intrinsic size if present

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -1707,6 +1707,21 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 			size: sizingPolicy instanceof PlotSizingPolicyCustom ? sizingPolicy.size : undefined
 		};
 		const plotClient = new PlotClientInstance(comm, this._configurationService, sizingPolicy ?? this._selectedSizingPolicy, { ...metadata, location: location });
+
+		// For non-Python plots, the intrinsic size is only known after querying
+		// the backend. R plots rendered through Quarto report an intrinsic size
+		// derived from the chunk's figure options (e.g. fig-width/fig-height).
+		// When such a size arrives and the plot is still using the default auto
+		// policy, prefer the intrinsic size, matching the Python/matplotlib
+		// behavior above.
+		if (plotClient.sizingPolicy.id === PlotSizingPolicyAuto.ID) {
+			plotClient.register(plotClient.onDidSetIntrinsicSize((intrinsicSize) => {
+				if (intrinsicSize && plotClient.sizingPolicy.id === PlotSizingPolicyAuto.ID) {
+					plotClient.sizingPolicy = this._intrinsicSizingPolicy;
+				}
+			}));
+		}
+
 		let plotClients = this._plotClientsByComm.get(metadata.id);
 
 		if (!plotClients) {

--- a/src/vs/workbench/contrib/positronPlots/test/electron-browser/positronPlotsService.vitest.ts
+++ b/src/vs/workbench/contrib/positronPlots/test/electron-browser/positronPlotsService.vitest.ts
@@ -16,6 +16,7 @@ import { RuntimeClientType } from '../../../../services/runtimeSession/common/ru
 import { TestLanguageRuntimeSession } from '../../../../services/runtimeSession/test/common/testLanguageRuntimeSession.js';
 import { startTestLanguageRuntimeSession } from '../../../../services/runtimeSession/test/common/testRuntimeSessionService.js';
 import { PositronPlotCommProxy } from '../../../../services/languageRuntime/common/positronPlotCommProxy.js';
+import { IntrinsicSize, PlotUnit } from '../../../../services/languageRuntime/common/positronPlotComm.js';
 import { PlotSizingPolicyAuto } from '../../../../services/positronPlots/common/sizingPolicyAuto.js';
 import { PlotSizingPolicyFill } from '../../../../services/positronPlots/common/sizingPolicyFill.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -157,6 +158,7 @@ describe('Positron - Plots Service', () => {
 			onDidClose: () => ({ dispose: () => { } }),
 			onDidRenderUpdate: () => ({ dispose: () => { } }),
 			onDidShowPlot: () => ({ dispose: () => { } }),
+			onDidSetIntrinsicSize: () => ({ dispose: () => { } }),
 			render: vi.fn(),
 			getIntrinsicSize: vi.fn(),
 			dispose: vi.fn(),
@@ -179,6 +181,45 @@ describe('Positron - Plots Service', () => {
 		await raceTimeout(didClosePlot, 100, () => expect.unreachable('onDidChangeSizingPolicy event did not fire'));
 
 		expect(sizingPolicyChanged, 'onDidChangeSizingPolicy event should fire').toBe(true);
+	});
+
+	it('sizing policy: prefers the intrinsic size when the backend reports one', async () => {
+		const session = await createSession();
+		session.session.createClient(RuntimeClientType.Plot, {}, {}, 'plot1');
+
+		const plotInstance = plotsService.positronPlotInstances[0] as PlotClientInstance;
+
+		// The plot starts out using the default auto sizing policy.
+		expect(plotInstance.sizingPolicy.id).toBe('auto');
+
+		// Make the backend report a Quarto intrinsic size (e.g. from fig-width/fig-height).
+		// eslint-disable-next-line local/code-no-any-casts -- private field access for stub injection in test only
+		const comm = (plotInstance as any)._commProxy._comm;
+		comm.getIntrinsicSize = vi.fn().mockResolvedValue({
+			width: 10, height: 3, unit: PlotUnit.Inches, source: 'Quarto',
+		} satisfies IntrinsicSize);
+
+		// Querying the intrinsic size should upgrade the plot to the intrinsic policy.
+		await plotInstance.getIntrinsicSize();
+
+		expect(plotInstance.sizingPolicy.id).toBe('intrinsic');
+	});
+
+	it('sizing policy: keeps the auto policy when the backend reports no intrinsic size', async () => {
+		const session = await createSession();
+		session.session.createClient(RuntimeClientType.Plot, {}, {}, 'plot1');
+
+		const plotInstance = plotsService.positronPlotInstances[0] as PlotClientInstance;
+		expect(plotInstance.sizingPolicy.id).toBe('auto');
+
+		// The backend reports no intrinsic size (e.g. a plain R plot without figure options).
+		// eslint-disable-next-line local/code-no-any-casts -- private field access for stub injection in test only
+		const comm = (plotInstance as any)._commProxy._comm;
+		comm.getIntrinsicSize = vi.fn().mockResolvedValue(undefined);
+
+		await plotInstance.getIntrinsicSize();
+
+		expect(plotInstance.sizingPolicy.id).toBe('auto');
 	});
 
 	it('selection: select plot', async () => {

--- a/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
+++ b/src/vs/workbench/services/languageRuntime/common/languageRuntimePlotClient.ts
@@ -244,8 +244,13 @@ export class PlotClientInstance extends Disposable implements IPositronPlotClien
 		// Connect the show plot emitter event
 		this.onDidShowPlot = this._didShowPlotEmitter.event;
 
-		// Connect the intrinsic size emitter event
+		// Connect the intrinsic size emitter event, forwarding the comm proxy's
+		// event so consumers of the plot client are notified when the backend
+		// reports the plot's intrinsic size.
 		this.onDidSetIntrinsicSize = this._didSetIntrinsicSizeEmitter.event;
+		this._register(this._commProxy.onDidSetIntrinsicSize((size) => {
+			this._didSetIntrinsicSizeEmitter.fire(size);
+		}));
 
 		// Connect the sizing policy emitter event
 		this.onDidChangeSizingPolicy = this._sizingPolicyEmitter.event;


### PR DESCRIPTION
Plots that report an intrinsic size are now automatically displayed at that size, without the user having to manually select the "Intrinsic" sizing policy.

<img width="1278" height="734" alt="image" src="https://github.com/user-attachments/assets/4548cb1f-a2c5-443b-9967-7ad7ee0a25f1" />


This already worked for matplotlib (Python) plots, which always report an intrinsic size; this PR extends the same behavior to any plot that reports one.

The motivating case is Quarto: R plots executed from a `.qmd`/`.Rmd` chunk with figure options (e.g. `fig-width`/`fig-height`) report a "Quarto" intrinsic size derived from those options. When such a size is available and the plot is still using the default `Auto` sizing policy, Positron now switches it to the intrinsic policy so the figure honors the chunk dimensions. Plain plots that report no intrinsic size keep the `Auto` policy as before.

Two pieces made this work:
- `PlotClientInstance` exposed an `onDidSetIntrinsicSize` event that was never fired. It is now wired to forward the comm proxy's event, so consumers (including the sizing-policy label in the action bar) are notified when the backend reports an intrinsic size.
- The plots service subscribes to that event for plots on the default `Auto` policy and upgrades them to the intrinsic policy when a size arrives, mirroring the existing matplotlib handling.

Closes #3676.

### Release Notes

#### New Features

- Plots with Quarto figure dimensions (`fig-width`/`fig-height`) are now drawn using those dimensions in the Plots pane (#3676)

#### Bug Fixes

- N/A

### Validation Steps

@:plots @:quarto

1. Open a `.qmd` document with an R chunk that sets figure options:

   ````
   ```{r}
   #| fig-width: 10
   #| fig-height: 3

   plot(1:10)
   ```
   ````

2. Run the chunk and confirm the plot appears in the Plots pane sized to the 10x3 (in) intrinsic dimensions, with the sizing policy showing "Quarto (10x3 in)" rather than "Auto".
3. Run a chunk with no figure options (e.g. just `plot(1:10)`) and confirm the plot still uses the `Auto` sizing policy.
4. Create a matplotlib plot in Python and confirm it continues to render at its intrinsic size as before.
