### PR TITLE
Restore notebook keyboard shortcuts help panel registration

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -8,6 +8,7 @@ import './contrib/find/positronNotebookFind.contribution.js';
 import './contrib/assistant/positronNotebookAssistant.contribution.js';
 import './contrib/ghostCell/positronNotebookGhostCell.contribution.js';
 import './contrib/outline/positronNotebookOutline.contribution.js';
+import './contrib/help/NotebookHelpAction.js';
 
 // Self-registering Action2 contributions
 import './notebookCells/InlineDataExplorerActions.js';

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookHelpRegistration.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookHelpRegistration.vitest.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { CommandsRegistry } from '../../../../../platform/commands/common/commands.js';
+
+// Importing the contribution barrel runs its side-effect imports, which is what
+// registers the notebook actions. The keyboard-shortcuts help action lives in
+// its own file and is only wired up by the barrel's
+// `import './contrib/help/NotebookHelpAction.js'`. That import was dropped in a
+// merge once (#14365), silently killing the toolbar button, command, and
+// keybinding while the action's own tests stayed green. This guards the wiring.
+import '../../browser/positronNotebook.contribution.js';
+
+describe('Positron notebook contribution registration', () => {
+	it('registers the keyboard shortcuts help action', () => {
+		expect(CommandsRegistry.getCommand('positronNotebook.showKeyboardShortcuts')).toBeDefined();
+	});
+});


### PR DESCRIPTION
The notebook keyboard shortcuts help panel disappeared. No toolbar icon, no "Notebook: Keyboard Shortcuts" command, no Cmd/Ctrl+Shift+H.

The whole feature (added in #13516) was still in the tree, but the one side-effect import that registers it, `import './contrib/help/NotebookHelpAction.js'`, got dropped in the merge for #14227. Without that import `registerAction2` never runs, so nothing shows up. Re-adding the single import line brings it back.

CI didn't catch it because the action's vitest tests render the panel directly. None of them check that it's actually registered. Could add a registration sanity check as a fast follow if we want to guard against this kind of thing.

Fixes #14365

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Restored the keyboard shortcuts help panel in the Positron notebook editor (#14365)

### Validation Steps

`@:positron-notebooks`

1. Open a `.ipynb` in the Positron notebook editor.
2. Confirm the keyboard icon is back on the left of the editor toolbar, and clicking it opens the shortcuts modal.
3. Confirm Cmd/Ctrl+Shift+H opens it too, and that "Notebook: Keyboard Shortcuts" shows up in the command palette.
