### PR TITLE
e2e: fix flaky distro pick in remote WSL connect helper

### DIFF
--- a/test/e2e/tests/remote-wsl/remote-wsl.test.ts
+++ b/test/e2e/tests/remote-wsl/remote-wsl.test.ts
@@ -56,11 +56,20 @@ async function connectToWslDistro(app: Application): Promise<{ wslWin: Page; wsl
 			// The remote-indicator entries ("Connect to WSL", "Connect to WSL using Distro...")
 			// reuse the current window. Invoke the "in New Window" variant from the Command
 			// Palette instead so we get a fresh window to drive, mirroring the remote-ssh flow.
-			await app.workbench.quickaccess.runCommand('openremotewsl.connectUsingDistroInNewWindow');
+			//
+			// `keepOpen` is essential: this command chains straight into the "Select WSL distro"
+			// quick pick, so the quick-input box never disappears -- it morphs from the command
+			// palette into the distro picker. Without `keepOpen`, runCommand's default
+			// `waitForQuickInputClosed()` races that morph and intermittently times out on a cold
+			// machine (the palette and the distro picker share the same input element, so there is
+			// often no frame where it reads as closed). `keepOpen` skips that close-check.
+			await app.workbench.quickaccess.runCommand('openremotewsl.connectUsingDistroInNewWindow', { keepOpen: true });
 
-			// Pick the target distro from the distro quick pick the command opens.
+			// Pick the target distro from the distro quick pick the command opens. Allow a generous
+			// timeout to absorb a cold `wsl --list` enumeration on CI (the default actionTimeout is
+			// 15s, which can be tight on a freshly provisioned runner).
 			await app.workbench.quickInput.waitForQuickInputOpened();
-			await app.workbench.quickInput.selectQuickInputElementContaining(WSL_DISTRO);
+			await app.workbench.quickInput.selectQuickInputElementContaining(WSL_DISTRO, { timeout: 30_000 });
 		}, { timeout: 60_000 });
 
 		const wslWin = await wslWinPromise;


### PR DESCRIPTION
### Summary

The `remote-wsl` tests were ~100% flaky in CI: they failed on the first attempt and passed on retry.

**Root cause.** `connectToWslDistro()` invoked `openremotewsl.connectUsingDistroInNewWindow` via `quickaccess.runCommand()` with its default behavior, which asserts the command palette closes after the command runs (`selectQuickInputElement(0)` -> `waitForQuickInputClosed()`, 5s). But that command chains straight into the "Select WSL distro" quick pick, so the quick-input box never disappears -- the palette input morphs into the distro picker input (same DOM element). Whether a "closed" frame is ever observed is a pure timing race:

- Cold (CI first run): seamless morph, input stays visible -> `waitForQuickInputClosed` times out -> fail.
- Warm (retry): brief gap where the input hides -> passes in ~50ms -> pass.

The failing trace points at `quickInput.ts:141` (`waitForQuickInputClosed`) inside `runCommand`, with the still-visible element carrying `aria-label="Select WSL distro"` -- confirming the palette had already advanced to the distro picker.

**Fix.** Pass `keepOpen: true` to `runCommand` so it skips the close-check, then wait for the distro picker and select the distro with a generous 30s timeout (the default `actionTimeout` is 15s, tight for a cold `wsl --list` on a freshly provisioned runner). The fix lives in the shared helper, so it covers all three remote-wsl tests.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps


Requires a Windows host with WSL, a glibc distro, a reachable Positron REH tarball, and Python + R interpreters inside the distro (see the "Remote WSL Tests" section of `test/e2e/README.md`).

```bash
POSITRON_WSL_DISTRO=Ubuntu-24.04 \
POSITRON_PY_WSL_VER_SEL=3.12.11 \
POSITRON_R_WSL_VER_SEL=4.3.3 \
npx playwright test --project e2e-remote-wsl --workers=1
```

All three tests pass locally with no retries; the connect step also dropped from ~28s to ~13s now that it no longer burns the 5s close-check race per connect.