### PR TITLE
Skip Python venv auto-creation e2e tests on openSUSE

### DIFF
--- a/test/e2e/tests/interpreters/python-venv-creation.test.ts
+++ b/test/e2e/tests/interpreters/python-venv-creation.test.ts
@@ -30,6 +30,7 @@ test.use({
 test.describe('Python Venv Auto-Creation', {
 	tag: [tags.INTERPRETER, tags.WEB]
 }, () => {
+	test.skip(process.env.IS_OPENSUSE === 'true', 'Skip on openSuse');
 	test.slow();
 
 	test.beforeAll(async function ({ settings }) {
@@ -41,8 +42,6 @@ test.describe('Python Venv Auto-Creation', {
 	});
 
 	test('Clicking Yes creates venv', async function ({ app, openFolder }) {
-		test.skip(process.env.IS_OPENSUSE === 'true', 'Skip on openSuse');
-
 		const tempWorkspace = path.join(os.tmpdir(), 'vscsmoke', 'qa-example-content', 'venv-creation-test');
 		await fs.mkdir(tempWorkspace, { recursive: true });
 		await fs.writeFile(path.join(tempWorkspace, 'requirements.txt'), 'requests\n');
@@ -65,8 +64,6 @@ test.describe('Python Venv Auto-Creation', {
 	});
 
 	test('Notification appears for workspace with requirements.txt', async function ({ app, openFolder }) {
-		test.skip(process.env.IS_OPENSUSE === 'true', 'Skip on openSuse');
-
 		await openFolder('workspaces/python-venv-creation/with-requirements');
 		await app.workbench.sessions.expectNoStartUpMessaging();
 
@@ -77,8 +74,6 @@ test.describe('Python Venv Auto-Creation', {
 	});
 
 	test('No notification when .venv already exists', async function ({ app, openFolder }) {
-		test.skip(process.env.IS_OPENSUSE === 'true', 'Skip on openSuse');
-
 		await openFolder('with-existing-venv');
 
 		await app.workbench.toasts.expectToastWithTitleNotToAppear(/requirements\.txt/);

--- a/test/e2e/tests/interpreters/python-venv-creation.test.ts
+++ b/test/e2e/tests/interpreters/python-venv-creation.test.ts
@@ -65,6 +65,8 @@ test.describe('Python Venv Auto-Creation', {
 	});
 
 	test('Notification appears for workspace with requirements.txt', async function ({ app, openFolder }) {
+		test.skip(process.env.IS_OPENSUSE === 'true', 'Skip on openSuse');
+
 		await openFolder('workspaces/python-venv-creation/with-requirements');
 		await app.workbench.sessions.expectNoStartUpMessaging();
 
@@ -75,6 +77,8 @@ test.describe('Python Venv Auto-Creation', {
 	});
 
 	test('No notification when .venv already exists', async function ({ app, openFolder }) {
+		test.skip(process.env.IS_OPENSUSE === 'true', 'Skip on openSuse');
+
 		await openFolder('with-existing-venv');
 
 		await app.workbench.toasts.expectToastWithTitleNotToAppear(/requirements\.txt/);


### PR DESCRIPTION
## Summary

The `Python Venv Auto-Creation` e2e suite relies on a global Python interpreter and the venv-creation flow, which is not reliable on openSUSE CI. This guards the suite so it is skipped there.

- Add the `IS_OPENSUSE` skip to all three test cases (previously only the first case had it).
- Collapse the three per-test skips into a single describe-level `test.skip`, which also short-circuits the `beforeAll` settings + web reload on openSUSE.

@:interpreter @:web