### PR TITLE
Fix weird spacing on "Start Session" button in empty console (#14155)

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/emptyConsole.css
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/emptyConsole.css
@@ -15,6 +15,8 @@
 
 .empty-console .title .link {
 	display: inline;
+	padding: 0;
+	vertical-align: baseline;
 	cursor: pointer;
 	text-decoration: underline;
 	color: var(--vscode-textLink-foreground);


### PR DESCRIPTION
Fixes #14155

## Description

Fixes the weird spacing around the **Start Session** button in the Console when no session is running.

## Root Cause

This was introduced in #12795 which replaced `PositronButton` (a `<div role="button">` with zero browser-default padding) with the `Button` component (a native `<button>` element).

Native `<button>` elements have browser UA stylesheet default padding (`1px 6px`). When used **inline** within a text sentence — _"There is no session running. Use [Start Session] to start one."_ — this padding creates unwanted vertical and horizontal whitespace around the button text, making it look like a hyperlink with extra internal spacing.

## Fix

Added two CSS properties to the `.link` rule in `emptyConsole.css`:

```css
padding: 0;           /* remove browser default button padding */
vertical-align: baseline; /* keep button text aligned with surrounding text */
```

This resets the UA default padding for the button in this specific inline-text context only (scoped to `.empty-console .title .link`), without affecting the `Button` component globally.

## Testing

- Existing Vitest unit tests in `emptyConsole.vitest.tsx` continue to pass — they verify the text content and click behavior, which are unaffected.
- Visually: open a new Positron window before any session is started and confirm the "Start Session" button text sits flush with the surrounding sentence text.