### PR TITLE
Gate Positron-integrated AI features on `ai.enabled`

### DIFF
--- a/.claude/rules/ai-gating.md
+++ b/.claude/rules/ai-gating.md
@@ -1,0 +1,50 @@
+# Gating AI features on `ai.enabled`
+
+`ai.enabled` is the single main switch for all of Positron's AI features (Next Edit Suggestions, notebook AI, console Fix/Explain, etc.). Anything that calls a model, suggests completions, or surfaces AI actions MUST be gated on it from the start, so the user (or a Posit Workbench admin) can turn everything off in one place.
+
+## The setting
+
+`ai.enabled` is Positron-owned, defaults to `true`, and is `WINDOW`-scoped. It's declared in [positronAIConfiguration.ts](../../src/vs/workbench/contrib/positronAssistant/common/positronAIConfiguration.ts), which exports the key as `AI_ENABLED_KEY`. Import that constant; don't hard-code the `'ai.enabled'` string.
+
+There's no shared helper that wraps the gate, so the key string is the contract. `ai.enabled` sits above each feature's own preconditions, so check it in addition to whatever feature-specific gates already exist (a feature setting, "has chat models", notebook mode, etc.) rather than replacing them. The feature shows only when `ai.enabled` and all its own conditions are true.
+
+## How to read it
+
+Pick the form that matches where the code runs. All three are in use today; copy the closest one.
+
+**Action `when` clause / precondition** (registering an action or menu item):
+
+```ts
+import { AI_ENABLED_KEY } from '.../positronAssistant/common/positronAIConfiguration.js';
+
+precondition: ContextKeyExpr.has(`config.${AI_ENABLED_KEY}`),
+```
+
+See [AskAssistantAction.tsx](../../src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx).
+
+**Service / non-React code**:
+
+```ts
+if (this._configurationService.getValue<boolean>(AI_ENABLED_KEY) === true) { ... }
+```
+
+See [ghostCell/controller.ts](../../src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/controller.ts).
+
+**React component**:
+
+```ts
+const aiEnabled = usePositronConfiguration<boolean>(AI_ENABLED_KEY);
+```
+
+See [NotebookCellQuickFix.tsx](../../src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx) and [activityErrorMessage.tsx](../../src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx).
+
+## Things to get right
+
+- **Read the value live, don't cache it at construction.** `ai.enabled` toggles without a window reload, so read `getValue` each time (or react to `onDidChangeConfiguration` / use the React hook). A value captured once in a constructor goes stale.
+- **Read the value, not a policy name.** In Posit Workbench `ai.enabled` is enforced through the `POSITRON_ENFORCED_SETTINGS` env var, not the VS Code policy block. `getValue` and the context key already reflect the enforced value; checking a policy name would miss it.
+- **Default is `true`.** A fresh profile with nothing set reads as enabled. Compare against `=== true` to show the feature, or `=== false` to hide it, so the on and off cases are spelled out and an undefined value can't slip through as truthy.
+- **Extension code reads it too.** If the feature lives in an extension (e.g. `next-edit-suggestions`), gate on the same `ai.enabled` key via the extension's configuration API.
+
+## Companion extensions
+
+Posit Assistant (separate repo, `posit-dev/assistant`) reads `ai.enabled` on its own and combines it with `assistant.enabled`, so the chat is on only when both are true. If your feature spans both Positron core and a companion extension, gate on both sides; don't rely on one to cover the other.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ Positron has three test categories:
   - Formatting: `node scripts/format.mts <file> [file2] ...`
   - ESLint: `npx eslint --fix <file> [file2] ...`
 - When registering user-facing configuration, follow the **[guidance on settings](.claude/rules/configuration.md)**. Setting keys, titles, and display names omit redundant terms ("Positron", "Setting", etc.); `localize()` IDs keep the `positron.` prefix.
