### PR TITLE
Support configurable secondary sidebar location

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -14,7 +14,7 @@ import { PanelPart } from './parts/panel/panelPart.js';
 // --- Start Positron ---
 // Positron doesn't use EditorActionsLocation; replaced with IPositronTopActionBarService for top-level actions
 // import { Position, Parts, PartOpensMaximizedOptions, IWorkbenchLayoutService, positionFromString, positionToString, partOpensMaximizedFromString, PanelAlignment, ActivityBarPosition, LayoutSettings, MULTI_WINDOW_PARTS, SINGLE_WINDOW_PARTS, ZenModeSettings, EditorTabsMode, EditorActionsLocation, shouldShowCustomTitleBar, isHorizontal, isMultiWindowPart, IPartVisibilityChangeEvent } from '../services/layout/browser/layoutService.js';
-import { Position, Parts, PartOpensMaximizedOptions, IWorkbenchLayoutService, positionFromString, positionToString, partOpensMaximizedFromString, PanelAlignment, ActivityBarPosition, LayoutSettings, MULTI_WINDOW_PARTS, SINGLE_WINDOW_PARTS, ZenModeSettings, EditorTabsMode, /* EditorActionsLocation, */ shouldShowCustomTitleBar, isHorizontal, isMultiWindowPart, IPartVisibilityChangeEvent } from '../services/layout/browser/layoutService.js';
+import { Position, Parts, PartOpensMaximizedOptions, IWorkbenchLayoutService, positionFromString, positionToString, partOpensMaximizedFromString, PanelAlignment, ActivityBarPosition, LayoutSettings, MULTI_WINDOW_PARTS, SINGLE_WINDOW_PARTS, ZenModeSettings, EditorTabsMode, /* EditorActionsLocation, */ shouldShowCustomTitleBar, isHorizontal, isMultiWindowPart, IPartVisibilityChangeEvent, auxiliaryBarPositionFromConfiguration, SecondarySideBarLocation } from '../services/layout/browser/layoutService.js';
 import { PartViewInfo } from '../services/positronLayout/browser/interfaces/positronLayoutService.js';
 import { CustomPositronLayoutDescription, KnownPositronLayoutParts, PartLayoutDescription } from '../services/positronLayout/common/positronCustomViews.js';
 // --- End Positron ---
@@ -474,6 +474,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				...TITLE_BAR_SETTINGS,
 				LegacyWorkbenchLayoutSettings.SIDEBAR_POSITION,
 				LegacyWorkbenchLayoutSettings.STATUSBAR_VISIBLE,
+				WorkbenchLayoutSettings.AUXILIARYBAR_LOCATION,
 			].some(setting => e.affectsConfiguration(setting))) {
 
 				// Show Command Center if command center actions enabled
@@ -512,6 +513,12 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			}
 
 			// Auxiliary Sidebar
+			if (e.affectsConfiguration(WorkbenchLayoutSettings.AUXILIARYBAR_LOCATION) && this.workbenchGrid) {
+				this.updateAuxiliaryBarPositionClasses();
+				this.getPart(Parts.AUXILIARYBAR_PART).updateStyles();
+				this.adjustPartPositions(this.getSideBarPosition(), this.getPanelAlignment(), this.getPanelPosition());
+			}
+
 			if (e.affectsConfiguration(WorkbenchLayoutSettings.AUXILIARYBAR_FORCE_MAXIMIZED)) {
 				const forceMaximized = this.configurationService.getValue(WorkbenchLayoutSettings.AUXILIARYBAR_FORCE_MAXIMIZED);
 				if (forceMaximized === true && this.mainPartEditorService.visibleEditors.length === 0) {
@@ -685,6 +692,23 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		}
 	}
 
