### PR TITLE
E2E test: support useLegacyNotebookEditor with docker

### DIFF
--- a/test/e2e/fixtures/test-setup/app-jupyter.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-jupyter.fixtures.ts
@@ -8,7 +8,7 @@ import { join } from 'path';
 import * as playwright from '@playwright/test';
 import { Application, createApp } from '../../infra';
 import { AppFixtureOptions } from './app.fixtures';
-import { runDockerCommand, copyUserSettingsToContainer, copyKeyBindingsToContainer, RunResult } from './docker-utils';
+import { runDockerCommand, copyUserSettingsToContainer, copyKeyBindingsToContainer, dockerSettingsOverrides, RunResult } from './docker-utils';
 
 export { RunResult };
 
@@ -20,7 +20,7 @@ export { RunResult };
 export async function JupyterApp(
 	fixtureOptions: AppFixtureOptions
 ): Promise<{ app: Application; start: () => Promise<void>; stop: () => Promise<void> }> {
-	const { options } = fixtureOptions;
+	const { options, useLegacyNotebookEditor } = fixtureOptions;
 	const JUPYTER_WORKSPACE_PATH = '/home/jupyter-admin/qa-example-content/';
 
 	const app = createApp({ ...options, workspacePath: JUPYTER_WORKSPACE_PATH });
@@ -32,7 +32,7 @@ export async function JupyterApp(
 		await app.positJupyter.auth.signIn();
 
 		// Now that the user exists, setup the environment
-		await setupJupyterEnvironment();
+		await setupJupyterEnvironment(useLegacyNotebookEditor);
 
 		// Open Positron from JupyterLab
 		await app.positJupyter.lab.openPositron();
@@ -116,7 +116,7 @@ export async function JupyterApp(
  * Setup the complete Jupyter environment: Docker container, configuration, and permissions
  * NOTE: This must be called AFTER login, as login creates the jupyter-admin user
  */
-async function setupJupyterEnvironment(): Promise<void> {
+async function setupJupyterEnvironment(useLegacyNotebookEditor?: boolean): Promise<void> {
 	const TEST_DATA_PATH = join(os.tmpdir(), 'vscsmoke');
 	const DEFAULT_WORKSPACE_PATH = join(TEST_DATA_PATH, 'qa-example-content');
 	const JUPYTER_WORKSPACE_PATH = '/home/jupyter-admin/qa-example-content/';
@@ -151,7 +151,8 @@ async function setupJupyterEnvironment(): Promise<void> {
 	await copyUserSettingsToContainer(
 		'jupyter-test',
 		'/home/jupyter-admin/.positron-server/data/User/',
-		['settings.json', 'settingsDocker.json', 'settingsWorkbench.json']
+		['settings.json', 'settingsDocker.json', 'settingsWorkbench.json'],
+		dockerSettingsOverrides({ useLegacyNotebookEditor })
 	);
 	await copyKeyBindingsToContainer('jupyter-test', '/home/jupyter-admin/.positron-server/data/User/');
 

--- a/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
@@ -7,7 +7,7 @@ import * as os from 'os';
 import { join } from 'path';
 import { Application, createApp } from '../../infra';
 import { AppFixtureOptions } from './app.fixtures';
-import { runDockerCommand, copyUserSettingsToContainer, copyKeyBindingsToContainer, RunResult } from './docker-utils';
+import { runDockerCommand, copyUserSettingsToContainer, copyKeyBindingsToContainer, dockerSettingsOverrides, RunResult } from './docker-utils';
 
 export { RunResult };
 
@@ -19,8 +19,8 @@ export { RunResult };
 export async function WorkbenchApp(
 	fixtureOptions: AppFixtureOptions
 ): Promise<{ app: Application; start: () => Promise<void>; stop: () => Promise<void> }> {
-	const { options, managedCredentials } = fixtureOptions;
-	const { workspacePath } = await setupWorkbenchEnvironment(managedCredentials);
+	const { options, managedCredentials, useLegacyNotebookEditor } = fixtureOptions;
+	const { workspacePath } = await setupWorkbenchEnvironment(managedCredentials, useLegacyNotebookEditor);
 
 	const app = createApp({ ...options, workspacePath });
 
@@ -83,7 +83,7 @@ export async function WorkbenchApp(
  * the CI install step. The actual credential setup happens in install-workbench.sh; the fixture
  * just records it here so tests/fixtures can make conditional decisions if needed.
  */
-async function setupWorkbenchEnvironment(managedCredentials?: 'snowflake' | 'databricks' | 'azure'): Promise<{ workspacePath: string; userDataDir: string }> {
+async function setupWorkbenchEnvironment(managedCredentials?: 'snowflake' | 'databricks' | 'azure', useLegacyNotebookEditor?: boolean): Promise<{ workspacePath: string; userDataDir: string }> {
 	if (managedCredentials) {
 		console.log(`Workbench fixture: expecting managed credential "${managedCredentials}" to be provisioned in the container`);
 	}
@@ -121,7 +121,8 @@ async function setupWorkbenchEnvironment(managedCredentials?: 'snowflake' | 'dat
 	await copyUserSettingsToContainer(
 		'test',
 		'/home/user1/.positron-server/User/',
-		['settings.json', 'settingsDocker.json', 'settingsWorkbench.json']
+		['settings.json', 'settingsDocker.json', 'settingsWorkbench.json'],
+		dockerSettingsOverrides({ useLegacyNotebookEditor })
 	);
 	await copyKeyBindingsToContainer('test', '/home/user1/.positron-server/User/');
 

--- a/test/e2e/fixtures/test-setup/app.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app.fixtures.ts
@@ -16,6 +16,13 @@ export interface AppFixtureOptions {
 	logger: MultiLogger;
 	workerInfo: playwright.WorkerInfo;
 	managedCredentials?: 'snowflake' | 'databricks' | 'azure';
+	/**
+	 * When true, suites opt into the legacy (VS Code) notebook editor. The local
+	 * (Electron/managed) apps apply this via the host `settingsFile` in `beforeApp`,
+	 * but the Docker-based apps (Jupyter, Workbench) read settings copied into the
+	 * container, so they must merge the override in themselves.
+	 */
+	useLegacyNotebookEditor?: boolean;
 }
 
 /**

--- a/test/e2e/fixtures/test-setup/docker-utils.ts
+++ b/test/e2e/fixtures/test-setup/docker-utils.ts
@@ -49,12 +49,32 @@ export async function runDockerCommand(command: string, description: string): Pr
 }
 
 /**
- * Copy merged settings (base + Docker overrides) to the container
+ * Build the settings overrides driven by test options for the Docker apps.
+ *
+ * Mirrors the host-side `beforeApp` fixture: when a suite opts into the legacy
+ * (VS Code) notebook editor, the Positron notebook editor is disabled. Returns
+ * `undefined` when there is nothing to override.
+ */
+export function dockerSettingsOverrides(opts: { useLegacyNotebookEditor?: boolean }): object | undefined {
+	const overrides: Record<string, unknown> = {};
+	if (opts.useLegacyNotebookEditor) {
+		overrides['positron.notebook.enabled'] = false;
+	}
+	return Object.keys(overrides).length > 0 ? overrides : undefined;
+}
+
+/**
+ * Copy merged settings (base + Docker overrides) to the container.
+ *
+ * `overrides` are merged last so they win over anything in the fixture files. The
+ * Docker apps read settings from the container rather than the host `settingsFile`,
+ * so test-driven settings (e.g. `useLegacyNotebookEditor`) must be threaded in here.
  */
 export async function copyUserSettingsToContainer(
 	containerName: string,
 	userPath: string,
-	settingsFiles: string[]
+	settingsFiles: string[],
+	overrides?: object
 ): Promise<void> {
 	const fixturesDir = path.join(ROOT_PATH, 'test/e2e/fixtures');
 
@@ -66,6 +86,11 @@ export async function copyUserSettingsToContainer(
 			const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
 			Object.assign(mergedSettings, settings);
 		}
+	}
+
+	// Test-driven overrides win over the fixture files
+	if (overrides) {
+		Object.assign(mergedSettings, overrides);
 	}
 
 	// Create temporary merged settings file

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -115,8 +115,8 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 		},
 		{ scope: 'worker' }],
 
-	app: [async ({ options, logsPath, logger, managedCredentials, beforeApp: _beforeApp }, use, workerInfo) => {
-		const { app, start, stop } = await AppFixture({ options, logsPath, logger, workerInfo, managedCredentials });
+	app: [async ({ options, logsPath, logger, managedCredentials, useLegacyNotebookEditor, beforeApp: _beforeApp }, use, workerInfo) => {
+		const { app, start, stop } = await AppFixture({ options, logsPath, logger, workerInfo, managedCredentials, useLegacyNotebookEditor });
 
 		try {
 			await start();


### PR DESCRIPTION
Make settings overrides also apply to docker

@:workbench