### PR TITLE
Highlight newly installed or updated packages in the Packages pane

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -751,6 +751,7 @@
 		"--vscode-positronPackages-background",
 		"--vscode-positronPackages-border",
 		"--vscode-positronPackages-foreground",
+		"--vscode-positronPackages-recentlyChangedBackground",
 		"--vscode-positronPlots-background",
 		"--vscode-positronScrollBar-border",
 		"--vscode-positronSplitterExpandCollapseButton-background",

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1977,6 +1977,17 @@ export const POSITRON_PACKAGES_BORDER_COLOR = registerColor('positronPackages.bo
 	hcLight: tableColumnsBorder
 }, localize('positronPackages.border', "Positron packages border color."));
 
+// Background of a package row briefly highlighted after install or update.
+// Derived from the selection background with a brightness offset (lighter in
+// dark themes, darker in light themes) so the transient flash always reads as
+// distinct from a selected row, never colliding with the selection color.
+export const POSITRON_PACKAGES_RECENTLY_CHANGED_BACKGROUND_COLOR = registerColor('positronPackages.recentlyChangedBackground', {
+	dark: lighten(listActiveSelectionBackground, 0.3),
+	light: darken(listActiveSelectionBackground, 0.1),
+	hcDark: lighten(listActiveSelectionBackground, 0.3),
+	hcLight: darken(listActiveSelectionBackground, 0.1)
+}, localize('positronPackages.recentlyChangedBackground', "Background of a package row briefly highlighted after it is installed or updated."));
+
 // < --- Positron Plots --- >
 
 // Positron plots background color.

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -1978,15 +1978,15 @@ export const POSITRON_PACKAGES_BORDER_COLOR = registerColor('positronPackages.bo
 }, localize('positronPackages.border', "Positron packages border color."));
 
 // Background of a package row briefly highlighted after install or update.
