### PR TITLE
e2e: fix new-conversation button disabled-state race in Posit Assistant sign-in tests

### DIFF
--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -146,13 +146,33 @@ export class PositAssistant {
 	/**
 	 * Starts a new conversation by clicking the new chat button.
 	 * If the button is disabled (already on landing page), this is a no-op.
+	 *
+	 * The new-conversation button is disabled both while a response is streaming
+	 * and when the conversation is already empty (`isNewConversation`). That
+	 * disabled state is derived from async-loaded webview state (messages-loaded +
+	 * streaming), so immediately after the chat input renders the button can be
+	 * transiently enabled while messages are still loading, then flip to disabled
+	 * once an empty conversation finishes loading. A bare `isDisabled()` snapshot
+	 * followed by `click()` races that flip and fails with a 30s click timeout on
+	 * a now-disabled button, so guard the click and treat a disabled flip as the
+	 * desired "already on a fresh conversation" end state.
 	 */
 	async startNewConversation(): Promise<void> {
 		const button = this.frame.locator(NEW_CHAT_BUTTON);
 		if (await button.isDisabled()) {
+			// Already on a fresh conversation (or streaming) -- nothing to start.
 			return;
 		}
-		await button.click();
+		try {
+			await button.click({ timeout: 5000 });
+		} catch (e) {
+			// If the button flipped to disabled mid-click we're already on a fresh
+			// conversation, which is the desired end state; otherwise re-throw.
+			if (await button.isDisabled()) {
+				return;
+			}
+			throw e;
+		}
 		await this.waitForReady();
 	}
 


### PR DESCRIPTION
## Summary

Fixes a flaky/hard failure in `posit-assistant-signin.test.ts` (seen in the `e2e-chromium` job) where `startNewConversation()` timed out clicking the New conversation button.

This is **not** a locator change. The blob report showed:

```
TimeoutError: locator.click: Timeout 30000ms exceeded.
  - waiting for ...locator('button:has(svg.lucide-plus)')
    - locator resolved to <button disabled ...>
```

The locator resolved fine; the button was **disabled**.

## Root cause

In Posit Assistant, the New conversation button is disabled when `streamingState !== "idle" || isNewConversation`, and `isNewConversation = initialMessagesLoaded && messages.length === 0`. That state is derived from async-loaded webview state, so right after the chat input renders the button can be **transiently enabled** while messages are still loading, then flip to **disabled** once an empty conversation finishes loading.

The old page object snapshotted `isDisabled()` during that transient window, then `click()` waited the full 30s actionability timeout on a button that had flipped to disabled. (openai-api won the race on retry; anthropic-api lost it every retry -- pure timing, no Positron-side change.)

## Fix

Guard the click in `startNewConversation()`: a disabled flip mid-click (bounded to 5s) is treated as the desired "already on a fresh conversation" end state; any other failure re-throws.

## Testing

Ran locally against an installed build (`2026.07.0-157`, Assistant floated to latest main) for the two providers with available local credentials:

```
ok 1 anthropic-api - Sign in, send hello, sign out (16.0s)
ok 2 openai-api  - Sign in, send hello, sign out (9.0s)
2 passed
```

### QA Notes

Test-only change to an e2e page object. No product code affected.

@:posit-assistant @:web