### PR TITLE
unit test: cover plot action guards (copy / open in new window)

### DIFF
--- a/src/vs/workbench/contrib/positronPlots/test/electron-browser/positronPlotsService.vitest.ts
+++ b/src/vs/workbench/contrib/positronPlots/test/electron-browser/positronPlotsService.vitest.ts
@@ -377,4 +377,21 @@ describe('Positron - Plots Service', () => {
 		// The second render should cancel the first, so we expect only 1 render call
 		expect(renderCallCount, 'Should have called render only once due to cancellation').toBe(1);
 	});
+
+	// Guard-only coverage for the plot output action buttons (issue #12497). The real
+	// clipboard write and auxiliary-window creation are exercised by the plots e2e suite;
+	// here we only pin the branching that decides whether those side effects run at all.
+	describe('plot actions: copy and open in new window', () => {
+		it('open in new window: throws when no plot is selected', () => {
+			expect(() => plotsService.openPlotInNewWindow()).toThrow('no plot selected');
+		});
+
+		it('copy view plot: rejects when no plot is selected', async () => {
+			await expect(plotsService.copyViewPlotToClipboard()).rejects.toThrow('Plot not found');
+		});
+
+		it('copy editor plot: rejects when the plot id is unknown', async () => {
+			await expect(plotsService.copyEditorPlotToClipboard('missing')).rejects.toThrow('Plot not found');
+		});
+	});
 });


### PR DESCRIPTION
Closes #12497 (automated tests for the plot output's three action buttons).

Per the discussion on the issue, this rebalances rather than piles on e2e: the branching that decides whether a side effect runs is pushed down to fast unit tests, while the real clipboard write, saved file, and auxiliary-window creation stay in the existing `test/e2e/tests/plots/plots.test.ts` smokes.

## What this adds

Three guard tests in the existing `positronPlotsService.vitest.ts` (no product source change):

- `openPlotInNewWindow()` throws when no plot is selected
- `copyViewPlotToClipboard()` rejects with "Plot not found" when no plot is selected
- `copyEditorPlotToClipboard()` rejects with "Plot not found" for an unknown plot id

## Notes

- **Save data-URI parsing** was left to the existing e2e: unit-testing it cleanly would require either extracting the private `splitPlotDataUri` (a product change purely to enable a test) or brittle file-dialog/file-service stubbing.
- The **"not an HTML plot"** branch of `openPlotInNewWindow()` isn't cleanly unit-testable: `DynamicPlotInstance` (a React component) resolves to `undefined` in the Vitest environment, so its `instanceof` check throws before the branch is reached.