-// Derived from the selection background with a brightness offset (lighter in
-// dark themes, darker in light themes) so the transient flash always reads as
-// distinct from a selected row, never colliding with the selection color.
-export const POSITRON_PACKAGES_RECENTLY_CHANGED_BACKGROUND_COLOR = registerColor('positronPackages.recentlyChangedBackground', {
-	dark: lighten(listActiveSelectionBackground, 0.3),
-	light: darken(listActiveSelectionBackground, 0.1),
-	hcDark: lighten(listActiveSelectionBackground, 0.3),
-	hcLight: darken(listActiveSelectionBackground, 0.1)
-}, localize('positronPackages.recentlyChangedBackground', "Background of a package row briefly highlighted after it is installed or updated."));
+// A translucent foreground tint rather than a lighten/darken of the selection:
+// `lighten` is multiplicative on HSL lightness (l + l*factor), so it can't lift
+// a pure-black base (e.g. the high-contrast dark selection), leaving no visible
+// flash. The foreground contrasts the background in every theme by definition,
+// so an alpha overlay always shifts the surface -- including a selected row,
+// keeping the flash distinct from the selection color.
+export const POSITRON_PACKAGES_RECENTLY_CHANGED_BACKGROUND_COLOR = registerColor('positronPackages.recentlyChangedBackground',
+	transparent(POSITRON_PACKAGES_FOREGROUND_COLOR, 0.25),
+	localize('positronPackages.recentlyChangedBackground', "Background of a package row briefly highlighted after it is installed or updated."));
 
 // < --- Positron Plots --- >
 

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -281,7 +281,7 @@
 
 @keyframes packages-recently-changed {
 	from {
-		background-color: var(--vscode-editor-findMatchHighlightBackground);
+		background-color: var(--vscode-positronPackages-recentlyChangedBackground);
 	}
 	to {
 		background-color: transparent;
@@ -291,7 +291,7 @@
 @media (prefers-reduced-motion: reduce) {
 	.packages-list-item.recently-changed {
 		animation: none;
-		background-color: var(--vscode-editor-findMatchHighlightBackground);
+		background-color: var(--vscode-positronPackages-recentlyChangedBackground);
 	}
 }
 

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.css
@@ -269,6 +269,32 @@
 }
 
 
+/*
+ * Transient flash applied to packages just installed or updated. The row fades
+ * from a highlight tint back to transparent so the eye lands on the change; the
+ * class is removed by a timer once the animation has run. prefers-reduced-motion
+ * holds a steady tint for the same duration instead of animating.
+ */
+.packages-list-item.recently-changed {
+	animation: packages-recently-changed 2s ease-out;
+}
+
+@keyframes packages-recently-changed {
+	from {
+		background-color: var(--vscode-editor-findMatchHighlightBackground);
+	}
+	to {
+		background-color: transparent;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.packages-list-item.recently-changed {
+		animation: none;
+		background-color: var(--vscode-editor-findMatchHighlightBackground);
+	}
+}
+
 .positron-packages-list .positron-list-empty {
 	padding: 5px 8px;
 	cursor: default;

--- a/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
+++ b/src/vs/workbench/contrib/positronPackages/browser/components/listPackages.tsx
@@ -60,6 +60,14 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 
 	const [packages, setPackages] = useState<ILanguageRuntimePackage[]>([]);
 
+	// Packages to flash after an install/update completes. The nonce lets the
+	// apply effect run once per operation even though the same names may arrive
+	// while filteredPackages is still settling.
+	const [highlight, setHighlight] = useState<{ names: string[]; nonce: number }>();
+
+	// IDs of packages currently showing the transient "recently changed" flash.
+	const [flashedIds, setFlashedIds] = useState<ReadonlySet<string>>(new Set());
+
 	// Item size mode ('card' or 'row'), driven by the packages service.
 	const [itemSize, setItemSize] = useState(() => services.positronPackagesService.itemSize);
 	useEffect(() => {
@@ -80,13 +88,22 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 			return;
 		}
 
-		const disposable = activeInstance.onDidRefreshPackagesInstance((packages) => {
+		const refreshDisposable = activeInstance.onDidRefreshPackagesInstance((packages) => {
 			setPackages(packages);
+		});
+
+		// An install/update finished; record the affected packages so the apply
+		// effect below can scroll to and flash them once the list has refreshed.
+		const changeDisposable = activeInstance.onDidChangePackages((names) => {
+			setHighlight({ names, nonce: Date.now() });
 		});
 
 		setPackages(activeInstance.packages);
 
-		return () => disposable.dispose();
+		return () => {
+			refreshDisposable.dispose();
+			changeDisposable.dispose();
+		};
 	}, [activeInstance]);
 
 	useEffect(() => {
@@ -243,6 +260,47 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 		}
 	}, [listInstance, filteredPackages]);
 
+	// After an install/update, scroll to and flash the affected packages once
+	// the refreshed list reflects them. Keyed on the highlight nonce (consumed
+	// via a ref) so the asynchronous Stage 2 metadata refresh, which fires
+	// another package update, does not re-trigger the flash. Packages filtered
+	// out by an active search are skipped rather than revealed.
+	const handledHighlightNonce = useRef<number | undefined>(undefined);
+	useEffect(() => {
+		if (!highlight || highlight.nonce === handledHighlightNonce.current) {
+			return;
+		}
+		handledHighlightNonce.current = highlight.nonce;
+
+		const indices = highlight.names
+			.map(name => filteredPackages.findIndex(pkg => pkg.name === name))
+			.filter(index => index >= 0);
+		if (indices.length === 0) {
+			return;
+		}
+
+		const firstIndex = Math.min(...indices);
+		void listInstance.scrollToRow(firstIndex);
+		// A single affected package (install, single update) also becomes the
+		// selection; a bulk update has no meaningful single row to select.
+		if (highlight.names.length === 1) {
+			listInstance.selectRow(firstIndex);
+		}
+
+		setFlashedIds(new Set(indices.map(index => filteredPackages[index].id)));
+	}, [highlight, filteredPackages, listInstance]);
+
+	// Clear the flash after it has had time to play. Kept separate from the
+	// apply effect so the asynchronous Stage 2 refresh (which re-runs the apply
+	// effect via filteredPackages) cannot cancel the timer mid-flash.
+	useEffect(() => {
+		if (flashedIds.size === 0) {
+			return;
+		}
+		const timeout = setTimeout(() => setFlashedIds(new Set()), 2000);
+		return () => clearTimeout(timeout);
+	}, [flashedIds]);
+
 	// Show the help page for a package using the active session's language. Falls back to a
 	// notification if the help service can't find anything.
 	const showHelpForPackage = useCallback(async (packageName: string) => {
@@ -375,7 +433,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 			return (
 				// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 				<div
-					className={positronClassNames('packages-list-item', `item-size-${itemSize}`)}
+					className={positronClassNames('packages-list-item', `item-size-${itemSize}`, { 'recently-changed': flashedIds.has(pkg.id) })}
 					onContextMenu={(e) => {
 						// Right-click. The data grid's row cell calls e.stopPropagation() on
 						// mousedown, so right-click handling lives on contextmenu instead.
@@ -434,7 +492,7 @@ export const ListPackages = (props: React.PropsWithChildren<ViewsProps>) => {
 		};
 
 		listInstance.setItemRenderer(renderItem);
-	}, [listInstance, deduplicatedPackages, services, itemSize, showHelpForPackage]);
+	}, [listInstance, deduplicatedPackages, services, itemSize, showHelpForPackage, flashedIds]);
 
 	// Sync the currently-selected package's name into the packages service. onDidUpdate fires
 	// for any instance change (selection, cursor, scroll), so we dedupe before pushing.

--- a/src/vs/workbench/contrib/positronPackages/browser/positronPackagesInstance.ts
+++ b/src/vs/workbench/contrib/positronPackages/browser/positronPackagesInstance.ts
@@ -29,6 +29,14 @@ export interface IPositronPackagesInstance {
 
 	readonly onDidRefreshPackagesInstance: Event<ILanguageRuntimePackage[]>;
 
+	/**
+	 * Fires after a successful install or update with the names of the packages
+	 * the operation added or changed, so the view can scroll to and highlight
+	 * them. For install/update these are the requested packages; for update-all
+	 * they are the packages whose version actually changed.
+	 */
+	readonly onDidChangePackages: Event<string[]>;
+
 	readonly onDidChangeRefreshState: Event<boolean>;
 
 	readonly onDidChangeInstallState: Event<boolean>;
@@ -67,6 +75,8 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 
 	private readonly _onDidRefreshPackagesInstance = this._register(new Emitter<ILanguageRuntimePackage[]>());
 
+	private readonly _onDidChangePackages = this._register(new Emitter<string[]>());
+
 	private readonly _onDidChangeRefreshState = this._register(new Emitter<boolean>());
 
 	private readonly _onDidChangeInstallState = this._register(new Emitter<boolean>());
@@ -99,6 +109,8 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 	}
 
 	readonly onDidRefreshPackagesInstance = this._onDidRefreshPackagesInstance.event;
+
+	readonly onDidChangePackages = this._onDidChangePackages.event;
 
 	readonly onDidChangeRefreshState = this._onDidChangeRefreshState.event;
 
@@ -310,6 +322,11 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 
 			// Refresh packages with two-stage metadata fetch
 			await this._refreshPackagesInternal(packageManager, effectiveToken);
+
+			// Highlight the requested packages in the view. Dependencies the
+			// package manager pulled in are not in `packages`, so they are
+			// intentionally excluded.
+			this._onDidChangePackages.fire(packages.map((pkg) => pkg.name));
 		} finally {
 			// Completed
 			this._onDidChangeInstallState.fire(false);
@@ -354,6 +371,9 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 
 			// Refresh packages with two-stage metadata fetch
 			await this._refreshPackagesInternal(packageManager, effectiveToken);
+
+			// Highlight the updated packages in the view.
+			this._onDidChangePackages.fire(packages.map((pkg) => pkg.name));
 		} finally {
 			// Completed
 			this._onDidChangeUpdateState.fire(false);
@@ -367,6 +387,10 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 		// Loading
 		this._onDidChangeUpdateAllState.fire(true);
 
+		// Snapshot installed versions before the update so we can report which
+		// packages actually changed once the refresh completes.
+		const versionsBefore = new Map(this._packages.map((pkg) => [pkg.name, pkg.version]));
+
 		try {
 			await packageManager.updateAllPackages(effectiveToken);
 			if (effectiveToken.isCancellationRequested) {
@@ -379,6 +403,14 @@ export class PositronPackagesInstance extends Disposable implements IPositronPac
 
 			// Refresh packages with two-stage metadata fetch
 			await this._refreshPackagesInternal(packageManager, effectiveToken);
+
+			// Highlight every package whose version changed. Update-all may
+			// leave many packages untouched (already current), so diffing
+			// against the pre-update snapshot avoids flashing the whole list.
+			const changed = this._packages
+				.filter((pkg) => versionsBefore.get(pkg.name) !== pkg.version)
+				.map((pkg) => pkg.name);
+			this._onDidChangePackages.fire(changed);
 		} finally {
 			// Completed
 			this._onDidChangeUpdateAllState.fire(false);

--- a/src/vs/workbench/contrib/positronPackages/test/browser/listPackages.vitest.tsx
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/listPackages.vitest.tsx
@@ -1,0 +1,200 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+// React.
+import React from 'react';
+
+// Testing libraries.
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// Other dependencies.
+import { Emitter, Event } from '../../../../../base/common/event.js';
+import { IReactComponentContainer } from '../../../../../base/browser/positronReactRenderer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { ILanguageRuntimePackage } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { ListPackages } from '../../browser/components/listPackages.js';
+import { PositronPackagesContextProvider } from '../../browser/positronPackagesContext.js';
+import { IPositronPackagesService } from '../../browser/interfaces/positronPackagesService.js';
+import { IPositronPackagesInstance } from '../../browser/positronPackagesInstance.js';
+
+// A viewport large enough that both package rows paint at once.
+const VIEWPORT_WIDTH = 300;
+const VIEWPORT_HEIGHT = 400;
+
+const pkg = (name: string, version: string): ILanguageRuntimePackage => ({
+	id: name,
+	name,
+	displayName: name,
+	version,
+});
+
+/**
+ * The data grid sizes itself from the DOM via requestAnimationFrame + ResizeObserver, neither of
+ * which produces a real layout in happy-dom. Give elements a concrete offset size and hand that
+ * size to the grid synchronously through a ResizeObserver that fires on observe(), so the rows
+ * paint during render. Mirrors the helper in positronList.vitest.tsx. Returns a restore function
+ * for the offset overrides; callers must also call vi.unstubAllGlobals().
+ */
+function stubGridLayoutWithSize(width: number, height: number): () => void {
+	const offsetWidthDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth');
+	const offsetHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+	Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, get: () => width });
+	Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, get: () => height });
+
+	vi.stubGlobal('requestAnimationFrame', () => 0);
+	vi.stubGlobal('ResizeObserver', class {
+		private readonly _callback: ResizeObserverCallback;
+		constructor(callback: ResizeObserverCallback) { this._callback = callback; }
+		observe() {
+			const entry = { contentRect: { width, height } };
+			this._callback([entry] as unknown as ResizeObserverEntry[], this as unknown as ResizeObserver);
+		}
+		unobserve() { }
+		disconnect() { }
+	});
+
+	return () => {
+		Object.defineProperty(HTMLElement.prototype, 'offsetWidth', offsetWidthDescriptor!);
+		Object.defineProperty(HTMLElement.prototype, 'offsetHeight', offsetHeightDescriptor!);
+	};
+}
+
+describe('ListPackages highlight', () => {
+	// Emitters live at describe scope so the .stub() below captures their .event during build();
+	// tests fire them to drive the view (see the "Common mistakes" note in vitest-tests.md).
+	const onDidRefreshPackagesInstance = new Emitter<ILanguageRuntimePackage[]>();
+	const onDidChangePackages = new Emitter<string[]>();
+	const installed = [pkg('numpy', '1.26.0'), pkg('pandas', '2.0.0')];
+
+	const fakeInstance = stubInterface<IPositronPackagesInstance>({
+		packages: installed,
+		attachRuntime: () => { },
+		detachRuntime: () => { },
+		onDidRefreshPackagesInstance: onDidRefreshPackagesInstance.event,
+		onDidChangePackages: onDidChangePackages.event,
+	});
+
+	const ctx = createTestContainer()
+		.withReactServices()
+		.stub(IPositronPackagesService, {
+			activePackagesInstance: fakeInstance,
+			onDidChangeActivePackagesInstance: Event.None,
+			itemSize: 'row',
+			onDidChangeItemSize: Event.None,
+			setSelectedPackage: vi.fn(),
+		})
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	// ListPackages reads activeInstance through the packages context provider, which the env's
+	// reactComponentContainer feeds; the container itself is never touched in these tests.
+	const reactComponentContainer = stubInterface<IReactComponentContainer>({});
+
+	let restoreLayout: () => void;
+	beforeEach(() => { restoreLayout = stubGridLayoutWithSize(VIEWPORT_WIDTH, VIEWPORT_HEIGHT); });
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		restoreLayout();
+	});
+
+	function renderList() {
+		rtl.render(
+			<PositronPackagesContextProvider reactComponentContainer={reactComponentContainer}>
+				<ListPackages height={VIEWPORT_HEIGHT} reactComponentContainer={reactComponentContainer} width={VIEWPORT_WIDTH} />
+			</PositronPackagesContextProvider>
+		);
+	}
+
+	// .closest() walks up to the framework wrappers: .packages-list-item carries the flash class,
+	// the outer .positron-list-row carries the selection class.
+	const itemRow = (name: string) => screen.getByText(name).closest('.packages-list-item');
+	const listRow = (name: string) => screen.getByText(name).closest('.positron-list-row');
+
+	it('flashes and selects a single installed or updated package', async () => {
+		renderList();
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+
+		act(() => onDidChangePackages.fire(['numpy']));
+
+		await waitFor(() => expect(itemRow('numpy')).toHaveClass('recently-changed'));
+		expect(listRow('numpy')).toHaveClass('selected');
+		// Selecting the row also drives the service-level selection (what the detail pane reads).
+		await waitFor(() => expect(ctx.get(IPositronPackagesService).setSelectedPackage).toHaveBeenCalledWith('numpy'));
+		// The untouched package is neither flashed nor selected.
+		expect(itemRow('pandas')).not.toHaveClass('recently-changed');
+		expect(listRow('pandas')).not.toHaveClass('selected');
+	});
+
+	it('flashes every updated package but selects none on a bulk update', async () => {
+		renderList();
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+
+		act(() => onDidChangePackages.fire(['numpy', 'pandas']));
+
+		await waitFor(() => expect(itemRow('numpy')).toHaveClass('recently-changed'));
+		expect(itemRow('pandas')).toHaveClass('recently-changed');
+		// A bulk update has no single row to select: neither the CSS selection nor the
+		// service-level selection is set for any affected package.
+		expect(listRow('numpy')).not.toHaveClass('selected');
+		expect(listRow('pandas')).not.toHaveClass('selected');
+		const setSelectedPackage = ctx.get(IPositronPackagesService).setSelectedPackage;
+		expect(setSelectedPackage).not.toHaveBeenCalledWith('numpy');
+		expect(setSelectedPackage).not.toHaveBeenCalledWith('pandas');
+	});
+
+	it('does not flash or reveal a package hidden by the active filter', async () => {
+		const user = userEvent.setup();
+		renderList();
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+
+		// Filter to "pandas" so numpy drops out of view (300ms debounce).
+		await user.type(screen.getByPlaceholderText('Filter packages'), 'pandas');
+		await waitFor(() => expect(screen.queryByText('numpy')).not.toBeInTheDocument());
+
+		// An update for the now-hidden numpy must not reveal it or flash anything.
+		act(() => onDidChangePackages.fire(['numpy']));
+
+		await waitFor(() => expect(screen.getByText('pandas')).toBeInTheDocument());
+		expect(screen.queryByText('numpy')).not.toBeInTheDocument();
+		expect(itemRow('pandas')).not.toHaveClass('recently-changed');
+	});
+
+	it('keeps the flash through a Stage 2 refresh and clears it on schedule', async () => {
+		renderList();
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+
+		act(() => onDidChangePackages.fire(['numpy']));
+		await waitFor(() => expect(itemRow('numpy')).toHaveClass('recently-changed'));
+
+		// The async Stage 2 metadata refresh re-pushes the list; the flash must survive it
+		// (the clear timer lives in its own effect so this re-render can't cancel it).
+		act(() => onDidRefreshPackagesInstance.fire([pkg('numpy', '1.26.0'), pkg('pandas', '2.0.0')]));
+		expect(itemRow('numpy')).toHaveClass('recently-changed');
+
+		// Once the flash window elapses, the class is removed.
+		await waitFor(() => expect(itemRow('numpy')).not.toHaveClass('recently-changed'), { timeout: 3000 });
+	});
+
+	it('does not re-flash on a later refresh once the flash has cleared', async () => {
+		renderList();
+		expect(await screen.findByText('numpy')).toBeInTheDocument();
+
+		act(() => onDidChangePackages.fire(['numpy']));
+		await waitFor(() => expect(itemRow('numpy')).toHaveClass('recently-changed'));
+
+		// Let the flash clear on its own.
+		await waitFor(() => expect(itemRow('numpy')).not.toHaveClass('recently-changed'), { timeout: 3000 });
+
+		// A later Stage 2 refresh (no new change event) must not revive the cleared flash:
+		// the nonce is already consumed.
+		act(() => onDidRefreshPackagesInstance.fire([pkg('numpy', '1.26.0'), pkg('pandas', '2.0.0')]));
+		expect(itemRow('numpy')).not.toHaveClass('recently-changed');
+	});
+});

