### PR TITLE
Sync data driver lockfiles with protocol package metadata

### DIFF
--- a/extensions/positron-data-driver-duckdb/package-lock.json
+++ b/extensions/positron-data-driver-duckdb/package-lock.json
@@ -29,10 +29,7 @@
     },
     "../positron-data-explorer-protocol": {
       "version": "0.0.1",
-      "dev": true,
-      "engines": {
-        "vscode": "^1.65.0"
-      }
+      "dev": true
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.2",

--- a/extensions/positron-data-driver-postgresql/package-lock.json
+++ b/extensions/positron-data-driver-postgresql/package-lock.json
@@ -30,10 +30,7 @@
     },
     "../positron-data-explorer-protocol": {
       "version": "0.0.1",
-      "dev": true,
-      "engines": {
-        "vscode": "^1.65.0"
-      }
+      "dev": true
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.2",

--- a/extensions/positron-data-driver-sqlite/package-lock.json
+++ b/extensions/positron-data-driver-sqlite/package-lock.json
@@ -30,10 +30,7 @@
     },
     "../positron-data-explorer-protocol": {
       "version": "0.0.1",
-      "dev": true,
-      "engines": {
-        "vscode": "^1.65.0"
-      }
+      "dev": true
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.2",


### PR DESCRIPTION
### Description

Running `npm install` in the data driver extensions rewrites the cached snapshot of the linked `../positron-data-explorer-protocol` dependency to match its actual `package.json`, which has no engines field. Drop the stale `engines.vscode` entry these lockfiles carried over from the older vendored protocol packages consolidated in fc447a7802.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- N/A

### Validation Steps

Building Positron should not result in modified package-lock.json files in the `positron-data-driver-duckdb`, `positron-data-driver-postgresql` and `positron-data-driver-sqlite` extensions.