### PR TITLE
Assistant: suppress misleading copilot sign in UI

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
@@ -15,10 +15,21 @@ import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { URI } from '../../../../../base/common/uri.js';
 import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions.js';
 import { ICodeEditorService } from '../../../../../editor/browser/services/codeEditorService.js';
+// --- Start Positron ---
+// EditorContextKeys is only referenced by the suppressed editor context-menu
+// entries below (kept as a comment), so it is dropped here to avoid an
+// unused-import error.
+/*
 import { EditorContextKeys } from '../../../../../editor/common/editorContextKeys.js';
+*/
+// --- End Positron ---
 import { localize, localize2 } from '../../../../../nls.js';
 import { IActionViewItemService } from '../../../../../platform/actions/browser/actionViewItemService.js';
-import { Action2, MenuId, MenuRegistry, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+// --- Start Positron ---
+// MenuRegistry import dropped: its only uses were the suppressed editor context-menu
+// entries below (kept as a comment). See issue #13955.
+import { Action2, MenuId, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+// --- End Positron ---
 import { CommandsRegistry, ICommandService } from '../../../../../platform/commands/common/commands.js';
 // --- Start Positron ---
 // import { ConfigurationTarget, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
@@ -27,7 +38,13 @@ import { CommandsRegistry, ICommandService } from '../../../../../platform/comma
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 // --- End Positron ---
 import { ContextKeyExpr, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
+// --- Start Positron ---
+// IsWebContext is only referenced by the suppressed title-bar sign-in menu below
+// (kept as a comment), so it is dropped here to avoid an unused-import error.
+/*
 import { IsWebContext } from '../../../../../platform/contextkey/common/contextkeys.js';
+*/
+// --- End Positron ---
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { IEnvironmentService } from '../../../../../platform/environment/common/environment.js';
 import { ExtensionIdentifier } from '../../../../../platform/extensions/common/extensions.js';
@@ -357,6 +374,12 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 				super({
 					id: 'workbench.action.chat.triggerSetupFromAccounts',
 					title: localize2('triggerChatSetupFromAccounts', "Sign in to use AI features..."),
+					// --- Start Positron ---
+					// Suppress the Accounts menu entry: it opens the upstream Copilot
+					// chat-setup sign-in dialog, which reads as GitHub Copilot rather
+					// than Positron. The command still exists; only the menu
+					// contribution is omitted. See issue #13955.
+					/*
 					menu: {
 						id: MenuId.AccountsContext,
 						group: '2_copilot',
@@ -367,6 +390,8 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 							ChatContextKeys.Entitlement.signedOut
 						)
 					}
+					*/
+					// --- End Positron ---
 				});
 			}
 
@@ -389,6 +414,12 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 					id: ChatSetupSignInTitleBarAction.ID,
 					title: localize('signInIndicatorTitleBarAction', 'Sign In'),
 					f1: false,
+					// --- Start Positron ---
+					// Suppress the title-bar "Sign In" button: it opens the upstream
+					// Copilot chat-setup sign-in dialog, which reads as GitHub Copilot
+					// rather than Positron. The command still exists; only the menu
+					// contribution is omitted. See issue #13955.
+					/*
 					menu: [{
 						id: MenuId.TitleBarAdjacentCenter,
 						order: 0, // same position as the update button
@@ -401,6 +432,8 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 							ContextKeyExpr.has('updateTitleBar').negate()
 						),
 					}]
+					*/
+					// --- End Positron ---
 				});
 			}
 
@@ -579,6 +612,15 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 		registerGenerateCodeCommand('chat.internal.review', 'github.copilot.chat.review');
 		registerGenerateCodeCommand('chat.internal.codeReview.run', 'github.copilot.chat.codeReview.run');
 
