### PR TITLE
python: store the global active interpreter in state

### DIFF
--- a/extensions/positron-python/src/client/common/interpreterPathService.ts
+++ b/extensions/positron-python/src/client/common/interpreterPathService.ts
@@ -31,6 +31,9 @@ export const remoteWorkspaceKeysForWhichTheCopyIsDone_Key = 'remoteWorkspaceKeys
 export const remoteWorkspaceFolderKeysForWhichTheCopyIsDone_Key = 'remoteWorkspaceFolderKeysForWhichTheCopyIsDone_Key';
 export const isRemoteGlobalSettingCopiedKey = 'isRemoteGlobalSettingCopiedKey';
 export const defaultInterpreterPathSetting: keyof IPythonSettings = 'defaultInterpreterPath';
+// --- Start Positron ---
+const globalInterpreterPathKey = 'GLOBAL_INTERPRETER_PATH';
+// --- End Positron ---
 const CI_PYTHON_PATH = getCIPythonPath();
 
 export function getCIPythonPath(): string {
@@ -46,6 +49,11 @@ export class InterpreterPathService implements IInterpreterPathService {
     }
     public _didChangeInterpreterEmitter = new EventEmitter<InterpreterConfigurationScope>();
     private fileSystemPaths: FileSystemPaths;
+    // --- Start Positron ---
+    // Last-known User-scope python.defaultInterpreterPath value. Used by onDidChangeConfiguration to
+    // tell a genuine global setting edit apart from a workspace/workspace-folder edit.
+    private lastGlobalDefaultInterpreterPath: string | undefined;
+    // --- End Positron ---
     constructor(
         @inject(IPersistentStateFactory) private readonly persistentStateFactory: IPersistentStateFactory,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
@@ -54,11 +62,43 @@ export class InterpreterPathService implements IInterpreterPathService {
     ) {
         disposables.push(this.workspaceService.onDidChangeConfiguration(this.onDidChangeConfiguration.bind(this)));
         this.fileSystemPaths = FileSystemPaths.withDefaults();
+        // --- Start Positron ---
+        this.lastGlobalDefaultInterpreterPath = this.readGlobalDefaultInterpreterPath();
+        // --- End Positron ---
     }
 
     public async onDidChangeConfiguration(event: ConfigurationChangeEvent) {
         if (event.affectsConfiguration(`python.${defaultInterpreterPathSetting}`)) {
             // --- Start Positron ---
+            // inspect() prefers the internal global state over python.defaultInterpreterPath, so a
+            // user edit to the global setting would otherwise be shadowed by a value a prior session
+            // start persisted (e.g. /old/python keeps resolving). When the User-scope global value
+            // changes, clear the internal global state so the edited setting becomes the effective
+            // global value; the next session start repopulates it. Without this, the fire below is
+            // deduped away because the effective interpreter never changes.
+            //
+            // affectsConfiguration() is also true for workspace/workspace-folder edits, which must
+            // not wipe GLOBAL_INTERPRETER_PATH (it is only written and consumed in the no-workspace
+            // case). Comparing the inspected global value before/after isolates a genuine User-scope
+            // edit from a project-scoped one, regardless of which window made the change.
+            const newGlobalDefaultInterpreterPath = this.readGlobalDefaultInterpreterPath();
+            if (newGlobalDefaultInterpreterPath !== this.lastGlobalDefaultInterpreterPath) {
+                const persistentGlobal = this.persistentStateFactory.createGlobalPersistentState<string | undefined>(
+                    this.getGlobalSettingKey(),
+                    undefined,
+                );
+                if (persistentGlobal.value !== undefined) {
+                    await persistentGlobal.updateValue(undefined);
+                }
+                // updateValue() swallows storage failures rather than rejecting, so confirm the
+                // clear actually landed by re-reading before advancing the baseline. Otherwise a
+                // failed clear would be masked from future config events and the stale interpreter
+                // would keep shadowing the edited setting; leaving the baseline unchanged lets a
+                // later config event retry.
+                if (persistentGlobal.value === undefined) {
+                    this.lastGlobalDefaultInterpreterPath = newGlobalDefaultInterpreterPath;
+                }
+            }
             // This event only fires for real configuration changes: in Positron the extension
             // never writes `python.defaultInterpreterPath` itself (the Global branch of update()
             // below is disabled), so there is no "initial apply" fire at activation to filter out.
@@ -77,6 +117,14 @@ export class InterpreterPathService implements IInterpreterPathService {
 
     public inspect(resource: Resource, useOldKey = false): InspectInterpreterSettingType {
         resource = PythonSettings.getSettingsUriAndTarget(resource, this.workspaceService).uri;
+        // --- Start Positron ---
+        // Read the internal global persistent state outside the resource check so it applies even
+        // when no workspace folder is open. Falls back to python.defaultInterpreterPath.
+        const internalGlobalSetting = this.persistentStateFactory.createGlobalPersistentState<string | undefined>(
+            this.getGlobalSettingKey(useOldKey),
+            undefined,
+        );
+        // --- End Positron ---
         let workspaceFolderSetting: IPersistentState<string | undefined> | undefined;
         let workspaceSetting: IPersistentState<string | undefined> | undefined;
         if (resource) {
@@ -92,7 +140,13 @@ export class InterpreterPathService implements IInterpreterPathService {
         const defaultInterpreterPath: InspectInterpreterSettingType =
             this.workspaceService.getConfiguration('python', resource)?.inspect<string>('defaultInterpreterPath') ?? {};
         return {
-            globalValue: defaultInterpreterPath.globalValue,
+            // --- Start Positron ---
+            // globalValue: defaultInterpreterPath.globalValue,
+            globalValue:
+                internalGlobalSetting.value && internalGlobalSetting.value !== 'python'
+                    ? internalGlobalSetting.value
+                    : defaultInterpreterPath.globalValue,
+            // --- End Positron ---
             workspaceFolderValue:
                 !workspaceFolderSetting?.value || workspaceFolderSetting?.value === 'python'
                     ? defaultInterpreterPath.workspaceFolderValue
@@ -130,12 +184,25 @@ export class InterpreterPathService implements IInterpreterPathService {
         resource = PythonSettings.getSettingsUriAndTarget(resource, this.workspaceService).uri;
         if (configTarget === ConfigurationTarget.Global) {
             // --- Start Positron ---
-            // do not update global interpreter path setting via the Select Interpreter dropdown
+            // Store the global active interpreter in internal persistent state, never in settings.json.
             // const pythonConfig = this.workspaceService.getConfiguration('python');
             // const globalValue = pythonConfig.inspect<string>('defaultInterpreterPath')!.globalValue;
             // if (globalValue !== pythonPath) {
             //     await pythonConfig.update('defaultInterpreterPath', pythonPath, true);
             // }
+            const persistentGlobal = this.persistentStateFactory.createGlobalPersistentState<string | undefined>(
+                this.getGlobalSettingKey(),
+                undefined,
+            );
+            if (persistentGlobal.value !== pythonPath) {
+                await persistentGlobal.updateValue(pythonPath);
+                this._didChangeInterpreterEmitter.fire({
+                    uri: undefined,
+                    configTarget: ConfigurationTarget.Global,
+                    startSession: options?.startSession ?? true,
+                    source: options?.source ?? 'unspecified',
+                });
+            }
             // --- End Positron ---
             return;
         }
@@ -165,6 +232,24 @@ export class InterpreterPathService implements IInterpreterPathService {
         }
     }
 
+    // --- Start Positron ---
+    public getGlobalSettingKey(useOldKey = false): string {
+        const settingKey = globalInterpreterPathKey;
+        if (!useOldKey && this.appEnvironment.remoteName) {
+            return `${this.appEnvironment.remoteName}_${settingKey}`;
+        }
+        return settingKey;
+    }
+
+    /**
+     * Read the User-scope (global) value of python.defaultInterpreterPath, or undefined if unset.
+     */
+    private readGlobalDefaultInterpreterPath(): string | undefined {
+        return this.workspaceService.getConfiguration('python')?.inspect<string>(defaultInterpreterPathSetting)
+            ?.globalValue;
+    }
+    // --- End Positron ---
+
     public getSettingKey(
         resource: Uri,
         configTarget: ConfigurationTarget.Workspace | ConfigurationTarget.WorkspaceFolder,
@@ -177,10 +262,10 @@ export class InterpreterPathService implements IInterpreterPathService {
         } else {
             settingKey = this.workspaceService.workspaceFile
                 ? `WORKSPACE_INTERPRETER_PATH_${this.fileSystemPaths.normCase(
-                      this.workspaceService.workspaceFile.fsPath,
-                  )}`
+                    this.workspaceService.workspaceFile.fsPath,
+                )}`
                 : // Only a single folder is opened, use fsPath of the folder as key
-                  `WORKSPACE_FOLDER_INTERPRETER_PATH_${folderKey}`;
+                `WORKSPACE_FOLDER_INTERPRETER_PATH_${folderKey}`;
         }
         if (!useOldKey && this.appEnvironment.remoteName) {
             return `${this.appEnvironment.remoteName}_${settingKey}`;
@@ -206,9 +291,14 @@ export class InterpreterPathService implements IInterpreterPathService {
         // --- End Positron ---
         await Promise.all([
             // --- Start Positron ---
+            // adding migrationOptions to these two
             this._copyWorkspaceFolderValueToNewStorage(resource, oldSettings.workspaceFolderValue, migrationOptions),
             this._copyWorkspaceValueToNewStorage(resource, oldSettings.workspaceValue, migrationOptions),
-            this._moveGlobalSettingValueToNewStorage(oldSettings.globalValue, migrationOptions),
+            // Do not copy python.defaultInterpreterPath into internal global storage; it is a
+            // read-only fallback in inspect() only, so live changes to the user's setting are not
+            // shadowed by a stale persisted copy. Session start handles the authoritative write.
+            //
+            // this._moveGlobalSettingValueToNewStorage(oldSettings.globalValue),
             // --- End Positron ---
         ]);
     }
@@ -268,12 +358,10 @@ export class InterpreterPathService implements IInterpreterPathService {
         }
     }
 
-    public async _moveGlobalSettingValueToNewStorage(
-        value: string | undefined,
-        // --- Start Positron ---
-        options?: InterpreterPathUpdateOptions,
-        // --- End Positron ---
-    ) {
+    // --- Start Positron ---
+    // This method should not be used
+    // --- End Positron ---
+    public async _moveGlobalSettingValueToNewStorage(value: string | undefined) {
         // Move global setting into the new storage if it hasn't been moved already
         const isGlobalSettingCopiedStorage = this.persistentStateFactory.createGlobalPersistentState<boolean>(
             isRemoteGlobalSettingCopiedKey,
@@ -281,9 +369,7 @@ export class InterpreterPathService implements IInterpreterPathService {
         );
         const shouldUpdateGlobalSetting = !isGlobalSettingCopiedStorage.value;
         if (shouldUpdateGlobalSetting) {
-            // --- Start Positron ---
-            await this.update(undefined, ConfigurationTarget.Global, value, options);
-            // --- End Positron ---
+            await this.update(undefined, ConfigurationTarget.Global, value);
             await isGlobalSettingCopiedStorage.updateValue(true);
         }
     }

--- a/extensions/positron-python/src/client/interpreter/interpreterService.ts
+++ b/extensions/positron-python/src/client/interpreter/interpreterService.ts
@@ -94,7 +94,11 @@ export class InterpreterService implements Disposable, IInterpreterService {
         return this.didChangeInterpreterConfigurationEmitter.event;
     }
 
-    public _pythonPathSetting: string | undefined = '';
+    // --- Start Positron ---
+    // Keyed by getWorkspaceFolderIdentifier(resource) so changes in one folder don't mask another.
+    // public _pythonPathSetting: string | undefined = '';
+    public _pythonPathSetting: Map<string, string> = new Map();
+    // --- End Positron ---
 
     private readonly didChangeInterpreterConfigurationEmitter = new EventEmitter<Uri | undefined>();
 
@@ -298,9 +302,13 @@ export class InterpreterService implements Disposable, IInterpreterService {
         await sleep(1);
         const pySettings = this.configService.getSettings(resource);
         this.didChangeInterpreterConfigurationEmitter.fire(resource);
-        if (this._pythonPathSetting === '' || this._pythonPathSetting !== pySettings.pythonPath) {
-            this._pythonPathSetting = pySettings.pythonPath;
-            // --- Start Positron ---
+        // --- Start Positron ---
+        const workspaceKey = this.serviceContainer
+            .get<IWorkspaceService>(IWorkspaceService)
+            .getWorkspaceFolderIdentifier(resource);
+        const previousPath = this._pythonPathSetting.get(workspaceKey);
+        if (previousPath === undefined || previousPath !== pySettings.pythonPath) {
+            this._pythonPathSetting.set(workspaceKey, pySettings.pythonPath);
             this.fireInterpreterChanged(resource, scope.startSession ?? true, scope.source ?? 'unspecified');
             // --- End Positron ---
             const workspaceFolder = this.serviceContainer
@@ -310,13 +318,19 @@ export class InterpreterService implements Disposable, IInterpreterService {
                 path: pySettings.pythonPath,
                 resource: workspaceFolder,
             });
-            const workspaceKey = this.serviceContainer
-                .get<IWorkspaceService>(IWorkspaceService)
-                .getWorkspaceFolderIdentifier(resource);
+            // --- Start Positron ---
+            // moved this up
+            // const workspaceKey = this.serviceContainer
+            //     .get<IWorkspaceService>(IWorkspaceService)
+            //     .getWorkspaceFolderIdentifier(resource);
+            // --- End Positron ---
             this.activeInterpreterPaths.set(workspaceKey, { path: pySettings.pythonPath, workspaceFolder });
             const interpreterDisplay = this.serviceContainer.get<IInterpreterDisplay>(IInterpreterDisplay);
             interpreterDisplay.refresh().catch((ex) => traceError('Python Extension: display.refresh', ex));
-            await this.ensureEnvironmentContainsPython(this._pythonPathSetting, workspaceFolder);
+            // --- Start Positron ---
+            // await this.ensureEnvironmentContainsPython(this._pythonPathSetting, workspaceFolder);
+            await this.ensureEnvironmentContainsPython(pySettings.pythonPath, workspaceFolder);
+            // --- End Positron ---
         }
     }
 

--- a/extensions/positron-python/src/client/interpreter/virtualEnvs/activatedEnvLaunch.ts
+++ b/extensions/positron-python/src/client/interpreter/virtualEnvs/activatedEnvLaunch.ts
@@ -125,7 +125,15 @@ export class ActivatedEnvironmentLaunch implements IActivatedEnvironmentLaunch {
     private async setInterpeterInStorage(prefix: string) {
         const { workspaceFolders } = this.workspaceService;
         if (!workspaceFolders || workspaceFolders.length === 0) {
-            await this.pythonPathUpdaterService.updatePythonPath(prefix, ConfigurationTarget.Global, 'load');
+            await this.pythonPathUpdaterService.updatePythonPath(
+                prefix,
+                ConfigurationTarget.Global,
+                'load',
+                // --- Start Positron ---
+                undefined,
+                { startSession: false, source: 'load' },
+            );
+            // --- End Positron ---
         } else {
             await this.pythonPathUpdaterService.updatePythonPath(
                 prefix,

--- a/extensions/positron-python/src/client/positron/languageServerManager.ts
+++ b/extensions/positron-python/src/client/positron/languageServerManager.ts
@@ -11,6 +11,7 @@ import { IServiceContainer } from '../ioc/types';
 import { IWorkspaceService } from '../common/application/types';
 import { IPythonPathUpdaterServiceManager } from '../interpreter/configuration/types';
 import { IPersistentState, IPersistentStateFactory } from '../common/types';
+import { getActiveInterpreterConfigTarget } from './util';
 
 const lastForegroundSessionIdKey = 'positron.lastForegroundSessionId';
 
@@ -85,27 +86,11 @@ class LanguageServerManager implements vscode.Disposable {
     }
 
     /**
-     * Update the Python path as required by Pyright.
-     * This behavior only applies to workspaces; non-workspace editors do not update properly yet.
+     * Update the Python path as required by language servers.
      */
     private async updatePythonPath(pythonPath: string): Promise<void> {
-        let folderUri: vscode.Uri | undefined;
-        let configTarget: vscode.ConfigurationTarget;
-
-        const { workspaceFolders } = this._workspaceService;
-
-        if (workspaceFolders === undefined || workspaceFolders.length === 0) {
-            folderUri = undefined;
-            configTarget = vscode.ConfigurationTarget.Global;
-        } else if (this._workspaceService.workspaceFile) {
-            folderUri = this._workspaceService.workspaceFile;
-            configTarget = vscode.ConfigurationTarget.Workspace;
-        } else {
-            folderUri = workspaceFolders[0].uri;
-            configTarget = vscode.ConfigurationTarget.WorkspaceFolder;
-        }
-
-        // Storage-only: Pyright needs the path written but the session is already running.
+        const { configTarget, folderUri } = getActiveInterpreterConfigTarget(this._workspaceService);
+        // Storage-only: language servers need the path written but the session is already running.
         // 'load' means programmatic (not a user interpreter selection), so it avoids tracking
         // this as a user-selected environment.
         await this._pythonPathUpdaterService.updatePythonPath(pythonPath, configTarget, 'load', folderUri, {
@@ -117,7 +102,7 @@ class LanguageServerManager implements vscode.Disposable {
     /**
      *
      * Activates the console LSP for the given session. Deactivates all other console LSPs first.
-     * Also updates the Python path to the given session's runtime path as required by Pyright.
+     * Also updates the Python path to the given session's runtime path.
      *
      * @param session The Python runtime session to activate the language server for.
      * @param allSessions Python runtime sessions to deactivate, defaults to all non-foreground sessions.
@@ -144,7 +129,6 @@ class LanguageServerManager implements vscode.Disposable {
             // Activate the foreground session LSP.
             session.activateLsp(reason),
 
-            // Update the Python path as required by Pyright.
             this.updatePythonPath(session.runtimeMetadata.runtimePath),
         ]);
     }

--- a/extensions/positron-python/src/client/positron/session.ts
+++ b/extensions/positron-python/src/client/positron/session.ts
@@ -38,7 +38,7 @@ import { showErrorMessage } from '../common/vscodeApis/windowApis';
 import { Console } from '../common/utils/localize';
 import { Architecture } from '../common/utils/platform';
 import { getIpykernelBundle, IpykernelBundle } from './ipykernel';
-import { whenTimeout } from './util';
+import { getActiveInterpreterConfigTarget, whenTimeout } from './util';
 import { PackageManagerFactory } from './packages/packageManagerFactory';
 import { IPackageManager } from './packages/types';
 
@@ -514,12 +514,12 @@ export class PythonRuntimeSession implements positron.LanguageRuntimeSession, vs
             // Update the active environment in the Python extension.
             // Storage-only: the session is already starting here, so the listener in
             // PythonRuntimeManager must not start another one.
-            this._interpreterPathService.update(
-                undefined,
-                vscode.ConfigurationTarget.WorkspaceFolder,
-                interpreter.path,
-                { startSession: false, source: 'positron-session-start' },
-            );
+            const workspaceService = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);
+            const { configTarget, folderUri } = getActiveInterpreterConfigTarget(workspaceService);
+            this._interpreterPathService.update(folderUri, configTarget, interpreter.path, {
+                startSession: false,
+                source: 'positron-session-start',
+            });
         }
 
         // Register for console width changes, if we haven't already

--- a/extensions/positron-python/src/client/positron/util.ts
+++ b/extensions/positron-python/src/client/positron/util.ts
@@ -1,11 +1,12 @@
 /* eslint-disable max-classes-per-file */
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2022 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2022-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
 import { traceVerbose } from '../logging';
+import { IWorkspaceService } from '../common/application/types';
 
 export class PromiseHandles<T> {
     resolve!: (value: T | Promise<T>) => void;
@@ -29,6 +30,26 @@ export function delay(ms: number): Promise<void> {
 export async function whenTimeout<T>(ms: number, fn: () => T): Promise<T> {
     await delay(ms);
     return fn();
+}
+
+/**
+ * Returns the ConfigurationTarget and resource Uri for the current workspace state:
+ * - No workspace folder: Global with undefined resource
+ * - Multi-folder workspace (.code-workspace): Workspace with workspace file uri
+ * - Single folder workspace: WorkspaceFolder with folder[0] uri
+ */
+export function getActiveInterpreterConfigTarget(workspaceService: IWorkspaceService): {
+    configTarget: vscode.ConfigurationTarget;
+    folderUri: vscode.Uri | undefined;
+} {
+    const { workspaceFolders } = workspaceService;
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+        return { configTarget: vscode.ConfigurationTarget.Global, folderUri: undefined };
+    }
+    if (workspaceService.workspaceFile) {
+        return { configTarget: vscode.ConfigurationTarget.Workspace, folderUri: workspaceService.workspaceFile };
+    }
+    return { configTarget: vscode.ConfigurationTarget.WorkspaceFolder, folderUri: workspaceFolders[0].uri };
 }
 
 // Check if the current workspace contains files matching any of the passed glob ptaterns

--- a/extensions/positron-python/src/test/common/interpreterPathService.unit.test.ts
+++ b/extensions/positron-python/src/test/common/interpreterPathService.unit.test.ts
@@ -20,6 +20,9 @@ import {
     getCIPythonPath,
     InterpreterPathService,
 } from '../../client/common/interpreterPathService';
+// --- Start Positron ---
+const globalInterpreterPathKey = 'GLOBAL_INTERPRETER_PATH';
+// --- End Positron ---
 import { FileSystemPaths } from '../../client/common/platform/fs-paths';
 import { InterpreterConfigurationScope, IPersistentState, IPersistentStateFactory } from '../../client/common/types';
 import { createDeferred, sleep } from '../../client/common/utils/async';
@@ -60,50 +63,54 @@ suite('Interpreter Path Service', async () => {
         sinon.restore();
     });
 
+    // --- Start Positron ---
     test('Global settings are not updated if stored value is same as new value', async () => {
-        const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
-        workspaceService.setup((w) => w.getConfiguration('python')).returns(() => workspaceConfig.object);
-        workspaceConfig
-            .setup((w) => w.inspect<string>('defaultInterpreterPath'))
-            .returns(
-                () =>
-                    ({
-                        globalValue: interpreterPath,
-                    } as any),
-            );
-        workspaceConfig
-            .setup((w) => w.update('defaultInterpreterPath', interpreterPath, true))
+        const persistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
+        persistentStateFactory
+            .setup((p) => p.createGlobalPersistentState<string | undefined>(globalInterpreterPathKey, undefined))
+            .returns(() => persistentState.object);
+        persistentState.setup((p) => p.value).returns(() => interpreterPath);
+        persistentState
+            .setup((p) => p.updateValue(TypeMoq.It.isAny()))
             .returns(() => Promise.resolve())
             .verifiable(TypeMoq.Times.never());
 
-        await interpreterPathService.update(resource, ConfigurationTarget.Global, interpreterPath);
+        await interpreterPathService.update(undefined, ConfigurationTarget.Global, interpreterPath);
 
-        workspaceConfig.verifyAll();
+        persistentState.verifyAll();
     });
 
-    test('Global settings are correctly updated otherwise', async () => {
-        const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
-        workspaceService.setup((w) => w.getConfiguration('python')).returns(() => workspaceConfig.object);
-        workspaceConfig
-            .setup((w) => w.inspect<string>('defaultInterpreterPath'))
-            .returns(
-                () =>
-                    ({
-                        globalValue: 'storedValue',
-                    } as any),
-            );
-        workspaceConfig
-            .setup((w) => w.update('defaultInterpreterPath', interpreterPath, true))
+    test('Global settings are correctly updated and the emitter fires', async () => {
+        const persistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
+        persistentStateFactory
+            .setup((p) => p.createGlobalPersistentState<string | undefined>(globalInterpreterPathKey, undefined))
+            .returns(() => persistentState.object);
+        persistentState.setup((p) => p.value).returns(() => 'storedValue');
+        persistentState
+            .setup((p) => p.updateValue(interpreterPath))
             .returns(() => Promise.resolve())
-            /// --- Start Positron ---
-            // Do not reset defaultInterpreterPath setting unless the user does
-            .verifiable(TypeMoq.Times.never());
-        // --- End Positron ---
+            .verifiable(TypeMoq.Times.once());
 
-        await interpreterPathService.update(resource, ConfigurationTarget.Global, interpreterPath);
+        const _didChangeInterpreterEmitter = TypeMoq.Mock.ofType<EventEmitter<InterpreterConfigurationScope>>();
+        interpreterPathService._didChangeInterpreterEmitter = _didChangeInterpreterEmitter.object;
+        _didChangeInterpreterEmitter
+            .setup((emitter) =>
+                emitter.fire({
+                    uri: undefined,
+                    configTarget: ConfigurationTarget.Global,
+                    startSession: true,
+                    source: 'unspecified',
+                }),
+            )
+            .returns(() => undefined)
+            .verifiable(TypeMoq.Times.once());
 
-        workspaceConfig.verifyAll();
+        await interpreterPathService.update(undefined, ConfigurationTarget.Global, interpreterPath);
+
+        persistentState.verifyAll();
+        _didChangeInterpreterEmitter.verifyAll();
     });
+    // --- End Positron ---
 
     test('Workspace settings are not updated if stored value is same as new value', async () => {
         const expectedSettingKey = `WORKSPACE_FOLDER_INTERPRETER_PATH_${resource.fsPath}`;
@@ -299,16 +306,20 @@ suite('Interpreter Path Service', async () => {
             .setup((w) => w.inspect<string>('defaultInterpreterPath'))
             .returns(
                 () =>
-                    ({
-                        globalValue: 'default/path/to/interpreter',
-                    } as any),
+                ({
+                    globalValue: 'default/path/to/interpreter',
+                } as any),
             );
-        const persistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
+        // --- Start Positron ---
         workspaceService.setup((w) => w.workspaceFolders).returns(() => undefined);
+        // inspect() now always reads the internal global state; no internal value is set here so
+        // it falls back to defaultInterpreterPath.globalValue.
+        const globalPersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
+        globalPersistentState.setup((p) => p.value).returns(() => undefined);
         persistentStateFactory
-            .setup((p) => p.createGlobalPersistentState<string | undefined>(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-            .returns(() => persistentState.object)
-            .verifiable(TypeMoq.Times.never());
+            .setup((p) => p.createGlobalPersistentState<string | undefined>(globalInterpreterPathKey, undefined))
+            .returns(() => globalPersistentState.object);
+        // --- End Positron ---
 
         const settings = interpreterPathService.inspect(resourceOutsideOfWorkspace);
         assert.deepEqual(settings, {
@@ -316,9 +327,51 @@ suite('Interpreter Path Service', async () => {
             workspaceFolderValue: undefined,
             workspaceValue: undefined,
         });
-
-        persistentStateFactory.verifyAll();
     });
+
+    // --- Start Positron ---
+    test('inspect() returns internal global value when set, ignoring defaultInterpreterPath', async () => {
+        const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
+        workspaceService
+            .setup((w) => w.getConfiguration('python', TypeMoq.It.isAny()))
+            .returns(() => workspaceConfig.object);
+        workspaceConfig
+            .setup((w) => w.inspect<string>('defaultInterpreterPath'))
+            .returns(() => ({ globalValue: 'default/path/to/interpreter' } as any));
+        workspaceService.setup((w) => w.workspaceFolders).returns(() => undefined);
+        const globalPersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
+        globalPersistentState.setup((p) => p.value).returns(() => '/active/venv/python');
+        persistentStateFactory
+            .setup((p) => p.createGlobalPersistentState<string | undefined>(globalInterpreterPathKey, undefined))
+            .returns(() => globalPersistentState.object);
+
+        const settings = interpreterPathService.inspect(resourceOutsideOfWorkspace);
+        assert.deepEqual(settings, {
+            globalValue: '/active/venv/python',
+            workspaceFolderValue: undefined,
+            workspaceValue: undefined,
+        });
+    });
+
+    test('get(undefined) returns internal global value when set', async () => {
+        const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
+        workspaceService
+            .setup((w) => w.getConfiguration('python', TypeMoq.It.isAny()))
+            .returns(() => workspaceConfig.object);
+        workspaceConfig
+            .setup((w) => w.inspect<string>('defaultInterpreterPath'))
+            .returns(() => ({} as any));
+        workspaceService.setup((w) => w.workspaceFolders).returns(() => undefined);
+        const globalPersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
+        globalPersistentState.setup((p) => p.value).returns(() => '/active/venv/python');
+        persistentStateFactory
+            .setup((p) => p.createGlobalPersistentState<string | undefined>(globalInterpreterPathKey, undefined))
+            .returns(() => globalPersistentState.object);
+
+        const value = interpreterPathService.get(undefined);
+        assert.equal(value, '/active/venv/python');
+    });
+    // --- End Positron ---
 
     test('Inspecting settings returns as expected if a folder is directly opened', async () => {
         const expectedSettingKey = `WORKSPACE_FOLDER_INTERPRETER_PATH_${resource.fsPath}`;
@@ -331,9 +384,9 @@ suite('Interpreter Path Service', async () => {
             .setup((w) => w.inspect<string>('defaultInterpreterPath'))
             .returns(
                 () =>
-                    ({
-                        globalValue: 'default/path/to/interpreter',
-                    } as any),
+                ({
+                    globalValue: 'default/path/to/interpreter',
+                } as any),
             );
         const workspaceFolderPersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
         workspaceService.setup((w) => w.workspaceFolders).returns(() => undefined);
@@ -344,6 +397,13 @@ suite('Interpreter Path Service', async () => {
             .setup((p) => p.createGlobalPersistentState<string | undefined>(expectedSettingKey, undefined))
             .returns(() => workspaceFolderPersistentState.object);
         workspaceFolderPersistentState.setup((p) => p.value).returns(() => 'workspaceFolderValue');
+        // --- Start Positron ---
+        const globalPersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
+        globalPersistentState.setup((p) => p.value).returns(() => undefined);
+        persistentStateFactory
+            .setup((p) => p.createGlobalPersistentState<string | undefined>(globalInterpreterPathKey, undefined))
+            .returns(() => globalPersistentState.object);
+        // --- End Positron ---
 
         const settings = interpreterPathService.inspect(resource);
 
@@ -367,9 +427,9 @@ suite('Interpreter Path Service', async () => {
             .setup((w) => w.inspect<string>('defaultInterpreterPath'))
             .returns(
                 () =>
-                    ({
-                        globalValue: 'default/path/to/interpreter',
-                    } as any),
+                ({
+                    globalValue: 'default/path/to/interpreter',
+                } as any),
             );
         const workspaceFolderPersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
         const workspacePersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
@@ -384,6 +444,13 @@ suite('Interpreter Path Service', async () => {
             .returns(() => workspacePersistentState.object);
         workspaceFolderPersistentState.setup((p) => p.value).returns(() => 'workspaceFolderValue');
         workspacePersistentState.setup((p) => p.value).returns(() => 'workspaceValue');
+        // --- Start Positron ---
+        const globalPersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
+        globalPersistentState.setup((p) => p.value).returns(() => undefined);
+        persistentStateFactory
+            .setup((p) => p.createGlobalPersistentState<string | undefined>(globalInterpreterPathKey, undefined))
+            .returns(() => globalPersistentState.object);
+        // --- End Positron ---
 
         const settings = interpreterPathService.inspect(resource);
 
@@ -407,11 +474,11 @@ suite('Interpreter Path Service', async () => {
             .setup((w) => w.inspect<string>('defaultInterpreterPath'))
             .returns(
                 () =>
-                    ({
-                        globalValue: 'default/path/to/interpreter',
-                        workspaceValue: 'defaultWorkspaceValue',
-                        workspaceFolderValue: 'defaultWorkspaceFolderValue',
-                    } as any),
+                ({
+                    globalValue: 'default/path/to/interpreter',
+                    workspaceValue: 'defaultWorkspaceValue',
+                    workspaceFolderValue: 'defaultWorkspaceFolderValue',
+                } as any),
             );
         const workspaceFolderPersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
         const workspacePersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
@@ -426,6 +493,13 @@ suite('Interpreter Path Service', async () => {
             .returns(() => workspacePersistentState.object);
         workspaceFolderPersistentState.setup((p) => p.value).returns(() => undefined);
         workspacePersistentState.setup((p) => p.value).returns(() => undefined);
+        // --- Start Positron ---
+        const globalPersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
+        globalPersistentState.setup((p) => p.value).returns(() => undefined);
+        persistentStateFactory
+            .setup((p) => p.createGlobalPersistentState<string | undefined>(globalInterpreterPathKey, undefined))
+            .returns(() => globalPersistentState.object);
+        // --- End Positron ---
 
         const settings = interpreterPathService.inspect(resource);
 
@@ -486,6 +560,16 @@ suite('Interpreter Path Service', async () => {
             .verifiable(TypeMoq.Times.once());
         interpreterPathService._didChangeInterpreterEmitter = _didChangeInterpreterEmitter.object;
         // --- Start Positron ---
+        // The global value is unchanged (undefined before and after), so nothing is cleared.
+        const globalPersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
+        globalPersistentState.setup((p) => p.value).returns(() => undefined);
+        globalPersistentState
+            .setup((p) => p.updateValue(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve())
+            .verifiable(TypeMoq.Times.never());
+        persistentStateFactory
+            .setup((p) => p.createGlobalPersistentState<string | undefined>(globalInterpreterPathKey, undefined))
+            .returns(() => globalPersistentState.object);
         // Config changes are always session intent: the extension never writes
         // `python.defaultInterpreterPath` itself in Positron, so every fire is a real edit.
         _didChangeInterpreterEmitter
@@ -499,11 +583,152 @@ suite('Interpreter Path Service', async () => {
             )
             .returns(() => undefined)
             .verifiable(TypeMoq.Times.once());
-        // --- End Positron ---
         await interpreterPathService.onDidChangeConfiguration(event.object);
         _didChangeInterpreterEmitter.verifyAll();
+        globalPersistentState.verifyAll();
         event.verifyAll();
     });
+
+    test('If the global defaultInterpreterPath value changes, the internal global state is cleared even with a workspace open', async () => {
+        // A mutable global value lets us model the user editing the User-scope setting after the
+        // service captured its baseline at construction.
+        let globalValue: string | undefined = '/old/global';
+        const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
+        workspaceConfig
+            .setup((c) => c.inspect<string>('defaultInterpreterPath'))
+            .returns(() => ({ globalValue } as any));
+        workspaceService.setup((w) => w.getConfiguration('python')).returns(() => workspaceConfig.object);
+        // A workspace is open: the clear must not be gated on workspace state, otherwise a global
+        // edit from a workspace window stays ineffective for future no-workspace windows.
+        workspaceService
+            .setup((w) => w.workspaceFolders)
+            .returns(() => [{ uri: resource, name: 'Workspacefolder', index: 0 }]);
+        const service = new InterpreterPathService(
+            persistentStateFactory.object,
+            workspaceService.object,
+            [],
+            appEnvironment.object,
+        );
+        globalValue = '/new/global';
+
+        const event = TypeMoq.Mock.ofType<ConfigurationChangeEvent>();
+        event.setup((e) => e.affectsConfiguration(`python.${defaultInterpreterPathSetting}`)).returns(() => true);
+        const _didChangeInterpreterEmitter = TypeMoq.Mock.ofType<EventEmitter<InterpreterConfigurationScope>>();
+        service._didChangeInterpreterEmitter = _didChangeInterpreterEmitter.object;
+        const globalPersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
+        globalPersistentState.setup((p) => p.value).returns(() => '/old/python');
+        globalPersistentState
+            .setup((p) => p.updateValue(undefined))
+            .returns(() => Promise.resolve())
+            .verifiable(TypeMoq.Times.once());
+        persistentStateFactory
+            .setup((p) => p.createGlobalPersistentState<string | undefined>(globalInterpreterPathKey, undefined))
+            .returns(() => globalPersistentState.object);
+        _didChangeInterpreterEmitter
+            .setup((emitter) =>
+                emitter.fire({
+                    uri: undefined,
+                    configTarget: ConfigurationTarget.Global,
+                    startSession: true,
+                    source: 'config-change',
+                }),
+            )
+            .returns(() => undefined)
+            .verifiable(TypeMoq.Times.once());
+
+        await service.onDidChangeConfiguration(event.object);
+
+        globalPersistentState.verifyAll();
+        _didChangeInterpreterEmitter.verifyAll();
+    });
+
+    test('If only a workspace-scoped defaultInterpreterPath changes, the internal global state is preserved', async () => {
+        // The global value is stable across the edit, so the change was workspace/workspace-folder
+        // scoped and must not wipe the shared global state.
+        const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
+        workspaceConfig
+            .setup((c) => c.inspect<string>('defaultInterpreterPath'))
+            .returns(() => ({ globalValue: '/stable/global' } as any));
+        workspaceService.setup((w) => w.getConfiguration('python')).returns(() => workspaceConfig.object);
+        workspaceService
+            .setup((w) => w.workspaceFolders)
+            .returns(() => [{ uri: resource, name: 'Workspacefolder', index: 0 }]);
+        const service = new InterpreterPathService(
+            persistentStateFactory.object,
+            workspaceService.object,
+            [],
+            appEnvironment.object,
+        );
+
+        const event = TypeMoq.Mock.ofType<ConfigurationChangeEvent>();
+        event.setup((e) => e.affectsConfiguration(`python.${defaultInterpreterPathSetting}`)).returns(() => true);
+        const _didChangeInterpreterEmitter = TypeMoq.Mock.ofType<EventEmitter<InterpreterConfigurationScope>>();
+        service._didChangeInterpreterEmitter = _didChangeInterpreterEmitter.object;
+        const globalPersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
+        globalPersistentState.setup((p) => p.value).returns(() => '/old/python');
+        globalPersistentState
+            .setup((p) => p.updateValue(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve())
+            .verifiable(TypeMoq.Times.never());
+        persistentStateFactory
+            .setup((p) => p.createGlobalPersistentState<string | undefined>(globalInterpreterPathKey, undefined))
+            .returns(() => globalPersistentState.object);
+        _didChangeInterpreterEmitter
+            .setup((emitter) =>
+                emitter.fire({
+                    uri: undefined,
+                    configTarget: ConfigurationTarget.Global,
+                    startSession: true,
+                    source: 'config-change',
+                }),
+            )
+            .returns(() => undefined)
+            .verifiable(TypeMoq.Times.once());
+
+        await service.onDidChangeConfiguration(event.object);
+
+        globalPersistentState.verifyAll();
+        _didChangeInterpreterEmitter.verifyAll();
+    });
+
+    test('If clearing the internal global state fails, a later config event retries the clear', async () => {
+        let globalValue: string | undefined = '/old/global';
+        const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
+        workspaceConfig
+            .setup((c) => c.inspect<string>('defaultInterpreterPath'))
+            .returns(() => ({ globalValue } as any));
+        workspaceService.setup((w) => w.getConfiguration('python')).returns(() => workspaceConfig.object);
+        workspaceService.setup((w) => w.workspaceFolders).returns(() => undefined);
+        const service = new InterpreterPathService(
+            persistentStateFactory.object,
+            workspaceService.object,
+            [],
+            appEnvironment.object,
+        );
+        globalValue = '/new/global';
+
+        const event = TypeMoq.Mock.ofType<ConfigurationChangeEvent>();
+        event.setup((e) => e.affectsConfiguration(`python.${defaultInterpreterPathSetting}`)).returns(() => true);
+        const _didChangeInterpreterEmitter = TypeMoq.Mock.ofType<EventEmitter<InterpreterConfigurationScope>>();
+        service._didChangeInterpreterEmitter = _didChangeInterpreterEmitter.object;
+        // updateValue() swallows storage failures: the stored value stays set, so the baseline must
+        // not advance and the next config event must retry the clear.
+        const globalPersistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
+        globalPersistentState.setup((p) => p.value).returns(() => '/old/python');
+        globalPersistentState
+            .setup((p) => p.updateValue(undefined))
+            .returns(() => Promise.resolve())
+            .verifiable(TypeMoq.Times.exactly(2));
+        persistentStateFactory
+            .setup((p) => p.createGlobalPersistentState<string | undefined>(globalInterpreterPathKey, undefined))
+            .returns(() => globalPersistentState.object);
+
+        await service.onDidChangeConfiguration(event.object);
+        await service.onDidChangeConfiguration(event.object);
+
+        globalPersistentState.verifyAll();
+    });
+    // --- End Positron ---
 
     test('If some other setting changed, no event is fired', async () => {
         const _didChangeInterpreterEmitter = TypeMoq.Mock.ofType<EventEmitter<InterpreterConfigurationScope>>();

--- a/extensions/positron-python/src/test/interpreters/interpreterService.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/interpreterService.unit.test.ts
@@ -99,6 +99,9 @@ suite('Interpreters service', () => {
         pythonSettings = createTypeMoq<IPythonSettings>();
         pythonSettings.setup((s) => s.pythonPath).returns(() => PYTHON_PATH);
         configService.setup((c) => c.getSettings(TypeMoq.It.isAny())).returns(() => pythonSettings.object);
+        // --- Start Positron ---
+        workspace.setup((w) => w.getWorkspaceFolderIdentifier(TypeMoq.It.isAny())).returns(() => '');
+        // --- End Positron ---
 
         pythonExecutionService.setup((p: any) => p.then).returns(() => undefined);
         workspace.setup((x) => x.getConfiguration('python', TypeMoq.It.isAny())).returns(() => config.object);
@@ -263,7 +266,10 @@ suite('Interpreters service', () => {
         const resource = Uri.parse('a');
         const workspaceFolder = { uri: resource, name: '', index: 0 };
         workspace.setup((w) => w.getWorkspaceFolder(resource)).returns(() => workspaceFolder);
-        service._pythonPathSetting = '';
+        // --- Start Positron ---
+        // No entry in _pythonPathSetting map = initial state (equivalent to old empty-string sentinel).
+        // service._pythonPathSetting = '';
+        // --- End Positron ---
         configService.reset();
         configService.setup((c) => c.getSettings(resource)).returns(() => ({ pythonPath: 'current path' } as any));
         interpreterDisplay
@@ -283,7 +289,9 @@ suite('Interpreters service', () => {
         const resource = Uri.parse('a');
         const workspaceFolder = { uri: resource, name: '', index: 0 };
         workspace.setup((w) => w.getWorkspaceFolder(resource)).returns(() => workspaceFolder);
-        service._pythonPathSetting = 'stored setting';
+        // --- Start Positron ---
+        service._pythonPathSetting.set('', 'stored setting');
+        // --- End Positron ---
         configService.reset();
         configService.setup((c) => c.getSettings(resource)).returns(() => ({ pythonPath: 'current path' } as any));
         interpreterDisplay
@@ -301,7 +309,9 @@ suite('Interpreters service', () => {
     test('If stored setting is equal to current interpreter path setting, do not refresh the interpreter display', async () => {
         const service = new InterpreterService(serviceContainer, pyenvs.object);
         const resource = Uri.parse('a');
-        service._pythonPathSetting = 'setting';
+        // --- Start Positron ---
+        service._pythonPathSetting.set('', 'setting');
+        // --- End Positron ---
         configService.reset();
         configService.setup((c) => c.getSettings(resource)).returns(() => ({ pythonPath: 'setting' } as any));
         interpreterDisplay
@@ -319,7 +329,7 @@ suite('Interpreters service', () => {
         const resource = Uri.parse('a');
         const workspaceFolder = { uri: resource, name: '', index: 0 };
         workspace.setup((w) => w.getWorkspaceFolder(resource)).returns(() => workspaceFolder);
-        service._pythonPathSetting = 'stored setting';
+        service._pythonPathSetting.set('', 'stored setting');
         configService.reset();
         configService.setup((c) => c.getSettings(resource)).returns(() => ({ pythonPath: 'current path' } as any));
         interpreterDisplay.setup((i) => i.refresh()).returns(() => Promise.resolve());
@@ -341,7 +351,7 @@ suite('Interpreters service', () => {
         const resource = Uri.parse('a');
         const workspaceFolder = { uri: resource, name: '', index: 0 };
         workspace.setup((w) => w.getWorkspaceFolder(resource)).returns(() => workspaceFolder);
-        service._pythonPathSetting = 'stored setting';
+        service._pythonPathSetting.set('', 'stored setting');
         configService.reset();
         configService.setup((c) => c.getSettings(resource)).returns(() => ({ pythonPath: 'current path' } as any));
         interpreterDisplay.setup((i) => i.refresh()).returns(() => Promise.resolve());
@@ -351,6 +361,37 @@ suite('Interpreters service', () => {
         await service._onConfigChanged(resource);
 
         expect(events).to.deep.equal([{ resource, startSession: true, source: 'unspecified' }]);
+    });
+
+    test('A change under one folder does not suppress the change for another folder with the same path', async () => {
+        const service = new InterpreterService(serviceContainer, pyenvs.object);
+        const folderA = Uri.parse('folderA');
+        const folderB = Uri.parse('folderB');
+
+        // Distinct identifiers per folder so the per-folder _pythonPathSetting keys don't collide.
+        workspace
+            .setup((w) => w.getWorkspaceFolderIdentifier(TypeMoq.It.isAny()))
+            .returns((resource?: Uri) => resource?.toString() ?? '');
+
+        // Both folders resolve to the same interpreter path. The old single-value _pythonPathSetting
+        // would treat folder B's path as unchanged after folder A and suppress its refresh; the
+        // per-folder Map must not.
+        configService.reset();
+        configService
+            .setup((c) => c.getSettings(TypeMoq.It.isAny()))
+            .returns(() => ({ pythonPath: 'shared path' } as any));
+        interpreterDisplay.setup((i) => i.refresh()).returns(() => Promise.resolve());
+
+        const events: InterpreterChangeEvent[] = [];
+        service.onDidChangeInterpreter((e) => events.push(e));
+
+        await service._onConfigChanged(folderA);
+        await service._onConfigChanged(folderB);
+
+        expect(events).to.deep.equal([
+            { resource: folderA, startSession: true, source: 'unspecified' },
+            { resource: folderB, startSession: true, source: 'unspecified' },
+        ]);
     });
     // --- End Positron ---
 });

--- a/extensions/positron-python/src/test/interpreters/virtualEnvs/activatedEnvLaunch.unit.test.ts
+++ b/extensions/positron-python/src/test/interpreters/virtualEnvs/activatedEnvLaunch.unit.test.ts
@@ -246,6 +246,10 @@ suite('Activated Env Launch', async () => {
                         TypeMoq.It.isValue(condaPrefix),
                         TypeMoq.It.isValue(ConfigurationTarget.Global),
                         TypeMoq.It.isValue('load'),
+                        // --- Start Positron ---
+                        TypeMoq.It.isValue(undefined),
+                        TypeMoq.It.isValue({ startSession: false, source: 'load' }),
+                        // --- End Positron ---
                     ),
                 )
                 .returns(() => Promise.resolve())

--- a/extensions/positron-python/src/test/positron/session.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/session.unit.test.ts
@@ -210,7 +210,8 @@ suite('Python Runtime Session', () => {
         sinon.restore();
     });
 
-    test('Start: updates the active interpreter for console sessions', async () => {
+    test('Start: updates the active interpreter with Global target when no workspace is opened', async () => {
+        // workspaceService.workspaceFolders is undefined in the test setup -> Global target.
         const target = sinon.spy(interpreterPathService, 'update');
 
         const session = createSession(positron.LanguageRuntimeSessionMode.Console);
@@ -219,7 +220,7 @@ suite('Python Runtime Session', () => {
         sinon.assert.calledOnceWithExactly(
             target,
             undefined,
-            vscode.ConfigurationTarget.WorkspaceFolder,
+            vscode.ConfigurationTarget.Global,
             interpreter.path,
             // Session start is a storage-only fire: the session is already starting here, so the
             // PythonRuntimeManager listener must not start another one.

--- a/extensions/positron-python/src/test/positron/util.unit.test.ts
+++ b/extensions/positron-python/src/test/positron/util.unit.test.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { WorkspaceFolder } from 'vscode';
+import { IWorkspaceService } from '../../client/common/application/types';
+import { getActiveInterpreterConfigTarget } from '../../client/positron/util';
+import { mock } from './utils';
+
+suite('getActiveInterpreterConfigTarget', () => {
+    [undefined, []].forEach((workspaceFolders) => {
+        const suffix = workspaceFolders === undefined ? 'no workspace folders' : 'empty workspace folders';
+        test(`Global target with no resource when there are ${suffix}`, () => {
+            const workspaceService = mock<IWorkspaceService>({
+                workspaceFolders,
+                workspaceFile: undefined,
+            });
+
+            assert.deepStrictEqual(getActiveInterpreterConfigTarget(workspaceService), {
+                configTarget: vscode.ConfigurationTarget.Global,
+                folderUri: undefined,
+            });
+        });
+    });
+
+    test('Workspace target with the workspace file uri for a multi-folder (.code-workspace) workspace', () => {
+        const workspaceFile = vscode.Uri.file('/path/to/my.code-workspace');
+        const workspaceService = mock<IWorkspaceService>({
+            workspaceFolders: [{ uri: vscode.Uri.file('/path/to/folder'), name: 'folder', index: 0 }],
+            workspaceFile,
+        });
+
+        assert.deepStrictEqual(getActiveInterpreterConfigTarget(workspaceService), {
+            configTarget: vscode.ConfigurationTarget.Workspace,
+            folderUri: workspaceFile,
+        });
+    });
+
+    test('WorkspaceFolder target with the folder uri for a single-folder workspace', () => {
+        const folderUri = vscode.Uri.file('/path/to/folder');
+        const workspaceFolders: WorkspaceFolder[] = [{ uri: folderUri, name: 'folder', index: 0 }];
+        const workspaceService = mock<IWorkspaceService>({
+            workspaceFolders,
+            workspaceFile: undefined,
+        });
+
+        assert.deepStrictEqual(getActiveInterpreterConfigTarget(workspaceService), {
+            configTarget: vscode.ConfigurationTarget.WorkspaceFolder,
+            folderUri,
+        });
+    });
+});


### PR DESCRIPTION
Fixes #11281, where the Python extension could report the wrong active interpreter. Starting multiple Python consoles and switching foreground would leave `getActiveEnvironmentPath()` pointing at a stale interpreter, so package-install tooling targeted the wrong environment and Pyrefly did not refresh diagnostics for the foreground session.

The cause was that we commented out some code so that a session switch never mutates the user's `settings.json`, but as a result the active interpreter was never persisted and `inspect()` returned a stale value. This change stores the global active interpreter in internal persistent state instead of `settings.json`:

- `update()` for the Global target now writes the path to a `GLOBAL_INTERPRETER_PATH` persistent-state key (remote-name prefixed) and fires the interpreter-changed event, instead of being a no-op.
- `inspect()` reads that internal state as the global value, falling back to `python.defaultInterpreterPath` when it is unset. The read happens outside the resource check so it applies with no workspace folder open.
- A genuine user edit to the User-scope `python.defaultInterpreterPath` clears the internal state so the edited setting is no longer shadowed by a value a prior session start persisted. Workspace and workspace-folder edits are isolated from this path so they do not wipe the global state.
- `session.ts` and `languageServerManager.ts` now share a new `getActiveInterpreterConfigTarget()` helper to resolve the config target and resource URI (Global / Workspace / WorkspaceFolder) consistently.
- `InterpreterService._pythonPathSetting` is now a `Map` keyed by workspace-folder identifier so a change in one folder no longer masks another.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix the Python extension sometimes using the wrong active interpreter (wrong package-install target, stale Pyrefly diagnostics) when no folder is open (#11281)

### Validation Steps

@:interpreter @:sessions @:console @:pyrefly

1. Launch Positron with **no folder open**. Start a Python console on a venv interpreter that has a package the system Python lacks. Open an untitled/standalone `.py` that imports it -> Pyrefly should resolve it (no "cannot find module"), querying site-packages from the venv, not system Python. (Pyrefly does have stubs for some popular libraries like pandas, so you can check it's using the right thing by right-clicking the module > Go To Definition to make sure it's using the correct environment's files.)
2. Have Posit Assistant try to install a Python package with no workspace -> it should target the active venv.
3. Open two console sessions on different venvs and switch foreground -> Pyrefly diagnostics and `getActiveEnvironmentPath` should follow the foreground session, with no manual project reopen needed.
4. With no folder open, edit `python.defaultInterpreterPath` in user settings -> the edited value should take effect rather than being shadowed by the previously active interpreter.
