### PR TITLE
Skip notebook click-to-cursor test blocked by #14085

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-click-cursor-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-click-cursor-position.test.ts
@@ -30,7 +30,11 @@ test.describe('Notebook Click-to-Cursor Position', {
 		await hotKeys.closeSecondarySidebar();
 	});
 
-	test('Clicking a line after Esc places the cursor on that line', async function ({ app }) {
+	// Skipped: this test reliably reproduces the click-to-cursor misplacement
+	// bug, so it fails until the underlying issue is fixed. Unskip once resolved.
+	test.skip('Clicking a line after Esc places the cursor on that line', {
+		annotation: { type: 'issue', description: 'https://github.com/posit-dev/positron/issues/14085' }
+	}, async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.currentPage.keyboard;
 


### PR DESCRIPTION
## Summary

Skips the `notebook-click-cursor-position` e2e test, which currently fails on every run because it reliably reproduces the click-to-cursor misplacement bug reported in #14085.

The test exercises the user-reported scenario: after pressing `Esc` to exit edit mode and clicking a specific line, the cursor can land on a *different* line when Monaco's internal layout is out of sync (a hit-test miscalculation). Its failure confirms the issue is real even with a small cell (8 lines).

## Changes

- Convert the test to `test.skip(...)` with an `annotation: { type: 'issue', description: 'https://github.com/posit-dev/positron/issues/14085' }`, matching the existing skip-with-issue convention in the e2e suite (e.g. `variables-memory-usage.test.ts`).
- Add a comment noting it should be unskipped once the underlying bug is fixed.

## Why skip rather than delete

The test is valuable regression coverage. Keeping it skipped-with-annotation preserves the repro and links it to the tracking issue, so it can be re-enabled as the verification that #14085 is fixed.

Related: #14085