### PR TITLE
Protect prompt visibility calculation from config changes

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -27,7 +27,7 @@ import { InQuickPickContextKey } from '../../../../browser/quickaccess.js';
 import { FormatOnType } from '../../../../../editor/contrib/format/browser/formatActions.js';
 import { EditorExtensionsRegistry } from '../../../../../editor/browser/editorExtensions.js';
 import { MarkerController } from '../../../../../editor/contrib/gotoError/browser/gotoError.js';
-import { IEditorOptions, LineNumbersType } from '../../../../../editor/common/config/editorOptions.js';
+import { IEditorOptions } from '../../../../../editor/common/config/editorOptions.js';
 import { CodeEditorWidget } from '../../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
 import { SuggestController } from '../../../../../editor/contrib/suggest/browser/suggestController.js';
 import { SnippetController2 } from '../../../../../editor/contrib/snippet/browser/snippetController2.js';
@@ -48,7 +48,7 @@ import { ContentHoverController } from '../../../../../editor/contrib/hover/brow
 import { IInputHistoryEntry } from '../../../../services/positronHistory/common/executionHistoryService.js';
 import { CodeAttributionSource, IConsoleCodeAttribution } from '../../../../services/positronConsole/common/positronConsoleCodeExecution.js';
 import { localize } from '../../../../../nls.js';
-import { IFontOptions } from '../../../../browser/fontConfigurationManager.js';
+import { createConsoleInputEditorOptions, createConsoleInputLineNumbersOptions, ILineNumbersOptions } from './consoleInputOptions.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { getForegroundDebugState, isForegroundDebugSession } from '../../../debug/common/debug.js';
 
@@ -57,9 +57,6 @@ const enum Position {
 	First,
 	Last
 }
-
-// Utility type for just the line numbers options from IEditorOptions.
-type ILineNumbersOptions = Pick<IEditorOptions, 'lineNumbers' | 'lineNumbersMinChars'>;
 
 // ConsoleInputProps interface.
 interface ConsoleInputProps {
@@ -673,85 +670,25 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			}
 		}
 
-		/**
-		 * Creates the ILineNumbersOptions from IEditorOptions for the CodeEditorWidget.
-		 * @returns The ILineNumbersOptions from IEditorOptions for the CodeEditorWidget.
-		 */
-		const createLineNumbersOptions = (): ILineNumbersOptions => {
-			const session = props.positronConsoleInstance.attachedRuntimeSession;
-			if (!session) {
-				return { lineNumbers: () => '', lineNumbersMinChars: 0 };
-			}
-			return {
-				lineNumbers: ((): LineNumbersType => {
-					switch (props.positronConsoleInstance.state) {
-						// When uninitialized, starting, or ready, use the show prompt line numbers
-						// function.
-						case PositronConsoleState.Uninitialized:
-						case PositronConsoleState.Starting:
-						case PositronConsoleState.Ready:
-							return (lineNumber: number) => lineNumber < 2 ?
-								session.dynState.inputPrompt :
-								session.dynState.continuationPrompt;
+		// Creates the state-driven line number (prompt) options. Thin wrapper
+		// over the pure builder so the prompt's visibility is recomputed only on
+		// console state / prompt-config changes.
+		const createLineNumbersOptions = (): ILineNumbersOptions =>
+			createConsoleInputLineNumbersOptions(props.positronConsoleInstance);
 
-						// In any other state, use the hide prompt line numbers function.
-						default:
-							return (_lineNumber: number) => '';
-					}
-				})(),
-				lineNumbersMinChars: Math.max(
-					session.dynState.inputPrompt.length,
-					session.dynState.continuationPrompt.length
-				)
-			};
-		};
+		// Creates the configuration-driven editor options. Thin wrapper over the
+		// pure builder; deliberately excludes line number (prompt) options.
+		const createEditorOptions = (): IEditorOptions =>
+			createConsoleInputEditorOptions(services.configurationService);
 
