### PR TITLE
ci: work around broken r-lib/rig Homebrew cask

### DIFF
--- a/.github/actions/setup-release-screenshot-runtimes/action.yml
+++ b/.github/actions/setup-release-screenshot-runtimes/action.yml
@@ -97,12 +97,13 @@ runs:
       run: |
         # Install rig directly from GitHub releases to avoid a broken cask in
         # the r-lib/homebrew-rig tap (double-quote typo in rig.rb line 5).
+        RIG_VERSION="0.8.1"
         if [ "$(uname -m)" = "x86_64" ]; then
-          RIG_PKG="rig-macos-x86_64-latest.pkg"
+          RIG_PKG="rig-${RIG_VERSION}-macOS-x86_64.pkg"
         else
-          RIG_PKG="rig-macos-arm64-latest.pkg"
+          RIG_PKG="rig-${RIG_VERSION}-macOS-arm64.pkg"
         fi
-        curl -fsSL "https://github.com/r-lib/rig/releases/latest/download/${RIG_PKG}" -o /tmp/rig.pkg
+        curl -fsSL "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_PKG}" -o /tmp/rig.pkg
         sudo installer -pkg /tmp/rig.pkg -target /
 
     - name: Install R (primary)

--- a/.github/actions/setup-release-screenshot-runtimes/action.yml
+++ b/.github/actions/setup-release-screenshot-runtimes/action.yml
@@ -95,8 +95,15 @@ runs:
     - name: Install rig
       shell: bash
       run: |
-        brew tap r-lib/rig
-        brew install --cask rig
+        # Install rig directly from GitHub releases to avoid a broken cask in
+        # the r-lib/homebrew-rig tap (double-quote typo in rig.rb line 5).
+        if [ "$(uname -m)" = "x86_64" ]; then
+          RIG_PKG="rig-macos-x86_64-latest.pkg"
+        else
+          RIG_PKG="rig-macos-arm64-latest.pkg"
+        fi
+        curl -fsSL "https://github.com/r-lib/rig/releases/latest/download/${RIG_PKG}" -o /tmp/rig.pkg
+        sudo installer -pkg /tmp/rig.pkg -target /
 
     - name: Install R (primary)
       shell: bash

--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -189,8 +189,15 @@ jobs:
           R_VERSION="4.5.2"
           R_ALTERNATE_VERSION="4.3.0"
           echo "Installing R version $R_VERSION using Rig..."
-          brew tap r-lib/rig
-          brew install --cask rig
+          # Install rig directly from GitHub releases to avoid a broken cask in
+          # the r-lib/homebrew-rig tap (double-quote typo in rig.rb line 5).
+          if [ "${{ inputs.arch }}" = "x64" ]; then
+            RIG_PKG="rig-macos-x86_64-latest.pkg"
+          else
+            RIG_PKG="rig-macos-arm64-latest.pkg"
+          fi
+          curl -fsSL "https://github.com/r-lib/rig/releases/latest/download/${RIG_PKG}" -o /tmp/rig.pkg
+          sudo installer -pkg /tmp/rig.pkg -target /
           rig add "$R_VERSION"
           echo "Installing R version $R_ALTERNATE_VERSION using Rig..."
           rig add "$R_ALTERNATE_VERSION"

--- a/.github/workflows/test-e2e-macos-run.yml
+++ b/.github/workflows/test-e2e-macos-run.yml
@@ -191,12 +191,13 @@ jobs:
           echo "Installing R version $R_VERSION using Rig..."
           # Install rig directly from GitHub releases to avoid a broken cask in
           # the r-lib/homebrew-rig tap (double-quote typo in rig.rb line 5).
+          RIG_VERSION="0.8.1"
           if [ "${{ inputs.arch }}" = "x64" ]; then
-            RIG_PKG="rig-macos-x86_64-latest.pkg"
+            RIG_PKG="rig-${RIG_VERSION}-macOS-x86_64.pkg"
           else
-            RIG_PKG="rig-macos-arm64-latest.pkg"
+            RIG_PKG="rig-${RIG_VERSION}-macOS-arm64.pkg"
           fi
-          curl -fsSL "https://github.com/r-lib/rig/releases/latest/download/${RIG_PKG}" -o /tmp/rig.pkg
+          curl -fsSL "https://github.com/r-lib/rig/releases/download/v${RIG_VERSION}/${RIG_PKG}" -o /tmp/rig.pkg
           sudo installer -pkg /tmp/rig.pkg -target /
           rig add "$R_VERSION"
           echo "Installing R version $R_ALTERNATE_VERSION using Rig..."


### PR DESCRIPTION
### Summary
The r-lib/homebrew-rig tap has a syntax error in `rig.rb` (double-quote typo on the sha256 line) that makes `brew install --cask rig` fail on all macOS CI runs right now. Install rig directly from the GitHub releases `.pkg` instead, with arch detection to handle both arm64 and x64 runners.

- Replaces `brew tap r-lib/rig && brew install --cask rig` with a direct `curl` + `installer` from the GitHub releases endpoint
- Handles both `arm64` and `x64` runners via the existing `inputs.arch` input

### QA Notes
See run here: https://github.com/posit-dev/positron/actions/runs/28122855894