### PR TITLE
e2e: drop @:win tag from "Jupyter Folder Defaults"

### DIFF
--- a/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
+++ b/test/e2e/tests/new-folder-flow/new-folder-flow-jupyter.test.ts
@@ -21,9 +21,13 @@ test.describe('New Folder Flow: Jupyter Project', {
 		await settings.set({ 'interpreters.startupBehavior': 'auto' }, { waitMs: 5000 });
 	});
 
-	// Removing WIN tag until we get uv into windows CI as this expects uv to be the interpreter
+	// No WIN tag: the #14163 workaround below switches the notebook kernel to the
+	// global interpreter (POSITRON_PY_VER_SEL = System Python 3.10.10 on Windows),
+	// which fails to start as a notebook kernel on the Windows runner ("Starting
+	// Python 3.10.10 (System) interpreter ... failed"), so the kernel never reaches
+	// idle. Restore the WIN tag once #14163 is fixed and the workaround is removed.
 	test('Jupyter Folder Defaults', {
-		tag: [tags.CRITICAL, tags.INTERPRETER, tags.WIN]
+		tag: [tags.CRITICAL, tags.INTERPRETER]
 	}, async function ({ app }) {
 		const { notebooksPositron } = app.workbench;
 		const folderName = addRandomNumSuffix('python-notebook-runtime');


### PR DESCRIPTION
The `Jupyter Folder Defaults` test fails deterministically on Windows e2e (it has since the notebook migration in #14362; it only became visible once Windows e2e was unblocked from building in #14364/#14392).

Its workaround for #14163 calls `kernel.change('Python')`, which switches the notebook to the global interpreter (System Python 3.10.10 on Windows). That interpreter fails to start as a notebook kernel on the Windows runner, so the kernel never reaches idle and the test times out. The same workaround works on Linux/electron, where the test still runs and passes.

This drops the `@:win` tag (and replaces the stale "until uv is in windows CI" comment with the real reason) to get Windows e2e green. Restore the tag once #14163 is fixed and the workaround is removed.

### QA Notes
@:new-folder-flow @:critical
