### PR TITLE
Make the R pak install prompt non-blocking

### DIFF
--- a/extensions/positron-r/src/packages.ts
+++ b/extensions/positron-r/src/packages.ts
@@ -16,8 +16,8 @@ import { RSession } from './session';
  * primary backend with base R fallback. Communicates with Ark via RPC methods.
  */
 export class RPackageManager {
-	/** Whether the user has declined to install pak (session-scoped) */
-	private _pakDeclined: boolean = false;
+	/** Whether the pak install recommendation has been shown this session */
+	private _pakRecommendationShown: boolean = false;
 
 	constructor(private readonly _session: RSession) { }
 
@@ -139,6 +139,8 @@ export class RPackageManager {
 		await this._execute(code, token);
 		if (isRenv) {
 			this._snapshotRenv();
+		} else {
+			void this._maybeRecommendPak();
 		}
 		this._session.invalidatePackageResourceCaches();
 	}
@@ -187,6 +189,8 @@ export class RPackageManager {
 		await this._execute(code, token);
 		if (isRenv) {
 			this._snapshotRenv();
+		} else {
+			void this._maybeRecommendPak();
 		}
 		this._session.invalidatePackageResourceCaches();
 	}
@@ -223,6 +227,7 @@ export class RPackageManager {
 			} else {
 				await this._execute(`update.packages(ask = FALSE)`, token);
 			}
+			void this._maybeRecommendPak();
 		}
 
 		this._session.invalidatePackageResourceCaches();
