### PR TITLE
python: fix seaborn axis duplication

### DIFF
--- a/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
+++ b/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
@@ -262,24 +262,6 @@ class FigureCanvasPositron(FigureCanvasAgg):
             frontend.
         """
         logger.debug("Drawing to canvas")
-
-        # A high-level library (e.g. seaborn) may draw onto a figure that plain
-        # matplotlib created via an implicit `plt.gca()` (for example a leftover figure
-        # from an earlier cell). Re-tag the figure here -- the library's frames are on
-        # the stack during the draw it triggers -- so it is detached after the cell like
-        # a freshly-created seaborn figure (see `detach_library_figures`). Only runs on
-        # user-initiated draws, and only upgrades the tag (a figure is never reverted to
-        # matplotlib). See https://github.com/posit-dev/positron/issues/8898.
-        manager = getattr(self, "manager", None)
-        if (
-            not is_rendering
-            and manager is not None
-            and manager.plotting_library not in _DETACH_AFTER_CELL_KINDS
-        ):
-            library = _detect_plotting_library()
-            if library in _DETACH_AFTER_CELL_KINDS:
-                manager.plotting_library = library
-
         try:
             super().draw()
         finally:
@@ -359,6 +341,52 @@ class FigureCanvasPositron(FigureCanvasAgg):
     def _hash_buffer_rgba(self) -> str:
         """Hash the canvas contents for change detection."""
         return hashlib.sha1(self.buffer_rgba()).hexdigest()
+
+
+_library_gca_redirect_installed = False
+
+
+def _install_library_gca_redirect() -> None:
+    """
+    Make a high-level library (e.g. seaborn) draw on a fresh figure instead of an
+    existing one created by a different library.
+
+    Seaborn's axes-level functions draw on `plt.gca()` when no `ax=` is given. With a
+    persistent figure registry, that current figure may be a leftover from a different
+    library (for example a matplotlib plot from an earlier cell), so seaborn would draw
+    over it. We intercept `plt.gca()`: when a library on the call stack differs from the
+    library that created the active figure, return the axes of a fresh figure instead.
+
+    This only affects the implicit `plt.gca()` path -- an explicit `ax=` is untouched --
+    and only fires across libraries, so plain matplotlib figures remain reusable
+    (preserving cross-cell persistence). See https://github.com/posit-dev/positron/issues/8898.
+    """
+    global _library_gca_redirect_installed
+    if _library_gca_redirect_installed:
+        return
+
+    import matplotlib.pyplot as plt
+    from matplotlib._pylab_helpers import Gcf
+
+    original_gca = plt.gca
+
+    def gca(*args, **kwargs):
+        manager = Gcf.get_active()
+        if (
+            isinstance(manager, FigureManagerPositron)
+            and manager.plotting_library not in _DETACH_AFTER_CELL_KINDS
+            and _detect_plotting_library() in _DETACH_AFTER_CELL_KINDS
+        ):
+            # Drawing library differs from the active figure's library: start fresh so
+            # the existing figure isn't overwritten.
+            return plt.figure().gca()
+        return original_gca(*args, **kwargs)
+
+    plt.gca = gca
+    _library_gca_redirect_installed = True
+
+
+_install_library_gca_redirect()
 
 
 # Fulfill the matplotlib backend API.

--- a/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
+++ b/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
@@ -350,8 +350,10 @@ _library_gca_redirect_installed = False
 
 def _install_library_gca_redirect() -> None:
     """
-    Make a high-level library (e.g. seaborn) draw on a fresh figure instead of an
-    existing one created by a different library.
+    Redirect a high-level library's implicit `plt.gca()` to a fresh figure.
+
+    Make a high-level library (e.g. seaborn) draw on a fresh figure instead of an existing
+    one created by a different library.
 
     Seaborn's axes-level functions draw on `plt.gca()` when no `ax=` is given. With a
     persistent figure registry, that current figure may be a leftover from a different

