### PR TITLE
e2e: fix flaky afterEach in interpreter-commands test

### DIFF
--- a/test/e2e/tests/interpreters/interpreter-commands.test.ts
+++ b/test/e2e/tests/interpreters/interpreter-commands.test.ts
@@ -31,6 +31,28 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, Shutdown, Clear Inte
 		await app.workbench.sessions.deleteAll();
 	});
 
+	test('R - Verify Clear Saved Interpreter command works', { tag: [tags.WIN] }, async function ({ app, page, runCommand, sessions }) {
+		const { quickInput, toasts } = app.workbench;
+
+		await sessions.start('r');
+		await runCommand('workbench.action.languageRuntime.clearAffiliatedRuntime', { keepOpen: true });
+		await quickInput.waitForQuickInputOpened();
+		const anyRSession = app.workbench.quickInput.quickInputList.getByText(/R:/);
+		await anyRSession.waitFor({ state: 'visible' });
+		await page.keyboard.press('Enter');
+		await quickInput.waitForQuickInputClosed();
+		await toasts.expectToastWithTitle(/R .* interpreter has been cleared/);
+	});
+
+	test('R - Verify Interrupt Interpreter command works', { tag: [tags.WIN] }, async function ({ app, page, runCommand, sessions }) {
+		const { console } = app.workbench;
+
+		await sessions.start('r');
+		await console.executeCode('R', 'Sys.sleep(5)', { waitForReady: false });
+		await runCommand('workbench.action.languageRuntime.interrupt');
+		await expect(page.locator('div.activity-error-stream')).toBeVisible();
+	});
+
 	// Skip this test for tags.WIN (e2e-windows) due to Bug #4604
 	test('Python - Verify Interrupt Interpreter command works', async function ({ app, runCommand, sessions }) {
 		const { console } = app.workbench;
@@ -52,27 +74,5 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, Shutdown, Clear Inte
 		await page.keyboard.press('Enter');
 		await quickInput.waitForQuickInputClosed();
 		await toasts.expectToastWithTitle(/Python .* interpreter has been cleared/);
-	});
-
-	test('R - Verify Clear Saved Interpreter command works', { tag: [tags.WIN] }, async function ({ app, r, page, runCommand, sessions }) {
-		const { quickInput, toasts } = app.workbench;
-
-		await sessions.start('r');
-		await runCommand('workbench.action.languageRuntime.clearAffiliatedRuntime', { keepOpen: true });
-		await quickInput.waitForQuickInputOpened();
-		const anyRSession = app.workbench.quickInput.quickInputList.getByText(/R:/);
-		await anyRSession.waitFor({ state: 'visible' });
-		await page.keyboard.press('Enter');
-		await quickInput.waitForQuickInputClosed();
-		await toasts.expectToastWithTitle(/R .* interpreter has been cleared/);
-	});
-
-	test('R - Verify Interrupt Interpreter command works', { tag: [tags.WIN] }, async function ({ app, page, runCommand, sessions }) {
-		const { console } = app.workbench;
-
-		await sessions.start('r');
-		await console.executeCode('R', 'Sys.sleep(5)', { waitForReady: false });
-		await runCommand('workbench.action.languageRuntime.interrupt');
-		await expect(page.locator('div.activity-error-stream')).toBeVisible();
 	});
 });

--- a/test/e2e/tests/interpreters/interpreter-commands.test.ts
+++ b/test/e2e/tests/interpreters/interpreter-commands.test.ts
@@ -7,7 +7,7 @@
 Summary:
 - This test suite verifies the functionality of interpreter commands via Interrupt and Clear for both Python and R.
 - Tests confirm that each quick input command triggers the expected behavior, verified through console outputs (see Table below).
-- After each test, console is cleared and session is fully deleted. Doing both for each test makes the tests more robust indeed.
+- After each test, the session is fully deleted.
 
  * |Command   |Language|Targeted Console Output    |
  * |----------|--------|---------------------------|
