### PR TITLE
Add external-link button to the Packages pane

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_ui.py
@@ -186,6 +186,77 @@ def test_get_packages_installed_attached(
     assert numpy_entry["attached"] is expected_attached
 
 
+class _StubMetadata:
+    """Minimal `Distribution.metadata` stand-in (only the accessors we use)."""
+
+    def __init__(self, headers: Dict[str, Any]) -> None:
+        self._headers = headers
+
+    def get(self, key: str, default: Any = None) -> Any:
+        value = self._headers.get(key, default)
+        if isinstance(value, list):
+            return value[0] if value else default
+        return value
+
+    def get_all(self, key: str) -> Any:
+        value = self._headers.get(key)
+        if value is None:
+            return None
+        return value if isinstance(value, list) else [value]
+
+
+class _StubDist:
+    def __init__(self, **headers: Any) -> None:
+        self.metadata = _StubMetadata(headers)
+
+
+@pytest.mark.parametrize(
+    ("headers", "expected_url"),
+    [
+        # A Project-URL homepage is the top choice.
+        ({"Project-URL": ["Homepage, https://home"]}, "https://home"),
+        # The legacy singular Home-page header counts as a homepage.
+        ({"Home-page": "https://legacy"}, "https://legacy"),
+        # Repository wins as a fallback when there's no homepage.
+        ({"Project-URL": ["Repository, https://repo"]}, "https://repo"),
+        # Homepage outranks repository regardless of order.
+        (
+            {"Project-URL": ["Repository, https://repo", "Homepage, https://home"]},
+            "https://home",
+        ),
+        # Free-form labels normalize ("Source Code" -> repository).
+        ({"Project-URL": ["Source Code, https://src"]}, "https://src"),
+        # A Project-URL homepage outranks the legacy Home-page header.
+        (
+            {"Project-URL": ["Homepage, https://home"], "Home-page": "https://legacy"},
+            "https://home",
+        ),
+        # An unrecognized label still beats having no URL at all.
+        ({"Project-URL": ["Funding, https://fund"]}, "https://fund"),
+        # No URL metadata of any kind.
+        ({}, None),
+    ],
+    ids=[
+        "project-url-homepage",
+        "legacy-home-page",
+        "repository-only",
+        "homepage-beats-repository",
+        "normalized-label",
+        "project-url-beats-legacy",
+        "unrecognized-fallback",
+        "none",
+    ],
+)
+def test_best_package_url(headers: Dict[str, Any], expected_url: Any) -> None:
+    """Rank homepage > repository > docs > other.
+
+    The legacy `Home-page` header acts as a homepage fallback.
+    """
+    from positron.ui import _best_package_url
+
+    assert _best_package_url(_StubDist(**headers)) == expected_url  # type: ignore[arg-type]
+
+
 def test_is_module_loaded(ui_comm: DummyComm) -> None:
     """Test the `isModuleLoaded` RPC method called from Positron."""
     module = "fallingStars"

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -135,6 +135,66 @@ def _import_names_for_dist(dist: importlib.metadata.Distribution, canonical: str
     return [canonical.replace("-", "_")]
 
 
+# `Project-URL` labels are free-form author text with no official vocabulary
+# (you see "Homepage", "Home", "Repository", "Source", "GitHub", ... with varied
+# casing), so we normalize each label and match it against this synonym table to
+# rank candidates when choosing the single best URL to surface.
+_URL_CATEGORY_BY_LABEL: Dict[str, str] = {
+    "home": "homepage",
+    "homepage": "homepage",
+    "repository": "repository",
+    "repo": "repository",
+    "source": "repository",
+    "sourcecode": "repository",
+    "code": "repository",
+    "github": "repository",
+    "gitlab": "repository",
+    "doc": "documentation",
+    "docs": "documentation",
+    "documentation": "documentation",
+}
+
+# Lower number = higher priority. Any URL that doesn't match a known category
+# still beats no URL at all, hence the fallback rank below.
+_URL_CATEGORY_PRIORITY: Dict[str, int] = {"homepage": 0, "repository": 1, "documentation": 2}
+_URL_FALLBACK_PRIORITY = 3
+
+
+def _normalize_url_label(label: str) -> str:
+    """Lowercase a Project-URL label and strip everything but alphanumerics."""
+    return "".join(char for char in label.lower() if char.isalnum())
+
+
+def _best_package_url(dist: importlib.metadata.Distribution) -> Optional[str]:
+    """Pick the single best external URL from a distribution's metadata.
+
+    Prefers the homepage, then the repository/source, then documentation, then
+    any other `Project-URL`. The legacy singular `Home-page` header counts as a
+    homepage candidate. Returns None when the distribution advertises no URL.
+    Core (the Packages pane) validates the scheme before opening it.
+    """
+    best_url: Optional[str] = None
+    best_priority = _URL_FALLBACK_PRIORITY + 1
+    for entry in dist.metadata.get_all("Project-URL") or []:
+        label, _, url = entry.partition(",")
+        url = url.strip()
+        if not url:
+            continue
+        category = _URL_CATEGORY_BY_LABEL.get(_normalize_url_label(label))
+        priority = _URL_CATEGORY_PRIORITY.get(category, _URL_FALLBACK_PRIORITY)
+        # Strict `<` keeps the first URL seen at a given priority (so the first
+        # repository wins over a later one, etc.).
+        if priority < best_priority:
+            best_url, best_priority = url, priority
+    # Only let the legacy `Home-page` win if no homepage-priority URL was already
+    # found in `Project-URL`; a homepage outranks a repository/other we may hold.
+    if best_priority > _URL_CATEGORY_PRIORITY["homepage"]:
+        home_page = dist.metadata.get("Home-page")
+        if home_page and home_page.strip():
+            best_url = home_page.strip()
+    return best_url
+
+
 # Get all installed packages
 def _get_packages_installed(kernel: "PositronIPyKernel", _params: List[JsonData]) -> JsonData:
     # `attached` mirrors R's search()-membership semantics: true when the
@@ -164,7 +224,7 @@ def _get_packages_installed(kernel: "PositronIPyKernel", _params: List[JsonData]
             # runtime object (email.message.Message) always has it.
             metadata: Any = dist.metadata
             summary = metadata.get("Summary")
-            packages_dict[canonical] = {
+            entry: Dict[str, JsonData] = {
                 "id": f"{canonical}-{dist.version}",
                 "name": name,
                 "displayName": canonical,
@@ -172,6 +232,10 @@ def _get_packages_installed(kernel: "PositronIPyKernel", _params: List[JsonData]
                 "attached": attached,
                 "description": summary if summary and summary != "UNKNOWN" else "",
             }
+            url = _best_package_url(dist)
+            if url:
+                entry["url"] = url
+            packages_dict[canonical] = entry
     return sorted(packages_dict.values(), key=lambda p: p["displayName"])
 
 

--- a/extensions/positron-python/python_files/posit/positron/ui.py
+++ b/extensions/positron-python/python_files/posit/positron/ui.py
@@ -173,15 +173,21 @@ def _best_package_url(dist: importlib.metadata.Distribution) -> Optional[str]:
     homepage candidate. Returns None when the distribution advertises no URL.
     Core (the Packages pane) validates the scheme before opening it.
     """
+    # PackageMetadata (the 3.14 protocol) doesn't expose .get(), but the runtime
+    # object (email.message.Message) always has it -- mirror the cast used by
+    # _get_packages_installed so both accessors type-check across Python versions.
+    metadata: Any = dist.metadata
     best_url: Optional[str] = None
     best_priority = _URL_FALLBACK_PRIORITY + 1
-    for entry in dist.metadata.get_all("Project-URL") or []:
+    for entry in metadata.get_all("Project-URL") or []:
         label, _, url = entry.partition(",")
         url = url.strip()
         if not url:
             continue
         category = _URL_CATEGORY_BY_LABEL.get(_normalize_url_label(label))
-        priority = _URL_CATEGORY_PRIORITY.get(category, _URL_FALLBACK_PRIORITY)
+        # Every value in `_URL_CATEGORY_BY_LABEL` is a key in `_URL_CATEGORY_PRIORITY`,
+        # so a recognized category always resolves; anything else is the fallback.
+        priority = _URL_CATEGORY_PRIORITY[category] if category else _URL_FALLBACK_PRIORITY
         # Strict `<` keeps the first URL seen at a given priority (so the first
         # repository wins over a later one, etc.).
         if priority < best_priority:
@@ -189,7 +195,7 @@ def _best_package_url(dist: importlib.metadata.Distribution) -> Optional[str]:
     # Only let the legacy `Home-page` win if no homepage-priority URL was already
     # found in `Project-URL`; a homepage outranks a repository/other we may hold.
     if best_priority > _URL_CATEGORY_PRIORITY["homepage"]:
-        home_page = dist.metadata.get("Home-page")
+        home_page = metadata.get("Home-page")
         if home_page and home_page.strip():
             best_url = home_page.strip()
     return best_url

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1255,6 +1255,14 @@ declare module 'positron' {
 
 		/** Optional short description or summary shown in the Packages pane card view. */
 		description?: string;
+
+		/**
+		 * The package's primary external URL (its homepage, falling back to its
+		 * repository, etc.). Runtimes should pick the single best link from
+		 * whatever metadata they have; the Packages pane validates it
+		 * (http/https only) and surfaces it via the row's external-link button.
+		 */
+		url?: string;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -194,9 +194,13 @@
 	background-color: var(--vscode-button-hoverBackground);
 }
 
-.packages-list-item .packages-list-item-help {
+/*
+ * The help and external-link buttons are the same icon button. They share
+ * .packages-list-item-action-button for the box, icon size, and hover so they
+ * stay identical; only their margins (which way the group right-aligns) differ.
+ */
+.packages-list-item .packages-list-item-action-button {
 	flex: 0 0 auto;
-	margin-left: auto;
 	box-sizing: border-box;
 	width: 27px;
 	height: 17px;
@@ -212,25 +216,56 @@
 }
 
 /*
- * In card mode the help button lives inside the header row, which baseline-aligns
- * the name/version text. Center the icon-only button on the text line instead of
- * letting its baseline (its bottom edge) sit on the text baseline.
+ * The workbench-global `.monaco-workbench .codicon[class*='codicon-']` forces
+ * codicons to 16px at the same specificity (0,3,0) as a plain three-class rule,
+ * so it would win on source order. Prefix with .monaco-workbench to outrank it
+ * and render both icons at the button's intended size.
  */
-.packages-list-item.item-size-card .packages-list-item-header .packages-list-item-help {
-	align-self: center;
-}
-
-.packages-list-item .packages-list-item-help .codicon {
+.monaco-workbench .packages-list-item .packages-list-item-action-button .codicon {
 	font-size: 13px;
 }
 
-.packages-list-item:hover .packages-list-item-help {
+/*
+ * The link-external glyph reads heavier than the help book at the same size, so
+ * nudge it down for optical balance. Matching both classes on the element keeps
+ * this more specific (0,5,0) than the shared rule above, so it wins regardless
+ * of order.
+ */
+.monaco-workbench .packages-list-item .packages-list-item-action-button.packages-list-item-url .codicon {
+	font-size: 11px;
+}
+
+/*
+ * In card mode the buttons live inside the header row, which baseline-aligns the
+ * name/version text. Center the icon-only button on the text line instead of
+ * letting its baseline (its bottom edge) sit on the text baseline.
+ */
+.packages-list-item.item-size-card .packages-list-item-header .packages-list-item-action-button {
+	align-self: center;
+}
+
+.packages-list-item:hover .packages-list-item-action-button {
 	opacity: 0.85;
 }
 
-.packages-list-item .packages-list-item-help:hover {
+.packages-list-item .packages-list-item-action-button:hover {
 	background: var(--vscode-toolbar-hoverBackground);
 	opacity: 1;
+}
+
+/*
+ * Right-align the action group. The external-link button sits just before the
+ * help button and owns the margin-left:auto that pushes the group to the right
+ * edge; the help button then only needs a small gap. When no URL is present the
+ * help button keeps its own margin-left:auto and right-aligns on its own.
+ */
+.packages-list-item .packages-list-item-help,
+.packages-list-item .packages-list-item-url {
+	margin-left: auto;
+}
+
+.packages-list-item .packages-list-item-url + .packages-list-item-help {
+	margin-left: 4px;
 }
 
 

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -21,6 +21,8 @@ import { ActionBarFilter, ActionBarFilterHandle } from '../../../../../platform/
 import { ViewsProps } from '../positronPackages.js';
 import { Separator } from '../../../../../base/common/actions.js';
 import { localize } from '../../../../../nls.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { matchesSomeScheme, Schemas } from '../../../../../base/common/network.js';
 import { usePositronPackagesContext } from '../positronPackagesContext.js';
 import { ILanguageRuntimePackage } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { RuntimeCodeExecutionMode, RuntimeErrorBehavior } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
@@ -279,7 +281,11 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 	// instance.
 	useEffect(() => {
 		const renderItem = (pkg: ILanguageRuntimePackage, ctx: PositronListItemContext) => {
-			const { name, displayName, version, latestVersion, attached, outdated, description } = pkg;
+			const { name, displayName, version, latestVersion, attached, outdated, description, url } = pkg;
+			// Validate the kernel-provided URL in core: only surface http(s) links
+			// so a malformed or non-web scheme (file:, javascript:, ...) coming from
+			// the runtime can never reach the opener.
+			const hasValidUrl = !!url && matchesSomeScheme(url, Schemas.http, Schemas.https);
 			// Display the update indicator only when the runtime has confirmed the
 			// package is outdated *and* we know which version to advertise. The
 			// resolver-supplied `latestVersion` (or P3M as fallback) feeds the
@@ -340,12 +346,30 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 			const helpButton = (
 				<Button
 					ariaLabel={localize('positronPackages.showHelpAriaLabel', "Show help for {0}", name)}
-					className='packages-list-item-help'
+					className='packages-list-item-action-button packages-list-item-help'
 					tooltip={localize('positronPackages.showHelpTooltip', "Show help for {0}", name)}
 					onPressed={() => { void showHelpForPackage(name); }}
 				>
 					<span className='codicon codicon-book' />
 				</Button>
+			);
+
+			const urlButton = hasValidUrl ? (
+				<Button
+					ariaLabel={localize('positronPackages.openUrlAriaLabel', "Open website for {0}", name)}
+					className='packages-list-item-action-button packages-list-item-url'
+					tooltip={localize('positronPackages.openUrlTooltip', "Open website for {0}", name)}
+					onPressed={() => { void services.openerService.open(URI.parse(url!), { openExternal: true }); }}
+				>
+					<span className='codicon codicon-link-external' />
+				</Button>
+			) : null;
+
+			const rowActions = (
+				<>
+					{urlButton}
+					{helpButton}
+				</>
 			);
 
 			return (
@@ -384,7 +408,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 									&#x2191;
 								</div>
 							)}
-							{itemSize === 'card' && helpButton}
+							{itemSize === 'card' && rowActions}
 						</div>
 						{itemSize === 'card' && (
 							<div className='packages-list-item-description-row'>
@@ -404,7 +428,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 							</div>
 						)}
 					</div>
-					{itemSize === 'row' && helpButton}
+					{itemSize === 'row' && rowActions}
 				</div>
 			);
 		};

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -317,6 +317,14 @@ export interface ILanguageRuntimePackage {
 
 	/** Optional short description or summary. */
 	description?: string;
+
+	/**
+	 * The package's primary external URL (its homepage, falling back to its
+	 * repository, etc.). Chosen by the language runtime from whatever metadata
+	 * it has. The Packages pane validates it (http/https only) and surfaces it
+	 * via the row's external-link button.
+	 */
+	url?: string;
 }
 
 /**

--- a/test/e2e/pages/packages.ts
+++ b/test/e2e/pages/packages.ts
@@ -145,6 +145,14 @@ export class Packages {
 	}
 
 	/**
+	 * Locates the external-link button on a package row.
+	 * @param packageName The exact package name whose URL button to return.
+	 */
+	urlButton(packageName: string): Locator {
+		return this.packagesContainer.getByRole('button', { name: `Open website for ${packageName}` });
+	}
+
+	/**
 	 * Click the filter funnel to open the Filter/Sort options menu.
 	 * Asserts the top-level menu is visible.
 	 */

--- a/test/e2e/tests/packages-pane/packages-pane.test.ts
+++ b/test/e2e/tests/packages-pane/packages-pane.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, tags } from '../_test.setup';
+import { test, tags, expect } from '../_test.setup';
 import { SessionRuntimes } from '../../pages/sessions.js';
 
 test.use({
@@ -88,6 +88,19 @@ test.describe('Packages Pane', {
 
 				await packages.clickHelpButton('numpy');
 				await packages.expectHelpPaneToContainText('NumPy', 1);
+			});
+	});
+
+	test.describe('URL button', () => {
+		test('Python - Shows external link for a package with a homepage', { tag: [tags.WEB] },
+			async function ({ app, python: _python }) {
+				const { packages } = app.workbench;
+
+				// numpy publishes a `Project-URL: Homepage` in its wheel metadata,
+				// so the kernel surfaces a `url` and the row renders the link button.
+				await packages.verifyPackagesList();
+				await packages.searchPackages('numpy');
+				await expect(packages.urlButton('numpy')).toBeVisible();
 			});
 	});
 });


### PR DESCRIPTION
### Summary

Adds an external-link button to each Packages pane row. When a package
advertises a website, the row shows a button (beside the help button) that
opens it in the user's external browser.

The URL comes from the language runtime via the existing `getPackages` call
-- no third-party API, so it works offline. A new optional `url` is added to
`ILanguageRuntimePackage` (and the public `LanguageRuntimePackage`). The
Python kernel picks the single best URL from a distribution's `Project-URL`
metadata (homepage > repository > documentation, with the legacy `Home-page`
header as a homepage fallback). The frontend validates the scheme (http/https
only) before rendering the button, so a malformed or non-web scheme from a
runtime can never reach the opener.

R support comes from a companion ark PR (posit-dev/ark#1261); the R button
lights up once that lands and the ark submodule is bumped in Positron.

See #13890

### Screenshots

<img width="412" height="981" alt="Screenshot 2026-06-09 at 5 15 22 PM" src="https://github.com/user-attachments/assets/0c857640-eaec-4ae1-8953-884b214f4098" />
<img width="380" height="957" alt="Screenshot 2026-06-09 at 5 15 18 PM" src="https://github.com/user-attachments/assets/a3b7171c-26db-4960-911a-c88ac247a606" />
<img width="405" height="757" alt="Screenshot 2026-06-09 at 5 15 10 PM" src="https://github.com/user-attachments/assets/09f717c0-adb1-481f-bcfc-ae4dadb002a9" />
<img width="417" height="823" alt="Screenshot 2026-06-09 at 5 15 06 PM" src="https://github.com/user-attachments/assets/f7df56d7-2906-4566-9b95-b93d0f67253f" />

### Release Notes

#### New Features
- Added an external-link button to Packages pane rows that opens a package's website (#13890)

#### Bug Fixes
- N/A

### Validation Steps

@:packages-pane

1. Start a Python session and open the Packages pane.
2. Filter to a package that publishes a homepage (e.g. `numpy`, `pandas`, `requests`).
3. Confirm an external-link button appears beside the help button, and clicking it opens the package's website in your browser.
4. Confirm a package with no URL metadata shows no link button.
