### PR TITLE
Windows E2E CI: always install VS 2022 build tools (fix cache-hit node-gyp failure)

### DIFF
--- a/.github/workflows/test-e2e-windows-run.yml
+++ b/.github/workflows/test-e2e-windows-run.yml
@@ -166,13 +166,11 @@ jobs:
       # toolchain check is satisfied too. The Spectre-mitigated runtime libs are
       # added explicitly because our native modules (e.g. @vscode/native-watchdog,
       # @vscode/deviceid) build with Spectre mitigation required (MSB8040).
-      # Gated on the same condition as the install step below, since the
-      # toolchain is only needed when native modules are actually (re)built
-      # (i.e. on an npm cache miss).
+      # Runs unconditionally rather than only on an npm cache miss: the
+      # "Download binaries" step below runs `npm rebuild` on every run (even on
+      # a cache hit), which re-invokes node-gyp, so the toolchain must always be
+      # present regardless of cache state.
       - name: Install Visual Studio 2022 C++ build tools
-        if: steps.restore-caches.outputs.cache-npm-core-hit != 'true' ||
-            steps.restore-caches.outputs.cache-npm-extensions-volatile-hit != 'true' ||
-            steps.restore-caches.outputs.cache-npm-extensions-stable-hit != 'true'
         shell: pwsh
         run: |
           choco install visualstudio2022-workload-vctools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre --includeRecommended"


### PR DESCRIPTION
## Description

Follow-up to #14364. That PR installs the VS 2022 C++ build tools on the VS 2026 runner image so node-gyp falls back to a compiler it recognizes, but it **gated the install on the npm cache-miss condition** -- on the assumption that native modules are only (re)built during "Install node dependencies", which is itself cache-gated.

That assumption misses the **"Download binaries (Ark, Kallichore)"** step, which has no `if:` gate and runs `npm rebuild --foreground-scripts` in `positron-r` and `positron-supervisor` on **every** run. `npm rebuild` re-invokes node-gyp to recompile native addons (`@vscode/windows-registry`) regardless of cache state.

So on a **cache-hit** run, the VS 2022 install was skipped while the Download-binaries rebuild still ran -- and failed with the identical VS 2026 error #14364 set out to fix:

```
gyp ERR! find VS unknown version "undefined" found at "C:\...\Microsoft Visual Studio\18\Enterprise"
gyp ERR! find VS could not find a version of Visual Studio 2017 or newer to use
npm error path ...\extensions\positron-r\node_modules\@vscode\windows-registry
npm error command ... node-gyp rebuild
```

The first cache-miss run after #14364 went green (the install ran); the first **cache-hit** merge-to-main run surfaced this gap: https://github.com/posit-dev/positron/actions/runs/27846759959/job/82417470039

| Step | cache-miss run | cache-**hit** run (the failure) |
|---|---|---|
| Install VS 2022 | runs | **skipped** |
| Install node deps | runs | skipped |
| Download binaries (`npm rebuild`) | runs (compiler present) | **runs -- no compiler -> fails** |

## Changes

Drop the `if:` gate so the VS 2022 build tools are always installed. A compiler is then present whenever node-gyp runs -- the cache-gated "Install node dependencies" step **and** the always-on "Download binaries" rebuild. Comment updated to explain why.

Gating the Download-binaries step instead would be wrong: it downloads the Ark/Kallichore runtime binaries via those rebuild scripts and must run on every shard.

@:win
