### PR TITLE
e2e: add missing copyright header to `test-setup/index.ts`

### DIFF
--- a/test/e2e/fixtures/test-setup/index.ts
+++ b/test/e2e/fixtures/test-setup/index.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 // Re-export constants
 export { TEMP_DIR, LOGS_ROOT_PATH, fixtureScreenshot, setSpecName } from './constants';
 export * from './metrics.fixtures';


### PR DESCRIPTION
`test/e2e/fixtures/test-setup/index.ts` was created without a license header (every sibling in the folder has one). Adds the standard Posit header to bring it in line.

The good news is that this is the onyl file that has neither Posit nor Microsoft copyright header, so we should be good on this front.