### PR TITLE
e2e: fix flaky VS import settings notification locator

### DIFF
--- a/test/e2e/pages/dialog-toasts.ts
+++ b/test/e2e/pages/dialog-toasts.ts
@@ -185,7 +185,7 @@ export class Toasts {
 			// Open the notification center to check for the import settings notification.
 			await this.openNotificationCenter();
 
-			const importSettingsNotification = this.notificationsCenter.locator('.notification-list-item').filter({
+			const importSettingsNotification = this.code.driver.currentPage.locator('.notification-list-item').filter({
 				hasText: /Import your settings from Visual Studio Code/
 			});
 


### PR DESCRIPTION
Widens the notification locator to search the full page rather than only inside the notifications center container, so the check is reliable regardless of how the notification is rendered.

### QA Notes

@:vscode-settings