### PR TITLE
e2e: remote-ssh - select Python 3.10.12 (uv: root) explicitly

### DIFF
--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -79,7 +79,14 @@ test.describe('Remote SSH', {
 
 
 		const pythonSession = await test.step(`Check that correct Python is being used`, async () => {
-			const pythonSession = await sshWorkbench.sessions.start('python');
+			// Select Python 3.10.12 (uv: root) specifically - disambiguator filters the picker
+			// to avoid picking a different 3.10.12 interpreter
+			const pythonSessionId = await sshWorkbench.sessions.startAndSkipMetadata({
+				language: 'Python',
+				version: '3.10.12',
+				disambiguator: 'uv: root',
+			});
+			const pythonSession = await sshWorkbench.sessions.getMetadata(pythonSessionId);
 			await sshWorkbench.console.pasteCodeToConsole('import sys; print(sys.executable)', true);
 			await sshWorkbench.console.waitForConsoleContents('/root/.venv/bin/python');
 

--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -81,10 +81,10 @@ test.describe('Remote SSH', {
 		const pythonSession = await test.step(`Check that correct Python is being used`, async () => {
 			// Append '(uv: root)' to the version so the picker selects the correct interpreter
 			// when multiple Python entries share the same version number.
-			// The base version still comes from POSITRON_PY_VER_SEL (set from the yml).
+			// The base version comes from POSITRON_PY_REMOTE_VER_SEL (set in the yml).
 			const pythonSessionId = await sshWorkbench.sessions.startAndSkipMetadata({
 				language: 'Python',
-				version: `${process.env.POSITRON_PY_VER_SEL} (uv: root)`,
+				version: `${process.env.POSITRON_PY_REMOTE_VER_SEL} (uv: root)`,
 			});
 			const pythonSession = await sshWorkbench.sessions.getMetadata(pythonSessionId);
 			await sshWorkbench.console.pasteCodeToConsole('import sys; print(sys.executable)', true);

--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -79,11 +79,12 @@ test.describe('Remote SSH', {
 
 
 		const pythonSession = await test.step(`Check that correct Python is being used`, async () => {
-			// disambiguator narrows the picker to (uv: root) when multiple interpreters
-			// share the same version string; version still comes from POSITRON_PY_VER_SEL
+			// Append '(uv: root)' to the version so the picker selects the correct interpreter
+			// when multiple Python entries share the same version number.
+			// The base version still comes from POSITRON_PY_VER_SEL (set from the yml).
 			const pythonSessionId = await sshWorkbench.sessions.startAndSkipMetadata({
 				language: 'Python',
-				disambiguator: 'uv: root',
+				version: `${process.env.POSITRON_PY_VER_SEL} (uv: root)`,
 			});
 			const pythonSession = await sshWorkbench.sessions.getMetadata(pythonSessionId);
 			await sshWorkbench.console.pasteCodeToConsole('import sys; print(sys.executable)', true);

--- a/test/e2e/tests/remote-ssh/remote-ssh.test.ts
+++ b/test/e2e/tests/remote-ssh/remote-ssh.test.ts
@@ -79,11 +79,10 @@ test.describe('Remote SSH', {
 
 
 		const pythonSession = await test.step(`Check that correct Python is being used`, async () => {
-			// Select Python 3.10.12 (uv: root) specifically - disambiguator filters the picker
-			// to avoid picking a different 3.10.12 interpreter
+			// disambiguator narrows the picker to (uv: root) when multiple interpreters
+			// share the same version string; version still comes from POSITRON_PY_VER_SEL
 			const pythonSessionId = await sshWorkbench.sessions.startAndSkipMetadata({
 				language: 'Python',
-				version: '3.10.12',
 				disambiguator: 'uv: root',
 			});
 			const pythonSession = await sshWorkbench.sessions.getMetadata(pythonSessionId);


### PR DESCRIPTION
## Summary

- A product change introduced a second Python 3.10.12 interpreter in the remote SSH docker environment, causing the test to pick the wrong one.
- Updated the \"Check that correct Python is being used\" step to use `startAndSkipMetadata` with `disambiguator: 'uv: root'`, which appends the disambiguator to the quick pick search input so the picker filters down to `Python 3.10.12 (uv: root)` specifically.
- Temporary fix while the product-side change is being discussed with devs.

## Test plan

@:remote-ssh