### PR TITLE
Remove old experimental themes in favor of 2026 variants

### DIFF
--- a/extensions/theme-defaults/package.json
+++ b/extensions/theme-defaults/package.json
@@ -62,18 +62,6 @@
         "path": "./themes/positron_light.json"
       },
       {
-        "id": "Experimental Positron Dark",
-        "label": "%positronExperimentalDarkThemeLabel%",
-        "uiTheme": "vs-dark",
-        "path": "./themes/positron_experimental_dark.json"
-      },
-      {
-        "id": "Experimental Positron Light",
-        "label": "%positronExperimentalLightThemeLabel%",
-        "uiTheme": "vs",
-        "path": "./themes/positron_experimental_light.json"
-      },
-      {
         "id": "Visual Studio Dark",
         "label": "%darkColorThemeLabel%",
         "uiTheme": "vs-dark",

--- a/extensions/theme-defaults/package.nls.json
+++ b/extensions/theme-defaults/package.nls.json
@@ -13,7 +13,5 @@
 	"lightHcColorThemeLabel": "Light High Contrast",
 	"minimalIconThemeLabel": "Minimal (Visual Studio Code)",
 	"positronDarkThemeLabel": "Dark",
-	"positronLightThemeLabel": "Light",
-	"positronExperimentalDarkThemeLabel": "Dark Experimental",
-	"positronExperimentalLightThemeLabel": "Light Experimental"
+	"positronLightThemeLabel": "Light"
 }

--- a/extensions/theme-defaults/themes/positron_experimental_dark.json
+++ b/extensions/theme-defaults/themes/positron_experimental_dark.json
@@ -1,5 +1,0 @@
-{
-	"$schema": "vscode://schemas/color-theme",
-	"name": "Dark Experimental",
-	"include": "../../theme-2026/themes/2026-dark.json"
-}

--- a/extensions/theme-defaults/themes/positron_experimental_light.json
+++ b/extensions/theme-defaults/themes/positron_experimental_light.json
@@ -1,5 +1,0 @@
-{
-	"$schema": "vscode://schemas/color-theme",
-	"name": "Light Experimental",
-	"include": "../../theme-2026/themes/2026-light.json"
-}

--- a/src/vs/workbench/services/themes/browser/positronColorThemeFilter.ts
+++ b/src/vs/workbench/services/themes/browser/positronColorThemeFilter.ts
@@ -25,8 +25,6 @@ export function isColorThemeVisibleInPicker(themeId: string, currentThemeId: str
 		case 'vs-dark vscode-theme-monokai-themes-monokai-color-theme-json':
 		case 'vs-dark vscode-theme-red-themes-Red-color-theme-json':
 		case 'vs-dark vscode-theme-solarized-dark-themes-solarized-dark-color-theme-json':
-		case 'vs vscode-theme-2026-themes-2026-light-json':
-		case 'vs-dark vscode-theme-2026-themes-2026-dark-json':
 			return false;
 		default:
 			return true;

--- a/src/vs/workbench/services/themes/test/browser/positronColorThemeFilter.vitest.ts
+++ b/src/vs/workbench/services/themes/test/browser/positronColorThemeFilter.vitest.ts
@@ -7,23 +7,18 @@
 
 import { isColorThemeVisibleInPicker } from '../../browser/positronColorThemeFilter.js';
 
-const upstreamExperimentalDark = 'vs-dark vscode-theme-2026-themes-2026-dark-json';
 const upstreamVisualStudioLight = 'vs vscode-theme-defaults-themes-light_vs-json';
-const positronExperimentalDark = 'vs-dark vscode-theme-defaults-themes-positron_experimental_dark-json';
+const positron2026Dark = 'vs-dark vscode-theme-defaults-themes-2026-dark-json';
 const positronDark = 'vs-dark vscode-theme-defaults-themes-positron_dark-json';
 const userInstalled = 'vs-dark some-publisher.cool-theme-themes-cool-json';
 
 describe('isColorThemeVisibleInPicker', () => {
-	it('hides upstream theme-2026 entries', () => {
-		expect(isColorThemeVisibleInPicker(upstreamExperimentalDark, positronDark)).toBe(false);
-	});
-
-	it('hides legacy upstream entries Positron has always suppressed', () => {
+	it('hides legacy upstream entries Positron suppresses', () => {
 		expect(isColorThemeVisibleInPicker(upstreamVisualStudioLight, positronDark)).toBe(false);
 	});
 
-	it('keeps Positron-branded experimental themes', () => {
-		expect(isColorThemeVisibleInPicker(positronExperimentalDark, positronDark)).toBe(true);
+	it('keeps the 2026 themes', () => {
+		expect(isColorThemeVisibleInPicker(positron2026Dark, positronDark)).toBe(true);
 	});
 
 	it('keeps unknown user-installed themes by default', () => {
@@ -32,6 +27,6 @@ describe('isColorThemeVisibleInPicker', () => {
 
 	it('always keeps the user\'s current theme, even when blacklisted', () => {
 		// Protects users who selected an upstream theme before our filter shipped.
-		expect(isColorThemeVisibleInPicker(upstreamExperimentalDark, upstreamExperimentalDark)).toBe(true);
+		expect(isColorThemeVisibleInPicker(upstreamVisualStudioLight, upstreamVisualStudioLight)).toBe(true);
 	});
 });


### PR DESCRIPTION
The "Dark Experimental" and "Light Experimental" themes were broken: selecting either one fell back to the default light theme. They were thin wrapper themes added in #13330 that `include`d the upstream `theme-2026` extension's files. The 1.118.0 upstream merge removed the `theme-2026` extension and promoted those themes into `theme-defaults` as the visible "Light 2026" / "Dark 2026" entries, which left the wrappers pointing at a path that no longer exists.

Since the 2026 themes are the upstream GA replacement and are already available in the picker, this PR drops the now-redundant experimental wrappers:

- Removed the two `Experimental Positron Dark/Light` theme entries from `theme-defaults/package.json` and their labels from `package.nls.json`.
- Deleted the broken `positron_experimental_{dark,light}.json` wrapper files.
- Removed two now-dead `vscode-theme-2026-*` cases from the Positron color theme picker filter (that extension no longer exists) and updated its unit test.

Fixes #14128.


### Release Notes

#### New Features
- N/A

#### Bug Fixes

- Removed the broken "Dark Experimental" and "Light Experimental" themes, which rendered as the default light theme. Use the "Dark 2026" / "Light 2026" themes instead. (#14128)

### Validation Steps

No e2e coverage exists for color themes; validation is manual plus the updated `positronColorThemeFilter.vitest.ts` unit test.

1. Open the Command Palette and run **Preferences: Color Theme**.
2. Confirm "Dark Experimental" and "Light Experimental" no longer appear.
3. Confirm "Dark 2026" and "Light 2026" still appear and render correctly  (Dark 2026 is actually dark).
4. Select "Dark 2026" and "Light 2026" and confirm the colors apply.
