### PR TITLE
Updates to data explorer connection PR

### DIFF
--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -542,6 +542,10 @@ const excludedExtensions = [
 	// --- Start Positron ---
 	'positron-zed',
 	'positron-javascript',
+	// Build-time-only package: generated Data Explorer protocol types/enums that
+	// the data driver extensions bundle via esbuild. It is not an extension and
+	// must not be packaged or activated at runtime.
+	'positron-data-explorer-protocol',
 	// --- End Positron ---
 ];
 

--- a/extensions/positron-data-driver-duckdb/package-lock.json
+++ b/extensions/positron-data-driver-duckdb/package-lock.json
@@ -8,8 +8,7 @@
       "name": "positron-data-driver-duckdb",
       "version": "0.0.1",
       "dependencies": {
-        "@duckdb/node-api": "^1.5.3-r.3",
-        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol"
+        "@duckdb/node-api": "^1.5.3-r.3"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.0",
@@ -20,6 +19,7 @@
         "@vscode/vsce": "^3.3.2",
         "eslint": "^8.9.0",
         "mocha": "^9.2.1",
+        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
         "ts-node": "^10.9.1",
         "typescript": "^4.5.5"
       },
@@ -28,7 +28,11 @@
       }
     },
     "../positron-data-explorer-protocol": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true,
+      "engines": {
+        "vscode": "^1.65.0"
+      }
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.2",

--- a/extensions/positron-data-driver-duckdb/package.json
+++ b/extensions/positron-data-driver-duckdb/package.json
@@ -9,7 +9,7 @@
     "vscode": "^1.65.0"
   },
   "activationEvents": [
-    "onStartupFinished"
+    "onView:workbench.panel.positronDataConnections"
   ],
   "main": "./out/extension.js",
   "scripts": {

--- a/extensions/positron-data-driver-duckdb/package.json
+++ b/extensions/positron-data-driver-duckdb/package.json
@@ -19,11 +19,11 @@
   },
   "contributes": {},
   "dependencies": {
-    "@duckdb/node-api": "^1.5.3-r.3",
-    "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol"
+    "@duckdb/node-api": "^1.5.3-r.3"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.0",
+    "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
     "@types/node": "14.x",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",

--- a/extensions/positron-data-driver-postgresql/package-lock.json
+++ b/extensions/positron-data-driver-postgresql/package-lock.json
@@ -8,8 +8,7 @@
       "name": "positron-data-driver-postgresql",
       "version": "0.0.1",
       "dependencies": {
-        "pg": "^8.20.0",
-        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol"
+        "pg": "^8.20.0"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.0",
@@ -21,6 +20,7 @@
         "@vscode/vsce": "^3.3.2",
         "eslint": "^8.9.0",
         "mocha": "^9.2.1",
+        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
         "ts-node": "^10.9.1",
         "typescript": "^4.5.5"
       },
@@ -29,7 +29,11 @@
       }
     },
     "../positron-data-explorer-protocol": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true,
+      "engines": {
+        "vscode": "^1.65.0"
+      }
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.2",

--- a/extensions/positron-data-driver-postgresql/package.json
+++ b/extensions/positron-data-driver-postgresql/package.json
@@ -9,7 +9,7 @@
     "vscode": "^1.65.0"
   },
   "activationEvents": [
-    "onStartupFinished"
+    "onView:workbench.panel.positronDataConnections"
   ],
   "main": "./out/extension.js",
   "scripts": {

--- a/extensions/positron-data-driver-postgresql/package.json
+++ b/extensions/positron-data-driver-postgresql/package.json
@@ -19,11 +19,11 @@
   },
   "contributes": {},
   "dependencies": {
-    "pg": "^8.20.0",
-    "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol"
+    "pg": "^8.20.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.0",
+    "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
     "@types/node": "14.x",
     "@types/pg": "^8.20.0",
     "@typescript-eslint/eslint-plugin": "^5.12.1",

--- a/extensions/positron-data-driver-sqlite/package-lock.json
+++ b/extensions/positron-data-driver-sqlite/package-lock.json
@@ -8,8 +8,7 @@
       "name": "positron-data-driver-sqlite",
       "version": "0.0.1",
       "dependencies": {
-        "better-sqlite3": "^12.8.0",
-        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol"
+        "better-sqlite3": "^12.8.0"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.0",
@@ -21,6 +20,7 @@
         "@vscode/vsce": "^3.3.2",
         "eslint": "^8.9.0",
         "mocha": "^9.2.1",
+        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
         "ts-node": "^10.9.1",
         "typescript": "^4.5.5"
       },
@@ -29,7 +29,11 @@
       }
     },
     "../positron-data-explorer-protocol": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true,