+- When adding AI-related functionality (anything that calls a model, suggests completions, or surfaces AI actions), gate it on the `ai.enabled` main switch -- see **[AI feature gating](.claude/rules/ai-gating.md)**.
 
 ## General
 

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -5164,7 +5164,7 @@
 				},
 				{
 					"command": "github.copilot.interactiveSession.feedback",
-					"when": "github.copilot-chat.activated && !github.copilot.interactiveSession.disabled && !config.chat.disableAIFeatures"
+					"when": "github.copilot-chat.activated && !github.copilot.interactiveSession.disabled && chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.debug.workbenchState",
@@ -5192,7 +5192,7 @@
 				},
 				{
 					"command": "github.copilot.chat.review",
-					"when": "!github.copilot.interactiveSession.disabled && !config.chat.disableAIFeatures"
+					"when": "!github.copilot.interactiveSession.disabled && chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.chat.review.apply",
@@ -5444,11 +5444,11 @@
 				},
 				{
 					"command": "github.copilot.chat.tools.memory.showMemories",
-					"when": "config.github.copilot.chat.tools.memory.enabled && !config.chat.disableAIFeatures"
+					"when": "config.github.copilot.chat.tools.memory.enabled && chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.chat.tools.memory.clearMemories",
-					"when": "config.github.copilot.chat.tools.memory.enabled && !config.chat.disableAIFeatures"
+					"when": "config.github.copilot.chat.tools.memory.enabled && chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.sessions.commit",
@@ -5492,79 +5492,79 @@
 				},
 				{
 					"command": "github.copilot.cli.newSession",
-					"when": "!config.chat.disableAIFeatures"
+					"when": "chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.cli.newSessionToSide",
-					"when": "!config.chat.disableAIFeatures"
+					"when": "chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.chat.explain.palette",
-					"when": "!config.chat.disableAIFeatures"
+					"when": "chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.chat.codeReview.run",
-					"when": "!config.chat.disableAIFeatures"
+					"when": "chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.chat.openUserPreferences",
-					"when": "config.github.copilot.chat.enableUserPreferences && !config.chat.disableAIFeatures"
+					"when": "config.github.copilot.chat.enableUserPreferences && chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.chat.generate",
-					"when": "!config.chat.disableAIFeatures"
+					"when": "chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.chat.fix",
-					"when": "!config.chat.disableAIFeatures"
+					"when": "chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.terminal.explainTerminalLastCommand",
-					"when": "!config.chat.disableAIFeatures"
+					"when": "chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.chat.attachFile",
-					"when": "!config.chat.disableAIFeatures"
+					"when": "chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.chat.attachSelection",
-					"when": "!config.chat.disableAIFeatures"
+					"when": "chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.open.walkthrough",
-					"when": "!config.chat.disableAIFeatures"
+					"when": "chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.debug.generateInlineEditTests",
-					"when": "resourceScheme == 'ccreq' && !config.chat.disableAIFeatures"
+					"when": "resourceScheme == 'ccreq' && chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.buildRemoteWorkspaceIndex",
-					"when": "github.copilot-chat.activated && !config.chat.disableAIFeatures"
+					"when": "github.copilot-chat.activated && chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.report",
-					"when": "!config.chat.disableAIFeatures"
+					"when": "chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.chat.otel.exportAgentTracesDB",
-					"when": "config.github.copilot.chat.otel.dbSpanExporter.enabled && !config.chat.disableAIFeatures"
+					"when": "config.github.copilot.chat.otel.dbSpanExporter.enabled && chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.debug.showChatLogView",
-					"when": "!config.chat.disableAIFeatures"
+					"when": "chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.debug.collectDiagnostics",
-					"when": "!config.chat.disableAIFeatures"
+					"when": "chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.chat.notebook.enableFollowCellExecution",
-					"when": "config.github.copilot.chat.notebook.followCellExecution.enabled && !config.chat.disableAIFeatures"
+					"when": "config.github.copilot.chat.notebook.followCellExecution.enabled && chatAiFeaturesEnabled"
 				},
 				{
 					"command": "github.copilot.chat.notebook.disableFollowCellExecution",
-					"when": "config.github.copilot.chat.notebook.followCellExecution.enabled && !config.chat.disableAIFeatures"
+					"when": "config.github.copilot.chat.notebook.followCellExecution.enabled && chatAiFeaturesEnabled"
 				}
 			],
 			"view/title": [

--- a/extensions/copilot/package.json
+++ b/extensions/copilot/package.json
@@ -5549,6 +5549,22 @@
 				{
 					"command": "github.copilot.chat.otel.exportAgentTracesDB",
 					"when": "config.github.copilot.chat.otel.dbSpanExporter.enabled && !config.chat.disableAIFeatures"
+				},
+				{
+					"command": "github.copilot.debug.showChatLogView",
+					"when": "!config.chat.disableAIFeatures"
+				},
+				{
+					"command": "github.copilot.debug.collectDiagnostics",
+					"when": "!config.chat.disableAIFeatures"
+				},
+				{
+					"command": "github.copilot.chat.notebook.enableFollowCellExecution",
+					"when": "config.github.copilot.chat.notebook.followCellExecution.enabled && !config.chat.disableAIFeatures"
+				},
+				{
+					"command": "github.copilot.chat.notebook.disableFollowCellExecution",
+					"when": "config.github.copilot.chat.notebook.followCellExecution.enabled && !config.chat.disableAIFeatures"
 				}
 			],
 			"view/title": [

--- a/extensions/next-edit-suggestions/src/config.ts
+++ b/extensions/next-edit-suggestions/src/config.ts
@@ -34,6 +34,16 @@ export function getSelectedCompletionModelId(): string {
 		.get<string>('selectedCompletionModel') || '';
 }
 
+/**
+ * Whether Positron's AI features are enabled. Gated on the Positron-owned
+ * `ai.enabled` main switch. Next Edit Suggestions only work when AI is enabled.
+ */
+function isAIEnabled(): boolean {
+	return vscode.workspace
+		.getConfiguration('ai')
+		.get<boolean>('enabled') === true;
+}
+
 function isFileExcludedFromAI(uri: vscode.Uri): boolean {
 	const config = vscode.workspace.getConfiguration('positron.assistant');
 
@@ -78,11 +88,17 @@ function isCompletionEnabledForFileType(document: vscode.TextDocument): boolean 
 /** Determines whether inline completions are enabled for a document.
  *
  * Checks are evaluated in order:
- * 1. `positron.assistant.aiExcludes` -- file excluded from all AI features.
- * 2. `nextEditSuggestions.enable` -- per-language ID, then filename glob.
- * 3. `nextEditSuggestions.enable` -- `*` wildcard.
+ * 1. `ai.enabled` -- main switch for Positron's AI features.
+ * 2. `positron.assistant.aiExcludes` -- file excluded from all AI features.
+ * 3. `nextEditSuggestions.enable` -- per-language ID, then filename glob.
+ * 4. `nextEditSuggestions.enable` -- `*` wildcard.
  */
 export function isCompletionEnabled(document: vscode.TextDocument): boolean {
+	if (!isAIEnabled()) {
+		log.debug('Inline completions are disabled because the ai.enabled setting is off.');
+		return false;
+	}
+
 	if (isFileExcludedFromAI(document.uri)) {
 		log.debug(`AI features are disabled for ${document.uri.fsPath} based on positron.assistant.aiExcludes configuration.`);
 		return false;

--- a/extensions/next-edit-suggestions/src/test/config.test.ts
+++ b/extensions/next-edit-suggestions/src/test/config.test.ts
@@ -11,6 +11,7 @@ import { isCompletionEnabled } from '../config.js';
 function setupConfigStubs(values: {
 	aiExcludes?: string[];
 	enable?: Record<string, boolean>;
+	aiEnabled?: boolean;
 }): void {
 	const positronAssistantGet = sinon.stub();
 	positronAssistantGet.withArgs('aiExcludes').returns(values.aiExcludes);
@@ -18,9 +19,16 @@ function setupConfigStubs(values: {
 	const nextEditSuggestionsGet = sinon.stub();
 	nextEditSuggestionsGet.withArgs('enable').returns(values.enable);
 
+	// Default the AI main switch on so existing cases exercise the per-file /
+	// per-language logic; the gate has its own dedicated suite. An explicit
+	// `aiEnabled: undefined` models the setting being unset.
+	const aiGet = sinon.stub();
+	aiGet.withArgs('enabled').returns(Object.hasOwn(values, 'aiEnabled') ? values.aiEnabled : true);
+
 	const getConfiguration = sinon.stub(vscode.workspace, 'getConfiguration');
 	getConfiguration.withArgs('positron.assistant').returns({ get: positronAssistantGet } as unknown as vscode.WorkspaceConfiguration);
 	getConfiguration.withArgs('nextEditSuggestions').returns({ get: nextEditSuggestionsGet } as unknown as vscode.WorkspaceConfiguration);
+	getConfiguration.withArgs('ai').returns({ get: aiGet } as unknown as vscode.WorkspaceConfiguration);
 }
 
 function mockDocument(fsPath: string, languageId: string): vscode.TextDocument {
@@ -31,6 +39,41 @@ function mockDocument(fsPath: string, languageId: string): vscode.TextDocument {
 suite('config / isCompletionEnabled', () => {
 	teardown(() => {
 		sinon.restore();
+	});
+
+	suite('ai.enabled gates everything', () => {
+		test('completions disabled when ai.enabled is false', () => {
+			setupConfigStubs({
+				aiEnabled: false,
+				aiExcludes: [],
+				enable: { '*': true, typescript: true },
+			});
+
+			const doc = mockDocument('/project/src/file.ts', 'typescript');
+			assert.strictEqual(isCompletionEnabled(doc), false);
+		});
+
+		test('completions disabled when ai.enabled is unset', () => {
+			setupConfigStubs({
+				aiEnabled: undefined,
+				aiExcludes: [],
+				enable: { '*': true },
+			});
+
+			const doc = mockDocument('/project/src/file.ts', 'typescript');
+			assert.strictEqual(isCompletionEnabled(doc), false);
+		});
+
+		test('completions enabled when ai.enabled is true', () => {
+			setupConfigStubs({
+				aiEnabled: true,
+				aiExcludes: [],
+				enable: { '*': true },
+			});
+
+			const doc = mockDocument('/project/src/file.ts', 'typescript');
+			assert.strictEqual(isCompletionEnabled(doc), true);
+		});
 	});
 
 	suite('aiExcludes takes precedence over nextEditSuggestions.enable', () => {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -208,7 +208,7 @@ abstract class OpenChatGlobalAction extends Action2 {
 			precondition: ContextKeyExpr.and(
 				ChatContextKeys.Setup.hidden.negate(),
 				ChatContextKeys.Setup.disabledInWorkspace.negate(),
-				ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+				ChatContextKeys.aiFeaturesEnabled,
 			),
 			// --- End Positron ---
 		});
@@ -935,7 +935,7 @@ export function registerChatActions() {
 				// Hide from command palette when AI features are disabled.
 				precondition: ContextKeyExpr.and(
 					ChatContextKeys.chatModeKind.isEqualTo(ChatModeKind.Agent),
-					ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+					ChatContextKeys.aiFeaturesEnabled,
 				),
 				// --- End Positron ---
 				keybinding: [{
@@ -972,7 +972,7 @@ export function registerChatActions() {
 				// Hide from command palette when AI features are disabled.
 				precondition: ContextKeyExpr.and(
 					ChatContextKeys.inChatSession,
-					ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+					ChatContextKeys.aiFeaturesEnabled,
 				),
 				// --- End Positron ---
 				keybinding: [{
@@ -1007,7 +1007,7 @@ export function registerChatActions() {
 				precondition: ContextKeyExpr.and(
 					ChatContextKeys.inChatSession,
 					ChatContextKeys.Editing.hasQuestionCarousel,
-					ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+					ChatContextKeys.aiFeaturesEnabled,
 				),
 				// --- End Positron ---
 				keybinding: [{
@@ -1038,7 +1038,7 @@ export function registerChatActions() {
 				precondition: ContextKeyExpr.and(
 					ChatContextKeys.inChatSession,
 					ChatContextKeys.Editing.hasQuestionCarousel,
-					ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+					ChatContextKeys.aiFeaturesEnabled,
 				),
 				// --- End Positron ---
 				keybinding: [{
@@ -1070,7 +1070,7 @@ export function registerChatActions() {
 					ChatContextKeys.inChatSession,
 					ChatContextKeys.Editing.hasQuestionCarousel,
 					ChatContextKeys.chatQuestionCarouselHasTerminal,
-					ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+					ChatContextKeys.aiFeaturesEnabled,
 				),
 				// --- End Positron ---
 				keybinding: [{
@@ -1100,7 +1100,7 @@ export function registerChatActions() {
 				// Hide from command palette when AI features are disabled.
 				precondition: ContextKeyExpr.and(
 					ChatContextKeys.inChatSession,
-					ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+					ChatContextKeys.aiFeaturesEnabled,
 				),
 				// --- End Positron ---
 				keybinding: [{

--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
@@ -614,7 +614,7 @@ registerAction2(class RestoreLastCheckpoint extends Action2 {
 				ChatContextKeys.inChatSession,
 				ContextKeyExpr.equals(`config.${ChatConfiguration.CheckpointsEnabled}`, true),
 				ContextKeyExpr.or(ChatContextKeys.lockedToCodingAgent.negate(), ChatContextKeyExprs.isAgentHostSession),
-				ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+				ChatContextKeys.aiFeaturesEnabled,
 			),
 			// --- End Positron ---
 		});

--- a/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts
@@ -79,7 +79,7 @@ const chatViewDescriptor: IViewDescriptor = {
 		// --- Start Positron ---
 		// Hide the Chat view (and its auto-generated "Focus on Chat View" command)
 		// when AI features are disabled.
-		ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+		ChatContextKeys.aiFeaturesEnabled,
 		// --- End Positron ---
 		ContextKeyExpr.or(
 			ContextKeyExpr.and(

--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
@@ -261,7 +261,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 							ChatContextKeys.Setup.completed.negate(),
 							ChatContextKeys.Entitlement.canSignUp
 						),
-						ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+						ChatContextKeys.aiFeaturesEnabled,
 					),
 					// --- End Positron ---
 				});
@@ -464,7 +464,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 							ChatContextKeys.Entitlement.canSignUp,
 							ChatContextKeys.Entitlement.planFree
 						),
-						ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+						ChatContextKeys.aiFeaturesEnabled,
 					),
 					// --- End Positron ---
 					menu: {
@@ -526,7 +526,7 @@ export class ChatSetupContribution extends Disposable implements IWorkbenchContr
 							ChatContextKeys.Entitlement.planProPlus,
 							ChatContextKeys.Entitlement.planEdu,
 						),
-						ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+						ChatContextKeys.aiFeaturesEnabled,
 					),
 					// --- End Positron ---
 					menu: {

--- a/src/vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorActions.ts
@@ -13,6 +13,9 @@ import { IEditorService } from '../../../../services/editor/common/editorService
 import { isCodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { IPlanReviewFeedbackService } from './planReviewFeedbackService.js';
 import { CHAT_CATEGORY } from '../actions/chatActions.js';
+// --- Start Positron ---
+import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
+// --- End Positron ---
 
 export const PlanReviewFeedbackMenuId = MenuId.for('planReviewFeedback.editorContent');
 
@@ -58,7 +61,7 @@ class SubmitPlanReviewFeedbackAction extends Action2 {
 			// Hide when AI features are disabled.
 			precondition: ContextKeyExpr.and(
 				hasPlanReviewFeedback,
-				ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+				ChatContextKeys.aiFeaturesEnabled,
 			),
 			// --- End Positron ---
 			menu: {
@@ -96,7 +99,7 @@ class NavigatePlanReviewFeedbackAction extends Action2 {
 			// Hide when AI features are disabled.
 			precondition: ContextKeyExpr.and(
 				hasPlanReviewFeedback,
-				ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+				ChatContextKeys.aiFeaturesEnabled,
 			),
 			// --- End Positron ---
 			menu: {
@@ -145,7 +148,7 @@ class ClearAllPlanReviewFeedbackAction extends Action2 {
 			// Hide when AI features are disabled.
 			precondition: ContextKeyExpr.and(
 				hasPlanReviewFeedback,
-				ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true),
+				ChatContextKeys.aiFeaturesEnabled,
 			),
 			// --- End Positron ---
 			menu: {

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -11,6 +11,9 @@ import { ViewContainerLocation } from '../../../../common/views.js';
 import { ChatEntitlementContextKeys } from '../../../../services/chat/common/chatEntitlementService.js';
 import { ChatAccountPolicyGateActiveContext } from '../../../../services/policies/common/accountPolicyService.js';
 import { ChatAgentLocation, ChatModeKind, ChatPermissionLevel } from '../constants.js';
+// --- Start Positron ---
+import { AI_ENABLED_KEY } from '../../../positronAssistant/common/positronAIConfiguration.js';
+// --- End Positron ---
 
 export namespace ChatContextKeys {
 	export const responseVote = new RawContextKey<string>('chatSessionResponseVote', '', { type: 'string', description: localize('interactiveSessionResponseVote', "When the response has been voted up, is set to 'up'. When voted down, is set to 'down'. Otherwise an empty string.") });
@@ -58,9 +61,12 @@ export namespace ChatContextKeys {
 	export const supported = ContextKeyExpr.or(IsWebContext.negate(), RemoteNameContext.notEqualsTo(''), ContextKeyExpr.has('config.chat.experimental.serverlessWebEnabled'));
 	export const enabled = new RawContextKey<boolean>('chatIsEnabled', false, { type: 'boolean', description: localize('chatIsEnabled', "True when chat is enabled because a default chat participant is activated with an implementation.") });
 	// --- Start Positron ---
-	// available = enabled AND Positron's AI features are not disabled via chat.disableAIFeatures.
+	// available = enabled AND chat AI is not disabled by either killswitch:
+	// Copilot's own `chat.disableAIFeatures`, or Positron's `ai.enabled` main switch.
 	// Use this in action preconditions instead of combining enabled + notEquals() inline everywhere.
-	export const available = ContextKeyExpr.and(enabled, ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true))!;
+	// `ai.enabled` defaults to true, so notEquals(false) keeps unset profiles enabled and only
+	// an explicit `false` hides the commands.
+	export const available = ContextKeyExpr.and(enabled, ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true), ContextKeyExpr.notEquals(`config.${AI_ENABLED_KEY}`, false))!;
 	// --- End Positron ---
 	export const accountPolicyGateActive = ChatAccountPolicyGateActiveContext;
 

--- a/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
+++ b/src/vs/workbench/contrib/chat/common/actions/chatContextKeys.ts
@@ -11,9 +11,6 @@ import { ViewContainerLocation } from '../../../../common/views.js';
 import { ChatEntitlementContextKeys } from '../../../../services/chat/common/chatEntitlementService.js';
 import { ChatAccountPolicyGateActiveContext } from '../../../../services/policies/common/accountPolicyService.js';
 import { ChatAgentLocation, ChatModeKind, ChatPermissionLevel } from '../constants.js';
-// --- Start Positron ---
-import { AI_ENABLED_KEY } from '../../../positronAssistant/common/positronAIConfiguration.js';
-// --- End Positron ---
 
 export namespace ChatContextKeys {
 	export const responseVote = new RawContextKey<string>('chatSessionResponseVote', '', { type: 'string', description: localize('interactiveSessionResponseVote', "When the response has been voted up, is set to 'up'. When voted down, is set to 'down'. Otherwise an empty string.") });
@@ -61,12 +58,16 @@ export namespace ChatContextKeys {
 	export const supported = ContextKeyExpr.or(IsWebContext.negate(), RemoteNameContext.notEqualsTo(''), ContextKeyExpr.has('config.chat.experimental.serverlessWebEnabled'));
 	export const enabled = new RawContextKey<boolean>('chatIsEnabled', false, { type: 'boolean', description: localize('chatIsEnabled', "True when chat is enabled because a default chat participant is activated with an implementation.") });
 	// --- Start Positron ---
-	// available = enabled AND chat AI is not disabled by either killswitch:
-	// Copilot's own `chat.disableAIFeatures`, or Positron's `ai.enabled` main switch.
-	// Use this in action preconditions instead of combining enabled + notEquals() inline everywhere.
-	// `ai.enabled` defaults to true, so notEquals(false) keeps unset profiles enabled and only
-	// an explicit `false` hides the commands.
-	export const available = ContextKeyExpr.and(enabled, ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true), ContextKeyExpr.notEquals(`config.${AI_ENABLED_KEY}`, false))!;
+	// True when both AI enablement switches permit AI: Copilot's own `chat.disableAIFeatures`
+	// is not on, AND Positron's `ai.enabled` main switch is not off. `ChatAgentService`
+	// keeps this in sync from `!_isAIDisabled()` (it already watches both settings).
+	// Reference it in an action's precondition / a menu `when` (in core or in the
+	// Copilot extension's package.json, by the key name) wherever the gate previously
+	// checked only `chat.disableAIFeatures`, so `ai.enabled` hides the command too.
+	// Defaults to true so unset profiles stay enabled until the service runs.
+	export const aiFeaturesEnabled = new RawContextKey<boolean>('chatAiFeaturesEnabled', true, { type: 'boolean', description: localize('positron.chatAiFeaturesEnabled', "True when Positron's AI features are enabled, i.e. neither `chat.disableAIFeatures` nor the `ai.enabled` main switch turns AI off.") });
+	// available = a chat agent is registered AND AI features are enabled.
+	export const available = ContextKeyExpr.and(enabled, aiFeaturesEnabled)!;
 	// --- End Positron ---
 	export const accountPolicyGateActive = ChatAccountPolicyGateActiveContext;
 

--- a/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
@@ -306,6 +306,9 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 	private readonly _hasDefaultAgent: IContextKey<boolean>;
 	private readonly _extensionAgentRegistered: IContextKey<boolean>;
 	private readonly _defaultAgentRegistered: IContextKey<boolean>;
+	// --- Start Positron ---
+	private readonly _aiFeaturesEnabled: IContextKey<boolean>;
+	// --- End Positron ---
 	private _hasToolsAgent = false;
 
 	private _chatParticipantDetectionProviders = new Map<number, IChatParticipantDetectionProvider>();
@@ -329,6 +332,10 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 		this._hasDefaultAgent = ChatContextKeys.enabled.bindTo(this.contextKeyService);
 		this._extensionAgentRegistered = ChatContextKeys.extensionParticipantRegistered.bindTo(this.contextKeyService);
 		this._defaultAgentRegistered = ChatContextKeys.panelParticipantRegistered.bindTo(this.contextKeyService);
+		// --- Start Positron ---
+		this._aiFeaturesEnabled = ChatContextKeys.aiFeaturesEnabled.bindTo(this.contextKeyService);
+		this._aiFeaturesEnabled.set(!this._isAIDisabled());
+		// --- End Positron ---
 		this._register(contextKeyService.onDidChangeContext((e) => {
 			if (e.affectsSome(this._agentsContextKeys)) {
 				this._updateContextKeys();
@@ -452,6 +459,8 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 		if (testAgentRegistered || this.configurationService.getValue('positron.assistant.enable')) {
 			this._defaultAgentRegistered.set(defaultAgentRegistered && !this._isAIDisabled());
 		}
+		// Keep the `chatAiFeaturesEnabled` gate in sync with both AI switches.
+		this._aiFeaturesEnabled.set(!this._isAIDisabled());
 		// --- End Positron ---
 		this._extensionAgentRegistered.set(extensionAgentRegistered);
 		if (toolsAgentRegistered !== this._hasToolsAgent) {

--- a/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/participants/chatAgents.ts
@@ -337,13 +337,15 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 		// --- Start Positron ---
 		// `chat.disableAIFeatures` should hide the chat UI while keeping the chat
 		// extension's `vscode.lm` model provider available for other consumers.
+		// `ai.enabled` is Positron's main AI switch and sits above it: turning it
+		// off also hides the chat UI.
 		// The chat UI is gated by the `chatIsEnabled` / `chatPanelParticipantRegistered`
-		// context keys, so recompute them when the setting changes. Fire
+		// context keys, so recompute them when either setting changes. Fire
 		// `onDidChangeAgents` too so consumers that resolve agents lazily (e.g. the
 		// inline chat enabler, which reads `getDefaultAgent(EditorInline)`) recompute
-		// their enablement when the setting is toggled at runtime.
+		// their enablement when a setting is toggled at runtime.
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(ChatConfiguration.AIDisabled)) {
+			if (e.affectsConfiguration(ChatConfiguration.AIDisabled) || e.affectsConfiguration('ai.enabled')) {
 				this._updateHasDefaultAgent();
 				this._updateContextKeys();
 				this._onDidChangeAgents.fire(undefined);
@@ -354,7 +356,12 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 
 	// --- Start Positron ---
 	private _isAIDisabled(): boolean {
-		return this.configurationService.getValue(ChatConfiguration.AIDisabled) === true;
+		// `chat.disableAIFeatures` is Copilot's own switch. Positron's `ai.enabled`
+		// is the main switch on top: if it's off, AI is off no matter what
+		// `chat.disableAIFeatures` says. When `ai.enabled` is on, Copilot is back to
+		// being governed by `chat.disableAIFeatures` alone.
+		return this.configurationService.getValue(ChatConfiguration.AIDisabled) === true
+			|| this.configurationService.getValue('ai.enabled') === false;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions.ts
@@ -12,6 +12,7 @@ import { IWorkbenchEnvironmentService } from '../../../../services/environment/c
 import { OPEN_AGENTS_WINDOW_COMMAND_ID, OPEN_AGENTS_WINDOW_PRECONDITION } from '../../common/constants.js';
 // --- Start Positron ---
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
+import { ChatContextKeys } from '../../common/actions/chatContextKeys.js';
 // --- End Positron ---
 
 export class OpenAgentsWindowAction extends Action2 {
@@ -22,7 +23,7 @@ export class OpenAgentsWindowAction extends Action2 {
 			category: CHAT_CATEGORY,
 			// --- Start Positron ---
 			// Hide when AI features are disabled.
-			precondition: ContextKeyExpr.and(OPEN_AGENTS_WINDOW_PRECONDITION, ContextKeyExpr.notEquals('config.chat.disableAIFeatures', true)),
+			precondition: ContextKeyExpr.and(OPEN_AGENTS_WINDOW_PRECONDITION, ChatContextKeys.aiFeaturesEnabled),
 			// --- End Positron ---
 			f1: true,
 			menu: [{

--- a/src/vs/workbench/contrib/chat/test/common/participants/chatAgents.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/participants/chatAgents.test.ts
@@ -202,14 +202,15 @@ suite('ChatAgents', function () {
 			panelParticipantRegistered: ChatContextKeys.panelParticipantRegistered.getValue(contextKeyService),
 		});
 
-		const fireAIDisabledChange = () => {
+		const fireConfigChange = (changedKey: string) => {
 			configurationService.onDidChangeConfigurationEmitter.fire({
-				affectsConfiguration: (key: string) => key === ChatConfiguration.AIDisabled,
-				affectedKeys: new Set([ChatConfiguration.AIDisabled]),
+				affectsConfiguration: (key: string) => key === changedKey,
+				affectedKeys: new Set([changedKey]),
 				change: { keys: [], overrides: [] },
 				source: ConfigurationTarget.USER,
 			});
 		};
+		const fireAIDisabledChange = () => fireConfigChange(ChatConfiguration.AIDisabled);
 
 		test('chat context keys are set when AI features are enabled', () => {
 			store.add(chatAgentService.registerAgent(defaultAgentId, defaultAgentData));
@@ -273,6 +274,42 @@ suite('ChatAgents', function () {
 			fireAIDisabledChange();
 
 			assert.strictEqual(agentsChangedCount, 1, 'onDidChangeAgents fires when the setting is toggled at runtime');
+		});
+
+		// `ai.enabled` is Positron's master AI switch. It overrides
+		// `chat.disableAIFeatures` in one direction only: `ai.enabled = false` forces
+		// the chat UI off regardless of `chat.disableAIFeatures`, while `ai.enabled =
+		// true` (or unset) leaves `chat.disableAIFeatures` to govern Copilot on its own.
+		test('ai.enabled off hides the chat UI even when chat.disableAIFeatures is off', () => {
+			configurationService.setUserConfiguration(ChatConfiguration.AIDisabled, false);
+			configurationService.setUserConfiguration('ai.enabled', false);
+			store.add(chatAgentService.registerAgent(inlineAgentId, inlineAgentData));
+			store.add(chatAgentService.registerAgentImplementation(inlineAgentId, agentImpl));
+
+			assert.deepStrictEqual(contextKeys(), { enabled: false, panelParticipantRegistered: false });
+			assert.strictEqual(chatAgentService.getDefaultAgent(ChatAgentLocation.EditorInline), undefined);
+		});
+
+		test('ai.enabled on does not force the chat UI on while chat.disableAIFeatures is on', () => {
+			configurationService.setUserConfiguration('ai.enabled', true);
+			configurationService.setUserConfiguration(ChatConfiguration.AIDisabled, true);
+			store.add(chatAgentService.registerAgent(defaultAgentId, defaultAgentData));
+			store.add(chatAgentService.registerAgentImplementation(defaultAgentId, agentImpl));
+
+			assert.deepStrictEqual(contextKeys(), { enabled: false, panelParticipantRegistered: false });
+		});
+
+		test('config listener recomputes chat context keys when ai.enabled flips', () => {
+			store.add(chatAgentService.registerAgent(defaultAgentId, defaultAgentData));
+			store.add(chatAgentService.registerAgentImplementation(defaultAgentId, agentImpl));
+
+			configurationService.setUserConfiguration('ai.enabled', false);
+			fireConfigChange('ai.enabled');
+			assert.deepStrictEqual(contextKeys(), { enabled: false, panelParticipantRegistered: false }, 'keys hide when the master switch is off at runtime');
+
+			configurationService.setUserConfiguration('ai.enabled', true);
+			fireConfigChange('ai.enabled');
+			assert.deepStrictEqual(contextKeys(), { enabled: true, panelParticipantRegistered: true }, 'keys return when the master switch is back on at runtime');
 		});
 	});
 	// --- End Positron ---

--- a/src/vs/workbench/contrib/chat/test/common/participants/chatAgents.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/participants/chatAgents.test.ts
@@ -200,6 +200,7 @@ suite('ChatAgents', function () {
 		const contextKeys = () => ({
 			enabled: ChatContextKeys.enabled.getValue(contextKeyService),
 			panelParticipantRegistered: ChatContextKeys.panelParticipantRegistered.getValue(contextKeyService),
+			aiFeaturesEnabled: ChatContextKeys.aiFeaturesEnabled.getValue(contextKeyService),
 		});
 
 		const fireConfigChange = (changedKey: string) => {
@@ -216,7 +217,7 @@ suite('ChatAgents', function () {
 			store.add(chatAgentService.registerAgent(defaultAgentId, defaultAgentData));
 			store.add(chatAgentService.registerAgentImplementation(defaultAgentId, agentImpl));
 
-			assert.deepStrictEqual(contextKeys(), { enabled: true, panelParticipantRegistered: true });
+			assert.deepStrictEqual(contextKeys(), { enabled: true, panelParticipantRegistered: true, aiFeaturesEnabled: true });
 		});
 
 		test('chat context keys are cleared when AI features are disabled', () => {
@@ -224,7 +225,7 @@ suite('ChatAgents', function () {
 			store.add(chatAgentService.registerAgent(defaultAgentId, defaultAgentData));
 			store.add(chatAgentService.registerAgentImplementation(defaultAgentId, agentImpl));
 
-			assert.deepStrictEqual(contextKeys(), { enabled: false, panelParticipantRegistered: false });
+			assert.deepStrictEqual(contextKeys(), { enabled: false, panelParticipantRegistered: false, aiFeaturesEnabled: false });
 		});
 
 		test('config listener recomputes chat context keys when the setting flips', () => {
@@ -233,11 +234,11 @@ suite('ChatAgents', function () {
 
 			configurationService.setUserConfiguration(ChatConfiguration.AIDisabled, true);
 			fireAIDisabledChange();
-			assert.deepStrictEqual(contextKeys(), { enabled: false, panelParticipantRegistered: false }, 'keys hide when AI is disabled at runtime');
+			assert.deepStrictEqual(contextKeys(), { enabled: false, panelParticipantRegistered: false, aiFeaturesEnabled: false }, 'keys hide when AI is disabled at runtime');
 
 			configurationService.setUserConfiguration(ChatConfiguration.AIDisabled, false);
 			fireAIDisabledChange();
-			assert.deepStrictEqual(contextKeys(), { enabled: true, panelParticipantRegistered: true }, 'keys return when AI is re-enabled at runtime');
+			assert.deepStrictEqual(contextKeys(), { enabled: true, panelParticipantRegistered: true, aiFeaturesEnabled: true }, 'keys return when AI is re-enabled at runtime');
 		});
 
 		test('API test agent registers the panel participant regardless of positron.assistant.enable', () => {
@@ -286,7 +287,7 @@ suite('ChatAgents', function () {
 			store.add(chatAgentService.registerAgent(inlineAgentId, inlineAgentData));
 			store.add(chatAgentService.registerAgentImplementation(inlineAgentId, agentImpl));
 
-			assert.deepStrictEqual(contextKeys(), { enabled: false, panelParticipantRegistered: false });
+			assert.deepStrictEqual(contextKeys(), { enabled: false, panelParticipantRegistered: false, aiFeaturesEnabled: false });
 			assert.strictEqual(chatAgentService.getDefaultAgent(ChatAgentLocation.EditorInline), undefined);
 		});
 
@@ -296,7 +297,7 @@ suite('ChatAgents', function () {
 			store.add(chatAgentService.registerAgent(defaultAgentId, defaultAgentData));
 			store.add(chatAgentService.registerAgentImplementation(defaultAgentId, agentImpl));
 
-			assert.deepStrictEqual(contextKeys(), { enabled: false, panelParticipantRegistered: false });
+			assert.deepStrictEqual(contextKeys(), { enabled: false, panelParticipantRegistered: false, aiFeaturesEnabled: false });
 		});
 
 		test('config listener recomputes chat context keys when ai.enabled flips', () => {
@@ -305,11 +306,11 @@ suite('ChatAgents', function () {
 
 			configurationService.setUserConfiguration('ai.enabled', false);
 			fireConfigChange('ai.enabled');
-			assert.deepStrictEqual(contextKeys(), { enabled: false, panelParticipantRegistered: false }, 'keys hide when the master switch is off at runtime');
+			assert.deepStrictEqual(contextKeys(), { enabled: false, panelParticipantRegistered: false, aiFeaturesEnabled: false }, 'keys hide when the master switch is off at runtime');
 
 			configurationService.setUserConfiguration('ai.enabled', true);
 			fireConfigChange('ai.enabled');
-			assert.deepStrictEqual(contextKeys(), { enabled: true, panelParticipantRegistered: true }, 'keys return when the master switch is back on at runtime');
+			assert.deepStrictEqual(contextKeys(), { enabled: true, panelParticipantRegistered: true, aiFeaturesEnabled: true }, 'keys return when the master switch is back on at runtime');
 		});
 	});
 	// --- End Positron ---

--- a/src/vs/workbench/contrib/positronAssistant/browser/positronAssistant.contribution.ts
+++ b/src/vs/workbench/contrib/positronAssistant/browser/positronAssistant.contribution.ts
@@ -1,5 +1,5 @@
 /*---------------------------------------------------------------------------------------------
- *  Copyright (C) 2024-2025 Posit Software, PBC. All rights reserved.
+ *  Copyright (C) 2024-2026 Posit Software, PBC. All rights reserved.
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
@@ -22,6 +22,9 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { ChatAgentLocation, ChatConfiguration } from '../../chat/common/constants.js';
 import { CodeAttributionSource, IConsoleCodeAttribution } from '../../../services/positronConsole/common/positronConsoleCodeExecution.js';
 import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.js';
+
+// Register the `ai.enabled` main switch for Positron's AI features.
+import '../common/positronAIConfiguration.js';
 
 const consoleLanguageIds = ['r', 'python'];
 

--- a/src/vs/workbench/contrib/positronAssistant/common/positronAIConfiguration.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/positronAIConfiguration.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from '../../../../nls.js';
+import {
+	ConfigurationScope,
+	Extensions,
+	IConfigurationRegistry,
+} from '../../../../platform/configuration/common/configurationRegistry.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+
+/**
+ * Main switch for Positron's AI features. When off, all of Positron's AI
+ * features (Next Edit Suggestions, notebook AI, console Fix/Explain, etc.) are
+ * turned off.
+ *
+ * Owned by Positron. It sits above the Posit Assistant extension's
+ * `assistant.enabled` (which controls the chat UI): Posit Assistant also reads
+ * `ai.enabled`, so when it's off the assistant is off regardless of
+ * `assistant.enabled`. This setting seeds the `ai.*` namespace for
+ * Positron-owned AI configuration.
+ */
+export const AI_ENABLED_KEY = 'ai.enabled';
+
+const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
+configurationRegistry.registerConfiguration({
+	id: 'ai',
+	order: 5,
+	title: localize('positron.ai.title', "AI"),
+	type: 'object',
+	properties: {
+		[AI_ENABLED_KEY]: {
+			type: 'boolean',
+			default: true,
+			description: localize(
+				'positron.ai.enabled',
+				"Enable Positron's AI features, such as Next Edit Suggestions and AI features in notebooks and the console. When disabled, all of Positron's AI features are turned off."
+			),
+			scope: ConfigurationScope.WINDOW,
+		}
+	}
+});

--- a/src/vs/workbench/contrib/positronAssistant/common/positronAIConfiguration.ts
+++ b/src/vs/workbench/contrib/positronAssistant/common/positronAIConfiguration.ts
@@ -36,7 +36,7 @@ configurationRegistry.registerConfiguration({
 			default: true,
 			description: localize(
 				'positron.ai.enabled',
-				"Enable Positron's AI features, such as Next Edit Suggestions and AI features in notebooks and the console. When disabled, all of Positron's AI features are turned off."
+				"Enable Positron's AI features, such as Posit Assistant, Posit AI Next Edit Suggestions and AI features in notebooks and the console. When disabled, all of Positron's AI features are turned off."
 			),
 			scope: ConfigurationScope.WINDOW,
 		}

--- a/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx
+++ b/src/vs/workbench/contrib/positronConsole/browser/components/activityErrorMessage.tsx
@@ -16,6 +16,7 @@ import { Button } from '../../../../../base/browser/ui/positronComponents/button
 import { ActivityItemErrorMessage } from '../../../../services/positronConsole/browser/classes/activityItemErrorMessage.js';
 import { ConsoleQuickFix } from './activityErrorQuickFix.js';
 import { usePositronConfiguration, useContextKeyFromString, usePositronExtensionInstalled } from '../../../../../base/browser/positronReactHooks.js';
+import { AI_ENABLED_KEY } from '../../../positronAssistant/common/positronAIConfiguration.js';
 
 // ActivityErrorProps interface.
 export interface ActivityErrorMessageProps {
@@ -35,6 +36,8 @@ export const ActivityErrorMessage = (props: ActivityErrorMessageProps) => {
 	const [showTraceback, setShowTraceback] = useState(false);
 
 	// Configuration hooks.
+	// Main switch for Positron's AI features.
+	const aiEnabled = usePositronConfiguration<boolean>(AI_ENABLED_KEY);
 	const enableAssistantActions = usePositronConfiguration<boolean>('console.assistantActions.enabled');
 	const positAssistantInstalled = usePositronExtensionInstalled('posit.assistant');
 	// Set by the Posit Assistant extension when it has at least one usable model
@@ -43,7 +46,7 @@ export const ActivityErrorMessage = (props: ActivityErrorMessageProps) => {
 	// string is mirrored in the Posit Assistant extension (the two repositories
 	// cannot share a module).
 	const hasChatModels = useContextKeyFromString<boolean>('posit-assistant.hasChatModels');
-	const showAssistantActions = enableAssistantActions && positAssistantInstalled && !!hasChatModels;
+	const showAssistantActions = aiEnabled && enableAssistantActions && positAssistantInstalled && !!hasChatModels;
 
 	// Traceback useEffect.
 	useEffect(() => {

--- a/src/vs/workbench/contrib/positronConsole/test/browser/activityErrorMessage.vitest.tsx
+++ b/src/vs/workbench/contrib/positronConsole/test/browser/activityErrorMessage.vitest.tsx
@@ -32,18 +32,25 @@ describe('ActivityErrorMessage assistant actions gate', () => {
 		.build();
 	const rtl = setupRTLRenderer(() => ctx.reactServices);
 
-	function setup(options: { actionsEnabled?: boolean; hasChatModels?: boolean }) {
+	function setup(options: { aiEnabled?: boolean; actionsEnabled?: boolean; hasChatModels?: boolean }) {
 		const configurationService = ctx.get(IConfigurationService) as TestConfigurationService;
 		const contextKeyService = ctx.get(IContextKeyService) as MockContextKeyService;
+		configurationService.setUserConfiguration('ai.enabled', options.aiEnabled ?? true);
 		configurationService.setUserConfiguration('console.assistantActions.enabled', options.actionsEnabled ?? true);
 		contextKeyService.createKey('posit-assistant.hasChatModels', options.hasChatModels ?? true);
 	}
 
 	it('shows Fix and Explain when enabled, installed, and a model is available', () => {
-		setup({ actionsEnabled: true, hasChatModels: true });
+		setup({ aiEnabled: true, actionsEnabled: true, hasChatModels: true });
 		rtl.render(<ActivityErrorMessage activityItemErrorMessage={errorMessage} />);
 		expect(screen.getByText('Fix')).toBeInTheDocument();
 		expect(screen.getByText('Explain')).toBeInTheDocument();
+	});
+
+	it('hides the actions when the AI main switch is off', () => {
+		setup({ aiEnabled: false, actionsEnabled: true, hasChatModels: true });
+		rtl.render(<ActivityErrorMessage activityItemErrorMessage={errorMessage} />);
+		expect(screen.queryByText('Fix')).not.toBeInTheDocument();
 	});
 
 	it('hides the actions when no model is available', () => {
@@ -69,6 +76,7 @@ describe('ActivityErrorMessage assistant actions gate (Posit Assistant not insta
 	it('hides the actions when Posit Assistant is not installed', () => {
 		const configurationService = ctx.get(IConfigurationService) as TestConfigurationService;
 		const contextKeyService = ctx.get(IContextKeyService) as MockContextKeyService;
+		configurationService.setUserConfiguration('ai.enabled', true);
 		configurationService.setUserConfiguration('console.assistantActions.enabled', true);
 		contextKeyService.createKey('posit-assistant.hasChatModels', true);
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
@@ -17,6 +17,7 @@ import { ChatModeKind } from '../../chat/common/constants.js';
 import { IChatEditingService } from '../../chat/common/editing/chatEditingService.js';
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
+import { AI_ENABLED_KEY } from '../../positronAssistant/common/positronAIConfiguration.js';
 import { PositronModalReactRenderer } from '../../../../base/browser/positronModalReactRenderer.js';
 import { AssistantPanel } from './AssistantPanel/AssistantPanel.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
@@ -52,7 +53,7 @@ export class AskAssistantAction extends Action2 {
 				order: 50,
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('activeEditor', POSITRON_NOTEBOOK_EDITOR_ID),
-					ContextKeyExpr.has('config.positron.assistant.enable'),
+					ContextKeyExpr.has(`config.${AI_ENABLED_KEY}`),
 				)
 			}
 		});

--- a/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
@@ -42,6 +42,9 @@ export class AskAssistantAction extends Action2 {
 			tooltip: localize2('askAssistant.tooltip', 'Ask the assistant about this notebook'),
 			icon: ThemeIcon.fromId('positron-assistant'),
 			f1: true,
+			// Gate the command palette entry and command execution on the AI main switch.
+			// The menu `when` below hides the toolbar button; precondition covers the rest.
+			precondition: ContextKeyExpr.has(`config.${AI_ENABLED_KEY}`),
 			category: localize2('positronNotebook.category', 'Notebook'),
 			positronActionBarOptions: {
 				controlType: 'button',

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/controller.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/controller.ts
@@ -17,6 +17,7 @@ import { INotebookExecutionStateService, NotebookExecutionType } from '../../../
 import { CellEditType } from '../../../../notebook/common/notebookCommon.js';
 import { CellKind as PositronCellKind } from '../../PositronNotebookCells/IPositronNotebookCell.js';
 import { getAssistantSettings, setAssistantSettings } from '../../../common/notebookAssistantMetadata.js';
+import { AI_ENABLED_KEY } from '../../../../positronAssistant/common/positronAIConfiguration.js';
 import {
 	POSITRON_NOTEBOOK_GHOST_CELL_SUGGESTIONS_KEY,
 	POSITRON_NOTEBOOK_GHOST_CELL_DELAY_KEY,
@@ -670,9 +671,22 @@ export class GhostCellController extends Disposable implements IPositronNotebook
 	// ===== Private Helpers =====
 
 	/**
+	 * Main switch for Positron's AI features. Ghost cell suggestions only work
+	 * when AI is enabled.
+	 */
+	private _isAIEnabled(): boolean {
+		return this._configurationService.getValue<boolean>(AI_ENABLED_KEY) === true;
+	}
+
+	/**
 	 * Check if ghost cell suggestions are enabled for this notebook.
 	 */
 	private _isGhostCellEnabled(): boolean {
+		// Gated on the AI main switch.
+		if (!this._isAIEnabled()) {
+			return false;
+		}
+
 		// Check per-notebook override first
 		const settings = getAssistantSettings(this._notebook.textModel?.metadata);
 		if (settings.ghostCellSuggestions !== undefined) {
@@ -710,6 +724,11 @@ export class GhostCellController extends Disposable implements IPositronNotebook
 	 * Returns true if: user hasn't explicitly set enabled, no per-notebook override, and not dismissed this open.
 	 */
 	private _shouldShowOptInPrompt(): boolean {
+		// Don't prompt to opt in when AI is disabled.
+		if (!this._isAIEnabled()) {
+			return false;
+		}
+
 		// Check per-notebook override first - if set, no prompt needed
 		const settings = getAssistantSettings(this._notebook.textModel?.metadata);
 		if (settings.ghostCellSuggestions !== undefined) {

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/test/controller.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/test/controller.vitest.ts
@@ -8,7 +8,6 @@
 import { Event } from '../../../../../../../base/common/event.js';
 import { observableValue } from '../../../../../../../base/common/observable.js';
 import { URI } from '../../../../../../../base/common/uri.js';
-import { ICommandService } from '../../../../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../../../platform/configuration/test/common/testConfigurationService.js';
 import { ILogService, NullLogService } from '../../../../../../../platform/log/common/log.js';
@@ -18,13 +17,13 @@ import { stubInterface } from '../../../../../../../test/vitest/stubInterface.js
 import { INotebookExecutionStateService } from '../../../../../notebook/common/notebookExecutionStateService.js';
 import { NotebookTextModel } from '../../../../../notebook/common/model/notebookTextModel.js';
 import { AI_ENABLED_KEY } from '../../../../../positronAssistant/common/positronAIConfiguration.js';
+import { IPositronNotebookCell, IPositronNotebookCodeCell } from '../../../PositronNotebookCells/IPositronNotebookCell.js';
 import { IPositronNotebookInstance } from '../../../IPositronNotebookInstance.js';
 import { GhostCellController } from '../controller.js';
 
 describe('GhostCellController ai.enabled gate', () => {
 	const config = new TestConfigurationService();
 	const ctx = createTestContainer()
-		.stub(ICommandService, { executeCommand: () => Promise.resolve(undefined) })
 		.stub(IConfigurationService, config)
 		.stub(INotebookExecutionStateService, stubInterface<INotebookExecutionStateService>({ onDidChangeExecution: Event.None }))
 		.stub(INotificationService, stubInterface<INotificationService>())
@@ -35,12 +34,19 @@ describe('GhostCellController ai.enabled gate', () => {
 	// variable across the two tests: with it off the controller must still stay
 	// hidden; with it on the gate lets the suggestion through.
 	function createController(): GhostCellController {
+		const mockCell = stubInterface<IPositronNotebookCell>({
+			isCodeCell: function (this: IPositronNotebookCell): this is IPositronNotebookCodeCell { return true; },
+			getContent: () => '',
+			outputs: observableValue('outputs', []),
+		});
 		const notebook = stubInterface<IPositronNotebookInstance>({
 			uri: URI.parse('file:///test.ipynb'),
-			cells: observableValue('cells', []),
+			cells: observableValue('cells', [mockCell]),
 			container: observableValue<HTMLElement | undefined>('container', undefined),
+			runtimeSession: observableValue('runtimeSession', undefined),
 			textModel: stubInterface<NotebookTextModel>({
 				metadata: { metadata: { positron: { assistant: { ghostCellSuggestions: 'enabled' } } } },
+				cells: undefined,
 			}),
 		});
 		return ctx.instantiationService.createInstance(GhostCellController, notebook);

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/test/controller.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/test/controller.vitest.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { Event } from '../../../../../../../base/common/event.js';
+import { observableValue } from '../../../../../../../base/common/observable.js';
+import { URI } from '../../../../../../../base/common/uri.js';
+import { ICommandService } from '../../../../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { ILogService, NullLogService } from '../../../../../../../platform/log/common/log.js';
+import { INotificationService } from '../../../../../../../platform/notification/common/notification.js';
+import { createTestContainer } from '../../../../../../../test/vitest/positronTestContainer.js';
+import { stubInterface } from '../../../../../../../test/vitest/stubInterface.js';
+import { INotebookExecutionStateService } from '../../../../../notebook/common/notebookExecutionStateService.js';
+import { NotebookTextModel } from '../../../../../notebook/common/model/notebookTextModel.js';
+import { AI_ENABLED_KEY } from '../../../../../positronAssistant/common/positronAIConfiguration.js';
+import { IPositronNotebookInstance } from '../../../IPositronNotebookInstance.js';
+import { GhostCellController } from '../controller.js';
+
+describe('GhostCellController ai.enabled gate', () => {
+	const config = new TestConfigurationService();
+	const ctx = createTestContainer()
+		.stub(ICommandService, { executeCommand: () => Promise.resolve(undefined) })
+		.stub(IConfigurationService, config)
+		.stub(INotebookExecutionStateService, stubInterface<INotebookExecutionStateService>({ onDidChangeExecution: Event.None }))
+		.stub(INotificationService, stubInterface<INotificationService>())
+		.stub(ILogService, new NullLogService())
+		.build();
+
+	// The per-notebook override turns ghost cells ON, so `ai.enabled` is the only
+	// variable across the two tests: with it off the controller must still stay
+	// hidden; with it on the gate lets the suggestion through.
+	function createController(): GhostCellController {
+		const notebook = stubInterface<IPositronNotebookInstance>({
+			uri: URI.parse('file:///test.ipynb'),
+			cells: observableValue('cells', []),
+			container: observableValue<HTMLElement | undefined>('container', undefined),
+			textModel: stubInterface<NotebookTextModel>({
+				metadata: { metadata: { positron: { assistant: { ghostCellSuggestions: 'enabled' } } } },
+			}),
+		});
+		return ctx.instantiationService.createInstance(GhostCellController, notebook);
+	}
+
+	it('stays hidden when ai.enabled is false, even with the per-notebook override on', () => {
+		config.setUserConfiguration(AI_ENABLED_KEY, false);
+		const controller = createController();
+
+		controller.triggerGhostCellSuggestion(0);
+
+		expect(controller.ghostCellState.get().status).toBe('hidden');
+		controller.dispose();
+	});
+
+	it('lets the suggestion through when ai.enabled is true', () => {
+		config.setUserConfiguration(AI_ENABLED_KEY, true);
+		const controller = createController();
+
+		controller.triggerGhostCellSuggestion(0);
+
+		expect(controller.ghostCellState.get().status).toBe('loading');
+		controller.dispose();
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/notebookCells/NotebookCellQuickFix.tsx
@@ -19,6 +19,7 @@ import { encodeBase64, VSBuffer } from '../../../../../base/common/buffer.js';
 import { CHAT_OPEN_ACTION_ID, ACTION_ID_NEW_CHAT } from '../../../chat/browser/actions/chatActions.js';
 import { ChatModeKind } from '../../../chat/common/constants.js';
 import { POSITRON_NOTEBOOK_ENABLED_KEY } from '../../common/positronNotebookConfig.js';
+import { AI_ENABLED_KEY } from '../../../positronAssistant/common/positronAIConfiguration.js';
 import { SplitButton } from '../utilityComponents/SplitButton.js';
 
 const fixPrompt = localize('positronNotebookAssistantFixPrompt', "Fix this notebook cell error.");
@@ -47,13 +48,13 @@ export const NotebookCellQuickFix = (props: NotebookCellQuickFixProps) => {
 	const { commandService, contextMenuService, notificationService } = services;
 
 	// Configuration hooks to conditionally show the quick-fix buttons
-	const enableAssistant = usePositronConfiguration<boolean>('positron.assistant.enable');
+	const aiEnabled = usePositronConfiguration<boolean>(AI_ENABLED_KEY);
 	const enableNotebookMode = usePositronConfiguration<boolean>(POSITRON_NOTEBOOK_ENABLED_KEY);
 	const hasChatModels = useContextKeyFromString<boolean>('positron-assistant.hasChatModels');
 	const sidebarViewEnabled = usePositronConfiguration<boolean>(SIDEBAR_VIEW_SETTING);
 
-	// Only show buttons if assistant is enabled, notebook mode is enabled, and chat models are available
-	const showQuickFix = enableAssistant && enableNotebookMode && hasChatModels;
+	// Only show buttons if AI is enabled, notebook mode is enabled, and chat models are available
+	const showQuickFix = aiEnabled && enableNotebookMode && hasChatModels;
 
 	const cleanError = useMemo(
 		() => removeAnsiEscapeCodes(props.errorContent).trim(),

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/askAssistantAction.vitest.ts
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/askAssistantAction.vitest.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { AskAssistantAction } from '../../browser/AskAssistantAction.js';
+
+/**
+ * The Ask Assistant action is gated on the AI main switch (`config.ai.enabled`).
+ * The menu `when` clause hides the editor toolbar button, but the action also
+ * sets `f1: true`, so it gets a command palette entry whose visibility is driven
+ * by the action's `precondition`. Without a precondition the command stayed in
+ * the palette (and runnable) even with AI disabled, so assert both gates.
+ */
+describe('AskAssistantAction', () => {
+	const desc = new AskAssistantAction().desc;
+
+	it('gates the command palette entry and execution via precondition', () => {
+		expect(desc.precondition?.serialize()).toBe('config.ai.enabled');
+	});
+
+	it('gates the editor toolbar button via the menu when clause', () => {
+		const menu = Array.isArray(desc.menu) ? desc.menu[0] : desc.menu;
+		expect(menu?.when?.serialize()).toContain('config.ai.enabled');
+	});
+});

--- a/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.vitest.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/test/browser/notebookCells/CellTextOutput.vitest.tsx
@@ -88,7 +88,7 @@ describe('CellTextOutput', () => {
 		// here gives isolated state without any manual reset.
 		const configurationService = ctx.get(IConfigurationService) as TestConfigurationService;
 		const contextKeyService = ctx.get(IContextKeyService) as MockContextKeyService;
-		configurationService.setUserConfiguration('positron.assistant.enable', true);
+		configurationService.setUserConfiguration('ai.enabled', true);
 		configurationService.setUserConfiguration('positron.notebook.enabled', true);
 		contextKeyService.createKey('positron-assistant.hasChatModels', true);
 

--- a/src/vs/workbench/services/chat/common/chatEntitlementService.ts
+++ b/src/vs/workbench/services/chat/common/chatEntitlementService.ts
@@ -1055,6 +1055,12 @@ export class ChatEntitlementContext extends Disposable {
 
 	private static readonly CHAT_DISABLED_CONFIGURATION_KEY = 'chat.disableAIFeatures';
 
+	// --- Start Positron ---
+	// Positron's main AI switch. When off, it hides the chat UI (pane and status
+	// icon) just like `chat.disableAIFeatures`, so it feeds the same hidden state.
+	private static readonly AI_ENABLED_CONFIGURATION_KEY = 'ai.enabled';
+	// --- End Positron ---
+
 	private readonly canSignUpContextKey: IContextKey<boolean>;
 	private readonly signedOutContextKey: IContextKey<boolean>;
 
@@ -1142,7 +1148,12 @@ export class ChatEntitlementContext extends Disposable {
 
 	private registerListeners(): void {
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(ChatEntitlementContext.CHAT_DISABLED_CONFIGURATION_KEY)) {
+			// --- Start Positron ---
+			// Recompute when either Copilot's own switch or Positron's `ai.enabled`
+			// changes, so toggling `ai.enabled` at runtime hides/shows the chat UI
+			// without a reload.
+			if (e.affectsConfiguration(ChatEntitlementContext.CHAT_DISABLED_CONFIGURATION_KEY) || e.affectsConfiguration(ChatEntitlementContext.AI_ENABLED_CONFIGURATION_KEY)) {
+				// --- End Positron ---
 				this.updateContext();
 			}
 		}));
@@ -1151,7 +1162,11 @@ export class ChatEntitlementContext extends Disposable {
 	private _forceHidden = false;
 
 	private withConfiguration(state: IChatEntitlementContextState): IChatEntitlementContextState {
-		if (this._forceHidden || this.configurationService.getValue(ChatEntitlementContext.CHAT_DISABLED_CONFIGURATION_KEY) === true) {
+		// --- Start Positron ---
+		// `ai.enabled === false` is Positron's main switch and hides the chat UI
+		// the same way `chat.disableAIFeatures === true` does.
+		if (this._forceHidden || this.configurationService.getValue(ChatEntitlementContext.CHAT_DISABLED_CONFIGURATION_KEY) === true || this.configurationService.getValue(ChatEntitlementContext.AI_ENABLED_CONFIGURATION_KEY) === false) {
+			// --- End Positron ---
 			return {
 				...state,
 				hidden: true

--- a/src/vs/workbench/services/chat/test/common/chatEntitlementService.vitest.ts
+++ b/src/vs/workbench/services/chat/test/common/chatEntitlementService.vitest.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { ConfigurationTarget } from '../../../../../platform/configuration/common/configuration.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { NullLogService } from '../../../../../platform/log/common/log.js';
+import { InMemoryStorageService } from '../../../../../platform/storage/common/storage.js';
+import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
+import { ensureNoLeakedDisposables } from '../../../../../test/vitest/vitestUtils.js';
+import { ChatEntitlementContext, ChatEntitlementContextKeys } from '../../common/chatEntitlementService.js';
+
+// `ai.enabled` is Positron's main AI switch. When it's off, the chat UI (the
+// chat pane and the Copilot status icon) must hide just like Copilot's own
+// `chat.disableAIFeatures`. Both feed the `chatSetupHidden` context key through
+// `ChatEntitlementContext`, so these tests assert that key flips with
+// `ai.enabled` -- including at runtime, without a reload.
+describe('ChatEntitlementContext ai.enabled gating', () => {
+	const disposables = ensureNoLeakedDisposables();
+
+	let contextKeyService: MockContextKeyService;
+	let configurationService: TestConfigurationService;
+
+	beforeEach(() => {
+		contextKeyService = new MockContextKeyService();
+		configurationService = new TestConfigurationService();
+	});
+
+	const createContext = () => disposables.add(new ChatEntitlementContext(
+		contextKeyService,
+		disposables.add(new InMemoryStorageService()),
+		new NullLogService(),
+		configurationService,
+		NullTelemetryService,
+	));
+
+	const isHidden = () => ChatEntitlementContextKeys.Setup.hidden.getValue(contextKeyService) === true;
+
+	const fireConfigChange = (changedKey: string) => {
+		configurationService.onDidChangeConfigurationEmitter.fire({
+			affectsConfiguration: (key: string) => key === changedKey,
+			affectedKeys: new Set([changedKey]),
+			change: { keys: [], overrides: [] },
+			source: ConfigurationTarget.USER,
+		});
+	};
+
+	it('hides the chat UI when ai.enabled is off at startup', () => {
+		configurationService.setUserConfiguration('ai.enabled', false);
+		createContext();
+
+		expect(isHidden()).toBe(true);
+	});
+
+	it('leaves the chat UI visible when ai.enabled is unset and Copilot is not disabled', () => {
+		createContext();
+
+		expect(isHidden()).toBe(false);
+	});
+
+	it('flips chatSetupHidden when ai.enabled toggles at runtime, no reload', async () => {
+		createContext();
+		expect(isHidden()).toBe(false);
+
+		// The config listener recomputes via the async `updateContext()`, so let
+		// its microtask settle before asserting.
+		configurationService.setUserConfiguration('ai.enabled', false);
+		fireConfigChange('ai.enabled');
+		await Promise.resolve();
+		expect(isHidden()).toBe(true);
+
+		configurationService.setUserConfiguration('ai.enabled', true);
+		fireConfigChange('ai.enabled');
+		await Promise.resolve();
+		expect(isHidden()).toBe(false);
+	});
+});

--- a/test/e2e/tests/assistant/chat-command-palette-gating.test.ts
+++ b/test/e2e/tests/assistant/chat-command-palette-gating.test.ts
@@ -11,17 +11,21 @@ test.use({
 
 /**
  * Verifies that the "Chat" command category is hidden from the command palette
- * when AI features are disabled via the `chat.disableAIFeatures` setting.
+ * when AI features are turned off by either switch: Copilot's own
+ * `chat.disableAIFeatures`, or Positron's `ai.enabled` main switch.
  *
- * The change swaps Chat command preconditions from `ChatContextKeys.enabled` to
- * `ChatContextKeys.available` (enabled AND `chat.disableAIFeatures` not set), and
- * a command's precondition gates its command palette visibility. The palette
- * renders these commands with a "Chat: " category prefix
+ * Chat command preconditions (core and the Copilot extension's `commandPalette`
+ * entries) gate on the `chatAiFeaturesEnabled` context key, which `ChatAgentService`
+ * keeps in sync from both settings. A command's precondition gates its command
+ * palette visibility, and the palette renders these commands with a "Chat: " prefix
  * (see commandsQuickAccess.ts "commandWithCategory").
+ *
+ * Both switches are covered: an earlier version only flipped `chat.disableAIFeatures`,
+ * so an `ai.enabled = false` regression (commands still showing) went uncaught.
  *
  * The e2e settings fixture enables Positron Assistant (`positron.assistant.enable`),
  * which registers the default chat participant, so chat is "enabled" by default and
- * the "Chat" category is shown until AI features are explicitly disabled.
+ * the "Chat" category is shown until AI features are explicitly turned off.
  *
  * @see https://github.com/posit-dev/positron/pull/14054 (single-command gating this extends)
  */
@@ -30,27 +34,37 @@ test.describe('Chat Command Palette Gating', { tag: [tags.ASSISTANT, tags.POSIT_
 	// Anchor at the start so other categories (e.g. "GitHub Copilot Chat: ...") are excluded.
 	const CHAT_CATEGORY_ROW = /^Chat: /;
 
-	test.afterEach('Reset chat.disableAIFeatures', async function ({ settings }) {
-		await settings.remove(['chat.disableAIFeatures']);
+	test.afterEach('Reset AI switch settings', async function ({ settings }) {
+		await settings.remove(['chat.disableAIFeatures', 'ai.enabled']);
 	});
 
-	test('Chat category is hidden when AI features are disabled', async function ({ app, settings }) {
-		await settings.set({ 'chat.disableAIFeatures': true }, { reload: true });
+	// Each switch must hide the Chat category on its own, with the *other*
+	// switch left in its AI-on position. The `ai.enabled` row is the reported bug:
+	// `chat.disableAIFeatures` is false yet AI is still off via the main switch.
+	const offCases = [
+		{ name: 'chat.disableAIFeatures is on', config: { 'chat.disableAIFeatures': true, 'ai.enabled': true } },
+		{ name: 'the ai.enabled main switch is off', config: { 'chat.disableAIFeatures': false, 'ai.enabled': false } },
+		{ name: 'both switches are off', config: { 'chat.disableAIFeatures': true, 'ai.enabled': false } },
+	];
+	for (const { name, config } of offCases) {
+		test(`Chat category is hidden when ${name}`, async function ({ app, settings }) {
+			await settings.set(config, { reload: true });
 
-		await app.workbench.hotKeys.openCommandPalette();
-		await app.workbench.quickInput.type('>Chat: ');
-		// With the category gated out, the picker falls back to fuzzy "similar
-		// commands", so we can't rely on a "No matching commands" message. Wait for
-		// the list to render, then assert no command is shown under "Chat".
-		await app.workbench.quickInput.waitForQuickInputElementText();
-		await expect(
-			app.workbench.quickInput.quickInputResult.filter({ hasText: CHAT_CATEGORY_ROW })
-		).toHaveCount(0);
-		await app.workbench.quickInput.closeQuickInput();
-	});
+			await app.workbench.hotKeys.openCommandPalette();
+			await app.workbench.quickInput.type('>Chat: ');
+			// With the category gated out, the picker falls back to fuzzy "similar
+			// commands", so we can't rely on a "No matching commands" message. Wait for
+			// the list to render, then assert no command is shown under "Chat".
+			await app.workbench.quickInput.waitForQuickInputElementText();
+			await expect(
+				app.workbench.quickInput.quickInputResult.filter({ hasText: CHAT_CATEGORY_ROW })
+			).toHaveCount(0);
+			await app.workbench.quickInput.closeQuickInput();
+		});
+	}
 
 	test('Chat category is visible when AI features are enabled', async function ({ app, settings }) {
-		await settings.set({ 'chat.disableAIFeatures': false }, { reload: true });
+		await settings.set({ 'chat.disableAIFeatures': false, 'ai.enabled': true }, { reload: true });
 
 		await app.workbench.hotKeys.openCommandPalette();
 		await app.workbench.quickInput.type('>Chat: ');

--- a/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
+++ b/test/e2e/tests/notebooks-positron/notebook-assistant-features.test.ts
@@ -14,11 +14,11 @@ test.describe('Notebook Assistant: Feature Toggle', {
 	tag: [tags.POSITRON_NOTEBOOKS, tags.ASSISTANT, tags.WIN]
 }, () => {
 
-	test('Notebook AI features hidden when assistant disabled', async function ({ app, settings }) {
+	test('Notebook AI features hidden when AI disabled', async function ({ app, settings }) {
 		const { notebooksPositron } = app.workbench;
 
-		// Disable assistant features
-		await settings.set({ 'positron.assistant.enable': false });
+		// Turn off the AI main switch, which gates all of Positron's AI features
+		await settings.set({ 'ai.enabled': false });
 
 		// Create a new notebook
 		await notebooksPositron.createNewNotebook();
@@ -34,11 +34,11 @@ test.describe('Notebook Assistant: Feature Toggle', {
 		await notebooksPositron.expectErrorAssistantButtonsVisible(false);
 	});
 
-	test.skip('Notebook AI features visible when assistant enabled', async function ({ app, settings }) {
+	test.skip('Notebook AI features visible when AI enabled', async function ({ app, settings }) {
 		const { notebooksPositron, assistant } = app.workbench;
 
-		// Enable assistant and sign in to echo provider
-		await settings.set({ 'positron.assistant.enable': true });
+		// Turn on the AI main switch, enable the assistant, and sign in to echo provider
+		await settings.set({ 'ai.enabled': true, 'positron.assistant.enable': true });
 		await assistant.loginModelProvider('echo');
 
 		// Create a new notebook with a cell that produces an error


### PR DESCRIPTION
- closes https://github.com/posit-dev/positron/issues/14356
- companion assistant PR: https://github.com/posit-dev/assistant/pull/1680
- docs pr: https://github.com/posit-dev/positron-website/pull/394

Gates the following features:

- Posit AI NES
- Notebooks AI features (Fix & Explain, ghost cells, ask assistant)
- Console Fix & Explain
- Posit Assistant
- GitHub Copilot

`ai.enabled` is true by default, which means that AI features are gated by their own settings by default, if they exist. For example, `ai.enabled` is true by default, so Posit Assistant is gated on whether `assistant.enabled` is true or false. If `ai.enabled` is admin-enforced true, but `assistant.enabled` is false, then Posit Assistant remains disabled.

When `ai.enabled` is false, all of the above features are disabled even if their own setting is enabled. For example, if `ai.enabled` is false but `assistant.enabled` is true, then Posit Assistant is disabled. Even if `assistant.enabled` is admin-enforced to be true, `ai.enabled` takes precedence in disabling all AI features.

The setting is used to force features off, but can't force features to be on. I suppose we could change the setting name to be `ai.allowed` (or something else), if that seems more aligned with the behaviour.

This also includes a skill and rule to ensure that new AI functionality is properly gated behind `ai.enabled` going forward.

### Release Notes

#### New Features

- Added AI enablement switch for all Positron-integrated AI features (#14356)

### Validation Steps

Added/updated various tests across the affected features to check that AI features are gated when `ai.enabled` is false.

@:assistant

when `ai.enabled` is left as the default `true`, individual AI features are gated on their own enablement setting if they have one

when `ai.enabled` is false, Posit AI NES, Notebooks AI features, Console Fix & Explain, Posit Assistant and GitHub Copilot should all be disabled in positron
- UI for these features are removed or indicated as disabled
- commands for these features are unavailable
- most/many settings for these features are unavailable