### PR TITLE
fix: add typescript devDep to positron-data-explorer-protocol

### DIFF
--- a/build/gulpfile.extensions.ts
+++ b/build/gulpfile.extensions.ts
@@ -311,7 +311,19 @@ const tasks = compilations.map(function (tsconfigFile) {
 const transpileExtensionsTask = task.define('transpile-extensions', task.parallel(...tasks.map(t => t.transpileTask)));
 gulp.task(transpileExtensionsTask);
 
-export const compileExtensionsTask = task.define('compile-extensions', task.parallel(...tasks.map(t => t.compileTask)));
+// --- Start Positron ---
+// positron-data-explorer-protocol must compile before extensions that depend on its out/ directory.
+// Running all compile tasks in parallel causes a race: the clean step deletes out/, and extensions
+// that import from positron-data-explorer-protocol fail if they start compiling before it rebuilds.
+const dataExplorerProtocolIndex = compilations.indexOf('extensions/positron-data-explorer-protocol/tsconfig.json');
+const compileExtensionsImpl = dataExplorerProtocolIndex >= 0
+	? task.series(
+		tasks[dataExplorerProtocolIndex].compileTask,
+		task.parallel(...tasks.filter((_, i) => i !== dataExplorerProtocolIndex).map(t => t.compileTask))
+	)
+	: task.parallel(...tasks.map(t => t.compileTask));
+export const compileExtensionsTask = task.define('compile-extensions', compileExtensionsImpl);
+// --- End Positron ---
 gulp.task(compileExtensionsTask);
 
 export const watchExtensionsTask = task.define('watch-extensions', task.parallel(...tasks.map(t => t.watchTask)));

--- a/extensions/positron-data-explorer-protocol/package-lock.json
+++ b/extensions/positron-data-explorer-protocol/package-lock.json
@@ -6,7 +6,24 @@
   "packages": {
     "": {
       "name": "positron-data-explorer-protocol",
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     }
   }
 }

--- a/extensions/positron-data-explorer-protocol/package.json
+++ b/extensions/positron-data-explorer-protocol/package.json
@@ -15,5 +15,8 @@
     "compile": "tsc -p tsconfig.json",
     "watch": "tsc -w -p tsconfig.json",
     "prepare": "npm run compile"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
### Summary
Two Windows CI failures in extensions that depend on `positron-data-explorer-protocol`.

- **Install failure**: `tsc` not found during `prepare` — the package had no `typescript` of its own and fell back to `extensions/node_modules/typescript`, which may not exist yet during parallel cold-cache installs. Fix: add `typescript ^6.0.3` to `positron-data-explorer-protocol` devDependencies.
- **Compile failure**: `positron-duckdb` (and data driver extensions) failed with `Cannot find module 'positron-data-explorer-protocol'` — the gulp `compile-extensions` task runs all extensions in parallel, so the clean step deletes `out/` and the duckdb compile starts before the protocol package finishes rebuilding it. Fix: compile `positron-data-explorer-protocol` first, then all others in parallel.

### QA Notes
`@:win` — verify Windows install and compile steps pass.