### PR TITLE
Pne update modals

### DIFF
--- a/src/vs/base/browser/positronModalDialogReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalDialogReactRenderer.tsx
@@ -14,6 +14,7 @@ import { createRoot, Root } from 'react-dom/client';
 import * as DOM from './dom.js';
 import { Emitter } from '../common/event.js';
 import { Disposable } from '../common/lifecycle.js';
+import { KeyCode } from '../common/keyCodes.js';
 import { StandardKeyboardEvent } from './keyboardEvent.js';
 import { PositronReactServices } from './positronReactServices.js';
 import { PositronReactServicesProvider } from './positronReactRendererContext.js';
@@ -208,7 +209,16 @@ export class PositronModalDialogReactRenderer extends Disposable {
 			);
 			if (resolutionResult.kind === ResultKind.KbFound && resolutionResult.commandId !== null) {
 				if (ALLOWABLE_COMMANDS.indexOf(resolutionResult.commandId) === -1) {
-					DOM.EventHelper.stop(event, true);
+					// Escape needs special handling: the native <dialog> closes itself on Escape via
+					// the keydown's default action. When Escape is bound to a command in the
+					// underlying editor (e.g. a notebook cell's exit-edit-mode binding), only stop
+					// propagation so that command doesn't also run -- do NOT preventDefault, which
+					// would suppress the dialog's own close and leave the modal stuck open.
+					if (event.keyCode === KeyCode.Escape) {
+						event.stopPropagation();
+					} else {
+						DOM.EventHelper.stop(event, true);
+					}
 				}
 			}
 		};

--- a/src/vs/base/browser/positronModalDialogReactRenderer.tsx
+++ b/src/vs/base/browser/positronModalDialogReactRenderer.tsx
@@ -35,6 +35,38 @@ const ALLOWABLE_COMMANDS = [
 ];
 
 /**
+ * Decides how a keydown should be suppressed while a modal is open, given the command (if any) the
+ * key resolves to. Extracted from the renderer's window-level keydown handler so it can be
+ * unit-tested without a live <dialog>.
+ *
+ * - If the key resolves to no command, or to an allowable command (copy/cut/paste/etc.), it is left
+ *   alone so the modal's inputs keep working.
+ * - Escape that resolves to a non-allowable command only gets stopPropagation, so the bound command
+ *   does not run but the native <dialog>'s own close-on-Escape (a default action) still fires.
+ * - Any other non-allowable bound key gets the full stop (preventDefault + stopPropagation).
+ *
+ * @param commandId The command the key resolves to, or null when it resolves to none.
+ * @param event The keyboard event to (possibly) suppress.
+ */
+export function applyModalKeydownSuppression(
+	commandId: string | null,
+	event: { readonly keyCode: KeyCode; preventDefault(): void; stopPropagation(): void },
+): void {
+	if (commandId === null || ALLOWABLE_COMMANDS.indexOf(commandId) !== -1) {
+		return;
+	}
+	// Escape needs special handling: the native <dialog> closes itself on Escape via the keydown's
+	// default action. When Escape is bound to a command in the underlying editor (e.g. a notebook
+	// cell's exit-edit-mode binding), only stop propagation so that command does not also run -- do
+	// NOT preventDefault, which would suppress the dialog's own close and leave the modal stuck open.
+	if (event.keyCode === KeyCode.Escape) {
+		event.stopPropagation();
+	} else {
+		DOM.EventHelper.stop(event, true);
+	}
+}
+
+/**
  * Options passed to PositronModalDialogReactRenderer. `container` defaults to the active workbench
  * container; `onDisposed` is invoked after the dialog is closed and removed from the DOM.
  */
@@ -207,20 +239,8 @@ export class PositronModalDialogReactRenderer extends Disposable {
 				event,
 				PositronReactServices.services.workbenchLayoutService.activeContainer
 			);
