### PR TITLE
Update Kallichore to 0.1.65

### DIFF
--- a/extensions/positron-supervisor/package.json
+++ b/extensions/positron-supervisor/package.json
@@ -189,7 +189,7 @@
   },
   "positron": {
     "binaryDependencies": {
-      "kallichore": "0.1.64"
+      "kallichore": "0.1.65"
     }
   },
   "extensionDependencies": [


### PR DESCRIPTION
Bumps Kallichore to 0.1.65. This release includes the following updates:

https://github.com/posit-dev/kallichore/pull/65: Fixes a spurious warning about `startup_environment_arg`. Fixes https://github.com/posit-dev/positron/issues/13952. 

https://github.com/posit-dev/kallichore/pull/66: Speculative fix for issues starting kernels after closing/reopening on Remote Desktop. May fix or improve https://github.com/posit-dev/positron/issues/13951. 

https://github.com/posit-dev/kallichore/pull/67: Run startup command in an interactive login shell. A defensive change meant to ensure that startup commands that depend on variables or initialization from shell startup scripts will succeed; related to https://github.com/posit-dev/positron/issues/13949. 