--- a/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
+++ b/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
@@ -101,7 +101,9 @@ def detach_library_figures() -> None:
             and manager.plotting_library in _DETACH_AFTER_CELL_KINDS
         ):
             # Removes the manager from the registry and invokes our no-op `destroy`.
-            Gcf.destroy(manager.num)
+            # Pass the manager rather than its number: numbers freed here can be reused
+            # by matplotlib, so destroying by number could hit a different figure.
+            Gcf.destroy(manager)
 
 
 class FigureManagerPositron(FigureManagerBase):

--- a/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
+++ b/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
@@ -262,6 +262,24 @@ class FigureCanvasPositron(FigureCanvasAgg):
             frontend.
         """
         logger.debug("Drawing to canvas")
+
+        # A high-level library (e.g. seaborn) may draw onto a figure that plain
+        # matplotlib created via an implicit `plt.gca()` (for example a leftover figure
+        # from an earlier cell). Re-tag the figure here -- the library's frames are on
+        # the stack during the draw it triggers -- so it is detached after the cell like
+        # a freshly-created seaborn figure (see `detach_library_figures`). Only runs on
+        # user-initiated draws, and only upgrades the tag (a figure is never reverted to
+        # matplotlib). See https://github.com/posit-dev/positron/issues/8898.
+        manager = getattr(self, "manager", None)
+        if (
+            not is_rendering
+            and manager is not None
+            and manager.plotting_library not in _DETACH_AFTER_CELL_KINDS
+        ):
+            library = _detect_plotting_library()
+            if library in _DETACH_AFTER_CELL_KINDS:
+                manager.plotting_library = library
+
         try:
             super().draw()
         finally:

--- a/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
+++ b/extensions/positron-python/python_files/posit/positron/matplotlib_backend.py
@@ -17,9 +17,9 @@ the backend is set by matplotlib.
 from __future__ import annotations
 
 import hashlib
+import inspect
 import io
 import logging
-import sys
 from typing import TYPE_CHECKING, Any, cast
 
 import matplotlib
@@ -40,24 +40,68 @@ logger = logging.getLogger(__name__)
 matplotlib.interactive(True)  # noqa: FBT003
 
 
+# High-level libraries that build on matplotlib. A figure produced by one of these is
+# attributed to that library (used for the plot's display name and, for seaborn,
+# detached after each cell; see `detach_library_figures`).
+_LIBRARY_MODULE_ROOTS = ("seaborn", "plotnine")
+
+# Kinds whose figures are detached from matplotlib's global registry after each
+# interactive cell. Limited to seaborn: its axes-level functions (heatmap,
+# scatterplot, ...) draw onto the current axes, so re-running stacks elements (e.g.
+# colorbars) onto the previous figure. Plain matplotlib is intentionally left
+# persistent so a plot can be updated or re-shown across cells.
+# See https://github.com/posit-dev/positron/issues/8898.
+_DETACH_AFTER_CELL_KINDS = frozenset({"seaborn"})
+
+
 def _detect_plotting_library() -> str:
     """
-    Detect the most likely high-level plotting library in use.
+    Detect the high-level plotting library that created the current figure.
 