-		/**
-		 * Creates the full set of IEditorOptions for the CodeEditorWidget.
-		 * @returns The full set of IEditorOptions for the CodeEditorWidget.
-		 */
-		const createEditorOptions = (): IEditorOptions => ({
-			// Configured IEditorOptions is the base of editor options.
-			...services.configurationService.getValue<IEditorOptions>('editor'),
-			// Console-specific font options overlay the configured editor options.
-			...services.configurationService.getValue<IFontOptions>('console'),
-			// IEditorOptions we override from their configured values.
-			...{
-				readOnly: false,
-				minimap: {
-					enabled: false
-				},
-				glyphMargin: false,
-				folding: false,
-				fixedOverflowWidgets: true,
-				lineDecorationsWidth: '1.0ch',
-				renderLineHighlight: 'none',
-				renderFinalNewline: 'on',
-				wordWrap: 'bounded',
-				wordWrapColumn: 2048,
-				scrollbar: {
-					vertical: 'hidden',
-					useShadows: false
-				},
-				overviewRulerLanes: 0,
-				// This appears to disable the ruler.
-				// https://github.com/posit-dev/positron/issues/1080
-				rulers: [],
-				scrollBeyondLastLine: false,
-				// This appears to disable validations to address:
-				// https://github.com/posit-dev/positron/issues/979
-				// https://github.com/posit-dev/positron/issues/1051
-				renderValidationDecorations: 'off'
-			},
-			// The ILineNumbersOptions.
-			...createLineNumbersOptions(),
-		});
-
-		// Create the code editor widget.
+		// Create the code editor widget. The initial options combine the
+		// configuration-driven editor options with the state-driven line number
+		// (prompt) options; thereafter the two are updated independently so that
+		// configuration changes cannot affect the prompt (see createEditorOptions).
 		const codeEditorWidget = services.instantiationService.createInstance(
 			CodeEditorWidget,
 			codeEditorWidgetContainerRef.current,
-			createEditorOptions(),
+			{ ...createEditorOptions(), ...createLineNumbersOptions() },
 			{
 				// Make the console input's code editor widget a "simple" widget. This prevents the
 				// console input's code editor widget from being the active text editor (i.e. being
@@ -806,8 +743,11 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 			services.configurationService.onDidChangeConfiguration(
 				configurationChangeEvent => {
 					if (configurationChangeEvent.affectsConfiguration('editor') || configurationChangeEvent.affectsConfiguration('console')) {
-						// When the editor configuration changes, we must update ALL the options.
-						// So, in this case, use createEditorOptions() to get the full set.
+						// When the editor configuration changes, update the
+						// configuration-driven editor options. This deliberately
+						// does not touch the line number (prompt) options, which
+						// are driven by the console state instead; see
+						// createEditorOptions and issue #13925.
 						codeEditorWidget.updateOptions(createEditorOptions());
 					}
 				}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInputOptions.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInputOptions.ts
@@ -1,0 +1,107 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
+import { IEditorOptions, LineNumbersType } from '../../../../../editor/common/config/editorOptions.js';
+import { IFontOptions } from '../../../../browser/fontConfigurationManager.js';
+import { IPositronConsoleInstance, PositronConsoleState } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
+
+/**
+ * The subset of IEditorOptions that controls the console input's line numbers,
+ * which render the input/continuation prompt (e.g. the `>` glyph).
+ */
+export type ILineNumbersOptions = Pick<IEditorOptions, 'lineNumbers' | 'lineNumbersMinChars'>;
+
+/**
+ * Creates the configuration-driven IEditorOptions for the console input's code
+ * editor widget.
+ *
+ * @param configurationService The configuration service to read editor/console settings from.
+ * @returns The configuration-driven IEditorOptions for the console input's code editor widget.
+ */
+export function createConsoleInputEditorOptions(configurationService: IConfigurationService): IEditorOptions {
+	// Drop the configured `editor.lineNumbers` / `editor.lineNumbersMinChars`
+	// from the base options. The console input renders its prompt through the
+	// line numbers (see createConsoleInputLineNumbersOptions); letting the
+	// user's editor line-number settings flow through here would clobber the
+	// prompt with numeric line numbers on the next configuration-driven
+	// updateOptions().
+	const { lineNumbers: _lineNumbers, lineNumbersMinChars: _lineNumbersMinChars, ...editorOptions } =
+		configurationService.getValue<IEditorOptions>('editor');
+	return {
+		// Configured IEditorOptions (sans line number options) is the base.
+		...editorOptions,
+		// Console-specific font options overlay the configured editor options.
+		...configurationService.getValue<IFontOptions>('console'),
+		// IEditorOptions we override from their configured values.
+		...{
+			readOnly: false,
+			minimap: {
+				enabled: false
+			},
+			glyphMargin: false,
+			folding: false,
+			fixedOverflowWidgets: true,
+			lineDecorationsWidth: '1.0ch',
+			renderLineHighlight: 'none',
+			renderFinalNewline: 'on',
+			wordWrap: 'bounded',
+			wordWrapColumn: 2048,
+			scrollbar: {
+				vertical: 'hidden',
+				useShadows: false
+			},
+			overviewRulerLanes: 0,
+			// This appears to disable the ruler.
+			// https://github.com/posit-dev/positron/issues/1080
+			rulers: [],
+			scrollBeyondLastLine: false,
+			// This appears to disable validations to address:
+			// https://github.com/posit-dev/positron/issues/979
+			// https://github.com/posit-dev/positron/issues/1051
+			renderValidationDecorations: 'off'
+		}
+	};
+}
+
+/**
+ * Creates the line number options for the console input's code editor widget.
+ *
+ * The line numbers render the input/continuation prompt. The prompt is only
+ * shown when there is an attached session AND the console is in a prompt-bearing
+ * state (Uninitialized, Starting, or Ready); in any other state (e.g. Busy,
+ * Offline, Exiting, Exited, Disconnected) the prompt is hidden.
+ *
+ * @param instance The console instance whose state/session drives the prompt.
+ * @returns The line number options for the console input's code editor widget.
+ */
+export function createConsoleInputLineNumbersOptions(instance: IPositronConsoleInstance): ILineNumbersOptions {
+	const session = instance.attachedRuntimeSession;
+	if (!session) {
+		return { lineNumbers: () => '', lineNumbersMinChars: 0 };
+	}
+	return {
+		lineNumbers: ((): LineNumbersType => {
+			switch (instance.state) {
+				// When uninitialized, starting, or ready, use the show prompt line numbers
+				// function.
+				case PositronConsoleState.Uninitialized:
+				case PositronConsoleState.Starting:
+				case PositronConsoleState.Ready:
+					return (lineNumber: number) => lineNumber < 2 ?
+						session.dynState.inputPrompt :
+						session.dynState.continuationPrompt;
+
+				// In any other state, use the hide prompt line numbers function.
+				default:
+					return (_lineNumber: number) => '';
+			}
+		})(),
+		lineNumbersMinChars: Math.max(
+			session.dynState.inputPrompt.length,
+			session.dynState.continuationPrompt.length
+		)
+	};
+}

--- a/src/vs/workbench/contrib/positronConsole/test/browser/consoleInputOptions.vitest.ts
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/consoleInputOptions.vitest.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ILanguageRuntimeSessionState } from '../../../../services/languageRuntime/common/languageRuntimeService.js';
+import { ILanguageRuntimeSession } from '../../../../services/runtimeSession/common/runtimeSessionService.js';
+import { IPositronConsoleInstance, PositronConsoleState } from '../../../../services/positronConsole/browser/interfaces/positronConsoleService.js';
+import { createConsoleInputEditorOptions, createConsoleInputLineNumbersOptions } from '../../browser/components/consoleInputOptions.js';
+
+/**
+ * Builds a console instance stub with the given state and (optionally) an
+ * attached session whose prompts are `> ` / `+ `.
+ */
+function consoleInstance(state: PositronConsoleState, attached: boolean): IPositronConsoleInstance {
+	const dynState: ILanguageRuntimeSessionState = {
+		inputPrompt: '> ',
+		continuationPrompt: '+ ',
+		currentWorkingDirectory: '',
+		busy: false,
+		sessionName: 'test'
+	};
+	const session = attached
+		? stubInterface<ILanguageRuntimeSession>({ dynState })
+		: undefined;
+	return stubInterface<IPositronConsoleInstance>({ state, attachedRuntimeSession: session });
+}
+
+describe('consoleInputOptions', () => {
+	describe('createConsoleInputEditorOptions', () => {
+		const configurationService = new TestConfigurationService();
+		configurationService.setUserConfiguration('editor', { fontSize: 14, lineNumbers: 'on' });
+		configurationService.setUserConfiguration('console', { fontFamily: 'monospace' });
+
+		it('omits line number options even when editor.lineNumbers is configured', () => {
+			const keys = Object.keys(createConsoleInputEditorOptions(configurationService));
+			expect(keys).not.toContain('lineNumbers');
+			expect(keys).not.toContain('lineNumbersMinChars');
+		});
+
+		it('overlays the console font options and forces the console-specific overrides', () => {
+			const options = createConsoleInputEditorOptions(configurationService);
+			expect({
+				fontSize: options.fontSize,
+				fontFamily: options.fontFamily,
+				readOnly: options.readOnly,
+				wordWrap: options.wordWrap
+			}).toMatchInlineSnapshot(`
+				{
+				  "fontFamily": "monospace",
+				  "fontSize": 14,
+				  "readOnly": false,
+				  "wordWrap": "bounded",
+				}
+			`);
+		});
+	});
+
+	describe('createConsoleInputLineNumbersOptions', () => {
+		it('hides the prompt when there is no attached session', () => {
+			const { lineNumbers, lineNumbersMinChars } =
+				createConsoleInputLineNumbersOptions(consoleInstance(PositronConsoleState.Ready, false));
+			expect((lineNumbers as (n: number) => string)(1)).toBe('');
+			expect(lineNumbersMinChars).toBe(0);
+		});
+
+		it('shows the input/continuation prompt in prompt-bearing states', () => {
+			for (const state of [PositronConsoleState.Uninitialized, PositronConsoleState.Starting, PositronConsoleState.Ready]) {
+				const { lineNumbers } =
+					createConsoleInputLineNumbersOptions(consoleInstance(state, true));
+				const prompt = lineNumbers as (n: number) => string;
+				expect([prompt(1), prompt(2)]).toStrictEqual(['> ', '+ ']);
+			}
+		});
+
+		it('hides the prompt in non-prompt states such as Busy', () => {
+			for (const state of [PositronConsoleState.Busy, PositronConsoleState.Offline, PositronConsoleState.Exiting, PositronConsoleState.Exited, PositronConsoleState.Disconnected]) {
+				const { lineNumbers } =
+					createConsoleInputLineNumbersOptions(consoleInstance(state, true));
+				const prompt = lineNumbers as (n: number) => string;
+				expect([prompt(1), prompt(2)]).toStrictEqual(['', '']);
+			}
+		});
+	});
+});


### PR DESCRIPTION
Addresses an issue in which the console intermittently lost its `>` input prompt. The prompt is rendered as the console input editor's line-number gutter, and its options were embedded in the configuration-driven editor options. As a result, any `editor`/`console` configuration change recomputed the prompt from the console's live state -- and if the change landed while the console was in a transient non-prompt state (e.g. `Busy`), it blanked the prompt. Because the configuration change was the last writer of the gutter (with no follow-up state event in an idle console), the prompt stayed gone.

The best clue to this issue was in the video in #13925, where you can see that `DidChangeConfiguration` events correlate directly with the prompt disappearing:

<img width="1249" height="360" alt="image" src="https://github.com/user-attachments/assets/3dee10e7-5bee-4dba-b96b-31c5c2ddc2f3" />

This PR decouples prompt rendering from editor configuration. The configuration-driven editor options no longer carry any line-number options (and explicitly strip the user's `editor.lineNumbers` setting so it cannot clobber the prompt), so a configuration change can never affect the prompt. Prompt visibility is now driven solely by console state and prompt-config changes. The option builders were extracted into a small pure module (`consoleInputOptions.ts`) with unit-test coverage.

Fixes #13925.

### Release Notes

#### New Features
- N/A

#### Bug Fixes

- Fixed the console losing its input prompt intermittently (#13925)

### Validation Steps

@:console

1. Open an R (or Python) console and confirm the `>` prompt is visible.
2. Open a notebook with many code cells, or otherwise generate configuration-change activity, and run code in the console.
3. While interacting, toggle an editor setting (e.g. change `editor.fontSize`).
4. Verify the `>` prompt remains visible at all times and is never replaced by numeric line numbers.

