### PR TITLE
e2e: fix welcome walkthrough title after #14079 rename

### DIFF
--- a/test/e2e/tests/welcome/welcome.test.ts
+++ b/test/e2e/tests/welcome/welcome.test.ts
@@ -42,7 +42,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 			await hotKeys.reloadWindow(true);
 
 			await welcome.expectWalkthroughsToHaveCount(3);
-			await welcome.expectWalkthroughsToContain(['Migrating from VSCode to Positron', 'Migrating from RStudio to Positron', 'Explore the Positron Notebook Editor']);
+			await welcome.expectWalkthroughsToContain(['Migrating from VSCode to Positron', 'Migrating from RStudio to Positron', 'Jupyter Notebooks in Positron']);
 
 			await welcome.walkthroughSection.getByText('More...').click();
 			await quickInput.expectTitleBarToHaveText('Open Walkthrough...');
@@ -52,7 +52,7 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 				'Migrating from RStudio to Positron',
 				'Get Started with Jupyter Notebooks',
 				'Get Started with Posit Publisher',
-				'Explore the Positron Notebook Editor'
+				'Jupyter Notebooks in Positron'
 			]);
 		});
 


### PR DESCRIPTION
### Summary
Fixes the welcome walkthrough e2e test broken by #14079, which renamed the walkthrough from "Explore the Positron Notebook Editor" to "Jupyter Notebooks in Positron".

- Update two `expectWalkthroughsToContain` assertions to match the new title

### QA Notes
@:welcome