### PR TITLE
e2e: clear workspace before copying cached repo

### DIFF
--- a/test/e2e/infra/test-runner/utils.ts
+++ b/test/e2e/infra/test-runner/utils.ts
@@ -68,6 +68,10 @@ export function cloneTestRepo(workspacePath = process.env.WORKSPACE_PATH || 'WOR
 }
 
 function copyRepo(source: string, destination: string): void {
+	// Start clean: git pack files are read-only (0444), so copying over a
+	// previous copy fails with "Permission denied".
+	rimraf.sync(destination);
+	fs.mkdirSync(destination, { recursive: true });
 	if (process.platform === 'win32') {
 		cp.execSync(`xcopy /E /H /K /Y "${source}\\*" "${destination}\\"`);
 	} else {


### PR DESCRIPTION
### Summary
`cloneTestRepo` copies the cached `qa-example-content` into the workspace with `cp -R source/. dest`. Git writes pack files read-only (0444), so when the destination already holds a previous copy, `cp` can't overwrite them and fails with "Permission denied".

- Clears and recreates the destination before copying, so the workspace is always populated from a clean state.
- Fixes the failure seen via the VS Code Playwright extension, where `POSITRON_TEST_DATA_PATH` points at a persistent `/tmp/positron-e2e` path (the CLI uses a self-purging temp dir and usually avoids it).

### QA Notes
After pulling, restart the Playwright test-server once (Testing panel refresh, or `pkill -f "@playwright/test/cli.js test-server"`) so the extension reloads the changed infra module; otherwise the stale daemon keeps serving the old code.