### PR TITLE
feat: port StreamingTagLexer from the assistant extension into the workbench

### DIFF
--- a/src/vs/workbench/common/positron/streamingTagLexer.ts
+++ b/src/vs/workbench/common/positron/streamingTagLexer.ts
@@ -1,0 +1,367 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * A streaming lexer for XML-style tags, adapted from the MIT licensed
+ * https://github.com/posit-dev/databot repo.
+ *
+ * This is the canonical Positron-side copy, shared by headless language-model
+ * consumers (ghost cells today; the visualization builder and quick actions
+ * next). A separate legacy copy lives in the positron-assistant extension
+ * (extensions/positron-assistant/src/streamingTagLexer.ts), still load-bearing
+ * for the chat participant's text/edit processors (defaultTextProcessor,
+ * replaceStringProcessor, replaceSelectionProcessor); it persists until that
+ * extension is deprecated. This copy carries a single-quote attribute fix the
+ * extension copy still lacks.
+ */
+
+export type ProcessedText = {
+	type: 'text';
+	text: string;
+};
+
+export type ProcessedTag<TagNameT extends string> = {
+	type: 'tag';
+	name: TagNameT;
+	kind: 'open' | 'close';
+	attributes: Record<string, string>;
+	originalText: string;
+};
+
+export type Chunk<T extends string> = ProcessedText | ProcessedTag<T>;
+
+export class StreamingTagLexer<TagNameT extends string> {
+	private readonly tagNames: TagNameT[];
+	private readonly contentHandler: (
+		chunk: Chunk<TagNameT>
+	) => void | Promise<void>;
+
+	// Variables for tracking the state of the lexer
+	private state:
+		| 'TEXT' // Initial state - we're not in a potential tag
+		| 'TAG_START' // We've seen '<'
+		| 'TAG_START_SLASH' // We've seen '</'
+		| 'TAG_NAME' // We're in a potential tag name, like '<SH' or '</SH'
+		| 'WHITESPACE' // We're in whitespace after the tag name or between attrs
+		| 'ATTR_NAME' // We're in an attribute name, like '<FILESET F'
+		| 'ATTR_NAME_END' // Finished attr name with whitespace, like '<FILESET FOO ' (doesn't always go into this state)
+		| 'ATTR_EQUAL_FOUND' // Found = sign after attr name, like '<FILESET FOO='
+		| 'IN_ATTR_VALUE_DOUBLE_QUOTE' // Found opening double quote for attr value, like `<FILESET FOO="`
+		| 'IN_ATTR_VALUE_SINGLE_QUOTE' // Found opening single quote for attr value, like `<FILESET FOO='`
+		| 'ATTRIBUTE_VALUE_END' // Found closing quote for attr value, like `<FILESET FOO='1'`
+		| 'TAG_END' = 'TEXT'; // Found closing angle bracket, like `<FILESET>`
+
+	private scannedText: string = '';
+
+	// Variables for tracking the state when we're in a potential tag
+	private tagName: TagNameT | null = null;
+	private tagNamePartial: string = ''; // Partial tag name as we build it
+	private kind: 'open' | 'close' = 'open';
+	private currentAttributeName: string = '';
+	private currentAttributeValue: string = '';
+	private attributes: Record<string, string> = {};
+	// Counter for iterating over a tag name character by character.
+	private tagNamePartialIdx = 0;
+	private potentialTagNameMatches: TagNameT[] = [];
+
+	private resetPotentialTagStateVars() {
+		this.tagNamePartialIdx = 0;
+		this.potentialTagNameMatches = [...this.tagNames];
+		this.tagName = null;
+		this.tagNamePartial = '';
+		this.kind = 'open';
+		this.currentAttributeName = '';
+		this.currentAttributeValue = '';
+		this.attributes = {};
+	}
+
+	/**
+	 * Creates a new StreamingTagLexer that looks for specified XML-style tags.
+	 * @param tagNames - Array of tag names without angle brackets or attributes
+	 *   (e.g., ['FILESET', 'FILE'])
+	 * @param contentHandler - Callback function that will be invoked with each
+	 *   processed chunk, either text or a tag
+	 */
+	constructor({
+		tagNames,
+		contentHandler,
+	}: {
+		tagNames: Readonly<Array<TagNameT>>;
+		contentHandler: (
+			chunk: ProcessedText | ProcessedTag<TagNameT>
+		) => void | Promise<void>;
+	}) {
+		this.tagNames = [...new Set(tagNames)];
+		this.contentHandler = contentHandler;
+		this.resetPotentialTagStateVars();
+	}
+
+	/**
+	 * Processes a chunk of text to identify and handle specific tags. Accumulates
+	 * text until a complete tag is found, then invokes the contentHandler
+	 * callback with each processed chunk (text or tag).
+	 *
+	 * @param chunk - The chunk of text to process.
+	 */
+	async process(chunk: string): Promise<void> {
+		for (const char of chunk) {
+			if (this.state === 'TEXT') {
+				if (char === '<') {
+					if (this.scannedText.length > 0) {
+						await this.contentHandler({ type: 'text', text: this.scannedText });
+						this.scannedText = '';
+					}
+
+					this.state = 'TAG_START';
+				}
+			} else if (this.state === 'TAG_START') {
+				if (char === '/') {
+					// We have '</'
+					this.state = 'TAG_START_SLASH';
+				} else if (/^[a-zA-Z0-9]$/.test(char)) {
+					// This is a valid starting character for a tag name
+					// Iterate backward over the list of potentialTagNameMatches because we
+					// may remove items as we go.
+					for (let j = this.potentialTagNameMatches.length - 1; j >= 0; j--) {
+						if (
+							char !== this.potentialTagNameMatches[j][this.tagNamePartialIdx]
+						) {
+							// Character mismatch: we can remove this tag name from the list of
+							// potential matches.
+							this.potentialTagNameMatches.splice(j, 1);
+						}
+					}
+
+					if (this.potentialTagNameMatches.length === 0) {
+						// Didn't match any tag names, as in '<Z'
+						this.resetPotentialTagStateVars();
+						this.state = 'TEXT';
+					} else {
+						this.state = 'TAG_NAME';
+						this.tagNamePartial = char;
+						this.kind = 'open';
+						this.tagNamePartialIdx++;
+					}
+				} else {
+					// Not a valid tag name starting character
+					this.resetPotentialTagStateVars();
+					this.state = 'TEXT';
+				}
+			} else if (this.state === 'TAG_START_SLASH') {
+				if (/^[a-zA-Z0-9]$/.test(char)) {
+					for (let j = this.potentialTagNameMatches.length - 1; j >= 0; j--) {
+						if (
+							char !== this.potentialTagNameMatches[j][this.tagNamePartialIdx]
+						) {
+							this.potentialTagNameMatches.splice(j, 1);
+						}
+					}
+
+					if (this.potentialTagNameMatches.length === 0) {
+						// Didn't match any tag names, as in '</Z'
+						this.resetPotentialTagStateVars();
+						this.state = 'TEXT';
+					} else {
+						this.state = 'TAG_NAME';
+						this.tagNamePartial = char;
+						this.kind = 'close';
+						this.tagNamePartialIdx++;
+					}
+				} else {
+					// Not a valid tag name starting character
+					this.resetPotentialTagStateVars();
+					this.state = 'TEXT';
+				}
+			} else if (this.state === 'TAG_NAME') {
+				// This state: We're in a tag name and have at least one character
+
+				if (char === ' ' || char === '>') {
+					// Filter out potentialTagNameMatches that aren't the correct length.
+					// So if the potentialTagNameMatches are ['SHINY', 'FILESET'], and
+					// the text up to here is '<SHINY>', we should remove 'FILESET' from
+					// the potential matches. (For consistency, we're not using filter();
+					// elsewhere in the code we're modifying the array in place.)
+					for (let i = this.potentialTagNameMatches.length - 1; i >= 0; i--) {
+						if (
+							this.tagNamePartialIdx !== this.potentialTagNameMatches[i].length
+						) {
+							this.potentialTagNameMatches.splice(i, 1);
+						}
+					}
+					// If we hit the end of a tag name, we can transition to the next state.
+					if (this.potentialTagNameMatches.length === 1) {
+						this.tagName = this.tagNamePartial as TagNameT;
+						if (char === ' ') {
+							// '<FILESET '
+							this.state = 'WHITESPACE';
+						} else if (char === '>') {
+							// '<FILESET>'
+							this.state = 'TAG_END';
+						} else {
+							// Shouldn't get here, throw error
+							throw new Error(`Unexpected character: ${char}`);
+						}
+					} else {
+						// If we got here, then it's something like '<SHIN>' or '<SHINYA '
+						this.resetPotentialTagStateVars();
+						this.state = 'TEXT';
+					}
+				} else if (/^[a-zA-Z0-9_-]$/.test(char)) {
+					for (let j = this.potentialTagNameMatches.length - 1; j >= 0; j--) {
+						if (
+							char !== this.potentialTagNameMatches[j][this.tagNamePartialIdx]
+						) {
+							this.potentialTagNameMatches.splice(j, 1);
+						}
+					}
+
+					if (this.potentialTagNameMatches.length === 0) {
+						// Didn't match any tag names, as in '<SHINYX'
+						this.resetPotentialTagStateVars();
+						this.state = 'TEXT';
+					} else {
+						this.tagNamePartial += char;
+						this.tagNamePartialIdx++;
+					}
+				} else {
+					// Not a valid tag name character, as in '<SHIN!'
+					this.resetPotentialTagStateVars();
+					this.state = 'TEXT';
+				}
+			} else if (this.state === 'WHITESPACE') {
+				if (/^[a-zA-Z0-9]$/.test(char)) {
+					// Could be the start of an attribute name. (Attributes on a
+					// closing tag are invalid XML, but they're tolerated and
+					// ignored here, matching the databot source.)
+					this.state = 'ATTR_NAME';
+					this.currentAttributeName = char;
+				} else if (char === ' ') {
+					// Stay in this state
+				} else if (char === '>') {
+					this.state = 'TAG_END';
+				} else {
+					// Invalid character - we're not in a tag
+					this.resetPotentialTagStateVars();
+					this.state = 'TEXT';
+				}
+			} else if (this.state === 'ATTR_NAME') {
+				if (/^[a-zA-Z0-9_-]$/.test(char)) {
+					// Stay in this state
+					this.currentAttributeName += char;
+				} else if (char === ' ') {
+					this.state = 'ATTR_NAME_END';
+				} else if (char === '=') {
+					this.state = 'ATTR_EQUAL_FOUND';
+				} else {
+					// Invalid character
+					this.resetPotentialTagStateVars();
+					this.state = 'TEXT';
+				}
+			} else if (this.state === 'ATTR_NAME_END') {
+				if (char === ' ') {
+					// Stay in this state
+				} else if (char === '=') {
+					this.state = 'ATTR_EQUAL_FOUND';
+				} else {
+					// Invalid character
+					this.resetPotentialTagStateVars();
+					this.state = 'TEXT';
+				}
+			} else if (this.state === 'ATTR_EQUAL_FOUND') {
+				if (char === ' ') {
+					// Stay in this state
+				} else if (char === '"') {
+					// Found opening quote - now we're in the attribute value
+					this.state = 'IN_ATTR_VALUE_DOUBLE_QUOTE';
+					this.currentAttributeValue = '';
+				} else if (char === '\'') {
+					this.state = 'IN_ATTR_VALUE_SINGLE_QUOTE';
+					this.currentAttributeValue = '';
+				} else {
+					this.resetPotentialTagStateVars();
+					this.state = 'TEXT';
+				}
+			} else if (this.state === 'IN_ATTR_VALUE_DOUBLE_QUOTE') {
+				if (char === '"') {
+					// Found closing quote. Save the attribute name-value pair and reset
+					// the accumulators.
+					this.state = 'ATTRIBUTE_VALUE_END';
+					this.attributes[this.currentAttributeName] =
+						this.currentAttributeValue;
+					this.currentAttributeName = '';
+					this.currentAttributeValue = '';
+				} else if (char === '>') {
+					// The attribute value shouldn't have a '>'. Those should be escaped.
+					this.resetPotentialTagStateVars();
+					this.state = 'TEXT';
+				} else {
+					this.currentAttributeValue += char;
+				}
+			} else if (this.state === 'IN_ATTR_VALUE_SINGLE_QUOTE') {
+				// This block behaves the same as the double-quote block above.
+				if (char === '\'') {
+					this.state = 'ATTRIBUTE_VALUE_END';
+					this.attributes[this.currentAttributeName] =
+						this.currentAttributeValue;
+					this.currentAttributeName = '';
+					this.currentAttributeValue = '';
+				} else if (char === '>') {
+					this.resetPotentialTagStateVars();
+					this.state = 'TEXT';
+				} else {
+					this.currentAttributeValue += char;
+				}
+			} else if (this.state === 'ATTRIBUTE_VALUE_END') {
+				if (char === ' ') {
+					this.state = 'WHITESPACE';
+				} else if (char === '>') {
+					this.state = 'TAG_END';
+				} else {
+					this.resetPotentialTagStateVars();
+					this.state = 'TEXT';
+				}
+			}
+
+			this.scannedText += char;
+
+			// We found a complete tag! Add it to the result and reset the state.
+			if (this.state === 'TAG_END') {
+				await this.contentHandler({
+					type: 'tag',
+					name: this.tagName as TagNameT,
+					kind: this.kind,
+					attributes: structuredClone(this.attributes),
+					originalText: this.scannedText,
+				});
+				this.scannedText = '';
+				this.resetPotentialTagStateVars();
+				this.state = 'TEXT';
+			}
+		}
+
+		// At the end of the chunk, if we're in the TEXT state, we can flush the
+		// text.
+		if (this.state === 'TEXT') {
+			if (this.scannedText.length > 0) {
+				await this.contentHandler({ type: 'text', text: this.scannedText });
+				this.scannedText = '';
+			}
+		}
+	}
+
+	/**
+	 * Sends any content that has been scanned but not yet sent to the
+	 * contentHandler (for example, if it was a potential start of a tag like
+	 * '<FI', and waiting for the rest of the tag) will be sent to the
+	 * contentHandler, as type: 'text'. This should be called at the end of the
+	 * text stream.
+	 */
+	async flush(): Promise<void> {
+		if (this.scannedText.length > 0) {
+			await this.contentHandler({ type: 'text', text: this.scannedText });
+			this.scannedText = '';
+		}
+	}
+}