--- a/src/vs/workbench/contrib/positronPackages/test/browser/positronPackagesInstance.vitest.ts
+++ b/src/vs/workbench/contrib/positronPackages/test/browser/positronPackagesInstance.vitest.ts
@@ -216,4 +216,34 @@ describe('PositronPackagesInstance disk-cache integration', () => {
 			pandas: { version: '2.0.0', outdated: true, latestVersion: '2.2.0' },
 		});
 	});
+
+	it('fires onDidChangePackages with the requested names after install', async () => {
+		const instance = makeInstance();
+		const fired = waitForEvents(instance.onDidChangePackages, 1);
+		await instance.installPackages([{ name: 'requests' }], CancellationToken.None);
+
+		expect(await fired).toEqual([['requests']]);
+	});
+
+	it('fires onDidChangePackages with the requested names after update', async () => {
+		const instance = makeInstance();
+		const fired = waitForEvents(instance.onDidChangePackages, 1);
+		await instance.updatePackages([{ name: 'numpy' }], CancellationToken.None);
+
+		expect(await fired).toEqual([['numpy']]);
+	});
+
+	it('fires onDidChangePackages with only the version-changed packages after updateAll', async () => {
+		const instance = makeInstance();
+		// Seed the pre-update snapshot (numpy 1.26.0, pandas 2.0.0).
+		await instance.refreshPackages();
+
+		// After update-all the kernel reports a new numpy but an unchanged pandas.
+		getPackages.mockResolvedValue([pkg('numpy', '2.1.0'), pkg('pandas', '2.0.0')]);
+
+		const fired = waitForEvents(instance.onDidChangePackages, 1);
+		await instance.updateAllPackages(CancellationToken.None);
+
+		expect(await fired).toEqual([['numpy']]);
+	});
 });


