### PR TITLE
Show all R expression outputs in Quarto cells

### DIFF
--- a/extensions/positron-r/src/input-boundaries.ts
+++ b/extensions/positron-r/src/input-boundaries.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { RequestType } from 'vscode-languageclient/node';
+
+export interface InputBoundariesParams {
+	text: string;
+}
+
+export interface InputBoundaryRange {
+	start: number;
+	end: number;
+}
+
+export type InputBoundaryKind = 'whitespace' | 'complete' | 'incomplete' | 'invalid';
+
+export interface InputBoundary {
+	range: InputBoundaryRange;
+	kind: InputBoundaryKind;
+	data?: {
+		message?: string;
+	};
+}
+
+export interface InputBoundariesResponse {
+	boundaries: InputBoundary[];
+}
+
+export namespace InputBoundariesRequest {
+	export const type = new RequestType<InputBoundariesParams, InputBoundariesResponse, any>('positron/inputBoundaries');
+}

--- a/extensions/positron-r/src/input-boundaries.ts
+++ b/extensions/positron-r/src/input-boundaries.ts
@@ -3,7 +3,9 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RequestType } from 'vscode-languageclient/node';
+import * as positron from 'positron';
+import * as vscode from 'vscode';
+import { LanguageClient, RequestType } from 'vscode-languageclient/node';
 
 export interface InputBoundariesParams {
 	text: string;
@@ -30,4 +32,24 @@ export interface InputBoundariesResponse {
 
 export namespace InputBoundariesRequest {
 	export const type = new RequestType<InputBoundariesParams, InputBoundariesResponse, any>('positron/inputBoundaries');
+}
+
+/**
+ * Provides R input boundaries through the Ark LSP.
+ */
+export class RInputBoundaryProvider implements positron.InputBoundaryProvider {
+	constructor(
+		private readonly _client: LanguageClient,
+	) { }
+
+	async provideInputBoundaries(
+		document: vscode.TextDocument,
+		range: vscode.Range,
+		token: vscode.CancellationToken
+	): Promise<positron.InputBoundary[]> {
+		const text = document.getText(range);
+		const response = await this._client.sendRequest(InputBoundariesRequest.type, { text }, token);
+
+		return response.boundaries;
+	}
 }

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -30,7 +30,7 @@ const VDOC_PATTERN = /^\.vdoc\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[
 
 // Selector for Quarto virtual documents.
 const VDOC_SELECTOR = { language: 'r', pattern: '**/.vdoc.*.{r,R}' };
-const QUARTO_INPUT_BOUNDARY_SELECTOR = { language: 'r', scheme: 'inmemory', pattern: '**/quarto-input-boundaries/*.{r,R}' };
+const QUARTO_INPUT_BOUNDARY_SELECTOR = { language: 'r', scheme: 'inmemory', pattern: '**/quarto-input-boundaries/*' };
 
 // Regex to match notebook console REPL URIs: /notebook-repl-<lang>-<uuid>
 const NOTEBOOK_REPL_PATTERN = /^\/notebook-repl-/;

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -8,7 +8,7 @@ import * as positron from 'positron';
 import * as path from 'path';
 import { PromiseHandles, timeout } from './util';
 import { RStatementRangeProvider } from './statement-range';
-import { InputBoundariesRequest, InputBoundariesResponse } from './input-boundaries';
+import { RInputBoundaryProvider } from './input-boundaries';
 import { LOGGER } from './extension';
 import { RErrorHandler } from './error-handler';
 
@@ -380,14 +380,6 @@ export class ArkLsp implements vscode.Disposable {
 		}
 	}
 
-	async inputBoundaries(text: string): Promise<InputBoundariesResponse> {
-		if (!this.client) {
-			throw new Error('Cannot get input boundaries; LSP client has not been started');
-		}
-
-		return await this.client.sendRequest(InputBoundariesRequest.type, { text });
-	}
-
 	/**
 	 * Registers additional Positron-specific LSP methods. These programmatic
 	 * language features are not part of the LSP specification, and are
@@ -416,6 +408,10 @@ export class ArkLsp implements vscode.Disposable {
 		const rangeDisposable = positron.languages.registerStatementRangeProvider(selector,
 			new RStatementRangeProvider(client));
 		this.activationDisposables.push(rangeDisposable);
+
+		const inputBoundaryDisposable = positron.languages.registerInputBoundaryProvider(selector,
+			new RInputBoundaryProvider(client));
+		this.activationDisposables.push(inputBoundaryDisposable);
 
 		const helpDisposable = positron.languages.registerHelpTopicProvider(selector,
 			new RHelpTopicProvider(client));

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -30,6 +30,7 @@ const VDOC_PATTERN = /^\.vdoc\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[
 
 // Selector for Quarto virtual documents.
 const VDOC_SELECTOR = { language: 'r', pattern: '**/.vdoc.*.{r,R}' };
+const QUARTO_INPUT_BOUNDARY_SELECTOR = { language: 'r', scheme: 'inmemory', pattern: '**/quarto-input-boundaries/*.{r,R}' };
 
 // Regex to match notebook console REPL URIs: /notebook-repl-<lang>-<uuid>
 const NOTEBOOK_REPL_PATTERN = /^\/notebook-repl-/;
@@ -404,12 +405,15 @@ export class ArkLsp implements vscode.Disposable {
 		const selector: vscode.DocumentSelector = this._metadata.notebookUri
 			? [VDOC_SELECTOR, { language: 'r', scheme: 'vscode-notebook-cell' }]
 			: 'r';
+		const inputBoundarySelector: vscode.DocumentSelector = this._metadata.notebookUri
+			? [VDOC_SELECTOR, { language: 'r', scheme: 'vscode-notebook-cell' }, QUARTO_INPUT_BOUNDARY_SELECTOR]
+			: selector;
 
 		const rangeDisposable = positron.languages.registerStatementRangeProvider(selector,
 			new RStatementRangeProvider(client));
 		this.activationDisposables.push(rangeDisposable);
 
-		const inputBoundaryDisposable = positron.languages.registerInputBoundaryProvider(selector,
+		const inputBoundaryDisposable = positron.languages.registerInputBoundaryProvider(inputBoundarySelector,
 			new RInputBoundaryProvider(client));
 		this.activationDisposables.push(inputBoundaryDisposable);
 

--- a/extensions/positron-r/src/lsp.ts
+++ b/extensions/positron-r/src/lsp.ts
@@ -8,6 +8,7 @@ import * as positron from 'positron';
 import * as path from 'path';
 import { PromiseHandles, timeout } from './util';
 import { RStatementRangeProvider } from './statement-range';
+import { InputBoundariesRequest, InputBoundariesResponse } from './input-boundaries';
 import { LOGGER } from './extension';
 import { RErrorHandler } from './error-handler';
 
@@ -377,6 +378,14 @@ export class ArkLsp implements vscode.Disposable {
 				return await handles.promise;
 			}
 		}
+	}
+
+	async inputBoundaries(text: string): Promise<InputBoundariesResponse> {
+		if (!this.client) {
+			throw new Error('Cannot get input boundaries; LSP client has not been started');
+		}
+
+		return await this.client.sendRequest(InputBoundariesRequest.type, { text });
 	}
 
 	/**

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -260,7 +260,19 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		}
 	}
 
-	callMethod(method: string, ...args: any[]): Thenable<any> {
+	async callMethod(method: string, ...args: any[]): Promise<any> {
+		if (method === 'inputBoundaries') {
+			// Quarto asks for R input boundaries through the LSP so it can split
+			// expressions without paying for a completeness check per line.
+			const text = typeof args[0] === 'string' ? args[0] : '';
+			const lsp = await this.waitLsp();
+			if (!lsp) {
+				throw new Error(`Cannot call method '${method}'; LSP not running`);
+			}
+
+			return lsp.inputBoundaries(text);
+		}
+
 		if (this._kernel) {
 			return this._kernel.callMethod(method, ...args);
 		} else {

--- a/extensions/positron-r/src/session.ts
+++ b/extensions/positron-r/src/session.ts
@@ -260,19 +260,7 @@ export class RSession implements positron.LanguageRuntimeSession, vscode.Disposa
 		}
 	}
 
-	async callMethod(method: string, ...args: any[]): Promise<any> {
-		if (method === 'inputBoundaries') {
-			// Quarto asks for R input boundaries through the LSP so it can split
-			// expressions without paying for a completeness check per line.
-			const text = typeof args[0] === 'string' ? args[0] : '';
-			const lsp = await this.waitLsp();
-			if (!lsp) {
-				throw new Error(`Cannot call method '${method}'; LSP not running`);
-			}
-
-			return lsp.inputBoundaries(text);
-		}
-
+	callMethod(method: string, ...args: any[]): Thenable<any> {
 		if (this._kernel) {
 			return this._kernel.callMethod(method, ...args);
 		} else {

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -1791,6 +1791,53 @@ declare module 'positron' {
 		constructor(line?: number);
 	}
 
+	export interface InputBoundaryRange {
+		/**
+		 * Zero indexed starting line of the input.
+		 */
+		readonly start: number;
+
+		/**
+		 * Zero indexed ending line of the input, exclusive.
+		 */
+		readonly end: number;
+	}
+
+	export type InputBoundaryKind = 'whitespace' | 'complete' | 'incomplete' | 'invalid';
+
+	export interface InputBoundary {
+		/**
+		 * The line range of this input boundary, relative to the requested range.
+		 */
+		readonly range: InputBoundaryRange;
+
+		/**
+		 * The parse status of this input.
+		 */
+		readonly kind: InputBoundaryKind;
+
+		/**
+		 * Additional data for this input boundary.
+		 */
+		readonly data?: {
+			readonly message?: string;
+		};
+	}
+
+	export interface InputBoundaryProvider {
+		/**
+		 * Given a document range, return the input boundaries within that range.
+		 *
+		 * @param document The document containing the requested range.
+		 * @param range The range to split into input boundaries.
+		 * @param token A cancellation token.
+		 * @return The input boundaries within the requested range.
+		 */
+		provideInputBoundaries(document: vscode.TextDocument,
+			range: vscode.Range,
+			token: vscode.CancellationToken): vscode.ProviderResult<InputBoundary[]>;
+	}
+
 	export interface HelpTopicProvider {
 		/**
 		 * Given a cursor position, return the help topic relevant to the cursor
@@ -2200,6 +2247,17 @@ declare module 'positron' {
 		export function registerStatementRangeProvider(
 			selector: vscode.DocumentSelector,
 			provider: StatementRangeProvider): vscode.Disposable;
+
+		/**
+		 * Register an input boundary provider.
+		 *
+		 * @param selector A selector that defines the documents this provider is applicable to.
+		 * @param provider An input boundary provider.
+		 * @return A {@link Disposable} that unregisters this provider when being disposed.
+		 */
+		export function registerInputBoundaryProvider(
+			selector: vscode.DocumentSelector,
+			provider: InputBoundaryProvider): vscode.Disposable;
 
 		/**
 		 * Register a help topic provider.

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -2145,6 +2145,29 @@ export interface IStatementRangeSyntaxRejection {
 	readonly line?: number;
 }
 
+export type InputBoundaryKind = 'whitespace' | 'complete' | 'incomplete' | 'invalid';
+
+export interface IInputBoundaryRange {
+	readonly start: number;
+	readonly end: number;
+}
+
+export interface IInputBoundary {
+	readonly range: IInputBoundaryRange;
+	readonly kind: InputBoundaryKind;
+	readonly data?: {
+		readonly message?: string;
+	};
+}
+
+export interface InputBoundaryProvider {
+	/**
+	 * Provide input boundaries within the given range.
+	 */
+	provideInputBoundaries(model: model.ITextModel, range: Range, token: CancellationToken):
+		ProviderResult<IInputBoundary[]>;
+}
+
 export interface HelpTopicProvider {
 	/**
 	 * Provide a help topic relevant to the current cursor position.

--- a/src/vs/editor/common/services/languageFeatures.ts
+++ b/src/vs/editor/common/services/languageFeatures.ts
@@ -10,7 +10,7 @@ import { createDecorator } from '../../../platform/instantiation/common/instanti
 // --- Start Positron ---
 // This import is on its own line to avoid unnecessary merge conflicts.
 // eslint-disable-next-line no-duplicate-imports
-import { StatementRangeProvider, HelpTopicProvider } from '../languages.js';
+import { StatementRangeProvider, InputBoundaryProvider, HelpTopicProvider } from '../languages.js';
 // --- End Positron ---
 
 export const ILanguageFeaturesService = createDecorator<ILanguageFeaturesService>('ILanguageFeaturesService');
@@ -70,6 +70,8 @@ export interface ILanguageFeaturesService {
 	// --- Start Positron ---
 
 	readonly statementRangeProvider: LanguageFeatureRegistry<StatementRangeProvider>;
+
+	readonly inputBoundaryProvider: LanguageFeatureRegistry<InputBoundaryProvider>;
 
 	readonly helpTopicProvider: LanguageFeatureRegistry<HelpTopicProvider>;
 

--- a/src/vs/editor/common/services/languageFeaturesService.ts
+++ b/src/vs/editor/common/services/languageFeaturesService.ts
@@ -12,7 +12,7 @@ import { InstantiationType, registerSingleton } from '../../../platform/instanti
 // --- Start Positron ---
 // This import is on its own line to avoid unnecessary merge conflicts.
 // eslint-disable-next-line no-duplicate-imports
-import { StatementRangeProvider, HelpTopicProvider } from '../languages.js';
+import { StatementRangeProvider, InputBoundaryProvider, HelpTopicProvider } from '../languages.js';
 // --- End Positron ---
 
 export class LanguageFeaturesService implements ILanguageFeaturesService {
@@ -53,6 +53,7 @@ export class LanguageFeaturesService implements ILanguageFeaturesService {
 
 	// --- Start Positron ---
 	readonly statementRangeProvider = new LanguageFeatureRegistry<StatementRangeProvider>(this._score.bind(this));
+	readonly inputBoundaryProvider = new LanguageFeatureRegistry<InputBoundaryProvider>(this._score.bind(this));
 	readonly helpTopicProvider = new LanguageFeatureRegistry<HelpTopicProvider>(this._score.bind(this));
 	// --- End Positron ---
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -8513,6 +8513,28 @@ declare namespace monaco.languages {
 		readonly line?: number;
 	}
 
+	export type InputBoundaryKind = 'whitespace' | 'complete' | 'incomplete' | 'invalid';
+
+	export interface IInputBoundaryRange {
+		readonly start: number;
+		readonly end: number;
+	}
+
+	export interface IInputBoundary {
+		readonly range: IInputBoundaryRange;
+		readonly kind: InputBoundaryKind;
+		readonly data?: {
+			readonly message?: string;
+		};
+	}
+
+	export interface InputBoundaryProvider {
+		/**
+		 * Provide input boundaries within the given range.
+		 */
+		provideInputBoundaries(model: editor.ITextModel, range: Range, token: CancellationToken): ProviderResult<IInputBoundary[]>;
+	}
+
 	export interface HelpTopicProvider {
 		/**
 		 * Provide a help topic relevant to the current cursor position.

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -906,6 +906,14 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 		}));
 	}
 
+	$registerInputBoundaryProvider(handle: number, selector: IDocumentFilterDto[]): void {
+		this._registrations.set(handle, this._languageFeaturesService.inputBoundaryProvider.register(selector, {
+			provideInputBoundaries: (model, range, token) => {
+				return this._proxy.$provideInputBoundaries(handle, model.uri, range, token);
+			}
+		}));
+	}
+
 	$registerHelpTopicProvider(handle: number, selector: IDocumentFilterDto[]): void {
 		this._registrations.set(handle, this._languageFeaturesService.helpTopicProvider.register(selector, {
 			provideHelpTopic: (model, position, token) => {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -578,6 +578,7 @@ export interface MainThreadLanguageFeaturesShape extends IDisposable {
 	$registerSelectionRangeProvider(handle: number, selector: IDocumentFilterDto[]): void;
 	// --- Start Positron ---
 	$registerStatementRangeProvider(handle: number, selector: IDocumentFilterDto[]): void;
+	$registerInputBoundaryProvider(handle: number, selector: IDocumentFilterDto[]): void;
 	$registerHelpTopicProvider(handle: number, selector: IDocumentFilterDto[]): void;
 	// --- End Positron ---
 	$registerCallHierarchyProvider(handle: number, selector: IDocumentFilterDto[]): void;
@@ -2874,6 +2875,7 @@ export interface ExtHostLanguageFeaturesShape {
 	$provideSelectionRanges(handle: number, resource: UriComponents, positions: IPosition[], token: CancellationToken): Promise<languages.SelectionRange[][]>;
 	// --- Start Positron ---
 	$provideStatementRange(handle: number, resource: UriComponents, position: IPosition, token: CancellationToken): Promise<languages.IStatementRange | undefined>;
+	$provideInputBoundaries(handle: number, resource: UriComponents, range: IRange, token: CancellationToken): Promise<languages.IInputBoundary[] | undefined>;
 	$provideHelpTopic(handle: number, resource: UriComponents, position: IPosition, token: CancellationToken): Promise<string | undefined>;
 	// --- End Positron ---
 	$prepareCallHierarchy(handle: number, resource: UriComponents, position: IPosition, token: CancellationToken): Promise<ICallHierarchyItemDto[] | undefined>;

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1984,6 +1984,75 @@ class StatementRangeAdapter {
 	}
 }
 
+function isInputBoundaryKind(kind: unknown): kind is languages.InputBoundaryKind {
+	return kind === 'whitespace' ||
+		kind === 'complete' ||
+		kind === 'incomplete' ||
+		kind === 'invalid';
+}
+
+/**
+ * Adapter for the `InputBoundaryProvider` API.
+ */
+class InputBoundaryAdapter {
+
+	constructor(
+		private readonly _documents: ExtHostDocuments,
+		private readonly _provider: positron.InputBoundaryProvider
+	) { }
+
+	async provideInputBoundaries(resource: URI, range: IRange, token: CancellationToken): Promise<languages.IInputBoundary[] | undefined> {
+		const document = this._documents.getDocument(resource);
+		const apiRange = typeConvert.Range.to(range);
+		const result = await this._provider.provideInputBoundaries(document, apiRange, token);
+
+		if (!Array.isArray(result)) {
+			return undefined;
+		}
+
+		const boundaries: languages.IInputBoundary[] = [];
+		for (const boundary of result) {
+			if (!isObject(boundary)) {
+				continue;
+			}
+
+			const boundaryCandidate = boundary as Partial<positron.InputBoundary>;
+			const boundaryRange = boundaryCandidate.range;
+			if (!isObject(boundaryRange) ||
+				typeof boundaryRange.start !== 'number' ||
+				typeof boundaryRange.end !== 'number'
+			) {
+				continue;
+			}
+
+			if (!isInputBoundaryKind(boundaryCandidate.kind)) {
+				continue;
+			}
+
+			const converted: languages.IInputBoundary = {
+				range: {
+					start: boundaryRange.start,
+					end: boundaryRange.end,
+				},
+				kind: boundaryCandidate.kind,
+			};
+
+			if (isObject(boundaryCandidate.data) && typeof boundaryCandidate.data.message === 'string') {
+				boundaries.push({
+					...converted,
+					data: {
+						message: boundaryCandidate.data.message,
+					},
+				});
+			} else {
+				boundaries.push(converted);
+			}
+		}
+
+		return boundaries;
+	}
+}
+
 
 /**
  * Adapter for the `HelpTopicProvider` API.
@@ -2286,8 +2355,8 @@ type Adapter = DocumentSymbolAdapter | CodeLensAdapter | DefinitionAdapter | Hov
 	| EvaluatableExpressionAdapter | InlineValuesAdapter
 	| LinkedEditingRangeAdapter | InlayHintsAdapter | InlineCompletionAdapter
 	// --- Start Positron ---
-	// Add 'StatementRangeAdapter and 'HelpTopicAdapter' to the list of adapters
-	| StatementRangeAdapter | HelpTopicAdapter
+	// Add Positron adapters to the list of adapters
+	| StatementRangeAdapter | InputBoundaryAdapter | HelpTopicAdapter
 	// --- End Positron ---
 	| DocumentDropEditAdapter | NewSymbolNamesAdapter;
 
@@ -3003,6 +3072,16 @@ export class ExtHostLanguageFeatures extends CoreDisposable implements extHostPr
 
 	$provideStatementRange(handle: number, resource: UriComponents, position: IPosition, token: CancellationToken): Promise<languages.IStatementRange | undefined> {
 		return this._withAdapter(handle, StatementRangeAdapter, adapter => adapter.provideStatementRange(URI.revive(resource), position, token), undefined, token);
+	}
+
+	registerInputBoundaryProvider(extension: IExtensionDescription, selector: vscode.DocumentSelector, provider: positron.InputBoundaryProvider): vscode.Disposable {
+		const handle = this._addNewAdapter(new InputBoundaryAdapter(this._documents, provider), extension);
+		this._proxy.$registerInputBoundaryProvider(handle, this._transformDocumentSelector(selector, extension));
+		return this._createDisposable(handle);
+	}
+
+	$provideInputBoundaries(handle: number, resource: UriComponents, range: IRange, token: CancellationToken): Promise<languages.IInputBoundary[] | undefined> {
+		return this._withAdapter(handle, InputBoundaryAdapter, adapter => adapter.provideInputBoundaries(URI.revive(resource), range, token), undefined, token);
 	}
 
 	registerHelpTopicProvider(extension: IExtensionDescription, selector: vscode.DocumentSelector, provider: positron.HelpTopicProvider): vscode.Disposable {

--- a/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
+++ b/src/vs/workbench/api/common/positron/extHost.positron.api.impl.ts
@@ -268,6 +268,11 @@ export function createPositronApiFactoryAndRegisterActors(accessor: ServicesAcce
 				provider: positron.StatementRangeProvider): vscode.Disposable {
 				return extHostLanguageFeatures.registerStatementRangeProvider(extension, selector, provider);
 			},
+			registerInputBoundaryProvider(
+				selector: vscode.DocumentSelector,
+				provider: positron.InputBoundaryProvider): vscode.Disposable {
+				return extHostLanguageFeatures.registerInputBoundaryProvider(extension, selector, provider);
+			},
 			registerHelpTopicProvider(
 				selector: vscode.DocumentSelector,
 				provider: positron.HelpTopicProvider): vscode.Disposable {

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -4,13 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { CancellationError, isCancellationError } from '../../../../base/common/errors.js';
+import { isCancellationError } from '../../../../base/common/errors.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
 import { Range } from '../../../../editor/common/core/range.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { ResourceMap } from '../../../../base/common/map.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { IEphemeralStateService } from '../../../../platform/ephemeralState/common/ephemeralState.js';
@@ -35,7 +36,8 @@ import {
 	DEFAULT_EXECUTION_CONFIG,
 	DATA_EXPLORER_MIME_TYPE,
 } from '../common/quartoExecutionTypes.js';
-import { RuntimeOnlineState, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, ILanguageRuntimeMessageWebOutput } from '../../../services/languageRuntime/common/languageRuntimeService.js';
+import { usingQuartoInlineOutputStatementSplitting } from '../common/positronQuartoConfig.js';
+import { RuntimeOnlineState, RuntimeCodeExecutionMode, RuntimeErrorBehavior, ILanguageRuntimeMessageWebOutput } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { getWebviewMessageType } from '../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
 import { DeferredPromise, raceCancellationError, RunOnceScheduler, timeout } from '../../../../base/common/async.js';
 import { CodeAttributionSource, ILanguageRuntimeCodeExecutedEvent } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
@@ -93,21 +95,6 @@ interface SerializedQueueState {
 	runningCell: string | undefined;
 }
 
-interface RInputBoundaryRange {
-	start: number;
-	end: number;
-}
-
-type RInputBoundaryKind = 'whitespace' | 'complete' | 'incomplete' | 'invalid';
-
-interface RInputBoundary {
-	range: RInputBoundaryRange;
-	kind: RInputBoundaryKind;
-	data?: {
-		message?: string;
-	};
-}
-
 /**
  * Implementation of the Quarto execution manager.
  * Manages code execution queue and output collection for Quarto documents.
@@ -154,6 +141,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		@IEditorService private readonly _editorService: IEditorService,
 		@IEphemeralStateService private readonly _ephemeralStateService: IEphemeralStateService,
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ILogService private readonly _logService: ILogService,
 		@IPositronConsoleService private readonly _consoleService: IPositronConsoleService,
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
@@ -655,12 +643,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 				});
 				cancellationPromise.catch(() => undefined);
 
-				// R only returns the final implicit result from a multi-expression
-				// request. Execute complete expressions separately so each result
-				// is appended to the cell's inline output.
-				const codeFragments = cellLanguage === 'r'
-					? await this._getRCodeFragments(session, code, cts.token)
-					: [code];
+				const codeFragments = await this._getCodeFragments(cellLanguage, code, cts.token);
 				const errorBehavior = options.error
 					? RuntimeErrorBehavior.Stop
 					: RuntimeErrorBehavior.Continue;
@@ -1563,33 +1546,27 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 	}
 
 	/**
-	 * Split R code into complete expressions using the R input boundary provider.
-	 *
-	 * Falls back to the older line-by-line completeness probe if no provider
-	 * exposes input boundaries.
+	 * Split code into complete language inputs when the feature is enabled and
+	 * a language input boundary provider is available.
 	 */
-	private async _getRCodeFragments(session: ILanguageRuntimeSession, code: string, token: CancellationToken): Promise<string[]> {
-		const boundaryFragments = await this._getRCodeFragmentsFromInputBoundaryProvider(code, token);
-		if (boundaryFragments) {
-			return boundaryFragments;
+	private async _getCodeFragments(languageId: string, code: string, token: CancellationToken): Promise<string[]> {
+		if (!usingQuartoInlineOutputStatementSplitting(this._configurationService)) {
+			return [code];
 		}
 
-		if (token.isCancellationRequested) {
-			throw new CancellationError();
-		}
-
-		return this._getRCodeFragmentsByCompleteness(session, code, token);
+		const boundaryFragments = await this._getCodeFragmentsFromInputBoundaryProvider(languageId, code, token);
+		return boundaryFragments ?? [code];
 	}
 
 	/**
 	 * Ask a language provider for all input boundaries in one request and split
 	 * the code accordingly.
 	 */
-	private async _getRCodeFragmentsFromInputBoundaryProvider(code: string, token: CancellationToken): Promise<string[] | undefined> {
+	private async _getCodeFragmentsFromInputBoundaryProvider(languageId: string, code: string, token: CancellationToken): Promise<string[] | undefined> {
 		const model = this._modelService.createModel(
 			code,
-			this._languageService.createById('r'),
-			URI.from({ scheme: 'inmemory', path: `/quarto-input-boundaries/${generateUuid()}.R` })
+			this._languageService.createById(languageId),
+			URI.from({ scheme: 'inmemory', path: `/quarto-input-boundaries/${generateUuid()}` })
 		);
 
 		try {
@@ -1607,15 +1584,15 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 					if (isCancellationError(error)) {
 						throw error;
 					}
-					this._logService.debug('[QuartoExecutionManager] Failed to query R input boundaries; falling back to line-by-line completeness checks', error);
+					this._logService.debug('[QuartoExecutionManager] Failed to query input boundaries; trying the next provider', error);
 					continue;
 				}
 
-				const fragments = this._getRCodeFragmentsFromBoundaries(code, boundaries);
+				const fragments = this._getCodeFragmentsFromBoundaries(code, boundaries);
 				if (fragments) {
 					return fragments;
 				}
-				this._logService.debug('[QuartoExecutionManager] Ignoring malformed R input boundaries; falling back to line-by-line completeness checks');
+				this._logService.debug('[QuartoExecutionManager] Ignoring malformed input boundaries; executing the full code range');
 				return undefined;
 			}
 		} finally {
@@ -1625,7 +1602,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		return undefined;
 	}
 
-	private _getRCodeFragmentsFromBoundaries(code: string, boundaries: unknown): string[] | undefined {
+	private _getCodeFragmentsFromBoundaries(code: string, boundaries: unknown): string[] | undefined {
 		if (!Array.isArray(boundaries)) {
 			return undefined;
 		}
@@ -1640,7 +1617,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 				return undefined;
 			}
 
-			const kind = (boundary as RInputBoundary).kind;
+			const kind = (boundary as IInputBoundary).kind;
 			if (kind !== 'whitespace' &&
 				kind !== 'complete' &&
 				kind !== 'incomplete' &&
@@ -1649,7 +1626,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 				return undefined;
 			}
 
-			const range = (boundary as RInputBoundary).range;
+			const range = (boundary as IInputBoundary).range;
 			if (!range ||
 				!Number.isInteger(range.start) ||
 				!Number.isInteger(range.end) ||
@@ -1686,54 +1663,6 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		}
 
 		return fragments.length > 0 ? fragments : [code];
-	}
-
-	/**
-	 * Legacy fallback for runtimes that do not expose input boundaries.
-	 */
-	private async _getRCodeFragmentsByCompleteness(session: ILanguageRuntimeSession, code: string, token: CancellationToken): Promise<string[]> {
-		const fragments: string[] = [];
-		const pendingLines: string[] = [];
-
-		for (const line of code.split('\n')) {
-			pendingLines.push(line);
-			const pendingCode = pendingLines.join('\n');
-			let status: RuntimeCodeFragmentStatus;
-			try {
-				status = await raceCancellationError(Promise.resolve(session.isCodeFragmentComplete(pendingCode)), token);
-			} catch (error) {
-				if (isCancellationError(error)) {
-					throw error;
-				}
-				return [code];
-			}
-
-			if (status === RuntimeCodeFragmentStatus.Unknown) {
-				return [code];
-			}
-
-			if (status === RuntimeCodeFragmentStatus.Complete ||
-				status === RuntimeCodeFragmentStatus.Invalid
-			) {
-				if (this._containsExecutableRCode(pendingCode)) {
-					fragments.push(pendingCode);
-				}
-				pendingLines.length = 0;
-			}
-		}
-
-		if (pendingLines.length > 0) {
-			fragments.push(pendingLines.join('\n'));
-		}
-
-		return fragments.length > 0 ? fragments : [code];
-	}
-
-	/**
-	 * Check whether R code contains more than whitespace and comments.
-	 */
-	private _containsExecutableRCode(code: string): boolean {
-		return code.split('\n').some(line => !/^\s*(?:#.*)?$/.test(line));
 	}
 
 	async cancelQueuedCell(documentUri: URI, cellId: string): Promise<void> {

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Emitter, Event } from '../../../../base/common/event.js';
+import { CancellationError, isCancellationError } from '../../../../base/common/errors.js';
 import { Disposable, DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
@@ -36,7 +37,7 @@ import {
 } from '../common/quartoExecutionTypes.js';
 import { RuntimeOnlineState, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, ILanguageRuntimeMessageWebOutput } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { getWebviewMessageType } from '../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
-import { DeferredPromise, RunOnceScheduler, timeout } from '../../../../base/common/async.js';
+import { DeferredPromise, raceCancellationError, RunOnceScheduler, timeout } from '../../../../base/common/async.js';
 import { CodeAttributionSource, ILanguageRuntimeCodeExecutedEvent } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
 import { IPositronConsoleService } from '../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
 import { IRuntimeSessionService, ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
@@ -628,16 +629,6 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 					throw new Error('Could not get code in range');
 				}
 
-				// R only returns the final implicit result from a multi-expression
-				// request. Execute complete expressions separately so each result
-				// is appended to the cell's inline output.
-				const codeFragments = cellLanguage === 'r'
-					? await this._getRCodeFragments(session, code)
-					: [code];
-				const errorBehavior = options.error
-					? RuntimeErrorBehavior.Stop
-					: RuntimeErrorBehavior.Continue;
-
 				// Set up timeout
 				const timeoutMs = DEFAULT_EXECUTION_CONFIG.executionTimeout;
 				let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
@@ -662,6 +653,17 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 					});
 					disposables.add(cancellationListener);
 				});
+				cancellationPromise.catch(() => undefined);
+
+				// R only returns the final implicit result from a multi-expression
+				// request. Execute complete expressions separately so each result
+				// is appended to the cell's inline output.
+				const codeFragments = cellLanguage === 'r'
+					? await this._getRCodeFragments(session, code, cts.token)
+					: [code];
+				const errorBehavior = options.error
+					? RuntimeErrorBehavior.Stop
+					: RuntimeErrorBehavior.Continue;
 
 				for (let index = 0; index < codeFragments.length; index++) {
 					const fragment = codeFragments[index];
@@ -742,7 +744,8 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 
 				return hadError;
 			},
-			{ trackRunningCell: true, persistQueueState: true }
+			{ trackRunningCell: true, persistQueueState: true },
+			token
 		);
 	}
 
@@ -843,7 +846,9 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 				}
 
 				return hadError;
