### PR TITLE
e2e: add Posit Assistant Foundry test for Azure managed credentials

### DIFF
--- a/test/e2e/fixtures/test-setup/app-jupyter.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-jupyter.fixtures.ts
@@ -20,7 +20,7 @@ export { RunResult };
 export async function JupyterApp(
 	fixtureOptions: AppFixtureOptions
 ): Promise<{ app: Application; start: () => Promise<void>; stop: () => Promise<void> }> {
-	const { options, useLegacyNotebookEditor, enableDataConnections } = fixtureOptions;
+	const { options, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant } = fixtureOptions;
 	const JUPYTER_WORKSPACE_PATH = '/home/jupyter-admin/qa-example-content/';
 
 	const app = createApp({ ...options, workspacePath: JUPYTER_WORKSPACE_PATH });
@@ -32,7 +32,7 @@ export async function JupyterApp(
 		await app.positJupyter.auth.signIn();
 
 		// Now that the user exists, setup the environment
-		await setupJupyterEnvironment(useLegacyNotebookEditor, enableDataConnections);
+		await setupJupyterEnvironment(useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant);
 
 		// Open Positron from JupyterLab
 		await app.positJupyter.lab.openPositron();
@@ -116,7 +116,7 @@ export async function JupyterApp(
  * Setup the complete Jupyter environment: Docker container, configuration, and permissions
  * NOTE: This must be called AFTER login, as login creates the jupyter-admin user
  */
-async function setupJupyterEnvironment(useLegacyNotebookEditor?: boolean, enableDataConnections?: boolean): Promise<void> {
+async function setupJupyterEnvironment(useLegacyNotebookEditor?: boolean, enableDataConnections?: boolean, enableFoundryAssistant?: boolean): Promise<void> {
 	const TEST_DATA_PATH = join(os.tmpdir(), 'vscsmoke');
 	const DEFAULT_WORKSPACE_PATH = join(TEST_DATA_PATH, 'qa-example-content');
 	const JUPYTER_WORKSPACE_PATH = '/home/jupyter-admin/qa-example-content/';
@@ -152,7 +152,7 @@ async function setupJupyterEnvironment(useLegacyNotebookEditor?: boolean, enable
 		'jupyter-test',
 		'/home/jupyter-admin/.positron-server/data/User/',
 		['settings.json', 'settingsDocker.json', 'settingsWorkbench.json'],
-		dockerSettingsOverrides({ useLegacyNotebookEditor, enableDataConnections })
+		dockerSettingsOverrides({ useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant })
 	);
 	await copyKeyBindingsToContainer('jupyter-test', '/home/jupyter-admin/.positron-server/data/User/');
 

--- a/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
@@ -21,8 +21,8 @@ const CONTAINER_NAME = 'test';
 export async function WorkbenchApp(
 	fixtureOptions: AppFixtureOptions
 ): Promise<{ app: Application; start: () => Promise<void>; stop: () => Promise<void> }> {
-	const { options, managedCredentials, useLegacyNotebookEditor, enableDataConnections } = fixtureOptions;
-	const { workspacePath } = await setupWorkbenchEnvironment(managedCredentials, useLegacyNotebookEditor, enableDataConnections);
+	const { options, managedCredentials, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant } = fixtureOptions;
+	const { workspacePath } = await setupWorkbenchEnvironment(managedCredentials, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant);
 
 	const app = createApp({ ...options, workspacePath });
 
@@ -87,7 +87,7 @@ export async function WorkbenchApp(
  * the CI install step. The actual credential setup happens in install-workbench.sh; the fixture
  * just records it here so tests/fixtures can make conditional decisions if needed.
  */
-async function setupWorkbenchEnvironment(managedCredentials?: 'snowflake' | 'databricks' | 'azure', useLegacyNotebookEditor?: boolean, enableDataConnections?: boolean): Promise<{ workspacePath: string; userDataDir: string }> {
+async function setupWorkbenchEnvironment(managedCredentials?: 'snowflake' | 'databricks' | 'azure', useLegacyNotebookEditor?: boolean, enableDataConnections?: boolean, enableFoundryAssistant?: boolean): Promise<{ workspacePath: string; userDataDir: string }> {
 	if (managedCredentials) {
 		console.log(`Workbench fixture: expecting managed credential "${managedCredentials}" to be provisioned in the container`);
 	}
@@ -126,7 +126,7 @@ async function setupWorkbenchEnvironment(managedCredentials?: 'snowflake' | 'dat
 		CONTAINER_NAME,
 		'/home/user1/.positron-server/User/',
 		['settings.json', 'settingsDocker.json', 'settingsWorkbench.json'],
-		dockerSettingsOverrides({ useLegacyNotebookEditor, enableDataConnections })
+		dockerSettingsOverrides({ useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant })
 	);
 	await copyKeyBindingsToContainer(CONTAINER_NAME, '/home/user1/.positron-server/User/');
 

--- a/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
@@ -67,11 +67,19 @@ export async function WorkbenchApp(
 			);
 			await app.positWorkbench.dashboard.openWorkspaceFolder('qa-example-content');
 		}
-		// Give startup messaging a chance to appear before asserting it's gone,
-		// so we don't pass instantly when this check runs ahead of the UI.
-		await app.code.driver.currentPage.waitForTimeout(5000);
-		await app.workbench.sessions.expectNoStartUpMessaging();
-		await app.workbench.sessions.deleteAll();
+		// The Azure shard runs as a freshly-provisioned JIT user (rstudio-ide-test)
+		// whose interpreter discovery / runtime startup does not settle the way
+		// user1's warm environment does -- it sits on "Discovering interpreters"
+		// well past the 90s gate. These credential/assistant tests don't use a
+		// Python/R runtime session, so skip the session-readiness gate for this
+		// shard rather than block the fixture on a signal we never consume.
+		if (managedCredentials !== 'azure') {
+			// Give startup messaging a chance to appear before asserting it's gone,
+			// so we don't pass instantly when this check runs ahead of the UI.
+			await app.code.driver.currentPage.waitForTimeout(5000);
+			await app.workbench.sessions.expectNoStartUpMessaging();
+			await app.workbench.sessions.deleteAll();
+		}
 
 		await app.workbench.hotKeys.closeAllEditors();
 	};

--- a/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app-workbench.fixtures.ts
@@ -54,6 +54,17 @@ export async function WorkbenchApp(
 				`docker exec ${CONTAINER_NAME} bash -c "cp -r /home/user1/qa-example-content /home/rstudio-ide-test/ && chown -R rstudio-ide-test /home/rstudio-ide-test/qa-example-content"`,
 				'Copy qa-example-content into rstudio-ide-test home (Azure JIT user)'
 			);
+			// The Azure session runs as the JIT user rstudio-ide-test, which reads
+			// settings from its own home dir (created by PAM on session launch), not
+			// user1's. Provision the same settings there so the workspace opens trusted
+			// (security.workspace.trust.enabled=false) and provider settings like the
+			// Foundry endpoint reach the session. openWorkspaceFolder reloads the window
+			// into the folder, so the freshly-written settings take effect.
+			await provisionUserSettings(
+				'/home/rstudio-ide-test/.positron-server/',
+				'rstudio-ide-test',
+				dockerSettingsOverrides({ useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant })
+			);
 			await app.positWorkbench.dashboard.openWorkspaceFolder('qa-example-content');
 		}
 		// Give startup messaging a chance to appear before asserting it's gone,
@@ -97,9 +108,8 @@ async function setupWorkbenchEnvironment(managedCredentials?: 'snowflake' | 'dat
 	const WORKBENCH_USER_SERVER_DIR = '/home/user1/.positron-server/';
 	const WORKBENCH_USER_DATA_DIR = `${WORKBENCH_USER_SERVER_DIR}User/`;
 
-	// Create workspace and settings directories
+	// Create workspace directory (the settings directory is created by provisionUserSettings).
 	await runDockerCommand(`docker exec ${CONTAINER_NAME} mkdir -p ${WORKBENCH_WORKSPACE_PATH}`, 'Create workspace directory');
-	await runDockerCommand(`docker exec ${CONTAINER_NAME} mkdir -p ${WORKBENCH_USER_DATA_DIR}`, 'Create user settings directory');
 
 	const src = DEFAULT_WORKSPACE_PATH;
 	const dst = WORKBENCH_WORKSPACE_PATH;
@@ -121,21 +131,47 @@ async function setupWorkbenchEnvironment(managedCredentials?: 'snowflake' | 'dat
 	);
 
 
-	// Copy settings to container
-	await copyUserSettingsToContainer(
-		CONTAINER_NAME,
-		'/home/user1/.positron-server/User/',
-		['settings.json', 'settingsDocker.json', 'settingsWorkbench.json'],
+	// Provision user1's Positron server settings + keybindings.
+	await provisionUserSettings(
+		WORKBENCH_USER_SERVER_DIR,
+		'user1:user1g',
 		dockerSettingsOverrides({ useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant })
 	);
-	await copyKeyBindingsToContainer(CONTAINER_NAME, '/home/user1/.positron-server/User/');
 
-	// Fix permissions
-	await runDockerCommand(`docker exec ${CONTAINER_NAME} chown -R user1:user1g ${WORKBENCH_USER_SERVER_DIR}`, 'Set ownership of server directory');
+	// Fix workspace permissions
 	await runDockerCommand(`docker exec ${CONTAINER_NAME} chown -R user1 ${WORKBENCH_WORKSPACE_PATH}`, 'Set ownership of workspace directory');
-	await runDockerCommand(`docker exec ${CONTAINER_NAME} chmod -R 755 ${WORKBENCH_USER_DATA_DIR}`, 'Set permissions of settings directory');
 	await runDockerCommand(`docker exec ${CONTAINER_NAME} chmod -R 755 ${WORKBENCH_WORKSPACE_PATH}`, 'Set permissions of workspace directory');
 
 	return { workspacePath: WORKBENCH_WORKSPACE_PATH, userDataDir: WORKBENCH_USER_DATA_DIR };
+}
+
+/**
+ * Provision a user's Positron server settings directory: write the merged
+ * settings (base fixtures + Docker overrides) and keybindings, then fix
+ * ownership/permissions so the session user can read them.
+ *
+ * Used for the standard `user1` account and, on the Azure shard, for the JIT
+ * user (`rstudio-ide-test`) whose home dir only exists after PAM creates it on
+ * session launch. The Azure session reads settings from the JIT user's home, so
+ * the workspace-trust disablers and provider settings (e.g. the Foundry
+ * endpoint) must be copied there too -- otherwise the session opens in
+ * restricted mode with an unconfigured provider.
+ *
+ * @param serverDir The `.positron-server/` directory, with trailing slash.
+ * @param owner The chown target (e.g. `user1:user1g` or `rstudio-ide-test`).
+ * @param settingsOverrides Test-driven settings merged last over the fixtures.
+ */
+async function provisionUserSettings(serverDir: string, owner: string, settingsOverrides?: object): Promise<void> {
+	const userDataDir = `${serverDir}User/`;
+	await runDockerCommand(`docker exec ${CONTAINER_NAME} mkdir -p ${userDataDir}`, 'Create user settings directory');
+	await copyUserSettingsToContainer(
+		CONTAINER_NAME,
+		userDataDir,
+		['settings.json', 'settingsDocker.json', 'settingsWorkbench.json'],
+		settingsOverrides
+	);
+	await copyKeyBindingsToContainer(CONTAINER_NAME, userDataDir);
+	await runDockerCommand(`docker exec ${CONTAINER_NAME} chown -R ${owner} ${serverDir}`, 'Set ownership of server directory');
+	await runDockerCommand(`docker exec ${CONTAINER_NAME} chmod -R 755 ${userDataDir}`, 'Set permissions of settings directory');
 }
 

--- a/test/e2e/fixtures/test-setup/app.fixtures.ts
+++ b/test/e2e/fixtures/test-setup/app.fixtures.ts
@@ -30,6 +30,14 @@ export interface AppFixtureOptions {
 	 * copied into the container.
 	 */
 	enableDataConnections?: boolean;
+	/**
+	 * When true, suites opt into the Microsoft Foundry (msFoundry) assistant
+	 * provider, authenticated via Posit Workbench managed credentials. As with
+	 * the other override flags, the local apps apply this via the host
+	 * `settingsFile` in `beforeApp`, while the Docker-based apps merge the
+	 * settings into the container settings.
+	 */
+	enableFoundryAssistant?: boolean;
 }
 
 /**

--- a/test/e2e/fixtures/test-setup/docker-utils.ts
+++ b/test/e2e/fixtures/test-setup/docker-utils.ts
@@ -49,19 +49,42 @@ export async function runDockerCommand(command: string, description: string): Pr
 }
 
 /**
+ * Settings that enable the Microsoft Foundry (msFoundry) assistant provider.
+ *
+ * On the Azure Workbench shard the provider is authenticated transparently via
+ * Posit Workbench managed credentials (the authentication extension brokers an
+ * `ms-foundry` session, gated on `posit.workbench.foundry.endpoint` being set),
+ * so no interactive sign-in is required. positAI is disabled so the Foundry
+ * model is the one exercised. Shared by the host-side `beforeApp` fixture and
+ * `dockerSettingsOverrides` so the two paths cannot drift.
+ */
+export const FOUNDRY_ASSISTANT_SETTINGS = {
+	'positron.assistant.enable': true,
+	'positron.assistant.provider.positAI.enable': false,
+	'positron.assistant.models.overrides.msFoundry': [{ name: 'model-router', identifier: 'model-router' }],
+	'positron.assistant.provider.msFoundry.enable': true,
+	'posit.workbench.foundry.endpoint': 'https://east2testai.services.ai.azure.com/',
+	'authentication.foundry.baseUrl': 'https://east2testai.services.ai.azure.com/openai/v1',
+} as const;
+
+/**
  * Build the settings overrides driven by test options for the Docker apps.
  *
  * Mirrors the host-side `beforeApp` fixture: when a suite opts into the legacy
- * (VS Code) notebook editor, the Positron notebook editor is disabled. Returns
+ * (VS Code) notebook editor, the Positron notebook editor is disabled; when a
+ * suite opts into the Foundry assistant, its settings are merged in. Returns
  * `undefined` when there is nothing to override.
  */
-export function dockerSettingsOverrides(opts: { useLegacyNotebookEditor?: boolean; enableDataConnections?: boolean }): object | undefined {
+export function dockerSettingsOverrides(opts: { useLegacyNotebookEditor?: boolean; enableDataConnections?: boolean; enableFoundryAssistant?: boolean }): object | undefined {
 	const overrides: Record<string, unknown> = {};
 	if (opts.useLegacyNotebookEditor) {
 		overrides['positron.notebook.enabled'] = false;
 	}
 	if (opts.enableDataConnections) {
 		overrides['databases.enabled'] = true;
+	}
+	if (opts.enableFoundryAssistant) {
+		Object.assign(overrides, FOUNDRY_ASSISTANT_SETTINGS);
 	}
 	return Object.keys(overrides).length > 0 ? overrides : undefined;
 }

--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -326,12 +326,14 @@ export class PositAssistant {
 		await this.frame.locator('[role="menuitem"][aria-haspopup="menu"]:has(span:text-is("Model"))').click();
 
 		// 3. Locate the desired model. `:text-is()` is exact-match so
-		//    "GPT-5.4" does not collide with "GPT-5.4 Mini". Wait for the submenu
-		//    to render (the model itself or the "More models" disclosure), then
-		//    expand "More models" if the model isn't in the initial slice (e.g.
-		//    non-top-tier providers like Microsoft Foundry's "model-router").
+		//    "GPT-5.4" does not collide with "GPT-5.4 Mini". Within each provider
+		//    group, less-preferred models (e.g. those flagged with a warning note,
+		//    like Microsoft Foundry's "model-router") are collapsed under a "More
+		//    models" inline disclosure -- a plain <button>, not a menuitem. Wait
+		//    for the submenu to render (the model itself or the disclosure), then
+		//    expand the disclosure if the model isn't already shown.
 		const model = this.frame.locator(`[role="menuitem"]:has(span.flex-1:text-is("${modelName}"))`);
-		const moreModels = this.frame.locator('[role="menuitem"]:has-text("More models")');
+		const moreModels = this.frame.locator('button:has-text("More models")');
 		await expect(model.or(moreModels).first()).toBeVisible();
 		if (!(await model.isVisible())) {
 			await moreModels.click();

--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -309,9 +309,10 @@ export class PositAssistant {
 	 * includes decorations (check icon column, trailing note/multiplier),
 	 * so we match on the span text instead.
 	 *
-	 * Some providers auto-pick a default and do not need this call. Models
-	 * beyond the initial slice are hidden behind a "More models" inline
-	 * disclosure — add that fallback when a test needs a non-top-tier model.
+	 * Some providers auto-pick a default and do not need this call. Only
+	 * top-tier models appear in the initial slice; the rest are hidden behind a
+	 * "More models" disclosure, which this method expands automatically when the
+	 * requested model isn't already shown.
 	 *
 	 * @param modelName Exact model name as displayed in the menu (e.g. "GPT-5.4 Mini").
 	 */
@@ -324,9 +325,20 @@ export class PositAssistant {
 		//    "Model" label span; that label is stable across states.
 		await this.frame.locator('[role="menuitem"][aria-haspopup="menu"]:has(span:text-is("Model"))').click();
 
-		// 3. Click the desired model. `:text-is()` is exact-match so
-		//    "GPT-5.4" does not collide with "GPT-5.4 Mini".
-		await this.frame.locator(`[role="menuitem"]:has(span.flex-1:text-is("${modelName}"))`).click();
+		// 3. Locate the desired model. `:text-is()` is exact-match so
+		//    "GPT-5.4" does not collide with "GPT-5.4 Mini". Wait for the submenu
+		//    to render (the model itself or the "More models" disclosure), then
+		//    expand "More models" if the model isn't in the initial slice (e.g.
+		//    non-top-tier providers like Microsoft Foundry's "model-router").
+		const model = this.frame.locator(`[role="menuitem"]:has(span.flex-1:text-is("${modelName}"))`);
+		const moreModels = this.frame.locator('[role="menuitem"]:has-text("More models")');
+		await expect(model.or(moreModels).first()).toBeVisible();
+		if (!(await model.isVisible())) {
+			await moreModels.click();
+		}
+
+		// 4. Click the model.
+		await model.click();
 
 		// Menu closes on selection; wait for the trigger to collapse so
 		// subsequent actions (e.g. Send) don't race an open overlay.

--- a/test/e2e/tests/_test.setup.ts
+++ b/test/e2e/tests/_test.setup.ts
@@ -21,7 +21,7 @@ import {
 } from '../fixtures/test-setup';
 import { loadEnvironmentVars, validateEnvironmentVars } from '../fixtures/load-environment-vars.js';
 import { RecordMetric } from '../utils/metrics/metric-base.js';
-import { runDockerCommand, RunResult } from '../fixtures/test-setup/docker-utils.js';
+import { runDockerCommand, RunResult, FOUNDRY_ASSISTANT_SETTINGS } from '../fixtures/test-setup/docker-utils.js';
 
 // used specifically for app fixture error handling in test.afterAll
 let appFixtureFailed = false;
@@ -37,6 +37,8 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 	useLegacyNotebookEditor: [false, { scope: 'worker', option: true }],
 
 	enableDataConnections: [false, { scope: 'worker', option: true }],
+
+	enableFoundryAssistant: [false, { scope: 'worker', option: true }],
 
 	envVars: [async ({ }, use, workerInfo) => {
 		const projectName = workerInfo.project.name;
@@ -104,7 +106,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 	// placeholder for area-specific fixtures that need to run before app starts
 	// e.g. changing settings that require an app reload
 	beforeApp: [
-		async ({ useLegacyNotebookEditor, enableDataConnections, settingsFile }, use) => {
+		async ({ useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant, settingsFile }, use) => {
 			if (useLegacyNotebookEditor) {
 				// These tests exercise the legacy (VS Code) notebook editor. The
 				// Positron notebook editor is now the default, so disable it before
@@ -121,12 +123,20 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 				await settingsFile.append({ 'databases.enabled': true });
 			}
 
+			if (enableFoundryAssistant) {
+				// Enable the Microsoft Foundry (msFoundry) assistant provider before
+				// the app starts so no reload is needed. Suites opt in with
+				// `test.use({ enableFoundryAssistant: true })`. The Docker apps merge
+				// the same settings via dockerSettingsOverrides.
+				await settingsFile.append({ ...FOUNDRY_ASSISTANT_SETTINGS });
+			}
+
 			await use();
 		},
 		{ scope: 'worker' }],
 
-	app: [async ({ options, logsPath, logger, managedCredentials, useLegacyNotebookEditor, enableDataConnections, beforeApp: _beforeApp }, use, workerInfo) => {
-		const { app, start, stop } = await AppFixture({ options, logsPath, logger, workerInfo, managedCredentials, useLegacyNotebookEditor, enableDataConnections });
+	app: [async ({ options, logsPath, logger, managedCredentials, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant, beforeApp: _beforeApp }, use, workerInfo) => {
+		const { app, start, stop } = await AppFixture({ options, logsPath, logger, workerInfo, managedCredentials, useLegacyNotebookEditor, enableDataConnections, enableFoundryAssistant });
 
 		try {
 			await start();
@@ -544,6 +554,7 @@ export interface WorkerFixtures {
 	managedCredentials: 'snowflake' | 'databricks' | 'azure' | undefined;
 	useLegacyNotebookEditor: boolean;
 	enableDataConnections: boolean;
+	enableFoundryAssistant: boolean;
 	envVars: string;
 	snapshots: boolean;
 	artifactDir: string;

--- a/test/e2e/tests/workbench/posit-assistant/posit-assistant-foundry.test.ts
+++ b/test/e2e/tests/workbench/posit-assistant/posit-assistant-foundry.test.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, test, tags } from '../../_test.setup';
+
+test.use({
+	suiteId: __filename,
+	managedCredentials: 'azure',
+	enableFoundryAssistant: true,
+});
+
+test.describe('Posit Assistant - Microsoft Foundry (Azure managed credentials)', {
+	tag: [tags.WORKBENCH_AZURE, tags.POSIT_ASSISTANT, tags.ASSISTANT],
+}, () => {
+	test('Foundry model responds when authenticated via Azure managed credentials', async function ({ app }) {
+		// No interactive sign-in: the msFoundry provider obtains its token via
+		// `vscode.authentication.getSession('ms-foundry', ...)`, which the
+		// authentication extension brokers from the Posit Workbench managed
+		// credential (scope `msfoundry`) once the fixture has signed into PWB via
+		// Azure OIDC. The `posit.workbench.foundry.endpoint` setting (pushed by the
+		// fixture via `enableFoundryAssistant`) gates that credential, so the
+		// session is silently available here.
+		await app.workbench.positAssistant.open();
+		await app.workbench.positAssistant.waitForReady();
+		await app.workbench.positAssistant.startNewConversation();
+
+		// Other base-fixture providers stay enabled but unauthenticated on this
+		// shard, so select the Foundry model explicitly rather than relying on an
+		// auto-selected default. `newConversation: false` keeps the model we just
+		// picked instead of resetting to a fresh chat.
+		await app.workbench.positAssistant.selectModel('model-router');
+		await app.workbench.positAssistant.sendMessage('Say hello', true, { newConversation: false });
+		await app.workbench.positAssistant.expectResponseVisible();
+
+		const responseText = await app.workbench.positAssistant.getLastResponseText();
+		expect(responseText.length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
Adds an e2e test that exercises Posit Assistant with the Microsoft Foundry (msFoundry) model provider, authenticated via Posit Workbench managed credentials on the Azure Workbench shard.

### Summary

A new `enableFoundryAssistant` worker option pushes the msFoundry assistant settings into both the host `settingsFile` (`beforeApp`) and the Docker container settings (`dockerSettingsOverrides`), sharing one `FOUNDRY_ASSISTANT_SETTINGS` constant so the two paths cannot drift. `positAI` is disabled so the Foundry model is the one exercised.

The test runs on the Azure Workbench shard (`@:workbench-azure`). The msFoundry provider is authenticated transparently via Workbench managed credentials -- the authentication extension brokers an `ms-foundry` session gated on `posit.workbench.foundry.endpoint`, so no interactive sign-in is required. The test opens Posit Assistant, selects the Foundry `model-router` model, sends a message, and asserts a non-empty response.

This is the first Posit Assistant test to run on the Workbench Docker shard. It depends on the Azure shard's Workbench being configured to broker the `msfoundry` credential and reach the configured Foundry endpoint.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### Validation Steps

@:workbench

The new test is tagged `@:workbench-azure` and runs in the Azure shard of the Workbench e2e matrix. The bare `@:workbench` tag above is what triggers the Workbench e2e job -- `pr-tags-parse.sh` only matches the bare tag, not `@:workbench-azure` -- and that job runs the full shard matrix (default, snowflake, databricks, azure).
