### PR TITLE
Fix runtime cache missing R versions installed with rig

### DIFF
--- a/extensions/positron-r/src/provider.ts
+++ b/extensions/positron-r/src/provider.ts
@@ -93,10 +93,58 @@ const R_AD_HOC_BINARIES: readonly string[] = [
  * resolved (symlinks followed) before being reported; `mtimeMs` is 0 when
  * `exists` is false.
  */
-interface RRootEntry {
+export interface RRootEntry {
 	path: string;
 	exists: boolean;
 	mtimeMs: number;
+}
+
+/**
+ * Stat each candidate root, follow symlinks, and dedupe by resolved path into
+ * an ordered list of signature entries. Extracted as a pure function (it only
+ * touches `fs`, no settings or platform globals) so it can be tested against a
+ * real temporary directory with real symlinks, rather than mocking `fs`.
+ *
+ * A non-existent candidate still contributes an entry (with `exists: false`):
+ * if it later starts existing, that flips `exists` to true and the signature
+ * changes, triggering discovery. Following symlinks before recording the
+ * resolved path means distinct candidates pointing at the same physical
+ * location (e.g. an `/opt/R/current` symlink and the version dir it targets)
+ * collapse to one entry, and -- crucially for rig -- a repointed
+ * `current`/`Current` symlink changes the recorded resolved path, flipping the
+ * signature even when the parent directory's mtime did not move.
+ *
+ * @param candidates Ordered candidate root paths; order is preserved in the
+ *   output (it is part of the signature).
+ * @returns One entry per unique resolved path, in first-seen order.
+ */
+export function computeRootSignatureEntries(candidates: readonly string[]): RRootEntry[] {
+	const seen = new Set<string>();
+	const entries: RRootEntry[] = [];
+	for (const candidate of candidates) {
+		let resolved = candidate;
+		let exists = false;
+		let mtimeMs = 0;
+		try {
+			const st = fs.statSync(candidate);
+			try {
+				resolved = fs.realpathSync(candidate);
+			} catch {
+				resolved = candidate;
+			}
+			exists = true;
+			mtimeMs = st.mtimeMs;
+		} catch {
+			// ENOENT (or any other stat failure): treat as non-existent.
+			resolved = candidate;
+		}
+		if (seen.has(resolved)) {
+			continue;
+		}
+		seen.add(resolved);
+		entries.push({ path: resolved, exists, mtimeMs });
+	}
+	return entries;
 }
 
 /**
@@ -107,6 +155,12 @@ interface RRootEntry {
  *
  * Sources covered:
  *   - System headquarters (`rHeadquarters()`).
+ *   - The `current`/`Current` default-version symlink inside each
+ *     headquarters directory (see `rCurrentSymlinks()`), resolved to its
+ *     target version directory. This makes a `rig default <ver>` switch -- a
+ *     symlink repoint that may not move a headquarters mtime the signature
+ *     already captured -- flip the signature and trigger a clean
+ *     re-discovery, instead of relying on the per-binary fingerprint path.
  *   - User-specified `positron.r.customRootFolders`.
  *   - User-specified `positron.r.customBinaries`.
  *   - User-specified `positron.r.interpreters.override`.
@@ -135,7 +189,9 @@ export async function getRDiscoveryRootSignature(): Promise<positron.RuntimeRoot
 		}
 	};
 	addAll(rHeadquarters());
+	addAll(rCurrentSymlinks(rHeadquarters()));
 	addAll(userRHeadquarters());
+	addAll(rCurrentSymlinks(userRHeadquarters()));
 	addAll(userRBinaries());
 	addAll(getInterpreterOverridePaths());
 	if (process.platform !== 'win32') {
@@ -143,42 +199,7 @@ export async function getRDiscoveryRootSignature(): Promise<positron.RuntimeRoot
 	}
 	addAll(R_AD_HOC_BINARIES);
 
-	// Dedupe by resolved path -- two different settings may both point at the
-	// same on-disk location (e.g. /opt/local/bin and a symlink to it). We keep
-	// the first occurrence's input path as the entry path, so the signature
-	// remains stable regardless of which alias the user wrote first.
-	const seen = new Set<string>();
-	const entries: RRootEntry[] = [];
-	for (const candidate of candidates) {
-		let resolved = candidate;
-		let exists = false;
-		let mtimeMs = 0;
-		try {
-			const st = fs.statSync(candidate);
-			// Follow symlinks before recording the resolved path so that
-			// distinct settings pointing at the same physical directory
-			// collapse to one entry.
-			try {
-				resolved = fs.realpathSync(candidate);
-			} catch {
-				resolved = candidate;
-			}
-			exists = true;
-			mtimeMs = st.mtimeMs;
-		} catch {
-			// ENOENT (or any other stat failure): treat as non-existent. The
-			// path still contributes to the signature -- if it later starts
-			// existing, that flips `exists` to true and triggers discovery.
-			resolved = candidate;
-		}
-		if (seen.has(resolved)) {
-			continue;
-		}
-		seen.add(resolved);
-		entries.push({ path: resolved, exists, mtimeMs });
-	}
-
-	return { entries, opaque: getRFilterSettingsDigest() };
+	return { entries: computeRootSignatureEntries(candidates), opaque: getRFilterSettingsDigest() };
 }
 
 /**
@@ -1148,6 +1169,31 @@ function rHeadquarters(): string[] {
 		default:
 			throw new Error(`Unsupported platform: ${process.platform}`);
 	}
+}
+
+/**
+ * The `current`/`Current` default-version symlink that rig (and the macOS R
+ * framework) keep inside each headquarters directory to mark the default R
+ * version. Returned so the discovery-root signature can resolve and record the
+ * symlink's target: a `rig default <ver>` switch repoints this symlink, which
+ * changes the resolved target path and therefore flips the signature, forcing
+ * a clean re-discovery rather than depending on the per-binary fingerprint and
+ * revalidation path (which re-resolves `current: true` entries and can leave
+ * the cache holding a stale or wrong default).
+ *
+ * Windows is excluded: rig has no `current` symlink there (the default comes
+ * from the registry, which discovery probes directly).
+ *
+ * @param hqDirs Headquarters directories to look in.
+ * @returns The candidate `current`/`Current` symlink paths, one per directory.
+ */
+export function rCurrentSymlinks(hqDirs: readonly string[]): string[] {
+	if (process.platform === 'win32') {
+		return [];
+	}
+	// macOS uses 'Current' (uppercase 'C'); Linux uses 'current' (lowercase).
+	const name = process.platform === 'darwin' ? 'Current' : 'current';
+	return hqDirs.map(dir => path.join(dir, name));
 }
 
 function firstExisting(base: string, fragments: string[]): string {

--- a/extensions/positron-r/src/test/rootSignature.test.ts
+++ b/extensions/positron-r/src/test/rootSignature.test.ts
@@ -1,0 +1,102 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import './mocha-setup';
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { computeRootSignatureEntries, rCurrentSymlinks } from '../provider';
+
+/**
+ * Set `process.platform` for the duration of a callback and restore it after.
+ * `process.platform` is read at call time by `rCurrentSymlinks()`, so PR CI
+ * (R discovery runs Linux-only) can't exercise the darwin / win32 branches
+ * without this -- we assert all three explicitly.
+ */
+function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
+	const original = Object.getOwnPropertyDescriptor(process, 'platform')!;
+	Object.defineProperty(process, 'platform', { value: platform });
+	try {
+		fn();
+	} finally {
+		Object.defineProperty(process, 'platform', original);
+	}
+}
+
+suite('R discovery-root signature', () => {
+
+	suite('rCurrentSymlinks', () => {
+		test('returns the platform-appropriate default-version symlink, or none on Windows', () => {
+			const hq = ['/opt/R'];
+			withPlatform('linux', () => assert.deepStrictEqual(rCurrentSymlinks(hq), ['/opt/R/current']));
+			// macOS uses uppercase 'Current'.
+			withPlatform('darwin', () => assert.deepStrictEqual(rCurrentSymlinks(hq), ['/opt/R/Current']));
+			// Windows has no `current` symlink (default comes from the registry).
+			withPlatform('win32', () => assert.deepStrictEqual(rCurrentSymlinks(hq), []));
+		});
+
+		test('maps each headquarters directory', () => {
+			withPlatform('linux', () => assert.deepStrictEqual(
+				rCurrentSymlinks(['/opt/R', '/custom/R']),
+				['/opt/R/current', '/custom/R/current'],
+			));
+		});
+	});
+
+	// Exercises the signature against a real temporary headquarters directory
+	// with real version subdirectories and a real `current` symlink. No `fs`
+	// mocking (stubbing the `fs` module is unreliable in the extension host --
+	// it's why the sibling discovery suite is skipped); the symlink repoint is
+	// performed for real.
+	suite('computeRootSignatureEntries (rig current symlink)', () => {
+		let hq: string;
+		// The helper records realpath'd paths; on macOS os.tmpdir() lives under
+		// /var, which realpath resolves to /private/var. Build expectations from
+		// the realpath'd headquarters so the assertions are platform-stable.
+		let realHq: string;
+
+		setup(() => {
+			hq = fs.mkdtempSync(path.join(os.tmpdir(), 'r-hq-'));
+			realHq = fs.realpathSync(hq);
+			fs.mkdirSync(path.join(hq, '4.5.2'));
+			fs.mkdirSync(path.join(hq, '4.6.0'));
+			fs.symlinkSync(path.join(hq, '4.5.2'), path.join(hq, 'current'));
+		});
+
+		teardown(() => {
+			fs.rmSync(hq, { recursive: true, force: true });
+		});
+
+		test('records the resolved current-symlink target, and repointing it flips the signature', () => {
+			const candidates = [hq, path.join(hq, 'current')];
+
+			// current -> 4.5.2
+			const before = computeRootSignatureEntries(candidates);
+			assert.deepStrictEqual(before.map(e => e.path), [realHq, path.join(realHq, '4.5.2')]);
+			assert.ok(before.every(e => e.exists), 'all entries should resolve to existing paths');
+
+			// rig default 4.6.0: repoint the symlink for real.
+			fs.unlinkSync(path.join(hq, 'current'));
+			fs.symlinkSync(path.join(hq, '4.6.0'), path.join(hq, 'current'));
+
+			const after = computeRootSignatureEntries(candidates);
+			// The current-symlink entry now resolves to 4.6.0 -- the signature
+			// changed, so a warm start would trigger a clean re-discovery.
+			assert.deepStrictEqual(after.map(e => e.path), [realHq, path.join(realHq, '4.6.0')]);
+		});
+
+		test('a missing current symlink still contributes a (non-existent) entry', () => {
+			fs.unlinkSync(path.join(hq, 'current'));
+			const entries = computeRootSignatureEntries([hq, path.join(hq, 'current')]);
+			// A non-existent candidate isn't realpath'd, so it keeps its raw path.
+			assert.deepStrictEqual(entries, [
+				{ path: realHq, exists: true, mtimeMs: fs.statSync(hq).mtimeMs },
+				{ path: path.join(hq, 'current'), exists: false, mtimeMs: 0 },
+			]);
+		});
+	});
+});

--- a/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
+++ b/src/vs/workbench/services/runtimeStartup/common/runtimeStartup.ts
@@ -1507,6 +1507,16 @@ export class RuntimeStartupService extends Disposable implements IRuntimeStartup
 					`with ${formatLanguageRuntimeMetadata(validated)}`);
 				this._languageRuntimeService.registerRuntime(validated);
 			}
