### PR TITLE
Adapt to testthat 3.3.0 behaviour around nested test descriptions

### DIFF
--- a/extensions/positron-r/src/testing/util-testing.ts
+++ b/extensions/positron-r/src/testing/util-testing.ts
@@ -27,7 +27,7 @@ export function encodeNodeId(
 	testSuperLabel: string | undefined = undefined
 ) {
 	return testSuperLabel
-		? `${testFile}&${testSuperLabel}: ${testLabel}`
+		? `${testFile}&${testSuperLabel} / ${testLabel}`
 		: testLabel
 			? `${testFile}&${testLabel}`
 			: testFile;


### PR DESCRIPTION
Fixes #10682 

testthat 3.3.0 changed how nested tests are labelled and this broke positron-r's ability to match test outcomes to the test items identified in test files.

This small change fixes things for typical `describe()` / `it()` usage.

I've empirically verified in a dev build that `describe()` / `it()` tests now work with the test explorer.

https://github.com/user-attachments/assets/b32098db-6936-43b9-9fd6-ff3c9281f883

(Note that deeper nesting is still not supported. That is much lower priority and is tracked in #2805.)

(As part of a general push on the test explorer, I'll have more inbound PRs to start improving the testing situation and that's when I will deal with un-skipping the e2e test mentioned in #10682. I actually think that's more of a problem with the fixture.)