### PR TITLE
e2e: fix tests broken by Copilot Chat revert

### DIFF
--- a/test/e2e/pages/notebooksVscode.ts
+++ b/test/e2e/pages/notebooksVscode.ts
@@ -7,19 +7,16 @@ import { Notebooks } from './notebooks';
 import { Code } from '../infra/code';
 import { QuickInput } from './quickInput';
 import { QuickAccess } from './quickaccess';
-import test, { expect, Locator } from '@playwright/test';
+import test, { expect } from '@playwright/test';
 import { HotKeys } from './hotKeys.js';
 
 /**
  * Notebooks functionality exclusive to VS Code notebooks.
  */
 export class VsCodeNotebooks extends Notebooks {
-	startChatButton: Locator;
 
 	constructor(code: Code, quickinput: QuickInput, quickaccess: QuickAccess, hotKeys: HotKeys) {
 		super(code, quickinput, quickaccess, hotKeys);
-
-		this.startChatButton = this.code.driver.currentPage.getByLabel(/Start Chat to Generate Code/).first();
 	}
 
 	/**
@@ -27,7 +24,7 @@ export class VsCodeNotebooks extends Notebooks {
 	 */
 	async expectToBeVisible(timeout = 25000): Promise<void> {
 		await test.step('Verify VS Code notebook is visible', async () => {
-			await expect(this.startChatButton).toBeVisible({ timeout });
+			await expect(this.code.driver.currentPage.locator('.notebook-editor').first()).toBeVisible({ timeout });
 		});
 	}
 }

--- a/test/e2e/pages/positronAssistant.ts
+++ b/test/e2e/pages/positronAssistant.ts
@@ -246,11 +246,10 @@ export class Assistant {
 	}
 
 	async openPositronAssistantChat() {
-		await test.step('Verify Assistant is enabled and Open it.', async () => {
-			await this.verifyChatButtonVisible();
-			const addModelLinkIsVisible = await this.code.driver.currentPage.locator(CHAT_PANEL).isVisible();
-			if (!addModelLinkIsVisible) {
-				await this.code.driver.currentPage.locator(CHAT_BUTTON).click();
+		await test.step('Open Positron Assistant Chat.', async () => {
+			const chatPanelIsVisible = await this.code.driver.currentPage.locator(CHAT_PANEL).isVisible();
+			if (!chatPanelIsVisible) {
+				await this.quickaccess.runCommand('workbench.action.chat.open');
 			}
 		});
 	}
@@ -270,7 +269,7 @@ export class Assistant {
 	}
 
 	async runConfigureProviders() {
-		await this.clickConfigureProvidersButton();
+		await this.hotKeys.configureProviders();
 	}
 
 	async clickConfigureProvidersLink() {

--- a/test/e2e/tests/notebooks-positron/notebook-ghost-cell-keyboard-shortcut.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-ghost-cell-keyboard-shortcut.test.ts
@@ -13,7 +13,7 @@ test.use({
 test.describe('Notebook: Ghost Cell Keyboard Shortcut', {
 	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
 }, () => {
-	test.beforeAll(async function ({ app, settings, assistant }) {
+	test.beforeAll(async function ({ app, settings, assistant, python }) {
 		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
 
 		// Enable ghost cell suggestions and configure Anthropic model
@@ -23,41 +23,19 @@ test.describe('Notebook: Ghost Cell Keyboard Shortcut', {
 			'positron.assistant.notebook.ghostCellSuggestions.model': ['claude'],
 			'positron.assistant.notebook.ghostCellSuggestions.automatic': false
 		}, { keepOpen: false });
-
-		// Open assistant and login to Anthropic provider
-		// Uses ANTHROPIC_API_KEY env var if set (auto-sign-in), or ANTHROPIC_KEY for manual login
-		await assistant.openPositronAssistantChat();
-		await assistant.loginModelProvider('anthropic-api');
-	});
-
-	test.beforeAll(async function ({ sessions }) {
-		await sessions.start('python');
-	});
-
-	test.afterAll(async function ({ assistant, settings }) {
-		await assistant.logoutModelProvider('anthropic-api');
-
-		// Clean up ghost cell settings to ensure no interference with other tests
-		await settings.remove([
-			'positron.assistant.notebook.ghostCellSuggestions.enabled',
-			'positron.assistant.notebook.ghostCellSuggestions.model',
-			'positron.assistant.notebook.ghostCellSuggestions.automatic'
-		]);
 	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();
 	});
 
-	test('Cmd+Shift+G triggers ghost cell suggestion', async function ({ app, hotKeys }) {
+	test('Cmd+Shift+G triggers ghost cell suggestion', async function ({ app, hotKeys, page }) {
 		const { notebooksPositron } = app.workbench;
 
 		// Create notebook - Positron will auto-select an available kernel
 		await notebooksPositron.createNewNotebook();
 		await notebooksPositron.expectToBeVisible();
-
-		// Wait for kernel to be ready
-		await app.code.driver.currentPage.waitForTimeout(5000);
+		await notebooksPositron.kernel.expectStatusToBe('idle');
 
 		// Add and execute a simple cell to provide context for ghost cell suggestions
 		// Using comment which works in both Python and R
@@ -77,7 +55,6 @@ test.describe('Notebook: Ghost Cell Keyboard Shortcut', {
 
 		// Note: "Generating suggestion..." appears too quickly to reliably wait for
 		// Instead, verify the ghost cell UI elements are present
-		const page = app.code.driver.currentPage;
 
 		// Verify Get Suggestion button is visible
 		await page.getByRole('button', { name: 'Get Suggestion' }).waitFor({ timeout: 10000 });


### PR DESCRIPTION
### Summary
Fix tests broken by #13994, which removed Positron Assistant UI elements
* `notebook-ghost-cell-keyboard-shortcut.test.ts`
* `notebook-editor.test.ts`

### QA Notes
@:positron-notebooks