@@ -28,42 +28,49 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, Shutdown, Clear Inte
 }, () => {
 
 	test.afterEach(async ({ app }) => {
-		await app.workbench.console.clearButton.click();
 		await app.workbench.sessions.deleteAll();
 	});
 
 	// Skip this test for tags.WIN (e2e-windows) due to Bug #4604
-	test('Verify Interrupt Interpreter command works (→ KeyboardInterrupt) - Python', async function ({ app, python }) {
-		await app.workbench.console.executeCode('Python', 'import time; time.sleep(5)', { waitForReady: false });
-		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.interrupt');
-		await app.workbench.console.waitForConsoleContents('KeyboardInterrupt');
+	test('Python - Verify Interrupt Interpreter command works', async function ({ app, runCommand, python }) {
+		const { console } = app.workbench;
+
+		await console.executeCode('Python', 'import time; time.sleep(5)', { waitForReady: false });
+		await runCommand('workbench.action.languageRuntime.interrupt');
+		await console.waitForConsoleContents('KeyboardInterrupt');
 	});
 
-	test('Verify Interrupt Interpreter command works (→ empty error line) - R', { tag: [tags.WIN] }, async function ({ app, page, r }) {
-		await app.workbench.console.executeCode('R', 'Sys.sleep(5)', { waitForReady: false });
-		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.interrupt');
+	test('R - Verify Interrupt Interpreter command works', { tag: [tags.WIN] }, async function ({ app, page, runCommand, r }) {
+		const { console } = app.workbench;
+
+		await console.executeCode('R', 'Sys.sleep(5)', { waitForReady: false });
+		await runCommand('workbench.action.languageRuntime.interrupt');
 		await expect(page.locator('div.activity-error-stream')).toBeVisible();
 	});
 
-	test('Verify Clear Saved Interpreter command works (→ interpreter has been cleared) - Python', { tag: [tags.WIN] }, async function ({ app, python, page }) {
-		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.clearAffiliatedRuntime', { keepOpen: true });
-		await app.workbench.quickInput.waitForQuickInputOpened();
+	test('Python - Verify Clear Saved Interpreter command works', { tag: [tags.WIN] }, async function ({ app, python, page, runCommand }) {
+		const { quickInput, toasts } = app.workbench;
+
+		await runCommand('workbench.action.languageRuntime.clearAffiliatedRuntime', { keepOpen: true });
+		await quickInput.waitForQuickInputOpened();
 		const anyPythonSession = app.workbench.quickInput.quickInputList.getByText(/Python:/);
 		await anyPythonSession.waitFor({ state: 'visible' });
 		await page.keyboard.press('Enter');
-		await app.workbench.quickInput.waitForQuickInputClosed();
-		await app.workbench.toasts.expectToastWithTitle(/Python .* interpreter has been cleared/);
+		await quickInput.waitForQuickInputClosed();
+		await toasts.expectToastWithTitle(/Python .* interpreter has been cleared/);
 
 	});
 
-	test('Verify Clear Saved Interpreter command works (→ interpreter has been cleared) - R', { tag: [tags.WIN] }, async function ({ app, r, page }) {
-		await app.workbench.quickaccess.runCommand('workbench.action.languageRuntime.clearAffiliatedRuntime', { keepOpen: true });
-		await app.workbench.quickInput.waitForQuickInputOpened();
+	test('R - Verify Clear Saved Interpreter command works', { tag: [tags.WIN] }, async function ({ app, r, page, runCommand }) {
+		const { quickInput, toasts } = app.workbench;
+
+		await runCommand('workbench.action.languageRuntime.clearAffiliatedRuntime', { keepOpen: true });
+		await quickInput.waitForQuickInputOpened();
 		const anyRSession = app.workbench.quickInput.quickInputList.getByText(/R:/);
 		await anyRSession.waitFor({ state: 'visible' });
 		await page.keyboard.press('Enter');
-		await app.workbench.quickInput.waitForQuickInputClosed();
-		await app.workbench.toasts.expectToastWithTitle(/R .* interpreter has been cleared/);
+		await quickInput.waitForQuickInputClosed();
+		await toasts.expectToastWithTitle(/R .* interpreter has been cleared/);
 	});
 
 });

--- a/test/e2e/tests/interpreters/interpreter-commands.test.ts
+++ b/test/e2e/tests/interpreters/interpreter-commands.test.ts
@@ -32,25 +32,19 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, Shutdown, Clear Inte
 	});
 
 	// Skip this test for tags.WIN (e2e-windows) due to Bug #4604
-	test('Python - Verify Interrupt Interpreter command works', async function ({ app, runCommand, python }) {
+	test('Python - Verify Interrupt Interpreter command works', async function ({ app, runCommand, sessions }) {
 		const { console } = app.workbench;
 
+		await sessions.start('python');
 		await console.executeCode('Python', 'import time; time.sleep(5)', { waitForReady: false });
 		await runCommand('workbench.action.languageRuntime.interrupt');
 		await console.waitForConsoleContents('KeyboardInterrupt');
 	});
 
-	test('R - Verify Interrupt Interpreter command works', { tag: [tags.WIN] }, async function ({ app, page, runCommand, r }) {
-		const { console } = app.workbench;
-
-		await console.executeCode('R', 'Sys.sleep(5)', { waitForReady: false });
-		await runCommand('workbench.action.languageRuntime.interrupt');
-		await expect(page.locator('div.activity-error-stream')).toBeVisible();
-	});
-
-	test('Python - Verify Clear Saved Interpreter command works', { tag: [tags.WIN] }, async function ({ app, python, page, runCommand }) {
+	test('Python - Verify Clear Saved Interpreter command works', { tag: [tags.WIN] }, async function ({ app, page, runCommand, sessions }) {
 		const { quickInput, toasts } = app.workbench;
 
+		await sessions.start('python');
 		await runCommand('workbench.action.languageRuntime.clearAffiliatedRuntime', { keepOpen: true });
 		await quickInput.waitForQuickInputOpened();
 		const anyPythonSession = app.workbench.quickInput.quickInputList.getByText(/Python:/);
@@ -58,12 +52,12 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, Shutdown, Clear Inte
 		await page.keyboard.press('Enter');
 		await quickInput.waitForQuickInputClosed();
 		await toasts.expectToastWithTitle(/Python .* interpreter has been cleared/);
-
 	});
 
-	test('R - Verify Clear Saved Interpreter command works', { tag: [tags.WIN] }, async function ({ app, r, page, runCommand }) {
+	test('R - Verify Clear Saved Interpreter command works', { tag: [tags.WIN] }, async function ({ app, r, page, runCommand, sessions }) {
 		const { quickInput, toasts } = app.workbench;
 
+		await sessions.start('r');
 		await runCommand('workbench.action.languageRuntime.clearAffiliatedRuntime', { keepOpen: true });
 		await quickInput.waitForQuickInputOpened();
 		const anyRSession = app.workbench.quickInput.quickInputList.getByText(/R:/);
@@ -73,4 +67,12 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, Shutdown, Clear Inte
 		await toasts.expectToastWithTitle(/R .* interpreter has been cleared/);
 	});
 
+	test('R - Verify Interrupt Interpreter command works', { tag: [tags.WIN] }, async function ({ app, page, runCommand, sessions }) {
+		const { console } = app.workbench;
+
+		await sessions.start('r');
+		await console.executeCode('R', 'Sys.sleep(5)', { waitForReady: false });
+		await runCommand('workbench.action.languageRuntime.interrupt');
+		await expect(page.locator('div.activity-error-stream')).toBeVisible();
+	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-click-cursor-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-click-cursor-position.test.ts
@@ -23,7 +23,7 @@ test.use({
 // the line's own text (not its DOM/array index), so it does not depend on the
 // order Monaco renders .view-line elements in.
 test.describe('Notebook Click-to-Cursor Position', {
-	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS, tags.CROSS_BROWSER]
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
 }, () => {
 
 	test.beforeAll(async function ({ hotKeys }) {


### PR DESCRIPTION
Fix flaky `interpreter-commands.test.ts` e2e tests.

### Summary
- Cleaned up test and after each to be more resilient
- Applied linter cleanups: `runCommand` fixture, destructuring, language-first test names
- untagged notebook-click-cursor test from cross browser nightly run

### QA Notes
@:win @:interpreter