### PR TITLE
ci: raise test-unit job timeout from 40 to 60 minutes

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -34,7 +34,10 @@ jobs:
   unit-tests:
     name: unit
     runs-on: ubuntu-latest-4x
-    timeout-minutes: 40
+    # Tests themselves take ~8m; the rest is uncached, network-bound installs
+    # (apt + cold-npm on a cache miss). 40m left no headroom and runs were
+    # getting cancelled at the cap. 60m matches test-ext-host.yml.
+    timeout-minutes: 60
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       POSITRON_BUILD_NUMBER: 0 # CI skips building releases


### PR DESCRIPTION
## Problem

The `test / unit` job (defined in the reusable `.github/workflows/test-unit.yml`) has been getting **cancelled at its 40-minute cap** across many unrelated branches (`license-updates`, `mi/pine-garage`, `fix/session-state-test`, `feature/improve-cell-gutter-width`, `bump/ark-salsa`, and others). It's a flaky, repo-wide timeout, not any one PR's fault.

## Root cause

The tests themselves are cheap (**~8m total**: Vitest ~3m + the three VS Code suites ~5m). All the time and variance lives in two uncached, network-bound install steps running under the 40m cap with **no headroom**:

- **`Install system dependencies`** (`apt-get update` + install of ~25 packages, cold every run): usually a couple of minutes, but observed as high as **38m** on a slow apt-mirror draw -- that single step ate the whole budget in one run.
- **`Install node dependencies`** (~14m, but only on a cache **miss**): PRs only *restore* caches that `main` saves and never save their own (intentional -- see the header comment in `test-unit.yml`), so a package-lock change forces a cold install until `main` re-saves.

Same branch, same code, opposite outcomes -- which is what proves it's variance, not a real slowdown:

- pass @39m: https://github.com/posit-dev/positron/actions/runs/27771634063/job/82172884426
- timeout @40m: https://github.com/posit-dev/positron/actions/runs/27776522565/job/82190001552

## This change (the immediate cliff-remover)

Raise `timeout-minutes` from **40 to 60**. Cold runs land around ~40m and the apt spike is an outlier, so 60m absorbs both without changing any test logic or the cache strategy. This matches the timeout already used by `test-ext-host.yml`.

`test-unit.yml` is a reusable workflow, so the bump applies to every caller (`test-pull-request.yml`, `test-merge.yml`, `test-full-suite.yml`). That's fine: a higher ceiling only affects the rare runs that exceed 40m; everything that already finishes is unchanged.

## Recommended follow-up (the real speedup, NOT in this PR)

The timeout bump removes the cliff but doesn't make the slow step fast. The higher-value fix is to **cache the apt packages** so `Install system dependencies` drops from "up to 38m" to seconds.

I deliberately left this out of this PR because it's net-new CI infra (no apt-cache precedent in the repo) that **can't be validated locally** -- it needs a real CI run to confirm. Two mechanisms, with their trade-offs for whoever picks this up:

- **`awalsh128/cache-apt-pkgs-action`** -- cleanest API, but it caches installed files and skips post-install scripts. The current package set includes `dbus` (creates the messagebus user / registers the system bus) and `build-essential` (metapackage), which are exactly that action's documented weak spot. Since `install-system-deps` is a **shared** composite action, a subtle `dbus` regression could quietly affect other workflows.
- **Keyed `actions/cache` over `/var/cache/apt/archives/*.deb`** (keep `apt-get install` as-is, just cache the downloaded `.deb`s) -- transparent and preserves all post-install behavior + the existing retry/timeout config. The download is the slow/variable part, so this targets the actual cost. Gotchas to verify in CI: `/var/cache/apt/archives` is root-owned (cache restore permissions), and runners may auto-clean `.deb`s (set `Binary::apt::APT::Keep-Downloaded-Packages "true"`).

Either way, the existing Ubuntu-version-conditional `libasound2` vs `libasound2t64` install and the apt timeout/retry config must be preserved, and the cache must stay transparent to the action's other callers.

## Scope / what this PR does NOT touch

- No test logic.
- No change to the PR-restore / main-save cache strategy (intentional -- see lines 3-12 of `test-unit.yml`).

cc @midleman (you own the caching strategy here) for review.