+		// --- Start Positron ---
+		// Suppress the pre-setup editor context-menu entries (Explain / Fix / Code
+		// Review). Their gate is `Setup.completed.negate()`, so upstream shows them
+		// to signed-out users as an on-ramp into the Copilot chat-setup flow. In
+		// Positron these affordances should only appear once the user is signed in
+		// with Copilot, at which point the chat extension contributes its own
+		// equivalents. The `chat.internal.*` commands stay registered above but are
+		// no longer wired to any menu. See issue #13955.
+		/*
 		const internalGenerateCodeContext = ContextKeyExpr.and(
 			ChatContextKeys.Setup.hidden.negate(),
 			ChatContextKeys.Setup.disabledInWorkspace.negate(),
@@ -617,6 +659,8 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 			order: 6,
 			when: internalGenerateCodeContext
 		});
+		*/
+		// --- End Positron ---
 
 	}
 
@@ -842,7 +886,14 @@ export class ChatTeardownContribution extends Disposable implements IWorkbenchCo
 				super({
 					id: ChatSetupHideAction.ID,
 					title: ChatSetupHideAction.TITLE,
+					// --- Start Positron ---
+					// Don't show the "Learn How to Hide AI Features" action: it sounds general but only points
+					// at the Copilot `chat.disableAIFeatures` setting, so it's misleading in Positron. Drop the
+					// F1 palette entry and the Chat title-bar menu so it isn't reachable. See issue #13955.
+					/*
 					f1: true,
+					*/
+					// --- End Positron ---
 					category: CHAT_CATEGORY,
 					// --- Start Positron ---
 					// Hide from command palette when AI features are disabled.
@@ -851,13 +902,19 @@ export class ChatTeardownContribution extends Disposable implements IWorkbenchCo
 						ChatContextKeys.Setup.disabledInWorkspace.negate(),
 						ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
 					),
-					// --- End Positron ---
+					// Suppress the "Learn How to Hide AI Features" action: it sounds
+					// general but only points at the Copilot `chat.disableAIFeatures`
+					// setting, so it's misleading in Positron. Drop the F1 palette entry
+					// and the Chat title-bar menu so it isn't reachable. See issue #13955.
+					/*
 					menu: {
 						id: MenuId.ChatTitleBarMenu,
 						group: 'z_hide',
 						order: 1,
 						when: ChatContextKeys.Setup.completed.negate()
 					}
+					*/
+					// --- End Positron ---
 				});
 			}
 

--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
@@ -250,8 +250,16 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 					id: CHAT_SETUP_ACTION_ID,
 					title: ChatSetupTriggerAction.CHAT_SETUP_ACTION_LABEL,
 					category: CHAT_CATEGORY,
-					f1: true,
 					// --- Start Positron ---