-			if (resolutionResult.kind === ResultKind.KbFound && resolutionResult.commandId !== null) {
-				if (ALLOWABLE_COMMANDS.indexOf(resolutionResult.commandId) === -1) {
-					// Escape needs special handling: the native <dialog> closes itself on Escape via
-					// the keydown's default action. When Escape is bound to a command in the
-					// underlying editor (e.g. a notebook cell's exit-edit-mode binding), only stop
-					// propagation so that command doesn't also run -- do NOT preventDefault, which
-					// would suppress the dialog's own close and leave the modal stuck open.
-					if (event.keyCode === KeyCode.Escape) {
-						event.stopPropagation();
-					} else {
-						DOM.EventHelper.stop(event, true);
-					}
-				}
-			}
+			const commandId = resolutionResult.kind === ResultKind.KbFound ? resolutionResult.commandId : null;
+			applyModalKeydownSuppression(commandId, event);
 		};
 
 		/**

--- a/src/vs/base/browser/test/positronModalDialogReactRenderer.vitest.ts
+++ b/src/vs/base/browser/test/positronModalDialogReactRenderer.vitest.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/// <reference types="vitest/globals" />
+
+import { KeyCode } from '../../common/keyCodes.js';
+import { applyModalKeydownSuppression } from '../positronModalDialogReactRenderer.js';
+
+/** A keyboard event with only the members applyModalKeydownSuppression touches. */
+function fakeEvent(keyCode: KeyCode) {
+	return { keyCode, preventDefault: vi.fn(), stopPropagation: vi.fn() };
+}
+
+describe('applyModalKeydownSuppression', () => {
+	it('leaves unbound keys alone (no matching command)', () => {
+		const event = fakeEvent(KeyCode.KeyA);
+		applyModalKeydownSuppression(null, event);
+		expect(event.preventDefault).not.toHaveBeenCalled();
+		expect(event.stopPropagation).not.toHaveBeenCalled();
+	});
+
+	it('leaves allowable commands alone so modal inputs keep working', () => {
+		const event = fakeEvent(KeyCode.KeyC);
+		applyModalKeydownSuppression('copy', event);
+		expect(event.preventDefault).not.toHaveBeenCalled();
+		expect(event.stopPropagation).not.toHaveBeenCalled();
+	});
+
+	it('Escape bound to a non-allowable command stops propagation but NOT default, so the dialog still closes', () => {
+		const event = fakeEvent(KeyCode.Escape);
+		applyModalKeydownSuppression('notebook.cell.quitEdit', event);
+		expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+		expect(event.preventDefault).not.toHaveBeenCalled();
+	});
+
+	it('a non-Escape bound key gets the full stop (preventDefault + stopPropagation)', () => {
+		const event = fakeEvent(KeyCode.KeyP);
+		applyModalKeydownSuppression('workbench.action.showCommands', event);
+		expect(event.preventDefault).toHaveBeenCalledTimes(1);
+		expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/oneButtonFooter.css
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/oneButtonFooter.css
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.positron-dynamic-modal-dialog-box .one-button-footer {
+	height: 48px;
+	display: flex;
+	padding: 0 16px;
+	flex: 0 0 auto;
+	justify-content: end;
+	align-items: flex-start;
+}

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/oneButtonFooter.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/components/oneButtonFooter.tsx
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (C) 2026 Posit Software, PBC. All rights reserved.
+ *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// CSS.
+import './oneButtonFooter.css';
+
+// Other dependencies.
+import { FooterButton } from './footerButton.js';
+
+/**
+ * OneButtonFooterProps interface.
+ */
+interface OneButtonFooterProps {
+	buttonTitle: string;
+	onButton: () => void;
+}
+
+/**
+ * OneButtonFooter component. A single right-aligned default button, used by acknowledge-style
+ * dialogs (e.g. an OK / Close / Got it button). The button is type='submit' so Enter activates it
+ * via the dialog's wrapping form.
+ * @param props A OneButtonFooterProps that contains the component properties.
+ * @returns The rendered component.
+ */
+export const OneButtonFooter = (props: OneButtonFooterProps) => {
+	return (
+		<div className='one-button-footer'>
+			<FooterButton autoFocus default type='submit' onPressed={props.onButton}>
+				{props.buttonTitle}
+			</FooterButton>
+		</div>
+	);
+};

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.tsx
@@ -33,11 +33,6 @@ export interface PositronDynamicModalDialogProps {
 	footer?: ReactNode;
 	onCancel?: () => void;
 
-	// Optional click-outside handler. When provided, clicking the backdrop area outside the dialog
-	// box invokes this callback (the native <dialog> does not close on backdrop click on its own).
-	// Leave undefined to keep the dialog open on outside clicks.
-	onClickOutside?: () => void;
-
 	// Optional form submit handler. The content and footer are always wrapped in a <form>; when this
 	// is provided, pressing Enter in any input fires this callback (the dialog calls preventDefault on
 	// the underlying submit event automatically). Enter-to-submit only fires if the footer includes a
@@ -230,18 +225,7 @@ export const PositronDynamicModalDialog = (props: PositronDynamicModalDialogProp
 
 	// Render.
 	return (
-		// eslint-disable-next-line jsx-a11y/no-static-element-interactions -- backdrop click-to-dismiss is a mouse-only convenience; the keyboard/AT path to close is the native <dialog>'s Escape handling.
-		<div
-			ref={dialogContainerRef}
-			className='positron-dynamic-modal-dialog-box-container'
-			onClick={(e) => {
-				// Close only when the click lands directly on the backdrop container, not on the
-				// dialog box or its descendants. Mirrors the old PositronModalDialog behavior.
-				if (props.onClickOutside && e.target === dialogContainerRef.current) {
-					props.onClickOutside();
-				}
-			}}
-		>
+		<div ref={dialogContainerRef} className='positron-dynamic-modal-dialog-box-container'>
 			<div ref={dialogBoxRef} className='positron-dynamic-modal-dialog-box' style={{
 				left: dialogBoxState.left,
 				top: dialogBoxState.top,

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.tsx
@@ -43,6 +43,8 @@ export interface PositronDynamicModalDialogProps {
 	// the underlying submit event automatically). Enter-to-submit only fires if the footer includes a
 	// button with type='submit' to serve as the form's implicit submit target -- callers opt in
 	// per button (Button defaults to type='button', so other buttons never become the submit target).
+	// Wire onSubmit to the SAME action as that submit button's onPressed, otherwise Enter and a mouse
+	// click on the primary button will do different things.
 	onSubmit?: () => void;
 }
 

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.tsx
@@ -33,6 +33,11 @@ export interface PositronDynamicModalDialogProps {
 	footer?: ReactNode;
 	onCancel?: () => void;
 
+	// Optional click-outside handler. When provided, clicking the backdrop area outside the dialog
+	// box invokes this callback (the native <dialog> does not close on backdrop click on its own).
+	// Leave undefined to keep the dialog open on outside clicks.
+	onClickOutside?: () => void;
+
 	// Optional form submit handler. When provided, the dialog renders a hidden submit button and
 	// inside the wrapping <form> so pressing Enter in any input fires this callback. The dialog
 	// calls preventDefault on the underlying submit event automatically. Footer/content buttons
@@ -223,7 +228,18 @@ export const PositronDynamicModalDialog = (props: PositronDynamicModalDialogProp
 
 	// Render.
 	return (
-		<div ref={dialogContainerRef} className='positron-dynamic-modal-dialog-box-container'>
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions -- backdrop click-to-dismiss is a mouse-only convenience; the keyboard/AT path to close is the native <dialog>'s Escape handling.
+		<div
+			ref={dialogContainerRef}
+			className='positron-dynamic-modal-dialog-box-container'
+			onClick={(e) => {
+				// Close only when the click lands directly on the backdrop container, not on the
+				// dialog box or its descendants. Mirrors the old PositronModalDialog behavior.
+				if (props.onClickOutside && e.target === dialogContainerRef.current) {
+					props.onClickOutside();
+				}
+			}}
+		>
 			<div ref={dialogBoxRef} className='positron-dynamic-modal-dialog-box' style={{
 				left: dialogBoxState.left,
 				top: dialogBoxState.top,

--- a/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.tsx
+++ b/src/vs/workbench/browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.tsx
@@ -38,11 +38,11 @@ export interface PositronDynamicModalDialogProps {
 	// Leave undefined to keep the dialog open on outside clicks.
 	onClickOutside?: () => void;
 
-	// Optional form submit handler. When provided, the dialog renders a hidden submit button and
-	// inside the wrapping <form> so pressing Enter in any input fires this callback. The dialog
-	// calls preventDefault on the underlying submit event automatically. Footer/content buttons
-	// stay type='button' and never become implicit submit targets themselves -- callers wire
-	// Enter-to-submit by passing onSubmit, not by promoting a button.
+	// Optional form submit handler. The content and footer are always wrapped in a <form>; when this
+	// is provided, pressing Enter in any input fires this callback (the dialog calls preventDefault on
+	// the underlying submit event automatically). Enter-to-submit only fires if the footer includes a
+	// button with type='submit' to serve as the form's implicit submit target -- callers opt in
+	// per button (Button defaults to type='button', so other buttons never become the submit target).
 	onSubmit?: () => void;
 }
 
@@ -247,12 +247,11 @@ export const PositronDynamicModalDialog = (props: PositronDynamicModalDialogProp
 			}}>
 				<TitleBar size={props.titleBarSize} title={props.title} onDrag={dragHandler} onStartDrag={startDragHandler} onStopDrag={stopDragHandler} />
 				{/*
-					The content area and footer are always wrapped in a <form>. Enter-key
-					implicit submission only activates when a submit target exists -- in this
-					component that target is the hidden <button type='submit'> rendered below
-					when the caller passes onSubmit. Other buttons in the dialog use type='button'
-					and never serve as the submit target, so callers can compose any footer or
-					content without worrying about which button "is" the submit button.
+					The content area and footer are always wrapped in a <form>. Enter-key implicit
+					submission only activates when a submit target exists -- i.e. when the footer
+					includes a button with type='submit'. Button defaults to type='button', so other
+					buttons never serve as the submit target, letting callers compose any footer or
+					content while choosing exactly which button "is" the submit button.
 				*/}
 				<form className='positron-dynamic-modal-dialog-form' onSubmit={submitHandler}>
 					<div className='content-area' style={{

--- a/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AskAssistantAction.tsx
@@ -18,7 +18,7 @@ import { IChatEditingService } from '../../chat/common/editing/chatEditingServic
 import { IDialogService } from '../../../../platform/dialogs/common/dialogs.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../common/positronNotebookCommon.js';
 import { AI_ENABLED_KEY } from '../../positronAssistant/common/positronAIConfiguration.js';
-import { PositronModalReactRenderer } from '../../../../base/browser/positronModalReactRenderer.js';
+import { PositronModalDialogReactRenderer } from '../../../../base/browser/positronModalDialogReactRenderer.js';
 import { AssistantPanel } from './AssistantPanel/AssistantPanel.js';
 import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
 import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
@@ -86,7 +86,7 @@ export class AskAssistantAction extends Action2 {
 
 		// Create the modal renderer for a centered dialog
 		// Hook up cancellation so polling stops if the modal is closed early
-		const renderer = new PositronModalReactRenderer({
+		const renderer = new PositronModalDialogReactRenderer({
 			container: layoutService.activeContainer,
 			onDisposed: () => {
 				notebookPromise?.cancel();

--- a/src/vs/workbench/contrib/positronNotebook/browser/AssistantPanel/AssistantPanel.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AssistantPanel/AssistantPanel.css
@@ -3,11 +3,6 @@
  *  Licensed under the Elastic License 2.0. See LICENSE.txt for license information.
  *--------------------------------------------------------------------------------------------*/
 
-/* Override content-area to extend to bottom (no action buttons) */
-.positron-modal-dialog-box:has(.assistant-panel-content) .content-area {
-	bottom: 0;
-}
-
 /* Wrapper for content inside the modal dialog */
 .assistant-panel-content {
 	display: flex;

--- a/src/vs/workbench/contrib/positronNotebook/browser/AssistantPanel/AssistantPanel.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AssistantPanel/AssistantPanel.css
@@ -12,11 +12,6 @@
 	position: relative;
 }
 
-/* Adjust section spacing for modal context */
-.positron-modal-dialog-box .assistant-panel-section {
-	margin: 0;
-}
-
 .assistant-panel {
 	display: flex;
 	flex-direction: column;

--- a/src/vs/workbench/contrib/positronNotebook/browser/AssistantPanel/AssistantPanel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AssistantPanel/AssistantPanel.tsx
@@ -700,7 +700,6 @@ export const AssistantPanel = (props: AssistantPanelProps) => {
 			renderer={renderer}
 			title={panelTitle}
 			width={480}
-			onClickOutside={handleClose}
 		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronNotebook/browser/AssistantPanel/AssistantPanel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AssistantPanel/AssistantPanel.tsx
@@ -13,9 +13,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import * as DOM from '../../../../../base/browser/dom.js';
 import { localize } from '../../../../../nls.js';
 import { Popover } from '../../../../browser/positronComponents/popover/popover.js';
-import { PositronModalDialog } from '../../../../browser/positronComponents/positronModalDialog/positronModalDialog.js';
-import { ContentArea } from '../../../../browser/positronComponents/positronModalDialog/components/contentArea.js';
-import { PositronModalReactRenderer } from '../../../../../base/browser/positronModalReactRenderer.js';
+import { PositronDynamicModalDialog } from '../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
+import { PositronModalDialogReactRenderer } from '../../../../../base/browser/positronModalDialogReactRenderer.js';
 import { IPositronNotebookInstance } from '../IPositronNotebookInstance.js';
 import { PositronNotebookAssistantController } from '../contrib/assistant/controller.js';
 import { AssistantPanelContext } from './AssistantPanelContext.js';
@@ -95,7 +94,7 @@ export interface AssistantPanelProps {
 	initialNotebook: IPositronNotebookInstance | undefined;
 	/** Promise that resolves to the notebook instance (used when initialNotebook is undefined) */
 	notebookPromise: CancelablePromise<IPositronNotebookInstance> | undefined;
-	renderer: PositronModalReactRenderer;
+	renderer: PositronModalDialogReactRenderer;
 	chatEditingService: IChatEditingService;
 	commandService: ICommandService;
 	configurationService: IConfigurationService;
@@ -690,19 +689,18 @@ export const AssistantPanel = (props: AssistantPanelProps) => {
 	};
 
 	return (
-		<PositronModalDialog
-			closeOnClickOutside={true}
-			height={450}
-			renderer={renderer}
-			title={panelTitle}
-			width={400}
-			onCancel={handleClose}
-		>
-			<ContentArea>
+		<PositronDynamicModalDialog
+			content={
 				<div className='assistant-panel-content'>
 					{renderContent()}
 				</div>
-			</ContentArea>
-		</PositronModalDialog>
+			}
+			contentMaxHeight={600}
+			contentMinHeight={200}
+			renderer={renderer}
+			title={panelTitle}
+			width={480}
+			onClickOutside={handleClose}
+		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronNotebook/browser/AssistantPanel/AssistantPanel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/AssistantPanel/AssistantPanel.tsx
@@ -14,6 +14,7 @@ import * as DOM from '../../../../../base/browser/dom.js';
 import { localize } from '../../../../../nls.js';
 import { Popover } from '../../../../browser/positronComponents/popover/popover.js';
 import { PositronDynamicModalDialog } from '../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
+import { OneButtonFooter } from '../../../../browser/positronComponents/positronDynamicModalDialog/components/oneButtonFooter.js';
 import { PositronModalDialogReactRenderer } from '../../../../../base/browser/positronModalDialogReactRenderer.js';
 import { IPositronNotebookInstance } from '../IPositronNotebookInstance.js';
 import { PositronNotebookAssistantController } from '../contrib/assistant/controller.js';
@@ -697,6 +698,11 @@ export const AssistantPanel = (props: AssistantPanelProps) => {
 			}
 			contentMaxHeight={600}
 			contentMinHeight={200}
+			// A footer Close button gives an explicit way out (Escape also works). onSubmit is
+			// intentionally not wired: unlike the read-only Help/Ghost Cell dialogs, this panel has
+			// interactive controls, and Enter-to-submit would dismiss it from any focused input. The
+			// autofocused Close button still closes on Enter via the Button's own key handling.
+			footer={<OneButtonFooter buttonTitle={closeButtonLabel} onButton={handleClose} />}
 			renderer={renderer}
 			title={panelTitle}
 			width={480}

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/GhostCell.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/GhostCell.tsx
@@ -18,7 +18,7 @@ import { GhostCellState } from './controller.js';
 import { useGhostCellController } from './useGhostCellController.js';
 import { ScreenReaderOnly } from '../../../../../../base/browser/ui/positronComponents/ScreenReaderOnly.js';
 import { usePositronReactServicesContext } from '../../../../../../base/browser/positronReactRendererContext.js';
-import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
+import { PositronModalDialogReactRenderer } from '../../../../../../base/browser/positronModalDialogReactRenderer.js';
 import { GhostCellInfoModalDialog } from './GhostCellInfoModalDialog.js';
 import { SELECT_GHOST_CELL_MODEL_COMMAND_ID } from './config.js';
 import { IAction } from '../../../../../../base/common/actions.js';
@@ -556,7 +556,7 @@ export const GhostCell: React.FC = () => {
 	}, [controller]);
 
 	const handleShowInfo = React.useCallback(() => {
-		const renderer = new PositronModalReactRenderer({
+		const renderer = new PositronModalDialogReactRenderer({
 			container: workbenchLayoutService.getContainer(DOM.getWindow(containerRef.current))
 		});
 		// Extract modelName from state if available

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/GhostCellInfoModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/GhostCellInfoModalDialog.tsx
@@ -12,8 +12,9 @@ import React from 'react';
 // Other dependencies.
 import { localize } from '../../../../../../nls.js';
 import { isMacintosh } from '../../../../../../base/common/platform.js';
-import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
-import { OKModalDialog } from '../../../../../browser/positronComponents/positronModalDialog/positronOKModalDialog.js';
+import { PositronModalDialogReactRenderer } from '../../../../../../base/browser/positronModalDialogReactRenderer.js';
+import { PositronDynamicModalDialog } from '../../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
+import { OneButtonFooter } from '../../../../../browser/positronComponents/positronDynamicModalDialog/components/oneButtonFooter.js';
 import { REQUEST_GHOST_CELL_SUGGESTION_COMMAND_ID } from './config.js';
 
 // Localized strings.
@@ -44,7 +45,7 @@ const openModelSettingLabel = localize('ghostCellInfo.openModelSetting', 'Open m
  * GhostCellInfoModalDialogProps interface.
  */
 interface GhostCellInfoModalDialogProps {
-	renderer: PositronModalReactRenderer;
+	renderer: PositronModalDialogReactRenderer;
 	modelName?: string;
 }
 
@@ -78,64 +79,66 @@ export const GhostCellInfoModalDialog: React.FC<GhostCellInfoModalDialogProps> =
 	}, [renderer, commandService]);
 
 	return (
-		<OKModalDialog
-			height={modelName ? 520 : 490}
-			okButtonTitle={gotItButtonLabel}
+		<PositronDynamicModalDialog
+			content={
+				<div className='ghost-cell-info-content'>
+					<div className='ghost-cell-info-section'>
+						<h3 className='ghost-cell-info-heading'>{whatAreGhostCellsHeading}</h3>
+						<p className='ghost-cell-info-text'>{whatAreGhostCellsText}</p>
+					</div>
+					<div className='ghost-cell-info-section'>
+						<h3 className='ghost-cell-info-heading'>{howDoTheyWorkHeading}</h3>
+						<p className='ghost-cell-info-text'>{howDoTheyWorkText}</p>
+						<p className='ghost-cell-info-text'>
+							{keyboardShortcutPrefix}{' '}
+							<kbd className='ghost-cell-info-kbd'>{shortcutLabel}</kbd>.
+						</p>
+					</div>
+					<div className='ghost-cell-info-section'>
+						<h3 className='ghost-cell-info-heading'>{modelSelectionHeading}</h3>
+						{modelName && (
+							<p className='ghost-cell-info-text'>
+								{currentModelText} <strong>{modelName}</strong>.
+							</p>
+						)}
+						<p className='ghost-cell-info-text'>
+							{modelExplanationTextPart1}
+							<a
+								aria-label={openModelSettingLabel}
+								className='ghost-cell-info-settings-link'
+								href=''
+								onClick={handleOpenModelSetting}
+							>
+								{modelSettingsLinkText}
+							</a>
+							{modelExplanationTextPart2}
+						</p>
+					</div>
+					<div className='ghost-cell-info-section'>
+						<h3 className='ghost-cell-info-heading'>{howToDisableHeading}</h3>
+						<p className='ghost-cell-info-text'>
+							{howToDisableTextPart1}
+							<a
+								aria-label={openSettingLabel}
+								className='ghost-cell-info-settings-link'
+								href=''
+								onClick={handleOpenSetting}
+							>
+								{settingsLinkText}
+							</a>
+							{howToDisableTextPart2}
+						</p>
+					</div>
+				</div>
+			}
+			contentMaxHeight={600}
+			footer={
+				<OneButtonFooter buttonTitle={gotItButtonLabel} onButton={handleClose} />
+			}
 			renderer={renderer}
 			title={dialogTitle}
 			width={480}
-			onAccept={handleClose}
-			onCancel={handleClose}
-		>
-			<div className='ghost-cell-info-content'>
-				<div className='ghost-cell-info-section'>
-					<h3 className='ghost-cell-info-heading'>{whatAreGhostCellsHeading}</h3>
-					<p className='ghost-cell-info-text'>{whatAreGhostCellsText}</p>
-				</div>
-				<div className='ghost-cell-info-section'>
-					<h3 className='ghost-cell-info-heading'>{howDoTheyWorkHeading}</h3>
-					<p className='ghost-cell-info-text'>{howDoTheyWorkText}</p>
-					<p className='ghost-cell-info-text'>
-						{keyboardShortcutPrefix}{' '}
-						<kbd className='ghost-cell-info-kbd'>{shortcutLabel}</kbd>.
-					</p>
-				</div>
-				<div className='ghost-cell-info-section'>
-					<h3 className='ghost-cell-info-heading'>{modelSelectionHeading}</h3>
-					{modelName && (
-						<p className='ghost-cell-info-text'>
-							{currentModelText} <strong>{modelName}</strong>.
-						</p>
-					)}
-					<p className='ghost-cell-info-text'>
-						{modelExplanationTextPart1}
-						<a
-							aria-label={openModelSettingLabel}
-							className='ghost-cell-info-settings-link'
-							href=''
-							onClick={handleOpenModelSetting}
-						>
-							{modelSettingsLinkText}
-						</a>
-						{modelExplanationTextPart2}
-					</p>
-				</div>
-				<div className='ghost-cell-info-section'>
-					<h3 className='ghost-cell-info-heading'>{howToDisableHeading}</h3>
-					<p className='ghost-cell-info-text'>
-						{howToDisableTextPart1}
-						<a
-							aria-label={openSettingLabel}
-							className='ghost-cell-info-settings-link'
-							href=''
-							onClick={handleOpenSetting}
-						>
-							{settingsLinkText}
-						</a>
-						{howToDisableTextPart2}
-					</p>
-				</div>
-			</div>
-		</OKModalDialog>
+			onSubmit={handleClose}
+		/>
 	);
 };

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/actions.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/ghostCell/actions.tsx
@@ -11,7 +11,7 @@ import { Action2, IAction2Options, registerAction2 } from '../../../../../../pla
 import { ServicesAccessor } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { IConfigurationService } from '../../../../../../platform/configuration/common/configuration.js';
 import { IQuickInputService } from '../../../../../../platform/quickinput/common/quickInput.js';
-import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
+import { PositronModalDialogReactRenderer } from '../../../../../../base/browser/positronModalDialogReactRenderer.js';
 import { IPositronNotebookInstance } from '../../IPositronNotebookInstance.js';
 import { NotebookAction2 } from '../../NotebookAction2.js';
 import { NotebookContextKeys } from '../../../common/notebookContextKeys.js';
@@ -104,7 +104,7 @@ registerGhostCellAction({
 	run: (controller) => {
 		const state = controller.ghostCellState.get();
 		const modelName = state.status === 'ready' ? state.modelName : undefined;
-		const renderer = new PositronModalReactRenderer();
+		const renderer = new PositronModalDialogReactRenderer();
 		renderer.render(<GhostCellInfoModalDialog modelName={modelName} renderer={renderer} />);
 	},
 });

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpAction.tsx
@@ -13,7 +13,7 @@ import { ICommandService } from '../../../../../../platform/commands/common/comm
 import { KeybindingWeight } from '../../../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { KeyCode, KeyMod } from '../../../../../../base/common/keyCodes.js';
 import { Codicon } from '../../../../../../base/common/codicons.js';
-import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
+import { PositronModalDialogReactRenderer } from '../../../../../../base/browser/positronModalDialogReactRenderer.js';
 import { POSITRON_NOTEBOOK_EDITOR_ID } from '../../../common/positronNotebookCommon.js';
 import { NotebookContextKeys } from '../../../common/notebookContextKeys.js';
 import { NotebookHelpPanel, resolveShortcutBindings } from './NotebookHelpPanel.js';
@@ -52,7 +52,7 @@ registerAction2(class NotebookShowKeyboardShortcutsAction extends Action2 {
 		// before the modal steals it and changes the active context.
 		const resolvedBindings = resolveShortcutBindings(keybindingService);
 
-		const renderer = new PositronModalReactRenderer({
+		const renderer = new PositronModalDialogReactRenderer({
 			container: layoutService.activeContainer,
 		});
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
@@ -162,7 +162,7 @@ export function NotebookHelpPanel({ renderer, resolvedBindings, onOpenAllShortcu
 						</div>
 					))}
 					<div className='notebook-help-all-shortcuts'>
-						<button className='all-shortcuts-link' onClick={() => { renderer.dispose(); onOpenAllShortcuts(); }}>
+						<button className='all-shortcuts-link' type='button' onClick={() => { renderer.dispose(); onOpenAllShortcuts(); }}>
 							{localize('positron.notebookHelp.allShortcuts', 'View All Notebook Keyboard Shortcuts...')}
 						</button>
 					</div>

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
@@ -175,7 +175,6 @@ export function NotebookHelpPanel({ renderer, resolvedBindings, onOpenAllShortcu
 			renderer={renderer}
 			title={localize('positron.notebookHelp.title', 'Notebook Keyboard Shortcuts')}
 			width={500}
-			onClickOutside={() => renderer.dispose()}
 			onSubmit={() => renderer.dispose()}
 		/>
 	);

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/help/NotebookHelpPanel.tsx
@@ -13,8 +13,9 @@ import { ReactElement } from 'react';
 // Other dependencies.
 import { localize } from '../../../../../../nls.js';
 import { IKeybindingService } from '../../../../../../platform/keybinding/common/keybinding.js';
-import { OKModalDialog } from '../../../../../browser/positronComponents/positronModalDialog/positronOKModalDialog.js';
-import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
+import { PositronDynamicModalDialog } from '../../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
+import { OneButtonFooter } from '../../../../../browser/positronComponents/positronDynamicModalDialog/components/oneButtonFooter.js';
+import { PositronModalDialogReactRenderer } from '../../../../../../base/browser/positronModalDialogReactRenderer.js';
 import { ResolvedChord, ResolvedKeybinding } from '../../../../../../base/common/keybindings.js';
 import { UILabelProvider } from '../../../../../../base/common/keybindingLabels.js';
 import { OS } from '../../../../../../base/common/platform.js';
@@ -96,7 +97,7 @@ export function resolveShortcutBindings(keybindingService: IKeybindingService): 
 }
 
 interface NotebookHelpPanelProps {
-	renderer: PositronModalReactRenderer;
+	renderer: PositronModalDialogReactRenderer;
 	resolvedBindings: ResolvedBindingsMap;
 	onOpenAllShortcuts: () => void;
 }
@@ -142,38 +143,40 @@ function KeybindingDisplay({ commandId, resolvedBindings }: { commandId: string;
 
 export function NotebookHelpPanel({ renderer, resolvedBindings, onOpenAllShortcuts }: NotebookHelpPanelProps): ReactElement {
 	return (
-		<OKModalDialog
-			closeOnClickOutside={true}
-			height={620}
-			okButtonTitle={localize('positron.notebookHelp.close', 'Close')}
+		<PositronDynamicModalDialog
+			content={
+				<div className='notebook-help-panel'>
+					{SHORTCUT_SECTIONS.map(section => (
+						<div key={section.title}>
+							<h2>{section.title}</h2>
+							<div className='shortcut-grid'>
+								{section.shortcuts.map(shortcut => (
+									<div key={shortcut.commandId} className='shortcut-row'>
+										<span className='shortcut-label'>{shortcut.label}</span>
+										<span className='shortcut-keys'>
+											<KeybindingDisplay commandId={shortcut.commandId} resolvedBindings={resolvedBindings} />
+										</span>
+									</div>
+								))}
+							</div>
+						</div>
+					))}
+					<div className='notebook-help-all-shortcuts'>
+						<button className='all-shortcuts-link' onClick={() => { renderer.dispose(); onOpenAllShortcuts(); }}>
+							{localize('positron.notebookHelp.allShortcuts', 'View All Notebook Keyboard Shortcuts...')}
+						</button>
+					</div>
+				</div>
+			}
+			contentMaxHeight={540}
+			footer={
+				<OneButtonFooter buttonTitle={localize('positron.notebookHelp.close', 'Close')} onButton={() => renderer.dispose()} />
+			}
 			renderer={renderer}
 			title={localize('positron.notebookHelp.title', 'Notebook Keyboard Shortcuts')}
 			width={500}
-			onAccept={() => renderer.dispose()}
-			onCancel={() => renderer.dispose()}
-		>
-			<div className='notebook-help-panel'>
-				{SHORTCUT_SECTIONS.map(section => (
-					<div key={section.title}>
-						<h2>{section.title}</h2>
-						<div className='shortcut-grid'>
-							{section.shortcuts.map(shortcut => (
-								<div key={shortcut.commandId} className='shortcut-row'>
-									<span className='shortcut-label'>{shortcut.label}</span>
-									<span className='shortcut-keys'>
-										<KeybindingDisplay commandId={shortcut.commandId} resolvedBindings={resolvedBindings} />
-									</span>
-								</div>
-							))}
-						</div>
-					</div>
-				))}
-				<div className='notebook-help-all-shortcuts'>
-					<button className='all-shortcuts-link' onClick={() => { renderer.dispose(); onOpenAllShortcuts(); }}>
-						{localize('positron.notebookHelp.allShortcuts', 'View All Notebook Keyboard Shortcuts...')}
-					</button>
-				</div>
-			</div>
-		</OKModalDialog>
+			onClickOutside={() => renderer.dispose()}
+			onSubmit={() => renderer.dispose()}
+		/>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.css
@@ -454,6 +454,16 @@
 	color: var(--vscode-foreground);
 }
 
+.visualize-column-select {
+	width: 100%;
+	padding: 4px;
+	border-radius: 4px;
+	box-sizing: border-box;
+	color: var(--vscode-foreground);
+	background: var(--vscode-positronModalDialog-textInputBackground);
+	border: 1px solid var(--vscode-positronModalDialog-textInputBorder);
+}
+
 /* Insert step */
 
 .visualize-code-preview {

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.css
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.css
@@ -10,6 +10,22 @@
 	align-items: stretch;
 }
 
+/* Footer: Back on the left, Cancel + Next/Insert grouped on the right. */
+.positron-dynamic-modal-dialog-box .visualize-footer {
+	height: 48px;
+	display: flex;
+	padding: 0 16px;
+	flex: 0 0 auto;
+	justify-content: space-between;
+	align-items: flex-start;
+}
+
+.positron-dynamic-modal-dialog-box .visualize-footer .visualize-footer-right {
+	gap: 10px;
+	display: flex;
+	align-items: flex-start;
+}
+
 .visualize-split > .visualize-modal-content {
 	flex: 1 1 420px;
 	min-width: 0;

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
@@ -15,9 +15,6 @@ import { PositronModalDialogReactRenderer } from '../../../../../../base/browser
 import { PositronDynamicModalDialog } from '../../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
 import { FooterButton } from '../../../../../browser/positronComponents/positronDynamicModalDialog/components/footerButton.js';
 import { LabeledTextInput } from '../../../../../browser/positronComponents/positronModalDialog/components/labeledTextInput.js';
-import { DropDownListBox, DropDownListBoxEntry } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBox.js';
-import { DropDownListBoxItem } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBoxItem.js';
-import { DropDownListBoxSeparator } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBoxSeparator.js';
 import { positronClassNames } from '../../../../../../base/common/positronUtilities.js';
 import { URI } from '../../../../../../base/common/uri.js';
 import { ChartType, codeSnippetToCellSource, generateVizCode, isValidDataFrameExpr, VizAnswers, VizLibrary } from './generateVizCode.js';
@@ -589,19 +586,7 @@ function ColumnPicker({ label, value, onChange, columns, autoFocus, allowClear }
 }) {
 	const hasColumns = columns.length > 0;
 
-	// Dropdown autoFocus: LabeledTextInput handles its own autoFocus via
-	// the native input attribute; DropDownListBox doesn't, so focus the
-	// button ourselves on mount.
-	const dropdownRef = useRef<HTMLButtonElement>(null);
-	const didAutoFocusRef = useRef(false);
-	useEffect(() => {
-		if (autoFocus && hasColumns && !didAutoFocusRef.current) {
-			dropdownRef.current?.focus();
-			didAutoFocusRef.current = true;
-		}
-	}, [autoFocus, hasColumns]);
-
-	// Fallback when the dataframe wasn't inspectable -- the dropdown would
+	// Fallback when the dataframe wasn't inspectable -- the select would
 	// be empty, so let the user type a column name.
 	if (!hasColumns) {
 		return (
@@ -614,44 +599,29 @@ function ColumnPicker({ label, value, onChange, columns, autoFocus, allowClear }
 		);
 	}
 
-	const entries: DropDownListBoxEntry<string, string>[] = columns.map(c =>
-		new DropDownListBoxItem<string, string>({
-			identifier: c.name,
-			title: `${c.name}   ${c.type}`,
-			value: c.name,
-		})
-	);
-	// Identify the "None" / clear entry by reference rather than by
-	// identifier string, so a column literally named (e.g.) "None" can't
-	// be misinterpreted as a clear action.
-	const clearEntry = allowClear
-		? new DropDownListBoxItem<string, string>({
-			identifier: '',
-			title: localize('positron.notebook.visualize.columnPicker.none', 'None'),
-			value: '',
-		})
-		: null;
-	if (clearEntry) {
-		entries.push(new DropDownListBoxSeparator());
-		entries.push(clearEntry);
-	}
-
+	// A native <select> is used instead of the styled DropDownListBox because
+	// this dialog is a native <dialog> opened with showModal(), which lives in
+	// the browser top layer. DropDownListBox renders its popup into the normal
+	// DOM, so it would be occluded behind the dialog. Native <select> popups
+	// render in the OS layer and appear correctly above the dialog.
+	const placeholder = localize('positron.notebook.visualize.columnPicker.placeholder', 'Select a column');
 	return (
 		<div className='visualize-column-picker'>
 			<span className='visualize-column-picker-label'>{label}</span>
-			<DropDownListBox<string, string>
-				ref={dropdownRef}
-				entries={entries}
-				selectedIdentifier={value || undefined}
-				title={localize('positron.notebook.visualize.columnPicker.placeholder', 'Select a column')}
-				onSelectionChanged={(item) => {
-					if (item === clearEntry) {
-						onChange('');
-					} else {
-						onChange(item.options.value);
-					}
-				}}
-			/>
+			<select
+				autoFocus={autoFocus}
+				className='visualize-column-select'
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+			>
+				{/* Empty placeholder option. When allowClear, this doubles as the "None" choice; otherwise it's an unselectable prompt. */}
+				<option value=''>
+					{allowClear ? localize('positron.notebook.visualize.columnPicker.none', 'None') : placeholder}
+				</option>
+				{columns.map(c => (
+					<option key={c.name} value={c.name}>{`${c.name}   ${c.type}`}</option>
+				))}
+			</select>
 		</div>
 	);
 }

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
@@ -19,6 +19,7 @@ import { positronClassNames } from '../../../../../../base/common/positronUtilit
 import { URI } from '../../../../../../base/common/uri.js';
 import { ChartType, codeSnippetToCellSource, generateVizCode, isValidDataFrameExpr, VizAnswers, VizLibrary } from './generateVizCode.js';
 import { InsertMode } from './applyVisualizeResult.js';
+import { createSingleCallFunction } from '../../../../../../base/common/functional.js';
 import { VisualizePreview } from './visualizePreview.js';
 
 export type { InsertMode };
@@ -97,15 +98,11 @@ export const showVisualizeModalDialog = (
 	notebookUri?: URI,
 ): Promise<VisualizeResult | undefined> => {
 	return new Promise(resolve => {
-		let resolved = false;
-		// Resolve the promise at most once. Routed through the renderer's onDisposed so any close
-		// path -- the Cancel/Insert buttons or Escape (native <dialog> close) -- settles the promise
-		// exactly once.
-		const settle = (r: VisualizeResult | undefined) => {
-			if (resolved) { return; }
-			resolved = true;
-			resolve(r);
-		};
+		// Resolve the promise at most once across every close path. settle wraps resolve via
+		// createSingleCallFunction and is wired to the renderer's onDisposed, so Escape / click-outside
+		// settle with undefined. finish is the button path: settle with the result, then dispose -- the
+		// dispose's onDisposed -> settle(undefined) is a no-op because settle already ran.
+		const settle = createSingleCallFunction(resolve);
 		const renderer = new PositronModalDialogReactRenderer({
 			onDisposed: () => settle(undefined),
 		});

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
@@ -11,11 +11,10 @@ import { useEffect, useRef, useState } from 'react';
 
 // Other dependencies.
 import { localize } from '../../../../../../nls.js';
-import { PositronModalReactRenderer } from '../../../../../../base/browser/positronModalReactRenderer.js';
-import { PositronModalDialog } from '../../../../../browser/positronComponents/positronModalDialog/positronModalDialog.js';
-import { ContentArea } from '../../../../../browser/positronComponents/positronModalDialog/components/contentArea.js';
+import { PositronModalDialogReactRenderer } from '../../../../../../base/browser/positronModalDialogReactRenderer.js';
+import { PositronDynamicModalDialog } from '../../../../../browser/positronComponents/positronDynamicModalDialog/positronDynamicModalDialog.js';
+import { FooterButton } from '../../../../../browser/positronComponents/positronDynamicModalDialog/components/footerButton.js';
 import { LabeledTextInput } from '../../../../../browser/positronComponents/positronModalDialog/components/labeledTextInput.js';
-import { OKCancelBackNextActionBar } from '../../../../../browser/positronComponents/positronModalDialog/components/okCancelBackNextActionBar.js';
 import { DropDownListBox, DropDownListBoxEntry } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBox.js';
 import { DropDownListBoxItem } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBoxItem.js';
 import { DropDownListBoxSeparator } from '../../../../../browser/positronComponents/dropDownListBox/dropDownListBoxSeparator.js';
@@ -101,13 +100,21 @@ export const showVisualizeModalDialog = (
 	notebookUri?: URI,
 ): Promise<VisualizeResult | undefined> => {
 	return new Promise(resolve => {
-		const renderer = new PositronModalReactRenderer();
 		let resolved = false;
-		const finish = (r: VisualizeResult | undefined) => {
+		// Resolve the promise at most once. Routed through the renderer's onDisposed so any close
+		// path -- the Cancel/Insert buttons, Escape (native <dialog> close), or a click outside --
+		// settles the promise exactly once.
+		const settle = (r: VisualizeResult | undefined) => {
 			if (resolved) { return; }
 			resolved = true;
-			renderer.dispose();
 			resolve(r);
+		};
+		const renderer = new PositronModalDialogReactRenderer({
+			onDisposed: () => settle(undefined),
+		});
+		const finish = (r: VisualizeResult | undefined) => {
+			settle(r);
+			renderer.dispose();
 		};
 		renderer.render(
 			<VisualizeModalDialog
@@ -124,7 +131,7 @@ export const showVisualizeModalDialog = (
 };
 
 interface Props {
-	renderer: PositronModalReactRenderer;
+	renderer: PositronModalDialogReactRenderer;
 	initialDfName: string;
 	columns: DataFrameColumn[];
 	notebookUri?: URI;
@@ -275,14 +282,8 @@ const VisualizeModalDialog = (props: Props) => {
 	const previewReady = dfNameValid && answers.x.trim().length > 0;
 
 	return (
-		<PositronModalDialog
-			height={560}
-			renderer={props.renderer}
-			title={localize('positron.notebook.visualize.title', 'Visualize dataframe')}
-			width={900}
-			onCancel={props.onCancel}
-		>
-			<ContentArea>
+		<PositronDynamicModalDialog
+			content={
 				<div className='visualize-split'>
 					<div className='visualize-modal-content'>
 						<StepIndicator currentIdx={currentIdx} total={STEP_ORDER.length} />
@@ -405,25 +406,33 @@ const VisualizeModalDialog = (props: Props) => {
 						</div>
 					)}
 				</div>
-			</ContentArea>
-
-			<OKCancelBackNextActionBar
-				backButtonConfig={{
-					disable: currentIdx === 0,
-					onClick: goBack,
-				}}
-				cancelButtonConfig={{ onClick: props.onCancel }}
-				nextButtonConfig={isLastStep ? undefined : {
-					disable: !canAdvance,
-					onClick: advanceOrSubmit,
-				}}
-				okButtonConfig={isLastStep ? {
-					title: localize('positron.notebook.visualize.insert', 'Insert'),
-					disable: !canInsert,
-					onClick: advanceOrSubmit,
-				} : undefined}
-			/>
-		</PositronModalDialog>
+			}
+			contentMaxHeight={480}
+			contentMinHeight={480}
+			footer={
+				<div className='visualize-footer'>
+					<FooterButton disabled={currentIdx === 0} onPressed={goBack}>
+						{localize('positron.notebook.visualize.back', 'Back')}
+					</FooterButton>
+					<div className='visualize-footer-right'>
+						<FooterButton onPressed={props.onCancel}>
+							{localize('positron.notebook.visualize.cancel', 'Cancel')}
+						</FooterButton>
+						{isLastStep
+							? <FooterButton default disabled={!canInsert} type='submit' onPressed={advanceOrSubmit}>
+								{localize('positron.notebook.visualize.insert', 'Insert')}
+							</FooterButton>
+							: <FooterButton default disabled={!canAdvance} type='submit' onPressed={advanceOrSubmit}>
+								{localize('positron.notebook.visualize.next', 'Next')}
+							</FooterButton>}
+					</div>
+				</div>
+			}
+			renderer={props.renderer}
+			title={localize('positron.notebook.visualize.title', 'Visualize dataframe')}
+			width={900}
+			onSubmit={advanceOrSubmit}
+		/>
 	);
 };
 

--- a/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
+++ b/src/vs/workbench/contrib/positronNotebook/browser/contrib/visualize/visualizeModalDialog.tsx
@@ -99,8 +99,8 @@ export const showVisualizeModalDialog = (
 	return new Promise(resolve => {
 		let resolved = false;
 		// Resolve the promise at most once. Routed through the renderer's onDisposed so any close
-		// path -- the Cancel/Insert buttons, Escape (native <dialog> close), or a click outside --
-		// settles the promise exactly once.
+		// path -- the Cancel/Insert buttons or Escape (native <dialog> close) -- settles the promise
+		// exactly once.
 		const settle = (r: VisualizeResult | undefined) => {
 			if (resolved) { return; }
 			resolved = true;
@@ -614,7 +614,11 @@ function ColumnPicker({ label, value, onChange, columns, autoFocus, allowClear }
 				value={value}
 				onChange={(e) => onChange(e.target.value)}
 			>
-				{/* Empty placeholder option. When allowClear, this doubles as the "None" choice; otherwise it's an unselectable prompt. */}
+				{/*
+					Empty placeholder option. When allowClear, this is the "None" choice; otherwise it's
+					the initial prompt. Selecting it sets the value to '', which the canAdvance/canInsert
+					guards treat as "no column chosen" -- so it can't be submitted either way.
+				*/}
 				<option value=''>
 					{allowClear ? localize('positron.notebook.visualize.columnPicker.none', 'None') : placeholder}
 				</option>


### PR DESCRIPTION
Fixes #14127 and #13559 

### Summary

Migrates the Positron notebook editor's custom React modals from the older
`PositronModalReactRenderer` (a manual overlay div) to the native-`<dialog>`-backed
`PositronModalDialogReactRenderer` + `PositronDynamicModalDialog`, introduced in #13336.
The native `<dialog>` + `showModal()` hands focus-trapping, Escape-to-close, backdrop
dimming, and top-layer stacking to the browser instead of bespoke event/overlay handling.

Modals migrated:

| Modal | Before | After |
|---|---|---|
| Ghost Cell Info | `OKModalDialog` + `PositronModalReactRenderer` | `OneButtonFooter` + `PositronDynamicModalDialog` |
| Assistant Panel | `PositronModalDialog` + `PositronModalReactRenderer` | `PositronDynamicModalDialog` |
| Notebook Help | `OKModalDialog` + `PositronModalReactRenderer` | `OneButtonFooter` + `PositronDynamicModalDialog` |
| Visualize DataFrame | `PositronModalDialog` + `PositronModalReactRenderer` | `PositronDynamicModalDialog` |

The issue scoped three modals; the Notebook Help modal used the same old renderer, so it
was migrated in the same pass. No references to `PositronModalReactRenderer` remain in the
notebook editor. The dialog chrome (border, shadow, backdrop dim, title bar) is unchanged;
the visible differences are the Visualize column pickers (see Screenshots) and a slightly
shorter footer.

Supporting changes:

- **Shared renderer Escape fix.** The renderer's capture-phase keydown handler called
  `EventHelper.stop()` (preventDefault + stopPropagation) on any key resolving to a
  non-allowable command, to suppress keybindings while a modal is open. For Escape this
  also suppressed the native `<dialog>`'s own close, so a modal over an editor that binds
  Escape (e.g. a notebook cell's exit-edit-mode binding) got stuck open. Escape is now
  special-cased to only `stopPropagation` (the bound command still doesn't run) without
  `preventDefault`, letting the dialog close. Data Connections dialogs are unaffected.
- **New `OneButtonFooter` component**, a sibling of the existing `twoButtonFooter` /
  `threeButtonFooter`, for acknowledge-style dialogs (Ghost Cell, Help).
- **Visualize column picker uses a native `<select>`** instead of `DropDownListBox`. The
  styled dropdown rendered its popup into the normal DOM (z-index 2500) and was painted
  behind the top-layer `<dialog>`; a native `<select>` popup renders in the OS layer above
  the dialog.

### Screenshots

<img width="482" height="263" alt="image" src="https://github.com/user-attachments/assets/1264d118-ac19-4708-b3f0-370e2eda3475" />

_The dialog chrome is unchanged, so the only meaningful visual delta is the Visualize column pickers (X/Y column), which are now native OS `<select>` controls instead of the styled `DropDownListBox`._

<img width="537" height="669" alt="image" src="https://github.com/user-attachments/assets/aa01f678-9086-4b03-aead-7c9d0d1b6bda" />

_The new modal's size themselves correctly and thus fixes the issue of the assistant modal having scrollbars because it's not big enough._

### Release Notes

#### New Features

- N/A

#### Bug Fixes

- Notebook modals (Help, Ghost Cell Info, Assistant, Visualize) now close on Escape when
  opened over a notebook cell in edit mode (#14127)

### Validation Steps

@:positron-notebooks @:help @:assistant

Open a Positron notebook and verify each modal renders, traps focus, dims the backdrop,
and closes on Escape and via its footer button:

1. **Notebook Help** -- run the "Show Keyboard Shortcuts" action (or F1 in the notebook).
   Confirm Escape closes it, the Close button closes it, and "View All Notebook Keyboard
   Shortcuts..." opens the full shortcuts editor.
2. **Ghost Cell Info** -- open the ghost-cell info modal; confirm Escape and "Got it" both
   close it.
3. **Assistant Panel** -- open the Ask Assistant modal; confirm Escape, the close button,
   and clicking outside all dismiss it (and cancel any in-flight request).
4. **Visualize DataFrame** -- on a dataframe, open Visualize. Step through library -> chart
   -> columns -> insert. Confirm: Enter advances/inserts, the X/Y column `<select>` popups
   render above the dialog, Back/Cancel work, and Escape closes the dialog at any step.
5. **Edit-mode Escape regression** -- enter edit mode in a notebook cell, open any of the
   above modals, press Escape, and confirm the modal closes (rather than only exiting cell
   edit mode).
