### PR TITLE
Add positron-abstract-svg skill

### DIFF
--- a/.claude/skills/positron-abstract-svg/SKILL.md
+++ b/.claude/skills/positron-abstract-svg/SKILL.md
@@ -15,27 +15,37 @@ description: >
 # Positron Abstract SVG Skill
 
 This skill helps you create clean, on-brand abstract SVG illustrations of the
-Positron IDE for use in documentation and in-app walkthroughs.
+Positron IDE for documentation, walkthroughs, onboarding, and feature previews.
+
+It applies to **any part of the Positron IDE** -- editor, notebooks, data
+explorer, console, plots, variables pane, terminal, AI assistant, and so on. The
+bundled examples and component patterns happen to focus on notebooks (that is
+what has been built so far), so treat them as a starting library rather than the
+full scope: the constraints, palette, fonts, layering rules, and icon
+conventions generalize to any surface. For a surface not yet covered, work from a
+screenshot and compose new components from the same primitives in the same style.
 
 ## Critical Constraints
 
-**These SVGs are loaded as `<img src="...">` inside a VS Code webview.** This means:
+**These are static SVGs rendered as plain images (e.g. `<img src="...">`) in many different contexts** -- documentation sites, in-app walkthroughs, READMEs, etc. They cannot rely on the host page's styles or scripts. This means:
 
-- **No CSS variables** -- `var(--vscode-editor-background)` will NOT work. All colors must be hardcoded hex values.
+- **No external CSS / CSS variables** -- references like `var(--some-token)` will NOT resolve. All colors must be self-contained (hardcoded hex values, or an inline `<style>` block within the SVG itself).
 - **No JavaScript** -- static SVG only.
-- **Light theme only** -- these images are always shown in a light context.
-- **Standard walkthrough size**: `width="520" height="260"` (can vary for other uses).
+- **Assume a light background by default** -- the palette and examples target a light context. Supporting both light and dark themes is a nice-to-have, not a requirement (see below); reach for it when the SVG will appear on surfaces of both kinds.
+- **Sizing**: walkthrough images are commonly `width="520" height="260"`, but pick a size and aspect ratio that suits the surface you are depicting and where the image will appear.
 
-Always start every SVG with a white background rect:
+For a light-only image, start with an opaque white background rect:
 ```svg
 <rect width="520" height="260" fill="#FFFFFF"/>
 ```
+
+To support light **and** dark, omit the opaque background and either use colors that read on both, or adapt with an inline `<style>` block inside the SVG (a `@media (prefers-color-scheme: dark)` rule honored when the SVG carries its own styles). Keep it simple and always preview on both backgrounds.
 
 ## Color Palette
 
 These images exist to communicate complex UI simply. **Clarity comes first** -- a color that helps the eye parse the layout is worth using even if it isn't an exact Positron theme color. Matching the Positron theme is a nice-to-have, not a requirement; reach for whatever reads clearly at small sizes.
 
-The palette below is a tested starting point. `#447099` is the Positron brand blue (it matches the positron-python gallery banner in `extensions/positron-python/package.json`); reserve it for the focal point. Treat the grays as a coherent set rather than precise values to match.
+The palette below is a tested starting point. `#447099` is the Positron brand blue; reserve it for the focal point. Treat the grays as a coherent set rather than precise values to match.
 
 | Color | Hex | Use |
 |-------|-----|-----|
@@ -80,11 +90,11 @@ The more context you have about the actual UI, the better the abstract image wil
 
 ## SVG Layering (Z-order)
 
-SVG renders elements in document order -- later elements appear on top. Keep this in mind:
+SVG renders elements in document order -- later elements appear on top. The general rule: draw containers before their contents, and floating/overlay elements last. For example:
 
-- Draw cell borders and backgrounds **before** their content.
-- Draw **cell action bars after** their parent cell, so the action bar floats on top.
-- Draw **panel separator lines** early so content overlaps them correctly.
+- Draw a container's border and background **before** the content inside it (a cell, panel, dialog, etc.).
+- Draw **floating toolbars and overlays after** their parent so they sit on top (e.g. a cell action bar).
+- Draw **separator/divider lines** early so later content overlaps them cleanly.
 
 ## Fonts
 
@@ -93,7 +103,7 @@ SVG renders elements in document order -- later elements appear on top. Keep thi
 
 ## Code Representation
 
-Never write real readable code in these illustrations unless the content is the focal point of the image. Use placeholder gray rects instead:
+Never write real readable text (code, labels, descriptions) in these illustrations unless the content is the focal point of the image. Use placeholder gray rects for any body text instead:
 
 ```svg
 <!-- Good: placeholder code lines -->
@@ -130,7 +140,7 @@ For smaller contexts (cell action bar at ~11px), scale down:
 
 ## Component Patterns
 
-See `references/patterns.md` for copy-pasteable SVG snippets for every major component:
+See `references/patterns.md` for copy-pasteable SVG snippets. The current set is notebook-focused (it covers what has been built so far). For other Positron surfaces, reuse the general primitives below -- tab bars, panels, toolbars, icons, placeholder text, separators -- and compose new components in the same style. Available snippets:
 
 - Tab bar with active file tab
 - Notebook toolbar (Run All, Clear All, + Code, + Markdown, Refresh, Python dropdown)
@@ -145,12 +155,17 @@ See `references/patterns.md` for copy-pasteable SVG snippets for every major com
 
 ## Tips
 
-- **Blue is a focal point color** -- don't use `#447099` everywhere. Reserve it for the one element that should draw the eye (active tab underline, active cell border, Python dropdown border, key highlights).
-- **Keep the Variables pane and Posit Assistant panel visually distinct** -- use the gray header (`#F4F4F4`) to anchor them.
-- **Consistent cell padding**: line numbers at `text-anchor="end"` positioned 20px from cell left edge; code content 26px from cell left edge.
-- **Separator lines** between code and output areas inside cells should be `#EEEEEE`, 1px.
-- **Output areas** are always white (`fill="#FFFFFF"`), not gray -- they represent rendered output, not a code editor.
-- **Close (x) on active tab**: two crossing lines, not an SVG symbol -- use two `<line>` elements.
+General (apply to any surface):
+
+- **Blue is a focal-point color** -- don't use `#447099` everywhere. Reserve it for the one element that should draw the eye (the active/selected item, a key highlight).
+- **Anchor distinct regions with a gray header** (`#F4F4F4`) -- it keeps panels (Variables, Posit Assistant, any sidebar) visually separate.
+- **Build glyphs from primitives, not font symbols** -- e.g. a close (x) is two crossing `<line>` elements, not an SVG symbol.
+- **Output/content areas are white** (`fill="#FFFFFF"`), reserved for rendered results; gray backgrounds read as editors/inputs.
+
+Notebook-specific (examples of applying the above):
+
+- **Consistent cell padding**: line numbers at `text-anchor="end"` positioned 20px from the cell's left edge; code content 26px from the left edge.
+- **Code/output separator lines** inside a cell: `#EEEEEE`, 1px.
 
 ## Reference Images
 

--- a/.claude/skills/positron-abstract-svg/SKILL.md
+++ b/.claude/skills/positron-abstract-svg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: positron-abstract-svg
 description: >
-  Create or update abstract SVG illustrations for the Positron IDE — for use in
+  Create or update abstract SVG illustrations for the Positron IDE -- for use in
   documentation, walkthrough steps, onboarding images, and feature previews.
   Use this skill whenever someone asks to make, update, or redesign an SVG image
   for Positron docs, walkthroughs, or any visual asset representing the Positron
@@ -21,9 +21,9 @@ Positron IDE for use in documentation and in-app walkthroughs.
 
 **These SVGs are loaded as `<img src="...">` inside a VS Code webview.** This means:
 
-- **No CSS variables** — `var(--vscode-editor-background)` will NOT work. All colors must be hardcoded hex values.
-- **No JavaScript** — static SVG only.
-- **Light theme only** — these images are always shown in a light context.
+- **No CSS variables** -- `var(--vscode-editor-background)` will NOT work. All colors must be hardcoded hex values.
+- **No JavaScript** -- static SVG only.
+- **Light theme only** -- these images are always shown in a light context.
 - **Standard walkthrough size**: `width="520" height="260"` (can vary for other uses).
 
 Always start every SVG with a white background rect:
@@ -33,9 +33,13 @@ Always start every SVG with a white background rect:
 
 ## Color Palette
 
+These images exist to communicate complex UI simply. **Clarity comes first** -- a color that helps the eye parse the layout is worth using even if it isn't an exact Positron theme color. Matching the Positron theme is a nice-to-have, not a requirement; reach for whatever reads clearly at small sizes.
+
+The palette below is a tested starting point. `#447099` is the Positron brand blue (it matches the positron-python gallery banner in `extensions/positron-python/package.json`); reserve it for the focal point. Treat the grays as a coherent set rather than precise values to match.
+
 | Color | Hex | Use |
 |-------|-----|-----|
-| Positron blue | `#447099` | Active tab underline, active cell border, Python dropdown border, focal-point highlights only — use sparingly |
+| Positron blue | `#447099` | Active tab underline, active cell border, Python dropdown border, focal-point highlights only -- use sparingly |
 | Running kernel green | `#3DAA6E` | Session status dot in kernel/Python dropdown |
 | Icon gray | `#5A5A5A` | All toolbar and action bar icons |
 | Line number blue | `#8DA5B8` | Code cell line numbers |
@@ -61,22 +65,22 @@ Always start every SVG with a white background rect:
 
 The more context you have about the actual UI, the better the abstract image will be. Ask the user for:
 
