### PR TITLE
Fix Enter navigation in Help find

### DIFF
--- a/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
+++ b/src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts
@@ -764,12 +764,6 @@ export class HelpEntry extends Disposable implements IHelpEntry, WebviewFindDele
 					findValue: value
 				});
 			}
-
-			setTimeout(() => {
-				this._helpOverlayWebview?.postMessage({
-					id: 'positron-help-focus'
-				});
-			}, 100);
 		}
 	}
 

--- a/src/vs/workbench/contrib/positronHelp/browser/resources/welcome.html
+++ b/src/vs/workbench/contrib/positronHelp/browser/resources/welcome.html
@@ -159,11 +159,6 @@
 						}
 						break;
 
-					// positron-help-focus message. Sent to focus the help window.
-					case "positron-help-focus":
-						window.focus();
-						break;
-
 					// positron-help-copy-selection message. Sent to copy the selection.
 					case "positron-help-copy-selection":
 						// Post the positron-help-selection message.

--- a/src/vs/workbench/contrib/positronHelp/test/browser/helpEntry.vitest.ts
+++ b/src/vs/workbench/contrib/positronHelp/test/browser/helpEntry.vitest.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Event } from '../../../../../base/common/event.js';
+import { URI } from '../../../../../base/common/uri.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { IOverlayWebview, IWebviewService } from '../../../webview/browser/webview.js';
+import { HelpEntry } from '../../browser/helpEntry.js';
+
+type HelpMessage = {
+	readonly id: string;
+	readonly findValue?: string;
+};
+
+describe('HelpEntry', () => {
+	let messages: HelpMessage[];
+	let helpEntry: HelpEntry;
+
+	const overlayWebview = (): IOverlayWebview => stubInterface<IOverlayWebview>({
+		container: document.createElement('div'),
+		origin: 'test-origin',
+		options: {},
+		onDidFocus: Event.None,
+		onDidBlur: Event.None,
+		onDidDispose: Event.None,
+		onDidClickLink: Event.None,
+		onDidScroll: Event.None,
+		onDidWheel: Event.None,
+		onDidUpdateState: Event.None,
+		onFatalError: Event.None,
+		onMissingCsp: Event.None,
+		onMessage: Event.None,
+		onDidNavigate: Event.None,
+		onDidLoad: Event.None,
+		intrinsicContentSize: undefined,
+		postMessage: async message => {
+			messages.push(message as HelpMessage);
+			return true;
+		},
+		setHtml: () => { },
+		claim: () => { },
+		setAnchorElement: () => { },
+		dispose: () => { },
+		reload: () => { },
+	});
+
+	const ctx = createTestContainer()
+		.withWorkbenchServices()
+		.stub(IWebviewService, {
+			createWebviewOverlay: () => overlayWebview(),
+		})
+		.build();
+
+	function createHelpEntry(): void {
+		messages = [];
+
+		helpEntry = ctx.disposables.add(ctx.instantiationService.createInstance(
+			HelpEntry,
+			'<html>__sourceURL__</html>',
+			'r',
+			'test-session',
+			'R',
+			'http://localhost/help/library/graphics/html/plot.html',
+			URI.parse('http://localhost/help/library/graphics/html/plot.html').toString(),
+		));
+
+		const anchor = document.createElement('div');
+		Object.defineProperty(anchor, 'getBoundingClientRect', {
+			value: () => ({ x: 0, y: 0, width: 100, height: 100 }),
+		});
+		document.body.appendChild(anchor);
+		helpEntry.showHelpOverlayWebview(anchor);
+	}
+
+	afterEach(() => {
+		helpEntry?.dispose();
+		document.body.replaceChildren();
+	});
+
+	describe('Find navigation', () => {
+		it('advances without moving focus into the Help webview', async () => {
+			vi.useFakeTimers();
+			createHelpEntry();
+
+			helpEntry.find('title', false);
+			await vi.runAllTimersAsync();
+
+			expect(messages).toEqual([{ id: 'positron-help-find-next', findValue: 'title' }]);
+		});
+	});
+});

