### PR TITLE
Security upgrade undici to 7.28.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "react-window": "^1.8.10",
         "tas-client": "0.3.1",
         "tas-client-umd": "0.2.0",
-        "undici": "^7.18.2",
+        "undici": "^7.28.0",
         "v8-inspect-profiler": "^0.1.1",
         "vscode-oniguruma": "1.7.0",
         "vscode-regexpp": "^3.1.0",
@@ -10182,16 +10182,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cheerio/node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/cheerio/node_modules/whatwg-mimetype": {
@@ -26785,9 +26775,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "react-window": "^1.8.10",
     "tas-client": "0.3.1",
     "tas-client-umd": "0.2.0",
-    "undici": "^7.18.2",
+    "undici": "^7.28.0",
     "v8-inspect-profiler": "^0.1.1",
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",


### PR DESCRIPTION
Backports 412898474f3 onto `release/2026.06`.

Bumps `undici` from `^7.18.2` to `^7.28.0` to address Snyk-reported vulnerabilities:
- https://snyk.io/vuln/SNYK-JS-UNDICI-17372658
- https://snyk.io/vuln/SNYK-JS-UNDICI-17372667
- https://snyk.io/vuln/SNYK-JS-UNDICI-17372758
- https://snyk.io/vuln/SNYK-JS-UNDICI-17372754
- https://snyk.io/vuln/SNYK-JS-UNDICI-17372697

Note: on `release/2026.06` undici was at `^7.18.2` (the original commit bumped from `^7.24.0`), so the conflict was resolved to the target `^7.28.0`.
