### PR TITLE
Don't expose `r.useTest` in the command palette

### DIFF
--- a/extensions/positron-r/package.json
+++ b/extensions/positron-r/package.json
@@ -710,6 +710,10 @@
           "when": "isRPackage"
         },
         {
+          "command": "r.useTest",
+          "when": "false"
+        },
+        {
           "category": "R",
           "command": "r.packageCheck",
           "when": "isRPackage"

--- a/extensions/positron-r/package.nls.json
+++ b/extensions/positron-r/package.nls.json
@@ -14,7 +14,7 @@
 	"r.command.packageTest.title": "Test R Package in Terminal",
 	"r.command.packageTestExplorer.title": "Test R Package in Test Explorer",
 	"r.command.useTestthat.title": "Configure testthat",
-	"r.command.useTest.title": "Add (or visit) a test file",
+	"r.command.useTest.title": "Add a test file",
 	"r.command.packageCheck.title": "Check R Package",
 	"r.command.packageDocument.title": "Document R Package",
 	"r.command.selectInterpreter.title": "Select Interpreter",

--- a/extensions/positron-r/src/commands.ts
+++ b/extensions/positron-r/src/commands.ts
@@ -153,7 +153,7 @@ export async function registerCommands(context: vscode.ExtensionContext, runtime
 		}),
 
 		vscode.commands.registerCommand('r.useTest', async () => {
-			executeCodeForCommand('usethis', 'usethis::use_test("rename-me")');
+			executeCodeForCommand('usethis', 'usethis::use_test("something")');
 		}),
 
 		vscode.commands.registerCommand('r.packageCheck', async () => {


### PR DESCRIPTION
Closes #13602 

The reason `r.useTest` was created is to power a button in the R test explorer's welcome view. If we appear to be in a testthat-using R package, but there are no tests, we want to help the user place that first test.

*However*, `r.useTest` is not really or fully `usethis::use_test()`, because we hardwire the test file, by necessity. I think it's better to simply not expose `r.useTest` in the command palette.

### Validation Steps

I don't think this needs any formal tests.

I verified this behaviour in a dev build in a toy R package:

* `r.useTest` no longer appears in the Command Palette
* The "Add a test" button still appears and works.


https://github.com/user-attachments/assets/94eef37f-8098-414a-87c9-b9e8ae1bcfac

