### PR TITLE
e2e: migrate notebook tests to Positron notebooks

### DIFF
--- a/test/e2e/pages/console.ts
+++ b/test/e2e/pages/console.ts
@@ -42,7 +42,7 @@ export class Console {
 	constructor(private code: Code, private quickinput: QuickInput, private hotKeys: HotKeys, private contextMenu: ContextMenu) {
 		// Standard Console Button Locators
 		this.restartButton = this.code.driver.currentPage.getByTestId('restart-session');
-		this.clearButton = this.code.driver.currentPage.getByLabel('Clear console');
+		this.clearButton = this.code.driver.currentPage.getByRole('button', { name: 'Clear Console' });
 		this.trashButton = this.code.driver.currentPage.getByTestId('trash-session');
 
 		// `+` Add Session Split Button Locators

--- a/test/e2e/pages/help.ts
+++ b/test/e2e/pages/help.ts
@@ -33,8 +33,22 @@ export class Help {
 		return innerInnerFrame;
 	}
 
-	async getHelpFrame(nth: number): Promise<FrameLocator> {
-		const outerFrame = this.code.driver.currentPage.locator(OUTER_FRAME).nth(nth).contentFrame();
+	/**
+	 * Returns the FrameLocator for the Positron Help pane's content iframe.
+	 *
+	 * The Help webview is always the LAST `.webview` iframe in the DOM (Help is
+	 * opened after any other webviews -- editors, notebooks, plots). Selecting it
+	 * with `.last()` instead of a positional index avoids a race: while a transient
+	 * extra webview exists, the help content sits at a shifting index, so a fixed
+	 * `.nth(n)` polls the wrong frame for ~14s (~7 assertion retries) until that
+	 * webview is torn down. `.last()` resolves the help frame as soon as it renders.
+	 *
+	 * @param _nth Deprecated and ignored. Previously the positional index of the
+	 *   help webview; callers no longer need it. Retained so existing call sites
+	 *   keep compiling.
+	 */
+	async getHelpFrame(_nth?: number): Promise<FrameLocator> {
+		const outerFrame = this.code.driver.currentPage.locator(OUTER_FRAME).last().contentFrame();
 		const innerFrame = outerFrame.frameLocator(MIDDLE_FRAME);
 		const innerInnerFrame = innerFrame.frameLocator(INNER_FRAME);
 		return innerInnerFrame;

--- a/test/e2e/pages/help.ts
+++ b/test/e2e/pages/help.ts
@@ -34,14 +34,10 @@ export class Help {
 	}
 
 	/**
-	 * Returns the FrameLocator for the Positron Help pane's content iframe.
-	 *
-	 * The Help webview is always the LAST `.webview` iframe in the DOM (Help is
-	 * opened after any other webviews -- editors, notebooks, plots). Selecting it
-	 * with `.last()` instead of a positional index avoids a race: while a transient
-	 * extra webview exists, the help content sits at a shifting index, so a fixed
-	 * `.nth(n)` polls the wrong frame for ~14s (~7 assertion retries) until that
-	 * webview is torn down. `.last()` resolves the help frame as soon as it renders.
+	 * FrameLocator for the Help pane's content iframe. Help is always the LAST
+	 * `.webview` (opened after editors/notebooks/plots), so `.last()` resolves it
+	 * immediately; a fixed `.nth(n)` races a shifting index while a transient
+	 * webview exists.
 	 */
 	async getHelpFrame(): Promise<FrameLocator> {
 		const outerFrame = this.code.driver.currentPage.locator(OUTER_FRAME).last().contentFrame();

--- a/test/e2e/pages/help.ts
+++ b/test/e2e/pages/help.ts
@@ -42,12 +42,8 @@ export class Help {
 	 * extra webview exists, the help content sits at a shifting index, so a fixed
 	 * `.nth(n)` polls the wrong frame for ~14s (~7 assertion retries) until that
 	 * webview is torn down. `.last()` resolves the help frame as soon as it renders.
-	 *
-	 * @param _nth Deprecated and ignored. Previously the positional index of the
-	 *   help webview; callers no longer need it. Retained so existing call sites
-	 *   keep compiling.
 	 */
-	async getHelpFrame(_nth?: number): Promise<FrameLocator> {
+	async getHelpFrame(): Promise<FrameLocator> {
 		const outerFrame = this.code.driver.currentPage.locator(OUTER_FRAME).last().contentFrame();
 		const innerFrame = outerFrame.frameLocator(MIDDLE_FRAME);
 		const innerInnerFrame = innerFrame.frameLocator(INNER_FRAME);

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -1880,7 +1880,7 @@ export class Kernel extends KernelBase {
 	 */
 	async change(
 		kernelGroup: 'Python' | 'R',
-		{ version }: { version?: string; waitForReady?: boolean } = {}
+		{ version }: { version?: string } = {}
 	): Promise<void> {
 		const desiredKernel = version ?? (kernelGroup === 'Python'
 			? process.env.POSITRON_PY_VER_SEL!

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -1737,7 +1737,7 @@ class KernelBase {
 	protected activeStatus: Locator;
 	protected idleStatus: Locator;
 	protected disconnectedStatus: Locator;
-	quickinput: any;
+	protected quickinput!: QuickInput;
 
 	constructor(
 		statusBadge: Locator,
@@ -1888,13 +1888,14 @@ export class Kernel extends KernelBase {
 		private notebooks: PositronNotebooks,
 		contextMenu: ContextMenu,
 		private hotKeys: HotKeys,
-		private quickinput: QuickInput
+		quickinput: QuickInput
 	) {
 		super(
 			code.driver.currentPage.getByRole('button', { name: 'Kernel Actions' }),
 			notebooks.editorActionBar,
 			contextMenu
 		);
+		this.quickinput = quickinput;
 	}
 
 	// #region ACTIONS

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -1737,6 +1737,7 @@ class KernelBase {
 	protected activeStatus: Locator;
 	protected idleStatus: Locator;
 	protected disconnectedStatus: Locator;
+	quickinput: any;
 
 	constructor(
 		statusBadge: Locator,
@@ -1783,6 +1784,29 @@ class KernelBase {
 				menuItemLabel: /Shutdown Kernel/
 			});
 			await this.expectStatusToBe('disconnected', 15000);
+		});
+	}
+
+	/**
+	 * Action: Change the kernel for the current notebook.
+	 */
+	async change(
+		kernelGroup: 'Python' | 'R',
+		{ version }: { version?: string; waitForReady?: boolean } = {}
+	): Promise<void> {
+		const desiredKernel = version ?? (kernelGroup === 'Python'
+			? process.env.POSITRON_PY_VER_SEL!
+			: process.env.POSITRON_R_VER_SEL!);
+		await test.step('Change kernel', async () => {
+			await this.contextMenu.triggerAndClick({
+				menuTrigger: this.statusBadge,
+				menuItemLabel: /Change Kernel/
+			});
+			// select the kernel
+			await this.quickinput.waitForQuickInputOpened({ timeout: 1000 });
+			await this.quickinput.type(desiredKernel);
+			await this.quickinput.selectQuickInputElementContaining(desiredKernel, { timeout: 1000, force: false });
+			await this.quickinput.waitForQuickInputClosed();
 		});
 	}
 

--- a/test/e2e/pages/notebooksPositron.ts
+++ b/test/e2e/pages/notebooksPositron.ts
@@ -1737,7 +1737,6 @@ class KernelBase {
 	protected activeStatus: Locator;
 	protected idleStatus: Locator;
 	protected disconnectedStatus: Locator;
-	protected quickinput!: QuickInput;
 
 	constructor(
 		statusBadge: Locator,
@@ -1784,29 +1783,6 @@ class KernelBase {
 				menuItemLabel: /Shutdown Kernel/
 			});
 			await this.expectStatusToBe('disconnected', 15000);
-		});
-	}
-
-	/**
-	 * Action: Change the kernel for the current notebook.
-	 */
-	async change(
-		kernelGroup: 'Python' | 'R',
-		{ version }: { version?: string; waitForReady?: boolean } = {}
-	): Promise<void> {
-		const desiredKernel = version ?? (kernelGroup === 'Python'
-			? process.env.POSITRON_PY_VER_SEL!
-			: process.env.POSITRON_R_VER_SEL!);
-		await test.step('Change kernel', async () => {
-			await this.contextMenu.triggerAndClick({
-				menuTrigger: this.statusBadge,
-				menuItemLabel: /Change Kernel/
-			});
-			// select the kernel
-			await this.quickinput.waitForQuickInputOpened({ timeout: 1000 });
-			await this.quickinput.type(desiredKernel);
-			await this.quickinput.selectQuickInputElementContaining(desiredKernel, { timeout: 1000, force: false });
-			await this.quickinput.waitForQuickInputClosed();
 		});
 	}
 
@@ -1888,17 +1864,39 @@ export class Kernel extends KernelBase {
 		private notebooks: PositronNotebooks,
 		contextMenu: ContextMenu,
 		private hotKeys: HotKeys,
-		quickinput: QuickInput
+		private quickinput: QuickInput
 	) {
 		super(
 			code.driver.currentPage.getByRole('button', { name: 'Kernel Actions' }),
 			notebooks.editorActionBar,
 			contextMenu
 		);
-		this.quickinput = quickinput;
 	}
 
 	// #region ACTIONS
+
+	/**
+	 * Action: Change the kernel for the current notebook.
+	 */
+	async change(
+		kernelGroup: 'Python' | 'R',
+		{ version }: { version?: string; waitForReady?: boolean } = {}
+	): Promise<void> {
+		const desiredKernel = version ?? (kernelGroup === 'Python'
+			? process.env.POSITRON_PY_VER_SEL!
+			: process.env.POSITRON_R_VER_SEL!);
+		await test.step('Change kernel', async () => {
+			await this.contextMenu.triggerAndClick({
+				menuTrigger: this.statusBadge,
+				menuItemLabel: /Change Kernel/
+			});
+			// select the kernel
+			await this.quickinput.waitForQuickInputOpened({ timeout: 1000 });
+			await this.quickinput.type(desiredKernel);
+			await this.quickinput.selectQuickInputElementContaining(desiredKernel, { timeout: 1000, force: false });
+			await this.quickinput.waitForQuickInputClosed();
+		});
+	}
 
 	/**
 	 * Action: Open the notebook session scratchpad in console.

--- a/test/e2e/pages/packages.ts
+++ b/test/e2e/pages/packages.ts
@@ -192,11 +192,10 @@ export class Packages {
 	 * Waits for the Help pane to render content for a package, retrying past the
 	 * help-frame load delay.
 	 * @param expectedText Substring that must appear in the help frame body
-	 * @param helpFrameIndex Index of the help webview to check (0 for the first opened, etc.)
 	 */
-	async expectHelpPaneToContainText(expectedText: string, helpFrameIndex: number): Promise<void> {
+	async expectHelpPaneToContainText(expectedText: string): Promise<void> {
 		await expect(async () => {
-			const helpFrame = await this.help.getHelpFrame(helpFrameIndex);
+			const helpFrame = await this.help.getHelpFrame();
 			await expect(helpFrame.locator('body')).toContainText(expectedText);
 		}).toPass();
 	}

--- a/test/e2e/tests/console/console-ansi.test.ts
+++ b/test/e2e/tests/console/console-ansi.test.ts
@@ -53,7 +53,7 @@ test.describe('Console ANSI styling', { tag: [tags.CONSOLE, tags.WIN, tags.WEB] 
 			await link.click();
 			await app.code.wait(200);
 
-			const helpFrame = await app.workbench.help.getHelpFrame(0);
+			const helpFrame = await app.workbench.help.getHelpFrame();
 			await expect(helpFrame.locator('body')).toContainText('Arithmetic Mean');
 		}).toPass({ timeout: 60000 });
 	});

--- a/test/e2e/tests/console/console-r-hyperlinks.test.ts
+++ b/test/e2e/tests/console/console-r-hyperlinks.test.ts
@@ -21,7 +21,7 @@ test.describe('Console Pane: R Hyperlinks', {
 
 		await console.activeConsole.locator('span', { hasText: 'utils::available.packages' }).click();
 
-		await expect((await help.getHelpFrame(0)).getByText('List Available Packages at CRAN-like Repositories')).toBeVisible({ timeout: 30000 });
+		await expect((await help.getHelpFrame()).getByText('List Available Packages at CRAN-like Repositories')).toBeVisible({ timeout: 30000 });
 	});
 
 
@@ -34,7 +34,7 @@ test.describe('Console Pane: R Hyperlinks', {
 
 		await console.activeConsole.locator('span', { hasText: 'CLICK HERE' }).nth(2).click();
 
-		await expect((await help.getHelpFrame(0)).getByText('Collect Information About the Current R Session')).toBeVisible({ timeout: 30000 });
+		await expect((await help.getHelpFrame()).getByText('Collect Information About the Current R Session')).toBeVisible({ timeout: 30000 });
 	});
 
 	test('R - Verify help for a topic that is not a function', async function ({ app, r }) {
@@ -46,7 +46,7 @@ test.describe('Console Pane: R Hyperlinks', {
 
 		await console.activeConsole.locator('span', { hasText: 'utils::BATCH' }).nth(2).click();
 
-		await expect((await help.getHelpFrame(0)).getByText('Batch Execution of R')).toBeVisible({ timeout: 30000 });
+		await expect((await help.getHelpFrame()).getByText('Batch Execution of R')).toBeVisible({ timeout: 30000 });
 	});
 
 	test('R - Verify help for a vignette', async function ({ app, r }) {
@@ -58,7 +58,7 @@ test.describe('Console Pane: R Hyperlinks', {
 
 		await console.activeConsole.locator('span', { hasText: 'dplyr::dplyr' }).nth(3).click();
 
-		await expect((await help.getHelpFrame(0)).getByText('Introduction to dplyr')).toBeVisible({ timeout: 30000 });
+		await expect((await help.getHelpFrame()).getByText('Introduction to dplyr')).toBeVisible({ timeout: 30000 });
 	});
 
 	test('R - Verify automatically runnable code link', async function ({ app, r }) {

--- a/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
@@ -7,8 +7,7 @@ import { join } from 'path';
 import { test, tags } from '../_test.setup';
 
 test.use({
-	suiteId: __filename,
-	useLegacyNotebookEditor: true
+	suiteId: __filename
 });
 
 test.describe('Data Explorer - Python Pandas', {
@@ -93,14 +92,13 @@ test.describe('Data Explorer - Python Pandas', {
 
 
 	test('Python Pandas - Verify can execute cell, open data grid, and data present', async function ({ app, hotKeys, python }) {
-		const { dataExplorer, notebooks, variables, editors } = app.workbench;
+		const { dataExplorer, notebooksPositron, variables, editors } = app.workbench;
 
 		// open a notebook and execute a cell to create a DataFrame
 		const pythonNotebook = 'pandas-update-dataframe.ipynb';
-		await notebooks.openNotebook(join(app.workspacePathOrFolder, 'workspaces', 'data-explorer-update-datasets', pythonNotebook));
-		await notebooks.selectInterpreter('Python', process.env.POSITRON_PY_VER_SEL!);
-		await notebooks.selectCellAtIndex(0);
-		await notebooks.executeCodeInCell();
+		await notebooksPositron.openNotebook(join(app.workspacePathOrFolder, 'workspaces', 'data-explorer-update-datasets', pythonNotebook));
+		await notebooksPositron.kernel.select('Python');
+		await notebooksPositron.runCodeAtIndex(0);
 
 		// open the DataFrame in data explorer and verify data
 		await variables.expectVariableToBe('df', /11 rows/);
@@ -111,8 +109,7 @@ test.describe('Data Explorer - Python Pandas', {
 
 		// execute the next cell and verify data in the data explorer
 		await editors.clickTab(pythonNotebook);
-		await notebooks.selectCellAtIndex(1);
-		await notebooks.executeCodeInCell();
+		await notebooksPositron.runCodeAtIndex(1);
 		await variables.expectVariableToBe('df', /12 rows/);
 		await variables.doubleClickVariableRow('df');
 		await dataExplorer.grid.verifyTableDataLength(12);

--- a/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
+++ b/test/e2e/tests/data-explorer/data-explorer-python-pandas.test.ts
@@ -97,7 +97,6 @@ test.describe('Data Explorer - Python Pandas', {
 		// open a notebook and execute a cell to create a DataFrame
 		const pythonNotebook = 'pandas-update-dataframe.ipynb';
 		await notebooksPositron.openNotebook(join(app.workspacePathOrFolder, 'workspaces', 'data-explorer-update-datasets', pythonNotebook));
-		await notebooksPositron.kernel.select('Python');
 		await notebooksPositron.runCodeAtIndex(0);
 
 		// open the DataFrame in data explorer and verify data

--- a/test/e2e/tests/help/f1.test.ts
+++ b/test/e2e/tests/help/f1.test.ts
@@ -14,13 +14,11 @@ test.describe('F1 Help', {
 	tag: [tags.WEB, tags.WIN, tags.HELP]
 }, () => {
 
-	// Teardown only. Each test sets its own layout precondition at the start
+	// Teardown only; each test sets its own layout precondition at the start.
 	test.afterEach(async function ({ app, hotKeys }) {
 		await hotKeys.closeAllEditors();
 		await hotKeys.closeSecondarySidebar();
-		// Notebook tests end in the notebook layout, which can hide the console
-		// panel; only clear the console when its button is visible so teardown
-		// never fails on the hidden panel.
+		// Notebook layout can hide the console panel; only clear when visible.
 		if (await app.workbench.console.clearButton.isVisible()) {
 			await app.workbench.console.clearButton.click();
 		}
@@ -86,10 +84,8 @@ test.describe('F1 Help', {
 		await expect(helpFrame.locator('h1').first()).toContainText('pandas.DataFrame', { timeout: 30000 });
 	});
 
-	// Notebook help tests run last: switching from the notebook layout back to a
-	// stacked layout leaves the Help webview in a state where a following console/
-	// editor help test cannot resolve its help frame. Grouping the notebook tests
-	// at the end avoids that transition.
+	// Notebook tests run last: the notebook->stacked transition leaves the Help
+	// webview unresolvable for a following console/editor test.
 	test('R - Verify basic F1 notebook help functionality', { tag: tags.POSITRON_NOTEBOOKS }, async function ({ app, page, r, openDataFile }) {
 		const { layouts } = app.workbench;
 
@@ -98,8 +94,7 @@ test.describe('F1 Help', {
 
 		await page.locator('span').filter({ hasText: 'options(digits = 2)' }).locator('span').first().dblclick();
 
-		// Pressing F1 in a notebook cell may not register until the cell editor has
-		// focus on the token, so re-press until the help topic appears.
+		// F1 in a notebook cell may not register until the editor has token focus; retry.
 		await expect(async () => {
 			await page.keyboard.press('F1');
 			const helpFrame = await app.workbench.help.getHelpFrame();
@@ -131,8 +126,7 @@ test.describe('F1 Help', {
 
 		await target.dblclick();
 
-		// Pressing F1 in a notebook cell may not register until the cell editor has
-		// focus on the token, so re-press until the help topic appears.
+		// F1 in a notebook cell may not register until the editor has token focus; retry.
 		await expect(async () => {
 			await page.keyboard.press('F1');
 			const helpFrame = await app.workbench.help.getHelpFrame();

--- a/test/e2e/tests/help/f1.test.ts
+++ b/test/e2e/tests/help/f1.test.ts
@@ -7,8 +7,7 @@ import { join } from 'path';
 import { test, expect, tags } from '../_test.setup';
 
 test.use({
-	suiteId: __filename,
-	useLegacyNotebookEditor: true
+	suiteId: __filename
 });
 
 
@@ -59,8 +58,8 @@ test.describe('F1 Help', {
 
 		await app.workbench.layouts.enterLayout('notebook');
 
-		// workaround
-		await app.workbench.notebooks.selectInterpreter('R', process.env.POSITRON_R_VER_SEL!);
+		// workaround: select the R kernel so the language server backs F1 help
+		await app.workbench.notebooksPositron.kernel.select('R');
 
 		await app.code.driver.currentPage.locator('span').filter({ hasText: 'options(digits = 2)' }).locator('span').first().dblclick();
 
@@ -119,7 +118,7 @@ test.describe('F1 Help', {
 		await app.workbench.quickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'large_py_notebook', 'spotify.ipynb'));
 
 		// Position the mouse over the notebook for scrolling
-		await app.code.driver.currentPage.locator('.cell').first().hover();
+		await app.workbench.notebooksPositron.cell.first().hover();
 
 		const target = app.code.driver.currentPage.locator('span').filter({ hasText: 'warnings.filterwarnings(\'ignore\')' }).locator('span').first();
 

--- a/test/e2e/tests/help/f1.test.ts
+++ b/test/e2e/tests/help/f1.test.ts
@@ -86,10 +86,7 @@ test.describe('F1 Help', {
 
 		// Wait for editor content to be fully rendered before interacting
 		await app.workbench.editor.waitForEditorContents(fileName, (content) => content.includes('pd.DataFrame'));
-
-		await expect(async () => {
-			await app.code.driver.currentPage.locator('span').filter({ hasText: 'df = pd.DataFrame(data)' }).locator('span').first().dblclick();
-		}).toPass({ timeout: 30000 });
+		await app.code.driver.currentPage.locator('span').filter({ hasText: 'df = pd.DataFrame(data)' }).locator('span').first().dblclick();
 
 		await page.keyboard.press('F1');
 

--- a/test/e2e/tests/help/f1.test.ts
+++ b/test/e2e/tests/help/f1.test.ts
@@ -35,7 +35,7 @@ test.describe('F1 Help', {
 		await console.doubleClickConsoleText('colnames');
 
 		await page.keyboard.press('F1');
-		const helpFrame = await app.workbench.help.getHelpFrame(0);
+		const helpFrame = await app.workbench.help.getHelpFrame();
 		await expect(helpFrame.locator('body')).toContainText('Row and Column Names', { timeout: 30000 });
 	});
 
@@ -45,7 +45,7 @@ test.describe('F1 Help', {
 		await page.locator('span').filter({ hasText: 'colnames(df) <- paste0(\'col\', 1:num_cols)' }).locator('span').first().dblclick();
 
 		await page.keyboard.press('F1');
-		const helpFrame = await app.workbench.help.getHelpFrame(0);
+		const helpFrame = await app.workbench.help.getHelpFrame();
 		await expect(helpFrame.locator('h2').first()).toContainText('Row and Column Names', { timeout: 30000 });
 	});
 
@@ -63,7 +63,7 @@ test.describe('F1 Help', {
 		await console.doubleClickConsoleText('list');
 
 		await page.keyboard.press('F1');
-		const helpFrame = await app.workbench.help.getHelpFrame(0);
+		const helpFrame = await app.workbench.help.getHelpFrame();
 		await expect(helpFrame.locator('p').first()).toContainText('Built-in mutable sequence.', { timeout: 30000 });
 	});
 
@@ -77,7 +77,7 @@ test.describe('F1 Help', {
 		await app.code.driver.currentPage.locator('span').filter({ hasText: 'df = pd.DataFrame(data)' }).locator('span').first().dblclick();
 
 		await page.keyboard.press('F1');
-		const helpFrame = await app.workbench.help.getHelpFrame(0);
+		const helpFrame = await app.workbench.help.getHelpFrame();
 		await expect(helpFrame.locator('h1').first()).toContainText('pandas.DataFrame', { timeout: 30000 });
 	});
 

--- a/test/e2e/tests/help/f1.test.ts
+++ b/test/e2e/tests/help/f1.test.ts
@@ -7,7 +7,7 @@ import { join } from 'path';
 import { test, expect, tags } from '../_test.setup';
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
 });
 
 
@@ -15,87 +15,73 @@ test.describe('F1 Help', {
 	tag: [tags.WEB, tags.WIN, tags.HELP]
 }, () => {
 
-	test.afterEach(async function ({ app }) {
-		await app.workbench.quickaccess.runCommand('workbench.action.closeAllEditors');
-		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
+	// Teardown only. Each test sets its own layout precondition at the start
+	// (stacked for console/editor help, notebook for notebook help) so the
+	// suite does not depend on test execution order.
+	test.afterEach(async function ({ app, hotKeys }) {
+		await hotKeys.closeAllEditors();
+		await hotKeys.closeSecondarySidebar();
 		await app.workbench.console.clearButton.click();
-		await app.workbench.quickaccess.runCommand('workbench.action.toggleAuxiliaryBar');
 	});
 
-	test('R - Verify basic F1 console help functionality', async function ({ app, page, r }) {
-		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'nyc-flights-data-r', 'flights-data-frame.r'));
-		await app.workbench.quickaccess.runCommand('r.sourceCurrentFile');
+	test('R - Verify basic F1 console help functionality', async function ({ app, page, r, openFile, runCommand }) {
+		const { variables, console, layouts } = app.workbench;
 
-		await app.workbench.variables.clickSessionLink();
-		await app.workbench.variables.waitForVariableRow('df2');
+		await layouts.enterLayout('stacked');
+		await openFile(join('workspaces', 'nyc-flights-data-r', 'flights-data-frame.r'));
+		await runCommand('r.sourceCurrentFile');
 
-		await app.workbench.console.pasteCodeToConsole('colnames(df2)');
-		await app.workbench.console.doubleClickConsoleText('colnames');
-		await page.keyboard.press('F1');
+		await variables.clickSessionLink();
+		await variables.waitForVariableRow('df2');
 
-		await expect(async () => {
-			const helpFrame = await app.workbench.help.getHelpFrame(0);
-			await expect(helpFrame.locator('body')).toContainText('Row and Column Names', { timeout: 30000 });
-		}).toPass({ timeout: 30000 });
-
-	});
-
-	test('R - Verify basic F1 editor help functionality', async function ({ app, page, r }) {
-		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'generate-data-frames-r', 'generate-data-frames.r'));
-
-		await app.code.driver.currentPage.locator('span').filter({ hasText: 'colnames(df) <- paste0(\'col\', 1:num_cols)' }).locator('span').first().dblclick();
-		await page.keyboard.press('F1');
-
-		await expect(async () => {
-			const helpFrame = await app.workbench.help.getHelpFrame(0);
-			await expect(helpFrame.locator('h2').first()).toContainText('Row and Column Names', { timeout: 30000 });
-		}).toPass({ timeout: 30000 });
-
-	});
-
-	test('R - Verify basic F1 notebook help functionality', { tag: tags.NOTEBOOKS }, async function ({ app, page, r }) {
-		await app.workbench.quickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'large_r_notebook', 'spotify.ipynb'));
-
-		await app.workbench.layouts.enterLayout('notebook');
-
-		// workaround: select the R kernel so the language server backs F1 help
-		await app.workbench.notebooksPositron.kernel.select('R');
-
-		await app.code.driver.currentPage.locator('span').filter({ hasText: 'options(digits = 2)' }).locator('span').first().dblclick();
+		await console.pasteCodeToConsole('colnames(df2)');
+		await console.doubleClickConsoleText('colnames');
 
 		await expect(async () => {
 			await page.keyboard.press('F1');
-
-			// Note that we are getting help frame 1 instead of 0 because the notebook structure matches the same locators as help
-			const helpFrame = await app.workbench.help.getHelpFrame(1);
-
-			await expect(helpFrame.locator('h2').first()).toContainText('Options Settings', { timeout: 2000 });
+			const helpFrame = await app.workbench.help.getHelpFrame(0);
+			await expect(helpFrame.locator('body')).toContainText('Row and Column Names', { timeout: 2000 });
 		}).toPass({ timeout: 30000 });
-
-		await app.workbench.layouts.enterLayout('stacked');
 
 	});
 
-	test('Python - Verify basic F1 console help functionality', async function ({ app, page, python }) {
-		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'nyc-flights-data-py', 'flights-data-frame.py'));
-		await app.workbench.quickaccess.runCommand('python.execInConsole');
-
-		await app.workbench.variables.clickSessionLink();
-		await app.workbench.variables.waitForVariableRow('df');
-
-		await app.workbench.console.pasteCodeToConsole('list(df.columns)');
-		await app.workbench.console.doubleClickConsoleText('list');
-		await page.keyboard.press('F1');
+	test('R - Verify basic F1 editor help functionality', async function ({ app, page, r, openFile }) {
+		await app.workbench.layouts.enterLayout('stacked');
+		await openFile(join('workspaces', 'generate-data-frames-r', 'generate-data-frames.r'));
+		await page.locator('span').filter({ hasText: 'colnames(df) <- paste0(\'col\', 1:num_cols)' }).locator('span').first().dblclick();
 
 		await expect(async () => {
+			await page.keyboard.press('F1');
 			const helpFrame = await app.workbench.help.getHelpFrame(0);
-			await expect(helpFrame.locator('p').first()).toContainText('Built-in mutable sequence.', { timeout: 30000 });
+			await expect(helpFrame.locator('h2').first()).toContainText('Row and Column Names', { timeout: 2000 });
+		}).toPass({ timeout: 30000 });
+
+	});
+
+	test('Python - Verify basic F1 console help functionality', async function ({ app, page, python, openFile, runCommand }) {
+		const { variables, console, layouts } = app.workbench;
+
+		await layouts.enterLayout('stacked');
+		await openFile(join('workspaces', 'nyc-flights-data-py', 'flights-data-frame.py'));
+		await runCommand('python.execInConsole');
+
+		await variables.clickSessionLink();
+		await variables.waitForVariableRow('df');
+
+		await console.pasteCodeToConsole('list(df.columns)');
+		await console.doubleClickConsoleText('list');
+
+		await expect(async () => {
+			await page.keyboard.press('F1');
+			const helpFrame = await app.workbench.help.getHelpFrame(0);
+			await expect(helpFrame.locator('p').first()).toContainText('Built-in mutable sequence.', { timeout: 2000 });
 		}).toPass({ timeout: 30000 });
 
 	});
 
 	test('Python - Verify basic F1 editor help functionality', async function ({ app, page, python }) {
 		const fileName = 'generate-data-frames.py';
+		await app.workbench.layouts.enterLayout('stacked');
 		await app.workbench.quickaccess.openFile(join(app.workspacePathOrFolder, 'workspaces', 'generate-data-frames-py', fileName));
 
 		// Wait for editor content to be fully rendered before interacting
@@ -114,13 +100,36 @@ test.describe('F1 Help', {
 
 	});
 
-	test('Python - Verify basic F1 notebook help functionality', { tag: tags.NOTEBOOKS }, async function ({ app, page, python }) {
-		await app.workbench.quickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'large_py_notebook', 'spotify.ipynb'));
+	// Notebook help tests run last: switching from the notebook layout back to a
+	// stacked layout leaves the Help webview in a state where a following console/
+	// editor help test cannot resolve its help frame. Grouping the notebook tests
+	// at the end avoids that transition.
+	test('R - Verify basic F1 notebook help functionality', { tag: tags.NOTEBOOKS }, async function ({ app, page, r, openDataFile }) {
+		const { layouts } = app.workbench;
+
+		await openDataFile(join('workspaces', 'large_r_notebook', 'spotify.ipynb'));
+		await layouts.enterLayout('notebook');
+
+		await page.locator('span').filter({ hasText: 'options(digits = 2)' }).locator('span').first().dblclick();
+
+		await expect(async () => {
+			await page.keyboard.press('F1');
+
+			// Note that we are getting help frame 1 instead of 0 because the notebook structure matches the same locators as help
+			const helpFrame = await app.workbench.help.getHelpFrame(1);
+			await expect(helpFrame.locator('h2').first()).toContainText('Options Settings', { timeout: 2000 });
+		}).toPass({ timeout: 30000 });
+	});
+
+	test('Python - Verify basic F1 notebook help functionality', { tag: tags.NOTEBOOKS }, async function ({ app, page, python, openDataFile }) {
+		const { notebooksPositron, layouts } = app.workbench;
+
+		await openDataFile(join('workspaces', 'large_py_notebook', 'spotify.ipynb'));
+		await layouts.enterLayout('notebook');
 
 		// Position the mouse over the notebook for scrolling
-		await app.workbench.notebooksPositron.cell.first().hover();
-
-		const target = app.code.driver.currentPage.locator('span').filter({ hasText: 'warnings.filterwarnings(\'ignore\')' }).locator('span').first();
+		await notebooksPositron.cell.first().hover();
+		const target = page.locator('span').filter({ hasText: 'warnings.filterwarnings(\'ignore\')' }).locator('span').first();
 
 		// Scroll the notebook until the target line is rendered in the DOM.
 		// The cell may be taller than the viewport, so Monaco only renders visible lines.
@@ -137,15 +146,11 @@ test.describe('F1 Help', {
 		await target.dblclick();
 
 		await expect(async () => {
-
 			await page.keyboard.press('F1');
-
 			// Note that we are getting help frame 1 instead of 0 because the notbook structure matches the same locators as help
 			const helpFrame = await app.workbench.help.getHelpFrame(1);
-
 			await expect(helpFrame.locator('body').first()).toContainText('warnings.filterwarnings', { timeout: 2000 });
 		}).toPass({ timeout: 30000 });
-
 	});
 
 });

--- a/test/e2e/tests/help/f1.test.ts
+++ b/test/e2e/tests/help/f1.test.ts
@@ -85,7 +85,7 @@ test.describe('F1 Help', {
 	// stacked layout leaves the Help webview in a state where a following console/
 	// editor help test cannot resolve its help frame. Grouping the notebook tests
 	// at the end avoids that transition.
-	test('R - Verify basic F1 notebook help functionality', { tag: tags.NOTEBOOKS }, async function ({ app, page, r, openDataFile }) {
+	test('R - Verify basic F1 notebook help functionality', { tag: tags.POSITRON_NOTEBOOKS }, async function ({ app, page, r, openDataFile }) {
 		const { layouts } = app.workbench;
 
 		await openDataFile(join('workspaces', 'large_r_notebook', 'spotify.ipynb'));
@@ -93,9 +93,8 @@ test.describe('F1 Help', {
 
 		await page.locator('span').filter({ hasText: 'options(digits = 2)' }).locator('span').first().dblclick();
 
-		// F1 must be retried inside toPass: a single press in a notebook cell may not
-		// register until the cell editor has focus on the token, so re-press until the
-		// help topic appears. (getHelpFrame resolves the help webview via .last().)
+		// Pressing F1 in a notebook cell may not register until the cell editor has
+		// focus on the token, so re-press until the help topic appears.
 		await expect(async () => {
 			await page.keyboard.press('F1');
 			const helpFrame = await app.workbench.help.getHelpFrame();
@@ -103,7 +102,7 @@ test.describe('F1 Help', {
 		}).toPass({ timeout: 30000 });
 	});
 
-	test('Python - Verify basic F1 notebook help functionality', { tag: tags.NOTEBOOKS }, async function ({ app, page, python, openDataFile }) {
+	test('Python - Verify basic F1 notebook help functionality', { tag: tags.POSITRON_NOTEBOOKS }, async function ({ app, page, python, openDataFile }) {
 		const { notebooksPositron, layouts } = app.workbench;
 
 		await openDataFile(join('workspaces', 'large_py_notebook', 'spotify.ipynb'));
@@ -127,9 +126,8 @@ test.describe('F1 Help', {
 
 		await target.dblclick();
 
-		// F1 must be retried inside toPass: a single press in a notebook cell may not
-		// register until the cell editor has focus on the token, so re-press until the
-		// help topic appears. (getHelpFrame resolves the help webview via .last().)
+		// Pressing F1 in a notebook cell may not register until the cell editor has
+		// focus on the token, so re-press until the help topic appears.
 		await expect(async () => {
 			await page.keyboard.press('F1');
 			const helpFrame = await app.workbench.help.getHelpFrame();

--- a/test/e2e/tests/help/f1.test.ts
+++ b/test/e2e/tests/help/f1.test.ts
@@ -10,14 +10,11 @@ test.use({
 	suiteId: __filename,
 });
 
-
 test.describe('F1 Help', {
 	tag: [tags.WEB, tags.WIN, tags.HELP]
 }, () => {
 
 	// Teardown only. Each test sets its own layout precondition at the start
-	// (stacked for console/editor help, notebook for notebook help) so the
-	// suite does not depend on test execution order.
 	test.afterEach(async function ({ app, hotKeys }) {
 		await hotKeys.closeAllEditors();
 		await hotKeys.closeSecondarySidebar();
@@ -37,12 +34,9 @@ test.describe('F1 Help', {
 		await console.pasteCodeToConsole('colnames(df2)');
 		await console.doubleClickConsoleText('colnames');
 
-		await expect(async () => {
-			await page.keyboard.press('F1');
-			const helpFrame = await app.workbench.help.getHelpFrame(0);
-			await expect(helpFrame.locator('body')).toContainText('Row and Column Names', { timeout: 2000 });
-		}).toPass({ timeout: 30000 });
-
+		await page.keyboard.press('F1');
+		const helpFrame = await app.workbench.help.getHelpFrame(0);
+		await expect(helpFrame.locator('body')).toContainText('Row and Column Names', { timeout: 30000 });
 	});
 
 	test('R - Verify basic F1 editor help functionality', async function ({ app, page, r, openFile }) {
@@ -50,12 +44,9 @@ test.describe('F1 Help', {
 		await openFile(join('workspaces', 'generate-data-frames-r', 'generate-data-frames.r'));
 		await page.locator('span').filter({ hasText: 'colnames(df) <- paste0(\'col\', 1:num_cols)' }).locator('span').first().dblclick();
 
-		await expect(async () => {
-			await page.keyboard.press('F1');
-			const helpFrame = await app.workbench.help.getHelpFrame(0);
-			await expect(helpFrame.locator('h2').first()).toContainText('Row and Column Names', { timeout: 2000 });
-		}).toPass({ timeout: 30000 });
-
+		await page.keyboard.press('F1');
+		const helpFrame = await app.workbench.help.getHelpFrame(0);
+		await expect(helpFrame.locator('h2').first()).toContainText('Row and Column Names', { timeout: 30000 });
 	});
 
 	test('Python - Verify basic F1 console help functionality', async function ({ app, page, python, openFile, runCommand }) {
@@ -71,12 +62,9 @@ test.describe('F1 Help', {
 		await console.pasteCodeToConsole('list(df.columns)');
 		await console.doubleClickConsoleText('list');
 
-		await expect(async () => {
-			await page.keyboard.press('F1');
-			const helpFrame = await app.workbench.help.getHelpFrame(0);
-			await expect(helpFrame.locator('p').first()).toContainText('Built-in mutable sequence.', { timeout: 2000 });
-		}).toPass({ timeout: 30000 });
-
+		await page.keyboard.press('F1');
+		const helpFrame = await app.workbench.help.getHelpFrame(0);
+		await expect(helpFrame.locator('p').first()).toContainText('Built-in mutable sequence.', { timeout: 30000 });
 	});
 
 	test('Python - Verify basic F1 editor help functionality', async function ({ app, page, python }) {
@@ -89,12 +77,8 @@ test.describe('F1 Help', {
 		await app.code.driver.currentPage.locator('span').filter({ hasText: 'df = pd.DataFrame(data)' }).locator('span').first().dblclick();
 
 		await page.keyboard.press('F1');
-
-		await expect(async () => {
-			const helpFrame = await app.workbench.help.getHelpFrame(0);
-			await expect(helpFrame.locator('h1').first()).toContainText('pandas.DataFrame', { timeout: 30000 });
-		}).toPass({ timeout: 30000 });
-
+		const helpFrame = await app.workbench.help.getHelpFrame(0);
+		await expect(helpFrame.locator('h1').first()).toContainText('pandas.DataFrame', { timeout: 30000 });
 	});
 
 	// Notebook help tests run last: switching from the notebook layout back to a
@@ -109,11 +93,12 @@ test.describe('F1 Help', {
 
 		await page.locator('span').filter({ hasText: 'options(digits = 2)' }).locator('span').first().dblclick();
 
+		// F1 must be retried inside toPass: a single press in a notebook cell may not
+		// register until the cell editor has focus on the token, so re-press until the
+		// help topic appears. (getHelpFrame resolves the help webview via .last().)
 		await expect(async () => {
 			await page.keyboard.press('F1');
-
-			// Note that we are getting help frame 1 instead of 0 because the notebook structure matches the same locators as help
-			const helpFrame = await app.workbench.help.getHelpFrame(1);
+			const helpFrame = await app.workbench.help.getHelpFrame();
 			await expect(helpFrame.locator('h2').first()).toContainText('Options Settings', { timeout: 2000 });
 		}).toPass({ timeout: 30000 });
 	});
@@ -142,10 +127,12 @@ test.describe('F1 Help', {
 
 		await target.dblclick();
 
+		// F1 must be retried inside toPass: a single press in a notebook cell may not
+		// register until the cell editor has focus on the token, so re-press until the
+		// help topic appears. (getHelpFrame resolves the help webview via .last().)
 		await expect(async () => {
 			await page.keyboard.press('F1');
-			// Note that we are getting help frame 1 instead of 0 because the notbook structure matches the same locators as help
-			const helpFrame = await app.workbench.help.getHelpFrame(1);
+			const helpFrame = await app.workbench.help.getHelpFrame();
 			await expect(helpFrame.locator('body').first()).toContainText('warnings.filterwarnings', { timeout: 2000 });
 		}).toPass({ timeout: 30000 });
 	});

--- a/test/e2e/tests/help/f1.test.ts
+++ b/test/e2e/tests/help/f1.test.ts
@@ -18,7 +18,12 @@ test.describe('F1 Help', {
 	test.afterEach(async function ({ app, hotKeys }) {
 		await hotKeys.closeAllEditors();
 		await hotKeys.closeSecondarySidebar();
-		await app.workbench.console.clearButton.click();
+		// Notebook tests end in the notebook layout, which can hide the console
+		// panel; only clear the console when its button is visible so teardown
+		// never fails on the hidden panel.
+		if (await app.workbench.console.clearButton.isVisible()) {
+			await app.workbench.console.clearButton.click();
+		}
 	});
 
 	test('R - Verify basic F1 console help functionality', async function ({ app, page, r, openFile, runCommand }) {

--- a/test/e2e/tests/help/help.test.ts
+++ b/test/e2e/tests/help/help.test.ts
@@ -50,7 +50,7 @@ test.describe('Help', { tag: [tags.HELP, tags.WEB] }, () => {
 		await app.workbench.console.executeCode('Python', `?load`);
 
 		await expect(async () => {
-			const helpFrame = await app.workbench.help.getHelpFrame(0);
+			const helpFrame = await app.workbench.help.getHelpFrame();
 			await expect(helpFrame.locator('body')).toContainText('Load code into the current frontend.');
 		}).toPass();
 
@@ -60,7 +60,7 @@ test.describe('Help', { tag: [tags.HELP, tags.WEB] }, () => {
 		await app.workbench.console.executeCode('R', `?load()`);
 
 		await expect(async () => {
-			const helpFrame = await app.workbench.help.getHelpFrame(1);
+			const helpFrame = await app.workbench.help.getHelpFrame();
 			await expect(helpFrame.locator('body')).toContainText('Reload Saved Datasets');
 		}).toPass();
 

--- a/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
+++ b/test/e2e/tests/new-folder-flow/helpers/new-folder-flow.ts
@@ -26,9 +26,11 @@ export async function verifyConsoleReady(app: Application, folderTemplate: Folde
 	await test.step(`Verify console is ready`, async () => {
 		const consoleSymbol = folderTemplate === FolderTemplate.R_PROJECT ? '>' : '>>>';
 
+		await app.workbench.sessions.expectAllSessionsToBeReady();
 		await app.workbench.hotKeys.closeSecondarySidebar();
 		await app.workbench.console.waitForReadyAndStarted(consoleSymbol, 90000);
 		await app.workbench.hotKeys.showSecondarySidebar();
+
 	});
 }
 

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
@@ -62,6 +62,9 @@ async function verifyNotebookKernelPythonVersion(app: Application) {
 
 	await sessions.expectSessionPickerToBe(/Untitled-1\.ipynb/);
 	// Assert the kernel resolved to a concrete Python version, not just a generic
-	// "Python" label, so a stuck/unresolved kernel would fail here.
+	// "Python" label, so a stuck/unresolved kernel would fail here. The legacy
+	// test also checked the project folder name in the kernel label, but the
+	// #14163 workaround above rebinds the kernel to the global Python (not the
+	// project runtime), so the folder name is intentionally not asserted.
 	await notebooksPositron.kernel.expectBadgeToContain(/Python \d+\.\d+\.\d+/);
 }

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
@@ -24,7 +24,8 @@ test.describe('New Folder Flow: Jupyter Project', {
 	// Removing WIN tag until we get uv into windows CI as this expects uv to be the interpreter
 	test('Jupyter Folder Defaults', {
 		tag: [tags.CRITICAL, tags.INTERPRETER, tags.WIN]
-	}, async function ({ app, settings }) {
+	}, async function ({ app }) {
+		const { notebooksPositron } = app.workbench;
 		const folderName = addRandomNumSuffix('python-notebook-runtime');
 
 		// Create a new Python notebook folder
@@ -36,38 +37,26 @@ test.describe('New Folder Flow: Jupyter Project', {
 		await verifyFolderCreation(app, folderName);
 		await verifyConsoleReady(app, folderTemplate);
 		await verifyNotebookEditorVisible(app);
-		// Workaround for https://github.com/posit-dev/positron/issues/14163: the Positron
-		// notebook editor does not auto-bind the project runtime as the kernel for the
-		// notebook auto-opened by the New Folder Flow, so the kernel badge stays on
-		// "No Kernel Selected". Select it manually so the rest of the flow stays under test.
-		// Remove this once #14163 is fixed and the kernel binds automatically.
-		await app.workbench.notebooksPositron.kernel.select('Python');
+
+		// Workaround for https://github.com/posit-dev/positron/issues/14163
+		// Shouldn't have to re-select the kernel. Remove lines 40-45 when fixed.
+		await notebooksPositron.kernel.change('Python');
+		await notebooksPositron.kernel.expectStatusToBe('idle');
+
 		await verifyNotebookAndConsolePythonVersion(app);
 		await verifyPyprojectTomlNotCreated(app);
 	});
 });
 
 async function verifyNotebookEditorVisible(app: Application) {
-	// .first() works around the duplicate editor tab from #14163.
-	const notebookEditorTab = app.code.driver.currentPage.locator('[id="workbench.parts.editor"]').getByText('Untitled-1.ipynb', { exact: true }).first();
-	await expect(notebookEditorTab).toBeVisible();
+	const { editors } = app.workbench;
+
+	editors.verifyTab('Untitled-1.ipynb', { isVisible: true });
 }
 
 async function verifyNotebookAndConsolePythonVersion(app: Application) {
-	const sessionSelectorButton = app.code.driver.currentPage.getByRole('button', { name: 'Select Session' });
-	const sessionSelectorText = await sessionSelectorButton.textContent();
+	const { sessions, notebooksPositron } = app.workbench;
 
-	// Extract the version number (e.g., '3.10.12') from the button text
-	const versionMatch = sessionSelectorText && sessionSelectorText.match(/Python ([0-9]+\.[0-9]+\.[0-9]+)/);
-	const pythonVersion = versionMatch ? versionMatch[1] : undefined;
-
-	// Fail the test if we can't extract the version
-	expect(pythonVersion, 'Python version should be present in session selector').toBeTruthy();
-
-	// After the runtime starts up the kernel status badge should show the kernel name.
-	// The kernel name should contain the Python version from the session selector.
-	// Scope to the Positron notebook editor's "Kernel Actions" status badge to avoid false positives.
-	const kernelBadge = app.workbench.notebooksPositron.kernel.statusBadge;
-	await expect(kernelBadge).toContainText(`Python ${pythonVersion}`);
-	await expect(kernelBadge).toContainText('python-notebook-runtime');
+	await sessions.expectSessionPickerToBe(/Untitled-1\.ipynb/);
+	await notebooksPositron.kernel.expectBadgeToContain(/Python/);
 }

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
@@ -51,9 +51,7 @@ test.describe('New Folder Flow: Jupyter Project', {
 async function verifyNotebookEditorVisible(app: Application) {
 	const { notebooksPositron } = app.workbench;
 
-	// New Folder Flow opens duplicate notebook tabs (#14163), so matching the tab
-	// by name hits a strict-mode violation. Assert the notebook editor itself is
-	// visible instead.
+	// Assert the editor, not the tab: New Folder Flow opens duplicate tabs (#14163).
 	await notebooksPositron.expectToBeVisible();
 }
 
@@ -61,10 +59,7 @@ async function verifyNotebookKernelPythonVersion(app: Application) {
 	const { sessions, notebooksPositron } = app.workbench;
 
 	await sessions.expectSessionPickerToBe(/Untitled-1\.ipynb/);
-	// Assert the kernel resolved to a concrete Python version, not just a generic
-	// "Python" label, so a stuck/unresolved kernel would fail here. The legacy
-	// test also checked the project folder name in the kernel label, but the
-	// #14163 workaround above rebinds the kernel to the global Python (not the
-	// project runtime), so the folder name is intentionally not asserted.
+	// Concrete version, not just "Python". Folder name not checked: the #14163
+	// workaround rebinds the kernel to the global Python, not the project runtime.
 	await notebooksPositron.kernel.expectBadgeToContain(/Python \d+\.\d+\.\d+/);
 }

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
@@ -5,7 +5,7 @@
 
 import { Application } from '../../infra/index.js';
 import { FolderTemplate } from '../../pages/newFolderFlow.js';
-import { test, tags, expect } from '../_test.setup';
+import { test, tags } from '../_test.setup';
 import { addRandomNumSuffix, verifyConsoleReady, verifyFolderCreation, verifyPyprojectTomlNotCreated } from './helpers/new-folder-flow.js';
 
 test.use({

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
@@ -49,9 +49,12 @@ test.describe('New Folder Flow: Jupyter Project', {
 });
 
 async function verifyNotebookEditorVisible(app: Application) {
-	const { editors } = app.workbench;
+	const { notebooksPositron } = app.workbench;
 
-	await editors.verifyTab('Untitled-1.ipynb', { isVisible: true });
+	// New Folder Flow opens duplicate notebook tabs (#14163), so matching the tab
+	// by name hits a strict-mode violation. Assert the notebook editor itself is
+	// visible instead.
+	await notebooksPositron.expectToBeVisible();
 }
 
 async function verifyNotebookKernelPythonVersion(app: Application) {

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
@@ -43,7 +43,7 @@ test.describe('New Folder Flow: Jupyter Project', {
 		await notebooksPositron.kernel.change('Python');
 		await notebooksPositron.kernel.expectStatusToBe('idle');
 
-		await verifyNotebookAndConsolePythonVersion(app);
+		await verifyNotebookKernelPythonVersion(app);
 		await verifyPyprojectTomlNotCreated(app);
 	});
 });
@@ -54,9 +54,11 @@ async function verifyNotebookEditorVisible(app: Application) {
 	await editors.verifyTab('Untitled-1.ipynb', { isVisible: true });
 }
 
-async function verifyNotebookAndConsolePythonVersion(app: Application) {
+async function verifyNotebookKernelPythonVersion(app: Application) {
 	const { sessions, notebooksPositron } = app.workbench;
 
 	await sessions.expectSessionPickerToBe(/Untitled-1\.ipynb/);
-	await notebooksPositron.kernel.expectBadgeToContain(/Python/);
+	// Assert the kernel resolved to a concrete Python version, not just a generic
+	// "Python" label, so a stuck/unresolved kernel would fail here.
+	await notebooksPositron.kernel.expectBadgeToContain(/Python \d+\.\d+\.\d+/);
 }

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
@@ -51,7 +51,7 @@ test.describe('New Folder Flow: Jupyter Project', {
 async function verifyNotebookEditorVisible(app: Application) {
 	const { editors } = app.workbench;
 
-	editors.verifyTab('Untitled-1.ipynb', { isVisible: true });
+	await editors.verifyTab('Untitled-1.ipynb', { isVisible: true });
 }
 
 async function verifyNotebookAndConsolePythonVersion(app: Application) {

--- a/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
@@ -9,8 +9,7 @@ import { test, tags, expect } from '../_test.setup';
 import { addRandomNumSuffix, verifyConsoleReady, verifyFolderCreation, verifyPyprojectTomlNotCreated } from './helpers/new-folder-flow.js';
 
 test.use({
-	suiteId: __filename,
-	useLegacyNotebookEditor: true
+	suiteId: __filename
 });
 
 test.describe('New Folder Flow: Jupyter Project', {
@@ -37,13 +36,20 @@ test.describe('New Folder Flow: Jupyter Project', {
 		await verifyFolderCreation(app, folderName);
 		await verifyConsoleReady(app, folderTemplate);
 		await verifyNotebookEditorVisible(app);
+		// Workaround for https://github.com/posit-dev/positron/issues/14163: the Positron
+		// notebook editor does not auto-bind the project runtime as the kernel for the
+		// notebook auto-opened by the New Folder Flow, so the kernel badge stays on
+		// "No Kernel Selected". Select it manually so the rest of the flow stays under test.
+		// Remove this once #14163 is fixed and the kernel binds automatically.
+		await app.workbench.notebooksPositron.kernel.select('Python');
 		await verifyNotebookAndConsolePythonVersion(app);
 		await verifyPyprojectTomlNotCreated(app);
 	});
 });
 
 async function verifyNotebookEditorVisible(app: Application) {
-	const notebookEditorTab = app.code.driver.currentPage.locator('[id="workbench.parts.editor"]').getByText('Untitled-1.ipynb', { exact: true });
+	// .first() works around the duplicate editor tab from #14163.
+	const notebookEditorTab = app.code.driver.currentPage.locator('[id="workbench.parts.editor"]').getByText('Untitled-1.ipynb', { exact: true }).first();
 	await expect(notebookEditorTab).toBeVisible();
 }
 
@@ -58,10 +64,10 @@ async function verifyNotebookAndConsolePythonVersion(app: Application) {
 	// Fail the test if we can't extract the version
 	expect(pythonVersion, 'Python version should be present in session selector').toBeTruthy();
 
-	// After the runtime starts up the kernel status should be replaced with the kernel name.
-	// The kernel name should contain the Python version from the session selector
-	// Only look within an 'a' tag with class 'kernel-label' to avoid false positives
-	const kernelLabel = app.code.driver.currentPage.locator('a.kernel-label');
-	await expect(kernelLabel).toContainText(`Python ${pythonVersion}`);
-	await expect(kernelLabel).toContainText('python-notebook-runtime');
+	// After the runtime starts up the kernel status badge should show the kernel name.
+	// The kernel name should contain the Python version from the session selector.
+	// Scope to the Positron notebook editor's "Kernel Actions" status badge to avoid false positives.
+	const kernelBadge = app.workbench.notebooksPositron.kernel.statusBadge;
+	await expect(kernelBadge).toContainText(`Python ${pythonVersion}`);
+	await expect(kernelBadge).toContainText('python-notebook-runtime');
 }

--- a/test/e2e/tests/packages-pane/packages-pane.test.ts
+++ b/test/e2e/tests/packages-pane/packages-pane.test.ts
@@ -85,7 +85,7 @@ test.describe('Packages Pane', {
 
 			// Base is always attached
 			await packages.clickHelpButton('base');
-			await packages.expectHelpPaneToContainText('The R Base Package', 0);
+			await packages.expectHelpPaneToContainText('The R Base Package');
 		});
 
 		test('Python - Opens package help in Help pane', { tag: [tags.WEB] },
@@ -97,7 +97,7 @@ test.describe('Packages Pane', {
 				await packages.clickRefreshPackagesButton();
 
 				await packages.clickHelpButton('numpy');
-				await packages.expectHelpPaneToContainText('NumPy', 1);
+				await packages.expectHelpPaneToContainText('NumPy');
 			});
 	});
 

--- a/test/e2e/tests/plots/matplotlib-interact.test.ts
+++ b/test/e2e/tests/plots/matplotlib-interact.test.ts
@@ -29,10 +29,10 @@ test.describe('Matplotlib Interact', { tag: [tags.PLOTS, tags.POSITRON_NOTEBOOKS
 
 		// The interact() output renders in an overlay webview that is only claimed
 		// once the cell output is scrolled into view; otherwise the frame is empty.
-		await notebooksPositron.cell.nth(0).getByTestId('cell-output').scrollIntoViewIfNeeded();
+		await notebooksPositron.cellOutput(0).scrollIntoViewIfNeeded();
 
 		const plotImage = notebooksPositron.frameLocator.locator('.widget-output img');
-		const radiusReadout = notebooksPositron.frameLocator.locator('.widget-slider .widget-readout').first();
+		const radiusReadout = notebooksPositron.widgetReadout.first();
 		const radiusSlider = notebooksPositron.widgetSlider.first();
 
 		// The circle figure is not drawn until a slider is moved (interact defers the

--- a/test/e2e/tests/plots/matplotlib-interact.test.ts
+++ b/test/e2e/tests/plots/matplotlib-interact.test.ts
@@ -27,22 +27,18 @@ test.describe('Matplotlib Interact', { tag: [tags.PLOTS, tags.POSITRON_NOTEBOOKS
 		await notebooksPositron.expectNoActiveSpinners(30000);
 		await hotKeys.toggleBottomPanel();
 
-		// The interact() output renders in an overlay webview that is only claimed
-		// once the cell output is scrolled into view; otherwise the frame is empty.
+		// Scroll the output into view to claim its overlay webview, else the frame is empty.
 		await notebooksPositron.cellOutput(0).scrollIntoViewIfNeeded();
 
 		const plotImage = notebooksPositron.frameLocator.locator('.widget-output img');
 		const radiusReadout = notebooksPositron.widgetReadout.first();
 		const radiusSlider = notebooksPositron.widgetSlider.first();
 
-		// The circle figure is not drawn until a slider is moved (interact defers the
-		// first render), so the plot image is absent initially.
+		// interact() defers the first render: the plot is absent until a slider moves.
 		await expect(radiusReadout).toHaveText('1.00');
 		await expect(plotImage).toHaveCount(0);
 
-		// Move the radius slider and verify both the readout and the rendered plot
-		// update. The keypress is retried until the value changes because a single
-		// press can land before the slider handle has focus.
+		// Retry the keypress until the value changes (a single press can precede focus).
 		await radiusSlider.click();
 		await expect(async () => {
 			await radiusSlider.press('ArrowRight');

--- a/test/e2e/tests/plots/matplotlib-interact.test.ts
+++ b/test/e2e/tests/plots/matplotlib-interact.test.ts
@@ -10,7 +10,7 @@ test.use({
 	suiteId: __filename
 });
 
-test.describe('Matplotlib Interact', { tag: [tags.PLOTS, tags.NOTEBOOKS] }, () => {
+test.describe('Matplotlib Interact', { tag: [tags.PLOTS, tags.POSITRON_NOTEBOOKS] }, () => {
 
 	test('Python - Matplotlib Interact Test', {
 		tag: [tags.WEB, tags.WIN],

--- a/test/e2e/tests/plots/matplotlib-interact.test.ts
+++ b/test/e2e/tests/plots/matplotlib-interact.test.ts
@@ -27,20 +27,30 @@ test.describe('Matplotlib Interact', { tag: [tags.PLOTS, tags.NOTEBOOKS] }, () =
 		await notebooksPositron.expectNoActiveSpinners(30000);
 		await hotKeys.toggleBottomPanel();
 
-		// interact with the sliders and verify the plot updates
-		const plotLocator = notebooksPositron.frameLocator.locator('.widget-output');
-		const plotImageLocator = plotLocator.locator('img');
+		// The interact() output renders in an overlay webview that is only claimed
+		// once the cell output is scrolled into view; otherwise the frame is empty.
+		await notebooksPositron.cell.nth(0).getByTestId('cell-output').scrollIntoViewIfNeeded();
 
-		const imgSrcBefore = await plotImageLocator.getAttribute('src');
+		const plotImage = notebooksPositron.frameLocator.locator('.widget-output img');
+		const radiusReadout = notebooksPositron.frameLocator.locator('.widget-slider .widget-readout').first();
+		const radiusSlider = notebooksPositron.widgetSlider.first();
 
-		const sliders = await notebooksPositron.frameLocator.locator('.slider-container .slider').all();
-		for (const slider of sliders) {
-			await slider.hover();
-			await slider.click();
-		}
+		// The circle figure is not drawn until a slider is moved (interact defers the
+		// first render), so the plot image is absent initially.
+		await expect(radiusReadout).toHaveText('1.00');
+		await expect(plotImage).toHaveCount(0);
 
-		const imgSrcAfter = await plotImageLocator.getAttribute('src');
-		expect(imgSrcBefore).not.toBe(imgSrcAfter);
+		// Move the radius slider and verify both the readout and the rendered plot
+		// update. The keypress is retried until the value changes because a single
+		// press can land before the slider handle has focus.
+		await radiusSlider.click();
+		await expect(async () => {
+			await radiusSlider.press('ArrowRight');
+			await expect(radiusReadout).not.toHaveText('1.00');
+			await expect(plotImage).toBeVisible();
+		}).toPass({ timeout: 30000 });
+
+		expect(await plotImage.getAttribute('src')).toMatch(/^data:image\/png/);
 	});
 
 });

--- a/test/e2e/tests/plots/matplotlib-interact.test.ts
+++ b/test/e2e/tests/plots/matplotlib-interact.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -7,8 +7,7 @@ import { join } from 'path';
 import { test, expect, tags } from '../_test.setup';
 
 test.use({
-	suiteId: __filename,
-	useLegacyNotebookEditor: true
+	suiteId: __filename
 });
 
 test.describe('Matplotlib Interact', { tag: [tags.PLOTS, tags.NOTEBOOKS] }, () => {
@@ -16,24 +15,25 @@ test.describe('Matplotlib Interact', { tag: [tags.PLOTS, tags.NOTEBOOKS] }, () =
 	test('Python - Matplotlib Interact Test', {
 		tag: [tags.WEB, tags.WIN],
 	}, async function ({ app, hotKeys, python }) {
-		const { notebooks, quickaccess } = app.workbench;
+		const { notebooksPositron, quickaccess } = app.workbench;
 
 		// open the Matplotlib Interact notebook and run all cells
 		await quickaccess.openDataFile(join(app.workspacePathOrFolder, 'workspaces', 'matplotlib', 'interact.ipynb'));
-		await notebooks.selectInterpreter('Python');
+		await notebooksPositron.kernel.select('Python');
 
 		await hotKeys.closeSecondarySidebar();
 
-		await notebooks.runAllCells();
+		await notebooksPositron.clickActionBarButtton('Run All');
+		await notebooksPositron.expectNoActiveSpinners(30000);
 		await hotKeys.toggleBottomPanel();
 
 		// interact with the sliders and verify the plot updates
-		const plotLocator = notebooks.frameLocator.locator('.widget-output');
+		const plotLocator = notebooksPositron.frameLocator.locator('.widget-output');
 		const plotImageLocator = plotLocator.locator('img');
 
 		const imgSrcBefore = await plotImageLocator.getAttribute('src');
 
-		const sliders = await notebooks.frameLocator.locator('.slider-container .slider').all();
+		const sliders = await notebooksPositron.frameLocator.locator('.slider-container .slider').all();
 		for (const slider of sliders) {
 			await slider.hover();
 			await slider.click();

--- a/test/e2e/tests/variables/variables-notebook.test.ts
+++ b/test/e2e/tests/variables/variables-notebook.test.ts
@@ -18,12 +18,11 @@ test.describe('Variables Pane - Notebook', {
 }, () => {
 	test('R - Verify Variables pane basic function for notebook', {
 		tag: [tags.ARK]
-	}, async function ({ app, hotKeys }) {
+	}, async function ({ app, hotKeys, r }) {
 		const { notebooksPositron, variables } = app.workbench;
 
 		// Create a variable via a notebook
 		await notebooksPositron.newNotebook();
-		await notebooksPositron.kernel.select('R');
 		await notebooksPositron.addCodeToCell(0, 'y <- c(2, 3, 4, 5)', { run: true });
 
 		// Verify the var in the variable pane
@@ -31,12 +30,11 @@ test.describe('Variables Pane - Notebook', {
 		await variables.expectVariableToBe('y', '2 3 4 5');
 	});
 
-	test('Python - Verify Variables pane basic function for notebook', async function ({ app }) {
+	test('Python - Verify Variables pane basic function for notebook', async function ({ app, python }) {
 		const { notebooksPositron, variables, hotKeys } = app.workbench;
 
 		// Create a variable via a notebook
 		await notebooksPositron.newNotebook();
-		await notebooksPositron.kernel.select('Python');
 		await notebooksPositron.addCodeToCell(0, 'y = [2, 3, 4, 5]', { run: true });
 
 		// Verify the var in the variable pane
@@ -44,12 +42,11 @@ test.describe('Variables Pane - Notebook', {
 		await variables.expectVariableToBe('y', '[2, 3, 4, 5]');
 	});
 
-	test('Python - Verify Variables available after reload', async function ({ app, hotKeys }) {
+	test('Python - Verify Variables available after reload', async function ({ app, hotKeys, python }) {
 		const { notebooksPositron, variables } = app.workbench;
 
 		// Create a variable via a notebook
 		await notebooksPositron.newNotebook();
-		await notebooksPositron.kernel.select('Python');
 		await notebooksPositron.addCodeToCell(0, 'dict = [{"a":1,"b":2},{"a":3,"b":4}]', { run: true });
 
 		// Verify the var in the variable pane
@@ -63,12 +60,10 @@ test.describe('Variables Pane - Notebook', {
 		await variables.expectVariableToBe('dict', `[{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]`);
 	});
 
-	test('Python - Verify variables persist across cells', async function ({ app }) {
+	test('Python - Verify variables persist across cells', async function ({ app, python }) {
 		const { notebooksPositron } = app.workbench;
 
 		await notebooksPositron.newNotebook();
-		await notebooksPositron.kernel.select('Python');
-
 		await notebooksPositron.addCodeToCell(0, variableCode, { run: true });
 		await notebooksPositron.addCodeToCell(1, useVariableCode, { run: true });
 
@@ -78,14 +73,11 @@ test.describe('Variables Pane - Notebook', {
 
 	test('Python - Verify Variables pane stays on notebook session after opening Data Explorer', {
 		tag: [tags.DATA_EXPLORER]
-	}, async function ({ app, hotKeys }) {
+	}, async function ({ app, hotKeys, python }) {
 		const { notebooksPositron, variables, editors } = app.workbench;
 
 		// Create a dataframe in a notebook
 		await notebooksPositron.newNotebook();
-		await notebooksPositron.kernel.select('Python');
-		// Wait for the cell to finish executing (pandas import takes a moment) before
-		// asserting on the Variables pane, matching the legacy executeCodeInCell() wait.
 		await notebooksPositron.addCodeToCell(0, 'import pandas as pd\ndf = pd.DataFrame({"a": [1, 2, 3]})', { run: true, waitForSpinner: true });
 
 		// Verify we're on the notebook session

--- a/test/e2e/tests/variables/variables-notebook.test.ts
+++ b/test/e2e/tests/variables/variables-notebook.test.ts
@@ -69,13 +69,16 @@ test.describe('Variables Pane - Notebook', {
 		const { notebooksPositron } = app.workbench;
 
 		await notebooksPositron.newNotebook();
-		// waitForSpinner so each cell finishes executing (and its output renders)
-		// before asserting; otherwise the notebook layout is still settling when
-		// expectOutputAtIndex scrolls to cell 0, which flakes scrollIntoViewIfNeeded.
-		await notebooksPositron.addCodeToCell(0, variableCode, { run: true, waitForSpinner: true });
-		await notebooksPositron.addCodeToCell(1, useVariableCode, { run: true, waitForSpinner: true });
 
+		// fast: true inserts the code atomically so Monaco's auto-closing brackets
+		// and auto-indent don't corrupt this bracket/quote-heavy multi-line code as
+		// it types; pressSequentially intermittently produced invalid syntax and the
+		// cell errored instead of printing its output. Assert cell 0's output before
+		// running cell 1 so its layout is stable before the next cell is added.
+		await notebooksPositron.addCodeToCell(0, variableCode, { run: true, fast: true });
 		await notebooksPositron.expectOutputAtIndex(0, ['Hello from first cell']);
+
+		await notebooksPositron.addCodeToCell(1, useVariableCode, { run: true, fast: true });
 		await notebooksPositron.expectOutputAtIndex(1, ['Sum of numbers: 15', 'Modified numbers: [1, 2, 3, 4, 5, 6]']);
 	});
 

--- a/test/e2e/tests/variables/variables-notebook.test.ts
+++ b/test/e2e/tests/variables/variables-notebook.test.ts
@@ -6,8 +6,7 @@
 import { test, tags } from '../_test.setup';
 
 test.use({
-	suiteId: __filename,
-	useLegacyNotebookEditor: true
+	suiteId: __filename
 });
 
 test.afterEach(async function ({ hotKeys }) {
@@ -20,13 +19,12 @@ test.describe('Variables Pane - Notebook', {
 	test('R - Verify Variables pane basic function for notebook', {
 		tag: [tags.ARK]
 	}, async function ({ app, hotKeys }) {
-		const { notebooks, variables } = app.workbench;
+		const { notebooksPositron, variables } = app.workbench;
 
 		// Create a variable via a notebook
-		await notebooks.createNewNotebook();
-		await notebooks.selectInterpreter('R');
-		await notebooks.addCodeToCellAtIndex(0, 'y <- c(2, 3, 4, 5)');
-		await notebooks.executeCodeInCell();
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.kernel.select('R');
+		await notebooksPositron.addCodeToCell(0, 'y <- c(2, 3, 4, 5)', { run: true });
 
 		// Verify the var in the variable pane
 		await hotKeys.fullSizeSecondarySidebar();
@@ -34,13 +32,12 @@ test.describe('Variables Pane - Notebook', {
 	});
 
 	test('Python - Verify Variables pane basic function for notebook', async function ({ app }) {
-		const { notebooks, variables, hotKeys } = app.workbench;
+		const { notebooksPositron, variables, hotKeys } = app.workbench;
 
 		// Create a variable via a notebook
-		await notebooks.createNewNotebook();
-		await notebooks.selectInterpreter('Python');
-		await notebooks.addCodeToCellAtIndex(0, 'y = [2, 3, 4, 5]');
-		await notebooks.executeCodeInCell();
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.kernel.select('Python');
+		await notebooksPositron.addCodeToCell(0, 'y = [2, 3, 4, 5]', { run: true });
 
 		// Verify the var in the variable pane
 		await hotKeys.fullSizeSecondarySidebar();
@@ -48,13 +45,12 @@ test.describe('Variables Pane - Notebook', {
 	});
 
 	test('Python - Verify Variables available after reload', async function ({ app, hotKeys }) {
-		const { notebooks, variables } = app.workbench;
+		const { notebooksPositron, variables } = app.workbench;
 
 		// Create a variable via a notebook
-		await notebooks.createNewNotebook();
-		await notebooks.selectInterpreter('Python');
-		await notebooks.addCodeToCellAtIndex(0, 'dict = [{"a":1,"b":2},{"a":3,"b":4}]');
-		await notebooks.executeCodeInCell();
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.kernel.select('Python');
+		await notebooksPositron.addCodeToCell(0, 'dict = [{"a":1,"b":2},{"a":3,"b":4}]', { run: true });
 
 		// Verify the var in the variable pane
 		await hotKeys.fullSizeSecondarySidebar();
@@ -68,32 +64,29 @@ test.describe('Variables Pane - Notebook', {
 	});
 
 	test('Python - Verify variables persist across cells', async function ({ app }) {
-		const { notebooks } = app.workbench;
+		const { notebooksPositron } = app.workbench;
 
-		await notebooks.createNewNotebook();
-		await notebooks.selectInterpreter('Python');
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.kernel.select('Python');
 
-		await notebooks.addCodeToCellAtIndex(0, variableCode);
-		await notebooks.executeCodeInCell();
-		await notebooks.insertNotebookCell('code');
+		await notebooksPositron.addCodeToCell(0, variableCode, { run: true });
+		await notebooksPositron.addCodeToCell(1, useVariableCode, { run: true });
 
-		await notebooks.addCodeToCellAtIndex(1, useVariableCode);
-		await notebooks.executeCodeInCell();
-		await notebooks.assertCellOutput('Hello from first cell', 0);
-		await notebooks.assertCellOutput('Sum of numbers: 15');
-		await notebooks.assertCellOutput('Modified numbers: [1, 2, 3, 4, 5, 6]');
+		await notebooksPositron.expectOutputAtIndex(0, ['Hello from first cell']);
+		await notebooksPositron.expectOutputAtIndex(1, ['Sum of numbers: 15', 'Modified numbers: [1, 2, 3, 4, 5, 6]']);
 	});
 
 	test('Python - Verify Variables pane stays on notebook session after opening Data Explorer', {
 		tag: [tags.DATA_EXPLORER]
 	}, async function ({ app, hotKeys }) {
-		const { notebooks, variables, editors } = app.workbench;
+		const { notebooksPositron, variables, editors } = app.workbench;
 
 		// Create a dataframe in a notebook
-		await notebooks.createNewNotebook();
-		await notebooks.selectInterpreter('Python');
-		await notebooks.addCodeToCellAtIndex(0, 'import pandas as pd\ndf = pd.DataFrame({"a": [1, 2, 3]})');
-		await notebooks.executeCodeInCell();
+		await notebooksPositron.newNotebook();
+		await notebooksPositron.kernel.select('Python');
+		// Wait for the cell to finish executing (pandas import takes a moment) before
+		// asserting on the Variables pane, matching the legacy executeCodeInCell() wait.
+		await notebooksPositron.addCodeToCell(0, 'import pandas as pd\ndf = pd.DataFrame({"a": [1, 2, 3]})', { run: true, waitForSpinner: true });
 
 		// Verify we're on the notebook session
 		await hotKeys.fullSizeSecondarySidebar();

--- a/test/e2e/tests/variables/variables-notebook.test.ts
+++ b/test/e2e/tests/variables/variables-notebook.test.ts
@@ -14,7 +14,7 @@ test.afterEach(async function ({ hotKeys }) {
 });
 
 test.describe('Variables Pane - Notebook', {
-	tag: [tags.CRITICAL, tags.WEB, tags.VARIABLES, tags.NOTEBOOKS]
+	tag: [tags.CRITICAL, tags.WEB, tags.VARIABLES, tags.POSITRON_NOTEBOOKS]
 }, () => {
 	test('R - Verify Variables pane basic function for notebook', {
 		tag: [tags.ARK]

--- a/test/e2e/tests/variables/variables-notebook.test.ts
+++ b/test/e2e/tests/variables/variables-notebook.test.ts
@@ -56,8 +56,13 @@ test.describe('Variables Pane - Notebook', {
 		// Reload window
 		await hotKeys.reloadWindow(true);
 
+		// After reload a console session is foregrounded in the Variables pane, so
+		// the notebook's variables sit in a background instance. Re-activate the
+		// notebook by clicking its tab so its session's variables show again.
+		await app.workbench.editors.clickTab('Untitled-1.ipynb');
+
 		// Ensure the variable is still present
-		await variables.expectVariableToBe('dict', `[{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]`);
+		await variables.expectVariableToBe('dict', `[{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]`, 30000);
 	});
 
 	test('Python - Verify variables persist across cells', async function ({ app, python }) {

--- a/test/e2e/tests/variables/variables-notebook.test.ts
+++ b/test/e2e/tests/variables/variables-notebook.test.ts
@@ -56,9 +56,7 @@ test.describe('Variables Pane - Notebook', {
 		// Reload window
 		await hotKeys.reloadWindow(true);
 
-		// After reload a console session is foregrounded in the Variables pane, so
-		// the notebook's variables sit in a background instance. Re-activate the
-		// notebook by clicking its tab so its session's variables show again.
+		// After reload a console session is foregrounded; click the notebook tab to surface its variables.
 		await app.workbench.editors.clickTab('Untitled-1.ipynb');
 
 		// Ensure the variable is still present
@@ -70,11 +68,8 @@ test.describe('Variables Pane - Notebook', {
 
 		await notebooksPositron.newNotebook();
 
-		// fast: true inserts the code atomically so Monaco's auto-closing brackets
-		// and auto-indent don't corrupt this bracket/quote-heavy multi-line code as
-		// it types; pressSequentially intermittently produced invalid syntax and the
-		// cell errored instead of printing its output. Assert cell 0's output before
-		// running cell 1 so its layout is stable before the next cell is added.
+		// fast: true avoids Monaco auto-closing brackets corrupting this multi-line
+		// code (pressSequentially produced SyntaxErrors); check cell 0 before cell 1.
 		await notebooksPositron.addCodeToCell(0, variableCode, { run: true, fast: true });
 		await notebooksPositron.expectOutputAtIndex(0, ['Hello from first cell']);
 

--- a/test/e2e/tests/variables/variables-notebook.test.ts
+++ b/test/e2e/tests/variables/variables-notebook.test.ts
@@ -69,8 +69,11 @@ test.describe('Variables Pane - Notebook', {
 		const { notebooksPositron } = app.workbench;
 
 		await notebooksPositron.newNotebook();
-		await notebooksPositron.addCodeToCell(0, variableCode, { run: true });
-		await notebooksPositron.addCodeToCell(1, useVariableCode, { run: true });
+		// waitForSpinner so each cell finishes executing (and its output renders)
+		// before asserting; otherwise the notebook layout is still settling when
+		// expectOutputAtIndex scrolls to cell 0, which flakes scrollIntoViewIfNeeded.
+		await notebooksPositron.addCodeToCell(0, variableCode, { run: true, waitForSpinner: true });
+		await notebooksPositron.addCodeToCell(1, useVariableCode, { run: true, waitForSpinner: true });
 
 		await notebooksPositron.expectOutputAtIndex(0, ['Hello from first cell']);
 		await notebooksPositron.expectOutputAtIndex(1, ['Sum of numbers: 15', 'Modified numbers: [1, 2, 3, 4, 5, 6]']);

--- a/test/e2e/tests/welcome/welcome.test.ts
+++ b/test/e2e/tests/welcome/welcome.test.ts
@@ -61,9 +61,6 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 			await welcome.newNotebookButton.click();
 			await popups.clickItem('Python Notebook');
 			await editors.expectActiveEditorIconClassToMatch(/ipynb-ext-file-icon/);
-			// Verify the Positron notebook editor's kernel badge shows the Python runtime.
-			// Match the legacy assertion (label text only), not execution status, since the
-			// notebook is created from the Welcome page without running a cell.
 			await notebooksPositron.kernel.expectBadgeToContain(availableRuntimes['python'].name);
 		});
 

--- a/test/e2e/tests/welcome/welcome.test.ts
+++ b/test/e2e/tests/welcome/welcome.test.ts
@@ -7,8 +7,7 @@ import { availableRuntimes } from '../../infra';
 import { test, tags } from '../_test.setup';
 
 test.use({
-	suiteId: __filename,
-	useLegacyNotebookEditor: true
+	suiteId: __filename
 });
 
 test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
@@ -57,12 +56,15 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 		});
 
 		test('Python - Verify clicking on `new notebook` from the Welcome page opens notebook and sets kernel', async function ({ app, python }) {
-			const { welcome, popups, editors, notebooks } = app.workbench;
+			const { welcome, popups, editors, notebooksPositron } = app.workbench;
 
 			await welcome.newNotebookButton.click();
 			await popups.clickItem('Python Notebook');
 			await editors.expectActiveEditorIconClassToMatch(/ipynb-ext-file-icon/);
-			await notebooks.expectKernelToBe(availableRuntimes['python'].name);
+			// Verify the Positron notebook editor's kernel badge shows the Python runtime.
+			// Match the legacy assertion (label text only), not execution status, since the
+			// notebook is created from the Welcome page without running a cell.
+			await notebooksPositron.kernel.expectBadgeToContain(availableRuntimes['python'].name);
 		});
 
 		test('Python - Verify clicking on `new file` from the Welcome page opens editor', async function ({ app, python }) {
@@ -74,13 +76,14 @@ test.describe('Welcome Page', { tag: [tags.WELCOME, tags.WEB] }, () => {
 		});
 
 		test('R - Verify clicking on `new notebook` from the Welcome page opens notebook and sets kernel', async function ({ app, sessions, r }) {
-			const { welcome, popups, editors, notebooks } = app.workbench;
+			const { welcome, popups, editors, notebooksPositron } = app.workbench;
 
 			await welcome.newNotebookButton.click();
 			await popups.clickItem('R Notebook');
 
 			await editors.expectActiveEditorIconClassToMatch(/ipynb-ext-file-icon/);
-			await notebooks.expectKernelToBe(availableRuntimes['r'].name);
+			// Verify the Positron notebook editor's kernel badge shows the R runtime.
+			await notebooksPositron.kernel.expectBadgeToContain(availableRuntimes['r'].name);
 			await sessions.deleteAll();
 		});
 


### PR DESCRIPTION
### Summary
Closes ticket #14069.

This PR migrates the remaining notebook tests off the `useLegacyNotebookEditor` pin so they use Positron notebooks:
- `welcome.test.ts`
- `variables-notebook.test.ts`
- `data-explorer-python-pandas.test.ts`
- `new-folder-flow-jupyter.test.ts`
- `f1.test.ts`
- `matplotlib-interact.test.ts`

Also fixed the Help frame via `.last()` instead of a positional index, removing a ~14s unnecessary poll shared by all help tests

Updated tags for the migrated notebook tests to `@:positron-notebooks`

### QA Notes
@:positron-notebooks @:help @:console @:new-folder-flow @:welcome @:data-explorer @:web
