### PR TITLE
Add "Positron (with Assistant)" launch config for dev builds of Posit Assistant

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -330,6 +330,51 @@
 			},
 		},
 		{
+			// Loads a dev copy of Posit Assistant from a sibling assistant checkout.
+			"type": "chrome",
+			"request": "launch",
+			"name": "Launch Positron Internal (with Assistant)",
+			"windows": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/code.bat"
+			},
+			"osx": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/code.sh"
+			},
+			"linux": {
+				"runtimeExecutable": "${workspaceFolder}/scripts/code.sh"
+			},
+			"port": 9222,
+			"timeout": 0,
+			"env": {
+				"VSCODE_EXTHOST_WILL_SEND_SOCKET": null,
+				"VSCODE_SKIP_PRELAUNCH": "1",
+				"VSCODE_DEV_DEBUG_OBSERVABLES": "1",
+			},
+			"cleanUp": "wholeBrowser",
+			"killBehavior": "polite",
+			"runtimeArgs": [
+				"--inspect-brk=5875",
+				"--no-cached-data",
+				"--crash-reporter-directory=${workspaceFolder}/.profile-oss/crashes",
+				"--disable-features=CalculateNativeWinOcclusion",
+				"--disable-extension=vscode.vscode-api-tests",
+				"--extensionDevelopmentPath=${workspaceFolder}/../assistant/packages/positron"
+			],
+			"userDataDir": "${userHome}/.vscode-oss-dev",
+			"webRoot": "${workspaceFolder}",
+			"cascadeTerminateToConfigurations": [
+				"Attach to Extension Host"
+			],
+			"pauseForSourceMap": false,
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"browserLaunchLocation": "workspace",
+			"presentation": {
+				"hidden": true,
+			},
+		},
+		{
 			"type": "chrome",
 			"request": "launch",
 			"name": "Launch VS Code Agents Internal",
@@ -789,6 +834,22 @@
 				"Attach to Agent Host Process"
 			],
 			"preLaunchTask": "Ensure Prelaunch Dependencies",
+			"presentation": {
+				"group": "0_vscode",
+				"order": 1
+			}
+		},
+		{
+			"name": "Positron (with Assistant)",
+			"stopAll": true,
+			"configurations": [
+				"Launch Positron Internal (with Assistant)",
+				"Attach to Main Process",
+				"Attach to Extension Host",
+				"Attach to Shared Process",
+				"Attach to Agent Host Process"
+			],
+			"preLaunchTask": "Ensure Prelaunch Dependencies (with Assistant)",
 			"presentation": {
 				"group": "0_vscode",
 				"order": 1

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -576,6 +576,34 @@
 				"Write-Output \"134 passed, 0 failed, 1 skipped, 135 total\"; Start-Sleep -Seconds 2; Write-Output \"[PASS] E2E Tests\"; Write-Output \"Watching for changes...\""
 			],
 			"isBackground": false
+		},
+		{
+			// One-shot build of the sibling Posit Assistant checkout so its dist/
+			// is current before "Positron (with Assistant)" launches. Terminating
+			// (not a watcher): run `npm run watch:positron` separately for live
+			// rebuilds during the session.
+			"label": "Build Posit Assistant",
+			"type": "shell",
+			"command": "npm run build:positron",
+			"options": {
+				"cwd": "${workspaceFolder}/../assistant"
+			},
+			"presentation": {
+				"reveal": "silent",
+				"close": true
+			},
+			"problemMatcher": []
+		},
+		{
+			// Prelaunch for "Positron (with Assistant)": run Positron's own
+			// dependency prep, then build the assistant. Both terminate before
+			// Positron launches.
+			"label": "Ensure Prelaunch Dependencies (with Assistant)",
+			"dependsOn": [
+				"Ensure Prelaunch Dependencies",
+				"Build Posit Assistant"
+			],
+			"dependsOrder": "sequence"
 		}
 	]
 }


### PR DESCRIPTION
### Summary

Adds a "Positron (with Assistant)" debug launch config for working against a dev build of the Posit Assistant extension. The play button builds the `assistant` checkout, then launches Positron with that build loaded via `--extensionDevelopmentPath`.

The config assumes the assistant repo is cloned alongside the Positron checkout in the same parent directory (`../assistant`). A prelaunch task builds it before launch.
