### PR TITLE
Fix untitled notebook name reuse under concurrent creation (#13561)

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/notebook.api.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/notebook.api.test.ts
@@ -216,6 +216,21 @@ const apiTestSerializer: vscode.NotebookSerializer = {
 		assert.strictEqual(doc.isDirty, true);
 	});
 
+	// --- Start Positron ---
+	// https://github.com/posit-dev/positron/issues/13561
+	test('Opening multiple untitled notebooks concurrently assigns distinct names', async function () {
+		const makeData = () => new vscode.NotebookData([new vscode.NotebookCellData(vscode.NotebookCellKind.Code, '', 'python')]);
+		const docs = await Promise.all([
+			vscode.workspace.openNotebookDocument('jupyter-notebook', makeData()),
+			vscode.workspace.openNotebookDocument('jupyter-notebook', makeData()),
+			vscode.workspace.openNotebookDocument('jupyter-notebook', makeData()),
+		]);
+
+		const uris = new Set(docs.map(doc => doc.uri.toString()));
+		assert.strictEqual(uris.size, docs.length, `Expected ${docs.length} distinct untitled notebooks, got: ${[...uris].join(', ')}`);
+	});
+	// --- End Positron ---
+
 	test.skip('Cannot open notebook from cell-uri with vscode.open-command', async function () {
 
 		const document = await openRandomNotebookDocument();

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
@@ -168,6 +168,12 @@ export class NotebookModelResolverServiceImpl implements INotebookEditorModelRes
 	private readonly _onWillFailWithConflict = new AsyncEmitter<INotebookConflictEvent>();
 	readonly onWillFailWithConflict = this._onWillFailWithConflict.event;
 
+	// --- Start Positron ---
+	// Untitled resources handed out by createUntitledUri whose models are
+	// still being created. See createUntitledUri for why (#13561).
+	private readonly _pendingUntitledUris = new Set<string>();
+	// --- End Positron ---
+
 	constructor(
 		@IInstantiationService instantiationService: IInstantiationService,
 		@INotebookService private readonly _notebookService: INotebookService,
@@ -194,12 +200,29 @@ export class NotebookModelResolverServiceImpl implements INotebookEditorModelRes
 		}
 
 		const suffix = NotebookProviderInfo.possibleFileEnding(info.selectors) ?? '';
+		// --- Start Positron ---
+		// The two checks below only see a notebook once its model has finished
+		// loading, which includes an async round trip to the extension host
+		// serializer. Two concurrent untitled creations could therefore be
+		// handed the same Untitled-N name and silently coalesce into a single
+		// document (#13561). Reserve the name until the model becomes visible
+		// to those checks; callers release the reservation when the model
+		// resolves or fails.
+		// Commented out upstream code:
+		// for (let counter = 1; ; counter++) {
+		// 	const candidate = URI.from({ scheme: Schemas.untitled, path: `Untitled-${counter}${suffix}`, query: notebookType });
+		// 	if (!this._notebookService.getNotebookTextModel(candidate) && !this._data.isListeningToModel(candidate)) {
+		// 		return candidate;
+		// 	}
+		// }
 		for (let counter = 1; ; counter++) {
 			const candidate = URI.from({ scheme: Schemas.untitled, path: `Untitled-${counter}${suffix}`, query: notebookType });
-			if (!this._notebookService.getNotebookTextModel(candidate) && !this._data.isListeningToModel(candidate)) {
+			if (!this._notebookService.getNotebookTextModel(candidate) && !this._data.isListeningToModel(candidate) && !this._pendingUntitledUris.has(candidate.toString())) {
+				this._pendingUntitledUris.add(candidate.toString());
 				return candidate;
 			}
 		}
+		// --- End Positron ---
 	}
 
 	private async validateResourceViewType(uri: URI | undefined, viewType: string | undefined) {
@@ -250,7 +273,18 @@ export class NotebookModelResolverServiceImpl implements INotebookEditorModelRes
 	public async createUntitledNotebookTextModel(viewType: string) {
 		const resource = this._uriIdentService.asCanonicalUri(this.createUntitledUri(viewType));
 
-		return (await this._notebookService.createNotebookTextModel(viewType, resource));
+		// --- Start Positron ---
+		// Release the name reservation made by createUntitledUri once the
+		// model exists (it is then visible to createUntitledUri's own checks)
+		// or its creation failed (#13561).
+		// Commented out upstream code:
+		// return (await this._notebookService.createNotebookTextModel(viewType, resource));
+		try {
+			return (await this._notebookService.createNotebookTextModel(viewType, resource));
+		} finally {
+			this._pendingUntitledUris.delete(resource.toString());
+		}
+		// --- End Positron ---
 	}
 
 	async resolve(resource: URI, viewType?: string, options?: NotebookEditorModelCreationOptions): Promise<IReference<IResolvedNotebookEditorModel>>;
@@ -281,6 +315,16 @@ export class NotebookModelResolverServiceImpl implements INotebookEditorModelRes
 		} catch (err) {
 			reference.dispose();
 			throw err;
+			// --- Start Positron ---
+			// If validateResourceViewType minted an untitled resource for us
+			// (no resource was provided), release the name reservation made by
+			// createUntitledUri: the model is now either resolved (and visible to
+			// createUntitledUri's checks) or failed to load (#13561).
+		} finally {
+			if (!resource) {
+				this._pendingUntitledUris.delete(validated.resource.toString());
+			}
+			// --- End Positron ---
 		}
 	}
 }

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
@@ -316,11 +316,14 @@ export class NotebookModelResolverServiceImpl implements INotebookEditorModelRes
 			reference.dispose();
 			throw err;
 			// --- Start Positron ---
