### PR TITLE
Fix broken unit test with positronList

### DIFF
--- a/src/vs/workbench/browser/positronList/test/browser/positronList.vitest.tsx
+++ b/src/vs/workbench/browser/positronList/test/browser/positronList.vitest.tsx
@@ -113,8 +113,8 @@ describe('PositronListInstance', () => {
 		const instance = new PositronListInstance<string, string>({
 			itemRenderer: item => <div>{item}</div>,
 			sectionRenderer: section => <div>{section}</div>,
-			defaultItemHeight: ITEM_HEIGHT,
-			defaultSectionHeight: SECTION_HEIGHT,
+			itemHeight: ITEM_HEIGHT,
+			sectionHeight: SECTION_HEIGHT,
 		});
 		store.add(instance);
 		return instance;
@@ -203,8 +203,8 @@ describe('PositronList keyboard navigation', () => {
 		const common = {
 			itemRenderer: (item: string) => <div>{item}</div>,
 			sectionRenderer: (section: string) => <div>{section}</div>,
-			defaultItemHeight: ITEM_HEIGHT,
-			defaultSectionHeight: SECTION_HEIGHT,
+			itemHeight: ITEM_HEIGHT,
+			sectionHeight: SECTION_HEIGHT,
 		};
 		const instance = selectionFollowsCursor
 			? new PositronListInstance<string, string>({ ...common, selectionFollowsCursor: true })
@@ -339,8 +339,8 @@ describe('PositronList rendering', () => {
 		const instance = new PositronListInstance<string, string>({
 			itemRenderer: item => <div>{item}</div>,
 			sectionRenderer: section => <div>{section}</div>,
-			defaultItemHeight: ITEM_HEIGHT,
-			defaultSectionHeight: SECTION_HEIGHT,
+			itemHeight: ITEM_HEIGHT,
+			sectionHeight: SECTION_HEIGHT,
 		});
 		store.add(instance);
 		return instance;


### PR DESCRIPTION
Repairs the `positronList` Vitest suite, which broke on `main` after the
`PositronListInstance` constructor options were renamed (`defaultItemHeight`
-> `itemHeight`, `defaultSectionHeight` -> `sectionHeight`) without updating
the tests added in #14107. The tests still passed the old names, so the item
height resolved to `undefined` (row height 0), collapsing `scrollHeight` and
rendering zero rows -- three failures in CI. This renames the options in the
test file to match the current API.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A (test-only)

### Validation Steps

Unit tests only; no e2e run needed. Verify locally:

```bash
npx vitest run src/vs/workbench/browser/positronList/test/browser/positronList.vitest.tsx
Expected: 12 passing.