### PR TITLE
E2E test: fix remote ssh flake

### DIFF
--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -114,8 +114,15 @@ test.describe('Remote SSH', {
 			await sshWin.keyboard.press(process.platform === 'darwin' ? 'Meta+S' : 'Control+S');
 
 			await sshWorkbench.quickInput.waitForQuickInputOpened();
-			await sshWin.keyboard.press('Backspace'); // clear any pre-filled text
-			await sshWorkbench.quickInput.type('test.py');
+
+			// The remote Save As dialog asynchronously re-populates its path
+			// input with a suggested name derived from the file's first line,
+			// which can clobber a single type() before we click OK. Retry the
+			// type until "test.py" actually sticks in the input.
+			await expect(async () => {
+				await sshWorkbench.quickInput.type('test.py');
+				await expect(sshWorkbench.quickInput.quickInput).toHaveValue('test.py');
+			}).toPass({ timeout: 30000 });
 
 			await expect(async () => {
 				await sshWorkbench.quickInput.clickOkButton();

--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -118,10 +118,14 @@ test.describe('Remote SSH', {
 			// The remote Save As dialog asynchronously re-populates its path
 			// input with a suggested name derived from the file's first line,
 			// which can clobber a single type() before we click OK. Retry the
-			// type until "test.py" actually sticks in the input.
+			// type until "test.py" actually sticks. Use a short settle wait +
+			// short assertion timeout so toPass can re-type quickly if the
+			// value was reset (the default 15s expect timeout would block the
+			// loop and only allow a couple of attempts).
 			await expect(async () => {
 				await sshWorkbench.quickInput.type('test.py');
-				await expect(sshWorkbench.quickInput.quickInput).toHaveValue('test.py');
+				await sshWin.waitForTimeout(750); // let any async re-population land
+				await expect(sshWorkbench.quickInput.quickInput).toHaveValue('test.py', { timeout: 1000 });
 			}).toPass({ timeout: 30000 });
 
 			await expect(async () => {


### PR DESCRIPTION
Small flake fix for remote ssh test. I think the play button was not showing up because the file was not properly being saved as a python file due to an issue getting the name into the quick input. This adds retry logic.

@:remote-ssh