### PR TITLE
Add spinner for language runtime picker

### DIFF
--- a/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
+++ b/src/vs/workbench/contrib/languageRuntime/browser/languageRuntimeActions.ts
@@ -580,6 +580,22 @@ export const selectNewLanguageRuntime = async (
 	quickPick.title = options?.title || localize('positron.languageRuntime.startSession', 'Start New Interpreter Session');
 	quickPick.canSelectMany = false;
 
+	// Reflect discovery state in the picker: a busy spinner while runtimes are
+	// still being discovered, and an explanatory placeholder for an empty list.
+	// Phase is read from ILanguageRuntimeService -- the same service the rebuild
+	// subscription below uses.
+	const updateDiscoveryProgress = () => {
+		const discovering = languageRuntimeService.startupPhase !== RuntimeStartupPhase.Complete;
+		quickPick.busy = discovering;
+		if (discovering) {
+			quickPick.placeholder = localize('positron.languageRuntime.discoveringInterpreters', "Discovering interpreters...");
+		} else if (!quickPick.items.some(item => item.type !== 'separator')) {
+			quickPick.placeholder = localize('positron.languageRuntime.noInterpretersFound', "No interpreters found");
+		} else {
+			quickPick.placeholder = undefined;
+		}
+	};
+
 	// Reassigning quickPick.items resets activeItems to the first row, so
 	// rebuilds via this helper preserve the previously focused item (whether
 	// it was the caller's currentRuntimeId or a row the user keyboard-
@@ -596,6 +612,7 @@ export const selectNewLanguageRuntime = async (
 				quickPick.activeItems = [stillPresent];
 			}
 		}
+		updateDiscoveryProgress();
 	};
 
 	quickPick.items = buildItems();
@@ -611,6 +628,9 @@ export const selectNewLanguageRuntime = async (
 		}
 	}
 
+	// Set the initial busy/placeholder state for the phase the picker opened in.
+	updateDiscoveryProgress();
+
 	// Rebuild when a new runtime registers - covers late initial discovery
 	// and post-startup rediscovery.
 	disposables.add(languageRuntimeService.onDidRegisterRuntime(() => {
@@ -621,8 +641,14 @@ export const selectNewLanguageRuntime = async (
 	// (which we previously skipped) and rebuild.
 	disposables.add(languageRuntimeService.onDidChangeRuntimeStartupPhase(async phase => {
 		if (phase === RuntimeStartupPhase.Complete) {
+			// Discovery finished: pick up contributions we skipped, rebuild (which
+			// also clears the spinner via updateDiscoveryProgress), and we're done.
 			await fetchContributedItems();
 			rebuildItems();
+		} else {
+			// Any other transition (e.g. into Discovering): refresh the spinner /
+			// placeholder.
+			updateDiscoveryProgress();
 		}
 	}));
 

--- a/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
+++ b/src/vs/workbench/contrib/languageRuntime/test/browser/languageRuntimeActions.vitest.ts
@@ -308,6 +308,95 @@ describe('selectNewLanguageRuntime', () => {
 			pick.cancel(QuickInputHideReason.Gesture);
 			await promise;
 		});
+
+		it('shows a busy spinner and discovering placeholder while phase is not Complete', async () => {
+			const runtimeService = ctx.get(ILanguageRuntimeService);
+			runtimeService.setStartupPhase(RuntimeStartupPhase.Discovering);
+			registerRuntime(makeRuntime({ runtimeId: 'py-1' }));
+
+			const promise = runPicker();
+			await waitUntilOpened();
+			expect(pick.busy).toBe(true);
+			expect(pick.placeholder).toBe('Discovering interpreters...');
+
+			runtimeService.setStartupPhase(RuntimeStartupPhase.Complete);
+			// The Complete handler is async (re-fetches contributions); poll for busy to clear.
+			await vi.waitFor(() => expect(pick.busy).toBe(false));
+			expect(pick.placeholder).toBeUndefined();
+
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+
+		it('shows "No interpreters found" when discovery completes with no runtimes', async () => {
+			// beforeEach leaves the phase at Complete; register nothing.
+			const promise = runPicker();
+			await waitUntilOpened();
+			expect(pick.busy).toBe(false);
+			expect(pick.placeholder).toBe('No interpreters found');
+
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+
+		it('does not show a spinner when discovery is already complete on open', async () => {
+			registerRuntime(makeRuntime({ runtimeId: 'py-1' }));
+			const promise = runPicker();
+			await waitUntilOpened();
+			expect(pick.busy).toBe(false);
+			expect(pick.placeholder).toBeUndefined();
+
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+
+		it('toggles the spinner back on when phase leaves Complete while the picker is open', async () => {
+			const runtimeService = ctx.get(ILanguageRuntimeService);
+			registerRuntime(makeRuntime({ runtimeId: 'py-1' }));
+			// beforeEach leaves the phase at Complete.
+			const promise = runPicker();
+			await waitUntilOpened();
+			expect(pick.busy).toBe(false);
+
+			// Phase leaving Complete (e.g. a user-triggered rediscovery) must flip
+			// the spinner back on -- the regression the broadened handler fixes.
+			runtimeService.setStartupPhase(RuntimeStartupPhase.Discovering);
+			expect(pick.busy).toBe(true);
+			expect(pick.placeholder).toBe('Discovering interpreters...');
+
+			runtimeService.setStartupPhase(RuntimeStartupPhase.Complete);
+			await vi.waitFor(() => expect(pick.busy).toBe(false));
+
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
+
+		it('shows no empty-state placeholder when only contributed items are present at Complete', async () => {
+			const runtimeService = ctx.get(ILanguageRuntimeService);
+			// beforeEach leaves the phase at Complete; register a contribution but no runtimes.
+			const contribution: IRuntimePickerContribution = {
+				handle: 8,
+				languageId: 'python',
+				getItems: async () => [{ id: 'install-uv', label: 'Install Python via uv' }],
+				onSelect: vi.fn(),
+			};
+			ctx.disposables.add(runtimeService.registerPickerContribution(contribution));
+
+			const promise = runPicker();
+			await waitUntilOpened();
+
+			// A contributed item counts as a selectable row, so the empty-state
+			// placeholder must NOT appear even though there are no runtimes.
+			const contributedItem = pick.items.find(
+				(item): item is IQuickPickItem => item.type !== 'separator' && item.label === 'Install Python via uv',
+			);
+			expect(contributedItem).toBeDefined();
+			expect(pick.busy).toBe(false);
+			expect(pick.placeholder).toBeUndefined();
+
+			pick.cancel(QuickInputHideReason.Gesture);
+			await promise;
+		});
 	});
 
 	describe('contributed items', () => {


### PR DESCRIPTION
Fixes #13135. Now, while discovery is in progress, the picker shows a busy spinner and a "Discovering interpreters..." placeholder, and interpreters continue to stream into the open list as they are registered. When discovery finishes with no interpreters, the placeholder reads "No interpreters found"; otherwise the spinner and placeholder clear.

### Screenshots


https://github.com/user-attachments/assets/0bc47c5b-c3c1-4b6b-bac4-667f2cae7d30



### Release Notes

#### New Features

- The interpreter picker now shows a progress spinner and status message while interpreters are still being discovered (#13135)

#### Bug Fixes

- N/A

### Validation Steps

@:interpreter @:sessions

1. Open a project and click "Start Session" immediately, before discovery finishes.
2. Verify the picker shows a busy spinner and the "Discovering interpreters..." placeholder, and that interpreters appear in the list as they are discovered (no need to close and reopen).
3. Verify the spinner and placeholder clear once discovery completes.
