### PR TITLE
e2e: update jupyter-notebooks screenshot to use Positron notebook POM

### DIFF
--- a/test/e2e/release-screenshots/jupyter-notebooks.screenshot.ts
+++ b/test/e2e/release-screenshots/jupyter-notebooks.screenshot.ts
@@ -29,12 +29,12 @@ test.describe('Release Screenshots - Jupyter Notebooks', () => {
 	 * Img Path: https://positron.posit.co/images/jupyter-notebooks-kernel-selector.png
 	 */
 	test('Release Screenshot - jupyter-notebooks-kernel-selector.png', async ({ app, page, python }) => {
-		const { notebooksVscode, hotKeys, sessions, layouts } = app.workbench;
+		const { notebooksPositron, hotKeys, sessions, layouts } = app.workbench;
 
 		// Open a new notebook and select the Python interpreter
-		await notebooksVscode.createNewNotebook();
-		await notebooksVscode.expectToBeVisible();
-		await notebooksVscode.selectInterpreter('Python');
+		await notebooksPositron.createNewNotebook();
+		await notebooksPositron.expectToBeVisible();
+		// await notebooksPositron.selectInterpreter('Python');
 		await sessions.expectSessionPickerToBe('Untitled-1.ipynb');
 
 		// customize the layout
@@ -50,8 +50,7 @@ test.describe('Release Screenshots - Jupyter Notebooks', () => {
 		await prepareForScreenshot(app, page);
 		await overrideWorkspaceName(page, 'qa-example-content', 'positron-demos-notebooks');
 		await annotate(page, [
-			// Wrap the whole kernel-action-view-item so the icon stays inside the box.
-			{ selector: '.kernel-action-view-item', label: '', color: ANNOTATION_COLOR, padding: 3 },
+			{ selector: 'button[aria-label="Kernel Actions"]', label: '', color: ANNOTATION_COLOR, padding: 3 },
 		]);
 		await captureFullWindow(page, 'jupyter-notebooks-kernel-selector.png');
 	});


### PR DESCRIPTION
### Summary
Updates the jupyter-notebooks release screenshot test to use the Positron notebook editor instead of the VS Code notebook editor.

- Swaps `notebooksVscode` for `notebooksPositron` throughout
- Updates annotation selector from `.kernel-action-view-item` to `button[aria-label="Kernel Actions"]` to target the Positron kernel action button

### QA Notes
Current (Vscode)
<img width="2040" height="1400" alt="jupyter-notebooks-kernel-selector-current" src="https://github.com/user-attachments/assets/3c085c20-22d8-4176-bcc5-6a7235b43def" />


New (Positron Notebooks)
<img width="2040" height="1400" alt="jupyter-notebooks-kernel-selector-new" src="https://github.com/user-attachments/assets/4366f539-6564-4d72-925b-623c546020a7" />
