### PR TITLE
Honor view container order when selecting a location's default

### DIFF
--- a/src/vs/workbench/services/views/browser/viewDescriptorService.ts
+++ b/src/vs/workbench/services/views/browser/viewDescriptorService.ts
@@ -373,7 +373,26 @@ export class ViewDescriptorService extends Disposable implements IViewDescriptor
 
 	getDefaultViewContainer(location: ViewContainerLocation): ViewContainer | undefined {
 		const viewContainers = this.viewContainersRegistry.getDefaultViewContainers(location);
-		return viewContainers.find(viewContainer => this.isViewContainerEnabled(viewContainer));
+		// --- Start Positron ---
+		// Honor the `order` field when picking the default view container for a
+		// location. Multiple containers can register as default (e.g. both the
+		// Console and the Terminal are panel defaults), and the registry returns
+		// them in registration order. Without this sort the first-registered
+		// container wins, which is why new windows could open to the Terminal
+		// instead of the Console. Sorting by `order` makes the lowest-order
+		// container (Console, order 1) the default. Containers without an
+		// explicit order keep their relative registration order and sort last.
+		//
+		// We sort here rather than dropping `isDefault` from the Terminal: the
+		// sessions window (vs/sessions) registers the Terminal panel container
+		// but never registers the Console, so the Terminal is its only panel
+		// default. Removing `isDefault` would leave that window's panel without
+		// a default. Honoring `order` is correct in both bundles with no gate.
+		const orderedViewContainers = viewContainers
+			.slice()
+			.sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER));
+		return orderedViewContainers.find(viewContainer => this.isViewContainerEnabled(viewContainer));
+		// --- End Positron ---
 	}
 
 	canMoveViews(): boolean {

--- a/src/vs/workbench/services/views/test/browser/viewDescriptorServiceDefaultContainer.vitest.ts
+++ b/src/vs/workbench/services/views/test/browser/viewDescriptorServiceDefaultContainer.vitest.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Registry } from '../../../../../platform/registry/common/platform.js';
+import { SyncDescriptor } from '../../../../../platform/instantiation/common/descriptors.js';
+import { generateUuid } from '../../../../../base/common/uuid.js';
+import { localize2 } from '../../../../../nls.js';
+import { Extensions as ViewContainerExtensions, IViewContainersRegistry, ViewContainer, ViewContainerLocation } from '../../../../common/views.js';
+import { ViewDescriptorService } from '../../browser/viewDescriptorService.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+
+const ViewContainersRegistry = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry);
+
+describe('ViewDescriptorService.getDefaultViewContainer', () => {
+	const ctx = createTestContainer()
+		.withWorkbenchServices()
+		.build();
+
+	const registered: ViewContainer[] = [];
+
+	/** Register a panel default container with the given order, tracked for cleanup. */
+	function registerPanelDefault(order: number | undefined): ViewContainer {
+		const container = ViewContainersRegistry.registerViewContainer({
+			id: `testDefaultContainer-${generateUuid()}`,
+			title: localize2('test', 'Test'),
+			// The pane container is never instantiated in this test; only the
+			// container metadata (order) is exercised.
+			// eslint-disable-next-line local/code-no-any-casts, @typescript-eslint/no-explicit-any
+			ctorDescriptor: new SyncDescriptor(<any>{}),
+			order,
+		}, ViewContainerLocation.Panel, { isDefault: true });
+		registered.push(container);
+		return container;
+	}
+
+	afterEach(() => {
+		while (registered.length) {
+			ViewContainersRegistry.deregisterViewContainer(registered.pop()!);
+		}
+	});
+
+	it('returns the lowest-order default container regardless of registration order', () => {
+		// Register the higher-order container first so registration order and
+		// `order` disagree. This mirrors the real bug: Terminal (order 2) is
+		// imported before the Console (order 1), so without honoring `order`
+		// the Terminal would win.
+		const higherOrder = registerPanelDefault(2);
+		const lowerOrder = registerPanelDefault(1);
+
+		const testObject = ctx.disposables.add(ctx.instantiationService.createInstance(ViewDescriptorService));
+
+		expect(testObject.getDefaultViewContainer(ViewContainerLocation.Panel)).toBe(lowerOrder);
+		expect(testObject.getDefaultViewContainer(ViewContainerLocation.Panel)).not.toBe(higherOrder);
+	});
+
+	it('prefers a container with an explicit order over one without', () => {
+		const ordered = registerPanelDefault(1);
+		registerPanelDefault(undefined);
+
+		const testObject = ctx.disposables.add(ctx.instantiationService.createInstance(ViewDescriptorService));
+
+		expect(testObject.getDefaultViewContainer(ViewContainerLocation.Panel)).toBe(ordered);
+	});
+});


### PR DESCRIPTION
Both the Console (order 1) and the Terminal (order 2) register as default panel view containers. getDefaultViewContainer returned the first one in registration order, and since the Terminal contribution loads before the Console, new windows could open to the Terminal instead of the Console.

Sort the location's default containers by order before picking the first enabled one, so the lowest-order container (the Console) wins. This is preferred over dropping the Terminal's isDefault flag because the sessions window registers the Terminal but not the Console, and must keep the Terminal as its panel default.

See #13532

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- New windows should now consistently open to the Console

### Validation Steps

Run this in an R prompt. If you don't have it, install `usethis`

```
usethis::create_from_github("r-lib/rprojroot")
```

@:console @:layouts @:sessions @:viewer