### PR TITLE
Improve PNE left cell gutter width

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/BaseCellEditorOptions.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/BaseCellEditorOptions.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -14,6 +14,7 @@ import { NotebookOptions } from '../../notebook/browser/notebookOptions.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IEditorOptions } from '../../../../editor/common/config/editorOptions.js';
 import { deepClone } from '../../../../base/common/objects.js';
+import { POSITRON_NOTEBOOK_FOLDING_KEY } from '../common/positronNotebookConfig.js';
 
 export class BaseCellEditorOptions extends Disposable implements IBaseCellEditorOptions {
 	private static fixedEditorOptions: IEditorOptions = {
@@ -29,7 +30,6 @@ export class BaseCellEditorOptions extends Disposable implements IBaseCellEditor
 		renderLineHighlightOnlyWhenFocus: true,
 		overviewRulerLanes: 0,
 		lineDecorationsWidth: 10,
-		folding: true,
 		fixedOverflowWidgets: true,
 		minimap: { enabled: false },
 		renderValidationDecorations: 'on',
@@ -48,7 +48,7 @@ export class BaseCellEditorOptions extends Disposable implements IBaseCellEditor
 	constructor(readonly notebookEditor: Pick<INotebookEditorDelegate, 'onDidChangeModel' | 'hasModel' | 'onDidChangeOptions' | 'isReadOnly'>, readonly notebookOptions: NotebookOptions, readonly configurationService: IConfigurationService, readonly language: string) {
 		super();
 		this._register(configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('editor') || e.affectsConfiguration('notebook')) {
+			if (e.affectsConfiguration('editor') || e.affectsConfiguration('notebook') || e.affectsConfiguration(POSITRON_NOTEBOOK_FOLDING_KEY)) {
 				this._recomputeOptions();
 			}
 		}));
@@ -87,17 +87,19 @@ export class BaseCellEditorOptions extends Disposable implements IBaseCellEditor
 
 	private _computeEditorOptions() {
 		const editorOptions = deepClone(this.configurationService.getValue<IEditorOptions>('editor', { overrideIdentifier: this.language }));
-		const editorOptionsOverrideRaw = this.notebookOptions.getDisplayOptions().editorOptionsCustomizations ?? {} as any;
+		const editorOptionsOverrideRaw = this.notebookOptions.getDisplayOptions().editorOptionsCustomizations ?? {};
 		const editorOptionsOverride: { [key: string]: any } = {};
-		for (const key in editorOptionsOverrideRaw) {
+		for (const [key, value] of Object.entries(editorOptionsOverrideRaw)) {
 			if (key.indexOf('editor.') === 0) {
-				editorOptionsOverride[key.substring(7)] = editorOptionsOverrideRaw[key];
+				editorOptionsOverride[key.substring(7)] = value;
 			}
 		}
+		const folding = this.configurationService.getValue<boolean>(POSITRON_NOTEBOOK_FOLDING_KEY) ?? true;
 		const computed = Object.freeze({
 			...editorOptions,
 			...BaseCellEditorOptions.fixedEditorOptions,
 			...editorOptionsOverride,
+			folding,
 			...{ padding: { top: 12, bottom: 12 } },
 			readOnly: this.notebookEditor.isReadOnly
 		});

--- a/src/vs/workbench/contrib/positronNotebook/browser/BaseCellEditorOptions.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/BaseCellEditorOptions.tsx
@@ -28,12 +28,12 @@ export class BaseCellEditorOptions extends Disposable implements IBaseCellEditor
 		},
 		renderLineHighlightOnlyWhenFocus: true,
 		overviewRulerLanes: 0,
-		lineDecorationsWidth: 0,
+		lineDecorationsWidth: 10,
 		folding: true,
 		fixedOverflowWidgets: true,
 		minimap: { enabled: false },
 		renderValidationDecorations: 'on',
-		lineNumbersMinChars: 3
+		lineNumbersMinChars: 2
 	};
 
 	private readonly _localDisposableStore = this._register(new DisposableStore());

--- a/src/vs/workbench/contrib/positronNotebook/browser/BaseCellEditorOptions.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/BaseCellEditorOptions.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -14,7 +14,6 @@ import { NotebookOptions } from '../../notebook/browser/notebookOptions.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IEditorOptions } from '../../../../editor/common/config/editorOptions.js';
 import { deepClone } from '../../../../base/common/objects.js';
-import { POSITRON_NOTEBOOK_FOLDING_KEY } from '../common/positronNotebookConfig.js';
 
 export class BaseCellEditorOptions extends Disposable implements IBaseCellEditorOptions {
 	private static fixedEditorOptions: IEditorOptions = {
@@ -30,6 +29,7 @@ export class BaseCellEditorOptions extends Disposable implements IBaseCellEditor
 		renderLineHighlightOnlyWhenFocus: true,
 		overviewRulerLanes: 0,
 		lineDecorationsWidth: 10,
+		folding: true,
 		fixedOverflowWidgets: true,
 		minimap: { enabled: false },
 		renderValidationDecorations: 'on',
@@ -48,7 +48,7 @@ export class BaseCellEditorOptions extends Disposable implements IBaseCellEditor
 	constructor(readonly notebookEditor: Pick<INotebookEditorDelegate, 'onDidChangeModel' | 'hasModel' | 'onDidChangeOptions' | 'isReadOnly'>, readonly notebookOptions: NotebookOptions, readonly configurationService: IConfigurationService, readonly language: string) {
 		super();
 		this._register(configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('editor') || e.affectsConfiguration('notebook') || e.affectsConfiguration(POSITRON_NOTEBOOK_FOLDING_KEY)) {
+			if (e.affectsConfiguration('editor') || e.affectsConfiguration('notebook')) {
 				this._recomputeOptions();
 			}
 		}));
@@ -87,19 +87,17 @@ export class BaseCellEditorOptions extends Disposable implements IBaseCellEditor
 
 	private _computeEditorOptions() {
 		const editorOptions = deepClone(this.configurationService.getValue<IEditorOptions>('editor', { overrideIdentifier: this.language }));
-		const editorOptionsOverrideRaw = this.notebookOptions.getDisplayOptions().editorOptionsCustomizations ?? {};
+		const editorOptionsOverrideRaw = this.notebookOptions.getDisplayOptions().editorOptionsCustomizations ?? {} as any;
 		const editorOptionsOverride: { [key: string]: any } = {};
-		for (const [key, value] of Object.entries(editorOptionsOverrideRaw)) {
+		for (const key in editorOptionsOverrideRaw) {
 			if (key.indexOf('editor.') === 0) {
-				editorOptionsOverride[key.substring(7)] = value;
+				editorOptionsOverride[key.substring(7)] = editorOptionsOverrideRaw[key];
 			}
 		}
-		const folding = this.configurationService.getValue<boolean>(POSITRON_NOTEBOOK_FOLDING_KEY) ?? true;
 		const computed = Object.freeze({
 			...editorOptions,
 			...BaseCellEditorOptions.fixedEditorOptions,
 			...editorOptionsOverride,
-			folding,
 			...{ padding: { top: 12, bottom: 12 } },
 			readOnly: this.notebookEditor.isReadOnly
 		});

--- a/src/vs/workbench/contrib/positronNotebook/browser/BaseCellEditorOptions.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/BaseCellEditorOptions.tsx
@@ -15,6 +15,8 @@ import { IConfigurationService } from '../../../../platform/configuration/common
 import { IEditorOptions } from '../../../../editor/common/config/editorOptions.js';
 import { deepClone } from '../../../../base/common/objects.js';
 
+export const DEFAULT_LINE_NUMBERS_MIN_CHARS = 2;
+
 export class BaseCellEditorOptions extends Disposable implements IBaseCellEditorOptions {
 	private static fixedEditorOptions: IEditorOptions = {
 		scrollBeyondLastLine: false,
@@ -32,17 +34,25 @@ export class BaseCellEditorOptions extends Disposable implements IBaseCellEditor
 		folding: true,
 		fixedOverflowWidgets: true,
 		minimap: { enabled: false },
-		renderValidationDecorations: 'on',
-		lineNumbersMinChars: 2
+		renderValidationDecorations: 'on'
 	};
 
 	private readonly _localDisposableStore = this._register(new DisposableStore());
 	private readonly _onDidChange = this._register(new Emitter<void>());
 	readonly onDidChange: Event<void> = this._onDidChange.event;
 	private _value: IEditorOptions;
+	private _lineNumbersMinChars = DEFAULT_LINE_NUMBERS_MIN_CHARS;
 
 	get value(): Readonly<IEditorOptions> {
 		return this._value;
+	}
+
+	setLineNumbersMinChars(value: number): void {
+		if (this._lineNumbersMinChars === value) {
+			return;
+		}
+		this._lineNumbersMinChars = value;
+		this._recomputeOptions();
 	}
 
 	constructor(readonly notebookEditor: Pick<INotebookEditorDelegate, 'onDidChangeModel' | 'hasModel' | 'onDidChangeOptions' | 'isReadOnly'>, readonly notebookOptions: NotebookOptions, readonly configurationService: IConfigurationService, readonly language: string) {
@@ -87,17 +97,18 @@ export class BaseCellEditorOptions extends Disposable implements IBaseCellEditor
 
 	private _computeEditorOptions() {
 		const editorOptions = deepClone(this.configurationService.getValue<IEditorOptions>('editor', { overrideIdentifier: this.language }));
-		const editorOptionsOverrideRaw = this.notebookOptions.getDisplayOptions().editorOptionsCustomizations ?? {} as any;
+		const editorOptionsOverrideRaw = this.notebookOptions.getDisplayOptions().editorOptionsCustomizations ?? {};
 		const editorOptionsOverride: { [key: string]: any } = {};
-		for (const key in editorOptionsOverrideRaw) {
+		for (const [key, value] of Object.entries(editorOptionsOverrideRaw)) {
 			if (key.indexOf('editor.') === 0) {
-				editorOptionsOverride[key.substring(7)] = editorOptionsOverrideRaw[key];
+				editorOptionsOverride[key.substring(7)] = value;
 			}
 		}
 		const computed = Object.freeze({
 			...editorOptions,
 			...BaseCellEditorOptions.fixedEditorOptions,
 			...editorOptionsOverride,
+			lineNumbersMinChars: this._lineNumbersMinChars,
 			...{ padding: { top: 12, bottom: 12 } },
 			readOnly: this.notebookEditor.isReadOnly
 		});

--- a/src/vs/workbench/contrib/positronNotebook/browser/BaseCellEditorOptions.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/BaseCellEditorOptions.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -30,7 +30,6 @@ export class BaseCellEditorOptions extends Disposable implements IBaseCellEditor
 		},
 		renderLineHighlightOnlyWhenFocus: true,
 		overviewRulerLanes: 0,
-		lineDecorationsWidth: 10,
 		folding: true,
 		fixedOverflowWidgets: true,
 		minimap: { enabled: false },

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/IPositronNotebookCell.ts
@@ -73,6 +73,8 @@ export interface IPositronNotebookCell extends Disposable, IPositronCellViewMode
 	 */
 	getContent(): string;
 
+	getLineCount(): number;
+
 	/**
 	 * The cell's current code editor widget.
 	 */

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -172,6 +172,10 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 		return this.model.getValue();
 	}
 
+	getLineCount(): number {
+		return this.model.textModel?.getLineCount() ?? 1;
+	}
+
 	async getTextEditorModel(): Promise<ITextModel> {
 		// Cache and reuse a single model reference for the lifetime of this cell.
 		// This reference will be disposed when the cell is disposed.

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookCells/PositronNotebookCell.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -173,7 +173,7 @@ export abstract class PositronNotebookCellGeneral extends Disposable implements 
 	}
 
 	getLineCount(): number {
-		return this.model.textModel?.getLineCount() ?? 1;
+		return this.model.textBuffer.getLineCount();
 	}
 
 	async getTextEditorModel(): Promise<ITextModel> {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -19,7 +19,7 @@ import { CellEditType, CellKind, ICellEditOperation, ISelectionState, SelectionS
 import { INotebookExecutionService } from '../../notebook/common/notebookExecutionService.js';
 import { INotebookExecutionStateService } from '../../notebook/common/notebookExecutionStateService.js';
 import { createNotebookCell } from './PositronNotebookCells/createNotebookCell.js';
-import { BaseCellEditorOptions } from './BaseCellEditorOptions.js';
+import { BaseCellEditorOptions, DEFAULT_LINE_NUMBERS_MIN_CHARS } from './BaseCellEditorOptions.js';
 import * as DOM from '../../../../base/browser/dom.js';
 import { IPositronNotebookCell } from './PositronNotebookCells/IPositronNotebookCell.js';
 import { CellSelectionType, getActiveCell, getEditingCell, getSelectedCells, SelectionState, SelectionStateMachine, toCellRanges } from '../../../contrib/positronNotebook/browser/selectionMachine.js';
@@ -36,7 +36,7 @@ import { ILanguageRuntimeSession, IRuntimeSessionService } from '../../../servic
 import { ILanguageRuntimeService, RuntimeStartupPhase, RuntimeState } from '../../../services/languageRuntime/common/languageRuntimeService.js';
 import { isEqual } from '../../../../base/common/resources.js';
 import { IPositronWebviewPreloadService } from '../../../services/positronWebviewPreloads/browser/positronWebviewPreloadService.js';
-import { autorunDelta, IObservable, observableFromEvent, observableValue, runOnChange } from '../../../../base/common/observable.js';
+import { autorun, autorunDelta, IObservable, observableFromEvent, observableValue, runOnChange } from '../../../../base/common/observable.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { cellToCellDto2 } from './cellClipboardUtils.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
@@ -149,6 +149,8 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 * Key-value map of language to base cell editor options for cells of that language.
 	 */
 	private _baseCellEditorOptions: Map<string, IBaseCellEditorOptions> = new Map();
+
+	private readonly _lineNumberWidthDisposables = this._register(new DisposableStore());
 
 	/**
 	 * Cached font information for the notebook editor.
@@ -460,6 +462,16 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		super();
 
 		this.cells = observableValue<IPositronNotebookCell[]>('positronNotebookCells', []);
+
+		this._register(autorun(reader => {
+			this.cells.read(reader);
+			const textModel = this._textModel.read(reader);
+			this._lineNumberWidthDisposables.clear();
+			if (textModel) {
+				this._lineNumberWidthDisposables.add(textModel.onDidChangeContent(() => this._recomputeLineNumberWidth()));
+			}
+			this._recomputeLineNumberWidth();
+		}));
 
 		const { startupPhase } = this._languageRuntimeService;
 		this.kernelStatus = observableValue<NotebookKernelStatus>('positronNotebookKernelStatus', kernelStatusForStartupPhase(startupPhase));
@@ -1916,7 +1928,40 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			isReadOnly: this.isReadOnly,
 		}, this.notebookOptions, this.configurationService, language);
 		this._baseCellEditorOptions.set(language, options);
+		this._recomputeLineNumberWidth();
 		return options;
+	}
+
+	/**
+	 * Recomputes the line number width for all cell editor options
+	 * based on the maximum line count across all the code cells for
+	 * the notebook instance. This should be called whenever cells
+	 * are added, removed, or their content changes in a way that
+	 * affects the line count, to ensure the line number width is
+	 * the same across all cells regardless of their individual line
+	 * counts.
+	 *
+	 * The line number width is determined by the number of digits in
+	 * the maximum line count, with a minimum of 2 characters.
+	 */
+	private _recomputeLineNumberWidth(): void {
+		// Figure out which cell has the longest line count in this notebook.
+		let maxLineCount = 1;
+		for (const cell of this.cells.get()) {
+			if (cell.isCodeCell()) {
+				maxLineCount = Math.max(maxLineCount, cell.getLineCount());
+			}
+		}
+
+		// Determine the new line number width based off the line count
+		// e.g. if the longest cell has 150 lines, "150" is 3 digits
+		// so every cell reserves 3 characters worth of room for the
+		// line number width.
+		const newLineNumberWidth = Math.max(DEFAULT_LINE_NUMBERS_MIN_CHARS, String(maxLineCount).length);
+		// update each cell's editor options with the new line number width.
+		for (const options of this._baseCellEditorOptions.values()) {
+			(options as BaseCellEditorOptions).setLineNumbersMinChars(newLineNumberWidth);
+		}
 	}
 
 	getContribution<T extends IPositronNotebookContribution>(id: string): T | undefined {

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -1921,12 +1921,12 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 			return existingOptions;
 		}
 
-		const options = new BaseCellEditorOptions({
+		const options = this._register(new BaseCellEditorOptions({
 			onDidChangeModel: this.onDidChangeModel,
 			hasModel: <() => this is IActiveNotebookEditorDelegate>(() => Boolean(this.textModel)),
 			onDidChangeOptions: this._onDidChangeOptions.event,
 			isReadOnly: this.isReadOnly,
-		}, this.notebookOptions, this.configurationService, language);
+		}, this.notebookOptions, this.configurationService, language));
 		this._baseCellEditorOptions.set(language, options);
 		this._recomputeLineNumberWidth();
 		return options;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookInstance.ts
@@ -150,7 +150,7 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 	 */
 	private _baseCellEditorOptions: Map<string, IBaseCellEditorOptions> = new Map();
 
-	private readonly _lineNumberWidthDisposables = this._register(new DisposableStore());
+	private readonly _lineNumberWidthDisposable = this._register(new MutableDisposable());
 
 	/**
 	 * Cached font information for the notebook editor.
@@ -466,9 +466,9 @@ export class PositronNotebookInstance extends Disposable implements IPositronNot
 		this._register(autorun(reader => {
 			this.cells.read(reader);
 			const textModel = this._textModel.read(reader);
-			this._lineNumberWidthDisposables.clear();
+			this._lineNumberWidthDisposable.clear();
 			if (textModel) {
-				this._lineNumberWidthDisposables.add(textModel.onDidChangeContent(() => this._recomputeLineNumberWidth()));
+				this._lineNumberWidthDisposable.value = textModel.onDidChangeContent(() => this._recomputeLineNumberWidth());
 			}
 			this._recomputeLineNumberWidth();
 		}));

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellEditorMonacoWidget.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -14,6 +14,7 @@ import { localize } from '../../../../../nls.js';
 
 import { EditorExtensionsRegistry, IEditorContributionDescription } from '../../../../../editor/browser/editorExtensions.js';
 import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
+import { IEditorOptions } from '../../../../../editor/common/config/editorOptions.js';
 
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { IEditorProgressService } from '../../../../../platform/progress/common/progress.js';
@@ -146,28 +147,41 @@ export function useCellEditorWidget(cell: PositronNotebookCellGeneral) {
 		);
 
 		const editorInstaService = instance.scopedInstantiationService.createChild(serviceCollection);
-		const editorOptions = new CellEditorOptions(instance.getBaseCellEditorOptions(language), instance.notebookOptions, services.configurationService);
+		const editorOptions = disposables.add(new CellEditorOptions(instance.getBaseCellEditorOptions(language), instance.notebookOptions, services.configurationService));
 
-		const defaultOptions = editorOptions.getDefaultValue();
-		const editor = disposables.add(editorInstaService.createInstance(CodeEditorWidget, editorPartRef.current, {
-			...defaultOptions,
-			// Override padding for Positron notebooks to add breathing room between action bar and editor content
-			padding: { top: 16, bottom: 16 },
-			scrollbar: {
-				...defaultOptions.scrollbar,
-				// Smaller scrollbars since we embed many editor widgets
-				verticalScrollbarSize: 8,
-				horizontalScrollbarSize: 8
-			},
-			tabIndex: -1, // Remove editor from tab order - use Enter to focus
-			dimension: {
-				width: 0,
-				height: 0,
-			},
-		}, {
+		// Build the final editor options from the cell editor defaults merged with
+		// the Positron Notebook editor overrides. Used for both initial creation
+		// and live updates so the overrides are never lost on update.
+		const buildEditorOptions = () => {
+			const defaultOptions = editorOptions.getDefaultValue();
+			return {
+				...defaultOptions,
+				// Override padding for Positron notebooks to add breathing room between action bar and editor content
+				padding: { top: 16, bottom: 16 },
+				scrollbar: {
+					...defaultOptions.scrollbar,
+					// Smaller scrollbars since we embed many editor widgets
+					verticalScrollbarSize: 8,
+					horizontalScrollbarSize: 8
+				},
+				tabIndex: -1, // Remove editor from tab order - use Enter to focus
+				dimension: {
+					width: 0,
+					height: 0,
+				},
+			};
+		};
+
+		const editor = disposables.add(editorInstaService.createInstance(CodeEditorWidget, editorPartRef.current, buildEditorOptions(), {
 			contributions: getNotebookEditorContributions()
 		}));
 		cell.attachEditor(editor);
+
+		// Re-apply options when they change so the open notebook
+		// updates without requiring a reload.
+		disposables.add(editorOptions.onDidChange(() => {
+			editor.updateOptions(buildEditorOptions() as IEditorOptions);
+		}));
 
 		// Request model for cell and pass to editor.
 		cell.getTextEditorModel().then(model => {

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookConfig.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookConfig.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -34,9 +34,6 @@ export const POSITRON_NOTEBOOK_INLINE_DATA_EXPLORER_MAX_HEIGHT_KEY = 'positron.n
 
 // Configuration key that gates experimental Positron notebook features.
 export const POSITRON_NOTEBOOK_EXPERIMENTAL_KEY = 'positron.notebook.experimental';
-
-// Configuration key for showing code folding controls in notebook cell editors.
-export const POSITRON_NOTEBOOK_FOLDING_KEY = 'positron.notebook.folding';
 
 // Register the configuration setting
 const configurationRegistry = Registry.as<IConfigurationRegistry>(
@@ -131,16 +128,6 @@ configurationRegistry.registerConfiguration({
 			),
 			tags: ['experimental', 'positronNotebook'],
 			scope: ConfigurationScope.WINDOW,
-		},
-		[POSITRON_NOTEBOOK_FOLDING_KEY]: {
-			type: 'boolean',
-			default: true,
-			markdownDescription: localize(
-				'positron.notebook.folding',
-				'Show code folding controls in the editor of code cells. When disabled, the code cell gutter is narrower.'
-			),
-			scope: ConfigurationScope.WINDOW,
-			tags: ['positronNotebook'],
 		},
 	},
 });

--- a/src/vs/workbench/contrib/positronNotebook/common/positronNotebookConfig.ts
+++ b/src/vs/workbench/contrib/positronNotebook/common/positronNotebookConfig.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -34,6 +34,9 @@ export const POSITRON_NOTEBOOK_INLINE_DATA_EXPLORER_MAX_HEIGHT_KEY = 'positron.n
 
 // Configuration key that gates experimental Positron notebook features.
 export const POSITRON_NOTEBOOK_EXPERIMENTAL_KEY = 'positron.notebook.experimental';
+
+// Configuration key for showing code folding controls in notebook cell editors.
+export const POSITRON_NOTEBOOK_FOLDING_KEY = 'positron.notebook.folding';
 
 // Register the configuration setting
 const configurationRegistry = Registry.as<IConfigurationRegistry>(
@@ -128,6 +131,16 @@ configurationRegistry.registerConfiguration({
 			),
 			tags: ['experimental', 'positronNotebook'],
 			scope: ConfigurationScope.WINDOW,
+		},
+		[POSITRON_NOTEBOOK_FOLDING_KEY]: {
+			type: 'boolean',
+			default: true,
+			markdownDescription: localize(
+				'positron.notebook.folding',
+				'Show code folding controls in the editor of code cells. When disabled, the code cell gutter is narrower.'
+			),
+			scope: ConfigurationScope.WINDOW,
+			tags: ['positronNotebook'],
 		},
 	},
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/baseCellEditorOptions.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/baseCellEditorOptions.vitest.ts
@@ -7,11 +7,13 @@
 
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { Event } from '../../../../../base/common/event.js';
+import { IConfigurationChangeEvent } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { INotebookEditorDelegate } from '../../../notebook/browser/notebookBrowser.js';
 import { NotebookDisplayOptions, NotebookOptions } from '../../../notebook/browser/notebookOptions.js';
 import { BaseCellEditorOptions } from '../../browser/BaseCellEditorOptions.js';
+import { POSITRON_NOTEBOOK_FOLDING_KEY } from '../../common/positronNotebookConfig.js';
 
 describe('BaseCellEditorOptions', () => {
 	const store = new DisposableStore();
@@ -20,8 +22,8 @@ describe('BaseCellEditorOptions', () => {
 		store.clear();
 	});
 
-	function createOptions() {
-		const configurationService = new TestConfigurationService({ editor: {} });
+	function createOptions(config: Record<string, unknown> = {}) {
+		const configurationService = new TestConfigurationService({ editor: {}, ...config });
 		const notebookOptions = stubInterface<NotebookOptions>({
 			onDidChangeOptions: Event.None,
 			getDisplayOptions: () => stubInterface<NotebookDisplayOptions>({ editorOptionsCustomizations: {} }),
@@ -32,13 +34,33 @@ describe('BaseCellEditorOptions', () => {
 			hasModel: (): this is never => false,
 			isReadOnly: false,
 		});
-		return store.add(new BaseCellEditorOptions(notebookEditor, notebookOptions, configurationService, 'python'));
+
+		// BaseCellEditorOptions extends Disposable, so the store can own it.
+		const options = store.add(new BaseCellEditorOptions(notebookEditor, notebookOptions, configurationService, 'python'));
+		return { options, configurationService };
 	}
 
 	it('applies the default gutter options', () => {
-		const options = createOptions();
+		const { options } = createOptions();
 		expect(options.value.folding).toBe(true);
 		expect(options.value.lineNumbersMinChars).toBe(2);
 		expect(options.value.lineDecorationsWidth).toBe(10);
+	});
+
+	it('disables folding when the setting is off', () => {
+		const { options } = createOptions({ [POSITRON_NOTEBOOK_FOLDING_KEY]: false });
+		expect(options.value.folding).toBe(false);
+	});
+
+	it('recomputes folding when the setting changes', () => {
+		const { options, configurationService } = createOptions();
+		expect(options.value.folding).toBe(true);
+
+		configurationService.setUserConfiguration(POSITRON_NOTEBOOK_FOLDING_KEY, false);
+		configurationService.onDidChangeConfigurationEmitter.fire(stubInterface<IConfigurationChangeEvent>({
+			affectsConfiguration: (key: string) => key === POSITRON_NOTEBOOK_FOLDING_KEY,
+		}));
+
+		expect(options.value.folding).toBe(false);
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/baseCellEditorOptions.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/baseCellEditorOptions.vitest.ts
@@ -7,13 +7,11 @@
 
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { Event } from '../../../../../base/common/event.js';
-import { IConfigurationChangeEvent } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
 import { INotebookEditorDelegate } from '../../../notebook/browser/notebookBrowser.js';
 import { NotebookDisplayOptions, NotebookOptions } from '../../../notebook/browser/notebookOptions.js';
 import { BaseCellEditorOptions } from '../../browser/BaseCellEditorOptions.js';
-import { POSITRON_NOTEBOOK_FOLDING_KEY } from '../../common/positronNotebookConfig.js';
 
 describe('BaseCellEditorOptions', () => {
 	const store = new DisposableStore();
@@ -22,8 +20,8 @@ describe('BaseCellEditorOptions', () => {
 		store.clear();
 	});
 
-	function createOptions(config: Record<string, unknown> = {}) {
-		const configurationService = new TestConfigurationService({ editor: {}, ...config });
+	function createOptions() {
+		const configurationService = new TestConfigurationService({ editor: {} });
 		const notebookOptions = stubInterface<NotebookOptions>({
 			onDidChangeOptions: Event.None,
 			getDisplayOptions: () => stubInterface<NotebookDisplayOptions>({ editorOptionsCustomizations: {} }),
@@ -34,33 +32,13 @@ describe('BaseCellEditorOptions', () => {
 			hasModel: (): this is never => false,
 			isReadOnly: false,
 		});
-
-		// BaseCellEditorOptions extends Disposable, so the store can own it.
-		const options = store.add(new BaseCellEditorOptions(notebookEditor, notebookOptions, configurationService, 'python'));
-		return { options, configurationService };
+		return store.add(new BaseCellEditorOptions(notebookEditor, notebookOptions, configurationService, 'python'));
 	}
 
 	it('applies the default gutter options', () => {
-		const { options } = createOptions();
+		const options = createOptions();
 		expect(options.value.folding).toBe(true);
 		expect(options.value.lineNumbersMinChars).toBe(2);
 		expect(options.value.lineDecorationsWidth).toBe(10);
-	});
-
-	it('disables folding when the setting is off', () => {
-		const { options } = createOptions({ [POSITRON_NOTEBOOK_FOLDING_KEY]: false });
-		expect(options.value.folding).toBe(false);
-	});
-
-	it('recomputes folding when the setting changes', () => {
-		const { options, configurationService } = createOptions();
-		expect(options.value.folding).toBe(true);
-
-		configurationService.setUserConfiguration(POSITRON_NOTEBOOK_FOLDING_KEY, false);
-		configurationService.onDidChangeConfigurationEmitter.fire(stubInterface<IConfigurationChangeEvent>({
-			affectsConfiguration: (key: string) => key === POSITRON_NOTEBOOK_FOLDING_KEY,
-		}));
-
-		expect(options.value.folding).toBe(false);
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/baseCellEditorOptions.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/baseCellEditorOptions.vitest.ts
@@ -39,7 +39,6 @@ describe('BaseCellEditorOptions', () => {
 		const options = createOptions();
 		expect(options.value.folding).toBe(true);
 		expect(options.value.lineNumbersMinChars).toBe(2);
-		expect(options.value.lineDecorationsWidth).toBe(10);
 	});
 
 	it('updates the line-number width via setLineNumbersMinChars', () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/baseCellEditorOptions.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/baseCellEditorOptions.vitest.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { Event } from '../../../../../base/common/event.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { INotebookEditorDelegate } from '../../../notebook/browser/notebookBrowser.js';
+import { NotebookDisplayOptions, NotebookOptions } from '../../../notebook/browser/notebookOptions.js';
+import { BaseCellEditorOptions } from '../../browser/BaseCellEditorOptions.js';
+
+describe('BaseCellEditorOptions', () => {
+	const store = new DisposableStore();
+
+	afterEach(() => {
+		store.clear();
+	});
+
+	function createOptions() {
+		const configurationService = new TestConfigurationService({ editor: {} });
+		const notebookOptions = stubInterface<NotebookOptions>({
+			onDidChangeOptions: Event.None,
+			getDisplayOptions: () => stubInterface<NotebookDisplayOptions>({ editorOptionsCustomizations: {} }),
+		});
+		const notebookEditor = stubInterface<Pick<INotebookEditorDelegate, 'onDidChangeModel' | 'hasModel' | 'onDidChangeOptions' | 'isReadOnly'>>({
+			onDidChangeModel: Event.None,
+			onDidChangeOptions: Event.None,
+			hasModel: (): this is never => false,
+			isReadOnly: false,
+		});
+		return store.add(new BaseCellEditorOptions(notebookEditor, notebookOptions, configurationService, 'python'));
+	}
+
+	it('applies the default gutter options', () => {
+		const options = createOptions();
+		expect(options.value.folding).toBe(true);
+		expect(options.value.lineNumbersMinChars).toBe(2);
+		expect(options.value.lineDecorationsWidth).toBe(10);
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/baseCellEditorOptions.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/baseCellEditorOptions.vitest.ts
@@ -41,4 +41,11 @@ describe('BaseCellEditorOptions', () => {
 		expect(options.value.lineNumbersMinChars).toBe(2);
 		expect(options.value.lineDecorationsWidth).toBe(10);
 	});
+
+	it('updates the line-number width via setLineNumbersMinChars', () => {
+		const options = createOptions();
+		expect(options.value.lineNumbersMinChars).toBe(2);
+		options.setLineNumbersMinChars(3);
+		expect(options.value.lineNumbersMinChars).toBe(3);
+	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookInstance.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookInstance.vitest.ts
@@ -273,6 +273,58 @@ describe('PositronNotebookInstance', () => {
 		});
 	});
 
+	describe('left gutter alignment of code cells (lineNumbersMinChars)', () => {
+		function linesOf(n: number): string {
+			return Array.from({ length: n }, (_, i) => `line ${i}`).join('\n');
+		}
+
+		it('initial width is 2 when all cells have fewer than 100 lines', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[
+					[linesOf(5), 'python', CellKind.Code],
+					[linesOf(20), 'python', CellKind.Code],
+				],
+				ctx,
+			);
+			expect(notebook.getBaseCellEditorOptions('python').value.lineNumbersMinChars).toBe(2);
+		});
+
+		it('initial width scales to the widest cell', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[
+					[linesOf(5), 'python', CellKind.Code],
+					[linesOf(20), 'python', CellKind.Code],
+					[linesOf(150), 'python', CellKind.Code],
+				],
+				ctx,
+			);
+			expect(notebook.getBaseCellEditorOptions('python').value.lineNumbersMinChars).toBe(3);
+		});
+
+		it('returns the same options instance for repeated calls with the same language', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[[linesOf(5), 'python', CellKind.Code]],
+				ctx,
+			);
+			const a = notebook.getBaseCellEditorOptions('python');
+			const b = notebook.getBaseCellEditorOptions('python');
+			expect(a).toBe(b);
+		});
+
+		it('width updates when a cell crosses a digit boundary', () => {
+			const notebook = createTestPositronNotebookInstance(
+				[
+					[linesOf(5), 'python', CellKind.Code],
+					[linesOf(9), 'python', CellKind.Code],
+				],
+				ctx,
+			);
+			expect(notebook.getBaseCellEditorOptions('python').value.lineNumbersMinChars).toBe(2);
+			notebook.cells.get()[1].model.textModel!.setValue(linesOf(100));
+			expect(notebook.getBaseCellEditorOptions('python').value.lineNumbersMinChars).toBe(3);
+		});
+	});
+
 	describe('identity', () => {
 		// This test was introduced when we added support for split editing.
 		// Split editing required the move from having a unique instance per

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookInstance.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/positronNotebookInstance.vitest.ts
@@ -320,7 +320,11 @@ describe('PositronNotebookInstance', () => {
 				ctx,
 			);
 			expect(notebook.getBaseCellEditorOptions('python').value.lineNumbersMinChars).toBe(2);
-			notebook.cells.get()[1].model.textModel!.setValue(linesOf(100));
+			// Edit in place via applyEdits (as production does) so the cell's
+			// shared text buffer reflects the new line count. setValue would
+			// replace the model's buffer and leave the cell's buffer stale.
+			const textModel = notebook.cells.get()[1].model.textModel!;
+			textModel.applyEdits([{ range: textModel.getFullModelRange(), text: linesOf(100) }]);
 			expect(notebook.getBaseCellEditorOptions('python').value.lineNumbersMinChars).toBe(3);
 		});
 	});


### PR DESCRIPTION
Fixes #13567

Tries to improve how much space we reserve to the left of the code cell contents.

There are three different changes:

1. Reduced the default gutter width by changing `lineNumbersMinChars` from 3 to 2. Now we only reserve space for line numbers up to "99". The left gutter width will increase when a cell has a line count of 100+.

2. Fixed spacing bug between left cell gutter and code cell contents  by changing `lineDecorationsWidth` from 0 to 10. Now the line number and collapse/expand code icons won't be right up against the code contents

3.  Cell editor options (e.g. `notebook.lineNumbers`) now apply immediately without requiring a notebook reload.

4. **Dynamic cross-cell gutter alignment** -- All code cells in a notebook share the same line-number column width. Previously, a cell crossing a line-count boundary (e.g. 9 -> 10 lines) would jump wider than its neighbors. 

### Screenshots

**Line number live setting + Spacing fix for code folding**

https://github.com/user-attachments/assets/1abe1a82-1e0d-4f11-b21f-c3ebb9e5451b

**Dynamic line number gutter alignment across all notebook cells** 

https://github.com/user-attachments/assets/e6f6a4a8-d5ac-44aa-bfe9-f13cae245a1b

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix excessive left gutter padding on Positron Notebook Editor code cells (#13567)

### Validation Steps

@:positron-notebooks

**Matching left gutter widths across cells:**
1. Open a notebook with multiple code cells of varying lengths (5 lines, 20 lines, 100 lines, 1000 lines)
2. Verify all cells have the same line-number column width which should be 2 characters wide if the largest line numbers across all cells is 99 or lower. It should be 3 characters wide if the largest line numbers across all cells is 999 or lower, and so on.

**Left gutter widths update for all cells as you type:**
1. Open a new notebook and create two cells. 
2. Add lines to one of the cells until it crosses a digit boundary (99 -> 100 lines) and verify both cell left gutters widen together.

**Settings update without requiring a reload:**
1. Toggle `notebook.lineNumbers` in settings and verify it applies without a reload.