### PR DESCRIPTION
Fixes #13129

### Summary

After installing or updating a package in the Packages pane, the affected package(s) now scroll into view and briefly flash so the change is easy to spot in a long list.

- **Install** and **single update** select, scroll to, and flash the requested package. Dependencies the package manager pulls in are excluded; only the package you asked for is highlighted.
- **Update All** flashes every package whose version actually changed (diffed against a pre-update snapshot) and scrolls to the first one.
- A package hidden by an active filter is skipped rather than revealing it.

A new `onDidChangePackages` event on the packages instance reports the affected names after a successful operation; the view scrolls/selects/flashes them via a transient `recently-changed` CSS animation (which respects `prefers-reduced-motion`). The flash is gated on a nonce, and its clear timer lives in a dedicated effect, so the asynchronous Stage 2 metadata refresh cannot re-trigger or cancel the flash mid-animation.

### Screenshots

https://github.com/user-attachments/assets/1dd179c6-a20a-4079-9d4e-68132420e818

### Release Notes

#### New Features

- Highlight and scroll to a package in the Packages pane after it is installed or updated (#13129)

#### Bug Fixes

- N/A

### Validation Steps

@:packages-pane

1. Open the Packages pane with a runtime (R or Python) that has a long package list.
2. Install a package not currently installed and verify the new row scrolls into view, is selected, and briefly flashes.
3. Update a single outdated package and verify its row flashes.
4. Run **Update All** and verify every package whose version changed flashes, scrolling to the first.
5. Type a filter that excludes the package you install, then install it; verify the list does not jump or clear the filter.
