### PR TITLE
Fix stale package-lock.json files

### DIFF
--- a/extensions/positron-data-driver-duckdb/package-lock.json
+++ b/extensions/positron-data-driver-duckdb/package-lock.json
@@ -29,7 +29,10 @@
     },
     "../positron-data-explorer-protocol": {
       "version": "0.0.1",
-      "dev": true
+      "dev": true,
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      }
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.2",

--- a/extensions/positron-data-driver-postgresql/package-lock.json
+++ b/extensions/positron-data-driver-postgresql/package-lock.json
@@ -30,7 +30,10 @@
     },
     "../positron-data-explorer-protocol": {
       "version": "0.0.1",
-      "dev": true
+      "dev": true,
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      }
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.2",

--- a/extensions/positron-data-driver-sqlite/package-lock.json
+++ b/extensions/positron-data-driver-sqlite/package-lock.json
@@ -30,7 +30,10 @@
     },
     "../positron-data-explorer-protocol": {
       "version": "0.0.1",
-      "dev": true
+      "dev": true,
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      }
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.2",

--- a/extensions/positron-duckdb/package-lock.json
+++ b/extensions/positron-duckdb/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "positron-duckdb",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@duckdb/node-api": "1.5.3-r.3",
         "yauzl": "^3.4.0"

--- a/extensions/positron-python/package-lock.json
+++ b/extensions/positron-python/package-lock.json
@@ -14890,6 +14890,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
             "license": "0BSD"
         },
         "node_modules/tty-browserify": {


### PR DESCRIPTION
## Stale package-lock.json files re-modified on every `npm install`

### Problem

After a fresh clone and `npm install`, five `package-lock.json` files show up as modified every time, creating persistent dirty working trees:

- `extensions/positron-data-driver-duckdb/package-lock.json`
- `extensions/positron-data-driver-postgresql/package-lock.json`
- `extensions/positron-data-driver-sqlite/package-lock.json`
- `extensions/positron-duckdb/package-lock.json`
- `extensions/positron-python/package-lock.json`

### Root cause

This is not version drift -- node/npm match `.nvmrc` (22.22.1 / 10.9.4) and the lockfiles are already `lockfileVersion: 3`. The committed lock files are simply stale relative to their `package.json` files, so `npm install` deterministically reconciles them on every run. The changes are forward-fixes npm derives from the current manifests:

- **Data drivers (duckdb, postgresql, sqlite):** the local `file:` dependency `../positron-data-explorer-protocol` gained a `typescript` devDependency in its `package.json`, but the dependent locks were never regenerated. npm re-adds `devDependencies: { "typescript": "^6.0.3" }`.
- **positron-duckdb:** its `package.json` defines an install script, so npm adds `hasInstallScript: true`.
- **positron-python:** `tslib` is now dev-only, so npm adds `"dev": true`.

### Fix

Commit the regenerated lock files exactly as `npm install` produces them, bringing the committed locks in line with the current `package.json` files. No `.gitignore` change or config workaround is involved -- the lock content itself was out of date.

### Verification

Confirmed idempotent: running `npm install --package-lock-only` a second time produces no further changes beyond the initial reconciliation. Once these locks are committed, `npm install` leaves them untouched and the working tree stays clean after a fresh clone.
