### PR TITLE
unit tests - find (f&r) navigates to the correct line in PNE

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronNotebookFind.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronNotebookFind.vitest.ts
@@ -489,6 +489,47 @@ describe('PositronNotebookFindController', () => {
 			expect(revealSpy).toHaveBeenCalledWith(notebook.cells.get()[1]);
 		});
 
+		// https://github.com/posit-dev/positron/issues/14130: find jumps to the
+		// right cell but not the matching line. navigateToMatch() only sets the
+		// selection and reveals the line when the cell already has an attached
+		// editor; for a cell whose editor attaches late (e.g. it was outside the
+		// viewport when the search navigated to it), the line reveal is skipped
+		// and never retried. These tests document the expected behavior and are
+		// marked `fails` until the bug is fixed -- flip them to `it` then.
+
+		it.fails('applies the match selection once a late-attaching editor attaches', () => {
+			const { notebook, controller, find } = findFixture([
+				['alpha', 'python', CellKind.Code],
+				['line one\nline two\ntarget here', 'python', CellKind.Code],
+			]);
+			const cell = notebook.cells.get()[1];
+			const editor = cell.currentEditor!;
+			cell.detachEditor();
+
+			find.searchString.set('target', undefined);
+			controller.findNext();
+			cell.attachEditor(editor);
+
+			expect(getCellSelection(cell)).toEqual([3, 1, 3, 7]);
+		});
+
+		it.fails('requests an editor reveal once a late-attaching editor attaches', () => {
+			const { notebook, controller, find } = findFixture([
+				['alpha', 'python', CellKind.Code],
+				['line one\nline two\ntarget here', 'python', CellKind.Code],
+			]);
+			const cell = notebook.cells.get()[1];
+			const editor = cell.currentEditor!;
+			const revealSpy = vi.spyOn(editor, 'revealRangeInCenter');
+			cell.detachEditor();
+
+			find.searchString.set('target', undefined);
+			controller.findNext();
+			cell.attachEditor(editor);
+
+			expect(revealSpy).toHaveBeenCalledWith(expect.objectContaining({ startLineNumber: 3 }));
+		});
+
 	});
 
 	describe('Notebook Structure Changes', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronNotebookFind.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronNotebookFind.vitest.ts
@@ -490,7 +490,7 @@ describe('PositronNotebookFindController', () => {
 		});
 
 		// https://github.com/posit-dev/positron/issues/14130: find jumps to the
-		// right cell but not the matching line. navigateToMatch() only sets the
+		// right cell but not the matching line. `navigateToMatch()` only sets the
 		// selection and reveals the line when the cell already has an attached
 		// editor; for a cell whose editor attaches late (e.g. it was outside the
 		// viewport when the search navigated to it), the line reveal is skipped

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronNotebookFind.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/contrib/find/positronNotebookFind.vitest.ts
@@ -451,6 +451,46 @@ describe('PositronNotebookFindController', () => {
 
 	});
 
+	describe('Match Reveal', () => {
+
+		it('navigating to a match on a later line selects that line in the editor', () => {
+			const { notebook, controller, find } = findFixture([
+				['line one\nline two\ntarget here', 'python', CellKind.Code],
+			]);
+			find.searchString.set('target', undefined);
+
+			controller.findNext();
+
+			expect(getCellSelection(notebook.cells.get()[0])).toEqual([3, 1, 3, 7]);
+		});
+
+		it('navigating to a match requests an editor reveal of the match line', () => {
+			const { notebook, controller, find } = findFixture([
+				['line one\nline two\ntarget here', 'python', CellKind.Code],
+			]);
+			const revealSpy = vi.spyOn(notebook.cells.get()[0].currentEditor!, 'revealRangeInCenter');
+			find.searchString.set('target', undefined);
+
+			controller.findNext();
+
+			expect(revealSpy).toHaveBeenCalledWith(expect.objectContaining({ startLineNumber: 3 }));
+		});
+
+		it('navigating to a match in another cell requests a cell reveal', () => {
+			const { notebook, controller, find } = findFixture([
+				['alpha', 'python', CellKind.Code],
+				['target', 'python', CellKind.Code],
+			]);
+			const revealSpy = vi.spyOn(notebook, 'revealInCenterIfOutsideViewport');
+			find.searchString.set('target', undefined);
+
+			controller.findNext();
+
+			expect(revealSpy).toHaveBeenCalledWith(notebook.cells.get()[1]);
+		});
+
+	});
+
 	describe('Notebook Structure Changes', () => {
 
 		it('adding a cell with matching content recomputes matches', () => runWithFakedTimers({}, async () => {


### PR DESCRIPTION
Adds unit tests covering find-widget match reveal behavior in Positron notebooks and documents #14130 (find navigates to the correct cell but not always to the matching line).

Refs #14130 (does not close it; the bug remains). These tests establish the expected behavior for a future fix.

## New Tests

Adds a `Match Reveal` block to `positronNotebookFind.vitest.ts`.

### Passing Tests

These verify that navigating to a match:

- Selects the matching line in the editor.
- Requests an editor reveal for that line.
- Requests a notebook-level reveal (`revealInCenterIfOutsideViewport`) when the match is in another cell.

### Expected-Fail Tests

These document the bug.

When navigation occurs before an off-screen cell's editor is attached, the selection and reveal should still be applied once the editor becomes available. Today they are not, because `navigateToMatch()` checks `cell.currentEditor` only once and never retries.

The tests mirror the passing cases and can be flipped from `it.fails` to `it` when #14130 is fixed.

## Limitations

One possible part of #14130 cannot be observed in jsdom: editor-level reveals may be ineffective because notebook editors auto-grow, leaving notebook scrolling as the only way to bring a line into view.

That behavior requires an e2e test (for example, asserting the current match decoration is in the viewport within a taller-than-viewport cell) and is best added alongside the fix.

## Results

`87 passed | 2 expected fail (89)`

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

@:positron-notebooks @:web @:win