+					// Don't surface "Use AI Features with Copilot for free..." in the
+					// command palette: it reads as GitHub Copilot and opens the upstream
+					// Copilot chat-setup sign-in dialog. The command stays registered so
+					// the programmatic callers (chat status dashboard, anonymous
+					// rate-limited part, title-bar status widget) still work; only the F1
+					// palette entry is dropped. See issue #13955.
+					/*
+					f1: true,
+					*/
 					// Hide from command palette when AI features are disabled.
 					precondition: ContextKeyExpr.and(
 						ContextKeyExpr.or(

--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
@@ -250,16 +250,8 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 					id: CHAT_SETUP_ACTION_ID,
 					title: ChatSetupTriggerAction.CHAT_SETUP_ACTION_LABEL,
 					category: CHAT_CATEGORY,
-					// --- Start Positron ---
-					// Don't surface "Use AI Features with Copilot for free..." in the
-					// command palette: it reads as GitHub Copilot and opens the upstream
-					// Copilot chat-setup sign-in dialog. The command stays registered so
-					// the programmatic callers (chat status dashboard, anonymous
-					// rate-limited part, title-bar status widget) still work; only the F1
-					// palette entry is dropped. See issue #13955.
-					/*
 					f1: true,
-					*/
+					// --- Start Positron ---
 					// Hide from command palette when AI features are disabled.
 					precondition: ContextKeyExpr.and(
 						ContextKeyExpr.or(
@@ -895,34 +887,23 @@ export class ChatTeardownContribution extends Disposable implements IWorkbenchCo
 					id: ChatSetupHideAction.ID,
 					title: ChatSetupHideAction.TITLE,
 					// --- Start Positron ---
-					// Don't show the "Learn How to Hide AI Features" action: it sounds general but only points
-					// at the Copilot `chat.disableAIFeatures` setting, so it's misleading in Positron. Drop the
-					// F1 palette entry and the Chat title-bar menu so it isn't reachable. See issue #13955.
-					/*
-					f1: true,
-					*/
+					// Keep this Copilot affordance out of the command palette regardless of
+					// the `chat.disableAIFeatures` setting (f1: false instead of upstream's true).
+					// The command only applies to Copilot affordances but sounds general, so better
+					// to hide it from the palette altogether to avoid confusion. See issue #13955.
+					f1: false,
 					// --- End Positron ---
 					category: CHAT_CATEGORY,
-					// --- Start Positron ---
-					// Hide from command palette when AI features are disabled.
 					precondition: ContextKeyExpr.and(
 						ChatContextKeys.Setup.hidden.negate(),
 						ChatContextKeys.Setup.disabledInWorkspace.negate(),
-						ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
 					),
-					// Suppress the "Learn How to Hide AI Features" action: it sounds
-					// general but only points at the Copilot `chat.disableAIFeatures`
-					// setting, so it's misleading in Positron. Drop the F1 palette entry
-					// and the Chat title-bar menu so it isn't reachable. See issue #13955.
-					/*
 					menu: {
 						id: MenuId.ChatTitleBarMenu,
 						group: 'z_hide',
 						order: 1,
 						when: ChatContextKeys.Setup.completed.negate()
 					}
-					*/
-					// --- End Positron ---
 				});
 			}
 

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/startupPage.ts
@@ -240,6 +240,16 @@ export class StartupPageRunnerContribution extends Disposable implements IWorkbe
 	}
 
 	private tryShowOnboarding(): void {
+		// --- Start Positron ---
+		// Never auto-show the upstream onboarding wizard; it's VS Code / Copilot
+		// content that doesn't apply to Positron. See issue #13955. (Typed as
+		// boolean so the upstream body below stays reachable for clean merges.)
+		const suppressOnboarding: boolean = true;
+		if (suppressOnboarding) {
+			return;
+		}
+		// --- End Positron ---
+
 		if (this.environmentService.skipWelcome) {
 			return; // skip welcome flag is set
 		}
@@ -272,7 +282,7 @@ export class StartupPageRunnerContribution extends Disposable implements IWorkbe
 
 // --- Start Positron ---
 function isStartupPageEnabled(configurationService: IConfigurationService, contextService: IWorkspaceContextService, environmentService: IWorkbenchEnvironmentService, positronNewFolderService: IPositronNewFolderService) {
-// --- End Positron ---
+	// --- End Positron ---
 	if (environmentService.skipWelcome) {
 		return false;
 	}

--- a/test/e2e/tests/assistant/copilot-signin-suppressed.test.ts
+++ b/test/e2e/tests/assistant/copilot-signin-suppressed.test.ts
@@ -10,12 +10,23 @@ test.use({
 });
 
 /**
- * On a signed-out launch, upstream surfaces Copilot chat-setup affordances that read as
- * GitHub Copilot, not Positron. Positron suppresses them in chatSetupContributions.ts;
- * these e2e assertions guard against them reappearing on a VS Code merge.
+ * Upstream surfaces Copilot chat-setup affordances that read as GitHub Copilot, not Positron.
+ * Positron suppresses them in chatSetupContributions.ts; these e2e assertions guard against
+ * them reappearing on a VS Code merge.
  *
- * Not covered: the onboarding wizard only auto-shows for a brand-new profile, which the
- * reused e2e profile isn't, so it stays a manual check.
+ * Most of these affordances are gated on `Setup.hidden.negate()`, and Positron defaults
+ * `chat.disableAIFeatures` to true (so `hidden` is true at launch). That means upstream
+ * wouldn't render them in the default state anyway, so a test in that state passes whether or
+ * not the suppression is in place. To actually exercise the suppression we flip AI features on
+ * for those checks (see the second describe). The "Use AI Features" on-ramp is the exception:
+ * it shows precisely when chat is hidden, so it stays in the default state.
+ *
+ * Not covered:
+ * - The title-bar "Sign In" button: also gated behind the `chat.signInTitleBar.enabled`
+ *   experiment (and hidden on web / when the update button shows), so it can't be driven into
+ *   view in a realistic state. Suppressed in source; left unverified here.
+ * - The onboarding wizard only auto-shows for a brand-new profile, which the reused e2e
+ *   profile isn't, so it stays a manual check.
  *
  * @see https://github.com/posit-dev/positron/issues/13955
  */
@@ -24,41 +35,65 @@ test.use({
 // confirm the surface actually rendered (otherwise a zero count proves nothing). Distinctive
 // wording is matched loosely (catches a renamed re-add); generic labels are matched exactly.
 const AI_SIGNIN_CONCEPT = /copilot|ai features/i;
-const TITLE_BAR_SIGN_IN = 'Sign In';
 const EDITOR_PRESETUP_ITEMS = ['Explain', 'Fix', 'Code Review'];
 const HIDE_AI_COMMAND = 'Learn How to Hide AI Features';
 const USE_AI_FEATURES_COMMAND = 'Use AI Features with Copilot for free';
 
-test.describe('Assistant: Copilot sign-in surfaces suppressed', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
+test.describe('Assistant: Copilot setup on-ramp suppressed', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
 
-	test('Signed-out user sees no Copilot AI sign-in entry in Accounts menu or title bar', async function ({ app, page }) {
-		await test.step('Accounts menu has no AI/Copilot sign-in entry', async () => {
-			// Accounts button lives in the activity bar; its aria-label gets a badge
-			// suffix when signed out (e.g. "Accounts - Sign in ..."), so scope to the
-			// activity bar and match the prefix rather than the exact name.
-			const accountsButton = page.locator('.activitybar')
-				.getByRole('button', { name: /^Accounts/ });
-			await expect(accountsButton).toBeVisible();
-			await accountsButton.click();
+	test('Command palette does not list the Copilot "Use AI Features with Copilot for free..." command', async function ({ app }) {
+		const { hotKeys, quickInput } = app.workbench;
 
-			const menu = page.locator('.monaco-menu');
-			await expect(menu).toBeVisible();
-			// Confirm items rendered first, so the count below means the AI entry is gone.
-			await expect(menu.getByRole('menuitem').first()).toBeVisible();
+		await hotKeys.openCommandPalette();
+		await quickInput.type(`>${USE_AI_FEATURES_COMMAND}`);
+		// Wait for the palette to return a result first, so the count below is meaningful.
+		await quickInput.waitForQuickInputElementText();
 
-			// Loose match (not the exact label) catches a reworded re-add.
-			await expect(menu.getByRole('menuitem', { name: AI_SIGNIN_CONCEPT })).toHaveCount(0);
+		// With the f1 entry suppressed, the palette falls back to fuzzy "similar commands",
+		// so assert the exact command title isn't among them.
+		await expect(
+			quickInput.quickInputResult.filter({ hasText: USE_AI_FEATURES_COMMAND })
+		).toHaveCount(0);
 
-			await page.keyboard.press('Escape');
-			await expect(menu).toBeHidden();
-		});
+		await quickInput.closeQuickInput();
+	});
+});
 
-		await test.step('Title bar has no "Sign In" button', async () => {
-			// Where ChatSetupSignInTitleBarAction would render when signed out. The upstream
-			// button is also gated behind the `chat.signInTitleBar.enabled` experiment, so
-			// this is a coarse guard; "Sign In" is too generic to widen.
-			await expect(page.getByRole('button', { name: TITLE_BAR_SIGN_IN, exact: true })).toHaveCount(0);
-		});
+// These affordances are gated on AI features being enabled (their `when` includes
+// `Setup.hidden.negate()`), but Positron defaults `chat.disableAIFeatures` to true, so they're
+// already hidden by that gate. We turn AI features on so the gate passes and the dropped menu /
+// f1 entries are the only thing keeping them out of view; otherwise the assertions would pass
+// trivially. The default is restored afterward.
+test.describe('Assistant: Copilot sign-in surfaces suppressed with AI features on', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
+
+	test.beforeAll(async ({ settings }) => {
+		await settings.set({ 'chat.disableAIFeatures': false }, { reload: true });
+	});
+
+	test.afterAll(async ({ settings, app }) => {
+		await settings.remove(['chat.disableAIFeatures']);
+		await app.workbench.hotKeys.reloadWindow(true);
+	});
+
+	test('Signed-out user sees no Copilot AI sign-in entry in the Accounts menu', async function ({ page }) {
+		// Accounts button lives in the activity bar; its aria-label gets a badge suffix when
+		// signed out (e.g. "Accounts - Sign in ..."), so scope to the activity bar and match
+		// the prefix rather than the exact name.
+		const accountsButton = page.locator('.activitybar')
+			.getByRole('button', { name: /^Accounts/ });
+		await expect(accountsButton).toBeVisible();
+		await accountsButton.click();
+
+		const menu = page.locator('.monaco-menu');
+		await expect(menu).toBeVisible();
+		// Confirm items rendered first, so the count below means the AI entry is gone.
+		await expect(menu.getByRole('menuitem').first()).toBeVisible();
+
+		// Loose match (not the exact label) catches a reworded re-add.
+		await expect(menu.getByRole('menuitem', { name: AI_SIGNIN_CONCEPT })).toHaveCount(0);
+
+		await page.keyboard.press('Escape');
+		await expect(menu).toBeHidden();
 	});
 
 	test('Signed-out user sees no Copilot pre-setup entries in the editor context menu', async function ({ page, openFile }) {
@@ -79,40 +114,6 @@ test.describe('Assistant: Copilot sign-in surfaces suppressed', { tag: [tags.WIN
 
 		await page.keyboard.press('Escape');
 		await expect(menu).toBeHidden();
-	});
-
-	test('Command palette does not list the Copilot "Use AI Features with Copilot for free..." command', async function ({ app }) {
-		const { hotKeys, quickInput } = app.workbench;
-
-		await hotKeys.openCommandPalette();
-		await quickInput.type(`>${USE_AI_FEATURES_COMMAND}`);
-		// Wait for the palette to return a result first, so the count below is meaningful.
-		await quickInput.waitForQuickInputElementText();
-
-		// With the f1 entry suppressed, the palette falls back to fuzzy "similar commands",
-		// so assert the exact command title isn't among them.
-		await expect(
-			quickInput.quickInputResult.filter({ hasText: USE_AI_FEATURES_COMMAND })
-		).toHaveCount(0);
-
-		await quickInput.closeQuickInput();
-	});
-});
-
-// "Learn How to Hide AI Features" is gated on AI features being enabled (its precondition is
-// Setup.hidden.negate()), but Positron defaults chat.disableAIFeatures to true, so the command
-// is already hidden by its own precondition. We flip AI features on for this check so the
-// precondition passes and the dropped f1 entry is the only thing keeping it out of the palette;
-// otherwise the assertion would pass trivially. The default is restored afterward.
-test.describe('Assistant: "Learn How to Hide AI Features" suppressed with AI features on', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
-
-	test.beforeAll(async ({ settings }) => {
-		await settings.set({ 'chat.disableAIFeatures': false }, { reload: true });
-	});
-
-	test.afterAll(async ({ settings, app }) => {
-		await settings.remove(['chat.disableAIFeatures']);
-		await app.workbench.hotKeys.reloadWindow(true);
 	});
 
 	test('Command palette does not list the Copilot "Learn How to Hide AI Features" command', async function ({ app }) {

--- a/test/e2e/tests/assistant/copilot-signin-suppressed.test.ts
+++ b/test/e2e/tests/assistant/copilot-signin-suppressed.test.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test, expect, tags } from '../_test.setup';
+
+test.use({
+	suiteId: __filename
+});
+
+/**
+ * On a signed-out launch, upstream surfaces Copilot chat-setup affordances that read as
+ * GitHub Copilot, not Positron. Positron suppresses them in chatSetupContributions.ts;
+ * these e2e assertions guard against them reappearing on a VS Code merge.
+ *
+ * Not covered: the onboarding wizard only auto-shows for a brand-new profile, which the
+ * reused e2e profile isn't, so it stays a manual check.
+ *
+ * @see https://github.com/posit-dev/positron/issues/13955
+ */
+
+// The menu DOM exposes only the label (no command id), so before each absence check we
+// confirm the surface actually rendered (otherwise a zero count proves nothing). Distinctive
+// wording is matched loosely (catches a renamed re-add); generic labels are matched exactly.
+const AI_SIGNIN_CONCEPT = /copilot|ai features/i;
+const TITLE_BAR_SIGN_IN = 'Sign In';
+const EDITOR_PRESETUP_ITEMS = ['Explain', 'Fix', 'Code Review'];
+const HIDE_AI_COMMAND = 'Learn How to Hide AI Features';
+
+test.describe('Assistant: Copilot sign-in surfaces suppressed', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
+
+	test('Signed-out user sees no Copilot AI sign-in entry in Accounts menu or title bar', async function ({ app, page }) {
+		await test.step('Accounts menu has no AI/Copilot sign-in entry', async () => {
+			const accountsButton = page.getByRole('button', { name: 'Accounts', exact: true });
+			await expect(accountsButton).toBeVisible();
+			await accountsButton.click();
+
+			const menu = page.locator('.monaco-menu');
+			await expect(menu).toBeVisible();
+			// Confirm items rendered first, so the count below means the AI entry is gone.
+			await expect(menu.getByRole('menuitem').first()).toBeVisible();
+
+			// Loose match (not the exact label) catches a reworded re-add.
+			await expect(menu.getByRole('menuitem', { name: AI_SIGNIN_CONCEPT })).toHaveCount(0);
+
+			await page.keyboard.press('Escape');
+			await expect(menu).toBeHidden();
+		});
+
+		await test.step('Title bar has no "Sign In" button', async () => {
+			// Where ChatSetupSignInTitleBarAction would render when signed out. The upstream
+			// button is also gated behind the `chat.signInTitleBar.enabled` experiment, so
+			// this is a coarse guard; "Sign In" is too generic to widen.
+			await expect(page.getByRole('button', { name: TITLE_BAR_SIGN_IN, exact: true })).toHaveCount(0);
+		});
+	});
+
+	test('Signed-out user sees no Copilot pre-setup entries in the editor context menu', async function ({ page, openFile }) {
+		await openFile('workspaces/generate-data-frames-r/simple-data-frames.r');
+
+		// Upstream contributes Explain / Fix / Code Review here while signed out.
+		await page.locator('.monaco-editor .view-line').first().click({ button: 'right' });
+
+		const menu = page.locator('.monaco-menu');
+		await expect(menu).toBeVisible();
+		// Confirm the menu rendered first, so a 0-count below is meaningful.
+		await expect(menu.getByRole('menuitem').first()).toBeVisible();
+
+		// Exact match: these verbs are too generic to widen (e.g. another extension's "Fix").
+		for (const label of EDITOR_PRESETUP_ITEMS) {
+			await expect(menu.getByRole('menuitem', { name: label, exact: true })).toHaveCount(0);
+		}
+
+		await page.keyboard.press('Escape');
+		await expect(menu).toBeHidden();
+	});
+
+	test('Command palette does not list the Copilot "Learn How to Hide AI Features" command', async function ({ app }) {
+		const { hotKeys, quickInput } = app.workbench;
+
+		await hotKeys.openCommandPalette();
+		await quickInput.type(`>${HIDE_AI_COMMAND}`);
+		// Wait for the palette to return a result first, so the count below is meaningful.
+		await quickInput.waitForQuickInputElementText();
+
+		// With the f1 entry suppressed, the palette falls back to fuzzy "similar commands",
+		// so assert the exact command title isn't among them.
+		await expect(
+			quickInput.quickInputResult.filter({ hasText: HIDE_AI_COMMAND })
+		).toHaveCount(0);
+
+		await quickInput.closeQuickInput();
+	});
+});

--- a/test/e2e/tests/assistant/copilot-signin-suppressed.test.ts
+++ b/test/e2e/tests/assistant/copilot-signin-suppressed.test.ts
@@ -32,7 +32,11 @@ test.describe('Assistant: Copilot sign-in surfaces suppressed', { tag: [tags.WIN
 
 	test('Signed-out user sees no Copilot AI sign-in entry in Accounts menu or title bar', async function ({ app, page }) {
 		await test.step('Accounts menu has no AI/Copilot sign-in entry', async () => {
-			const accountsButton = page.getByRole('button', { name: 'Accounts', exact: true });
+			// Accounts button lives in the activity bar; its aria-label gets a badge
+			// suffix when signed out (e.g. "Accounts - Sign in ..."), so scope to the
+			// activity bar and match the prefix rather than the exact name.
+			const accountsButton = page.locator('.activitybar')
+				.getByRole('button', { name: /^Accounts/ });
 			await expect(accountsButton).toBeVisible();
 			await accountsButton.click();
 

--- a/test/e2e/tests/assistant/copilot-signin-suppressed.test.ts
+++ b/test/e2e/tests/assistant/copilot-signin-suppressed.test.ts
@@ -81,23 +81,6 @@ test.describe('Assistant: Copilot sign-in surfaces suppressed', { tag: [tags.WIN
 		await expect(menu).toBeHidden();
 	});
 
-	test('Command palette does not list the Copilot "Learn How to Hide AI Features" command', async function ({ app }) {
-		const { hotKeys, quickInput } = app.workbench;
-
-		await hotKeys.openCommandPalette();
-		await quickInput.type(`>${HIDE_AI_COMMAND}`);
-		// Wait for the palette to return a result first, so the count below is meaningful.
-		await quickInput.waitForQuickInputElementText();
-
-		// With the f1 entry suppressed, the palette falls back to fuzzy "similar commands",
-		// so assert the exact command title isn't among them.
-		await expect(
-			quickInput.quickInputResult.filter({ hasText: HIDE_AI_COMMAND })
-		).toHaveCount(0);
-
-		await quickInput.closeQuickInput();
-	});
-
 	test('Command palette does not list the Copilot "Use AI Features with Copilot for free..." command', async function ({ app }) {
 		const { hotKeys, quickInput } = app.workbench;
 
@@ -110,6 +93,40 @@ test.describe('Assistant: Copilot sign-in surfaces suppressed', { tag: [tags.WIN
 		// so assert the exact command title isn't among them.
 		await expect(
 			quickInput.quickInputResult.filter({ hasText: USE_AI_FEATURES_COMMAND })
+		).toHaveCount(0);
+
+		await quickInput.closeQuickInput();
+	});
+});
+
+// "Learn How to Hide AI Features" is gated on AI features being enabled (its precondition is
+// Setup.hidden.negate()), but Positron defaults chat.disableAIFeatures to true, so the command
+// is already hidden by its own precondition. We flip AI features on for this check so the
+// precondition passes and the dropped f1 entry is the only thing keeping it out of the palette;
+// otherwise the assertion would pass trivially. The default is restored afterward.
+test.describe('Assistant: "Learn How to Hide AI Features" suppressed with AI features on', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
+
+	test.beforeAll(async ({ settings }) => {
+		await settings.set({ 'chat.disableAIFeatures': false }, { reload: true });
+	});
+
+	test.afterAll(async ({ settings, app }) => {
+		await settings.remove(['chat.disableAIFeatures']);
+		await app.workbench.hotKeys.reloadWindow(true);
+	});
+
+	test('Command palette does not list the Copilot "Learn How to Hide AI Features" command', async function ({ app }) {
+		const { hotKeys, quickInput } = app.workbench;
+
+		await hotKeys.openCommandPalette();
+		await quickInput.type(`>${HIDE_AI_COMMAND}`);
+		// Wait for the palette to return a result first, so the count below is meaningful.
+		await quickInput.waitForQuickInputElementText();
+
+		// With the f1 entry suppressed, the palette falls back to fuzzy "similar commands",
+		// so assert the exact command title isn't among them.
+		await expect(
+			quickInput.quickInputResult.filter({ hasText: HIDE_AI_COMMAND })
 		).toHaveCount(0);
 
 		await quickInput.closeQuickInput();

--- a/test/e2e/tests/assistant/copilot-signin-suppressed.test.ts
+++ b/test/e2e/tests/assistant/copilot-signin-suppressed.test.ts
@@ -27,6 +27,7 @@ const AI_SIGNIN_CONCEPT = /copilot|ai features/i;
 const TITLE_BAR_SIGN_IN = 'Sign In';
 const EDITOR_PRESETUP_ITEMS = ['Explain', 'Fix', 'Code Review'];
 const HIDE_AI_COMMAND = 'Learn How to Hide AI Features';
+const USE_AI_FEATURES_COMMAND = 'Use AI Features with Copilot for free';
 
 test.describe('Assistant: Copilot sign-in surfaces suppressed', { tag: [tags.WIN, tags.ASSISTANT, tags.WEB] }, () => {
 
@@ -92,6 +93,23 @@ test.describe('Assistant: Copilot sign-in surfaces suppressed', { tag: [tags.WIN
 		// so assert the exact command title isn't among them.
 		await expect(
 			quickInput.quickInputResult.filter({ hasText: HIDE_AI_COMMAND })
+		).toHaveCount(0);
+
+		await quickInput.closeQuickInput();
+	});
+
+	test('Command palette does not list the Copilot "Use AI Features with Copilot for free..." command', async function ({ app }) {
+		const { hotKeys, quickInput } = app.workbench;
+
+		await hotKeys.openCommandPalette();
+		await quickInput.type(`>${USE_AI_FEATURES_COMMAND}`);
+		// Wait for the palette to return a result first, so the count below is meaningful.
+		await quickInput.waitForQuickInputElementText();
+
+		// With the f1 entry suppressed, the palette falls back to fuzzy "similar commands",
+		// so assert the exact command title isn't among them.
+		await expect(
+			quickInput.quickInputResult.filter({ hasText: USE_AI_FEATURES_COMMAND })
 		).toHaveCount(0);
 
 		await quickInput.closeQuickInput();

--- a/test/e2e/tests/assistant/copilot-signin-suppressed.test.ts
+++ b/test/e2e/tests/assistant/copilot-signin-suppressed.test.ts
@@ -49,8 +49,9 @@ test.describe('Assistant: Copilot setup on-ramp suppressed', { tag: [tags.WIN, t
 		// Wait for the palette to return a result first, so the count below is meaningful.
 		await quickInput.waitForQuickInputElementText();
 
-		// With the f1 entry suppressed, the palette falls back to fuzzy "similar commands",
-		// so assert the exact command title isn't among them.
+		// In the default state AI features are off, so this command's precondition gates
+		// it out of the palette (it only reappears once AI is enabled). The palette then
+		// falls back to fuzzy "similar commands", so assert the exact title isn't among them.
 		await expect(
 			quickInput.quickInputResult.filter({ hasText: USE_AI_FEATURES_COMMAND })
 		).toHaveCount(0);


### PR DESCRIPTION
Suppresses misleading Copilot sign-in surfaces for a signed-out launch of Positron. All edits are in upstream files, wrapped in Positron markers.

- fixes https://github.com/posit-dev/positron/issues/13955
- Onboarding wizard no longer auto-shows (`startupPage.ts`, early-return guard)
- Removed "Sign in to use AI features..." from the Accounts menu
- Removed the title-bar "Sign In" button
- Removed Explain / Fix / Code Review from the editor context menu (+ orphaned imports)
- Removed "Learn How to Hide AI Features" from palette + menu (this is always removed regardless of the chat.disableAIFeatures setting)

### Release Notes

#### Bug Fixes

- Remove misleading copilot sign in affordances (#13955)

### Validation Steps

@:assistant

- added E2E tests to check that affordances are not present in copilot-signin-suppressed.test.ts
- manual repro by removing user state (e.g., `rm -rf ~/.vscode-oss-dev`, signed-out dev build), and confirming that the affordances in #13955 don't show
  1. Launch Positron signed out of all accounts (no GitHub/Copilot session).
  2. Confirm no AI/Copilot sign-in modal auto-shows on launch.
  3. Open the Accounts menu (bottom-left): confirm there's no "Sign in to use AI features..." entry.
  4. Confirm the title bar has no "Sign In" button.
  5. Right-click in an open editor: confirm no Explain / Fix / Code Review entries appear while signed out.
  6. Open the Command Palette and search "Learn How to Hide AI Features": confirm it's not listed.