### PR TITLE
chore: wire pyrefly E2E workflow to test insights dashboard

### DIFF
--- a/.github/workflows/test-e2e-pyrefly.yml
+++ b/.github/workflows/test-e2e-pyrefly.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Send Results to GH Summary
         uses: ./.github/actions/gen-report-dir
         with:
-          identifier: e2e-electron
+          identifier: e2e-electron-pyrefly
 
       - name: 🧪 Run Playwright Tests - Electron
         shell: bash

--- a/.github/workflows/test-e2e-pyrefly.yml
+++ b/.github/workflows/test-e2e-pyrefly.yml
@@ -71,10 +71,11 @@ jobs:
           POSITRON_HIDDEN_R: 4.4.1
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
           PWTEST_BLOB_DO_NOT_REMOVE: 1
+          CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
           USE_KEY: true
           GH_SUMMARY_REPORT: true
         run: |
-          ALLOW_PYREFLY=true npx playwright test test/e2e/tests/lsp --project=e2e-electron --workers=1 --reporter=html
+          ALLOW_PYREFLY=true npx playwright test test/e2e/tests/lsp --project=e2e-electron --workers=1
 
       - name: Upload Playwright Report to S3
         if: ${{ success() || failure() }}

--- a/.github/workflows/test-e2e-pyrefly.yml
+++ b/.github/workflows/test-e2e-pyrefly.yml
@@ -72,7 +72,7 @@ jobs:
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
-          SHARD_NAME: pyrefly-electron
+          SHARD_NAME: electron-pyrefly
           USE_KEY: true
           GH_SUMMARY_REPORT: true
         run: |

--- a/.github/workflows/test-e2e-pyrefly.yml
+++ b/.github/workflows/test-e2e-pyrefly.yml
@@ -72,6 +72,7 @@ jobs:
           COMMIT_INFO_MESSAGE: ${{ github.event.head_commit.message }}
           PWTEST_BLOB_DO_NOT_REMOVE: 1
           CONNECT_API_KEY: ${{ secrets.CONNECT_API_KEY }}
+          SHARD_NAME: pyrefly-electron
           USE_KEY: true
           GH_SUMMARY_REPORT: true
         run: |


### PR DESCRIPTION
### Summary
Wire the pyrefly E2E workflow to the test insights dashboard.
- Add `CONNECT_API_KEY` to authenticate the reporter with Posit Connect
- Drop `--reporter=html` override so `playwright.config.ts` reporters (including the custom one) actually run
- Add `SHARD_NAME=electron-pyrefly` and `gen-report-dir` identifier `e2e-electron-pyrefly` to avoid collisions with the standard ubuntu electron job

### QA Notes
`@:pyrefly`