### PR TITLE
python: shut down LSP thread nicer

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_lsp.py
@@ -520,15 +520,23 @@ class PositronLanguageServer(LanguageServer):
             """Handle an incoming LSP connection."""
             logger.debug("Connected to LSP client")
             self.protocol.set_writer(writer)  # type: ignore[attr-defined]
-            await run_async(
-                stop_event=stop_event,
-                reader=reader,
-                protocol=self.protocol,
-                logger=logger,
-                error_handler=self.report_server_error,
-            )
-            logger.debug("LSP connection closed")
-            self._shutdown_server()
+            try:
+                await run_async(
+                    stop_event=stop_event,
+                    reader=reader,
+                    protocol=self.protocol,
+                    logger=logger,
+                    error_handler=self.report_server_error,
+                )
+            finally:
+                logger.debug("LSP connection closed")
+                # Close this connection's transport so the server can detach it
+                # and wait_closed() (awaited by serve_forever) can complete.
+                writer.close()
+                # Stop accepting connections so serve_forever() returns; the
+                # thread's finally block performs the full teardown. Closing the
+                # loop from here would fail because it is still running.
+                self._stop_serving()
 
         async def start_server() -> None:
             # Use port=0 to let the OS pick a port
@@ -587,11 +595,10 @@ class PositronLanguageServer(LanguageServer):
         existing_thread = self._server_thread
         if existing_thread is not None and existing_thread.is_alive():
             logger.warning("LSP server thread already exists, shutting it down")
-            if self._stop_event:
-                self._stop_event.set()
-                existing_thread.join(timeout=5)
-                if existing_thread.is_alive():
-                    logger.warning("LSP server thread did not exit after 5s, dropping it")
+            self.stop()
+            existing_thread.join(timeout=5)
+            if existing_thread.is_alive():
+                logger.warning("LSP server thread did not exit after 5s, dropping it")
 
         # Start the server in a new thread
         logger.info("Starting LSP server thread")
@@ -604,7 +611,7 @@ class PositronLanguageServer(LanguageServer):
         self._server_thread.start()
 
     def _shutdown_server(self) -> None:
-        """Internal shutdown logic."""
+        """Internal shutdown logic. Runs on the server thread once the loop is idle."""
         logger.info("Shutting down LSP server")
 
         if self._stop_event:
@@ -617,9 +624,29 @@ class PositronLanguageServer(LanguageServer):
             self._server.close()
 
         if self._loop and not self._loop.is_closed():
+            # Cancel and drain any pending tasks (e.g. serve_forever) before
+            # closing the loop. Closing a loop while a coroutine is still
+            # suspended makes Python throw GeneratorExit into it on garbage
+            # collection, printing a spurious "coroutine ignored GeneratorExit"
+            # RuntimeError to the Console.
+            pending = asyncio.all_tasks(self._loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                self._loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            self._loop.run_until_complete(self._loop.shutdown_asyncgens())
             self._loop.close()
 
         self._server_thread = None
+
+    def _stop_serving(self) -> None:
+        """Close the asyncio server so serve_forever() returns.
+
+        Must run on the server thread's event loop, either directly from a loop
+        callback or scheduled via ``call_soon_threadsafe``.
+        """
+        if self._server is not None:
+            self._server.close()
 
     def stop(self) -> None:
         """Stop the LSP server from another thread."""
@@ -627,6 +654,15 @@ class PositronLanguageServer(LanguageServer):
             logger.warning("Cannot stop LSP server, it was not started")
             return
         self._stop_event.set()
+
+        # Setting the threading.Event alone does not interrupt the running event
+        # loop. Schedule the server to close on the loop thread so serve_forever()
+        # returns and the thread exits cleanly instead of being orphaned with a
+        # suspended coroutine.
+        loop = self._loop
+        if loop is not None and not loop.is_closed():
+            with contextlib.suppress(RuntimeError):
+                loop.call_soon_threadsafe(self._stop_serving)
 
     def set_debug(self, debug: bool) -> None:  # noqa: FBT001
         """Enable or disable debug mode."""

--- a/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py
@@ -5,9 +5,14 @@
 
 """Tests for the Positron Language Server (positron_lsp.py)."""
 
+import contextlib
+import gc
 import os
+import socket
+import sys
+import threading
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 from unittest.mock import Mock, patch
 
 import pandas as pd
@@ -1707,3 +1712,114 @@ class TestGetDocumentLine:
         )
         ctx = _get_document_line(server, params)
         assert ctx.line == ""
