### PR TITLE
chore: bump @midleman/playwright-reporter to ^0.52.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
       },
       "devDependencies": {
         "@midleman/github-actions-reporter": "^1.10.1",
-        "@midleman/playwright-reporter": "^0.47.16",
+        "@midleman/playwright-reporter": "^0.52.0",
         "@playwright/cli": "^0.1.1",
         "@playwright/test": "^1.58.2",
         "@stylistic/eslint-plugin-ts": "^2.8.0",
@@ -2990,9 +2990,9 @@
       }
     },
     "node_modules/@midleman/playwright-reporter": {
-      "version": "0.47.16",
-      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.47.16.tgz",
-      "integrity": "sha512-OTVFLDXqyI81wCYKxGPHASbt7kICe7FrYimfGsHE/3MgNBmpysi0m3/elYMnxHBcRJtgQBqNqSYg+L1vo7ci/g==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@midleman/playwright-reporter/-/playwright-reporter-0.52.0.tgz",
+      "integrity": "sha512-ysJvtpf040UB+ZHiENKvxjSiZIzI6aNqe7HOa5bfTzCEFQgfNvpM+POAdN7oWKUEoAEVFNoCUSIbtSegOTQOVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
   },
   "devDependencies": {
     "@midleman/github-actions-reporter": "^1.10.1",
-    "@midleman/playwright-reporter": "^0.47.16",
+    "@midleman/playwright-reporter": "^0.52.0",
     "@playwright/cli": "^0.1.1",
     "@playwright/test": "^1.58.2",
     "@stylistic/eslint-plugin-ts": "^2.8.0",


### PR DESCRIPTION
### Summary
Bumps `@midleman/playwright-reporter` from `^0.47.16` to `^0.52.0` and updates `package-lock.json` to match.

### QA Notes
n/a