### PR TITLE
Add e2e tests for notebook find and replace

### DIFF
--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -100,6 +100,9 @@ export class PositronNotebooks extends Notebooks {
 	private searchPreviousButton = this.searchWidget.getByRole('button', { name: 'Previous Match' });
 	private searchCloseButton = this.searchWidget.getByRole('button', { name: 'Close', exact: true });
 	private searchDecoration = this.code.driver.currentPage.locator('.findMatchInline');
+	private searchMatchCaseToggle = this.searchWidget.getByRole('checkbox', { name: 'Match Case' });
+	private searchWholeWordToggle = this.searchWidget.getByRole('checkbox', { name: 'Match Whole Word' });
+	private searchRegexToggle = this.searchWidget.getByRole('checkbox', { name: 'Use Regular Expression' });
 
 	// Ghost Cell
 	private ghostCellHeader = this.code.driver.currentPage.locator('.ghost-cell-header');
@@ -1007,6 +1010,59 @@ export class PositronNotebooks extends Notebooks {
 		});
 	}
 
+	/**
+	 * Action: Set a search option toggle to the given state.
+	 * Clicks the toggle only if its current state differs from the desired one.
+	 * @param toggle - The search option toggle to set.
+	 * @param enabled - The desired checked state.
+	 */
+	async searchSetToggle(toggle: 'matchCase' | 'wholeWord' | 'regex', enabled: boolean): Promise<void> {
+		await test.step(`Set search toggle ${toggle} to ${enabled}`, async () => {
+			const toggleLocator = {
+				matchCase: this.searchMatchCaseToggle,
+				wholeWord: this.searchWholeWordToggle,
+				regex: this.searchRegexToggle,
+			}[toggle];
+
+			if (await toggleLocator.getAttribute('aria-checked') !== String(enabled)) {
+				await toggleLocator.click();
+			}
+			await expect(toggleLocator).toHaveAttribute('aria-checked', String(enabled), { timeout: 2000 });
+		});
+	}
+
+	/**
+	 * Action: Fill the replace input without performing a replace.
+	 * Expands the replace row if it is not already visible.
+	 * @param replaceText - The text to fill into the replace input.
+	 */
+	async searchSetReplaceText(replaceText: string): Promise<void> {
+		await test.step(`Set replace text to: ${replaceText}`, async () => {
+			await this.searchExpandReplace();
+			await this.replaceInput.fill(replaceText);
+		});
+	}
+
+	/**
+	 * Action: Click the 'Replace' button.
+	 * Replaces the current match and advances to the next one. Note: if no
+	 * match is active yet, the first click only navigates to the first match
+	 * without replacing (two-step behavior, matching the editor find widget).
+	 */
+	async searchReplaceNext(): Promise<void> {
+		await test.step('Replace current match', async () => {
+			await this.replaceButton.click();
+		});
+	}
+
+	/**
+	 * Action: Click the 'Replace All' button.
+	 */
+	async searchReplaceAll(): Promise<void> {
+		await test.step('Replace all matches', async () => {
+			await this.replaceAllButton.click();
+		});
+	}
 
 	// #endregion
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -1005,6 +1005,8 @@ export class PositronNotebooks extends Notebooks {
 	async searchExpandReplace(): Promise<void> {
 		await test.step('Expand replace row', async () => {
 			if (!await this.replaceInput.isVisible()) {
+				// Move the mouse away to dismiss any tooltip that may intercept the click
+				await this.code.driver.currentPage.mouse.move(0, 0);
 				await this.toggleReplaceButton.click();
 			}
 			await expect(this.replaceInput).toBeVisible({ timeout: 2000 });

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -103,6 +103,7 @@ export class PositronNotebooks extends Notebooks {
 	private searchMatchCaseToggle = this.searchWidget.getByRole('checkbox', { name: 'Match Case' });
 	private searchWholeWordToggle = this.searchWidget.getByRole('checkbox', { name: 'Match Whole Word' });
 	private searchRegexToggle = this.searchWidget.getByRole('checkbox', { name: 'Use Regular Expression' });
+	private hoverTooltip = this.code.driver.currentPage.locator('.hover-contents');
 
 	// Ghost Cell
 	private ghostCellHeader = this.code.driver.currentPage.locator('.ghost-cell-header');
@@ -1147,6 +1148,52 @@ export class PositronNotebooks extends Notebooks {
 	async expectSearchDecorationCountToBe(expectedCount: number): Promise<void> {
 		await test.step(`Expect search decoration count to be: ${expectedCount}`, async () => {
 			await expect(this.searchDecoration).toHaveCount(expectedCount, { timeout: DEFAULT_TIMEOUT });
+		});
+	}
+
+	/**
+	 * Verify: Replace and Replace All buttons enabled state.
+	 * Note: the widget disables these buttons only when the find text is
+	 * empty, not when a query has zero matches.
+	 * @param enabled - Whether the buttons should be enabled (true) or disabled (false).
+	 */
+	async expectReplaceButtonsEnabled(enabled: boolean = true): Promise<void> {
+		await test.step(`Expect replace buttons to be ${enabled ? 'enabled' : 'disabled'}`, async () => {
+			if (enabled) {
+				await expect(this.replaceButton).toBeEnabled({ timeout: DEFAULT_TIMEOUT });
+				await expect(this.replaceAllButton).toBeEnabled({ timeout: DEFAULT_TIMEOUT });
+			} else {
+				await expect(this.replaceButton).toBeDisabled({ timeout: DEFAULT_TIMEOUT });
+				await expect(this.replaceAllButton).toBeDisabled({ timeout: DEFAULT_TIMEOUT });
+			}
+		});
+	}
+
+	/**
+	 * Verify: hovering a search widget button shows a tooltip with the expected text.
+	 * @param button - The search widget button to hover.
+	 * @param expectedTooltip - The expected tooltip text (string or regex).
+	 */
+	async expectSearchButtonTooltip(
+		button: 'previous' | 'next' | 'close' | 'toggleReplace' | 'replace' | 'replaceAll',
+		expectedTooltip: string | RegExp
+	): Promise<void> {
+		await test.step(`Expect tooltip on ${button} button: ${expectedTooltip}`, async () => {
+			const buttonLocator = {
+				previous: this.searchPreviousButton,
+				next: this.searchNextButton,
+				close: this.searchCloseButton,
+				toggleReplace: this.toggleReplaceButton,
+				replace: this.replaceButton,
+				replaceAll: this.replaceAllButton,
+			}[button];
+
+			// Park the mouse elsewhere first so the hover delay applies cleanly,
+			// then hover the button and wait for the tooltip to render.
+			await this.code.driver.currentPage.mouse.move(0, 0);
+			await expect(this.hoverTooltip).not.toBeVisible({ timeout: 5000 });
+			await buttonLocator.hover();
+			await expect(this.hoverTooltip).toContainText(expectedTooltip, { timeout: DEFAULT_TIMEOUT });
 		});
 	}
 

--- a/test/e2e/tests/notebooks-positron/notebook-find-and-replace.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-find-and-replace.test.ts
@@ -87,4 +87,95 @@ test.describe('Positron Notebooks: Find & Replace', {
 		// The skipped 'apple_two' prefix match is intact
 		await notebooksPositron.expectCellContentsToBe(['pear = 1', 'apple_two = pear', 'apple_three = apple + 1']);
 	});
+
+	test('Verify replace updates markdown cells', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Cell contents are '# Cell 0' (code) and '### Cell 1' (markdown, rendered)
+		await notebooksPositron.newNotebook({ codeCells: 1, markdownCells: 1 });
+
+		await notebooksPositron.search('Cell');
+		await notebooksPositron.expectSearchCountToBe({ total: 2 });
+
+		await notebooksPositron.searchSetReplaceText('Block');
+		await notebooksPositron.searchReplaceAll();
+		await notebooksPositron.expectSearchCountToBe({ total: 0 });
+		await notebooksPositron.searchClose('button');
+
+		// Source updated in both the code cell and the markdown cell
+		await notebooksPositron.expectCellContentAtIndexToBe(0, '# Block 0');
+		await notebooksPositron.expectCellContentAtIndexToBe(1, '### Block 1');
+
+		// Rendered markdown reflects the replacement
+		await notebooksPositron.expectMarkdownTagToBe('h3', 'Block 1');
+	});
+
+	test('Verify case sensitivity and whole word toggles', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.addCodeToCell(0, 'test = Test');
+		await notebooksPositron.addCodeToCell(1, 'testing = "test"', { fast: true });
+
+		// Case-insensitive, partial word: test, Test, testing, "test"
+		await notebooksPositron.search('test');
+		await notebooksPositron.expectSearchCountToBe({ total: 4 });
+
+		// Case-sensitive drops 'Test'
+		await notebooksPositron.searchSetToggle('matchCase', true);
+		await notebooksPositron.expectSearchCountToBe({ total: 3 });
+
+		// Whole word additionally drops 'testing' (quotes are word boundaries)
+		await notebooksPositron.searchSetToggle('wholeWord', true);
+		await notebooksPositron.expectSearchCountToBe({ total: 2 });
+
+		// Case-insensitive again: 'Test' matches once more
+		await notebooksPositron.searchSetToggle('matchCase', false);
+		await notebooksPositron.expectSearchCountToBe({ total: 3 });
+
+		// Replace all with whole word on: 'testing' is untouched
+		await notebooksPositron.searchSetReplaceText('exam');
+		await notebooksPositron.searchReplaceAll();
+		await notebooksPositron.searchClose('button');
+		await notebooksPositron.expectCellContentsToBe(['exam = exam', 'testing = "exam"']);
+	});
+
+	test('Verify no matches state', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.addCodeToCell(0, 'alpha = 1');
+
+		await notebooksPositron.search('zebra');
+		await notebooksPositron.expectSearchCountToBe({ total: 0 });
+		await notebooksPositron.expectSearchDecorationCountToBe(0);
+
+		// The widget disables Replace/Replace All only when the find text is
+		// empty (matching the editor find widget), so with a query that has
+		// zero matches the buttons stay enabled and replacing is a no-op.
+		await notebooksPositron.searchExpandReplace();
+		await notebooksPositron.expectReplaceButtonsEnabled(true);
+		await notebooksPositron.searchSetReplaceText('x');
+		await notebooksPositron.searchReplaceAll();
+		await notebooksPositron.expectCellContentAtIndexToBe(0, 'alpha = 1');
+
+		// With an empty find text the replace buttons are disabled
+		await notebooksPositron.search('', { enterKey: false });
+		await notebooksPositron.expectReplaceButtonsEnabled(false);
+	});
+
+	test('Verify replacing with an empty string deletes matches', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.addCodeToCell(0, 'hello_world = 1');
+
+		await notebooksPositron.search('_world');
+		await notebooksPositron.expectSearchCountToBe({ current: 1, total: 1 });
+
+		await notebooksPositron.searchSetReplaceText('');
+		await notebooksPositron.searchReplaceAll();
+		await notebooksPositron.expectSearchCountToBe({ total: 0 });
+		await notebooksPositron.expectCellContentAtIndexToBe(0, 'hello = 1');
+	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-find-and-replace.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-find-and-replace.test.ts
@@ -10,7 +10,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Positron Notebooks: Find & Replace', {
+test.describe('Positron Notebooks: Find and Replace', {
 	tag: [tags.POSITRON_NOTEBOOKS, tags.WEB, tags.WIN]
 }, () => {
 
@@ -150,8 +150,8 @@ test.describe('Positron Notebooks: Find & Replace', {
 		await notebooksPositron.expectSearchCountToBe({ total: 0 });
 		await notebooksPositron.expectSearchDecorationCountToBe(0);
 
-		// The widget disables Replace/Replace All only when the find text is
-		// empty (matching the editor find widget), so with a query that has
+		// The widget disables Replace/Replace All only when the  text is
+		// empty (matching the editor  widget), so with a query that has
 		// zero matches the buttons stay enabled and replacing is a no-op.
 		await notebooksPositron.searchExpandReplace();
 		await notebooksPositron.expectReplaceButtonsEnabled(true);
@@ -159,7 +159,7 @@ test.describe('Positron Notebooks: Find & Replace', {
 		await notebooksPositron.searchReplaceAll();
 		await notebooksPositron.expectCellContentAtIndexToBe(0, 'alpha = 1');
 
-		// With an empty find text the replace buttons are disabled
+		// With an empty  text the replace buttons are disabled
 		await notebooksPositron.search('', { enterKey: false });
 		await notebooksPositron.expectReplaceButtonsEnabled(false);
 	});
@@ -179,7 +179,7 @@ test.describe('Positron Notebooks: Find & Replace', {
 		await notebooksPositron.expectCellContentAtIndexToBe(0, 'hello = 1');
 	});
 
-	// Skipped until the find widget tooltip fix (#14198) merges -- the widget
+	// Skipped until the  widget tooltip fix (#14198) merges -- the widget
 	// buttons do not show tooltips without it. Unskip after that PR lands.
 	test.skip('Verify search widget buttons show tooltips on hover', async function ({ app }) {
 		const { notebooksPositron } = app.workbench;

--- a/test/e2e/tests/notebooks-positron/notebook-find-and-replace.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-find-and-replace.test.ts
@@ -178,4 +178,27 @@ test.describe('Positron Notebooks: Find & Replace', {
 		await notebooksPositron.expectSearchCountToBe({ total: 0 });
 		await notebooksPositron.expectCellContentAtIndexToBe(0, 'hello = 1');
 	});
+
+	// Skipped until the find widget tooltip fix (#14198) merges -- the widget
+	// buttons do not show tooltips without it. Unskip after that PR lands.
+	test.skip('Verify search widget buttons show tooltips on hover', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		// Use a query with a match so every button is enabled (disabled
+		// buttons do not receive mouse events, so no tooltip can show)
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.addCodeToCell(0, 'alpha = 1');
+		await notebooksPositron.search('alpha');
+		await notebooksPositron.expectSearchCountToBe({ current: 1, total: 1 });
+		await notebooksPositron.searchExpandReplace();
+
+		// Tooltips are the button label plus a platform-specific keybinding
+		// hint, so assert on the label substring only
+		await notebooksPositron.expectSearchButtonTooltip('previous', 'Previous Match');
+		await notebooksPositron.expectSearchButtonTooltip('next', 'Next Match');
+		await notebooksPositron.expectSearchButtonTooltip('close', 'Close');
+		await notebooksPositron.expectSearchButtonTooltip('toggleReplace', 'Toggle Replace');
+		await notebooksPositron.expectSearchButtonTooltip('replace', 'Replace');
+		await notebooksPositron.expectSearchButtonTooltip('replaceAll', 'Replace All');
+	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-find-and-replace.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-find-and-replace.test.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Positron Notebooks: Find & Replace', {
+	tag: [tags.POSITRON_NOTEBOOKS, tags.WEB, tags.WIN]
+}, () => {
+
+	test.beforeAll(async function ({ hotKeys }) {
+		await hotKeys.minimizeBottomPanel();
+	});
+
+	test('Verify replace, replace all, match counter, and undo in code cells', async function ({ app, hotKeys }) {
+		const { notebooksPositron } = app.workbench;
+
+		// 4 matches for 'foo' across 3 code cells
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.addCodeToCell(0, 'foo = 1');
+		await notebooksPositron.addCodeToCell(1, 'foo2 = foo + 1');
+		await notebooksPositron.addCodeToCell(2, 'print(foo)', { fast: true });
+
+		await notebooksPositron.search('foo');
+		await notebooksPositron.expectSearchCountToBe({ current: 1, total: 4 });
+		await notebooksPositron.expectSearchDecorationCountToBe(4);
+
+		// Replace a single match and verify the counter decrements
+		await notebooksPositron.searchSetReplaceText('bar');
+		await notebooksPositron.searchReplaceNext();
+		await notebooksPositron.expectSearchCountToBe({ total: 3 });
+		await notebooksPositron.expectCellContentAtIndexToBe(0, 'bar = 1');
+
+		// Replace all remaining matches
+		await notebooksPositron.searchReplaceAll();
+		await notebooksPositron.expectSearchCountToBe({ total: 0 });
+		await notebooksPositron.expectCellContentsToBe(['bar = 1', 'bar2 = bar + 1', 'print(bar)']);
+
+		// Replace All applies one bulk edit, so it is a single undo step.
+		// With the default per-cell undo stacks (notebook.undoRedoPerCell),
+		// undoing from any cell touched by Replace All reverts every cell it
+		// changed at once, while cell 0's earlier single replace stays put.
+		await notebooksPositron.searchClose('button');
+		await notebooksPositron.selectCellAtIndex(1);
+		await hotKeys.undo();
+		await notebooksPositron.expectCellContentsToBe(['bar = 1', 'foo2 = foo + 1', 'print(foo)']);
+
+		// The single replace is its own undo step in cell 0
+		await notebooksPositron.selectCellAtIndex(0);
+		await hotKeys.undo();
+		await notebooksPositron.expectCellContentAtIndexToBe(0, 'foo = 1');
+	});
+
+	test('Verify step-through replace advances and Next skips a match', async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
+
+		// 5 matches for 'apple' in document order. The last cell must not end
+		// with a match: the search starts from the cursor (end of the last
+		// typed cell), and only wraps to the first match when the cursor sits
+		// strictly after the final match.
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.addCodeToCell(0, 'apple = 1');
+		await notebooksPositron.addCodeToCell(1, 'apple_two = apple');
+		await notebooksPositron.addCodeToCell(2, 'apple_three = apple + 1');
+
+		await notebooksPositron.search('apple');
+		await notebooksPositron.expectSearchCountToBe({ current: 1, total: 5 });
+
+		// Replace the first match and verify focus advanced to the next one
+		await notebooksPositron.searchSetReplaceText('pear');
+		await notebooksPositron.searchReplaceNext();
+		await notebooksPositron.expectSearchCountToBe({ current: 1, total: 4 });
+		await notebooksPositron.expectCellContentAtIndexToBe(0, 'pear = 1');
+
+		// Skip a match (next without replacing), then replace the following one
+		await notebooksPositron.searchNext('button');
+		await notebooksPositron.expectSearchCountToBe({ current: 2, total: 4 });
+		await notebooksPositron.searchReplaceNext();
+		await notebooksPositron.expectSearchCountToBe({ total: 3 });
+
+		// The skipped 'apple_two' prefix match is intact
+		await notebooksPositron.expectCellContentsToBe(['pear = 1', 'apple_two = pear', 'apple_three = apple + 1']);
+	});
+});


### PR DESCRIPTION
Adds Playwright e2e coverage for the Positron notebook Find & Replace feature (shipped in #12102), following the patterns of `notebook-search.test.ts`.

Closes #12321

New `notebook-find-and-replace.test.ts` (7 tests) plus page-object helpers in `notebooksPositron.ts` (search option toggles, standalone Replace/Replace All clicks, replace-buttons and tooltip assertions). Tests run on fresh untitled notebooks; no fixture files are mutated and no kernel is needed.

| Issue scenario | Test |
| --- | --- |
| 1. Basic find & replace (code cells) | Verify replace, replace all, match counter, and undo in code cells |
| 2. Replace in markdown cells | Verify replace updates markdown cells |
| 3. Step-through replace | Verify step-through replace advances and Next skips a match |
| 4. Match counter accuracy | Verify replace, replace all, match counter, and undo in code cells |
| 5. Replace All with undo | Verify replace, replace all, match counter, and undo in code cells |
| 6. Case sensitivity toggle | Verify case sensitivity and whole word toggles |
| 7. Whole word toggle | Verify case sensitivity and whole word toggles |
| 8. No matches state | Verify no matches state |
| 9. Empty replace string | Verify replacing with an empty string deletes matches |
| Tooltips (#14189) | Verify search widget buttons show tooltips on hover (skipped) |

Notes:

- **Scenario 8**: the widget disables Replace/Replace All only when the find text is empty (matching VS Code upstream), not at 0 matches. The test asserts the actual behavior, including that Replace All is a no-op with no matches.
- **Scenario 5**: `notebook.undoRedoPerCell` defaults to `true` (per-cell undo stacks), but Replace All is a single bulk edit, so one undo from any cell it touched reverts every cell it changed at once; the earlier single replace stays its own undo step. The test asserts both.
- The tooltip test is **skipped** until the tooltip fix (#14198) merges; unskip it after that lands.

### Regression check

No-opping `controller.replace()`/`replaceAll()` fails 5 of 7 tests (all the replace-behavior tests); restored, all pass.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:positron-notebooks @:web @:win

- 6 tests pass + 1 skipped locally (`--project e2e-electron`); with the #14198 fix applied, all 7 pass.
- eslint and precommit clean on the new/changed files.
