### PR TITLE
E2E test: fix packages pane test on Windows

### DIFF
--- a/test/e2e/pages/packages.ts
+++ b/test/e2e/pages/packages.ts
@@ -265,7 +265,7 @@ export class Packages {
 		await this.quickInput.waitForQuickInputClosed();
 
 		// Wait for the "Installing packages..." toast to appear and then disappear
-		await this.toasts.waitForAppear('Installing packages...', { timeout: 10000 });
+		await this.toasts.waitForAppear('Installing packages...', { timeout: 30000 });
 		await this.toasts.waitForDisappear('Installing packages...', { timeout: 60000 });
 	}
 


### PR DESCRIPTION
We were not waiting long enough to see notification.

@:packages-pane @:win