-			}
+			},
+			undefined,
+			token
 		);
 	}
 
@@ -911,7 +916,9 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 					this._setCellState(cell.id, CellExecutionState.Completed, documentUri);
 					return false;
 				}
-			}
+			},
+			undefined,
+			token
 		);
 	}
 
@@ -1465,13 +1472,14 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		codeRange: Range,
 		executionIdSuffix: string,
 		executeFn: (tracker: ExecutionTracker) => Promise<boolean>,
-		options?: { trackRunningCell?: boolean; persistQueueState?: boolean }
+		options?: { trackRunningCell?: boolean; persistQueueState?: boolean },
+		parentToken?: CancellationToken
 	): Promise<boolean> {
 		let hadError = false;
 
 		const idPart = executionIdSuffix ? `-${executionIdSuffix}` : '';
 		const executionId = `${QUARTO_EXEC_PREFIX}${idPart}-${generateUuid()}`;
-		const cts = new CancellationTokenSource();
+		const cts = new CancellationTokenSource(parentToken);
 		const deferred = new DeferredPromise<void>();
 		const disposables = new DisposableStore();
 
@@ -1560,20 +1568,24 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 	 * Falls back to the older line-by-line completeness probe if no provider
 	 * exposes input boundaries.
 	 */
-	private async _getRCodeFragments(session: ILanguageRuntimeSession, code: string): Promise<string[]> {
-		const boundaryFragments = await this._getRCodeFragmentsFromInputBoundaryProvider(code);
+	private async _getRCodeFragments(session: ILanguageRuntimeSession, code: string, token: CancellationToken): Promise<string[]> {
+		const boundaryFragments = await this._getRCodeFragmentsFromInputBoundaryProvider(code, token);
 		if (boundaryFragments) {
 			return boundaryFragments;
 		}
 
-		return this._getRCodeFragmentsByCompleteness(session, code);
+		if (token.isCancellationRequested) {
+			throw new CancellationError();
+		}
+
+		return this._getRCodeFragmentsByCompleteness(session, code, token);
 	}
 
 	/**
 	 * Ask a language provider for all input boundaries in one request and split
 	 * the code accordingly.
 	 */
-	private async _getRCodeFragmentsFromInputBoundaryProvider(code: string): Promise<string[] | undefined> {
+	private async _getRCodeFragmentsFromInputBoundaryProvider(code: string, token: CancellationToken): Promise<string[] | undefined> {
 		const model = this._modelService.createModel(
 			code,
 			this._languageService.createById('r'),
@@ -1590,8 +1602,11 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 			for (const provider of providers) {
 				let boundaries: IInputBoundary[] | undefined | null;
 				try {
-					boundaries = await provider.provideInputBoundaries(model, range, CancellationToken.None);
+					boundaries = await raceCancellationError(Promise.resolve(provider.provideInputBoundaries(model, range, token)), token);
 				} catch (error) {
+					if (isCancellationError(error)) {
+						throw error;
+					}
 					this._logService.debug('[QuartoExecutionManager] Failed to query R input boundaries; falling back to line-by-line completeness checks', error);
 					continue;
 				}
@@ -1600,6 +1615,8 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 				if (fragments) {
 					return fragments;
 				}
+				this._logService.debug('[QuartoExecutionManager] Ignoring malformed R input boundaries; falling back to line-by-line completeness checks');
+				return undefined;
 			}
 		} finally {
 			model.dispose();
@@ -1616,10 +1633,11 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		const lines = code.split('\n');
 		const fragments: string[] = [];
 		let sawValidBoundary = false;
+		let nextStart = 0;
 
 		for (const boundary of boundaries) {
 			if (!boundary || typeof boundary !== 'object') {
-				continue;
+				return undefined;
 			}
 
 			const kind = (boundary as RInputBoundary).kind;
@@ -1628,15 +1646,27 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 				kind !== 'incomplete' &&
 				kind !== 'invalid'
 			) {
-				continue;
+				return undefined;
 			}
 
 			const range = (boundary as RInputBoundary).range;
-			if (!range || typeof range.start !== 'number' || typeof range.end !== 'number') {
-				continue;
+			if (!range ||
+				!Number.isInteger(range.start) ||
+				!Number.isInteger(range.end) ||
+				range.start !== nextStart ||
+				range.start < 0 ||
+				range.end < range.start ||
+				range.end > lines.length
+			) {
+				return undefined;
+			}
+
+			if (kind !== 'whitespace' && range.start === range.end) {
+				return undefined;
 			}
 
 			sawValidBoundary = true;
+			nextStart = range.end;
 			if (kind === 'whitespace') {
 				continue;
 			}
@@ -1651,13 +1681,17 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 			return undefined;
 		}
 
+		if (nextStart !== lines.length) {
+			return undefined;
+		}
+
 		return fragments.length > 0 ? fragments : [code];
 	}
 
 	/**
 	 * Legacy fallback for runtimes that do not expose input boundaries.
 	 */
-	private async _getRCodeFragmentsByCompleteness(session: ILanguageRuntimeSession, code: string): Promise<string[]> {
+	private async _getRCodeFragmentsByCompleteness(session: ILanguageRuntimeSession, code: string, token: CancellationToken): Promise<string[]> {
 		const fragments: string[] = [];
 		const pendingLines: string[] = [];
 
@@ -1666,8 +1700,11 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 			const pendingCode = pendingLines.join('\n');
 			let status: RuntimeCodeFragmentStatus;
 			try {
-				status = await session.isCodeFragmentComplete(pendingCode);
-			} catch {
+				status = await raceCancellationError(Promise.resolve(session.isCodeFragmentComplete(pendingCode)), token);
+			} catch (error) {
+				if (isCancellationError(error)) {
+					throw error;
+				}
 				return [code];
 			}
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -15,6 +15,10 @@ import { IWorkspaceContextService } from '../../../../platform/workspace/common/
 import { IEphemeralStateService } from '../../../../platform/ephemeralState/common/ephemeralState.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { ITextModel } from '../../../../editor/common/model.js';
+import { IModelService } from '../../../../editor/common/services/model.js';
+import { ILanguageFeaturesService } from '../../../../editor/common/services/languageFeatures.js';
+import { ILanguageService } from '../../../../editor/common/languages/language.js';
+import type { IInputBoundary } from '../../../../editor/common/languages.js';
 import { IQuartoKernelManager } from './quartoKernelManager.js';
 import { IQuartoDocumentModelService } from './quartoDocumentModelService.js';
 import { QuartoCodeCell } from '../common/quartoTypes.js';
@@ -103,10 +107,6 @@ interface RInputBoundary {
 	};
 }
 
-interface RInputBoundariesResponse {
-	boundaries: RInputBoundary[];
-}
-
 /**
  * Implementation of the Quarto execution manager.
  * Manages code execution queue and output collection for Quarto documents.
@@ -157,6 +157,9 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		@IPositronConsoleService private readonly _consoleService: IPositronConsoleService,
 		@IRuntimeSessionService private readonly _runtimeSessionService: IRuntimeSessionService,
 		@ITerminalService private readonly _terminalService: ITerminalService,
+		@IModelService private readonly _modelService: IModelService,
+		@ILanguageService private readonly _languageService: ILanguageService,
+		@ILanguageFeaturesService private readonly _languageFeaturesService: ILanguageFeaturesService,
 	) {
 		super();
 
@@ -1552,13 +1555,13 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 	}
 
 	/**
-	 * Split R code into complete expressions using the runtime's boundary RPC.
+	 * Split R code into complete expressions using the R input boundary provider.
 	 *
-	 * Falls back to the older line-by-line completeness probe if the runtime
-	 * does not expose input boundaries.
+	 * Falls back to the older line-by-line completeness probe if no provider
+	 * exposes input boundaries.
 	 */
 	private async _getRCodeFragments(session: ILanguageRuntimeSession, code: string): Promise<string[]> {
-		const boundaryFragments = await this._getRCodeFragmentsFromBoundaries(session, code);
+		const boundaryFragments = await this._getRCodeFragmentsFromInputBoundaryProvider(code);
 		if (boundaryFragments) {
 			return boundaryFragments;
 		}
@@ -1567,31 +1570,45 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 	}
 
 	/**
-	 * Ask the runtime for all input boundaries in one request and split the
-	 * code accordingly.
+	 * Ask a language provider for all input boundaries in one request and split
+	 * the code accordingly.
 	 */
-	private async _getRCodeFragmentsFromBoundaries(session: ILanguageRuntimeSession, code: string): Promise<string[] | undefined> {
-		if (!session.callMethod) {
-			return undefined;
-		}
+	private async _getRCodeFragmentsFromInputBoundaryProvider(code: string): Promise<string[] | undefined> {
+		const model = this._modelService.createModel(
+			code,
+			this._languageService.createById('r'),
+			URI.from({ scheme: 'inmemory', path: `/quarto-input-boundaries/${generateUuid()}.R` })
+		);
 
-		let response: unknown;
 		try {
-			response = await session.callMethod('inputBoundaries', code);
-		} catch (error) {
-			this._logService.debug('[QuartoExecutionManager] Failed to query R input boundaries; falling back to line-by-line completeness checks', error);
-			return undefined;
+			const providers = this._languageFeaturesService.inputBoundaryProvider.ordered(model);
+			if (providers.length === 0) {
+				return undefined;
+			}
+
+			const range = model.getFullModelRange();
+			for (const provider of providers) {
+				let boundaries: IInputBoundary[] | undefined | null;
+				try {
+					boundaries = await provider.provideInputBoundaries(model, range, CancellationToken.None);
+				} catch (error) {
+					this._logService.debug('[QuartoExecutionManager] Failed to query R input boundaries; falling back to line-by-line completeness checks', error);
+					continue;
+				}
+
+				const fragments = this._getRCodeFragmentsFromBoundaries(code, boundaries);
+				if (fragments) {
+					return fragments;
+				}
+			}
+		} finally {
+			model.dispose();
 		}
 
-		return this._getRCodeFragmentsFromBoundaryResponse(code, response);
+		return undefined;
 	}
 
-	private _getRCodeFragmentsFromBoundaryResponse(code: string, response: unknown): string[] | undefined {
-		if (!response || typeof response !== 'object') {
-			return undefined;
-		}
-
-		const boundaries = (response as Partial<RInputBoundariesResponse>).boundaries;
+	private _getRCodeFragmentsFromBoundaries(code: string, boundaries: unknown): string[] | undefined {
 		if (!Array.isArray(boundaries)) {
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -30,7 +30,7 @@ import {
 	DEFAULT_EXECUTION_CONFIG,
 	DATA_EXPLORER_MIME_TYPE,
 } from '../common/quartoExecutionTypes.js';
-import { RuntimeOnlineState, RuntimeCodeExecutionMode, RuntimeErrorBehavior, ILanguageRuntimeMessageWebOutput } from '../../../services/languageRuntime/common/languageRuntimeService.js';
+import { RuntimeOnlineState, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, ILanguageRuntimeMessageWebOutput } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { getWebviewMessageType } from '../../../services/positronIPyWidgets/common/webviewPreloadUtils.js';
 import { DeferredPromise, RunOnceScheduler, timeout } from '../../../../base/common/async.js';
 import { CodeAttributionSource, ILanguageRuntimeCodeExecutedEvent } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
@@ -600,53 +600,21 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 				const { execution, deferred, disposables, cts } = tracker;
 				const executionId = execution.executionId;
 
-				// Set up message handlers, passing options for error tracking
-				this._setupMessageHandlers(tracker, session, documentUri, () => {
-					hadError = true;
-				});
-
 				// Get just the code in the specified range
 				const code = await this._getCodeInRange(documentUri, codeRange);
 				if (!code) {
 					throw new Error('Could not get code in range');
 				}
 
-				// Execute the code
-				this._logService.debug(`[QuartoExecutionManager] Executing inline code in cell ${cell.id} with execution ID ${executionId}`);
+				// R only returns the final implicit result from a multi-expression
+				// request. Execute complete expressions separately so each result
+				// is appended to the cell's inline output.
+				const codeFragments = cellLanguage === 'r'
+					? await this._getRCodeFragments(session, code)
+					: [code];
 				const errorBehavior = options.error
 					? RuntimeErrorBehavior.Stop
 					: RuntimeErrorBehavior.Continue;
-				session.execute(
-					code,
-					executionId,
-					RuntimeCodeExecutionMode.Interactive,
-					errorBehavior,
-					undefined,
-					executionMetadata
-				);
-
-				// Fire the event signaling code execution.
-				const event: ILanguageRuntimeCodeExecutedEvent = {
-					executionId,
-					sessionId: session.sessionId,
-					attribution: {
-						source: CodeAttributionSource.Notebook,
-						metadata: {
-							cell: {
-								uri: cell.id,
-								notebook: {
-									uri: documentUri,
-								},
-							},
-						},
-					},
-					code,
-					languageId: cell.language,
-					runtimeName: session.runtimeMetadata.runtimeName,
-					errorBehavior,
-					mode: RuntimeCodeExecutionMode.Interactive,
-				};
-				this._onDidExecuteCode.fire(event);
 
 				// Set up timeout
 				const timeoutMs = DEFAULT_EXECUTION_CONFIG.executionTimeout;
@@ -666,16 +634,82 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 					}));
 				}
 
-				// Wait for completion
-				await Promise.race([
-					deferred.p,
-					new Promise<void>((_, reject) => {
-						const cancellationListener = cts.token.onCancellationRequested(() => {
-							reject(new Error('Execution cancelled'));
-						});
-						disposables.add(cancellationListener);
-					}),
-				]);
+				const cancellationPromise = new Promise<void>((_, reject) => {
+					const cancellationListener = cts.token.onCancellationRequested(() => {
+						reject(new Error('Execution cancelled'));
+					});
+					disposables.add(cancellationListener);
+				});
+
+				for (let index = 0; index < codeFragments.length; index++) {
+					const fragment = codeFragments[index];
+					const fragmentExecutionId = codeFragments.length === 1
+						? executionId
+						: `${executionId}-${index + 1}`;
+					const fragmentDeferred = new DeferredPromise<void>();
+					const fragmentDisposables = new DisposableStore();
+					disposables.add(fragmentDisposables);
+
+					this._setupMessageHandlers(
+						tracker,
+						session,
+						documentUri,
+						() => {
+							hadError = true;
+						},
+						fragmentExecutionId,
+						() => fragmentDeferred.complete(),
+						fragmentDisposables
+					);
+
+					this._logService.debug(
+						`[QuartoExecutionManager] Executing inline code in cell ${cell.id} with execution ID ${fragmentExecutionId}`
+					);
+					session.execute(
+						fragment,
+						fragmentExecutionId,
+						RuntimeCodeExecutionMode.Interactive,
+						errorBehavior,
+						undefined,
+						executionMetadata
+					);
+
+					// Fire the event signaling code execution.
+					const event: ILanguageRuntimeCodeExecutedEvent = {
+						executionId: fragmentExecutionId,
+						sessionId: session.sessionId,
+						attribution: {
+							source: CodeAttributionSource.Notebook,
+							metadata: {
+								cell: {
+									uri: cell.id,
+									notebook: {
+										uri: documentUri,
+									},
+								},
+							},
+						},
+						code: fragment,
+						languageId: cell.language,
+						runtimeName: session.runtimeMetadata.runtimeName,
+						errorBehavior,
+						mode: RuntimeCodeExecutionMode.Interactive,
+					};
+					this._onDidExecuteCode.fire(event);
+
+					await Promise.race([
+						fragmentDeferred.p,
+						deferred.p,
+						cancellationPromise,
+					]);
+					fragmentDisposables.dispose();
+
+					if (hadError && options.error) {
+						break;
+					}
+				}
+
+				deferred.complete();
 
 				// Update state to completed or error based on whether runtime errors occurred
 				if (hadError) {
@@ -1498,6 +1532,54 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		}
 	}
 
+	/**
+	 * Split R code into line-aligned complete expressions.
+	 *
+	 * Falls back to executing the original code as one request if the runtime
+	 * cannot determine whether a prefix is complete.
+	 */
+	private async _getRCodeFragments(session: ILanguageRuntimeSession, code: string): Promise<string[]> {
+		const fragments: string[] = [];
+		const pendingLines: string[] = [];
+
+		for (const line of code.split('\n')) {
+			pendingLines.push(line);
+			const pendingCode = pendingLines.join('\n');
+			let status: RuntimeCodeFragmentStatus;
+			try {
+				status = await session.isCodeFragmentComplete(pendingCode);
+			} catch {
+				return [code];
+			}
+
+			if (status === RuntimeCodeFragmentStatus.Unknown) {
+				return [code];
+			}
+
+			if (status === RuntimeCodeFragmentStatus.Complete ||
+				status === RuntimeCodeFragmentStatus.Invalid
+			) {
+				if (this._containsExecutableRCode(pendingCode)) {
+					fragments.push(pendingCode);
+				}
+				pendingLines.length = 0;
+			}
+		}
+
+		if (pendingLines.length > 0) {
+			fragments.push(pendingLines.join('\n'));
+		}
+
+		return fragments.length > 0 ? fragments : [code];
+	}
+
+	/**
+	 * Check whether R code contains more than whitespace and comments.
+	 */
+	private _containsExecutableRCode(code: string): boolean {
+		return code.split('\n').some(line => !/^\s*(?:#.*)?$/.test(line));
+	}
+
 	async cancelQueuedCell(documentUri: URI, cellId: string): Promise<void> {
 		this._logService.debug(`[QuartoExecutionManager] Cancelling queued cell ${cellId} for ${documentUri.toString()}`);
 
@@ -1697,16 +1779,19 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 	 * @param session Runtime session
 	 * @param documentUri Document URI
 	 * @param onError Optional callback invoked when an error message is received
+	 * @param executionId Execution ID whose messages should be handled
+	 * @param onComplete Callback invoked when the execution becomes idle
+	 * @param disposables Store for the message handler disposables
 	 */
 	private _setupMessageHandlers(
 		tracker: ExecutionTracker,
 		session: ILanguageRuntimeSession,
 		documentUri: URI,
-		onError?: () => void
+		onError?: () => void,
+		executionId = tracker.execution.executionId,
+		onComplete: () => void = () => tracker.deferred.complete(),
+		disposables = tracker.disposables
 	): void {
-		const { execution, deferred, disposables } = tracker;
-		const executionId = execution.executionId;
-
 		// Handle output messages (display_data)
 		disposables.add(session.onDidReceiveRuntimeMessageOutput(message => {
 			if (message.parent_id !== executionId) {
@@ -1761,7 +1846,7 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 			}
 			if (message.state === RuntimeOnlineState.Idle) {
 				this._logService.debug(`[QuartoExecutionManager] Execution completed for ${executionId}`);
-				deferred.complete();
+				onComplete();
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -88,6 +88,25 @@ interface SerializedQueueState {
 	runningCell: string | undefined;
 }
 
+interface RInputBoundaryRange {
+	start: number;
+	end: number;
+}
+
+type RInputBoundaryKind = 'whitespace' | 'complete' | 'incomplete' | 'invalid';
+
+interface RInputBoundary {
+	range: RInputBoundaryRange;
+	kind: RInputBoundaryKind;
+	data?: {
+		message?: string;
+	};
+}
+
+interface RInputBoundariesResponse {
+	boundaries: RInputBoundary[];
+}
+
 /**
  * Implementation of the Quarto execution manager.
  * Manages code execution queue and output collection for Quarto documents.
@@ -1533,12 +1552,95 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 	}
 
 	/**
-	 * Split R code into line-aligned complete expressions.
+	 * Split R code into complete expressions using the runtime's boundary RPC.
 	 *
-	 * Falls back to executing the original code as one request if the runtime
-	 * cannot determine whether a prefix is complete.
+	 * Falls back to the older line-by-line completeness probe if the runtime
+	 * does not expose input boundaries.
 	 */
 	private async _getRCodeFragments(session: ILanguageRuntimeSession, code: string): Promise<string[]> {
+		const boundaryFragments = await this._getRCodeFragmentsFromBoundaries(session, code);
+		if (boundaryFragments) {
+			return boundaryFragments;
+		}
+
+		return this._getRCodeFragmentsByCompleteness(session, code);
+	}
+
+	/**
+	 * Ask the runtime for all input boundaries in one request and split the
+	 * code accordingly.
+	 */
+	private async _getRCodeFragmentsFromBoundaries(session: ILanguageRuntimeSession, code: string): Promise<string[] | undefined> {
+		if (!session.callMethod) {
+			return undefined;
+		}
+
+		let response: unknown;
+		try {
+			response = await session.callMethod('inputBoundaries', code);
+		} catch (error) {
+			this._logService.debug('[QuartoExecutionManager] Failed to query R input boundaries; falling back to line-by-line completeness checks', error);
+			return undefined;
+		}
+
+		return this._getRCodeFragmentsFromBoundaryResponse(code, response);
+	}
+
+	private _getRCodeFragmentsFromBoundaryResponse(code: string, response: unknown): string[] | undefined {
+		if (!response || typeof response !== 'object') {
+			return undefined;
+		}
+
+		const boundaries = (response as Partial<RInputBoundariesResponse>).boundaries;
+		if (!Array.isArray(boundaries)) {
+			return undefined;
+		}
+
+		const lines = code.split('\n');
+		const fragments: string[] = [];
+		let sawValidBoundary = false;
+
+		for (const boundary of boundaries) {
+			if (!boundary || typeof boundary !== 'object') {
+				continue;
+			}
+
+			const kind = (boundary as RInputBoundary).kind;
+			if (kind !== 'whitespace' &&
+				kind !== 'complete' &&
+				kind !== 'incomplete' &&
+				kind !== 'invalid'
+			) {
+				continue;
+			}
+
+			const range = (boundary as RInputBoundary).range;
+			if (!range || typeof range.start !== 'number' || typeof range.end !== 'number') {
+				continue;
+			}
+
+			sawValidBoundary = true;
+			if (kind === 'whitespace') {
+				continue;
+			}
+
+			const fragment = lines.slice(range.start, range.end).join('\n');
+			if (fragment.length > 0) {
+				fragments.push(fragment);
+			}
+		}
+
+		if (!sawValidBoundary) {
+			return undefined;
+		}
+
+		return fragments.length > 0 ? fragments : [code];
+	}
+
+	/**
+	 * Legacy fallback for runtimes that do not expose input boundaries.
+	 */
+	private async _getRCodeFragmentsByCompleteness(session: ILanguageRuntimeSession, code: string): Promise<string[]> {
 		const fragments: string[] = [];
 		const pendingLines: string[] = [];
 

--- a/src/vs/workbench/contrib/positronQuarto/common/positronQuartoConfig.ts
+++ b/src/vs/workbench/contrib/positronQuarto/common/positronQuartoConfig.ts
@@ -25,6 +25,11 @@ export const POSITRON_QUARTO_INLINE_OUTPUT_KEY = 'positron.quarto.inlineOutput.e
 export const POSITRON_QUARTO_INLINE_OUTPUT_MAX_LINES_KEY = 'positron.quarto.inlineOutput.maxLines';
 
 /**
+ * Configuration key for splitting Quarto inline code into language-defined statements.
+ */
+export const POSITRON_QUARTO_INLINE_OUTPUT_SPLIT_STATEMENTS_KEY = 'positron.quarto.inlineOutput.splitStatements';
+
+/**
  * Context key for whether Quarto inline output is enabled.
  * Used for conditionally showing commands and menus.
  */
@@ -94,6 +99,15 @@ configurationRegistry.registerConfiguration({
 			),
 			scope: ConfigurationScope.WINDOW,
 		},
+		[POSITRON_QUARTO_INLINE_OUTPUT_SPLIT_STATEMENTS_KEY]: {
+			type: 'boolean',
+			default: true,
+			markdownDescription: localize(
+				'positron.quarto.inlineOutput.splitStatements',
+				'Execute Quarto inline code statement by statement when the language provides input boundaries, so each statement can produce inline output.'
+			),
+			scope: ConfigurationScope.WINDOW,
+		},
 	},
 });
 
@@ -104,6 +118,15 @@ configurationRegistry.registerConfiguration({
  */
 export function usingQuartoInlineOutput(configurationService: IConfigurationService): boolean {
 	return configurationService.getValue<boolean>(POSITRON_QUARTO_INLINE_OUTPUT_KEY) ?? false;
+}
+
+/**
+ * Helper function to check if Quarto inline output should split code at statement boundaries.
+ * @param configurationService The configuration service instance
+ * @returns true if statement splitting is enabled
+ */
+export function usingQuartoInlineOutputStatementSplitting(configurationService: IConfigurationService): boolean {
+	return configurationService.getValue<boolean>(POSITRON_QUARTO_INLINE_OUTPUT_SPLIT_STATEMENTS_KEY) ?? true;
 }
 
 /**

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
@@ -18,7 +18,7 @@ import { ILanguageService } from '../../../../../editor/common/languages/languag
 import { IModelService } from '../../../../../editor/common/services/model.js';
 import { ILanguageFeaturesService } from '../../../../../editor/common/services/languageFeatures.js';
 import { createModelServices } from '../../../../../editor/test/common/testTextModel.js';
-import { RuntimeOnlineState, RuntimeOutputKind, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionMode, ILanguageRuntimeMetadata, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { RuntimeOnlineState, RuntimeOutputKind, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionMode, ILanguageRuntimeMetadata, RuntimeErrorBehavior, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { QuartoExecutionManager } from '../../browser/quartoExecutionManager.js';
 import { IQuartoKernelManager } from '../../browser/quartoKernelManager.js';
@@ -33,6 +33,8 @@ import { IPositronConsoleService } from '../../../../services/positronConsole/br
 import { ITerminalService } from '../../../terminal/browser/terminal.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { Event } from '../../../../../base/common/event.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { POSITRON_QUARTO_INLINE_OUTPUT_SPLIT_STATEMENTS_KEY } from '../../common/positronQuartoConfig.js';
 
 const TestLanguageRuntimeMetadata: ILanguageRuntimeMetadata = {
 	base64EncodedIconSvg: '',
@@ -72,6 +74,7 @@ describe('QuartoExecutionManager', () => {
 	let mockEditorService: MockEditorService;
 	let mockConsoleService: RecordingConsoleService;
 	let mockRuntimeSessionService: MockRuntimeSessionService;
+	let configurationService: TestConfigurationService;
 	let modelService: IModelService;
 	let languageService: ILanguageService;
 	let languageFeaturesService: ILanguageFeaturesService;
@@ -94,6 +97,7 @@ describe('QuartoExecutionManager', () => {
 		const mockWorkspaceContextService = new MockWorkspaceContextService();
 		mockConsoleService = new RecordingConsoleService();
 		mockRuntimeSessionService = new MockRuntimeSessionService();
+		configurationService = new TestConfigurationService();
 		const mockTerminalService = new MockTerminalService();
 		const modelDisposables = ctx.disposables.add(new DisposableStore());
 		const modelInstantiationService = createModelServices(modelDisposables);
@@ -101,6 +105,7 @@ describe('QuartoExecutionManager', () => {
 		languageService = modelInstantiationService.get(ILanguageService);
 		languageFeaturesService = modelInstantiationService.get(ILanguageFeaturesService);
 		modelDisposables.add(languageService.registerLanguage({ id: 'r' }));
+		modelDisposables.add(languageService.registerLanguage({ id: 'python' }));
 
 		// Create execution manager
 		executionManager = new QuartoExecutionManager(
@@ -109,6 +114,7 @@ describe('QuartoExecutionManager', () => {
 			asEditorService(mockEditorService),
 			asEphemeralStateService(mockEphemeralStateService),
 			asWorkspaceContextService(mockWorkspaceContextService),
+			configurationService,
 			logService,
 			asConsoleService(mockConsoleService),
 			asRuntimeSessionService(mockRuntimeSessionService),
@@ -190,7 +196,7 @@ describe('QuartoExecutionManager', () => {
 	});
 
 	describe('Output Handling', () => {
-		const quartoInputBoundarySelector = { language: 'r', scheme: 'inmemory', pattern: '**/quarto-input-boundaries/*.{r,R}' };
+		const quartoInputBoundarySelector = { language: 'r', scheme: 'inmemory', pattern: '**/quarto-input-boundaries/*' };
 
 		async function executeRCellWithBoundaries(
 			testId: string,
@@ -256,10 +262,10 @@ describe('QuartoExecutionManager', () => {
 			};
 		}
 
-		async function executeRCellWithFallbackBoundaries(
+		async function executeRCellWithMalformedBoundaries(
 			testId: string,
 			boundaries: unknown
-		): Promise<{ providerCalls: number; executedCode: string[]; completenessCalls: number }> {
+		): Promise<{ providerCalls: number; executedCode: string[] }> {
 			const documentUri = URI.file(`/${testId}.qmd`);
 			const cell: QuartoCodeCell = {
 				id: testId,
@@ -293,27 +299,22 @@ describe('QuartoExecutionManager', () => {
 					return boundaries as IInputBoundary[];
 				}
 			}));
-			const completenessSpy = vi.spyOn(mockSession, 'isCodeFragmentComplete')
-				.mockResolvedValue(RuntimeCodeFragmentStatus.Complete);
 			const executeSpy = vi.spyOn(mockSession, 'execute');
 
 			const executionPromise = executionManager.executeCell(documentUri, cell);
 
-			for (let i = 0; i < 2; i++) {
-				const executionId = await mockKernelManager.waitForExecution();
-				mockSession.receiveStateMessage({
-					parent_id: executionId,
-					state: RuntimeOnlineState.Idle,
-				});
-				mockSession.setRuntimeState(RuntimeState.Ready);
-			}
+			const executionId = await mockKernelManager.waitForExecution();
+			mockSession.receiveStateMessage({
+				parent_id: executionId,
+				state: RuntimeOnlineState.Idle,
+			});
+			mockSession.setRuntimeState(RuntimeState.Ready);
 
 			await executionPromise;
 
 			return {
 				providerCalls,
 				executedCode: executeSpy.mock.calls.map(call => call[0]),
-				completenessCalls: completenessSpy.mock.calls.length,
 			};
 		}
 
@@ -415,6 +416,89 @@ describe('QuartoExecutionManager', () => {
 			expect(outputsReceived.map(output => output.items[0].data)).toEqual(['1', '2']);
 		});
 
+		it('executes R code as one range when statement splitting is disabled', async () => {
+			await configurationService.setUserConfiguration(POSITRON_QUARTO_INLINE_OUTPUT_SPLIT_STATEMENTS_KEY, false);
+
+			const result = await executeRCellWithBoundaries(
+				'test-r-splitting-disabled',
+				['1', '2'],
+				[
+					{ range: { start: 0, end: 1 }, kind: 'complete' },
+					{ range: { start: 1, end: 2 }, kind: 'complete' },
+				],
+				['1\n2']
+			);
+
+			expect(result.providerCalls).toBe(0);
+			expect(result.requestedCode).toBeUndefined();
+			expect(result.executedCode).toEqual(['1\n2']);
+		});
+
+		it('splits non-R primary-language code when a matching input boundary provider exists', async () => {
+			const documentUri = URI.file('/test-python-boundaries.qmd');
+			const cell: QuartoCodeCell = {
+				id: 'test-python-boundaries',
+				index: 0,
+				language: 'python',
+				startLine: 1,
+				endLine: 4,
+				codeStartLine: 2,
+				codeEndLine: 3,
+				label: undefined,
+				options: '',
+				contentHash: 'python-boundaries',
+			};
+			const documentLines = [
+				'```{python}',
+				'x = 1',
+				'x + 1',
+				'```',
+			];
+			const mockModel = new MockQuartoDocumentModel([cell], documentLines);
+			mockDocumentModelService.setMockModel(mockModel);
+			mockEditorService.getValueInRangeCallback = (range: unknown) => {
+				const r = range as { startLineNumber: number; endLineNumber: number };
+				return documentLines.slice(r.startLineNumber - 1, r.endLineNumber).join('\n');
+			};
+
+			let requestedCode: string | undefined;
+			let requestedLanguage: string | undefined;
+			let providerCalls = 0;
+			ctx.disposables.add(languageFeaturesService.inputBoundaryProvider.register(
+				{ language: 'python', scheme: 'inmemory', pattern: '**/quarto-input-boundaries/*' },
+				{
+					provideInputBoundaries(model, range, _token) {
+						providerCalls++;
+						requestedLanguage = model.getLanguageId();
+						requestedCode = model.getValueInRange(range);
+						return [
+							{ range: { start: 0, end: 1 }, kind: 'complete' },
+							{ range: { start: 1, end: 2 }, kind: 'complete' },
+						];
+					}
+				}
+			));
+			const executeSpy = vi.spyOn(mockSession, 'execute');
+
+			const executionPromise = executionManager.executeCell(documentUri, cell);
+
+			for (let i = 0; i < 2; i++) {
+				const executionId = await mockKernelManager.waitForExecution();
+				mockSession.receiveStateMessage({
+					parent_id: executionId,
+					state: RuntimeOnlineState.Idle,
+				});
+				mockSession.setRuntimeState(RuntimeState.Ready);
+			}
+
+			await executionPromise;
+
+			expect(providerCalls).toBe(1);
+			expect(requestedLanguage).toBe('python');
+			expect(requestedCode).toBe('x = 1\nx + 1');
+			expect(executeSpy.mock.calls.map(call => call[0])).toEqual(['x = 1', 'x + 1']);
+		});
+
 		it('does not match notebook-cell-only providers for Quarto input boundary models', async () => {
 			const documentUri = URI.file('/test-r-boundary-selector-fallback.qmd');
 			const cell: QuartoCodeCell = {
@@ -451,26 +535,21 @@ describe('QuartoExecutionManager', () => {
 					];
 				}
 			}));
-			const completenessSpy = vi.spyOn(mockSession, 'isCodeFragmentComplete')
-				.mockResolvedValue(RuntimeCodeFragmentStatus.Complete);
 			const executeSpy = vi.spyOn(mockSession, 'execute');
 
 			const executionPromise = executionManager.executeCell(documentUri, cell);
 
-			for (let i = 0; i < 2; i++) {
-				const executionId = await mockKernelManager.waitForExecution();
-				mockSession.receiveStateMessage({
-					parent_id: executionId,
-					state: RuntimeOnlineState.Idle,
-				});
-				mockSession.setRuntimeState(RuntimeState.Ready);
-			}
+			const executionId = await mockKernelManager.waitForExecution();
+			mockSession.receiveStateMessage({
+				parent_id: executionId,
+				state: RuntimeOnlineState.Idle,
+			});
+			mockSession.setRuntimeState(RuntimeState.Ready);
 
 			await executionPromise;
 
 			expect(providerCalls).toBe(0);
-			expect(completenessSpy).toHaveBeenCalled();
-			expect(executeSpy.mock.calls.map(call => call[0])).toEqual(['1', '2']);
+			expect(executeSpy.mock.calls.map(call => call[0])).toEqual(['1\n2']);
 		});
 
 		it('cancels a pending R input boundary provider request without executing code', async () => {
@@ -622,15 +701,14 @@ describe('QuartoExecutionManager', () => {
 					{ range: { start: 0, end: 2 }, kind: 'complete' },
 				],
 			},
-		])('falls back to completeness checks for malformed input boundaries: $name', async ({ name, boundaries }) => {
-			const result = await executeRCellWithFallbackBoundaries(
+		])('executes the full range for malformed input boundaries: $name', async ({ name, boundaries }) => {
+			const result = await executeRCellWithMalformedBoundaries(
 				`test-r-malformed-boundaries-${name.replace(/\W/g, '-')}`,
 				boundaries
 			);
 
 			expect(result.providerCalls).toBe(1);
-			expect(result.completenessCalls).toBeGreaterThan(0);
-			expect(result.executedCode).toEqual(['1', '2']);
+			expect(result.executedCode).toEqual(['1\n2']);
 		});
 
 		it('executes an incomplete R section as one fragment from input boundaries', async () => {
@@ -992,6 +1070,7 @@ describe('QuartoExecutionManager', () => {
 				asEditorService(trackingEditorService),
 				asEphemeralStateService(new MockEphemeralStateService()),
 				asWorkspaceContextService(new MockWorkspaceContextService()),
+				configurationService,
 				logService,
 				new TestPositronConsoleService(),
 				asRuntimeSessionService(new MockRuntimeSessionService()),
@@ -1090,6 +1169,7 @@ describe('QuartoExecutionManager', () => {
 				asEditorService(localMockEditorService),
 				asEphemeralStateService(new MockEphemeralStateService()),
 				asWorkspaceContextService(new MockWorkspaceContextService()),
+				configurationService,
 				logService,
 				new TestPositronConsoleService(),
 				asRuntimeSessionService(new MockRuntimeSessionService()),

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
@@ -13,7 +13,7 @@ import { TestLanguageRuntimeSession } from '../../../../services/runtimeSession/
 import { TestPositronConsoleService } from '../../../../services/positronConsole/test/browser/testPositronConsoleService.js';
 import { CellExecutionState, ExecutionOutputEvent, ICellOutput } from '../../common/quartoExecutionTypes.js';
 import { Range } from '../../../../../editor/common/core/range.js';
-import { RuntimeOnlineState, RuntimeOutputKind, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionMode, ILanguageRuntimeMetadata, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { RuntimeOnlineState, RuntimeOutputKind, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionMode, ILanguageRuntimeMetadata, RuntimeErrorBehavior, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { QuartoExecutionManager } from '../../browser/quartoExecutionManager.js';
 import { IQuartoKernelManager } from '../../browser/quartoKernelManager.js';
@@ -173,7 +173,7 @@ describe('QuartoExecutionManager', () => {
 	});
 
 	describe('Output Handling', () => {
-		it('executes complete R expressions separately and keeps each result', async () => {
+		it('queries input boundaries once and keeps each R result', async () => {
 			const documentUri = URI.file('/test-r-expressions.qmd');
 			const cell: QuartoCodeCell = {
 				id: 'test-r-expressions',
@@ -203,13 +203,20 @@ describe('QuartoExecutionManager', () => {
 				return documentLines.slice(r.startLineNumber - 1, r.endLineNumber).join('\n');
 			};
 
-			vi.spyOn(mockSession, 'isCodeFragmentComplete').mockImplementation(async code => {
-				const openParens = code.match(/\(/g)?.length ?? 0;
-				const closeParens = code.match(/\)/g)?.length ?? 0;
-				return openParens === closeParens
-					? RuntimeCodeFragmentStatus.Complete
-					: RuntimeCodeFragmentStatus.Incomplete;
+			let requestedMethod: string | undefined;
+			let requestedCode: string | undefined;
+			const callMethodSpy = vi.spyOn(mockSession, 'callMethod').mockImplementation(async (method, ...args) => {
+				requestedMethod = method;
+				requestedCode = typeof args[0] === 'string' ? args[0] : undefined;
+				return {
+					boundaries: [
+						{ range: { start: 0, end: 3 }, kind: 'complete' },
+						{ range: { start: 3, end: 4 }, kind: 'complete' },
+						{ range: { start: 4, end: 5 }, kind: 'complete' },
+					],
+				};
 			});
+			const completenessSpy = vi.spyOn(mockSession, 'isCodeFragmentComplete');
 			const executeSpy = vi.spyOn(mockSession, 'execute');
 			const outputsReceived: ICellOutput[] = [];
 			ctx.disposables.add(executionManager.onDidReceiveOutput(event => {
@@ -251,6 +258,10 @@ describe('QuartoExecutionManager', () => {
 
 			await executionPromise;
 
+			expect(callMethodSpy).toHaveBeenCalledTimes(1);
+			expect(requestedMethod).toBe('inputBoundaries');
+			expect(requestedCode).toBe('values <- list(\n  1\n)\nvalues[[1]]\n2');
+			expect(completenessSpy).not.toHaveBeenCalled();
 			expect(executeSpy.mock.calls.map(call => call[0])).toEqual([
 				'values <- list(\n  1\n)',
 				'values[[1]]',

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
@@ -6,13 +6,18 @@
 /// <reference types="vitest/globals" />
 
 import { URI } from '../../../../../base/common/uri.js';
-import { Disposable } from '../../../../../base/common/lifecycle.js';
+import { Disposable, DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { NullLogService } from '../../../../../platform/log/common/log.js';
 import { TestLanguageRuntimeSession } from '../../../../services/runtimeSession/test/common/testLanguageRuntimeSession.js';
 import { TestPositronConsoleService } from '../../../../services/positronConsole/test/browser/testPositronConsoleService.js';
 import { CellExecutionState, ExecutionOutputEvent, ICellOutput } from '../../common/quartoExecutionTypes.js';
 import { Range } from '../../../../../editor/common/core/range.js';
+import type { IInputBoundary } from '../../../../../editor/common/languages.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { IModelService } from '../../../../../editor/common/services/model.js';
+import { ILanguageFeaturesService } from '../../../../../editor/common/services/languageFeatures.js';
+import { createModelServices } from '../../../../../editor/test/common/testTextModel.js';
 import { RuntimeOnlineState, RuntimeOutputKind, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionMode, ILanguageRuntimeMetadata, RuntimeErrorBehavior, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { QuartoExecutionManager } from '../../browser/quartoExecutionManager.js';
@@ -67,6 +72,9 @@ describe('QuartoExecutionManager', () => {
 	let mockEditorService: MockEditorService;
 	let mockConsoleService: RecordingConsoleService;
 	let mockRuntimeSessionService: MockRuntimeSessionService;
+	let modelService: IModelService;
+	let languageService: ILanguageService;
+	let languageFeaturesService: ILanguageFeaturesService;
 
 	beforeEach(() => {
 		// Create mock session
@@ -87,6 +95,12 @@ describe('QuartoExecutionManager', () => {
 		mockConsoleService = new RecordingConsoleService();
 		mockRuntimeSessionService = new MockRuntimeSessionService();
 		const mockTerminalService = new MockTerminalService();
+		const modelDisposables = ctx.disposables.add(new DisposableStore());
+		const modelInstantiationService = createModelServices(modelDisposables);
+		modelService = modelInstantiationService.get(IModelService);
+		languageService = modelInstantiationService.get(ILanguageService);
+		languageFeaturesService = modelInstantiationService.get(ILanguageFeaturesService);
+		modelDisposables.add(languageService.registerLanguage({ id: 'r' }));
 
 		// Create execution manager
 		executionManager = new QuartoExecutionManager(
@@ -99,6 +113,9 @@ describe('QuartoExecutionManager', () => {
 			asConsoleService(mockConsoleService),
 			asRuntimeSessionService(mockRuntimeSessionService),
 			asTerminalService(mockTerminalService),
+			modelService,
+			languageService,
+			languageFeaturesService,
 		);
 		ctx.disposables.add(executionManager);
 	});
@@ -173,7 +190,71 @@ describe('QuartoExecutionManager', () => {
 	});
 
 	describe('Output Handling', () => {
-		it('queries input boundaries once and keeps each R result', async () => {
+		async function executeRCellWithBoundaries(
+			testId: string,
+			codeLines: string[],
+			boundaries: IInputBoundary[],
+			expectedFragments: string[]
+		): Promise<{ requestedCode: string | undefined; providerCalls: number; executedCode: string[] }> {
+			const documentUri = URI.file(`/${testId}.qmd`);
+			const cell: QuartoCodeCell = {
+				id: testId,
+				index: 0,
+				language: 'r',
+				startLine: 1,
+				endLine: codeLines.length + 2,
+				codeStartLine: 2,
+				codeEndLine: codeLines.length + 1,
+				label: undefined,
+				options: '',
+				contentHash: testId,
+			};
+			const documentLines = [
+				'```{r}',
+				...codeLines,
+				'```',
+			];
+			const mockModel = new MockQuartoDocumentModel([cell], documentLines, 'r');
+			mockDocumentModelService.setMockModel(mockModel);
+			mockEditorService.getValueInRangeCallback = (range: unknown) => {
+				const r = range as { startLineNumber: number; endLineNumber: number };
+				return documentLines.slice(r.startLineNumber - 1, r.endLineNumber).join('\n');
+			};
+
+			let requestedCode: string | undefined;
+			let providerCalls = 0;
+			ctx.disposables.add(languageFeaturesService.inputBoundaryProvider.register('r', {
+				provideInputBoundaries(model, range, _token) {
+					providerCalls++;
+					requestedCode = model.getValueInRange(range);
+					return boundaries;
+				}
+			}));
+			const completenessSpy = vi.spyOn(mockSession, 'isCodeFragmentComplete');
+			const executeSpy = vi.spyOn(mockSession, 'execute');
+
+			const executionPromise = executionManager.executeCell(documentUri, cell);
+
+			for (let i = 0; i < expectedFragments.length; i++) {
+				const executionId = await mockKernelManager.waitForExecution();
+				mockSession.receiveStateMessage({
+					parent_id: executionId,
+					state: RuntimeOnlineState.Idle,
+				});
+				mockSession.setRuntimeState(RuntimeState.Ready);
+			}
+
+			await executionPromise;
+
+			expect(completenessSpy).not.toHaveBeenCalled();
+			return {
+				requestedCode,
+				providerCalls,
+				executedCode: executeSpy.mock.calls.map(call => call[0]),
+			};
+		}
+
+		it('queries input boundaries once through the R provider and keeps each R result', async () => {
 			const documentUri = URI.file('/test-r-expressions.qmd');
 			const cell: QuartoCodeCell = {
 				id: 'test-r-expressions',
@@ -203,19 +284,20 @@ describe('QuartoExecutionManager', () => {
 				return documentLines.slice(r.startLineNumber - 1, r.endLineNumber).join('\n');
 			};
 
-			let requestedMethod: string | undefined;
 			let requestedCode: string | undefined;
-			const callMethodSpy = vi.spyOn(mockSession, 'callMethod').mockImplementation(async (method, ...args) => {
-				requestedMethod = method;
-				requestedCode = typeof args[0] === 'string' ? args[0] : undefined;
-				return {
-					boundaries: [
+			let providerCalls = 0;
+			ctx.disposables.add(languageFeaturesService.inputBoundaryProvider.register('r', {
+				provideInputBoundaries(model, range, _token) {
+					providerCalls++;
+					requestedCode = model.getValueInRange(range);
+					return [
 						{ range: { start: 0, end: 3 }, kind: 'complete' },
 						{ range: { start: 3, end: 4 }, kind: 'complete' },
 						{ range: { start: 4, end: 5 }, kind: 'complete' },
-					],
-				};
-			});
+					];
+				}
+			}));
+			const callMethodSpy = vi.spyOn(mockSession, 'callMethod');
 			const completenessSpy = vi.spyOn(mockSession, 'isCodeFragmentComplete');
 			const executeSpy = vi.spyOn(mockSession, 'execute');
 			const outputsReceived: ICellOutput[] = [];
@@ -258,9 +340,9 @@ describe('QuartoExecutionManager', () => {
 
 			await executionPromise;
 
-			expect(callMethodSpy).toHaveBeenCalledTimes(1);
-			expect(requestedMethod).toBe('inputBoundaries');
+			expect(providerCalls).toBe(1);
 			expect(requestedCode).toBe('values <- list(\n  1\n)\nvalues[[1]]\n2');
+			expect(callMethodSpy).not.toHaveBeenCalled();
 			expect(completenessSpy).not.toHaveBeenCalled();
 			expect(executeSpy.mock.calls.map(call => call[0])).toEqual([
 				'values <- list(\n  1\n)',
@@ -268,6 +350,55 @@ describe('QuartoExecutionManager', () => {
 				'2',
 			]);
 			expect(outputsReceived.map(output => output.items[0].data)).toEqual(['1', '2']);
+		});
+
+		it('executes an incomplete R section as one fragment from input boundaries', async () => {
+			const codeLines = [
+				'if (TRUE) {',
+				'  1',
+			];
+			const expectedFragments = [
+				'if (TRUE) {\n  1',
+			];
+
+			const result = await executeRCellWithBoundaries(
+				'test-r-incomplete',
+				codeLines,
+				[
+					{ range: { start: 0, end: 2 }, kind: 'incomplete' },
+				],
+				expectedFragments
+			);
+
+			expect(result.providerCalls).toBe(1);
+			expect(result.requestedCode).toBe('if (TRUE) {\n  1');
+			expect(result.executedCode).toEqual(expectedFragments);
+		});
+
+		it('keeps a trailing R parse-error section as its own fragment from input boundaries', async () => {
+			const codeLines = [
+				'1',
+				')',
+				'2',
+			];
+			const expectedFragments = [
+				'1',
+				')\n2',
+			];
+
+			const result = await executeRCellWithBoundaries(
+				'test-r-invalid',
+				codeLines,
+				[
+					{ range: { start: 0, end: 1 }, kind: 'complete' },
+					{ range: { start: 1, end: 3 }, kind: 'invalid', data: { message: 'unexpected )' } },
+				],
+				expectedFragments
+			);
+
+			expect(result.providerCalls).toBe(1);
+			expect(result.requestedCode).toBe('1\n)\n2');
+			expect(result.executedCode).toEqual(expectedFragments);
 		});
 
 		it('filters out text/plain when text/html is present (DataFrame case)', async () => {
@@ -584,6 +715,9 @@ describe('QuartoExecutionManager', () => {
 				new TestPositronConsoleService(),
 				asRuntimeSessionService(new MockRuntimeSessionService()),
 				asTerminalService(new MockTerminalService()),
+				modelService,
+				languageService,
+				languageFeaturesService,
 			);
 			ctx.disposables.add(executionManagerWithMock);
 
@@ -679,6 +813,9 @@ describe('QuartoExecutionManager', () => {
 				new TestPositronConsoleService(),
 				asRuntimeSessionService(new MockRuntimeSessionService()),
 				asTerminalService(new MockTerminalService()),
+				modelService,
+				languageService,
+				languageFeaturesService,
 			);
 			ctx.disposables.add(localExecutionManager);
 

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
@@ -18,7 +18,7 @@ import { ILanguageService } from '../../../../../editor/common/languages/languag
 import { IModelService } from '../../../../../editor/common/services/model.js';
 import { ILanguageFeaturesService } from '../../../../../editor/common/services/languageFeatures.js';
 import { createModelServices } from '../../../../../editor/test/common/testTextModel.js';
-import { RuntimeOnlineState, RuntimeOutputKind, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionMode, ILanguageRuntimeMetadata, RuntimeErrorBehavior, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { RuntimeOnlineState, RuntimeOutputKind, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionMode, ILanguageRuntimeMetadata, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { QuartoExecutionManager } from '../../browser/quartoExecutionManager.js';
 import { IQuartoKernelManager } from '../../browser/quartoKernelManager.js';
@@ -190,6 +190,8 @@ describe('QuartoExecutionManager', () => {
 	});
 
 	describe('Output Handling', () => {
+		const quartoInputBoundarySelector = { language: 'r', scheme: 'inmemory', pattern: '**/quarto-input-boundaries/*.{r,R}' };
+
 		async function executeRCellWithBoundaries(
 			testId: string,
 			codeLines: string[],
@@ -223,7 +225,7 @@ describe('QuartoExecutionManager', () => {
 
 			let requestedCode: string | undefined;
 			let providerCalls = 0;
-			ctx.disposables.add(languageFeaturesService.inputBoundaryProvider.register('r', {
+			ctx.disposables.add(languageFeaturesService.inputBoundaryProvider.register(quartoInputBoundarySelector, {
 				provideInputBoundaries(model, range, _token) {
 					providerCalls++;
 					requestedCode = model.getValueInRange(range);
@@ -251,6 +253,67 @@ describe('QuartoExecutionManager', () => {
 				requestedCode,
 				providerCalls,
 				executedCode: executeSpy.mock.calls.map(call => call[0]),
+			};
+		}
+
+		async function executeRCellWithFallbackBoundaries(
+			testId: string,
+			boundaries: unknown
+		): Promise<{ providerCalls: number; executedCode: string[]; completenessCalls: number }> {
+			const documentUri = URI.file(`/${testId}.qmd`);
+			const cell: QuartoCodeCell = {
+				id: testId,
+				index: 0,
+				language: 'r',
+				startLine: 1,
+				endLine: 4,
+				codeStartLine: 2,
+				codeEndLine: 3,
+				label: undefined,
+				options: '',
+				contentHash: testId,
+			};
+			const documentLines = [
+				'```{r}',
+				'1',
+				'2',
+				'```',
+			];
+			const mockModel = new MockQuartoDocumentModel([cell], documentLines, 'r');
+			mockDocumentModelService.setMockModel(mockModel);
+			mockEditorService.getValueInRangeCallback = (range: unknown) => {
+				const r = range as { startLineNumber: number; endLineNumber: number };
+				return documentLines.slice(r.startLineNumber - 1, r.endLineNumber).join('\n');
+			};
+
+			let providerCalls = 0;
+			ctx.disposables.add(languageFeaturesService.inputBoundaryProvider.register(quartoInputBoundarySelector, {
+				provideInputBoundaries() {
+					providerCalls++;
+					return boundaries as IInputBoundary[];
+				}
+			}));
+			const completenessSpy = vi.spyOn(mockSession, 'isCodeFragmentComplete')
+				.mockResolvedValue(RuntimeCodeFragmentStatus.Complete);
+			const executeSpy = vi.spyOn(mockSession, 'execute');
+
+			const executionPromise = executionManager.executeCell(documentUri, cell);
+
+			for (let i = 0; i < 2; i++) {
+				const executionId = await mockKernelManager.waitForExecution();
+				mockSession.receiveStateMessage({
+					parent_id: executionId,
+					state: RuntimeOnlineState.Idle,
+				});
+				mockSession.setRuntimeState(RuntimeState.Ready);
+			}
+
+			await executionPromise;
+
+			return {
+				providerCalls,
+				executedCode: executeSpy.mock.calls.map(call => call[0]),
+				completenessCalls: completenessSpy.mock.calls.length,
 			};
 		}
 
@@ -286,7 +349,7 @@ describe('QuartoExecutionManager', () => {
 
 			let requestedCode: string | undefined;
 			let providerCalls = 0;
-			ctx.disposables.add(languageFeaturesService.inputBoundaryProvider.register('r', {
+			ctx.disposables.add(languageFeaturesService.inputBoundaryProvider.register(quartoInputBoundarySelector, {
 				provideInputBoundaries(model, range, _token) {
 					providerCalls++;
 					requestedCode = model.getValueInRange(range);
@@ -350,6 +413,224 @@ describe('QuartoExecutionManager', () => {
 				'2',
 			]);
 			expect(outputsReceived.map(output => output.items[0].data)).toEqual(['1', '2']);
+		});
+
+		it('does not match notebook-cell-only providers for Quarto input boundary models', async () => {
+			const documentUri = URI.file('/test-r-boundary-selector-fallback.qmd');
+			const cell: QuartoCodeCell = {
+				id: 'test-r-boundary-selector-fallback',
+				index: 0,
+				language: 'r',
+				startLine: 1,
+				endLine: 4,
+				codeStartLine: 2,
+				codeEndLine: 3,
+				label: undefined,
+				options: '',
+				contentHash: 'r-boundary-selector-fallback',
+			};
+			const documentLines = [
+				'```{r}',
+				'1',
+				'2',
+				'```',
+			];
+			const mockModel = new MockQuartoDocumentModel([cell], documentLines, 'r');
+			mockDocumentModelService.setMockModel(mockModel);
+			mockEditorService.getValueInRangeCallback = (range: unknown) => {
+				const r = range as { startLineNumber: number; endLineNumber: number };
+				return documentLines.slice(r.startLineNumber - 1, r.endLineNumber).join('\n');
+			};
+
+			let providerCalls = 0;
+			ctx.disposables.add(languageFeaturesService.inputBoundaryProvider.register({ language: 'r', scheme: 'vscode-notebook-cell' }, {
+				provideInputBoundaries() {
+					providerCalls++;
+					return [
+						{ range: { start: 0, end: 2 }, kind: 'complete' },
+					];
+				}
+			}));
+			const completenessSpy = vi.spyOn(mockSession, 'isCodeFragmentComplete')
+				.mockResolvedValue(RuntimeCodeFragmentStatus.Complete);
+			const executeSpy = vi.spyOn(mockSession, 'execute');
+
+			const executionPromise = executionManager.executeCell(documentUri, cell);
+
+			for (let i = 0; i < 2; i++) {
+				const executionId = await mockKernelManager.waitForExecution();
+				mockSession.receiveStateMessage({
+					parent_id: executionId,
+					state: RuntimeOnlineState.Idle,
+				});
+				mockSession.setRuntimeState(RuntimeState.Ready);
+			}
+
+			await executionPromise;
+
+			expect(providerCalls).toBe(0);
+			expect(completenessSpy).toHaveBeenCalled();
+			expect(executeSpy.mock.calls.map(call => call[0])).toEqual(['1', '2']);
+		});
+
+		it('cancels a pending R input boundary provider request without executing code', async () => {
+			const documentUri = URI.file('/test-r-boundary-cancel.qmd');
+			const cell: QuartoCodeCell = {
+				id: 'test-r-boundary-cancel',
+				index: 0,
+				language: 'r',
+				startLine: 1,
+				endLine: 3,
+				codeStartLine: 2,
+				codeEndLine: 2,
+				label: undefined,
+				options: '',
+				contentHash: 'r-boundary-cancel',
+			};
+			const documentLines = [
+				'```{r}',
+				'1',
+				'```',
+			];
+			const mockModel = new MockQuartoDocumentModel([cell], documentLines, 'r');
+			mockDocumentModelService.setMockModel(mockModel);
+			mockEditorService.getValueInRangeCallback = (range: unknown) => {
+				const r = range as { startLineNumber: number; endLineNumber: number };
+				return documentLines.slice(r.startLineNumber - 1, r.endLineNumber).join('\n');
+			};
+
+			let providerToken: CancellationToken | undefined;
+			let providerStartedResolve!: () => void;
+			const providerStarted = new Promise<void>(resolve => {
+				providerStartedResolve = resolve;
+			});
+			ctx.disposables.add(languageFeaturesService.inputBoundaryProvider.register(quartoInputBoundarySelector, {
+				provideInputBoundaries(_model, _range, token) {
+					providerToken = token;
+					providerStartedResolve();
+					return new Promise<IInputBoundary[]>(() => { });
+				}
+			}));
+			const executeSpy = vi.spyOn(mockSession, 'execute');
+
+			const executionPromise = executionManager.executeCell(documentUri, cell);
+			await providerStarted;
+			await executionManager.cancelExecution(documentUri, cell.id);
+			await executionPromise;
+
+			expect(providerToken?.isCancellationRequested).toBe(true);
+			expect(executeSpy).not.toHaveBeenCalled();
+			expect(executionManager.getExecutionState(cell.id)).toBe(CellExecutionState.Idle);
+		});
+
+		it('prefers the Quarto input boundary provider over a broad in-memory R provider', async () => {
+			const documentUri = URI.file('/test-r-boundary-selector-conflict.qmd');
+			const cell: QuartoCodeCell = {
+				id: 'test-r-boundary-selector-conflict',
+				index: 0,
+				language: 'r',
+				startLine: 1,
+				endLine: 4,
+				codeStartLine: 2,
+				codeEndLine: 3,
+				label: undefined,
+				options: '',
+				contentHash: 'r-boundary-selector-conflict',
+			};
+			const documentLines = [
+				'```{r}',
+				'1',
+				'2',
+				'```',
+			];
+			const mockModel = new MockQuartoDocumentModel([cell], documentLines, 'r');
+			mockDocumentModelService.setMockModel(mockModel);
+			mockEditorService.getValueInRangeCallback = (range: unknown) => {
+				const r = range as { startLineNumber: number; endLineNumber: number };
+				return documentLines.slice(r.startLineNumber - 1, r.endLineNumber).join('\n');
+			};
+
+			let broadProviderCalls = 0;
+			let quartoProviderCalls = 0;
+			ctx.disposables.add(languageFeaturesService.inputBoundaryProvider.register({ language: 'r', scheme: 'inmemory' }, {
+				provideInputBoundaries() {
+					broadProviderCalls++;
+					return [
+						{ range: { start: 0, end: 2 }, kind: 'complete' },
+					];
+				}
+			}));
+			ctx.disposables.add(languageFeaturesService.inputBoundaryProvider.register(quartoInputBoundarySelector, {
+				provideInputBoundaries() {
+					quartoProviderCalls++;
+					return [
+						{ range: { start: 0, end: 1 }, kind: 'complete' },
+						{ range: { start: 1, end: 2 }, kind: 'complete' },
+					];
+				}
+			}));
+			const completenessSpy = vi.spyOn(mockSession, 'isCodeFragmentComplete');
+			const executeSpy = vi.spyOn(mockSession, 'execute');
+
+			const executionPromise = executionManager.executeCell(documentUri, cell);
+
+			for (let i = 0; i < 2; i++) {
+				const executionId = await mockKernelManager.waitForExecution();
+				mockSession.receiveStateMessage({
+					parent_id: executionId,
+					state: RuntimeOnlineState.Idle,
+				});
+				mockSession.setRuntimeState(RuntimeState.Ready);
+			}
+
+			await executionPromise;
+
+			expect(broadProviderCalls).toBe(0);
+			expect(quartoProviderCalls).toBe(1);
+			expect(completenessSpy).not.toHaveBeenCalled();
+			expect(executeSpy.mock.calls.map(call => call[0])).toEqual(['1', '2']);
+		});
+
+		it.each([
+			{
+				name: 'out-of-bounds range',
+				boundaries: [{ range: { start: 0, end: 3 }, kind: 'complete' }],
+			},
+			{
+				name: 'non-array response',
+				boundaries: { range: { start: 0, end: 2 }, kind: 'complete' },
+			},
+			{
+				name: 'invalid kind',
+				boundaries: [{ range: { start: 0, end: 2 }, kind: 'unknown' }],
+			},
+			{
+				name: 'gap or partial coverage',
+				boundaries: [{ range: { start: 0, end: 1 }, kind: 'complete' }],
+			},
+			{
+				name: 'overlap or out-of-order range',
+				boundaries: [
+					{ range: { start: 0, end: 2 }, kind: 'complete' },
+					{ range: { start: 1, end: 2 }, kind: 'complete' },
+				],
+			},
+			{
+				name: 'empty non-whitespace range',
+				boundaries: [
+					{ range: { start: 0, end: 0 }, kind: 'complete' },
+					{ range: { start: 0, end: 2 }, kind: 'complete' },
+				],
+			},
+		])('falls back to completeness checks for malformed input boundaries: $name', async ({ name, boundaries }) => {
+			const result = await executeRCellWithFallbackBoundaries(
+				`test-r-malformed-boundaries-${name.replace(/\W/g, '-')}`,
+				boundaries
+			);
+
+			expect(result.providerCalls).toBe(1);
+			expect(result.completenessCalls).toBeGreaterThan(0);
+			expect(result.executedCode).toEqual(['1', '2']);
 		});
 
 		it('executes an incomplete R section as one fragment from input boundaries', async () => {
@@ -889,7 +1170,7 @@ describe('QuartoExecutionManager', () => {
 
 			expect(executeSpy).toHaveBeenCalledOnce();
 			// session.execute(code, id, mode, errorBehavior, _attribution, executionMetadata)
-			return executeSpy.mock.calls[0][5] as Record<string, unknown> | undefined;
+			return (executeSpy.mock.calls[0] as unknown[])[5] as Record<string, unknown> | undefined;
 		}
 
 		it('passes fig-width and fig-height from chunk options to session.execute', async () => {
@@ -1260,7 +1541,7 @@ function asTerminalService(mock: MockTerminalService): ITerminalService {
 		// Cast: the mock's return type is loose; production expects an
 		// ITerminalInstance. None of the cell-metadata tests hit shell
 		// languages, so this branch is never exercised in this file.
-		getActiveOrCreateInstance: mock.getActiveOrCreateInstance.bind(mock) as ITerminalService['getActiveOrCreateInstance'],
+		getActiveOrCreateInstance: mock.getActiveOrCreateInstance.bind(mock) as unknown as ITerminalService['getActiveOrCreateInstance'],
 	});
 }
 

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
@@ -13,7 +13,7 @@ import { TestLanguageRuntimeSession } from '../../../../services/runtimeSession/
 import { TestPositronConsoleService } from '../../../../services/positronConsole/test/browser/testPositronConsoleService.js';
 import { CellExecutionState, ExecutionOutputEvent, ICellOutput } from '../../common/quartoExecutionTypes.js';
 import { Range } from '../../../../../editor/common/core/range.js';
-import { RuntimeOnlineState, RuntimeOutputKind, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionMode, ILanguageRuntimeMetadata, RuntimeErrorBehavior, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { RuntimeOnlineState, RuntimeOutputKind, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionMode, ILanguageRuntimeMetadata, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
 import { QuartoExecutionManager } from '../../browser/quartoExecutionManager.js';
 import { IQuartoKernelManager } from '../../browser/quartoKernelManager.js';
@@ -173,6 +173,92 @@ describe('QuartoExecutionManager', () => {
 	});
 
 	describe('Output Handling', () => {
+		it('executes complete R expressions separately and keeps each result', async () => {
+			const documentUri = URI.file('/test-r-expressions.qmd');
+			const cell: QuartoCodeCell = {
+				id: 'test-r-expressions',
+				index: 0,
+				language: 'r',
+				startLine: 1,
+				endLine: 7,
+				codeStartLine: 2,
+				codeEndLine: 6,
+				label: undefined,
+				options: '',
+				contentHash: 'r-expressions',
+			};
+			const documentLines = [
+				'```{r}',
+				'values <- list(',
+				'  1',
+				')',
+				'values[[1]]',
+				'2',
+				'```',
+			];
+			const mockModel = new MockQuartoDocumentModel([cell], documentLines, 'r');
+			mockDocumentModelService.setMockModel(mockModel);
+			mockEditorService.getValueInRangeCallback = (range: unknown) => {
+				const r = range as { startLineNumber: number; endLineNumber: number };
+				return documentLines.slice(r.startLineNumber - 1, r.endLineNumber).join('\n');
+			};
+
+			vi.spyOn(mockSession, 'isCodeFragmentComplete').mockImplementation(async code => {
+				const openParens = code.match(/\(/g)?.length ?? 0;
+				const closeParens = code.match(/\)/g)?.length ?? 0;
+				return openParens === closeParens
+					? RuntimeCodeFragmentStatus.Complete
+					: RuntimeCodeFragmentStatus.Incomplete;
+			});
+			const executeSpy = vi.spyOn(mockSession, 'execute');
+			const outputsReceived: ICellOutput[] = [];
+			ctx.disposables.add(executionManager.onDidReceiveOutput(event => {
+				outputsReceived.push(event.output);
+			}));
+
+			const executionPromise = executionManager.executeCell(documentUri, cell);
+
+			const assignmentId = await mockKernelManager.waitForExecution();
+			mockSession.receiveStateMessage({
+				parent_id: assignmentId,
+				state: RuntimeOnlineState.Idle,
+			});
+			mockSession.setRuntimeState(RuntimeState.Ready);
+
+			const firstResultId = await mockKernelManager.waitForExecution();
+			mockSession.receiveResultMessage({
+				parent_id: firstResultId,
+				kind: RuntimeOutputKind.Text,
+				data: { 'text/plain': '1' },
+			});
+			mockSession.receiveStateMessage({
+				parent_id: firstResultId,
+				state: RuntimeOnlineState.Idle,
+			});
+			mockSession.setRuntimeState(RuntimeState.Ready);
+
+			const secondResultId = await mockKernelManager.waitForExecution();
+			mockSession.receiveResultMessage({
+				parent_id: secondResultId,
+				kind: RuntimeOutputKind.Text,
+				data: { 'text/plain': '2' },
+			});
+			mockSession.receiveStateMessage({
+				parent_id: secondResultId,
+				state: RuntimeOnlineState.Idle,
+			});
+			mockSession.setRuntimeState(RuntimeState.Ready);
+
+			await executionPromise;
+
+			expect(executeSpy.mock.calls.map(call => call[0])).toEqual([
+				'values <- list(\n  1\n)',
+				'values[[1]]',
+				'2',
+			]);
+			expect(outputsReceived.map(output => output.items[0].data)).toEqual(['1', '2']);
+		});
+
 		it('filters out text/plain when text/html is present (DataFrame case)', async () => {
 			// This test verifies that when both text/html and text/plain are returned
 			// (as happens with pandas DataFrames), only text/html is included in output.
@@ -768,8 +854,13 @@ class MockKernelManager extends Disposable {
 		super();
 		// Listen for executions via the session's built-in test event
 		this._register(_session.onDidExecute(id => {
-			this.lastExecutionId = id;
-			this._executionResolve?.(id);
+			const executionResolve = this._executionResolve;
+			if (executionResolve) {
+				this.lastExecutionId = undefined;
+				executionResolve(id);
+			} else {
+				this.lastExecutionId = id;
+			}
 		}));
 	}
 
@@ -894,13 +985,14 @@ function asDocumentModelService(mock: MockDocumentModelService): IQuartoDocument
 class MockQuartoDocumentModel {
 	private _cells: Map<string, QuartoCodeCell> = new Map();
 	private _documentLines: string[] = [];
-	readonly primaryLanguage = 'python';
+	readonly primaryLanguage: string;
 
 	get cells(): QuartoCodeCell[] {
 		return Array.from(this._cells.values());
 	}
 
-	constructor(cells: QuartoCodeCell[], documentLines: string[]) {
+	constructor(cells: QuartoCodeCell[], documentLines: string[], primaryLanguage = 'python') {
+		this.primaryLanguage = primaryLanguage;
 		for (const cell of cells) {
 			this._cells.set(cell.id, cell);
 		}

--- a/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
+++ b/src/vs/workbench/services/runtimeSession/common/runtimeSessionService.ts
@@ -193,6 +193,12 @@ export interface ILanguageRuntimeSession extends IDisposable {
 		executionMetadata?: Record<string, unknown>,
 	): void;
 
+	/**
+	 * Calls a runtime-specific method and returns the result.
+	 * Implementations may expose only a subset of methods.
+	 */
+	callMethod?(method: string, ...args: unknown[]): Thenable<unknown>;
+
 	/** Test a code fragment for completeness */
 	isCodeFragmentComplete(code: string): Thenable<RuntimeCodeFragmentStatus>;
 

--- a/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
@@ -153,6 +153,10 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 		});
 	}
 
+	async callMethod(_method: string, ..._args: unknown[]): Promise<unknown> {
+		throw new Error('Not implemented.');
+	}
+
 	async isCodeFragmentComplete(_code: string): Promise<RuntimeCodeFragmentStatus> {
 		throw new Error('Not implemented.');
 	}

--- a/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
@@ -161,10 +161,6 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 		throw new Error('Not implemented.');
 	}
 
-	async callMethod(_method: string, ..._args: unknown[]): Promise<unknown> {
-		throw new Error('Not implemented.');
-	}
-
 	getDynState(): Promise<ILanguageRuntimeSessionState> {
 		return Promise.resolve(this.dynState);
 	}

--- a/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
+++ b/src/vs/workbench/services/runtimeSession/test/common/testLanguageRuntimeSession.ts
@@ -161,6 +161,10 @@ export class TestLanguageRuntimeSession extends Disposable implements ILanguageR
 		throw new Error('Not implemented.');
 	}
 
+	async callMethod(_method: string, ..._args: unknown[]): Promise<unknown> {
+		throw new Error('Not implemented.');
+	}
+
 	getDynState(): Promise<ILanguageRuntimeSessionState> {
 		return Promise.resolve(this.dynState);
 	}


### PR DESCRIPTION
## Summary

- split primary R Quarto cell code into line-aligned complete expressions before execution
- execute those expressions sequentially so every implicit result or plot is appended to the cell's inline output
- fall back to the original whole-cell execution when a runtime cannot determine expression completeness
- preserve existing behavior for other languages and non-primary-language console execution
- add regression coverage for a multiline R expression followed by multiple visible results

This makes separate outputs from an R chunk appear together below the chunk instead of showing only the final implicit result.

Related to #5272 and #13505.

## Testing

- `npm run compile-check-ts-native`
- `npx vitest run src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts`
- targeted ESLint on the two changed files: 0 errors