### PR TITLE
Remove underscore artifact on unexecuted code cells

### DIFF
--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/CellLeftActionMenu.tsx
@@ -21,9 +21,6 @@ export function CellLeftActionMenu({ cell }: CellLeftActionMenuProps) {
 	// Observed values
 	const executionOrder = useDebouncedObservedValue(cell.lastExecutionOrder);
 
-	// Determine what to show
-	const showPending = executionOrder === undefined;
-
 	return (
 		<div
 			className='left-hand-action-container'
@@ -31,10 +28,8 @@ export function CellLeftActionMenu({ cell }: CellLeftActionMenuProps) {
 			<div
 				className='left-hand-action-container-bottom'
 			>
-				{/* Execution order badge */}
-				{showPending ? (
-					<span className='execution-order-badge'>-</span>
-				) : executionOrder !== undefined ? (
+				{/* Execution order badge (only shown once the cell has been executed) */}
+				{executionOrder !== undefined ? (
 					<div className='execution-order-badge-container'>
 						<span className='execution-order-badge-bracket'>[</span>
 						<span className='execution-order-badge'> {String(executionOrder)} </span>


### PR DESCRIPTION
Fixes #13565

The left-gutter action menu rendered a `-` placeholder for unexecuted code cells, which showed up as a small underscore-like artifact. The execution-order badge now renders only once a cell has been run; nothing is drawn before that.

### Screenshots

| Before | After |
| --- | --- |
| <img width="95" height="196" alt="image" src="https://github.com/user-attachments/assets/6653bd81-7fa6-4641-89c0-30e78329fb16" /> | <img width="101" height="188" alt="image" src="https://github.com/user-attachments/assets/69a361a8-a9f9-4742-a0e0-2e5cd87cf4a6" /> |

_Note the after screenshots are taken on a branch that hasnt had the gutter shrinking work merged in yet._

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- Remove underscore-like artifact to the left of unexecuted notebook code cells (#13565)

### Validation Steps

@:positron-notebooks

1. Open or create a notebook and add a new code cell (do not run it).
2. Confirm no `-`/underscore artifact appears in the left gutter.
3. Run the cell and confirm the `[ 1 ]` execution-order badge appears in that same slot.
