### PR TITLE
e2e: trim beforeApp fixtures to only relevant settings

### DIFF
--- a/test/e2e/tests/console/console-python.test.ts
+++ b/test/e2e/tests/console/console-python.test.ts
@@ -7,13 +7,7 @@ import { test as base, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
-			if (useLegacyNotebookEditor) {
-				await settingsFile.append({ 'positron.notebook.enabled': false });
-			}
-			if (enableDataConnections) {
-				await settingsFile.append({ 'dataConnections.enabled': true });
-			}
+		async ({ settingsFile }, use) => {
 			await settingsFile.append({ 'python.useBundledIpykernel': false });
 			await use();
 		},

--- a/test/e2e/tests/help/help.test.ts
+++ b/test/e2e/tests/help/help.test.ts
@@ -7,13 +7,7 @@ import { test as base, expect, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
-			if (useLegacyNotebookEditor) {
-				await settingsFile.append({ 'positron.notebook.enabled': false });
-			}
-			if (enableDataConnections) {
-				await settingsFile.append({ 'dataConnections.enabled': true });
-			}
+		async ({ settingsFile }, use) => {
 			// Enable reduced motion so we don't have to wait for animations of expanding
 			// and collapsing the panel.
 			await settingsFile.append({ 'workbench.reduceMotion': 'on' });

--- a/test/e2e/tests/interpreters/new-uv-project.test.ts
+++ b/test/e2e/tests/interpreters/new-uv-project.test.ts
@@ -9,13 +9,7 @@ import * as fs from 'fs';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
-			if (useLegacyNotebookEditor) {
-				await settingsFile.append({ 'positron.notebook.enabled': false });
-			}
-			if (enableDataConnections) {
-				await settingsFile.append({ 'dataConnections.enabled': true });
-			}
+		async ({ settingsFile }, use) => {
 			await settingsFile.append({ 'interpreters.startupBehavior': 'auto' });
 			await use();
 		},

--- a/test/e2e/tests/interpreters/python-venv-creation.test.ts
+++ b/test/e2e/tests/interpreters/python-venv-creation.test.ts
@@ -20,7 +20,21 @@ Summary:
 import * as os from 'os';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { test, expect, tags } from '../_test.setup';
+import { test as base, expect, tags } from '../_test.setup';
+
+const test = base.extend<{}, {}>({
+	beforeApp: [
+		async ({ settingsFile }, use) => {
+			await settingsFile.append({
+				'python.createEnvironment.trigger': 'prompt',
+				'interpreters.startupBehavior': 'auto',
+				'python.defaultInterpreterPath': '/usr/bin/python3',
+			});
+			await use();
+		},
+		{ scope: 'worker' }
+	],
+});
 
 test.use({
 	suiteId: __filename
@@ -31,14 +45,6 @@ test.describe('Python Venv Auto-Creation', {
 }, () => {
 	test.skip(process.env.IS_OPENSUSE === 'true', 'Skip on openSuse');
 	test.slow();
-
-	test.beforeAll(async function ({ settings }) {
-		await settings.set({
-			'python.createEnvironment.trigger': 'prompt',
-			'interpreters.startupBehavior': 'auto',
-			'python.defaultInterpreterPath': '/usr/bin/python3',
-		}, { reload: 'web' });
-	});
 
 	test('Clicking Yes creates venv', async function ({ app, openFolder }) {
 		const tempWorkspace = path.join(os.tmpdir(), 'vscsmoke', 'qa-example-content', 'venv-creation-test');

--- a/test/e2e/tests/notebooks-positron/_test.setup.ts
+++ b/test/e2e/tests/notebooks-positron/_test.setup.ts
@@ -10,22 +10,24 @@ interface NotebooksPositronTestFixtures extends TestFixtures {
 
 interface NotebooksPositronWorkerFixtures extends WorkerFixtures {
 	enablePositronNotebooks: boolean;
-	ghostCellSettings: Record<string, unknown> | undefined;
+	extraSettings: Record<string, unknown> | undefined;
 }
 
 export const test = base.extend<NotebooksPositronTestFixtures, NotebooksPositronWorkerFixtures>({
 	enablePositronNotebooks: [true, { scope: 'worker', option: true }],
-	ghostCellSettings: [undefined, { scope: 'worker', option: true }],
+	extraSettings: [undefined, { scope: 'worker', option: true }],
 
 	beforeApp: [
-		async ({ enablePositronNotebooks, ghostCellSettings, settingsFile }, use) => {
+		async ({ enablePositronNotebooks, extraSettings, settingsFile }, use) => {
 			if (enablePositronNotebooks) {
 				// Enable Positron notebooks before the app fixture starts
 				// to avoid waiting for a window reload
 				await settingsFile.append({ 'positron.notebook.enabled': true });
 			}
-			if (ghostCellSettings) {
-				await settingsFile.append(ghostCellSettings);
+			if (extraSettings) {
+				// Suite-specific settings applied before launch (opt in with
+				// `test.use({ extraSettings: { ... } })`) to avoid a window reload.
+				await settingsFile.append(extraSettings);
 			}
 
 			await use();

--- a/test/e2e/tests/notebooks-positron/notebook-ghost-cell-keyboard-shortcut.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-ghost-cell-keyboard-shortcut.test.ts
@@ -8,7 +8,7 @@ import { test } from './_test.setup.js';
 
 test.use({
 	suiteId: __filename,
-	ghostCellSettings: {
+	extraSettings: {
 		'positron.assistant.notebook.ghostCellSuggestions.enabled': true,
 		'positron.assistant.notebook.ghostCellSuggestions.model': ['claude'],
 		'positron.assistant.notebook.ghostCellSuggestions.automatic': false,

--- a/test/e2e/tests/notebooks-positron/notebook-output-resize.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-output-resize.test.ts
@@ -7,20 +7,20 @@ import { expect, tags } from '../_test.setup';
 import { test } from './_test.setup.js';
 
 test.use({
-	suiteId: __filename
+	suiteId: __filename,
+	// Enable output scrolling explicitly - the default differs in dev vs release
+	// builds. Applied before launch to avoid a window reload.
+	extraSettings: { 'notebook.output.scrolling': true }
 });
 
 test.describe('Positron Notebooks: Output Resize', {
 	tag: [tags.WIN, tags.WEB, tags.POSITRON_NOTEBOOKS]
 }, () => {
 
-	test('Drag sash resizes scrollable cell output', async function ({ app, settings }) {
+	test('Drag sash resizes scrollable cell output', async function ({ app }) {
 		const { notebooks, notebooksPositron } = app.workbench;
 
 		await test.step('Setup: Create notebook with scrollable output', async () => {
-			// Enable output scrolling explicitly - the default differs in dev vs release builds.
-			await settings.set({ 'notebook.output.scrolling': true }, { reload: 'web' });
-
 			await notebooks.createNewNotebook();
 			await notebooksPositron.expectCellCountToBe(1);
 			await notebooksPositron.kernel.select('Python');

--- a/test/e2e/tests/packages-pane/packages-pane.test.ts
+++ b/test/e2e/tests/packages-pane/packages-pane.test.ts
@@ -8,13 +8,7 @@ import { SessionRuntimes } from '../../pages/sessions.js';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
-			if (useLegacyNotebookEditor) {
-				await settingsFile.append({ 'positron.notebook.enabled': false });
-			}
-			if (enableDataConnections) {
-				await settingsFile.append({ 'dataConnections.enabled': true });
-			}
+		async ({ settingsFile }, use) => {
 			await settingsFile.append({ 'packages.enabled': true });
 			await use();
 		},

--- a/test/e2e/tests/quarto/_test.setup.ts
+++ b/test/e2e/tests/quarto/_test.setup.ts
@@ -7,24 +7,10 @@ import { test as base, TestFixtures, WorkerFixtures } from '../_test.setup';
 
 interface QuartoTestFixtures extends TestFixtures { }
 
-interface QuartoWorkerFixtures extends WorkerFixtures {
-	enableQuartoInlineOutput: boolean;
-}
-
-export const test = base.extend<QuartoTestFixtures, QuartoWorkerFixtures>({
-	enableQuartoInlineOutput: [true, { scope: 'worker', option: true }],
-
+export const test = base.extend<QuartoTestFixtures, WorkerFixtures>({
 	beforeApp: [
-		async ({ useLegacyNotebookEditor, enableDataConnections, enableQuartoInlineOutput, settingsFile }, use) => {
-			if (useLegacyNotebookEditor) {
-				await settingsFile.append({ 'positron.notebook.enabled': false });
-			}
-			if (enableDataConnections) {
-				await settingsFile.append({ 'dataConnections.enabled': true });
-			}
-			if (enableQuartoInlineOutput) {
-				await settingsFile.append({ 'positron.quarto.inlineOutput.enabled': true });
-			}
+		async ({ settingsFile }, use) => {
+			await settingsFile.append({ 'positron.quarto.inlineOutput.enabled': true });
 			await use();
 		},
 		{ scope: 'worker' }

--- a/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range-python.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range-python.test.ts
@@ -8,13 +8,7 @@ import { test as base, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
-			if (useLegacyNotebookEditor) {
-				await settingsFile.append({ 'positron.notebook.enabled': false });
-			}
-			if (enableDataConnections) {
-				await settingsFile.append({ 'dataConnections.enabled': true });
-			}
+		async ({ settingsFile }, use) => {
 			await settingsFile.append({
 				'positron.quarto.inlineOutput.enabled': true,
 				'console.showNotebookConsoles': true,

--- a/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-notebook-statement-range.test.ts
@@ -8,13 +8,7 @@ import { test as base, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
-			if (useLegacyNotebookEditor) {
-				await settingsFile.append({ 'positron.notebook.enabled': false });
-			}
-			if (enableDataConnections) {
-				await settingsFile.append({ 'dataConnections.enabled': true });
-			}
+		async ({ settingsFile }, use) => {
 			await settingsFile.append({
 				'positron.quarto.inlineOutput.enabled': true,
 				'console.showNotebookConsoles': true,

--- a/test/e2e/tests/quarto/quarto-inline-output-statement-range-python.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-statement-range-python.test.ts
@@ -8,13 +8,7 @@ import { test as base, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
-			if (useLegacyNotebookEditor) {
-				await settingsFile.append({ 'positron.notebook.enabled': false });
-			}
-			if (enableDataConnections) {
-				await settingsFile.append({ 'dataConnections.enabled': true });
-			}
+		async ({ settingsFile }, use) => {
 			await settingsFile.append({
 				'positron.quarto.inlineOutput.enabled': true,
 				'console.showNotebookConsoles': true,

--- a/test/e2e/tests/quarto/quarto-inline-output-statement-range.test.ts
+++ b/test/e2e/tests/quarto/quarto-inline-output-statement-range.test.ts
@@ -8,13 +8,7 @@ import { test as base, tags } from '../_test.setup';
 
 const test = base.extend<{}, {}>({
 	beforeApp: [
-		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
-			if (useLegacyNotebookEditor) {
-				await settingsFile.append({ 'positron.notebook.enabled': false });
-			}
-			if (enableDataConnections) {
-				await settingsFile.append({ 'dataConnections.enabled': true });
-			}
+		async ({ settingsFile }, use) => {
 			await settingsFile.append({
 				'positron.quarto.inlineOutput.enabled': true,
 				'console.showNotebookConsoles': true,

--- a/test/e2e/tests/reticulate/_test.setup.ts
+++ b/test/e2e/tests/reticulate/_test.setup.ts
@@ -7,27 +7,15 @@ import { test as base, TestFixtures, WorkerFixtures } from '../_test.setup';
 
 interface ReticulateTestFixtures extends TestFixtures { }
 
-interface ReticulateWorkerFixtures extends WorkerFixtures {
-	enableReticulate: boolean;
-}
 
-export const test = base.extend<ReticulateTestFixtures, ReticulateWorkerFixtures>({
-	enableReticulate: [true, { scope: 'worker', option: true }],
+export const test = base.extend<ReticulateTestFixtures, WorkerFixtures>({
 
 	beforeApp: [
-		async ({ useLegacyNotebookEditor, enableDataConnections, enableReticulate, settingsFile }, use) => {
-			if (useLegacyNotebookEditor) {
-				await settingsFile.append({ 'positron.notebook.enabled': false });
-			}
-			if (enableDataConnections) {
-				await settingsFile.append({ 'dataConnections.enabled': true });
-			}
-			if (enableReticulate) {
-				await settingsFile.append({
-					'positron.reticulate.enabled': true,
-					'kernelSupervisor.transport': 'tcp'
-				});
-			}
+		async ({ settingsFile }, use) => {
+			await settingsFile.append({
+				'positron.reticulate.enabled': true,
+				'kernelSupervisor.transport': 'tcp'
+			});
 			await use();
 		},
 		{ scope: 'worker' }

--- a/test/e2e/tests/sessions/session-interpreter-sync.test.ts
+++ b/test/e2e/tests/sessions/session-interpreter-sync.test.ts
@@ -10,22 +10,7 @@
  * when navigating between different file types (.R, .py, .ipynb).
  */
 
-import { test as base, tags } from '../_test.setup';
-
-const test = base.extend<{}, {}>({
-	beforeApp: [
-		async ({ enableDataConnections, settingsFile }, use) => {
-			if (enableDataConnections) {
-				await settingsFile.append({ 'dataConnections.enabled': true });
-			}
-			// This test requires the new notebook editor and is incompatible with
-			// useLegacyNotebookEditor; always enable it.
-			await settingsFile.append({ 'positron.notebook.enabled': true });
-			await use();
-		},
-		{ scope: 'worker' }
-	],
-});
+import { test, tags } from '../_test.setup';
 
 test.use({
 	suiteId: __filename


### PR DESCRIPTION
### Summary
Suite-level `beforeApp` overrides carried dead `if (useLegacyNotebookEditor)` / `if (enableDataConnections)` branches from an old copy/paste; both flags default to false and the base `beforeApp` already handles them, so the branches never fired. Each override now sets only what its suite needs.

Also migrated `python-venv-creation` and `notebook-output-resize` to apply settings pre-launch instead of an in-test reload

### QA Notes
@:console @:help @:interpreter @:packages-pane @:quarto @:reticulate @:sessions @:positron-notebooks @:web
