### PR TITLE
PNE: Add option to add new raw cells with inline add cell buttons and clean up styling

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.css
@@ -6,15 +6,36 @@
 .positron-add-cell-buttons {
 	position: relative;
 	display: flex;
+	align-items: center;
 	justify-content: center;
 	opacity: 0;
 	transition: opacity 0.2s;
-	gap: 8px;
 	color: inherit;
+}
+
+/*
+ * Equal-width Code and Markdown buttons that auto-size to the wider label (no
+ * magic number, so localized labels stay equal). `grid-auto-columns: 1fr`
+ * makes both columns the width of the widest, and grid items stretch to fill.
+ * This lives on an inner group rather than the container because the container
+ * spans the full notebook width (the drop indicator is absolutely positioned
+ * across it), which would defeat the auto-sizing.
+ */
+.positron-add-cell-buttons .add-cell-buttons-group {
+	display: grid;
+	grid-auto-flow: column;
+	grid-auto-columns: 1fr;
+	align-items: center;
+	gap: 6px;
 }
 
 .positron-add-cell-buttons:hover,
 .positron-add-cell-buttons:focus-within {
+	opacity: 1;
+}
+
+/* Keep the group visible while its dropdown menu is open; the menu renders at the body level, so focus and hover leave the container when it opens. */
+.positron-add-cell-buttons.menu-open {
 	opacity: 1;
 }
 
@@ -25,8 +46,125 @@
 	opacity: 1 !important;
 }
 
