### PR TITLE
fix(terminal-suggest): dedupe PATH dirs in PathExecutableCache

### DIFF
--- a/extensions/terminal-suggest/src/env/pathExecutableCache.ts
+++ b/extensions/terminal-suggest/src/env/pathExecutableCache.ts
@@ -99,7 +99,16 @@ export class PathExecutableCache implements vscode.Disposable {
 		}
 
 		// Extract executables from PATH
-		const paths = pathValue.split(isWindows ? ';' : ':');
+		// --- Start Positron ---
+		// Dedupe PATH directories. A directory that appears more than once
+		// (common in container PATHs) would otherwise be scanned twice
+		// concurrently below; the shared `labels` set splits that directory's
+		// executables across the two scans, but only the first scan's result is
+		// cached (see the `!this._cachedExes.has(pathDir)` guard), so the rest
+		// are dropped on later calls and the result set is nondeterministic.
+		// The merge loop already dedupes via `processedPaths`; match that here.
+		const paths = Array.from(new Set(pathValue.split(isWindows ? ';' : ':')));
+		// --- End Positron ---
 		const pathSeparator = isWindows ? '\\' : '/';
 		const promisePaths: string[] = [];
 		const promises: Promise<Set<ICompletionResource> | undefined>[] = [];


### PR DESCRIPTION
## Summary

Follow-up to the ext-host containerization (#14372, #14400). The full ext-host suite started failing reliably on merge:

```
PathExecutableCache > results are the same on successive calls
  Set(1565)  (first call)  !=  Set(1475)  (second call)
  missing on 2nd call: R, Rscript, aws, quarto, npm, npx, yarn, latex, tlmgr, ...
```

## Cause

`getExecutablesInPath` dedupes executable basenames across directories via a shared `labels` set: whichever concurrent scan reaches a name first claims it into *that* directory's result set; others skip it. When a directory appears **twice in PATH**, it is scanned twice concurrently, the two scans split its executables between their result sets, but only the **first** result set is cached (`if (!this._cachedExes.has(pathDir))`). The executables claimed by the discarded second scan are added to the fresh `labels` set but lost from the cache, so the next call returns a smaller, nondeterministic set.

The CI image's PATH contains `/usr/local/bin` twice (and `/root/.local/bin` twice) - and `/usr/local/bin` is where the missing executables (R/TeX/aws/npm/yarn symlinks) live.

## Fix

Dedupe PATH directories up front. The merge loop already dedupes via `processedPaths`; this matches that for the scan/cache loop. Timing-independent, and fixes determinism for any duplicate-PATH environment, not just CI. Wrapped in Positron markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)