### PR TITLE
PETE: react to /recheck-tests with eyes -> rocket

### DIFF
--- a/.github/workflows/pr-test-checker.yml
+++ b/.github/workflows/pr-test-checker.yml
@@ -204,6 +204,22 @@ jobs:
       group: pr-test-checker-${{ github.event.issue.number }}
       cancel-in-progress: true
     steps:
+      # Acknowledge the recheck command with an "eyes" reaction so the commenter
+      # gets immediate visual confirmation that PETE picked it up and is running.
+      # First step so it lands before the slower checkout/analysis steps. Capture
+      # the reaction id so the finalize step can remove it once PETE is done.
+      - name: Acknowledge recheck command
+        id: ack
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          REACTION_ID=$(gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content=eyes --jq '.id' 2>/dev/null) || echo "Failed to add reaction (non-fatal)"
+          echo "reaction_id=${REACTION_ID}" >> "$GITHUB_OUTPUT"
+
       - name: Resolve PR head SHA
         id: pr
         env:
@@ -250,3 +266,30 @@ jobs:
           anthropic-api-key: ${{ env.ANTHROPIC_KEY }}
           repo-root: ${{ github.workspace }}/pr-head
           force-regrade: "true"
+
+      # Replace the "eyes" acknowledgement with a terminal reaction once PETE
+      # finishes: rocket on success, confused on failure. Runs on always() so the
+      # comment never gets stuck showing "running". Skipped if the ack step never
+      # recorded a reaction id (e.g. the initial reaction POST failed).
+      - name: Finalize recheck reaction
+        if: always() && steps.ack.outputs.reaction_id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REACTION_ID: ${{ steps.ack.outputs.reaction_id }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          # Remove the "eyes" acknowledgement reaction.
+          gh api --method DELETE \
+            "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions/${REACTION_ID}" \
+            || echo "Failed to remove eyes reaction (non-fatal)"
+          # Signal completion: rocket on success, confused otherwise.
+          if [ "$JOB_STATUS" = "success" ]; then
+            FINAL=rocket
+          else
+            FINAL=confused
+          fi
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content="$FINAL" || echo "Failed to add ${FINAL} reaction (non-fatal)"


### PR DESCRIPTION
## Summary

When a positron-dev member comments a recheck command (`/recheck-tests`, `/rePETE`, `/re-pete`) on a PR, PETE now reacts to that comment so the commenter gets a visual signal that it was acknowledged and is running:

- **On command** -> adds an :eyes: reaction as the *first* step of the `on-recheck` job, before the slower checkout/secrets/analysis steps. The reaction id is captured for cleanup.
- **On finish** -> an `always()` finalize step removes the :eyes: and replaces it with :rocket: on success (or :confused: on failure), so the comment never stays stuck showing "running".

## Notes

- Reactions use the default `GITHUB_TOKEN` (the `on-recheck` job already declares `issues: write`, which covers reacting to issue comments). No new permissions or secrets.
- Every reaction API call is non-fatal (`|| echo ...`) -- a transient hiccup never fails the re-grade.
- The finalize step is skipped if the initial reaction POST failed (no captured id).
- Failure terminal reaction is :confused: rather than just deleting the :eyes: so failure stays legible instead of showing no reaction at all.

## Why it won't be dogfooded by its own CI run

The `issue_comment` half of this workflow runs from the **default branch** (GitHub reads `pull_request_target`/`issue_comment` workflow definitions from the base), so the reaction behavior only takes effect after merge -- a `/recheck-tests` on this PR won't show the new reactions.

## Test plan

- [ ] After merge, comment `/recheck-tests` on a PR and confirm :eyes: appears promptly, then flips to :rocket: when PETE posts its verdict.