-.positron-add-cell-buttons.drop-target .positron-iconed-button {
+.positron-add-cell-buttons.drop-target .positron-iconed-button,
+.positron-add-cell-buttons.drop-target .split-button {
 	opacity: 0;
+}
+
+/*
+ * Button polish (#13562): keep the split button and the Markdown button
+ * visually consistent with each other and the editor's action buttons. Scoped
+ * here so SplitButton.css / IconedButton.css (shared elsewhere) stay untouched.
+ */
+
+/*
+ * Both controls share one box model so they read as siblings: same height,
+ * border, and corner radius. The Markdown button defines no padding of its
+ * own, so match the split button's main-segment padding here too. (Equal width
+ * comes from the grid group above.)
+ */
+.positron-add-cell-buttons .split-button.add-cell-split-button,
+.positron-add-cell-buttons .positron-iconed-button.bordered {
+	box-sizing: border-box;
+	height: 24px;
+	border-color: var(--vscode-positronNotebook-actionBarBorder);
+	border-radius: 4px;
+}
+
+.positron-add-cell-buttons .positron-iconed-button.bordered {
+	padding: 2px 8px;
+	/* Center the icon+label within the shared min-width. */
+	justify-content: center;
+}
+
+/*
+ * Match label sizing and inner spacing across both controls. Stretch the main
+ * segment to the container's full height (the caret already does) so its hover
+ * fill reaches the top and bottom edges instead of leaving an unfilled band.
+ */
+.positron-add-cell-buttons .add-cell-split-button .split-button-main {
+	align-self: stretch;
+	/* Absorb the min-width slack so the caret stays pinned to the right edge. */
+	flex: 1;
+	justify-content: center;
+	gap: 4px;
+	font-size: 12px;
+}
+
+/*
+ * Add icons: 11px, thickened with a text stroke. codicon.ttf ships a single
+ * weight, so numeric font-weights are no-ops; `-webkit-text-stroke` strokes the
+ * glyph outline at a width we control (unlike the browser-decided amount of
+ * `font-weight: bold`) and defaults to currentColor, so it still tracks the
+ * theme. Tune the stroke width to taste. Three selectors share this: the inline
+ * split button and Markdown button (this group), and the notebook's editor
+ * action bar Code/Markdown buttons, which are plain action-bar buttons
+ * (registered as Action2s) rather than React buttons. The `codicon-add-small`
+ * class only appears on these buttons within an editor action bar, so other
+ * editors' action bars are untouched. Selectors stay specific enough to win
+ * over the 16px codicon base rule.
+ */
+.positron-add-cell-buttons .add-cell-split-button .button-icon.codicon-add-small,
+.positron-add-cell-buttons .positron-iconed-button .button-icon.codicon-add-small,
+.editor-action-bar-container .action-bar-button-icon.codicon-add-small {
+	font-size: 11px;
+	-webkit-text-stroke: 0.35px currentColor;
+}
+
+/*
+ * Nudge each plus a sub-pixel to optically center it. The amount differs by
+ * box: the inline buttons and the action-bar buttons size their glyph slots
+ * differently.
+ */
+.positron-add-cell-buttons .add-cell-split-button .button-icon.codicon-add-small,
+.positron-add-cell-buttons .positron-iconed-button .button-icon.codicon-add-small {
+	transform: translate(1px, 0.7px);
+}
+
+.editor-action-bar-container .action-bar-button-icon.codicon-add-small {
+	transform: translate(0, 0.5px);
+}
+
+/*
+ * The caret reads as a sibling of the plus (same 14px weight) and is divided
+ * off by an inset rule rather than a full-height border. A 1px gutter
+ * (margin-left) holds the divider between the two segments so neither side's
+ * hover fill covers it: each fill stops at its edge of the gutter and the
+ * divider sits centered on the boundary. The caret needs less breathing room
+ * than the label, so it uses tighter horizontal padding (2px) than the main
+ * segment's 8px.
+ */
+.positron-add-cell-buttons .add-cell-split-button .split-button-dropdown {
+	position: relative;
+	margin-left: 1px;
+	padding: 0 2px;
+	border-left: none;
+}
+
+.positron-add-cell-buttons .add-cell-split-button .split-button-dropdown::before {
+	content: '';
+	position: absolute;
+	top: 2px;
+	bottom: 2px;
+	left: -1px;
+	width: 1px;
+	background-color: var(--vscode-positronNotebook-actionBarBorder);
+}
+
+.positron-add-cell-buttons .add-cell-split-button .split-button-dropdown .codicon {
+	font-size: 14px;
+}
+
+/*
+ * Soften the hover fill across all three controls. The split button highlights
+ * per-segment (main vs caret are distinct actions), so a saturated fill on one
+ * half reads as half-lit. The toolbar token is translucent, so it blends instead
+ * of stamping a flat block, and each segment keeps its rounded outer corners.
+ */
+.positron-add-cell-buttons .add-cell-split-button .split-button-main:hover,
+.positron-add-cell-buttons .add-cell-split-button .split-button-dropdown:hover,
+.positron-add-cell-buttons .positron-iconed-button.bordered:hover {
+	background: var(--vscode-toolbar-hoverBackground);
 }
 
 .positron-add-cell-buttons .drag-drop-indicator {

--- a/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.css
@@ -96,33 +96,24 @@
  * weight, so numeric font-weights are no-ops; `-webkit-text-stroke` strokes the
  * glyph outline at a width we control (unlike the browser-decided amount of
  * `font-weight: bold`) and defaults to currentColor, so it still tracks the
- * theme. Tune the stroke width to taste. Three selectors share this: the inline
- * split button and Markdown button (this group), and the notebook's editor
- * action bar Code/Markdown buttons, which are plain action-bar buttons
- * (registered as Action2s) rather than React buttons. The `codicon-add-small`
- * class only appears on these buttons within an editor action bar, so other
- * editors' action bars are untouched. Selectors stay specific enough to win
- * over the 16px codicon base rule.
+ * theme. Tune the stroke width to taste. Two selectors share this: the inline
+ * split button and Markdown button (this group). The notebook's editor action
+ * bar Code/Markdown buttons use the standard `add` codicon instead, which
+ * matches the weight of the other action-bar icons on its own. Selectors stay
+ * specific enough to win over the 16px codicon base rule.
  */
 .positron-add-cell-buttons .add-cell-split-button .button-icon.codicon-add-small,
-.positron-add-cell-buttons .positron-iconed-button .button-icon.codicon-add-small,
-.editor-action-bar-container .action-bar-button-icon.codicon-add-small {
+.positron-add-cell-buttons .positron-iconed-button .button-icon.codicon-add-small {
 	font-size: 11px;
 	-webkit-text-stroke: 0.35px currentColor;
 }
 
 /*
- * Nudge each plus a sub-pixel to optically center it. The amount differs by
- * box: the inline buttons and the action-bar buttons size their glyph slots
- * differently.
+ * Nudge each plus a sub-pixel to optically center it within its glyph slot.
  */
 .positron-add-cell-buttons .add-cell-split-button .button-icon.codicon-add-small,
 .positron-add-cell-buttons .positron-iconed-button .button-icon.codicon-add-small {
 	transform: translate(1px, 0.7px);
-}
-
-.editor-action-bar-container .action-bar-button-icon.codicon-add-small {
-	transform: translate(0, 0.5px);
 }
 
 /*

--- a/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.css
@@ -117,6 +117,20 @@
 }
 
 /*
+ * The editor action bar Code/Markdown buttons use the standard `add` codicon
+ * (not add-small). At the 16px codicon base size the plus reads a touch large
+ * beside the sibling action-bar icons, so drop it to 14px, then nudge it 2px
+ * right to optically center the smaller glyph in its slot. Scoped to the plus
+ * icon within the action bar container; the notebook's add-cell actions are the
+ * only `add`-icon buttons rendered there, so other action-bar icons (run-all,
+ * outline) are untouched. Specificity wins over the 16px codicon base rule.
+ */
+.editor-action-bar-container .action-bar-button-icon.codicon-add {
+	font-size: 14px;
+	transform: translateX(2px);
+}
+
+/*
  * The caret reads as a sibling of the plus (same 14px weight) and is divided
  * off by an inset rule rather than a full-height border. A 1px gutter
  * (margin-left) holds the divider between the two segments so neither side's

--- a/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AddCellButtons.tsx
@@ -6,15 +6,40 @@
 // CSS.
 import './AddCellButtons.css';
 
+// React.
+import { useCallback, useState } from 'react';
+
 // Other dependencies.
 import { useNotebookInstance } from './NotebookInstanceProvider.js';
 import { localize } from '../../../../nls.js';
 import { CellKind } from '../../notebook/common/notebookCommon.js';
 import { IPositronNotebookInstance } from './IPositronNotebookInstance.js';
 import { IconedButton } from './utilityComponents/IconedButton.js';
+import { SplitButton } from './utilityComponents/SplitButton.js';
+import { Icon } from '../../../../platform/positronActionBar/browser/components/icon.js';
 import { Codicon } from '../../../../base/common/codicons.js';
+import { IAction } from '../../../../base/common/actions.js';
 import { positronClassNames } from '../../../../base/common/positronUtilities.js';
+import { usePositronReactServicesContext } from '../../../../base/browser/positronReactRendererContext.js';
 import { useDragState } from './notebookCells/SortableCellList.js';
+
+/**
+ * The cell types offered by the add-cell split button. A "raw" cell is a code
+ * cell whose language is set to `raw`, matching how the notebook model and the
+ * "Convert to Raw" command represent raw cells.
+ */
+type AddableCellType = 'code' | 'raw';
+
+interface CellTypeSpec {
+	readonly language?: string;
+	readonly label: string;
+	readonly fullLabel: string;
+}
+
+const CELL_TYPE_SPECS: Record<AddableCellType, CellTypeSpec> = {
+	code: { label: localize('newCodeCellshort', 'Code'), fullLabel: localize('newCodeCellLong', 'New Code Cell') },
+	raw: { language: 'raw', label: localize('newRawCellShort', 'Raw'), fullLabel: localize('newRawCellLong', 'New Raw Cell') },
+};
 
 export function AddCellButtons({ index }: { index: number }) {
 	const notebookInstance = useNotebookInstance();
@@ -22,32 +47,62 @@ export function AddCellButtons({ index }: { index: number }) {
 	const isDropTarget = dropIndicatorIndex === index;
 	const showIndicator = isDropTarget && !isDropNoOp;
 
+	// The group hides itself when focus/hover leave it. The split button's
+	// dropdown menu renders at the body level, so opening it would otherwise make
+	// the group vanish mid-interaction; keep it visible while the menu is open.
+	const [menuOpen, setMenuOpen] = useState(false);
+
 	return <div className={positronClassNames(
 		'positron-add-cell-buttons',
 		{ 'drop-target': showIndicator },
+		{ 'menu-open': menuOpen },
 	)}>
 		{showIndicator && <div className='drag-drop-indicator' data-testid='drop-indicator' />}
-		<AddCodeCellButton bordered index={index} notebookInstance={notebookInstance} />
-		<AddMarkdownCellButton bordered index={index} notebookInstance={notebookInstance} />
+		<div className='add-cell-buttons-group'>
+			<AddCellSplitButton index={index} notebookInstance={notebookInstance} onMenuOpenChange={setMenuOpen} />
+			<AddMarkdownCellButton bordered index={index} notebookInstance={notebookInstance} />
+		</div>
 	</div>;
 }
 
+/**
+ * Split button that adds a cell. The main action adds a Code cell; the dropdown
+ * offers Code and Raw. Markdown has its own dedicated button
+ * (AddMarkdownCellButton), so it stays out of this menu.
+ */
+export function AddCellSplitButton({ notebookInstance, index, onMenuOpenChange }: { notebookInstance: IPositronNotebookInstance; index: number; onMenuOpenChange?: (open: boolean) => void }) {
+	const { contextMenuService } = usePositronReactServicesContext();
 
-export function AddCodeCellButton({ notebookInstance, index, bordered }: { notebookInstance: IPositronNotebookInstance; index: number; bordered?: boolean }) {
+	const insertCell = useCallback((type: AddableCellType) => {
+		// Both code and raw cells are CellKind.Code; raw differs only by language.
+		// enterEditMode === true focuses the new cell.
+		notebookInstance.addCell(CellKind.Code, index, true, '', CELL_TYPE_SPECS[type].language);
+	}, [notebookInstance, index]);
 
-	const label = localize('newCodeCellshort', 'Code');
-	const fullLabel = localize('newCodeCellLong', 'New Code Cell');
-	return <IconedButton
-		bordered={bordered}
-		fullLabel={fullLabel}
-		hoverManager={notebookInstance.hoverManager}
-		icon={Codicon.plus}
-		label={label}
-		onClick={() => notebookInstance.addCell(CellKind.Code, index, true)}
-	/>;
+	const dropdownActions: IAction[] = (['code', 'raw'] as const).map(type => ({
+		id: `positronNotebook.addCell.${type}`,
+		label: CELL_TYPE_SPECS[type].label,
+		tooltip: CELL_TYPE_SPECS[type].fullLabel,
+		class: undefined,
+		enabled: true,
+		run: () => insertCell(type),
+	}));
 
+	const code = CELL_TYPE_SPECS.code;
+
+	return <SplitButton
+		ariaLabel={code.fullLabel}
+		className='add-cell-split-button'
+		contextMenuService={contextMenuService}
+		dropdownActions={dropdownActions}
+		dropdownTooltip={localize('newCellDropdownTooltip', "Choose cell type")}
+		onMainAction={() => insertCell('code')}
+		onMenuOpenChange={onMenuOpenChange}
+	>
+		<Icon className='button-icon' icon={Codicon.addSmall} />
+		<span className='action-label'>{code.label}</span>
+	</SplitButton>;
 }
-
 
 export function AddMarkdownCellButton({ notebookInstance, index, bordered }: { notebookInstance: IPositronNotebookInstance; index: number; bordered?: boolean }) {
 
@@ -57,7 +112,7 @@ export function AddMarkdownCellButton({ notebookInstance, index, bordered }: { n
 		bordered={bordered}
 		fullLabel={fullLabel}
 		hoverManager={notebookInstance.hoverManager}
-		icon={Codicon.plus}
+		icon={Codicon.addSmall}
 		label={label}
 		onClick={() => notebookInstance.addCell(CellKind.Markup, index, true)}
 	/>;

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -2337,7 +2337,7 @@ registerAction2(class extends NotebookAction2 {
 			id: 'positronNotebook.addCodeCell',
 			title: localize2('addCodeCell', 'Code'),
 			tooltip: localize2('addCodeCell.tooltip', 'New Code Cell'),
-			icon: ThemeIcon.fromId('add-small'),
+			icon: ThemeIcon.fromId('add'),
 			f1: true,
 			category: POSITRON_NOTEBOOK_CATEGORY,
 			positronActionBarOptions: {
@@ -2374,7 +2374,7 @@ registerAction2(class extends NotebookAction2 {
 			id: 'positronNotebook.addMarkdownCell',
 			title: localize2('addMarkdownCell', 'Markdown'),
 			tooltip: localize2('addMarkdownCell.tooltip', 'New Markdown Cell'),
-			icon: ThemeIcon.fromId('add-small'),
+			icon: ThemeIcon.fromId('add'),
 			f1: true,
 			category: POSITRON_NOTEBOOK_CATEGORY,
 			positronActionBarOptions: {

--- a/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/positronNotebook.contribution.ts
@@ -2337,7 +2337,7 @@ registerAction2(class extends NotebookAction2 {
 			id: 'positronNotebook.addCodeCell',
 			title: localize2('addCodeCell', 'Code'),
 			tooltip: localize2('addCodeCell.tooltip', 'New Code Cell'),
-			icon: ThemeIcon.fromId('add'),
+			icon: ThemeIcon.fromId('add-small'),
 			f1: true,
 			category: POSITRON_NOTEBOOK_CATEGORY,
 			positronActionBarOptions: {
@@ -2374,7 +2374,7 @@ registerAction2(class extends NotebookAction2 {
 			id: 'positronNotebook.addMarkdownCell',
 			title: localize2('addMarkdownCell', 'Markdown'),
 			tooltip: localize2('addMarkdownCell.tooltip', 'New Markdown Cell'),
-			icon: ThemeIcon.fromId('add'),
+			icon: ThemeIcon.fromId('add-small'),
 			f1: true,
 			category: POSITRON_NOTEBOOK_CATEGORY,
 			positronActionBarOptions: {

--- a/src/vs/workbench/contrib/positronNotebook/browser/utilityComponents/SplitButton.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/utilityComponents/SplitButton.tsx
@@ -38,6 +38,8 @@ export interface SplitButtonProps {
 	contextMenuService: IContextMenuService;
 	/** Custom dropdown icon class (defaults to codicon-chevron-down) */
 	dropdownIconClass?: string;
+	/** Notified when the dropdown menu opens (true) and closes (false). */
+	onMenuOpenChange?: (open: boolean) => void;
 }
 
 /**
@@ -57,6 +59,7 @@ export const SplitButton: React.FC<PropsWithChildren<SplitButtonProps>> = ({
 	dropdownActions,
 	contextMenuService,
 	dropdownIconClass = 'codicon-chevron-down',
+	onMenuOpenChange,
 	children
 }) => {
 	const dropdownRef = useRef<HTMLButtonElement>(null);
@@ -70,11 +73,13 @@ export const SplitButton: React.FC<PropsWithChildren<SplitButtonProps>> = ({
 		}
 
 		const rect = dropdownRef.current.getBoundingClientRect();
+		onMenuOpenChange?.(true);
 		contextMenuService.showContextMenu({
 			getActions: () => dropdownActions,
 			getAnchor: () => ({ x: rect.left, y: rect.bottom }),
 			anchorAlignment: AnchorAlignment.LEFT,
-			anchorAxisAlignment: AnchorAxisAlignment.VERTICAL
+			anchorAxisAlignment: AnchorAxisAlignment.VERTICAL,
+			onHide: () => onMenuOpenChange?.(false)
 		});
 	};
 

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/addCellSplitButton.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/addCellSplitButton.vitest.tsx
@@ -1,0 +1,111 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IAction } from '../../../../../base/common/actions.js';
+import { IContextMenuService } from '../../../../../platform/contextview/browser/contextView.js';
+import { IContextMenuDelegate } from '../../../../../base/browser/contextmenu.js';
+import { setupRTLRenderer } from '../../../../../test/vitest/reactTestingLibrary.js';
+import { createTestContainer } from '../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../test/vitest/stubInterface.js';
+import { CellKind } from '../../../notebook/common/notebookCommon.js';
+import { AddCellSplitButton } from '../../browser/AddCellButtons.js';
+import { IPositronNotebookInstance } from '../../browser/IPositronNotebookInstance.js';
+
+describe('AddCellSplitButton', () => {
+	const showContextMenu = vi.fn();
+	const ctx = createTestContainer()
+		.withReactServices()
+		// The dropdown opens via the context menu service; capturing the call
+		// lets us inspect the actions and invoke them without rendering a menu.
+		.stub(IContextMenuService, { showContextMenu })
+		.build();
+	const rtl = setupRTLRenderer(() => ctx.reactServices);
+
+	function renderButton(index: number) {
+		const addCell = vi.fn();
+		const notebookInstance = stubInterface<IPositronNotebookInstance>({ addCell });
+		rtl.render(<AddCellSplitButton index={index} notebookInstance={notebookInstance} />);
+		return { addCell };
+	}
+
+	/** Open the dropdown and return the actions handed to the context menu. */
+	async function openDropdownActions(user: ReturnType<typeof userEvent.setup>): Promise<IAction[]> {
+		await user.click(screen.getByRole('button', { name: 'Choose cell type' }));
+		const delegate = showContextMenu.mock.calls.at(-1)?.[0] as IContextMenuDelegate;
+		return delegate.getActions() as IAction[];
+	}
+
+	it('primary button inserts a code cell in edit mode by default', async () => {
+		const { addCell } = renderButton(1);
+
+		const user = userEvent.setup();
+		await user.click(screen.getByRole('button', { name: 'New Code Cell' }));
+
+		expect(addCell).toHaveBeenCalledTimes(1);
+		// enterEditMode === true is how the new cell is focused.
+		expect(addCell).toHaveBeenCalledWith(CellKind.Code, 1, true, '', undefined);
+	});
+
+	it('dropdown offers exactly Code and Raw', async () => {
+		renderButton(1);
+
+		const user = userEvent.setup();
+		const actions = await openDropdownActions(user);
+
+		// Markdown is intentionally absent: it has its own dedicated button.
+		expect(actions.map(a => a.label)).toEqual(['Code', 'Raw']);
+	});
+
+	it('dropdown "Code" option inserts a code cell in edit mode', async () => {
+		const { addCell } = renderButton(1);
+
+		const user = userEvent.setup();
+		const actions = await openDropdownActions(user);
+		act(() => { actions.find(a => a.label === 'Code')!.run(); });
+
+		expect(addCell).toHaveBeenCalledWith(CellKind.Code, 1, true, '', undefined);
+	});
+
+	it('dropdown "Raw" option inserts a raw cell (code cell, language "raw") in edit mode', async () => {
+		const { addCell } = renderButton(1);
+
+		const user = userEvent.setup();
+		const actions = await openDropdownActions(user);
+		act(() => { actions.find(a => a.label === 'Raw')!.run(); });
+
+		expect(addCell).toHaveBeenCalledWith(CellKind.Code, 1, true, '', 'raw');
+	});
+
+	it('signals the menu open on dropdown click and closed on hide', async () => {
+		// The group's container hides itself when focus/hover leave it. The menu
+		// renders at the body level, so without this signal opening the dropdown
+		// would make the whole group vanish. onHide covers escape, selection, and
+		// click-away alike.
+		const onMenuOpenChange = vi.fn();
+		const notebookInstance = stubInterface<IPositronNotebookInstance>({ addCell: vi.fn() });
+		rtl.render(<AddCellSplitButton index={1} notebookInstance={notebookInstance} onMenuOpenChange={onMenuOpenChange} />);
+
+		const user = userEvent.setup();
+		await user.click(screen.getByRole('button', { name: 'Choose cell type' }));
+		expect(onMenuOpenChange).toHaveBeenLastCalledWith(true);
+
+		const delegate = showContextMenu.mock.calls.at(-1)?.[0] as IContextMenuDelegate;
+		act(() => { delegate.onHide?.(false); });
+		expect(onMenuOpenChange).toHaveBeenLastCalledWith(false);
+	});
+
+	it('passes the index prop through to addCell', async () => {
+		const { addCell } = renderButton(0);
+
+		const user = userEvent.setup();
+		await user.click(screen.getByRole('button', { name: 'New Code Cell' }));
+
+		expect(addCell).toHaveBeenCalledWith(CellKind.Code, 0, true, '', undefined);
+	});
+});


### PR DESCRIPTION
Closes #13562 and #13314

Adds a Code/Raw split button to the inline add-cell affordance in Positron
notebooks: the main button adds a Code cell, and its dropdown offers Code or
Raw. Markdown keeps its own dedicated button alongside it. Also polishes the
styling of both inline buttons and the editor action bar's add-cell buttons
(spacing, corner radii, a softened hover, and a lighter `add-small` plus icon).

### Screenshots

**Inline add-cell buttons**

| Before | After |
| --- | --- |
| <img width="222" height="70" alt="image" src="https://github.com/user-attachments/assets/74954a52-eb40-49ca-a2a5-dcfd266ceae5" /> | <img width="227" height="55" alt="image" src="https://github.com/user-attachments/assets/343f5deb-b7d8-42cd-8302-1298426da0c0" /> |

**Editor action bar buttons**

| Before | After |
| --- | --- |
| <img width="174" height="60" alt="image" src="https://github.com/user-attachments/assets/8d5c7cd0-69f1-425c-a8c3-65bd7be84e89" /> | <img width="216" height="59" alt="image" src="https://github.com/user-attachments/assets/92a3c51d-c34f-4d13-a69c-7ef1c98b90d2" />|

### Release Notes

#### New Features
- Added a Code/Raw split button to the inline add-cell control in Positron notebooks (#13314)
- Polished the design of the add cell buttons in Positron notebooks (#13562)

#### Bug Fixes
- N/A

### Validation Steps

@:positron-notebooks

1. Open a Positron notebook and hover between cells to reveal the add-cell controls.
2. Click the main split button and confirm a Code cell is added.
3. Open its dropdown and confirm it offers Code and Raw; add one of each.
4. Confirm the dedicated Markdown button still adds a Markdown cell.
5. Check the inline buttons and the editor action bar add-cell buttons for consistent spacing, corner radii, and hover styling.