-    Checks sys.modules for known plotting libraries that build on matplotlib,
-    returning the most specific library name found.
+    Walks the call stack, which still contains the creating library's frames since
+    this runs during figure creation, and returns the most specific known library.
+    This is more precise than checking ``sys.modules``, which would misattribute a
+    plain matplotlib figure to seaborn whenever seaborn is merely imported (for
+    example via ``sns.set_theme()``).
     """
-    # Check for high-level libraries that build on matplotlib
-    # Order matters - check more specific libraries first
-    # Note: We don't include pandas here because pandas.plotting is auto-loaded
-    # when pandas is imported, even if not used for plotting.
-    library_priority = ["seaborn", "plotnine"]
-
-    for module_name in library_priority:
-        if module_name in sys.modules:
-            return module_name
+    frame = inspect.currentframe()
+    try:
+        while frame is not None:
+            module_root = frame.f_globals.get("__name__", "").split(".", 1)[0]
+            if module_root in _LIBRARY_MODULE_ROOTS:
+                return module_root
+            frame = frame.f_back
+    finally:
+        # Break the local reference to the frame to avoid creating a reference cycle.
+        del frame
 
     return "matplotlib"
+
+
+def detach_library_figures() -> None:
+    """
+    Detach high-level library figures (e.g. seaborn) from matplotlib's global registry.
+
+    Called after each interactive cell. The figures are only removed from the registry,
+    not destroyed: the comm and cached render stay alive (``FigureManagerPositron.destroy``
+    is a no-op and the figure is still referenced by the plots service), so the plot
+    remains visible in the Plots pane and can still be re-rendered on resize. Removing
+    them from the registry means the next execution starts with a fresh figure instead of
+    drawing onto the previous one, avoiding duplicated elements such as stacked colorbars.
+    See https://github.com/posit-dev/positron/issues/8898.
+
+    Plain matplotlib figures are intentionally left in the registry to preserve Positron's
+    cross-cell figure persistence (updating or re-showing a plot across cells).
+    """
+    from matplotlib._pylab_helpers import Gcf
+
+    for manager in list(Gcf.get_all_fig_managers()):
+        if (
+            isinstance(manager, FigureManagerPositron)
+            and manager.plotting_library in _DETACH_AFTER_CELL_KINDS
+        ):
+            # Removes the manager from the registry and invokes our no-op `destroy`.
+            Gcf.destroy(manager.num)
 
 
 class FigureManagerPositron(FigureManagerBase):
@@ -113,8 +157,10 @@ class FigureManagerPositron(FigureManagerBase):
                 ),
             )
 
-        # Detect which plotting library was used
+        # Detect which plotting library was used. Stored so `detach_library_figures`
+        # can decide whether this figure should be detached after each cell.
         kind = _detect_plotting_library()
+        self.plotting_library = kind
 
         # Create the plot instance via the plots service.
         self._plots_service = kernel.plots_service
@@ -135,8 +181,13 @@ class FigureManagerPositron(FigureManagerBase):
 
         This ensures matplotlib's internal figure cache is cleared when the frontend
         closes the plot, preventing figures from being restored when the comm reopens.
+
+        Close by figure object rather than by number: `detach_library_figures` removes
+        figures from the registry, freeing their numbers for matplotlib to reuse, so
+        closing by number could destroy a different figure that reused this number.
+        Closing an already-detached figure is a safe no-op.
         """
-        plt.close(self.num)
+        plt.close(self.canvas.figure)
 
     @property
     def closed(self) -> bool:

--- a/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
+++ b/extensions/positron-python/python_files/posit/positron/positron_ipkernel.py
@@ -531,6 +531,19 @@ class PositronShell(ZMQInteractiveShell):
         except Exception:
             logger.exception("Error polling variables")
 
