### PR TITLE
Export Jupyter notebooks to percent script format (Python & R)

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -119,6 +119,11 @@ const extensions = [
 		mocha: { timeout: 60_000 }
 	},
 	{
+		label: 'positron-notebook-export',
+		workspaceFolder: 'extensions/positron-notebook-export/test-workspace',
+		mocha: { timeout: 60_000 }
+	},
+	{
 		label: 'positron-run-app',
 		workspaceFolder: 'extensions/positron-run-app/test-workspace',
 		mocha: { timeout: 60_000 }

--- a/build/gulpfile.extensions.ts
+++ b/build/gulpfile.extensions.ts
@@ -76,6 +76,7 @@ const compilations = [
 	'extensions/positron-ipywidgets/renderer/tsconfig.json',
 	'extensions/positron-javascript/tsconfig.json',
 	'extensions/positron-notebooks/tsconfig.json',
+	'extensions/positron-notebook-export/tsconfig.json',
 	'extensions/positron-pdf-server/tsconfig.json',
 	'extensions/positron-proxy/tsconfig.json',
 	'extensions/positron-python/tsconfig.json',

--- a/build/npm/dirs.ts
+++ b/build/npm/dirs.ts
@@ -38,6 +38,7 @@ export let dirs = [
 	'extensions/positron-ipywidgets',
 	'extensions/positron-javascript',
 	'extensions/positron-notebooks',
+	'extensions/positron-notebook-export',
 	'extensions/positron-pdf-server',
 	'extensions/positron-r',
 	'extensions/positron-reticulate',

--- a/extensions/positron-notebook-export/esbuild.mts
+++ b/extensions/positron-notebook-export/esbuild.mts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as path from 'node:path';
+import { run } from '../esbuild-extension-common.mts';
+
+const srcDir = path.join(import.meta.dirname, 'src');
+const outDir = path.join(import.meta.dirname, 'dist');
+
+run({
+	platform: 'node',
+	entryPoints: {
+		'extension': path.join(srcDir, 'extension.ts'),
+	},
+	srcDir,
+	outdir: outDir,
+}, process.argv);

--- a/extensions/positron-notebook-export/package-lock.json
+++ b/extensions/positron-notebook-export/package-lock.json
@@ -1,0 +1,43 @@
+{
+  "name": "notebook-export",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "notebook-export",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/mocha": "^10.0.10",
+        "@types/node": "^24.1.0"
+      },
+      "engines": {
+        "vscode": "^1.65.0"
+      }
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
+      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/extensions/positron-notebook-export/package.json
+++ b/extensions/positron-notebook-export/package.json
@@ -15,15 +15,15 @@
   "contributes": {
     "commands": [
       {
-        "command": "notebook.export",
-        "title": "%command.notebook.export.title%",
+        "command": "positronNotebook.export",
+        "title": "%command.positronNotebook.export.title%",
         "category": "%category.notebook%"
       }
     ],
     "menus": {
       "editor/title": [
         {
-          "command": "notebook.export",
+          "command": "positronNotebook.export",
           "group": "share",
           "when": "resourceExtname == .ipynb"
         }

--- a/extensions/positron-notebook-export/package.json
+++ b/extensions/positron-notebook-export/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "notebook-export",
+  "displayName": "%displayName%",
+  "description": "%description%",
+  "version": "0.0.1",
+  "publisher": "positron",
+  "private": true,
+  "engines": {
+    "vscode": "^1.65.0"
+  },
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "notebook.export",
+        "title": "%command.notebook.export.title%",
+        "category": "%category.notebook%"
+      }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "notebook.export",
+          "group": "share",
+          "when": "resourceExtname == .ipynb"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile"
+  },
+  "devDependencies": {
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^24.1.0"
+  }
+}

--- a/extensions/positron-notebook-export/package.nls.json
+++ b/extensions/positron-notebook-export/package.nls.json
@@ -2,5 +2,5 @@
 	"displayName": "Notebook Export",
 	"description": "Export Jupyter notebooks to other file formats.",
 	"category.notebook": "Notebook",
-	"command.notebook.export.title": "Export..."
+	"command.positronNotebook.export.title": "Export..."
 }

--- a/extensions/positron-notebook-export/package.nls.json
+++ b/extensions/positron-notebook-export/package.nls.json
@@ -1,0 +1,6 @@
+{
+	"displayName": "Notebook Export",
+	"description": "Export Jupyter notebooks to other file formats.",
+	"category.notebook": "Notebook",
+	"command.notebook.export.title": "Export..."
+}

--- a/extensions/positron-notebook-export/src/api.ts
+++ b/extensions/positron-notebook-export/src/api.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as vscode from 'vscode';
+import { NotebookExporter, NotebookExportExtension } from './positron-notebook-export.js';
+import { Disposable } from './util/disposable.js';
+
+export class NotebookExportExtensionImpl extends Disposable implements NotebookExportExtension {
+	private readonly _exporters: NotebookExporter[] = [];
+
+	get exporters(): readonly NotebookExporter[] {
+		return this._exporters;
+	}
+
+	registerNotebookExporter(exporter: NotebookExporter): vscode.Disposable {
+		if (this.isDisposed) {
+			throw new Error('Cannot register notebook exporter; the extension is deactivated.');
+		}
+		this._exporters.push(exporter);
+		return this._register({
+			dispose: () => {
+				const index = this._exporters.indexOf(exporter);
+				if (index !== -1) {
+					this._exporters.splice(index, 1);
+				}
+			}
+		});
+	}
+}

--- a/extensions/positron-notebook-export/src/extension.ts
+++ b/extensions/positron-notebook-export/src/extension.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { PythonPercentNotebookExporter, RPercentNotebookExporter } from './percentNotebookExporter.js';
+import { NotebookExportExtensionImpl } from './api.js';
+import { NotebookExportExtension } from './positron-notebook-export.js';
+import { NotebookExportCommand } from './notebookExportCommand.js';
+
+export function activate(context: vscode.ExtensionContext): NotebookExportExtension {
+	const log = vscode.window.createOutputChannel('Notebook Export', { log: true });
+	context.subscriptions.push(log);
+	log.info('Activating extension...');
+
+	const api = new NotebookExportExtensionImpl();
+	context.subscriptions.push(new NotebookExportCommand(api, log));
+
+	// Register builtin percent script exporters for Python and R.
+	context.subscriptions.push(api.registerNotebookExporter(new PythonPercentNotebookExporter()));
+	context.subscriptions.push(api.registerNotebookExporter(new RPercentNotebookExporter()));
+
+	log.info('Activated!');
+	return api;
+}

--- a/extensions/positron-notebook-export/src/notebookExportCommand.ts
+++ b/extensions/positron-notebook-export/src/notebookExportCommand.ts
@@ -14,7 +14,10 @@ import { getNotebookLanguage } from './util/notebook.js';
  * See {@link NotebookExportExtension} for more details about how this feature works.
  */
 export class NotebookExportCommand extends NotebookCommand {
-	static ID = 'notebook.export';
+	// Using `positronNotebook` prefix (matching other Positron notebook commands)
+	// even though this command is compatible with Code OSS notebooks,
+	// to gaurd against a conflict if upstream eventually use `notebook.export`.
+	static ID = 'positronNotebook.export';
 
 	constructor(
 		private readonly _api: NotebookExportExtension,

--- a/extensions/positron-notebook-export/src/notebookExportCommand.ts
+++ b/extensions/positron-notebook-export/src/notebookExportCommand.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { NotebookExportExtension } from './positron-notebook-export.js';
+import { NotebookCommand } from './util/command.js';
+import { getNotebookLanguage } from './util/notebook.js';
+
+/**
+ * Command to export a notebook to another file format.
+ *
+ * See {@link NotebookExportExtension} for more details about how this feature works.
+ */
+export class NotebookExportCommand extends NotebookCommand {
+	static ID = 'notebook.export';
+
+	constructor(
+		private readonly _api: NotebookExportExtension,
+		private readonly _log: vscode.LogOutputChannel,
+	) {
+		super(NotebookExportCommand.ID);
+	}
+
+	async runWithNotebook(notebook: vscode.NotebookDocument | undefined): Promise<void> {
+		if (!notebook) {
+			vscode.window.showInformationMessage(
+				vscode.l10n.t('No active notebook to export.')
+			);
+			return;
+		}
+
+		// Create quick pick items for each exporter that can export this notebook.
+		const notebookLanguage = getNotebookLanguage(notebook);
+		const items: NotebookExporterQuickPickItem[] = [];
+		for (const exporter of this._api.exporters) {
+			// Skip this exporter if:
+			// - It specifies a supported language, and
+			// - The notebook has a language, and
+			// - The exporter's supported language does not match the notebook's language.
+			if (exporter.supportedLanguageId &&
+				notebookLanguage &&
+				exporter.supportedLanguageId !== notebookLanguage) {
+				this._log.debug(
+					`Skipping exporter ${exporter.label} ` +
+					`for notebook ${notebook.uri.toString()} ` +
+					`due to unsupported language. ` +
+					`Exporter supports ${exporter.supportedLanguageId ?? 'any'}, ` +
+					`notebook language is ${notebookLanguage ?? 'unknown'}.`
+				);
+				continue;
+			}
+
+			items.push({
+				label: exporter.label,
+				description: `(${exporter.fileExtension})`,
+				// By setting the icon to File and resourceUri ending with a file extension,
+				// the file extension's primary icon will be used. Includes custom file
+				// extensions & icons like Quarto.
+				iconPath: vscode.ThemeIcon.File,
+				resourceUri: vscode.Uri.file(exporter.fileExtension),
+				export: async () => {
+					await exporter.export(notebook);
+				}
+			});
+		}
+
+		// Display items in alphabetical order by label.
+		items.sort((a, b) => a.label.localeCompare(b.label));
+
+		// Wait for the user to choose an exporter.
+		const item = await vscode.window.showQuickPick(items);
+
+		// Export the notebook.
+		await item?.export();
+	}
+}
+
+interface NotebookExporterQuickPickItem extends vscode.QuickPickItem {
+	export: () => Promise<void>;
+}

--- a/extensions/positron-notebook-export/src/percentNotebookExporter.ts
+++ b/extensions/positron-notebook-export/src/percentNotebookExporter.ts
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { NotebookExporter } from './positron-notebook-export.js';
+
+type PercentCellType = 'code' | 'markdown' | 'raw';
+
+/**
+ * Options for exporting a notebook to the percent script format.
+ */
+interface PercentExportOptions {
+	/**
+	 * The comment prefix to use for markdown and raw cells.
+	 * Added to each line of markdown and raw cells in the exported script.
+	 */
+	commentPrefix: string;
+}
+
+/**
+ * A notebook exporter for the language-agnostic percent script format (e.g. `# %%`).
+ *
+ * See {@link https://jupytext.org/formats/scripts/} for more details on the format.
+ */
+abstract class PercentNotebookExporter implements Partial<NotebookExporter> {
+	abstract supportedLanguageId: string;
+
+	abstract options: PercentExportOptions;
+
+	async export(notebook: vscode.NotebookDocument): Promise<void> {
+		const content = notebookToPercentScript(notebook, this.options);
+		const doc = await vscode.workspace.openTextDocument({
+			content,
+			language: this.supportedLanguageId
+		});
+		await vscode.window.showTextDocument(doc);
+	}
+}
+
+/**
+ * A notebook exporter for the percent script format for R notebooks.
+ */
+export class RPercentNotebookExporter extends PercentNotebookExporter implements NotebookExporter {
+	label = 'R';
+	fileExtension = '.R';
+	supportedLanguageId = 'r';
+	options = { commentPrefix: '#' };
+}
+
+/**
+ * A notebook exporter for the percent script format for Python notebooks.
+ */
+export class PythonPercentNotebookExporter extends PercentNotebookExporter implements NotebookExporter {
+	label = 'Python';
+	fileExtension = '.py';
+	supportedLanguageId = 'python';
+	options = { commentPrefix: '#' };
+}
+
+/**
+ * Export a notebook to the percent script format.
+ */
+export function notebookToPercentScript(
+	notebook: vscode.NotebookDocument,
+	options: PercentExportOptions,
+): string {
+	return notebook.getCells()
+		.map(cell => cellToPercentScript(cell, options))
+		.join('\n\n') + '\n';
+}
+
+function cellToPercentScript(
+	cell: vscode.NotebookCell,
+	options: PercentExportOptions
+): string {
+	if (cell.kind === vscode.NotebookCellKind.Markup) {
+		return formatPercentCell(cell.document.getText(), 'markdown', options);
+	} else if (
+		cell.kind === vscode.NotebookCellKind.Code &&
+		cell.document.languageId === 'raw'
+	) {
+		return formatPercentCell(cell.document.getText(), 'raw', options);
+	} else {
+		return formatPercentCell(cell.document.getText(), 'code', options);
+	}
+}
+
+function formatPercentCell(
+	text: string,
+	type: PercentCellType,
+	options: PercentExportOptions
+): string {
+	return `${formatPercentCellDelimiter(type, options)}
+${formatPercentCellText(text, type, options)}`;
+}
+
+function formatPercentCellDelimiter(
+	type: PercentCellType,
+	{ commentPrefix }: PercentExportOptions
+): string {
+	return prefixLine(
+		`%%${formatPercentCellType(type)}`,
+		commentPrefix
+	);
+}
+
+function formatPercentCellType(type: PercentCellType): string {
+	return type === 'code' ? '' : ` [${type}]`;
+}
+
+function formatPercentCellText(
+	text: string,
+	type: PercentCellType,
+	{ commentPrefix }: PercentExportOptions
+): string {
+	if (type === 'code') {
+		return text;
+	}
+	return prefixLines(text, commentPrefix);
+}
+
+function prefixLines(text: string, prefix: string): string {
+	return text
+		.split('\n')
+		.map((line) => prefixLine(line, prefix))
+		.join('\n');
+}
+
+function prefixLine(line: string, prefix: string): string {
+	return line.length > 0 ? `${prefix} ${line}` : prefix;
+}

--- a/extensions/positron-notebook-export/src/positron-notebook-export.d.ts
+++ b/extensions/positron-notebook-export/src/positron-notebook-export.d.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+/**
+ * A notebook exporter, which can export {@link vscode.NotebookDocument}s to a specific file format.
+ */
+export interface NotebookExporter {
+	/**
+	 * A human-readable label for the exporter, shown in the export picker.
+	 */
+	readonly label: string;
+
+	/**
+	 * The language ID that this exporter supports, e.g. `python`. If not provided,
+	 * the exporter will be available for all languages.
+	 */
+	readonly supportedLanguageId?: string;
+
+	/**
+	 * The file extension that this exporter exports to, including the prefix `.`, e.g. `.py`.
+	 * Also used to determine the icon in the export picker.
+	 */
+	readonly fileExtension: string;
+
+	/**
+	 * Export a notebook.
+	 *
+	 * The exporter is responsible for saving the notebook if needed, and showing the
+	 * exported result in the UI.
+	 *
+	 * The recommended pattern is not to save the notebook unless it's necessary to perform
+	 * the export (e.g. if using a CLI that requires a file path), and to show the exported
+	 * result in a new unsaved editor tab if possible.
+	 *
+	 * @param notebook The notebook to export.
+	 * @returns A promise that resolves when the export is complete and the result is visible
+	 *  to the user.
+	 */
+	export(notebook: vscode.NotebookDocument): Promise<unknown>;
+}
+
+/**
+ * The public API for the Positron Notebook Export extension.
+ */
+export interface NotebookExportExtension {
+	/**
+	 * All notebook exporters registered with the extension.
+	 */
+	readonly exporters: readonly NotebookExporter[];
+
+	/**
+	 * Register a {@link NotebookExporter} with the extension.
+	 *
+	 * Registered exporters are included in the export picker if they support
+	 * the active notebook's language.
+	 *
+	 * @param exporter The notebook exporter to register.
+	 * @returns A disposable which unregisters the notebook exporter.
+	 */
+	registerNotebookExporter(exporter: NotebookExporter): vscode.Disposable;
+}

--- a/extensions/positron-notebook-export/src/test/extension.test.ts
+++ b/extensions/positron-notebook-export/src/test/extension.test.ts
@@ -7,6 +7,7 @@ import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { NotebookExporter } from '../positron-notebook-export.js';
 import { activateExtension, openAndShowWorkspaceNotebook } from './util.js';
+import { NotebookExportCommand } from '../notebookExportCommand.js';
 
 function makeTestExporter() {
 	return {
@@ -40,7 +41,7 @@ suite('Positron Notebook Export', () => {
 		const notebook = await openAndShowWorkspaceNotebook('test-notebook.ipynb');
 		const showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(undefined);
 
-		await vscode.commands.executeCommand('notebook.export', notebook.uri);
+		await vscode.commands.executeCommand(NotebookExportCommand.ID, notebook.uri);
 
 		sinon.assert.calledOnceWithExactly(showQuickPickStub, []);
 	});
@@ -56,7 +57,7 @@ suite('Positron Notebook Export', () => {
 		disposables.push(api.registerNotebookExporter(makeTestPythonExporter()));
 		const showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(undefined);
 
-		await vscode.commands.executeCommand('notebook.export', notebook.uri);
+		await vscode.commands.executeCommand(NotebookExportCommand.ID, notebook.uri);
 
 		sinon.assert.calledOnceWithExactly(showQuickPickStub, [
 			sinon.match((item: vscode.QuickPickItem) => item.label === exporter.label),
@@ -74,7 +75,7 @@ suite('Positron Notebook Export', () => {
 			return item;
 		});
 
-		await vscode.commands.executeCommand('notebook.export', notebook.uri);
+		await vscode.commands.executeCommand(NotebookExportCommand.ID, notebook.uri);
 
 		// eslint-disable-next-line local/code-no-any-casts
 		sinon.assert.calledOnceWithExactly(showQuickPickStub, [{
@@ -94,7 +95,7 @@ suite('Positron Notebook Export', () => {
 		const registration = api.registerNotebookExporter(exporter);
 		const showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(undefined);
 
-		await vscode.commands.executeCommand('notebook.export', notebook.uri);
+		await vscode.commands.executeCommand(NotebookExportCommand.ID, notebook.uri);
 
 		// Double-check that it shows before we dispose it.
 		sinon.assert.calledOnceWithExactly(showQuickPickStub, [
@@ -105,7 +106,7 @@ suite('Positron Notebook Export', () => {
 		showQuickPickStub.resetHistory();
 		registration.dispose();
 
-		await vscode.commands.executeCommand('notebook.export', notebook.uri);
+		await vscode.commands.executeCommand(NotebookExportCommand.ID, notebook.uri);
 
 		sinon.assert.calledOnceWithExactly(showQuickPickStub, []);
 	});

--- a/extensions/positron-notebook-export/src/test/extension.test.ts
+++ b/extensions/positron-notebook-export/src/test/extension.test.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { NotebookExporter } from '../positron-notebook-export.js';
+import { activateExtension, openAndShowWorkspaceNotebook } from './util.js';
+
+function makeTestExporter() {
+	return {
+		label: 'Test',
+		fileExtension: '.test',
+		supportedLanguageId: 'test',
+		export: sinon.stub(),
+	} satisfies NotebookExporter;
+}
+
+function makeTestPythonExporter() {
+	return {
+		label: 'Python',
+		fileExtension: '.py',
+		supportedLanguageId: 'python',
+		export: sinon.stub(),
+	} satisfies NotebookExporter;
+}
+
+suite('Positron Notebook Export', () => {
+	let disposables: vscode.Disposable[] = [];
+
+	teardown(async () => {
+		await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+		disposables.forEach(d => d.dispose());
+		disposables = [];
+		sinon.restore();
+	});
+
+	test('shows empty quick pick when no exporters are registered', async () => {
+		const notebook = await openAndShowWorkspaceNotebook('test-notebook.ipynb');
+		const showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(undefined);
+
+		await vscode.commands.executeCommand('notebook.export', notebook.uri);
+
+		sinon.assert.calledOnceWithExactly(showQuickPickStub, []);
+	});
+
+	test('shows only exporters that support the notebook language', async () => {
+		// The test notebook has the language "test".
+		// If we register an exporter with another language, it should not
+		// show in the export quick pick.
+		const notebook = await openAndShowWorkspaceNotebook('test-notebook.ipynb');
+		const api = await activateExtension();
+		const exporter = makeTestExporter();
+		disposables.push(api.registerNotebookExporter(exporter));
+		disposables.push(api.registerNotebookExporter(makeTestPythonExporter()));
+		const showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(undefined);
+
+		await vscode.commands.executeCommand('notebook.export', notebook.uri);
+
+		sinon.assert.calledOnceWithExactly(showQuickPickStub, [
+			sinon.match((item: vscode.QuickPickItem) => item.label === exporter.label),
+		]);
+	});
+
+	test('exports a notebook with a registered exporter', async () => {
+		const notebook = await openAndShowWorkspaceNotebook('test-notebook.ipynb');
+		const api = await activateExtension();
+		const exporter = makeTestExporter();
+		disposables.push(api.registerNotebookExporter(exporter));
+		const showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick').callsFake(async (items) => {
+			// Return the test exporter item, as if it were selected by the user.
+			const item = (await items).find(item => item.label === exporter.label);
+			return item;
+		});
+
+		await vscode.commands.executeCommand('notebook.export', notebook.uri);
+
+		// eslint-disable-next-line local/code-no-any-casts
+		sinon.assert.calledOnceWithExactly(showQuickPickStub, [{
+			label: exporter.label,
+			description: `(${exporter.fileExtension})`,
+			iconPath: vscode.ThemeIcon.File,
+			resourceUri: sinon.match((uri: vscode.Uri) => uri.fsPath.endsWith(exporter.fileExtension)),
+			export: sinon.match.func,
+		} as any]);
+		sinon.assert.calledOnceWithExactly(exporter.export, notebook);
+	});
+
+	test('removes an exporter from the quick pick when it is disposed', async () => {
+		const notebook = await openAndShowWorkspaceNotebook('test-notebook.ipynb');
+		const api = await activateExtension();
+		const exporter = makeTestExporter();
+		const registration = api.registerNotebookExporter(exporter);
+		const showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick').resolves(undefined);
+
+		await vscode.commands.executeCommand('notebook.export', notebook.uri);
+
+		// Double-check that it shows before we dispose it.
+		sinon.assert.calledOnceWithExactly(showQuickPickStub, [
+			sinon.match((item: vscode.QuickPickItem) => item.label === exporter.label)
+		]);
+
+		// Dispose, and verify that it no longer shows in the quick pick.
+		showQuickPickStub.resetHistory();
+		registration.dispose();
+
+		await vscode.commands.executeCommand('notebook.export', notebook.uri);
+
+		sinon.assert.calledOnceWithExactly(showQuickPickStub, []);
+	});
+});

--- a/extensions/positron-notebook-export/src/test/percentNotebookExporter.test.ts
+++ b/extensions/positron-notebook-export/src/test/percentNotebookExporter.test.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { notebookToPercentScript } from '../percentNotebookExporter.js';
+
+function mockCell(text: string, languageId: string, kind: 'code' | 'markup') {
+	return {
+		kind: kind === 'code' ? vscode.NotebookCellKind.Code : vscode.NotebookCellKind.Markup,
+		document: {
+			getText: () => text,
+			languageId,
+		},
+	} as vscode.NotebookCell;
+}
+
+function mockNotebook(cells: ReturnType<typeof mockCell>[]) {
+	return {
+		getCells: () => cells,
+	} as vscode.NotebookDocument;
+}
+
+// We only test the internal export logic here.
+// The exporter classes are thin wrappers over this,
+// much of which is tested in extension.test.ts.
+suite('notebookToPercentScript', () => {
+	let disposables: vscode.Disposable[] = [];
+
+	teardown(() => {
+		disposables.forEach(d => d.dispose());
+		disposables = [];
+		sinon.restore();
+	});
+
+	test('code cell', () => {
+		const actual = notebookToPercentScript(mockNotebook([
+			mockCell('print("Hello, world!")', 'python', 'code'),
+		]), { commentPrefix: '#' });
+		assert.strictEqual(actual, `# %%
+print("Hello, world!")
+`);
+	});
+
+	test('markdown cell', () => {
+		const actual = notebookToPercentScript(mockNotebook([
+			mockCell('# Heading\n\nContent', 'markdown', 'markup'),
+		]), { commentPrefix: '#' });
+		assert.strictEqual(actual, `# %% [markdown]
+# # Heading
+#
+# Content
+`);
+	});
+
+	test('raw cell', () => {
+		const actual = notebookToPercentScript(mockNotebook([
+			mockCell('---\ntitle: My Title\n---', 'raw', 'code'),
+		]), { commentPrefix: '#' });
+		assert.strictEqual(actual, `# %% [raw]
+# ---
+# title: My Title
+# ---
+`);
+	});
+
+	test('multiple cells of different types', () => {
+		const actual = notebookToPercentScript(mockNotebook([
+			mockCell('---\ntitle: My Title\n---', 'raw', 'code'),
+			mockCell('# Heading\n\nContent', 'markdown', 'markup'),
+			mockCell('print("Hello, world!")', 'python', 'code'),
+		]), { commentPrefix: '#' });
+		assert.strictEqual(actual, `# %% [raw]
+# ---
+# title: My Title
+# ---
+
+# %% [markdown]
+# # Heading
+#
+# Content
+
+# %%
+print("Hello, world!")
+`);
+	});
+
+	test('custom comment prefix', () => {
+		const actual = notebookToPercentScript(mockNotebook([
+			mockCell('# Heading\n\nContent', 'markdown', 'markup'),
+		]), { commentPrefix: '//' });
+		assert.strictEqual(actual, `// %% [markdown]
+// # Heading
+//
+// Content
+`);
+	});
+});

--- a/extensions/positron-notebook-export/src/test/percentNotebookExporter.test.ts
+++ b/extensions/positron-notebook-export/src/test/percentNotebookExporter.test.ts
@@ -98,4 +98,16 @@ print("Hello, world!")
 // Content
 `);
 	});
+
+	// No special treatment for cell delimiters inside code cells, for now.
+	// Notebooks containing this case will not round-trip, however this
+	// matches `jupytext` behavior, which is the current standard.
+	test('cell delimiter in code cell', () => {
+		const actual = notebookToPercentScript(mockNotebook([
+			mockCell('# %%', 'python', 'code'),
+		]), { commentPrefix: '#' });
+		assert.strictEqual(actual, `# %%
+# %%
+`);
+	});
 });

--- a/extensions/positron-notebook-export/src/test/util.ts
+++ b/extensions/positron-notebook-export/src/test/util.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { extensions, NotebookDocument, Uri, window, workspace, WorkspaceFolder } from 'vscode';
+import { NotebookExportExtension } from '../positron-notebook-export.js';
+
+export const extensionId = 'positron.notebook-export';
+
+export function activeWorkspaceFolder(): WorkspaceFolder {
+	const workspaceFolder = workspace.workspaceFolders?.[0];
+	if (!workspaceFolder) {
+		throw new Error('No active workspace folder');
+	}
+	return workspaceFolder;
+}
+
+export function workspaceUri(...pathSegments: string[]): Uri {
+	const workspaceFolder = activeWorkspaceFolder();
+	return Uri.joinPath(workspaceFolder.uri, ...pathSegments);
+}
+
+export async function openAndShowWorkspaceNotebook(...pathSegments: string[]): Promise<NotebookDocument> {
+	const uri = workspaceUri(...pathSegments);
+	const notebook = await workspace.openNotebookDocument(uri);
+	await window.showNotebookDocument(notebook);
+	return notebook;
+}
+
+export async function activateExtension(): Promise<NotebookExportExtension> {
+	const extension = extensions.getExtension<NotebookExportExtension>(extensionId);
+	assert.ok(extension, `Extension ${extensionId} not found`);
+	const api = await extension.activate();
+	return api;
+}

--- a/extensions/positron-notebook-export/src/util/command.ts
+++ b/extensions/positron-notebook-export/src/util/command.ts
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { Disposable } from './disposable.js';
+
+export abstract class Command extends Disposable {
+	constructor(public readonly id: string) {
+		super();
+
+		this._register(vscode.commands.registerCommand(
+			this.id,
+			(args) => this.run(args)
+		));
+	}
+
+	/**
+	 * Run the command.
+	 */
+	abstract run(...args: unknown[]): Promise<void>;
+}
+
+export abstract class ResourceCommand extends Command {
+	run(...args: unknown[]): Promise<void> {
+		let resource: vscode.Uri | undefined;
+		if (args[0] instanceof vscode.Uri) {
+			resource = args[0];
+		}
+		return this.runWithResource(resource);
+	}
+
+	/**
+	 * Run the command with an optional resource.
+	 * @param resource The resource that the command was called with.
+	 */
+	abstract runWithResource(resource: vscode.Uri | undefined): Promise<void>;
+}
+
+export abstract class NotebookCommand extends ResourceCommand {
+	runWithResource(resource: vscode.Uri | undefined): Promise<void> {
+		let notebook: vscode.NotebookDocument | undefined;
+		if (resource) {
+			const resourceStr = resource.toString();
+			notebook = vscode.workspace.notebookDocuments.find(doc => doc.uri.toString() === resourceStr);
+		} else {
+			notebook = vscode.window.activeNotebookEditor?.notebook;
+		}
+		return this.runWithNotebook(notebook);
+	}
+
+	/**
+	 * Run the command with an optional notebook.
+	 * @param notebook The notebook that the command was called with, or the active notebook.
+	 */
+	abstract runWithNotebook(notebook: vscode.NotebookDocument | undefined): Promise<void>;
+}

--- a/extensions/positron-notebook-export/src/util/disposable.ts
+++ b/extensions/positron-notebook-export/src/util/disposable.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export class DisposableStore implements vscode.Disposable {
+	private _disposables = new Set<vscode.Disposable>();
+
+	public add<T extends vscode.Disposable>(disposable: T): T {
+		this._disposables.add(disposable);
+		return disposable;
+	}
+
+	public dispose(): void {
+		for (const disposable of this._disposables) {
+			disposable.dispose();
+		}
+
+		this._disposables.clear();
+	}
+}
+
+export abstract class Disposable implements vscode.Disposable {
+	private _isDisposed = false;
+
+	protected readonly _disposables = new DisposableStore();
+
+	public dispose(): void {
+		if (this._isDisposed) {
+			return;
+		}
+		this._isDisposed = true;
+		this._disposables.dispose();
+	}
+
+	protected _register<T extends vscode.Disposable>(value: T): T {
+		if (this._isDisposed) {
+			value.dispose();
+		} else {
+			this._disposables.add(value);
+		}
+		return value;
+	}
+
+	protected get isDisposed() {
+		return this._isDisposed;
+	}
+}

--- a/extensions/positron-notebook-export/src/util/notebook.ts
+++ b/extensions/positron-notebook-export/src/util/notebook.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+/**
+ * Try to determine the language of a notebook by inspecting its metadata and cells.
+ * @param notebook The notebook document to inspect.
+ * @returns The language ID of the notebook, or `undefined` if it cannot be determined.
+ */
+export function getNotebookLanguage(notebook: vscode.NotebookDocument): string | undefined {
+	// First try the notebook metadata.
+	// eslint-disable-next-line local/code-no-any-casts
+	const metadata = notebook.metadata?.metadata as any;
+	const languageId = metadata?.language_info?.name ?? metadata?.kernelspec?.language;
+	if (languageId &&
+		languageId !== 'raw' &&
+		languageId !== 'plaintext'
+	) {
+		return languageId;
+	}
+
+	// Fall back to the first cell's language, if available.
+	for (const cell of notebook.getCells()) {
+		if (cell.kind === vscode.NotebookCellKind.Code &&
+			cell.document.languageId !== 'raw' &&
+			cell.document.languageId !== 'plaintext') {
+			return cell.document.languageId;
+		}
+	}
+
+	// Could not determine the notebook's language.
+	return undefined;
+}

--- a/extensions/positron-notebook-export/test-workspace/test-notebook.ipynb
+++ b/extensions/positron-notebook-export/test-workspace/test-notebook.ipynb
@@ -1,0 +1,1 @@
+{"cells":[],"metadata":{"language_info":{"name":"test"}},"nbformat":4,"nbformat_minor":5}

--- a/extensions/positron-notebook-export/tsconfig.json
+++ b/extensions/positron-notebook-export/tsconfig.json
@@ -3,16 +3,19 @@
 		"module": "commonjs",
 		"target": "ES2020",
 		"outDir": "out",
-		"esModuleInterop": true,
 		"lib": ["ES2020"],
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true,
 		"skipLibCheck": true,
-		"types": ["node"],
+		"typeRoots": ["./node_modules/@types"],
+		"types": ["node", "mocha"],
 		"paths": {
 			"*": ["./node_modules/*"]
 		}
 	},
-	"include": ["src/**/*", "../../src/vscode-dts/vscode.d.ts"]
+	"include": [
+		"src/**/*",
+		"../../src/vscode-dts/vscode.d.ts"
+	]
 }


### PR DESCRIPTION
Toward #9791.

This PR adds functionality to export Jupyter notebooks to other file formats. It's designed so that third party extensions can contribute their own notebook exporters. I packaged this in a new extension (rather than the `positron-notebooks-helper` extension) since it has a public-facing API.

Here is the corresponding PR setting up an exporter in the Quarto extension: https://github.com/quarto-dev/quarto/pull/999.

Demo:

https://github.com/user-attachments/assets/8af2714b-1fe7-4ccc-9791-321d3d967367

### Release Notes

#### New Features

- Export Jupyter notebooks to Quarto (.qmd), Python, and R (#9791)

#### Bug Fixes

- N/A

### Validation Steps

@positron-notebooks @:web

1. Open a Python or R Jupyter notebook
2. Click the "..." menu in the notebook toolbar
3. Click "Export..."
4. Choose Python or R
5. Verify that the exported file is opened in a new, untitled editor tab