### PR TITLE
unit tests for `Collapse Output`, `Show hidden output`, and `Clear Output` buttons in PNE

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.vitest.ts
@@ -281,4 +281,143 @@ describe('Positron Notebook Cell Outputs', () => {
 			expect(outputs[0].parsed.type).toBe('html');
 		});
 	});
+
+	// Model-level coverage for the Collapse Output, Show Hidden Output (expand),
+	// and Clear Output cell actions (#12411). The action handlers in
+	// positronNotebook.contribution.ts delegate to these cell/instance methods,
+	// and their menu visibility is driven by the context keys asserted below.
+	describe('output visibility and clear actions (#12411)', () => {
+		function cellWithOutputs(...outputs: { mime: string; data: VSBuffer }[][]): TestCellInput {
+			return {
+				source: 'print("hello")',
+				language: 'python',
+				mime: undefined,
+				cellKind: CellKind.Code,
+				outputs: outputs.map((items, i) => ({
+					outputId: `output-${i + 1}`,
+					outputs: items,
+				})),
+			};
+		}
+
+		// Narrowing accessor: expect(cell.isCodeCell()).toBe(true) does not
+		// narrow the union type, so output members would not typecheck.
+		function firstCodeCell(notebook: ReturnType<typeof createTestPositronNotebookInstance>) {
+			const cell = notebook.cells.get()[0];
+			if (!cell.isCodeCell()) {
+				throw new Error('expected a code cell');
+			}
+			return cell;
+		}
+
+		it('collapse output hides the output without deleting it', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[cellWithOutputs([textOutputItem('hello')])],
+				ctx
+			);
+			const cell = firstCodeCell(notebook);
+			expect(cell.outputIsCollapsed.get(), 'output should start expanded').toBe(false);
+
+			cell.collapseOutput();
+
+			expect(cell.outputIsCollapsed.get()).toBe(true);
+			const outputs = cell.outputs.get();
+			expect(outputs.length, 'collapse is visibility-only; outputs must survive').toBe(1);
+			expect(outputs[0].parsed.type).toBe('stdout');
+		});
+
+		it('show hidden output (expand) restores visibility with outputs intact', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[cellWithOutputs([textOutputItem('hello')])],
+				ctx
+			);
+			const cell = firstCodeCell(notebook);
+
+			cell.collapseOutput();
+			expect(cell.outputIsCollapsed.get()).toBe(true);
+
+			cell.expandOutput();
+
+			expect(cell.outputIsCollapsed.get()).toBe(false);
+			const outputs = cell.outputs.get();
+			expect(outputs.length, 'outputs must be unchanged after a collapse/expand cycle').toBe(1);
+			expect(outputs[0].parsed.type).toBe('stdout');
+		});
+
+		it('toggleOutputCollapse flips the collapse state', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[cellWithOutputs([textOutputItem('hello')])],
+				ctx
+			);
+			const cell = firstCodeCell(notebook);
+
+			cell.toggleOutputCollapse();
+			expect(cell.outputIsCollapsed.get()).toBe(true);
+
+			cell.toggleOutputCollapse();
+			expect(cell.outputIsCollapsed.get()).toBe(false);
+		});
+
+		it('collapse state initializes from cell collapseState metadata', () => {
+			const collapsedCell: TestCellInput = {
+				source: 'print("hello")',
+				language: 'python',
+				mime: undefined,
+				cellKind: CellKind.Code,
+				outputs: [{ outputId: 'output-1', outputs: [textOutputItem('hello')] }],
+				collapseState: { outputCollapsed: true },
+			};
+			const notebook = createTestPositronNotebookInstance([collapsedCell], ctx);
+			const cell = firstCodeCell(notebook);
+
+			expect(
+				cell.outputIsCollapsed.get(),
+				'cell saved with outputCollapsed metadata should open collapsed'
+			).toBe(true);
+		});
+
+		it('clear output removes all outputs from the cell', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[cellWithOutputs([textOutputItem('hello')], [pngOutputItem()])],
+				ctx
+			);
+			const cell = firstCodeCell(notebook);
+			expect(cell.outputs.get().length).toBe(2);
+
+			notebook.clearCellOutput(cell);
+
+			expect(cell.outputs.get().length).toBe(0);
+		});
+
+		it('context keys driving the action buttons track output state', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[cellWithOutputs([textOutputItem('hello')])],
+				ctx
+			);
+			const cell = firstCodeCell(notebook);
+
+			// Attaching a container creates the cell's scoped context key
+			// service and CellContextKeyManager, as the view layer does.
+			cell.attachContainer(document.createElement('div'));
+			const scoped = cell.scopedContextKeyService;
+			expect(scoped).toBeDefined();
+
+			// With outputs expanded: Collapse Output is eligible
+			// (hasOutputs && !outputIsCollapsed per its menu when clause).
+			expect(scoped?.getContextKeyValue(CellContextKeys.hasOutputs.key)).toBe(true);
+			expect(scoped?.getContextKeyValue(CellContextKeys.outputIsCollapsed.key)).toBe(false);
+
+			// Collapsed: Show Hidden Output (expand) becomes eligible
+			// (hasOutputs && outputIsCollapsed).
+			cell.collapseOutput();
+			expect(scoped?.getContextKeyValue(CellContextKeys.outputIsCollapsed.key)).toBe(true);
+
+			cell.expandOutput();
+			expect(scoped?.getContextKeyValue(CellContextKeys.outputIsCollapsed.key)).toBe(false);
+
+			// Cleared: no output-dependent action is eligible.
+			notebook.clearCellOutput(cell);
+			expect(scoped?.getContextKeyValue(CellContextKeys.hasOutputs.key)).toBe(false);
+		});
+	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.vitest.ts
@@ -284,7 +284,7 @@ describe('Positron Notebook Cell Outputs', () => {
 
 	// Model-level coverage for the Collapse Output, Show Hidden Output (expand),
 	// and Clear Output cell actions (#12411). The action handlers in
-	// positronNotebook.contribution.ts delegate to these cell/instance methods,
+	// `positronNotebook.contribution.ts` delegate to these cell/instance methods,
 	// and their menu visibility is driven by the context keys asserted below.
 	describe('output visibility and clear actions (#12411)', () => {
 		function cellWithOutputs(...outputs: { mime: string; data: VSBuffer }[][]): TestCellInput {


### PR DESCRIPTION
Closes #12411.

Per the [discussion on the issue](https://github.com/posit-dev/positron/issues/12411#issuecomment-4664160714), collapse, show-hidden, and clear are observable state mutations on the cell model (`outputIsCollapsed` and `clearCellOutput()`) with no runtime or layout dependence, so they are covered as Vitest unit tests rather than additional e2e.

Adds an `output visibility and clear actions (#12411)` suite to `positronNotebookCellOutputs.vitest.ts` (6 tests):

- **Collapse Output** hides the output without deleting it (`collapseOutput()` sets `outputIsCollapsed` while outputs survive intact)
- **Show Hidden Output** (expand) restores visibility with outputs unchanged through the collapse/expand cycle
- `toggleOutputCollapse()` flips the state (the chevron toggle path)
- Collapse state initializes from cell `collapseState.outputCollapsed` metadata (persistence across reopen)
- **Clear Output** empties the outputs observable (cell with 2 outputs -> 0)
- The context keys driving the action buttons (`hasOutputs`, `outputIsCollapsed`) track cell state through collapse -> expand -> clear, via a real `CellContextKeyManager` created by `cell.attachContainer()`. These keys are exactly the menu `when` clauses of the three actions, so this is the unit-level check that the right button is offered.

The new tests use a small narrowing helper (`firstCodeCell`) instead of the file's existing `expect(cell.isCodeCell()).toBe(true)` pattern, which does not narrow the union type; the new block adds zero `check-ts` type errors (the file's 14 pre-existing ones are untouched).

### Regression-detection check

To confirm the tests fail if any of the three buttons stop working:

1. **Collapse / Show Hidden Output broken**: with `PositronNotebookCodeCell.ts` temporarily reverted to its pre-#11680 state (`a6c5876926^`, before output expand/collapse support existed), **7 of 16 tests fail**, including all 5 new collapse/expand tests (e.g. `collapse output hides the output without deleting it` fails because `collapseOutput` is not a function) and the pre-existing `clearing outputs resets collapse state`.
2. **Clear Output broken**: with `PositronNotebookInstance.clearCellOutput()` temporarily made a no-op (`return;` inserted at the top), **3 of 16 tests fail**: `clear output removes all outputs from the cell`, `context keys driving the action buttons track output state` (`hasOutputs` stays true), and the pre-existing `clearing outputs resets collapse state`.

Both source files were restored after the checks; the final run on this branch is 16/16 green.

### Future e2e cleanup (optional)

The collapse-click, expand-click, and clear steps of `test/e2e/tests/notebooks-positron/notebook-cell-output.test.ts` (`Collapse, expand, and clear output`) are now unit-covered at the state level; only the DOM click -> action dispatch wiring remains e2e-exclusive for those steps. The hover/selection visibility steps genuinely need the full app and should stay e2e. Slimming those three steps is optional - if desirable, it could be filed as a ticket and done in a separate PR. This PR intentionally leaves the e2e test untouched.

### QA notes

`npx vitest run src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookCellOutputs.vitest.ts` -- 16 tests pass (10 existing + 6 new).

@:positron-notebooks @:web @:win