+      "engines": {
+        "vscode": "^1.65.0"
+      }
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.2",

--- a/extensions/positron-data-driver-sqlite/package.json
+++ b/extensions/positron-data-driver-sqlite/package.json
@@ -9,7 +9,7 @@
     "vscode": "^1.65.0"
   },
   "activationEvents": [
-    "onStartupFinished"
+    "onView:workbench.panel.positronDataConnections"
   ],
   "main": "./out/extension.js",
   "scripts": {

--- a/extensions/positron-data-driver-sqlite/package.json
+++ b/extensions/positron-data-driver-sqlite/package.json
@@ -19,11 +19,11 @@
   },
   "contributes": {},
   "dependencies": {
-    "better-sqlite3": "^12.8.0",
-    "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol"
+    "better-sqlite3": "^12.8.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
+    "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
     "@types/mocha": "^9.1.0",
     "@types/node": "14.x",
     "@typescript-eslint/eslint-plugin": "^5.12.1",

--- a/extensions/positron-duckdb/package-lock.json
+++ b/extensions/positron-duckdb/package-lock.json
@@ -8,8 +8,7 @@
       "name": "positron-duckdb",
       "version": "0.0.1",
       "dependencies": {
-        "@duckdb/node-api": "1.5.3-r.3",
-        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol"
+        "@duckdb/node-api": "1.5.3-r.3"
       },
       "devDependencies": {
         "@types/glob": "^7.2.0",
@@ -22,6 +21,7 @@
         "eslint": "^8.9.0",
         "glob": "^7.2.0",
         "mocha": "^9.2.1",
+        "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol",
         "ts-node": "^10.9.1",
         "typescript": "^4.5.5"
       },
@@ -30,7 +30,8 @@
       }
     },
     "../positron-data-explorer-protocol": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",

--- a/extensions/positron-duckdb/package.json
+++ b/extensions/positron-duckdb/package.json
@@ -30,11 +30,11 @@
     "mocha": "^9.2.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.5.5",
