### PR TITLE
python: fix uv install dropdown to all _uv_ pythons

### DIFF
--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -190,26 +190,6 @@ export interface GetUvPythonVersionInfoOptions {
 }
 
 /**
- * Extracts the interpreter path from a `uv python list` output line, stripping any
- * " -> ..." symlink suffix. Returns undefined for "<download available>" rows or lines
- * without a path column.
- *   "cpython-3.13.7-macos-aarch64-none   /usr/local/bin/python3.13 -> ..." -> "/usr/local/bin/python3.13"
- *   "cpython-3.13.7-windows-x86_64-none  C:\\Program Files\\Python\\python.exe"
- */
-function parseUvPythonPath(line: string): string | undefined {
-    if (line.includes('<download available>')) {
-        return undefined;
-    }
-    // Columns are separated by 2+ spaces; the path is the second column.
-    const pathColumn = line
-        .split(/\s{2,}/)[1]
-        ?.trim()
-        .split(' -> ')[0]
-        .trim();
-    return pathColumn || undefined;
-}
-
-/**
  * Checks what Python version uv would install for a given version request.
  * Uses `uv python list` to see available versions without actually installing.
  * @param requestedVersion The version requested (e.g., "3.14", "3.13")
@@ -282,10 +262,33 @@ export async function getUvPythonVersionInfo(
 
         const isPrerelease = isVersionPrerelease(version);
 
+        // Check if this version is locally installed
+        const isLocal = !selectedLine.includes('<download available>');
+
+        // Extract path if this is a local install
+        let pythonPath: string | undefined;
+        if (isLocal) {
+            // Extract path from format like:
+            //   "cpython-3.13.7-macos-aarch64-none     /usr/local/bin/python3.13 -> ..."
+            //   "cpython-3.13.7-windows-x86_64-none   C:\Program Files\Python\python.exe"
+            // Split on 2+ spaces to separate columns, then strip " -> ..." suffix
+            const columns = selectedLine.split(/\s{2,}/);
+            if (columns.length >= 2) {
+                let pathColumn = columns[1].trim();
+                const arrowIndex = pathColumn.indexOf(' -> ');
+                if (arrowIndex !== -1) {
+                    pathColumn = pathColumn.substring(0, arrowIndex);
+                }
+                if (pathColumn.length > 0) {
+                    pythonPath = pathColumn;
+                }
+            }
+        }
+
         return {
             version,
             isPrerelease,
-            path: parseUvPythonPath(selectedLine),
+            path: pythonPath,
         };
     } catch (ex) {
         traceVerbose(`Error checking uv Python version: ${ex}`);
@@ -433,7 +436,9 @@ export async function getAvailablePythonVersions(): Promise<UvAvailablePython[]>
         // installs should count as already installed; a system Python is shown as installable.
         // On Windows ARM64, use --all-arches to see ARM64 builds (uv defaults to x64)
         // See: https://github.com/astral-sh/uv/issues/12906
-        const args = ['python', 'list', '--managed-python', ...(isWindowsArm64() ? ['--all-arches'] : [])];
+        const args = isWindowsArm64()
+            ? ['python', 'list', '--managed-python', '--all-arches']
+            : ['python', 'list', '--managed-python'];
         const result = await exec(uvUtils.command, args, { throwOnStdErr: false });
         const output = result?.stdout.trim();
 
@@ -502,10 +507,25 @@ export async function getAvailablePythonVersions(): Promise<UvAvailablePython[]>
 
             const minorVersion = `${majorVersion}.${minorVersionNum}`;
 
-            // Identifier is the first column; install state and path come from the same line.
-            const identifier = line.split(/\s{2,}/)[0].trim();
+            // Extract the identifier (first column)
+            const columns = line.split(/\s{2,}/);
+            const identifier = columns[0].trim();
+
+            // Check if installed (has a path, not "<download available>")
             const isInstalled = !line.includes('<download available>');
-            const pythonPath = parseUvPythonPath(line);
+
+            let pythonPath: string | undefined;
+            if (isInstalled && columns.length >= 2) {
+                let pathColumn = columns[1].trim();
+                // Strip " -> ..." symlink suffix if present
+                const arrowIndex = pathColumn.indexOf(' -> ');
+                if (arrowIndex !== -1) {
+                    pathColumn = pathColumn.substring(0, arrowIndex);
+                }
+                if (pathColumn.length > 0) {
+                    pythonPath = pathColumn;
+                }
+            }
 
             // Only keep one entry per minor version. uv lists patches newest-first, so the
             // first entry for a minor version is often a newer "<download available>" patch
@@ -532,9 +552,18 @@ export async function getAvailablePythonVersions(): Promise<UvAvailablePython[]>
 
         // Sort by version descending (newest first)
         versions.sort((a, b) => {
-            const [aMajor, aMinor] = a.version.split('.').map(Number);
-            const [bMajor, bMinor] = b.version.split('.').map(Number);
-            return bMajor - aMajor || bMinor - aMinor;
+            const aParts = a.version.split('.').map(Number);
+            const bParts = b.version.split('.').map(Number);
+
+            // Compare major version
+            if (aParts[0] !== bParts[0]) {
+                return bParts[0] - aParts[0];
+            }
+            // Compare minor version
+            if (aParts[1] !== bParts[1]) {
+                return bParts[1] - aParts[1];
+            }
+            return 0;
         });
 
         return versions;

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -190,6 +190,26 @@ export interface GetUvPythonVersionInfoOptions {
 }
 
 /**
+ * Extracts the interpreter path from a `uv python list` output line, stripping any
+ * " -> ..." symlink suffix. Returns undefined for "<download available>" rows or lines
+ * without a path column.
+ *   "cpython-3.13.7-macos-aarch64-none   /usr/local/bin/python3.13 -> ..." -> "/usr/local/bin/python3.13"
+ *   "cpython-3.13.7-windows-x86_64-none  C:\\Program Files\\Python\\python.exe"
+ */
+function parseUvPythonPath(line: string): string | undefined {
+    if (line.includes('<download available>')) {
+        return undefined;
+    }
+    // Columns are separated by 2+ spaces; the path is the second column.
+    const pathColumn = line
+        .split(/\s{2,}/)[1]
+        ?.trim()
+        .split(' -> ')[0]
+        .trim();
+    return pathColumn || undefined;
+}
+
+/**
  * Checks what Python version uv would install for a given version request.
  * Uses `uv python list` to see available versions without actually installing.
  * @param requestedVersion The version requested (e.g., "3.14", "3.13")
@@ -262,33 +282,10 @@ export async function getUvPythonVersionInfo(
 
         const isPrerelease = isVersionPrerelease(version);
 
-        // Check if this version is locally installed
-        const isLocal = !selectedLine.includes('<download available>');
-
-        // Extract path if this is a local install
-        let pythonPath: string | undefined;
-        if (isLocal) {
-            // Extract path from format like:
-            //   "cpython-3.13.7-macos-aarch64-none     /usr/local/bin/python3.13 -> ..."
-            //   "cpython-3.13.7-windows-x86_64-none   C:\Program Files\Python\python.exe"
-            // Split on 2+ spaces to separate columns, then strip " -> ..." suffix
-            const columns = selectedLine.split(/\s{2,}/);
-            if (columns.length >= 2) {
-                let pathColumn = columns[1].trim();
-                const arrowIndex = pathColumn.indexOf(' -> ');
-                if (arrowIndex !== -1) {
-                    pathColumn = pathColumn.substring(0, arrowIndex);
-                }
-                if (pathColumn.length > 0) {
-                    pythonPath = pathColumn;
-                }
-            }
-        }
-
         return {
             version,
             isPrerelease,
-            path: pythonPath,
+            path: parseUvPythonPath(selectedLine),
         };
     } catch (ex) {
         traceVerbose(`Error checking uv Python version: ${ex}`);
@@ -508,24 +505,12 @@ export async function getAvailablePythonVersions(): Promise<UvAvailablePython[]>
             const minorVersion = `${majorVersion}.${minorVersionNum}`;
 
             // Extract the identifier (first column)
-            const columns = line.split(/\s{2,}/);
-            const identifier = columns[0].trim();
+            const identifier = line.split(/\s{2,}/)[0].trim();
 
             // Check if installed (has a path, not "<download available>")
             const isInstalled = !line.includes('<download available>');
 
-            let pythonPath: string | undefined;
-            if (isInstalled && columns.length >= 2) {
-                let pathColumn = columns[1].trim();
-                // Strip " -> ..." symlink suffix if present
-                const arrowIndex = pathColumn.indexOf(' -> ');
-                if (arrowIndex !== -1) {
-                    pathColumn = pathColumn.substring(0, arrowIndex);
-                }
-                if (pathColumn.length > 0) {
-                    pythonPath = pathColumn;
-                }
-            }
+            const pythonPath = parseUvPythonPath(line);
 
             // Only keep one entry per minor version. uv lists patches newest-first, so the
             // first entry for a minor version is often a newer "<download available>" patch

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -190,6 +190,26 @@ export interface GetUvPythonVersionInfoOptions {
 }
 
 /**
+ * Extracts the interpreter path from a `uv python list` output line, stripping any
+ * " -> ..." symlink suffix. Returns undefined for "<download available>" rows or lines
+ * without a path column.
+ *   "cpython-3.13.7-macos-aarch64-none   /usr/local/bin/python3.13 -> ..." -> "/usr/local/bin/python3.13"
+ *   "cpython-3.13.7-windows-x86_64-none  C:\\Program Files\\Python\\python.exe"
+ */
+function parseUvPythonPath(line: string): string | undefined {
+    if (line.includes('<download available>')) {
+        return undefined;
+    }
+    // Columns are separated by 2+ spaces; the path is the second column.
+    const pathColumn = line
+        .split(/\s{2,}/)[1]
+        ?.trim()
+        .split(' -> ')[0]
+        .trim();
+    return pathColumn || undefined;
+}
+
+/**
  * Checks what Python version uv would install for a given version request.
  * Uses `uv python list` to see available versions without actually installing.
  * @param requestedVersion The version requested (e.g., "3.14", "3.13")
@@ -262,33 +282,10 @@ export async function getUvPythonVersionInfo(
 
         const isPrerelease = isVersionPrerelease(version);
 
-        // Check if this version is locally installed
-        const isLocal = !selectedLine.includes('<download available>');
-
-        // Extract path if this is a local install
-        let pythonPath: string | undefined;
-        if (isLocal) {
-            // Extract path from format like:
-            //   "cpython-3.13.7-macos-aarch64-none     /usr/local/bin/python3.13 -> ..."
-            //   "cpython-3.13.7-windows-x86_64-none   C:\Program Files\Python\python.exe"
-            // Split on 2+ spaces to separate columns, then strip " -> ..." suffix
-            const columns = selectedLine.split(/\s{2,}/);
-            if (columns.length >= 2) {
-                let pathColumn = columns[1].trim();
-                const arrowIndex = pathColumn.indexOf(' -> ');
-                if (arrowIndex !== -1) {
-                    pathColumn = pathColumn.substring(0, arrowIndex);
-                }
-                if (pathColumn.length > 0) {
-                    pythonPath = pathColumn;
-                }
-            }
-        }
-
         return {
             version,
             isPrerelease,
-            path: pythonPath,
+            path: parseUvPythonPath(selectedLine),
         };
     } catch (ex) {
         traceVerbose(`Error checking uv Python version: ${ex}`);
@@ -436,9 +433,7 @@ export async function getAvailablePythonVersions(): Promise<UvAvailablePython[]>
         // installs should count as already installed; a system Python is shown as installable.
         // On Windows ARM64, use --all-arches to see ARM64 builds (uv defaults to x64)
         // See: https://github.com/astral-sh/uv/issues/12906
-        const args = isWindowsArm64()
-            ? ['python', 'list', '--managed-python', '--all-arches']
-            : ['python', 'list', '--managed-python'];
+        const args = ['python', 'list', '--managed-python', ...(isWindowsArm64() ? ['--all-arches'] : [])];
         const result = await exec(uvUtils.command, args, { throwOnStdErr: false });
         const output = result?.stdout.trim();
 
@@ -507,25 +502,10 @@ export async function getAvailablePythonVersions(): Promise<UvAvailablePython[]>
 
             const minorVersion = `${majorVersion}.${minorVersionNum}`;
 
-            // Extract the identifier (first column)
-            const columns = line.split(/\s{2,}/);
-            const identifier = columns[0].trim();
-
-            // Check if installed (has a path, not "<download available>")
+            // Identifier is the first column; install state and path come from the same line.
+            const identifier = line.split(/\s{2,}/)[0].trim();
             const isInstalled = !line.includes('<download available>');
-
-            let pythonPath: string | undefined;
-            if (isInstalled && columns.length >= 2) {
-                let pathColumn = columns[1].trim();
-                // Strip " -> ..." symlink suffix if present
-                const arrowIndex = pathColumn.indexOf(' -> ');
-                if (arrowIndex !== -1) {
-                    pathColumn = pathColumn.substring(0, arrowIndex);
-                }
-                if (pathColumn.length > 0) {
-                    pythonPath = pathColumn;
-                }
-            }
+            const pythonPath = parseUvPythonPath(line);
 
             // Only keep one entry per minor version. uv lists patches newest-first, so the
             // first entry for a minor version is often a newer "<download available>" patch
@@ -552,18 +532,9 @@ export async function getAvailablePythonVersions(): Promise<UvAvailablePython[]>
 
         // Sort by version descending (newest first)
         versions.sort((a, b) => {
-            const aParts = a.version.split('.').map(Number);
-            const bParts = b.version.split('.').map(Number);
-
-            // Compare major version
-            if (aParts[0] !== bParts[0]) {
-                return bParts[0] - aParts[0];
-            }
-            // Compare minor version
-            if (aParts[1] !== bParts[1]) {
-                return bParts[1] - aParts[1];
-            }
-            return 0;
+            const [aMajor, aMinor] = a.version.split('.').map(Number);
+            const [bMajor, bMinor] = b.version.split('.').map(Number);
+            return bMajor - aMajor || bMinor - aMinor;
         });
 
         return versions;

--- a/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
+++ b/extensions/positron-python/src/client/pythonEnvironments/common/environmentManagers/uv.ts
@@ -430,9 +430,15 @@ export async function getAvailablePythonVersions(): Promise<UvAvailablePython[]>
         // Output format:
         //   cpython-3.13.1-macos-aarch64-none     /Users/.../.local/share/uv/python/cpython-3.13.1.../bin/python3.13
         //   cpython-3.12.8-macos-aarch64-none     <download available>
+        // --managed-python restricts the listing to uv-managed Pythons. This still includes the
+        // "<download available>" rows for installable versions, but excludes system Pythons (e.g.
+        // /usr/bin/python3, Homebrew). For this "Install Python via uv" flow, only uv-managed
+        // installs should count as already installed; a system Python is shown as installable.
         // On Windows ARM64, use --all-arches to see ARM64 builds (uv defaults to x64)
         // See: https://github.com/astral-sh/uv/issues/12906
-        const args = isWindowsArm64() ? ['python', 'list', '--all-arches'] : ['python', 'list'];
+        const args = isWindowsArm64()
+            ? ['python', 'list', '--managed-python', '--all-arches']
+            : ['python', 'list', '--managed-python'];
         const result = await exec(uvUtils.command, args, { throwOnStdErr: false });
         const output = result?.stdout.trim();
 
@@ -445,8 +451,8 @@ export async function getAvailablePythonVersions(): Promise<UvAvailablePython[]>
             .map((line) => line.trim())
             .filter((line) => line.length > 0);
 
-        const versions: UvAvailablePython[] = [];
-        const seenMinorVersions = new Set<string>();
+        // Keyed by minor version (e.g. "3.13") so we keep one entry per minor version.
+        const versionsByMinor = new Map<string, UvAvailablePython>();
 
         // On Windows ARM64, we use --all-arches which returns both x64 and arm64 versions.
         // We need to prefer arm64 versions. The identifier contains the arch, e.g.:
@@ -501,12 +507,6 @@ export async function getAvailablePythonVersions(): Promise<UvAvailablePython[]>
 
             const minorVersion = `${majorVersion}.${minorVersionNum}`;
 
-            // Only show one entry per minor version
-            if (seenMinorVersions.has(minorVersion)) {
-                continue;
-            }
-            seenMinorVersions.add(minorVersion);
-
             // Extract the identifier (first column)
             const columns = line.split(/\s{2,}/);
             const identifier = columns[0].trim();
@@ -527,13 +527,28 @@ export async function getAvailablePythonVersions(): Promise<UvAvailablePython[]>
                 }
             }
 
-            versions.push({
+            // Only keep one entry per minor version. uv lists patches newest-first, so the
+            // first entry for a minor version is often a newer "<download available>" patch
+            // while an older patch of the same minor version is actually installed. Prefer the
+            // installed entry (and its path) so the quick pick reflects what is really installed.
+            const existing = versionsByMinor.get(minorVersion);
+            if (existing) {
+                if (!existing.isInstalled && isInstalled) {
+                    existing.isInstalled = true;
+                    existing.path = pythonPath;
+                }
+                continue;
+            }
+
+            versionsByMinor.set(minorVersion, {
                 version: minorVersion,
                 isInstalled,
                 path: pythonPath,
                 identifier,
             });
         }
+
+        const versions = Array.from(versionsByMinor.values());
 
         // Sort by version descending (newest first)
         versions.sort((a, b) => {

--- a/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
+++ b/extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts
@@ -133,10 +133,15 @@ suite('UV Python Installer Tests', () => {
 
             const result = await getAvailablePythonVersions();
 
-            // Should only have 3.13 and 3.12 (first occurrence of each minor version)
+            // Should only have 3.13 and 3.12 (one entry per minor version). A newer
+            // "<download available>" patch is listed before the installed older patch, so
+            // 3.13 must still be reported as installed with the installed patch's path.
             assert.strictEqual(result.length, 2);
             assert.strictEqual(result[0].version, '3.13');
+            assert.strictEqual(result[0].isInstalled, true);
+            assert.strictEqual(result[0].path, '/usr/local/bin/python3.13');
             assert.strictEqual(result[1].version, '3.12');
+            assert.strictEqual(result[1].isInstalled, false);
         });
 
         test('Sorts versions in descending order', async () => {
@@ -212,6 +217,52 @@ suite('UV Python Installer Tests', () => {
 
             assert.ok(v311);
             assert.strictEqual(v311.isInstalled, false);
+        });
+
+        test('Requests only uv-managed Pythons (passes --managed-python)', async () => {
+            // System Pythons (e.g. /usr/bin/python3) must not be reported as installed in the
+            // "Install Python via uv" flow, so the listing is restricted to uv-managed Pythons.
+            execStub.resolves({
+                stdout: 'cpython-3.13.1-macos-aarch64-none    <download available>',
+            });
+
+            await getAvailablePythonVersions();
+
+            const listCall = execStub
+                .getCalls()
+                .find((call) => Array.isArray(call.args[1]) && (call.args[1] as string[]).includes('list'));
+            assert.ok(listCall, 'Expected uv python list to be invoked');
+            assert.ok(
+                (listCall.args[1] as string[]).includes('--managed-python'),
+                'Expected uv python list to be called with --managed-python',
+            );
+        });
+
+        test('Reports a minor version as installed when a newer patch is download-available', async () => {
+            // Mirrors real `uv python list` output: newest patches are listed first as
+            // "<download available>", freethreaded variants are interleaved, and the installed
+            // patch (further down) uses a "actual -> target" symlink path.
+            execStub.resolves({
+                stdout: [
+                    'cpython-3.14.6-macos-aarch64-none                 <download available>',
+                    'cpython-3.14.6+freethreaded-macos-aarch64-none    <download available>',
+                    'cpython-3.14.5-macos-aarch64-none                 /Users/test/.local/bin/python3.14 -> /Users/test/.local/share/uv/python/cpython-3.14-macos-aarch64-none/bin/python3.14',
+                    'cpython-3.13.14-macos-aarch64-none                <download available>',
+                    'cpython-3.13.13-macos-aarch64-none                /Users/test/.local/bin/python3.13 -> /Users/test/.local/share/uv/python/cpython-3.13.13-macos-aarch64-none/bin/python3.13',
+                    'cpython-3.12.13-macos-aarch64-none                /Users/test/.local/bin/python3.12 -> /Users/test/.local/share/uv/python/cpython-3.12-macos-aarch64-none/bin/python3.12',
+                ].join('\n'),
+            });
+
+            const result = await getAvailablePythonVersions();
+
+            assert.deepStrictEqual(
+                result.map((v) => ({ version: v.version, isInstalled: v.isInstalled, path: v.path })),
+                [
+                    { version: '3.14', isInstalled: true, path: '/Users/test/.local/bin/python3.14' },
+                    { version: '3.13', isInstalled: true, path: '/Users/test/.local/bin/python3.13' },
+                    { version: '3.12', isInstalled: true, path: '/Users/test/.local/bin/python3.12' },
+                ],
+            );
         });
 
         test('Handles empty lines and whitespace in output', async () => {


### PR DESCRIPTION
Improves the "Install Python via uv" version list so it reflects what is actually installed.

Two related changes to `getAvailablePythonVersions()`:

1. **Restrict the listing to uv-managed Pythons.** `uv python list` now runs with `--managed-python`, so system Pythons (e.g. `/usr/bin/python3`, Homebrew) are no longer reported as already installed in this flow. 

2. **Show all available minor versions.** uv lists patches newest-first, so the first row for a minor version is often a `<download available>` patch while an older, already-installed patch of the same minor version appears further down. The previous logic kept the first row and dropped the rest, causing an installed minor version (e.g. 3.13) to be shown as not installed. We now keep one entry per minor version but prefer the installed entry and its path.

### Screenshots

<img width="650" height="298" alt="Screenshot 2026-06-22 at 4 01 46 PM" src="https://github.com/user-attachments/assets/d4c70e62-056c-4467-8901-307412fee316" />


### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fix the "Install Python via uv" version list incorrectly showing an installed Python minor version as available to install, and excluding system Pythons from the "already installed" set

### Validation Steps

@:interpreter

Covered by unit tests in `extensions/positron-python/src/test/pythonEnvironments/common/environmentManagers/uvPythonInstaller.unit.test.ts`:

```
npm run test-extension -- -l positron-python --grep "UV Python Installer"
```

Manual check:
1. Have a uv-managed Python installed at an older patch of a minor version that also has a newer patch available (e.g. 3.13.13 installed, 3.13.14 download-available).
2. Open the "Install Python via uv" flow.
3. Verify that minor version shows as installed (not as available to install), and that system Pythons are not listed as already installed.