--- a/src/vs/workbench/contrib/webview/browser/webviewFindWidget.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewFindWidget.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Event } from '../../../../base/common/event.js';
+import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { IContextKey, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IContextViewService } from '../../../../platform/contextview/browser/contextView.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
@@ -54,6 +55,16 @@ export class WebviewFindWidget extends SimpleFindWidget {
 		this._register(_delegate.onDidStopFind(() => {
 			this.updateButtons(false);
 		}));
+
+		this.onkeydown(this.getFindInputDomNode(), e => {
+			if (e.browserEvent.isComposing || e.keyCode !== KeyCode.Enter || e.altKey || e.ctrlKey || e.metaKey) {
+				return;
+			}
+
+			e.preventDefault();
+			e.stopPropagation();
+			this.find(e.shiftKey);
+		});
 	}
 
 	public find(previous: boolean) {

--- a/src/vs/workbench/contrib/webview/test/browser/webviewFindWidget.vitest.ts
+++ b/src/vs/workbench/contrib/webview/test/browser/webviewFindWidget.vitest.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Event } from '../../../../../base/common/event.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { WebviewFindDelegate, WebviewFindWidget } from '../../browser/webviewFindWidget.js';
+
+type FindCall = {
+	readonly value: string;
+	readonly previous: boolean;
+};
+
+type EnterKeyEventOptions = {
+	readonly shiftKey?: boolean;
+	readonly altKey?: boolean;
+	readonly ctrlKey?: boolean;
+	readonly metaKey?: boolean;
+	readonly isComposing?: boolean;
+};
+
+function createEnterKeyEvent(options: EnterKeyEventOptions = {}): KeyboardEvent {
+	const event = new KeyboardEvent('keydown', {
+		key: 'Enter',
+		code: 'Enter',
+		bubbles: true,
+		cancelable: true,
+		shiftKey: options.shiftKey,
+		altKey: options.altKey,
+		ctrlKey: options.ctrlKey,
+		metaKey: options.metaKey,
+	});
+	Object.defineProperty(event, 'keyCode', { get: () => 13 });
+	Object.defineProperty(event, 'isComposing', { get: () => options.isComposing === true });
+	return event;
+}
+
+describe('WebviewFindWidget', () => {
+	const ctx = createTestContainer().withWorkbenchServices().build();
+
+	let findCalls: FindCall[];
+	let widget: WebviewFindWidget;
+
+	function createWidget(): void {
+		findCalls = [];
+		const delegate: WebviewFindDelegate = {
+			hasFindResult: Event.None,
+			onDidStopFind: Event.None,
+			checkImeCompletionState: true,
+			find: (value, previous) => {
+				findCalls.push({ value, previous });
+			},
+			updateFind: () => { },
+			stopFind: () => { },
+			focus: () => { },
+		};
+
+		widget = ctx.disposables.add(ctx.instantiationService.createInstance(WebviewFindWidget, delegate));
+		document.body.appendChild(widget.getDomNode());
+		widget.reveal('needle', false);
+	}
+
+	afterEach(() => {
+		widget?.getDomNode().remove();
+	});
+
+	describe('Keyboard navigation', () => {
+		it('Enter invokes find next with the current input value', () => {
+			createWidget();
+
+			const event = createEnterKeyEvent();
+			const stopPropagation = vi.spyOn(event, 'stopPropagation');
+			widget.getFindInputDomNode().dispatchEvent(event);
+
+			expect(findCalls).toEqual([{ value: 'needle', previous: false }]);
+			expect(event.defaultPrevented).toBe(true);
+			expect(stopPropagation).toHaveBeenCalledOnce();
+		});
+
+		it('Shift+Enter invokes find previous with the current input value', () => {
+			createWidget();
+
+			const event = createEnterKeyEvent({ shiftKey: true });
+			const stopPropagation = vi.spyOn(event, 'stopPropagation');
+			widget.getFindInputDomNode().dispatchEvent(event);
+
+			expect(findCalls).toEqual([{ value: 'needle', previous: true }]);
+			expect(event.defaultPrevented).toBe(true);
+			expect(stopPropagation).toHaveBeenCalledOnce();
+		});
+
+		it('ignores modified Enter chords', () => {
+			createWidget();
+
+			for (const options of [{ altKey: true }, { ctrlKey: true }, { metaKey: true }]) {
+				const event = createEnterKeyEvent(options);
+				widget.getFindInputDomNode().dispatchEvent(event);
+				expect(event.defaultPrevented).toBe(false);
+			}
+
+			expect(findCalls).toEqual([]);
+		});
+
+		it('ignores Enter while IME composition is active', () => {
+			createWidget();
+
+			const event = createEnterKeyEvent({ isComposing: true });
+			widget.getFindInputDomNode().dispatchEvent(event);
+
+			expect(findCalls).toEqual([]);
+			expect(event.defaultPrevented).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
Fixes #12921

This PR handles plain Enter in the shared webview find widget so pressing Enter advances to the next webview match and Shift+Enter moves to the previous match. It also removes the Help pane's post-find focus message so the Find input keeps focus after navigation, matching the Help accessibility text and normal find behavior.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fix Help search so Enter advances results without leaving the Find input (#12921)

### Validation Steps

@:help @:search

1. Open help for `plot()` with `?plot`.
2. Search for the word `title`.
3. Press Enter repeatedly and verify the Help pane advances through matches while focus stays in the Find input.
4. Press Shift+Enter and verify the Help pane moves to the previous match.

### Demo                                                                           
  

https://github.com/user-attachments/assets/3a5c5728-a70c-421b-a9e9-00fd9d81b744


Automated validation run locally:

- `npm run compile-check-ts-native`
- `npx vitest run src/vs/workbench/contrib/webview/test/browser/webviewFindWidget.vitest.ts src/vs/workbench/contrib/positronHelp/test/browser/helpEntry.vitest.ts`
- `npx eslint --max-warnings 0 src/vs/workbench/contrib/webview/browser/webviewFindWidget.ts src/vs/workbench/contrib/webview/test/browser/webviewFindWidget.vitest.ts src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts src/vs/workbench/contrib/positronHelp/test/browser/helpEntry.vitest.ts`
- `node --experimental-strip-types build/hygiene.ts src/vs/workbench/contrib/webview/browser/webviewFindWidget.ts src/vs/workbench/contrib/webview/test/browser/webviewFindWidget.vitest.ts src/vs/workbench/contrib/positronHelp/browser/helpEntry.ts src/vs/workbench/contrib/positronHelp/browser/resources/welcome.html src/vs/workbench/contrib/positronHelp/test/browser/helpEntry.vitest.ts`