### PR TITLE
e2e test - Use `clickAwayFromCell` instead of `Esc` to prevent toast interference in cursor in-cell nb

### DIFF
--- a/test/e2e/tests/notebooks-positron/notebook-click-cursor-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-click-cursor-position.test.ts
@@ -30,11 +30,7 @@ test.describe('Notebook Click-to-Cursor Position', {
 		await hotKeys.closeSecondarySidebar();
 	});
 
-	// Skipped: this test reliably reproduces the click-to-cursor misplacement
-	// bug, so it fails until the underlying issue is fixed. Unskip once resolved.
-	test.skip('Clicking a line after Esc places the cursor on that line', {
-		annotation: { type: 'issue', description: 'https://github.com/posit-dev/positron/issues/14085' }
-	}, async function ({ app }) {
+	test('Clicking a line after Esc places the cursor on that line', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.currentPage.keyboard;
 

--- a/test/e2e/tests/notebooks-positron/notebook-click-cursor-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-click-cursor-position.test.ts
@@ -30,7 +30,11 @@ test.describe('Notebook Click-to-Cursor Position', {
 		await hotKeys.closeSecondarySidebar();
 	});
 
-	test('Clicking a line after Esc places the cursor on that line', async function ({ app }) {
+	// Skipped: this test reliably reproduces the click-to-cursor misplacement
+	// bug, so it fails until the underlying issue is fixed. Unskip once resolved.
+	test.skip('Clicking a line after Esc places the cursor on that line', {
+		annotation: { type: 'issue', description: 'https://github.com/posit-dev/positron/issues/14085' }
+	}, async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.currentPage.keyboard;
 

--- a/test/e2e/tests/notebooks-positron/notebook-click-cursor-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-click-cursor-position.test.ts
@@ -12,9 +12,10 @@ test.use({
 
 // Regression coverage for cursor placement on click in Positron Notebooks.
 //
-// After exiting edit mode (Esc), clicking a specific line can drop the cursor
-// on a *different* line when the embedded Monaco editor's internal layout is
-// out of sync with what is rendered (a hit-test miscalculation).
+// After exiting edit mode (by clicking away from the cell), clicking a specific
+// line can drop the cursor on a *different* line when the embedded Monaco
+// editor's internal layout is out of sync with what is rendered (a hit-test
+// miscalculation).
 //
 // We can't read Monaco's cursor position directly from Playwright, so we assert
 // the user-visible consequence: click a known line, type a unique marker, and
@@ -30,7 +31,7 @@ test.describe('Notebook Click-to-Cursor Position', {
 		await hotKeys.closeSecondarySidebar();
 	});
 
-	test('Clicking a line after Esc places the cursor on that line', async function ({ app }) {
+	test('Clicking a line after exiting edit mode places the cursor on that line', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const keyboard = app.code.driver.currentPage.keyboard;
 
@@ -53,8 +54,10 @@ test.describe('Notebook Click-to-Cursor Position', {
 		await notebooksPositron.newNotebook({ codeCells: 1 });
 		await notebooksPositron.addCodeToCell(0, lines.join('\n'), { fast: true });
 
-		// Repro step: press Esc to defocus the cell (exit edit mode).
-		await keyboard.press('Escape');
+		// Repro step: click away from the cell to defocus it (exit edit mode).
+		// Using a click rather than Esc avoids CI flake where Esc dismisses a
+		// transient toast instead of exiting the cell.
+		await notebooksPositron.clickAwayFromCell(0);
 		await notebooksPositron.expectCellIndexToBeSelected(0, { inEditMode: false });
 
 		// Repro step: click directly on the target line (the function call).


### PR DESCRIPTION
## Summary

The `notebook-click-cursor-position` e2e test was failing in CI for a reason unrelated to #14085. A transient toast could consume the `Esc` keypress used to exit edit mode, causing the test to fail before reaching the cursor-position assertion.

## Changes

- Replace `keyboard.press('Escape')` with `clickAwayFromCell(0)` to reliably exit edit mode without depending on keyboard focus.
- Update the test name and comments to reflect the new behavior.

Supersedes #14136 (closed to rename the branch to avoid misleading name).

@:web @:win @:positron-notebooks