### PR TITLE
e2e: import expect from `_test.setup` instead of `@playwright/test`

### DIFF
--- a/test/e2e/tests/autocomplete/autocomplete.test.ts
+++ b/test/e2e/tests/autocomplete/autocomplete.test.ts
@@ -3,9 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
 import { Application, SessionMetaData } from '../../infra/index.js';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/catalog-explorer/catalog-explorer.test.ts
+++ b/test/e2e/tests/catalog-explorer/catalog-explorer.test.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/code-actions/r.test.ts
+++ b/test/e2e/tests/code-actions/r.test.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path, { join } from 'path';
-import { test, tags } from '../_test.setup';
-import { expect } from '@playwright/test';
+import { test, expect, tags } from '../_test.setup';
 import { fail } from 'assert';
 
 test.use({

--- a/test/e2e/tests/connections/connections-postgres.test.ts
+++ b/test/e2e/tests/connections/connections-postgres.test.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/console/basic-performance.test.ts
+++ b/test/e2e/tests/console/basic-performance.test.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/console/console-r-hyperlinks.test.ts
+++ b/test/e2e/tests/console/console-r-hyperlinks.test.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-headless.test.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 import { TestTags } from '../../infra';
 import { MetricTargetType } from '../../utils/metrics/index.js';
-import { expect } from '@playwright/test';
 
 const LAST_CELL_CONTENTS = '2013-09-30 08:00:00';
 

--- a/test/e2e/tests/data-explorer/data-explorer-split-editor.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-split-editor.test.ts
@@ -19,8 +19,7 @@
  * - Apply a filter and verify the data updates
  */
 
-import { expect } from '@playwright/test';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-summary-panel.test.ts
@@ -11,8 +11,7 @@
  */
 
 import { join } from 'path';
-import { test, tags } from '../_test.setup';
-import { expect } from '@playwright/test';
+import { test, expect, tags } from '../_test.setup';
 
 const columnOrder = {
 	default: ['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column6', 'column7', 'column8', 'column9'],

--- a/test/e2e/tests/debug/python-debug.test.ts
+++ b/test/e2e/tests/debug/python-debug.test.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 import { join } from 'path';
 import { Application } from '../../infra';
 

--- a/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
+++ b/test/e2e/tests/editor-action-bar/editor-action-bar-document-files.test.ts
@@ -16,8 +16,8 @@
  * - Confirm expected visibility/invisibility of the action bar based on file type
  */
 
-import { expect, Page } from '@playwright/test';
-import { test, tags } from '../_test.setup';
+import { Page } from '@playwright/test';
+import { test, expect, tags } from '../_test.setup';
 import { EditorActionBar } from '../../pages/editorActionBar';
 import { Application } from '../../infra';
 

--- a/test/e2e/tests/extensions/blocked-installs.test.ts
+++ b/test/e2e/tests/extensions/blocked-installs.test.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/interpreters/default-python-interpreter.test.ts
+++ b/test/e2e/tests/interpreters/default-python-interpreter.test.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 import { deletePositronHistoryFiles } from './helpers/default-interpreters.js';
 import { buildPythonPath } from './helpers/include-excludes.js';
 import path from 'path';

--- a/test/e2e/tests/interpreters/default-r-interpreter.test.ts
+++ b/test/e2e/tests/interpreters/default-r-interpreter.test.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 import { deletePositronHistoryFiles } from './helpers/default-interpreters.js';
 
 test.use({

--- a/test/e2e/tests/interpreters/new-uv-project.test.ts
+++ b/test/e2e/tests/interpreters/new-uv-project.test.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path from 'path';
-import { test, tags } from '../_test.setup';
-import { expect } from '@playwright/test';
+import { test, expect, tags } from '../_test.setup';
 import * as fs from 'fs/promises';
 
 test.use({

--- a/test/e2e/tests/interpreters/python-venv-creation.test.ts
+++ b/test/e2e/tests/interpreters/python-venv-creation.test.ts
@@ -20,8 +20,7 @@ Summary:
 import * as os from 'os';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { expect } from '@playwright/test';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/lsp/lsp-outline.test.ts
+++ b/test/e2e/tests/lsp/lsp-outline.test.ts
@@ -5,8 +5,7 @@
 
 import { join } from 'path';
 import { Outline } from '../../pages/outline.js';
-import { test, tags } from '../_test.setup.js';
-import { expect } from '@playwright/test';
+import { test, expect, tags } from '../_test.setup.js';
 
 const R_FILE = 'basic-outline-with-vars.r';
 const PY_FILE = 'basic-outline-with-vars.py';

--- a/test/e2e/tests/lsp/lsp-references.test.ts
+++ b/test/e2e/tests/lsp/lsp-references.test.ts
@@ -3,9 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
 import { Application } from '../../infra';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 import { join } from 'path';
 
 test.use({

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-empty.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-empty.test.ts
@@ -3,9 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
 import { FolderTemplate } from '../../infra';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 import { addRandomNumSuffix, verifyGitStatus, verifyPyprojectTomlNotCreated } from './helpers/new-folder-flow.js';
 
 test.use({

--- a/test/e2e/tests/notebook/notebook-create.test.ts
+++ b/test/e2e/tests/notebook/notebook-create.test.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path from 'path';
-import { tags } from '../_test.setup';
+import { expect, tags } from '../_test.setup';
 import { test } from './_test.setup.js';
-import { expect } from '@playwright/test';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/notebook/notebook-debug.test.ts
+++ b/test/e2e/tests/notebook/notebook-debug.test.ts
@@ -21,9 +21,8 @@
  */
 
 
-import { tags } from '../_test.setup';
+import { expect, tags } from '../_test.setup';
 import { test } from './_test.setup.js';
-import { expect } from '@playwright/test';
 
 test.use({ suiteId: __filename });
 

--- a/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
-import { tags } from '../_test.setup';
+import { expect, tags } from '../_test.setup';
 import { test } from './_test.setup.js';
 
 test.use({

--- a/test/e2e/tests/notebooks-positron/notebook-copy-output-image.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-copy-output-image.test.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
-import { tags } from '../_test.setup';
+import { expect, tags } from '../_test.setup';
 import { test } from './_test.setup.js';
 
 test.use({

--- a/test/e2e/tests/notebooks-positron/notebook-editor.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-editor.test.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path from 'path';
-import { tags } from '../_test.setup';
+import { expect, tags } from '../_test.setup';
 import { test } from './_test.setup.js';
-import { expect } from '@playwright/test';
 
 const NOTEBOOK_PATH = path.join('workspaces', 'bitmap-notebook', 'bitmap-notebook.ipynb');
 

--- a/test/e2e/tests/notebooks-positron/notebook-inline-data-explorer.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-inline-data-explorer.test.ts
@@ -3,9 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { tags } from '../_test.setup';
+import { expect, tags } from '../_test.setup';
 import { test } from './_test.setup.js';
-import { expect } from '@playwright/test';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-kernel-behavior.test.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path from 'path';
-import { expect } from '@playwright/test';
-import { tags } from '../_test.setup';
+import { expect, tags } from '../_test.setup';
 import { test } from './_test.setup.js';
 
 test.use({

--- a/test/e2e/tests/notebooks-positron/notebook-markdown-anchor.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-markdown-anchor.test.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
-import { tags } from '../_test.setup';
+import { expect, tags } from '../_test.setup';
 import { test } from './_test.setup.js';
 
 test.use({

--- a/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-scroll-position.test.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path from 'path';
-import { tags } from '../_test.setup';
+import { expect, tags } from '../_test.setup';
 import { test } from './_test.setup.js';
-import { expect } from '@playwright/test';
 
 // Use the pokemon notebook because it has mixed markdown and code cells,
 // which have different rendering times that could affect scroll restoration.

--- a/test/e2e/tests/plots/matplotlib-interact.test.ts
+++ b/test/e2e/tests/plots/matplotlib-interact.test.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { tags, test } from '../_test.setup';
-import { expect } from '@playwright/test';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename,

--- a/test/e2e/tests/quarto/quarto-inline-output-cell-metadata.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-cell-metadata.test.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { expect } from '@playwright/test';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/references/references.test.ts
+++ b/test/e2e/tests/references/references.test.ts
@@ -3,9 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
 import { Application } from '../../infra';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 import { join } from 'path';
 
 test.use({

--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import { createWorkbenchFromPage, waitForAnyNewWindow } from '../../infra/workbench';

--- a/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
@@ -3,9 +3,8 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, tags } from '../_test.setup';
+import { test, expect, tags } from '../_test.setup';
 import { RETICULATE_SESSION, verifyReticulateFunctionality } from './helpers/verifyReticulateFunction.js';
-import { expect } from '@playwright/test';
 
 test.use({
 	suiteId: __filename

--- a/test/e2e/tests/workbench/extensions/workbench-extension.test.ts
+++ b/test/e2e/tests/workbench/extensions/workbench-extension.test.ts
@@ -3,8 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { expect } from '@playwright/test';
-import { test, tags } from '../../_test.setup';
+import { test, expect, tags } from '../../_test.setup';
 
 test.use({
 	suiteId: __filename


### PR DESCRIPTION
Per [author-e2e-tests / test-structure.md](https://github.com/posit-dev/positron/blob/main/.claude/skills/author-e2e-tests/references/test-structure.md#always-import-from-_testsetup), e2e tests should import `test`, `expect`, and `tags` from `_test.setup`, not `@playwright/test`.

These 34 test files already imported `test`/`tags` from `_test.setup` (as expected) but pulled `expect` separately from `@playwright/test` (wrongfully). 

- Folded `expect` into the `_test.setup` import. `editor-action-bar-document-files.test.ts` keeps its 
- `Page` type import from `@playwright/test` (not re-exported by `_test.setup`).

Import-only change; no test logic touched.