### PR TITLE
Bump Ark to Salsa

### DIFF
--- a/test/e2e/tests/autocomplete/autocomplete-notebook-console.test.ts
+++ b/test/e2e/tests/autocomplete/autocomplete-notebook-console.test.ts
@@ -345,7 +345,6 @@ test.describe('Autocomplete with Notebook Console', {
 	}, async function ({ app, page, openFile, sessions, hotKeys, settings, r }) {
 		const { editors, inlineQuarto } = app.workbench;
 		const keyboard = page.keyboard;
-		const suggestionList = page.locator('.suggest-widget .monaco-list-row');
 
 		// Open the simple R rmd file
 		await openFile(join('workspaces', 'quarto_inline_output', 'simple_r.rmd'));
@@ -361,22 +360,15 @@ test.describe('Autocomplete with Notebook Console', {
 		await keyboard.press('Enter');
 		await keyboard.type('data.f', { delay: 250 });
 
-		// Explicitly trigger completions and verify we get results.
-		// Before the fix, the console LSP skipped vdoc files and
-		// no completions appeared. With the fix, the console LSP
-		// handles vdocs and provides R completions like data.frame.
+		// The console LSP serves completions for the Quarto vdoc, so
+		// typing data.f should offer base R's data.frame.
+		const suggestWidget = page.locator('.suggest-widget');
 		await expect(async () => {
 			await keyboard.press('Control+Space');
-			await expect(suggestionList.first()).toBeVisible({ timeout: 5000 });
+			await expect(
+				suggestWidget.getByRole('option', { name: /^data\.frame[,\s]/ })
+			).toBeVisible({ timeout: 5000 });
 		}).toPass({ timeout: 30000 });
-
-		// Verify we see data.frame from the R LSP (match the
-		// first exact entry, not substrings like as.data.frame)
-		const suggestWidget = page.locator('.suggest-widget');
-		await expect(suggestWidget.getByRole('option', {
-			name: 'data.frame, {base}, Function',
-			exact: true
-		})).toBeVisible();
 
 	});
 });

--- a/test/e2e/tests/references/references.test.ts
+++ b/test/e2e/tests/references/references.test.ts
@@ -15,6 +15,12 @@ test.describe('References', {
 	tag: [tags.REFERENCES, tags.WEB, tags.WIN]
 }, () => {
 
+	test.beforeAll(async ({ settings }) => {
+		// Drive the Open Folder picker via the quick input instead of the native
+		// OS dialog, which Playwright cannot operate.
+		await settings.set({ 'files.simpleDialog.enable': true });
+	});
+
 	test.afterEach(async ({ app, runCommand }) => {
 
 		await app.workbench.references.close();
@@ -24,9 +30,14 @@ test.describe('References', {
 
 	test('R - Verify References Pane Lists All Function References Across Files', {
 		tag: [tags.ARK]
-	}, async function ({ app, r, openFile }) {
+	}, async function ({ app, openFolder, openFile }) {
 		const helper = 'helper.R';
 
+		// Scope the workspace to the fixture folder so find-references can resolve
+		// `source()` from the right root.
+		await openFolder('qa-example-content/workspaces/references_tests/r');
+
+		await app.workbench.sessions.start('r');
 		await openFile(join('workspaces', 'references_tests', 'r', helper));
 
 		await openAndCommonValidations(app, helper);


### PR DESCRIPTION
Include Salsa changes in Positron (see linked PRs in https://github.com/posit-dev/ark/issues/1212).

Closes https://github.com/posit-dev/positron/issues/4525

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- The R language intelligence features (diagnostics, workspace symbols, etc) are now reactive to changes outside open editors, such as changing a git branch or an agent writing to a file in the workspace.
- Goto definition, find references, and rename symbol now work across files, both in packages and in standalone scripts. For scripts, cross-file symbol resolution follows `source()` calls (https://github.com/posit-dev/positron/issues/11112). This stricter and more accurate resolution strategy is experimental and currently only used for symbol navigation. Diagnostics will be ported to the new resolution engine at a later time after collecting feedback on that new approach.

#### Bug Fixes

- N/A


### Validation Steps

<!--
  Positron team members: please add relevant e2e test tags, so the tests can be
  run when you open this pull request.

  - Instructions: https://github.com/posit-dev/positron/blob/main/test/e2e/README.md#pull-requests-and-test-tags
  - Available tags: https://github.com/posit-dev/positron/blob/main/test/e2e/infra/test-runner/test-tags.ts
-->


<!--
  Add additional information on how to validate the change, paying
  special attention to the level of risk, adjacent areas that could
  be affected by the change, and any important contextual information
  not present in the linked issues.
-->

@:ark

Full test suite passed at https://github.com/posit-dev/positron/actions/runs/27821946547 (minus electron-win which doesn't build right now)