+	private getAuxiliaryBarPosition(sideBarPosition = this.getSideBarPosition()): Position {
+		return auxiliaryBarPositionFromConfiguration(
+			sideBarPosition,
+			this.configurationService.getValue<SecondarySideBarLocation>(LayoutSettings.SECONDARY_SIDE_BAR_LOCATION)
+		);
+	}
+
+	private updateAuxiliaryBarPositionClasses(position = this.getAuxiliaryBarPosition()): void {
+		const auxiliaryBar = this.getPart(Parts.AUXILIARYBAR_PART);
+		const auxiliaryBarContainer = assertReturnsDefined(auxiliaryBar.getContainer());
+		const positionValue = positionToString(position);
+		const oldPositionValue = position === Position.LEFT ? 'right' : 'left';
+
+		auxiliaryBarContainer.classList.remove(oldPositionValue);
+		auxiliaryBarContainer.classList.add(positionValue);
+	}
+
 	private setSideBarPosition(position: Position): void {
 		const activityBar = this.getPart(Parts.ACTIVITYBAR_PART);
 		const sideBar = this.getPart(Parts.SIDEBAR_PART);
@@ -699,15 +723,12 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		// Adjust CSS
 		const activityBarContainer = assertReturnsDefined(activityBar.getContainer());
 		const sideBarContainer = assertReturnsDefined(sideBar.getContainer());
-		const auxiliaryBarContainer = assertReturnsDefined(auxiliaryBar.getContainer());
 		activityBarContainer.classList.remove(oldPositionValue);
 		sideBarContainer.classList.remove(oldPositionValue);
 		activityBarContainer.classList.add(newPositionValue);
 		sideBarContainer.classList.add(newPositionValue);
 
-		// Auxiliary Bar has opposite values
-		auxiliaryBarContainer.classList.remove(newPositionValue);
-		auxiliaryBarContainer.classList.add(oldPositionValue);
+		this.updateAuxiliaryBarPositionClasses(this.getAuxiliaryBarPosition(position));
 
 		// Update Styles
 		activityBar.updateStyles();
@@ -2074,8 +2095,10 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 		// Move activity bar and side bars
 		const isPanelVertical = !isHorizontal(panelPosition);
-		const sideBarSiblingToEditor = isPanelVertical || !(panelAlignment === 'center' || (sideBarPosition === Position.LEFT && panelAlignment === 'right') || (sideBarPosition === Position.RIGHT && panelAlignment === 'left'));
-		const auxiliaryBarSiblingToEditor = isPanelVertical || !(panelAlignment === 'center' || (sideBarPosition === Position.RIGHT && panelAlignment === 'right') || (sideBarPosition === Position.LEFT && panelAlignment === 'left'));
+		const auxiliaryBarPosition = this.getAuxiliaryBarPosition(sideBarPosition);
+		const isPartSiblingToEditor = (position: Position) => isPanelVertical || !(panelAlignment === 'center' || (position === Position.LEFT && panelAlignment === 'right') || (position === Position.RIGHT && panelAlignment === 'left'));
+		const sideBarSiblingToEditor = isPartSiblingToEditor(sideBarPosition);
+		const auxiliaryBarSiblingToEditor = isPartSiblingToEditor(auxiliaryBarPosition);
 		const preMovePanelWidth = !this.isVisible(Parts.PANEL_PART) ? Sizing.Invisible(this.workbenchGrid.getViewCachedVisibleSize(this.panelPartView) ?? this.panelPartView.minimumWidth) : this.workbenchGrid.getViewSize(this.panelPartView).width;
 		const preMovePanelHeight = !this.isVisible(Parts.PANEL_PART) ? Sizing.Invisible(this.workbenchGrid.getViewCachedVisibleSize(this.panelPartView) ?? this.panelPartView.minimumHeight) : this.workbenchGrid.getViewSize(this.panelPartView).height;
 		const preMoveSideBarSize = !this.isVisible(Parts.SIDEBAR_PART) ? Sizing.Invisible(this.workbenchGrid.getViewCachedVisibleSize(this.sideBarPartView) ?? this.sideBarPartView.minimumWidth) : this.workbenchGrid.getViewSize(this.sideBarPartView).width;
@@ -2088,19 +2111,17 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		if (sideBarPosition === Position.LEFT) {
 			this.workbenchGrid.moveViewTo(this.activityBarPartView, [3, 0]);
 			this.workbenchGrid.moveView(this.sideBarPartView, preMoveSideBarSize, sideBarSiblingToEditor ? this.editorPartView : this.activityBarPartView, sideBarSiblingToEditor ? Direction.Left : Direction.Right);
-			if (auxiliaryBarSiblingToEditor) {
-				this.workbenchGrid.moveView(this.auxiliaryBarPartView, preMoveAuxiliaryBarSize, this.editorPartView, Direction.Right);
-			} else {
-				this.workbenchGrid.moveViewTo(this.auxiliaryBarPartView, [3, -1]);
-			}
 		} else {
 			this.workbenchGrid.moveViewTo(this.activityBarPartView, [3, -1]);
 			this.workbenchGrid.moveView(this.sideBarPartView, preMoveSideBarSize, sideBarSiblingToEditor ? this.editorPartView : this.activityBarPartView, sideBarSiblingToEditor ? Direction.Right : Direction.Left);
-			if (auxiliaryBarSiblingToEditor) {
-				this.workbenchGrid.moveView(this.auxiliaryBarPartView, preMoveAuxiliaryBarSize, this.editorPartView, Direction.Left);
-			} else {
-				this.workbenchGrid.moveViewTo(this.auxiliaryBarPartView, [3, 0]);
-			}
+		}
+
+		if (auxiliaryBarSiblingToEditor) {
+			this.workbenchGrid.moveView(this.auxiliaryBarPartView, preMoveAuxiliaryBarSize, this.editorPartView, auxiliaryBarPosition === Position.LEFT ? Direction.Left : Direction.Right);
+		} else if (auxiliaryBarPosition === sideBarPosition) {
+			this.workbenchGrid.moveView(this.auxiliaryBarPartView, preMoveAuxiliaryBarSize, this.sideBarPartView, auxiliaryBarPosition === Position.LEFT ? Direction.Right : Direction.Left);
+		} else {
+			this.workbenchGrid.moveViewTo(this.auxiliaryBarPartView, auxiliaryBarPosition === Position.LEFT ? [3, 0] : [3, -1]);
 		}
 		// --- End Positron ---
 
@@ -2731,8 +2752,10 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 		const result = [nodes.editor];
 		nodes.editor.size = availableWidth;
+		const sideBarPosition = this.stateModel.getRuntimeValue(LayoutStateKeys.SIDEBAR_POSITON);
+		const auxiliaryBarPosition = this.getAuxiliaryBarPosition(sideBarPosition);
 		if (nodes.sideBar) {
-			if (this.stateModel.getRuntimeValue(LayoutStateKeys.SIDEBAR_POSITON) === Position.LEFT) {
+			if (sideBarPosition === Position.LEFT) {
 				result.splice(0, 0, nodes.sideBar);
 			} else {
 				result.push(nodes.sideBar);
@@ -2742,7 +2765,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		}
 
 		if (nodes.auxiliaryBar) {
-			if (this.stateModel.getRuntimeValue(LayoutStateKeys.SIDEBAR_POSITON) === Position.RIGHT) {
+			if (auxiliaryBarPosition === Position.LEFT) {
 				result.splice(0, 0, nodes.auxiliaryBar);
 			} else {
 				result.push(nodes.auxiliaryBar);
@@ -2767,30 +2790,38 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 		const panelPostion = this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_POSITION);
 		const sideBarPosition = this.stateModel.getRuntimeValue(LayoutStateKeys.SIDEBAR_POSITON);
+		const auxiliaryBarPosition = this.getAuxiliaryBarPosition(sideBarPosition);
 
 		const result = [] as ISerializedNode[];
 		if (!isHorizontal(panelPostion)) {
-			result.push(nodes.editor);
+			const centerNodes = [nodes.editor];
 			nodes.editor.size = availableWidth - activityBarSize - sideBarSize - panelSize - auxiliaryBarSize;
 			if (panelPostion === Position.RIGHT) {
-				result.push(nodes.panel);
+				centerNodes.push(nodes.panel);
 			} else {
-				result.splice(0, 0, nodes.panel);
+				centerNodes.splice(0, 0, nodes.panel);
 			}
 
+			const leftEdgeNodes = [] as ISerializedNode[];
+			const rightEdgeNodes = [] as ISerializedNode[];
 			if (sideBarPosition === Position.LEFT) {
-				result.push(nodes.auxiliaryBar);
-				result.splice(0, 0, nodes.sideBar);
-				result.splice(0, 0, nodes.activityBar);
+				leftEdgeNodes.push(nodes.activityBar, nodes.sideBar);
 			} else {
-				result.splice(0, 0, nodes.auxiliaryBar);
-				result.push(nodes.sideBar);
-				result.push(nodes.activityBar);
+				rightEdgeNodes.push(nodes.sideBar, nodes.activityBar);
 			}
+
+			if (auxiliaryBarPosition === Position.LEFT) {
+				leftEdgeNodes.push(nodes.auxiliaryBar);
+			} else {
+				rightEdgeNodes.splice(0, 0, nodes.auxiliaryBar);
+			}
+
+			result.push(...leftEdgeNodes, ...centerNodes, ...rightEdgeNodes);
 		} else {
 			const panelAlignment = this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_ALIGNMENT);
-			const sideBarNextToEditor = !(panelAlignment === 'center' || (sideBarPosition === Position.LEFT && panelAlignment === 'right') || (sideBarPosition === Position.RIGHT && panelAlignment === 'left'));
-			const auxiliaryBarNextToEditor = !(panelAlignment === 'center' || (sideBarPosition === Position.RIGHT && panelAlignment === 'right') || (sideBarPosition === Position.LEFT && panelAlignment === 'left'));
+			const isPartNextToEditor = (position: Position) => !(panelAlignment === 'center' || (position === Position.LEFT && panelAlignment === 'right') || (position === Position.RIGHT && panelAlignment === 'left'));
+			const sideBarNextToEditor = isPartNextToEditor(sideBarPosition);
+			const auxiliaryBarNextToEditor = isPartNextToEditor(auxiliaryBarPosition);
 
 			const editorSectionWidth = availableWidth - activityBarSize - (sideBarNextToEditor ? 0 : sideBarSize) - (auxiliaryBarNextToEditor ? 0 : auxiliaryBarSize);
 
@@ -2808,27 +2839,30 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				visible: data.some(node => node.visible)
 			});
 
-			if (!sideBarNextToEditor) {
-				if (sideBarPosition === Position.LEFT) {
-					result.splice(0, 0, nodes.sideBar);
-				} else {
-					result.push(nodes.sideBar);
+			const leftEdgeNodes = [] as ISerializedNode[];
+			const rightEdgeNodes = [] as ISerializedNode[];
+			if (sideBarPosition === Position.LEFT) {
+				leftEdgeNodes.push(nodes.activityBar);
+				if (!sideBarNextToEditor) {
+					leftEdgeNodes.push(nodes.sideBar);
 				}
+			} else {
+				if (!sideBarNextToEditor) {
+					rightEdgeNodes.push(nodes.sideBar);
+				}
+				rightEdgeNodes.push(nodes.activityBar);
 			}
 
 			if (!auxiliaryBarNextToEditor) {
-				if (sideBarPosition === Position.RIGHT) {
-					result.splice(0, 0, nodes.auxiliaryBar);
+				if (auxiliaryBarPosition === Position.LEFT) {
+					leftEdgeNodes.push(nodes.auxiliaryBar);
 				} else {
-					result.push(nodes.auxiliaryBar);
+					rightEdgeNodes.splice(0, 0, nodes.auxiliaryBar);
 				}
 			}
 
-			if (sideBarPosition === Position.LEFT) {
-				result.splice(0, 0, nodes.activityBar);
-			} else {
-				result.push(nodes.activityBar);
-			}
+			result.splice(0, 0, ...leftEdgeNodes);
+			result.push(...rightEdgeNodes);
 		}
 
 		return result;
@@ -3219,6 +3253,7 @@ interface ILayoutStateChangeEvent<T extends StorageKeyType> {
 enum WorkbenchLayoutSettings {
 	AUXILIARYBAR_DEFAULT_VISIBILITY = 'workbench.secondarySideBar.defaultVisibility',
 	AUXILIARYBAR_FORCE_MAXIMIZED = 'workbench.secondarySideBar.forceMaximized',
+	AUXILIARYBAR_LOCATION = LayoutSettings.SECONDARY_SIDE_BAR_LOCATION,
 	ACTIVITY_BAR_VISIBLE = 'workbench.activityBar.visible',
 	PANEL_POSITION = 'workbench.panel.defaultLocation',
 	PANEL_OPENS_MAXIMIZED = 'workbench.panel.opensMaximized',

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
@@ -17,13 +17,12 @@ import { ActiveAuxiliaryContext, AuxiliaryBarFocusContext } from '../../../commo
 import { ACTIVITY_BAR_BADGE_BACKGROUND, ACTIVITY_BAR_BADGE_FOREGROUND, ACTIVITY_BAR_TOP_ACTIVE_BORDER, ACTIVITY_BAR_TOP_DRAG_AND_DROP_BORDER, ACTIVITY_BAR_TOP_FOREGROUND, ACTIVITY_BAR_TOP_INACTIVE_FOREGROUND, PANEL_ACTIVE_TITLE_BORDER, PANEL_ACTIVE_TITLE_FOREGROUND, PANEL_DRAG_AND_DROP_BORDER, PANEL_INACTIVE_TITLE_FOREGROUND, SIDE_BAR_BACKGROUND, SIDE_BAR_BORDER, SIDE_BAR_TITLE_BORDER, SIDE_BAR_FOREGROUND } from '../../../common/theme.js';
 import { IViewDescriptorService, ViewContainerLocation } from '../../../common/views.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
-import { ActivityBarPosition, IWorkbenchLayoutService, LayoutSettings, Parts, Position } from '../../../services/layout/browser/layoutService.js';
+import { ActivityBarPosition, auxiliaryBarPositionFromConfiguration, IWorkbenchLayoutService, LayoutSettings, Parts, Position, SecondarySideBarLocation } from '../../../services/layout/browser/layoutService.js';
 import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 import { IAction, Separator, SubmenuAction, toAction } from '../../../../base/common/actions.js';
 import { ToggleAuxiliaryBarAction } from './auxiliaryBarActions.js';
 import { assertReturnsDefined } from '../../../../base/common/types.js';
 import { LayoutPriority } from '../../../../base/browser/ui/splitview/splitview.js';
-import { ToggleSidebarPositionAction } from '../../actions/layoutActions.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { AbstractPaneCompositePart, CompositeBarPosition } from '../paneCompositePart.js';
 import { ActionsOrientation } from '../../../../base/browser/ui/actionbar/actionbar.js';
@@ -138,6 +137,9 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 			if (e.affectsConfiguration(LayoutSettings.ACTIVITY_BAR_LOCATION)) {
 				this.configuration = this.resolveConfiguration();
 				this.onDidChangeActivityBarLocation();
+			} else if (e.affectsConfiguration(LayoutSettings.SECONDARY_SIDE_BAR_LOCATION)) {
+				this.updateStyles();
+				this.updateCompositeBar(true);
 			} else if (e.affectsConfiguration('workbench.secondarySideBar.showLabels')) {
 				this.configuration = this.resolveConfiguration();
 				this.updateCompositeBar(true);
@@ -168,6 +170,13 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 		return { position, canShowLabels, showLabels };
 	}
 
+	private getAuxiliaryBarPosition(): Position {
+		return auxiliaryBarPositionFromConfiguration(
+			this.layoutService.getSideBarPosition(),
+			this.configurationService.getValue<SecondarySideBarLocation>(LayoutSettings.SECONDARY_SIDE_BAR_LOCATION)
+		);
+	}
+
 	private onDidChangeActivityBarLocation(): void {
 		this.updateCompositeBar();
 
@@ -183,7 +192,7 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 		const container = assertReturnsDefined(this.getContainer());
 		container.style.backgroundColor = this.getColor(SIDE_BAR_BACKGROUND) || '';
 		const borderColor = this.getColor(SIDE_BAR_BORDER) || this.getColor(contrastBorder);
-		const isPositionLeft = this.layoutService.getSideBarPosition() === Position.RIGHT;
+		const isPositionLeft = this.getAuxiliaryBarPosition() === Position.LEFT;
 
 		container.style.color = this.getColor(SIDE_BAR_FOREGROUND) || '';
 
@@ -230,7 +239,7 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 	}
 
 	private fillExtraContextMenuActions(actions: IAction[]): void {
-		const currentPositionRight = this.layoutService.getSideBarPosition() === Position.LEFT;
+		const currentPositionRight = this.getAuxiliaryBarPosition() === Position.RIGHT;
 
 		if (this.getCompositeBarPosition() === CompositeBarPosition.TITLE) {
 			const viewsSubmenuAction = this.getViewsSubmenuAction();
@@ -262,7 +271,11 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 			// See https://github.com/posit-dev/positron/issues/2951
 			// new SubmenuAction('workbench.action.panel.position', localize('activity bar position', "Activity Bar Position"), positionActions),
 			// --- End Positron ---
-			toAction({ id: ToggleSidebarPositionAction.ID, label: currentPositionRight ? localize('move second side bar left', "Move Secondary Side Bar Left") : localize('move second side bar right', "Move Secondary Side Bar Right"), run: () => this.commandService.executeCommand(ToggleSidebarPositionAction.ID) }),
+			toAction({
+				id: 'workbench.action.toggleSecondarySideBarPosition',
+				label: currentPositionRight ? localize('move second side bar left', "Move Secondary Side Bar Left") : localize('move second side bar right', "Move Secondary Side Bar Right"),
+				run: () => this.configurationService.updateValue(LayoutSettings.SECONDARY_SIDE_BAR_LOCATION, currentPositionRight ? SecondarySideBarLocation.LEFT : SecondarySideBarLocation.RIGHT)
+			}),
 			toggleShowLabelsAction,
 			toAction({ id: ToggleAuxiliaryBarAction.ID, label: localize('hide second side bar', "Hide Secondary Side Bar"), run: () => this.commandService.executeCommand(ToggleAuxiliaryBarAction.ID) })
 		]);

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -14,7 +14,7 @@ import { NotificationsPosition, NotificationsSettings } from '../common/notifica
 import { CustomEditorLabelService } from '../services/editor/common/customEditorLabelService.js';
 // --- Start Positron ---
 // Editor actions are disabled in Positron. They have been moved to the Editor Action Bar.
-import { ActivityBarPosition, /*EditorActionsLocation,*/ EditorTabsMode, LayoutSettings } from '../services/layout/browser/layoutService.js';
+import { ActivityBarPosition, /*EditorActionsLocation,*/ EditorTabsMode, LayoutSettings, SecondarySideBarLocation } from '../services/layout/browser/layoutService.js';
 // --- End Positron ---
 import { defaultWindowTitle, defaultWindowTitleSeparator } from './parts/titlebar/windowTitle.js';
 
@@ -615,6 +615,17 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 					localize('workbench.secondarySideBar.defaultVisibility.visible', "The secondary side bar is visible by default."),
 					localize('workbench.secondarySideBar.defaultVisibility.maximizedInWorkspace', "The secondary side bar is visible and maximized by default if a workspace is opened."),
 					localize('workbench.secondarySideBar.defaultVisibility.maximized', "The secondary side bar is visible and maximized by default.")
+				]
+			},
+			[LayoutSettings.SECONDARY_SIDE_BAR_LOCATION]: {
+				'type': 'string',
+				'enum': [SecondarySideBarLocation.OPPOSITE, SecondarySideBarLocation.LEFT, SecondarySideBarLocation.RIGHT],
+				'default': SecondarySideBarLocation.OPPOSITE,
+				'description': localize('secondarySideBarLocation', "Controls the location of the secondary side bar relative to the primary side bar."),
+				'enumDescriptions': [
+					localize('workbench.secondarySideBar.location.opposite', "Show the secondary side bar on the opposite side of the primary side bar."),
+					localize('workbench.secondarySideBar.location.left', "Show the secondary side bar on the left."),
+					localize('workbench.secondarySideBar.location.right', "Show the secondary side bar on the right.")
 				]
 			},
 			'workbench.secondarySideBar.forceMaximized': {

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -15,7 +15,7 @@ import { isWindows, isLinux, isWeb, isNative, isMacintosh } from '../../base/com
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from '../common/contributions.js';
 import { IEditorFactoryRegistry, EditorExtensions } from '../common/editor.js';
 import { getSingletonServiceDescriptors } from '../../platform/instantiation/common/extensions.js';
-import { Position, Parts, IWorkbenchLayoutService, positionToString } from '../services/layout/browser/layoutService.js';
+import { Position, Parts, IWorkbenchLayoutService, positionToString, auxiliaryBarPositionFromConfiguration, LayoutSettings, SecondarySideBarLocation } from '../services/layout/browser/layoutService.js';
 import { IStorageService, WillSaveStateReason, StorageScope, StorageTarget } from '../../platform/storage/common/storage.js';
 import { IConfigurationChangeEvent, IConfigurationService } from '../../platform/configuration/common/configuration.js';
 import { IInstantiationService } from '../../platform/instantiation/common/instantiation.js';
@@ -352,6 +352,11 @@ export class Workbench extends Layout {
 		this.restoreFontInfo(storageService, configurationService);
 
 		// Create Parts
+		const auxiliaryBarPosition = auxiliaryBarPositionFromConfiguration(
+			this.getSideBarPosition(),
+			configurationService.getValue<SecondarySideBarLocation>(LayoutSettings.SECONDARY_SIDE_BAR_LOCATION)
+		);
+
 		for (const { id, role, classes, options } of [
 			{ id: Parts.TITLEBAR_PART, role: 'none', classes: ['titlebar'] },
 			// --- Start Positron ---
@@ -362,7 +367,7 @@ export class Workbench extends Layout {
 			{ id: Parts.SIDEBAR_PART, role: 'none', classes: ['sidebar', this.getSideBarPosition() === Position.LEFT ? 'left' : 'right'] },
 			{ id: Parts.EDITOR_PART, role: 'main', classes: ['editor'], options: { restorePreviousState: this.willRestoreEditors() } },
 			{ id: Parts.PANEL_PART, role: 'none', classes: ['panel', 'basepanel', positionToString(this.getPanelPosition())] },
-			{ id: Parts.AUXILIARYBAR_PART, role: 'none', classes: ['auxiliarybar', 'basepanel', this.getSideBarPosition() === Position.LEFT ? 'right' : 'left'] },
+			{ id: Parts.AUXILIARYBAR_PART, role: 'none', classes: ['auxiliarybar', 'basepanel', positionToString(auxiliaryBarPosition)] },
 			{ id: Parts.STATUSBAR_PART, role: 'status', classes: ['statusbar'] }
 		]) {
 			const partContainer = this.createPart(id, role, classes);

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -66,8 +66,9 @@ export const enum LayoutSettings {
 	LAYOUT_ACTIONS = 'workbench.layoutControl.enabled',
 	SHADOWS = 'workbench.shadows',
 	// --- Start Positron ---
-	TOP_ACTION_BAR_VISIBLE = 'workbench.topActionBar.visible'
+	TOP_ACTION_BAR_VISIBLE = 'workbench.topActionBar.visible',
 	// --- End Positron ---
+	SECONDARY_SIDE_BAR_LOCATION = 'workbench.secondarySideBar.location'
 }
 
 export const enum ActivityBarPosition {
@@ -87,6 +88,12 @@ export const enum EditorActionsLocation {
 	DEFAULT = 'default',
 	TITLEBAR = 'titleBar',
 	HIDDEN = 'hidden'
+}
+
+export const enum SecondarySideBarLocation {
+	OPPOSITE = 'opposite',
+	LEFT = 'left',
+	RIGHT = 'right'
 }
 
 export const enum Position {
@@ -127,6 +134,17 @@ const positionsByString: { [key: string]: Position } = {
 
 export function positionFromString(str: string): Position {
 	return positionsByString[str];
+}
+
+export function auxiliaryBarPositionFromConfiguration(sideBarPosition: Position, secondarySideBarLocation: SecondarySideBarLocation | undefined): Position {
+	switch (secondarySideBarLocation) {
+		case SecondarySideBarLocation.LEFT:
+			return Position.LEFT;
+		case SecondarySideBarLocation.RIGHT:
+			return Position.RIGHT;
+		default:
+			return sideBarPosition === Position.LEFT ? Position.RIGHT : Position.LEFT;
+	}
 }
 
 function partOpensMaximizedSettingToString(setting: PartOpensMaximizedOptions): string {


### PR DESCRIPTION
## Summary

This change adds a new `workbench.secondarySideBar.location` setting so the secondary side bar can be placed independently from the primary side bar. The existing behavior remains the default through the `opposite` value, while `left` and `right` allow users to explicitly choose where the secondary side bar should appear.

The layout code now resolves the secondary side bar position from that setting when creating workbench parts, serializing the layout, and adjusting part positions at runtime. The secondary side bar context menu also updates this setting directly, so moving the secondary side bar no longer changes the primary side bar position.

## Motivation

This is motivated by a common RStudio-style workflow where the source editor is kept on the upper left, the console sits below it, and the right side contains session-oriented views such as Environment at the top with Files, Plots, Packages, and related views available below. Positron already has the pieces for this kind of workflow, but the secondary side bar was effectively tied to the opposite side of the primary side bar. That made it difficult to keep Files, Packages, session views, and Plots together on the right side while preserving the editor and console layout on the left.

This keeps the current default intact while making that style of workspace layout configurable.

## Validation

I ran `git diff --check`, built a macOS arm64 package with `gulp vscode-darwin-arm64`, installed and launched the packaged `Positron.app` locally, and verified the right-side layout behavior with the workbench, session views, Python PET, and supervisor startup logs.

## Example

<img width="1792" height="1073" alt="image" src="https://github.com/user-attachments/assets/b9d94094-2932-4c49-b0ff-e258c9ef5db1" />