### PR TITLE
Fix plot disposal causing double deletion

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
+++ b/src/vs/workbench/contrib/positronPlots/browser/positronPlotsService.ts
@@ -1140,13 +1140,17 @@ export class PositronPlotsService extends Disposable implements IPositronPlotsSe
 	 * @param id The ID of the plot to remove
 	 */
 	removePlot(id: string): void {
-		// Find the plot with the given ID and dispose it
-		this._plots.forEach((plot, index) => {
-			if (plot.id === id) {
-				this.unregisterPlotClient(plot);
-				this._plots.splice(index, 1);
-			}
-		});
+		// Find the plot with the given ID, remove it from the list, and dispose
+		// it. We remove the plot from the list *before* disposing it: disposing
+		// a PlotClientInstance also removes it from the list (see
+		// registerPlotClient), so splicing by index after disposal could remove
+		// the wrong plot once the array had shifted.
+		const index = this._plots.findIndex(plot => plot.id === id);
+		if (index >= 0) {
+			const plot = this._plots[index];
+			this._plots.splice(index, 1);
+			this.unregisterPlotClient(plot);
+		}
 
 		// If this plot was selected, select the first plot in the list
 		if (this._selectedPlotId === id) {

--- a/src/vs/workbench/contrib/positronPlots/test/browser/plotGalleryRemoval.vitest.tsx
+++ b/src/vs/workbench/contrib/positronPlots/test/browser/plotGalleryRemoval.vitest.tsx
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { act, screen } from '@testing-library/react';
+import { Event } from '../../../../../base/common/event.js';
+import { IReactComponentContainer } from '../../../../../base/browser/positronReactRenderer.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { PositronPlots } from '../../browser/positronPlots.js';
+import { IPositronPlotsService } from '../../../../services/positronPlots/common/positronPlots.js';
+import { RuntimeClientType } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { startTestLanguageRuntimeSession } from '../../../../services/runtimeSession/test/common/testRuntimeSessionService.js';
+
+describe('Plot gallery removal', () => {
+	const ctx = createTestContainer().withReactServices().build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	// A large container so the "Automatic" history policy keeps the gallery visible.
+	const reactComponentContainer: IReactComponentContainer = {
+		width: 800,
+		height: 600,
+		containerVisible: true,
+		takeFocus: () => { },
+		onFocused: Event.None,
+		onSizeChanged: Event.None,
+		onPositionChanged: Event.None,
+		onVisibilityChanged: Event.None,
+		onSaveScrollPosition: Event.None,
+		onRestoreScrollPosition: Event.None,
+	};
+
+	async function createPlots(): Promise<IPositronPlotsService> {
+		const plotsService = ctx.reactServices.positronPlotsService;
+		const session = await startTestLanguageRuntimeSession(ctx.instantiationService, ctx.disposables);
+		session.createClient(RuntimeClientType.Plot, {}, {}, 'plot1');
+		session.createClient(RuntimeClientType.Plot, {}, {}, 'plot2');
+		session.createClient(RuntimeClientType.Plot, {}, {}, 'plot3');
+		return plotsService;
+	}
+
+	it('removing one plot from the gallery leaves the other plots in the gallery', async () => {
+		const plotsService = await createPlots();
+		expect(plotsService.positronPlotInstances.length).toBe(3);
+
+		rtl.render(<PositronPlots reactComponentContainer={reactComponentContainer} />);
+
+		// The gallery shows one "Remove plot" button per plot thumbnail.
+		expect(screen.getAllByRole('button', { name: 'Remove plot' })).toHaveLength(3);
+
+		// Remove a single (non-selected) plot, as the user would by clicking the
+		// Remove button on its thumbnail.
+		act(() => {
+			plotsService.removePlot('plot1');
+		});
+
+		// Only the removed plot should be gone; the service should still hold
+		// the other two plots.
+		expect(plotsService.positronPlotInstances.map(p => p.id)).toEqual(['plot2', 'plot3']);
+
+		// The two remaining plots should still be shown in the gallery.
+		expect(screen.getAllByRole('button', { name: 'Remove plot' })).toHaveLength(2);
+	});
+});

--- a/src/vs/workbench/contrib/positronPlots/test/electron-browser/positronPlotsService.vitest.ts
+++ b/src/vs/workbench/contrib/positronPlots/test/electron-browser/positronPlotsService.vitest.ts
@@ -231,6 +231,21 @@ describe('Positron - Plots Service', () => {
 		expect(plotsService.selectedPlotId).toBe(undefined);
 	});
 
+	it('removal: removing a single plot leaves the other plots intact', async () => {
+		const session = await createSession();
+
+		session.session.createClient(RuntimeClientType.Plot, {}, {}, 'plot1');
+		session.session.createClient(RuntimeClientType.Plot, {}, {}, 'plot2');
+		session.session.createClient(RuntimeClientType.Plot, {}, {}, 'plot3');
+
+		expect(plotsService.positronPlotInstances.length).toBe(3);
+
+		// Removing one plot should remove only that plot, not its neighbor.
+		plotsService.removePlot('plot1');
+
+		expect(plotsService.positronPlotInstances.map(p => p.id)).toEqual(['plot2', 'plot3']);
+	});
+
 	it('selection: expect error removing plot when no plot selected', () => {
 		expect(() => plotsService.removeSelectedPlot()).toThrow('No plot is selected');
 	});


### PR DESCRIPTION
Removing a single plot from the gallery caused the entire gallery to disappear. `PositronPlotsService.removePlot()` disposed the plot via `unregisterPlotClient()` (which already removes it from the plot list during disposal) and *then* also spliced the same index out of the list, deleting an innocent neighbor. Removing one of three plots dropped the count to one, and the Automatic history policy hides the gallery when fewer than two plots remain.

This was regressed by #4628, which re-added `this._plots.splice(index, 1)` to `removePlot` (and dropped the comment noting the plot is removed automatically on dispose), reintroducing the double-removal originally fixed in #3236. It was masked because the existing tests only exercised single-plot removal, where the off-by-one neighbor deletion isn't observable. The fix removes the plot from the list before disposing it, so the dispose-time self-removal becomes a no-op. This remains correct for static and webview plots, which do not self-remove on disposal.

Fixes #14131.

### Release Notes

#### New Features
- N/A

#### Bug Fixes

- Fixed an issue where removing a single plot from the gallery would hide the entire gallery (#14131)

### Validation Steps

@:plots

1. Create three plots.
2. Hover over any plot thumbnail in the gallery and click the Remove Plot button.
3. Verify that only the removed plot disappears and the remaining two plots stay visible in the gallery.

Added regression coverage (`removePlot` removes only the named plot, and the gallery keeps the remaining thumbnails) in `positronPlotsService.vitest.ts` and `plotGalleryRemoval.vitest.tsx`.
