### PR TITLE
unit test: undo/redo works when notebook is empty

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookUndoRedo.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookUndoRedo.vitest.ts
@@ -394,7 +394,7 @@ describe('PositronNotebookInstance undo/redo', () => {
 			expect(setOpSpy).toHaveBeenCalledWith(NotebookOperationType.Redo);
 		});
 
-		it('handleNotebookUndo claims undo and restores the cell when the notebook is empty and no focus key is set (#10397)', async () => {
+		it('handleNotebookUndo restores previously deleted cells when the notebook is empty and no focus key is set (#10397)', async () => {
 			// Regression for #10397: after deleting the last cell the notebook is
 			// empty, so neither editorFocused nor cellEditorFocused can be set --
 			// yet Cmd+Z must still unwind the delete. shouldHandleUndoRedo's

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookUndoRedo.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookUndoRedo.vitest.ts
@@ -426,7 +426,7 @@ describe('PositronNotebookInstance undo/redo', () => {
 			expect(setOpSpy).toHaveBeenCalledWith(NotebookOperationType.Undo);
 		});
 
-		it('handleNotebookRedo claims redo and re-adds the cell when the notebook is empty and no focus key is set', async () => {
+		it('handleNotebookRedo re-adds the cells when the notebook is empty and no focus key is set', async () => {
 			// Symmetric to the undo case: add a cell into an empty notebook, undo
 			// to return to empty (staging a redo entry), then redo while still
 			// empty and unfocused. Exercises the emptyNotebook branch for redo.

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookUndoRedo.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookUndoRedo.vitest.ts
@@ -425,5 +425,33 @@ describe('PositronNotebookInstance undo/redo', () => {
 			expect(restored[0].getContent()).toBe('# Cell 0');
 			expect(setOpSpy).toHaveBeenCalledWith(NotebookOperationType.Undo);
 		});
+
+		it('handleNotebookRedo claims redo and re-adds the cell when the notebook is empty and no focus key is set', async () => {
+			// Symmetric to the undo case: add a cell into an empty notebook, undo
+			// to return to empty (staging a redo entry), then redo while still
+			// empty and unfocused. Exercises the emptyNotebook branch for redo.
+			const notebook = createTestPositronNotebookInstance([], ctx);
+			notebook.addCell(CellKind.Code, 0, false, '# Cell 0');
+			expect(notebook.cells.get().length).toBe(1);
+			await ctx.get(IUndoRedoService).undo(notebook.uri);
+			expect(notebook.cells.get().length).toBe(0);
+
+			const editorService = stubInterface<IEditorService>({
+				activeEditorPane: makeNotebookEditorPane(notebook),
+			});
+			NotebookContextKeys.editorFocused.bindTo(notebook.scopedContextKeyService).set(false);
+			NotebookContextKeys.cellEditorFocused.bindTo(notebook.scopedContextKeyService).set(false);
+
+			const setOpSpy = vi.spyOn(notebook, 'setCurrentOperation');
+
+			const result = await handleNotebookRedo(editorService, ctx.get(IUndoRedoService));
+
+			expect(result).toBeUndefined();
+
+			const cells = notebook.cells.get();
+			expect(cells.length).toBe(1);
+			expect(cells[0].getContent()).toBe('# Cell 0');
+			expect(setOpSpy).toHaveBeenCalledWith(NotebookOperationType.Redo);
+		});
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookUndoRedo.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookUndoRedo.vitest.ts
@@ -393,5 +393,37 @@ describe('PositronNotebookInstance undo/redo', () => {
 
 			expect(setOpSpy).toHaveBeenCalledWith(NotebookOperationType.Redo);
 		});
+
+		it('handleNotebookUndo claims undo and restores the cell when the notebook is empty and no focus key is set (#10397)', async () => {
+			// Regression for #10397: after deleting the last cell the notebook is
+			// empty, so neither editorFocused nor cellEditorFocused can be set --
+			// yet Cmd+Z must still unwind the delete. shouldHandleUndoRedo's
+			// emptyNotebook branch is the only thing that lets the handler claim
+			// the command here; without it undo silently does nothing.
+			const notebook = createTestPositronNotebookInstance([
+				['# Cell 0', 'python', CellKind.Code],
+			], ctx);
+			notebook.deleteCells(notebook.cells.get());
+			expect(notebook.cells.get().length).toBe(0);
+
+			const editorService = stubInterface<IEditorService>({
+				activeEditorPane: makeNotebookEditorPane(notebook),
+			});
+			// Both focus keys explicitly false: an empty notebook holds no focus,
+			// so only the emptyNotebook branch can carry this.
+			NotebookContextKeys.editorFocused.bindTo(notebook.scopedContextKeyService).set(false);
+			NotebookContextKeys.cellEditorFocused.bindTo(notebook.scopedContextKeyService).set(false);
+
+			const setOpSpy = vi.spyOn(notebook, 'setCurrentOperation');
+
+			const result = await handleNotebookUndo(editorService, ctx.get(IUndoRedoService));
+
+			expect(result).toBeUndefined();
+
+			const restored = notebook.cells.get();
+			expect(restored.length).toBe(1);
+			expect(restored[0].getContent()).toBe('# Cell 0');
+			expect(setOpSpy).toHaveBeenCalledWith(NotebookOperationType.Undo);
+		});
 	});
 });


### PR DESCRIPTION
Closes #12289.

## What

Adds two Vitest wiring tests for the empty-notebook undo/redo path, guarding the regression from #10397 ("Undo button and cmd + z does not work when there are no cells"), which was fixed in #10678.

- `handleNotebookUndo` claims undo and restores the deleted cell when the notebook is empty and **no focus key is set**
- `handleNotebookRedo` does the same for redo (add into empty notebook -> undo -> redo while still empty)

## Why a unit test instead of e2e

#12289 proposed an e2e Playwright test (PR #12292, since closed). The root cause of #10397 lives in a single boolean branch in `shouldHandleUndoRedo` (`positronNotebookUndoRedo.ts`): when the last cell is deleted the notebook is empty, so neither `editorFocused` nor `cellEditorFocused` can be set, and without the `emptyNotebook` term the handler never claims the global `UndoCommand` -- undo silently does nothing.

The handlers were deliberately exported "so tests can drive the same code path the global UndoCommand dispatcher would hit without standing up a keybinding harness." Existing coverage had a gap:

- the `handleNotebookUndo wiring` tests only exercised the focus gate with **non-empty** notebooks, and
- the model-level tests call `IUndoRedoService.undo()` **directly, bypassing the gate**.

So the `emptyNotebook` branch -- the actual fix -- had no coverage. These tests close that gap at the lowest level that reproduces the bug (milliseconds, no Playwright).

## Verified the tests fail without the fix

Temporarily reverting the fix (changing the gate back to `return containerFocused || cellEditorFocused;`) makes **both new tests fail** while the other 15 in the file stay green -- confirming they pin the `emptyNotebook` branch specifically and don't over-assert:

```
Tests  2 failed | 15 passed (17)
AssertionError: expected false to be undefined   // handler yielded instead of claiming undo/redo
```

With the fix in place, all 17 pass. ESLint clean.

## Note

The pre-existing `IEditorPane` vs `IVisibleEditorPane` type-check warnings in this file (from the merged #10678 tests) are unchanged; the new tests follow the same established `makeNotebookEditorPane` helper pattern.

## QA Notes

@:positron-notebooks @:win @:web