-- **A screenshot of the actual Positron UI** being depicted — this shows exact proportions, which elements are present, and what the focal point should be. If no screenshot is available, describe what you plan to show and confirm with the user.
-- **Codicon names for any toolbar or action bar icons** — e.g., `notebook-execute`, `debug-alt-small`, `run-above`. Look up the SVG path data in `references/codicons.md`. If a codicon isn't there, search the Positron codebase in `node_modules/@vscode/codicons/src/icons/` for the `.svg` file.
-- **File type icons** — Positron uses the [Seti UI](https://github.com/jesseweed/seti-ui) file icon theme. If the image should show a tab with a file icon (`.ipynb`, `.R`, `.py`, `.csv`, etc.), fetch the relevant SVG from that repo and inline it into the tab bar.
+- **A screenshot of the actual Positron UI** being depicted -- this shows exact proportions, which elements are present, and what the focal point should be. If no screenshot is available, describe what you plan to show and confirm with the user.
+- **Codicon names for any toolbar or action bar icons** -- e.g., `notebook-execute`, `debug-alt-small`, `run-above`. Use the ready-made paths in `references/codicons.md`; these are the curated, consistent set the existing walkthrough images already use. For an icon not listed there, copy the `d=` from `node_modules/@vscode/codicons/src/icons/<name>.svg`, then simplify it to match the flat style of the existing set (upstream codicons have evolved, so a fresh pull may not match visually).
+- **File type icons** -- Positron uses the [Seti UI](https://github.com/jesseweed/seti-ui) file icon theme. Locally it ships only as a font (`extensions/theme-seti/icons/seti.woff`), so there is no per-file SVG to extract from the repo. To show a tab file icon (`.ipynb`, `.R`, `.py`, `.csv`, etc.), fetch the source SVG from the `icons/` folder of that repo (an external network call) and inline it, or hand-draw a simple file glyph. NOTE: this seti-icon approach is currently untested in practice -- verify the result in a preview and keep the glyph simple.
 
 ## Workflow
 
-1. **Gather input** — screenshot of the UI, icon names, file types (see above).
-2. **Plan the layout** — decide what panels/components to show and their proportions.
-3. **Sketch in SVG** — write the SVG, starting with background elements, then building up layers.
-4. **Preview** — always use `show_widget` to render a preview before saving to file. This catches layout issues early.
-5. **Iterate** — adjust based on the preview, re-render, repeat until it looks right.
-6. **Save** — write the final SVG to the correct path in the repository.
+1. **Gather input** -- screenshot of the UI, icon names, file types (see above).
+2. **Plan the layout** -- decide what panels/components to show and their proportions.
+3. **Sketch in SVG** -- write the SVG, starting with background elements, then building up layers.
+4. **Preview** -- always render a preview before saving to file; this catches layout issues early. In **Claude Desktop**, use the `show_widget` tool -- it renders the SVG inline and is the fastest way to iterate. In other environments (CLI, etc.), `show_widget` is unavailable, so preview by writing the SVG to a temp file and opening it in a browser or image viewer.
+5. **Iterate** -- adjust based on the preview, re-render, repeat until it looks right.
+6. **Save** -- write the final SVG to the correct path in the repository. If you previewed via a renderer (e.g. `show_widget` in Claude Desktop), strip any cruft it injected before saving: per-element `style="fill:rgb(...);..."` attributes (the `fill="#hex"` attribute already carries the color) and any `Anthropic Sans` / renderer-specific font names. Ship clean SVG with only the font stacks listed below.
 
 ## SVG Layering (Z-order)
 
-SVG renders elements in document order — later elements appear on top. Keep this in mind:
+SVG renders elements in document order -- later elements appear on top. Keep this in mind:
 
 - Draw cell borders and backgrounds **before** their content.
 - Draw **cell action bars after** their parent cell, so the action bar floats on top.
@@ -108,9 +112,9 @@ When a specific piece of code IS the point (e.g., showing syntax highlighting fo
 
 ## Toolbar Icons (Codicons)
 
-All toolbar icons use codicon SVG paths scaled to fit inside a 16×16 coordinate space. See `references/codicons.md` for the full list of paths.
+All toolbar icons use codicon SVG paths scaled to fit inside a 16x16 coordinate space. See `references/codicons.md` for the curated, ready-to-use icon paths.
 
-**Usage pattern** — scale icons to 16px at `translate(x, y)`:
+**Usage pattern** -- scale icons to 16px at `translate(x, y)`:
 ```svg
 <g transform="translate(10, 37)" fill="#5A5A5A">
   <path d="...codicon path..."/>
@@ -141,18 +145,20 @@ See `references/patterns.md` for copy-pasteable SVG snippets for every major com
 
 ## Tips
 
-- **Blue is a focal point color** — don't use `#447099` everywhere. Reserve it for the one element that should draw the eye (active tab underline, active cell border, Python dropdown border, key highlights).
-- **Keep the Variables pane and Posit Assistant panel visually distinct** — use the gray header (`#F4F4F4`) to anchor them.
+- **Blue is a focal point color** -- don't use `#447099` everywhere. Reserve it for the one element that should draw the eye (active tab underline, active cell border, Python dropdown border, key highlights).
+- **Keep the Variables pane and Posit Assistant panel visually distinct** -- use the gray header (`#F4F4F4`) to anchor them.
 - **Consistent cell padding**: line numbers at `text-anchor="end"` positioned 20px from cell left edge; code content 26px from cell left edge.
 - **Separator lines** between code and output areas inside cells should be `#EEEEEE`, 1px.
-- **Output areas** are always white (`fill="#FFFFFF"`), not gray — they represent rendered output, not a code editor.
-- **Close (×) on active tab**: two crossing lines, not an SVG symbol — use two `<line>` elements.
+- **Output areas** are always white (`fill="#FFFFFF"`), not gray -- they represent rendered output, not a code editor.
+- **Close (x) on active tab**: two crossing lines, not an SVG symbol -- use two `<line>` elements.
 
 ## Reference Images
 
-The four completed walkthrough SVGs in `src/vs/workbench/contrib/welcomeGettingStarted/common/media/` are the canonical style references:
+The canonical style references live in `references/examples/` next to this skill. They were produced with this skill and are the ground truth for palette, spacing, and conventions -- open them and match their style:
 
-- `notebook-hero-abstract.svg` — full-width notebook, cell action bar, large bar chart output
-- `notebook-editor-abstract.svg` — editor + variables pane, Python dropdown focal point
-- `notebook-ai-context-abstract.svg` — split Posit Assistant (left) / notebook (right)
-- `kernel-selector-abstract.svg` — kernel dropdown menu open
+- `notebook-hero-abstract.svg` -- full-width notebook, floating cell action bar, large bar chart output
+- `notebook-editor-abstract.svg` -- editor + variables pane, Python dropdown focal point
+- `notebook-ai-context-abstract.svg` -- split Posit Assistant / notebook view
+- `kernel-selector-abstract.svg` -- kernel dropdown menu open (note the 400x210 canvas)
+
+**Caveat:** some `*-abstract.svg` files in the repo's walkthrough media folder (`src/vs/workbench/contrib/welcomeGettingStarted/common/media/`, e.g. `data-explorer-abstract.svg`) were NOT created with this skill. Do not treat those as style references -- their palette and conventions differ. Use the bundled `references/examples/` set instead.

--- a/.claude/skills/positron-abstract-svg/SKILL.md
+++ b/.claude/skills/positron-abstract-svg/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: positron-abstract-svg
+description: >
+  Create or update abstract SVG illustrations for the Positron IDE — for use in
+  documentation, walkthrough steps, onboarding images, and feature previews.
+  Use this skill whenever someone asks to make, update, or redesign an SVG image
+  for Positron docs, walkthroughs, or any visual asset representing the Positron
+  IDE UI. Also use it when asked to make images "consistent" with existing
+  Positron walkthrough images, or to add a new image to match an existing set.
+  Trigger on: "make an SVG for the walkthrough", "create an abstract image for
+  the notebook feature", "update the hero image", "make it look like the other
+  Positron SVGs", "add a docs image for X feature".
+---
+
+# Positron Abstract SVG Skill
+
+This skill helps you create clean, on-brand abstract SVG illustrations of the
+Positron IDE for use in documentation and in-app walkthroughs.
+
+## Critical Constraints
+
+**These SVGs are loaded as `<img src="...">` inside a VS Code webview.** This means:
+
+- **No CSS variables** — `var(--vscode-editor-background)` will NOT work. All colors must be hardcoded hex values.
+- **No JavaScript** — static SVG only.
+- **Light theme only** — these images are always shown in a light context.
+- **Standard walkthrough size**: `width="520" height="260"` (can vary for other uses).
+
+Always start every SVG with a white background rect:
+```svg
+<rect width="520" height="260" fill="#FFFFFF"/>
+```
+
+## Color Palette
+
+| Color | Hex | Use |
+|-------|-----|-----|
+| Positron blue | `#447099` | Active tab underline, active cell border, Python dropdown border, focal-point highlights only — use sparingly |
+| Running kernel green | `#3DAA6E` | Session status dot in kernel/Python dropdown |
+| Icon gray | `#5A5A5A` | All toolbar and action bar icons |
+| Line number blue | `#8DA5B8` | Code cell line numbers |
+| Code placeholder | `#C8C8C8` | Gray rects representing code lines |
+| Output placeholder | `#D0D0D0` | X-axis tick labels and secondary placeholder rects |
+| Panel header bg | `#F4F4F4` | Panel headers (Variables, Posit Assistant) |
+| Toolbar bg | `#FAFAFA` | Notebook toolbar background |
+| Tab bar bg | `#F2F2F2` | Inactive tab area |
+| Active tab bg | `#FFFFFF` | Active file tab |
+| Cell separator | `#EEEEEE` | Line between code area and output area in cells |
+| Panel separator | `#E0E0E0` | Vertical dividers between panels; toolbar bottom border |
+| Inactive cell bg | `#F8F8F8` | Gray background of code area inside cells |
+| Highlighted row | `#EEF3F8` | Selected/highlighted row in variables pane |
+| Syntax: variable | `#447099` | Variable names in code (blue) |
+| Syntax: number/value | `#098658` | Numbers and values in code (green) |
+| Syntax: function | `#C75C5C` | Function names like `print` (red) |
+| Syntax: string | `#B07020` | String literals (orange-brown) |
+| Header text | `#3E4246` | Panel header labels |
+| Body text | `#333333` | Tab labels and readable text |
+| Muted text | `#8A8A8A` | Execution count `[n]`, secondary labels |
+
+## Gathering Input Before You Start
+
+The more context you have about the actual UI, the better the abstract image will be. Ask the user for:
+
+- **A screenshot of the actual Positron UI** being depicted — this shows exact proportions, which elements are present, and what the focal point should be. If no screenshot is available, describe what you plan to show and confirm with the user.
+- **Codicon names for any toolbar or action bar icons** — e.g., `notebook-execute`, `debug-alt-small`, `run-above`. Look up the SVG path data in `references/codicons.md`. If a codicon isn't there, search the Positron codebase in `node_modules/@vscode/codicons/src/icons/` for the `.svg` file.
+- **File type icons** — Positron uses the [Seti UI](https://github.com/jesseweed/seti-ui) file icon theme. If the image should show a tab with a file icon (`.ipynb`, `.R`, `.py`, `.csv`, etc.), fetch the relevant SVG from that repo and inline it into the tab bar.
+
+## Workflow
+
+1. **Gather input** — screenshot of the UI, icon names, file types (see above).
+2. **Plan the layout** — decide what panels/components to show and their proportions.
+3. **Sketch in SVG** — write the SVG, starting with background elements, then building up layers.
+4. **Preview** — always use `show_widget` to render a preview before saving to file. This catches layout issues early.
+5. **Iterate** — adjust based on the preview, re-render, repeat until it looks right.
+6. **Save** — write the final SVG to the correct path in the repository.
+
+## SVG Layering (Z-order)
+
+SVG renders elements in document order — later elements appear on top. Keep this in mind:
+
+- Draw cell borders and backgrounds **before** their content.
+- Draw **cell action bars after** their parent cell, so the action bar floats on top.
+- Draw **panel separator lines** early so content overlaps them correctly.
+
+## Fonts
+
+- **UI labels, tab names, panel headers**: `-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`
+- **Code and line numbers**: `'Consolas', 'SF Mono', 'Menlo', monospace`
+
+## Code Representation
+
+Never write real readable code in these illustrations unless the content is the focal point of the image. Use placeholder gray rects instead:
+
+```svg
+<!-- Good: placeholder code lines -->
+<rect x="58" y="90" width="200" height="4" rx="2" fill="#C8C8C8"/>
+<rect x="58" y="102" width="80" height="4" rx="2" fill="#C8C8C8"/>
+<rect x="58" y="114" width="120" height="4" rx="2" fill="#C8C8C8"/>
+```
+
+When a specific piece of code IS the point (e.g., showing syntax highlighting for a kernel selector image), use `<tspan>` elements inside a `<text>` element for multi-color syntax:
+
+```svg
+<text x="58" y="86" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="10.5">
+  <tspan fill="#447099">x</tspan><tspan fill="#5A5A5A"> = </tspan><tspan fill="#098658">10</tspan>
+</text>
+```
+
+## Toolbar Icons (Codicons)
+
+All toolbar icons use codicon SVG paths scaled to fit inside a 16×16 coordinate space. See `references/codicons.md` for the full list of paths.
+
+**Usage pattern** — scale icons to 16px at `translate(x, y)`:
+```svg
+<g transform="translate(10, 37)" fill="#5A5A5A">
+  <path d="...codicon path..."/>
+</g>
+```
+
+For smaller contexts (cell action bar at ~11px), scale down:
+```svg
+<g transform="translate(35, 68) scale(0.7)" fill="#5A5A5A">
+  <path d="...codicon path..."/>
+</g>
+```
+
+## Component Patterns
+
+See `references/patterns.md` for copy-pasteable SVG snippets for every major component:
+
+- Tab bar with active file tab
+- Notebook toolbar (Run All, Clear All, + Code, + Markdown, Refresh, Python dropdown)
+- Code cell (inactive / active / combined code+output)
+- Cell action bar (floating toolbar above cell)
+- Execution count `[n]`
+- Vertical panel separator
+- Variables pane header + rows
+- Posit Assistant chat panel
+- Context chip (file attachment pill)
+- Bar chart output
+
+## Tips
+
+- **Blue is a focal point color** — don't use `#447099` everywhere. Reserve it for the one element that should draw the eye (active tab underline, active cell border, Python dropdown border, key highlights).
+- **Keep the Variables pane and Posit Assistant panel visually distinct** — use the gray header (`#F4F4F4`) to anchor them.
+- **Consistent cell padding**: line numbers at `text-anchor="end"` positioned 20px from cell left edge; code content 26px from cell left edge.
+- **Separator lines** between code and output areas inside cells should be `#EEEEEE`, 1px.
+- **Output areas** are always white (`fill="#FFFFFF"`), not gray — they represent rendered output, not a code editor.
+- **Close (×) on active tab**: two crossing lines, not an SVG symbol — use two `<line>` elements.
+
+## Reference Images
+
+The four completed walkthrough SVGs in `src/vs/workbench/contrib/welcomeGettingStarted/common/media/` are the canonical style references:
+
+- `notebook-hero-abstract.svg` — full-width notebook, cell action bar, large bar chart output
+- `notebook-editor-abstract.svg` — editor + variables pane, Python dropdown focal point
+- `notebook-ai-context-abstract.svg` — split Posit Assistant (left) / notebook (right)
+- `kernel-selector-abstract.svg` — kernel dropdown menu open

--- a/.claude/skills/positron-abstract-svg/references/codicons.md
+++ b/.claude/skills/positron-abstract-svg/references/codicons.md
@@ -1,0 +1,151 @@
+# Positron Codicon SVG Paths
+
+All paths use a 16×16 coordinate space. Use `transform="translate(x, y)"` to position and `scale(n)` to resize.
+
+## Toolbar-scale usage (full 16px)
+
+```svg
+<g transform="translate(X, Y)" fill="#5A5A5A">
+  <path d="..."/>
+</g>
+```
+
+## Action-bar-scale usage (~11px, centered in a 16px-tall bar at y=BAR_TOP)
+
+```svg
+<!-- scale(0.7) → 11.2px icon; to center in 16px bar: translate y = BAR_TOP + 2.4 -->
+<g transform="translate(X, BAR_TOP_PLUS_2) scale(0.7)" fill="#5A5A5A">
+  <path d="..."/>
+</g>
+```
+
+---
+
+## Run All (notebook-execute-all)
+
+Two overlapping play triangles — use both paths together.
+
+```svg
+<g transform="translate(X, Y)" fill="#5A5A5A">
+  <path d="M2.78 2L2 2.41v12l.78.42 9-6V8l-9-6zM3 13.48V3.35l7.6 5.07L3 13.48z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd"
+        d="M6 14.683l8.78-5.853V8L6 2.147V3.35l7.6 5.07L6 13.48v1.203z"/>
+</g>
+```
+
+## Notebook Execute (single play — notebook-execute)
+
+Single play triangle, used in cell action bars.
+
+```svg
+<path d="M3.78 2L3 2.41v12l.78.42 9-6V8l-9-6zM4 13.48V3.35l7.6 5.07L4 13.48z"/>
+```
+
+## Clear All
+
+```svg
+<path d="M10 12.6l.7.7 1.6-1.6 1.6 1.6.8-.7L13 11l1.7-1.6-.8-.8-1.6 1.7-1.6-1.7-.7.8 1.6 1.6-1.6 1.6zM1 4h14V3H1v1zm0 3h14V6H1v1zm8 2.5V9H1v1h8v-.5zM9 13v-1H1v1h8z"/>
+```
+
+## Add (plus — used for + Code and + Markdown buttons)
+
+Scale to 0.6875 when rendering at toolbar size alongside text labels.
+
+```svg
+<path d="M8 1.5C8 1.22386 7.77614 1 7.5 1C7.22386 1 7 1.22386 7 1.5V7H1.5C1.22386 7 1 7.22386 1 7.5C1 7.77614 1.22386 8 1.5 8H7V13.5C7 13.7761 7.22386 14 7.5 14C7.77614 14 8 13.7761 8 13.5V8H13.5C13.7761 8 14 7.77614 14 7.5C14 7.22386 13.7761 7 13.5 7H8V1.5Z"/>
+```
+
+## Refresh
+
+```svg
+<path fill-rule="evenodd" clip-rule="evenodd"
+      d="M4.681 3H2V2h3.5l.5.5V6H5V4a5 5 0 1 0 4.53-.761l.302-.954A6 6 0 1 1 4.681 3z"/>
+```
+
+## Chevron Down (used in Python session dropdown)
+
+Scale to 0.625 when rendering small.
+
+```svg
+<path fill-rule="evenodd" clip-rule="evenodd"
+      d="M7.976 10.072l4.357-4.357.62.618L8.284 11h-.618L3 6.333l.619-.618 4.357 4.357z"/>
+```
+
+## Trash
+
+```svg
+<path fill-rule="evenodd" clip-rule="evenodd"
+      d="M10 3h3v1h-1v9l-1 1H4l-1-1V4H2V3h3V2a1 1 0 0 1 1-1h3a1 1 0 0 1 1 1v1zM9 2H6v1h3V2zM4 13h7V4H4v9zm2-8H5v7h1V5zm1 0h1v7H7V5zm2 0h1v7H9V5z"/>
+```
+
+## Debug Alt Small (debug-alt-small)
+
+Two paths — use both together.
+
+```svg
+<g transform="translate(X, Y)" fill="#5A5A5A">
+  <path d="M7.293 9.006l-.88.88A2.484 2.484 0 0 0 4 8a2.488 2.488 0 0 0-2.413 1.886l-.88-.88L0 9.712l1.147 1.146-.147.146v1H0v.999h1v.053c.051.326.143.643.273.946L0 15.294.707 16l1.1-1.099A2.873 2.873 0 0 0 4 16a2.875 2.875 0 0 0 2.193-1.099L7.293 16 8 15.294l-1.273-1.292A3.92 3.92 0 0 0 7 13.036v-.067h1v-.965H7v-1l-.147-.146L8 9.712l-.707-.706zM4 9.006a1.5 1.5 0 0 1 1.5 1.499h-3A1.498 1.498 0 0 1 4 9.006zm2 3.997A2.217 2.217 0 0 1 4 15a2.22 2.22 0 0 1-2-1.998v-1.499h4v1.499z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd"
+        d="M5 2.41L5.78 2l9 6v.83L9 12.683v-1.2l4.6-3.063L6 3.35V7H5V2.41z"/>
+</g>
+```
+
+## Run Above (run-above)
+
+```svg
+<path d="M1.77 1.01L1 1.42v12l.78.42 9-6v-.83l-9.01-6zM2 12.49V2.36l7.6 5.07L2 12.49zM12.15 8h.71l2.5 2.5-.71.71L13 9.56V15h-1V9.55l-1.65 1.65-.7-.7 2.5-2.5z"/>
+```
+
+## Ellipsis
+
+```svg
+<path d="M4 8a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm5 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm5 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
+```
+
+## Send (used in AI chat input box)
+
+```svg
+<path d="M1.17683 1.11898C1.32953 0.989634 1.54464 0.963786 1.72363 1.05328L14.7236 7.55328C14.893 7.63797 15 7.8111 15 8.00049C15 8.18987 14.893 8.36301 14.7236 8.4477L1.72363 14.9477C1.54464 15.0372 1.32953 15.0113 1.17683 14.882C1.02414 14.7526 0.96328 14.5447 1.02213 14.3534L2.97688 8.00049L1.02213 1.64754C0.96328 1.45627 1.02414 1.24833 1.17683 1.11898ZM3.8693 8.50049L2.32155 13.5307L13.382 8.00049L2.32155 2.47027L3.8693 7.50049H9.50001C9.77615 7.50049 10 7.72435 10 8.00049C10 8.27663 9.77615 8.50049 9.50001 8.50049H3.8693Z"/>
+```
+
+---
+
+## Cell Action Bar — Full Example
+
+The action bar floats at the top-left of its parent cell. Draw it **after** the cell rect in SVG document order so it renders on top.
+
+```svg
+<!-- Cell action bar: x=CELL_X, y=CELL_TOP-10, width=88, height=16 -->
+<rect x="30" y="66" width="88" height="16" rx="3" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/>
+
+<!-- notebook-execute -->
+<g transform="translate(35, 68) scale(0.7)" fill="#5A5A5A">
+  <path d="M3.78 2L3 2.41v12l.78.42 9-6V8l-9-6zM4 13.48V3.35l7.6 5.07L4 13.48z"/>
+</g>
+
+<!-- vertical separator between execute and the rest -->
+<line x1="51" y1="70" x2="51" y2="78" stroke="#D0D0D0" stroke-width="1"/>
+
+<!-- debug-alt-small -->
+<g transform="translate(55, 68) scale(0.7)" fill="#5A5A5A">
+  <path d="M7.293 9.006l-.88.88A2.484 2.484 0 0 0 4 8a2.488 2.488 0 0 0-2.413 1.886l-.88-.88L0 9.712l1.147 1.146-.147.146v1H0v.999h1v.053c.051.326.143.643.273.946L0 15.294.707 16l1.1-1.099A2.873 2.873 0 0 0 4 16a2.875 2.875 0 0 0 2.193-1.099L7.293 16 8 15.294l-1.273-1.292A3.92 3.92 0 0 0 7 13.036v-.067h1v-.965H7v-1l-.147-.146L8 9.712l-.707-.706zM4 9.006a1.5 1.5 0 0 1 1.5 1.499h-3A1.498 1.498 0 0 1 4 9.006zm2 3.997A2.217 2.217 0 0 1 4 15a2.22 2.22 0 0 1-2-1.998v-1.499h4v1.499z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd"
+        d="M5 2.41L5.78 2l9 6v.83L9 12.683v-1.2l4.6-3.063L6 3.35V7H5V2.41z"/>
+</g>
+
+<!-- run-above -->
+<g transform="translate(70, 68) scale(0.7)" fill="#5A5A5A">
+  <path d="M1.77 1.01L1 1.42v12l.78.42 9-6v-.83l-9.01-6zM2 12.49V2.36l7.6 5.07L2 12.49zM12.15 8h.71l2.5 2.5-.71.71L13 9.56V15h-1V9.55l-1.65 1.65-.7-.7 2.5-2.5z"/>
+</g>
+
+<!-- ellipsis -->
+<g transform="translate(85, 68) scale(0.7)" fill="#5A5A5A">
+  <path d="M4 8a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm5 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm5 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
+</g>
+
+<!-- trash -->
+<g transform="translate(100, 68) scale(0.7)" fill="#5A5A5A">
+  <path fill-rule="evenodd" clip-rule="evenodd"
+        d="M10 3h3v1h-1v9l-1 1H4l-1-1V4H2V3h3V2a1 1 0 0 1 1-1h3a1 1 0 0 1 1 1v1zM9 2H6v1h3V2zM4 13h7V4H4v9zm2-8H5v7h1V5zm1 0h1v7H7V5zm2 0h1v7H9V5z"/>
+</g>
+```

--- a/.claude/skills/positron-abstract-svg/references/codicons.md
+++ b/.claude/skills/positron-abstract-svg/references/codicons.md
@@ -1,6 +1,8 @@
 # Positron Codicon SVG Paths
 
-All paths use a 16×16 coordinate space. Use `transform="translate(x, y)"` to position and `scale(n)` to resize.
+These are the **curated icon paths used across the existing Positron walkthrough SVGs** -- a frozen, internally-consistent set. Use them as-is so new images match the canonical look. All paths use a 16x16 coordinate space. Use `transform="translate(x, y)"` to position and `scale(n)` to resize.
+
+> Need an icon that isn't here? Grab it from `node_modules/@vscode/codicons/src/icons/<name>.svg` and copy its `d=`. Be aware upstream codicons have been redesigned over time, so a freshly pulled icon may have slightly different geometry than this set -- simplify it to match the flat style of the icons below rather than mixing visual eras.
 
 ## Toolbar-scale usage (full 16px)
 
@@ -13,7 +15,7 @@ All paths use a 16×16 coordinate space. Use `transform="translate(x, y)"` to po
 ## Action-bar-scale usage (~11px, centered in a 16px-tall bar at y=BAR_TOP)
 
 ```svg
-<!-- scale(0.7) → 11.2px icon; to center in 16px bar: translate y = BAR_TOP + 2.4 -->
+<!-- scale(0.7) -> 11.2px icon; to center in 16px bar: translate y = BAR_TOP + 2.4 -->
 <g transform="translate(X, BAR_TOP_PLUS_2) scale(0.7)" fill="#5A5A5A">
   <path d="..."/>
 </g>
@@ -23,7 +25,7 @@ All paths use a 16×16 coordinate space. Use `transform="translate(x, y)"` to po
 
 ## Run All (notebook-execute-all)
 
-Two overlapping play triangles — use both paths together.
+Two overlapping play triangles -- use both paths together.
 
 ```svg
 <g transform="translate(X, Y)" fill="#5A5A5A">
@@ -33,7 +35,7 @@ Two overlapping play triangles — use both paths together.
 </g>
 ```
 
-## Notebook Execute (single play — notebook-execute)
+## Notebook Execute (single play -- notebook-execute)
 
 Single play triangle, used in cell action bars.
 
@@ -47,7 +49,7 @@ Single play triangle, used in cell action bars.
 <path d="M10 12.6l.7.7 1.6-1.6 1.6 1.6.8-.7L13 11l1.7-1.6-.8-.8-1.6 1.7-1.6-1.7-.7.8 1.6 1.6-1.6 1.6zM1 4h14V3H1v1zm0 3h14V6H1v1zm8 2.5V9H1v1h8v-.5zM9 13v-1H1v1h8z"/>
 ```
 
-## Add (plus — used for + Code and + Markdown buttons)
+## Add (plus -- used for + Code and + Markdown buttons)
 
 Scale to 0.6875 when rendering at toolbar size alongside text labels.
 
@@ -80,7 +82,7 @@ Scale to 0.625 when rendering small.
 
 ## Debug Alt Small (debug-alt-small)
 
-Two paths — use both together.
+Two paths -- use both together.
 
 ```svg
 <g transform="translate(X, Y)" fill="#5A5A5A">
@@ -110,7 +112,7 @@ Two paths — use both together.
 
 ---
 
-## Cell Action Bar — Full Example
+## Cell Action Bar -- Full Example
 
 The action bar floats at the top-left of its parent cell. Draw it **after** the cell rect in SVG document order so it renders on top.
 

--- a/.claude/skills/positron-abstract-svg/references/examples/kernel-selector-abstract.svg
+++ b/.claude/skills/positron-abstract-svg/references/examples/kernel-selector-abstract.svg
@@ -1,0 +1,45 @@
+<svg width="400" height="210" viewBox="0 0 410 210" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="400" height="200" fill="#FFFFFF"/>
+  <rect x="0" y="0" width="400" height="44" fill="#FAFAFA"/>
+  <line x1="0" y1="44" x2="400" y2="44" stroke="#E0E0E0" stroke-width="1"/>
+  <g transform="translate(12, 14)" fill="#5A5A5A">
+    <path d="M2.78 2L2 2.41v12l.78.42 9-6V8l-9-6zM3 13.48V3.35l7.6 5.07L3 13.48z"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M6 14.683l8.78-5.853V8L6 2.147V3.35l7.6 5.07L6 13.48v1.203z"/>
+  </g>
+  <g transform="translate(36, 14)" fill="#5A5A5A">
+    <path d="M10 12.6l.7.7 1.6-1.6 1.6 1.6.8-.7L13 11l1.7-1.6-.8-.8-1.6 1.7-1.6-1.7-.7.8 1.6 1.6-1.6 1.6zM1 4h14V3H1v1zm0 3h14V6H1v1zm8 2.5V9H1v1h8v-.5zM9 13v-1H1v1h8z"/>
+  </g>
+  <g transform="translate(60, 17) scale(0.6875)" fill="#5A5A5A">
+    <path d="M8 1.5C8 1.22386 7.77614 1 7.5 1C7.22386 1 7 1.22386 7 1.5V7H1.5C1.22386 7 1 7.22386 1 7.5C1 7.77614 1.22386 8 1.5 8H7V13.5C7 13.7761 7.22386 14 7.5 14C7.77614 14 8 13.7761 8 13.5V8H13.5C13.7761 8 14 7.77614 14 7.5C14 7.22386 13.7761 7 13.5 7H8V1.5Z"/>
+  </g>
+  <text x="72" y="26" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#5A5A5A">Code</text>
+  <g transform="translate(103, 17) scale(0.6875)" fill="#5A5A5A">
+    <path d="M8 1.5C8 1.22386 7.77614 1 7.5 1C7.22386 1 7 1.22386 7 1.5V7H1.5C1.22386 7 1 7.22386 1 7.5C1 7.77614 1.22386 8 1.5 8H7V13.5C7 13.7761 7.22386 14 7.5 14C7.77614 14 8 13.7761 8 13.5V8H13.5C13.7761 8 14 7.77614 14 7.5C14 7.22386 13.7761 7 13.5 7H8V1.5Z"/>
+  </g>
+  <text x="115" y="26" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="11" fill="#5A5A5A">Markdown</text>
+  <g transform="translate(272, 14)" fill="#5A5A5A">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M4.681 3H2V2h3.5l.5.5V6H5V4a5 5 0 1 0 4.53-.761l.302-.954A6 6 0 1 1 4.681 3z"/>
+  </g>
+  <rect x="296" y="11" width="92" height="22" rx="4" fill="#FFFFFF" stroke="#447099" stroke-width="1.5"/>
+  <circle cx="307" cy="22" r="4" fill="#3DAA6E"/>
+  <text x="315" y="26" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10.5" fill="#333333">Python</text>
+  <g transform="translate(373, 17) scale(0.625)" fill="#5A5A5A">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M7.976 10.072l4.357-4.357.62.618L8.284 11h-.618L3 6.333l.619-.618 4.357 4.357z"/>
+  </g>
+  <rect x="278" y="47" width="116" height="56" rx="4" fill="#FFFFFF" stroke="#D8D8D8" stroke-width="1"/>
+  <rect x="279" y="48" width="114" height="26" rx="3" fill="#EEF3F8"/>
+  <text x="291" y="66" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10.5" fill="#333333">Change Kernel</text>
+  <text x="291" y="91" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10.5" fill="#555555">Shutdown Kernel</text>
+  
+  <rect x="12" y="112" width="376" height="72" rx="4" fill="#F8F8F8" stroke="#E0E0E0" stroke-width="1"/>
+  
+  <text x="33" y="130" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">1</text>
+  <text x="33" y="142" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">2</text>
+  <text x="33" y="154" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">3</text>
+  <text x="33" y="166" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">4</text>
+  
+  <rect x="44" y="126" width="88" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="44" y="138" width="140" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="44" y="150" width="68" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="44" y="162" width="112" height="4" rx="2" fill="#C8C8C8"/>
+</svg>

--- a/.claude/skills/positron-abstract-svg/references/examples/notebook-ai-context-abstract.svg
+++ b/.claude/skills/positron-abstract-svg/references/examples/notebook-ai-context-abstract.svg
@@ -1,0 +1,107 @@
+<svg width="520" height="270" viewBox="0 0 530 270" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="520" height="260" fill="#FFFFFF"/>
+  <line x1="225" y1="0" x2="225" y2="260" stroke="#E0E0E0" stroke-width="1"/>
+  
+  <rect x="0" y="0" width="225" height="28" fill="#F4F4F4"/>
+  <line x1="0" y1="28" x2="225" y2="28" stroke="#E0E0E0" stroke-width="1"/>
+  <text x="12" y="18" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" font-weight="500" fill="#3E4246">Posit Assistant</text>
+  
+  <rect x="225" y="0" width="295" height="28" fill="#F2F2F2"/>
+  <line x1="225" y1="28" x2="520" y2="28" stroke="#E0E0E0" stroke-width="1"/>
+  <rect x="225" y="0" width="148" height="28" fill="#FFFFFF"/>
+  <line x1="225" y1="27" x2="373" y2="27" stroke="#447099" stroke-width="2"/>
+  <text x="237" y="18" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#333333">analysis.ipynb</text>
+  <line x1="356" y1="9" x2="366" y2="19" stroke="#8A8A8A" stroke-width="1.2"/>
+  <line x1="366" y1="9" x2="356" y2="19" stroke="#8A8A8A" stroke-width="1.2"/>
+  <line x1="373" y1="0" x2="373" y2="28" stroke="#E0E0E0" stroke-width="1"/>
+  
+  <rect x="225" y="28" width="295" height="34" fill="#FAFAFA"/>
+  <line x1="225" y1="62" x2="520" y2="62" stroke="#E0E0E0" stroke-width="1"/>
+  <g transform="translate(235, 37)" fill="#5A5A5A">
+    <path d="M2.78 2L2 2.41v12l.78.42 9-6V8l-9-6zM3 13.48V3.35l7.6 5.07L3 13.48z"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M6 14.683l8.78-5.853V8L6 2.147V3.35l7.6 5.07L6 13.48v1.203z"/>
+  </g>
+  <g transform="translate(257, 37)" fill="#5A5A5A">
+    <path d="M10 12.6l.7.7 1.6-1.6 1.6 1.6.8-.7L13 11l1.7-1.6-.8-.8-1.6 1.7-1.6-1.7-.7.8 1.6 1.6-1.6 1.6zM1 4h14V3H1v1zm0 3h14V6H1v1zm8 2.5V9H1v1h8v-.5zM9 13v-1H1v1h8z"/>
+  </g>
+  <g transform="translate(279, 40) scale(0.6875)" fill="#5A5A5A">
+    <path d="M8 1.5C8 1.22386 7.77614 1 7.5 1C7.22386 1 7 1.22386 7 1.5V7H1.5C1.22386 7 1 7.22386 1 7.5C1 7.77614 1.22386 8 1.5 8H7V13.5C7 13.7761 7.22386 14 7.5 14C7.77614 14 8 13.7761 8 13.5V8H13.5C13.7761 8 14 7.77614 14 7.5C14 7.22386 13.7761 7 13.5 7H8V1.5Z"/>
+  </g>
+  <text x="291" y="49" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#5A5A5A">Code</text>
+  <g transform="translate(322, 40) scale(0.6875)" fill="#5A5A5A">
+    <path d="M8 1.5C8 1.22386 7.77614 1 7.5 1C7.22386 1 7 1.22386 7 1.5V7H1.5C1.22386 7 1 7.22386 1 7.5C1 7.77614 1.22386 8 1.5 8H7V13.5C7 13.7761 7.22386 14 7.5 14C7.77614 14 8 13.7761 8 13.5V8H13.5C13.7761 8 14 7.77614 14 7.5C14 7.22386 13.7761 7 13.5 7H8V1.5Z"/>
+  </g>
+  <text x="334" y="49" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#5A5A5A">Markdown</text>
+  <g transform="translate(410, 37)" fill="#5A5A5A">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M4.681 3H2V2h3.5l.5.5V6H5V4a5 5 0 1 0 4.53-.761l.302-.954A6 6 0 1 1 4.681 3z"/>
+  </g>
+  <rect x="430" y="34" width="82" height="22" rx="4" fill="#FFFFFF" stroke="#447099" stroke-width="1.5"/>
+  <circle cx="440" cy="45" r="4" fill="#3DAA6E"/>
+  <text x="448" y="49" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9.5" fill="#333333">Python</text>
+  <g transform="translate(498, 40) scale(0.625)" fill="#5A5A5A">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M7.976 10.072l4.357-4.357.62.618L8.284 11h-.618L3 6.333l.619-.618 4.357 4.357z"/>
+  </g>
+  
+  <rect x="235" y="70" width="278" height="110" rx="4" fill="#FFFFFF" stroke="#447099" stroke-width="1.5"/>
+  <rect x="236.5" y="71.5" width="275" height="63" fill="#F8F8F8"/>
+  <line x1="236" y1="134" x2="512" y2="134" stroke="#EEEEEE" stroke-width="1"/>
+  <text x="253" y="86" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">1</text>
+  <text x="253" y="98" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">2</text>
+  <text x="253" y="110" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">3</text>
+  <text x="253" y="122" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">4</text>
+  <text x="261" y="86" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="10.5">
+    <tspan fill="#447099">x</tspan><tspan fill="#5A5A5A"> = </tspan><tspan fill="#098658">10</tspan>
+  </text>
+  <rect x="261" y="93" width="100" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="261" y="105" width="140" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="261" y="117" width="80" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="255" y="151" width="6" height="14" fill="#447099" opacity="0.7"/>
+  <rect x="267" y="156" width="6" height="9" fill="#447099" opacity="0.7"/>
+  <rect x="279" y="148" width="6" height="17" fill="#447099" opacity="0.7"/>
+  <rect x="291" y="153" width="6" height="12" fill="#447099" opacity="0.7"/>
+  <rect x="303" y="149" width="6" height="16" fill="#447099" opacity="0.7"/>
+  <rect x="315" y="157" width="6" height="8" fill="#447099" opacity="0.7"/>
+  <line x1="249" y1="165" x2="335" y2="165" stroke="#DDDDDD" stroke-width="0.8"/>
+  
+  <rect x="235" y="190" width="278" height="42" rx="4" fill="#F8F8F8" stroke="#E0E0E0" stroke-width="1"/>
+  <text x="253" y="206" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">1</text>
+  <text x="253" y="218" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">2</text>
+  <rect x="261" y="202" width="110" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="261" y="214" width="75" height="4" rx="2" fill="#C8C8C8"/>
+  
+  
+  <rect x="69" y="36" width="148" height="28" rx="6" fill="#EEF3F8" stroke="#D0DFE8" stroke-width="1"/>
+  <rect x="79" y="44" width="108" height="4" rx="2" fill="#8DA5B8"/>
+  <rect x="79" y="52" width="84" height="4" rx="2" fill="#8DA5B8"/>
+  
+  <rect x="8" y="72" width="209" height="86" rx="6" fill="#F8F8F8" stroke="#E8E8E8" stroke-width="1"/>
+  <rect x="17" y="82" width="182" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="17" y="92" width="160" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="17" y="102" width="172" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="17" y="113" width="192" height="33" rx="3" fill="#F0F0F0" stroke="#E0E0E0" stroke-width="1"/>
+  <text x="25" y="126" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9">
+    <tspan fill="#447099">y</tspan><tspan fill="#5A5A5A"> = </tspan><tspan fill="#447099">x</tspan><tspan fill="#5A5A5A"> * </tspan><tspan fill="#098658">2</tspan>
+  </text>
+  <rect x="25" y="134" width="130" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="25" y="142" width="95" height="4" rx="2" fill="#C8C8C8"/>
+  
+  <rect x="74" y="166" width="143" height="28" rx="6" fill="#EEF3F8" stroke="#D0DFE8" stroke-width="1"/>
+  <rect x="84" y="174" width="100" height="4" rx="2" fill="#8DA5B8"/>
+  <rect x="84" y="182" width="68" height="4" rx="2" fill="#8DA5B8"/>
+  
+  <rect x="8" y="200" width="209" height="54" rx="6" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/>
+  
+  <rect x="14" y="207" width="106" height="15" rx="7.5" fill="#EEF3F8" stroke="#C8D9E8" stroke-width="1"/>
+  <rect x="21" y="210.5" width="7" height="8" rx="1" fill="none" stroke="#447099" stroke-width="1"/>
+  <line x1="23" y1="213" x2="27" y2="213" stroke="#447099" stroke-width="0.8"/>
+  <line x1="23" y1="215" x2="27" y2="215" stroke="#447099" stroke-width="0.8"/>
+  <text x="33" y="218" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" fill="#447099">analysis.ipynb</text>
+  
+  <line x1="14" y1="226" x2="209" y2="226" stroke="#EEEEEE" stroke-width="1"/>
+  
+  <rect x="14" y="236" width="72" height="4" rx="2" fill="#DDDDDD"/>
+  
+  <g transform="translate(199, 232) scale(0.82)" fill="#447099">
+    <path d="M1.17683 1.11898C1.32953 0.989634 1.54464 0.963786 1.72363 1.05328L14.7236 7.55328C14.893 7.63797 15 7.8111 15 8.00049C15 8.18987 14.893 8.36301 14.7236 8.4477L1.72363 14.9477C1.54464 15.0372 1.32953 15.0113 1.17683 14.882C1.02414 14.7526 0.96328 14.5447 1.02213 14.3534L2.97688 8.00049L1.02213 1.64754C0.96328 1.45627 1.02414 1.24833 1.17683 1.11898ZM3.8693 8.50049L2.32155 13.5307L13.382 8.00049L2.32155 2.47027L3.8693 7.50049H9.50001C9.77615 7.50049 10 7.72435 10 8.00049C10 8.27663 9.77615 8.50049 9.50001 8.50049H3.8693Z"/>
+  </g>
+</svg>

--- a/.claude/skills/positron-abstract-svg/references/examples/notebook-editor-abstract.svg
+++ b/.claude/skills/positron-abstract-svg/references/examples/notebook-editor-abstract.svg
@@ -1,0 +1,90 @@
+<svg width="520" height="260" viewBox="0 0 530 260" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="520" height="250" fill="#FFFFFF"/>
+  
+  <rect x="0" y="0" width="355" height="36" fill="#FAFAFA"/>
+  <line x1="0" y1="36" x2="355" y2="36" stroke="#E0E0E0" stroke-width="1"/>
+  <g transform="translate(10, 10)" fill="#5A5A5A">
+    <path d="M2.78 2L2 2.41v12l.78.42 9-6V8l-9-6zM3 13.48V3.35l7.6 5.07L3 13.48z"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M6 14.683l8.78-5.853V8L6 2.147V3.35l7.6 5.07L6 13.48v1.203z"/>
+  </g>
+  <g transform="translate(32, 10)" fill="#5A5A5A">
+    <path d="M10 12.6l.7.7 1.6-1.6 1.6 1.6.8-.7L13 11l1.7-1.6-.8-.8-1.6 1.7-1.6-1.7-.7.8 1.6 1.6-1.6 1.6zM1 4h14V3H1v1zm0 3h14V6H1v1zm8 2.5V9H1v1h8v-.5zM9 13v-1H1v1h8z"/>
+  </g>
+  <g transform="translate(54, 13) scale(0.6875)" fill="#5A5A5A">
+    <path d="M8 1.5C8 1.22386 7.77614 1 7.5 1C7.22386 1 7 1.22386 7 1.5V7H1.5C1.22386 7 1 7.22386 1 7.5C1 7.77614 1.22386 8 1.5 8H7V13.5C7 13.7761 7.22386 14 7.5 14C7.77614 14 8 13.7761 8 13.5V8H13.5C13.7761 8 14 7.77614 14 7.5C14 7.22386 13.7761 7 13.5 7H8V1.5Z"/>
+  </g>
+  <text x="66" y="22" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#5A5A5A">Code</text>
+  <g transform="translate(97, 13) scale(0.6875)" fill="#5A5A5A">
+    <path d="M8 1.5C8 1.22386 7.77614 1 7.5 1C7.22386 1 7 1.22386 7 1.5V7H1.5C1.22386 7 1 7.22386 1 7.5C1 7.77614 1.22386 8 1.5 8H7V13.5C7 13.7761 7.22386 14 7.5 14C7.77614 14 8 13.7761 8 13.5V8H13.5C13.7761 8 14 7.77614 14 7.5C14 7.22386 13.7761 7 13.5 7H8V1.5Z"/>
+  </g>
+  <text x="109" y="22" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#5A5A5A">Markdown</text>
+  <g transform="translate(242, 10)" fill="#5A5A5A">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M4.681 3H2V2h3.5l.5.5V6H5V4a5 5 0 1 0 4.53-.761l.302-.954A6 6 0 1 1 4.681 3z"/>
+  </g>
+  <rect x="262" y="7" width="82" height="22" rx="4" fill="#FFFFFF" stroke="#447099" stroke-width="1.5"/>
+  <circle cx="272" cy="18" r="4" fill="#3DAA6E"/>
+  <text x="280" y="22" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9.5" fill="#333333">Python</text>
+  <g transform="translate(330, 13) scale(0.625)" fill="#5A5A5A">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M7.976 10.072l4.357-4.357.62.618L8.284 11h-.618L3 6.333l.619-.618 4.357 4.357z"/>
+  </g>
+  <line x1="355" y1="0" x2="355" y2="250" stroke="#E0E0E0" stroke-width="1"/>
+  
+  <rect x="355" y="0" width="165" height="36" fill="#F4F4F4"/>
+  <line x1="355" y1="36" x2="520" y2="36" stroke="#E0E0E0" stroke-width="1"/>
+  <text x="365" y="22" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9.5" font-weight="500" fill="#3E4246" letter-spacing="0.8">VARIABLES</text>
+  <g transform="translate(478, 10)" fill="#5A5A5A">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M4.681 3H2V2h3.5l.5.5V6H5V4a5 5 0 1 0 4.53-.761l.302-.954A6 6 0 1 1 4.681 3z"/>
+  </g>
+  <g transform="translate(498, 10)" fill="#5A5A5A">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M10 3h3v1h-1v9l-1 1H4l-1-1V4H2V3h3V2a1 1 0 0 1 1-1h3a1 1 0 0 1 1 1v1zM9 2H6v1h3V2zM4 13h7V4H4v9zm2-8H5v7h1V5zm1 0h1v7H7V5zm2 0h1v7H9V5z"/>
+  </g>
+  
+  <rect x="355" y="37" width="164" height="18" fill="#EEF3F8"/>
+  <text x="365" y="50" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" fill="#5A5A5A">x</text>
+  <text x="420" y="50" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" fill="#5A5A5A">1</text>
+  <text x="472" y="50" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9" fill="#5A5A5A">int</text>
+  <line x1="355" y1="55" x2="520" y2="55" stroke="#EEEEEE" stroke-width="1"/>
+  
+  <rect x="365" y="62" width="28" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="420" y="62" width="22" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="472" y="62" width="28" height="4" rx="2" fill="#C8C8C8"/>
+  <line x1="355" y1="73" x2="520" y2="73" stroke="#EEEEEE" stroke-width="1"/>
+  <rect x="365" y="80" width="20" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="420" y="80" width="30" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="472" y="80" width="22" height="4" rx="2" fill="#C8C8C8"/>
+  <line x1="355" y1="91" x2="520" y2="91" stroke="#EEEEEE" stroke-width="1"/>
+  <rect x="365" y="98" width="34" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="420" y="98" width="18" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="472" y="98" width="26" height="4" rx="2" fill="#C8C8C8"/>
+  <line x1="355" y1="109" x2="520" y2="109" stroke="#EEEEEE" stroke-width="1"/>
+  <rect x="365" y="116" width="24" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="420" y="116" width="28" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="472" y="116" width="20" height="4" rx="2" fill="#C8C8C8"/>
+  <line x1="355" y1="127" x2="520" y2="127" stroke="#EEEEEE" stroke-width="1"/>
+  
+  <rect x="10" y="44" width="338" height="76" rx="4" fill="#F8F8F8" stroke="#447099" stroke-width="1.5"/>
+  <text x="28" y="59" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">1</text>
+  <text x="28" y="71" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">2</text>
+  <text x="28" y="83" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">3</text>
+  <text x="28" y="95" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">4</text>
+  <text x="28" y="107" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">5</text>
+  <text x="36" y="59" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="10.5">
+    <tspan fill="#447099">x</tspan><tspan fill="#5A5A5A"> = </tspan><tspan fill="#098658">1</tspan>
+  </text>
+  <rect x="36" y="66" width="110" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="36" y="78" width="75" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="36" y="90" width="140" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="36" y="102" width="90" height="4" rx="2" fill="#C8C8C8"/>
+  
+  <rect x="10" y="130" width="338" height="58" rx="4" fill="#F8F8F8" stroke="#E0E0E0" stroke-width="1"/>
+  <text x="28" y="148" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">1</text>
+  <text x="28" y="160" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">2</text>
+  <text x="28" y="172" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">3</text>
+  <rect x="36" y="144" width="130" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="36" y="156" width="80" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="36" y="168" width="110" height="4" rx="2" fill="#C8C8C8"/>
+  
+  <rect x="10" y="198" width="338" height="36" rx="4" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/>
+  <rect x="20" y="208" width="150" height="4" rx="2" fill="#AAAAAA"/>
+  <rect x="20" y="220" width="90" height="4" rx="2" fill="#C8C8C8"/>
+</svg>

--- a/.claude/skills/positron-abstract-svg/references/examples/notebook-hero-abstract.svg
+++ b/.claude/skills/positron-abstract-svg/references/examples/notebook-hero-abstract.svg
@@ -1,0 +1,73 @@
+<svg width="520" height="270" viewBox="0 0 530 270" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="520" height="260" fill="#FFFFFF"/>
+  <rect x="0" y="0" width="520" height="28" fill="#F2F2F2"/>
+  <line x1="0" y1="28" x2="520" y2="28" stroke="#E0E0E0" stroke-width="1"/>
+  <rect x="0" y="0" width="148" height="28" fill="#FFFFFF"/>
+  <line x1="0" y1="27" x2="148" y2="27" stroke="#447099" stroke-width="2"/>
+  <text x="12" y="18" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#333333">analysis.ipynb</text>
+  <line x1="131" y1="9" x2="141" y2="19" stroke="#8A8A8A" stroke-width="1.2"/>
+  <line x1="141" y1="9" x2="131" y2="19" stroke="#8A8A8A" stroke-width="1.2"/>
+  <line x1="148" y1="0" x2="148" y2="28" stroke="#E0E0E0" stroke-width="1"/>
+  <rect x="0" y="28" width="520" height="34" fill="#FAFAFA"/>
+  <line x1="0" y1="62" x2="520" y2="62" stroke="#E0E0E0" stroke-width="1"/>
+  <g transform="translate(10, 37)" fill="#5A5A5A"><path d="M2.78 2L2 2.41v12l.78.42 9-6V8l-9-6zM3 13.48V3.35l7.6 5.07L3 13.48z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M6 14.683l8.78-5.853V8L6 2.147V3.35l7.6 5.07L6 13.48v1.203z"/></g>
+  <g transform="translate(32, 37)" fill="#5A5A5A"><path d="M10 12.6l.7.7 1.6-1.6 1.6 1.6.8-.7L13 11l1.7-1.6-.8-.8-1.6 1.7-1.6-1.7-.7.8 1.6 1.6-1.6 1.6zM1 4h14V3H1v1zm0 3h14V6H1v1zm8 2.5V9H1v1h8v-.5zM9 13v-1H1v1h8z"/></g>
+  <g transform="translate(54, 40) scale(0.6875)" fill="#5A5A5A"><path d="M8 1.5C8 1.22386 7.77614 1 7.5 1C7.22386 1 7 1.22386 7 1.5V7H1.5C1.22386 7 1 7.22386 1 7.5C1 7.77614 1.22386 8 1.5 8H7V13.5C7 13.7761 7.22386 14 7.5 14C7.77614 14 8 13.7761 8 13.5V8H13.5C13.7761 8 14 7.77614 14 7.5C14 7.22386 13.7761 7 13.5 7H8V1.5Z"/></g>
+  <text x="66" y="49" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#5A5A5A">Code</text>
+  <g transform="translate(97, 40) scale(0.6875)" fill="#5A5A5A"><path d="M8 1.5C8 1.22386 7.77614 1 7.5 1C7.22386 1 7 1.22386 7 1.5V7H1.5C1.22386 7 1 7.22386 1 7.5C1 7.77614 1.22386 8 1.5 8H7V13.5C7 13.7761 7.22386 14 7.5 14C7.77614 14 8 13.7761 8 13.5V8H13.5C13.7761 8 14 7.77614 14 7.5C14 7.22386 13.7761 7 13.5 7H8V1.5Z"/></g>
+  <text x="109" y="49" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="10" fill="#5A5A5A">Markdown</text>
+  <g transform="translate(395, 37)" fill="#5A5A5A"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.681 3H2V2h3.5l.5.5V6H5V4a5 5 0 1 0 4.53-.761l.302-.954A6 6 0 1 1 4.681 3z"/></g>
+  <rect x="415" y="34" width="92" height="22" rx="4" fill="#FFFFFF" stroke="#447099" stroke-width="1.5"/>
+  <circle cx="425" cy="45" r="4" fill="#3DAA6E"/>
+  <text x="433" y="49" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="9.5" fill="#333333">Python</text>
+  <g transform="translate(492, 40) scale(0.625)" fill="#5A5A5A"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.976 10.072l4.357-4.357.62.618L8.284 11h-.618L3 6.333l.619-.618 4.357 4.357z"/></g>
+  
+  <rect x="30" y="76" width="478" height="172" rx="4" fill="#FFFFFF" stroke="#447099" stroke-width="1.5"/>
+  <rect x="31.5" y="82" width="475" height="56" fill="#F8F8F8"/>
+  <line x1="31" y1="138" x2="507" y2="138" stroke="#EEEEEE" stroke-width="1"/>
+  <text x="50" y="94" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">1</text>
+  <text x="50" y="106" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">2</text>
+  <text x="50" y="118" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">3</text>
+  <text x="50" y="130" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8DA5B8" text-anchor="end">4</text>
+  <rect x="58" y="90" width="200" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="58" y="102" width="80" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="58" y="114" width="120" height="4" rx="2" fill="#C8C8C8"/>
+  <rect x="58" y="126" width="160" height="4" rx="2" fill="#C8C8C8"/>
+  <text x="2" y="150" font-family="'Consolas', 'SF Mono', 'Menlo', monospace" font-size="9" fill="#8A8A8A">[1]</text>
+  <rect x="204" y="197" width="12" height="38" fill="#447099" opacity="0.7"/>
+  <rect x="221" y="180" width="12" height="55" fill="#447099" opacity="0.7"/>
+  <rect x="238" y="193" width="12" height="42" fill="#447099" opacity="0.7"/>
+  <rect x="255" y="170" width="12" height="65" fill="#447099" opacity="0.7"/>
+  <rect x="272" y="187" width="12" height="48" fill="#447099" opacity="0.7"/>
+  <rect x="289" y="177" width="12" height="58" fill="#447099" opacity="0.7"/>
+  <rect x="306" y="203" width="12" height="32" fill="#447099" opacity="0.7"/>
+  <rect x="323" y="185" width="12" height="50" fill="#447099" opacity="0.7"/>
+  <line x1="197" y1="235" x2="342" y2="235" stroke="#DDDDDD" stroke-width="1"/>
+  <rect x="205" y="239" width="10" height="3" rx="1.5" fill="#D0D0D0"/>
+  <rect x="222" y="239" width="10" height="3" rx="1.5" fill="#D0D0D0"/>
+  <rect x="239" y="239" width="10" height="3" rx="1.5" fill="#D0D0D0"/>
+  <rect x="256" y="239" width="10" height="3" rx="1.5" fill="#D0D0D0"/>
+  <rect x="273" y="239" width="10" height="3" rx="1.5" fill="#D0D0D0"/>
+  <rect x="290" y="239" width="10" height="3" rx="1.5" fill="#D0D0D0"/>
+  <rect x="307" y="239" width="10" height="3" rx="1.5" fill="#D0D0D0"/>
+  <rect x="324" y="239" width="10" height="3" rx="1.5" fill="#D0D0D0"/>
+  
+  <rect x="30" y="66" width="88" height="16" rx="3" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/>
+  <g transform="translate(35, 68) scale(0.7)" fill="#5A5A5A">
+    <path d="M3.78 2L3 2.41v12l.78.42 9-6V8l-9-6zM4 13.48V3.35l7.6 5.07L4 13.48z"/>
+  </g>
+  <line x1="51" y1="70" x2="51" y2="78" stroke="#D0D0D0" stroke-width="1"/>
+  <g transform="translate(55, 68) scale(0.7)" fill="#5A5A5A">
+    <path d="M7.293 9.006l-.88.88A2.484 2.484 0 0 0 4 8a2.488 2.488 0 0 0-2.413 1.886l-.88-.88L0 9.712l1.147 1.146-.147.146v1H0v.999h1v.053c.051.326.143.643.273.946L0 15.294.707 16l1.1-1.099A2.873 2.873 0 0 0 4 16a2.875 2.875 0 0 0 2.193-1.099L7.293 16 8 15.294l-1.273-1.292A3.92 3.92 0 0 0 7 13.036v-.067h1v-.965H7v-1l-.147-.146L8 9.712l-.707-.706zM4 9.006a1.5 1.5 0 0 1 1.5 1.499h-3A1.498 1.498 0 0 1 4 9.006zm2 3.997A2.217 2.217 0 0 1 4 15a2.22 2.22 0 0 1-2-1.998v-1.499h4v1.499z"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M5 2.41L5.78 2l9 6v.83L9 12.683v-1.2l4.6-3.063L6 3.35V7H5V2.41z"/>
+  </g>
+  <g transform="translate(70, 68) scale(0.7)" fill="#5A5A5A">
+    <path d="M1.77 1.01L1 1.42v12l.78.42 9-6v-.83l-9.01-6zM2 12.49V2.36l7.6 5.07L2 12.49zM12.15 8h.71l2.5 2.5-.71.71L13 9.56V15h-1V9.55l-1.65 1.65-.7-.7 2.5-2.5z"/>
+  </g>
+  <g transform="translate(85, 68) scale(0.7)" fill="#5A5A5A">
+    <path d="M4 8a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm5 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0zm5 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
+  </g>
+  <g transform="translate(100, 68) scale(0.7)" fill="#5A5A5A">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M10 3h3v1h-1v9l-1 1H4l-1-1V4H2V3h3V2a1 1 0 0 1 1-1h3a1 1 0 0 1 1 1v1zM9 2H6v1h3V2zM4 13h7V4H4v9zm2-8H5v7h1V5zm1 0h1v7H7V5zm2 0h1v7H9V5z"/>
+  </g>
+</svg>

--- a/.claude/skills/positron-abstract-svg/references/patterns.md
+++ b/.claude/skills/positron-abstract-svg/references/patterns.md
@@ -1,6 +1,6 @@
 # Positron SVG Component Patterns
 
-Copy-pasteable SVG snippets for every major UI component. All assume a 520×260 canvas unless noted. Adjust x/y/width/height to fit your layout.
+Copy-pasteable SVG snippets for every major UI component. All assume a 520x260 canvas unless noted. Adjust x/y/width/height to fit your layout.
 
 ---
 
@@ -14,7 +14,7 @@ When creating a new abstract image, **ask the user for a screenshot of the actua
 
 You can also search the Positron codebase for the codicon name used in code (e.g., `Codicon.notebookExecute`) and look it up in `references/codicons.md`.
 
-For file-type icons in the tab bar (e.g., `.ipynb`, `.R`, `.py`), Positron uses the **Seti UI** icon theme: https://github.com/jesseweed/seti-ui — fetch the relevant SVG from there if needed.
+For file-type icons in the tab bar (e.g., `.ipynb`, `.R`, `.py`), Positron uses the **Seti UI** icon theme: https://github.com/jesseweed/seti-ui. Locally it ships only as a font (`extensions/theme-seti/icons/seti.woff`), so there is no per-file SVG to extract from the repo -- fetch the source SVG from that repo's `icons/` folder (an external network call) or hand-draw a simple file glyph. NOTE: the existing walkthrough SVGs use plain text tab labels, not file-type glyphs, so this seti-icon approach is currently untested -- verify it in a preview and keep the glyph simple.
 
 ---
 
@@ -33,7 +33,7 @@ Full-width tab bar with one active file tab and close button. The blue underline
 <text x="12" y="18"
       font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
       font-size="10" fill="#333333">analysis.ipynb</text>
-<!-- Close × (two crossing lines) -->
+<!-- Close x (two crossing lines) -->
 <line x1="131" y1="9" x2="141" y2="19" stroke="#8A8A8A" stroke-width="1.2"/>
 <line x1="141" y1="9" x2="131" y2="19" stroke="#8A8A8A" stroke-width="1.2"/>
 <!-- Tab right border -->
@@ -44,7 +44,7 @@ Full-width tab bar with one active file tab and close button. The blue underline
 
 ## Notebook Toolbar
 
-Full-width toolbar with all standard notebook actions. The Python dropdown is the focal point — blue border, green session dot.
+Full-width toolbar with all standard notebook actions. The Python dropdown is the focal point -- blue border, green session dot.
 
 ```svg
 <!-- Toolbar background -->
@@ -83,7 +83,7 @@ Full-width toolbar with all standard notebook actions. The Python dropdown is th
         d="M4.681 3H2V2h3.5l.5.5V6H5V4a5 5 0 1 0 4.53-.761l.302-.954A6 6 0 1 1 4.681 3z"/>
 </g>
 
-<!-- Python session dropdown (FOCAL POINT — blue border, green dot) -->
+<!-- Python session dropdown (FOCAL POINT -- blue border, green dot) -->
 <rect x="415" y="34" width="92" height="22" rx="4" fill="#FFFFFF" stroke="#447099" stroke-width="1.5"/>
 <circle cx="425" cy="45" r="4" fill="#3DAA6E"/>
 <text x="433" y="49" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
@@ -96,7 +96,7 @@ Full-width toolbar with all standard notebook actions. The Python dropdown is th
 
 ---
 
-## Code Cell — Active (blue border, with combined output)
+## Code Cell -- Active (blue border, with combined output)
 
 The active cell has a blue border. Code area is gray; output area is white. Both share a single outer rect. Draw the action bar **after** this element.
 
@@ -130,7 +130,7 @@ The active cell has a blue border. Code area is gray; output area is white. Both
 
 ---
 
-## Code Cell — Inactive (gray border)
+## Code Cell -- Inactive (gray border)
 
 ```svg
 <rect x="12" y="184" width="496" height="42" rx="4"
@@ -175,7 +175,7 @@ A compact 6-bar chart for small output areas (~38px tall). Adjust bar heights an
 <line x1="19" y1="159" x2="105" y2="159" stroke="#DDDDDD" stroke-width="0.8"/>
 ```
 
-For a **large output area** (~110px), use wider bars (width=12) and taller heights. Add x-axis tick labels as 10×3 gray rects below the baseline.
+For a **large output area** (~110px), use wider bars (width=12) and taller heights. Add x-axis tick labels as 10x3 gray rects below the baseline.
 
 ---
 
@@ -197,7 +197,7 @@ See `references/codicons.md` for the full ready-to-use snippet.
 
 Key rules:
 - Position bar rect: `x=CELL_X`, `y=CELL_TOP - 10`, `height=16`, `rx=3`
-- **Draw the action bar AFTER the cell rect** — SVG renders in document order, so later = on top
+- **Draw the action bar AFTER the cell rect** -- SVG renders in document order, so later = on top
 - Always include a vertical separator (`stroke="#D0D0D0"`) after the execute icon
 
 ---

--- a/.claude/skills/positron-abstract-svg/references/patterns.md
+++ b/.claude/skills/positron-abstract-svg/references/patterns.md
@@ -1,0 +1,309 @@
+# Positron SVG Component Patterns
+
+Copy-pasteable SVG snippets for every major UI component. All assume a 520×260 canvas unless noted. Adjust x/y/width/height to fit your layout.
+
+---
+
+## Screenshot-Driven Workflow
+
+When creating a new abstract image, **ask the user for a screenshot of the actual UI** if available. A screenshot tells you:
+- Exact layout and proportions of panels
+- Which icons appear in which toolbars (identify by name then look up codicon path)
+- Text labels, tab names, column headers
+- Which element is the focal point (the thing the feature is trying to explain)
+
+You can also search the Positron codebase for the codicon name used in code (e.g., `Codicon.notebookExecute`) and look it up in `references/codicons.md`.
+
+For file-type icons in the tab bar (e.g., `.ipynb`, `.R`, `.py`), Positron uses the **Seti UI** icon theme: https://github.com/jesseweed/seti-ui — fetch the relevant SVG from there if needed.
+
+---
+
+## Tab Bar
+
+Full-width tab bar with one active file tab and close button. The blue underline (`#447099`) is the key active-tab signal.
+
+```svg
+<!-- Tab bar background -->
+<rect x="0" y="0" width="520" height="28" fill="#F2F2F2"/>
+<line x1="0" y1="28" x2="520" y2="28" stroke="#E0E0E0" stroke-width="1"/>
+
+<!-- Active tab (white, blue underline) -->
+<rect x="0" y="0" width="148" height="28" fill="#FFFFFF"/>
+<line x1="0" y1="27" x2="148" y2="27" stroke="#447099" stroke-width="2"/>
+<text x="12" y="18"
+      font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="10" fill="#333333">analysis.ipynb</text>
+<!-- Close × (two crossing lines) -->
+<line x1="131" y1="9" x2="141" y2="19" stroke="#8A8A8A" stroke-width="1.2"/>
+<line x1="141" y1="9" x2="131" y2="19" stroke="#8A8A8A" stroke-width="1.2"/>
+<!-- Tab right border -->
+<line x1="148" y1="0" x2="148" y2="28" stroke="#E0E0E0" stroke-width="1"/>
+```
+
+---
+
+## Notebook Toolbar
+
+Full-width toolbar with all standard notebook actions. The Python dropdown is the focal point — blue border, green session dot.
+
+```svg
+<!-- Toolbar background -->
+<rect x="0" y="28" width="520" height="34" fill="#FAFAFA"/>
+<line x1="0" y1="62" x2="520" y2="62" stroke="#E0E0E0" stroke-width="1"/>
+
+<!-- Run All -->
+<g transform="translate(10, 37)" fill="#5A5A5A">
+  <path d="M2.78 2L2 2.41v12l.78.42 9-6V8l-9-6zM3 13.48V3.35l7.6 5.07L3 13.48z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd"
+        d="M6 14.683l8.78-5.853V8L6 2.147V3.35l7.6 5.07L6 13.48v1.203z"/>
+</g>
+
+<!-- Clear All -->
+<g transform="translate(32, 37)" fill="#5A5A5A">
+  <path d="M10 12.6l.7.7 1.6-1.6 1.6 1.6.8-.7L13 11l1.7-1.6-.8-.8-1.6 1.7-1.6-1.7-.7.8 1.6 1.6-1.6 1.6zM1 4h14V3H1v1zm0 3h14V6H1v1zm8 2.5V9H1v1h8v-.5zM9 13v-1H1v1h8z"/>
+</g>
+
+<!-- + Code (add icon + label) -->
+<g transform="translate(54, 40) scale(0.6875)" fill="#5A5A5A">
+  <path d="M8 1.5C8 1.22386 7.77614 1 7.5 1C7.22386 1 7 1.22386 7 1.5V7H1.5C1.22386 7 1 7.22386 1 7.5C1 7.77614 1.22386 8 1.5 8H7V13.5C7 13.7761 7.22386 14 7.5 14C7.77614 14 8 13.7761 8 13.5V8H13.5C13.7761 8 14 7.77614 14 7.5C14 7.22386 13.7761 7 13.5 7H8V1.5Z"/>
+</g>
+<text x="66" y="49" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="10" fill="#5A5A5A">Code</text>
+
+<!-- + Markdown (add icon + label) -->
+<g transform="translate(97, 40) scale(0.6875)" fill="#5A5A5A">
+  <path d="M8 1.5C8 1.22386 7.77614 1 7.5 1C7.22386 1 7 1.22386 7 1.5V7H1.5C1.22386 7 1 7.22386 1 7.5C1 7.77614 1.22386 8 1.5 8H7V13.5C7 13.7761 7.22386 14 7.5 14C7.77614 14 8 13.7761 8 13.5V8H13.5C13.7761 8 14 7.77614 14 7.5C14 7.22386 13.7761 7 13.5 7H8V1.5Z"/>
+</g>
+<text x="109" y="49" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="10" fill="#5A5A5A">Markdown</text>
+
+<!-- Refresh (right-side icon, adjust x for full-width vs split layout) -->
+<g transform="translate(395, 37)" fill="#5A5A5A">
+  <path fill-rule="evenodd" clip-rule="evenodd"
+        d="M4.681 3H2V2h3.5l.5.5V6H5V4a5 5 0 1 0 4.53-.761l.302-.954A6 6 0 1 1 4.681 3z"/>
+</g>
+
+<!-- Python session dropdown (FOCAL POINT — blue border, green dot) -->
+<rect x="415" y="34" width="92" height="22" rx="4" fill="#FFFFFF" stroke="#447099" stroke-width="1.5"/>
+<circle cx="425" cy="45" r="4" fill="#3DAA6E"/>
+<text x="433" y="49" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="9.5" fill="#333333">Python</text>
+<g transform="translate(492, 40) scale(0.625)" fill="#5A5A5A">
+  <path fill-rule="evenodd" clip-rule="evenodd"
+        d="M7.976 10.072l4.357-4.357.62.618L8.284 11h-.618L3 6.333l.619-.618 4.357 4.357z"/>
+</g>
+```
+
+---
+
+## Code Cell — Active (blue border, with combined output)
+
+The active cell has a blue border. Code area is gray; output area is white. Both share a single outer rect. Draw the action bar **after** this element.
+
+```svg
+<!-- Outer cell border (blue = active) -->
+<rect x="12" y="70" width="496" height="104" rx="4"
+      fill="#FFFFFF" stroke="#447099" stroke-width="1.5"/>
+<!-- Code area gray background -->
+<rect x="13.5" y="71.5" width="493" height="60" fill="#F8F8F8"/>
+<!-- Separator between code and output -->
+<line x1="13" y1="131" x2="507" y2="131" stroke="#EEEEEE" stroke-width="1"/>
+
+<!-- Line numbers (text-anchor end, 20px from cell left edge) -->
+<text x="30" y="86" font-family="'Consolas', 'SF Mono', 'Menlo', monospace"
+      font-size="9" fill="#8DA5B8" text-anchor="end">1</text>
+<text x="30" y="98" font-family="'Consolas', 'SF Mono', 'Menlo', monospace"
+      font-size="9" fill="#8DA5B8" text-anchor="end">2</text>
+<text x="30" y="110" font-family="'Consolas', 'SF Mono', 'Menlo', monospace"
+      font-size="9" fill="#8DA5B8" text-anchor="end">3</text>
+<text x="30" y="122" font-family="'Consolas', 'SF Mono', 'Menlo', monospace"
+      font-size="9" fill="#8DA5B8" text-anchor="end">4</text>
+
+<!-- Placeholder code lines (code starts 26px from cell left edge) -->
+<rect x="38" y="82" width="200" height="4" rx="2" fill="#C8C8C8"/>
+<rect x="38" y="94" width="80"  height="4" rx="2" fill="#C8C8C8"/>
+<rect x="38" y="106" width="130" height="4" rx="2" fill="#C8C8C8"/>
+<rect x="38" y="118" width="160" height="4" rx="2" fill="#C8C8C8"/>
+
+<!-- Output: bar chart (see Bar Chart Output pattern below) -->
+```
+
+---
+
+## Code Cell — Inactive (gray border)
+
+```svg
+<rect x="12" y="184" width="496" height="42" rx="4"
+      fill="#F8F8F8" stroke="#E0E0E0" stroke-width="1"/>
+<!-- Line numbers -->
+<text x="30" y="200" font-family="'Consolas', 'SF Mono', 'Menlo', monospace"
+      font-size="9" fill="#8DA5B8" text-anchor="end">1</text>
+<text x="30" y="212" font-family="'Consolas', 'SF Mono', 'Menlo', monospace"
+      font-size="9" fill="#8DA5B8" text-anchor="end">2</text>
+<text x="30" y="224" font-family="'Consolas', 'SF Mono', 'Menlo', monospace"
+      font-size="9" fill="#8DA5B8" text-anchor="end">3</text>
+<!-- Placeholder code lines -->
+<rect x="38" y="196" width="180" height="4" rx="2" fill="#C8C8C8"/>
+<rect x="38" y="208" width="240" height="4" rx="2" fill="#C8C8C8"/>
+<rect x="38" y="220" width="150" height="4" rx="2" fill="#C8C8C8"/>
+```
+
+---
+
+## Markdown Cell
+
+```svg
+<rect x="12" y="236" width="496" height="18" rx="4"
+      fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/>
+<rect x="22" y="243" width="180" height="4" rx="2" fill="#AAAAAA"/>
+```
+
+---
+
+## Bar Chart Output
+
+A compact 6-bar chart for small output areas (~38px tall). Adjust bar heights and x positions to fit. Baseline is a light gray line.
+
+```svg
+<!-- 6 bars, baseline at y=BASELINE -->
+<rect x="25"  y="143" width="6" height="16" fill="#447099" opacity="0.7"/>
+<rect x="37"  y="150" width="6" height="9"  fill="#447099" opacity="0.7"/>
+<rect x="49"  y="141" width="6" height="18" fill="#447099" opacity="0.7"/>
+<rect x="61"  y="146" width="6" height="13" fill="#447099" opacity="0.7"/>
+<rect x="73"  y="143" width="6" height="16" fill="#447099" opacity="0.7"/>
+<rect x="85"  y="152" width="6" height="7"  fill="#447099" opacity="0.7"/>
+<line x1="19" y1="159" x2="105" y2="159" stroke="#DDDDDD" stroke-width="0.8"/>
+```
+
+For a **large output area** (~110px), use wider bars (width=12) and taller heights. Add x-axis tick labels as 10×3 gray rects below the baseline.
+
+---
+
+## Execution Count
+
+Positioned to the left of the cell, aligned to the **top of the output area** (not the center of the whole cell).
+
+```svg
+<text x="2" y="OUTPUT_TOP_PLUS_12"
+      font-family="'Consolas', 'SF Mono', 'Menlo', monospace"
+      font-size="9" fill="#8A8A8A">[1]</text>
+```
+
+---
+
+## Cell Action Bar
+
+See `references/codicons.md` for the full ready-to-use snippet.
+
+Key rules:
+- Position bar rect: `x=CELL_X`, `y=CELL_TOP - 10`, `height=16`, `rx=3`
+- **Draw the action bar AFTER the cell rect** — SVG renders in document order, so later = on top
+- Always include a vertical separator (`stroke="#D0D0D0"`) after the execute icon
+
+---
+
+## Vertical Panel Separator
+
+```svg
+<line x1="355" y1="0" x2="355" y2="260" stroke="#E0E0E0" stroke-width="1"/>
+```
+
+---
+
+## Variables Pane (right panel)
+
+Typically occupies the right 165px (x=355 to x=520) of a 520px canvas.
+
+```svg
+<!-- Header -->
+<rect x="355" y="28" width="165" height="34" fill="#F4F4F4"/>
+<line x1="355" y1="62" x2="520" y2="62" stroke="#E0E0E0" stroke-width="1"/>
+<text x="365" y="49"
+      font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="9.5" font-weight="500" fill="#3E4246" letter-spacing="0.8">VARIABLES</text>
+<!-- Refresh icon (right side of header) -->
+<g transform="translate(478, 37)" fill="#5A5A5A">
+  <path fill-rule="evenodd" clip-rule="evenodd"
+        d="M4.681 3H2V2h3.5l.5.5V6H5V4a5 5 0 1 0 4.53-.761l.302-.954A6 6 0 1 1 4.681 3z"/>
+</g>
+<!-- Trash icon -->
+<g transform="translate(498, 37)" fill="#5A5A5A">
+  <path fill-rule="evenodd" clip-rule="evenodd"
+        d="M10 3h3v1h-1v9l-1 1H4l-1-1V4H2V3h3V2a1 1 0 0 1 1-1h3a1 1 0 0 1 1 1v1zM9 2H6v1h3V2zM4 13h7V4H4v9zm2-8H5v7h1V5zm1 0h1v7H7V5zm2 0h1v7H9V5z"/>
+</g>
+
+<!-- Highlighted variable row (18px tall) -->
+<rect x="355" y="62" width="165" height="18" fill="#EEF3F8"/>
+<text x="365" y="75" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="9" fill="#5A5A5A">x</text>
+<text x="420" y="75" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="9" fill="#5A5A5A">10</text>
+<text x="472" y="75" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="9" fill="#5A5A5A">int</text>
+<line x1="355" y1="80" x2="520" y2="80" stroke="#EEEEEE" stroke-width="1"/>
+
+<!-- Placeholder rows (repeat for each row, 18px spacing) -->
+<rect x="365" y="87" width="28" height="4" rx="2" fill="#C8C8C8"/>
+<rect x="420" y="87" width="22" height="4" rx="2" fill="#C8C8C8"/>
+<rect x="472" y="87" width="28" height="4" rx="2" fill="#C8C8C8"/>
+<line x1="355" y1="98" x2="520" y2="98" stroke="#EEEEEE" stroke-width="1"/>
+```
+
+---
+
+## Posit Assistant Panel (left or right)
+
+Typically 225px wide. Header matches the tab bar height (28px).
+
+```svg
+<!-- Panel header -->
+<rect x="0" y="0" width="225" height="28" fill="#F4F4F4"/>
+<line x1="0" y1="28" x2="225" y2="28" stroke="#E0E0E0" stroke-width="1"/>
+<text x="12" y="18"
+      font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="10" font-weight="500" fill="#3E4246">Posit Assistant</text>
+
+<!-- User message bubble (right-aligned, #EEF3F8) -->
+<rect x="69" y="36" width="148" height="28" rx="6" fill="#EEF3F8" stroke="#D0DFE8" stroke-width="1"/>
+<rect x="79" y="44" width="108" height="4" rx="2" fill="#8DA5B8"/>
+<rect x="79" y="52" width="84"  height="4" rx="2" fill="#8DA5B8"/>
+
+<!-- AI response bubble (left-aligned, #F8F8F8) -->
+<rect x="8" y="72" width="209" height="60" rx="6" fill="#F8F8F8" stroke="#E8E8E8" stroke-width="1"/>
+<rect x="17" y="82" width="182" height="4" rx="2" fill="#C8C8C8"/>
+<rect x="17" y="92" width="160" height="4" rx="2" fill="#C8C8C8"/>
+<rect x="17" y="102" width="172" height="4" rx="2" fill="#C8C8C8"/>
+```
+
+---
+
+## Context Chip (file attachment pill in AI input box)
+
+Shows the user what file context the AI has. Place inside a taller input box.
+
+```svg
+<!-- Taller input box -->
+<rect x="8" y="200" width="209" height="54" rx="6" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/>
+
+<!-- Context chip pill -->
+<rect x="14" y="207" width="106" height="15" rx="7.5" fill="#EEF3F8" stroke="#C8D9E8" stroke-width="1"/>
+<!-- Small doc icon inside chip -->
+<rect x="21" y="210.5" width="7" height="8" rx="1" fill="none" stroke="#447099" stroke-width="1"/>
+<line x1="23" y1="213" x2="27" y2="213" stroke="#447099" stroke-width="0.8"/>
+<line x1="23" y1="215" x2="27" y2="215" stroke="#447099" stroke-width="0.8"/>
+<!-- Filename label -->
+<text x="33" y="218"
+      font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="9" fill="#447099">analysis.ipynb</text>
+
+<!-- Divider between chip area and text entry area -->
+<line x1="14" y1="226" x2="209" y2="226" stroke="#EEEEEE" stroke-width="1"/>
+
+<!-- Placeholder text in text area -->
+<rect x="14" y="236" width="72" height="4" rx="2" fill="#DDDDDD"/>
+
+<!-- Send button (bottom-right inside text area) -->
+<g transform="translate(199, 232) scale(0.82)" fill="#447099">
+  <path d="M1.17683 1.11898C1.32953 0.989634 1.54464 0.963786 1.72363 1.05328L14.7236 7.55328C14.893 7.63797 15 7.8111 15 8.00049C15 8.18987 14.893 8.36301 14.7236 8.4477L1.72363 14.9477C1.54464 15.0372 1.32953 15.0113 1.17683 14.882C1.02414 14.7526 0.96328 14.5447 1.02213 14.3534L2.97688 8.00049L1.02213 1.64754C0.96328 1.45627 1.02414 1.24833 1.17683 1.11898ZM3.8693 8.50049L2.32155 13.5307L13.382 8.00049L2.32155 2.47027L3.8693 7.50049H9.50001C9.77615 7.50049 10 7.72435 10 8.00049C10 8.27663 9.77615 8.50049 9.50001 8.50049H3.8693Z"/>
+</g>
+```


### PR DESCRIPTION
## Summary

Adds the `positron-abstract-svg` skill, which helps create clean, on-brand abstract SVG illustrations of the Positron IDE for documentation, walkthrough steps, onboarding images, and feature previews.

The skill captures the constraints and conventions for these images (loaded as `<img src>` inside a VS Code webview: hardcoded hex colors, no CSS vars, no JS, light theme), a tested color palette, component patterns, and a curated codicon set, so new images stay consistent with the existing walkthrough set.

## What's included

- `SKILL.md` -- constraints, color palette, fonts, workflow (gather input -> plan -> sketch -> preview -> iterate -> save), layering rules, and references.
- `references/patterns.md` -- copy-pasteable SVG snippets for every major component (tab bar, notebook toolbar, code cells, variables pane, Posit Assistant panel, context chip, bar chart output).
- `references/codicons.md` -- the curated, consistent icon paths the walkthrough images use, with guidance on sourcing new icons from `node_modules/@vscode/codicons` and matching the flat style.
- `references/examples/` -- four cleaned canonical example SVGs (hero, editor, AI context, kernel selector) that serve as the ground-truth style reference. Renderer cruft (inline `style=` blocks, non-shipping fonts) stripped; verified well-formed XML.

## Notes

- Files live under `.claude/` (gitignored), so they were force-added like the rest of the skill directory.
- The Seti file-icon approach is documented but flagged as currently untested; the existing examples use plain text tab labels.

## Test plan

- Skill-only change; no source or e2e impact.
- Invoke the skill and confirm it loads the references and example SVGs.