### PR TITLE
Fix save-conflict editor action bar buttons doing nothing

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
@@ -11,7 +11,7 @@ import { localize } from '../../../../nls.js';
 import { IEditorGroupView } from './editor.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
-import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { Disposable, DisposableMap, DisposableStore } from '../../../../base/common/lifecycle.js';
 import { EditorResourceAccessor, SideBySideEditor } from '../../../common/editor.js';
 import { IAction, Separator, SubmenuAction } from '../../../../base/common/actions.js';
 import { actionTooltip } from '../../../../platform/positronActionBar/common/helpers.js';
@@ -70,9 +70,10 @@ export class EditorActionBarFactory extends Disposable {
 	//#region Private Properties
 
 	/**
-	 * Gets the menu disposable stores.
+	 * Gets the menu disposable stores. Registered so the stores are disposed when the
+	 * factory is disposed, and replacing an entry disposes the previous store.
 	 */
-	private readonly _menuDisposableStores = new Map<MenuId, DisposableStore>();
+	private readonly _menuDisposableStores = this._register(new DisposableMap<MenuId, DisposableStore>());
 
 	/**
 	 * Gets the menus.
@@ -241,10 +242,7 @@ export class EditorActionBarFactory extends Disposable {
 	 * @param menuId The menu ID.
 	 */
 	private createMenu(menuId: MenuId) {
-		// Dispose the current menu disposable store.
-		this._menuDisposableStores.get(menuId)?.dispose();
-
-		// Add the menu disposable store.
+		// Add the menu disposable store. Setting it disposes any existing store for this menu.
 		const disposableStore = new DisposableStore();
 		this._menuDisposableStores.set(menuId, disposableStore);
 

--- a/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
+++ b/src/vs/workbench/browser/parts/editor/editorActionBarFactory.tsx
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -12,6 +12,7 @@ import { IEditorGroupView } from './editor.js';
 import { Emitter } from '../../../../base/common/event.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Disposable, DisposableStore } from '../../../../base/common/lifecycle.js';
+import { EditorResourceAccessor, SideBySideEditor } from '../../../common/editor.js';
 import { IAction, Separator, SubmenuAction } from '../../../../base/common/actions.js';
 import { actionTooltip } from '../../../../platform/positronActionBar/common/helpers.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
@@ -293,7 +294,11 @@ export class EditorActionBarFactory extends Disposable {
 		const secondaryActions: IAction[] = [];
 		const submenuDescriptors = new Set<SubmenuDescriptor>();
 		const options = {
-			arg: this._editorGroup.activeEditor?.resource,
+			// Resolve the primary side's URI so the argument is forwarded correctly for
+			// diff editors (e.g. the save-conflict editor), whose `resource` getter returns
+			// undefined when the two sides differ. This matches how the upstream editor
+			// title bar (EditorGroupView) builds the same EditorTitle menu actions.
+			arg: EditorResourceAccessor.getOriginalUri(this._editorGroup.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY }),
 			shouldForwardArgs: true
 		} satisfies IMenuActionOptions;
 		for (const [group, actions] of menu.getActions(options)) {

--- a/src/vs/workbench/browser/parts/editor/test/browser/editorActionBarFactory.vitest.tsx
+++ b/src/vs/workbench/browser/parts/editor/test/browser/editorActionBarFactory.vitest.tsx
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Event } from '../../../../../../base/common/event.js';
+import { URI } from '../../../../../../base/common/uri.js';
+import { IContextKeyService } from '../../../../../../platform/contextkey/common/contextkey.js';
+import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
+import { IMenu, IMenuActionOptions, IMenuService } from '../../../../../../platform/actions/common/actions.js';
+import { createTestContainer } from '../../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../../test/vitest/stubInterface.js';
+import { DiffEditorInput } from '../../../../../common/editor/diffEditorInput.js';
+import { TestEditorInput } from '../../../../../test/browser/workbenchTestServices.js';
+import { IEditorGroupView } from '../../editor.js';
+import { EditorActionBarFactory } from '../../editorActionBarFactory.js';
+
+describe('EditorActionBarFactory', () => {
+	const ctx = createTestContainer().withWorkbenchServices().build();
+
+	it('forwards the modified-side URI as the menu action argument for diff editors', () => {
+		// The save-conflict editor is a DiffEditorInput, whose `resource` getter returns
+		// undefined when the two sides differ. The factory must resolve the primary
+		// (modified) side's URI instead, otherwise EditorTitle commands like
+		// acceptLocalChanges receive undefined and silently no-op. See discussion #14397.
+		const original = ctx.disposables.add(new TestEditorInput(URI.file('/conflict-resolution/file.ts'), 'test.original'));
+		const modified = ctx.disposables.add(new TestEditorInput(URI.file('/workspace/file.ts'), 'test.modified'));
+		const diffInput = ctx.disposables.add(
+			ctx.instantiationService.createInstance(DiffEditorInput, undefined, undefined, original, modified, undefined)
+		);
+
+		// A diff editor exposes no single resource: this is the trap that broke the buttons.
+		expect(diffInput.resource).toBeUndefined();
+
+		// Capture the options the factory passes when it reads the EditorTitle menu actions.
+		const capturedArgs: Array<unknown> = [];
+		const menu = stubInterface<IMenu>({
+			onDidChange: Event.None,
+			getActions: (options?: IMenuActionOptions) => {
+				capturedArgs.push(options?.arg);
+				return [];
+			},
+			dispose: () => { },
+		});
+		const menuService = stubInterface<IMenuService>({ createMenu: () => menu });
+
+		const group = stubInterface<IEditorGroupView>({
+			activeEditor: diffInput,
+			activeEditorPane: undefined,
+			scopedContextKeyService: ctx.get(IContextKeyService),
+			onDidActiveEditorChange: Event.None,
+		});
+
+		const factory = ctx.disposables.add(new EditorActionBarFactory(
+			group,
+			ctx.get(IContextKeyService),
+			ctx.get(IKeybindingService),
+			menuService,
+		));
+		factory.create();
+
+		// Every menu read forwards the modified-side URI, never undefined.
+		expect(capturedArgs.length).toBeGreaterThan(0);
+		expect(capturedArgs.every(arg => arg === modified.resource)).toBe(true);
+	});
+});


### PR DESCRIPTION
Fixes https://github.com/posit-dev/positron/issues/14418

The save-conflict diff editor's accept ("Use your changes and overwrite file contents") and discard buttons did nothing when clicked from Positron's custom editor action bar. The action bar forwarded `activeEditor?.resource` as the command argument, but a diff editor's `resource` getter returns `undefined` when its two sides differ (which is always the case for the save-conflict editor). The `acceptLocalChanges` / `revertLocalChanges` commands require a file URI and silently return when it is `undefined`.

This resolves the URI the same way the upstream editor title bar does, via `EditorResourceAccessor.getOriginalUri(activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY })`, so the modified side's URI is forwarded for diff editors. Running `File: Revert File` from the Command Palette already worked because it resolves its target from the active editor directly rather than from the forwarded argument.

Also converts the factory's menu `DisposableStore` map to a registered `DisposableMap` so the stores are disposed on factory teardown (they were previously leaked) and replacing an entry disposes the previous store.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Fixed the accept and discard buttons in the save-conflict editor doing nothing when clicked (https://github.com/posit-dev/positron/issues/14418)

### Validation Steps

@:editor-action-bar

1. Open a file in the editor and make an unsaved edit so the buffer is dirty.
2. Modify the same file on disk from outside Positron (for example, append a line from a terminal, or have an agent edit it).
3. Save. Positron opens the save-conflict diff editor (left = file on disk, right = your changes).
4. Click the checkmark in the editor action bar to accept your changes. Confirm the conflict resolves and the editor closes.
5. Repeat and instead click the discard button. Confirm your changes are reverted to the on-disk contents.
