### PR TITLE
feat: add pete-local skill for pre-PR test-coverage previews

### DIFF
--- a/.claude/skills/pete-local/SKILL.md
+++ b/.claude/skills/pete-local/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: pete-local
+description: Run PETE's test-coverage analysis locally on the current branch / working tree, as a pre-PR preview of the verdict the CI PR Test Checker (PETE) will post. Uses the same rubric and file classification as CI. Use when asked to "run PETE locally", preview test coverage before opening a PR, or check whether the current branch has adequate tests.
+---
+
+# PETE (local preview)
+
+You produce a **local preview** of PETE's test-coverage verdict for the current git branch, before a PR exists. You do the grading yourself in this session -- there is no Agent SDK and no separate API key involved.
+
+This preview shares its rubric and file classification with the CI workflow, so the substance should track what PETE eventually posts. It is **not** authoritative and posts nothing: the PR Test Checker workflow remains the official grader.
+
+## Steps
+
+Do these in order.
+
+1. **Gather context** (deterministic, shared with CI). From the repo root, run:
+
+   ```
+   node .claude/skills/pr-test-checker/scripts/gather-local-context.mjs "$TMPDIR/pete-context.json"
+   ```
+
+   Use any writable temp path for the output (e.g. the OS temp dir); just keep it consistent below. The script reads the working tree (committed + uncommitted + untracked) against the merge-base with the default branch -- no `gh`, no network. It prints a one-line summary ending in `skip=...`.
+
+2. **Handle the skip pre-filter.** If the script reports `skip=<reason>` (anything other than `skip=no`), it also wrote a `comment.md` next to the context file. Read that `comment.md` and present it verbatim (it is the same static "Not applicable" verdict CI would post). Then stop -- do not grade further.
+
+3. **Read the rubric.** Otherwise, `Read` the shared rubric at `.claude/skills/pr-test-checker/SKILL.md`. That file is the single source of truth for the taxonomy, cost guidance, deployment coverage, decision rule, investigation steps, verdict table, output template, and constraints. Follow it exactly.
+
+4. **Read the gathered context.** `Read` the `pete-context.json` you wrote in step 1. It contains the change metadata, the pre-classified file list (`files[].category`), and the diff. Treat this as the "Inputs you'll receive" the rubric describes. The repo checkout you Read/Grep/Glob is the current working tree.
+
+5. **Grade.** Carry out the rubric's Investigation steps against the diff and the working tree, then produce the verdict in the rubric's exact Output-format template. Honor every Constraint (cite real files only, one verdict, keep it under ~80 lines, etc.).
+
+6. **Swap the footer for a local-preview note.** The rubric's output template ends with a CI footer that mentions `/recheck-tests`. That mechanism does not exist locally, so replace that final `<small>...</small>` footer line with:
+
+   ```
+   <small>PETE local preview -- not posted to any PR. Graded from your working tree (HEAD vs the merge-base with the default branch). CI PETE grades on Opus; on a different model the verdict may differ. Open a PR to get the official PETE check.</small>
+   ```
+
+7. **Present, don't post.** Output the rendered report to the user in this session. Do not create a PR comment or run any `gh` command.
+
+## Notes
+
+- This is a working-tree preview: it includes uncommitted and untracked changes, so a brand-new test file you have not committed yet still counts. The eventual PR diff may differ slightly once you commit and push.
+- If you are not running on an Opus model, say so briefly when presenting -- the CI grader uses Opus and a borderline verdict can shift between models.

--- a/.claude/skills/pete-local/SKILL.md
+++ b/.claude/skills/pete-local/SKILL.md
@@ -21,7 +21,7 @@ Do these in order.
 
    Use any writable temp path for the output (e.g. the OS temp dir); just keep it consistent below. The script reads the working tree (committed + uncommitted + untracked) against the merge-base with the default branch -- no `gh`, no network. It prints a one-line summary ending in `skip=...`.
 
-2. **Handle the skip pre-filter.** If the script reports `skip=<reason>` (anything other than `skip=no`), it also wrote a `comment.md` next to the context file. Read that `comment.md` and present it verbatim (it is the same static "Not applicable" verdict CI would post). Then stop -- do not grade further.
+2. **Handle the skip pre-filter.** If the script reports `skip=<reason>` (anything other than `skip=no`), it also wrote a `comment.md` next to the context file. Read that `comment.md` and present it (it is the same static "Not applicable" verdict CI would post). Its footer is an HTML `<sub>...</sub>` line meant for GitHub; since this renders in Claude Code, present that footer line as plain markdown italic (drop the `<sub>` tag) so it doesn't show up as a literal tag. Then stop -- do not grade further.
 
 3. **Read the rubric.** Otherwise, `Read` the shared rubric at `.claude/skills/pr-test-checker/SKILL.md`. That file is the single source of truth for the taxonomy, cost guidance, deployment coverage, decision rule, investigation steps, verdict table, output template, and constraints. Follow it exactly.
 
