### PR TITLE
e2e: dismiss toasts before clicking Close in posit assistant sign-in

### DIFF
--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -490,6 +490,8 @@ export class Assistant {
 	}
 
 	async clickCloseButton({ abandonChanges = true } = {}) {
+		// Credential-expiry toasts render in the bottom-right and can cover the Close button.
+		await this.toasts.closeAll();
 		await this.code.driver.currentPage.locator(CLOSE_BUTTON).click();
 
 		const abandonModalisVisible = await this.modals.modalTitle.filter({ hasText: 'Authentication Incomplete' }).isVisible();


### PR DESCRIPTION
Fixes a flaky failure in `posit-assistant-signin.test.ts` where a credential-expiry notification toast covers the Close button.

- Credential-expiry toasts (`Credentials for Posit AI are no longer available`) render in the bottom-right corner
- The toast subtree intercepts pointer events on the Close button, causing a 30s timeout
- `clickCloseButton()` now calls `this.toasts.closeAll()` before the click to clear the overlay

### QA Notes

@:posit-assistant @:web @:win