### PR TITLE
Fall back to session-scoped URLs for daily builds

### DIFF
--- a/src/vs/server/node/positronStaticRoute.ts
+++ b/src/vs/server/node/positronStaticRoute.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Daily builds differ from Workbench's nginx-served install, so they use session-scoped URLs.
+export function shouldUseSessionLessStaticRoute(isWorkbench: boolean, hasStaticRoute: boolean, quality: string | undefined): boolean {
+	return isWorkbench && hasStaticRoute && quality !== 'dailies';
+}

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -195,6 +195,13 @@ export class WebClientServer {
 		// --- End PWB ---
 	}
 
+	// --- Start Positron ---
+	// Daily builds don't match Workbench's nginx-served install, so they use session-scoped URLs.
+	private get _useSessionLessStaticRoute(): boolean {
+		return isWorkbench && HAS_STATIC_ROUTE && this._productService.quality !== 'dailies';
+	}
+	// --- End Positron ---
+
 	/**
 	 * Handle web resources (i.e. only needed by the web client).
 	 * **NOTE**: This method is only invoked when the server has web bits.
@@ -208,7 +215,7 @@ export class WebClientServer {
 			// URL shape: /<product-label>-static/<quality>-<commit>/static/<path>  →  serve APP_ROOT/<path>
 			// Only active when running under Workbench; standalone/dev code-server keeps the
 			// session-scoped /static/ route below.
-			if (isWorkbench && HAS_STATIC_ROUTE && pathname.startsWith(VSCODE_STATIC_PREFIX) && pathname.charCodeAt(VSCODE_STATIC_PREFIX.length) === CharCode.Slash) {
+			if (this._useSessionLessStaticRoute && pathname.startsWith(VSCODE_STATIC_PREFIX) && pathname.charCodeAt(VSCODE_STATIC_PREFIX.length) === CharCode.Slash) {
 				const afterPrefix = pathname.substring(VSCODE_STATIC_PREFIX.length + 1); // strip "/<product-label>-static/"
 				const versionSlash = afterPrefix.indexOf('/');
 				if (versionSlash === -1) {
@@ -489,7 +496,7 @@ export class WebClientServer {
 		const vscodeBase = relativePath(req.url!);
 		// When under Workbench, session-less URLs are absolute-from-root; otherwise keep the
 		// session-scoped relative form that works behind the default reverse proxy.
-		const useStaticRoute = isWorkbench && HAS_STATIC_ROUTE;
+		const useStaticRoute = this._useSessionLessStaticRoute;
 		const effectiveVsBase = useStaticRoute ? '' : vscodeBase;
 		const effectiveStaticRoute = useStaticRoute ? sessionlessStaticRoute : staticRoute;
 		// --- End PWB ---

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -35,6 +35,7 @@ import httpProxy from 'http-proxy';
 // eslint-disable-next-line no-duplicate-imports
 import { existsSync } from 'fs';
 import { kProxyRegex, VSCODE_STATIC_PREFIX, WORKBENCH_DEPLOYMENT_PREFIX, HAS_STATIC_ROUTE } from './pwbConstants.js';
+import { shouldUseSessionLessStaticRoute } from './positronStaticRoute.js';
 // --- End PWB ---
 
 const textMimeType: { [ext: string]: string | undefined } = {
@@ -196,9 +197,8 @@ export class WebClientServer {
 	}
 
 	// --- Start Positron ---
-	// Daily builds don't match Workbench's nginx-served install, so they use session-scoped URLs.
 	private get _useSessionLessStaticRoute(): boolean {
-		return isWorkbench && HAS_STATIC_ROUTE && this._productService.quality !== 'dailies';
+		return shouldUseSessionLessStaticRoute(isWorkbench, HAS_STATIC_ROUTE, this._productService.quality);
 	}
 	// --- End Positron ---
 

--- a/src/vs/server/test/node/positronStaticRoute.vitest.ts
+++ b/src/vs/server/test/node/positronStaticRoute.vitest.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { shouldUseSessionLessStaticRoute } from '../../node/positronStaticRoute.js';
+
+describe('shouldUseSessionLessStaticRoute', () => {
+	it('returns false for a daily build so it uses session-scoped URLs', () => {
+		expect(shouldUseSessionLessStaticRoute(true, true, 'dailies')).toBe(false);
+	});
+
+	it('only carves out daily builds: other qualities keep the shared static route', () => {
+		expect(shouldUseSessionLessStaticRoute(true, true, 'releases')).toBe(true);
+		expect(shouldUseSessionLessStaticRoute(true, true, undefined)).toBe(true);
+	});
+
+	it('returns false when not running under Workbench, regardless of quality', () => {
+		expect(shouldUseSessionLessStaticRoute(false, true, 'releases')).toBe(false);
+	});
+
+	it('returns false when the host lacks the static route, regardless of quality', () => {
+		expect(shouldUseSessionLessStaticRoute(true, false, 'releases')).toBe(false);
+	});
+});


### PR DESCRIPTION
Fixes #14303

Positron serves shared static copies of its large JavaScript files at a session-less, commit-keyed URL that the Workbench host serves off its configured install. rstudio/rstudio-pro#11420 will let users run preview images whose build differs from the host. Because the host serves these URLs from its own build, a preview session would load JavaScript from the wrong commit and fail to connect with `Client refused: version mismatch`.

Daily builds now fall back to session-scoped URLs, which route to the session and serve matching assets. Release builds keep the shared static route.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:workbench @:web

Launch a preview Positron session on a Workbench host running a different Positron install. Confirm the session connects without `Client refused: version mismatch`.
