### PR TITLE
Fix scroll beyond last line in Positron notebooks

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.css
@@ -72,7 +72,8 @@
 }
 
 .positron-notebook-cells-container {
-	padding-block: var(--_positron-notebook-cells-padding-block);
+	padding-block-start: var(--_positron-notebook-cells-padding-block);
+	padding-block-end: var(--_positron-notebook-cells-padding-block);
 	padding-inline: 1rem;
 	display: flex;
 	flex-direction: column;

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -39,7 +39,6 @@ import { getSelectedCells } from './selectionMachine.js';
 import { startScrollRestorationLoop } from './scrollRestorationLoop.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import type { NotebookDisplayOptions, NotebookLayoutConfiguration } from '../../notebook/browser/notebookOptions.js';
-import { useEnvironment } from './EnvironmentProvider.js';
 import { useScrollBeyondLastLinePadding } from './useScrollBeyondLastLinePadding.js';
 
 export function PositronNotebookComponent() {
@@ -144,10 +143,8 @@ export function PositronNotebookComponent() {
 		return getSelectedCells(notebookInstance.selectionStateMachine.state.get());
 	}, [notebookInstance]);
 
-	const environment = useEnvironment();
 	const scrollBeyondLastLinePadding = useScrollBeyondLastLinePadding(
 		services.configurationService,
-		environment.size,
 	);
 
 	return (

--- a/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/PositronNotebookComponent.tsx
@@ -39,6 +39,8 @@ import { getSelectedCells } from './selectionMachine.js';
 import { startScrollRestorationLoop } from './scrollRestorationLoop.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import type { NotebookDisplayOptions, NotebookLayoutConfiguration } from '../../notebook/browser/notebookOptions.js';
+import { useEnvironment } from './EnvironmentProvider.js';
+import { useScrollBeyondLastLinePadding } from './useScrollBeyondLastLinePadding.js';
 
 export function PositronNotebookComponent() {
 	const notebookInstance = useNotebookInstance();
@@ -142,6 +144,12 @@ export function PositronNotebookComponent() {
 		return getSelectedCells(notebookInstance.selectionStateMachine.state.get());
 	}, [notebookInstance]);
 
+	const environment = useEnvironment();
+	const scrollBeyondLastLinePadding = useScrollBeyondLastLinePadding(
+		services.configurationService,
+		environment.size,
+	);
+
 	return (
 		<div className='positron-notebook' style={{ ...fontStyles }}>
 			{showDecoration && (
@@ -151,7 +159,7 @@ export function PositronNotebookComponent() {
 					role='presentation'
 				/>
 			)}
-			<div ref={containerCallbackRef} className='positron-notebook-cells-container positron-notebook-scrollable'>
+			<div ref={containerCallbackRef} className='positron-notebook-cells-container positron-notebook-scrollable' style={{ paddingBlockEnd: scrollBeyondLastLinePadding }}>
 				<SortableCellList
 					cells={notebookCells}
 					getSelectedCells={getSelectedCellsCallback}

--- a/src/vs/workbench/contrib/positronNotebook/browser/useScrollBeyondLastLinePadding.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/useScrollBeyondLastLinePadding.tsx
@@ -4,21 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 
 import React from 'react';
-import { IObservable } from '../../../../base/common/observable.js';
-import { ISize } from '../../../../base/browser/positronReactRenderer.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { useEnvironment } from './EnvironmentProvider.js';
 import { useObservedValue } from './useObservedValue.js';
 
 /**
- * Returns the paddingBottom value (in pixels) needed to implement scroll-beyond-last-line
- * in the notebook cells container, matching VS Code's native notebook behavior.
+ * Returns the paddingBlockEnd value (in pixels) needed to implement scroll-beyond-last-line
+ * in the notebook cells container, matching VS Code's native notebook behavior. We rely on
+ * padding to change the scrollable area because scrolling is handled by the browser in the
+ * Positron Notebook Editor.
  *
  * Returns undefined when the setting is disabled so CSS controls the default bottom padding.
  */
 export function useScrollBeyondLastLinePadding(
 	configurationService: IConfigurationService,
-	size: IObservable<ISize>,
 ): number | undefined {
+	const { size } = useEnvironment();
 	const { height } = useObservedValue(size);
 
 	const [enabled, setEnabled] = React.useState(

--- a/src/vs/workbench/contrib/positronNotebook/browser/useScrollBeyondLastLinePadding.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/useScrollBeyondLastLinePadding.tsx
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import React from 'react';
+import { IObservable } from '../../../../base/common/observable.js';
+import { ISize } from '../../../../base/browser/positronReactRenderer.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { useObservedValue } from './useObservedValue.js';
+
+/**
+ * Returns the paddingBottom value (in pixels) needed to implement scroll-beyond-last-line
+ * in the notebook cells container, matching VS Code's native notebook behavior.
+ *
+ * Returns undefined when the setting is disabled so CSS controls the default bottom padding.
+ */
+export function useScrollBeyondLastLinePadding(
+	configurationService: IConfigurationService,
+	size: IObservable<ISize>,
+): number | undefined {
+	const { height } = useObservedValue(size);
+
+	const [enabled, setEnabled] = React.useState(
+		() => configurationService.getValue<boolean>('editor.scrollBeyondLastLine')
+	);
+
+	React.useEffect(() => {
+		const disposable = configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('editor.scrollBeyondLastLine')) {
+				setEnabled(configurationService.getValue<boolean>('editor.scrollBeyondLastLine'));
+			}
+		});
+		return () => disposable.dispose();
+	}, [configurationService]);
+
+	if (!enabled) {
+		return undefined;
+	}
+	return Math.max(0, height - 50);
+}

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/useScrollBeyondLastLinePadding.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/useScrollBeyondLastLinePadding.vitest.tsx
@@ -5,32 +5,45 @@
 
 /// <reference types="vitest/globals" />
 
+import React from 'react';
 import { act, screen } from '@testing-library/react';
 import { observableValue } from '../../../../../base/common/observable.js';
 import { ISize } from '../../../../../base/browser/positronReactRenderer.js';
 import { IConfigurationChangeEvent, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IScopedContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
 import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { EnvironentProvider } from '../../browser/EnvironmentProvider.js';
 import { useScrollBeyondLastLinePadding } from '../../browser/useScrollBeyondLastLinePadding.js';
 
-function TestComponent({ configurationService, size }: {
+function TestComponent({ configurationService }: {
 	configurationService: IConfigurationService;
-	size: ReturnType<typeof observableValue<ISize>>;
 }) {
-	const padding = useScrollBeyondLastLinePadding(configurationService, size);
+	const padding = useScrollBeyondLastLinePadding(configurationService);
 	return <div data-testid='container' style={{ paddingBottom: padding }} />;
 }
 
 describe('useScrollBeyondLastLinePadding', () => {
 	const rtl = setupRTLRenderer();
 
+	function renderWithSize(configurationService: IConfigurationService, size: ReturnType<typeof observableValue<ISize>>) {
+		return rtl.render(
+			<EnvironentProvider environmentBundle={{
+				size,
+				scopedContextKeyProviderCallback: () => null as unknown as IScopedContextKeyService,
+			}}>
+				<TestComponent configurationService={configurationService} />
+			</EnvironentProvider>
+		);
+	}
+
 	it('returns undefined when scrollBeyondLastLine is false', () => {
 		const configurationService = new TestConfigurationService();
 		configurationService.setUserConfiguration('editor.scrollBeyondLastLine', false);
 		const size = observableValue<ISize>('size', { width: 800, height: 600 });
 
-		rtl.render(<TestComponent configurationService={configurationService} size={size} />);
+		renderWithSize(configurationService, size);
 
 		expect(screen.getByTestId('container')).not.toHaveAttribute('style');
 	});
@@ -40,7 +53,7 @@ describe('useScrollBeyondLastLinePadding', () => {
 		configurationService.setUserConfiguration('editor.scrollBeyondLastLine', true);
 		const size = observableValue<ISize>('size', { width: 800, height: 600 });
 
-		rtl.render(<TestComponent configurationService={configurationService} size={size} />);
+		renderWithSize(configurationService, size);
 
 		expect(screen.getByTestId('container')).toHaveStyle({ paddingBottom: '550px' });
 	});
@@ -50,7 +63,7 @@ describe('useScrollBeyondLastLinePadding', () => {
 		configurationService.setUserConfiguration('editor.scrollBeyondLastLine', true);
 		const size = observableValue<ISize>('size', { width: 800, height: 30 });
 
-		rtl.render(<TestComponent configurationService={configurationService} size={size} />);
+		renderWithSize(configurationService, size);
 
 		expect(screen.getByTestId('container')).toHaveStyle({ paddingBottom: '0px' });
 	});
@@ -60,7 +73,7 @@ describe('useScrollBeyondLastLinePadding', () => {
 		configurationService.setUserConfiguration('editor.scrollBeyondLastLine', false);
 		const size = observableValue<ISize>('size', { width: 800, height: 600 });
 
-		rtl.render(<TestComponent configurationService={configurationService} size={size} />);
+		renderWithSize(configurationService, size);
 		expect(screen.getByTestId('container')).not.toHaveAttribute('style');
 
 		await act(async () => {
@@ -80,7 +93,7 @@ describe('useScrollBeyondLastLinePadding', () => {
 		configurationService.setUserConfiguration('editor.scrollBeyondLastLine', true);
 		const size = observableValue<ISize>('size', { width: 800, height: 600 });
 
-		rtl.render(<TestComponent configurationService={configurationService} size={size} />);
+		renderWithSize(configurationService, size);
 		expect(screen.getByTestId('container')).toHaveStyle({ paddingBottom: '550px' });
 
 		await act(async () => {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/useScrollBeyondLastLinePadding.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/useScrollBeyondLastLinePadding.vitest.tsx
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { act, screen } from '@testing-library/react';
+import { observableValue } from '../../../../../base/common/observable.js';
+import { ISize } from '../../../../../base/browser/positronReactRenderer.js';
+import { IConfigurationChangeEvent, IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { useScrollBeyondLastLinePadding } from '../../browser/useScrollBeyondLastLinePadding.js';
+
+function TestComponent({ configurationService, size }: {
+	configurationService: IConfigurationService;
+	size: ReturnType<typeof observableValue<ISize>>;
+}) {
+	const padding = useScrollBeyondLastLinePadding(configurationService, size);
+	return <div data-testid='container' style={{ paddingBottom: padding }} />;
+}
+
+describe('useScrollBeyondLastLinePadding', () => {
+	const rtl = setupRTLRenderer();
+
+	it('returns undefined when scrollBeyondLastLine is false', () => {
+		const configurationService = new TestConfigurationService();
+		configurationService.setUserConfiguration('editor.scrollBeyondLastLine', false);
+		const size = observableValue<ISize>('size', { width: 800, height: 600 });
+
+		rtl.render(<TestComponent configurationService={configurationService} size={size} />);
+
+		expect(screen.getByTestId('container')).not.toHaveAttribute('style');
+	});
+
+	it('returns height minus 50 when scrollBeyondLastLine is true', () => {
+		const configurationService = new TestConfigurationService();
+		configurationService.setUserConfiguration('editor.scrollBeyondLastLine', true);
+		const size = observableValue<ISize>('size', { width: 800, height: 600 });
+
+		rtl.render(<TestComponent configurationService={configurationService} size={size} />);
+
+		expect(screen.getByTestId('container')).toHaveStyle({ paddingBottom: '550px' });
+	});
+
+	it('clamps to 0 when height is less than 50', () => {
+		const configurationService = new TestConfigurationService();
+		configurationService.setUserConfiguration('editor.scrollBeyondLastLine', true);
+		const size = observableValue<ISize>('size', { width: 800, height: 30 });
+
+		rtl.render(<TestComponent configurationService={configurationService} size={size} />);
+
+		expect(screen.getByTestId('container')).toHaveStyle({ paddingBottom: '0px' });
+	});
+
+	it('updates when scrollBeyondLastLine changes from false to true', async () => {
+		const configurationService = new TestConfigurationService();
+		configurationService.setUserConfiguration('editor.scrollBeyondLastLine', false);
+		const size = observableValue<ISize>('size', { width: 800, height: 600 });
+
+		rtl.render(<TestComponent configurationService={configurationService} size={size} />);
+		expect(screen.getByTestId('container')).not.toHaveAttribute('style');
+
+		await act(async () => {
+			configurationService.setUserConfiguration('editor.scrollBeyondLastLine', true);
+			configurationService.onDidChangeConfigurationEmitter.fire(
+				stubInterface<IConfigurationChangeEvent>({
+					affectsConfiguration: (key: string) => key === 'editor.scrollBeyondLastLine',
+				})
+			);
+		});
+
+		expect(screen.getByTestId('container')).toHaveStyle({ paddingBottom: '550px' });
+	});
+
+	it('updates when the editor size changes', async () => {
+		const configurationService = new TestConfigurationService();
+		configurationService.setUserConfiguration('editor.scrollBeyondLastLine', true);
+		const size = observableValue<ISize>('size', { width: 800, height: 600 });
+
+		rtl.render(<TestComponent configurationService={configurationService} size={size} />);
+		expect(screen.getByTestId('container')).toHaveStyle({ paddingBottom: '550px' });
+
+		await act(async () => {
+			size.set({ width: 800, height: 400 }, undefined);
+		});
+
+		expect(screen.getByTestId('container')).toHaveStyle({ paddingBottom: '350px' });
+	});
+});


### PR DESCRIPTION
Fixes #12665

When `editor.scrollBeyondLastLine` is enabled, the Positron Notebook Editor now adds
some bottom padding to the end of the editor which allows you to scroll beyond the last cell. This matches the legacy notebook behavior that some users were expecting in the new PNE.

The implementation extracts a `useScrollBeyondLastLinePadding` hook that reads the
setting from `IConfigurationService` and the editor pane size from `EnvironmentProvider`,
then applies the computed `paddingBlockEnd` as an inline style on the cells container.

### Screenshots

https://github.com/user-attachments/assets/608b84c2-8fad-444a-a5c2-e508a40902b7

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix `editor.scrollBeyondLastLine` having no effect in Positron notebooks (#12665)

### Validation Steps

@:positron-notebooks

1. Open a `.ipynb` notebook with several cells
2. Enable `editor.scrollBeyondLastLine` in your settings
3. Verify you can scroll past the bottom of the cell until the last cell is almost to the top of the editor
4. Disable `editor.scrollBeyondLastLine` in your settings
5. Verify the notebook removes the extra padding from the bottom of the file and does not let you scroll beyond the last cell