### PR TITLE
e2e: release-screenshot - use keybinding for preview focus

### DIFF
--- a/test/e2e/fixtures/keybindings.json
+++ b/test/e2e/fixtures/keybindings.json
@@ -152,5 +152,9 @@
     {
         "key": "cmd+j e",
         "command": "workbench.action.showCommands" // Show Command Palette
+    },
+    {
+        "key": "cmd+l b",
+        "command": "workbench.panel.positronPreview.focus"
     }
 ]

--- a/test/e2e/pages/hotKeys.ts
+++ b/test/e2e/pages/hotKeys.ts
@@ -185,6 +185,10 @@ export class HotKeys {
 		await this.pressHotKeys('Cmd+C', 'Send interrupt to console');
 	}
 
+	public async focusPreviewPanel() {
+		await this.pressHotKeys('Cmd+L B', 'Focus preview panel');
+	}
+
 	// ----------------------
 	// --- Layout Views ---
 	// ----------------------

--- a/test/e2e/release-screenshots/apps/run-app-button.screenshot.ts
+++ b/test/e2e/release-screenshots/apps/run-app-button.screenshot.ts
@@ -39,7 +39,7 @@ test.describe('Release Screenshots - Run App Button', () => {
 		await expect(editor.playButton).toBeVisible();
 
 		// customize layout
-		await runCommand('workbench.panel.positronPreview.focus');
+		await hotKeys.focusPreviewPanel();
 		await hotKeys.closePrimarySidebar();
 		await layouts.resizePanel({ y: -50 });
 

--- a/test/e2e/release-screenshots/notebooks/positron-notebook.screenshot.ts
+++ b/test/e2e/release-screenshots/notebooks/positron-notebook.screenshot.ts
@@ -26,10 +26,6 @@ test.use({
 	suiteId: __filename,
 });
 
-test.beforeAll(async ({ app }) => {
-	await app.workbench.assistant.loginModelProvider('anthropic-api');
-});
-
 test.afterEach(async ({ page, hotKeys, cleanup }) => {
 	await page.keyboard.press('Escape');
 	await clearAnnotations(page);
@@ -149,7 +145,8 @@ test.describe('Release Screenshots - Positron Notebook', () => {
 		await quickInput.clickOkButton();
 		await editors.waitForActiveTab('explore-energy-data.ipynb', false);
 
-		// Open Posit Assistant chat on the left and ask about the notebook.
+		// Log in to the model provider and open Posit Assistant chat on the left.
+		await positAssistant.loginModelProvider('anthropic-api');
 		await positAssistant.open();
 		await positAssistant.waitForReady();
 		await positAssistant.sendMessageAndWait('Tell me about this notebook', { timeout: 90_000, newConversation: true });

--- a/test/e2e/release-screenshots/notebooks/positron-notebook.screenshot.ts
+++ b/test/e2e/release-screenshots/notebooks/positron-notebook.screenshot.ts
@@ -103,7 +103,7 @@ test.describe('Release Screenshots - Positron Notebook', () => {
 	 * left having responded to "Tell me about this notebook", variables on right.
 	 */
 	test('Release Screenshot - positron-notebook.png', async ({ app, page, settings, python }) => {
-		const { notebooksPositron, variables, hotKeys, layouts, plots, quickaccess, quickInput, editors, positAssistant } = app.workbench;
+		const { notebooksPositron, variables, hotKeys, layouts, plots, quickaccess, quickInput, editors, positAssistant, assistant } = app.workbench;
 
 		await settings.set({
 			'positron.assistant.notebook.ghostCellSuggestions.enabled': false,
@@ -146,7 +146,7 @@ test.describe('Release Screenshots - Positron Notebook', () => {
 		await editors.waitForActiveTab('explore-energy-data.ipynb', false);
 
 		// Log in to the model provider and open Posit Assistant chat on the left.
-		await positAssistant.loginModelProvider('anthropic-api');
+		await assistant.loginModelProvider('anthropic-api');
 		await positAssistant.open();
 		await positAssistant.waitForReady();
 		await positAssistant.sendMessageAndWait('Tell me about this notebook', { timeout: 90_000, newConversation: true });


### PR DESCRIPTION
### Summary
Fixes a flake that appeared in CI:
- Remove `beforeAll` that called `loginModelProvider` for all three notebook screenshot tests — only one test uses the model (moved it there)
- Add `workbench.panel.positronPreview.focus` keybinding (`Cmd+L B`) and `hotKeys.focusPreviewPanel()` helper; use it in the run-app-button screenshot instead of `runCommand`

### QA Notes
[See run here](https://github.com/posit-dev/positron/actions/runs/27683601642).