### PR TITLE
e2e: use function syntax for tests and hooks

### DIFF
--- a/test/e2e/tests/console/basic-performance.test.ts
+++ b/test/e2e/tests/console/basic-performance.test.ts
@@ -14,7 +14,7 @@ test.describe('Console Performance', {
 	tag: [tags.SESSIONS, tags.CONSOLE, tags.WEB, tags.WIN]
 }, () => {
 
-	test('Python Performance - Console loads under 30 seconds', async ({ app, python, sessions }) => {
+	test('Python Performance - Console loads under 30 seconds', async function ({ app, python, sessions }) {
 		const start = Date.now();
 		await sessions.expectAllSessionsToBeReady();
 		const end = Date.now();
@@ -23,7 +23,7 @@ test.describe('Console Performance', {
 		expect(loadTime).toBeLessThan(30);
 	});
 
-	test('R Performance - Console loads under 30 seconds', { tag: [tags.ARK] }, async ({ app, r, sessions }) => {
+	test('R Performance - Console loads under 30 seconds', { tag: [tags.ARK] }, async function ({ app, r, sessions }) {
 		const start = Date.now();
 		await sessions.expectAllSessionsToBeReady();
 		const end = Date.now();

--- a/test/e2e/tests/console/console-clipboard.test.ts
+++ b/test/e2e/tests/console/console-clipboard.test.ts
@@ -31,7 +31,7 @@ test.describe('Console - Clipboard', { tag: [tags.CONSOLE, tags.WIN, tags.WEB, t
 
 	for (const { language, testLine, prompt, restartRegex, extraTags } of testCases) {
 
-		test(`${language} - Verify copy from console & paste to console`, { tag: extraTags }, async ({ app, sessions, hotKeys }) => {
+		test(`${language} - Verify copy from console & paste to console`, { tag: extraTags }, async function ({ app, sessions, hotKeys }) {
 			const { console, clipboard } = app.workbench;
 
 			// start a new session

--- a/test/e2e/tests/console/console-python.test.ts
+++ b/test/e2e/tests/console/console-python.test.ts
@@ -11,11 +11,11 @@ test.use({
 
 test.describe('Console Pane: Alternate Python', { tag: [tags.WEB, tags.CONSOLE, tags.WIN] }, () => {
 
-	test.beforeAll(async ({ settings }) => {
+	test.beforeAll(async function ({ settings }) {
 		await settings.set({ 'python.useBundledIpykernel': false }, { reload: true, waitMs: 1000 });
 	});
 
-	test('Verify alternate python can skip bundled ipykernel', async ({ app, sessions }) => {
+	test('Verify alternate python can skip bundled ipykernel', async function ({ app, sessions }) {
 		await sessions.start('pythonAlt');
 		await sessions.clearConsoleAllSessions();
 		await app.workbench.console.executeCode('Python', 'import ipykernel; ipykernel.__file__');

--- a/test/e2e/tests/console/files-pane-refresh.test.ts
+++ b/test/e2e/tests/console/files-pane-refresh.test.ts
@@ -14,7 +14,7 @@ test.use({
 
 test.describe('Files Pane Refresh', { tag: [tags.WEB, tags.WORKBENCH, tags.CONSOLE, tags.JUPYTER] }, () => {
 
-	test.afterAll(async ({ cleanup }) => {
+	test.afterAll(async function ({ cleanup }) {
 		await cleanup.removeTestFiles(['file.txt']);
 	});
 

--- a/test/e2e/tests/data-explorer/histogram-rounding.test.ts
+++ b/test/e2e/tests/data-explorer/histogram-rounding.test.ts
@@ -38,7 +38,7 @@ test.describe('Data Explorer - Histogram Rounding', {
   tag: [tags.WEB, tags.WIN, tags.DATA_EXPLORER]
 }, () => {
 
-  test.afterEach(async ({ hotKeys }) => {
+  test.afterEach(async function ({ hotKeys }) {
     await hotKeys.closeAllEditors();
   });
 
@@ -86,7 +86,7 @@ test.describe('Data Explorer - Histogram Rounding', {
   ];
 
   for (const testCase of cases) {
-    test(testCase.name, async ({ app, python }) => {
+    test(testCase.name, async function ({ app, python }) {
       const { dataExplorer, variables, editors } = app.workbench;
       await app.workbench.console.pasteCodeToConsole(testCase.python, true);
 

--- a/test/e2e/tests/data-explorer/sparklines.test.ts
+++ b/test/e2e/tests/data-explorer/sparklines.test.ts
@@ -17,11 +17,11 @@ test.describe('Data Explorer - Sparklines', {
 		await hotKeys.stackedLayout();
 	});
 
-	test.afterEach(async ({ hotKeys }) => {
+	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();
 	});
 
-	test('Python Pandas - Verify downward trending graph', async ({ app, executeCode, hotKeys, python }) => {
+	test('Python Pandas - Verify downward trending graph', async function ({ app, executeCode, hotKeys, python }) {
 		const { dataExplorer, variables, editors } = app.workbench;
 
 		await executeCode('Python', pythonScript);
@@ -37,7 +37,7 @@ test.describe('Data Explorer - Sparklines', {
 	});
 
 
-	test('R - Verify downward trending graph', async ({ app, executeCode, hotKeys, r }) => {
+	test('R - Verify downward trending graph', async function ({ app, executeCode, hotKeys, r }) {
 		const { dataExplorer, variables, editors } = app.workbench;
 
 		await executeCode('R', rScript);

--- a/test/e2e/tests/debug/r-debug.test.ts
+++ b/test/e2e/tests/debug/r-debug.test.ts
@@ -46,7 +46,7 @@ test.describe('R Debugging', {
 		await app.workbench.console.clearButton.click();
 	});
 
-	test('R - Verify call stack behavior and order', async ({ app, page }) => {
+	test('R - Verify call stack behavior and order', async function ({ app, page }) {
 		const { debug, console, editors } = app.workbench;
 
 		// Trigger the breakpoint
@@ -125,7 +125,7 @@ test.describe('R Debugging', {
 			await console.waitForConsoleContents('Found 2 fruits!');
 		});
 
-	test('R - Verify debugging with `browser()` via console', async ({ app, page, openFile, runCommand, executeCode }) => {
+	test('R - Verify debugging with `browser()` via console', async function ({ app, page, openFile, runCommand, executeCode }) {
 		const { debug, console } = app.workbench;
 
 		await openFile(`workspaces/r-debugging/fruit_avg_browser.r`);
@@ -157,7 +157,7 @@ test.describe('R Debugging', {
 		await console.waitForConsoleContents('Found 2 fruits!');
 	});
 
-	test('R - Verify debugging with `browser()` via debugging UI tools', async ({ app, page, openFile, runCommand, executeCode }) => {
+	test('R - Verify debugging with `browser()` via debugging UI tools', async function ({ app, page, openFile, runCommand, executeCode }) {
 		const { debug, console } = app.workbench;
 
 		await openFile(`workspaces/r-debugging/fruit_avg_browser.r`);
@@ -186,7 +186,7 @@ test.describe('R Debugging', {
 		await console.waitForConsoleContents('Found 2 fruits!');
 	});
 
-	test('R - Verify debugging with `debugonce()` pauses only once', async ({ app, page, executeCode, openFile, runCommand }) => {
+	test('R - Verify debugging with `debugonce()` pauses only once', async function ({ app, page, executeCode, openFile, runCommand }) {
 		const { debug, console } = app.workbench;
 
 		await openFile('workspaces/r-debugging/fruit_avg.r');
@@ -220,11 +220,11 @@ test.describe('R Breakpoints', {
 }, () => {
 	let breakpointSession: SessionMetaData;
 
-	test.beforeAll(async ({ sessions }) => {
+	test.beforeAll(async function ({ sessions }) {
 		breakpointSession = await sessions.start('r');
 	});
 
-	test.afterEach(async ({ app, page, hotKeys, cleanup }) => {
+	test.afterEach(async function ({ app, page, hotKeys, cleanup }) {
 		// Focus the console
 		await app.workbench.console.focus();
 
@@ -286,7 +286,7 @@ test.describe('R Breakpoints', {
 		await console.waitForReady('>');
 	});
 
-	test('R - Verify breakpoints in dirty (unsaved) documents', async ({ app, page, openFile, hotKeys }) => {
+	test('R - Verify breakpoints in dirty (unsaved) documents', async function ({ app, page, openFile, hotKeys }) {
 		const { debug, console } = app.workbench;
 
 		await openFile('workspaces/r-debugging/breakpoint_test.r');
@@ -443,7 +443,7 @@ test.describe('R Breakpoints', {
 		await console.waitForReady('>');
 	});
 
-	test('R - Verify editing file while at breakpoint invalidates breakpoints', async ({ app, page, openFile, hotKeys }) => {
+	test('R - Verify editing file while at breakpoint invalidates breakpoints', async function ({ app, page, openFile, hotKeys }) {
 		const { debug, console } = app.workbench;
 
 		await openFile('workspaces/r-debugging/breakpoint_test.r');

--- a/test/e2e/tests/extensions/restart-host-ext.test.ts
+++ b/test/e2e/tests/extensions/restart-host-ext.test.ts
@@ -14,7 +14,7 @@ test.describe.skip('Restart Host Extension', {
 	annotation: { type: 'issue', description: 'https://github.com/posit-dev/positron/issues/12476' }
 }, () => {
 
-	test.afterEach(async ({ app }) => {
+	test.afterEach(async function ({ app }) {
 		await app.workbench.sessions.deleteAll();
 	});
 

--- a/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
+++ b/test/e2e/tests/import-vs-code-settings/import-vscode-settings.test.ts
@@ -30,7 +30,7 @@ test.use({
 });
 
 test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS] }, () => {
-	test.beforeAll(async ({ vsCodeSettings: vscodeUserSettings, settings: positronUserSettings }) => {
+	test.beforeAll(async function ({ vsCodeSettings: vscodeUserSettings, settings: positronUserSettings }) {
 		await vscodeUserSettings.append({
 			'test': 'vs-code-settings',
 			'editor.fontSize': 12,
@@ -44,13 +44,13 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS] }, () => {
 		}, { reload: true, waitMs: 1000 });
 	});
 
-	test.beforeEach(async ({ sessions, hotKeys }) => {
+	test.beforeEach(async function ({ sessions, hotKeys }) {
 		await sessions.expectNoStartUpMessaging(); // necessary to ensure that the import prompt is shown
 		await hotKeys.closeAllEditors();
 	});
 
 	test.describe('Defer Import', () => {
-		test('Verify import prompt behavior on "Later"', { tag: [tags.WIN] }, async ({ app, hotKeys }) => {
+		test('Verify import prompt behavior on "Later"', { tag: [tags.WIN] }, async function ({ app, hotKeys }) {
 			const { toasts } = app.workbench;
 
 			// select "Later" and verify that the prompt is no longer visible
@@ -63,7 +63,7 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS] }, () => {
 			await toasts.expectImportSettingsToastToBeVisible();
 		});
 
-		test('Verify import prompt behavior on "Don\'t Show Again"', { tag: [tags.WIN] }, async ({ sessions, app, hotKeys, page }) => {
+		test('Verify import prompt behavior on "Don\'t Show Again"', { tag: [tags.WIN] }, async function ({ sessions, app, hotKeys, page }) {
 			const { toasts } = app.workbench;
 
 			// select "Don't Show Again" and verify that the prompt is no longer visible
@@ -80,7 +80,7 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS] }, () => {
 	});
 
 	test.describe('Import with Positron settings', () => {
-		test('Verify diff displays and rejected settings are not saved', async ({ app, page, hotKeys }) => {
+		test('Verify diff displays and rejected settings are not saved', async function ({ app, page, hotKeys }) {
 			const { toasts } = app.workbench;
 			const testSettingLocator = page.getByText('"test": "positron-settings"');
 
@@ -97,7 +97,7 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS] }, () => {
 			await expect(testSettingLocator).toHaveCount(1);
 		});
 
-		test('Verify diff displays and accepted settings are saved', async ({ app, page, hotKeys }) => {
+		test('Verify diff displays and accepted settings are saved', async function ({ app, page, hotKeys }) {
 			const { toasts } = app.workbench;
 
 			// import settings and verify diff displays
@@ -115,11 +115,11 @@ test.describe('Import VSCode Settings', { tag: [tags.VSCODE_SETTINGS] }, () => {
 	});
 
 	test.describe('Import without Positron settings', () => {
-		test.beforeEach(async ({ settings }) => {
+		test.beforeEach(async function ({ settings }) {
 			await settings.clear();
 		});
 
-		test('Verify import import occurs and is clean without a diff', { tag: [tags.WIN] }, async ({ app, page, hotKeys }) => {
+		test('Verify import import occurs and is clean without a diff', { tag: [tags.WIN] }, async function ({ app, page, hotKeys }) {
 			const { toasts } = app.workbench;
 
 			// import settings

--- a/test/e2e/tests/interpreters/interpreter-commands.test.ts
+++ b/test/e2e/tests/interpreters/interpreter-commands.test.ts
@@ -27,7 +27,7 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, Shutdown, Clear Inte
 	tag: [tags.WEB, tags.INTERPRETER]
 }, () => {
 
-	test.afterEach(async ({ app }) => {
+	test.afterEach(async function ({ app }) {
 		await app.workbench.sessions.deleteAll();
 	});
 

--- a/test/e2e/tests/interpreters/new-uv-project.test.ts
+++ b/test/e2e/tests/interpreters/new-uv-project.test.ts
@@ -20,7 +20,7 @@ test.describe('New uv Environment', {
 		await settings.set({ 'interpreters.startupBehavior': 'auto' }, { reload: 'web' });
 	});
 
-	test.afterAll(async () => {
+	test.afterAll(async function () {
 		const projPath = '/tmp/vscsmoke/qa-example-content/proj';
 		try {
 			await fs.rm(projPath, { recursive: true, force: true });

--- a/test/e2e/tests/lsp/lsp-references.test.ts
+++ b/test/e2e/tests/lsp/lsp-references.test.ts
@@ -16,7 +16,7 @@ test.describe('References', {
 	tag: [tags.PYREFLY, tags.WEB]
 }, () => {
 
-	test.afterEach(async ({ app, runCommand }) => {
+	test.afterEach(async function ({ app, runCommand }) {
 
 		await app.workbench.references.close();
 		await runCommand('workbench.action.closeAllEditors');

--- a/test/e2e/tests/notebook/notebook-debug.test.ts
+++ b/test/e2e/tests/notebook/notebook-debug.test.ts
@@ -31,17 +31,17 @@ test.describe('Notebook Debugging', {
 	tag: [tags.DEBUG, tags.NOTEBOOKS, tags.WEB, tags.WIN]
 }, () => {
 
-	test.beforeEach(async ({ app }) => {
+	test.beforeEach(async function ({ app }) {
 		await app.workbench.notebooks.createNewNotebook();
 		await app.workbench.notebooks.selectInterpreter('Python');
 	});
 
-	test.afterEach(async ({ app }) => {
+	test.afterEach(async function ({ app }) {
 		await app.workbench.notebooks.closeNotebookWithoutSaving();
 	});
 
 	// Single, simpler test that covers it all basics, instead of many separate and redundant tests.
-	test('Python - Core debugging workflow: breakpoints, variable inspection, step controls, and output verification', async ({ app, logger, hotKeys }) => {
+	test('Python - Core debugging workflow: breakpoints, variable inspection, step controls, and output verification', async function ({ app, logger, hotKeys }) {
 		const code = [
 			'# Initialize variables',
 			'x = 10',

--- a/test/e2e/tests/notebooks-positron/notebook-ipywidgets-slider.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-ipywidgets-slider.test.ts
@@ -12,7 +12,7 @@ test.describe('Positron Notebooks: ipywidgets', {
 	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
 }, () => {
 
-	test.beforeEach(async ({ app }) => {
+	test.beforeEach(async function ({ app }) {
 		const { notebooks, notebooksPositron } = app.workbench;
 		await notebooks.createNewNotebook();
 		await notebooksPositron.expectCellCountToBe(1);

--- a/test/e2e/tests/quarto/quarto-r.test.ts
+++ b/test/e2e/tests/quarto/quarto-r.test.ts
@@ -53,7 +53,7 @@ test.describe('Quarto - R', { tag: [tags.WEB, tags.WIN, tags.QUARTO, tags.ARK] }
 		await expect(viewerFrame.locator('h1')).toHaveText('Diamond sizes', { timeout: 30000 });
 	});
 
-	test('Quarto Shiny App renders correctly', async ({ app, openFile }) => {
+	test('Quarto Shiny App renders correctly', async function ({ app, openFile }) {
 		await openFile(join('workspaces', 'quarto_shiny', 'mini-app.qmd'));
 		await app.code.driver.currentPage.getByRole('button', { name: 'Preview' }).click();
 		await app.code.driver.currentPage

--- a/test/e2e/tests/references/references.test.ts
+++ b/test/e2e/tests/references/references.test.ts
@@ -16,7 +16,7 @@ test.describe('References', {
 	tag: [tags.REFERENCES, tags.WEB, tags.WIN]
 }, () => {
 
-	test.afterEach(async ({ app, runCommand }) => {
+	test.afterEach(async function ({ app, runCommand }) {
 
 		await app.workbench.references.close();
 		await runCommand('workbench.action.closeAllEditors');

--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -29,7 +29,7 @@ test.describe('Remote SSH', {
 	tag: [tags.REMOTE_SSH]
 }, () => {
 
-	test.beforeAll(async ({ settings }) => {
+	test.beforeAll(async function ({ settings }) {
 
 		try {
 			sshKeyscan('127.0.0.1', 3456, '/tmp/known_hosts');

--- a/test/e2e/tests/remote-wsl/remote-wsl.test.ts
+++ b/test/e2e/tests/remote-wsl/remote-wsl.test.ts
@@ -89,7 +89,7 @@ test.describe('Remote WSL', {
 	tag: [tags.REMOTE_WSL]
 }, () => {
 
-	test.beforeAll(async ({ settings }) => {
+	test.beforeAll(async function ({ settings }) {
 		// `remote.WSL.serverDownloadUrlTemplate` is an application-scoped setting, so it must live in
 		// user settings (which `settings.set` writes). The WSL resolver reads it when installing the
 		// server inside the distro.


### PR DESCRIPTION
Per [test-structure.md](https://github.com/posit-dev/positron/blob/main/.claude/skills/author-e2e-tests/references/test-structure.md#function-syntax-requirement), tests and hooks should preferably use `function` syntax, not arrow functions. Converts the 18 remaining files (`async (...) => {` to `async function (...) {`).