### PR TITLE
Fix disappearing input prompt in console (take 2)

### DIFF
--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInput.tsx
@@ -11,10 +11,7 @@ import { FocusEvent, useEffect, useLayoutEffect, useRef } from 'react';
 
 // Other dependencies.
 import * as DOM from '../../../../../base/browser/dom.js';
-import { URI } from '../../../../../base/common/uri.js';
-import { Schemas } from '../../../../../base/common/network.js';
 import { KeyCode } from '../../../../../base/common/keyCodes.js';
-import { generateUuid } from '../../../../../base/common/uuid.js';
 import { isMacintosh } from '../../../../../base/common/platform.js';
 import { HistoryNavigator2 } from '../../../../../base/common/history.js';
 import { ISelection } from '../../../../../editor/common/core/selection.js';
@@ -49,6 +46,7 @@ import { IInputHistoryEntry } from '../../../../services/positronHistory/common/
 import { CodeAttributionSource, IConsoleCodeAttribution } from '../../../../services/positronConsole/common/positronConsoleCodeExecution.js';
 import { localize } from '../../../../../nls.js';
 import { createConsoleInputEditorOptions, createConsoleInputLineNumbersOptions, ILineNumbersOptions } from './consoleInputOptions.js';
+import { createConsoleInputModel } from './consoleInputModel.js';
 import { usePositronReactServicesContext } from '../../../../../base/browser/positronReactRendererContext.js';
 import { getForegroundDebugState, isForegroundDebugSession } from '../../../debug/common/debug.js';
 
