### PR TITLE
test: skip Disk File Service locked-file tests when running as root

### DIFF
--- a/src/vs/platform/files/test/node/diskFileService.integrationTest.ts
+++ b/src/vs/platform/files/test/node/diskFileService.integrationTest.ts
@@ -2285,25 +2285,34 @@ flakySuite('Disk File Service', function () {
 		assert.strictEqual(readFileSync(resource.fsPath).toString(), content);
 	});
 
-	test('writeFile - locked files and unlocking', async () => {
+	// --- Start Positron ---
+	// testLockedFiles() locks a file by clearing its write bit (chmod ~0o200)
+	// and expects writes to be rejected. When the test runs as root -- as it
+	// does in the containerized CI image -- the kernel bypasses permission
+	// checks (CAP_DAC_OVERRIDE), so the write succeeds and these assertions
+	// fail. Skip them when running as root; they stay active for non-root runs.
+	const skipIfRoot = process.getuid?.() === 0 ? test.skip : test;
+	// --- End Positron ---
+
+	skipIfRoot('writeFile - locked files and unlocking', async () => {
 		setCapabilities(fileProvider, FileSystemProviderCapabilities.FileReadWrite | FileSystemProviderCapabilities.FileWriteUnlock);
 
 		return testLockedFiles(false);
 	});
 
-	test('writeFile (stream) - locked files and unlocking', async () => {
+	skipIfRoot('writeFile (stream) - locked files and unlocking', async () => {
 		setCapabilities(fileProvider, FileSystemProviderCapabilities.FileOpenReadWriteClose | FileSystemProviderCapabilities.FileWriteUnlock);
 
 		return testLockedFiles(false);
 	});
 
-	test('writeFile - locked files and unlocking throws error when missing capability', async () => {
+	skipIfRoot('writeFile - locked files and unlocking throws error when missing capability', async () => {
 		setCapabilities(fileProvider, FileSystemProviderCapabilities.FileReadWrite);
 
 		return testLockedFiles(true);
 	});
 
-	test('writeFile (stream) - locked files and unlocking throws error when missing capability', async () => {
+	skipIfRoot('writeFile (stream) - locked files and unlocking throws error when missing capability', async () => {
 		setCapabilities(fileProvider, FileSystemProviderCapabilities.FileOpenReadWriteClose);
 
 		return testLockedFiles(true);


### PR DESCRIPTION
## Summary

Follow-up to the ext-host/unit containerization (#14372). After that merged, the **full** ext-host suite (`test-integration.sh`, which runs on merge but not on the PR subset) reliably fails 4 tests:

```
Disk File Service > writeFile - locked files and unlocking
Disk File Service > writeFile (stream) - locked files and unlocking
Disk File Service > writeFile - locked files and unlocking throws error when missing capability
Disk File Service > writeFile (stream) - locked files and unlocking throws error when missing capability
```

## Cause

`testLockedFiles()` locks a file by clearing its write bit (`chmod ~0o200`) and asserts that a subsequent write is rejected. The containerized ext-host job runs as **root** (`--user 0:0`), and root bypasses permission checks (`CAP_DAC_OVERRIDE`), so the write succeeds and `assert.ok(error)` fails. Upstream CI runs these as non-root, so the case never came up.

## Fix

Skip just these 4 permission-based tests when `process.getuid() === 0`, following the file's existing `(cond ? test.skip : test)('...')` idiom. They remain active for non-root local and CI runs. Wrapped in Positron markers.

Considered and rejected: de-rooting the job (the image is built around `/root`), and dropping `CAP_DAC_OVERRIDE` (would break npm/git/build steps that rely on root). Verified these 4 are the only tests using real filesystem permission bits; the other "readonly" tests use the in-memory provider flag and are root-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)