### PR TITLE
e2e test: console keeps focus during `input()`/`readline()` prompts

### DIFF
--- a/test/e2e/tests/console/console-input.test.ts
+++ b/test/e2e/tests/console/console-input.test.ts
@@ -25,6 +25,9 @@ test.describe('Console Input', {
 		await app.workbench.console.sendEnterKey();
 		await expect(app.workbench.console.activeConsole.getByText('Enter your name:', { exact: true })).toBeVisible();
 
+		// https://github.com/posit-dev/positron/issues/11758: focus must remain in the console while input() waits
+		await expect(app.workbench.console.activeConsole.locator('.activity-prompt .native-edit-context')).toBeFocused();
+
 		await app.workbench.console.typeToConsole('John Doe');
 		await app.workbench.console.sendEnterKey();
 		await app.workbench.console.waitForConsoleContents('Hello John Doe!');
@@ -40,6 +43,9 @@ cat(sprintf('Hello %s!\n', val))`;
 		await app.workbench.console.pasteCodeToConsole(inputCode);
 		await app.workbench.console.sendEnterKey();
 		await expect(app.workbench.console.activeConsole.getByText('Enter your name:', { exact: true })).toBeVisible();
+
+		// https://github.com/posit-dev/positron/issues/11758: focus must remain in the console while readline() waits
+		await expect(app.workbench.console.activeConsole.locator('.activity-prompt .native-edit-context')).toBeFocused();
 
 		// slight wait before starting to type
 		await app.code.wait(200);


### PR DESCRIPTION
Closes #11758.

Adds a focus assertion to the existing `input()` (Python) and `readline()` (R) console tests: while the prompt is waiting, focus must remain on the prompt's inline editor (`.activity-prompt .native-edit-context`). Lost focus is a symptom of deeper console issues (see #8687), so it's worth guarding. No new test files.

### Regression check
Confirmed the assertion actually catches focus loss by temporarily injecting a blur right before it:

```ts
await app.code.driver.currentPage.evaluate(() => (document.activeElement as HTMLElement)?.blur());
```

With the blur in place both tests fail (`Received: inactive`); without it they pass. Removed before committing.

### Tests
@:web @:critical @:win @:console @:ark
