### PR TITLE
e2e: fix "console accepts input after notebook cell execution" flake

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -216,9 +216,6 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await console.typeToConsole('x = 42', true);
 		await console.waitForReady('>>>');
 		await console.typeToConsole('print(f"value_is_{x}")', true);
-		// Assert on a sentinel that only appears in the output. Asserting on a bare
-		// "42" matches both the output and the "42" numeric-literal token span in the
-		// echoed "x = 42" input line, so the count flakes between 1 and 2.
 		await console.waitForConsoleContents('value_is_42');
 
 		// the notebook cell should still be running; if "done" appeared the test FAILS

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -215,8 +215,11 @@ test.describe('Positron Notebooks: Kernel Behavior', {
 		await console.waitForReady('>>>');
 		await console.typeToConsole('x = 42', true);
 		await console.waitForReady('>>>');
-		await console.typeToConsole('print(x)', true);
-		await console.waitForConsoleContents('42');
+		await console.typeToConsole('print(f"value_is_{x}")', true);
+		// Assert on a sentinel that only appears in the output. Asserting on a bare
+		// "42" matches both the output and the "42" numeric-literal token span in the
+		// echoed "x = 42" input line, so the count flakes between 1 and 2.
+		await console.waitForConsoleContents('value_is_42');
 
 		// the notebook cell should still be running; if "done" appeared the test FAILS
 		// idea here is to guarantee that user will always get console ready INSTANTLY, not eventually...


### PR DESCRIPTION
### Summary
Fix the notebook kernel-behavior test that intermittently failed with `toHaveCount` expecting 1 but receiving 2 when matching `42`.

- The echoed `x = 42` input line renders the `42` numeric literal as its own Monaco token span.
- That span matched `getByText('42')` alongside the `print` output, so the count flaked between 1 and 2.
- Now asserts on a unique sentinel (`value_is_42`) that only appears in the output.

### QA Notes
@:positron-notebooks