### PR TITLE
e2e: fix session deleteAll() shutdown guard

### DIFF
--- a/test/e2e/pages/sessions.ts
+++ b/test/e2e/pages/sessions.ts
@@ -161,13 +161,10 @@ export class Sessions {
 					const currentSessionId = await this.getCurrentSessionId();
 					if (currentSessionId === sessionId) {
 						await this.page.getByTestId('trash-session').click();
-						return;
+					} else if (/(8080|8787)/.test(this.code.driver.currentPage.url())) {
+						return; // workaround for server/workbench: session is already gone
 					} else {
-						if (/(8080|8787)/.test(this.code.driver.currentPage.url())) {
-							return; // workaround for server/workbench
-						} else {
-							throw new Error(`Cannot delete session ${sessionId} because it does not exist`);
-						}
+						throw new Error(`Cannot delete session ${sessionId} because it does not exist`);
 					}
 				} else {
 					// More that one session: Delete via the context menu. (The trash icon
@@ -175,6 +172,10 @@ export class Sessions {
 					await this.deleteViaUI(sessionId);
 				}
 
+				// Wait for the session to actually shut down before returning. Skipping
+				// this (e.g. an early return after the trash click) lets delete() return
+				// while the instance is still visible; deleteAll()'s detach guard then
+				// passes instantly and the dying session races the next test's reuse scan.
 				await expect(this.page.getByText('Shutting down')).not.toBeVisible();
 				await expect(this.consoleInstance(sessionId)).not.toBeVisible();
 			}, `Delete session: ${sessionId}`).toPass();

--- a/test/e2e/tests/interpreters/interpreter-commands.test.ts
+++ b/test/e2e/tests/interpreters/interpreter-commands.test.ts
@@ -57,11 +57,10 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, Shutdown, Clear Inte
 	test('Python - Verify Interrupt Interpreter command works', async function ({ app, runCommand, sessions }) {
 		const { console } = app.workbench;
 
-		const pySession = await sessions.start('python');
+		await sessions.start('python');
 		await console.executeCode('Python', 'import time; time.sleep(5)', { waitForReady: false });
 		await runCommand('workbench.action.languageRuntime.interrupt');
 		await console.waitForConsoleContents('KeyboardInterrupt');
-		await sessions.delete(pySession.id);
 	});
 
 	test('Python - Verify Clear Saved Interpreter command works', { tag: [tags.WIN] }, async function ({ app, page, runCommand, sessions }) {

--- a/test/e2e/tests/interpreters/interpreter-commands.test.ts
+++ b/test/e2e/tests/interpreters/interpreter-commands.test.ts
@@ -57,10 +57,11 @@ test.describe('Interpreter Commands (Force Quit, Interrupt, Shutdown, Clear Inte
 	test('Python - Verify Interrupt Interpreter command works', async function ({ app, runCommand, sessions }) {
 		const { console } = app.workbench;
 
-		await sessions.start('python');
+		const pySession = await sessions.start('python');
 		await console.executeCode('Python', 'import time; time.sleep(5)', { waitForReady: false });
 		await runCommand('workbench.action.languageRuntime.interrupt');
 		await console.waitForConsoleContents('KeyboardInterrupt');
+		await sessions.delete(pySession.id);
 	});
 
 	test('Python - Verify Clear Saved Interpreter command works', { tag: [tags.WIN] }, async function ({ app, page, runCommand, sessions }) {


### PR DESCRIPTION
### Summary
Fixes a flake where a console session appears to vanish and the next test times out clicking its tab.

- `delete()` returned before its shutdown guard, so a dying session could race the next test. Now it waits for the session to fully shut down.

### QA Notes
@:interpreter @:web