@@ -29,10 +29,10 @@ Do these in order.
 
 5. **Grade.** Carry out the rubric's Investigation steps against the diff and the working tree, then produce the verdict in the rubric's exact Output-format template. Honor every Constraint (cite real files only, one verdict, keep it under ~80 lines, etc.).
 
-6. **Swap the footer for a local-preview note.** The rubric's output template ends with a CI footer that mentions `/recheck-tests`. That mechanism does not exist locally, so replace that final `<small>...</small>` footer line with:
+6. **Swap the footer for a local-preview note.** The rubric's output template ends with a CI footer (an HTML `<small>...</small>` line that mentions `/recheck-tests`). Neither applies locally, and this report renders in Claude Code -- not on GitHub -- where raw HTML like `<small>` shows up literally instead of rendering. So drop the `<small>` tag and use plain markdown italic. Replace that final footer line with:
 
    ```
-   <small>PETE local preview -- not posted to any PR. Graded from your working tree (HEAD vs the merge-base with the default branch). CI PETE grades on Opus; on a different model the verdict may differ. Open a PR to get the official PETE check.</small>
+   _PETE local preview -- not posted to any PR. Graded from your working tree (HEAD vs the merge-base with the default branch). CI PETE grades on Opus; on a different model the verdict may differ. Open a PR to get the official PETE check._
    ```
 
 7. **Present, don't post.** Output the rendered report to the user in this session. Do not create a PR comment or run any `gh` command.

--- a/.claude/skills/pete-local/SKILL.md
+++ b/.claude/skills/pete-local/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: pete-local
+name: pete
 description: Run PETE's test-coverage analysis locally on the current branch / working tree, as a pre-PR preview of the verdict the CI PR Test Checker (PETE) will post. Uses the same rubric and file classification as CI. Use when asked to "run PETE locally", preview test coverage before opening a PR, or check whether the current branch has adequate tests.
 ---
 

--- a/.claude/skills/pete-local/SKILL.md
+++ b/.claude/skills/pete-local/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pete
-description: Run PETE's test-coverage analysis locally on the current branch / working tree, as a pre-PR preview of the verdict the CI PR Test Checker (PETE) will post. Uses the same rubric and file classification as CI. Use when asked to "run PETE locally", preview test coverage before opening a PR, or check whether the current branch has adequate tests.
+description: Preview the test-coverage verdict PETE will post, locally, before a PR exists. PETE is Positron's CI "PR Test Checker": it grades whether a PR adds adequate tests for its source changes and posts a verdict comment. This skill replays the same rubric and file classification against your working tree (committed + uncommitted + untracked changes vs the merge-base with the default branch) and renders the verdict in-session -- it posts nothing and needs no network or gh. Use when asked to "run PETE" / "run PETE locally", to preview or check test coverage before opening or pushing a PR, to see whether the current branch has adequate tests, or to anticipate what PETE / the PR Test Checker will say.
 ---
 
 # PETE (local preview)

--- a/.claude/skills/pr-test-checker/SKILL.md
+++ b/.claude/skills/pr-test-checker/SKILL.md
@@ -10,12 +10,12 @@ You evaluate whether a Positron pull request has adequate test coverage for the 
 
 ## Inputs you'll receive
 
-The action driver provides:
+You will be given (from a PR via the GitHub Action, or from a local branch via the `pete-local` skill):
 
