### PR TITLE
Run a selection or current line in a notebook cell

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/ExecuteSelectionInCellAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ExecuteSelectionInCellAction.ts
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
+import { localize, localize2 } from '../../../../nls.js';
+import { MenuId } from '../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
+import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
+import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { INotificationService } from '../../../../platform/notification/common/notification.js';
+import { IRuntimeNotebookKernelService } from '../../runtimeNotebookKernel/common/interfaces/runtimeNotebookKernelService.js';
+import { CellContextKeys } from '../common/cellContextKeys.js';
+import { NotebookContextKeys } from '../common/notebookContextKeys.js';
+import { SELECT_KERNEL_ID_POSITRON } from '../common/positronNotebookCommon.js';
+import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
+import { NotebookAction2 } from './NotebookAction2.js';
+import { getActiveCell } from './selectionMachine.js';
+
+/**
+ * Get the code to execute from a cell editor: the selected text, or the
+ * cursor's line (trimmed) when the selection is empty. Returns undefined when
+ * there is nothing runnable.
+ */
+export function getSelectedCodeFragment(editor: ICodeEditor): string | undefined {
+	if (!editor.hasModel()) {
+		return undefined;
+	}
+
+	const selection = editor.getSelection();
+	if (!selection) {
+		return undefined;
+	}
+
+	const model = editor.getModel();
+	const code = selection.isEmpty()
+		// No selection: run the entire line the cursor is on, trimmed so that
+		// an indented line (e.g. inside a Python block) runs on its own.
+		? model.getLineContent(selection.getStartPosition().lineNumber).trim()
+		: model.getValueInRange(selection);
+	return code.trim() ? code : undefined;
+}
+
+/**
+ * An action that executes the selected text in a notebook code cell (or the
+ * cursor's line when nothing is selected) in the notebook's kernel, with the
+ * output shown on that cell.
+ */
+export class ExecuteSelectionInCellAction extends NotebookAction2 {
+	constructor() {
+		super({
+			id: 'positronNotebook.cell.executeSelection',
+			title: localize2('positronNotebook.cell.executeSelection', "Run Selection in Cell"),
+			category: localize2('positronNotebook.category', 'Notebook'),
+			f1: true,
+			precondition: NotebookContextKeys.cellEditorFocused,
+			// Keep focus in the cell editor so the user can keep stepping
+			// through lines.
+			grabFocusOnRun: false,
+			keybinding: {
+				// Run All / Stop All bind the same key at EditorContrib weight
+				// for the whole notebook editor. WorkbenchContrib makes this
+				// binding deterministically win while a code cell editor is
+				// focused (Colab-style: Ctrl/Cmd+Shift+Enter runs the selection).
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter,
+				when: ContextKeyExpr.and(
+					NotebookContextKeys.cellEditorFocused,
+					CellContextKeys.isCode,
+				),
+			},
+			menu: [{
+				id: MenuId.PositronNotebookCellContext,
+				// PositronNotebookCellActionGroup.Execution in positronNotebook.contribution.ts
+				group: '4_execution',
+				order: 30,
+				when: ContextKeyExpr.and(
+					NotebookContextKeys.cellEditorFocused,
+					CellContextKeys.isCode,
+				),
+			}],
+		});
+	}
+
+	protected override async runNotebookAction(notebook: IPositronNotebookInstance, accessor: ServicesAccessor): Promise<void> {
+		// The accessor is only valid synchronously; get services up front.
+		const commandService = accessor.get(ICommandService);
+		const runtimeNotebookKernelService = accessor.get(IRuntimeNotebookKernelService);
+		const notificationService = accessor.get(INotificationService);
+
+		const cell = getActiveCell(notebook.selectionStateMachine.state.get());
+		if (!cell?.isCodeCell()) {
+			return;
+		}
+
+		const editor = cell.currentEditor;
+		if (!editor) {
+			return;
+		}
+
+		const code = getSelectedCodeFragment(editor);
+		if (code === undefined) {
+			return;
+		}
+
+		// Make sure a kernel is selected before executing, prompting the user
+		// if needed (mirrors PositronNotebookInstance._runCells).
+		if (!notebook.kernel.get()) {
+			await commandService.executeCommand(SELECT_KERNEL_ID_POSITRON);
+		}
+
+		try {
+			await runtimeNotebookKernelService.executeCodeInCell(notebook.uri, cell.handle, code);
+		} catch (err) {
+			notificationService.error(localize(
+				'positron.notebook.executeSelection.failed',
+				"Could not run the selected code: {0}",
+				err instanceof Error ? err.message : String(err)
+			));
+		}
+	}
+}

--- a/src/vs/workbench/contrib/positronNotebook/browser/ExecuteSelectionInCellAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ExecuteSelectionInCellAction.ts
@@ -16,7 +16,7 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { IRuntimeNotebookKernelService } from '../../runtimeNotebookKernel/common/interfaces/runtimeNotebookKernelService.js';
 import { CellContextKeys } from '../common/cellContextKeys.js';
 import { NotebookContextKeys } from '../common/notebookContextKeys.js';
-import { SELECT_KERNEL_ID_POSITRON } from '../common/positronNotebookCommon.js';
+import { PositronNotebookCellActionGroup, SELECT_KERNEL_ID_POSITRON } from '../common/positronNotebookCommon.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
 import { NotebookAction2 } from './NotebookAction2.js';
 import { getActiveCell } from './selectionMachine.js';
