### PR TITLE
Refresh cell footer time when cell scrolls into view

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
@@ -7,7 +7,7 @@
 import './CodeCellStatusFooter.css';
 
 // React.
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
@@ -51,23 +51,49 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 	 * This forces the component to re-render and update the displayed relative time.
 	 */
 	const [, setTick] = useState(0);
-	const containerRef = useRef<HTMLDivElement>(null);
 
+	// Refresh immediately when any part of the cell enters the viewport.
+	// We observe the whole cell container (not just the footer) so that tall
+	// cells where only the output is visible and the footer is scrolled above
+	// the viewport also trigger a refresh.
 	useEffect(() => {
-		// Only set up interval if we have a completion time to display
 		if (lastRunEndTime === undefined) {
 			return;
 		}
 
-		const targetWindow = DOM.getWindow(containerRef.current);
+		const cellContainer = cell.container;
+		if (!cellContainer) {
+			return;
+		}
+
+		// Use the cell's window in multi-window Electron contexts.
+		const targetWindow = DOM.getWindow(cellContainer);
+
+		// We track the current intersection state so the interval can
+		// use it to trigger a refresh when any part of the cell is visible.
+		let cellIsVisible = false;
+		const observer = new targetWindow.IntersectionObserver(
+			([entry]) => {
+				cellIsVisible = entry.isIntersecting;
+				if (entry.isIntersecting) {
+					setTick(tick => tick + 1);
+				}
+			},
+			{ threshold: 0 }
+		);
+		observer.observe(cellContainer);
+
+		// Keep refreshing every minute while any part of the cell is visible.
 		const intervalId = targetWindow.setInterval(() => {
-			// Only update if cell is visible to avoid unnecessary re-renders
-			if (cell.isInViewport()) {
+			if (cellIsVisible) {
 				setTick(tick => tick + 1);
 			}
 		}, 60000);
 
-		return () => targetWindow.clearInterval(intervalId);
+		return () => {
+			observer.disconnect();
+			targetWindow.clearInterval(intervalId);
+		};
 	}, [cell, lastRunEndTime]);
 
 	// Derive state conditions
@@ -197,7 +223,6 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 
 	return (
 		<div
-			ref={containerRef}
 			aria-hidden={isCollapsed || undefined}
 			aria-label={isCollapsed ? undefined : getAriaLabel()}
 			aria-live={isCurrentlyRunning ? 'polite' : 'off'}

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CodeCellStatusFooter.tsx
@@ -7,7 +7,7 @@
 import './CodeCellStatusFooter.css';
 
 // React.
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../nls.js';
@@ -51,49 +51,19 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 	 * This forces the component to re-render and update the displayed relative time.
 	 */
 	const [, setTick] = useState(0);
+	const containerRef = useRef<HTMLDivElement>(null);
 
-	// Refresh immediately when any part of the cell enters the viewport.
-	// We observe the whole cell container (not just the footer) so that tall
-	// cells where only the output is visible and the footer is scrolled above
-	// the viewport also trigger a refresh.
 	useEffect(() => {
 		if (lastRunEndTime === undefined) {
 			return;
 		}
 
-		const cellContainer = cell.container;
-		if (!cellContainer) {
-			return;
-		}
-
-		// Use the cell's window in multi-window Electron contexts.
-		const targetWindow = DOM.getWindow(cellContainer);
-
-		// We track the current intersection state so the interval can
-		// use it to trigger a refresh when any part of the cell is visible.
-		let cellIsVisible = false;
-		const observer = new targetWindow.IntersectionObserver(
-			([entry]) => {
-				cellIsVisible = entry.isIntersecting;
-				if (entry.isIntersecting) {
-					setTick(tick => tick + 1);
-				}
-			},
-			{ threshold: 0 }
-		);
-		observer.observe(cellContainer);
-
-		// Keep refreshing every minute while any part of the cell is visible.
+		const targetWindow = DOM.getWindow(containerRef.current);
 		const intervalId = targetWindow.setInterval(() => {
-			if (cellIsVisible) {
-				setTick(tick => tick + 1);
-			}
+			setTick(tick => tick + 1);
 		}, 60000);
 
-		return () => {
-			observer.disconnect();
-			targetWindow.clearInterval(intervalId);
-		};
+		return () => targetWindow.clearInterval(intervalId);
 	}, [cell, lastRunEndTime]);
 
 	// Derive state conditions
@@ -223,6 +193,7 @@ export function CodeCellStatusFooter({ cell, hasError }: CodeCellStatusFooterPro
 
 	return (
 		<div
+			ref={containerRef}
 			aria-hidden={isCollapsed || undefined}
 			aria-label={isCollapsed ? undefined : getAriaLabel()}
 			aria-live={isCurrentlyRunning ? 'polite' : 'off'}

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
@@ -31,23 +31,6 @@ describe('CodeCellStatusFooter', () => {
 	const ctx = createTestContainer().withReactServices().build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
-	let intersectionCallback: IntersectionObserverCallback | null = null;
-
-	beforeEach(() => {
-		intersectionCallback = null;
-		vi.stubGlobal('IntersectionObserver', class {
-			constructor(cb: IntersectionObserverCallback) {
-				intersectionCallback = cb;
-			}
-			observe() { }
-			disconnect() { }
-		});
-	});
-
-	afterEach(() => {
-		vi.unstubAllGlobals();
-	});
-
 	function renderFooter(state: CellState = {}, hasError = false) {
 		// Mirrors the real cell's tagUIVisible derivation (tags or an in-progress
 		// add, unless the notebook hides tags).
@@ -62,7 +45,6 @@ describe('CodeCellStatusFooter', () => {
 			isAddingTag: observableValue<boolean>('isAddingTag', state.isAddingTag ?? false),
 			tagUIVisible: observableValue<boolean>('tagUIVisible', tagUIVisible),
 			isInViewport: () => true,
-			container: document.createElement('div'),
 		});
 
 		return rtl.render(<CodeCellStatusFooter cell={cell} hasError={hasError} />);
@@ -178,7 +160,7 @@ describe('CodeCellStatusFooter', () => {
 		}
 	});
 
-	it('refreshes relative time when cell enters viewport', async () => {
+	it('refreshes the relative time for each footer in a one minute interval', async () => {
 		vi.useFakeTimers();
 		try {
 			const startTime = Date.now();
@@ -189,12 +171,8 @@ describe('CodeCellStatusFooter', () => {
 			});
 
 			expect(screen.getByText('1 min ago')).toBeInTheDocument();
-			vi.advanceTimersByTime(60_000);
 			await act(async () => {
-				intersectionCallback!(
-					[stubInterface<IntersectionObserverEntry>({ isIntersecting: true })],
-					stubInterface<IntersectionObserver>()
-				);
+				vi.advanceTimersByTime(60_000);
 			});
 			expect(screen.getByText('2 mins ago')).toBeInTheDocument();
 		} finally {

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
@@ -5,7 +5,7 @@
 
 /// <reference types="vitest/globals" />
 
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import { observableValue } from '../../../../../../base/common/observable.js';
 import { createTestContainer } from '../../../../../../test/vitest/positronTestContainer.js';
 import { setupRTLRenderer } from '../../../../../../test/vitest/reactTestingLibrary.js';
@@ -30,6 +30,23 @@ describe('CodeCellStatusFooter', () => {
 	// render through the provider tree rather than the prop-only renderer.
 	const ctx = createTestContainer().withReactServices().build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	let intersectionCallback: IntersectionObserverCallback | null = null;
+
+	beforeEach(() => {
+		intersectionCallback = null;
+		vi.stubGlobal('IntersectionObserver', class {
+			constructor(cb: IntersectionObserverCallback) {
+				intersectionCallback = cb;
+			}
+			observe() { }
+			disconnect() { }
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
 
 	function renderFooter(state: CellState = {}, hasError = false) {
 		// Mirrors the real cell's tagUIVisible derivation (tags or an in-progress
@@ -158,6 +175,30 @@ describe('CodeCellStatusFooter', () => {
 			expect(screen.getByTestId('cell-footer-metadata')).toBeInTheDocument();
 		} else {
 			expect(screen.queryByTestId('cell-footer-metadata')).not.toBeInTheDocument();
+		}
+	});
+
+	it('refreshes relative time when cell enters viewport', async () => {
+		vi.useFakeTimers();
+		try {
+			const startTime = Date.now();
+			renderFooter({
+				lastExecutionDuration: 500,
+				lastRunEndTime: startTime - 60_000,
+				lastRunSuccess: true,
+			});
+
+			expect(screen.getByText('1 min ago')).toBeInTheDocument();
+			vi.advanceTimersByTime(60_000);
+			await act(async () => {
+				intersectionCallback!(
+					[stubInterface<IntersectionObserverEntry>({ isIntersecting: true })],
+					stubInterface<IntersectionObserver>()
+				);
+			});
+			expect(screen.getByText('2 mins ago')).toBeInTheDocument();
+		} finally {
+			vi.useRealTimers();
 		}
 	});
 });

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/codeCellStatusFooter.vitest.tsx
@@ -45,6 +45,7 @@ describe('CodeCellStatusFooter', () => {
 			isAddingTag: observableValue<boolean>('isAddingTag', state.isAddingTag ?? false),
 			tagUIVisible: observableValue<boolean>('tagUIVisible', tagUIVisible),
 			isInViewport: () => true,
+			container: document.createElement('div'),
 		});
 
 		return rtl.render(<CodeCellStatusFooter cell={cell} hasError={hasError} />);


### PR DESCRIPTION
Fixes #11586

When a cell scrolled out of view and back in, the footer kept showing stale execution time (e.g. "2 mins ago") for up to 60 seconds at which point it would update on the next tick. This PR fixes that so cell footers update immediately once scrolled into view.

An `IntersectionObserver` on `CodeCellStatusFooter` now fires immediately when the cell enters the viewport. The observer targets the outermost cell container (`cell.container`) rather than the footer element itself, so it correctly fires even when only part of a cell is visible.

### Screenshot


https://github.com/user-attachments/assets/122efe5e-449c-4b74-9d44-c15f37379b82



### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix cell footer showing stale execution time when scrolling back to a cell (#11586)

### Validation Steps

@:positron-notebooks

1. Open a `.ipynb` notebook with enough cells to scroll
2. Run a cell near the top and wait for it to complete. The footer should show "Just now"
3. Scroll down so the executed cell is fully out of view and wait 1 minute
5. Scroll the cell back into view and verify the footer immediately shows the updated time (e.g. "1 min ago")
6. Repeat with a cell that has large output: scroll so only the output is visible (footer above viewport) and verify the time also updates immediately once the footer is scrolled into view