### PR TITLE
e2e: make Posit Assistant dev-build float best-effort

### DIFF
--- a/test/e2e/pages/positAssistant.ts
+++ b/test/e2e/pages/positAssistant.ts
@@ -579,6 +579,20 @@ export class PositAssistant {
 	 *
 	 * Note: this is for Posit Assistant (not Positron Assistant).
 	 *
+	 * Best-effort by design. The float exists to surface UI drift against the
+	 * latest assistant dev build; it is NOT a hard prerequisite for the suite.
+	 * The update installs a VSIX via `workbench.extensions.installExtension` and
+	 * the assistant silently swallows its own install errors (see the assistant
+	 * repo's auto-update.ts), so when the install fails the "...has been updated"
+	 * toast never appears. If that happens we log it and continue against the
+	 * bundled build rather than letting a `beforeAll` throw take down the whole
+	 * suite (which otherwise surfaces misleadingly as the first test failing).
+	 *
+	 * This tolerance is platform-agnostic on purpose: the float worked on web
+	 * through mid-June 2026 and then regressed there (electron unaffected), so we
+	 * don't hard-skip web -- once the upstream install regression is fixed, web
+	 * resumes floating with no code change here.
+	 *
 	 * @param settings The settings fixture used to write the user setting.
 	 * @param quickaccess The quickaccess page object used to run the command.
 	 * @param options.toastTimeout Maximum time to wait for each toast (default: 30000).
@@ -621,7 +635,15 @@ export class PositAssistant {
 		await toasts.clickButton('Update Now');
 
 		// 4. Wait for the follow-up "reload to apply changes" toast and click "Reload".
-		await toasts.waitForAppear(/Posit Assistant has been updated\. You must reload Positron/i, { timeout: toastTimeout });
+		//    The download+install is best-effort: the extension silently swallows
+		//    failures, so if it errors out the success toast never appears. Don't let
+		//    that take down the whole suite -- log and continue against the bundled build.
+		try {
+			await toasts.waitForAppear(/Posit Assistant has been updated\. You must reload Positron/i, { timeout: toastTimeout });
+		} catch {
+			this.code.logger.log('Posit Assistant dev-build update did not complete (no "updated" toast); continuing with the bundled build.');
+			return;
+		}
 		await toasts.clickButton('Reload');
 
 		// 5. Clicking Reload reloads the window natively. Wait for the

--- a/test/e2e/tests/posit-assistant/posit-assistant.test.ts
+++ b/test/e2e/tests/posit-assistant/posit-assistant.test.ts
@@ -26,6 +26,8 @@ test.describe('Posit Assistant', {
 				// Ensure we're running the latest Posit Assistant dev build.
 				// Enables the auto dev-build update check, triggers the check,
 				// and accepts the resulting "Update Now" / "Reload" toasts.
+				// Best-effort: if the update can't complete (e.g. the current web
+				// install regression), the suite continues on the bundled build.
 				await app.workbench.positAssistant.checkForDevBuildUpdate(settings, app.workbench.quickaccess);
 			});
 


### PR DESCRIPTION
### Summary

The Posit Assistant e2e suite's `beforeAll` floats the bootstrapped extension to the latest `main` dev build via `checkForDevBuildUpdate()`. That flow clicks "Update Now", then the assistant installs the new VSIX and shows a "...has been updated. You must reload Positron" toast.

When the install fails, the assistant silently swallows the error (see the assistant repo's `auto-update.ts`), so the success toast never appears and the 30s `waitForAppear` throws. Because this runs in `beforeAll`, Playwright fails the **first** test (`Open Posit Assistant and verify welcome page`) with 0ms and skips the rest -- which misleadingly looks like a welcome-page selector failure (and was mis-triaged as exactly that by the e2e failure analyzer).

The dev-build install regressed on **web** around mid-June 2026: the welcome test passed on chromium through 06-19, then started failing by 06-23 with the same dev-build-update timeout; electron is unaffected. This is **not** caused by the `posit.assistant` bootstrap bump (#14452) -- the same failure predates it across unrelated commits.

This makes the float best-effort: wrap the success-toast wait in `try/catch` and, on timeout, log and continue against the bundled build instead of throwing. Platform-agnostic on purpose (no hard web-skip), so web resumes floating to the latest dev build automatically once the upstream install regression is fixed.

Note: this restores green CI but intentionally degrades web dev-build drift coverage until the upstream (assistant repo) web-install regression is fixed; that should be tracked separately.

### Release Notes

#### New Features
- N/A

#### Bug Fixes
- N/A

### QA Notes

@:posit-assistant @:web

The Posit Assistant suite should run on web (chromium) and pass: `Open Posit Assistant and verify welcome page` (and the rest of the suite) no longer fails in `beforeAll` when the dev-build update can't complete. On electron the float still applies as before (update + reload), so behavior there is unchanged.