@@ -692,21 +690,21 @@ export const ConsoleInput = (props: ConsoleInputProps) => {
 		// Provide a reference to the code editor.
 		props.positronConsoleInstance.codeEditor = codeEditorWidget;
 
-		// Attach the text model. Use a different URI path prefix for
-		// notebook console inputs so that the notebook LSP can match
-		// them via document selectors, while the console LSP skips them.
+		// Create the text model that backs the input editor. This also holds a
+		// model reference for the editor's lifetime so the model can't be disposed
+		// out from under the editor and blank the prompt; see createConsoleInputModel.
 		const languageId = props.positronConsoleInstance.runtimeMetadata.languageId;
 		const isNotebook = props.positronConsoleInstance.sessionMetadata.sessionMode === LanguageRuntimeSessionMode.Notebook;
-		const replPrefix = isNotebook ? 'notebook-repl' : 'repl';
-		codeEditorWidget.setModel(services.modelService.createModel(
-			'',
-			services.languageService.createById(languageId),
-			URI.from({
-				scheme: Schemas.inMemory,
-				path: `/${replPrefix}-${languageId}-${generateUuid()}`
-			}),
-			false
-		));
+		const inputModel = createConsoleInputModel(
+			services.modelService,
+			services.textModelService,
+			services.languageService,
+			languageId,
+			isNotebook,
+			disposableStore
+		);
+
+		codeEditorWidget.setModel(inputModel);
 
 		// Add the onDidChangeConfiguration event handler.
 		disposableStore.add(

--- a/src/vs/workbench/contrib/positronConsole/browser/components/consoleInputModel.ts
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/consoleInputModel.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from '../../../../../base/common/uri.js';
+import { Schemas } from '../../../../../base/common/network.js';
+import { generateUuid } from '../../../../../base/common/uuid.js';
+import { DisposableStore, thenRegisterOrDispose } from '../../../../../base/common/lifecycle.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { IModelService } from '../../../../../editor/common/services/model.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
+
+/**
+ * Creates the in-memory text model that backs a console input editor and holds
+ * an {@link ITextModelService} reference to it for the model's lifetime.
+ *
+ * A different URI path prefix is used for notebook console inputs so that the
+ * notebook LSP can match them via document selectors, while the console LSP
+ * skips them.
+ *
+ * The console owns this model, but other consumers (e.g. a language server
+ * that opens the same document) acquire their own references via the text
+ * model service. When the last reference is released, the resolver disposes
+ * the underlying model (TextResourceEditorModel.dispose ->
+ * modelService.destroyModel). That would pull the model out from under the
+ * editor (model.onWillDispose -> CodeEditorWidget.setModel(null)), detach the
+ * editor's view, and make the input prompt disappear. Holding our own
+ * reference keeps the resolver's reference count above zero for as long as the
+ * editor exists, so an external consumer acquiring and later releasing a
+ * reference can no longer dispose the model. This mirrors how Positron
+ * notebook cells keep their cell models alive (see PositronNotebookCell).
+ *
+ * @param modelService The model service used to create the model.
+ * @param textModelService The text model service used to hold a reference.
+ * @param languageService The language service used to resolve the language.
+ * @param languageId The language id of the console's runtime.
+ * @param isNotebook Whether the console input belongs to a notebook session.
+ * @param store The disposable store the held model reference is registered to.
+ * @returns The created text model.
+ */
+export function createConsoleInputModel(
+	modelService: IModelService,
+	textModelService: ITextModelService,
+	languageService: ILanguageService,
+	languageId: string,
+	isNotebook: boolean,
+	store: DisposableStore
+): ITextModel {
+	const replPrefix = isNotebook ? 'notebook-repl' : 'repl';
+	const model = modelService.createModel(
+		'',
+		languageService.createById(languageId),
+		URI.from({
+			scheme: Schemas.inMemory,
+			path: `/${replPrefix}-${languageId}-${generateUuid()}`
+		}),
+		false
+	);
+
+	// Hold a reference for the model's lifetime so it cannot be disposed out from
+	// under the editor (see the doc comment above and issue #13925).
+	thenRegisterOrDispose(textModelService.createModelReference(model.uri), store);
+
+	return model;
+}

--- a/src/vs/workbench/contrib/positronConsole/test/browser/consoleInputModel.vitest.ts
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/consoleInputModel.vitest.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { URI } from '../../../../../base/common/uri.js';
+import { DisposableStore } from '../../../../../base/common/lifecycle.js';
+import { ITextModel } from '../../../../../editor/common/model.js';
+import { IModelService } from '../../../../../editor/common/services/model.js';
+import { ILanguageService } from '../../../../../editor/common/languages/language.js';
+import { ITextModelService } from '../../../../../editor/common/services/resolverService.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { createConsoleInputModel } from '../../browser/components/consoleInputModel.js';
+
+describe('createConsoleInputModel', () => {
+	// Capture the resource passed to createModel and echo it back on the model so
+	// the model's uri matches what was registered, mirroring the real ModelService.
+	function setup() {
+		let createdResource: URI | undefined;
+		const modelService = stubInterface<IModelService>({
+			createModel: vi.fn((_value, _language, resource?: URI) => {
+				createdResource = resource;
+				return stubInterface<ITextModel>({ uri: resource! });
+			})
+		});
+		const refDispose = vi.fn();
+		const textModelService = stubInterface<ITextModelService>({
+			createModelReference: vi.fn().mockResolvedValue({ object: {}, dispose: refDispose })
+		});
+		const languageService = stubInterface<ILanguageService>({
+			createById: vi.fn().mockReturnValue(undefined)
+		});
+		return { modelService, textModelService, languageService, refDispose, getCreatedResource: () => createdResource };
+	}
+
+	it('creates an in-memory model and holds a reference to it', async () => {
+		const { modelService, textModelService, languageService } = setup();
+		const store = new DisposableStore();
+
+		const model = createConsoleInputModel(modelService, textModelService, languageService, 'r', false, store);
+
+		// The created model is returned, and a reference is acquired for its URI.
+		expect(model.uri.scheme).toBe('inmemory');
+		expect(textModelService.createModelReference).toHaveBeenCalledWith(model.uri);
+
+		store.dispose();
+	});
+
+	it('releases the held reference when the store is disposed', async () => {
+		const { modelService, textModelService, languageService, refDispose } = setup();
+		const store = new DisposableStore();
+
+		createConsoleInputModel(modelService, textModelService, languageService, 'r', false, store);
+
+		// The reference is acquired asynchronously; let it resolve and register.
+		await Promise.resolve();
+		expect(refDispose).not.toHaveBeenCalled();
+
+		// Disposing the store releases the console's own reference, which on the
+		// real resolver is what finally allows the model to be disposed.
+		store.dispose();
+		expect(refDispose).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
The console intermittently lost its input prompt (the `>` glyph) and stopped accepting text until the window was reloaded.

The prompt is drawn by the console input's editor, which is backed by an in-memory text model the console owns. The editor blanks the prompt when that model is disposed. Screenshots and DOM captures from @gadenbuie were instrumental in diagnosing this as the cause; the fact that the `console-input` editor `<div>` is empty was a major clue.

The disposal came from the text-model reference system: when an extension (e.g. a language server) opens the same console document, it holds a reference to the model; when that reference is later released, the resolver disposes the model. 

The upstream 1.118 merge (#13572) removed a guard that previously protected in-memory models from this, so releasing the reference now disposed the console's model out from under the editor. It was intermittent because it depended on reference timing (whether anything re-opened the document before the reference was released), which is why it showed up most with many notebook cells or multiple consoles open.

The fix has the console hold its own reference to the input model for the lifetime of the editor, so the reference count never drops to zero while the editor is alive and an external consumer releasing its reference can no longer dispose the model. This mirrors how Positron notebook cells keep their models alive (`PositronNotebookCell`), touches no upstream files, and doesn't change global resolver behavior. 

Fixes #13925, again.

### Validation Steps

@:console

This is hard to trigger by hand (it depends on extension reference timing), so it is covered by a unit test (`consoleInputModel.vitest.ts`) that verifies the console holds a model reference and releases it only on teardown. To sanity-check manually:

1. Open an R or Python console (and/or a notebook with several code cells) and confirm the `>` prompt is visible.
2. Work in the console for an extended session with the language server active.
3. Verify the `>` prompt remains visible and the input stays editable throughout (it should never blank out, requiring a window reload).
