### PR TITLE
e2e: fix flaky quarto inline output collapse tests

### DIFF
--- a/test/e2e/tests/quarto/quarto-inline-output-collapse.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-collapse.test.ts
@@ -24,11 +24,13 @@ test.describe('Quarto - Inline Output: Collapse', {
 		await hotKeys.closeAllEditors();
 	});
 
-	test('Python - Verify output can be collapsed and expanded by clicking the chevron', async function ({ python, app, openFile }) {
+	test('Python - Verify output can be collapsed and expanded by clicking the chevron', async function ({ python, app, openFile, hotKeys }) {
 		const { editors, inlineQuarto } = app.workbench;
 
 		await openFile(join('workspaces', 'quarto_inline_output', 'simple_plot.qmd'));
 		await editors.waitForActiveTab('simple_plot.qmd');
+		await hotKeys.closeSecondarySidebar();
+		await hotKeys.toggleBottomPanel();
 		await inlineQuarto.expectKernelStatusVisible();
 
 		await editors.clickTab('simple_plot.qmd');
@@ -42,7 +44,7 @@ test.describe('Quarto - Inline Output: Collapse', {
 		await inlineQuarto.expectOutputExpanded();
 	});
 
-	test('Python - Verify output can be collapsed and expanded via toggle command', async function ({ python, app, openFile, runCommand }) {
+	test('Python - Verify output can be collapsed and expanded via toggle command', async function ({ python, app, openFile, runCommand, hotKeys }) {
 		const { editors, inlineQuarto } = app.workbench;
 
 		await openFile(join('workspaces', 'quarto_inline_output', 'simple_plot.qmd'));
@@ -50,6 +52,8 @@ test.describe('Quarto - Inline Output: Collapse', {
 		await inlineQuarto.expectKernelStatusVisible();
 
 		await editors.clickTab('simple_plot.qmd');
+		await hotKeys.closeSecondarySidebar();
+		await hotKeys.toggleBottomPanel();
 		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 25 });
 		await inlineQuarto.expectOutputExpanded();
 


### PR DESCRIPTION
### Summary
Fixes flakiness in the Quarto inline output collapse tests by closing the secondary sidebar and bottom panel before running cells.

- Both Python tests now call `hotKeys.closeSecondarySidebar()` and `hotKeys.toggleBottomPanel()` after opening the file
- Prevents UI panels from obscuring the inline output area, which caused intermittent failures

### QA Notes
@:quarto @:web