### PR TITLE
ci: surface S3 report upload failures instead of swallowing them

### DIFF
--- a/.github/actions/upload-report-to-s3/action.yml
+++ b/.github/actions/upload-report-to-s3/action.yml
@@ -30,4 +30,4 @@ runs:
         if [[ -n "$WORKDIR" ]]; then
           cd "$WORKDIR"
         fi
-        aws s3 cp playwright-report/. s3://positron-test-reports/${{ inputs.report-dir }} --recursive || true
+        aws s3 cp playwright-report/. s3://positron-test-reports/${{ inputs.report-dir }} --recursive

--- a/.github/workflows/release-screenshots.yml
+++ b/.github/workflows/release-screenshots.yml
@@ -187,6 +187,7 @@ jobs:
 
       - name: Upload Playwright Report to S3
         if: ${{ success() || failure() }}
+        continue-on-error: true
         uses: ./.github/actions/upload-report-to-s3
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}

--- a/.github/workflows/test-e2e-debian.yml
+++ b/.github/workflows/test-e2e-debian.yml
@@ -231,6 +231,7 @@ jobs:
 
       - name: Upload Playwright Report to S3
         if: ${{ success() || failure() }}
+        continue-on-error: true
         uses: ./.github/actions/upload-report-to-s3
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}

--- a/.github/workflows/test-e2e-jupyter-ubuntu.yml
+++ b/.github/workflows/test-e2e-jupyter-ubuntu.yml
@@ -152,6 +152,7 @@ jobs:
 
       - name: Upload HTML report to S3
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/upload-report-to-s3
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}

--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -419,6 +419,7 @@ jobs:
 
       - name: Upload HTML report to S3
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/upload-report-to-s3
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}

--- a/.github/workflows/test-e2e-pyrefly.yml
+++ b/.github/workflows/test-e2e-pyrefly.yml
@@ -80,6 +80,7 @@ jobs:
 
       - name: Upload Playwright Report to S3
         if: ${{ success() || failure() }}
+        continue-on-error: true
         uses: ./.github/actions/upload-report-to-s3
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}

--- a/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
+++ b/.github/workflows/test-e2e-remote-ssh-ubuntu.yml
@@ -193,6 +193,7 @@ jobs:
 
       - name: Upload Playwright Report to S3
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/upload-report-to-s3
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}

--- a/.github/workflows/test-e2e-rhel.yml
+++ b/.github/workflows/test-e2e-rhel.yml
@@ -231,6 +231,7 @@ jobs:
 
       - name: Upload Playwright Report to S3
         if: ${{ success() || failure() }}
+        continue-on-error: true
         uses: ./.github/actions/upload-report-to-s3
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}

--- a/.github/workflows/test-e2e-sles.yml
+++ b/.github/workflows/test-e2e-sles.yml
@@ -231,6 +231,7 @@ jobs:
 
       - name: Upload Playwright Report to S3
         if: ${{ success() || failure() }}
+        continue-on-error: true
         uses: ./.github/actions/upload-report-to-s3
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}

--- a/.github/workflows/test-e2e-suse.yml
+++ b/.github/workflows/test-e2e-suse.yml
@@ -231,6 +231,7 @@ jobs:
 
       - name: Upload Playwright Report to S3
         if: ${{ success() || failure() }}
+        continue-on-error: true
         uses: ./.github/actions/upload-report-to-s3
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}

--- a/.github/workflows/test-e2e-ubuntu-run.yml
+++ b/.github/workflows/test-e2e-ubuntu-run.yml
@@ -455,6 +455,7 @@ jobs:
 
       - name: Upload HTML report to S3
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/upload-report-to-s3
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}

--- a/.github/workflows/test-e2e-ubuntu.yml
+++ b/.github/workflows/test-e2e-ubuntu.yml
@@ -295,6 +295,7 @@ jobs:
 
       - name: Upload Playwright Report to S3
         if: ${{ success() || failure() }}
+        continue-on-error: true
         uses: ./.github/actions/upload-report-to-s3
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}

--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -596,6 +596,7 @@ jobs:
 
       - name: Upload HTML report to S3
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/upload-report-to-s3
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}

--- a/.github/workflows/test-e2e-workbench-ubuntu.yml
+++ b/.github/workflows/test-e2e-workbench-ubuntu.yml
@@ -205,6 +205,7 @@ jobs:
 
       - name: Upload HTML report to S3
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/upload-report-to-s3
         with:
           role-to-assume: ${{ secrets.AWS_TEST_REPORTS_ROLE }}


### PR DESCRIPTION
Previously the upload step used `|| true`, silently hiding credential errors (`SignatureDoesNotMatch` and similar). A failed upload would show as green in the UI with no way to know the report URL was broken or re-run the step.

### Summary
- Remove `|| true` from `aws s3 cp` in the shared `upload-report-to-s3` action so failures exit non-zero
- Add `continue-on-error: true` to the upload step in all 13 workflow callers so the job keeps running on failure
- Net result: upload failures show as a failed (orange) step, the job still completes, and "Re-run failed jobs" is available

### QA Notes
No test tags - CI-only change, no app code touched.