### PR TITLE
Fix PDF viewer CSP to allow sub-paths under server URL

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -138,6 +138,11 @@ const extensions = [
 		workspaceFolder: path.join(os.tmpdir(), `positron-zed-${Math.floor(Math.random() * 100000)}`),
 		mocha: { timeout: 60_000 }
 	},
+	{
+		label: 'positron-pdf-server',
+		workspaceFolder: path.join(os.tmpdir(), `positron-pdf-server-${Math.floor(Math.random() * 100000)}`),
+		mocha: { timeout: 60_000 }
+	},
 	// --- End Positron ---
 	{
 		label: 'microsoft-authentication',

--- a/extensions/positron-pdf-server/package-lock.json
+++ b/extensions/positron-pdf-server/package-lock.json
@@ -13,6 +13,7 @@
 			},
 			"devDependencies": {
 				"@types/express": "^4.17.17",
+				"@types/mocha": "^10.0.10",
 				"@types/node": "22.x",
 				"pdfjs-dist": "^5.4.624",
 				"ts-node": "^10.9.1"
@@ -410,6 +411,13 @@
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
 			"integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/mocha": {
+			"version": "10.0.10",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+			"integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/extensions/positron-pdf-server/package.json
+++ b/extensions/positron-pdf-server/package.json
@@ -47,6 +47,7 @@
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.17",
+		"@types/mocha": "^10.0.10",
 		"@types/node": "22.x",
 		"pdfjs-dist": "^5.4.624",
 		"ts-node": "^10.9.1"

--- a/extensions/positron-pdf-server/src/pdfViewerUrls.ts
+++ b/extensions/positron-pdf-server/src/pdfViewerUrls.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/extensions/positron-pdf-server/src/pdfViewerUrls.ts
+++ b/extensions/positron-pdf-server/src/pdfViewerUrls.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * The set of URLs the PDF viewer webview needs, derived from the server's base URL.
+ */
+export interface PdfViewerUrls {
+	/** The server base URL, guaranteed to end with a trailing slash. */
+	baseUrl: string;
+	/** URL of the PDF document served by the PDF server. */
+	pdfUrl: string;
+	/** URL of the PDF.js viewer wrapper, carrying the PDF and theme as query params. */
+	viewerUrl: string;
+}
+
+/**
+ * Build the PDF and viewer URLs from the server's base URL.
+ *
+ * The base URL is normalized to end with a trailing slash so that Content
+ * Security Policy source directives match every sub-path under it. Per CSP3
+ * 6.7.2.7, a source with a non-empty path that lacks a trailing slash requires
+ * an exact path match, which would otherwise reject the viewer/PDF sub-paths.
+ *
+ * @param serverUrl The server URL, with or without a trailing slash.
+ * @param pdfId The id of the registered PDF document.
+ * @param theme The PDF.js theme value (0 = auto, 1 = light, 2 = dark).
+ */
+export function buildPdfViewerUrls(serverUrl: string, pdfId: string, theme: number): PdfViewerUrls {
+	const baseUrl = serverUrl.endsWith('/') ? serverUrl : `${serverUrl}/`;
+	const pdfUrl = `${baseUrl}pdf/${pdfId}`;
+	const viewerUrl = `${baseUrl}viewer?file=${encodeURIComponent(pdfUrl)}&theme=${theme}`;
+	return { baseUrl, pdfUrl, viewerUrl };
+}

--- a/extensions/positron-pdf-server/src/pdfViewerWebview.ts
+++ b/extensions/positron-pdf-server/src/pdfViewerWebview.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2025-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/extensions/positron-pdf-server/src/pdfViewerWebview.ts
+++ b/extensions/positron-pdf-server/src/pdfViewerWebview.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import { PdfHttpServer } from './pdfHttpServer';
+import { buildPdfViewerUrls } from './pdfViewerUrls';
 
 /**
  * Generate a random nonce for CSP.
@@ -49,29 +50,24 @@ export async function createWebviewHtml(
 
 	// Get the CSP source for the webview and the server URL.
 	const cspSource = webview.cspSource;
-	let serverUrl = await httpServer.getExternalUrl();
+	const serverUrl = await httpServer.getExternalUrl();
 
-	// Remove trailing slash if present.
-	if (serverUrl.endsWith('/')) {
-		serverUrl = serverUrl.slice(0, -1);
-	}
+	// Build the normalized base URL and the viewer URL. The base URL ends with a
+	// trailing slash so CSP sources match all sub-paths under it (see buildPdfViewerUrls).
+	const theme = getPdfJsTheme();
+	const { baseUrl, viewerUrl } = buildPdfViewerUrls(serverUrl, pdfId, theme);
 
 	// Build CSP allowing localhost iframes with full PDF.js viewer resources.
 	const csp = [
 		`default-src 'none'`,
-		`style-src ${cspSource} 'unsafe-inline' ${serverUrl} http://localhost:* http://127.0.0.1:*`,
-		`script-src ${cspSource} 'nonce-${nonce}' ${serverUrl} http://localhost:* http://127.0.0.1:* 'unsafe-eval'`,
-		`frame-src ${serverUrl} http://localhost:* http://127.0.0.1:*`,
-		`img-src ${cspSource} data: ${serverUrl} http://localhost:* http://127.0.0.1:*`,
-		`font-src ${cspSource} data: ${serverUrl} http://localhost:* http://127.0.0.1:*`,
-		`worker-src ${cspSource} blob: ${serverUrl} http://localhost:* http://127.0.0.1:*`,
-		`connect-src ${serverUrl} http://localhost:* http://127.0.0.1:*`
+		`style-src ${cspSource} 'unsafe-inline' ${baseUrl} http://localhost:* http://127.0.0.1:*`,
+		`script-src ${cspSource} 'nonce-${nonce}' ${baseUrl} http://localhost:* http://127.0.0.1:* 'unsafe-eval'`,
+		`frame-src ${baseUrl} http://localhost:* http://127.0.0.1:*`,
+		`img-src ${cspSource} data: ${baseUrl} http://localhost:* http://127.0.0.1:*`,
+		`font-src ${cspSource} data: ${baseUrl} http://localhost:* http://127.0.0.1:*`,
+		`worker-src ${cspSource} blob: ${baseUrl} http://localhost:* http://127.0.0.1:*`,
+		`connect-src ${baseUrl} http://localhost:* http://127.0.0.1:*`
 	].join('; ');
-
-	// Build viewer URL - use custom wrapper that sets theme preference.
-	const pdfUrl = `${serverUrl}/pdf/${pdfId}`;
-	const theme = getPdfJsTheme();
-	const viewerUrl = `${serverUrl}/viewer?file=${encodeURIComponent(pdfUrl)}&theme=${theme}`;
 
 	// Return the complete HTML for the webview, including the CSP and the iframe pointing to the viewer URL.
 	// Also includes a script to forward keyboard events from the PDF viewer to VS Code's keybinding service.

--- a/extensions/positron-pdf-server/src/test/pdfViewerUrls.test.ts
+++ b/extensions/positron-pdf-server/src/test/pdfViewerUrls.test.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 

--- a/extensions/positron-pdf-server/src/test/pdfViewerUrls.test.ts
+++ b/extensions/positron-pdf-server/src/test/pdfViewerUrls.test.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2025 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { buildPdfViewerUrls } from '../pdfViewerUrls';
+
+suite('buildPdfViewerUrls', () => {
+	test('normalizes a base URL without a trailing slash', () => {
+		assert.deepStrictEqual(buildPdfViewerUrls('http://localhost:8080', 'abc', 1), {
+			baseUrl: 'http://localhost:8080/',
+			pdfUrl: 'http://localhost:8080/pdf/abc',
+			viewerUrl: `http://localhost:8080/viewer?file=${encodeURIComponent('http://localhost:8080/pdf/abc')}&theme=1`,
+		});
+	});
+
+	test('does not add a second slash when the base URL already ends with one', () => {
+		assert.deepStrictEqual(buildPdfViewerUrls('https://host/proxy/8080/', 'abc', 2), {
+			baseUrl: 'https://host/proxy/8080/',
+			pdfUrl: 'https://host/proxy/8080/pdf/abc',
+			viewerUrl: `https://host/proxy/8080/viewer?file=${encodeURIComponent('https://host/proxy/8080/pdf/abc')}&theme=2`,
+		});
+	});
+});

--- a/extensions/positron-pdf-server/tsconfig.json
+++ b/extensions/positron-pdf-server/tsconfig.json
@@ -18,7 +18,8 @@
 			"./node_modules/@types"
 		],
 		"types": [
-			"node"
+			"node",
+			"mocha"
 		],
 		"paths": {
 			"*": ["./node_modules/*"]


### PR DESCRIPTION
Fixes #13451

The PDF viewer builds a CSP that lists the server URL as a source in every directive. The old code stripped the trailing slash off that URL first. Per CSP3 path matching, a source with a path and no trailing slash only matches that exact path, so the viewer iframe (which lives at a sub-path) got blocked. This only bites in remote, path-routed deployments like Posit Workbench, where `asExternalUri` hands back a URL with a real path. Desktop is unaffected because the `http://localhost:*` wildcards in each directive already cover the localhost case.

The fix flips the strip into an append: normalize the server URL to always end in a slash, and every directive then matches sub-paths. This is the same idiom `extHostWebview.ts` already uses ("Always treat the location as a directory so that we allow all content under it"). While I was in there I pulled the URL building out into a small pure `buildPdfViewerUrls` helper so the trailing-slash logic is easy to unit test.

One wart worth calling out: the existing `@:pdf` e2e runs against a localhost server, which masks this bug entirely (the localhost wildcards cover it). A real e2e regression test would need a path-routed `asExternalUri` setup that the test infra doesn't have today. So I went with a unit test on the URL builder rather than building that infra out. Happy to walk through it if anyone wants.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix the PDF viewer being blocked by CSP in remote and Workbench browser sessions (#13451)

### Validation Steps

@:pdf

The bug only reproduces in a path-routed remote session, so the real check is manual:

1. Open Positron in a Posit Workbench browser session (or any path-routed remote deployment).
2. Open a PDF in the editor.
3. Confirm it renders in the viewer. Before this fix the frame is blocked and the console logs a `frame-src` CSP violation.
4. Sanity check on desktop: open a PDF and confirm it still renders fine.
