### PR TITLE
e2e: apply reload-required settings before app launch via beforeApp

### DIFF
--- a/test/e2e/tests/console/console-python.test.ts
+++ b/test/e2e/tests/console/console-python.test.ts
@@ -3,17 +3,23 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, tags } from '../_test.setup';
+import { test as base, tags } from '../_test.setup';
+
+const test = base.extend<{}, {}>({
+	beforeApp: [
+		async ({ settingsFile }, use) => {
+			settingsFile.append({ 'python.useBundledIpykernel': false });
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Console Pane: Alternate Python', { tag: [tags.WEB, tags.CONSOLE, tags.WIN] }, () => {
-
-	test.beforeAll(async ({ settings }) => {
-		await settings.set({ 'python.useBundledIpykernel': false }, { reload: true, waitMs: 1000 });
-	});
 
 	test('Verify alternate python can skip bundled ipykernel', async ({ app, sessions }) => {
 		await sessions.start('pythonAlt');

--- a/test/e2e/tests/console/console-python.test.ts
+++ b/test/e2e/tests/console/console-python.test.ts
@@ -7,8 +7,14 @@ import { test as base, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ settingsFile }, use) => {
-			settingsFile.append({ 'python.useBundledIpykernel': false });
+		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
+			if (useLegacyNotebookEditor) {
+				await settingsFile.append({ 'positron.notebook.enabled': false });
+			}
+			if (enableDataConnections) {
+				await settingsFile.append({ 'dataConnections.enabled': true });
+			}
+			await settingsFile.append({ 'python.useBundledIpykernel': false });
 			await use();
 		},
 		{ scope: 'worker' }

--- a/test/e2e/tests/help/help.test.ts
+++ b/test/e2e/tests/help/help.test.ts
@@ -3,19 +3,25 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect, tags } from '../_test.setup';
+import { test as base, expect, tags } from '../_test.setup';
+
+const test = base.extend<{}, {}>({
+	beforeApp: [
+		async ({ settingsFile }, use) => {
+			// Enable reduced motion so we don't have to wait for animations of expanding
+			// and collapsing the panel.
+			settingsFile.append({ 'workbench.reduceMotion': 'on' });
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Help', { tag: [tags.HELP, tags.WEB] }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		// Enable reduced motion so we don't have to wait for animations of expanding
-		// and collapsing the panel.
-		await settings.set({ 'workbench.reduceMotion': 'on' }, { reload: 'web' });
-	});
 
 	test('Python - Verify Help landing page', { tag: [tags.WIN] }, async function ({ app }) {
 

--- a/test/e2e/tests/help/help.test.ts
+++ b/test/e2e/tests/help/help.test.ts
@@ -7,10 +7,16 @@ import { test as base, expect, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ settingsFile }, use) => {
+		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
+			if (useLegacyNotebookEditor) {
+				await settingsFile.append({ 'positron.notebook.enabled': false });
+			}
+			if (enableDataConnections) {
+				await settingsFile.append({ 'dataConnections.enabled': true });
+			}
 			// Enable reduced motion so we don't have to wait for animations of expanding
 			// and collapsing the panel.
-			settingsFile.append({ 'workbench.reduceMotion': 'on' });
+			await settingsFile.append({ 'workbench.reduceMotion': 'on' });
 			await use();
 		},
 		{ scope: 'worker' }

--- a/test/e2e/tests/interpreters/new-uv-project.test.ts
+++ b/test/e2e/tests/interpreters/new-uv-project.test.ts
@@ -9,8 +9,14 @@ import * as fs from 'fs';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ settingsFile }, use) => {
-			settingsFile.append({ 'interpreters.startupBehavior': 'auto' });
+		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
+			if (useLegacyNotebookEditor) {
+				await settingsFile.append({ 'positron.notebook.enabled': false });
+			}
+			if (enableDataConnections) {
+				await settingsFile.append({ 'dataConnections.enabled': true });
+			}
+			await settingsFile.append({ 'interpreters.startupBehavior': 'auto' });
 			await use();
 		},
 		{ scope: 'worker' }

--- a/test/e2e/tests/interpreters/new-uv-project.test.ts
+++ b/test/e2e/tests/interpreters/new-uv-project.test.ts
@@ -4,8 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path from 'path';
-import { test, expect, tags } from '../_test.setup';
-import * as fs from 'fs/promises';
+import { test as base, expect, tags } from '../_test.setup';
+import * as fs from 'fs';
+
+const test = base.extend<{}, {}>({
+	beforeApp: [
+		async ({ settingsFile }, use) => {
+			settingsFile.append({ 'interpreters.startupBehavior': 'auto' });
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
 
 test.use({
 	suiteId: __filename
@@ -15,14 +25,10 @@ test.describe('New uv Environment', {
 	tag: [tags.INTERPRETER]
 }, () => {
 
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({ 'interpreters.startupBehavior': 'auto' }, { reload: 'web' });
-	});
-
 	test.afterAll(async () => {
 		const projPath = '/tmp/vscsmoke/qa-example-content/proj';
 		try {
-			await fs.rm(projPath, { recursive: true, force: true });
+			await fs.promises.rm(projPath, { recursive: true, force: true });
 			console.log(`Cleaned up test project: ${projPath}`);
 		} catch (err) {
 			console.warn(`Failed to delete ${projPath}:`, err);

--- a/test/e2e/tests/interpreters/new-uv-project.test.ts
+++ b/test/e2e/tests/interpreters/new-uv-project.test.ts
@@ -46,6 +46,7 @@ test.describe('New uv Environment', {
 		test.skip(process.env.IS_OPENSUSE === 'true', 'Skip on openSuse');
 
 		await app.workbench.terminal.clickTerminalTab();
+		await app.workbench.terminal.createTerminal();
 
 		await app.workbench.terminal.runCommandInTerminal('uv init proj');
 

--- a/test/e2e/tests/notebooks-positron/_test.setup.ts
+++ b/test/e2e/tests/notebooks-positron/_test.setup.ts
@@ -22,7 +22,7 @@ export const test = base.extend<NotebooksPositronTestFixtures, NotebooksPositron
 			if (enablePositronNotebooks) {
 				// Enable Positron notebooks before the app fixture starts
 				// to avoid waiting for a window reload
-				settingsFile.append({ 'positron.notebook.enabled': true });
+				await settingsFile.append({ 'positron.notebook.enabled': true });
 			}
 			if (ghostCellSettings) {
 				await settingsFile.append(ghostCellSettings);

--- a/test/e2e/tests/packages-pane/packages-pane.test.ts
+++ b/test/e2e/tests/packages-pane/packages-pane.test.ts
@@ -8,8 +8,14 @@ import { SessionRuntimes } from '../../pages/sessions.js';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ settingsFile }, use) => {
-			settingsFile.append({ 'packages.enabled': true });
+		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
+			if (useLegacyNotebookEditor) {
+				await settingsFile.append({ 'positron.notebook.enabled': false });
+			}
+			if (enableDataConnections) {
+				await settingsFile.append({ 'dataConnections.enabled': true });
+			}
+			await settingsFile.append({ 'packages.enabled': true });
 			await use();
 		},
 		{ scope: 'worker' }

--- a/test/e2e/tests/packages-pane/packages-pane.test.ts
+++ b/test/e2e/tests/packages-pane/packages-pane.test.ts
@@ -3,8 +3,18 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, tags, expect } from '../_test.setup';
+import { test as base, tags, expect } from '../_test.setup';
 import { SessionRuntimes } from '../../pages/sessions.js';
+
+const test = base.extend<{}, {}>({
+	beforeApp: [
+		async ({ settingsFile }, use) => {
+			settingsFile.append({ 'packages.enabled': true });
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
 
 test.use({
 	suiteId: __filename
@@ -13,12 +23,6 @@ test.use({
 test.describe('Packages Pane', {
 	tag: [tags.PACKAGES_PANE, tags.WEB]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'packages.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ app }) {
 		await app.workbench.packages.clearFilter();

--- a/test/e2e/tests/quarto/_test.setup.ts
+++ b/test/e2e/tests/quarto/_test.setup.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test as base, TestFixtures, WorkerFixtures } from '../_test.setup';
+
+interface QuartoTestFixtures extends TestFixtures { }
+
+interface QuartoWorkerFixtures extends WorkerFixtures {
+	enableQuartoInlineOutput: boolean;
+}
+
+export const test = base.extend<QuartoTestFixtures, QuartoWorkerFixtures>({
+	enableQuartoInlineOutput: [true, { scope: 'worker', option: true }],
+
+	beforeApp: [
+		async ({ enableQuartoInlineOutput, settingsFile }, use) => {
+			if (enableQuartoInlineOutput) {
+				settingsFile.append({ 'positron.quarto.inlineOutput.enabled': true });
+			}
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
+
+export { tags, expect } from '../_test.setup';

--- a/test/e2e/tests/quarto/_test.setup.ts
+++ b/test/e2e/tests/quarto/_test.setup.ts
@@ -15,9 +15,15 @@ export const test = base.extend<QuartoTestFixtures, QuartoWorkerFixtures>({
 	enableQuartoInlineOutput: [true, { scope: 'worker', option: true }],
 
 	beforeApp: [
-		async ({ enableQuartoInlineOutput, settingsFile }, use) => {
+		async ({ useLegacyNotebookEditor, enableDataConnections, enableQuartoInlineOutput, settingsFile }, use) => {
+			if (useLegacyNotebookEditor) {
+				await settingsFile.append({ 'positron.notebook.enabled': false });
+			}
+			if (enableDataConnections) {
+				await settingsFile.append({ 'dataConnections.enabled': true });
+			}
 			if (enableQuartoInlineOutput) {
-				settingsFile.append({ 'positron.quarto.inlineOutput.enabled': true });
+				await settingsFile.append({ 'positron.quarto.inlineOutput.enabled': true });
 			}
 			await use();
 		},

--- a/test/e2e/tests/quarto/quarto-inline-output-autostart.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-autostart.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags } from '../_test.setup';
+import { test, tags } from './_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -13,12 +13,6 @@ test.use({
 test.describe('Quarto - Inline Output: Kernel Auto-Start on Open', {
 	tag: [tags.QUARTO]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-basic.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-basic.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags } from '../_test.setup';
+import { test, tags } from './_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -13,12 +13,6 @@ test.use({
 test.describe('Quarto - Inline Output: Basic', {
 	tag: [tags.WEB, tags.WIN, tags.QUARTO]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-cell-metadata.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-cell-metadata.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, expect, tags } from '../_test.setup';
+import { test, expect, tags } from './_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -13,12 +13,6 @@ test.use({
 test.describe('Quarto - Inline Output: Cell Metadata', {
 	tag: [tags.WEB, tags.WIN, tags.QUARTO]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-collapse.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-collapse.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags } from '../_test.setup';
+import { test, tags } from './_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -13,12 +13,6 @@ test.use({
 test.describe('Quarto - Inline Output: Collapse', {
 	tag: [tags.WEB, tags.WIN, tags.QUARTO]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-copy-select.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-copy-select.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags, expect } from '../_test.setup';
+import { test, tags, expect } from './_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -13,12 +13,6 @@ test.use({
 test.describe('Quarto - Inline Output: Copy and Select', {
 	tag: [tags.WEB, tags.WIN, tags.QUARTO]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-dataframe.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-dataframe.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags } from '../_test.setup';
+import { test, tags } from './_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -13,12 +13,6 @@ test.use({
 test.describe('Quarto - Inline Output: DataFrame and Interactive HTML', {
 	tag: [tags.WEB, tags.WIN, tags.QUARTO]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test('Python - Verify DataFrame output shows HTML only, not duplicate text and HTML', async function ({ python, app, openFile, settings }) {
 		const { editors, inlineQuarto } = app.workbench;

--- a/test/e2e/tests/quarto/quarto-inline-output-execution.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-execution.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags, expect } from '../_test.setup';
+import { test, tags, expect } from './_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -13,12 +13,6 @@ test.use({
 test.describe('Quarto - Inline Output: Execution', {
 	tag: [tags.WEB, tags.WIN, tags.QUARTO]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range-python.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range-python.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test as base, tags } from './_test.setup';
+import { test as base, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [

--- a/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range-python.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range-python.test.ts
@@ -8,8 +8,14 @@ import { test as base, tags } from './_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ settingsFile }, use) => {
-			settingsFile.append({
+		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
+			if (useLegacyNotebookEditor) {
+				await settingsFile.append({ 'positron.notebook.enabled': false });
+			}
+			if (enableDataConnections) {
+				await settingsFile.append({ 'dataConnections.enabled': true });
+			}
+			await settingsFile.append({
 				'positron.quarto.inlineOutput.enabled': true,
 				'console.showNotebookConsoles': true,
 				'workbench.editor.enablePreview': false,

--- a/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range-python.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range-python.test.ts
@@ -4,7 +4,21 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags } from '../_test.setup';
+import { test as base, tags } from './_test.setup';
+
+const test = base.extend<{}, {}>({
+	beforeApp: [
+		async ({ settingsFile }, use) => {
+			settingsFile.append({
+				'positron.quarto.inlineOutput.enabled': true,
+				'console.showNotebookConsoles': true,
+				'workbench.editor.enablePreview': false,
+			});
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
 
 test.use({
 	suiteId: __filename
@@ -13,14 +27,6 @@ test.use({
 test.describe('Quarto - Inline Output: Notebook Statement Range (Python)', {
 	tag: [tags.QUARTO, tags.CONSOLE]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true,
-			'console.showNotebookConsoles': true,
-			'workbench.editor.enablePreview': false,
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test as base, tags } from './_test.setup';
+import { test as base, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [

--- a/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range.test.ts
@@ -8,8 +8,14 @@ import { test as base, tags } from './_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ settingsFile }, use) => {
-			settingsFile.append({
+		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
+			if (useLegacyNotebookEditor) {
+				await settingsFile.append({ 'positron.notebook.enabled': false });
+			}
+			if (enableDataConnections) {
+				await settingsFile.append({ 'dataConnections.enabled': true });
+			}
+			await settingsFile.append({
 				'positron.quarto.inlineOutput.enabled': true,
 				'console.showNotebookConsoles': true,
 				'workbench.editor.enablePreview': false,

--- a/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range.test.ts
@@ -4,7 +4,21 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags } from '../_test.setup';
+import { test as base, tags } from './_test.setup';
+
+const test = base.extend<{}, {}>({
+	beforeApp: [
+		async ({ settingsFile }, use) => {
+			settingsFile.append({
+				'positron.quarto.inlineOutput.enabled': true,
+				'console.showNotebookConsoles': true,
+				'workbench.editor.enablePreview': false,
+			});
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
 
 test.use({
 	suiteId: __filename
@@ -13,14 +27,6 @@ test.use({
 test.describe('Quarto - Inline Output: Notebook Statement Range', {
 	tag: [tags.QUARTO, tags.ARK, tags.CONSOLE]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true,
-			'console.showNotebookConsoles': true,
-			'workbench.editor.enablePreview': false,
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-persistence.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-persistence.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags } from '../_test.setup';
+import { test, tags } from './_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -13,12 +13,6 @@ test.use({
 test.describe('Quarto - Inline Output: Persistence', {
 	tag: [tags.WEB, tags.WIN, tags.QUARTO]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-popout.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-popout.test.ts
@@ -23,7 +23,7 @@ test.describe('Quarto - Inline Output: Popout', {
 		await cleanup.discardAllChanges();
 	});
 
-	test('Python - Verify save button saves plot to file', async function ({ app, openFile, page }) {
+	test('Python - Verify save button saves plot to file', async function ({ python, app, openFile, page }) {
 		const { editors, inlineQuarto, quickInput, toasts } = app.workbench;
 
 		// Set up a unique file name for the saved plot to avoid conflicts
@@ -61,7 +61,7 @@ test.describe('Quarto - Inline Output: Popout', {
 		expect(fileBuffer[1]).toBe(80);
 	});
 
-	test('Python - Verify popout button appears for plot output and opens image in new tab', async function ({ app, openFile }) {
+	test('Python - Verify popout button appears for plot output and opens image in new tab', async function ({ python, app, openFile }) {
 		const { editors, inlineQuarto } = app.workbench;
 
 		// Open a Quarto file and wait for the kernel to be ready
@@ -81,7 +81,7 @@ test.describe('Quarto - Inline Output: Popout', {
 		await editors.verifyTab('.positron-temp-simple_plot_cell0.png', { isVisible: true, isSelected: true });
 	});
 
-	test('Python - Verify popout command opens text output in new editor', async function ({ app, openFile }) {
+	test('Python - Verify popout command opens text output in new editor', async function ({ python, app, openFile }) {
 		const { editors, inlineQuarto } = app.workbench;
 		const tab1 = 'text_output.qmd';
 		const tab2 = 'Hello World from Quarto inline output te';
@@ -122,7 +122,7 @@ test.describe('Quarto - Inline Output: Popout', {
 	test('Python - Verify popout button opens interactive HTML in viewer panel',
 		{
 			annotation: [{ type: 'issue', description: 'https://github.com/posit-dev/positron/issues/12373' }]
-		}, async function ({ app, openFile }) {
+		}, async function ({ python, app, openFile }) {
 			const { editors, inlineQuarto, viewer, toasts } = app.workbench;
 
 			// Open a Quarto file and wait for the kernel to be ready
@@ -142,7 +142,7 @@ test.describe('Quarto - Inline Output: Popout', {
 			await toasts.expectToastWithTitleNotToAppear('Failed to open');
 		});
 
-	test('Python - Verify Open Output in New Tab command works', async function ({ app, openFile }) {
+	test('Python - Verify Open Output in New Tab command works', async function ({ python, app, openFile }) {
 		const { editors, inlineQuarto } = app.workbench;
 
 		// Open a Quarto file and wait for the kernel to be ready
@@ -162,7 +162,7 @@ test.describe('Quarto - Inline Output: Popout', {
 		await editors.verifyTab('.positron-temp-simple_plot_cell0.png', { isVisible: true, isSelected: true });
 	});
 
-	test('Python - Verify HTML popout displays DataFrame in viewer without errors', async function ({ app, openFile }) {
+	test('Python - Verify HTML popout displays DataFrame in viewer without errors', async function ({ python, app, openFile }) {
 		const { editors, inlineQuarto, viewer, toasts } = app.workbench;
 
 		// Open a Quarto file and wait for the kernel to be ready

--- a/test/e2e/tests/quarto/quarto-inline-output-popout.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-popout.test.ts
@@ -39,9 +39,11 @@ test.describe('Quarto - Inline Output: Popout', {
 		await editors.clickTab('simple_plot.qmd');
 		await inlineQuarto.runCellAndWaitForOutput({ cellLine: 12, outputLine: 25 });
 
-		// Save the plot
+		// Save the plot — hover directly on the (CSS-hidden) save button with
+		// force:true so the mouse lands at the button's position, triggering the
+		// :hover that reveals it; the subsequent click fires from the same spot.
 		await inlineQuarto.gotoLine(19);
-		await inlineQuarto.getInlineOutputAt(0).hover();
+		await inlineQuarto.saveButton.hover({ force: true });
 		await inlineQuarto.saveButton.click();
 		await quickInput.waitForQuickInputOpened();
 		await quickInput.type(savedPlotPath);

--- a/test/e2e/tests/quarto/quarto-inline-output-popout.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-popout.test.ts
@@ -41,6 +41,7 @@ test.describe('Quarto - Inline Output: Popout', {
 
 		// Save the plot
 		await inlineQuarto.gotoLine(19);
+		await inlineQuarto.getInlineOutputAt(0).hover();
 		await inlineQuarto.saveButton.click();
 		await quickInput.waitForQuickInputOpened();
 		await quickInput.type(savedPlotPath);

--- a/test/e2e/tests/quarto/quarto-inline-output-popout.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-popout.test.ts
@@ -5,7 +5,7 @@
 
 import { join } from 'path';
 import * as fs from 'fs';
-import { test, tags, expect } from '../_test.setup';
+import { test, tags, expect } from './_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -14,12 +14,6 @@ test.use({
 test.describe('Quarto - Inline Output: Popout', {
 	tag: [tags.WEB, tags.WIN, tags.QUARTO]
 }, () => {
-
-	test.beforeAll(async function ({ python, settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-r.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-r.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags, expect } from '../_test.setup';
+import { test, tags, expect } from './_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -13,12 +13,6 @@ test.use({
 test.describe('Quarto - Inline Output: R', {
 	tag: [tags.WEB, tags.WIN, tags.QUARTO]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-statement-range-python.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-statement-range-python.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test as base, tags } from './_test.setup';
+import { test as base, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [

--- a/test/e2e/tests/quarto/quarto-inline-output-statement-range-python.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-statement-range-python.test.ts
@@ -8,8 +8,14 @@ import { test as base, tags } from './_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ settingsFile }, use) => {
-			settingsFile.append({
+		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
+			if (useLegacyNotebookEditor) {
+				await settingsFile.append({ 'positron.notebook.enabled': false });
+			}
+			if (enableDataConnections) {
+				await settingsFile.append({ 'dataConnections.enabled': true });
+			}
+			await settingsFile.append({
 				'positron.quarto.inlineOutput.enabled': true,
 				'console.showNotebookConsoles': true,
 				'workbench.editor.enablePreview': false,

--- a/test/e2e/tests/quarto/quarto-inline-output-statement-range-python.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-statement-range-python.test.ts
@@ -4,7 +4,21 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags } from '../_test.setup';
+import { test as base, tags } from './_test.setup';
+
+const test = base.extend<{}, {}>({
+	beforeApp: [
+		async ({ settingsFile }, use) => {
+			settingsFile.append({
+				'positron.quarto.inlineOutput.enabled': true,
+				'console.showNotebookConsoles': true,
+				'workbench.editor.enablePreview': false,
+			});
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
 
 test.use({
 	suiteId: __filename
@@ -13,14 +27,6 @@ test.use({
 test.describe('Quarto - Inline Output: Statement Range (Python)', {
 	tag: [tags.QUARTO, tags.CONSOLE]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true,
-			'console.showNotebookConsoles': true,
-			'workbench.editor.enablePreview': false,
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-statement-range.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-statement-range.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test as base, tags } from './_test.setup';
+import { test as base, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [

--- a/test/e2e/tests/quarto/quarto-inline-output-statement-range.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-statement-range.test.ts
@@ -8,8 +8,14 @@ import { test as base, tags } from './_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ settingsFile }, use) => {
-			settingsFile.append({
+		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
+			if (useLegacyNotebookEditor) {
+				await settingsFile.append({ 'positron.notebook.enabled': false });
+			}
+			if (enableDataConnections) {
+				await settingsFile.append({ 'dataConnections.enabled': true });
+			}
+			await settingsFile.append({
 				'positron.quarto.inlineOutput.enabled': true,
 				'console.showNotebookConsoles': true,
 				'workbench.editor.enablePreview': false,

--- a/test/e2e/tests/quarto/quarto-inline-output-statement-range.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-statement-range.test.ts
@@ -4,7 +4,21 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags } from '../_test.setup';
+import { test as base, tags } from './_test.setup';
+
+const test = base.extend<{}, {}>({
+	beforeApp: [
+		async ({ settingsFile }, use) => {
+			settingsFile.append({
+				'positron.quarto.inlineOutput.enabled': true,
+				'console.showNotebookConsoles': true,
+				'workbench.editor.enablePreview': false,
+			});
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
 
 test.use({
 	suiteId: __filename
@@ -13,14 +27,6 @@ test.use({
 test.describe('Quarto - Inline Output: Statement Range', {
 	tag: [tags.QUARTO, tags.ARK, tags.CONSOLE]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true,
-			'console.showNotebookConsoles': true,
-			'workbench.editor.enablePreview': false,
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-static.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-static.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags, expect } from '../_test.setup';
+import { test, tags, expect } from './_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -13,12 +13,6 @@ test.use({
 test.describe('Quarto - Inline Output: Static Content', {
 	tag: [tags.WEB, tags.WIN, tags.QUARTO]
 }, () => {
-
-	test.beforeAll(async function ({ r, settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-tab-switch.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-tab-switch.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags } from '../_test.setup';
+import { test, tags } from './_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -13,12 +13,6 @@ test.use({
 test.describe('Quarto - Inline Output: Tab Switch Persistence', {
 	tag: [tags.QUARTO, tags.DATA_EXPLORER]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-inline-output-toolbar.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-toolbar.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags, expect } from '../_test.setup';
+import { test, tags, expect } from './_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -13,12 +13,6 @@ test.use({
 test.describe('Quarto - Inline Output: Cell Toolbar', {
 	tag: [tags.QUARTO]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test.afterEach(async function ({ hotKeys }) {
 		await hotKeys.closeAllEditors();

--- a/test/e2e/tests/quarto/quarto-variables-follow.test.ts
+++ b/test/e2e/tests/quarto/quarto-variables-follow.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { join } from 'path';
-import { test, tags, expect } from '../_test.setup';
+import { test, tags, expect } from './_test.setup';
 
 test.use({
 	suiteId: __filename
@@ -13,12 +13,6 @@ test.use({
 test.describe('Quarto - Variables Follow Mode', {
 	tag: [tags.WEB, tags.WIN, tags.QUARTO, tags.VARIABLES]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'positron.quarto.inlineOutput.enabled': true
-		}, { reload: 'web' });
-	});
 
 	test('Python - Variables pane follows active QMD editor', async function ({ app, python, openFile, page }) {
 		const { variables, console, hotKeys, inlineQuarto, editors } = app.workbench;

--- a/test/e2e/tests/reticulate/_test.setup.ts
+++ b/test/e2e/tests/reticulate/_test.setup.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { test as base, TestFixtures, WorkerFixtures } from '../_test.setup';
+
+interface ReticulateTestFixtures extends TestFixtures { }
+
+interface ReticulateWorkerFixtures extends WorkerFixtures {
+	enableReticulate: boolean;
+}
+
+export const test = base.extend<ReticulateTestFixtures, ReticulateWorkerFixtures>({
+	enableReticulate: [true, { scope: 'worker', option: true }],
+
+	beforeApp: [
+		async ({ enableReticulate, settingsFile }, use) => {
+			if (enableReticulate) {
+				settingsFile.append({
+					'positron.reticulate.enabled': true,
+					'kernelSupervisor.transport': 'tcp'
+				});
+			}
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
+
+export { tags, expect } from '../_test.setup';

--- a/test/e2e/tests/reticulate/_test.setup.ts
+++ b/test/e2e/tests/reticulate/_test.setup.ts
@@ -15,9 +15,15 @@ export const test = base.extend<ReticulateTestFixtures, ReticulateWorkerFixtures
 	enableReticulate: [true, { scope: 'worker', option: true }],
 
 	beforeApp: [
-		async ({ enableReticulate, settingsFile }, use) => {
+		async ({ useLegacyNotebookEditor, enableDataConnections, enableReticulate, settingsFile }, use) => {
+			if (useLegacyNotebookEditor) {
+				await settingsFile.append({ 'positron.notebook.enabled': false });
+			}
+			if (enableDataConnections) {
+				await settingsFile.append({ 'dataConnections.enabled': true });
+			}
 			if (enableReticulate) {
-				settingsFile.append({
+				await settingsFile.append({
 					'positron.reticulate.enabled': true,
 					'kernelSupervisor.transport': 'tcp'
 				});

--- a/test/e2e/tests/reticulate/reticulate-multiple.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-multiple.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, tags } from '../_test.setup';
+import { test, tags } from './_test.setup';
 import { verifyReticulateFunctionality } from './helpers/verifyReticulateFunction.js';
 
 test.use({
@@ -17,19 +17,6 @@ test.use({
 test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB, tags.ARK, tags.SOFT_FAIL],
 }, () => {
-	test.beforeAll(async function ({ app, settings }) {
-		try {
-			await settings.set({
-				'positron.reticulate.enabled': true,
-				'kernelSupervisor.transport': 'tcp'
-			}, { reload: true });
-
-		} catch (e) {
-			await app.code.driver.takeScreenshot('reticulateSetup');
-			throw e;
-		}
-	});
-
 	test('R - Verify Basic Reticulate Functionality using reticulate::repl_python() with multiple sessions', async function ({ app, sessions, logger }) {
 		const { console } = app.workbench;
 

--- a/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-repl-python.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, tags } from '../_test.setup';
+import { test, tags } from './_test.setup';
 import { verifyReticulateFunctionality } from './helpers/verifyReticulateFunction.js';
 
 test.use({
@@ -17,19 +17,6 @@ test.use({
 test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB, tags.ARK, tags.SOFT_FAIL],
 }, () => {
-	test.beforeAll(async function ({ app, settings }) {
-		try {
-			await settings.set({
-				'positron.reticulate.enabled': true,
-				'kernelSupervisor.transport': 'tcp'
-			}, { reload: true });
-
-		} catch (e) {
-			await app.code.driver.takeScreenshot('reticulateSetup');
-			throw e;
-		}
-	});
-
 	test('R - Verify Basic Reticulate Functionality using reticulate::repl_python()', async function ({ app, sessions, logger }) {
 		const { console } = app.workbench;
 

--- a/test/e2e/tests/reticulate/reticulate-restart.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-restart.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, tags } from '../_test.setup';
+import { test, tags } from './_test.setup';
 import { RETICULATE_SESSION } from './helpers/verifyReticulateFunction.js';
 
 test.use({
@@ -17,19 +17,6 @@ test.use({
 test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB, tags.SOFT_FAIL],
 }, () => {
-	test.beforeAll(async function ({ app, settings }) {
-		try {
-			await settings.set({
-				'positron.reticulate.enabled': true,
-				'kernelSupervisor.transport': 'tcp'
-			}, { reload: true });
-
-		} catch (e) {
-			await app.code.driver.takeScreenshot('reticulateSetup');
-			throw e;
-		}
-	});
-
 	test('R - Verify Reticulate Restart', {
 		tag: [tags.RETICULATE, tags.CONSOLE]
 	}, async function ({ sessions }) {

--- a/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
+++ b/test/e2e/tests/reticulate/reticulate-stop-start.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { test, expect, tags } from '../_test.setup';
+import { test, expect, tags } from './_test.setup';
 import { RETICULATE_SESSION, verifyReticulateFunctionality } from './helpers/verifyReticulateFunction.js';
 
 test.use({
@@ -17,19 +17,6 @@ test.use({
 test.describe('Reticulate', {
 	tag: [tags.RETICULATE, tags.WEB, tags.SOFT_FAIL],
 }, () => {
-	test.beforeAll(async function ({ app, settings }) {
-		try {
-			await settings.set({
-				'positron.reticulate.enabled': true,
-				'kernelSupervisor.transport': 'tcp'
-			}, { reload: true });
-
-		} catch (e) {
-			await app.code.driver.takeScreenshot('reticulateSetup');
-			throw e;
-		}
-	});
-
 	test('R - Verify Reticulate Stop/Start Functionality', {
 		tag: [tags.ARK]
 	}, async function ({ app, r }) {

--- a/test/e2e/tests/sessions/session-interpreter-sync.test.ts
+++ b/test/e2e/tests/sessions/session-interpreter-sync.test.ts
@@ -14,13 +14,12 @@ import { test as base, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
-			if (useLegacyNotebookEditor) {
-				await settingsFile.append({ 'positron.notebook.enabled': false });
-			}
+		async ({ enableDataConnections, settingsFile }, use) => {
 			if (enableDataConnections) {
 				await settingsFile.append({ 'dataConnections.enabled': true });
 			}
+			// This test requires the new notebook editor and is incompatible with
+			// useLegacyNotebookEditor; always enable it.
 			await settingsFile.append({ 'positron.notebook.enabled': true });
 			await use();
 		},

--- a/test/e2e/tests/sessions/session-interpreter-sync.test.ts
+++ b/test/e2e/tests/sessions/session-interpreter-sync.test.ts
@@ -10,7 +10,17 @@
  * when navigating between different file types (.R, .py, .ipynb).
  */
 
-import { test, tags } from '../_test.setup';
+import { test as base, tags } from '../_test.setup';
+
+const test = base.extend<{}, {}>({
+	beforeApp: [
+		async ({ settingsFile }, use) => {
+			settingsFile.append({ 'positron.notebook.enabled': true });
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
 
 test.use({
 	suiteId: __filename
@@ -19,15 +29,6 @@ test.use({
 test.describe('Sessions: Interpreter Sync', {
 	tag: [tags.WIN, tags.WEB, tags.SESSIONS, tags.CONSOLE]
 }, () => {
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set(
-			{
-				'positron.notebook.enabled': true
-			},
-			{ reload: 'web', waitMs: 1000 }
-		);
-	});
 
 	test.beforeEach(async function ({ hotKeys }) {
 		await hotKeys.closePrimarySidebar();

--- a/test/e2e/tests/sessions/session-interpreter-sync.test.ts
+++ b/test/e2e/tests/sessions/session-interpreter-sync.test.ts
@@ -14,8 +14,14 @@ import { test as base, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ settingsFile }, use) => {
-			settingsFile.append({ 'positron.notebook.enabled': true });
+		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
+			if (useLegacyNotebookEditor) {
+				await settingsFile.append({ 'positron.notebook.enabled': false });
+			}
+			if (enableDataConnections) {
+				await settingsFile.append({ 'dataConnections.enabled': true });
+			}
+			await settingsFile.append({ 'positron.notebook.enabled': true });
 			await use();
 		},
 		{ scope: 'worker' }

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -8,8 +8,14 @@ import { test as base, expect, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ settingsFile }, use) => {
-			settingsFile.append({ 'files.simpleDialog.enable': true });
+		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
+			if (useLegacyNotebookEditor) {
+				await settingsFile.append({ 'positron.notebook.enabled': false });
+			}
+			if (enableDataConnections) {
+				await settingsFile.append({ 'dataConnections.enabled': true });
+			}
+			await settingsFile.append({ 'files.simpleDialog.enable': true });
 			await use();
 		},
 		{ scope: 'worker' }

--- a/test/e2e/tests/test-explorer/test-explorer.test.ts
+++ b/test/e2e/tests/test-explorer/test-explorer.test.ts
@@ -4,24 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 import path = require('path');
-import { test, expect, tags } from '../_test.setup';
+import { test as base, expect, tags } from '../_test.setup';
+
+const test = base.extend<{}, {}>({
+	beforeApp: [
+		async ({ settingsFile }, use) => {
+			settingsFile.append({ 'files.simpleDialog.enable': true });
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
 
 test.use({
 	suiteId: __filename
 });
 
 test.describe('Test Explorer', { tag: [tags.TEST_EXPLORER, tags.WEB] }, () => {
-	test.beforeAll(async function ({ app, settings, r, hotKeys }) {
-		try {
-			// don't use native file picker
-			await settings.set({
-				'files.simpleDialog.enable': true
-			}, { reload: true, waitForReady: true });
-		} catch (e) {
-			await app.code.driver.takeScreenshot('testExplorerSetup');
-			throw e;
-		}
-	});
 
 	test.skip('R - Verify Basic Test Explorer Functionality', {
 		tag: [tags.ARK],


### PR DESCRIPTION
### Summary
Moves suite-level `settings.set(..., { reload: ... })` calls in `beforeAll` to `settingsFile.append` in a `beforeApp` worker fixture, so settings are written to disk before the app launches and no window reload is needed saving us precious time and $$$.

### QA Notes
@:quarto @:reticulate @:console @:help @:interpreter @:packages-pane @:sessions @:test-explorer @:web