### PR TITLE
e2e: dismiss toasts before clicking provider modal Close button

### DIFF
--- a/test/e2e/infra/workbench.ts
+++ b/test/e2e/infra/workbench.ts
@@ -155,7 +155,7 @@ export class Workbench {
 		this.assistant = new Assistant(code, this.quickaccess, this.toasts, this.modals);
 		this.positConnect = new PositConnect(code);
 		this.positAssistant = new PositAssistant(code);
-		this.modelProviderAuth = new ModelProviderAuth(code, this.modals);
+		this.modelProviderAuth = new ModelProviderAuth(code, this.modals, this.toasts);
 		this.inlineDataExplorer = new InlineDataExplorer(code.driver.currentPage);
 		this.inlineQuarto = new InlineQuarto(code, this.quickaccess, this.hotKeys);
 		this.publisher = new Publisher(this.quickInput);

--- a/test/e2e/pages/modelProviderAuth.ts
+++ b/test/e2e/pages/modelProviderAuth.ts
@@ -7,6 +7,7 @@ import { expect, test, chromium, Browser, BrowserContext, Locator, Page } from '
 import { Code } from '../infra/code';
 import { Modals } from './dialog-modals.js';
 import { HotKeys } from './hotKeys.js';
+import { Toasts } from './dialog-toasts.js';
 
 // Page object for the shared "Configure Language Model Providers" component.
 // Both Positron Assistant and Posit Assistant use this component to
@@ -182,7 +183,7 @@ export class ModelProviderAuth {
 
 	private hotKeys: HotKeys;
 
-	constructor(private code: Code, private modals: Modals) {
+	constructor(private code: Code, private modals: Modals, private toasts: Toasts) {
 		this.hotKeys = new HotKeys(code);
 	}
 
@@ -335,6 +336,11 @@ export class ModelProviderAuth {
 	}
 
 	async clickCloseButton({ abandonChanges = true } = {}) {
+		// Sign-in/sign-out can surface toast notifications that overlap the
+		// modal's Close button, making it fail Playwright's actionability check.
+		// Dismiss any toasts first so the click lands reliably.
+		await this.toasts.closeAll();
+
 		await this.code.driver.currentPage.locator(CLOSE_BUTTON).click();
 
 		const abandonModalisVisible = await this.modals.modalTitle.filter({ hasText: 'Authentication Incomplete' }).isVisible();


### PR DESCRIPTION
## Summary

`test/e2e/tests/posit-assistant/posit-assistant-signin.test.ts` can intermittently fail because a toast notification (surfaced by sign-in/sign-out) overlaps the "Configure Language Model Providers" modal's **Close** button. The overlapping toast makes the button fail Playwright's actionability check, so the click times out.

This dismisses any active toasts via the existing `Toasts.closeAll()` helper at the start of `clickCloseButton()`, so the click lands reliably. The fix lives in the shared `ModelProviderAuth` page object, so it covers both the sign-in and sign-out flows (and the early-return branches), not just the one failing test.

## Changes

- `ModelProviderAuth` now takes a `Toasts` dependency and calls `toasts.closeAll()` before clicking Close.
- Wired `this.toasts` into the `ModelProviderAuth` constructor in `workbench.ts`.

## Alternatives considered

- `force: true` on the click - rejected; bypasses actionability and can click through overlays, hiding real regressions.
- Dismiss toasts only in the test file - rejected; leaves the page object fragile for every other caller.

## Testing

- e2e TypeScript compiles cleanly (`npm run compile` in `test/e2e`).
- Ran the sign-in test locally against `anthropic-api` and `openai-api`.

## QA Notes

@:posit-assistant @:assistant @:web @:win