+		} finally {
 			// If validateResourceViewType minted an untitled resource for us
 			// (no resource was provided), release the name reservation made by
-			// createUntitledUri: the model is now either resolved (and visible to
-			// createUntitledUri's checks) or failed to load (#13561).
-		} finally {
+			// createUntitledUri: the model is now either resolved (and visible
+			// to createUntitledUri's checks) or failed to load (#13561).
+			// validateResourceViewType cannot throw after minting -- a freshly
+			// minted resource has no existing model to conflict with -- so a
+			// reservation always reaches this finally.
 			if (!resource) {
 				this._pendingUntitledUris.delete(validated.resource.toString());
 			}

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
@@ -13,7 +13,12 @@ import { AsyncEmitter, Emitter, Event } from '../../../../base/common/event.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uriIdentity.js';
 import { INotebookConflictEvent, INotebookEditorModelResolverService, IUntitledNotebookResource } from './notebookEditorModelResolverService.js';
-import { ResourceMap } from '../../../../base/common/map.js';
+// --- Start Positron ---
+// Also import ResourceSet for untitled name reservations (#13561).
+// Commented out upstream code:
+// import { ResourceMap } from '../../../../base/common/map.js';
+import { ResourceMap, ResourceSet } from '../../../../base/common/map.js';
+// --- End Positron ---
 import { FileWorkingCopyManager, IFileWorkingCopyManager } from '../../../services/workingCopy/common/fileWorkingCopyManager.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { NotebookProviderInfo } from './notebookProvider.js';
@@ -170,8 +175,12 @@ export class NotebookModelResolverServiceImpl implements INotebookEditorModelRes
 
 	// --- Start Positron ---
 	// Untitled resources handed out by createUntitledUri whose models are
-	// still being created. See createUntitledUri for why (#13561).
-	private readonly _pendingUntitledUris = new Set<string>();
+	// still being created. See createUntitledUri for why (#13561). Keyed by
+	// URI comparison key so that the canonical form callers release always
+	// matches the minted form reserved in createUntitledUri: asCanonicalUri
+	// finds the canonical entry by this same key, so the two agree by
+	// construction.
+	private readonly _pendingUntitledUris = new ResourceSet(uri => this._uriIdentService.extUri.getComparisonKey(uri));
 	// --- End Positron ---
 
 	constructor(
@@ -217,8 +226,8 @@ export class NotebookModelResolverServiceImpl implements INotebookEditorModelRes
 		// }
 		for (let counter = 1; ; counter++) {
 			const candidate = URI.from({ scheme: Schemas.untitled, path: `Untitled-${counter}${suffix}`, query: notebookType });
-			if (!this._notebookService.getNotebookTextModel(candidate) && !this._data.isListeningToModel(candidate) && !this._pendingUntitledUris.has(candidate.toString())) {
-				this._pendingUntitledUris.add(candidate.toString());
+			if (!this._notebookService.getNotebookTextModel(candidate) && !this._data.isListeningToModel(candidate) && !this._pendingUntitledUris.has(candidate)) {
+				this._pendingUntitledUris.add(candidate);
 				return candidate;
 			}
 		}
@@ -282,7 +291,7 @@ export class NotebookModelResolverServiceImpl implements INotebookEditorModelRes
 		try {
 			return (await this._notebookService.createNotebookTextModel(viewType, resource));
 		} finally {
-			this._pendingUntitledUris.delete(resource.toString());
+			this._pendingUntitledUris.delete(resource);
 		}
 		// --- End Positron ---
 	}
@@ -325,7 +334,7 @@ export class NotebookModelResolverServiceImpl implements INotebookEditorModelRes
 			// minted resource has no existing model to conflict with -- so a
 			// reservation always reaches this finally.
 			if (!resource) {
-				this._pendingUntitledUris.delete(validated.resource.toString());
+				this._pendingUntitledUris.delete(validated.resource);
 			}
 			// --- End Positron ---
 		}

--- a/test/e2e/tests/notebooks-positron/notebook-untitled-naming.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-untitled-naming.test.ts
@@ -10,6 +10,11 @@ test.use({
 	suiteId: __filename
 });
 
+// Regression tests for https://github.com/posit-dev/positron/issues/13561
+// (unsaved notebooks reusing the Untitled-1.ipynb name). The concurrent
+// creation race itself is covered at the API level in
+// extensions/vscode-api-tests/src/singlefolder-tests/notebook.api.test.ts;
+// these tests pin the user-visible naming behavior in the full app.
 test.describe('Positron Notebooks: Untitled naming', {
 	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
 }, () => {
@@ -17,20 +22,13 @@ test.describe('Positron Notebooks: Untitled naming', {
 	test('Creating multiple untitled notebooks increments the name suffix', async function ({ app }) {
 		const { notebooks, notebooksPositron, editors } = app.workbench;
 
-		// TEMP DIAGNOSTIC for #13561 -- surface renderer console logs in test output
-		app.code.driver.currentPage.on('console', msg => {
-			if (msg.text().includes('[13561]')) {
-				console.log('[renderer]', msg.text());
-			}
-		});
-
 		// First untitled notebook is named Untitled-1.ipynb
 		await notebooks.createNewNotebook();
 		await notebooksPositron.expectToBeVisible();
 		await editors.waitForActiveTab('Untitled-1.ipynb', true);
 
 		// Subsequent untitled notebooks increment the suffix instead of
-		// reusing Untitled-1.ipynb (https://github.com/posit-dev/positron/issues/13561)
+		// reusing Untitled-1.ipynb
 		await notebooks.createNewNotebook();
 		await editors.waitForActiveTab('Untitled-2.ipynb', true);
 
@@ -41,14 +39,6 @@ test.describe('Positron Notebooks: Untitled naming', {
 	test('Untitled names keep incrementing after a window reload restores a dirty notebook', async function ({ app, hotKeys }) {
 		const { notebooks, notebooksPositron, editors } = app.workbench;
 
-		// TEMP DIAGNOSTIC for #13561 -- surface renderer console logs in test output
-		const attachLogger = () => app.code.driver.currentPage.on('console', msg => {
-			if (msg.text().includes('[13561]')) {
-				console.log('[renderer]', msg.text());
-			}
-		});
-		attachLogger();
-
 		// Create a dirty untitled notebook then reload the window so it is
 		// restored from a working copy backup
 		await notebooks.createNewNotebook();
@@ -56,7 +46,6 @@ test.describe('Positron Notebooks: Untitled naming', {
 		await editors.waitForActiveTab('Untitled-1.ipynb', true);
 
 		await hotKeys.reloadWindow(true);
-		attachLogger(); // page changed after reload
 		await editors.waitForActiveTab('Untitled-1.ipynb', true);
 		await notebooksPositron.expectToBeVisible();
 
@@ -65,26 +54,19 @@ test.describe('Positron Notebooks: Untitled naming', {
 		await editors.waitForActiveTab('Untitled-2.ipynb', true);
 	});
 
-	test('VS Code editor: creating multiple untitled notebooks increments the name suffix', async function ({ app, settings }) {
-		const { notebooks, notebooksVscode, notebooksPositron, editors } = app.workbench;
+	test('Closing an unsaved notebook releases its name for reuse', async function ({ app, hotKeys }) {
+		const { notebooks, notebooksPositron, editors } = app.workbench;
 
-		// TEMP DIAGNOSTIC for #13561 -- surface renderer console logs in test output
-		app.code.driver.currentPage.on('console', msg => {
-			if (msg.text().includes('[13561]')) {
-				console.log('[renderer]', msg.text());
-			}
-		});
-
-		await notebooksPositron.disablePositronNotebooks(settings);
-
+		// Create and discard an untitled notebook
 		await notebooks.createNewNotebook();
-		await notebooksVscode.expectToBeVisible();
+		await notebooksPositron.expectToBeVisible();
 		await editors.waitForActiveTab('Untitled-1.ipynb', true);
+		await hotKeys.closeAllEditors();
 
+		// The discarded name is reused (matches untitled text file behavior),
+		// and creating the next notebook must not error
 		await notebooks.createNewNotebook();
-		await editors.waitForActiveTab('Untitled-2.ipynb', true);
-
-		await notebooks.createNewNotebook();
-		await editors.waitForActiveTab('Untitled-3.ipynb', true);
+		await notebooksPositron.expectToBeVisible();
+		await editors.waitForActiveTab('Untitled-1.ipynb', true);
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-untitled-naming.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-untitled-naming.test.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Positron Notebooks: Untitled naming', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
+}, () => {
+
+	test('Creating multiple untitled notebooks increments the name suffix', async function ({ app }) {
+		const { notebooks, notebooksPositron, editors } = app.workbench;
+
+		// TEMP DIAGNOSTIC for #13561 -- surface renderer console logs in test output
+		app.code.driver.currentPage.on('console', msg => {
+			if (msg.text().includes('[13561]')) {
+				console.log('[renderer]', msg.text());
+			}
+		});
+
+		// First untitled notebook is named Untitled-1.ipynb
+		await notebooks.createNewNotebook();
+		await notebooksPositron.expectToBeVisible();
+		await editors.waitForActiveTab('Untitled-1.ipynb', true);
+
+		// Subsequent untitled notebooks increment the suffix instead of
+		// reusing Untitled-1.ipynb (https://github.com/posit-dev/positron/issues/13561)
+		await notebooks.createNewNotebook();
+		await editors.waitForActiveTab('Untitled-2.ipynb', true);
+
+		await notebooks.createNewNotebook();
+		await editors.waitForActiveTab('Untitled-3.ipynb', true);
+	});
+
+	test('Untitled names keep incrementing after a window reload restores a dirty notebook', async function ({ app, hotKeys }) {
+		const { notebooks, notebooksPositron, editors } = app.workbench;
+
+		// TEMP DIAGNOSTIC for #13561 -- surface renderer console logs in test output
+		const attachLogger = () => app.code.driver.currentPage.on('console', msg => {
+			if (msg.text().includes('[13561]')) {
+				console.log('[renderer]', msg.text());
+			}
+		});
+		attachLogger();
+
+		// Create a dirty untitled notebook then reload the window so it is
+		// restored from a working copy backup
+		await notebooks.createNewNotebook();
+		await notebooksPositron.expectToBeVisible();
+		await editors.waitForActiveTab('Untitled-1.ipynb', true);
+
+		await hotKeys.reloadWindow(true);
+		attachLogger(); // page changed after reload
+		await editors.waitForActiveTab('Untitled-1.ipynb', true);
+		await notebooksPositron.expectToBeVisible();
+
+		// A new untitled notebook must not reuse the restored notebook's name
+		await notebooks.createNewNotebook();
+		await editors.waitForActiveTab('Untitled-2.ipynb', true);
+	});
+
+	test('VS Code editor: creating multiple untitled notebooks increments the name suffix', async function ({ app, settings }) {
+		const { notebooks, notebooksVscode, notebooksPositron, editors } = app.workbench;
+
+		// TEMP DIAGNOSTIC for #13561 -- surface renderer console logs in test output
+		app.code.driver.currentPage.on('console', msg => {
+			if (msg.text().includes('[13561]')) {
+				console.log('[renderer]', msg.text());
+			}
+		});
+
+		await notebooksPositron.disablePositronNotebooks(settings);
+
+		await notebooks.createNewNotebook();
+		await notebooksVscode.expectToBeVisible();
+		await editors.waitForActiveTab('Untitled-1.ipynb', true);
+
+		await notebooks.createNewNotebook();
+		await editors.waitForActiveTab('Untitled-2.ipynb', true);
+
+		await notebooks.createNewNotebook();
+		await editors.waitForActiveTab('Untitled-3.ipynb', true);
+	});
+});


### PR DESCRIPTION
Fixes #13561

Creating several untitled notebooks concurrently named them all `Untitled-1.ipynb` and collapsed the duplicate requests into a single document. `createUntitledUri` in `notebookEditorModelResolverServiceImpl.ts` only sees a name after its model finishes loading (an async round trip to the extension host), so concurrent `openNotebookDocument()` calls all grab the same name before any of them registers. The fix reserves a name the moment it's handed out and releases it once the model settles, so concurrent creations get distinct names.

Unfortunately this is mostly upstream code, not Positron-specific. It surfaces here because the assistant creates notebooks programmatically and concurrently; the UI path serializes each create, so clicking New Notebook never hits the window. Good candidate to send upstream.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix unsaved notebooks all being named `Untitled-1.ipynb` when created concurrently (#13561)

### Validation Steps

@:positron-notebooks

Create several untitled notebooks in quick succession and confirm they get distinct, incrementing names. Covered by the concurrent-creation API test in `notebook.api.test.ts` and the three e2e tests in `notebook-untitled-naming.test.ts`.