-- **PR metadata** -- number, title, body, author, base/head refs
+- **Change metadata** -- title, body, author, base/head refs (and PR number when grading a PR)
 - **File classification** -- each changed file is pre-tagged as one of: `test-vitest`, `test-mocha`, `test-ext-host`, `test-e2e`, `test-other`, `source-positron`, `source-extension`, `source-other`, plus `docs`/`config-*` (which short-circuit before you're invoked)
-- **The diff** -- the full PR diff, possibly truncated for very large PRs
-- **REPO_ROOT** -- a sparse checkout containing `src/`, `extensions/`, `test/e2e/`, the project `CLAUDE.md`, and `.claude/rules/*.md`. Use Read/Glob/Grep to explore.
+- **The diff** -- the full diff for the change, possibly truncated for very large changes
+- **Repo access** -- a checkout containing `src/`, `extensions/`, `test/e2e/`, the project `CLAUDE.md`, and `.claude/rules/*.md`. Use Read/Glob/Grep to explore.
 
 ## Test taxonomy (read before grading)
 

--- a/.claude/skills/pr-test-checker/scripts/context-core.mjs
+++ b/.claude/skills/pr-test-checker/scripts/context-core.mjs
@@ -1,0 +1,165 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Shared, deterministic core for the PR test checker. Both context gatherers
+// import this so a PR and a local branch with the same diff produce identical
+// classification, skip decisions, and context.json shape -- the parity
+// guarantee between the CI workflow and the local `pete-local` skill.
+//
+// Pure (no I/O, no network, no `gh`/`git`). Each gatherer is a thin adapter
+// that acquires raw fields (from the GitHub API or from local git) and hands
+// them to `buildContext()`.
+
+// Defensive cap on the diff sent to the model. Large diffs are usually
+// generated/vendored code where deep analysis adds no value; the grader can
+// still Read individual files via tools. Env-overridable so both paths honor
+// the same knob.
+export const MAX_DIFF_CHARS = Number(process.env.MAX_DIFF_CHARS) || 120_000;
+
+// Categories drive the rubric: the grader weighs source changes against tests
+// at the appropriate level. Order matters -- the first matching pattern wins.
+const CATEGORIES = [
+	// Tests (any of these counts as "has tests")
+	{ name: 'test-vitest', match: p => /\.vitest\.(ts|tsx)$/.test(p) },
+	{ name: 'test-e2e', match: p => p.startsWith('test/e2e/') },
+	{ name: 'test-ext-host', match: p => p.startsWith('extensions/') && /(\.test|\.integrationTest)\.tsx?$/.test(p) },
+	{ name: 'test-mocha', match: p => p.startsWith('src/') && /(\.test|\.integrationTest)\.tsx?$/.test(p) },
+	{ name: 'test-other', match: p => /\/(test|tests|__tests__)\//.test(p) },
+
+	// Docs / config / lockfiles -- not source, not tests
+	{ name: 'docs', match: p => /\.(md|mdx)$/i.test(p) || /^(LICENSE|NOTICE)(\.txt)?$/i.test(p) || /CHANGELOG\.md$/i.test(p) || /CONTRIBUTING\.md$/i.test(p) || /(^|\/)README(\.[^\/]+)?$/i.test(p) },
+	{ name: 'lockfile', match: p => /(package-lock\.json|yarn\.lock|pnpm-lock\.yaml)$/i.test(p) },
+	{ name: 'config-repo', match: p => p.startsWith('.github/') || p.startsWith('.vscode/') || /^\.(editorconfig|gitignore|gitattributes)$/.test(p) },
+	{ name: 'config-build', match: p => p.startsWith('build/azure-pipelines/') || p.startsWith('build/checksums/') || p.startsWith('build/lib/i18n/') },
+	{ name: 'config-ts', match: p => /tsconfig.*\.json$/.test(p) || /vitest\.(config|workspace)\./.test(p) || /playwright\.config\./.test(p) || /eslint\.config\./.test(p) || /\.eslintrc/.test(p) || /\.prettierrc/.test(p) },
+	{ name: 'config-pkg', match: p => /\/package\.json$/.test(p) || p === 'package.json' },
+	{ name: 'config-release', match: p => p === 'product.json' || p.startsWith('versions/') },
+
+	// Source (everything else falling into known source roots)
+	{ name: 'source-positron', match: p => p.startsWith('src/') },
+	{ name: 'source-extension', match: p => p.startsWith('extensions/') },
+	{ name: 'source-e2e-infra', match: p => p.startsWith('test/e2e/') }, // unreachable -- e2e tests already caught above
+	{ name: 'source-other', match: () => true },
+];
+
+function classify(path) {
+	for (const c of CATEGORIES) {
+		if (c.match(path)) { return c.name; }
+	}
+	return 'source-other';
+}
+
+// Skip categories: when every changed file falls into one of these and the PR
+// is chore-shaped (no source touched, no tests touched). Matches the
+// conjunctive rule from positron-pr-test-report.
+const SKIP_CATEGORIES = new Set([
+	'docs', 'lockfile', 'config-repo', 'config-build', 'config-ts',
+	'config-pkg', 'config-release',
+]);
+
+// Title-based skip (release/version/dep bumps). Match positron-pr-test-report.
+const SKIP_TITLE_PREFIXES = ['chore(deps):', 'build:', 'docs:', 'ci:', 'Bump '];
+
+/**
+ * Build the context object the grader consumes from raw, source-agnostic
+ * inputs. `gather-pr-context.mjs` supplies these from the GitHub API;
+ * `gather-local-context.mjs` supplies them from local git. The output schema is
+ * identical regardless of source.
+ *
+ * @param {object} raw
+ * @param {{ number: number|null, title: string, body: string, author: string, url: string, baseRef: string, headRef: string }} raw.pr
+ * @param {number} raw.additions Total additions across the change.
+ * @param {number} raw.deletions Total deletions across the change.
+ * @param {Array<{ path: string, additions: number, deletions: number }>} raw.files Changed files (unclassified).
+ * @param {string} raw.diff The full unified diff (untruncated; truncated here).
+ */
+export function buildContext(raw) {
+	const files = (raw.files || []).map(f => ({
+		path: f.path,
+		additions: f.additions ?? 0,
+		deletions: f.deletions ?? 0,
+		category: classify(f.path),
+	}));
+
+	const diffTruncated = raw.diff.length > MAX_DIFF_CHARS;
+	const diff = diffTruncated
+		? raw.diff.slice(0, MAX_DIFF_CHARS) + `\n\n[... diff truncated at ${MAX_DIFF_CHARS} chars; ${raw.diff.length - MAX_DIFF_CHARS} chars elided ...]`
+		: raw.diff;
+
+	const titleSkip = SKIP_TITLE_PREFIXES.some(p => raw.pr.title.startsWith(p));
+	const allFilesSkippable = files.length > 0 && files.every(f => SKIP_CATEGORIES.has(f.category));
+
+	let skip = null;
+	if (files.length === 0) {
+		skip = { reason: 'empty-pr', detail: 'No files changed.' };
+	} else if (titleSkip) {
+		skip = { reason: 'title-prefix', detail: `Title starts with a chore/release prefix.` };
+	} else if (allFilesSkippable) {
+		skip = { reason: 'docs-or-config-only', detail: 'All changed files are docs, config, or lockfiles.' };
+	}
+
+	const counts = files.reduce((acc, f) => {
+		acc[f.category] = (acc[f.category] || 0) + 1;
+		return acc;
+	}, {});
+	const testCount = files.filter(f => f.category.startsWith('test-')).length;
+	const sourceCount = files.filter(f => f.category.startsWith('source-')).length;
+
+	return {
+		pr: {
+			number: raw.pr.number,
+			title: raw.pr.title,
+			body: raw.pr.body || '',
+			author: raw.pr.author || '?',
+			url: raw.pr.url || '',
+			baseRef: raw.pr.baseRef,
+			headRef: raw.pr.headRef,
+		},
+		stats: {
+			additions: raw.additions ?? 0,
+			deletions: raw.deletions ?? 0,
+			fileCount: files.length,
+			testFileCount: testCount,
+			sourceFileCount: sourceCount,
+			categoryCounts: counts,
+		},
+		files,
+		diff,
+		diffTruncated,
+		skip,
+	};
+}
+
+function formatCategoryCounts(counts) {
+	const entries = Object.entries(counts || {}).sort((a, b) => b[1] - a[1]);
+	if (entries.length === 0) { return '(none)'; }
+	return entries.map(([k, v]) => `${k} (${v})`).join(', ');
+}
+
+/**
+ * Render the static "Not applicable" comment for PRs the pre-filter
+ * short-circuits (docs/config-only, chore titles, empty diffs). Shared so the
+ * CI workflow and the local skill emit identical skip verdicts.
+ */
+export function renderSkipComment(context) {
+	const { skip } = context;
+	const reasonText = {
+		'empty-pr': 'No files changed.',
+		'title-prefix': 'PR title indicates a chore / dependency / docs bump.',
+		'docs-or-config-only': 'All changed files are docs, config, or lockfiles -- no source behavior to test.',
+	}[skip.reason] || skip.detail || 'Skipped by pre-filter.';
+
+	return [
+		'## PETE\'s assessment 🧪',
+		'',
+		`**Verdict:** 🟡 Not applicable -- ${reasonText}`,
+		'',
+		`### What changed`,
+		`${context.stats.fileCount} file(s), categorized as: ${formatCategoryCounts(context.stats.categoryCounts)}.`,
+		'',
+		'---',
+		`<sub>PETE (Positron Extreme Test Experiment): an LLM-based test-coverage advisor, currently in pilot. Nothing to test here! A pre-filter handled this PR, so we skipped the LLM check. Comment \`/recheck-tests\` if that's wrong.</sub>`,
+	].join('\n');
+}

--- a/.claude/skills/pr-test-checker/scripts/gather-local-context.mjs
+++ b/.claude/skills/pr-test-checker/scripts/gather-local-context.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Build a context.json from the LOCAL git working tree, for the `pete-local`
+// skill -- a pre-PR preview of what PETE will say. Pure `git`: no `gh`, no
+// network, no auth. The classification, skip pre-filter, and context schema
+// come from the shared `context-core.mjs`, so this and the CI gatherer produce
+// identical output for the same diff.
+//
+// Working-tree mode: the diff is the current working tree (committed +
+// uncommitted + untracked) against the merge-base with the default branch.
+// Untracked files are included so a brand-new, not-yet-committed test file is
+// counted -- that is exactly the kind of change PETE cares about.
+//
+// Usage: node gather-local-context.mjs <output-path>
+
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { buildContext, renderSkipComment } from './context-core.mjs';
+
+const [, , outPath] = process.argv;
+if (!outPath) {
+	console.error('Usage: gather-local-context.mjs <output-path>');
+	process.exit(2);
+}
+
+// Run git. `allowExit1` tolerates exit code 1, which `git diff --no-index`
+// returns when files differ (the normal case) rather than as an error.
+function git(args, { allowExit1 = false } = {}) {
+	try {
+		return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024 });
+	} catch (err) {
+		if (allowExit1 && err.status === 1 && typeof err.stdout === 'string') {
+			return err.stdout;
+		}
+		console.error(`git ${args.join(' ')} failed:`, err.message);
+		process.exit(1);
+	}
+}
+
+function gitQuiet(args) {
+	try {
+		execFileSync('git', args, { stdio: 'ignore' });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// --- Resolve the base ref the eventual PR would target ----------------------
+
+function detectBaseRef() {
+	// Prefer origin/HEAD (e.g. "origin/main") -- what the PR base will be.
+	try {
+		// Suppress stderr: when origin/HEAD isn't set, git prints a "not a
+		// symbolic ref" fatal we handle by falling through to the candidates.
+		const r = execFileSync('git', ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+		if (r) { return r; }
+	} catch {
+		// origin/HEAD not set locally; fall through to candidates.
+	}
+	for (const cand of ['origin/main', 'origin/master', 'main', 'master']) {
+		if (gitQuiet(['rev-parse', '--verify', '--quiet', cand])) { return cand; }
+	}
+	return 'main';
+}
+
+const baseRef = detectBaseRef();
+const mergeBase = git(['merge-base', 'HEAD', baseRef]).trim();
+const headRef = git(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
+const author = (() => {
+	try { return execFileSync('git', ['config', 'user.name'], { encoding: 'utf8' }).trim() || '?'; } catch { return '?'; }
+})();
+
+// Title/body: when the branch has its own commits beyond the base, derive them
+// from the latest commit (the branch's work). When there are none, the latest
+// commit is just the base tip and has nothing to do with the working-tree
+// changes -- borrowing its subject would be misleading -- so use a clear
+// placeholder instead. This is a local preview, not a real PR, so we don't
+// accept overrides; this is enough to drive the skip pre-filter and give the
+// grader context.
+const commitsAhead = Number(git(['rev-list', '--count', `${baseRef}..HEAD`]).trim()) || 0;
+const title = commitsAhead > 0
+	? (git(['log', '-1', '--format=%s']).trim() || headRef)
+	: `[local preview] uncommitted working-tree changes on ${headRef}`;
+const body = commitsAhead > 0 ? git(['log', '-1', '--format=%b']).trim() : '';
+
+// --- Collect the working-tree diff (tracked + untracked) --------------------
+
+function countAddedLines(diffText) {
+	let n = 0;
+	for (const line of diffText.split('\n')) {
+		if (line.startsWith('+') && !line.startsWith('+++')) { n++; }
+	}
+	return n;
+}
+
+// Tracked changes (staged + unstaged) vs the merge-base.
+const trackedDiff = git(['diff', mergeBase]);
+const numstat = git(['diff', '--numstat', mergeBase]);
+
+const files = [];
+let totalAdd = 0;
+let totalDel = 0;
+
+for (const line of numstat.split('\n')) {
+	if (!line.trim()) { continue; }
+	const parts = line.split('\t');
+	if (parts.length < 3) { continue; }
+	const [a, d] = parts;
+	const path = parts.slice(2).join('\t');
+	const additions = a === '-' ? 0 : Number(a) || 0;
+	const deletions = d === '-' ? 0 : Number(d) || 0;
+	files.push({ path, additions, deletions });
+	totalAdd += additions;
+	totalDel += deletions;
+}
+
+// Untracked files: synthesize an added-file diff for each via --no-index
+// against /dev/null (git treats that literal specially on every OS).
+const untracked = git(['ls-files', '--others', '--exclude-standard']).split('\n').map(s => s.trim()).filter(Boolean);
+const untrackedDiffs = [];
+for (const path of untracked) {
+	const d = git(['diff', '--no-index', '--', '/dev/null', path], { allowExit1: true });
+	if (!d) { continue; }
+	const additions = countAddedLines(d);
+	files.push({ path, additions, deletions: 0 });
+	totalAdd += additions;
+	untrackedDiffs.push(d);
+}
+
+const diff = [trackedDiff, ...untrackedDiffs].filter(Boolean).join('\n');
+
+// --- Hand raw fields to the shared core -------------------------------------
+
+const context = buildContext({
+	pr: {
+		number: null,
+		title,
+		body,
+		author,
+		url: '',
+		baseRef,
+		headRef,
+	},
+	additions: totalAdd,
+	deletions: totalDel,
+	files,
+	diff,
+});
+
+writeFileSync(outPath, JSON.stringify(context, null, 2));
+
+// When the pre-filter short-circuits, render the static skip verdict here (via
+// the shared core) so the skill just presents it -- identical to what CI posts.
+if (context.skip) {
+	writeFileSync(join(dirname(outPath), 'comment.md'), renderSkipComment(context));
+}
+
+console.log(`[gather-local] base=${baseRef} head=${headRef} -- ${context.stats.fileCount} files, ${context.stats.testFileCount} test, ${context.stats.sourceFileCount} source, skip=${context.skip?.reason || 'no'}`);

--- a/.claude/skills/pr-test-checker/scripts/gather-pr-context.mjs
+++ b/.claude/skills/pr-test-checker/scripts/gather-pr-context.mjs
@@ -4,15 +4,17 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// Fetch PR metadata, classify each changed file, and emit a context.json the
-// agent driver can consume. Runs the cheap heuristic pre-filter so docs-only
-// and config-only PRs never invoke the LLM.
+// Fetch PR metadata + diff from the GitHub API and emit a context.json the
+// agent driver can consume. The classification, skip pre-filter, and context
+// schema live in the shared `context-core.mjs` so this and the local gatherer
+// produce identical output for the same diff. This file is a thin `gh` adapter.
 //
 // Usage: node gather-pr-context.mjs <pr-number> <output-path>
 // Requires: gh CLI authenticated; env GH_TOKEN or auth cache.
 
 import { execFileSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
+import { buildContext } from './context-core.mjs';
 
 const [, , prNumberArg, outPath] = process.argv;
 if (!prNumberArg || !outPath) {
@@ -26,10 +28,6 @@ if (!Number.isInteger(prNumber) || prNumber <= 0) {
 }
 
 const REPO = process.env.GITHUB_REPOSITORY || 'posit-dev/positron';
-// Defensive cap on the diff we send to the model. Sonnet handles >100k tokens
-// fine but huge diffs are usually generated/vendored code where deep analysis
-// adds no value. The agent can still Read individual files via tools.
-const MAX_DIFF_CHARS = Number(process.env.MAX_DIFF_CHARS) || 120_000;
 
 function gh(args) {
 	try {
@@ -40,7 +38,7 @@ function gh(args) {
 	}
 }
 
-// --- Fetch PR metadata and file list ----------------------------------------
+// --- Fetch raw PR metadata, file list, and diff -----------------------------
 
 const prJson = JSON.parse(gh([
 	'pr', 'view', String(prNumber),
@@ -49,91 +47,10 @@ const prJson = JSON.parse(gh([
 ]));
 
 const diffRaw = gh(['pr', 'diff', String(prNumber), '--repo', REPO]);
-const diffTruncated = diffRaw.length > MAX_DIFF_CHARS;
-const diff = diffTruncated
-	? diffRaw.slice(0, MAX_DIFF_CHARS) + `\n\n[... diff truncated at ${MAX_DIFF_CHARS} chars; ${diffRaw.length - MAX_DIFF_CHARS} chars elided ...]`
-	: diffRaw;
 
-// --- Classify each changed file ---------------------------------------------
+// --- Hand raw fields to the shared core -------------------------------------
 
-// Categories drive the rubric: the agent grades source changes against tests
-// at the appropriate level. Order matters -- the first matching pattern wins.
-const CATEGORIES = [
-	// Tests (any of these counts as "has tests")
-	{ name: 'test-vitest', match: p => /\.vitest\.(ts|tsx)$/.test(p) },
-	{ name: 'test-e2e', match: p => p.startsWith('test/e2e/') },
-	{ name: 'test-ext-host', match: p => p.startsWith('extensions/') && /(\.test|\.integrationTest)\.tsx?$/.test(p) },
-	{ name: 'test-mocha', match: p => p.startsWith('src/') && /(\.test|\.integrationTest)\.tsx?$/.test(p) },
-	{ name: 'test-other', match: p => /\/(test|tests|__tests__)\//.test(p) },
-
-	// Docs / config / lockfiles -- not source, not tests
-	{ name: 'docs', match: p => /\.(md|mdx)$/i.test(p) || /^(LICENSE|NOTICE)(\.txt)?$/i.test(p) || /CHANGELOG\.md$/i.test(p) || /CONTRIBUTING\.md$/i.test(p) || /(^|\/)README(\.[^\/]+)?$/i.test(p) },
-	{ name: 'lockfile', match: p => /(package-lock\.json|yarn\.lock|pnpm-lock\.yaml)$/i.test(p) },
-	{ name: 'config-repo', match: p => p.startsWith('.github/') || p.startsWith('.vscode/') || /^\.(editorconfig|gitignore|gitattributes)$/.test(p) },
-	{ name: 'config-build', match: p => p.startsWith('build/azure-pipelines/') || p.startsWith('build/checksums/') || p.startsWith('build/lib/i18n/') },
-	{ name: 'config-ts', match: p => /tsconfig.*\.json$/.test(p) || /vitest\.(config|workspace)\./.test(p) || /playwright\.config\./.test(p) || /eslint\.config\./.test(p) || /\.eslintrc/.test(p) || /\.prettierrc/.test(p) },
-	{ name: 'config-pkg', match: p => /\/package\.json$/.test(p) || p === 'package.json' },
-	{ name: 'config-release', match: p => p === 'product.json' || p.startsWith('versions/') },
-
-	// Source (everything else falling into known source roots)
-	{ name: 'source-positron', match: p => p.startsWith('src/') },
-	{ name: 'source-extension', match: p => p.startsWith('extensions/') },
-	{ name: 'source-e2e-infra', match: p => p.startsWith('test/e2e/') }, // unreachable -- e2e tests already caught above
-	{ name: 'source-other', match: () => true },
-];
-
-function classify(path) {
-	for (const c of CATEGORIES) {
-		if (c.match(path)) { return c.name; }
-	}
-	return 'source-other';
-}
-
-const files = (prJson.files || []).map(f => ({
-	path: f.path,
-	additions: f.additions ?? 0,
-	deletions: f.deletions ?? 0,
-	category: classify(f.path),
-}));
-
-// --- Decide whether to skip -------------------------------------------------
-
-// Skip categories: every changed file falls into one of these and the PR is
-// chore-shaped (no source touched, no tests touched). Matches the conjunctive
-// rule from positron-pr-test-report.
-const SKIP_CATEGORIES = new Set([
-	'docs', 'lockfile', 'config-repo', 'config-build', 'config-ts',
-	'config-pkg', 'config-release',
-]);
-
-// Title-based skip (release/version/dep bumps). Match positron-pr-test-report.
-const SKIP_TITLE_PREFIXES = ['chore(deps):', 'build:', 'docs:', 'ci:', 'Bump '];
-const titleSkip = SKIP_TITLE_PREFIXES.some(p => prJson.title.startsWith(p));
-
-const allFilesSkippable = files.length > 0 && files.every(f => SKIP_CATEGORIES.has(f.category));
-
-let skip = null;
-if (files.length === 0) {
-	skip = { reason: 'empty-pr', detail: 'No files changed.' };
-} else if (titleSkip) {
-	skip = { reason: 'title-prefix', detail: `Title starts with a chore/release prefix.` };
-} else if (allFilesSkippable) {
-	skip = { reason: 'docs-or-config-only', detail: 'All changed files are docs, config, or lockfiles.' };
-}
-
-// --- Summary counters (for the agent's prompt header) -----------------------
-
-const counts = files.reduce((acc, f) => {
-	acc[f.category] = (acc[f.category] || 0) + 1;
-	return acc;
-}, {});
-
-const testCount = files.filter(f => f.category.startsWith('test-')).length;
-const sourceCount = files.filter(f => f.category.startsWith('source-')).length;
-
-// --- Emit context.json ------------------------------------------------------
-
-const context = {
+const context = buildContext({
 	pr: {
 		number: prJson.number,
 		title: prJson.title,
@@ -143,19 +60,15 @@ const context = {
 		baseRef: prJson.baseRefName,
 		headRef: prJson.headRefName,
 	},
-	stats: {
-		additions: prJson.additions ?? 0,
-		deletions: prJson.deletions ?? 0,
-		fileCount: files.length,
-		testFileCount: testCount,
-		sourceFileCount: sourceCount,
-		categoryCounts: counts,
-	},
-	files,
-	diff,
-	diffTruncated,
-	skip,
-};
+	additions: prJson.additions ?? 0,
+	deletions: prJson.deletions ?? 0,
+	files: (prJson.files || []).map(f => ({
+		path: f.path,
+		additions: f.additions ?? 0,
+		deletions: f.deletions ?? 0,
+	})),
+	diff: diffRaw,
+});
 
 writeFileSync(outPath, JSON.stringify(context, null, 2));
-console.log(`[gather] wrote ${outPath} -- ${files.length} files, ${testCount} test, ${sourceCount} source, skip=${skip?.reason || 'no'}`);
+console.log(`[gather] wrote ${outPath} -- ${context.stats.fileCount} files, ${context.stats.testFileCount} test, ${context.stats.sourceFileCount} source, skip=${context.skip?.reason || 'no'}`);

--- a/.github/actions/pr-test-checker/analyze.mjs
+++ b/.github/actions/pr-test-checker/analyze.mjs
@@ -12,6 +12,9 @@
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import { readFileSync, existsSync, writeFileSync, realpathSync } from 'node:fs';
 import { join, resolve as resolvePath, relative as relativePath, isAbsolute } from 'node:path';
+// Shared with the local `pete-local` skill so both paths emit identical skip
+// verdicts. Lives in the skill tree (also checked out by the workflow).
+import { renderSkipComment } from '../../../.claude/skills/pr-test-checker/scripts/context-core.mjs';
 
 const WORK_DIR = mustEnv('WORK_DIR');
 const REPO_ROOT = mustEnv('REPO_ROOT');
@@ -53,35 +56,6 @@ function readJsonOrExit(path) {
 		console.error(`Failed to parse ${path}: ${err.message}`);
 		process.exit(1);
 	}
-}
-
-// --- Static comment for short-circuited skips -------------------------------
-
-function renderSkipComment(context) {
-	const { skip, pr } = context;
-	const reasonText = {
-		'empty-pr': 'No files changed.',
-		'title-prefix': 'PR title indicates a chore / dependency / docs bump.',
-		'docs-or-config-only': 'All changed files are docs, config, or lockfiles -- no source behavior to test.',
-	}[skip.reason] || skip.detail || 'Skipped by pre-filter.';
-
-	return [
-		'## PETE\'s assessment 🧪',
-		'',
-		`**Verdict:** 🟡 Not applicable -- ${reasonText}`,
-		'',
-		`### What changed`,
-		`${context.stats.fileCount} file(s), categorized as: ${formatCategoryCounts(context.stats.categoryCounts)}.`,
-		'',
-		'---',
-		`<sub>PETE (Positron Extreme Test Experiment): an LLM-based test-coverage advisor, currently in pilot. Nothing to test here! A pre-filter handled this PR, so we skipped the LLM check. Comment \`/recheck-tests\` if that's wrong.</sub>`,
-	].join('\n');
-}
-
-function formatCategoryCounts(counts) {
-	const entries = Object.entries(counts || {}).sort((a, b) => b[1] - a[1]);
-	if (entries.length === 0) { return '(none)'; }
-	return entries.map(([k, v]) => `${k} (${v})`).join(', ');
 }
 
 // --- Prompt building --------------------------------------------------------


### PR DESCRIPTION
### Summary

Adds a `pete-local` skill that lets developers preview PETE's test-coverage verdict on their working tree *before* opening a PR, grading in the current Claude Code session -- no Agent SDK and no separate API key.

The deterministic half of the PR test checker (file classification, the skip pre-filter, the context schema, and the skip-comment renderer) is extracted into a shared `context-core.mjs`, so the CI workflow and the new local path produce identical results for the same diff -- a single source of truth that updates both paths at once. The CI gatherer and `analyze.mjs` now consume the shared core; the workflow itself is unchanged.

**What's included:**
- `context-core.mjs` -- shared `classify()` / `buildContext()` / `renderSkipComment()` (pure, no I/O)
- `gather-local-context.mjs` -- pure-`git` working-tree gatherer (includes untracked files; uses a clear placeholder title when the branch has no commits beyond base)
- `pete-local/SKILL.md` -- the model-invocable orchestrator that runs the gatherer, reads the shared rubric, grades, and presents the verdict (posts nothing)
- `gather-pr-context.mjs` / `analyze.mjs` -- slimmed to consume the shared core (behavior-preserving)
- `pr-test-checker/SKILL.md` -- rubric wording generalized to read neutrally for both PR and local inputs

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

This change touches only PR-test-checker tooling and an agent skill -- no Positron product code and no e2e surface, so no e2e tags apply.

Manual verification:
1. CI parity (deterministic core unchanged for PRs): running `gather-pr-context.mjs <pr-number> <out>` produces the same `context.json` schema/classification as before. Verified locally against an existing PR.
2. Local skill: on a branch with changes, invoke `/pete-local` in Claude Code and confirm it gathers the working-tree diff, grades against the shared rubric, and presents a verdict without posting. Verified locally.

Note: the PR Test Checker runs its action/skill/rubric code from the default branch (main), not the PR branch (the pwn-request defense in `pr-test-checker.yml`). So CI PETE on *this* PR uses the existing main version of the checker -- the refactored shared core only takes effect for PRs opened after this merges. This PR does not exercise its own new code in CI.