### PR TITLE
e2e: add R and Python code-execution tests to the remote WSL suite

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -201,6 +201,7 @@ The `e2e-remote-wsl` project (tag `@:remote-wsl`, tests under `test/e2e/tests/re
 
 - Windows with WSL installed and at least one glibc-based distro registered (e.g. `Ubuntu`). The REH (remote extension host) is a glibc `linux-x64` binary, so musl distros (Alpine) won't work. Pick the distro with `POSITRON_WSL_DISTRO` (defaults to `Ubuntu`).
 - A Positron REH tarball reachable from inside the distro. A dev build's `product.json` has no `commit`/`version`, so the extension's default download URL (a CDN template with `${version}`/`${commit}`) can't be resolved. Provide a local tarball instead and point the extension at it with `POSITRON_WSL_SERVER_DOWNLOAD_URL`.
+- For the Python and R tests, the distro must have Python and R interpreters installed and discoverable by Positron. The session picker matches the version in `POSITRON_PY_VER_SEL` / `POSITRON_R_VER_SEL` (bare version strings, e.g. `3.12.11`, `4.4.3`); since the in-distro interpreters differ from the local Windows ones, override them with `POSITRON_PY_WSL_VER_SEL` / `POSITRON_R_WSL_VER_SEL`. When unset, the local selectors are used as-is.
 
 ### Build a local REH
 
@@ -219,10 +220,12 @@ tar czf positron-reh-linux-x64.tar.gz -C .. vscode-reh-linux-x64
 # Dev build (no BUILD). The file:// URL is read from inside the distro via /mnt/c.
 POSITRON_WSL_DISTRO=Ubuntu \
 POSITRON_WSL_SERVER_DOWNLOAD_URL=file:///mnt/c/path/to/positron-reh-linux-x64.tar.gz \
+POSITRON_PY_WSL_VER_SEL=3.12.11 \
+POSITRON_R_WSL_VER_SEL=4.4.3 \
 npx playwright test --project e2e-remote-wsl --workers=1
 ```
 
-The test connects to the distro, waits for the `WSL: <distro>` remote indicator, and runs `uname` in a terminal to confirm the workbench is executing inside Linux.
+The suite connects to the distro and waits for the `WSL: <distro>` remote indicator, then: runs `uname` in a terminal to confirm the workbench is executing inside Linux; starts a Python session and evaluates code, checking the result in the console and Variables pane; and does the same for R.
 
 > [!NOTE]
 > CI for this project (a Windows runner that provisions WSL + the REH) is not yet wired up; it is planned as a follow-up.

--- a/test/e2e/tests/remote-wsl/remote-wsl.test.ts
+++ b/test/e2e/tests/remote-wsl/remote-wsl.test.ts
@@ -3,9 +3,10 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
 import { test, tags } from '../_test.setup';
-import { createWorkbenchFromPage, waitForAnyNewWindow } from '../../infra/workbench';
+import { Application } from '../../infra';
+import { createWorkbenchFromPage, waitForAnyNewWindow, Workbench } from '../../infra/workbench';
 
 test.use({
 	suiteId: __filename
@@ -22,6 +23,58 @@ const WSL_DISTRO = process.env.POSITRON_WSL_DISTRO || 'Ubuntu';
 // cannot be resolved and the server install would fail. Pointing at a local tarball with no
 // placeholders sidesteps that. See the "Remote WSL Tests" section of test/e2e/README.md.
 const WSL_SERVER_DOWNLOAD_URL = process.env.POSITRON_WSL_SERVER_DOWNLOAD_URL;
+
+/**
+ * Point the session picker at the interpreters installed inside the distro.
+ *
+ * `sessions.start()` reads POSITRON_PY_VER_SEL / POSITRON_R_VER_SEL to choose an interpreter. The
+ * interpreters inside the distro differ from the local Windows ones, so allow overriding the
+ * selectors with WSL-specific values (mirrors how remote-ssh overrides them with its *_REMOTE_*
+ * vars). When the WSL-specific vars are unset, the local selectors are left in place so the picker
+ * still has something to match.
+ */
+function useWslInterpreterSelectors(): void {
+	if (process.env.POSITRON_PY_WSL_VER_SEL) {
+		process.env.POSITRON_PY_VER_SEL = process.env.POSITRON_PY_WSL_VER_SEL;
+	}
+	if (process.env.POSITRON_R_WSL_VER_SEL) {
+		process.env.POSITRON_R_VER_SEL = process.env.POSITRON_R_WSL_VER_SEL;
+	}
+}
+
+/**
+ * Connect Positron to {@link WSL_DISTRO} and return a workbench bound to the new remote window.
+ *
+ * Connecting opens the workbench in a fresh window (mirroring the remote-ssh flow) and, on the
+ * first connect, installs/starts the remote server inside the distro -- a slow, one-time REH
+ * download. Callers should mark their test `test.slow()` to absorb that.
+ */
+async function connectToWslDistro(app: Application): Promise<{ wslWin: Page; wslWorkbench: Workbench }> {
+	return test.step(`Connect to WSL distro "${WSL_DISTRO}"`, async () => {
+		// Connecting opens the workbench in a new window, so arm the listener before triggering.
+		const wslWinPromise = waitForAnyNewWindow(app.code.electronApp!, async () => {
+			// The remote-indicator entries ("Connect to WSL", "Connect to WSL using Distro...")
+			// reuse the current window. Invoke the "in New Window" variant from the Command
+			// Palette instead so we get a fresh window to drive, mirroring the remote-ssh flow.
+			await app.workbench.quickaccess.runCommand('openremotewsl.connectUsingDistroInNewWindow');
+
+			// Pick the target distro from the distro quick pick the command opens.
+			await app.workbench.quickInput.waitForQuickInputOpened();
+			await app.workbench.quickInput.selectQuickInputElementContaining(WSL_DISTRO);
+		}, { timeout: 60_000 });
+
+		const wslWin = await wslWinPromise;
+
+		// The resolver shows a "Setting up WSL Distro: <distro>" notification while it installs and
+		// starts the server. Once connected, the remote indicator reads "WSL: <distro>". Allow a
+		// generous timeout to cover the one-time server install.
+		const remoteIndicator = wslWin.locator('.statusbar-item[id="status.host"]');
+		await expect(remoteIndicator).toContainText(`WSL: ${WSL_DISTRO}`, { timeout: 180_000 });
+
+		const wslWorkbench = createWorkbenchFromPage(app.code, wslWin);
+		return { wslWin, wslWorkbench };
+	});
+}
 
 test.describe('Remote WSL', {
 	tag: [tags.REMOTE_WSL]
@@ -41,31 +94,7 @@ test.describe('Remote WSL', {
 		// slow (a cold REH download). Triple the default test timeout to absorb that.
 		test.slow();
 
-		const wslWin = await test.step(`Connect to WSL distro "${WSL_DISTRO}"`, async () => {
-			// Connecting opens the workbench in a new window, so arm the listener before triggering.
-			const wslWinPromise = waitForAnyNewWindow(app.code.electronApp!, async () => {
-				// The remote-indicator entries ("Connect to WSL", "Connect to WSL using Distro...")
-				// reuse the current window. Invoke the "in New Window" variant from the Command
-				// Palette instead so we get a fresh window to drive, mirroring the remote-ssh flow.
-				await app.workbench.quickaccess.runCommand('openremotewsl.connectUsingDistroInNewWindow');
-
-				// Pick the target distro from the distro quick pick the command opens.
-				await app.workbench.quickInput.waitForQuickInputOpened();
-				await app.workbench.quickInput.selectQuickInputElementContaining(WSL_DISTRO);
-			}, { timeout: 60_000 });
-
-			const wslWin = await wslWinPromise;
-
-			// The resolver shows a "Setting up WSL Distro: <distro>" notification while it installs and
-			// starts the server. Once connected, the remote indicator reads "WSL: <distro>". Allow a
-			// generous timeout to cover the one-time server install.
-			const remoteIndicator = wslWin.locator('.statusbar-item[id="status.host"]');
-			await expect(remoteIndicator).toContainText(`WSL: ${WSL_DISTRO}`, { timeout: 180_000 });
-
-			return wslWin;
-		});
-
-		const wslWorkbench = createWorkbenchFromPage(app.code, wslWin);
+		const { wslWorkbench } = await connectToWslDistro(app);
 
 		await test.step('Verify the remote runs in Linux', async () => {
 			// A trivial liveness check that proves the workbench is executing inside the distro:
@@ -73,6 +102,42 @@ test.describe('Remote WSL', {
 			await wslWorkbench.terminal.createTerminal();
 			await wslWorkbench.terminal.runCommandInTerminal('uname');
 			await wslWorkbench.terminal.waitForTerminalText('Linux');
+		});
+	});
+
+	test('Verify Python code runs in a WSL distro', async function ({ app }) {
+		// Reconnecting may still pay for a cold REH download if this test runs first.
+		test.slow();
+
+		useWslInterpreterSelectors();
+		const { wslWorkbench } = await connectToWslDistro(app);
+
+		await test.step('Start a Python session and evaluate code', async () => {
+			await wslWorkbench.sessions.start('python');
+
+			// Round-trip a trivial expression through the console, then confirm the result both in
+			// the console output and as a variable surfaced in the Variables pane.
+			await wslWorkbench.console.pasteCodeToConsole('x = 41 + 1; print(x)', true);
+			await wslWorkbench.console.waitForConsoleContents('42');
+			await wslWorkbench.variables.expectVariableToBe('x', '42');
+		});
+	});
+
+	test('Verify R code runs in a WSL distro', async function ({ app }) {
+		// Reconnecting may still pay for a cold REH download if this test runs first.
+		test.slow();
+
+		useWslInterpreterSelectors();
+		const { wslWorkbench } = await connectToWslDistro(app);
+
+		await test.step('Start an R session and evaluate code', async () => {
+			await wslWorkbench.sessions.start('r');
+
+			// Round-trip a trivial expression through the console, then confirm the result both in
+			// the console output and as a variable surfaced in the Variables pane.
+			await wslWorkbench.console.pasteCodeToConsole('x <- 41 + 1; print(x)', true);
+			await wslWorkbench.console.waitForConsoleContents('42');
+			await wslWorkbench.variables.expectVariableToBe('x', '42');
 		});
 	});
 });


### PR DESCRIPTION
### Summary

Extends the remote WSL e2e suite beyond the connect-only check. The suite now starts a Python and an R session inside the distro, evaluates a trivial expression, and verifies the result both in the console and in the Variables pane -- proving the language runtimes actually execute inside the distro, not against a local Windows interpreter.

Currently the only workflow to run these tests is in `positron-builds` repo for release builds. I've run tests locally, I'll have the PR up for the real workflow after this gets merged.

Changes:
- Extract a shared `connectToWslDistro()` helper so each test reuses the same connect-and-wait flow (open a new window via `openremotewsl.connectUsingDistroInNewWindow`, pick the distro, wait for the `WSL: <distro>` remote indicator).
- Add `useWslInterpreterSelectors()`, which points the session picker at the in-distro interpreters via `POSITRON_PY_WSL_VER_SEL` / `POSITRON_R_WSL_VER_SEL`, mirroring how the remote-ssh suite overrides selectors with its `*_REMOTE_*` vars. When unset, the local selectors are used as-is.
- Document the new interpreter prerequisite and selector env vars in `test/e2e/README.md`.

These tests run only on Windows (`@:remote-wsl`) and are excluded from the normal suites; CI for this project is still a planned follow-up.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps



These tests require a Windows host with WSL, a glibc distro, a reachable Positron REH tarball, and Python + R interpreters installed inside the distro. See the "Remote WSL Tests" section of `test/e2e/README.md` for full setup.

```bash
POSITRON_WSL_DISTRO=Ubuntu-24.04 \
POSITRON_PY_WSL_VER_SEL=3.12.11 \
POSITRON_R_WSL_VER_SEL=4.3.3 \
npx playwright test --project e2e-remote-wsl --workers=1
```

All three tests (connect, Python, R) pass locally against a release build.