### PR TITLE
Add tooltips and unit tests to the notebook find widget buttons

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/PositronFindInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/PositronFindInstance.ts
@@ -9,12 +9,13 @@ import * as DOM from '../../../../../../base/browser/dom.js';
 import { Disposable } from '../../../../../../base/common/lifecycle.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { IObservable, observableValue, transaction } from '../../../../../../base/common/observable.js';
-import { PositronFindWidget, PositronFindWidgetHandle, type PositronFindWidgetReplaceProps } from './PositronFindWidget.js';
+import { PositronFindWidget, PositronFindWidgetHandle, type PositronFindWidgetKeybindingHints, type PositronFindWidgetReplaceProps } from './PositronFindWidget.js';
 import type { IFindInputOptions } from '../../../../../../base/browser/ui/findinput/findInput.js';
 import type { IReplaceInputOptions } from '../../../../../../base/browser/ui/findinput/replaceInput.js';
 import { PositronReactRenderer } from '../../../../../../base/browser/positronReactRenderer.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IContextViewService } from '../../../../../../platform/contextview/browser/contextView.js';
+import { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
 
 /**
  * Options for configuring the PositronFindInstance.
@@ -45,6 +46,16 @@ export interface IPositronFindInstanceOptions {
 	 * Context view service for dropdowns and suggestions.
 	 */
 	contextViewService: IContextViewService;
+
+	/**
+	 * Hover manager used to show tooltips on the widget's action buttons.
+	 */
+	hoverManager?: IHoverManager;
+
+	/**
+	 * Keybinding hints appended to the action button tooltips, e.g. " (F3)".
+	 */
+	keybindingHints?: PositronFindWidgetKeybindingHints;
 }
 
 /**
@@ -139,7 +150,9 @@ export class PositronFindInstance extends Disposable {
 				contextViewService: this._options.contextViewService,
 				findInputOptions: this._options.findInputOptions,
 				findText: this.searchString,
+				hoverManager: this._options.hoverManager,
 				isVisible: this._isVisible,
+				keybindingHints: this._options.keybindingHints,
 				matchCase: this.matchCase,
 				matchCount: this.matchCount,
 				matchIndex: this.matchIndex,

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/PositronFindInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/PositronFindInstance.ts
@@ -15,7 +15,7 @@ import type { IReplaceInputOptions } from '../../../../../../base/browser/ui/fin
 import { PositronReactRenderer } from '../../../../../../base/browser/positronReactRenderer.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IContextViewService } from '../../../../../../platform/contextview/browser/contextView.js';
-import { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
+import type { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
 
 /**
  * Options for configuring the PositronFindInstance.

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/PositronFindWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/PositronFindWidget.tsx
@@ -20,6 +20,7 @@ import { Codicon } from '../../../../../../base/common/codicons.js';
 import { localize } from '../../../../../../nls.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IContextViewService } from '../../../../../../platform/contextview/browser/contextView.js';
+import { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import { KeyCode, KeyMod } from '../../../../../../base/common/keyCodes.js';
 
@@ -37,6 +38,19 @@ const matchCountLabel = (matchIndex: number, matchCount: number) =>
 
 export interface PositronFindWidgetHandle {
 	focusFindInput(): void;
+}
+
+/**
+ * Keybinding hints appended to the action button tooltips, e.g. " (F3)".
+ * Empty or missing entries leave the tooltip as the plain label.
+ */
+export interface PositronFindWidgetKeybindingHints {
+	readonly previousMatch?: string;
+	readonly nextMatch?: string;
+	readonly close?: string;
+	readonly toggleReplace?: string;
+	readonly replace?: string;
+	readonly replaceAll?: string;
 }
 
 export interface PositronFindWidgetReplaceProps {
@@ -60,6 +74,8 @@ export interface PositronFindWidgetProps {
 	readonly matchIndex: IObservable<number | undefined>;
 	readonly matchCount: IObservable<number | undefined>;
 	readonly findInputOptions: IFindInputOptions;
+	readonly hoverManager?: IHoverManager;
+	readonly keybindingHints?: PositronFindWidgetKeybindingHints;
 	readonly isVisible: ISettableObservable<boolean>;
 	readonly replace?: PositronFindWidgetReplaceProps;
 	readonly onPreviousMatch: () => void;
@@ -107,6 +123,16 @@ export const PositronFindWidget = forwardRef<PositronFindWidgetHandle, PositronF
 	const noMatches = !matchCount;
 	const hasNoResults = !!findText && matchCount === 0;
 	const replaceButtonsEnabled = !!findText;
+
+	// Button tooltips: localized label plus an optional keybinding hint,
+	// matching the editor find widget (e.g. "Next Match (F3)").
+	const hints = props.keybindingHints;
+	const previousMatchTooltip = previousMatchLabel + (hints?.previousMatch ?? '');
+	const nextMatchTooltip = nextMatchLabel + (hints?.nextMatch ?? '');
+	const closeTooltip = closeLabel + (hints?.close ?? '');
+	const toggleReplaceTooltip = toggleReplaceLabel + (hints?.toggleReplace ?? '');
+	const replaceTooltip = replaceLabel + (hints?.replace ?? '');
+	const replaceAllTooltip = replaceAllLabel + (hints?.replaceAll ?? '');
 
 	// --- Tab order key handlers ---
 	// These intercept Tab/Shift+Tab at points where the desired tab order
@@ -210,6 +236,8 @@ export const PositronFindWidget = forwardRef<PositronFindWidgetHandle, PositronF
 						ariaLabel={previousMatchLabel}
 						className='action-button'
 						disabled={noMatches}
+						hoverManager={props.hoverManager}
+						tooltip={previousMatchTooltip}
 						onPressed={props.onPreviousMatch}
 					>
 						<ThemeIcon icon={Codicon.arrowUp} />
@@ -219,6 +247,8 @@ export const PositronFindWidget = forwardRef<PositronFindWidgetHandle, PositronF
 						ariaLabel={nextMatchLabel}
 						className='action-button'
 						disabled={noMatches}
+						hoverManager={props.hoverManager}
+						tooltip={nextMatchTooltip}
 						onPressed={props.onNextMatch}
 					>
 						<ThemeIcon icon={Codicon.arrowDown} />
@@ -228,6 +258,8 @@ export const PositronFindWidget = forwardRef<PositronFindWidgetHandle, PositronF
 					ref={closeButtonRef}
 					ariaLabel={closeLabel}
 					className='action-button close-button'
+					hoverManager={props.hoverManager}
+					tooltip={closeTooltip}
 					onKeyDown={handleCloseButtonKeyDown}
 					onPressed={() => props.isVisible.set(false, undefined)}
 				>
@@ -247,6 +279,8 @@ export const PositronFindWidget = forwardRef<PositronFindWidgetHandle, PositronF
 				<ActionButton
 					ariaLabel={toggleReplaceLabel}
 					className='action-button toggle-replace'
+					hoverManager={props.hoverManager}
+					tooltip={toggleReplaceTooltip}
 					onPressed={() => props.replace!.isVisible.set(!props.replace!.isVisible.get(), undefined)}
 				>
 					<ThemeIcon icon={isReplaceVisible ? Codicon.chevronDown : Codicon.chevronRight} />
@@ -276,6 +310,8 @@ export const PositronFindWidget = forwardRef<PositronFindWidgetHandle, PositronF
 								ariaLabel={replaceLabel}
 								className='action-button replace-button'
 								disabled={!replaceButtonsEnabled}
+								hoverManager={props.hoverManager}
+								tooltip={replaceTooltip}
 								onKeyDown={handleReplaceButtonKeyDown}
 								onPressed={props.replace.onReplace}
 							>
@@ -285,6 +321,8 @@ export const PositronFindWidget = forwardRef<PositronFindWidgetHandle, PositronF
 								ariaLabel={replaceAllLabel}
 								className='action-button replace-all-button'
 								disabled={!replaceButtonsEnabled}
+								hoverManager={props.hoverManager}
+								tooltip={replaceAllTooltip}
 								onPressed={props.replace.onReplaceAll}
 							>
 								<ThemeIcon icon={Codicon.replaceAll} />

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/PositronFindWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/PositronFindWidget.tsx
@@ -20,7 +20,7 @@ import { Codicon } from '../../../../../../base/common/codicons.js';
 import { localize } from '../../../../../../nls.js';
 import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
 import { IContextViewService } from '../../../../../../platform/contextview/browser/contextView.js';
-import { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
+import type { IHoverManager } from '../../../../../../platform/hover/browser/hoverManager.js';
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import { KeyCode, KeyMod } from '../../../../../../base/common/keyCodes.js';
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/actions.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/actions.ts
@@ -19,7 +19,7 @@ import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 import { NotebookAction2 } from '../../NotebookAction2.js';
 import { getNotebookInstanceFromActiveEditorPane } from '../../notebookUtils.js';
 import { getActiveCell } from '../../selectionMachine.js';
-import { PositronNotebookFindController } from './controller.js';
+import { POSITRON_NOTEBOOK_FIND_COMMAND_IDS, PositronNotebookFindController } from './controller.js';
 
 function registerPositronNotebookFindAction(
 	options: IAction2Options & { run: (controller: PositronNotebookFindController) => void | Promise<void> },
@@ -71,7 +71,7 @@ function findEditorActionImplementation(handler: (controller: PositronNotebookFi
 
 // Start/reveal the find widget
 registerPositronNotebookFindAction({
-	id: 'positronNotebook.find.start',
+	id: POSITRON_NOTEBOOK_FIND_COMMAND_IDS.start,
 	title: localize2('positron.notebook.find.start.title', 'Find'),
 	keybinding: [{
 		when: NotebookContextKeys.editorFocused,
@@ -83,7 +83,7 @@ registerPositronNotebookFindAction({
 
 // Hide the find widget
 registerPositronNotebookFindAction({
-	id: 'positronNotebook.find.hide',
+	id: POSITRON_NOTEBOOK_FIND_COMMAND_IDS.hide,
 	title: localize2('positron.notebook.find.hide.title', 'Hide Find'),
 	keybinding: [{
 		when: ContextKeyExpr.and(
@@ -98,7 +98,7 @@ registerPositronNotebookFindAction({
 
 // Find the next match
 registerPositronNotebookFindAction({
-	id: 'positronNotebook.find.next',
+	id: POSITRON_NOTEBOOK_FIND_COMMAND_IDS.next,
 	title: localize2('positron.notebook.find.next.title', 'Find Next'),
 	keybinding: [{
 		// From cell editor
@@ -120,7 +120,7 @@ registerPositronNotebookFindAction({
 
 // Find the previous match from command mode
 registerPositronNotebookFindAction({
-	id: 'positronNotebook.find.previous',
+	id: POSITRON_NOTEBOOK_FIND_COMMAND_IDS.previous,
 	title: localize2('positron.notebook.find.previous.title', 'Find Previous'),
 	keybinding: [{
 		// From cell editor
@@ -146,7 +146,7 @@ PreviousMatchFindAction.addImplementation(0, findEditorActionImplementation((con
 
 // Open find widget with replace expanded
 registerPositronNotebookFindAction({
-	id: 'positronNotebook.find.replaceStart',
+	id: POSITRON_NOTEBOOK_FIND_COMMAND_IDS.replaceStart,
 	title: localize2('positron.notebook.find.replaceStart.title', 'Find and Replace'),
 	keybinding: [{
 		when: NotebookContextKeys.editorFocused,
@@ -159,7 +159,7 @@ registerPositronNotebookFindAction({
 
 // Replace the current match
 registerPositronNotebookFindAction({
-	id: 'positronNotebook.find.replace',
+	id: POSITRON_NOTEBOOK_FIND_COMMAND_IDS.replace,
 	title: localize2('positron.notebook.find.replace.title', 'Replace'),
 	keybinding: [{
 		when: ContextKeyExpr.and(
@@ -182,7 +182,7 @@ registerPositronNotebookFindAction({
 
 // Replace all matches
 registerPositronNotebookFindAction({
-	id: 'positronNotebook.find.replaceAll',
+	id: POSITRON_NOTEBOOK_FIND_COMMAND_IDS.replaceAll,
 	title: localize2('positron.notebook.find.replaceAll.title', 'Replace All'),
 	keybinding: [{
 		when: ContextKeyExpr.and(

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/controller.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/controller.ts
@@ -50,6 +50,17 @@ export class CurrentPositronCellMatch {
 /** Maximum matches returned by research() for decorations. */
 const MATCHES_LIMIT = 999;
 
+/** Command IDs for the notebook find actions registered in actions.ts. */
+export const POSITRON_NOTEBOOK_FIND_COMMAND_IDS = {
+	start: 'positronNotebook.find.start',
+	hide: 'positronNotebook.find.hide',
+	next: 'positronNotebook.find.next',
+	previous: 'positronNotebook.find.previous',
+	replaceStart: 'positronNotebook.find.replaceStart',
+	replace: 'positronNotebook.find.replace',
+	replaceAll: 'positronNotebook.find.replaceAll',
+} as const;
+
 export class PositronNotebookFindController extends Disposable implements IPositronNotebookContribution {
 	public static readonly ID = 'positron.notebook.contrib.findController';
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/controller.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/controller.ts
@@ -145,9 +145,6 @@ export class PositronNotebookFindController extends Disposable implements IPosit
 	}
 
 	/**
-	 * Gets the find instance, creating it if necessary.
-	 */
-	/**
 	 * Returns a parenthesized keybinding hint for a command, e.g. " (F3)",
 	 * or an empty string when the command has no keybinding.
 	 */
@@ -156,6 +153,9 @@ export class PositronNotebookFindController extends Disposable implements IPosit
 		return label ? ` (${label})` : '';
 	}
 
+	/**
+	 * Gets the find instance, creating it if necessary.
+	 */
 	private getOrCreateFindInstance(): PositronFindInstance {
 		if (!this._findInstance) {
 			if (!this._notebook.overlayContainer) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/controller.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/find/controller.ts
@@ -147,6 +147,15 @@ export class PositronNotebookFindController extends Disposable implements IPosit
 	/**
 	 * Gets the find instance, creating it if necessary.
 	 */
+	/**
+	 * Returns a parenthesized keybinding hint for a command, e.g. " (F3)",
+	 * or an empty string when the command has no keybinding.
+	 */
+	private keybindingLabelFor(commandId: string): string {
+		const label = this._keybindingService.lookupKeybinding(commandId)?.getLabel();
+		return label ? ` (${label})` : '';
+	}
+
 	private getOrCreateFindInstance(): PositronFindInstance {
 		if (!this._findInstance) {
 			if (!this._notebook.overlayContainer) {
@@ -182,6 +191,15 @@ export class PositronNotebookFindController extends Disposable implements IPosit
 				},
 				contextKeyService: this._notebook.scopedContextKeyService,
 				contextViewService: this._contextViewService,
+				hoverManager: this._notebook.hoverManager,
+				keybindingHints: {
+					previousMatch: this.keybindingLabelFor(POSITRON_NOTEBOOK_FIND_COMMAND_IDS.previous),
+					nextMatch: this.keybindingLabelFor(POSITRON_NOTEBOOK_FIND_COMMAND_IDS.next),
+					close: this.keybindingLabelFor(POSITRON_NOTEBOOK_FIND_COMMAND_IDS.hide),
+					toggleReplace: this.keybindingLabelFor(POSITRON_NOTEBOOK_FIND_COMMAND_IDS.replaceStart),
+					replace: this.keybindingLabelFor(POSITRON_NOTEBOOK_FIND_COMMAND_IDS.replace),
+					replaceAll: this.keybindingLabelFor(POSITRON_NOTEBOOK_FIND_COMMAND_IDS.replaceAll),
+				},
 			}));
 			this._findInstance = findInstance;
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.vitest.tsx
@@ -13,7 +13,7 @@ import { ISettableObservable, observableValue } from '../../../../../../../base/
 import { MockContextKeyService } from '../../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { stubInterface } from '../../../../../../../test/vitest/stubInterface.js';
 import { IContextViewService } from '../../../../../../../platform/contextview/browser/contextView.js';
-import { IHoverManager } from '../../../../../../../platform/hover/browser/hoverManager.js';
+import type { IHoverManager } from '../../../../../../../platform/hover/browser/hoverManager.js';
 import { unthemedInboxStyles } from '../../../../../../../base/browser/ui/inputbox/inputBox.js';
 import { unthemedToggleStyles } from '../../../../../../../base/browser/ui/toggle/toggle.js';
 import { PositronFindWidget, type PositronFindWidgetKeybindingHints } from '../../../../browser/contrib/find/PositronFindWidget.js';

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronFindWidget.vitest.tsx
@@ -7,14 +7,16 @@
 
 import type { Mock } from 'vitest';
 import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { setupRTLRenderer } from '../../../../../../../test/vitest/reactTestingLibrary.js';
 import { ISettableObservable, observableValue } from '../../../../../../../base/common/observable.js';
 import { MockContextKeyService } from '../../../../../../../platform/keybinding/test/common/mockKeybindingService.js';
 import { stubInterface } from '../../../../../../../test/vitest/stubInterface.js';
 import { IContextViewService } from '../../../../../../../platform/contextview/browser/contextView.js';
+import { IHoverManager } from '../../../../../../../platform/hover/browser/hoverManager.js';
 import { unthemedInboxStyles } from '../../../../../../../base/browser/ui/inputbox/inputBox.js';
 import { unthemedToggleStyles } from '../../../../../../../base/browser/ui/toggle/toggle.js';
-import { PositronFindWidget } from '../../../../browser/contrib/find/PositronFindWidget.js';
+import { PositronFindWidget, type PositronFindWidgetKeybindingHints } from '../../../../browser/contrib/find/PositronFindWidget.js';
 
 describe('PositronFindWidget', () => {
 	const rtl = setupRTLRenderer();
@@ -40,7 +42,11 @@ describe('PositronFindWidget', () => {
 	let onReplaceInputFocus: Mock;
 	let onReplaceInputBlur: Mock;
 
-	function renderWidget({ useReplace } = { useReplace: false }) {
+	function renderWidget({ useReplace = false, hoverManager, keybindingHints }: {
+		useReplace?: boolean;
+		hoverManager?: IHoverManager;
+		keybindingHints?: PositronFindWidgetKeybindingHints;
+	} = {}) {
 		const result = rtl.render(
 			<PositronFindWidget
 				contextKeyService={new MockContextKeyService()}
@@ -53,7 +59,9 @@ describe('PositronFindWidget', () => {
 					toggleStyles: unthemedToggleStyles,
 				}}
 				findText={findText}
+				hoverManager={hoverManager}
 				isVisible={isVisible}
+				keybindingHints={keybindingHints}
 				matchCase={matchCase}
 				matchCount={matchCount}
 				matchIndex={matchIndex}
@@ -277,6 +285,62 @@ describe('PositronFindWidget', () => {
 
 			expect(screen.getByRole('button', { name: /^Replace$/ })).toBeDisabled();
 			expect(screen.getByRole('button', { name: 'Replace All' })).toBeDisabled();
+		});
+	});
+
+	describe('Tooltips', () => {
+		let showHover: Mock;
+		let hoverManager: IHoverManager;
+
+		beforeEach(() => {
+			showHover = vi.fn();
+			hoverManager = stubInterface<IHoverManager>({ showHover, hideHover: vi.fn() });
+		});
+
+		it('shows label-plus-keybinding tooltips on hover', async () => {
+			const user = userEvent.setup();
+			// Enable every button: matches exist and a query is entered.
+			findText.set('foo', undefined);
+			matchCount.set(3, undefined);
+			replaceIsVisible.set(true, undefined);
+			renderWidget({
+				useReplace: true,
+				hoverManager,
+				keybindingHints: {
+					previousMatch: ' (Shift+F3)',
+					nextMatch: ' (F3)',
+					close: ' (Escape)',
+					toggleReplace: ' (Ctrl+H)',
+					replace: ' (Ctrl+Shift+1)',
+					replaceAll: ' (Ctrl+Alt+Enter)',
+				},
+			});
+
+			const expectedTooltips: [string | RegExp, string][] = [
+				['Previous Match', 'Previous Match (Shift+F3)'],
+				['Next Match', 'Next Match (F3)'],
+				['Close', 'Close (Escape)'],
+				['Toggle Replace', 'Toggle Replace (Ctrl+H)'],
+				[/^Replace$/, 'Replace (Ctrl+Shift+1)'],
+				['Replace All', 'Replace All (Ctrl+Alt+Enter)'],
+			];
+			for (const [name, tooltip] of expectedTooltips) {
+				const button = screen.getByRole('button', { name });
+				await user.hover(button);
+				expect(showHover, `Expected hover on "${tooltip}"`).toHaveBeenLastCalledWith(button, tooltip);
+				await user.unhover(button);
+			}
+		});
+
+		it('falls back to plain labels when no keybinding hints are provided', async () => {
+			const user = userEvent.setup();
+			matchCount.set(3, undefined);
+			renderWidget({ hoverManager });
+
+			const button = screen.getByRole('button', { name: 'Next Match' });
+			await user.hover(button);
+
+			expect(showHover).toHaveBeenLastCalledWith(button, 'Next Match');
 		});
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-find-and-replace.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-find-and-replace.test.ts
@@ -179,9 +179,7 @@ test.describe('Positron Notebooks: Find and Replace', {
 		await notebooksPositron.expectCellContentAtIndexToBe(0, 'hello = 1');
 	});
 
-	// Skipped until the  widget tooltip fix (#14198) merges -- the widget
-	// buttons do not show tooltips without it. Unskip after that PR lands.
-	test.skip('Verify search widget buttons show tooltips on hover', async function ({ app }) {
+	test('Verify search widget buttons show tooltips on hover', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 
 		// Use a query with a match so every button is enabled (disabled


### PR DESCRIPTION
Restores hover tooltips on the Find & Replace widget buttons in the Positron Notebook editor.

Closes #14189

> [!NOTE]
> Reopened after being auto-closed unmerged on 2026-06-19. The branch was rebuilt on current main (includes #14699): the original four commits are unchanged in substance, plus one follow-up commit addressing the Copilot review nits (type-only `IHoverManager` imports, JSDoc placement in `controller.ts`) and unskipping the e2e tooltip test that shipped skipped in #14199.

The notebook find widget is a custom React implementation whose `ActionButton`s only received `ariaLabel` -- the shared `Button` component's `tooltip`/`hoverManager` props were never passed, so its six buttons had no tooltips. The embedded VS Code toggles (Match Case, etc.) were unaffected, matching the present/missing split in the issue.

The fix plumbs the notebook's existing `hoverManager` and keybinding hints (via `IKeybindingService`, mirroring the editor find widget) from the controller through `PositronFindInstance` into the widget, so tooltips read _e.g.,_ "Next Match (F3)". The find command IDs moved into a shared constant in `controller.ts`, reused by `actions.ts`. Two new unit tests in `positronFindWidget.vitest.tsx` cover the hover behavior; the e2e tooltip test from #14199 is unskipped in this PR.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Restored hover tooltips (with keybinding hints) on the Find & Replace widget buttons in the Positron Notebook editor (#14189)

### Validation Steps

@:positron-notebooks @:web @:win

- Find contrib Vitest suites pass locally (108 tests incl. the 2 new tooltip tests); eslint and precommit clean; `build-check` 0 errors.
- Full `notebook-find-and-replace.test.ts` e2e file passes locally on e2e-electron (7/7, including the newly unskipped tooltip test).
- Manual: open an .ipynb, Cmd/Ctrl+F, expand replace, hover each button -> tooltips with keybinding hints, matching the .py editor's find widget.
