### PR TITLE
fix session teardown race in `sessions.deleteAll()`

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -269,6 +269,15 @@ export class Sessions {
 			}
 
 			try { await this.page.getByRole('button', { name: 'Delete Session' }).click({ timeout: 1000 }); } catch (error) { }
+
+			// Deleted sessions stay attached (hidden) in the DOM until the runtime
+			// finishes shutting down, and getSessionCount() counts attached nodes.
+			// Wait for full teardown so the next test's session-reuse check doesn't
+			// race it. Skipped on server/workbench, where delete() can intentionally
+			// leave a session behind (see workaround above).
+			if (!/(8080|8787)/.test(this.code.driver.currentPage.url())) {
+				await expect(this.sessions).toHaveCount(0, { timeout: 15000 });
+			}
 		});
 	}
 

--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -272,12 +272,11 @@ export class Sessions {
 
 			// Deleted sessions stay attached (hidden) in the DOM until the runtime
 			// finishes shutting down, and getSessionCount() counts attached nodes.
-			// Wait for full teardown so the next test's session-reuse check doesn't
-			// race it. Skipped on server/workbench, where delete() can intentionally
-			// leave a session behind (see workaround above).
-			if (!/(8080|8787)/.test(this.code.driver.currentPage.url())) {
-				await expect(this.sessions).toHaveCount(0, { timeout: 15000 });
-			}
+			// Wait for the deleted instances to fully detach so the next test's
+			// session-reuse check doesn't race them. A session intentionally left
+			// behind on server/workbench (see delete() workaround) stays visible,
+			// so it does not block this wait.
+			await expect(this.sessions.filter({ visible: false })).toHaveCount(0, { timeout: 15000 });
 		});
 	}
 


### PR DESCRIPTION
`deleteAll()` was returning before deleted sessions fully detached from the DOM, so any test whose teardown ran just before the next session-reuse check could leave a "ghost" session behind, causing that next test to try to reuse it and "mysteriously" time out. This change makes the teardown have to wait for the _real state_ instead of relying on a sometimes brittle UI proxy.

## Summary

`Verify Clear Saved Interpreter command works - R` has flaked in ~1/3 of merge-to-main runs since June 2 (0 flakes in the prior 45 runs), across both Electron and Chromium/Web.

All failures follow the same pattern: the next test's `sessions.start()` reuse check sees a session, takes the metadata-dialog path, and times out waiting for a session that no longer exists. Trace screenshots show an empty *"There is no session running"* console while the previous test's toast is still visible.

## Root Cause

`Sessions.delete()` returns once the console is `not.toBeVisible()`, but the console node remains attached (hidden) in the DOM until runtime shutdown completes.

`getSessionCount()` counts attached nodes, not visible ones, so it can briefly report a session that has already been deleted.

PR #13954 removed the post-delete wait from `deleteAll()` that had previously masked this race. The first flaky runs appeared immediately after that change landed.

## Why Fix This?

PR #14187 stabilized this specific suite, but the underlying race remains in `deleteAll()`.

Any test using the same teardown pattern can hit the issue if runtime shutdown takes longer than the gap before the next session-reuse check.

## Fix

After deleting all sessions, wait until no hidden console instance nodes remain attached:

```ts
await expect(sessions.filter({ visible: false })).toHaveCount(0);
```

This uses the same locator as `getSessionCount()`, ensuring both observe the same state.

The fix also applies to Web. Sessions intentionally left behind by the server/workbench workaround remain visible, so they do not block the wait.

### QA Notes

@:sessions @:interpreter @:web @:win