### PR TITLE
E2E test: basic data connections postgres tree test

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -6,3 +6,7 @@ POSITRON_PY_ALT_VER_SEL=3.9.6
 POSITRON_R_VER_SEL=4.4.1
 POSITRON_R_ALT_VER_SEL=4.3.2
 ANTHROPIC_KEY=your_anthropic_api_key_here
+
+# Password for the Postgres data connection used by data-connections e2e tests.
+# In CI this is read from 1Password.
+E2E_POSTGRES_PASSWORD=your_postgres_password_here

--- a/test/e2e/fixtures/test-setup/app-jupyter.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-jupyter.fixtures.ts
@@ -20,7 +20,7 @@ export { RunResult };
 export async function JupyterApp(
 	fixtureOptions: AppFixtureOptions
 ): Promise<{ app: Application; start: () => Promise<void>; stop: () => Promise<void> }> {
-	const { options, useLegacyNotebookEditor } = fixtureOptions;
+	const { options, useLegacyNotebookEditor, enableDataConnections } = fixtureOptions;
 	const JUPYTER_WORKSPACE_PATH = '/home/jupyter-admin/qa-example-content/';
 
 	const app = createApp({ ...options, workspacePath: JUPYTER_WORKSPACE_PATH });
@@ -32,7 +32,7 @@ export async function JupyterApp(
 		await app.positJupyter.auth.signIn();
 
 		// Now that the user exists, setup the environment
-		await setupJupyterEnvironment(useLegacyNotebookEditor);
+		await setupJupyterEnvironment(useLegacyNotebookEditor, enableDataConnections);
 
 		// Open Positron from JupyterLab
 		await app.positJupyter.lab.openPositron();
@@ -116,7 +116,7 @@ export async function JupyterApp(
  * Setup the complete Jupyter environment: Docker container, configuration, and permissions
  * NOTE: This must be called AFTER login, as login creates the jupyter-admin user
  */
-async function setupJupyterEnvironment(useLegacyNotebookEditor?: boolean): Promise<void> {
+async function setupJupyterEnvironment(useLegacyNotebookEditor?: boolean, enableDataConnections?: boolean): Promise<void> {
 	const TEST_DATA_PATH = join(os.tmpdir(), 'vscsmoke');
 	const DEFAULT_WORKSPACE_PATH = join(TEST_DATA_PATH, 'qa-example-content');
 	const JUPYTER_WORKSPACE_PATH = '/home/jupyter-admin/qa-example-content/';
@@ -152,7 +152,7 @@ async function setupJupyterEnvironment(useLegacyNotebookEditor?: boolean): Promi
 		'jupyter-test',
 		'/home/jupyter-admin/.positron-server/data/User/',
 		['settings.json', 'settingsDocker.json', 'settingsWorkbench.json'],
-		dockerSettingsOverrides({ useLegacyNotebookEditor })
+		dockerSettingsOverrides({ useLegacyNotebookEditor, enableDataConnections })
 	);
 	await copyKeyBindingsToContainer('jupyter-test', '/home/jupyter-admin/.positron-server/data/User/');
 

--- a/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
@@ -19,8 +19,8 @@ export { RunResult };
 export async function WorkbenchApp(
 	fixtureOptions: AppFixtureOptions
 ): Promise<{ app: Application; start: () => Promise<void>; stop: () => Promise<void> }> {
-	const { options, managedCredentials, useLegacyNotebookEditor } = fixtureOptions;
-	const { workspacePath } = await setupWorkbenchEnvironment(managedCredentials, useLegacyNotebookEditor);
+	const { options, managedCredentials, useLegacyNotebookEditor, enableDataConnections } = fixtureOptions;
+	const { workspacePath } = await setupWorkbenchEnvironment(managedCredentials, useLegacyNotebookEditor, enableDataConnections);
 
 	const app = createApp({ ...options, workspacePath });
 
@@ -83,7 +83,7 @@ export async function WorkbenchApp(
  * the CI install step. The actual credential setup happens in install-workbench.sh; the fixture
  * just records it here so tests/fixtures can make conditional decisions if needed.
  */
-async function setupWorkbenchEnvironment(managedCredentials?: 'snowflake' | 'databricks' | 'azure', useLegacyNotebookEditor?: boolean): Promise<{ workspacePath: string; userDataDir: string }> {
+async function setupWorkbenchEnvironment(managedCredentials?: 'snowflake' | 'databricks' | 'azure', useLegacyNotebookEditor?: boolean, enableDataConnections?: boolean): Promise<{ workspacePath: string; userDataDir: string }> {
 	if (managedCredentials) {
 		console.log(`Workbench fixture: expecting managed credential "${managedCredentials}" to be provisioned in the container`);
 	}
@@ -122,7 +122,7 @@ async function setupWorkbenchEnvironment(managedCredentials?: 'snowflake' | 'dat
 		'test',
 		'/home/user1/.positron-server/User/',
 		['settings.json', 'settingsDocker.json', 'settingsWorkbench.json'],
-		dockerSettingsOverrides({ useLegacyNotebookEditor })
+		dockerSettingsOverrides({ useLegacyNotebookEditor, enableDataConnections })
 	);
 	await copyKeyBindingsToContainer('test', '/home/user1/.positron-server/User/');
 

--- a/test/e2e/fixtures/test-setup/app.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app.fixtures.ts
@@ -23,6 +23,13 @@ export interface AppFixtureOptions {
 	 * container, so they must merge the override in themselves.
 	 */
 	useLegacyNotebookEditor?: boolean;
+	/**
+	 * When true, suites opt into the Data Connections preview panel. As with
+	 * `useLegacyNotebookEditor`, the local apps apply this via the host `settingsFile`
+	 * in `beforeApp`, while the Docker-based apps merge the override into the settings
+	 * copied into the container.
+	 */
+	enableDataConnections?: boolean;
 }
 
 /**

--- a/test/e2e/fixtures/test-setup/docker-utils.ts
+++ b/test/e2e/fixtures/test-setup/docker-utils.ts
@@ -55,10 +55,13 @@ export async function runDockerCommand(command: string, description: string): Pr
  * (VS Code) notebook editor, the Positron notebook editor is disabled. Returns
  * `undefined` when there is nothing to override.
  */
-export function dockerSettingsOverrides(opts: { useLegacyNotebookEditor?: boolean }): object | undefined {
+export function dockerSettingsOverrides(opts: { useLegacyNotebookEditor?: boolean; enableDataConnections?: boolean }): object | undefined {
 	const overrides: Record<string, unknown> = {};
 	if (opts.useLegacyNotebookEditor) {
 		overrides['positron.notebook.enabled'] = false;
+	}
+	if (opts.enableDataConnections) {
+		overrides['dataConnections.enabled'] = true;
 	}
 	return Object.keys(overrides).length > 0 ? overrides : undefined;
 }

--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -17,6 +17,7 @@ import { Plots } from '../pages/plots';
 import { NewFolderFlow } from '../pages/newFolderFlow';
 import { Explorer } from '../pages/explorer';
 import { Connections } from '../pages/connections';
+import { DataConnections } from '../pages/dataConnections';
 import { Help } from '../pages/help';
 import { TopActionBar } from '../pages/topActionBar';
 import { Layouts } from '../pages/layouts';
@@ -75,6 +76,7 @@ export class Workbench {
 	readonly newFolderFlow: NewFolderFlow;
 	readonly explorer: Explorer;
 	readonly connections: Connections;
+	readonly dataConnections: DataConnections;
 	readonly help: Help;
 	readonly topActionBar: TopActionBar;
 	readonly layouts: Layouts;
@@ -126,6 +128,7 @@ export class Workbench {
 		this.editors = new Editors(code);
 		this.quickaccess = new QuickAccess(code, this.editors, this.quickInput);
 		this.connections = new Connections(code, this.quickaccess);
+		this.dataConnections = new DataConnections(code, this.quickaccess);
 		this.newFolderFlow = new NewFolderFlow(code, this.quickaccess);
 		this.output = new Output(code, this.quickaccess, this.quickInput);
 		this.console = new Console(code, this.quickInput, this.hotKeys, this.contextMenu);

--- a/test/e2e/pages/dataConnections.ts
+++ b/test/e2e/pages/dataConnections.ts
@@ -1,0 +1,219 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import test, { expect, Locator } from '@playwright/test';
+import { Code } from '../infra/code';
+import { QuickAccess } from './quickaccess';
+
+// The focus command for the Data Connections view (gated behind `dataConnections.enabled`).
+const DATA_CONNECTIONS_VIEW_FOCUS_COMMAND = 'workbench.panel.positronDataConnections.focus';
+
+// The "Configure Data Connection" / "New Data Connection" dialog and its surrounding modal.
+const MODAL_DIALOG = '.positron-modal-dialog';
+const PARAMETER_FIELD = '.parameter-field';
+const DATA_CONNECTION_ENTRY_ROW = '.data-connection-entry-row';
+
+// Tree row selectors. The tree renders inside a virtualized data grid; each row exposes a twisty
+// button (aria-label "Expand" when collapsed) and a content area holding the node label.
+const TREE_ROW = '.positron-tree-row';
+const TREE_TWISTY_COLLAPSED = '.positron-tree-twisty-collapsed';
+
+// The virtualized grid that hosts the tree. It renders only the rows that fit in the viewport (no
+// overscan), so rows below the fold are absent from the DOM until scrolled into view.
+const TREE_WAFFLE = '#data-connection-profiles-list .data-grid-waffle';
+
+/**
+ * Reusable Positron Data Connections panel functionality for tests to leverage.
+ *
+ * Covers the panel gated behind the `dataConnections.enabled` setting: opening the view, adding a
+ * connection through the new-connection flow (select provider -> configure -> save), and asserting
+ * the resulting profile shows up in the tree.
+ */
+export class DataConnections {
+
+	addConnectionButton: Locator;
+	dialog: Locator;
+	saveButton: Locator;
+	nextButton: Locator;
+	connectionEntries: Locator;
+
+	constructor(private code: Code, private quickaccess: QuickAccess) {
+		const page = code.driver.currentPage;
+		this.addConnectionButton = page.locator('.codicon-positron-add-connection');
+		this.dialog = page.locator(MODAL_DIALOG);
+		this.saveButton = this.dialog.getByRole('button', { name: 'Save' });
+		this.nextButton = this.dialog.getByRole('button', { name: 'Next' });
+		this.connectionEntries = page.locator(DATA_CONNECTION_ENTRY_ROW);
+	}
+
+	/**
+	 * Focuses the Data Connections view. Requires `dataConnections.enabled` to be true.
+	 */
+	async openDataConnectionsView(): Promise<void> {
+		await this.quickaccess.runCommand(DATA_CONNECTIONS_VIEW_FOCUS_COMMAND);
+		await expect(this.addConnectionButton).toBeVisible();
+	}
+
+	/**
+	 * Opens the new-connection flow by clicking the Add Connection action.
+	 */
+	async clickAddConnection(): Promise<void> {
+		await this.addConnectionButton.click();
+		await expect(this.dialog).toBeVisible();
+	}
+
+	/**
+	 * Selects a provider in the "New Data Connection" dialog and advances to the configure step.
+	 * @param providerName The driver name shown on the provider card, e.g. 'PostgreSQL'.
+	 */
+	async selectProvider(providerName: string): Promise<void> {
+		await test.step(`Select provider: ${providerName}`, async () => {
+			await this.dialog.locator('.driver-card').filter({ hasText: providerName }).click();
+			await this.nextButton.click();
+		});
+	}
+
+	/**
+	 * Fills the connection form fields in the "Configure Data Connection" dialog. Keys are the
+	 * field labels (e.g. 'Connection Name', 'Host', 'Port', 'Database', 'User', 'Password') and
+	 * values are the text to enter.
+	 * @param fields A map of field label to value.
+	 */
+	async fillConnectionInputs(fields: Record<string, string>): Promise<void> {
+		await test.step('Fill connection inputs', async () => {
+			for (const [label, value] of Object.entries(fields)) {
+				const field = this.dialog.locator(PARAMETER_FIELD).filter({
+					has: this.code.driver.currentPage.getByText(label, { exact: true })
+				});
+				await field.locator('.parameter-input').fill(value);
+			}
+		});
+	}
+
+	/**
+	 * Saves the connection in the "Configure Data Connection" dialog and waits for it to close.
+	 */
+	async save(): Promise<void> {
+		await this.saveButton.click();
+		await expect(this.dialog).toBeHidden();
+	}
+
+	/**
+	 * Asserts that a connection profile is present in the tree.
+	 * @param connectionName The connection name shown in the tree.
+	 */
+	async expectConnectionInTree(connectionName: string): Promise<void> {
+		await expect(
+			this.connectionEntries.filter({ hasText: connectionName })
+		).toBeVisible();
+	}
+
+	/**
+	 * Returns the tree row whose node label exactly matches the given text. Exact matching avoids
+	 * false matches between names that share a substring (e.g. 'actor' vs 'actor_info').
+	 * @param label The node label, e.g. 'Schemas', 'public', 'Tables', 'actor'.
+	 */
+	private treeRow(label: string): Locator {
+		return this.code.driver.currentPage.locator(TREE_ROW).filter({
+			has: this.code.driver.currentPage.getByText(label, { exact: true })
+		});
+	}
+
+	/**
+	 * Expands a row's twisty, if it is currently collapsed. No-op if already expanded (toggling an
+	 * expanded twisty would collapse it). Waits for the twisty to leave the collapsed state so child
+	 * rows have begun loading before returning.
+	 *
+	 * Uses `dispatchEvent('click')` rather than `click()`: the tree renders inside a virtualized
+	 * data grid that uses `clip-path` (not native scrolling) and absolutely-positioned rows. A
+	 * coordinate-based `click()` on a row pushed below the clip edge lands on whichever row is
+	 * visually there, toggling the wrong node. Dispatching the event directly fires the twisty's
+	 * onClick handler on the correct element regardless of its scroll position.
+	 */
+	private async expandRow(row: Locator, label: string): Promise<void> {
+		await test.step(`Expand node: ${label}`, async () => {
+			// Every node expanded by this test lives near the top of the tree, so scrolling to the
+			// top guarantees the target is within the (overscan-free) rendered range, even if a
+			// prior verification step scrolled the grid down. toBeVisible then waits for the row to
+			// finish loading after its parent expanded.
+			await this.scrollToTop();
+			await expect(row).toBeVisible();
+
+			const collapsedTwisty = row.locator(TREE_TWISTY_COLLAPSED);
+			if (await collapsedTwisty.count() > 0) {
+				await collapsedTwisty.first().dispatchEvent('click');
+				await expect(row.locator(TREE_TWISTY_COLLAPSED)).toHaveCount(0);
+			}
+		});
+	}
+
+	/**
+	 * Expands the root connection entry, opening the live connection.
+	 * @param connectionName The connection name shown in the tree.
+	 */
+	async expandConnection(connectionName: string): Promise<void> {
+		const row = this.code.driver.currentPage.locator(TREE_ROW)
+			.filter({ has: this.connectionEntries.filter({ hasText: connectionName }) });
+		await this.expandRow(row, connectionName);
+	}
+
+	/**
+	 * Expands a tree node by its label.
+	 * @param label The node label to expand, e.g. 'Schemas', 'public', 'Tables', 'Views'.
+	 */
+	async expandNode(label: string): Promise<void> {
+		await this.expandRow(this.treeRow(label), label);
+	}
+
+	/**
+	 * Scrolls the virtualized tree to the top by hovering the grid and wheeling up past the start
+	 * (the offset is clamped to zero).
+	 */
+	private async scrollToTop(): Promise<void> {
+		const page = this.code.driver.currentPage;
+		await page.locator(TREE_WAFFLE).hover();
+		await page.mouse.wheel(0, -100000);
+	}
+
+	/**
+	 * Scrolls the virtualized tree until the given row is rendered. The grid renders no overscan, so
+	 * a row below the fold is absent from the DOM; without this it would never become visible. Resets
+	 * to the top first, then wheels down so the search is deterministic regardless of current scroll.
+	 * Returns immediately if the row is already rendered.
+	 */
+	private async revealNode(row: Locator): Promise<void> {
+		if (await row.count() > 0) {
+			return;
+		}
+
+		const page = this.code.driver.currentPage;
+		await this.scrollToTop();
+		for (let i = 0; i < 60 && await row.count() === 0; i++) {
+			await page.mouse.wheel(0, 200);
+		}
+	}
+
+	/**
+	 * Asserts that a tree node with the given label is visible, scrolling it into view if needed.
+	 * @param label The node label.
+	 */
+	async expectNodeVisible(label: string): Promise<void> {
+		const row = this.treeRow(label);
+		await this.revealNode(row);
+		await expect(row).toBeVisible();
+	}
+
+	/**
+	 * Asserts that a column node is visible with the expected name and data type.
+	 * @param name The column name, e.g. 'actor_id'.
+	 * @param dataType The column data type as shown in the tree, e.g. 'integer'.
+	 */
+	async expectColumn(name: string, dataType: string): Promise<void> {
+		const row = this.treeRow(name);
+		await this.revealNode(row);
+		await expect(row).toBeVisible();
+		await expect(row.locator('.data-connection-node-type')).toHaveText(dataType);
+	}
+}

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -36,6 +36,8 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 
 	useLegacyNotebookEditor: [false, { scope: 'worker', option: true }],
 
+	enableDataConnections: [false, { scope: 'worker', option: true }],
+
 	envVars: [async ({ }, use, workerInfo) => {
 		const projectName = workerInfo.project.name;
 
@@ -102,7 +104,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 	// placeholder for area-specific fixtures that need to run before app starts
 	// e.g. changing settings that require an app reload
 	beforeApp: [
-		async ({ useLegacyNotebookEditor, settingsFile }, use) => {
+		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
 			if (useLegacyNotebookEditor) {
 				// These tests exercise the legacy (VS Code) notebook editor. The
 				// Positron notebook editor is now the default, so disable it before
@@ -111,12 +113,20 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 				await settingsFile.append({ 'positron.notebook.enabled': false });
 			}
 
+			if (enableDataConnections) {
+				// The Data Connections panel is a preview feature gated behind this
+				// setting, which requires a reload to take effect. Enable it before the
+				// app starts so no reload is needed. Suites opt in with
+				// `test.use({ enableDataConnections: true })`.
+				await settingsFile.append({ 'dataConnections.enabled': true });
+			}
+
 			await use();
 		},
 		{ scope: 'worker' }],
 
-	app: [async ({ options, logsPath, logger, managedCredentials, useLegacyNotebookEditor, beforeApp: _beforeApp }, use, workerInfo) => {
-		const { app, start, stop } = await AppFixture({ options, logsPath, logger, workerInfo, managedCredentials, useLegacyNotebookEditor });
+	app: [async ({ options, logsPath, logger, managedCredentials, useLegacyNotebookEditor, enableDataConnections, beforeApp: _beforeApp }, use, workerInfo) => {
+		const { app, start, stop } = await AppFixture({ options, logsPath, logger, workerInfo, managedCredentials, useLegacyNotebookEditor, enableDataConnections });
 
 		try {
 			await start();
@@ -533,6 +543,7 @@ export interface WorkerFixtures {
 	suiteId: string;
 	managedCredentials: 'snowflake' | 'databricks' | 'azure' | undefined;
 	useLegacyNotebookEditor: boolean;
+	enableDataConnections: boolean;
 	envVars: string;
 	snapshots: boolean;
 	artifactDir: string;

--- a/test/e2e/tests/data-connections/postgres-tree.test.ts
+++ b/test/e2e/tests/data-connections/postgres-tree.test.ts
@@ -6,7 +6,11 @@
 import { test, tags } from '../_test.setup';
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
+	// The Data Connections panel is a preview feature gated behind `dataConnections.enabled`. This
+	// bakes the setting into the app (and the Workbench/Jupyter containers) at startup, since those
+	// read settings copied in at launch rather than the host settings file written at runtime.
+	enableDataConnections: true,
 });
 
 // The password is read from E2E_POSTGRES_PASSWORD (from the project's .env file locally, 1Password in CI).
@@ -37,13 +41,8 @@ const actorColumns = [
 const actorIndexes = ['actor_pkey', 'idx_actor_last_name'];
 
 test.describe('Data Connections - Postgres Tree', {
-	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH]
+	tag: [tags.WEB, tags.CONNECTIONS, tags.WORKBENCH]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		// The Data Connections panel is gated behind this preview setting and requires a reload.
-		await settings.set({ 'dataConnections.enabled': true }, { reload: true });
-	});
 
 	test('Can configure a Postgres data connection', async function ({ app }) {
 		const { dataConnections } = app.workbench;

--- a/test/e2e/tests/data-connections/postgres-tree.test.ts
+++ b/test/e2e/tests/data-connections/postgres-tree.test.ts
@@ -1,0 +1,99 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+// The password is read from E2E_POSTGRES_PASSWORD (from the project's .env file locally, 1Password in CI).
+const connectionName = 'dvdrental';
+const host = 'postgres';
+const port = '5432';
+const database = 'dvdrental';
+const user = 'e2e';
+const password = process.env.E2E_POSTGRES_PASSWORD || 'testpassword';
+
+// Tables and views in the dvdrental sample database.
+const tables = [
+	'actor', 'address', 'category', 'city', 'country', 'customer', 'film', 'film_actor',
+	'film_category', 'inventory', 'language', 'payment', 'rental', 'staff', 'store',
+];
+const views = [
+	'actor_info', 'customer_list', 'film_list', 'nicer_but_slower_film_list',
+	'sales_by_film_category', 'sales_by_store', 'staff_list',
+];
+
+// Columns and indexes of the dvdrental `actor` table.
+const actorColumns = [
+	{ name: 'actor_id', dataType: 'integer' },
+	{ name: 'first_name', dataType: 'character varying(45)' },
+	{ name: 'last_name', dataType: 'character varying(45)' },
+	{ name: 'last_update', dataType: 'timestamp without time zone' },
+];
+const actorIndexes = ['actor_pkey', 'idx_actor_last_name'];
+
+test.describe('Data Connections - Postgres Tree', {
+	tag: [tags.WEB, tags.WIN, tags.CONNECTIONS, tags.WORKBENCH]
+}, () => {
+
+	test.beforeAll(async function ({ settings }) {
+		// The Data Connections panel is gated behind this preview setting and requires a reload.
+		await settings.set({ 'dataConnections.enabled': true }, { reload: true });
+	});
+
+	test('Can configure a Postgres data connection', async function ({ app }) {
+		const { dataConnections } = app.workbench;
+
+		await dataConnections.openDataConnectionsView();
+		await dataConnections.clickAddConnection();
+		await dataConnections.selectProvider('PostgreSQL');
+
+		await dataConnections.fillConnectionInputs({
+			'Connection Name': connectionName,
+			'Host': host,
+			'Port': port,
+			'Database': database,
+			'User': user,
+			'Password': password,
+		});
+
+		await dataConnections.save();
+
+		await dataConnections.expectConnectionInTree(connectionName);
+
+		await test.step('Expand the tree down to tables and views', async () => {
+			await dataConnections.expandConnection(connectionName);
+			await dataConnections.expandNode('Schemas');
+			await dataConnections.expandNode('public');
+			await dataConnections.expandNode('Tables');
+			await dataConnections.expandNode('Views');
+		});
+
+		await test.step('Verify all tables and views are visible', async () => {
+			for (const table of tables) {
+				await dataConnections.expectNodeVisible(table);
+			}
+			for (const view of views) {
+				await dataConnections.expectNodeVisible(view);
+			}
+		});
+
+		await test.step('Verify columns and indexes for the actor table', async () => {
+			await dataConnections.expandNode('actor');
+
+			await dataConnections.expandNode('Columns');
+			for (const { name, dataType } of actorColumns) {
+				await dataConnections.expectColumn(name, dataType);
+			}
+
+			await dataConnections.expandNode('Indexes');
+			for (const index of actorIndexes) {
+				await dataConnections.expectNodeVisible(index);
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds an e2e test that exercises the new (preview) Data Connections panel by
configuring a PostgreSQL connection to the `dvdrental` sample database and
verifying the resulting connection tree.

## Changes

- New test: `test/e2e/tests/data-connections/postgres-tree.test.ts`
  - Enables the `dataConnections.enabled` preview setting (with reload) in `beforeAll`
  - Adds a PostgreSQL connection via the Add Connection flow (select provider -> configure -> save)
  - Expands the tree (Schemas -> public -> Tables/Views) and verifies all 15 tables and 7 views
  - Expands the `actor` table and verifies its columns (with data types) and indexes
- New page object: `test/e2e/pages/dataConnections.ts`, registered on `app.workbench.dataConnections`
- Documents the `E2E_POSTGRES_PASSWORD` env var in `.env.e2e.example`

## Notes on the virtualized tree

The connection tree renders inside a `clip-path`-based virtualized data grid with
no overscan, which required two test-side accommodations:

- **Expanding nodes** uses `dispatchEvent('click')` rather than `click()`. A
  coordinate-based click on a row pushed below the clip edge lands on whichever
  row is visually there, toggling the wrong node.
- **Asserting rows** scrolls the grid (via wheel) to bring a row into the rendered
  range first, since rows below the fold are absent from the DOM (notably in the
  1200x800 web viewport).

## Testing

- Tags: @:web @:connections @:workbench @:win
- Requires the `dvdrental` Postgres container (workbench/jupyter compose env);
  password from `E2E_POSTGRES_PASSWORD` (1Password in CI).
