### PR TITLE
e2e: fix ghost cell keyboard shortcut test on Chromium

### DIFF
--- a/test/e2e/tests/notebooks-positron/_test.setup.ts
+++ b/test/e2e/tests/notebooks-positron/_test.setup.ts
@@ -10,17 +10,22 @@ interface NotebooksPositronTestFixtures extends TestFixtures {
 
 interface NotebooksPositronWorkerFixtures extends WorkerFixtures {
 	enablePositronNotebooks: boolean;
+	ghostCellSettings: Record<string, unknown> | undefined;
 }
 
 export const test = base.extend<NotebooksPositronTestFixtures, NotebooksPositronWorkerFixtures>({
 	enablePositronNotebooks: [true, { scope: 'worker', option: true }],
+	ghostCellSettings: [undefined, { scope: 'worker', option: true }],
 
 	beforeApp: [
-		async ({ enablePositronNotebooks, settingsFile }, use) => {
+		async ({ enablePositronNotebooks, ghostCellSettings, settingsFile }, use) => {
 			if (enablePositronNotebooks) {
 				// Enable Positron notebooks before the app fixture starts
 				// to avoid waiting for a window reload
 				settingsFile.append({ 'positron.notebook.enabled': true });
+			}
+			if (ghostCellSettings) {
+				await settingsFile.append(ghostCellSettings);
 			}
 
 			await use();

--- a/test/e2e/tests/notebooks-positron/notebook-ghost-cell-keyboard-shortcut.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-ghost-cell-keyboard-shortcut.test.ts
@@ -7,27 +7,18 @@ import { tags } from '../_test.setup';
 import { test } from './_test.setup.js';
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
+	ghostCellSettings: {
+		'positron.assistant.notebook.ghostCellSuggestions.enabled': true,
+		'positron.assistant.notebook.ghostCellSuggestions.model': ['claude'],
+		'positron.assistant.notebook.ghostCellSuggestions.automatic': false,
+	}
 });
 
 test.describe('Notebook: Ghost Cell Keyboard Shortcut', {
 	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
 }, () => {
-	test.beforeAll(async function ({ settings, assistant, python }) {
-		// Enable ghost cell suggestions and configure Anthropic model
-		// Set automatic mode to false so only manual trigger (Cmd+Shift+G) generates suggestions
-		await settings.set({
-			'positron.assistant.notebook.ghostCellSuggestions.enabled': true,
-			'positron.assistant.notebook.ghostCellSuggestions.model': ['claude'],
-			'positron.assistant.notebook.ghostCellSuggestions.automatic': false
-		}, { keepOpen: false });
-	});
-
-	test.afterEach(async function ({ hotKeys }) {
-		await hotKeys.closeAllEditors();
-	});
-
-	test('Cmd+Shift+G triggers ghost cell suggestion', async function ({ app, hotKeys, page }) {
+	test('Cmd+Shift+G triggers ghost cell suggestion', async function ({ app, hotKeys, page, python }) {
 		const { notebooksPositron } = app.workbench;
 
 		// Create notebook - Positron will auto-select an available kernel

--- a/test/e2e/tests/notebooks-positron/notebook-ghost-cell-keyboard-shortcut.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-ghost-cell-keyboard-shortcut.test.ts
@@ -13,9 +13,7 @@ test.use({
 test.describe('Notebook: Ghost Cell Keyboard Shortcut', {
 	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
 }, () => {
-	test.beforeAll(async function ({ app, settings, assistant, python }) {
-		await app.workbench.notebooksPositron.enablePositronNotebooks(settings);
-
+	test.beforeAll(async function ({ settings, assistant, python }) {
 		// Enable ghost cell suggestions and configure Anthropic model
 		// Set automatic mode to false so only manual trigger (Cmd+Shift+G) generates suggestions
 		await settings.set({


### PR DESCRIPTION
### Summary
Fixes the ghost cell keyboard shortcut test on Chromium by moving feature settings into `beforeApp` via a new `ghostCellSettings` fixture option.
- Adds `ghostCellSettings: Record<string, unknown> | undefined` worker option to notebooks `_test.setup.ts`
- `beforeApp` now writes those settings to the settings file before app start — no in-session reload needed
- Test `beforeAll` removed; settings applied pre-launch, `python` fixture moved to test params
- Root cause: the old `enablePositronNotebooks()` call in `beforeAll` triggered a web reload on Chromium, clearing the session started by the `python` fixture; the restarted kernel had a race window where `lastRunSuccess` was null when `onDidChangeExecution` fired, so the ghost cell never entered `awaiting-request`

### QA Notes
@:web @:positron-notebooks