+        # Detach high-level plotting library figures (e.g. seaborn) so that re-running
+        # plotting code starts a fresh figure instead of drawing onto the previous one.
+        # See https://github.com/posit-dev/positron/issues/8898. Only act if matplotlib
+        # has already imported our backend: importing it here would run its module-level
+        # setup code, so we reuse the already-loaded module instead.
+        if "positron.matplotlib_backend" in sys.modules:
+            try:
+                from .matplotlib_backend import detach_library_figures
+
+                detach_library_figures()
+            except Exception:
+                logger.exception("Error detaching plotting library figures")
+
     def _add_editor_dir_to_sys_path(self) -> str | None:
         """
         Add the directory of the executed file to sys.path.

--- a/extensions/positron-python/python_files/posit/positron/tests/test_plots.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_plots.py
@@ -545,6 +545,30 @@ def test_mpl_seaborn_figure_detached_after_cell(
     assert "result" in _do_render(plot_comm)["data"]
 
 
+def test_mpl_seaborn_drawn_on_existing_figure_is_detached(
+    shell: PositronShell, plots_service: PlotsService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A high-level library drawing onto a plain matplotlib figure (e.g. seaborn reusing a
+    leftover figure via implicit plt.gca()) re-tags the figure so it is detached after
+    the cell, instead of accumulating across re-runs.
+
+    See https://github.com/posit-dev/positron/issues/8898.
+    """
+    # The figure starts as plain matplotlib (created before seaborn is involved).
+    _create_mpl_plot(shell, plots_service)
+    assert plt.get_fignums() == [1]
+
+    # Simulate a seaborn draw onto that existing figure: the draw re-tags it, and the
+    # post-cell detach then removes it.
+    monkeypatch.setattr(
+        "positron.matplotlib_backend._detect_plotting_library", lambda: "seaborn"
+    )
+    shell.run_cell("plt.plot([1, 2])").raise_error()
+
+    assert plt.get_fignums() == []
+
+
 def test_mpl_matplotlib_figure_persists_after_cell(
     shell: PositronShell, plots_service: PlotsService
 ) -> None:

