### PR TITLE
Enable regex-y assertions about terminal text

### DIFF
--- a/test/e2e/pages/dataExplorer.ts
+++ b/test/e2e/pages/dataExplorer.ts
@@ -7,6 +7,7 @@ import test, { expect, Locator } from '@playwright/test';
 import { Code } from '../infra/code';
 import { Workbench } from '../infra/workbench';
 import { MetricTargetType, RecordMetric } from '../utils/metrics/metric-base.js';
+import { escapeRegExp } from '../utils/strings';
 
 const HEADER_TITLES = '.data-grid-column-header .title';
 const DATA_GRID_ROWS = '.data-explorer-panel .right-column .data-grid-rows-container';
@@ -159,7 +160,7 @@ export class Filters {
 			// at the end of the name and requires either string-start or
 			// whitespace before it - so 'dep_time' matches "<icon> dep_time"
 			// without also matching "<icon> sched_dep_time".
-			const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+			const escaped = escapeRegExp(value);
 			return this.code.driver.currentPage
 				.locator('.positron-modal-popup')
 				.getByRole('button', { name: new RegExp(`(?:^|\\s)${escaped}$`) });

--- a/test/e2e/pages/editors.ts
+++ b/test/e2e/pages/editors.ts
@@ -5,6 +5,7 @@
 
 import test, { expect, Locator } from '@playwright/test';
 import { Code } from '../infra/code';
+import { escapeRegExp } from '../utils/strings';
 
 
 export class Editors {
@@ -68,10 +69,6 @@ export class Editors {
 		});
 	}
 
-	escapeRegex(s: string) {
-		return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-	}
-
 	async waitForActiveTab(fileName: string | RegExp, isDirty: boolean = false): Promise<void> {
 		const { currentPage } = this.code.driver;
 		const base = `.tabs-container div.tab.active${isDirty ? '.dirty' : ''}[aria-selected="true"]`;
@@ -82,7 +79,7 @@ export class Editors {
 		await expect(active).toBeVisible();
 
 		const attrMatcher =
-			fileName instanceof RegExp ? fileName : new RegExp(`${this.escapeRegex(fileName)}$`);
+			fileName instanceof RegExp ? fileName : new RegExp(`${escapeRegExp(fileName)}$`);
 
 		await expect(active).toHaveAttribute('data-resource-name', attrMatcher);
 	}

--- a/test/e2e/pages/notebooks.ts
+++ b/test/e2e/pages/notebooks.ts
@@ -9,6 +9,7 @@ import { QuickAccess } from './quickaccess';
 import { basename } from 'path';
 import test, { expect, FrameLocator, Locator } from '@playwright/test';
 import { HotKeys } from './hotKeys.js';
+import { escapeRegExp } from '../utils/strings';
 
 const KERNEL_DROPDOWN = 'a.kernel-label';
 const KERNEL_LABEL = '.codicon-notebook-kernel-select';
@@ -257,8 +258,4 @@ export class Notebooks {
 		await this.hotKeys.executeNotebookCell();
 		await expect(this.code.driver.currentPage.getByRole('button', { name: 'Go To' })).not.toBeVisible({ timeout: 30000 });
 	}
-}
-
-function escapeRegExp(str: string): string {
-	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/test/e2e/pages/terminal.ts
+++ b/test/e2e/pages/terminal.ts
@@ -6,6 +6,7 @@
 import test, { expect, Locator } from '@playwright/test';
 import { Code } from '../infra/code';
 import { QuickAccess } from './quickaccess';
+import { escapeRegExp } from '../utils/strings';
 
 const TERMINAL_WRAPPER = '#terminal .terminal-wrapper.active';
 
@@ -25,7 +26,7 @@ export class Terminal {
 	}
 
 	async waitForTerminalText(
-		terminalText: string,
+		terminalText: string | RegExp,
 		options: {
 			timeout?: number;
 			expectedCount?: number;
@@ -34,15 +35,22 @@ export class Terminal {
 	): Promise<string[]> {
 		const { timeout = 15000, expectedCount = 1 } = options;
 
+		let matcher: RegExp;
+		if (typeof terminalText === 'string') {
+			// treat input as literal string, match case-insensitively
+			matcher = new RegExp(escapeRegExp(terminalText), 'gi');
+		} else {
+			// force 'g' so all matches are counted, not just the first
+			const flags = terminalText.flags.includes('g') ? terminalText.flags : terminalText.flags + 'g';
+			matcher = new RegExp(terminalText, flags);
+		}
+
 		await expect(async () => {
 			// With GPU acceleration off, terminal renders as DOM and we can read text directly
 			const terminalWrapper = this.code.driver.currentPage.locator(TERMINAL_WRAPPER);
 			const text = await terminalWrapper.textContent() || '';
 
-			// clean up regex text
-			const safeTerminalText = terminalText.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-			// allow case insensitive matches
-			const matches = text.match(new RegExp(safeTerminalText, 'gi'));
+			const matches = text.match(matcher);
 
 			expect(matches?.length).toBe(expectedCount);
 

--- a/test/e2e/tests/r-pkg-development/r-pkg-development.test.ts
+++ b/test/e2e/tests/r-pkg-development/r-pkg-development.test.ts
@@ -39,7 +39,7 @@ test.describe('R Package Development', { tag: [tags.R_PKG_DEVELOPMENT, tags.ARK]
 			logger.log('Test R Package');
 			await app.workbench.quickaccess.runCommand('r.packageTest');
 			await expect(async () => {
-				await app.workbench.terminal.waitForTerminalText('[ FAIL 1 | WARN 0 | SKIP 1 | PASS 16 ]', { timeout: 20000 });
+				await app.workbench.terminal.waitForTerminalText(/\[ FAIL \d+ \| WARN \d+ \| SKIP \d+ \| PASS \d+ \]/, { timeout: 20000 });
 				await app.workbench.terminal.waitForTerminalText('Terminal will be reused by tasks', { timeout: 20000 });
 			}).toPass({ timeout: 70000 });
 		});

--- a/test/e2e/utils/strings.ts
+++ b/test/e2e/utils/strings.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Escape regex metacharacters in `value` so it matches as a literal inside a `RegExp`.
+ */
+export function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
This is a little quality of life PR re: e2e tests, motivated by the desire to make the R package development test less brittle.

Before, it was impossible to do anything to the fixture that might change the exact count of test failures/warning/skips/passes. It makes much more sense to just assert the *shape* of this result, not exact numbers.

What I did:

* Gave `waitForTerminalText()` the ability to take a `RegExp` as an alternative to a `string`. Existing callers are undisturbed.
* Created `escapeRegExp()` helper to de-duplicate and standardize the "escape regex metacharacters" move and to make the intent more obvious.