### PR TITLE
Focus console input on click without yanking the viewport when scrolled up

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityPrompt.tsx
@@ -68,10 +68,21 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 	/**
 	 * Focuses the appropriate input element.
 	 */
-	const focusInput = useCallback(() => {
+	const focusInput = useCallback((preventScroll: boolean = false) => {
 		if (isPassword) {
-			passwordInputRef.current?.scrollIntoView({ behavior: 'auto' });
-			passwordInputRef.current?.focus();
+			if (!preventScroll) {
+				passwordInputRef.current?.scrollIntoView({ behavior: 'auto' });
+			}
+			passwordInputRef.current?.focus({ preventScroll });
+		} else if (preventScroll) {
+			// Focus the editor's text area directly so the browser does not scroll it into
+			// view, preserving the user's scroll position (#11772).
+			const textArea = editorRef.current?.getDomNode()?.querySelector('textarea');
+			if (textArea) {
+				textArea.focus({ preventScroll: true });
+			} else {
+				editorRef.current?.focus();
+			}
 		} else {
 			editorContainerRef.current?.scrollIntoView({ behavior: 'auto' });
 			editorRef.current?.focus();
@@ -279,8 +290,8 @@ export const ActivityPrompt = (props: ActivityPromptProps) => {
 	useEffect(() => {
 		const disposableStore = new DisposableStore();
 
-		disposableStore.add(props.positronConsoleInstance.onFocusInput(() => {
-			focusInput();
+		disposableStore.add(props.positronConsoleInstance.onFocusInput((options) => {
+			focusInput(options.preventScroll);
 		}));
 
 		return () => disposableStore.dispose();

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -904,6 +904,17 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 
 		// Set the value change handler.
 		disposableStore.add(codeEditorWidget.onDidChangeModelContent(() => {
+			// When the user types into the focused input while the console is scrolled up to
+			// view history, scroll the input back into view. This keeps clicking from yanking
+			// the viewport (#11772) while still bringing the cursor's context into view as soon
+			// as the user starts typing (#13991).
+			if (props.positronConsoleInstance.scrollLocked && codeEditorWidget.hasTextFocus()) {
+				codeEditorWidgetContainerRef.current?.scrollIntoView({
+					behavior: 'auto',
+					block: 'end'
+				});
+			}
+
 			// If the history browser is up, update the list of history item matches with the
 			// current match strategy.
 			if (historyBrowserActiveRef.current) {
@@ -961,10 +972,22 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 		);
 
 		// Add the onFocusInput event handler.
-		disposableStore.add(props.positronConsoleInstance.onFocusInput(() => {
+		disposableStore.add(props.positronConsoleInstance.onFocusInput((options) => {
 			// Focus the input editor when the Console takes focus, i.e. when the
-			// user clicks somewhere on the console output
-			codeEditorWidget.focus();
+			// user clicks somewhere on the console output.
+			if (options.preventScroll) {
+				// Focus the editor's text area directly so the browser does not scroll it
+				// into view, preserving the user's scroll position (#11772). Typing will
+				// scroll the input back into view via onDidChangeModelContent (#13991).
+				const textArea = codeEditorWidget.getDomNode()?.querySelector('textarea');
+				if (textArea) {
+					textArea.focus({ preventScroll: true });
+				} else {
+					codeEditorWidget.focus();
+				}
+			} else {
+				codeEditorWidget.focus();
+			}
 		}));
 
 		// Add the onDidChangeState event handler.

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -976,12 +976,15 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			// Focus the input editor when the Console takes focus, i.e. when the
 			// user clicks somewhere on the console output.
 			if (options.preventScroll) {
-				// Focus the editor's text area directly so the browser does not scroll it
-				// into view, preserving the user's scroll position (#11772). Typing will
-				// scroll the input back into view via onDidChangeModelContent (#13991).
-				const textArea = codeEditorWidget.getDomNode()?.querySelector('textarea');
-				if (textArea) {
-					textArea.focus({ preventScroll: true });
+				// Focus the editor's editable element directly so the browser does not scroll
+				// it into view, preserving the user's scroll position (#11772). Typing will
+				// scroll the input back into view via onDidChangeModelContent (#13991). The
+				// editable element is a <textarea> or, when the EditContext API is in use (the
+				// Electron default), a .native-edit-context div; both support focus options.
+				const editTarget = codeEditorWidget.getDomNode()
+					?.querySelector<HTMLElement>('textarea, .native-edit-context');
+				if (editTarget) {
+					editTarget.focus({ preventScroll: true });
 				} else {
 					codeEditorWidget.focus();
 				}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -554,7 +554,11 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			// If the click was inside the selection, copy the selection to the clipboard.
 			if (insideSelection) {
 				getActiveWindow().document.execCommand('copy');
-				props.positronConsoleInstance.focusInput();
+				// Don't steal focus when the user has scrolled up to view history.
+				// Focusing the input causes the browser to scroll it into view.
+				if (!props.positronConsoleInstance.scrollLocked) {
+					props.positronConsoleInstance.focusInput();
+				}
 				return;
 			}
 		}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInstance.tsx
@@ -367,11 +367,12 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 	const clickHandler = (e: MouseEvent<HTMLDivElement>) => {
 		const selection = getSelection();
 		if (!selection || selection.type !== 'Range') {
-			// Don't steal focus when the user has scrolled up to view history.
-			// Focusing the input causes the browser to scroll it into view.
-			if (!props.positronConsoleInstance.scrollLocked) {
-				props.positronConsoleInstance.focusInput();
-			}
+			// Move the cursor to the console input. When the user has scrolled up to view
+			// history, focus without scrolling so the viewport stays put (#11772); typing
+			// will scroll the input back into view (#13991).
+			props.positronConsoleInstance.focusInput({
+				preventScroll: props.positronConsoleInstance.scrollLocked
+			});
 		}
 	};
 
@@ -554,11 +555,11 @@ export const ConsoleInstance = (props: ConsoleInstanceProps) => {
 			// If the click was inside the selection, copy the selection to the clipboard.
 			if (insideSelection) {
 				getActiveWindow().document.execCommand('copy');
-				// Don't steal focus when the user has scrolled up to view history.
-				// Focusing the input causes the browser to scroll it into view.
-				if (!props.positronConsoleInstance.scrollLocked) {
-					props.positronConsoleInstance.focusInput();
-				}
+				// Move the cursor to the console input. When the user has scrolled up to
+				// view history, focus without scrolling so the viewport stays put (#11772).
+				props.positronConsoleInstance.focusInput({
+					preventScroll: props.positronConsoleInstance.scrollLocked
+				});
 				return;
 			}
 		}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/runtimeRestartButton.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/runtimeRestartButton.tsx
@@ -35,10 +35,11 @@ export const RuntimeRestartButton = (props: RuntimeRestartButtonProps) => {
 	useEffect(() => {
 		const disposableStore = new DisposableStore();
 
-		disposableStore.add(props.positronConsoleInstance.onFocusInput(() => {
+		disposableStore.add(props.positronConsoleInstance.onFocusInput((options) => {
 			// Focus the button when the Console takes focus, i.e. when the
-			// user clicks somewhere on the console output
-			restartRef.current?.focus();
+			// user clicks somewhere on the console output. Honor preventScroll so
+			// focusing does not yank the viewport when scrolled up (#11772).
+			restartRef.current?.focus({ preventScroll: options.preventScroll });
 		}));
 
 		return () => disposableStore.dispose();

--- a/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/interfaces/positronConsoleService.ts
@@ -229,6 +229,18 @@ export type DidNavigateInputHistoryUpEventArgs = {
 };
 
 /**
+ * Options for focusing the console input.
+ */
+export type FocusInputOptions = {
+	/**
+	 * Whether to focus the input without scrolling it into view. Used when the
+	 * user has scrolled up to view history so that focusing the input does not
+	 * yank the viewport back to the bottom.
+	 */
+	preventScroll?: boolean;
+};
+
+/**
  * IConsoleFindWidget interface. Abstracts the find widget so the service layer
  * can own its lifecycle without depending on the concrete implementation.
  */
@@ -322,7 +334,7 @@ export interface IPositronConsoleInstance {
 	/**
 	 * The onFocusInput event.
 	 */
-	readonly onFocusInput: Event<void>;
+	readonly onFocusInput: Event<FocusInputOptions>;
 
 	/**
 	 * The onDidChangeState event.
@@ -413,8 +425,9 @@ export interface IPositronConsoleInstance {
 
 	/**
 	 * Focuses the input for the console.
+	 * @param options Options controlling how focus is taken.
 	 */
-	focusInput(): void;
+	focusInput(options?: FocusInputOptions): void;
 
 	/**
 	 * Gets the find widget's DOM node for insertion into the console container.

--- a/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/browser/positronConsoleService.ts
@@ -35,7 +35,7 @@ import { RuntimeItemStartupFailure } from './classes/runtimeItemStartupFailure.j
 import { ActivityItem, ActivityItemOutput, RuntimeItemActivity } from './classes/runtimeItemActivity.js';
 import { ActivityItemInput, ActivityItemInputState } from './classes/activityItemInput.js';
 import { ActivityItemStream, ActivityItemStreamType } from './classes/activityItemStream.js';
-import { DidNavigateInputHistoryUpEventArgs, IConsoleFindWidget, IConsoleFindWidgetFactory, IPositronConsoleInstance, IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID, PositronConsoleState, SessionAttachMode } from './interfaces/positronConsoleService.js';
+import { DidNavigateInputHistoryUpEventArgs, FocusInputOptions, IConsoleFindWidget, IConsoleFindWidgetFactory, IPositronConsoleInstance, IPositronConsoleService, POSITRON_CONSOLE_VIEW_ID, PositronConsoleState, SessionAttachMode } from './interfaces/positronConsoleService.js';
 import { ILanguageRuntimeExit, ILanguageRuntimeInfo, ILanguageRuntimeMessage, ILanguageRuntimeMessageOutput, ILanguageRuntimeMessageOutputData, ILanguageRuntimeMessageUpdateOutput, ILanguageRuntimeMetadata, LanguageRuntimeSessionMode, RuntimeCodeExecutionMode, RuntimeCodeFragmentStatus, RuntimeErrorBehavior, RuntimeExitReason, RuntimeOnlineState, RuntimeOutputKind, RuntimeState, formatLanguageRuntimeMetadata, formatLanguageRuntimeSession } from '../../languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService, RuntimeStartMode } from '../../runtimeSession/common/runtimeSessionService.js';
 import { UiFrontendEvent } from '../../languageRuntime/common/positronUiComm.js';
@@ -1177,7 +1177,7 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	/**
 	 * The _onFocusInput event emitter.
 	 */
-	private readonly _onFocusInputEmitter = this._register(new Emitter<void>);
+	private readonly _onFocusInputEmitter = this._register(new Emitter<FocusInputOptions>);
 
 	/**
 	 * The find widget for this console instance.
@@ -1618,8 +1618,8 @@ class PositronConsoleInstance extends Disposable implements IPositronConsoleInst
 	/**
 	 * Focuses the input for the console.
 	 */
-	focusInput() {
-		this._onFocusInputEmitter.fire();
+	focusInput(options: FocusInputOptions = {}) {
+		this._onFocusInputEmitter.fire(options);
 	}
 
 	requestFind() {

--- a/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
+++ b/src/vs/workbench/services/positronConsole/test/browser/testPositronConsoleService.ts
@@ -5,7 +5,7 @@
 
 import { Emitter, Event } from '../../../../../base/common/event.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
-import { DidNavigateInputHistoryUpEventArgs, IConsoleFindWidget, IPositronConsoleInstance, IPositronConsoleService, PositronConsoleState, SessionAttachMode } from '../../browser/interfaces/positronConsoleService.js';
+import { DidNavigateInputHistoryUpEventArgs, FocusInputOptions, IConsoleFindWidget, IPositronConsoleInstance, IPositronConsoleService, PositronConsoleState, SessionAttachMode } from '../../browser/interfaces/positronConsoleService.js';
 import { RuntimeItem } from '../../browser/classes/runtimeItem.js';
 import { ILanguageRuntimeMetadata, RuntimeCodeExecutionMode, RuntimeErrorBehavior } from '../../../languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata } from '../../../runtimeSession/common/runtimeSessionService.js';
@@ -294,7 +294,7 @@ export class TestPositronConsoleService implements IPositronConsoleService {
  * Test implementation of IPositronConsoleInstance for use in tests.
  */
 export class TestPositronConsoleInstance implements IPositronConsoleInstance {
-	private readonly _onFocusInputEmitter = new Emitter<void>();
+	private readonly _onFocusInputEmitter = new Emitter<FocusInputOptions>();
 	private readonly _onDidChangeStateEmitter = new Emitter<PositronConsoleState>();
 	private readonly _onDidChangeWordWrapEmitter = new Emitter<boolean>();
 	private readonly _onDidChangeTraceEmitter = new Emitter<boolean>();
@@ -333,7 +333,7 @@ export class TestPositronConsoleInstance implements IPositronConsoleInstance {
 		public readonly codeEditor: ICodeEditor | undefined = undefined
 	) { }
 
-	get onFocusInput(): Event<void> {
+	get onFocusInput(): Event<FocusInputOptions> {
 		return this._onFocusInputEmitter.event;
 	}
 
@@ -455,8 +455,8 @@ export class TestPositronConsoleInstance implements IPositronConsoleInstance {
 		this._runtimeAttached = runtimeAttached;
 	}
 
-	focusInput(): void {
-		this._onFocusInputEmitter.fire();
+	focusInput(options: FocusInputOptions = {}): void {
+		this._onFocusInputEmitter.fire(options);
 	}
 
 	layoutFindWidget(_width: number): void {

--- a/test/e2e/tests/console/console-input.test.ts
+++ b/test/e2e/tests/console/console-input.test.ts
@@ -66,6 +66,83 @@ cat(sprintf('Hello %s!\n', val))`;
 		await app.workbench.console.waitForConsoleContents('[1] 1');
 	});
 
+	test('Python - Clicking output while scrolled up focuses input without yanking the viewport', async function ({ app, page, python }) {
+		// Regression test for https://github.com/posit-dev/positron/issues/11772 and
+		// https://github.com/posit-dev/positron/issues/13991: clicking the console while
+		// scrolled up should focus the input without scrolling the viewport to the bottom,
+		// and typing should then scroll the input back into view.
+		const { console } = app.workbench;
+		const activeConsole = console.activeConsole;
+		const editContext = activeConsole.locator('.console-input .native-edit-context');
+
+		await test.step('Generate enough output to make the console scrollable', async () => {
+			await console.clearInput();
+			await console.pasteCodeToConsole('for i in range(200): print(f"scrollA {i}")', true);
+			await console.waitForConsoleContents('scrollA 199');
+		});
+
+		const scrollTopBefore = await test.step('Scroll up to view history', async () => {
+			// Use the mouse wheel to scroll up, which engages scroll lock immediately.
+			const box = await activeConsole.boundingBox();
+			await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+			await page.mouse.wheel(0, -10000);
+			await expect.poll(() => activeConsole.evaluate(el => el.scrollTop)).toBeLessThan(5);
+			return activeConsole.evaluate(el => el.scrollTop);
+		});
+
+		await test.step('Click the output and verify the input is focused without scrolling', async () => {
+			await activeConsole.click({ position: { x: 10, y: 10 } });
+			await expect(editContext).toBeFocused();
+			// The viewport must not have jumped to the bottom (#11772).
+			await expect.poll(() => activeConsole.evaluate(el => el.scrollTop)).toBeLessThanOrEqual(scrollTopBefore + 2);
+		});
+
+		await test.step('Type and verify the input scrolls back into view', async () => {
+			await page.keyboard.type('1 + 1');
+			await expect.poll(() => activeConsole.evaluate(
+				el => el.scrollHeight - el.clientHeight - el.scrollTop
+			)).toBeLessThan(5);
+		});
+	});
+
+	test('Python - Clicking back into a scrolled-up console refocuses the input and buffers typing', async function ({ app, page, python }) {
+		// Regression test for the prior "skip focus when scrolled up" approach, which left the
+		// input unfocused when clicking a scrolled-up console (#11772). Clicking back in should
+		// refocus the input without yanking the viewport, and typing should buffer correctly.
+		const { console } = app.workbench;
+		const activeConsole = console.activeConsole;
+		const editContext = activeConsole.locator('.console-input .native-edit-context');
+		const consoleInput = activeConsole.locator('.console-input');
+
+		await test.step('Generate output and scroll up to view history', async () => {
+			await console.clearInput();
+			await console.pasteCodeToConsole('for i in range(200): print(f"scrollB {i}")', true);
+			await console.waitForConsoleContents('scrollB 199');
+			const box = await activeConsole.boundingBox();
+			await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+			await page.mouse.wheel(0, -10000);
+			await expect.poll(() => activeConsole.evaluate(el => el.scrollTop)).toBeLessThan(5);
+		});
+
+		await test.step('Move focus out of the console input', async () => {
+			await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+			await expect(editContext).not.toBeFocused();
+		});
+
+		const scrollTopBefore = await activeConsole.evaluate(el => el.scrollTop);
+
+		await test.step('Click back into the console and verify the input refocuses without scrolling', async () => {
+			await activeConsole.click({ position: { x: 10, y: 10 } });
+			await expect(editContext).toBeFocused();
+			await expect.poll(() => activeConsole.evaluate(el => el.scrollTop)).toBeLessThanOrEqual(scrollTopBefore + 2);
+		});
+
+		await test.step('Verify typing buffers correctly', async () => {
+			await page.keyboard.type('x = 42');
+			await expect(consoleInput).toContainText('x = 42');
+		});
+	});
+
 	test("R - Verify ESC dismisses autocomplete without deleting typed text", {
 		tag: [tags.ARK]
 	}, async function ({ app, page, r }) {


### PR DESCRIPTION
Addresses #11772 and #13991.

Clicking the console now always focuses the input, so the cursor moves to the console regardless of scroll position (#13991). When the user has scrolled up to view history, focus is taken without scrolling the input into view, so the viewport stays put (#11772); typing then scrolls the input back into view.

This decouples *focus* from *scroll*, which previously moved together: #13991 wanted clicking to move focus to the input, while #11772 didn't want the viewport yanked to the bottom. A `preventScroll` option is plumbed through `focusInput` / `onFocusInput`. For the Monaco editor, `preventScroll` focuses the underlying text area directly with `{ preventScroll: true }`, since `CodeEditorWidget.focus()` has no such option.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Clicking the console now moves the cursor to the input even when the last line is not visible (#13991)
- Clicking the console after selecting output no longer jumps the viewport to the cursor (#11772)

### QA Notes

@:console

While the console is scrolled up to show history:

1. Click in the console output -> cursor moves to the input, viewport does **not** jump (#11772).
2. Click out of the console, then click back in -> input refocuses, viewport stays put, typing buffers correctly.
3. Start typing -> input scrolls back into view and shows the typed text (#13991).
4. Repeat with an active prompt (R `readline()` / Python `input()`) and in the runtime-exited (restart button) state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)