### PR TITLE
ci: pin openssl to 2.4.2 on Windows to unblock R package install

### DIFF
--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -333,6 +333,9 @@ jobs:
       - name: Install R packages for 4.4.0
         run: |
           Rscript -e "install.packages('pak')"
+          # openssl 2.4.1 Windows binary was never published to the package manager; pin to 2.4.2
+          # so pak doesn't attempt to download the missing binary.
+          Rscript -e "pak::pak('openssl@2.4.2')"
           Rscript -e "pak::local_install_dev_deps(ask = FALSE, upgrade = FALSE)"
 
       - name: Save R packages cache


### PR DESCRIPTION
### Summary
Pins the `openssl` R package to 2.4.2 in the Windows e2e workflow to unblock CI.

- `openssl` 2.4.1 was released but its Windows binary was never published to `packagemanager.posit.co`
- All 3 Windows e2e shards were failing at "Install R packages for 4.4.0" with a 404 on the zip
- Pre-installing 2.4.2 (which has a binary) before `local_install_dev_deps` prevents pak from resolving to the missing 2.4.1
- Pin can be removed once a future openssl release is naturally picked up through the cache

### QA Notes
@:win