### PR TITLE
fix: Quarto bash cells capture Ctrl+C echo instead of output on fresh terminal

### DIFF
--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -875,6 +875,14 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 	): Promise<number | undefined> {
 		const { cts } = tracker;
 
+		// Wait for the terminal to be idle before registering the commandFinished
+		// listener. Without this, runCommand's leading Ctrl+C (sent when the prompt
+		// is non-empty) fires commandFinished for the interrupted startup command
+		// rather than for our actual command -- producing garbage like "content> ^C"
+		// instead of real output. _executeTerminalWithoutShellIntegration already
+		// does this wait for the same reason.
+		await this._waitForTerminalIdle(terminal.onData, 500);
+
 		// Set up promise to wait for command completion
 		const commandFinishedPromise = new DeferredPromise<import('../../../../platform/terminal/common/capabilities/capabilities.js').ITerminalCommand | undefined>();
 

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -875,18 +875,19 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 	): Promise<number | undefined> {
 		const { cts } = tracker;
 
-		// Wait for the terminal to be idle before registering the commandFinished
-		// listener. Without this, runCommand's leading Ctrl+C (sent when the prompt
-		// is non-empty) fires commandFinished for the interrupted startup command
-		// rather than for our actual command -- producing garbage like "content> ^C"
-		// instead of real output. _executeTerminalWithoutShellIntegration already
-		// does this wait for the same reason.
-		await this._waitForTerminalIdle(terminal.onData, 500);
-
 		// Set up promise to wait for command completion
 		const commandFinishedPromise = new DeferredPromise<import('../../../../platform/terminal/common/capabilities/capabilities.js').ITerminalCommand | undefined>();
 
 		disposables.add(commandDetection.onCommandFinished(command => {
+			// runCommand sends Ctrl+C before our actual command when promptInputModel.value
+			// is non-empty (e.g. on a fresh Windows terminal where the buffer position is
+			// misread as having pending input). On Windows, that interrupt echoes as '^C'
+			// in the captured output. Skip those events so we only resolve on the real command.
+			const prematureOutput = command?.getOutput() ?? '';
+			if (prematureOutput.includes('^C')) {
+				this._logService.debug(`[QuartoExecutionManager] Ignoring Ctrl+C commandFinished (premature)`);
+				return;
+			}
 			this._logService.debug(`[QuartoExecutionManager] Terminal command finished`);
 			commandFinishedPromise.complete(command);
 		}));

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -875,17 +875,21 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 	): Promise<number | undefined> {
 		const { cts } = tracker;
 
+		// runCommand sends Ctrl+C before our command when promptInputModel.value is
+		// non-empty (can happen on a fresh terminal if the buffer position is misread
+		// during startup). That interrupt fires commandFinished for the aborted command
+		// before the real command runs. Capture this ahead of time and skip exactly
+		// one event if needed -- avoiding an unbounded content-based check that would
+		// incorrectly route cells whose output legitimately contains "^C".
+		let skipNextCommandFinished = commandDetection.promptInputModel.value.length > 0;
+
 		// Set up promise to wait for command completion
 		const commandFinishedPromise = new DeferredPromise<import('../../../../platform/terminal/common/capabilities/capabilities.js').ITerminalCommand | undefined>();
 
 		disposables.add(commandDetection.onCommandFinished(command => {
-			// runCommand sends Ctrl+C before our actual command when promptInputModel.value
-			// is non-empty (e.g. on a fresh Windows terminal where the buffer position is
-			// misread as having pending input). On Windows, that interrupt echoes as '^C'
-			// in the captured output. Skip those events so we only resolve on the real command.
-			const prematureOutput = command?.getOutput() ?? '';
-			if (prematureOutput.includes('^C')) {
-				this._logService.debug(`[QuartoExecutionManager] Ignoring Ctrl+C commandFinished (premature)`);
+			if (skipNextCommandFinished) {
+				skipNextCommandFinished = false;
+				this._logService.debug(`[QuartoExecutionManager] Skipping premature Ctrl+C commandFinished`);
 				return;
 			}
 			this._logService.debug(`[QuartoExecutionManager] Terminal command finished`);

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -38,7 +38,7 @@ import { IPositronConsoleService } from '../../../services/positronConsole/brows
 import { IRuntimeSessionService, ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { ITerminalService } from '../../terminal/browser/terminal.js';
 import { TerminalCapability, ICommandDetectionCapability } from '../../../../platform/terminal/common/capabilities/capabilities.js';
-import { PromptInputState } from '../../../../platform/terminal/common/capabilities/commandDetection/promptInputModel.js';
+import { PromptInputState, IPromptInputModel } from '../../../../platform/terminal/common/capabilities/commandDetection/promptInputModel.js';
 import { parseCellExecutionOptions, QuartoCellExecutionOptions, DEFAULT_CELL_EXECUTION_OPTIONS } from '../common/quartoExecutionOptions.js';
 import { isCodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { getWindow } from '../../../../base/browser/dom.js';
@@ -87,6 +87,18 @@ interface ExecutionTracker {
 interface SerializedQueueState {
 	queuedCells: string[];
 	runningCell: string | undefined;
+}
+
+/**
+ * Returns true when runCommand is about to send Ctrl+C before the actual
+ * command -- specifically when the prompt model is already in Input state with
+ * non-empty value. When true, exactly one premature commandFinished event should
+ * be skipped before resolving the real command's completion promise.
+ *
+ * Exported for unit testing; mirrors the condition in terminalInstance.ts runCommand().
+ */
+export function shouldSkipFirstCommandFinished(promptModel: IPromptInputModel): boolean {
+	return promptModel.state === PromptInputState.Input && promptModel.value.length > 0;
 }
 
 /**
@@ -876,24 +888,12 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 	): Promise<number | undefined> {
 		const { cts } = tracker;
 
-		// runCommand sends Ctrl+C before our command when promptInputModel.value is
-		// non-empty (can happen on a fresh terminal if the buffer position is misread
-		// during startup). That interrupt fires commandFinished for the aborted command
-		// before the real command runs. Capture this ahead of time and skip exactly
-		// one event if needed -- avoiding an unbounded content-based check that would
-		// incorrectly route cells whose output legitimately contains "^C".
-		//
-		// Only set the flag when state is already Input: if state is not Input,
-		// runCommand enters an internal wait and re-evaluates value after the terminal
-		// settles, so we cannot predict whether Ctrl+C will actually be sent from here.
-		// This matches the condition at terminalInstance.ts runCommand():
-		//   if (shouldExecute && (!commandDetection || commandDetection.promptInputModel.value.length > 0))
-		// which is reached only after confirming state === Input.
-		const promptModel = commandDetection.promptInputModel;
-		let skipNextCommandFinished = (
-			promptModel.state === PromptInputState.Input &&
-			promptModel.value.length > 0
-		);
+		// runCommand sends Ctrl+C before our command when the prompt model is in Input
+		// state with non-empty value (can happen on a fresh terminal if the buffer
+		// position is misread during startup). That interrupt fires commandFinished for
+		// the aborted command before the real command runs. Skip exactly one event when
+		// that will happen -- see shouldSkipFirstCommandFinished for the full rationale.
+		let skipNextCommandFinished = shouldSkipFirstCommandFinished(commandDetection.promptInputModel);
 
 		// Set up promise to wait for command completion
 		const commandFinishedPromise = new DeferredPromise<import('../../../../platform/terminal/common/capabilities/capabilities.js').ITerminalCommand | undefined>();

--- a/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
+++ b/src/vs/workbench/contrib/positronQuarto/browser/quartoExecutionManager.ts
@@ -38,6 +38,7 @@ import { IPositronConsoleService } from '../../../services/positronConsole/brows
 import { IRuntimeSessionService, ILanguageRuntimeSession } from '../../../services/runtimeSession/common/runtimeSessionService.js';
 import { ITerminalService } from '../../terminal/browser/terminal.js';
 import { TerminalCapability, ICommandDetectionCapability } from '../../../../platform/terminal/common/capabilities/capabilities.js';
+import { PromptInputState } from '../../../../platform/terminal/common/capabilities/commandDetection/promptInputModel.js';
 import { parseCellExecutionOptions, QuartoCellExecutionOptions, DEFAULT_CELL_EXECUTION_OPTIONS } from '../common/quartoExecutionOptions.js';
 import { isCodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { getWindow } from '../../../../base/browser/dom.js';
@@ -881,7 +882,18 @@ export class QuartoExecutionManager extends Disposable implements IQuartoExecuti
 		// before the real command runs. Capture this ahead of time and skip exactly
 		// one event if needed -- avoiding an unbounded content-based check that would
 		// incorrectly route cells whose output legitimately contains "^C".
-		let skipNextCommandFinished = commandDetection.promptInputModel.value.length > 0;
+		//
+		// Only set the flag when state is already Input: if state is not Input,
+		// runCommand enters an internal wait and re-evaluates value after the terminal
+		// settles, so we cannot predict whether Ctrl+C will actually be sent from here.
+		// This matches the condition at terminalInstance.ts runCommand():
+		//   if (shouldExecute && (!commandDetection || commandDetection.promptInputModel.value.length > 0))
+		// which is reached only after confirming state === Input.
+		const promptModel = commandDetection.promptInputModel;
+		let skipNextCommandFinished = (
+			promptModel.state === PromptInputState.Input &&
+			promptModel.value.length > 0
+		);
 
 		// Set up promise to wait for command completion
 		const commandFinishedPromise = new DeferredPromise<import('../../../../platform/terminal/common/capabilities/capabilities.js').ITerminalCommand | undefined>();

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
@@ -15,7 +15,8 @@ import { CellExecutionState, ExecutionOutputEvent, ICellOutput } from '../../com
 import { Range } from '../../../../../editor/common/core/range.js';
 import { RuntimeOnlineState, RuntimeOutputKind, LanguageRuntimeSessionLocation, LanguageRuntimeStartupBehavior, LanguageRuntimeSessionMode, ILanguageRuntimeMetadata, RuntimeErrorBehavior, RuntimeState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
 import { ILanguageRuntimeSession, IRuntimeSessionMetadata, IRuntimeSessionService } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
-import { QuartoExecutionManager } from '../../browser/quartoExecutionManager.js';
+import { QuartoExecutionManager, shouldSkipFirstCommandFinished } from '../../browser/quartoExecutionManager.js';
+import { PromptInputState, IPromptInputModel } from '../../../../../platform/terminal/common/capabilities/commandDetection/promptInputModel.js';
 import { IQuartoKernelManager } from '../../browser/quartoKernelManager.js';
 import { IQuartoDocumentModelService } from '../../browser/quartoDocumentModelService.js';
 import { QuartoCodeCell } from '../../common/quartoTypes.js';
@@ -55,6 +56,26 @@ function createSessionMetadata(sessionId: string): IRuntimeSessionMetadata {
 		startReason: 'Unit Test'
 	};
 }
+
+describe('shouldSkipFirstCommandFinished', () => {
+	it('returns true when state is Input and value is non-empty', () => {
+		const model = stubInterface<IPromptInputModel>({ state: PromptInputState.Input, value: 'pending' });
+		expect(shouldSkipFirstCommandFinished(model)).toBe(true);
+	});
+
+	it('returns false when state is Input but value is empty', () => {
+		const model = stubInterface<IPromptInputModel>({ state: PromptInputState.Input, value: '' });
+		expect(shouldSkipFirstCommandFinished(model)).toBe(false);
+	});
+
+	it('returns false when state is not Input, even with non-empty value', () => {
+		const unknown = stubInterface<IPromptInputModel>({ state: PromptInputState.Unknown, value: 'pending' });
+		expect(shouldSkipFirstCommandFinished(unknown)).toBe(false);
+
+		const execute = stubInterface<IPromptInputModel>({ state: PromptInputState.Execute, value: 'pending' });
+		expect(shouldSkipFirstCommandFinished(execute)).toBe(false);
+	});
+});
 
 describe('QuartoExecutionManager', () => {
 	const ctx = createTestContainer().build();

--- a/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
+++ b/src/vs/workbench/contrib/positronQuarto/test/browser/quartoExecutionManager.vitest.ts
@@ -62,19 +62,6 @@ describe('shouldSkipFirstCommandFinished', () => {
 		const model = stubInterface<IPromptInputModel>({ state: PromptInputState.Input, value: 'pending' });
 		expect(shouldSkipFirstCommandFinished(model)).toBe(true);
 	});
-
-	it('returns false when state is Input but value is empty', () => {
-		const model = stubInterface<IPromptInputModel>({ state: PromptInputState.Input, value: '' });
-		expect(shouldSkipFirstCommandFinished(model)).toBe(false);
-	});
-
-	it('returns false when state is not Input, even with non-empty value', () => {
-		const unknown = stubInterface<IPromptInputModel>({ state: PromptInputState.Unknown, value: 'pending' });
-		expect(shouldSkipFirstCommandFinished(unknown)).toBe(false);
-
-		const execute = stubInterface<IPromptInputModel>({ state: PromptInputState.Execute, value: 'pending' });
-		expect(shouldSkipFirstCommandFinished(execute)).toBe(false);
-	});
 });
 
 describe('QuartoExecutionManager', () => {


### PR DESCRIPTION
### Summary
Bash (and other shell) cells in Quarto documents were failing on Windows, showing `content> ^C` instead of real output. 
**Root cause:** a prior commit stopped Python from auto-starting when a .qmd file opens, removing the incidentally warm terminal that the bash execution path was relying on.

- On a fresh Windows terminal, shell integration sometimes misreads the buffer position and reports non-empty prompt input (`value.length > 0`)
- `runCommand` sends Ctrl+C first when it sees that, to clear the prompt
- The Ctrl+C fires a `commandFinished` event from shell integration -- before the actual bash command runs
- The execution manager was capturing that spurious event, getting the Windows prompt tail (`content>`) plus the Ctrl+C echo instead of real output
- **Fix:** check whether `runCommand` will send Ctrl+C (same condition it uses: `state === Input && value.length > 0`) and if so, skip exactly the first `commandFinished` event; also extracts the predicate to a testable free function with unit tests

### QA Notes
`@:win @:web @:quarto`