### PR TITLE
Bump the rstudio.rstudio-workbench extension to 2026.6.7

### DIFF
--- a/product.json
+++ b/product.json
@@ -94,10 +94,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "2026.6.5",
+			"version": "2026.6.6",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web-pwb",
-			"sha256": "b5b01d809dd07693554c71bc918590a48f07772db340c5849aa316528a0cf830",
+			"sha256": "99adf2bfc331c6cb35e300cba8a46f9394a74781346358a14e1e40e75b6deac0",
 			"metadata": {
 				"publisherDisplayName": "Posit PBC"
 			}

--- a/product.json
+++ b/product.json
@@ -94,10 +94,10 @@
 		},
 		{
 			"name": "rstudio.rstudio-workbench",
-			"version": "2026.6.6",
+			"version": "2026.6.7",
 			"positUrl": "https://cdn.posit.co/pwb-components/extension",
 			"type": "reh-web-pwb",
-			"sha256": "99adf2bfc331c6cb35e300cba8a46f9394a74781346358a14e1e40e75b6deac0",
+			"sha256": "aeb3190ab1bf6bd7c1cb172665baacfaeb85f65f218e3d79d4ef9df94a878b4b",
 			"metadata": {
 				"publisherDisplayName": "Posit PBC"
 			}


### PR DESCRIPTION
Updates the bundled `rstudio.rstudio-workbench` extension to version **2026.6.7** on the `release/2026.06` branch.

Manual companion to the automated vscode-server bump (rstudio/vscode-server#380) for the `2026.06` security release; Positron release-branch bumps aren't automated.

Package checksum: `aeb3190ab1bf6bd7c1cb172665baacfaeb85f65f218e3d79d4ef9df94a878b4b`
Commit: [`71f4669`](https://github.com/rstudio/rstudio-workbench-vscode-ext/commit/71f46692351e069176e2e6be6102cde48b0646f8)
Base branch: `release/2026.06`