+			// If the validator redirected the runtime to a different binary --
+			// e.g. R's validateMetadata re-resolves a `current: true` entry to
+			// wherever the rig `current`/`Current` symlink points right now --
+			// the cache is keyed by `runtimePath`, so an `upsert` of the new
+			// path would leave the original entry behind. Evict the old key so
+			// the cache can't accumulate stale or duplicate "current" entries
+			// across sessions.
+			if (validated.runtimePath !== task.metadata.runtimePath) {
+				this._discoveryCache.invalidate(task.extensionId, task.languageId, task.metadata.runtimePath);
+			}
 			// Refresh the cache entry with the (possibly-updated) metadata
 			// and the fresh fingerprint we already captured.
 			await this._discoveryCache.upsert(validated);

--- a/src/vs/workbench/services/runtimeStartup/test/common/runtimeStartup.vitest.ts
+++ b/src/vs/workbench/services/runtimeStartup/test/common/runtimeStartup.vitest.ts
@@ -93,6 +93,26 @@ function createTestCache(): ITestDiscoveryCache {
 				buckets.set(bucketKey(extId, langId), { ...bucket, entries: filtered });
 			}
 		},
+		upsert: async (md: ILanguageRuntimeMetadata) => {
+			const key = bucketKey(md.extensionId.value, md.languageId);
+			const bucket = buckets.get(key);
+			const entry: ICachedRuntime = {
+				metadata: md,
+				fingerprint: { size: 1, mtimeMs: 1, ctimeMs: 1 },
+				resolvedPath: md.runtimePath,
+				firstSeen: Date.now(),
+				lastValidated: Date.now(),
+			};
+			const others = (bucket?.entries ?? []).filter(e => e.metadata.runtimePath !== md.runtimePath);
+			buckets.set(key, {
+				extensionId: md.extensionId.value,
+				languageId: md.languageId,
+				entries: [...others, entry],
+				lastFullDiscovery: bucket?.lastFullDiscovery ?? 0,
+				discoveryRootSignature: bucket?.discoveryRootSignature,
+			});
+			return entry;
+		},
 		markValidated: () => true,
 		sessionCounters: counters,
 		setBucket(bucket: IDiscoveryCacheBucket) {
@@ -131,6 +151,13 @@ interface IManagerOptions {
 	 */
 	contributions?: IHostedLanguageContribution[];
 	contributionsBehavior?: 'normal' | 'throws';
+	/**
+	 * Override for `validateMetadata`. Defaults to the identity function. Set
+	 * this to model R's `current`-redirect, where revalidating a cached
+	 * `current: true` entry returns metadata for a *different* binary (wherever
+	 * the rig `current`/`Current` symlink now points).
+	 */
+	validate?: (m: ILanguageRuntimeMetadata) => Promise<ILanguageRuntimeMetadata>;
 }
 
 function makeManager(opts: IManagerOptions): IRuntimeManager {
@@ -147,7 +174,7 @@ function makeManager(opts: IManagerOptions): IRuntimeManager {
 		markDiscoveryComplete: () => { /* no-op for unit test */ },
 		recommendWorkspaceRuntimes: async () => [],
 		managesRuntime: async (metadata) => ownsByPath.has(metadata.runtimePath),
-		validateMetadata: async (m) => m,
+		validateMetadata: opts.validate ?? (async (m) => m),
 		getDiscoveryRootSignature: async (extensionId: string, languageId: string) => {
 			if (opts.rootSignatureBehavior === 'throws') {
 				throw new Error('boom');
@@ -767,6 +794,99 @@ describe('RuntimeStartupService - cache-aware discovery', () => {
 			await loadFromDiscoveryCache(svc, new Set());
 
 			expect(registeredPaths().sort()).toEqual(['/usr/bin/python3', '/usr/local/bin/R']);
+		});
+	});
+
+	describe('background revalidation key migration', () => {
+		// `revalidateOne` is private; test via string-index access.
+		function revalidateOne(svc: RuntimeStartupService, task: {
+			extensionId: string;
+			languageId: string;
+			metadata: ILanguageRuntimeMetadata;
+			freshFingerprint: IRuntimeFingerprint;
+		}): Promise<void> {
+			return (svc as unknown as {
+				revalidateOne: (t: typeof task) => Promise<void>;
+			}).revalidateOne(task);
+		}
+
+		it('evicts the stale key when a current-version entry is redirected to a new binary', async () => {
+			// Models the rig bug: a cached `current: true` R entry for the
+			// formerly-default version (4.5.2) is revalidated, and R's
+			// validateMetadata re-resolves "current" to wherever the rig
+			// `current` symlink now points (4.6.0). The cache is keyed by
+			// runtimePath, so without evicting the old key the cache would keep
+			// BOTH the stale 4.5.2 entry and the new 4.6.0 entry across sessions.
+			const oldMd = metadata({
+				extensionId: 'positron.positron-r',
+				languageId: 'r',
+				runtimePath: '/opt/R/4.5.2/bin/R',
+				runtimeId: 'r-452',
+			});
+			const newMd = metadata({
+				extensionId: 'positron.positron-r',
+				languageId: 'r',
+				runtimePath: '/opt/R/4.6.0/bin/R',
+				runtimeId: 'r-460',
+			});
+			cache.setBucket(makeBucket({
+				extensionId: 'positron.positron-r',
+				languageId: 'r',
+				runtimePath: '/opt/R/4.5.2/bin/R',
+				runtimeId: 'r-452',
+			}));
+
+			const svc = makeService();
+			ctx.disposables.add(svc.registerRuntimeManager(makeManager({
+				id: 1,
+				owns: [oldMd],
+				validate: async () => newMd,
+			})));
+
+			await revalidateOne(svc, {
+				extensionId: 'positron.positron-r',
+				languageId: 'r',
+				metadata: oldMd,
+				freshFingerprint: { size: 2, mtimeMs: 2, ctimeMs: 2 },
+			});
+
+			// Only the redirected entry survives; the stale 4.5.2 key is gone.
+			expect(cache.getEntries('positron.positron-r', 'r').map(e => e.metadata.runtimePath))
+				.toEqual(['/opt/R/4.6.0/bin/R']);
+		});
+
+		it('does not evict when the entry is revalidated in place (same path)', async () => {
+			// A normal fingerprint refresh (e.g. in-place R upgrade at the same
+			// path) must not trip the eviction branch.
+			const md = metadata({
+				extensionId: 'positron.positron-r',
+				languageId: 'r',
+				runtimePath: '/opt/R/4.6.0/bin/R',
+				runtimeId: 'r-460',
+			});
+			cache.setBucket(makeBucket({
+				extensionId: 'positron.positron-r',
+				languageId: 'r',
+				runtimePath: '/opt/R/4.6.0/bin/R',
+				runtimeId: 'r-460',
+			}));
+
+			const svc = makeService();
+			ctx.disposables.add(svc.registerRuntimeManager(makeManager({
+				id: 1,
+				owns: [md],
+				validate: async (m) => m,
+			})));
+
+			await revalidateOne(svc, {
+				extensionId: 'positron.positron-r',
+				languageId: 'r',
+				metadata: md,
+				freshFingerprint: { size: 2, mtimeMs: 2, ctimeMs: 2 },
+			});
+
+			expect(cache.getEntries('positron.positron-r', 'r').map(e => e.metadata.runtimePath))
+				.toEqual(['/opt/R/4.6.0/bin/R']);
 		});
 	});
 


### PR DESCRIPTION
Fixes #14222

The runtime discovery cache could serve a stale set of R installations for users who manage R with [rig](https://github.com/r-lib/rig), most visibly dropping or duplicating the **default ("current")** version. Three reports confirmed this, and all were resolved by disabling the discovery cache.

### Summary

rig represents the default R version with a moving `current`/`Current` symlink inside the headquarters directory (`/opt/R` on Linux, `.../R.framework/Versions` on macOS), and it touches the current version specially (re-link, fix-permissions). This breaks two assumptions the cache makes, and the default version is the only entry that hits the affected code paths because it's the only one whose cached metadata carries `current: true`.

Two fixes:

1. **`revalidateOne` cache-key migration.** When a cached entry's fingerprint changes, R's `validateMetadata` re-resolves a `current: true` entry to wherever the rig symlink now points -- a *different* `runtimePath` and `runtimeId`. The cache is keyed by `runtimePath`, so an `upsert` of the new path left the original entry behind, accumulating stale/duplicate "current" entries across sessions. We now evict the old key when the path changes before upserting.

2. **R discovery-root signature.** The signature only tracked the headquarters directory mtime, not the `current` symlink target. A `rig default <ver>` switch (or rig flows that only change files *inside* a version dir) could leave the signature matching while the default moved, so no full re-discovery ran to correct things. We now fold the resolved `current`/`Current` symlink target into the signature, so a default switch flips it and triggers a clean re-discovery (Windows excluded -- it has no `current` symlink; the default comes from the registry).

The two fixes are complementary: #2 routes default-switches through the safe full-discovery path, and #1 closes the corruption even when the signature path is defeated (e.g. the 500ms `getDiscoveryRootSignature` timeout).

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix the runtime discovery cache sometimes missing R versions installed with rig, particularly the default version (#14222)

### Validation Steps

@:interpreter

On a machine with rig and multiple R versions installed:

1. Install two R versions with rig (e.g. `rig add 4.5.2` then `rig add 4.6.0`) and confirm `rig list` / `ls /opt/R` (Linux) or the framework `Versions` dir (macOS) shows both plus a `current`/`Current` symlink.
2. Open Positron and confirm **both** versions appear in the R interpreter picker, including the default that `current` points to.
3. Switch the default: `rig default 4.5.2`. Reopen Positron (or rediscover) and confirm both versions still appear and the correct one is marked current.
4. With the discovery cache left at its default (enabled), repeat opening Positron across a few sessions and confirm the version set stays stable -- no version intermittently disappears.

Automated coverage: `runtimeStartup.vitest.ts > background revalidation key migration` reproduces the redirect scenario and asserts only the redirected entry survives.