-    "@vscode/vsce": "^3.3.2"
+    "@vscode/vsce": "^3.3.2",
+    "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol"
   },
   "dependencies": {
-    "@duckdb/node-api": "1.5.3-r.3",
-    "positron-data-explorer-protocol": "file:../positron-data-explorer-protocol"
+    "@duckdb/node-api": "1.5.3-r.3"
   },
   "repository": {
     "type": "git",

--- a/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnectionsView.tsx
+++ b/src/vs/workbench/contrib/positronDataConnections/browser/positronDataConnectionsView.tsx
@@ -21,6 +21,7 @@ import { IKeybindingService } from '../../../../platform/keybinding/common/keybi
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IReactComponentContainer, ISize, PositronReactRenderer } from '../../../../base/browser/positronReactRenderer.js';
 
 /**
@@ -85,6 +86,7 @@ export class PositronDataViewPane extends PositronViewPane implements IReactComp
 		@IOpenerService openerService: IOpenerService,
 		@IThemeService themeService: IThemeService,
 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
+		@IExtensionService private readonly _extensionService: IExtensionService,
 	) {
 		super(
 			options,
@@ -104,6 +106,13 @@ export class PositronDataViewPane extends PositronViewPane implements IReactComp
 				this._onSaveScrollPositionEmitter.fire();
 			} else {
 				this._onRestoreScrollPositionEmitter.fire();
+
+				// Activate extensions that register data connection drivers. Driver-providing
+				// extensions declare an `onView:<this view id>` activation event so they only load
+				// when the user actually opens this view. Unlike upstream tree/webview view panes,
+				// Positron's custom React pane has to fire this activation itself. The call is
+				// cached by the extension service, so re-firing on every visibility change is cheap.
+				this._extensionService.activateByEvent(`onView:${this.id}`);
 			}
 			this._onVisibilityChangedEmitter.fire(visible);
 		}));

--- a/src/vs/workbench/services/positronDataConnections/browser/dataConnectionsDriverManager.ts
+++ b/src/vs/workbench/services/positronDataConnections/browser/dataConnectionsDriverManager.ts
@@ -5,18 +5,21 @@
 
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
-import { onUnexpectedError } from '../../../../base/common/errors.js';
 import { IDataConnectionDriver } from '../common/interfaces/dataConnectionDriver.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IDataConnectionsDriverManager } from '../common/interfaces/dataConnectionsDriverManager.js';
 
 /**
+ * Activation event fired when the Data Connections view is shown. Driver-providing extensions
+ * declare this event so they only activate when the user actually opens the view, rather than
+ * eagerly on startup. Must match the view id registered in positronDataConnections.contribution.ts.
+ */
+const DATA_CONNECTIONS_VIEW_ACTIVATION_EVENT = 'onView:workbench.panel.positronDataConnections';
+
+/**
  * DataConnectionsDriverManager class.
  */
 export class DataConnectionsDriverManager extends Disposable implements IDataConnectionsDriverManager {
-	// A value which indicates whether the drivers are loaded.
-	private _driversLoaded = false;
-
 	// The registered data connection drivers.
 	private readonly _drivers: IDataConnectionDriver[] = [];
 
@@ -27,24 +30,15 @@ export class DataConnectionsDriverManager extends Disposable implements IDataCon
 	readonly onDidChangeDrivers: Event<IDataConnectionDriver[]> = this._onDidChangeDrivers.event;
 
 	/**
-	 * Constructor. Subscribes to onStartupFinished activation so callers can tell "still loading"
-	 * from "extension is genuinely absent" when looking up a driver.
+	 * Constructor. This manager is constructed eagerly at startup (via mainThreadDataConnections and
+	 * PositronReactServices), so it deliberately does not trigger driver activation here: doing so
+	 * would force the driver extensions to load on every session even though the Data Connections
+	 * feature is off by default and most sessions never use it. Driver extensions instead activate
+	 * lazily on the view activation event (see driversLoaded).
 	 */
-	constructor(extensionService: IExtensionService) {
+	constructor(private readonly _extensionService: IExtensionService) {
 		// Call the base class constructor.
 		super();
-
-		// Subscribe to the onStartupFinished activation event. Once it resolves, any extensions
-		// registered against it have had a chance to register their drivers, so a missing driver
-		// can be reported as "genuinely absent" rather than "still loading." If activation fails,
-		// flip the flag anyway so the UI doesn't hang in "still loading" forever.
-		extensionService.activateByEvent('onStartupFinished').then(
-			() => { this._driversLoaded = true; },
-			err => {
-				this._driversLoaded = true;
-				onUnexpectedError(err);
-			}
-		);
 	}
 
 	/**
@@ -85,10 +79,15 @@ export class DataConnectionsDriverManager extends Disposable implements IDataCon
 	/**
 	 * Gets a value indicating whether the drivers have finished loading. Callers can use this to determine
 	 * whether an absent driver is still loading or genuinely not present.
+	 *
+	 * This passively observes whether the view activation event has resolved (i.e. the driver
+	 * extensions registered against it have had a chance to register their drivers) without
+	 * triggering activation itself. The Data Connections view triggers the activation when it is
+	 * shown, so by the time a user can look up a driver from the view the event has resolved.
 	 * @returns true if the drivers have finished loading; otherwise, false.
 	 */
 	get driversLoaded(): boolean {
-		return this._driversLoaded;
+		return this._extensionService.activationEventIsDone(DATA_CONNECTIONS_VIEW_ACTIVATION_EVENT);
 	}
 
 	/**


### PR DESCRIPTION
A few minor tweaks:

- make the protocol "extension" a dev dependency so it doesn't generate bundle errors in release builds
- lazy activation of new extensions