--- a/extensions/positron-python/python_files/posit/positron/tests/test_plots.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_plots.py
@@ -545,28 +545,29 @@ def test_mpl_seaborn_figure_detached_after_cell(
     assert "result" in _do_render(plot_comm)["data"]
 
 
-def test_mpl_seaborn_drawn_on_existing_figure_is_detached(
+def test_mpl_seaborn_does_not_overwrite_existing_matplotlib_figure(
     shell: PositronShell, plots_service: PlotsService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """
-    A high-level library drawing onto a plain matplotlib figure (e.g. seaborn reusing a
-    leftover figure via implicit plt.gca()) re-tags the figure so it is detached after
-    the cell, instead of accumulating across re-runs.
+    When seaborn asks for the current axes while a matplotlib figure is active, it gets a
+    fresh figure instead of drawing over the existing one (e.g. plt then sns). The
+    matplotlib figure is left untouched.
 
     See https://github.com/posit-dev/positron/issues/8898.
     """
-    # The figure starts as plain matplotlib (created before seaborn is involved).
+    # An existing matplotlib figure is active.
     _create_mpl_plot(shell, plots_service)
     assert plt.get_fignums() == [1]
 
-    # Simulate a seaborn draw onto that existing figure: the draw re-tags it, and the
-    # post-cell detach then removes it.
+    # Simulate a seaborn call resolving its axes via plt.gca().
     monkeypatch.setattr(
         "positron.matplotlib_backend._detect_plotting_library", lambda: "seaborn"
     )
-    shell.run_cell("plt.plot([1, 2])").raise_error()
+    axes = plt.gca()
 
-    assert plt.get_fignums() == []
+    # gca returned a new figure (2), leaving the matplotlib figure (1) intact.
+    assert axes.figure.number == 2
+    assert plt.get_fignums() == [1, 2]
 
 
 def test_mpl_matplotlib_figure_persists_after_cell(

--- a/extensions/positron-python/python_files/posit/positron/tests/test_plots.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_plots.py
@@ -522,16 +522,15 @@ def test_mpl_seaborn_figure_detached_after_cell(
     shell: PositronShell, plots_service: PlotsService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """
-    A seaborn figure is removed from matplotlib's registry after the cell, so a re-run
-    starts a fresh figure, while the plot stays open and renderable.
+    A seaborn figure is detached from matplotlib's registry after the cell.
+
+    A re-run starts a fresh figure, while the plot stays open and renderable.
 
     See https://github.com/posit-dev/positron/issues/8898.
     """
     # Create the figure as if it were produced by seaborn (detection is exercised
     # separately in test_mpl_detect_library_walks_call_stack).
-    monkeypatch.setattr(
-        "positron.matplotlib_backend._detect_plotting_library", lambda: "seaborn"
-    )
+    monkeypatch.setattr("positron.matplotlib_backend._detect_plotting_library", lambda: "seaborn")
     plot_comm = _create_mpl_plot(shell, plots_service)
 
     # Running any cell triggers the post-cell detach.
@@ -549,8 +548,9 @@ def test_mpl_seaborn_does_not_overwrite_existing_matplotlib_figure(
     shell: PositronShell, plots_service: PlotsService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """
-    When seaborn asks for the current axes while a matplotlib figure is active, it gets a
-    fresh figure instead of drawing over the existing one (e.g. plt then sns). The
+    Seaborn gets a fresh figure when it resolves axes while a matplotlib figure is active.
+
+    It draws on the new figure instead of over the existing one (e.g. plt then sns); the
     matplotlib figure is left untouched.
 
     See https://github.com/posit-dev/positron/issues/8898.
@@ -560,13 +560,11 @@ def test_mpl_seaborn_does_not_overwrite_existing_matplotlib_figure(
     assert plt.get_fignums() == [1]
 
     # Simulate a seaborn call resolving its axes via plt.gca().
-    monkeypatch.setattr(
-        "positron.matplotlib_backend._detect_plotting_library", lambda: "seaborn"
-    )
+    monkeypatch.setattr("positron.matplotlib_backend._detect_plotting_library", lambda: "seaborn")
     axes = plt.gca()
 
-    # gca returned a new figure (2), leaving the matplotlib figure (1) intact.
-    assert axes.figure.number == 2
+    # gca returned axes on a new figure (2), leaving the matplotlib figure (1) intact.
+    assert axes.figure is plt.figure(2)
     assert plt.get_fignums() == [1, 2]
 
 
@@ -574,8 +572,10 @@ def test_mpl_matplotlib_figure_persists_after_cell(
     shell: PositronShell, plots_service: PlotsService
 ) -> None:
     """
-    Plain matplotlib figures stay in the registry across cells (intentional cross-cell
-    persistence; only seaborn figures are detached, see issue #8898).
+    Plain matplotlib figures stay in the registry across cells.
+
+    This is intentional cross-cell persistence; only seaborn figures are detached
+    (see issue #8898).
     """
     _create_mpl_plot(shell, plots_service)  # kind defaults to "matplotlib"
 
@@ -588,8 +588,9 @@ def test_mpl_seaborn_no_duplicate_on_rerun(
     shell: PositronShell, plots_service: PlotsService
 ) -> None:
     """
-    Re-running a seaborn axes-level plot creates a separate plot instead of stacking
-    onto the previous figure (which duplicated the colorbar).
+    Re-running a seaborn axes-level plot creates a separate plot.
+
+    It does not stack onto the previous figure (which duplicated the colorbar).
 
     See https://github.com/posit-dev/positron/issues/8898.
     """
@@ -606,9 +607,10 @@ def test_mpl_seaborn_no_duplicate_on_rerun(
 
 def test_mpl_detect_library_walks_call_stack() -> None:
     """
-    Detection attributes a figure to the library on the call stack, not one that is
-    merely imported -- so importing seaborn for styling doesn't mislabel a plain
-    matplotlib figure (which would otherwise be detached across cells).
+    Detection attributes a figure to the library on the call stack, not one merely imported.
+
+    So importing seaborn for styling doesn't mislabel a plain matplotlib figure (which
+    would otherwise be detached across cells).
 
     See https://github.com/posit-dev/positron/issues/8898.
     """

--- a/extensions/positron-python/python_files/posit/positron/tests/test_plots.py
+++ b/extensions/positron-python/python_files/posit/positron/tests/test_plots.py
@@ -518,6 +518,87 @@ def test_mpl_issue_2824(shell: PositronShell, plots_service: PlotsService) -> No
     assert len(plots_service._plots) == 1  # noqa: SLF001
 
 
+def test_mpl_seaborn_figure_detached_after_cell(
+    shell: PositronShell, plots_service: PlotsService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A seaborn figure is removed from matplotlib's registry after the cell, so a re-run
+    starts a fresh figure, while the plot stays open and renderable.
+
+    See https://github.com/posit-dev/positron/issues/8898.
+    """
+    # Create the figure as if it were produced by seaborn (detection is exercised
+    # separately in test_mpl_detect_library_walks_call_stack).
+    monkeypatch.setattr(
+        "positron.matplotlib_backend._detect_plotting_library", lambda: "seaborn"
+    )
+    plot_comm = _create_mpl_plot(shell, plots_service)
+
+    # Running any cell triggers the post-cell detach.
+    shell.run_cell("1").raise_error()
+
+    # The figure is removed from matplotlib's registry...
+    assert plt.get_fignums() == []
+    # ...but the plot remains open, registered, and renderable.
+    assert len(plots_service._plots) == 1  # noqa: SLF001
+    assert not plot_comm._closed  # noqa: SLF001
+    assert "result" in _do_render(plot_comm)["data"]
+
+
+def test_mpl_matplotlib_figure_persists_after_cell(
+    shell: PositronShell, plots_service: PlotsService
+) -> None:
+    """
+    Plain matplotlib figures stay in the registry across cells (intentional cross-cell
+    persistence; only seaborn figures are detached, see issue #8898).
+    """
+    _create_mpl_plot(shell, plots_service)  # kind defaults to "matplotlib"
+
+    shell.run_cell("1").raise_error()
+
+    assert plt.get_fignums() == [1]
+
+
+def test_mpl_seaborn_no_duplicate_on_rerun(
+    shell: PositronShell, plots_service: PlotsService
+) -> None:
+    """
+    Re-running a seaborn axes-level plot creates a separate plot instead of stacking
+    onto the previous figure (which duplicated the colorbar).
+
+    See https://github.com/posit-dev/positron/issues/8898.
+    """
+    pytest.importorskip("seaborn")
+
+    shell.run_cell("import seaborn as sns; import numpy as np").raise_error()
+    code = "sns.heatmap(np.array([[1.0, 2.0], [3.0, 4.0]]))"
+    shell.run_cell(code).raise_error()
+    shell.run_cell(code).raise_error()
+
+    # Two independent plots, not one figure with stacked colorbars.
+    assert len(plots_service._plots) == 2  # noqa: SLF001
+
+
+def test_mpl_detect_library_walks_call_stack() -> None:
+    """
+    Detection attributes a figure to the library on the call stack, not one that is
+    merely imported -- so importing seaborn for styling doesn't mislabel a plain
+    matplotlib figure (which would otherwise be detached across cells).
+
+    See https://github.com/posit-dev/positron/issues/8898.
+    """
+    from positron.matplotlib_backend import _detect_plotting_library
+
+    # A plain call site is attributed to matplotlib.
+    assert _detect_plotting_library() == "matplotlib"
+
+    # A call site inside a seaborn-rooted module is attributed to seaborn. Define a
+    # function whose frame reports `__name__ == "seaborn.matrix"` (mimicking sns.heatmap).
+    namespace: Dict[str, Any] = {"__name__": "seaborn.matrix"}
+    exec("def call(detect):\n    return detect()", namespace)
+    assert namespace["call"](_detect_plotting_library) == "seaborn"
+
+
 def test_mpl_shutdown(shell: PositronShell, plots_service: PlotsService) -> None:
     plot_comms = [_create_mpl_plot(shell, plots_service) for _ in range(2)]
 

--- a/extensions/positron-python/python_files/posit/pyproject.toml
+++ b/extensions/positron-python/python_files/posit/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pytest-mock",
     "pytest-rerunfailures",
     "scipy",
+    "seaborn",
     "snowflake-connector-python",
     "sqlalchemy",
     "syrupy",

--- a/extensions/positron-python/python_files/posit/uv.lock
+++ b/extensions/positron-python/python_files/posit/uv.lock
@@ -5980,7 +5980,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.10' and sys_platform == 'emscripten') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -6503,6 +6503,7 @@ dependencies = [
     { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "seaborn" },
     { name = "snowflake-connector-python", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "snowflake-connector-python", version = "4.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "sqlalchemy" },
@@ -6544,6 +6545,7 @@ requires-dist = [
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "scipy" },
+    { name = "seaborn" },
     { name = "snowflake-connector-python" },
     { name = "sqlalchemy" },
     { name = "syrupy" },
@@ -9091,6 +9093,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
     { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
     { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
+name = "seaborn"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914, upload-time = "2024-01-25T13:21:49.598Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #8898

  Seaborn's axes-level functions (`heatmap`, `scatterplot`, etc.) draw onto the
  current axes (`plt.gca()`) when no `ax=` is passed. Because Positron persists
  matplotlib figures across cells, re-running seaborn code drew onto the previous
  figure and stacked elements such as colorbars on every render.

  This fixes it by:

  - Detaching high-level library figures (currently seaborn) from matplotlib's
    global registry after each cell, so the next run starts on a fresh figure. The
    detached plot stays open and renderable in the Plots pane; only the registry
    entry is removed.
  - Redirecting `plt.gca()` so that when seaborn resolves its axes implicitly while
    a matplotlib figure is active, it gets a fresh figure instead of drawing over
    the existing one.
  - Detecting the plotting library by walking the call stack instead of checking
    `sys.modules`, so a plain matplotlib figure isn't misattributed to seaborn just
    because seaborn was imported (e.g. via `sns.set_theme()`).

  Plain matplotlib figures are intentionally left persistent, preserving Positron's
  cross-cell figure persistence (updating or re-showing a plot across cells).

### Release Notes

<!--
  Optionally, replace `N/A` with text to be included in the next release notes.
  The `N/A` bullets are ignored. If you refer to one or more Positron issues,
  these issues are used to collect information about the feature or bugfix, such
  as the relevant language pack as determined by Github labels of type `lang: `.
  The note will automatically be tagged with the language.

  These notes are typically filled by the Positron team. If you are an external
  contributor, you may ignore this section.
-->

#### New Features

- N/A

#### Bug Fixes

- Seaborn plots show as expected on multiple calls #8898 


### Validation Steps

@:plots

happy path, run line by line

```python
import seaborn as sns
import pandas as pd

tips = sns.load_dataset("tips")
tips_pivot = pd.crosstab(tips['day'], tips['time'])
sns.heatmap(tips_pivot)
sns.heatmap(tips_pivot) # should make 2nd plot
sns.heatmap(tips_pivot) # should make 3rd plot
```


test mixing mpl and sns, run line by line or in a chunk

```python
import matplotlib.pyplot as plt
import seaborn as sns

tips = sns.load_dataset("tips")
fig, ax = plt.subplots(figsize=(8, 5))
sns.boxplot(data=tips, x="day", y="total_bill", ax=ax, palette="pastel")

ax.set_title("Combining Seaborn and Matplotlib", fontsize=16, weight="bold")
ax.set_xlabel("Day of the Week", fontsize=12)
ax.set_ylabel("Total Bill ($)", fontsize=12)
ax.grid(axis='y', linestyle='--', alpha=0.7)
```

test going between sns and mpl, run line by line or as a chunk

```python
import seaborn as sns
import pandas as pd
import numpy as np
import matplotlib.pyplot as plt

tips = sns.load_dataset("tips")
tips_pivot = pd.crosstab(tips['day'], tips['time'])
data = [np.random.normal(size=100) for _ in range(3)]

sns.heatmap(tips_pivot) # first plot

plt.figure(figsize=(6, 4))
plt.boxplot(data, positions=[0, 1, 2])
plt.show() # second plot

sns.heatmap(tips_pivot) # third plot

plt.figure(figsize=(6, 4))
plt.boxplot(data, positions=[0, 1, 2])
plt.show() # fourth plot
```