+
+
+@contextlib.contextmanager
+def _capture_unraisable() -> Iterator[List[str]]:
+    """Capture exceptions reported via sys.unraisablehook (e.g. during GC).
+
+    The "coroutine ignored GeneratorExit" RuntimeError that this module guards
+    against is raised when Python finalizes a suspended coroutine, and is
+    surfaced through the unraisable hook rather than as a normal exception.
+    """
+    messages: List[str] = []
+    original = sys.unraisablehook
+
+    def hook(unraisable: Any) -> None:
+        messages.append(f"{unraisable.exc_type.__name__}: {unraisable.exc_value}")
+
+    sys.unraisablehook = hook
+    try:
+        yield messages
+    finally:
+        sys.unraisablehook = original
+
+
+class TestServerLifecycle:
+    """Tests for starting, stopping, and restarting the language server thread."""
+
+    @staticmethod
+    def _start_ready_server() -> Tuple[PositronLanguageServer, int]:
+        """Start a server and block until it reports ``server_started``."""
+        server = create_server()
+        ready = threading.Event()
+        port_box: Dict[str, int] = {}
+
+        comm = Mock()
+
+        def _send(msg: Dict[str, Any]) -> None:
+            if msg.get("msg_type") == "server_started":
+                port_box["port"] = msg["content"]["port"]
+                ready.set()
+
+        comm.send.side_effect = _send
+
+        server.start(lsp_host="127.0.0.1", shell=Mock(), comm=comm)
+        assert ready.wait(timeout=10), "LSP server did not report server_started"
+        return server, port_box["port"]
+
+    def test_stop_exits_thread_cleanly(self) -> None:
+        """stop() must wake the loop so the server thread actually exits."""
+        with _capture_unraisable() as unraisables:
+            server, _ = self._start_ready_server()
+            thread = server._server_thread  # noqa: SLF001
+
+            server.stop()
+
+            assert thread is not None
+            thread.join(timeout=10)
+            assert not thread.is_alive()
+
+            gc.collect()
+
+        assert server._loop is not None  # noqa: SLF001
+        assert server._loop.is_closed()  # noqa: SLF001
+        assert not any("GeneratorExit" in message for message in unraisables), unraisables
+
+    def test_client_disconnect_shuts_down_cleanly(self) -> None:
+        """A client disconnect tears the loop down without a stray coroutine."""
+        with _capture_unraisable() as unraisables:
+            server, port = self._start_ready_server()
+            thread = server._server_thread  # noqa: SLF001
+
+            # Connecting then closing exercises the lsp_connection teardown
+            # path (run_async returns -> _stop_serving()).
+            client = socket.create_connection(("127.0.0.1", port), timeout=10)
+            client.close()
+
+            assert thread is not None
+            thread.join(timeout=10)
+            assert not thread.is_alive()
+
+            gc.collect()
+
+        assert not any("GeneratorExit" in message for message in unraisables), unraisables
+
+    def test_restart_shuts_down_previous_thread(self) -> None:
+        """Restarting must cleanly stop the previous thread, not orphan it."""
+        with _capture_unraisable() as unraisables:
+            server, _ = self._start_ready_server()
+            first_thread = server._server_thread  # noqa: SLF001
+
+            ready = threading.Event()
+            comm = Mock()
+
+            def _send(msg: Dict[str, Any]) -> None:
+                if msg.get("msg_type") == "server_started":
+                    ready.set()
+
+            comm.send.side_effect = _send
+            server.start(lsp_host="127.0.0.1", shell=Mock(), comm=comm)
+            assert ready.wait(timeout=10), "restarted LSP server did not start"
+
+            assert first_thread is not None
+            assert not first_thread.is_alive()
+
+            server.stop()
+            second_thread = server._server_thread  # noqa: SLF001
+            if second_thread is not None:
+                second_thread.join(timeout=10)
+
+            gc.collect()
+
+        assert not any("GeneratorExit" in message for message in unraisables), unraisables


### PR DESCRIPTION
Fixes #14367. In a Python session, the Console occasionally printed a harmless `RuntimeError: coroutine ignored GeneratorExit` from the Positron language server, typically after Positron had been open for a while or when switching between sessions. 

This PR fixes the server teardown code so it's more clean:

- `_shutdown_server` cancels and drains pending tasks before closing the loop, so `serve_forever()` unwinds via `CancelledError` instead of being abandoned and finalized on garbage collection.
- `stop()` wakes the loop from the calling thread via `call_soon_threadsafe`. Previously it only set a `threading.Event` that the asyncio loop never checked, leaving the server thread (and its suspended coroutine) orphaned on restart.
- On client disconnect, the connection's writer and the server are closed instead of closing the loop from inside the running loop, so the thread's `finally` block performs a single, clean teardown.

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Fixed a harmless `RuntimeError` that the language server could print to the Python Console (#14367)

### Validation Steps

@:console @:sessions

This is a teardown race that is hard to trigger on demand. It is covered primarily by new unit tests in `extensions/positron-python/python_files/posit/positron/tests/test_positron_lsp.py` (`TestServerLifecycle`), which assert the server thread exits cleanly on `stop()`, client disconnect, and restart, with no stray `GeneratorExit`.

To smoke-test manually:

1. Start two Python sessions (for example, two different interpreters).
2. Switch back and forth between them a few times, and restart one of them.
3. Confirm the Console shows the normal startup banner with no `Exception ignored while closing generator ... RuntimeError: coroutine ignored GeneratorExit` message.