@@ -400,7 +405,7 @@ export class RPackageManager {
 
 	/**
 	 * Read the configured R packages installer preference.
-	 * 'auto' means: prefer pak, prompt to install it when missing, fall back to base on decline.
+	 * 'auto' means: use pak if installed, otherwise use base R and recommend pak (non-blocking).
 	 * 'pak' means: prefer pak, install it without prompting when missing.
 	 * 'base' means: never use or install pak.
 	 */
@@ -420,24 +425,66 @@ export class RPackageManager {
 	}
 
 	/**
-	 * Prompt the user to install pak.
+	 * Recommend installing pak after a package operation, without blocking it.
+	 *
+	 * Shown at most once per session and only when pak would be preferred
+	 * ('auto' setting) but is not installed. The notification is fired after the
+	 * operation completes so it never blocks the package command -- a blocking
+	 * prompt can hang when notifications are filtered (e.g. Do Not Disturb),
+	 * which is the bug this replaces (see #14195).
+	 *
+	 * - "Install pak" installs pak so subsequent operations use it.
+	 * - "Open Settings" reveals the `packages.r.installer` setting so the user
+	 *   can choose base R themselves rather than having a consequential setting
+	 *   changed silently on their behalf.
+	 * - Dismissing leaves everything untouched; the recommendation may return
+	 *   in a later session.
 	 */
-	private async _promptInstallPak(): Promise<boolean> {
+	private async _maybeRecommendPak(): Promise<void> {
+		if (this._pakRecommendationShown) {
+			return;
+		}
+		// Only 'auto' recommends: 'pak' installs silently, 'base' has opted out.
+		if (this._getConfiguredInstaller() !== 'auto') {
+			return;
+		}
+		if (await this._detectPak()) {
+			return;
+		}
+
+		// Guard before awaiting so a concurrent operation doesn't double-prompt.
+		this._pakRecommendationShown = true;
+
 		const install = vscode.l10n.t('Install pak');
+		const openSettings = vscode.l10n.t('Open Settings');
 		const result = await vscode.window.showInformationMessage(
 			vscode.l10n.t('The pak package provides faster and more reliable package operations. Would you like to install it?'),
 			install,
-			vscode.l10n.t('Not now')
+			openSettings
 		);
-		return result === install;
+
+		if (result === install) {
+			await this._execute('install.packages("pak")');
+			this._session.invalidatePackageResourceCaches();
+		} else if (result === openSettings) {
+			// Open the installer setting so the user can opt out (e.g. base R)
+			// themselves, rather than changing a consequential setting for them.
+			await vscode.commands.executeCommand('workbench.action.openSettings', '@id:packages.r.installer');
+		}
+		// Dismissing the notification does nothing; the session guard above
+		// prevents re-prompting until the next session.
 	}
 
 	/**
 	 * Resolve which installer to use, honoring the `packages.r.installer` setting.
 	 *
-	 * @param allowInstallPak When true (install/update operations), may install pak, either
-	 *                       by prompting the user (setting: 'auto') or silently (setting: 'pak').
-	 *                       When false (list/search/uninstall), only detects what is available.
+	 * @param allowInstallPak When true (install/update operations), may silently
+	 *                       install pak when the setting is 'pak'. When false
+	 *                       (list/search/uninstall), only detects what is
+	 *                       available. The 'auto' setting never installs pak
+	 *                       here; it falls back to base R and a non-blocking
+	 *                       recommendation is shown after the operation (see
+	 *                       _maybeRecommendPak).
 	 */
 	private async _resolveMethod(allowInstallPak: boolean): Promise<string> {
 		const setting = this._getConfiguredInstaller();
@@ -459,15 +506,7 @@ export class RPackageManager {
 			return (await this._detectPak()) ? 'pak' : 'base';
 		}
 
-		// setting === 'auto': prompt once per session, remember declines.
-		if (this._pakDeclined) {
-			return 'base';
-		}
-		if (await this._promptInstallPak()) {
-			await this._execute('install.packages("pak")');
-			return (await this._detectPak()) ? 'pak' : 'base';
-		}
-		this._pakDeclined = true;
+		// setting === 'auto': use base R now;
 		return 'base';
 	}
 

--- a/extensions/positron-r/src/test/packages.unit.test.ts
+++ b/extensions/positron-r/src/test/packages.unit.test.ts
@@ -1,0 +1,155 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as Sinon from 'sinon';
+import * as vscode from 'vscode';
+import * as positron from 'positron';
+import { RPackageManager } from '../packages';
+import { RSession } from '../session';
+
+// Button labels. vscode.l10n.t returns the source string when no bundle is
+// loaded (as in tests), so these match what the manager passes to the prompt.
+const INSTALL_PAK = 'Install pak';
+const OPEN_SETTINGS = 'Open Settings';
+
+/**
+ * Minimal fake RSession covering only what RPackageManager touches. `execute`
+ * resolves the manager's `_execute` by reporting the runtime returning to idle.
+ */
+class FakeRSession {
+	private readonly _emitter = new vscode.EventEmitter<positron.LanguageRuntimeMessage>();
+	readonly onDidReceiveRuntimeMessage = this._emitter.event;
+	readonly metadata = { sessionId: 'test-session' };
+
+	/** Value returned for the 'pak' package (null means not installed). */
+	pak: { compatible: boolean } | null = null;
+	/** Whether the session reports an active renv project. */
+	isRenv = false;
+
+	/** R code passed to execute(), in order. */
+	readonly executed: string[] = [];
+	invalidateCount = 0;
+
+	async packageVersion(pkgName: string): Promise<{ compatible: boolean } | null> {
+		return pkgName === 'pak' ? this.pak : null;
+	}
+
+	async evaluate(_code: string): Promise<{ result: boolean }> {
+		return { result: this.isRenv };
+	}
+
+	execute(code: string, id: string): void {
+		this.executed.push(code);
+		this._emitter.fire({
+			parent_id: id,
+			type: positron.LanguageRuntimeMessageType.State,
+			state: positron.RuntimeOnlineState.Idle,
+		} as positron.LanguageRuntimeState);
+	}
+
+	invalidatePackageResourceCaches(): void {
+		this.invalidateCount++;
+	}
+}
+
+suite('RPackageManager pak recommendation', () => {
+	let sandbox: Sinon.SinonSandbox;
+	let session: FakeRSession;
+	let manager: RPackageManager;
+	let showInfo: Sinon.SinonStub;
+	let executeCommand: Sinon.SinonStub;
+	let installer: 'auto' | 'pak' | 'base';
+
+	// The recommendation is fired fire-and-forget after the operation, so let
+	// pending microtasks drain before asserting on it.
+	const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+
+	setup(() => {
+		sandbox = Sinon.createSandbox();
+		session = new FakeRSession();
+		manager = new RPackageManager(session as unknown as RSession);
+		installer = 'auto';
+
+		sandbox.stub(vscode.workspace, 'getConfiguration').returns({
+			get: (key: string, def?: unknown) => key === 'installer' ? installer : def,
+		} as unknown as vscode.WorkspaceConfiguration);
+		showInfo = sandbox.stub(vscode.window, 'showInformationMessage').resolves(undefined);
+		executeCommand = sandbox.stub(vscode.commands, 'executeCommand').resolves(undefined);
+	});
+
+	teardown(() => sandbox.restore());
+
+	test('does not block the package operation on the notification (#14195)', async () => {
+		// A blocking await on a notification that never resolves would hang the
+		// operation; it must complete and only then fire the recommendation.
+		showInfo.callsFake(() => new Promise<string>(() => { /* never resolves */ }));
+
+		await manager.installPackages([{ name: 'dplyr' }]);
+		await flush();
+
+		assert.deepStrictEqual(
+			{ installed: session.executed, recommended: showInfo.calledOnce },
+			{ installed: ['install.packages(c("dplyr"))'], recommended: true },
+		);
+	});
+
+	test('recommends pak once per session when auto and pak is absent', async () => {
+		await manager.installPackages([{ name: 'dplyr' }]);
+		await flush();
+		await manager.updatePackages([{ name: 'dplyr' }]);
+		await flush();
+
+		assert.strictEqual(showInfo.callCount, 1);
+	});
+
+	test('does not recommend pak unless the installer is auto and pak is absent', async () => {
+		// pak installs silently; base has opted out; an installed pak needs no nudge.
+		const scenarios: Array<{ installer: 'auto' | 'pak' | 'base'; pak: { compatible: boolean } | null }> = [
+			{ installer: 'pak', pak: null },
+			{ installer: 'base', pak: null },
+			{ installer: 'auto', pak: { compatible: true } },
+		];
+
+		const shown: boolean[] = [];
+		for (const scenario of scenarios) {
+			installer = scenario.installer;
+			const sess = new FakeRSession();
+			sess.pak = scenario.pak;
+			const mgr = new RPackageManager(sess as unknown as RSession);
+			showInfo.resetHistory();
+
+			await mgr.installPackages([{ name: 'dplyr' }]);
+			await flush();
+			shown.push(showInfo.called);
+		}
+
+		assert.deepStrictEqual(shown, [false, false, false]);
+	});
+
+	test('Install pak installs pak and refreshes after the operation', async () => {
+		showInfo.resolves(INSTALL_PAK);
+
+		await manager.installPackages([{ name: 'dplyr' }]);
+		await flush();
+
+		assert.deepStrictEqual(
+			{ executed: session.executed, invalidated: session.invalidateCount },
+			{ executed: ['install.packages(c("dplyr"))', 'install.packages("pak")'], invalidated: 2 },
+		);
+	});
+
+	test('Open Settings reveals the installer setting instead of changing it', async () => {
+		showInfo.resolves(OPEN_SETTINGS);
+
+		await manager.installPackages([{ name: 'dplyr' }]);
+		await flush();
+
+		assert.deepStrictEqual(
+			executeCommand.args,
+			[['workbench.action.openSettings', '@id:packages.r.installer']],
+		);
+	});
+});

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackages.contribution.ts
@@ -97,7 +97,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			type: 'string',
 			enum: ['auto', 'pak', 'base'],
 			enumDescriptions: [
-				nls.localize('positron.packages.r.installer.auto', "Use pak if installed; otherwise prompt and fall back to base R."),
+				nls.localize('positron.packages.r.installer.auto', "Use pak if installed; otherwise use base R and offer to install pak."),
 				nls.localize('positron.packages.r.installer.pak', "Always use pak. Silently install it if missing."),
 				nls.localize('positron.packages.r.installer.base', "Always use base R."),
 			],


### PR DESCRIPTION
Fixes #14195

The first R package install or update in a session could hang indefinitely. The operation awaited a blocking "Install pak?" notification before running, and when notifications are filtered (e.g. Do Not Disturb) VS Code creates that notification as `SILENT` and never fires its close event, so the `await` never resolved.

This makes the pak recommendation non-blocking. With the `auto` installer setting, package operations now run immediately using base R, and a non-blocking notification is shown *after* the first package operation completes (at most once per session, and only when pak would be preferred but is not installed). The notification offers to install pak or to open the `packages.r.installer` setting, so a consequential setting is never changed silently on the user's behalf.

<img width="479" height="285" alt="Screenshot 2026-06-12 at 9 49 15 AM" src="https://github.com/user-attachments/assets/b7c41a3e-ea49-4378-93a6-3f08286995de" />

<img width="697" height="317" alt="Screenshot 2026-06-12 at 9 30 14 AM" src="https://github.com/user-attachments/assets/333e3e0d-624c-4ac4-90d0-9803010ff5ed" />


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix the first R package install or update in a session hanging when the pak install prompt was suppressed by notification filtering such as Do Not Disturb (#14195)

### Validation Steps

@:packages-pane

1. Ensure pak is not installed (`remove.packages("pak")`) and `packages.r.installer` is `auto` (the default).
2. Enable Do Not Disturb / notification filtering in Positron.
3. In an R session, install or update a package from the Packages pane.
4. Verify the operation completes without hanging (previously it hung with a loading bar and no console output). 
5. For completeness, at this point you need to restart Positron since we only show it once per session.
6. Verify a non-blocking notification appears afterward offering **Install pak** or **Open Settings**; confirm it is not shown again for the rest of the session, and that **Open Settings** reveals the `packages.r.installer` setting.