### PR TITLE
Update bootstrap extension: Quarto

### DIFF
--- a/product.json
+++ b/product.json
@@ -251,8 +251,8 @@
 		},
 		{
 			"name": "quarto.quarto",
-			"version": "1.132.0",
-			"sha256": "fe54121a32cae2b1bd9e6b8560fcfcbacc23515587abb09dd735110d3246245b",
+			"version": "1.134.0",
+			"sha256": "df2a4f8e2e68486a9c7e108ebebe2030c098890be9486d930f2303393f5ffbe4",
 			"repo": "https://github.com/quarto-dev/quarto/tree/main/apps/vscode",
 			"metadata": {
 				"id": "a1be81fc-0f3a-4f2e-92ee-3fdc7ab96c73",


### PR DESCRIPTION
This PR applies https://github.com/posit-dev/positron/pull/14420 to the 2026.06 release branch, which we need for the patch release for Workbnech.