@@ -79,8 +79,7 @@ export class ExecuteSelectionInCellAction extends NotebookAction2 {
 			},
 			menu: [{
 				id: MenuId.PositronNotebookCellContext,
-				// PositronNotebookCellActionGroup.Execution in positronNotebook.contribution.ts
-				group: '4_execution',
+				group: PositronNotebookCellActionGroup.Execution,
 				order: 30,
 				when: ContextKeyExpr.and(
 					NotebookContextKeys.cellEditorFocused,

--- a/src/vs/workbench/contrib/positronNotebook/browser/ExecuteSelectionInCellAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ExecuteSelectionInCellAction.ts
@@ -24,6 +24,10 @@ import { getActiveCell } from './selectionMachine.js';
  * Get the code to execute from a cell editor: the selected text, or the
  * cursor's line (trimmed) when the selection is empty. Returns undefined when
  * there is nothing runnable.
+ *
+ * A non-empty selection is returned exactly as highlighted (no trimming), for
+ * parity with ExecuteSelectionInConsoleAction. The current line is trimmed so
+ * that an indented line runs on its own (e.g. in Python).
  */
 export function getSelectedCodeFragment(editor: ICodeEditor): string | undefined {
 	if (!editor.hasModel()) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/ExecuteSelectionInCellAction.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/ExecuteSelectionInCellAction.ts
@@ -11,6 +11,7 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IRuntimeNotebookKernelService } from '../../runtimeNotebookKernel/common/interfaces/runtimeNotebookKernelService.js';
 import { CellContextKeys } from '../common/cellContextKeys.js';
@@ -94,6 +95,7 @@ export class ExecuteSelectionInCellAction extends NotebookAction2 {
 		const commandService = accessor.get(ICommandService);
 		const runtimeNotebookKernelService = accessor.get(IRuntimeNotebookKernelService);
 		const notificationService = accessor.get(INotificationService);
+		const logService = accessor.get(ILogService);
 
 		const cell = getActiveCell(notebook.selectionStateMachine.state.get());
 		if (!cell?.isCodeCell()) {
@@ -119,10 +121,12 @@ export class ExecuteSelectionInCellAction extends NotebookAction2 {
 		try {
 			await runtimeNotebookKernelService.executeCodeInCell(notebook.uri, cell.handle, code);
 		} catch (err) {
+			// The underlying error messages carry internal detail (URIs, etc.)
+			// that isn't useful to the user; log them and show a clean message.
+			logService.error(`Run Selection in Cell failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
 			notificationService.error(localize(
 				'positron.notebook.executeSelection.failed',
-				"Could not run the selected code: {0}",
-				err instanceof Error ? err.message : String(err)
+				"Could not run the selected code."
 			));
 		}
 	}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
@@ -35,6 +35,7 @@ const SHORTCUT_SECTIONS: ShortcutSection[] = [
 		shortcuts: [
 			{ label: localize('positron.notebookHelp.runCell', 'Run cell'), commandId: 'positronNotebook.cell.executeOrToggleEditor' },
 			{ label: localize('positron.notebookHelp.runCellAndAdvance', 'Run cell and advance'), commandId: 'positronNotebook.cell.executeAndSelectBelow' },
+			{ label: localize('positron.notebookHelp.runSelection', 'Run selection or current line'), commandId: 'positronNotebook.cell.executeSelection' },
 			{ label: localize('positron.notebookHelp.runAll', 'Run all cells'), commandId: 'positronNotebook.runAllCells' },
 		]
 	},

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -61,6 +61,7 @@ import { CellContextKeys } from '../common/cellContextKeys.js';
 import { NotebookContextKeys } from '../common/notebookContextKeys.js';
 import './contrib/undoRedo/positronNotebookUndoRedo.js';
 import { Action2, registerAction2, MenuId, MenuRegistry } from '../../../../platform/actions/common/actions.js';
+import { ExecuteSelectionInCellAction } from './ExecuteSelectionInCellAction.js';
 import { ExecuteSelectionInConsoleAction } from './ExecuteSelectionInConsoleAction.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { KernelStatusBadge } from './KernelStatusBadge.js';
@@ -2233,6 +2234,7 @@ registerNotebookWidget({
 //#endregion Notebook Header Actions
 
 // Register actions
+registerAction2(ExecuteSelectionInCellAction);
 registerAction2(ExecuteSelectionInConsoleAction);
 registerAction2(UpdateNotebookWorkingDirectoryAction);
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/executeSelectionInCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/executeSelectionInCell.vitest.ts
@@ -14,6 +14,7 @@ import { createTextModel } from '../../../../../editor/test/common/testTextModel
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
 import { IKeybindingRule, KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { ILogService } from '../../../../../platform/log/common/log.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
@@ -141,10 +142,12 @@ describe('ExecuteSelectionInCellAction', () => {
 			.mockResolvedValue(undefined);
 		const executeCommand = vi.fn().mockResolvedValue(undefined);
 		const notifyError = vi.fn();
+		const logError = vi.fn();
 		const services = new Map<unknown, unknown>([
 			[IRuntimeNotebookKernelService, { executeCodeInCell }],
 			[ICommandService, { executeCommand }],
 			[INotificationService, { error: notifyError }],
+			[ILogService, { error: logError }],
 		]);
 		const accessor: ServicesAccessor = {
 			get: <T>(id: unknown): T => {
@@ -154,7 +157,7 @@ describe('ExecuteSelectionInCellAction', () => {
 				return services.get(id) as T;
 			},
 		};
-		return { accessor, executeCodeInCell, executeCommand, notifyError };
+		return { accessor, executeCodeInCell, executeCommand, notifyError, logError };
 	}
 
 	it('declares the Cmd/Ctrl+Shift+Enter keybinding scoped to focused code cell editors', () => {
@@ -245,15 +248,19 @@ describe('ExecuteSelectionInCellAction', () => {
 			.toBeLessThan(executeCodeInCell.mock.invocationCallOrder[0]);
 	});
 
-	it('notifies the user when execution fails to start', async () => {
+	it('logs the failure detail but shows a clean message when execution fails', async () => {
 		const editor = createEditor('flights', new Selection(1, 1, 1, 8));
 		const cell = createCodeCell(5, editor);
 		const notebook = createNotebook(cell);
-		const { accessor, executeCodeInCell, notifyError } = createServices();
-		executeCodeInCell.mockRejectedValue(new Error('no kernel'));
+		const { accessor, executeCodeInCell, notifyError, logError } = createServices();
+		executeCodeInCell.mockRejectedValue(new Error('no selected kernel: file:///test.ipynb'));
 
 		await new TestableExecuteSelectionInCellAction().testRun(notebook, accessor);
 
+		// The user-facing toast is self-contained and must not leak the raw
+		// internal error (URIs, etc.); that detail goes to the log instead.
 		expect(notifyError).toHaveBeenCalledOnce();
+		expect(notifyError.mock.calls[0][0]).not.toContain('file:///');
+		expect(logError).toHaveBeenCalledOnce();
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/executeSelectionInCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/executeSelectionInCell.vitest.ts
@@ -55,6 +55,11 @@ describe('getSelectedCodeFragment', () => {
 		expect(getSelectedCodeFragment(editor)).toBe('x = 1\ny = 2');
 	});
 
+	it('does not trim surrounding whitespace from a selection', () => {
+		const editor = createEditor('  x = 1  ', new Selection(1, 1, 1, 10));
+		expect(getSelectedCodeFragment(editor)).toBe('  x = 1  ');
+	});
+
 	it('returns the cursor line, trimmed, when the selection is empty', () => {
 		const editor = createEditor('x = 1\n    y = 2', new Selection(2, 3, 2, 3));
 		expect(getSelectedCodeFragment(editor)).toBe('y = 2');

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/executeSelectionInCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/executeSelectionInCell.vitest.ts
@@ -13,12 +13,12 @@ import { Selection } from '../../../../../editor/common/core/selection.js';
 import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
-import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { IKeybindingRule, KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { INotificationService } from '../../../../../platform/notification/common/notification.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
-import { INotebookKernel } from '../../../notebook/common/notebookKernelService.js';
+import { RuntimeNotebookKernel } from '../../../runtimeNotebookKernel/browser/runtimeNotebookKernel.js';
 import { IRuntimeNotebookKernelService } from '../../../runtimeNotebookKernel/common/interfaces/runtimeNotebookKernelService.js';
 import { CellContextKeys } from '../../common/cellContextKeys.js';
 import { NotebookContextKeys } from '../../common/notebookContextKeys.js';
@@ -121,7 +121,7 @@ describe('ExecuteSelectionInCellAction', () => {
 	function createNotebook(cell: IPositronNotebookCell, options?: { kernelSelected?: boolean }): IPositronNotebookInstance {
 		const kernel = options?.kernelSelected === false
 			? undefined
-			: stubInterface<INotebookKernel>({ id: 'test-kernel' });
+			: stubInterface<RuntimeNotebookKernel>({ id: 'test-kernel' });
 		return stubInterface<IPositronNotebookInstance>({
 			uri: notebookUri,
 			kernel: observableValue('kernel', kernel),
@@ -155,11 +155,13 @@ describe('ExecuteSelectionInCellAction', () => {
 	it('declares the Cmd/Ctrl+Shift+Enter keybinding scoped to focused code cell editors', () => {
 		const action = new ExecuteSelectionInCellAction();
 		expect(action.desc.id).toBe('positronNotebook.cell.executeSelection');
-		expect(action.desc.keybinding?.primary).toBe(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter);
+		// The action declares a single keybinding rule; narrow from OneOrN.
+		const keybinding = action.desc.keybinding as Omit<IKeybindingRule, 'id'>;
+		expect(keybinding.primary).toBe(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter);
 		// WorkbenchContrib so it deterministically wins over the EditorContrib
 		// Run All / Stop All bindings on the same key while editing a code cell.
-		expect(action.desc.keybinding?.weight).toBe(KeybindingWeight.WorkbenchContrib);
-		expect(action.desc.keybinding?.when?.serialize()).toBe(
+		expect(keybinding.weight).toBe(KeybindingWeight.WorkbenchContrib);
+		expect(keybinding.when?.serialize()).toBe(
 			ContextKeyExpr.and(NotebookContextKeys.cellEditorFocused, CellContextKeys.isCode)!.serialize()
 		);
 	});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/executeSelectionInCell.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/executeSelectionInCell.vitest.ts
@@ -1,0 +1,252 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { KeyCode, KeyMod } from '../../../../../base/common/keyCodes.js';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
+import { Selection } from '../../../../../editor/common/core/selection.js';
+import { createTextModel } from '../../../../../editor/test/common/testTextModel.js';
+import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ServicesAccessor } from '../../../../../platform/instantiation/common/instantiation.js';
+import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { INotificationService } from '../../../../../platform/notification/common/notification.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { INotebookKernel } from '../../../notebook/common/notebookKernelService.js';
+import { IRuntimeNotebookKernelService } from '../../../runtimeNotebookKernel/common/interfaces/runtimeNotebookKernelService.js';
+import { CellContextKeys } from '../../common/cellContextKeys.js';
+import { NotebookContextKeys } from '../../common/notebookContextKeys.js';
+import { SELECT_KERNEL_ID_POSITRON } from '../../common/positronNotebookCommon.js';
+import { IPositronNotebookInstance } from '../../browser/IPositronNotebookInstance.js';
+import { IPositronNotebookCell } from '../../browser/PositronNotebookCells/IPositronNotebookCell.js';
+import { SelectionState, SelectionStateMachine } from '../../browser/selectionMachine.js';
+import { ExecuteSelectionInCellAction, getSelectedCodeFragment } from '../../browser/ExecuteSelectionInCellAction.js';
+
+describe('getSelectedCodeFragment', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	function createEditor(content: string, selection: Selection): ICodeEditor {
+		const model = disposables.add(createTextModel(content, 'python'));
+		return stubInterface<ICodeEditor>({
+			hasModel: (() => true) as ICodeEditor['hasModel'],
+			getModel: () => model,
+			getSelection: () => selection,
+		});
+	}
+
+	it('returns the selected text when there is a non-empty selection', () => {
+		const editor = createEditor('1 + 1\nflights', new Selection(2, 1, 2, 8));
+		expect(getSelectedCodeFragment(editor)).toBe('flights');
+	});
+
+	it('returns a partial selection within a line', () => {
+		const editor = createEditor('print(flights)', new Selection(1, 7, 1, 14));
+		expect(getSelectedCodeFragment(editor)).toBe('flights');
+	});
+
+	it('preserves a multi-line selection exactly', () => {
+		const editor = createEditor('x = 1\ny = 2\nprint(x + y)', new Selection(1, 1, 2, 6));
+		expect(getSelectedCodeFragment(editor)).toBe('x = 1\ny = 2');
+	});
+
+	it('returns the cursor line, trimmed, when the selection is empty', () => {
+		const editor = createEditor('x = 1\n    y = 2', new Selection(2, 3, 2, 3));
+		expect(getSelectedCodeFragment(editor)).toBe('y = 2');
+	});
+
+	it('returns undefined when the cursor line is blank', () => {
+		const editor = createEditor('x = 1\n\t \ny = 2', new Selection(2, 1, 2, 1));
+		expect(getSelectedCodeFragment(editor)).toBeUndefined();
+	});
+
+	it('returns undefined when the selection contains only whitespace', () => {
+		const editor = createEditor('x = 1\n   \nz = 3', new Selection(2, 1, 2, 4));
+		expect(getSelectedCodeFragment(editor)).toBeUndefined();
+	});
+
+	it('returns undefined when the editor has no model', () => {
+		const editor = stubInterface<ICodeEditor>({
+			hasModel: (() => false) as ICodeEditor['hasModel'],
+		});
+		expect(getSelectedCodeFragment(editor)).toBeUndefined();
+	});
+
+	it('returns undefined when the editor has no selection', () => {
+		const model = disposables.add(createTextModel('x = 1', 'python'));
+		const editor = stubInterface<ICodeEditor>({
+			hasModel: (() => true) as ICodeEditor['hasModel'],
+			getModel: () => model,
+			getSelection: () => null,
+		});
+		expect(getSelectedCodeFragment(editor)).toBeUndefined();
+	});
+});
+
+describe('ExecuteSelectionInCellAction', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	const notebookUri = URI.parse('file:///test.ipynb');
+
+	// Expose the protected runNotebookAction so behavior can be tested without
+	// standing up an active editor pane (same pattern as selectionKeybindings).
+	class TestableExecuteSelectionInCellAction extends ExecuteSelectionInCellAction {
+		public testRun(notebook: IPositronNotebookInstance, accessor: ServicesAccessor) {
+			return this.runNotebookAction(notebook, accessor);
+		}
+	}
+
+	function createEditor(content: string, selection: Selection): ICodeEditor {
+		const model = disposables.add(createTextModel(content, 'python'));
+		return stubInterface<ICodeEditor>({
+			hasModel: (() => true) as ICodeEditor['hasModel'],
+			getModel: () => model,
+			getSelection: () => selection,
+		});
+	}
+
+	function createCodeCell(handle: number, editor: ICodeEditor | undefined): IPositronNotebookCell {
+		return stubInterface<IPositronNotebookCell>({
+			handle,
+			currentEditor: editor,
+			isCodeCell: (() => true) as IPositronNotebookCell['isCodeCell'],
+		});
+	}
+
+	function createNotebook(cell: IPositronNotebookCell, options?: { kernelSelected?: boolean }): IPositronNotebookInstance {
+		const kernel = options?.kernelSelected === false
+			? undefined
+			: stubInterface<INotebookKernel>({ id: 'test-kernel' });
+		return stubInterface<IPositronNotebookInstance>({
+			uri: notebookUri,
+			kernel: observableValue('kernel', kernel),
+			selectionStateMachine: stubInterface<SelectionStateMachine>({
+				state: observableValue('state', { type: SelectionState.EditingSelection, active: cell }),
+			}),
+		});
+	}
+
+	function createServices() {
+		const executeCodeInCell = vi.fn<(uri: URI, handle: number, code: string) => Promise<void>>()
+			.mockResolvedValue(undefined);
+		const executeCommand = vi.fn().mockResolvedValue(undefined);
+		const notifyError = vi.fn();
+		const services = new Map<unknown, unknown>([
+			[IRuntimeNotebookKernelService, { executeCodeInCell }],
+			[ICommandService, { executeCommand }],
+			[INotificationService, { error: notifyError }],
+		]);
+		const accessor: ServicesAccessor = {
+			get: <T>(id: unknown): T => {
+				if (!services.has(id)) {
+					throw new Error(`Unexpected service requested in test: ${String(id)}`);
+				}
+				return services.get(id) as T;
+			},
+		};
+		return { accessor, executeCodeInCell, executeCommand, notifyError };
+	}
+
+	it('declares the Cmd/Ctrl+Shift+Enter keybinding scoped to focused code cell editors', () => {
+		const action = new ExecuteSelectionInCellAction();
+		expect(action.desc.id).toBe('positronNotebook.cell.executeSelection');
+		expect(action.desc.keybinding?.primary).toBe(KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Enter);
+		// WorkbenchContrib so it deterministically wins over the EditorContrib
+		// Run All / Stop All bindings on the same key while editing a code cell.
+		expect(action.desc.keybinding?.weight).toBe(KeybindingWeight.WorkbenchContrib);
+		expect(action.desc.keybinding?.when?.serialize()).toBe(
+			ContextKeyExpr.and(NotebookContextKeys.cellEditorFocused, CellContextKeys.isCode)!.serialize()
+		);
+	});
+
+	it('runs the selected text in the active cell via the kernel service', async () => {
+		const editor = createEditor('1 + 1\nflights', new Selection(2, 1, 2, 8));
+		const cell = createCodeCell(7, editor);
+		const notebook = createNotebook(cell);
+		const { accessor, executeCodeInCell, executeCommand } = createServices();
+
+		await new TestableExecuteSelectionInCellAction().testRun(notebook, accessor);
+
+		expect(executeCodeInCell).toHaveBeenCalledOnce();
+		expect(executeCodeInCell).toHaveBeenCalledWith(notebookUri, 7, 'flights');
+		// A kernel is already selected; no kernel selection prompt.
+		expect(executeCommand).not.toHaveBeenCalled();
+	});
+
+	it('runs the current line when the selection is empty', async () => {
+		const editor = createEditor('x = 1\ny = 2', new Selection(2, 3, 2, 3));
+		const cell = createCodeCell(3, editor);
+		const notebook = createNotebook(cell);
+		const { accessor, executeCodeInCell } = createServices();
+
+		await new TestableExecuteSelectionInCellAction().testRun(notebook, accessor);
+
+		expect(executeCodeInCell).toHaveBeenCalledWith(notebookUri, 3, 'y = 2');
+	});
+
+	it('does nothing for a non-code cell', async () => {
+		const editor = createEditor('# heading', new Selection(1, 1, 1, 10));
+		const cell = stubInterface<IPositronNotebookCell>({
+			handle: 1,
+			currentEditor: editor,
+			isCodeCell: (() => false) as IPositronNotebookCell['isCodeCell'],
+		});
+		const notebook = createNotebook(cell);
+		const { accessor, executeCodeInCell } = createServices();
+
+		await new TestableExecuteSelectionInCellAction().testRun(notebook, accessor);
+
+		expect(executeCodeInCell).not.toHaveBeenCalled();
+	});
+
+	it('does nothing when there is nothing runnable at the cursor', async () => {
+		const editor = createEditor('x = 1\n\nz = 3', new Selection(2, 1, 2, 1));
+		const cell = createCodeCell(2, editor);
+		const notebook = createNotebook(cell);
+		const { accessor, executeCodeInCell } = createServices();
+
+		await new TestableExecuteSelectionInCellAction().testRun(notebook, accessor);
+
+		expect(executeCodeInCell).not.toHaveBeenCalled();
+	});
+
+	it('does nothing when the cell has no attached editor', async () => {
+		const cell = createCodeCell(2, undefined);
+		const notebook = createNotebook(cell);
+		const { accessor, executeCodeInCell } = createServices();
+
+		await new TestableExecuteSelectionInCellAction().testRun(notebook, accessor);
+
+		expect(executeCodeInCell).not.toHaveBeenCalled();
+	});
+
+	it('prompts for kernel selection when no kernel is selected', async () => {
+		const editor = createEditor('flights', new Selection(1, 1, 1, 8));
+		const cell = createCodeCell(5, editor);
+		const notebook = createNotebook(cell, { kernelSelected: false });
+		const { accessor, executeCodeInCell, executeCommand } = createServices();
+
+		await new TestableExecuteSelectionInCellAction().testRun(notebook, accessor);
+
+		expect(executeCommand).toHaveBeenCalledWith(SELECT_KERNEL_ID_POSITRON);
+		expect(executeCommand.mock.invocationCallOrder[0])
+			.toBeLessThan(executeCodeInCell.mock.invocationCallOrder[0]);
+	});
+
+	it('notifies the user when execution fails to start', async () => {
+		const editor = createEditor('flights', new Selection(1, 1, 1, 8));
+		const cell = createCodeCell(5, editor);
+		const notebook = createNotebook(cell);
+		const { accessor, executeCodeInCell, notifyError } = createServices();
+		executeCodeInCell.mockRejectedValue(new Error('no kernel'));
+
+		await new TestableExecuteSelectionInCellAction().testRun(notebook, accessor);
+
+		expect(notifyError).toHaveBeenCalledOnce();
+	});
+});

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernel.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernel.ts
@@ -300,9 +300,12 @@ export class RuntimeNotebookKernel extends Disposable implements INotebookKernel
 						notebookUri,
 						`Runtime kernel ${this.id} executed a code fragment for notebook`,
 					);
+				// No `cellId` for fragments: the fragment's line numbers don't
+				// correspond to the cell's content, so the kernel's breakpoint
+				// mapping for the cell document would be wrong (see executeCell).
 				await this._notebookExecutionSequencer.queue(
 					notebookUri,
-					() => this.executeCell(cell, notebook, session, code),
+					() => this.executeCellCode(cell, notebook, session, { code }),
 				);
 			} finally {
 				// If the queued execution never started (e.g. the session failed
@@ -325,15 +328,43 @@ export class RuntimeNotebookKernel extends Disposable implements INotebookKernel
 	 * @param cell The notebook cell text model.
 	 * @param notebook The notebook text model.
 	 * @param session The session to execute in.
-	 * @param codeOverride When set, execute this code instead of the cell's
-	 *   content (see {@link executeCodeInCell}). Output still lands on the cell.
 	 * @returns
 	 */
 	private async executeCell(
 		cell: NotebookCellTextModel,
 		notebook: NotebookTextModel,
 		session: ILanguageRuntimeSession,
-		codeOverride?: string,
+	): Promise<void> {
+		return this.executeCellCode(cell, notebook, session, {
+			code: cell.getValue(),
+			// Include `cellId` so the kernel can identify this as a notebook
+			// cell execution and look up breakpoints via the Jupyter Debug
+			// Protocol's mapping of cell documents to kernel temp files. Only
+			// whole-cell executions get one; a fragment's line numbers don't
+			// match the cell document (see executeCodeInCell).
+			cellId: cell.uri.toString(),
+		});
+	}
+
+	/**
+	 * Execute code in a notebook cell, with replies (outputs, errors, etc.)
+	 * applied to that cell.
+	 *
+	 * Shared by {@link executeCell} (the cell's own content) and
+	 * {@link executeCodeInCell} (a fragment of the cell, e.g. the user's
+	 * selection); the two differ only in the options they pass.
+	 *
+	 * @param cell The notebook cell text model.
+	 * @param notebook The notebook text model.
+	 * @param session The session to execute in.
+	 * @param options The code to execute and, for whole-cell executions, the
+	 *   cell ID to attach to the execution for breakpoint mapping.
+	 */
+	private async executeCellCode(
+		cell: NotebookCellTextModel,
+		notebook: NotebookTextModel,
+		session: ILanguageRuntimeSession,
+		options: { code: string; cellId?: string },
 	): Promise<void> {
 		this._logService.trace(`[RuntimeNotebookKernel] Executing cell: ${cell.handle}`);
 
@@ -342,9 +373,9 @@ export class RuntimeNotebookKernel extends Disposable implements INotebookKernel
 			return;
 		}
 
-		const code = codeOverride ?? cell.getValue();
+		const code = options.code;
 
-		// If the cell is empty, skip it.
+		// If the code is empty, skip it.
 		if (!code.trim()) {
 			return;
 		}
@@ -402,12 +433,11 @@ export class RuntimeNotebookKernel extends Disposable implements INotebookKernel
 		// appropriately (e.g. for plot rendering).
 		const executionMetadata = this._getExecutionMetadata(notebook.uri);
 
-		// Execute the code. Include `cellId` in execution metadata so the
-		// kernel can identify this as a notebook cell execution and look up
-		// breakpoints via the Jupyter Debug Protocol's temp file mapping.
-		// Code fragments don't get a `cellId`: their line numbers don't
-		// correspond to the cell's content, so the breakpoint mapping would be
-		// wrong.
+		// Execute the code.
+		const metadata: Record<string, unknown> = { ...executionMetadata };
+		if (options.cellId !== undefined) {
+			metadata.cellId = options.cellId;
+		}
 		try {
 			session.execute(
 				code,
@@ -415,9 +445,7 @@ export class RuntimeNotebookKernel extends Disposable implements INotebookKernel
 				RuntimeCodeExecutionMode.Interactive,
 				errorBehavior,
 				undefined,
-				codeOverride === undefined
-					? { ...executionMetadata, cellId: cell.uri.toString() }
-					: { ...executionMetadata },
+				metadata,
 			);
 		} catch (err) {
 			execution.error(err);

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernel.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernel.ts
@@ -276,7 +276,11 @@ export class RuntimeNotebookKernel extends Disposable implements INotebookKernel
 				return;
 			}
 
-			// Match executeCell's guards before creating any execution state.
+			// Check raw/empty up front, before creating any execution state, so
+			// a fragment that would be skipped never flashes the cell into a
+			// pending state. executeCellCode re-checks at dequeue time; that
+			// copy of the guards is load-bearing for the whole-cell path, which
+			// has no pre-check.
 			if (cell.language === 'raw' || !code.trim()) {
 				return;
 			}

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernel.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernel.ts
@@ -417,7 +417,7 @@ export class RuntimeNotebookKernel extends Disposable implements INotebookKernel
 				undefined,
 				codeOverride === undefined
 					? { ...executionMetadata, cellId: cell.uri.toString() }
-					: executionMetadata,
+					: { ...executionMetadata },
 			);
 		} catch (err) {
 			execution.error(err);

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernel.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernel.ts
@@ -26,6 +26,7 @@ import { ILanguageRuntimeSession, INotebookLanguageRuntimeSession, IRuntimeSessi
 import { IRuntimeStartupService } from '../../../services/runtimeStartup/common/runtimeStartupService.js';
 import { NotebookCellTextModel } from '../../notebook/common/model/notebookCellTextModel.js';
 import { NotebookTextModel } from '../../notebook/common/model/notebookTextModel.js';
+import { NotebookCellExecutionState } from '../../notebook/common/notebookCommon.js';
 import { INotebookExecutionStateService } from '../../notebook/common/notebookExecutionStateService.js';
 import { INotebookKernel, INotebookKernelChangeEvent, VariablesResult } from '../../notebook/common/notebookKernelService.js';
 import { IPYNB_VIEW_TYPE } from '../../notebook/browser/notebookBrowser.js';
@@ -246,17 +247,93 @@ export class RuntimeNotebookKernel extends Disposable implements INotebookKernel
 	}
 
 	/**
+	 * Execute a code fragment in the context of an existing notebook cell.
+	 *
+	 * Used by the "run selection in cell" feature: the fragment (e.g. the
+	 * user's selection or current line) executes in the notebook's session and
+	 * its output lands on the originating cell, like a regular execution of
+	 * that cell.
+	 *
+	 * @param notebookUri The URI of the notebook.
+	 * @param cellHandle The handle of the cell the code belongs to.
+	 * @param code The code fragment to execute.
+	 */
+	async executeCodeInCell(notebookUri: URI, cellHandle: number, code: string): Promise<void> {
+		// NOTE: Like executeNotebookCellsRequest, this method should not throw;
+		// errors are logged and surfaced through the cell execution itself.
+		try {
+			const notebook = this._notebookService.getNotebookTextModel(notebookUri);
+			if (!notebook) {
+				throw new Error(`No notebook document for '${notebookUri.fsPath}'`);
+			}
+
+			const cell = notebook.cells.find(cell => cell.handle === cellHandle);
+			if (!cell) {
+				this._logService.warn(
+					`[RuntimeNotebookKernel] Cell handle ${cellHandle} not found in notebook ` +
+					`${notebookUri.fsPath}; skipping code fragment execution`
+				);
+				return;
+			}
+
+			// Match executeCell's guards before creating any execution state.
+			if (cell.language === 'raw' || !code.trim()) {
+				return;
+			}
+
+			// If the cell is already executing (or queued), don't interleave
+			// another execution on the same cell.
+			if (this._notebookExecutionStateService.getCellExecution(cell.uri)) {
+				this._logService.debug(
+					`[RuntimeNotebookKernel] Cell ${cell.handle} already has an active execution; ` +
+					`skipping code fragment execution`
+				);
+				return;
+			}
+
+			// Create the cell execution up front so the cell immediately shows
+			// as pending, mirroring NotebookExecutionService.executeNotebookCells.
+			const cellExecution = this._notebookExecutionStateService.createCellExecution(notebookUri, cell.handle);
+			try {
+				const session = this._runtimeSessionService.getNotebookSessionForNotebookUri(notebookUri)
+					?? await this.ensureSessionStarted(
+						notebookUri,
+						`Runtime kernel ${this.id} executed a code fragment for notebook`,
+					);
+				await this._notebookExecutionSequencer.queue(
+					notebookUri,
+					() => this.executeCell(cell, notebook, session, code),
+				);
+			} finally {
+				// If the queued execution never started (e.g. the session failed
+				// to start, or an earlier queued cell errored), complete the
+				// pending execution so the cell doesn't show as pending forever.
+				// Mirrors the unconfirmed-execution sweep in
+				// NotebookExecutionService.executeNotebookCells.
+				if (cellExecution.state === NotebookCellExecutionState.Unconfirmed) {
+					cellExecution.complete({});
+				}
+			}
+		} catch (err) {
+			this._logService.error(`Error executing code fragment in cell: ${err.stack ?? err.toString()}`);
+		}
+	}
+
+	/**
 	 * Execute a notebook cell.
 	 *
 	 * @param cell The notebook cell text model.
 	 * @param notebook The notebook text model.
-	 * @param session
+	 * @param session The session to execute in.
+	 * @param codeOverride When set, execute this code instead of the cell's
+	 *   content (see {@link executeCodeInCell}). Output still lands on the cell.
 	 * @returns
 	 */
 	private async executeCell(
 		cell: NotebookCellTextModel,
 		notebook: NotebookTextModel,
 		session: ILanguageRuntimeSession,
+		codeOverride?: string,
 	): Promise<void> {
 		this._logService.trace(`[RuntimeNotebookKernel] Executing cell: ${cell.handle}`);
 
@@ -265,7 +342,7 @@ export class RuntimeNotebookKernel extends Disposable implements INotebookKernel
 			return;
 		}
 
-		const code = cell.getValue();
+		const code = codeOverride ?? cell.getValue();
 
 		// If the cell is empty, skip it.
 		if (!code.trim()) {
@@ -328,6 +405,9 @@ export class RuntimeNotebookKernel extends Disposable implements INotebookKernel
 		// Execute the code. Include `cellId` in execution metadata so the
 		// kernel can identify this as a notebook cell execution and look up
 		// breakpoints via the Jupyter Debug Protocol's temp file mapping.
+		// Code fragments don't get a `cellId`: their line numbers don't
+		// correspond to the cell's content, so the breakpoint mapping would be
+		// wrong.
 		try {
 			session.execute(
 				code,
@@ -335,7 +415,9 @@ export class RuntimeNotebookKernel extends Disposable implements INotebookKernel
 				RuntimeCodeExecutionMode.Interactive,
 				errorBehavior,
 				undefined,
-				{ ...executionMetadata, cellId: cell.uri.toString() },
+				codeOverride === undefined
+					? { ...executionMetadata, cellId: cell.uri.toString() }
+					: executionMetadata,
 			);
 		} catch (err) {
 			execution.error(err);

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/browser/runtimeNotebookKernelService.ts
@@ -277,6 +277,21 @@ export class RuntimeNotebookKernelService extends Disposable implements IRuntime
 		return await kernel.ensureSessionStarted(notebook.uri, source);
 	}
 
+	public async executeCodeInCell(notebookUri: URI, cellHandle: number, code: string): Promise<void> {
+		// Get the notebook text model
+		const notebook = this._notebookService.getNotebookTextModel(notebookUri);
+		if (!notebook) {
+			throw new Error(`Could not execute code in cell for notebook without text model: ${notebookUri}`);
+		}
+		// Get the selected kernel
+		const kernel = this.getSelectedKernel(notebook);
+		if (!kernel) {
+			throw new Error(`Could not execute code in cell for notebook without selected kernel: ${notebookUri}`);
+		}
+
+		await kernel.executeCodeInCell(notebookUri, cellHandle, code);
+	}
+
 	/**
 	 * Get a runtime notebook kernel by runtime ID.
 	 *

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/common/interfaces/runtimeNotebookKernelService.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/common/interfaces/runtimeNotebookKernelService.ts
@@ -34,4 +34,16 @@ export interface IRuntimeNotebookKernelService {
 	 * @param source The source of the action for debugging purposes
 	 */
 	ensureSessionStarted(notebookUri: URI, source: string): Promise<INotebookLanguageRuntimeSession>;
+
+	/**
+	 * Execute a code fragment in the context of an existing notebook cell.
+	 *
+	 * The fragment executes in the notebook's session and its output lands on
+	 * the given cell, like a regular execution of that cell.
+	 *
+	 * @param notebookUri The URI of the notebook
+	 * @param cellHandle The handle of the cell the code belongs to
+	 * @param code The code fragment to execute
+	 */
+	executeCodeInCell(notebookUri: URI, cellHandle: number, code: string): Promise<void>;
 }

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/tests/browser/runtimeNotebookKernel.vitest.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/tests/browser/runtimeNotebookKernel.vitest.ts
@@ -512,6 +512,303 @@ describe('Positron - RuntimeNotebookKernel', () => {
 	});
 });
 
+describe('Positron - RuntimeNotebookKernel - executeCodeInCell', () => {
+	const ctx = createTestContainer().withWorkbenchServices().build();
+	let notebookExecutionStateService: FaithfulTestNotebookExecutionStateService;
+	let runtimeSessionService: IRuntimeSessionService;
+	let runtime: ILanguageRuntimeMetadata;
+	let kernel: RuntimeNotebookKernel;
+	let notebookDocument: NotebookTextModel;
+	let rawCell: NotebookCellTextModel;
+
+	beforeEach(async () => {
+		const accessor = ctx.instantiationService.createInstance(PositronTestServiceAccessor);
+
+		runtimeSessionService = accessor.runtimeSessionService;
+
+		notebookExecutionStateService = new FaithfulTestNotebookExecutionStateService();
+		ctx.instantiationService.stub(INotebookExecutionStateService, notebookExecutionStateService);
+
+		// Create a test notebook document.
+		notebookDocument = createTestNotebookEditor(
+			ctx.instantiationService,
+			ctx.disposables.add(new DisposableStore()),
+			[
+				['print(x)', 'python', CellKind.Code, [], {}],
+				['print(y)', 'python', CellKind.Code, [], {}],
+				['raw cell', 'raw', CellKind.Code, [], {}],
+			],
+		).viewModel.notebookDocument;
+		rawCell = notebookDocument.cells.find(cell => cell.language === 'raw')!;
+
+		// Stub a mocked notebook service that returns the test notebook document.
+		ctx.instantiationService.stub(INotebookService, new class extends mock<INotebookService>() {
+			override getNotebookTextModel(uri: URI): NotebookTextModel | undefined {
+				return notebookDocument;
+			}
+		});
+
+		// Stub a mocked notebook editor service that returns a widget with layout info.
+		ctx.instantiationService.stub(INotebookEditorService, new class extends mock<INotebookEditorService>() {
+			override retrieveExistingWidgetFromURI(_resource: URI) {
+				const mockNotebookOptions = {
+					getCellEditorContainerLeftMargin: () => 60,
+					getLayoutConfiguration: () => ({ cellRightMargin: 16 }),
+				} as unknown as NotebookOptions;
+
+				const mockWidget = {
+					getLayoutInfo: () => ({ width: 800 }),
+					getDomNode: () => document.createElement('div'),
+					notebookOptions: mockNotebookOptions,
+				} as unknown as NotebookEditorWidget;
+
+				return { value: mockWidget };
+			}
+		});
+
+		// Clean up active sessions between tests to prevent leakage.
+		ctx.disposables.add(toDisposable(() => {
+			runtimeSessionService.activeSessions.forEach(s => s.dispose());
+		}));
+
+		// Create a test language runtime.
+		runtime = createTestLanguageRuntimeMetadata(ctx.instantiationService, ctx.disposables);
+
+		// Create the runtime notebook kernel.
+		kernel = ctx.disposables.add(ctx.instantiationService.createInstance(RuntimeNotebookKernel, runtime));
+	});
+
+	/** Start a session for the test notebook and wait for it to be ready. */
+	async function startSession() {
+		const session = await startTestLanguageRuntimeSession(ctx.instantiationService, ctx.disposables, {
+			runtime,
+			notebookUri: notebookDocument.uri,
+			sessionName: 'test',
+			sessionMode: LanguageRuntimeSessionMode.Notebook,
+			startReason: '',
+		});
+		await waitForRuntimeState(session, RuntimeState.Ready);
+		return session;
+	}
+
+	/** Get the execution created for a cell, asserting it exists. */
+	function getExecution(cell: NotebookCellTextModel) {
+		const execution = notebookExecutionStateService.executions.get(cell.uri);
+		expect(execution).toBeDefined();
+		return execution!;
+	}
+
+	it('executes the fragment, not the cell content, with output on the target cell', async () => {
+		const session = await startSession();
+		const executeSpy = vi.spyOn(session, 'execute');
+		ctx.disposables.add(session.onDidExecute(parent_id => session.receiveStateMessage({ parent_id, state: RuntimeOnlineState.Idle })));
+
+		const cell = notebookDocument.cells[0];
+		await kernel.executeCodeInCell(notebookDocument.uri, cell.handle, 'flights');
+
+		// The fragment was sent to the session, not the cell's full content.
+		expect(executeSpy).toHaveBeenCalledOnce();
+		expect(executeSpy.mock.calls[0][0]).toBe('flights');
+
+		// The execution was created for the originating cell, started (clearing
+		// outputs), and completed successfully.
+		const execution = getExecution(cell);
+		expect(execution.update).toHaveBeenCalledWith([{
+			editType: CellExecutionUpdateType.ExecutionState,
+			runStartTime: expect.any(Number),
+		}, {
+			editType: CellExecutionUpdateType.Output,
+			cellHandle: cell.handle,
+			outputs: [],
+		}]);
+		expect(execution.complete).toHaveBeenCalledOnce();
+		expect(execution.complete).toHaveBeenCalledWith({
+			runEndTime: expect.any(Number),
+			lastRunSuccess: true,
+		});
+	});
+
+	it('fires onDidExecuteCode with the fragment code', async () => {
+		const session = await startSession();
+		ctx.disposables.add(session.onDidExecute(parent_id => session.receiveStateMessage({ parent_id, state: RuntimeOnlineState.Idle })));
+
+		let event: ILanguageRuntimeCodeExecutedEvent | undefined = undefined;
+		ctx.disposables.add(kernel.onDidExecuteCode(evt => {
+			event = evt;
+		}));
+
+		const cell = notebookDocument.cells[0];
+		await kernel.executeCodeInCell(notebookDocument.uri, cell.handle, 'flights');
+
+		expect(event).toBeDefined();
+		const executed = event as unknown as ILanguageRuntimeCodeExecutedEvent;
+		expect(executed.code).toBe('flights');
+		expect(executed.languageId).toBe('python');
+		expect(executed.attribution.source).toBe(CodeAttributionSource.Notebook);
+	});
+
+	it('passes layout metadata but no cellId for fragments; full cells still pass cellId', async () => {
+		const session = await startSession();
+		const executeSpy = vi.spyOn(session, 'execute');
+		ctx.disposables.add(session.onDidExecute(parent_id => session.receiveStateMessage({ parent_id, state: RuntimeOnlineState.Idle })));
+
+		// Execute a fragment.
+		const cell = notebookDocument.cells[0];
+		await kernel.executeCodeInCell(notebookDocument.uri, cell.handle, 'flights');
+
+		// A fragment's line numbers don't correspond to the cell's content, so
+		// the cellId used for breakpoint mapping must not be sent.
+		const fragmentMetadata = executeSpy.mock.calls[0][5] as Record<string, unknown>;
+		expect(fragmentMetadata.output_width_px).toBe(724);
+		expect(fragmentMetadata.cellId).toBeUndefined();
+
+		// Execute the full cell through the regular path for contrast.
+		notebookExecutionStateService.createCellExecution(notebookDocument.uri, cell.handle);
+		await kernel.executeNotebookCellsRequest(notebookDocument.uri, [cell.handle]);
+
+		const fullCellMetadata = executeSpy.mock.calls[1][5] as Record<string, unknown>;
+		expect(fullCellMetadata.cellId).toBe(cell.uri.toString());
+	});
+
+	it('skips raw cells', async () => {
+		const session = await startSession();
+		const executeSpy = vi.spyOn(session, 'execute');
+
+		await kernel.executeCodeInCell(notebookDocument.uri, rawCell.handle, 'some code');
+
+		expect(executeSpy).not.toHaveBeenCalled();
+		expect(notebookExecutionStateService.executions.size).toBe(0);
+	});
+
+	it('skips whitespace-only fragments', async () => {
+		const session = await startSession();
+		const executeSpy = vi.spyOn(session, 'execute');
+
+		await kernel.executeCodeInCell(notebookDocument.uri, notebookDocument.cells[0].handle, '  \n\t');
+
+		expect(executeSpy).not.toHaveBeenCalled();
+		expect(notebookExecutionStateService.executions.size).toBe(0);
+	});
+
+	it('skips unknown cell handles', async () => {
+		const session = await startSession();
+		const executeSpy = vi.spyOn(session, 'execute');
+
+		await kernel.executeCodeInCell(notebookDocument.uri, 12345, 'flights');
+
+		expect(executeSpy).not.toHaveBeenCalled();
+		expect(notebookExecutionStateService.executions.size).toBe(0);
+	});
+
+	it('skips when the cell already has an active execution', async () => {
+		const session = await startSession();
+		const executeSpy = vi.spyOn(session, 'execute');
+
+		// Simulate the cell already executing (or queued).
+		const cell = notebookDocument.cells[0];
+		const existing = notebookExecutionStateService.createCellExecution(notebookDocument.uri, cell.handle);
+
+		await kernel.executeCodeInCell(notebookDocument.uri, cell.handle, 'flights');
+
+		expect(executeSpy).not.toHaveBeenCalled();
+		// The pre-existing execution is left untouched.
+		expect(existing.update).not.toHaveBeenCalled();
+		expect(existing.complete).not.toHaveBeenCalled();
+	});
+
+	it('starts a new session if required', async () => {
+		// When a session is started, setup its execute handler to reply with an idle state.
+		ctx.disposables.add(runtimeSessionService.onWillStartSession(({ session }) => {
+			expect(session).toBeInstanceOf(TestLanguageRuntimeSession);
+			ctx.disposables.add(session);
+			ctx.disposables.add((session as TestLanguageRuntimeSession).onDidExecute(parent_id => (session as TestLanguageRuntimeSession).receiveStateMessage({ parent_id, state: RuntimeOnlineState.Idle })));
+		}));
+
+		const cell = notebookDocument.cells[0];
+		await kernel.executeCodeInCell(notebookDocument.uri, cell.handle, 'flights');
+
+		const execution = getExecution(cell);
+		expect(execution.complete).toHaveBeenCalledOnce();
+		expect(execution.complete).toHaveBeenCalledWith({
+			runEndTime: expect.any(Number),
+			lastRunSuccess: true,
+		});
+	});
+
+	it('queues behind an in-flight cell execution', async () => {
+		const session = await startSession();
+		ctx.disposables.add(session.onDidExecute(parent_id => session.receiveStateMessage({ parent_id, state: RuntimeOnlineState.Idle })));
+
+		const cell0 = notebookDocument.cells[0];
+		const cell1 = notebookDocument.cells[1];
+
+		// The regular path expects the execution to be created by the notebook
+		// execution service before the kernel is invoked.
+		notebookExecutionStateService.createCellExecution(notebookDocument.uri, cell0.handle);
+		await Promise.all([
+			kernel.executeNotebookCellsRequest(notebookDocument.uri, [cell0.handle]),
+			kernel.executeCodeInCell(notebookDocument.uri, cell1.handle, 'flights'),
+		]);
+
+		// The cell execution ran first; the fragment ran after it completed.
+		const execution0 = getExecution(cell0);
+		const execution1 = getExecution(cell1);
+		expect(execution0.update.mock.invocationCallOrder[0])
+			.toBeLessThan(execution0.complete.mock.invocationCallOrder[0]);
+		expect(execution0.complete.mock.invocationCallOrder[0])
+			.toBeLessThan(execution1.update.mock.invocationCallOrder[0]);
+		expect(execution1.update.mock.invocationCallOrder[0])
+			.toBeLessThan(execution1.complete.mock.invocationCallOrder[0]);
+	});
+
+	it('completes the pending execution without running when a queued predecessor errors', async () => {
+		const session = await startSession();
+		ctx.disposables.add(session.onDidExecute(parent_id => session.receiveErrorMessage({ parent_id })));
+
+		const cell0 = notebookDocument.cells[0];
+		const cell1 = notebookDocument.cells[1];
+
+		notebookExecutionStateService.createCellExecution(notebookDocument.uri, cell0.handle);
+		await Promise.all([
+			kernel.executeNotebookCellsRequest(notebookDocument.uri, [cell0.handle]),
+			kernel.executeCodeInCell(notebookDocument.uri, cell1.handle, 'flights'),
+		]);
+
+		// The first cell errored.
+		const execution0 = getExecution(cell0);
+		expect(execution0.complete).toHaveBeenCalledWith({
+			runEndTime: expect.any(Number),
+			lastRunSuccess: false,
+			error: expect.any(Object),
+		});
+
+		// The fragment never ran, but its pending execution was completed so the
+		// cell doesn't show as pending forever.
+		const execution1 = getExecution(cell1);
+		expect(execution1.update).not.toHaveBeenCalled();
+		expect(execution1.complete).toHaveBeenCalledOnce();
+		expect(execution1.complete).toHaveBeenCalledWith({});
+	});
+
+	it('resolves without throwing when the fragment errors at runtime', async () => {
+		const session = await startSession();
+		ctx.disposables.add(session.onDidExecute(parent_id => session.receiveErrorMessage({ parent_id })));
+
+		const cell = notebookDocument.cells[0];
+		await expect(kernel.executeCodeInCell(notebookDocument.uri, cell.handle, 'flights'))
+			.resolves.toBeUndefined();
+
+		// The error is surfaced through the cell execution.
+		const execution = getExecution(cell);
+		expect(execution.complete).toHaveBeenCalledOnce();
+		expect(execution.complete).toHaveBeenCalledWith({
+			runEndTime: expect.any(Number),
+			lastRunSuccess: false,
+			error: expect.any(Object),
+		});
+	});
+});
+
 /** A TestNotebookExecutionStateService that spies on cell executions. */
 class TestNotebookExecutionStateService2 extends TestNotebookExecutionStateService {
 	public readonly executions = new ResourceMap<TestCellExecution>();
@@ -542,4 +839,58 @@ class TestCellExecution implements INotebookCellExecution {
 	confirm = vi.fn();
 	update = vi.fn<(updates: ICellExecuteUpdate[]) => void>();
 	complete = vi.fn<(complete: ICellExecutionComplete) => void>();
+}
+
+/**
+ * A TestNotebookExecutionStateService that mirrors the production service's
+ * contract: createCellExecution registers an execution that getCellExecution
+ * returns until it completes.
+ */
+class FaithfulTestNotebookExecutionStateService extends TestNotebookExecutionStateService {
+	public readonly executions = new ResourceMap<TrackedTestCellExecution>();
+
+	override createCellExecution(notebook: URI, cellHandle: number): INotebookCellExecution {
+		const execution = new TrackedTestCellExecution(notebook, cellHandle);
+		this.executions.set(CellUri.generate(notebook, cellHandle), execution);
+		return execution;
+	}
+
+	override getCellExecution(cellUri: URI): INotebookCellExecution | undefined {
+		const execution = this.executions.get(cellUri);
+		return execution && !execution.isComplete ? execution : undefined;
+	}
+}
+
+/**
+ * An INotebookCellExecution with vi.fn() methods that tracks state transitions
+ * like the production CellExecution (Unconfirmed until the first ExecutionState
+ * update, gone from the service once completed).
+ */
+class TrackedTestCellExecution implements INotebookCellExecution {
+	constructor(
+		readonly notebook: URI,
+		readonly cellHandle: number,
+	) { }
+
+	private _state = NotebookCellExecutionState.Unconfirmed;
+	get state(): NotebookCellExecutionState {
+		return this._state;
+	}
+
+	isComplete = false;
+
+	readonly didPause: boolean = false;
+	readonly isPaused: boolean = false;
+
+	confirm = vi.fn(() => {
+		this._state = NotebookCellExecutionState.Pending;
+	});
+	update = vi.fn<(updates: ICellExecuteUpdate[]) => void>(updates => {
+		if (updates.some(update => update.editType === CellExecutionUpdateType.ExecutionState)) {
+			this._state = NotebookCellExecutionState.Executing;
+		}
+	});
+	complete = vi.fn<(complete: ICellExecutionComplete) => void>(() => {
+		this.isComplete = true;
+	});
 }

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/tests/browser/runtimeNotebookKernel.vitest.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/tests/browser/runtimeNotebookKernel.vitest.ts
@@ -15,6 +15,7 @@ import { createTestLanguageRuntimeMetadata, startTestLanguageRuntimeSession } fr
 import { PositronTestServiceAccessor } from '../../../../test/browser/positronWorkbenchTestServices.js';
 import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
 import { mock } from '../../../../test/common/workbenchTestServices.js';
+import { NotebookCellTextModel } from '../../../notebook/common/model/notebookCellTextModel.js';
 import { NotebookTextModel } from '../../../notebook/common/model/notebookTextModel.js';
 import { CellKind, CellUri, NotebookCellExecutionState } from '../../../notebook/common/notebookCommon.js';
 import { CellExecutionUpdateType } from '../../../notebook/common/notebookExecutionService.js';
@@ -658,7 +659,7 @@ describe('Positron - RuntimeNotebookKernel - executeCodeInCell', () => {
 
 		// A fragment's line numbers don't correspond to the cell's content, so
 		// the cellId used for breakpoint mapping must not be sent.
-		const fragmentMetadata = executeSpy.mock.calls[0][5] as Record<string, unknown>;
+		const fragmentMetadata = (executeSpy.mock.calls[0] as unknown as unknown[])[5] as Record<string, unknown>;
 		expect(fragmentMetadata.output_width_px).toBe(724);
 		expect(fragmentMetadata.cellId).toBeUndefined();
 
@@ -666,7 +667,7 @@ describe('Positron - RuntimeNotebookKernel - executeCodeInCell', () => {
 		notebookExecutionStateService.createCellExecution(notebookDocument.uri, cell.handle);
 		await kernel.executeNotebookCellsRequest(notebookDocument.uri, [cell.handle]);
 
-		const fullCellMetadata = executeSpy.mock.calls[1][5] as Record<string, unknown>;
+		const fullCellMetadata = (executeSpy.mock.calls[1] as unknown as unknown[])[5] as Record<string, unknown>;
 		expect(fullCellMetadata.cellId).toBe(cell.uri.toString());
 	});
 

--- a/src/vs/workbench/contrib/runtimeNotebookKernel/tests/browser/runtimeNotebookKernelService.vitest.ts
+++ b/src/vs/workbench/contrib/runtimeNotebookKernel/tests/browser/runtimeNotebookKernelService.vitest.ts
@@ -24,6 +24,7 @@ import { INotebookKernel } from '../../../notebook/common/notebookKernelService.
 import { INotebookService } from '../../../notebook/common/notebookService.js';
 import { createTestNotebookEditor } from '../../../notebook/test/browser/testNotebookEditor.js';
 import { IRuntimeNotebookKernelService } from '../../common/interfaces/runtimeNotebookKernelService.js';
+import { RuntimeNotebookKernel } from '../../browser/runtimeNotebookKernel.js';
 import { RuntimeNotebookKernelService } from '../../browser/runtimeNotebookKernelService.js';
 import { POSITRON_RUNTIME_NOTEBOOK_KERNELS_EXTENSION_ID } from '../../common/runtimeNotebookKernelConfig.js';
 import { POSITRON_NOTEBOOK_EDITOR_INPUT_ID } from '../../../positronNotebook/common/positronNotebookCommon.js';
@@ -352,6 +353,35 @@ describe('Positron - RuntimeNotebookKernelService', () => {
 
 			await timeout(50);
 			expect(runtimeSessionService.activeSessions.length).toBe(0);
+		});
+	});
+
+	describe('executeCodeInCell', () => {
+		it('delegates to the selected kernel', async () => {
+			// Select the kernel for the notebook.
+			notebookKernelService.selectKernelForNotebook(kernel, notebookDocument);
+
+			// Stub the kernel's executeCodeInCell to observe the delegation.
+			const executeCodeInCellSpy = vi.spyOn(kernel as RuntimeNotebookKernel, 'executeCodeInCell')
+				.mockResolvedValue(undefined);
+
+			const cell = notebookDocument.cells[0];
+			await runtimeNotebookKernelService.executeCodeInCell(notebookDocument.uri, cell.handle, '1 + 1');
+
+			expect(executeCodeInCellSpy).toHaveBeenCalledOnce();
+			expect(executeCodeInCellSpy).toHaveBeenCalledWith(notebookDocument.uri, cell.handle, '1 + 1');
+		});
+
+		it('throws when no kernel is selected for the notebook', async () => {
+			await expect(
+				runtimeNotebookKernelService.executeCodeInCell(notebookDocument.uri, notebookDocument.cells[0].handle, '1 + 1')
+			).rejects.toThrow(/selected kernel/);
+		});
+
+		it('throws when the notebook has no text model', async () => {
+			await expect(
+				runtimeNotebookKernelService.executeCodeInCell(URI.parse('file:///unknown.ipynb'), 0, '1 + 1')
+			).rejects.toThrow(/text model/);
 		});
 	});
 });

--- a/test/e2e/tests/notebooks-positron/notebook-run-interrupt-toggle.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-run-interrupt-toggle.test.ts
@@ -31,7 +31,10 @@ test.describe('Positron Notebooks: Run All / Interrupt Toggle', {
 		});
 
 		await test.step('Trigger Run All via keyboard shortcut', async () => {
-			await notebooksPositron.selectCellAtIndex(0);
+			// Exit edit mode first: while a code cell editor is focused,
+			// Cmd/Ctrl+Shift+Enter runs the selection in the cell (#3804). Run
+			// All / Interrupt own the shortcut in command mode.
+			await notebooksPositron.selectCellAtIndex(0, { editMode: false });
 			await keyboard.press(runAllOrInterrupt);
 		});
 

--- a/test/e2e/tests/notebooks-positron/notebook-run-selection.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-run-selection.test.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, tags } from '../_test.setup';
+import { test } from './_test.setup.js';
+
+test.use({
+	suiteId: __filename
+});
+
+test.describe('Positron Notebooks: Run Selection in Cell', {
+	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS],
+	annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/3804' }],
+}, () => {
+
+	test('Python - Runs only the highlighted selection, then the cursor line', async function ({ app, python }) {
+		const { notebooks, notebooksPositron } = app.workbench;
+		const keyboard = app.code.driver.currentPage.keyboard;
+		const runSelection = process.platform === 'darwin' ? 'Meta+Shift+Enter' : 'Control+Shift+Enter';
+
+		await test.step('Create a notebook with a two-line code cell', async () => {
+			await notebooks.createNewNotebook();
+			await notebooksPositron.expectCellCountToBe(1);
+			await notebooksPositron.kernel.select('Python');
+			// Leaves focus in the cell editor with the cursor at the end of line 2.
+			await notebooksPositron.addCodeToCell(0, 'print("first")\nprint("second")');
+		});
+
+		await test.step('Highlight the second line and run the selection', async () => {
+			await keyboard.press('Home');
+			await keyboard.press('Shift+End');
+			await keyboard.press(runSelection);
+		});
+
+		await test.step('Verify only the selected line ran, with output on the cell', async () => {
+			await notebooksPositron.expectOutputAtIndex(0, ['second']);
+			await expect(notebooksPositron.cellOutput(0).getByText('first')).toHaveCount(0);
+		});
+
+		await test.step('Move the cursor to the first line with no selection and run again', async () => {
+			await keyboard.press('Home');
+			await keyboard.press('ArrowUp');
+			await keyboard.press(runSelection);
+		});
+
+		await test.step('Verify the cursor line ran, replacing the previous output', async () => {
+			await notebooksPositron.expectOutputAtIndex(0, ['first']);
+			await expect(notebooksPositron.cellOutput(0).getByText('second')).toHaveCount(0);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #3804

### Demo video:

https://github.com/user-attachments/assets/c0ee1ef8-3c7a-4d3e-b19a-600ac66b68cd



### Summary

Adds a "Run Selection in Cell" action to Positron notebooks: highlight some code (or just leave your cursor on a line) and press Cmd/Ctrl+Shift+Enter to run only that fragment in the notebook's kernel, with the output landing on the cell like a normal run. This is the Colab behavior the issue asks for. Put `1 + 1` and `flights` in the same cell, highlight just `flights`, and you get the dataframe back instead of `2`.

Under the hood it reuses the existing cell execution path rather than inventing a parallel one. I split `executeCell` into a thin wrapper over a shared `executeCellCode`, so the fragment path and the normal whole-cell path go through the same machinery. The fragment's output, errors, and pending state all behave like a real cell run. The one intentional difference is that fragments don't send a `cellId` to the kernel: a fragment's line numbers don't line up with the cell document, so the debugger's breakpoint mapping would be wrong. Whole-cell runs still send it.

The keybinding is the fiddly part. Run All / Stop All already bind Cmd/Ctrl+Shift+Enter on the whole notebook editor at EditorContrib weight, so I registered this at WorkbenchContrib weight scoped to a focused code cell editor. That way the selection run deterministically wins while you're editing a cell, and Run All / Stop All keep the key in command mode. I had to nudge one existing e2e test to exit edit mode first because of this.

One deliberate gap: if no kernel is selected the action prompts you to pick one, and cancelling that picker shows a "could not run the selected code" toast where the whole-cell path stays silent. Matching it cleanly means re-checking the kernel right after the picker resolves, which can race the kernel observable, so I left it as a possible fast follow. Easy to fold in here if folks would rather.

Covered by vitest (the action's selection/line parsing, the kernel `executeCodeInCell` method, and the service delegation) plus an e2e that runs a selection and then the cursor line.

### Release Notes

#### New Features

- Run a selection or the current line in a notebook cell with Cmd/Ctrl+Shift+Enter, with the output shown on that cell (#3804)

#### Bug Fixes

- N/A

### Validation Steps

@:win @:web @:positron-notebooks

1. Open a Python notebook and start a kernel.
2. Add a code cell with two lines:
   ```python
   1 + 1
   "second line"
   ```
3. Highlight just `"second line"` and press Cmd/Ctrl+Shift+Enter. The cell output shows `'second line'`, not `2`.
4. Clear the selection, move the cursor to the `1 + 1` line, and press the shortcut again. The output updates to `2`.
5. Select the cell without editing it (command mode) and press the same shortcut. Run All should run, confirming the binding only takes over while you're editing a cell.