--- a/src/vs/workbench/test/common/positron/streamingTagLexer.vitest.ts
+++ b/src/vs/workbench/test/common/positron/streamingTagLexer.vitest.ts
@@ -1,0 +1,703 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Chunk, StreamingTagLexer } from '../../../common/positron/streamingTagLexer.js';
+
+/**
+ * Helper that collects all chunks emitted by the lexer.
+ */
+function createCollector() {
+	const chunks: Chunk<string>[] = [];
+	const contentHandler = (chunk: Chunk<string>) => { chunks.push(chunk); };
+	return { chunks, contentHandler };
+}
+
+describe('StreamingTagLexer', () => {
+	describe('complete XML parsed in one chunk', () => {
+		it('parses a single open and close tag', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['TOOL'],
+				contentHandler,
+			});
+
+			await lexer.process('<TOOL>hello</TOOL>');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "attributes": {},
+				    "kind": "open",
+				    "name": "TOOL",
+				    "originalText": "<TOOL>",
+				    "type": "tag",
+				  },
+				  {
+				    "text": "hello",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "close",
+				    "name": "TOOL",
+				    "originalText": "</TOOL>",
+				    "type": "tag",
+				  },
+				]
+			`);
+		});
+
+		it('parses text before, between, and after tags', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['B'],
+				contentHandler,
+			});
+
+			await lexer.process('before<B>inside</B>after');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "text": "before",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "open",
+				    "name": "B",
+				    "originalText": "<B>",
+				    "type": "tag",
+				  },
+				  {
+				    "text": "inside",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "close",
+				    "name": "B",
+				    "originalText": "</B>",
+				    "type": "tag",
+				  },
+				  {
+				    "text": "after",
+				    "type": "text",
+				  },
+				]
+			`);
+		});
+
+		it('parses a tag with attributes', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['FILE'],
+				contentHandler,
+			});
+
+			await lexer.process('<FILE path="foo.ts">content</FILE>');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "attributes": {
+				      "path": "foo.ts",
+				    },
+				    "kind": "open",
+				    "name": "FILE",
+				    "originalText": "<FILE path="foo.ts">",
+				    "type": "tag",
+				  },
+				  {
+				    "text": "content",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "close",
+				    "name": "FILE",
+				    "originalText": "</FILE>",
+				    "type": "tag",
+				  },
+				]
+			`);
+		});
+
+		it('parses a tag with single-quoted attributes', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['FILE'],
+				contentHandler,
+			});
+
+			await lexer.process('<FILE path=\'foo.ts\'>content</FILE>');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "attributes": {
+				      "path": "foo.ts",
+				    },
+				    "kind": "open",
+				    "name": "FILE",
+				    "originalText": "<FILE path='foo.ts'>",
+				    "type": "tag",
+				  },
+				  {
+				    "text": "content",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "close",
+				    "name": "FILE",
+				    "originalText": "</FILE>",
+				    "type": "tag",
+				  },
+				]
+			`);
+		});
+	});
+
+	describe('streaming chunks that split mid-tag', () => {
+		it('handles tag name split across chunks', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['TOOL'],
+				contentHandler,
+			});
+
+			await lexer.process('<TO');
+			await lexer.process('OL>');
+			await lexer.process('body');
+			await lexer.process('</TO');
+			await lexer.process('OL>');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "attributes": {},
+				    "kind": "open",
+				    "name": "TOOL",
+				    "originalText": "<TOOL>",
+				    "type": "tag",
+				  },
+				  {
+				    "text": "body",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "close",
+				    "name": "TOOL",
+				    "originalText": "</TOOL>",
+				    "type": "tag",
+				  },
+				]
+			`);
+		});
+
+		it('handles angle bracket arriving alone', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['X'],
+				contentHandler,
+			});
+
+			await lexer.process('a<');
+			await lexer.process('X>b</');
+			await lexer.process('X>');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "text": "a",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "open",
+				    "name": "X",
+				    "originalText": "<X>",
+				    "type": "tag",
+				  },
+				  {
+				    "text": "b",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "close",
+				    "name": "X",
+				    "originalText": "</X>",
+				    "type": "tag",
+				  },
+				]
+			`);
+		});
+
+		it('handles character-by-character streaming', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['AB'],
+				contentHandler,
+			});
+
+			const input = 'hi<AB>mid</AB>end';
+			for (const char of input) {
+				await lexer.process(char);
+			}
+			await lexer.flush();
+
+			// Each single-char text chunk flushes individually since process()
+			// flushes text at end of each call when in TEXT state.
+			const tagChunks = chunks.filter(c => c.type === 'tag');
+			const textContent = chunks
+				.filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+				.map(c => c.text)
+				.join('');
+
+			expect(tagChunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "attributes": {},
+				    "kind": "open",
+				    "name": "AB",
+				    "originalText": "<AB>",
+				    "type": "tag",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "close",
+				    "name": "AB",
+				    "originalText": "</AB>",
+				    "type": "tag",
+				  },
+				]
+			`);
+			expect(textContent).toBe('himidend');
+		});
+	});
+
+	describe('text outside known tags passed through', () => {
+		it('passes unknown tags as plain text', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['KNOWN'],
+				contentHandler,
+			});
+
+			await lexer.process('<UNKNOWN>text</UNKNOWN>');
+			await lexer.flush();
+
+			// The '<' causes a text flush boundary, so unrecognized tags
+			// split at the '<' of the closing tag.
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "text": "<UNKNOWN>text",
+				    "type": "text",
+				  },
+				  {
+				    "text": "</UNKNOWN>",
+				    "type": "text",
+				  },
+				]
+			`);
+		});
+
+		it('passes HTML-like tags as text when not in tagNames', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['TOOL'],
+				contentHandler,
+			});
+
+			await lexer.process('Use <div> for layout');
+			await lexer.flush();
+
+			// The '<' causes a flush of preceding text, then the unknown
+			// tag plus trailing text is emitted as a single text chunk.
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "text": "Use ",
+				    "type": "text",
+				  },
+				  {
+				    "text": "<div> for layout",
+				    "type": "text",
+				  },
+				]
+			`);
+		});
+
+		it('flushes incomplete potential tag as text', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['TOOL'],
+				contentHandler,
+			});
+
+			await lexer.process('start <TOO');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "text": "start ",
+				    "type": "text",
+				  },
+				  {
+				    "text": "<TOO",
+				    "type": "text",
+				  },
+				]
+			`);
+		});
+
+		it('flushes a tag left mid-attribute-value as text', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['TOOL'],
+				contentHandler,
+			});
+
+			// Stream ends inside an unterminated attribute value (the
+			// IN_ATTR_VALUE_DOUBLE_QUOTE state); the buffered tag start must be
+			// emitted verbatim as text rather than dropped.
+			await lexer.process('<TOOL attr="unclosed');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "text": "<TOOL attr="unclosed",
+				    "type": "text",
+				  },
+				]
+			`);
+		});
+	});
+
+	describe('nested tags', () => {
+		it('handles nested recognized tags', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['OUTER', 'INNER'],
+				contentHandler,
+			});
+
+			await lexer.process('<OUTER>before<INNER>deep</INNER>after</OUTER>');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "attributes": {},
+				    "kind": "open",
+				    "name": "OUTER",
+				    "originalText": "<OUTER>",
+				    "type": "tag",
+				  },
+				  {
+				    "text": "before",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "open",
+				    "name": "INNER",
+				    "originalText": "<INNER>",
+				    "type": "tag",
+				  },
+				  {
+				    "text": "deep",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "close",
+				    "name": "INNER",
+				    "originalText": "</INNER>",
+				    "type": "tag",
+				  },
+				  {
+				    "text": "after",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "close",
+				    "name": "OUTER",
+				    "originalText": "</OUTER>",
+				    "type": "tag",
+				  },
+				]
+			`);
+		});
+
+		it('handles multiple sibling tags', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['A', 'B'],
+				contentHandler,
+			});
+
+			await lexer.process('<A>first</A><B>second</B>');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "attributes": {},
+				    "kind": "open",
+				    "name": "A",
+				    "originalText": "<A>",
+				    "type": "tag",
+				  },
+				  {
+				    "text": "first",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "close",
+				    "name": "A",
+				    "originalText": "</A>",
+				    "type": "tag",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "open",
+				    "name": "B",
+				    "originalText": "<B>",
+				    "type": "tag",
+				  },
+				  {
+				    "text": "second",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "close",
+				    "name": "B",
+				    "originalText": "</B>",
+				    "type": "tag",
+				  },
+				]
+			`);
+		});
+	});
+
+	describe('self-closing handling', () => {
+		it('does not recognize self-closing syntax -- treats as text', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['BR'],
+				contentHandler,
+			});
+
+			// The lexer does not support self-closing tags like <BR/>.
+			// The '/' after the tag name is not a valid whitespace or '>'
+			// so it falls back to text.
+			await lexer.process('line1<BR/>line2');
+			await lexer.flush();
+
+			// The '<' flushes 'line1', then '/' after BR rejects the tag
+			// so the rest is emitted as text.
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "text": "line1",
+				    "type": "text",
+				  },
+				  {
+				    "text": "<BR/>line2",
+				    "type": "text",
+				  },
+				]
+			`);
+		});
+
+		it('recognizes tag with space before closing bracket', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['TAG'],
+				contentHandler,
+			});
+
+			await lexer.process('<TAG >content</TAG>');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "attributes": {},
+				    "kind": "open",
+				    "name": "TAG",
+				    "originalText": "<TAG >",
+				    "type": "tag",
+				  },
+				  {
+				    "text": "content",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "close",
+				    "name": "TAG",
+				    "originalText": "</TAG>",
+				    "type": "tag",
+				  },
+				]
+			`);
+		});
+	});
+
+	describe('no-match reset (false-match regression)', () => {
+		it('emits a tail-aligned mismatch as a single text chunk, not a fabricated tag', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['code'],
+				contentHandler,
+			});
+
+			// '<xode>' shares the tail of 'code' but mismatches the first
+			// char. It must be emitted as literal text, not a fabricated tag.
+			await lexer.process('<xode>');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "text": "<xode>",
+				    "type": "text",
+				  },
+				]
+			`);
+		});
+
+		it('still recognizes the real tag (control)', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['code'],
+				contentHandler,
+			});
+
+			await lexer.process('<code>');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "attributes": {},
+				    "kind": "open",
+				    "name": "code",
+				    "originalText": "<code>",
+				    "type": "tag",
+				  },
+				]
+			`);
+		});
+
+		it('passes a fully unmatched token as text (control)', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['code'],
+				contentHandler,
+			});
+
+			await lexer.process('<zzzz>');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "text": "<zzzz>",
+				    "type": "text",
+				  },
+				]
+			`);
+		});
+
+		it('does not let a mid-name mismatch poison the next valid tag', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['code'],
+				contentHandler,
+			});
+
+			// '<cxde>' matches 'c' then mismatches at 'x'. The reset must not
+			// leave a stale tag-name index that corrupts the following '<code>'.
+			await lexer.process('<cxde><code>ok</code>');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "text": "<cxde>",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "open",
+				    "name": "code",
+				    "originalText": "<code>",
+				    "type": "tag",
+				  },
+				  {
+				    "text": "ok",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "close",
+				    "name": "code",
+				    "originalText": "</code>",
+				    "type": "tag",
+				  },
+				]
+			`);
+		});
+
+		it('does not let a mid-name mismatch poison the next valid close tag', async () => {
+			const { chunks, contentHandler } = createCollector();
+			const lexer = new StreamingTagLexer({
+				tagNames: ['code'],
+				contentHandler,
+			});
+
+			// Close-tag equivalent: '</cxde>' is text, then '</code>' is a
+			// real close tag.
+			await lexer.process('</cxde></code>');
+			await lexer.flush();
+
+			expect(chunks).toMatchInlineSnapshot(`
+				[
+				  {
+				    "text": "</cxde>",
+				    "type": "text",
+				  },
+				  {
+				    "attributes": {},
+				    "kind": "close",
+				    "name": "code",
+				    "originalText": "</code>",
+				    "type": "tag",
+				  },
+				]
+			`);
+		});
+	});
+});


### PR DESCRIPTION
Part of #13729. Split out of #13730 to keep that PR focused on the headless LM service and the ghost-cell migration.

### Summary

This is a port, not new code. `StreamingTagLexer` has been running in the positron-assistant extension (where it parses the chat participant's streamed responses) since it was adapted from original databot lexer. This PR copies it into the workbench at `src/vs/workbench/common/positron/`, where main-thread consumers can use it: the headless LM consumers (#13730) parse model output as it streams, starting with ghost cells, with the visualization builder and quick actions to follow.

For review purposes the two copies are near-identical -- the whole divergence is 81 diff lines, most of it the expanded header comment. You can verify directly:

```bash
diff extensions/positron-assistant/src/streamingTagLexer.ts src/vs/workbench/common/positron/streamingTagLexer.ts
```

The three behavioral changes, all deliberate:

1. **Single-quote attribute fix:** the extension copy's `IN_ATTR_VALUE_SINGLE_QUOTE` state compared against `"` instead of `'`, so single-quoted attribute values never terminated correctly. This copy fixes the comparison.
2. **No-match reset fix:** the no-match branches reset state to `TEXT` but fell through to the tag-name transition, so malformed input whose tail aligned with a real tag name was emitted as a fabricated tag (and its literal text swallowed). All three branches are now properly guarded with `else`.
3. **Tag-name dedupe:** the constructor now dedupes `tagNames` (`[...new Set(tagNames)]`), replacing a `TODO: Validate tag names`.

Everything else -- the state machine, chunk handling, `flush()` semantics, the `ProcessedText`/`ProcessedTag` event shapes -- is unchanged from the extension copy.

What *is* new is the test suite: the extension copy shipped without tests, so the 20-test vitest suite here is written fresh -- split-chunk permutations (input split at any byte boundary produces the same output), single/double-quote attributes, near-miss text that merely resembles a known tag, unknown/HTML-like tags passing through as text, and `flush()` emitting a partial-tag tail verbatim. If you read one file closely, make it the tests.

**Why not move-and-delete?** The extension copy stays load-bearing for the chat participant's text/edit processors (`defaultTextProcessor`, `replaceStringProcessor`, `replaceSelectionProcessor`) until that extension is deprecated, so this PR leaves it untouched -- including not backporting the fixes above, since that surface is mid-deprecation. The workbench copy is the canonical one going forward; its header comment documents the relationship.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

No user-facing behavior (nothing consumes the lexer until #13730), so no e2e tags.

```bash
npx vitest run src/vs/workbench/test/common/positron/streamingTagLexer.vitest.ts
```
