### PR TITLE
assistant: show all providers by default in provider modal

### DIFF
--- a/extensions/authentication/package.json
+++ b/extensions/authentication/package.json
@@ -19,6 +19,7 @@
 		"onAuthenticationRequest:openai-compatible",
 		"onAuthenticationRequest:google",
 		"onAuthenticationRequest:google-cloud",
+		"onAuthenticationRequest:deepseek-api",
 		"onCommand:authentication.configureProviders",
 		"onCommand:authentication.migrateApiKey"
 	],
@@ -68,6 +69,10 @@
 			{
 				"id": "google-cloud",
 				"label": "Google Vertex AI"
+			},
+			{
+				"id": "deepseek-api",
+				"label": "DeepSeek"
 			}
 		],
 		"commands": [

--- a/extensions/authentication/package.json
+++ b/extensions/authentication/package.json
@@ -278,7 +278,7 @@
 				},
 				"assistant.provider.googleVertex.enabled": {
 					"type": "boolean",
-					"default": false,
+					"default": true,
 					"markdownDescription": "%configuration.provider.googleVertex.enabled.description%",
 					"tags": [
 						"experimental"
@@ -286,7 +286,7 @@
 				},
 				"assistant.provider.deepseek.enabled": {
 					"type": "boolean",
-					"default": false,
+					"default": true,
 					"markdownDescription": "%configuration.provider.deepseek.enabled.description%",
 					"tags": [
 						"experimental"

--- a/extensions/authentication/src/providerSources.ts
+++ b/extensions/authentication/src/providerSources.ts
@@ -28,6 +28,14 @@ export interface ProviderMetadata {
 	id: string;
 	displayName: string;
 	settingName: string;
+	/**
+	 * Maturity status of the provider, mirroring the `tags` on its
+	 * `*.enable` setting. The config modal lists stable providers (no status)
+	 * first, then 'preview', then 'experimental'. Providers that aren't ready
+	 * yet are kept out of the modal by defaulting their `*.enable` setting to
+	 * false, not by status.
+	 */
+	status?: 'preview' | 'experimental';
 }
 
 export const PROVIDER_METADATA: Record<string, ProviderMetadata> = {
@@ -50,6 +58,7 @@ export const PROVIDER_METADATA: Record<string, ProviderMetadata> = {
 		id: FOUNDRY_AUTH_PROVIDER_ID,
 		displayName: 'Microsoft Foundry',
 		settingName: 'msFoundry',
+		status: 'preview',
 	},
 	snowflake: {
 		id: 'snowflake-cortex',
@@ -65,26 +74,31 @@ export const PROVIDER_METADATA: Record<string, ProviderMetadata> = {
 		id: GEMINI_AUTH_PROVIDER_ID,
 		displayName: 'Gemini Code Assist',
 		settingName: 'google',
+		status: 'experimental',
 	},
 	googleVertex: {
 		id: GOOGLE_CLOUD_AUTH_PROVIDER_ID,
 		displayName: 'Google Vertex AI',
 		settingName: 'googleVertex',
+		status: 'experimental',
 	},
 	copilot: {
 		id: 'copilot-auth',
 		displayName: 'GitHub Copilot',
 		settingName: 'githubCopilot',
+		status: 'preview',
 	},
 	customProvider: {
 		id: CUSTOM_PROVIDER_AUTH_PROVIDER_ID,
 		displayName: 'Custom Provider',
 		settingName: 'customProvider',
+		status: 'experimental',
 	},
 	deepseek: {
 		id: DEEPSEEK_AUTH_PROVIDER_ID,
 		displayName: 'DeepSeek',
 		settingName: 'deepseek',
+		status: 'experimental',
 	},
 };
 

--- a/extensions/authentication/src/test/providerSources.test.ts
+++ b/extensions/authentication/src/test/providerSources.test.ts
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import { PROVIDER_METADATA } from '../providerSources';
+
+/**
+ * Guards against drift between PROVIDER_METADATA in providerSources.ts and the
+ * package.json contributions that own the same data. The metadata hardcodes
+ * provider ids, display names, setting names, and maturity status that really
+ * live in the manifests; nothing but this test keeps them in sync.
+ *
+ * Two manifests are involved:
+ *   - this extension's package.json: `contributes.authentication` (id + label)
+ *     and the `assistant.provider.<settingName>.enabled` settings for providers
+ *     that don't ship via positron-assistant (googleVertex, deepseek).
+ *   - positron-assistant's package.json: the `positron.assistant.provider.
+ *     <settingName>.enable` settings (and their tags, which `status` mirrors).
+ *
+ * NOTE: posit-dev/positron#13811 migrates the old `positron.assistant.provider.
+ * <name>.enable` keys to the new `assistant.provider.<name>.enabled` format
+ * (note the trailing `d`) and moves every enablement setting into a single home.
+ * Once that lands, this test simplifies:
+ *   - If the settings move here, drop `assistantPkg` and its `collect()` call;
+ *     the cross-extension read into positron-assistant goes away (it's being
+ *     deprecated anyway). If they move elsewhere, point the single read there.
+ *   - Tighten the `provider\.(?<name>[^.]+)\.enabled?$` regex to `\.enabled$`;
+ *     the optional `d` only exists to match both the old and new key formats.
+ *   - If the migration keeps the old keys around as deprecated aliases instead
+ *     of removing them, both keys will exist for the same provider. They map to
+ *     the same capture group, so skip anything carrying a `deprecationMessage`/
+ *     `markdownDeprecationMessage` to avoid the deprecated entry's tags winning.
+ */
+suite('PROVIDER_METADATA package.json consistency', () => {
+
+	function readPackageJson(...segments: string[]): any {
+		const file = path.join(__dirname, '..', '..', ...segments);
+		return JSON.parse(fs.readFileSync(file, 'utf8'));
+	}
+
+	const authPkg = readPackageJson('package.json');
+	const assistantPkg = readPackageJson('..', 'positron-assistant', 'package.json');
+
+	test('every authentication contribution has a PROVIDER_METADATA entry', () => {
+		// `label` (Accounts menu) and `displayName` (model picker) are deliberately
+		// allowed to differ per provider, so we don't couple them. What we do
+		// enforce is that every declared auth provider is known to the metadata:
+		// adding a contribution to package.json without a matching entry here is
+		// the drift we want to catch. Providers without a contribution (e.g.
+		// copilot, which rides GitHub's auth) aren't required to appear.
+		const metadataIds = Object.values(PROVIDER_METADATA).map(p => p.id);
+		const manifestIds = authPkg.contributes.authentication.map((c: { id: string }) => c.id);
+		const resolved = manifestIds.filter((id: string) => metadataIds.includes(id));
+
+		assert.deepStrictEqual(resolved, manifestIds);
+	});
+
+	test('settingName and status match the provider enable settings', () => {
+		// Collect every `provider.<name>.enable`/`.enabled` setting across both
+		// manifests, mapping the name to its maturity status (derived from tags).
+		// `status` in PROVIDER_METADATA must mirror that exactly.
+		const enableSettings: Record<string, 'preview' | 'experimental' | undefined> = {};
+		const collect = (pkg: any) => {
+			const properties = pkg.contributes?.configuration;
+			const sections = Array.isArray(properties) ? properties : [properties];
+			for (const section of sections) {
+				for (const [key, value] of Object.entries<any>(section?.properties ?? {})) {
+					const match = /provider\.(?<name>[^.]+)\.enabled?$/.exec(key);
+					if (match?.groups) {
+						const tags: string[] = value.tags ?? [];
+						enableSettings[match.groups.name] = tags.includes('experimental')
+							? 'experimental'
+							: tags.includes('preview') ? 'preview' : undefined;
+					}
+				}
+			}
+		};
+		collect(authPkg);
+		collect(assistantPkg);
+
+		const fromMetadata: Record<string, 'preview' | 'experimental' | undefined> = {};
+		for (const entry of Object.values(PROVIDER_METADATA)) {
+			fromMetadata[entry.settingName] = entry.status;
+		}
+
+		assert.deepStrictEqual(fromMetadata, enableSettings);
+	});
+});

--- a/extensions/positron-assistant/package.json
+++ b/extensions/positron-assistant/package.json
@@ -910,7 +910,7 @@
           },
           "positron.assistant.provider.msFoundry.enable": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "markdownDescription": "%configuration.provider.msFoundry.enable.description%",
             "tags": [
               "preview"
@@ -925,7 +925,7 @@
           },
           "positron.assistant.provider.customProvider.enable": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "markdownDescription": "%configuration.provider.customProvider.enable.description%",
             "tags": [
               "experimental"
@@ -940,11 +940,10 @@
           },
           "positron.assistant.provider.google.enable": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "markdownDescription": "%configuration.provider.google.enable.description%",
             "tags": [
-              "experimental",
-              "advanced"
+              "experimental"
             ],
             "order": 9
           }

--- a/scripts/test-integration-pr.sh
+++ b/scripts/test-integration-pr.sh
@@ -48,6 +48,12 @@ npm run test-extension -- -l positron-assistant
 kill_app
 
 echo
+echo "### Authentication tests"
+echo
+npm run test-extension -- -l authentication
+kill_app
+
+echo
 echo "### Positron Catalog Explorer tests"
 echo
 npm run test-extension -- -l positron-catalog-explorer

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -335,6 +335,12 @@ npm run test-extension -- -l positron-assistant
 kill_app
 
 echo
+echo "### Authentication tests"
+echo
+npm run test-extension -- -l authentication
+kill_app
+
+echo
 echo "### Positron Catalog Explorer tests"
 echo
 npm run test-extension -- -l positron-catalog-explorer

--- a/src/positron-dts/positron.d.ts
+++ b/src/positron-dts/positron.d.ts
@@ -3081,6 +3081,12 @@ declare module 'positron' {
 			 * Positron's Assistant Service automatically reads this from registered providers.
 			 */
 			settingName: string;
+			/**
+			 * Maturity status of the provider. Drives how it's presented in the
+			 * configuration modal: stable providers (no status) are listed first,
+			 * then 'preview', then 'experimental'.
+			 */
+			status?: 'preview' | 'experimental';
 		}
 
 		/**

--- a/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/components/languageModelButton.tsx
@@ -5,6 +5,7 @@
 
 import * as React from 'react';
 
+import { localize } from '../../../../../nls.js';
 import { Button } from '../../../../../base/browser/ui/positronComponents/button/button.js';
 import { VerticalStack } from '../../../../browser/positronComponents/positronModalDialog/components/verticalStack.js';
 import Claude from '../icons/claude.js';
@@ -24,13 +25,27 @@ interface LanguageModelButtonProps {
 	displayName: string;
 	selected?: boolean;
 	disabled?: boolean;
+	status?: 'preview' | 'experimental';
 	onClick?: () => void;
+}
+
+/** Human-readable label for a provider's maturity status, or undefined for stable providers. */
+function getStatusLabel(status: LanguageModelButtonProps['status']): string | undefined {
+	switch (status) {
+		case 'preview':
+			return localize('positron.languageModelButton.status.preview', "Preview");
+		case 'experimental':
+			return localize('positron.languageModelButton.status.experimental', "Experimental");
+		default:
+			return undefined;
+	}
 }
 
 /**
  * LanguageModelButton component.
  */
 export const LanguageModelButton = React.forwardRef<HTMLDivElement, LanguageModelButtonProps>((props, ref) => {
+	const statusLabel = getStatusLabel(props.status);
 	return (
 		<Button
 			className={positronClassNames(
@@ -44,6 +59,7 @@ export const LanguageModelButton = React.forwardRef<HTMLDivElement, LanguageMode
 				<VerticalStack>
 					<LanguageModelIcon provider={props.identifier} />
 					{props.displayName}
+					{statusLabel && <span className='language-model button-status'>{statusLabel}</span>}
 				</VerticalStack>
 			</div>
 		</Button>

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.css
@@ -21,7 +21,7 @@
 }
 
 .language-model.button-container .language-model.button {
-	width: 110px;
+	width: 124px;
 }
 
 .language-model.button .vertical-stack {
@@ -51,6 +51,17 @@
 
 .language-model.button .content {
 	align-items: center;
+}
+
+/* Matches the Settings editor's preview/experimental tag (.setting-item-preview). */
+.language-model.button-status {
+	align-self: center;
+	margin-top: 4px;
+	padding: 0 4px 2px;
+	border-radius: 4px;
+	background: var(--vscode-badge-background);
+	color: var(--vscode-badge-foreground);
+	font-style: italic;
 }
 
 .language-model.button.disabled {

--- a/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronAssistant/browser/languageModelModalDialog.tsx
@@ -48,6 +48,25 @@ export const showLanguageModelModalDialog = (
 	);
 };
 
+/**
+ * Sort rank for grouping providers in the modal: Posit AI first, then stable
+ * providers (no status), then preview, then experimental. Within a group,
+ * callers fall back to an alphabetical comparison.
+ */
+const providerSortRank = (provider: IPositronLanguageModelSource['provider']): number => {
+	if (provider.id === 'posit-ai') {
+		return 0;
+	}
+	switch (provider.status) {
+		case 'preview':
+			return 2;
+		case 'experimental':
+			return 3;
+		default:
+			return 1;
+	}
+};
+
 const providerSourceToConfig = (source: IPositronLanguageModelSource): IPositronLanguageModelConfig => {
 	return {
 		...source.defaults,
@@ -72,19 +91,11 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 	const providers = props.sources
 		.filter(source => source.type === 'chat' || (source.type === 'completion' && source.provider.id === 'copilot-auth'))
 		.sort((a, b) => {
-			// Posit AI should always be first
-			if (a.provider.id === 'posit-ai') {
-				return -1;
-			}
-			if (b.provider.id === 'posit-ai') {
-				return 1;
-			}
-			// Echo and Error providers should always be last
-			if (a.provider.id === 'echo' || a.provider.id === 'error') {
-				return 1;
-			}
-			if (b.provider.id === 'echo' || b.provider.id === 'error') {
-				return -1;
+			// Posit AI is always first, then stable providers, then preview,
+			// then experimental. Within each group, sort alphabetically.
+			const rankDiff = providerSortRank(a.provider) - providerSortRank(b.provider);
+			if (rankDiff !== 0) {
+				return rankDiff;
 			}
 			return a.provider.displayName.localeCompare(b.provider.displayName);
 		});
@@ -451,6 +462,7 @@ const LanguageModelConfiguration = (props: React.PropsWithChildren<LanguageModel
 							displayName={source.provider.displayName}
 							identifier={source.provider.id}
 							selected={source.provider.id === selectedProvider.provider.id}
+							status={source.provider.status}
 							onClick={() => onChangeProvider(source)}
 						/>;
 					})

--- a/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/interfaces/positronAssistantService.ts
@@ -58,6 +58,12 @@ export interface IPositronProviderMetadata {
 	 * `extensions/positron-assistant/package.json`) toggles the provider.
 	 */
 	settingName: string;
+	/**
+	 * Maturity status of the provider. Drives how it's presented in the
+	 * configuration modal: stable providers (no status) are listed first, then
+	 * 'preview', then 'experimental'.
+	 */
+	status?: 'preview' | 'experimental';
 }
 
 // Equivalent in positron.d.ts API: LanguageModelSource


### PR DESCRIPTION
Addresses part of https://github.com/posit-dev/positron/issues/13810, to show all providers in the modal by default, and indicate the provider preview or experimental status with a badge in the modal, if applicable.

https://github.com/user-attachments/assets/d92e5c4e-3f97-41e2-bfb4-8f2864a073cf

### Release Notes

#### Bug Fixes

- Assistant: show all providers in modal by default (#13810)

### Validation Steps

- all providers show in the modal by default
- posit ai is first provider
- providers are sorted alphabetically otherwise
- preview providers show after GA providers
- experimental providers show after preview providers

Run auth extension integration tests on PR and merge to main CI checks, or manually with `npm run test-extension -- -l authentication`.